### PR TITLE
Add script to create consistent issue labels across all repos.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 site
+node_modules
+.*.swp

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "fxa",
+  "version": "0.0.1",
+  "description": "Automate All the Firefox Accounts Things!",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mozilla/fxa.git"
+  },
+  "bugs": "https://github.com/mozilla/fxa/issues/",
+  "homepage": "https://github.com/mozilla/fxa/",
+  "license": "MPL-2.0",
+  "author": "Mozilla (https://mozilla.org/)",
+  "dependencies": {
+    "bluebird": "2.9.25",
+    "github": "0.2.4"
+  }
+}

--- a/scripts/gh.js
+++ b/scripts/gh.js
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//  High-level github automation API.
+
+
+const path = require('path')
+const fs = require('fs')
+
+const GitHubApi = require('github')
+const P = require('bluebird')
+
+
+function GH(options) {
+
+  options = options || {}
+  this._gh = P.promisifyAll(new GitHubApi({
+    version: '3.0.0',
+    host: options.host || 'api.github.com',
+    debug: options.debug,
+    timeout: options.timeout || 3000,
+  }))
+
+  var env = process.env
+  var api_key = options.api_key || env.GITHUB_API_KEY
+  if (api_key) {
+    var username = options.username || env.GITHUB_USERNAME || env.USER
+    this._gh.authenticate({
+      type: 'basic',
+      username: username,
+      password: api_key
+    })
+  }
+
+  // Expose the 'issues' API with promisified semantics, and with
+  // a wrapper to fetch all result pages at once.
+  var self = this
+  this.issues = {}
+  Object.keys(this._gh.issues).forEach(function(methodName) {
+    if (typeof self._gh.issues[methodName] === 'function') {
+      self.issues[methodName] = function(msg) {
+        msg.user = msg.user || 'mozilla'
+        msg.per_page = msg.per_page || 50
+        return new P(function(resolve, reject) {
+          self._gh.issues[methodName](msg, function(err, res) {
+            if (err) return reject(err)
+            resolve(self._getAllPages(res))
+          })
+        })
+      }
+    }
+  })
+}
+
+GH.prototype._getAllPages = function _getAllPages(curPage, acc) {
+  var self = this
+  acc = acc || []
+  acc = acc.concat(curPage)
+  if (!this._gh.hasNextPage(curPage)) {
+    return P.resolve(acc)
+  }
+  return self._gh.getNextPageAsync(curPage).then(function (nextPage) {
+    return self._getAllPages(nextPage, acc)
+  })
+}
+
+GH.ALL_REPOS = fs.readFileSync(path.join(__dirname, 'repos.txt')).toString().split('\n')
+                 .filter(function(r) { return r && r.charAt(0) !== '#' })
+
+module.exports = GH

--- a/scripts/repos.txt
+++ b/scripts/repos.txt
@@ -1,0 +1,29 @@
+# The names of all our repos.
+# They're all under the "mozilla" github org.
+fxa
+fxa-auth-db-mem
+fxa-auth-db-mysql
+fxa-auth-db-server
+fxa-auth-mailer
+fxa-auth-server
+fxa-basket-proxy
+fxa-content-experiments
+fxa-content-server
+fxa-content-server-l10n
+fxa-deployment
+fxa-dev
+fxa-js-client
+fxa-js-client-old
+fxa-jwtool
+fxa-local-dev
+fxa-notification-server
+fxa-oauth-console
+fxa-oauth-server
+fxa-profile-server
+fxa-python-client
+fxa-relier-client
+fxa-scrypt-helper
+hapi-fxa-oauth
+PyFxA
+fxa-easter-egg
+fxa-password-strength-checker

--- a/scripts/sync_labels.js
+++ b/scripts/sync_labels.js
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+// Script to apply our standard set of labels to each repo, and
+// do a bit of cleanup on the issues therein.
+
+GH = require('./gh.js')
+P = require('bluebird')
+
+COLORS = {
+  WAFFLE: 'ededed',
+  RESOLUTION: 'e6e6e6',
+  THEME: 'eb6420',
+  ALERT: 'e11d21',
+  INFO: '207de5',
+  TARGET: 'd4c5f9',
+}
+
+
+// These are labels that should exist on every repo, and that
+// we use as part of our development management process.
+
+STANDARD_LABELS = {
+  // Issue lifecycle management labels, for waffle.
+  'waffle:later': { color: COLORS.WAFFLE },
+  'waffle:ready': { color: COLORS.WAFFLE },
+  'waffle:progress': { color: COLORS.WAFFLE },
+  'waffle:review': { color: COLORS.WAFFLE },
+  // Issue deathcycle management labels, for reporting purposes.
+  'resolved:fixed': { color: COLORS.RESOLUTION },
+  'resolved:wontfix': { color: COLORS.RESOLUTION },
+  'resolved:invalid': { color: COLORS.RESOLUTION },
+  'resolved:duplicate': { color: COLORS.RESOLUTION },
+  'resolved:worksforme': { color: COLORS.RESOLUTION },
+  // Labels for active initiatives.  There are ongoing initiatives
+  // like "chore" and "quality"
+  'chore': { color: COLORS.THEME },
+  'quality': { color: COLORS.THEME },
+  // For calling out really important stuff.
+  'blocker': { color: COLORS.ALERT },
+  'good-first-bug': { color: '009800' },
+  // Firefox version targets by which issues have to land.
+  'Fx40': { color: COLORS.TARGET },
+  'Fx41': { color: COLORS.TARGET },
+  'Fx42': { color: COLORS.TARGET },
+  'Fx43': { color: COLORS.TARGET },
+  // Cross-cutting concerns that we need to account for when
+  // working with or reviewing the issue.
+  'strings': { color: COLORS.INFO },
+  'security': { color: COLORS.INFO },
+  'ux': { color: COLORS.INFO },
+},
+
+
+// These are old label names that we're maintaining for
+// compatibility with existing workflows.
+
+ALTERNATE_LABELS = {
+  'waffle:later': [ 'z-later', 'backlog' ],
+  'waffle:ready': [ 'ready' ],
+  'waffle:progress': [ 'waffle:in progress', 'waffle:wip', 'WIP' ],
+  'waffle:review': [ 'waffle:in review', 'waffle:needs review' ],
+  'resolved:fixed': [ 'fixed' ],
+  'resolved:wontfix': [ 'wontfix' ],
+  'resolved:invalid': [ 'invalid' ],
+  'resolved:duplicate': [ 'duplicate' ],
+  'resolved:worksforme': [ 'worksforme' ],
+  'good-first-bug': [ 'good first bug', 'help wanted' ],
+  'chore': [ 'cleanup' ],
+},
+
+module.exports = {
+
+  // Ensure that the given repo has our standard set of labels,
+  // with appropriate colorization.
+
+  makeStandardLabels: function makeStandardLabels(gh, repo) {
+    return gh.issues.getLabels({ repo: repo }).then(function(labels) {
+      var curLabels = {}
+      labels.forEach(function(labelInfo) {
+        curLabels[labelInfo.name] = labelInfo
+      })
+      var p = P.resolve(null);
+      Object.keys(STANDARD_LABELS).forEach(function(label) {
+        if (! (label in curLabels)) {
+          p = p.then(function() {
+            console.log("Creating '" + label + "' on " + repo)
+            gh.issues.createLabel({
+              repo: repo,
+              name: label,
+              color: STANDARD_LABELS[label].color
+            })
+          })
+        } else if (curLabels[label].color !== STANDARD_LABELS[label].color) {
+          p = p.then(function() {
+            console.log("Updating '" + label + "' on " + repo)
+            gh.issues.updateLabel({
+              repo: repo,
+              name: label,
+              color: STANDARD_LABELS[label].color
+            })
+          })
+        }
+      })
+      return p
+    })
+  },
+
+  // Ensure that issues in the repo have appropriate standard labels applied,
+  // based on any alternative labels they might have.
+
+  fixupStandardLabels: function fixupStandardLabels(gh, repo) {
+    var p = P.resolve(null);
+    Object.keys(ALTERNATE_LABELS).forEach(function(stdLabel) {
+      ALTERNATE_LABELS[stdLabel].forEach(function(altLabel) {
+        p = p.then(function() {
+          return gh.issues.repoIssues({
+            repo: repo,
+            labels: altLabel,
+            filter: 'all',
+            state: 'open'
+          }).each(function (issue) {
+            var labels = []
+            issue.labels.forEach(function(labelInfo) {
+              labels.push(labelInfo.name)
+            })
+            if (labels.indexOf(stdLabel) === -1) {
+              labels.push(stdLabel)
+              console.log("Adding '" + stdLabel + "' to " + repo + " #" + issue.number)
+              return gh.issues.edit({
+                repo: repo,
+                number: issue.number,
+                labels: labels
+              })
+            }
+          })
+        })
+      })
+    })
+    return p;
+  }
+
+}
+
+if (require.main == module) {
+  gh = new GH()
+  P.resolve(GH.ALL_REPOS).each(function(repo) {
+    console.log("Checking labels in " + repo)
+    return module.exports.makeStandardLabels(gh, repo)
+      .then(function() {
+        return module.exports.fixupStandardLabels(gh, repo)
+      })
+  }).catch(function(err) {
+    console.log(err)
+  })
+}


### PR DESCRIPTION
@vladikoff for your consideration.  What if we also use this repo as a place to hold various github automation/scripting tools to help streamline our workflow?  Here's a simple example, a script to make sure we've got a consistent set of labels across all the repos in the project.