### PR TITLE
fix(fxa-45): Remove any mention of OAuth from initial devices API.

### DIFF
--- a/features/FxA-45-device-registration-api/README.md
+++ b/features/FxA-45-device-registration-api/README.md
@@ -238,7 +238,7 @@ https://api-accounts.dev.lcip.org/v1/account/device \
 
 ### POST /v1/account/device
 
-Authenticated with session token or OAuth.
+Authenticated with session token.
 
 #### Requests
 
@@ -291,7 +291,7 @@ https://api-accounts.dev.lcip.org/v1/account/device \
 
 ### GET /v1/account/devices
 
-Authenticated with session token or OAuth.
+Authenticated with session token.
 
 #### Request
 
@@ -332,7 +332,7 @@ it means the device is disconnected.
 
 ### POST /v1/account/device/destroy
 
-Authenticated with session token or OAuth.
+Authenticated with session token.
 
 If the session is associated with a different device id,
 a 400 error will be returned.


### PR DESCRIPTION
We will oauth-enable these end-points eventually, but all our initial consumers will have a sessionToken, so let's whittle down the scope of the initial release as much as possible.  @philbooth r?