### PR TITLE
fix(docs): unrecognised device id causes a 400 error

### DIFF
--- a/features/FxA-45-device-registration-api/README.md
+++ b/features/FxA-45-device-registration-api/README.md
@@ -384,10 +384,9 @@ https://api-accounts.dev.lcip.org/v1/account/device/destroy \
 
 ### How are unrecognised devices handled?
 
-If a request to `/v1/account/login` or `/v1/account/device`
+If a POST to `/v1/account/login`, `/v1/account/device` or `/v1/account/device/destroy`
 specifies an unknown device id,
-a new device record will be created in the database
-and the newly-generated device id will be returned in the response.
+a 400 error will returned.
 
 ### What is a disconnected device?
 


### PR DESCRIPTION
Fixes #78.

I think this will make both the server and the client code better.