### PR TITLE
feat(FxA-97): Add initial values for the key metrics

### DIFF
--- a/features/FxA-97-password-strength/README.md
+++ b/features/FxA-97-password-strength/README.md
@@ -41,6 +41,18 @@ We believe that these changes will result in us collecting only the data that be
 * Datadog Dashboard › FxA Content Server - Registration › Signup funnel
  * Slightly reduced signup rate
 
+As of 25th July 2016,
+prior to shipping the new UX,;
+the [Datadog password-strength dashboard](https://app.datadoghq.com/dash/67511/fxa-content-server---password-strength)
+gives the following percentages for these events:
+
+* Passwords that are too short: 10.6%
+* Passwords that are just letters and numbers: 21.1%
+* Passwords that are too common (aka BLOOMFILTER_HIT): 1.67%
+* Bloom filter misses: 70.44%
+* Successful signups as a % of submissions: 70.9%
+
+
 ## Detailed design
 
 [comment]: # (This is the bulk of the RFC. Explain the design in enough detail for somebody familiar with the language to understand. This should get into specifics and corner-cases, and include examples of how the feature is used.)


### PR DESCRIPTION
Add the current values of the key metrics for this feature; once we deploy it, we'll be able to compare to these values to see if it made any difference.  @TDA r?

(a policy note: we're generally happy to public percentage-based metrics like this in public, but don't usually publish absolute numbers; of course each case should be considered on its metrics, but I think these ones are fine to be public about)