### PR TITLE
Calculate active milestones from issues in fxa-features repo.

### DIFF
--- a/scripts/sync_milestones.js
+++ b/scripts/sync_milestones.js
@@ -11,11 +11,56 @@
 var ghlib = require('./ghlib.js')
 var P = require('bluebird')
 
+var ACTIVE_FEATURE_LABELS = {
+  "defined": true,
+  "building": true,
+  "shipping": true,
+  "measuring": true
+}
+
+var FEATURE_NUMBER_RE = /(FxA-\d+): .*/
 
 module.exports = {
 
-  getTopLevelMilestones: function getTopLevelMilestones(gh) {
-    return module.exports.getMilestonesByTitle(gh, ghlib.TOP_LEVEL_REPO)
+  // Synthesize the list of current milestones, based on issues
+  // active in the fxa-features repo.
+
+  getCurrentMilestones: function getCurrentMilestones(gh) {
+    return gh.issues.getForRepo({ repo: 'fxa-features' }).filter(function(feature) {
+      // Filter to only those features in an "active" state.
+      for (var i = 0; i < feature.labels.length; i++) {
+        if (ACTIVE_FEATURE_LABELS[feature.labels[i].name]) {
+          return true
+        }
+      }
+      return false
+    }).map(function(feature) {
+      // Figure out the name of the corresponding milestone.
+      // We try to make it like `FxA-N: feature title`, where
+      // N is either the issue number, or a legacy Aha! card number.
+      var title
+      var featureNumMatch = FEATURE_NUMBER_RE.exec(feature.title)
+      if (! featureNumMatch) {
+        title = 'FxA-' + feature.number + ': ' + feature.title
+      } else {
+        title = feature.title
+      }
+      return {
+        title: title,
+        state: 'open',
+        description: feature.url
+      }
+    }).reduce(function(milestones, item) {
+      milestones[item.title] = item
+      return milestones
+    }, {
+      // This milestone should always exist.
+      'FxA-0: quality': {
+        title: 'FxA-0: quality',
+        state: 'open',
+        description: 'general quality improvements'
+      }
+    })
   },
 
   // Get the current set of milestones out of a repo, as a hash
@@ -42,31 +87,28 @@ module.exports = {
   },
 
   // Ensure that a repo's milestones are consistent with the given
-  // top-level milestones, which must be in the format returned by
-  // getMilestonesByTitle().
+  // set of milestones, as returned by getCurrentMilestones().
 
   syncMilestones: function syncMilestones(gh, repo, milestones) {
     return P.all([
       milestones,
       module.exports.getMilestonesByTitle(gh, repo)
     ]).spread(function(theirs, ours) {
+      // For each of their milestones, ensure we have a corresponding one.
       return P.resolve(Object.keys(theirs)).each(function(title) {
         var theirMilestone = theirs[title]
         var ourMilestone = module.exports.findMatchingMilestone(title, ours)
         if (!ourMilestone) {
           // It doesn't exist at all, create it.
-          if (theirMilestone.state === 'open') {
-            console.log("Creating '" + title + "' in " + repo.name)
-            return gh.issues.createMilestone({
-              repo: repo.name,
-              title: title,
-              due_on: theirMilestone.due_on,
-              description: theirMilestone.description
-            })
-          }
+          console.log("Creating '" + title + "' in " + repo.name)
+          return gh.issues.createMilestone({
+            repo: repo.name,
+            title: title,
+            description: theirMilestone.description
+          })
         } else {
           // It already exists, see if we need to update it. 
-          for (var k in {title: 1, due_on: 1, description: 1, state: 1}) {
+          for (var k in {title: 1, description: 1, state: 1}) {
             if (theirMilestone[k] !== ourMilestone[k]) {
               console.log("Updating '" + title + "' in " + repo.name)
               if (theirMilestone.title !== ourMilestone.title) {
@@ -77,7 +119,6 @@ module.exports = {
                 repo: repo.name,
                 number: ourMilestone.number,
                 title: theirMilestone.title,
-                due_on: theirMilestone.due_on,
                 description: theirMilestone.description,
                 state: theirMilestone.state
               })
@@ -88,8 +129,9 @@ module.exports = {
         return [theirs, ours]
       })
     }).spread(function(theirs, ours) {
+      // For each of our milestones that's not in their list, close it out.
       return P.resolve(Object.keys(ours)).each(function(title) {
-        if (!module.exports.findMatchingMilestone(title, theirs)) {
+        if (! module.exports.findMatchingMilestone(title, theirs)) {
           if (ours[title].state !== 'closed') {
             if (ours[title].open_issues > 0) {
               console.warn("Extra milestone in " + repo.name + ": '" + title + "'")
@@ -109,18 +151,17 @@ module.exports = {
   },
 
   // Find the milestone matching the one with the given title.
-  // This matches on Aha! feature number if present in the title,
+  // This matches on 'FxA-N' feature number if present in the title,
   // otherwise falls back to a simple string compare.
 
   findMatchingMilestone: function findMatchingMilestone(title, milestones) {
-    var featureRE = /(FxA-\d+): .*/
-    var featureMatch = featureRE.exec(title)
+    var featureMatch = FEATURE_NUMBER_RE.exec(title)
     if (!featureMatch) {
       return milestones[title]
     }
     var feature = featureMatch[1]
     for (var k in milestones) {
-      featureMatch = featureRE.exec(k)
+      featureMatch = FEATURE_NUMBER_RE.exec(k)
       if (featureMatch && featureMatch[1] === feature) {
         return milestones[k]
       }
@@ -129,7 +170,7 @@ module.exports = {
   },
 
   // Close out any past-due milestones in a repo.
-  // If the milestone stuff has issues in it, a warning is
+  // If the milestone still has issues in it, a warning is
   // printed instead.
 
   closeOldMilestones: function(gh, repo, now) {
@@ -167,13 +208,11 @@ module.exports = {
 if (require.main == module) {
   gh = new ghlib.GH()
   return module.exports.closeOldMilestones(gh, ghlib.TOP_LEVEL_REPO).then(function() {
-    return module.exports.getTopLevelMilestones(gh).then(function(milestones) {
+    return module.exports.getCurrentMilestones(gh).then(function(milestones) {
       return P.resolve(ghlib.REPOS).each(function(repo) {
-        if (repo.name !== ghlib.TOP_LEVEL_REPO.name)  {
-          return module.exports.closeOldMilestones(gh, repo).then(function() {
-            module.exports.syncMilestones(gh, repo, milestones)
-          })
-        }
+        return module.exports.closeOldMilestones(gh, repo).then(function() {
+          module.exports.syncMilestones(gh, repo, milestones)
+        })
       })
     })
   }).catch(function(err) {


### PR DESCRIPTION
# What's this about?

This changes our milestone-syncing script to calculate the set of active milestones based on the data in our features board, rather than just propagating milestones from the "fxa" repo to all the sub-repos.

# Why is it good?

The disconnect between milestones in the engineering board and features in the feature board has been growing, and it's largely due to the additional manual overhead of having to go in and create a milestone when we start working on a feature.  With this change, dragging the feature card into "defined" or further will cause this script to automatically make the matching milestone.

Less change for things to get our of sync, more change we'll use the milestones as intended.

For bonus points, we could consider trying to run this regularly in a similar manner to what @vladikoff recently set up for the bugzilla mirroring script.

# Any risks here?

Not really; if something does happen to go horribly wrong then I volunteer to sort out the resulting mess by hand :-)

One bit of weirdness to be aware of, is that we're now using the issues numbers from the fxa-features repo in the "FxA-N" title prefix; these will on occasional collide with numbers that were previously allocated in Aha, which might lead to some mild confusion.

One possible solution would be to create and close a bunch of issues in the fxa-features repo, to increment the issue numbers past what was used by Aha.  But I didn't want to generate bugmail spam for everyone.