### PR TITLE
fix(docs): Update documentation on how to create a milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ git push origin/master
 
 ### Adding new milestones
 
-* Add the milestone by hand on the mozilla/fxa repo
+* Create an issue card in the [fxa-features waffleboard](https://waffle.io/mozilla/fxa-features)
+* Move it into "designing" or further to the right
 * Get a [GitHub access token](https://github.com/settings/tokens), set `GITHUB_USERNAME` and `GITHUB_API_KEY`
-* Run `scripts/sync_milestones.js` to propagate it to the other repos
+* Run `scripts/sync_milestones.js` to create a corresponding milestone in all the repos

--- a/scripts/sync_milestones.js
+++ b/scripts/sync_milestones.js
@@ -12,6 +12,7 @@ var ghlib = require('./ghlib.js')
 var P = require('bluebird')
 
 var ACTIVE_FEATURE_LABELS = {
+  "designin": true,
   "defined": true,
   "building": true,
   "shipping": true,


### PR DESCRIPTION
I realized that these are out of date and may have lead to some hiccups in creating milestone for CAD phase 3; this updates them to match the reality of what the script currently does.  @mozilla/fxa-devs r?