### PR TITLE
Remove references to features repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ git push origin/master
 
 ### Adding new milestones
 
-* Create an issue card in the [fxa-features waffleboard](https://waffle.io/mozilla/fxa-features)
-* Move it into "designing" or further to the right
+* Add the milestone by hand on the mozilla/fxa repo
 * Get a [GitHub access token](https://github.com/settings/tokens), set `GITHUB_USERNAME` and `GITHUB_API_KEY`
-* Run `scripts/sync_milestones.js` to create a corresponding milestone in all the repos
+* Run `scripts/sync_milestones.js` to propagate it to the other repos

--- a/docs/dev-process.md
+++ b/docs/dev-process.md
@@ -22,10 +22,10 @@ cut a release "train" that goes through deployment to stage and into production.
 
 ## Product Planning
 
-Product-level feature planning is managed via github issues
-in a special "features waffleboard":
+Product-level feature planning is managed
+in a separate tool called "Projects":
 
-* [The fxa-features waffleboard](https://waffle.io/mozilla/fxa-features)
+* [The fxa features board](https://projects-beta.growthhackers.com/u/orgs/mozilla-corporation/projects/FAAS/notebook)
 
 ## Issue management
 

--- a/features/README.md
+++ b/features/README.md
@@ -4,17 +4,17 @@ This directory is our
 lightweight planning and tracking mechanism
 for new feature development in Firefox Accounts.
 
-Each sub-directory named "FxA-XX-YYY"
+Each sub-directory named "FxA-NUMBER-TITLE"
 corresponds to a feature card in the
-[features waffleboard](https://waffle.io/mozilla/fxa-features)
+[features board](https://projects-beta.growthhackers.com/u/orgs/mozilla-corporation/projects/FAAS/notebook)
 and provides the details of
 how the feature will look and behave,
 how it will be implemented,
 and how we'll determine whether it was successful.
 
 Proposing a new feature?
-You should start by filing an issue in the
-[features waffleboard](https://waffle.io/mozilla/fxa-features)
+You should start by suggesting an idea in the
+[features board](https://projects-beta.growthhackers.com/u/orgs/mozilla-corporation/projects/FAAS/notebook)
 for discussion.
 Once you're ready to specify things in detail,
 you can use the [TEMPLATE.md](TEMPLATE.md) and [TEMPLATE_CLEAN.md](TEMPLATE_CLEAN.md)

--- a/scripts/sync_milestones.js
+++ b/scripts/sync_milestones.js
@@ -70,14 +70,21 @@ module.exports = {
             })
           }
         } else {
+          // unfortunately some milestones wound up with duplicate
+          // feature numbers, so check if we found the right thing.
+          if (theirMilestone.title !== ourMilestone.title) {
+            if (theirs[ourMilestone.title]) {
+              return
+            }
+          }
           // It already exists, see if we need to update it. 
           for (var k in {title: 1, due_on: 1, description: 1, state: 1}) {
             if (theirMilestone[k] !== ourMilestone[k]) {
-              console.log("Updating '" + title + "' in " + repo.name)
               if (theirMilestone.title !== ourMilestone.title) {
                 ours[theirMilestone.title] = ourMilestone
                 delete ours[ourMilestone.title]
               }
+              console.log("Updating '" + title + "' in " + repo.name, ourMilestone, theirMilestone)
               return gh.issues.updateMilestone({
                 repo: repo.name,
                 number: ourMilestone.number,
@@ -120,6 +127,9 @@ module.exports = {
   // otherwise falls back to a simple string compare.
 
   findMatchingMilestone: function findMatchingMilestone(title, milestones) {
+    if (milestones[title]) {
+      return milestones[title]
+    }
     var featureRE = /(FxA-\d+):.*/
     var featureMatch = featureRE.exec(title)
     if (!featureMatch) {


### PR DESCRIPTION
We're closing down the fxa-features waffleboard and replacing it with the "Projects" tool, which has more features to help @davismtl be effective in his role.  This PR removes references to fxa-features and puts the milestone-syncing script back to the previous version that propagates them out from this repo.

@mozilla/fxa-devs r?