### PR TITLE
chore(scripts): remove archived repositories from milestone list

### DIFF
--- a/scripts/repos.txt
+++ b/scripts/repos.txt
@@ -38,3 +38,4 @@ fxa-activity-metrics
 mozlog
 fxa-sprint-planning
 fxa-amplitude-send
+mozilla-services/fxa-testing-e2e

--- a/scripts/repos.txt
+++ b/scripts/repos.txt
@@ -4,10 +4,8 @@ fxa
 fxa-auth-db-mem
 fxa-auth-db-mysql
 fxa-auth-db-server
-fxa-auth-mailer
 fxa-auth-server
 fxa-basket-proxy
-fxa-content-experiments
 fxa-content-server
 fxa-content-server-l10n
 fxa-customs-server
@@ -18,7 +16,6 @@ fxa-crypto-relier
 fxa-js-client-old
 fxa-jwtool
 fxa-local-dev
-fxa-notification-server
 fxa-oauth-console
 fxa-oauth-client
 fxa-oauth-server
@@ -39,6 +36,5 @@ fxa-bugzilla-mirror
 grunt-l10n-lint
 fxa-activity-metrics
 mozlog
-mozilla-services/fxa-testing-e2e
 fxa-sprint-planning
 fxa-amplitude-send


### PR DESCRIPTION
I ran the milestone sync script today and it failed because some of the repos have been archived and are now read-only:

```
{ [Error: {"message":"Repository was archived so is read-only.","documentation_url":"https://developer.github.com/v3/issues/milestones/#update-a-milestone"}]
  message: '{"message":"Repository was archived so is read-only.","documentation_url":"https://developer.github.com/v3/issues/milestones/#update-a-milestone"}',
  code: 403,
  status: 'Forbidden',
```

I removed four in total to get the script to finish successfully, not sure if that's the right course of action?

@mozilla/fxa-devs r?

