### PR TITLE
fix(labels): Remove apparently-now-unsupported emoji labels.

### DIFF
--- a/scripts/repos.txt
+++ b/scripts/repos.txt
@@ -37,5 +37,4 @@ fxa-sprint-planning
 fxa-amplitude-send
 fxa-email-service
 mozilla-services/fxa-testing-e2e
-#fxa-common-password-list <-- Github rejects creating heart labels saying "name must contain more than native emoji"
-
+fxa-common-password-list

--- a/scripts/sync_labels.js
+++ b/scripts/sync_labels.js
@@ -44,8 +44,6 @@ var STANDARD_LABELS = {
   'resolved:duplicate': { color: COLORS.RESOLUTION },
   'resolved:worksforme': { color: COLORS.RESOLUTION },
   // For calling out really important stuff.
-  '❤': { color: COLORS.ALERT },
-  '❤❤❤': { color: COLORS.ALERT },
   'blocker': { color: COLORS.ALERT },
   'shipit': { color: COLORS.WARNING },
   'help wanted': { color: COLORS.WELCOMING },


### PR DESCRIPTION
I don't think we really use these ❤️  labels anymore, and github refuses to sync them to new repos, so perhaps we should just remove them.  @shane-tomlinson r?