### PR TITLE
chore(scripts): remove oauth server from repo list

### DIFF
--- a/scripts/repos.txt
+++ b/scripts/repos.txt
@@ -16,7 +16,6 @@ fxa-jwtool
 fxa-local-dev
 fxa-oauth-console
 fxa-oauth-client
-fxa-oauth-server
 fxa-profile-server
 fxa-python-client
 fxa-relier-client


### PR DESCRIPTION
Archived repo causes the milestone script to fail.

@mozilla/fxa-devs r?