### PR TITLE
fix(scripts): ignore bouncing accounts in verification reminders

### DIFF
--- a/packages/fxa-auth-server/scripts/verification-reminders.js
+++ b/packages/fxa-auth-server/scripts/verification-reminders.js
@@ -79,12 +79,22 @@ async function run () {
         });
         sent[uid] = true;
       } catch (err) {
-        if (err.errno === error.ERRNO.ACCOUNT_UNKNOWN) {
-          console.log(`  * ignoring deleted account ${uid}`);
-        } else {
-          console.log(`  * failed ${uid}`);
-          console.error(err.stack);
-          failed.push({ timestamp, uid });
+        const { errno } = err;
+        switch (errno) {
+          case error.ERRNO.ACCOUNT_UNKNOWN:
+          case error.ERRNO.BOUNCE_COMPLAINT:
+          case error.ERRNO.BOUNCE_HARD:
+          case error.ERRNO.BOUNCE_SOFT:
+            console.log(`  * ignoring deleted/bouncing account ${uid}, errno: ${errno}`);
+            try {
+              await verificationReminders.delete(uid);
+            } catch (ignore) {
+            }
+            break;
+          default:
+            console.log(`  * failed ${uid}, errno: ${errno}`);
+            console.error(err.stack);
+            failed.push({ timestamp, uid });
         }
       }
 


### PR DESCRIPTION
If the verification reminder script gets a bounce response back, it seems sensible to delete the reminders for the affected `uid` rather than try them again. If bounce records exist for a user, there's no way of telling how long they'll continue for so it seems prudent to cut our losses early and remove them completely.

The only way I managed to test this locally was to hack `lib/senders/email.js` to reject with a bounce error, but crucially not to do that for the initial verification email because that will delete the account.

I mean this:

```diff
diff --git a/packages/fxa-auth-server/lib/senders/email.js b/packages/fxa-auth-server/lib/senders/email.js
index 00bfe4089..5d447e2d5 100644
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -13,6 +13,7 @@ const safeRegex = require('safe-regex');
 const safeUserAgent = require('../userAgent/safe');
 const Sandbox = require('sandbox');
 const url = require('url');
+const error = require('lib/error');

 const TEMPLATE_VERSIONS = require('./templates/_versions.json');

@@ -350,6 +351,10 @@ module.exports = function (log, config, oauthdb) {
               return d.reject(err);
             }

+            if (template === 'verificationReminderFirstEmail') {
+              return d.reject(error.emailBouncedHard(Date.now()));
+            }
+
             log.info('mailer.send.1', {
               status: status && status.message,
               id: status && status.messageId,
```

Not ideal, I realise, but at least it exercises the code. Doing that then running the script produces the expected output:

```
$ node scripts/verification-reminders
Processing 1 first reminders...
  * ignoring deleted/bouncing account 9b028ea8f27d4b63a857bc139ae9eccc, errno: 134
Processing 0 second reminders...
Done
```

If we're happy to merge this, I'll cut a patch release using [the first-release script](https://gist.github.com/philbooth/94a1f5ec37d9983a17adae1a38e13acd#file-first-release-sh). ~~But before cutting that, I could really do with getting the green light on #680 so that I know people are happy with the broad approach to changelogs and tagging that I've adopted.~~

@mozilla/fxa-devs r?