### PR TITLE
fix(totp): replace recovery codes keyboard accessibility

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/two_step_authentication.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/two_step_authentication.mustache
@@ -50,7 +50,7 @@
                 </li>
                 <li>
                     {{#hasToken}}
-                        <a class="replace-codes-link">{{#t}}Replace recovery codes{{/t}}</a>
+                        <button class="link replace-codes-link">{{#t}}Replace recovery codes{{/t}}</button>
                     {{/hasToken}}
                 </li>
             </ul>

--- a/packages/fxa-content-server/app/styles/_base.scss
+++ b/packages/fxa-content-server/app/styles/_base.scss
@@ -105,6 +105,19 @@ input {
   font-weight: inherit;
 }
 
+button.link {
+  color: $link-color-default;
+  font-size: 14px;
+  height: 20px;
+  justify-content: left;
+  letter-spacing: 0;
+  width: auto;
+}
+
+button.link:hover {
+  text-decoration: underline;
+}
+
 input[type='radio'] {
     @include font();
     // autoprefixer does not handle appearance, see https://github.com/ai/autoprefixer/issues/205

--- a/packages/fxa-content-server/app/styles/modules/_settings-totp.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings-totp.scss
@@ -115,7 +115,8 @@
   }
 }
 
-.replace-codes-link {
+.replace-codes-link,
+.replace-codes-link:hover {
   background: transparent url('/images/recovery_code_replace.svg') center left no-repeat;
   padding-left: 20px;
 }


### PR DESCRIPTION
Make 'Replace recovery codes' keyboard accessible.
Replace earlier used link with button element to allow
tab indexing and keyboard click events for keyboard
accessibility.

fixes: #598

Continuation of [archived repo PR](https://github.com/mozilla/fxa-content-server/pull/7090)
with all requested changes merged, @vbudhram