### PR TITLE
increase circleci parallelism to 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
             - project/*
 
   test-content-server:
-    parallelism: 3
+    parallelism: 6
     docker:
       - image: circleci/node:10-stretch-browsers
       - image: redis


### PR DESCRIPTION
6 is just a guess. 3 was optimal for my personal account with a max of 4 instances. I imagine the speedup has diminishing returns a we go higher.

Our longest running non-parallel task is `fxa-email-service` at ~20 minutes.