### PR TITLE
fix(emails): Make Done button responsive after adding email

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/emails.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/emails.mustache
@@ -72,9 +72,7 @@
                 {{#hasSecondaryEmail}}
                     <button type="submit" class="settings-button email-refresh primary-button enabled" title="{{ lastCheckedTime }}">{{#t}}Refresh Status{{/t}}</button>
 
-                    <button
-                        class="settings-button {{#hasSecondaryVerifiedEmail}}cancel secondary-button enabled{{/hasSecondaryVerifiedEmail}}
-                            {{^hasSecondaryVerifiedEmail}} disabled {{/hasSecondaryVerifiedEmail}}">
+                    <button class="settings-button cancel secondary-button">
                         {{#t}}Done{{/t}}
                     </button>
                 {{/hasSecondaryEmail}}

--- a/packages/fxa-content-server/app/scripts/views/settings/emails.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/emails.js
@@ -57,7 +57,6 @@ var View = FormView.extend({
       buttonClass: this._hasSecondaryEmail() ? 'secondary-button' : 'primary-button',
       emails: this._emails,
       hasSecondaryEmail: this._hasSecondaryEmail(),
-      hasSecondaryVerifiedEmail: this._hasSecondaryVerifiedEmail(),
       isPanelOpen: this.isPanelOpen(),
       lastCheckedTime: this.getLastCheckedTimeString(),
       newEmail: this.newEmail,


### PR DESCRIPTION
After adding new email in secondary email section, make
the done button responsive before email verification. Allow
done button to be clicked and panel to be closed. Do not
change the behavior of automatically opening panel if
secondary linked email is unverified.

fixes: #626

continuation of https://github.com/mozilla/fxa-content-server/pull/7092