### PR TITLE
fix(scripts): ensure release script pulls changes from private/master

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -303,7 +303,9 @@ if [ "$PRIVATE_BRANCH_EXISTS" = "" ]; then
 
   PRIVATE_REMOTE_BRANCH_EXISTS=`git branch -r | awk '{$1=$1};1' | grep "^$PRIVATE_REMOTE_BRANCH\$"` || true
   if [ "$PRIVATE_REMOTE_BRANCH_EXISTS" = "" ]; then
+    echo "Warning: $PRIVATE_BRANCH branch not found on local or remote, creating one from $PRIVATE_REMOTE/master."
     git checkout --no-track -b "$PRIVATE_BRANCH" "$PRIVATE_REMOTE/master" > /dev/null 2>&1
+    git pull "$PRIVATE_REMOTE" master > /dev/null 2>&1
   else
     git checkout --track -b "$PRIVATE_BRANCH" "$PRIVATE_REMOTE_BRANCH" > /dev/null 2>&1
   fi

--- a/release.sh
+++ b/release.sh
@@ -235,6 +235,13 @@ bump() {
     mv "$1/CHANGELOG.md.release.bak" "$1/CHANGELOG.md"
   fi
 
+  # Clear summaries before the next iteration
+  FEAT_SUMMARY=""
+  FIX_SUMMARY=""
+  PERF_SUMMARY=""
+  REFACTOR_SUMMARY=""
+  OTHER_SUMMARY=""
+
   # 8.4. If package.json exists, uppdate the version string in package.json.
   if [ -f "$1/package.json" ]; then
     sed -i.release.bak -e "s/$SED_FRIENDLY_LAST_VERSION/$NEW_VERSION/g" "$1/package.json"


### PR DESCRIPTION
Now that some private changes landed, I tried the release script again just to make sure it was pulling everything in correctly. And, quel surprise, it wasn't.

This fix ensures we pull from `private/master` after creating a fresh `train-xxx-private` branch. It also adds a log line to let the user know what it's doing at that point, in the same way it already does when it creates the public `train-xxx` branch.

With this change in place, the tree looks sane after tagging a release:

```
*    (tag: v1.134.1-private, train-134-private) ef4f13c6d Phil Booth Merge train-134 into train-134-private
|\
| *  (tag: v1.134.1, train-134) c57940238 Phil Booth Release fxa-profile-server 1.134.1
| *  7f613ee5d Phil Booth Release fxa-email-service 1.134.1
| *  71b542773 Phil Booth Release fxa-email-event-proxy 1.134.1
| *  e5f3dc4e2 Phil Booth Release fxa-customs-server 1.134.1
| *  ac9e3898b Phil Booth Release fxa-content-server 1.134.1
| *  636d6f838 Phil Booth Release fxa-auth-server 1.134.1
| *  a49160919 Phil Booth Release fxa-auth-db-mysql 1.134.1
* |    (private/master) 0e0a7ad66 Phil Booth Merge pull request #1 from mozilla/fxa-customs-server-private
```

Without this change applied, you can see that the private branch and tag are identical to their public counterparts:

```
*  (tag: v1.134.1-private, tag: v1.134.1, train-134-private, train-134) 15ad4b829 Phil Booth Release fxa-profile-server 1.134.1
*  c2f0d3937 Phil Booth Release fxa-email-service 1.134.1
*  ff14ce73d Phil Booth Release fxa-email-event-proxy 1.134.1
*  21b5341ab Phil Booth Release fxa-customs-server 1.134.1
*  2deae682b Phil Booth Release fxa-content-server 1.134.1
*  6789a1cd1 Phil Booth Release fxa-auth-server 1.134.1
*  4618f59d1 Phil Booth Release fxa-auth-db-mysql 1.134.1
```

@mozilla/fxa-devs r?