### PR TITLE
fix(oauth): bring back the jwk restriction

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/redirect.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/redirect.js
@@ -5,9 +5,17 @@
 const url = require('url');
 
 const contentUrl = require('../config').get('contentUrl');
+const AppError = require('../error');
 
 module.exports = {
   handler: async function redirectAuthorization(req, h) {
+    // keys_jwk is barred from transiting the OAuth server
+    // to prevent a malicious OAuth server from stealing
+    // a user's Scoped Keys. See bz1456351
+    if (req.query.keys_jwk) {
+      throw AppError.invalidRequestParameter('keys_jwk');
+    }
+
     const redirect = url.parse(contentUrl, true);
     redirect.pathname = '/authorization';
     redirect.query = req.query;

--- a/packages/fxa-auth-server/fxa-oauth-server/test/api.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/api.js
@@ -244,6 +244,17 @@ describe('/v1', function() {
           assert.equal(redirect.host, target.host);
         });
       });
+
+      it('should fail if keys_jwk specified', () => {
+        return Server.api
+          .get('/authorization?keys_jwk=xyz&client_id=123&state=321&scope=1')
+          .then(function(res) {
+            assert.equal(res.statusCode, 400);
+            assert.equal(res.result.errno, 109);
+            assert.equal(res.result.validation, 'keys_jwk');
+            assertSecurityHeaders(res);
+          });
+      });
     });
 
     describe('content-type', function() {


### PR DESCRIPTION
Brings back the logic from https://github.com/mozilla/fxa-auth-server/commit/69f8f3ad7131a78e23a1df9e5495fe22c1ee3ed0#diff-b1ab14854b56f6fbead482ff707dca1f to ban keys_jwk auth via the oauth server

Notes Mobile and WebExtension have been patched to use this: https://github.com/mozilla/fxa-crypto-relier/commit/2e198d0cbd42c10f1a62cc57f215455209b3ba17 should be okay to land this and by the time this deploys the clients should be up to date enough