### PR TITLE
style(avatar): oversizing of avatar on small screens

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_cropper.scss
+++ b/packages/fxa-content-server/app/styles/modules/_cropper.scss
@@ -10,9 +10,17 @@
     @include respond-to('compressedLandscape') {
       margin: 0 auto;
     }
+    @include respond-to('small') {
+      margin: 0 auto;
+      text-align: center;
+      width: auto;
+    }
 
     img {
       position: absolute;
+      @include respond-to('small') {
+        left: (420 - $avatar-size) / 6   !important;
+      }
     }
   }
 
@@ -43,6 +51,10 @@
 
     &::after {
       right: -(420 - $avatar-size) / 2;
+    }
+    @include respond-to('small') {
+      display: inline-block;
+      left: 0;
     }
   }
 


### PR DESCRIPTION
fixes #661 
ref [#7051](https://github.com/mozilla/fxa-content-server/pull/7051).

For a [tall sample image](https://github.com/recurser/exif-orientation-examples/blob/master/Portrait_1.jpg):
![Screenshot from 2019-04-03 10-33-14](https://user-images.githubusercontent.com/32164618/55605141-c1cf3480-5790-11e9-99c8-43932c6bff4f.png)

@lmorchard could you please review it now. Thanks!!
