### PR TITLE
chore(repo):remove husky and associated git hooks

### DIFF
--- a/packages/fxa-auth-server/npm-shrinkwrap.json
+++ b/packages/fxa-auth-server/npm-shrinkwrap.json
@@ -104,9 +104,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
-      "integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+      "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
       "dev": true
     },
     "@babel/template": {
@@ -121,16 +121,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
-      "integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+      "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.4.0",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.0",
-        "@babel/parser": "^7.4.0",
+        "@babel/parser": "^7.4.3",
         "@babel/types": "^7.4.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
@@ -969,12 +969,6 @@
         "readdirp": "^2.2.1",
         "upath": "^1.1.1"
       }
-    },
-    "ci-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-      "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
@@ -3012,7 +3006,7 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "fxa-auth-db-mysql": {
-      "version": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#be55658f57ab5f14e89f8a89bf89a131bae32ae4",
+      "version": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#7a44fc5e6960168d73d78817d241a4beeb39d979",
       "from": "git+https://github.com/mozilla/fxa-auth-db-mysql.git#master",
       "dev": true,
       "requires": {
@@ -9705,31 +9699,6 @@
         }
       }
     },
-    "husky": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
-      "dev": true,
-      "requires": {
-        "is-ci": "^1.0.10",
-        "normalize-path": "^1.0.0",
-        "strip-indent": "^2.0.0"
-      },
-      "dependencies": {
-        "normalize-path": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
-          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
-          "dev": true
-        },
-        "strip-indent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-          "dev": true
-        }
-      }
-    },
     "i18n-abide": {
       "version": "0.0.26",
       "resolved": "https://registry.npmjs.org/i18n-abide/-/i18n-abide-0.0.26.tgz",
@@ -9906,15 +9875,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
-    },
-    "is-ci": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-      "dev": true,
-      "requires": {
-        "ci-info": "^1.5.0"
-      }
     },
     "is-data-descriptor": {
       "version": "0.1.4",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -9,9 +9,8 @@
     "test": "test"
   },
   "scripts": {
-    "bump-template-versions": "node scripts/template-version-bump --silent && git add lib/senders/templates/_versions.json",
+    "bump-template-versions": "node scripts/template-version-bump",
     "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
-    "precommit": "npm run bump-template-versions",
     "postinstall": "scripts/download_l10n.sh",
     "shrink": "npmshrink && npm run postinstall",
     "start": "NODE_ENV=dev scripts/start-local.sh 2>&1",
@@ -108,7 +107,6 @@
     "grunt-eslint": "19.0.0",
     "grunt-newer": "1.2.0",
     "hawk": "7.0.7",
-    "husky": "0.14.3",
     "jsxgettext-recursive-next": "1.1.0",
     "jws": "3.1.5",
     "leftpad": "0.0.0",

--- a/packages/fxa-content-server/npm-shrinkwrap.json
+++ b/packages/fxa-content-server/npm-shrinkwrap.json
@@ -7902,23 +7902,6 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
-    "husky": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-0.11.4.tgz",
-      "integrity": "sha1-HQlcanBiQvRnHG9sq04ASP1kZCA=",
-      "dev": true,
-      "requires": {
-        "normalize-path": "^1.0.0"
-      },
-      "dependencies": {
-        "normalize-path": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
-          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
-          "dev": true
-        }
-      }
-    },
     "i18n-abide": {
       "version": "0.0.26",
       "resolved": "https://registry.npmjs.org/i18n-abide/-/i18n-abide-0.0.26.tgz",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build-production": "NODE_ENV=production grunt build",
     "postinstall": "scripts/download_l10n.sh",
-    "prepush": "npm run lint && grunt sasslint",
     "shrink": "npmshrink",
     "lint": "eslint app server tests --cache",
     "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
@@ -145,7 +144,6 @@
     "grunt-sass-lint": "0.2.0",
     "grunt-todo": "0.5.0",
     "htmlparser2": "3.9.0",
-    "husky": "0.11.4",
     "install": "0.12.1",
     "intern": "4.3.1",
     "jimp": "0.6.0",


### PR DESCRIPTION
Related to #689.

The git hooks aren't working in the monorepo context. Specifically:

* The content server `prepush` linter hook runs on all changes, slowing down local development. Ideally it should check `$PWD` and only run if it's in the content server directory.

* The auth server `precommit` hook never runs at all.

It doesn't appear that anyone has time to fix them at the moment, so let's remove them for now and we can bring them back when someone has time to figure it out. Keeping them in the tree broken is annoying.

@mozilla/fxa-devs r?