### PR TITLE
Issue #707: Initial auth DB changes to track subscriptions

### DIFF
--- a/packages/fxa-auth-db-mysql/db-server/index.js
+++ b/packages/fxa-auth-db-mysql/db-server/index.js
@@ -249,6 +249,28 @@ function createServer(db) {
   api.del('/account/:id/recoveryKey', withParams(db.deleteRecoveryKey))
   api.post('/account/:id/recoveryKey', withIdAndBody(db.createRecoveryKey))
 
+  api.get('/account/:id/subscriptions/:subscriptionId',
+    op(req => db.getAccountSubscription(
+      req.params.id,
+      req.params.subscriptionId
+    ))
+  )
+  api.put('/account/:id/subscriptions/:subscriptionId',
+    op(req => db.createAccountSubscription(
+      req.params.id,
+      req.params.subscriptionId,
+      req.body.productName,
+      req.body.createdAt
+    ))
+  )
+  api.del('/account/:id/subscriptions/:subscriptionId',
+    op(req => db.deleteAccountSubscription(
+      req.params.id,
+      req.params.subscriptionId
+    ))
+  )
+  api.get('/account/:id/subscriptions', withIdAndBody(db.fetchAccountSubscriptions))
+
   api.get(
     '/',
     function (req, res, next) {

--- a/packages/fxa-auth-db-mysql/docs/API.md
+++ b/packages/fxa-auth-db-mysql/docs/API.md
@@ -106,6 +106,11 @@ The following datatypes are used throughout this document:
     * createRecoverykey         : `POST /account/:id/recoveryKeys`
     * getRecoveryKey            : `GET /account/:id/recoveryKeys/:recoveryKeyId`
     * deleteRecoveryKey         : `DELETE /account/:id/recoveryKeys/:recoveryKeyId`
+* Subscriptions:
+    * createAccountSubscription : `PUT /account/:id/subscriptions/:subscriptionId`
+    * fetchAccountSubscriptions : `GET /account/:id/subscriptions`
+    * getAccountSubscription    : `GET /account/:id/subscriptions/:subscriptionId`
+    * deleteAccountSubscriptions : `DELETE /account/:id/subscriptions/:subscriptionId`
 
 ## Ping : `GET /`
 
@@ -2251,3 +2256,187 @@ Content-Length: 2
     * Conditions: if something goes wrong on the server
     * Content-Type : `application/json`
     * Body : `{"code":"InternalError","message":"..."}`
+
+## createAccountSubscription : `PUT /account/:id/subscriptions/:subscriptionId`
+
+### Example
+
+```
+curl \
+    -v \
+    -X PUT \
+    -H "Content-Type: application/json" \
+    -d '{
+        "productName" : "exampleProduct1",
+        "createdAt" : 1424832691282
+    }' \
+    http://localhost:8000/account/6044486dd15b42e08b1fb9167415b9ac/subscriptions/sub8675309
+```
+
+### Request
+
+* Method : `PUT`
+* Path : `/account/<uid>/subscriptions/<subscriptionId>`
+    * `uid` : hex
+    * `subscriptionId` : string255
+* Params:
+    * `productName`: Name of the subscribed product from the upstream payment system
+    * `createdAt`: Date of subscription creation
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+{}
+```
+
+* Status Code : `200 OK`
+    * Content-Type : `application/json`
+    * Body : `{}`
+* Status Code : `500 Internal Server Error`
+    * Conditions: if something goes wrong on the server
+    * Content-Type : `application/json`
+    * Body : `{"code":"InternalError","message":"..."}`
+
+## fetchAccountSubscriptions : `GET /account/:id/subscriptions`
+
+### Example
+
+```
+curl \
+    -v \
+    -X GET \
+    -H "Content-Type: application/json" \
+    http://localhost:8000/account/6044486dd15b42e08b1fb9167415b9ac/subscriptions
+```
+
+### Request
+
+* Method : `GET`
+* Path : `/account/<uid>/subscriptions`
+    * `uid` : hex
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+[
+  { 
+    "uid": 6044486dd15b42e08b1fb9167415b9ac,
+    "subscriptionId": "sub8675309",
+    "productName": "exampleProduct1",
+    "createdAt": 1424832691282
+  },
+  { 
+    "uid": 6044486dd15b42e08b1fb9167415b9ac,
+    "subscriptionId": "sub999",
+    "productName": "exampleProduct2",
+    "createdAt": 1424832691282
+  },
+  { 
+    "uid": 6044486dd15b42e08b1fb9167415b9ac,
+    "subscriptionId": "sub987",
+    "productName": "exampleProduct3",
+    "createdAt": 1424832691282
+  }
+]
+```
+
+* Status Code : `200 OK`
+    * Content-Type : `application/json`
+    * Body : `[{}]`
+      * `subscriptionId`: ID for the subscription from the upstream payment system
+      * `productName`: Name of the subscribed product from the upstream payment system
+      * `createdAt`: Date of subscription creation
+* Status Code : `500 Internal Server Error`
+    * Conditions: if something goes wrong on the server
+    * Content-Type : `application/json`
+    * Body : `{"code":"InternalError","message":"..."}`
+
+## getAccountSubscription    : `GET /account/:id/subscriptions/:subscriptionId`
+
+### Example
+
+```
+curl \
+    -v \
+    -X GET \
+    -H "Content-Type: application/json" \
+    http://localhost:8000/account/6044486dd15b42e08b1fb9167415b9ac/subscriptions/sub8675309
+```
+
+### Request
+
+* Method : `GET`
+* Path : `/account/<uid>/subscriptions/<subscriptionId>`
+    * `uid` : hex
+    * `subscriptionId` : string255
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+{ 
+  "uid": 6044486dd15b42e08b1fb9167415b9ac,
+  "subscriptionId": "sub8675309",
+  "productName": "exampleProduct1",
+  "createdAt": 1424832691282
+}
+```
+
+* Status Code : `200 OK`
+    * Content-Type : `application/json`
+    * Body : `{}`
+      * `subscriptionId`: ID for the subscription from the upstream payment system
+      * `productName`: Name of the subscribed product from the upstream payment system
+      * `createdAt`: Date of subscription creation
+* Status Code : `500 Internal Server Error`
+    * Conditions: if something goes wrong on the server
+    * Content-Type : `application/json`
+    * Body : `{"code":"InternalError","message":"..."}`
+
+## deleteAccountSubscriptions : `DELETE /account/:id/subscriptions/:subscriptionId`
+
+### Example
+
+```
+curl \
+    -v \
+    -X DELETE \
+    -H "Content-Type: application/json" \
+    http://localhost:8000/account/6044486dd15b42e08b1fb9167415b9ac/subscriptions/sub8675309
+```
+
+### Request
+
+* Method : `DELETE`
+* Path : `/account/<uid>/subscriptions`
+    * `uid` : hex
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+{}
+```
+
+* Status Code : `200 OK`
+    * Content-Type : `application/json`
+    * Body : `{}`
+* Status Code : `500 Internal Server Error`
+    * Conditions: if something goes wrong on the server
+    * Content-Type : `application/json`
+    * Body : `{"code":"InternalError","message":"..."}`
+

--- a/packages/fxa-auth-db-mysql/docs/DB_API.md
+++ b/packages/fxa-auth-db-mysql/docs/DB_API.md
@@ -75,6 +75,11 @@ There are a number of methods that a DB storage backend should implement:
     * .getRecoveryKey(data)
     * .deleteRecoveryKey(uid)
     * .recoveryKeyExists(uid)
+* Subscriptions
+    * .createAccountSubscription(uid, subscriptionId, productName, createdAt)
+    * .fetchAccountSubscriptions(uid)
+    * .getAccountSubscription(uid, subscriptionId)
+    * .deleteAccountSubscription(uid, subscriptionId)
 * General
     * .ping()
     * .close()
@@ -1018,5 +1023,87 @@ Returns:
 
 * Resolves with:
   * object {"exists": true}
+* Rejects with:
+  * Any error from the underlying storage system (wrapped in `error.wrap()`)
+
+## .createAccountSubscription(uid, subscriptionId, productName, createdAt)
+
+Create a product subscription for this user.
+
+Parameters:
+
+* `uid` (Buffer16):
+  The uid of the owning account
+* `subscriptionId` (String):
+  The subscription ID from the upstream payment system
+* `productName` (String):
+  The name of the product granted by the subscription
+* `createdAt` (number):
+  Creation timestamp for the subscription, milliseconds since the epoch
+
+Returns:
+
+* Resolves with:
+  * Empty object `{}`
+* Rejects with:
+  * Any error from the underlying storage system (wrapped in `error.wrap()`)
+
+## .fetchAccountSubscriptions(uid)
+
+Fetch all product subscriptions for this user.
+
+Parameters:
+
+* `uid` (Buffer16):
+  The uid of the owning account
+
+Returns:
+
+* Resolves with:
+  * An array of objects:
+     * `uid`
+     * `subscriptionId`
+     * `productName`
+     * `createdAt`
+* Rejects with:
+  * Any error from the underlying storage system (wrapped in `error.wrap()`)
+
+## .getAccountSubscription(uid, subscriptionId)
+
+Get a product subscription for this user.
+
+Parameters:
+
+* `uid` (Buffer16):
+  The uid of the owning account
+* `subscriptionId` (String):
+  The subscription ID from the upstream payment system
+
+Returns:
+
+* Resolves with:
+  * An object `{}`
+     * `uid`
+     * `subscriptionId`
+     * `productName`
+     * `createdAt`
+* Rejects with:
+  * Any error from the underlying storage system (wrapped in `error.wrap()`)
+
+## .deleteAccountSubscription(uid, subscriptionId)
+
+Delete a product subscription for this user.
+
+Parameters:
+
+* `uid` (Buffer16):
+  The uid of the owning account
+* `subscriptionId` (String):
+  The subscription ID from the upstream payment system
+
+Returns:
+
+* Resolves with:
+  * Empty object `{}`
 * Rejects with:
   * Any error from the underlying storage system (wrapped in `error.wrap()`)

--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -605,7 +605,7 @@ module.exports = function (log, error) {
   //          passwordForgotTokens, accounts, devices, deviceCommands, unverifiedTokens,
   //          emails, signinCodes, totp
   // Where  : uid = $1
-  var DELETE_ACCOUNT = 'CALL deleteAccount_16(?)'
+  var DELETE_ACCOUNT = 'CALL deleteAccount_17(?)'
 
   MySql.prototype.deleteAccount = function (uid) {
     return this.write(DELETE_ACCOUNT, [uid])
@@ -1610,6 +1610,40 @@ module.exports = function (log, error) {
       .then(() => {
         return {}
       })
+  }
+
+  const CREATE_ACCOUNT_SUBSCRIPTION = 'CALL createAccountSubscription_1(?,?,?,?)'
+  MySql.prototype.createAccountSubscription = function (uid, subscriptionId, productName, createdAt) {
+    return this.write(CREATE_ACCOUNT_SUBSCRIPTION, [
+      uid,
+      subscriptionId,
+      productName,
+      createdAt
+    ]).then(
+      result => ({}),
+      err => {
+        if (err.errno === ER_SIGNAL_NOT_FOUND) {
+          throw error.notFound()
+        }
+        throw err
+      }
+    )
+  }
+
+  const GET_ACCOUNT_SUBSCRIPTION = 'CALL getAccountSubscription_1(?,?)'
+  MySql.prototype.getAccountSubscription = function (uid, subscriptionId) {
+    return this.readFirstResult(GET_ACCOUNT_SUBSCRIPTION, [ uid, subscriptionId ])
+  }
+
+  const FETCH_ACCOUNT_SUBSCRIPTIONS = 'CALL fetchAccountSubscriptions_1(?)'
+  MySql.prototype.fetchAccountSubscriptions = function (uid) {
+    return this.readAllResults(FETCH_ACCOUNT_SUBSCRIPTIONS, [ uid ])
+  }
+
+  const DELETE_ACCOUNT_SUBSCRIPTION = 'CALL deleteAccountSubscription_1(?,?)'
+  MySql.prototype.deleteAccountSubscription = function (uid, subscriptionId) {
+    return this.write(DELETE_ACCOUNT_SUBSCRIPTION, [ uid, subscriptionId ])
+      .then(result => ({}))
   }
 
   return MySql

--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 97
+module.exports.level = 98

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-097-098.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-097-098.sql
@@ -1,0 +1,148 @@
+--
+-- This migration introduces subscriptions enabled for accounts
+--
+
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('97');
+
+CREATE TABLE IF NOT EXISTS accountSubscriptions (
+  id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  uid BINARY(16) NOT NULL,
+  productName VARCHAR(191), -- TBD pending subhub docs & integration
+  subscriptionId VARCHAR(191), -- TBD pending subhub docs & integration
+  createdAt BIGINT SIGNED NOT NULL,
+  UNIQUE KEY accountSubscriptionsSubscriptionIdUnique(subscriptionId),
+  UNIQUE INDEX accountSubscriptionsUnique(uid, productName, subscriptionId)
+) ENGINE=InnoDB;
+
+CREATE PROCEDURE `createAccountSubscription_1` (
+  IN inUid BINARY(16),
+  IN inSubscriptionId VARCHAR(191),
+  IN inProductName VARCHAR(191),
+  IN inCreatedAt BIGINT SIGNED
+)
+BEGIN
+
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  SET @accountCount = 0;
+
+  -- Signal error if no user found
+  SELECT COUNT(*) INTO @accountCount FROM accounts WHERE uid = inUid;
+  IF @accountCount = 0 THEN
+    SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1643, MESSAGE_TEXT = 'Can not create subscription for unknown user.';
+  END IF;
+
+  INSERT INTO accountSubscriptions(
+    uid,
+    subscriptionId,
+    productName,
+    createdAt
+  )
+  VALUES (
+    inUid,
+    inSubscriptionId,
+    inProductName,
+    inCreatedAt
+  );
+
+  COMMIT;
+END;
+
+CREATE PROCEDURE `deleteAccountSubscription_1` (
+  IN inUid BINARY(16),
+  IN inSubscriptionId VARCHAR(191)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM accountSubscriptions
+  WHERE
+    uid = inUid
+  AND
+    subscriptionId = inSubscriptionId;
+
+  COMMIT;
+END;
+
+CREATE PROCEDURE `getAccountSubscription_1` (
+  IN inUid BINARY(16),
+  IN inSubscriptionId VARCHAR(191)
+)
+BEGIN
+  SELECT
+    asi.uid,
+    asi.subscriptionId,
+    asi.productName,
+    asi.createdAt
+  FROM accountSubscriptions asi
+  WHERE
+    asi.uid = inUid
+  AND
+    asi.subscriptionId = inSubscriptionId;
+END;
+
+CREATE PROCEDURE `fetchAccountSubscriptions_1` (
+  IN inUid BINARY(16)
+)
+BEGIN
+  SELECT
+    asi.uid,
+    asi.subscriptionId,
+    asi.productName,
+    asi.createdAt
+  FROM accountSubscriptions asi
+  WHERE
+    asi.uid = inUid
+  ORDER BY
+    asi.createdAt asc;
+END;
+
+CREATE PROCEDURE `deleteAccount_17` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM sessionTokens WHERE uid = uidArg;
+  DELETE FROM keyFetchTokens WHERE uid = uidArg;
+  DELETE FROM accountResetTokens WHERE uid = uidArg;
+  DELETE FROM passwordChangeTokens WHERE uid = uidArg;
+  DELETE FROM passwordForgotTokens WHERE uid = uidArg;
+  DELETE FROM accounts WHERE uid = uidArg;
+  DELETE devices, deviceCommands FROM devices LEFT JOIN deviceCommands
+    ON (deviceCommands.uid = devices.uid AND deviceCommands.deviceId = devices.id)
+    WHERE devices.uid = uidArg;
+  DELETE FROM unverifiedTokens WHERE uid = uidArg;
+  DELETE FROM unblockCodes WHERE uid = uidArg;
+  DELETE FROM emails WHERE uid = uidArg;
+  DELETE FROM signinCodes WHERE uid = uidArg;
+  DELETE FROM totp WHERE uid = uidArg;
+  DELETE FROM recoveryKeys WHERE uid = uidArg;
+  DELETE FROM recoveryCodes WHERE uid = uidArg;
+  DELETE FROM securityEvents WHERE uid = uidArg;
+  DELETE FROM accountSubscriptions WHERE uid = uidArg;
+
+  COMMIT;
+END;
+
+UPDATE dbMetadata SET value = '98' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-098-097.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-098-097.sql
@@ -1,0 +1,11 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+-- 
+-- DROP PROCEDURE createAccountSubscription_1;
+-- DROP PROCEDURE deleteAccountSubscription_1;
+-- DROP PROCEDURE getAccountSubscription_1;
+-- DROP PROCEDURE fetchAccountSubscriptions_1;
+-- DROP PROCEDURE deleteAccount_17;
+-- 
+-- DROP TABLE accountSubscriptions;
+-- 
+-- UPDATE dbMetadata SET value = '97' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
This is just foundational DB changes to track subscriptions for accounts. No auth / profile / etc API changes yet.

TODO:
- [x] Ensure schema seems correct - as close as we'll get until subhub is final, I think.
- [x] Finish auth DB server API changes, tests, **and docs**

Turns out, these two tasks were not actually planned as part of #707:
- ~Wire up auth server API methods to expose relevant subscription capabilities to clients~
- ~Include subscription capabilities in profile server API~

Questions / points of interest:

- Simplifying the schema to be less tied to upstream payment provider ~Do the relations between Customers, Subscriptions, Plans, Products, Capabilities, and Clients make sense? Trying to base these on what I'm seeing as the shared data model across Stripe, [SubHub](https://docs.google.com/document/d/13HVlc_aDWp_nMQzTOTKsCT2VLIkMWZ0sbYV8P8QyFUM/edit#heading=h.1vw3bsdrvnnn), and FxA docs.~

- Moving Client-to-Capabilities map to Auth server configuration. ~Subscription status in a user profile will consist of a set of capability flags. I created a table mapping relevant capabilities to clients to restrict visibility. Maybe this should live in app config rather than in the database?~

- Moving Product-to-Capabilities map to Auth server configuration. ~Subscription to a Plan grants access to a Product. I created a table to associate Capabilities granted by a Product, because I figured different Products might represent different bundles of Capabilities. Maybe this should live in app config rather than in the database?~

- My mysql-fu is not super strong and I'm new to the FxA DBs - any critique would be very appreciated!
