### PR TITLE
chore(ci): run tests for email service/event proxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,6 +182,60 @@ jobs:
           at: ~/
       - run: ../../.circleci/test-js-client.sh
 
+  fxa-email-event-proxy:
+    docker:
+      - image: circleci/node:8
+    working_directory: ~/project/packages/fxa-email-event-proxy
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: npm ci
+      - run: npm run lint
+      - run: npm t
+
+  fxa-email-event-proxy-tag:
+    docker:
+      - image: circleci/node:8
+    working_directory: ~/project/packages/fxa-email-event-proxy
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: npm ci
+      - run: |
+          if [ -n "${CIRCLE_TAG}" ]; then
+            exit 0
+          fi
+          npm run build
+          mkdir artifacts
+          mv fxa-email-event-proxy.zip "artifacts/fxa-email-event-proxy.$CIRCLE_TAG.zip"
+      - store_artifacts:
+          path: artifacts
+
+  fxa-email-service:
+    docker:
+      - image: circleci/node:10
+      - image: mysql:5.6
+        environment:
+          - MYSQL_DATABASE: fxa
+          - MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          - MYSQL_ROOT_PASSWORD: ''
+      - image: redis
+    working_directory: ~/project/packages/fxa-email-service
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run: |
+          . ../../.circleci/install-rust.sh
+          rustup component add rustfmt-preview
+          cargo fmt -- --check
+          ./scripts/test_with_authdb.sh
+      - store_artifacts:
+          path: fxa-auth-db-mysql.log
+      - setup_remote_docker
+      - run: |
+          ../../.circleci/build.sh fxa-email-service
+          ../../.circleci/deploy.sh fxa-email-service
+
   docs:
     docker:
       - image: circleci/node:10
@@ -194,10 +248,7 @@ jobs:
             - "08:fc:2b:fb:06:0e:8f:0f:01:1f:28:86:83:89:11:28"
       - run: |
           ssh-keyscan github.com >> ~/.ssh/known_hosts
-          curl https://sh.rustup.rs > rustup-init.sh
-          . ./rustup-init.sh -y
-          rm ./rustup-init.sh
-          . "$HOME/.cargo/env"
+          . .circleci/install-rust.sh
           ./_scripts/gh-pages.sh
 
 workflows:
@@ -239,11 +290,6 @@ workflows:
           requires:
             - install
       - build-module:
-          name: fxa-email-service
-          module: fxa-email-service
-          requires:
-            - install
-      - build-module:
           name: fxa-oauth-console
           module: fxa-oauth-console
           requires:
@@ -266,6 +312,12 @@ workflows:
           requires:
             - install
       - fxa-oauth-server:
+          requires:
+            - install
+      - fxa-email-event-proxy:
+          requires:
+            - install
+      - fxa-email-service:
           requires:
             - install
       - docs:
@@ -378,6 +430,14 @@ workflows:
               ignore: /.*/
           name: fxa-content-server
           module: fxa-content-server
+          requires:
+            - install
+      - fxa-email-event-proxy-tag:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
           requires:
             - install
       - fxa-oauth-server:

--- a/.circleci/install-rust.sh
+++ b/.circleci/install-rust.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -ex
+
+curl https://sh.rustup.rs > rustup-init.sh
+. ./rustup-init.sh -y
+rm ./rustup-init.sh
+. "$HOME/.cargo/env"

--- a/packages/fxa-auth-db-mysql/npm-shrinkwrap.json
+++ b/packages/fxa-auth-db-mysql/npm-shrinkwrap.json
@@ -1003,9 +1003,9 @@
       }
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esrecurse": {
@@ -1327,9 +1327,9 @@
       "dev": true
     },
     "grunt": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.3.tgz",
-      "integrity": "sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.4.tgz",
+      "integrity": "sha512-PYsMOrOC+MsdGEkFVwMaMyc6Ob7pKmq+deg1Sjr+vvMWp35sztfwKE7qoN51V+UEtHsyNuMcGdgMLFkBHvMxHQ==",
       "dev": true,
       "requires": {
         "coffeescript": "~1.10.0",
@@ -1343,7 +1343,7 @@
         "grunt-legacy-log": "~2.0.0",
         "grunt-legacy-util": "~1.1.1",
         "iconv-lite": "~0.4.13",
-        "js-yaml": "~3.5.2",
+        "js-yaml": "~3.13.0",
         "minimatch": "~3.0.2",
         "mkdirp": "~0.5.1",
         "nopt": "~3.0.6",
@@ -1668,6 +1668,12 @@
         "stack-trace": "^0.0.7"
       },
       "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
         "stack-trace": {
           "version": "0.0.7",
           "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.7.tgz",
@@ -1815,13 +1821,13 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
-      "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.2",
-        "esprima": "^2.6.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {

--- a/packages/fxa-auth-db-mysql/package.json
+++ b/packages/fxa-auth-db-mysql/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "eslint-plugin-fxa": "git+https://github.com/mozilla/eslint-plugin-fxa#master",
-    "grunt": "1.0.3",
+    "grunt": "1.0.4",
     "grunt-copyright": "0.3.0",
     "grunt-eslint": "18.0.0",
     "insist": "1.0.0",

--- a/packages/fxa-email-service/scripts/test_with_authdb.sh
+++ b/packages/fxa-email-service/scripts/test_with_authdb.sh
@@ -1,17 +1,24 @@
 #!/bin/sh
 
-DB_REPO=fxa-auth-db-mysql
+set -ex
 
+DB_REPO=fxa-auth-db-mysql
 if [ ! -e "$DB_REPO" ]; then
-  git clone "https://github.com/mozilla/$DB_REPO.git"
+  git init "$DB_REPO"
+  cd "$DB_REPO"
+  git remote add origin https://github.com/mozilla/fxa.git
+  git config core.sparseCheckout true
+  echo "packages/$DB_REPO/*" > .git/info/sparse-checkout
+  git pull --depth=1 origin master
+  cd ..
 fi
 
 RUNNING_DB_SERVERS=`ps -ef | grep "[n]ode bin/server" | wc -l`
 if [ "$RUNNING_DB_SERVERS" -eq "0" ]; then
-  cd "$DB_REPO"
-  npm i
+  cd "$DB_REPO/packages/$DB_REPO"
+  npm ci
   node bin/db_patcher
-  node bin/server 2>&1 > "$DB_REPO.log" &
+  node bin/server 2>&1 > "../../../$DB_REPO.log" &
   cd ..
 fi
 

--- a/packages/fxa-email-service/src/api/send/test.rs
+++ b/packages/fxa-email-service/src/api/send/test.rs
@@ -114,31 +114,6 @@ fn without_optional_data() {
 }
 
 #[test]
-fn unicode_email_field() {
-    let client = setup();
-
-    let mut response = client
-        .post("/send")
-        .header(ContentType::JSON)
-        .body(
-            r#"{
-      "to": "시험@example.com",
-      "subject": "bar",
-      "body": {
-        "text": "baz"
-      },
-      "provider": "mock"
-    }"#,
-        )
-        .dispatch();
-
-    assert_eq!(response.status(), Status::Ok);
-
-    let body = response.body().unwrap().into_string().unwrap();
-    assert_eq!(body, json!({ "messageId": "mock:deadbeef" }).to_string());
-}
-
-#[test]
 fn unicode_message_body() {
     let client = setup();
 


### PR DESCRIPTION
Fixes #772.

Tests weren't running for `fxa-email-service` or `fxa-email-event-proxy`, with this change they are.

@mozilla/fxa-devs r?