### PR TITLE
fix(test): Fix the openid-config/metrics flow tests on teamcity

### DIFF
--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -19,7 +19,7 @@ const conf = module.exports = convict({
     format: Array
   },
   allowed_metrics_flow_cors_origins: {
-    default: [],
+    default: [null],
     doc: 'Origins that are allowed to request the /metrics-flow endpoint',
     env: 'ALLOWED_METRICS_FLOW_ORIGINS',
     format: Array
@@ -429,7 +429,7 @@ const conf = module.exports = convict({
       format: Array,
     },
     server_base_uri: {
-      default: 'wss://channelserver.services.mozilla.com',
+      default: 'wss://dev.channelserver.nonprod.cloudops.mozgcp.net',
       doc: 'The url of the Pairing channel server.',
       env: 'PAIRING_SERVER_BASE_URI'
     },

--- a/packages/fxa-content-server/tests/server/routes/get-fxa-client-configuration.js
+++ b/packages/fxa-content-server/tests/server/routes/get-fxa-client-configuration.js
@@ -35,7 +35,7 @@ suite.tests['get-fxa-client-configuration route function'] = {
     mocks.config.oauth_url = 'https://oauth.accounts.firefox.com';
     mocks.config.profile_url = 'https://profile.accounts.firefox.com';
     mocks.config.sync_tokenserver_url = 'https://token.services.mozilla.org';
-    mocks.config['pairing.server_base_uri'] = 'wss://channelserver.services.mozilla.com';
+    mocks.config['pairing.server_base_uri'] = config.get('pairing.server_base_uri');
     /*eslint-enable camelcase*/
   },
   tests: {


### PR DESCRIPTION
* Set a default value of allowed_metrics_flow_cors_origins to null
* Change the default value of pairing.server_base_uri to
  wss://dev.channelserver.nonprod.cloudops.mozgcp.net which is used
  by all dev boxes. 
fixes #542

@jrgm - r?