### PR TITLE
fix(reminders): auth: verification reminders must not use sinon in production

### DIFF
--- a/packages/fxa-auth-server/scripts/verification-reminders.js
+++ b/packages/fxa-auth-server/scripts/verification-reminders.js
@@ -20,7 +20,20 @@ const LIB_DIR = `${ROOT_DIR}/lib`;
 process.env.NODE_ENV = 'dev';
 
 const config = require(`${ROOT_DIR}/config`).getProperties();
-const log = require(`${ROOT_DIR}/test/mocks`).mockLog();
+
+// silence standard logging methods
+const log = {
+  activityEvent: Function.prototype,
+  amplitudeEvent: Function.prototype,
+  begin: Function.prototype,
+  error: Function.prototype,
+  flowEvent: Function.prototype,
+  info: Function.prototype,
+  notifyAttachedServices: Function.prototype,
+  warn: Function.prototype,
+  summary: Function.prototype,
+  trace: Function.prototype
+};
 
 const error = require(`${LIB_DIR}/error`);
 const oauthdb = require(`${LIB_DIR}/oauthdb`)(log, config);


### PR DESCRIPTION
The current code throws with a production image since `mockObject` depends on `sinon`, which is a devDependency, and not installed in that image. 

So, instead, stub out the possible method calls with a no-op function.

r? - @philbooth 