### PR TITLE
fix(version): fix content server ver.json properties

### DIFF
--- a/packages/fxa-content-server/server/lib/version.js
+++ b/packages/fxa-content-server/server/lib/version.js
@@ -38,7 +38,7 @@ function getCommitHash () {
   }
 
   let stdout = UNKNOWN;
-  const gitDir = path.resolve(__dirname, '..', '..', '.git');
+  const gitDir = path.resolve(__dirname, '../../../../.git');
 
   try {
     stdout = cp.execSync('git rev-parse HEAD', {cwd: gitDir});

--- a/packages/fxa-content-server/server/lib/version.js
+++ b/packages/fxa-content-server/server/lib/version.js
@@ -96,9 +96,16 @@ function getTosPpVersion () {
       gitHead = pkgInfo._resolved.split('#')[1];
     }
 
+    if (! gitHead) {
+      gitHead = require('../../npm-shrinkwrap.json')
+        .dependencies['legal-docs']
+        .version
+        .split('#')[1];
+    }
+
     return gitHead;
   } catch (e) {
-    /* ignore */
+    return UNKNOWN;
   }
 }
 

--- a/packages/fxa-content-server/tests/server/ver.json.js
+++ b/packages/fxa-content-server/tests/server/ver.json.js
@@ -21,15 +21,22 @@ function versionJson(route) {
         assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
 
         var body = JSON.parse(res.body);
-        /*eslint-disable sorting/sort-object-props*/
+        // eslint-disable-next-line sorting/sort-object-props
         assert.deepEqual(Object.keys(body), ['commit', 'version', 'l10n', 'tosPp', 'source' ]);
-        /*eslint-disable sorting/sort-object-props*/
-        assert.equal(body.version, pkg.version, 'package version');
-        assert.ok(body.source && body.source !== 'unknown', 'source repository');
-        assert.ok(body.l10n && body.l10n !== 'unknown', 'l10n version');
-        assert.ok(body.tosPp && body.tosPp !== 'unknown', 'tosPp version');
+
+        assert.equal(body.version, pkg.version);
+
+        assert.ok(body.source);
+        assert.notEqual(body.source, 'unknown');
+
+        assert.ok(body.l10n);
+        assert.notEqual(body.l10n, 'unknown');
+
+        assert.ok(body.tosPp);
+        assert.notEqual(body.tosPp, 'unknown');
+
         // check that the git hash just looks like a hash
-        assert.ok(body.commit.match(/^[0-9a-f]{40}$/), 'The git hash actually looks like one');
+        assert.match(body.commit, /^[0-9a-f]{40}$/);
       })
       .then(dfd.resolve.bind(dfd), dfd.reject.bind(dfd));
 


### PR DESCRIPTION
Fixes #783. Fixes #787.

`server/lib/version.js` in the content server needed a couple of tweaks to work with the new monorepo context. These are they.

I also improved the assertions while I was at it, just to make the error messages a bit more helpful.

@mozilla/fxa-devs r?