### PR TITLE
chore(db): remove old scrypt-hash dependency from auth db

### DIFF
--- a/packages/fxa-auth-db-mysql/npm-shrinkwrap.json
+++ b/packages/fxa-auth-db-mysql/npm-shrinkwrap.json
@@ -391,12 +391,6 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
       "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
     },
-    "bindings": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
-      "optional": true
-    },
     "bluebird": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
@@ -3793,9 +3787,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.1.tgz",
-          "integrity": "sha512-VRUfmQO0rCd3hKwBymAn3kxYzBHr3I/wdVMywgG3HhXOwrCQgN84ZagpdTm2tZ4TNtwsSmyJWYO88mb5XvzGqQ==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
+          "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
           "dev": true
         },
         "restify-errors": {
@@ -3907,24 +3901,6 @@
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
       "dev": true
     },
-    "scrypt-hash": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/scrypt-hash/-/scrypt-hash-1.1.14.tgz",
-      "integrity": "sha1-dNwlQl7V4ERiiAz829++IOhZtc4=",
-      "optional": true,
-      "requires": {
-        "bindings": "1.2.1",
-        "nan": "2.4.0"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
-          "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI=",
-          "optional": true
-        }
-      }
-    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -4003,9 +3979,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
+      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
       "dev": true
     },
     "spdy": {

--- a/packages/fxa-auth-db-mysql/package.json
+++ b/packages/fxa-auth-db-mysql/package.json
@@ -42,9 +42,6 @@
     "request": "2.88.0",
     "restify": "7.2.2"
   },
-  "optionalDependencies": {
-    "scrypt-hash": "1.1.14"
-  },
   "devDependencies": {
     "eslint-plugin-fxa": "git+https://github.com/mozilla/eslint-plugin-fxa#master",
     "grunt": "1.0.3",


### PR DESCRIPTION
I noticed the build errors for this were still showing up in the logs and there's no need for it any more now we're on node 10 in all the places, right? It will save a bit of time in the builds if we remove it.

@mozilla/fxa-devs r?