### PR TITLE
fix(docs): add some dependencies needed for installation on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ sudo easy_install pip && sudo pip install virtualenv
 ##### Ubuntu:
 ```
 sudo apt-get install build-essential git-core libgmp3-dev graphicsmagick  python-virtualenv
-python-dev docker-ce
+python-dev docker-ce pkg-config libssl-dev
 ```
 Docker commands require sudo, to avoid it, follow steps below:
 1. Add the docker group if it doesn't already exist


### PR DESCRIPTION
Just a quick edit after doing a fresh install on another machine - looks like Ubuntu needs a couple new dependencies to build openssl-sys for rust