### PR TITLE
chore(setup): Remove install_extras.sh, it's not needed

### DIFF
--- a/_scripts/install_extras.sh
+++ b/_scripts/install_extras.sh
@@ -1,8 +1,0 @@
-#!/bin/sh -ex
-
-# Set ulimit, need it for npm
-ulimit -S -n 2048 || echo "Setting ulimit failed"
-
-git clone https://github.com/mozilla-services/loop-server.git
-
-cd loop-server; npm i; cd ..

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Firefox Accounts monorepo",
   "scripts": {
     "postinstall": "_scripts/postinstall.sh",
-    "install-extras": "_scripts/install_extras.sh",
     "update": "./pm2 kill && _scripts/update_all.sh",
     "start": "fxa-dev-launcher",
     "start-android": "node _scripts/start-android.js",


### PR DESCRIPTION
install_extras.sh installed the Loop server, which
is no longer used and the repo has been archived.

@mozilla/fxa-devs - r?