### PR TITLE
fix(ci): run all auth server tests in ci

### DIFF
--- a/packages/fxa-auth-server/Dockerfile-test
+++ b/packages/fxa-auth-server/Dockerfile-test
@@ -3,6 +3,7 @@ FROM fxa-auth-server:build
 USER root
 RUN rm -rf /app/node_modules
 RUN rm -rf /app/fxa-content-server-l10n
+RUN chown -R app /app
 
 USER app
 RUN npm ci

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -18,9 +18,9 @@
     "start-mysql": "NODE_ENV=dev scripts/start-local-mysql.sh 2>&1",
     "test": "VERIFIER_VERSION=0 NO_COVERAGE=1 scripts/test-local.sh",
     "test-oauth": "fxa-oauth-server/scripts/test-local.sh",
-    "test-ci": "scripts/test-local.sh",
+    "test-ci": "scripts/test-local.sh && npm run test-e2e && npm run test-scripts",
     "test-e2e": "NODE_ENV=dev mocha test/e2e",
-    "test-scripts": "mocha test/scripts --exit",
+    "test-scripts": "NODE_ENV=dev mocha test/scripts --exit",
     "test-remote": "MAILER_HOST=restmail.net MAILER_PORT=80 CORS_ORIGIN=http://baz mocha --timeout=300000 test/remote"
   },
   "repository": {


### PR DESCRIPTION
We weren't running all the auth server tests in CI. With this change we are.

(I wonder if they'll all pass? 🤞)

@mozilla/fxa-devs r?