### PR TITLE
feat(basket): Make calls directly to the basket server rather than the proxy

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/marketing-email-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/marketing-email-client.js
@@ -54,7 +54,7 @@ class MarketingEmailClient {
       // I would prefer to place this into the MarketingEmailPrefs model
       // but doing so required passing around the preferencesUrl to lots of
       // irrelevant classes.
-      if (response.token) {
+      if ('token' in response) {
         response.preferencesUrl = this._preferencesUrl + response.token;
       }
 

--- a/packages/fxa-content-server/app/tests/spec/lib/marketing-email-client.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/marketing-email-client.js
@@ -76,14 +76,15 @@ describe('lib/marketing-email-client', () => {
     it('returns a preferences URL for the user', () => {
       sinon.stub(xhrMock, 'ajax').callsFake(() => {
         return Promise.resolve({
-          token: 'users_uuid'
+          // the fake basket server can return a token of the number 0, ensure this is handled.
+          token: 0
         });
       });
 
       return client.fetch('token', 'testuser@testuser.com')
         .then(function (data) {
-          assert.equal(data.token, 'users_uuid');
-          assert.equal(data.preferencesUrl, PREFERENCES_URL + 'users_uuid');
+          assert.strictEqual(data.token, 0);
+          assert.strictEqual(data.preferencesUrl, `${PREFERENCES_URL}0`);
 
           assert.isTrue(xhrMock.ajax.calledOnce);
           const request = xhrMock.ajax.args[0][0];

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -43,28 +43,6 @@ const conf = module.exports = convict({
     doc: 'Check if the resources are under the /dist directory',
     format: Boolean
   },
-  basket: {
-    api_key: {
-      default: 'test key please change',
-      doc: 'Basket API key',
-      format: String
-    },
-    api_timeout: {
-      default: '5 seconds',
-      doc: 'Timeout for talking to the Basket API server, in ms',
-      format: Number
-    },
-    api_url: {
-      default: 'http://127.0.0.1:10140',
-      doc: 'Url for the Basket API server',
-      format: String
-    },
-    proxy_url: {
-      default: 'http://127.0.0.1:1114',
-      doc: 'Url for the Basket proxy server',
-      format: String
-    }
-  },
   cachify_prefix: {
     default: 'v',
     doc: 'The prefix for cachify hashes in URLs'
@@ -354,8 +332,13 @@ const conf = module.exports = convict({
     }
   },
   marketing_email: {
+    api_key: {
+      default: 'test key please change',
+      doc: 'Basket API key',
+      format: String
+    },
     api_url: {
-      default: 'http://127.0.0.1:1114',
+      default: 'http://127.0.0.1:10140',
       doc: 'User facing URL of the Marketing Email Server',
       env: 'FXA_MARKETING_EMAIL_API_URL',
       format: 'url'

--- a/packages/fxa-content-server/tests/lib/basket.js
+++ b/packages/fxa-content-server/tests/lib/basket.js
@@ -4,8 +4,8 @@
 
 const request = require('./request');
 const config = require('../../server/lib/configuration');
-var API_KEY = config.get('basket.api_key');
-var API_URL = config.get('basket.api_url');
+var API_KEY = config.get('marketing_email.api_key');
+var API_URL = config.get('marketing_email.api_url');
 
 var LOOKUP_URL = API_URL + '/lookup-user/?email=';
 


### PR DESCRIPTION
Note: configuration under the basket namespace were merged into the marketing_email namespace,
there doesn't seem to be a good reason for both namespaces to exist.

fixes #545

BREAKING CHANGE - The config files deployed to prod will need to change to merge the two config namespaces.

@jrgm - r?