### PR TITLE
fix(customs): Standardize the log format in fetchIPReputation

### DIFF
--- a/packages/fxa-customs-server/lib/reputationService.js
+++ b/packages/fxa-customs-server/lib/reputationService.js
@@ -51,13 +51,18 @@ var get = function (log, ipClient, ip) {
         log.info({ op: 'fetchIPReputation', ip: ip, err: 'Reputation not found for IP.',
           rtime: getRequestTime(response) })
       } else {
-        var err = { status: response.statusCode, body: response.body }
-        log.error({ op: 'fetchIPReputation', ip: ip, err: err, rtime: getRequestTime(response) })
+        log.error({
+          err: response.body,
+          ip,
+          op: 'fetchIPReputation',
+          rtime: getRequestTime(response),
+          statusCode: response.statusCode,
+        })
       }
 
       return null
     }).catch(function (err) {
-      log.error({ op: 'fetchIPReputation', ip: ip, err: err})
+      log.error({ op: 'fetchIPReputation', ip: ip, err: String(err)})
       return null
     })
 }


### PR DESCRIPTION
`err` is expected to be a string all the time, if a request to fetch IP reputation
failed an object was logged, which would cause problems when Stackdriver 
validates against its schema.

This change makes it so that failing HTTP requests to the IP reputation service 
log a string `err` and add a new `statusCode` field.

fixes #769

@jbuck, @mozilla/fxa-devs - r?