### PR TITLE
fix(log): force boolean keys property in auth server log.summary

### DIFF
--- a/packages/fxa-auth-server/lib/log.js
+++ b/packages/fxa-auth-server/lib/log.js
@@ -102,7 +102,7 @@ Lug.prototype.summary = function (request, response) {
     service: payload.service || query.service,
     reason: payload.reason || query.reason,
     redirectTo: payload.redirectTo || query.redirectTo,
-    keys: query.keys,
+    keys: !! query.keys,
 
     // Additional data used by the DataFlow fraud detection pipeline.
     // Logging PII for the fraud detection pipeline has been given

--- a/packages/fxa-auth-server/test/local/log.js
+++ b/packages/fxa-auth-server/test/local/log.js
@@ -496,7 +496,7 @@ describe('log', () => {
         service: 'corge',
       },
       query: {
-        keys: true
+        keys: 'wibble'
       }
     }, {
       code: 200,


### PR DESCRIPTION
Fixes #768.

Coerces `keys` to boolean in the summary log line, as that is how it's interpreted in the route handlers.

@mozilla/fxa-devs r?