### PR TITLE
fix(ci): disable the docs build step on fork builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,9 +258,11 @@ jobs:
           fingerprints:
             - "08:fc:2b:fb:06:0e:8f:0f:01:1f:28:86:83:89:11:28"
       - run: |
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          . .circleci/install-rust.sh
-          ./_scripts/gh-pages.sh
+          if [ "$CIRCLE_REPOSITORY_URL" = "git@github.com:mozilla/fxa.git" ]; then
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+            . .circleci/install-rust.sh
+            ./_scripts/gh-pages.sh
+          fi
 
 workflows:
   test:


### PR DESCRIPTION
Fixes #811.

Wraps a little condition around the `docs` step so that it becomes a NOP for forked builds. We don't share secrets with forked builds, so they don't get access to the deploy key that is required for it to succeed.

@mozilla/fxa-devs r?

@lmorchard, if you were to rebase your branch over this change, you should find that your forked build works correctly.
