### PR TITLE
fix(build): put version.json in {/app,/app/config}/version.json

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -6,6 +6,10 @@ DIR=$(dirname "$0")
 if grep -e "$MODULE" -e 'all' $DIR/../packages/test.list; then
   docker -v
 
+  # Place version.json so it is available as `/app/version.json` in the
+  # container, and also as `/app/config/version.json` if `/app/config` is a
+  # directory.
+  cp $DIR/../packages/version.json .
   if [[ -d config ]]; then
     cp $DIR/../packages/version.json config
   fi

--- a/packages/fxa-content-server/tests/functional/fx_firstrun_v1.js
+++ b/packages/fxa-content-server/tests/functional/fx_firstrun_v1.js
@@ -21,7 +21,7 @@ const {
   testElementExists,
 } = FunctionalHelpers;
 
-registerSuite('Firefox Desktop Sync v1', {
+registerSuite('Firefox Desktop first-run v1', {
 
   beforeEach: function () {
     return this.remote

--- a/packages/fxa-content-server/tests/functional/fx_firstrun_v2.js
+++ b/packages/fxa-content-server/tests/functional/fx_firstrun_v2.js
@@ -21,7 +21,7 @@ const {
   testElementExists,
 } = FunctionalHelpers;
 
-registerSuite('Firefox Desktop Sync v1', {
+registerSuite('Firefox Desktop first-run v2', {
 
   beforeEach: function () {
     return this.remote


### PR DESCRIPTION
The `dockerflow` deployment pipeline use by cloudops requires that the version.json file be available at `/app/version.json` in the container.

So, make it available there as well as in `/app/config/version.json` if that directory exists.

This PR also contains a commit to `hack around "suite has already been added"`, which is to workaround https://github.com/mozilla/fxa/issues/814. I'll rebase to remove that commit when there is a fix for that before I merge this PR to master.

r? - @mozilla/fxa-devs 