### PR TITLE
feat(accounts): add APIs to manage subscriptions and report capabilities

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -35,4 +35,48 @@
     "key": "Correct_Horse_Battery_Staple_1",
     "maxTTL": "28 days"
   },
+  "subhub": {
+    "useStubs": true,
+    "stubs": {
+      "plans": [
+        {
+          "plan_id": "123doneProMonthly",
+          "product_id": "123doneProProduct",
+          "interval": "month",
+          "amount": 50,
+          "currency": "usd"
+        },
+        {
+          "plan_id": "321doneProMonthly",
+          "product_id": "321doneProProduct",
+          "interval": "month",
+          "amount": 50,
+          "currency": "usd"
+        },
+        {
+          "plan_id": "allDoneProMonthly",
+          "product_id": "allDoneProProduct",
+          "interval": "month",
+          "amount": 50,
+          "currency": "usd"
+        }
+      ]
+    }
+  },
+  "subscriptions": {
+    "enabled": true,
+    "managementClientId": "3c49430b43dfba77",
+    "productCapabilities": {
+      "123doneProProduct": [ "123donePro" ],
+      "321doneProProduct": [ "321donePro" ],
+      "allDoneProProduct": [ "123donePro", "321donePro" ],
+      "exampleProd1": [ "exampleCap1", "exampleCap2", "exampleCap3" ],
+      "exampleProd2": [ "exampleCap4", "exampleCap5" ],
+      "exampleProd3": [ "exampleCap1", "exampleCap2", "exampleCap3", "exampleCap4", "exampleCap5" ]
+    },
+    "clientCapabilities": {
+      "dcdb5ae7add825d2": [ "123donePro", "exampleCap1", "exampleCap3", "exampleCap5" ],
+      "325b4083e32fe8e7": [ "321donePro", "exampleCap2", "exampleCap4", "exampleCap6" ]
+    }
+  }
 }

--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -569,6 +569,72 @@ const conf = convict({
     env: 'DEVICE_NOTIFICATIONS_ENABLED',
     default: true
   },
+  subhub: {
+    enabled: {
+      doc: 'Indicates whether talking to the SubHub server is enabled',
+      format: Boolean,
+      default: false,
+      env: 'SUBHUB_ENABLED'
+    },
+    useStubs: {
+      doc: 'Indicates whether to use stub methods for SubHub instead of talking to the server',
+      format: Boolean,
+      default: false,
+      env: 'SUBHUB_USE_STUBS'
+    },
+    stubs: {
+      plans: {
+        doc: 'Stub data used for plans',
+        format: Array,
+        env: 'SUBHUB_STUB_PLANS',
+        default: []
+      }
+    },
+    url: {
+      doc: 'SubHub Server URL',
+      format: 'url',
+      default: 'https://subhub.services.mozilla.com/',
+      env: 'SUBHUB_URL'
+    },
+    key: {
+      doc: 'Authentication key to use when accessing SubHub server',
+      format: String,
+      default: 'YOU MUST CHANGE ME',
+      env: 'SUBHUB_KEY'
+    },
+  },
+  subscriptions: {
+    enabled: {
+      doc: 'Indicates whether subscriptions APIs are enabled',
+      format: Boolean,
+      env: 'SUBSCRIPTIONS_ENABLED',
+      default: false
+    },
+    managementClientId: {
+      doc: 'OAuth client ID for subscriptions management pages',
+      format: String,
+      env: 'SUBSCRIPTIONS_MANAGEMENT_CLIENT_ID',
+      default:  'YOU MUST CHANGE ME'
+    },
+    managementTokenTTL: {
+      doc: 'OAuth token time-to-live (in seconds) for subscriptions management pages',
+      format: 'nat',
+      env: 'SUBSCRIPTIONS_MANAGEMENT_TOKEN_TTL',
+      default: 900
+    },
+    productCapabilities: {
+      doc: 'Mappings from product names to subscription capability names',
+      format: Object,
+      env: 'SUBSCRIPTIONS_PRODUCT_CAPABILITIES',
+      default: {}
+    },
+    clientCapabilities: {
+      doc: 'Mappings from OAuth client IDs to relevant subscription capabilities',
+      format: Object,
+      env: 'SUBSCRIPTIONS_CLIENT_CAPABILITIES',
+      default: {}
+    }
+  },
   oauth: {
     url: {
       format: 'url',

--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -76,6 +76,12 @@ see [`mozilla/fxa-js-client`](https://github.com/mozilla/fxa-js-client).
   * [Sms](#sms)
     * [POST /sms (:lock: sessionToken)](#post-sms)
     * [GET /sms/status (:lock: sessionToken)](#get-smsstatus)
+  * [Subscriptions](#subscriptions)
+    * [GET /oauth/subscriptions/plans (:lock: oauthToken)](#get-subscriptionsplans)
+    * [GET /oauth/subscriptions/active (:lock: oauthToken)](#get-subscriptionsactive)
+    * [POST /oauth/subscriptions/active (:lock: oauthToken)](#post-subscriptionsactive)
+    * [DELETE /oauth/subscriptions/active/{subscriptionId} (:lock: oauthToken)](#delete-subscriptionsactivesubscriptionid)
+    * [POST /oauth/subscriptions/updatePayment (:lock: oauthToken)](#post-subscriptionsupdatepayment)
   * [Token codes](#token-codes)
     * [POST /session/verify/token (:lock: sessionToken)](#post-sessionverifytoken)
   * [Totp](#totp)
@@ -315,6 +321,12 @@ for `code` and `errno` are:
   Public clients require PKCE OAuth parameters
 * `code: 400, errno: 171`:
   Required Authentication Context Reference values could not be satisfied
+* `code: 404, errno: 176`:
+  Unknown subscription
+* `code: 400, errno: 177`:
+  Unknown subscription plan
+* `code: 400, errno: 178`:
+  Subscription payment token rejected
 * `code: 503, errno: 201`:
   Service unavailable
 * `code: 503, errno: 202`:
@@ -3008,6 +3020,32 @@ Returns SMS status for the current user.
   is in the specified country.
   <!--end-query-param-get-smsstatus-country-->
 
+### Subscriptions
+
+#### GET /oauth/subscriptions/plans
+
+:lock: authenticated with OAuth bearer token
+Returns a list of available subscription plans.
+
+#### GET /oauth/subscriptions/active
+
+:lock: authenticated with OAuth bearer token
+Returns a list of active subscriptions for the user.
+
+#### POST /oauth/subscriptions/active
+
+:lock: authenticated with OAuth bearer token
+Subscribe the user to a plan using a payment token.
+
+#### DELETE /oauth/subscriptions/active/{subscriptionId}
+
+:lock: authenticated with OAuth bearer token
+Cancel an active subscription for the user.
+
+#### POST /oauth/subscriptions/updatePayment
+
+:lock: authenticated with OAuth bearer token
+Update the user's default payment method using a payment token.
 
 ### Token codes
 

--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -107,11 +107,15 @@ module.exports = function (log, error) {
 
     const clonePayload = Object.assign({}, payload);
 
-    if (clonePayload.authPW) {
-      delete clonePayload.authPW;
-    }
-    if (clonePayload.oldAuthPW) {
-      delete clonePayload.oldAuthPW;
+    const fieldsToOmit = [
+      'authPW',
+      'oldAuthPW',
+      'paymentToken'
+    ];
+    for (const name of fieldsToOmit) {
+      if (clonePayload[name]) {
+        delete clonePayload[name];
+      }
     }
 
     return clonePayload;

--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -1358,6 +1358,47 @@ module.exports = (
     return this.pool.del(SAFE_URLS.deleteRecoveryKey, { uid });
   };
 
+  SAFE_URLS.createAccountSubscription = new SafeUrl(
+    '/account/:uid/subscriptions/:subscriptionId',
+    'db.createAccountSubscription'
+  );
+  DB.prototype.createAccountSubscription = function (data) {
+    const { uid, subscriptionId, productName, createdAt } = data;
+    log.trace('DB.createAccountSubscription', data);
+    return this.pool.put(
+      SAFE_URLS.createAccountSubscription,
+      { uid, subscriptionId },
+      { productName, createdAt }
+    );
+  };
+
+  SAFE_URLS.getAccountSubscription = new SafeUrl(
+    '/account/:uid/subscriptions/:subscriptionId',
+    'db.getAccountSubscription'
+  );
+  DB.prototype.getAccountSubscription = function (uid, subscriptionId) {
+    log.trace('DB.getAccountSubscription', { uid, subscriptionId });
+    return this.pool.get(SAFE_URLS.getAccountSubscription, { uid, subscriptionId });
+  };
+
+  SAFE_URLS.deleteAccountSubscription = new SafeUrl(
+    '/account/:uid/subscriptions/:subscriptionId',
+    'db.deleteAccountSubscription'
+  );
+  DB.prototype.deleteAccountSubscription = function (uid, subscriptionId) {
+    log.trace('DB.deleteAccountSubscription', { uid, subscriptionId });
+    return this.pool.del(SAFE_URLS.deleteAccountSubscription, { uid, subscriptionId });
+  };
+
+  SAFE_URLS.fetchAccountSubscriptions = new SafeUrl(
+    '/account/:uid/subscriptions',
+    'db.fetchAccountSubscriptions'
+  );
+  DB.prototype.fetchAccountSubscriptions = function (uid) {
+    log.trace('DB.fetchAccountSubscriptions', { uid });
+    return this.pool.get(SAFE_URLS.fetchAccountSubscriptions, { uid });
+  };
+
   DB.prototype.safeRedisGet = function (key) {
     return this.redis.get(key)
       .catch(err => {

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -86,6 +86,11 @@ const ERRNO = {
   EXPIRED_AUTHORIZATION_CODE: 174,
   INVALID_PKCE_CHALLENGE: 175,
 
+  UNKNOWN_SUBSCRIPTION_CUSTOMER: 176,
+  UNKNOWN_SUBSCRIPTION: 177,
+  UNKNOWN_SUBSCRIPTION_PLAN: 178,
+  REJECTED_SUBSCRIPTION_PAYMENT_TOKEN: 179,
+
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
   BACKEND_SERVICE_FAILURE: 203,
@@ -1030,6 +1035,50 @@ AppError.invalidPkceChallenge = (pkceHashValue) => {
     message: 'Public clients require PKCE OAuth parameters'
   }, {
     pkceHashValue
+  });
+};
+
+AppError.unknownCustomer = (uid) => {
+  return new AppError({
+    code: 404,
+    error: 'Not Found',
+    errno: ERRNO.UNKNOWN_SUBSCRIPTION_CUSTOMER,
+    message: 'Unknown customer'
+  }, {
+    uid
+  });
+};
+
+AppError.unknownSubscription = (subscriptionId) => {
+  return new AppError({
+    code: 404,
+    error: 'Not Found',
+    errno: ERRNO.UNKNOWN_SUBSCRIPTION,
+    message: 'Unknown subscription'
+  }, {
+    subscriptionId
+  });
+};
+
+AppError.unknownSubscriptionPlan = (planId) => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.UNKNOWN_SUBSCRIPTION_PLAN,
+    message: 'Unknown subscription plan'
+  }, {
+    planId
+  });
+};
+
+AppError.rejectedSubscriptionPaymentToken = (token) => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.REJECTED_SUBSCRIPTION_PAYMENT_TOKEN,
+    message: 'Rejected subscription payment token'
+  }, {
+    token
   });
 };
 

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -21,6 +21,7 @@ module.exports = function (
   // Various extra helpers.
   const push = require('../push')(log, db, config);
   const pushbox = require('../pushbox')(log, config);
+  const subhub = require('../subhub')(log, config);
   const devicesImpl = require('../devices')(log, db, push);
   const signinUtils = require('./utils/signin')(log, config, customs, db, mailer);
   const verificationReminders = require('../verification-reminders')(log, config);
@@ -34,6 +35,7 @@ module.exports = function (
     Password,
     config,
     customs,
+    subhub,
     signinUtils,
     push,
     verificationReminders,
@@ -62,6 +64,7 @@ module.exports = function (
   const totp = require('./totp')(log, db, mailer, customs, config.totp);
   const recoveryCodes = require('./recovery-codes')(log, db, config.totp, customs, mailer);
   const recoveryKey = require('./recovery-key')(log, db, Password, config.verifierVersion, customs, mailer);
+  const subscriptions = require('./subscriptions')(log, db, config, customs, push, oauthdb, subhub);
   const util = require('./util')(
     log,
     config,
@@ -86,7 +89,8 @@ module.exports = function (
     totp,
     unblockCodes,
     util,
-    recoveryKey
+    recoveryKey,
+    subscriptions
   );
   v1Routes.forEach(r => { r.path = `${basePath  }/v1${  r.path}`; });
   defaults.forEach(r => { r.path = basePath + r.path; });

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -1,0 +1,208 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const error = require('../error');
+const isA = require('joi');
+const ScopeSet = require('fxa-shared').oauth.scopes;
+const validators = require('./validators');
+
+module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
+  // Skip routes if the subscriptions feature is not configured & enabled
+  if (! config.subscriptions || ! config.subscriptions.enabled) {
+    return [];
+  }
+
+  const SUBSCRIPTIONS_MANAGEMENT_SCOPE =
+    'https://identity.mozilla.com/account/subscriptions';
+
+  function handleAuth(auth) {
+    const scope = ScopeSet.fromArray(auth.credentials.scope);
+    if (! scope.contains(SUBSCRIPTIONS_MANAGEMENT_SCOPE)) {
+      throw error.invalidScopes('Invalid authentication scope in token');
+    }
+    const { user, email } = auth.credentials;
+    return { uid: user, email };
+  }
+
+  return [
+    {
+      method: 'GET',
+      path: '/oauth/subscriptions/plans',
+      options: {
+        auth: {
+          payload: false,
+          strategy: 'oauthToken'
+        },
+        response: {
+          schema: isA.array().items(
+            isA.object().keys({
+              plan_id: validators.subscriptionsPlanId.required(),
+              product_id: validators.subscriptionsProductId.required(),
+              interval: isA.string().required(),
+              amount: isA.number().required(),
+              currency: isA.string().required()
+            })
+          )
+        }
+      },
+      handler: async function (request) {
+        log.begin('subscriptions.listPlans', request);
+        handleAuth(request.auth);
+        return subhub.listPlans();
+      }
+    },
+    {
+      method: 'GET',
+      path: '/oauth/subscriptions/active',
+      options: {
+        auth: {
+          payload: false,
+          strategy: 'oauthToken'
+        },
+        response: {
+          schema: isA.array().items(
+            isA.object().keys({
+              uid: isA.string().required(),
+              subscriptionId: validators.subscriptionsSubscriptionId.required(),
+              productName: validators.subscriptionsProductId.required(),
+              createdAt: isA.number().required()
+            })
+          )
+        }
+      },
+      handler: async function (request) {
+        log.begin('subscriptions.listActive', request);
+        const { uid } = handleAuth(request.auth);
+        return db.fetchAccountSubscriptions(uid);
+      }
+    },
+    {
+      method: 'POST',
+      path: '/oauth/subscriptions/active',
+      options: {
+        auth: {
+          payload: false,
+          strategy: 'oauthToken'
+        },
+        validate: {
+          payload: {
+            planId: validators.subscriptionsPlanId.required(),
+            paymentToken: validators.subscriptionsPaymentToken.required()
+          }
+        },
+        response: {
+          schema: isA.object().keys({
+            subscriptionId: validators.subscriptionsSubscriptionId.required()
+          })
+        }
+      },
+      handler: async function (request) {
+        log.begin('subscriptions.createSubscription', request);
+
+        const { uid, email } = handleAuth(request.auth);
+
+        await customs.check(request, email, 'createSubscription');
+
+        const { planId, paymentToken } = request.payload;
+
+        // Find the selected plan and get its product ID
+        const plans = await subhub.listPlans();
+        const selectedPlan = plans.filter(p => p.plan_id === planId)[0];
+        if (! selectedPlan) {
+          throw error.unknownSubscriptionPlan(planId);
+        }
+        const productName = selectedPlan.product_id;
+
+        const paymentResult = await subhub.createSubscription(uid, paymentToken, planId);
+
+        const subscriptionId = paymentResult.sub_id;
+        await db.createAccountSubscription({
+          uid,
+          subscriptionId,
+          productName,
+          createdAt: Date.now()
+        });
+
+        const devices = await request.app.devices;
+        await push.notifyProfileUpdated(uid, devices);
+        log.notifyAttachedServices('profileDataChanged', request, { uid, email });
+
+        log.info('subscriptions.createSubscription.success', { uid, subscriptionId });
+
+        return { subscriptionId };
+      }
+    },
+    {
+      method: 'POST',
+      path: '/oauth/subscriptions/updatePayment',
+      options: {
+        auth: {
+          payload: false,
+          strategy: 'oauthToken'
+        },
+        validate: {
+          payload: {
+            paymentToken: validators.subscriptionsPaymentToken.required()
+          }
+        }
+      },
+      handler: async function (request) {
+        log.begin('subscriptions.updatePayment', request);
+
+        const { uid, email } = handleAuth(request.auth);
+        await customs.check(request, email, 'updatePayment');
+
+        const { paymentToken } = request.payload;
+
+        await subhub.updateCustomer(uid, paymentToken);
+
+        log.info('subscriptions.updatePayment.success', { uid });
+
+        return {};
+      }
+    },
+    {
+      method: 'DELETE',
+      path: '/oauth/subscriptions/active/{subscriptionId}',
+      options: {
+        auth: {
+          payload: false,
+          strategy: 'oauthToken'
+        },
+        validate: {
+          params: {
+            subscriptionId: validators.subscriptionsSubscriptionId.required()
+          }
+        }
+      },
+      handler: async function (request) {
+        log.begin('subscriptions.deleteSubscription', request);
+
+        const { uid, email } = handleAuth(request.auth);
+        await customs.check(request, email, 'deleteSubscription');
+
+        const subscriptionId = request.params.subscriptionId;
+
+        const subscription =
+          await db.getAccountSubscription(uid, subscriptionId);
+        if (! subscription) {
+          throw error.unknownSubscription();
+        }
+
+        await subhub.cancelSubscription(uid, subscriptionId);
+        await db.deleteAccountSubscription(uid, subscriptionId);
+
+        const devices = await request.app.devices;
+        await push.notifyProfileUpdated(uid, devices);
+        log.notifyAttachedServices('profileDataChanged', request, { uid, email });
+
+        log.info('subscriptions.deleteSubscription.success', { uid, subscriptionId });
+
+        return {};
+      }
+    },
+  ];
+};

--- a/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const PRODUCT_SUBSCRIBED = 'defaultSubscribed';
+const PRODUCT_REGISTERED = 'defaultRegistered';
+
+module.exports = {
+  PRODUCT_SUBSCRIBED,
+  PRODUCT_REGISTERED,
+
+  determineClientVisibleSubscriptionCapabilities: async function (config, auth, db, uid, client_id) {
+    const {
+      subscriptions: {
+        productCapabilities = {},
+        clientCapabilities = {}
+      } = {}
+    } = config;
+
+    const subscriptions = await db.fetchAccountSubscriptions(uid) || [];
+
+    const subscribedProducts = [
+      // All accounts get this product
+      PRODUCT_REGISTERED,
+      // Other products come from actual subscriptions
+      ...subscriptions.map(({ productName }) => productName)
+    ];
+    // Accounts with at least one subscription get this product
+    if (subscriptions.length > 0) {
+      subscribedProducts.push(PRODUCT_SUBSCRIBED);
+    }
+
+    const subscribedCapabilities = subscribedProducts.reduce(
+      (capabilities, product) =>
+      capabilities.concat(productCapabilities[product] || []), []
+    );
+
+    const clientVisibleCapabilities = clientCapabilities[client_id] || [];
+
+    const capabilitiesToReveal = new Set(subscribedCapabilities
+      .filter(capability =>
+        auth.strategy === 'sessionToken'
+        || clientVisibleCapabilities.includes(capability)
+      )
+    );
+
+    return (capabilitiesToReveal.size > 0)
+      ? Array.from(capabilitiesToReveal)
+      : undefined;
+  }
+
+};

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -228,3 +228,8 @@ module.exports.wrapKb = isA.string().length(64).regex(HEX_STRING);
 
 module.exports.recoveryKeyId = isA.string().regex(HEX_STRING).max(32);
 module.exports.recoveryData = isA.string().regex(/[a-zA-Z0-9.]/).max(1024).required();
+
+module.exports.subscriptionsSubscriptionId = isA.string().max(255);
+module.exports.subscriptionsPlanId = isA.string().max(255);
+module.exports.subscriptionsProductId = isA.string().max(255);
+module.exports.subscriptionsPaymentToken = isA.string().max(255);

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -216,8 +216,12 @@ async function create (log, error, config, routes, db, oauthdb, translator) {
     defineLazyGetter(request.app, 'devices', () => {
       let uid;
 
-      if (request.auth && request.auth.credentials) {
+      if (request.auth && request.auth.credentials && request.auth.credentials.uid) {
+        // sessionToken strategy comes with uid as uid
         uid = request.auth.credentials.uid;
+      } else if (request.auth && request.auth.credentials && request.auth.credentials.user) {
+        // oauthToken strategy comes with uid as user
+        uid = request.auth.credentials.user;
       } else if (request.payload && request.payload.uid) {
         uid = request.payload.uid;
       }

--- a/packages/fxa-auth-server/lib/subhub.js
+++ b/packages/fxa-auth-server/lib/subhub.js
@@ -1,0 +1,315 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const isA = require('joi');
+const error = require('./error');
+const createBackendServiceAPI = require('./backendService');
+
+/*
+ * The subscriptions backend is called 'SubHub', a service managed outside the
+ * FxA team to abstract away some details of payments processing.
+ *
+ * This library implements a little proxy in front of the SubHub API, allowing
+ * it to be authenticated by FxA's bearer token.
+ */
+
+module.exports = function (log, config) {
+  if (config.subhub.useStubs) {
+    // TODO: Remove this someday after subhub is available
+    return buildStubAPI(log, config);
+  }
+
+  if (! config.subhub.enabled) {
+    return [
+      'listPlans',
+      'listSubscriptions',
+      'createSubscription',
+      'getCustomer',
+      'updateCustomer',
+      'cancelSubscription',
+    ].reduce((obj, name) => ({
+      ...obj,
+      [ name ]: () => Promise.reject(error.featureNotEnabled())
+    }), {});
+  }
+
+  const SubHubAPI = createBackendServiceAPI(log, config, 'subhub', {
+    listPlans: {
+      path: '/plans',
+      method: 'GET',
+      validate: {
+        // TODO: update with final plans schema from subhub
+        response: isA.array().items(isA.object({
+          plan_id: isA.string().required(),
+          product_id: isA.string().required(),
+          interval: isA.string().required(),
+          amount: isA.number().required(),
+          currency: isA.string().required()
+        }))
+      }
+    },
+
+    listSubscriptions: {
+      path: '/customer/:uid/subscriptions',
+      method: 'GET',
+      validate: {
+        params: {
+          uid: isA.string().required(),
+        },
+        // TODO: update with final subscriptions schema from subhub
+        response: isA.array().items(isA.object({
+          plan_id: isA.string().required(),
+          product_id: isA.string().required(),
+          current_period_end: isA.number().required(),
+          end_at: isA.number().required(),
+        }))
+      }
+    },
+
+    getCustomer: {
+      path: '/customer/:uid',
+      method: 'GET',
+      validate: {
+        params: {
+          uid: isA.string().required(),
+        },
+        // TODO: update with final customer schema from subhub
+        response: isA.object()
+      }
+    },
+
+    updateCustomer: {
+      path: '/customer/:uid',
+      method: 'POST',
+      validate: {
+        params: {
+          uid: isA.string().required(),
+        },
+        payload: {
+          pmt_token: isA.string().required(),
+        },
+        response: isA.alternatives(
+          // TODO: update with final customer schema from subhub
+          isA.object(),
+          isA.object({
+            message: isA.string()
+          })
+        )
+      }
+    },
+
+    createSubscription: {
+      path: '/customer/:uid/subscriptions',
+      method: 'POST',
+      validate: {
+        params: {
+          uid: isA.string().required(),
+        },
+        payload: {
+          pmt_token: isA.string().required(),
+          plan_id: isA.string().required(),
+          email: isA.string().required(),
+        },
+        response: isA.alternatives(
+          isA.object({
+            sub_id: isA.string()
+          }),
+          isA.object({
+            message: isA.string()
+          })
+        )
+      }
+    },
+
+    cancelSubscription: {
+      path: '/customer/:uid/subscriptions/:sub_id',
+      method: 'DELETE',
+      validate: {
+        params: {
+          uid: isA.string().required(),
+          sub_id: isA.string().required(),
+        },
+        response: isA.alternatives(
+          isA.object({}),
+          isA.object({
+            message: isA.string()
+          })
+        )
+      }
+    },
+
+  });
+
+  const api = new SubHubAPI(
+    config.subhub.url,
+    {
+      headers: {
+        // TODO: update with subhub final auth
+        Authorization: `Bearer ${config.subhub.key}`
+      },
+      timeout: 15000
+    }
+  );
+
+  return {
+    isStubAPI: false,
+
+    async listPlans() {
+      return api.listPlans();
+    },
+
+    async listSubscriptions(uid) {
+      try {
+        return await api.listSubscriptions(uid);
+      } catch (err) {
+        if (err.statusCode === 404) {
+          log.error('subhub.listSubscriptions.1', { uid, err });
+          // TODO: update with subhub listSubscriptions error response for invalid uid
+          if (err.message === 'invalid uid') {
+            throw error.unknownCustomer(uid);
+          }
+        }
+        throw err;
+      }
+    },
+
+    async createSubscription(uid, pmt_token, plan_id, email) {
+      try {
+        return await api.createSubscription(uid, { pmt_token, plan_id, email });
+      } catch (err) {
+        if (err.statusCode === 400) {
+          log.error('subhub.createSubscription.1', { uid, pmt_token, plan_id, email, err });
+          // TODO: update with subhub createSubscription error response for invalid payment token
+          if (err.message === 'invalid payment token') {
+            throw error.rejectedSubscriptionPaymentToken(pmt_token);
+          }
+          // TODO: update with subhub createSubscription error response for invalid plan ID
+          if (err.message === 'invalid plan id') {
+            throw error.unknownSubscriptionPlan(plan_id);
+          }
+        }
+        throw err;
+      }
+    },
+
+    async cancelSubscription(uid, sub_id) {
+      try {
+        return await api.cancelSubscription(uid, sub_id);
+      } catch (err) {
+        if (err.statusCode === 400 || err.statusCode === 404) {
+          log.error('subhub.cancelSubscription.1', { uid, sub_id, err });
+          // TODO: update with subhub cancelSubscription error response for invalid uid
+          if (err.message === 'invalid uid') {
+            throw error.unknownCustomer(uid);
+          }
+          // TODO: update with subhub cancelSubscription error response for invalid plan ID
+          if (err.message === 'invalid subscription id') {
+            throw error.unknownSubscription(sub_id);
+          }
+        }
+        throw err;
+      }
+    },
+
+    async getCustomer(uid) {
+      try {
+        return await api.getCustomer(uid);
+      } catch (err) {
+        if (err.statusCode === 404) {
+          log.error('subhub.getCustomer.1', { uid, err });
+          // TODO: update with subhub createSubscription error response for invalid uid
+          if (err.message === 'invalid uid') {
+            throw error.unknownCustomer(uid);
+          }
+        }
+        throw err;
+      }
+    },
+
+    async updateCustomer(uid, pmt_token) {
+      try {
+        return await api.updateCustomer(uid, { pmt_token });
+      } catch (err) {
+        if (err.statusCode === 400 || err.statusCode === 404) {
+          log.error('subhub.updateCustomer.1', { uid, pmt_token, err });
+          // TODO: update with subhub createSubscription error response for invalid uid
+          if (err.message === 'invalid uid') {
+            throw error.unknownCustomer(uid);
+          }
+          // TODO: update with subhub updateCustomer error response for invalid payment token
+          if (err.message === 'invalid payment token') {
+            throw error.rejectedSubscriptionPaymentToken(pmt_token);
+          }
+        }
+        throw err;
+      }
+    },
+  };
+};
+
+function buildStubAPI(log, config) {
+  const {
+    subhub: {
+      stubs: {
+        plans = []
+      } = {}
+    } = {}
+  } = config;
+
+  const getPlanById = plan_id => plans
+    .filter(plan => plan.plan_id === plan_id)[0];
+
+  const storage = { subscriptions: {} };
+  const subscriptionsKey = (uid, sub_id) => `${uid}|${sub_id}`;
+
+  return {
+    isStubAPI: true,
+
+    async listPlans() {
+      return plans;
+    },
+
+    async listSubscriptions(uid) {
+      return Object
+        .values(storage.subscriptions)
+        .filter(subscription => subscription.uid === uid);
+    },
+
+    async createSubscription(uid, pmt_token, plan_id, email) {
+      const plan = getPlanById(plan_id);
+      if (! plan) {
+        throw error.unknownSubscriptionPlan(plan_id);
+      }
+      const product_id = plan.product_id;
+      const sub_id = `sub${Math.random()}`;
+      const key = subscriptionsKey(uid, sub_id);
+      storage.subscriptions[key] = {
+        uid,
+        plan_id,
+        product_id,
+        email
+      };
+      return { sub_id };
+    },
+
+    async cancelSubscription(uid, sub_id) {
+      const key = subscriptionsKey(uid, sub_id);
+      if (! storage.subscriptions[key]) {
+        throw error.unknownSubscription(sub_id);
+      }
+      delete storage.subscriptions[key];
+      return {};
+    },
+
+    async getCustomer(uid) {
+      return { this_is_a_customer: true };
+    },
+
+    async updateCustomer(uid, pmt_token) {
+      return {};
+    },
+  };
+}

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -720,6 +720,16 @@ module.exports = config => {
       );
   };
 
+  ClientApi.prototype.createSubscription = function (planId, paymentToken, headers) {
+    return this.doRequest(
+      'POST',
+      `${this.baseURL}/oauth/subscriptions/active`,
+      undefined,
+      { planId, paymentToken },
+      headers
+    );
+  };
+
   ClientApi.prototype.accountProfile = function (sessionTokenHex, headers) {
     const o = sessionTokenHex ? tokens.SessionToken.fromHex(sessionTokenHex) : P.resolve(null);
     return o.then(

--- a/packages/fxa-auth-server/test/local/ip_profiling.js
+++ b/packages/fxa-auth-server/test/local/ip_profiling.js
@@ -32,6 +32,7 @@ function makeRoutes (options = {}, requireMocks) {
     check () { return P.resolve(true); },
     flag () {}
   };
+  const subhub = options.subhub || mocks.mockSubHub();
   const signinUtils = require('../../lib/routes/utils/signin')(log, config, customs, db, mailer);
   signinUtils.checkPassword = () => P.resolve(true);
   return proxyquire('../../lib/routes/account', requireMocks || {})(
@@ -41,6 +42,7 @@ function makeRoutes (options = {}, requireMocks) {
     require('../../lib/crypto/password')(log, config),
     config,
     customs,
+    subhub,
     signinUtils,
     mocks.mockPush(),
     mocks.mockVerificationReminders(),

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -1,0 +1,460 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const sinon = require('sinon');
+const assert = { ...sinon.assert, ...require('chai').assert };
+const uuid = require('uuid');
+const getRoute = require('../../routes_helpers').getRoute;
+const mocks = require('../../mocks');
+const error = require('../../../lib/error');
+const P = require('../../../lib/promise');
+
+let config, log, db, customs, push, oauthdb, subhub, routes, route, request, requestOptions;
+
+const SUBSCRIPTIONS_MANAGEMENT_SCOPE =
+  'https://identity.mozilla.com/account/subscriptions';
+
+const TEST_EMAIL = 'test@email.com';
+const UID = uuid.v4('binary').toString('hex');
+const NOW = Date.now();
+const PLANS = [
+  {
+    plan_id: 'firefox_pro_basic_823',
+    product_id: 'firefox_pro_basic',
+    interval: 'month',
+    amount: '123',
+    currency: 'usd'
+  },
+  {
+    plan_id: 'firefox_pro_basic_999',
+    product_id: 'firefox_pro_pro',
+    interval: 'month',
+    amount: '456',
+    currency: 'usd'
+  }
+];
+const SUBSCRIPTION_ID_1 = 'sub-8675309';
+const PAYMENT_TOKEN_VALID = '8675309-foobarbaz';
+const PAYMENT_TOKEN_NEW = 'new-8675309';
+const PAYMENT_TOKEN_BAD = 'thisisabadtoken';
+const ACTIVE_SUBSCRIPTIONS = [
+  {
+    uid: UID,
+    subscriptionId: SUBSCRIPTION_ID_1,
+    productName: PLANS[0].product_id,
+    createdAt: NOW,
+  }
+];
+
+const MOCK_CLIENT_ID = '3c49430b43dfba77';
+const MOCK_TTL = 3600;
+const MOCK_SCOPES = ['profile:email', SUBSCRIPTIONS_MANAGEMENT_SCOPE];
+const MOCK_TOKEN_RESPONSE = {
+  access_token: 'ACCESS',
+  scope: MOCK_SCOPES,
+  token_type: 'bearer',
+  expires_in: MOCK_TTL,
+  auth_at: 123456,
+};
+
+function runTest(routePath, requestOptions) {
+  routes = require('../../../lib/routes/subscriptions')(
+    log, db, config, customs, push, oauthdb, subhub
+  );
+  route = getRoute(routes, routePath, requestOptions.method || 'GET');
+  request = mocks.mockRequest(requestOptions);
+  request.emitMetricsEvent = sinon.spy(() => P.resolve({}));
+
+  return route.handler(request);
+}
+
+describe('subscriptions', () => {
+  beforeEach(() => {
+    config = {
+      subscriptions: {
+        enabled: true,
+        managementClientId: MOCK_CLIENT_ID,
+        managementTokenTTL: MOCK_TTL
+      }
+    };
+
+    log = mocks.mockLog();
+    customs = mocks.mockCustoms();
+
+    db = mocks.mockDB({
+      uid: UID,
+      email: TEST_EMAIL
+    });
+    db.createAccountSubscription = sinon.spy(async (data) => ({}));
+    db.deleteAccountSubscription = sinon.spy(
+      async (uid, subscriptionId) => ({})
+    );
+    db.fetchAccountSubscriptions = sinon.spy(
+      async (uid) => ACTIVE_SUBSCRIPTIONS
+        .filter(s => s.uid === uid)
+    );
+    db.getAccountSubscription = sinon.spy(
+      async (uid, subscriptionId) => ACTIVE_SUBSCRIPTIONS
+        .filter(s => s.uid === uid && s.subscriptionId === subscriptionId)[0]
+    );
+    push = mocks.mockPush();
+    oauthdb = mocks.mockOAuthDB({
+      getClientInfo: sinon.spy(async () => {
+        return { id: MOCK_CLIENT_ID, name: 'mock client' };
+      }),
+      grantTokensFromSessionToken: sinon.spy(async () => MOCK_TOKEN_RESPONSE)
+    });
+
+    subhub = mocks.mockSubHub({
+      listPlans: sinon.spy(async () => PLANS),
+      createSubscription: sinon.spy(
+        async (uid, token, plan_id) => ({ sub_id: SUBSCRIPTION_ID_1 })
+      ),
+      cancelSubscription: sinon.spy(
+        async (uid, subscriptionId) => true
+      ),
+      updateCustomer: sinon.spy(async (uid, token) => ({}))
+    });
+
+    requestOptions = {
+      metricsContext: mocks.mockMetricsContext(),
+      credentials: {
+        user: UID,
+        email: TEST_EMAIL,
+        scope: MOCK_SCOPES
+      },
+      log: log,
+      payload: {
+        metricsContext: {
+          flowBeginTime: Date.now(),
+          flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+        }
+      }
+    };
+  });
+
+  describe('with config.subscriptions.enabled = false', () => {
+    it('should not set up any routes', async () => {
+      config.subscriptions.enabled = false;
+      routes = require('../../../lib/routes/subscriptions')(
+        log, db, config, customs, push, oauthdb, subhub
+      );
+      assert.deepEqual(routes, []);
+    });
+  });
+
+  describe('GET /oauth/subscriptions/plans', () => {
+    it('should list available subscription plans', async () => {
+      const res = await runTest('/oauth/subscriptions/plans', requestOptions);
+      assert.equal(subhub.listPlans.callCount, 1);
+      assert.deepEqual(res, PLANS);
+    });
+
+    it('should correctly handle payment backend failure', async () => {
+      subhub.listPlans = sinon.spy(async () => {
+        throw error.backendServiceFailure();
+      });
+      try {
+        await runTest('/oauth/subscriptions/plans', requestOptions);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE);
+      }
+    });
+  });
+
+  describe('GET /oauth/subscriptions/active', () => {
+    it('should list active subscriptions', async () => {
+      const res = await runTest('/oauth/subscriptions/active', requestOptions);
+      assert.equal(db.fetchAccountSubscriptions.callCount, 1);
+      assert.equal(db.fetchAccountSubscriptions.args[0][0], UID);
+      assert.deepEqual(res, ACTIVE_SUBSCRIPTIONS);
+    });
+  });
+
+  describe('POST /oauth/subscriptions/active', () => {
+    it('should support creation of a new subscription', async () => {
+      const res = await runTest(
+        '/oauth/subscriptions/active',
+        {
+          ...requestOptions,
+          method: 'POST',
+          payload: {
+            ...requestOptions.payload,
+            planId: PLANS[0].plan_id,
+            paymentToken: PAYMENT_TOKEN_VALID,
+          },
+        }
+      );
+
+      assert.equal(customs.check.callCount, 1, 'calls customs.check');
+
+      assert.equal(subhub.listPlans.callCount, 1);
+      assert.deepEqual(
+        subhub.createSubscription.args,
+        [
+          [ UID, PAYMENT_TOKEN_VALID, PLANS[0].plan_id ]
+        ]
+      );
+      assert.equal(db.createAccountSubscription.callCount, 1);
+
+      const createArgs = db.createAccountSubscription.args[0][0];
+      assert.deepEqual(
+        createArgs,
+        {
+          uid: UID,
+          subscriptionId: SUBSCRIPTION_ID_1,
+          productName: PLANS[0].product_id,
+          createdAt: createArgs.createdAt
+        }
+      );
+      assert.deepEqual(
+        res,
+        { subscriptionId: SUBSCRIPTION_ID_1 }
+      );
+
+      assert.equal(push.notifyProfileUpdated.callCount, 1,
+        'call push.notifyProfileUpdated');
+      assert.equal(log.notifyAttachedServices.callCount, 1,
+        'logs verified');
+      assert.equal(log.notifyAttachedServices.args[0][0], 'profileDataChanged');
+      assert.deepEqual(log.notifyAttachedServices.args[0][2],
+        { uid: UID, email: TEST_EMAIL });
+    });
+
+    it('should correctly handle payment backend failure on listing plans', async () => {
+      subhub.listPlans = sinon.spy(async () => {
+        throw error.backendServiceFailure();
+      });
+      try {
+        await runTest(
+          '/oauth/subscriptions/active',
+          {
+            ...requestOptions,
+            method: 'POST',
+            payload: {
+              ...requestOptions.payload,
+              planId: PLANS[0].plan_id,
+              paymentToken: PAYMENT_TOKEN_VALID,
+            },
+          }
+        );
+        assert.fail();
+      } catch (err) {
+        assert.deepEqual(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE);
+        assert.equal(subhub.createSubscription.callCount, 0);
+        assert.equal(db.createAccountSubscription.callCount, 0);
+      }
+    });
+
+    it('should correctly handle payment backend failure on create', async () => {
+      subhub.createSubscription = sinon.spy(async () => {
+        throw error.backendServiceFailure();
+      });
+      try {
+        await runTest(
+          '/oauth/subscriptions/active',
+          {
+            ...requestOptions,
+            method: 'POST',
+            payload: {
+              ...requestOptions.payload,
+              planId: PLANS[0].plan_id,
+              paymentToken: PAYMENT_TOKEN_VALID,
+            },
+          }
+        );
+        assert.fail();
+      } catch (err) {
+        assert.deepEqual(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE);
+        assert.equal(db.createAccountSubscription.callCount, 0);
+      }
+    });
+
+    it('should correctly handle an unknown plan', async () => {
+      try {
+        await runTest(
+          '/oauth/subscriptions/active',
+          {
+            ...requestOptions,
+            method: 'POST',
+            payload: {
+              ...requestOptions.payload,
+              planId: 'thisisnotaplan',
+              paymentToken: PAYMENT_TOKEN_VALID,
+            },
+          }
+        );
+        assert.fail();
+      } catch (err) {
+        assert.deepEqual(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION_PLAN);
+        assert.equal(db.createAccountSubscription.callCount, 0);
+      }
+    });
+
+    it('should correctly handle payment token rejection', async () => {
+      subhub.createSubscription = sinon.spy(async (uid, token, plan_id) => {
+        throw error.rejectedSubscriptionPaymentToken(token);
+      });
+      try {
+        await runTest(
+          '/oauth/subscriptions/active',
+          {
+            ...requestOptions,
+            method: 'POST',
+            payload: {
+              ...requestOptions.payload,
+              planId: PLANS[0].plan_id,
+              paymentToken: PAYMENT_TOKEN_BAD
+            },
+          }
+        );
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.REJECTED_SUBSCRIPTION_PAYMENT_TOKEN);
+        assert.equal(db.createAccountSubscription.callCount, 0);
+      }
+    });
+  });
+
+  describe('POST /oauth/subscriptions/updatePayment', () => {
+    it('should allow updating of payment method', async () => {
+      // TODO: TBD subhub response for updatePayment, do something with it?
+      await runTest(
+        '/oauth/subscriptions/updatePayment',
+        {
+          ...requestOptions,
+          method: 'POST',
+          payload: { paymentToken: PAYMENT_TOKEN_NEW }
+        }
+      );
+      assert.equal(customs.check.callCount, 1, 'calls customs.check');
+      assert.deepEqual(
+        subhub.updateCustomer.args,
+        [ [ UID, PAYMENT_TOKEN_NEW ] ]
+      );
+    });
+
+    it('should correctly handle subscription backend failure', async () => {
+      subhub.updateCustomer = sinon.spy(async () => {
+        throw error.backendServiceFailure();
+      });
+      try {
+        await runTest(
+          '/oauth/subscriptions/updatePayment',
+          {
+            ...requestOptions,
+            method: 'POST',
+            payload: { paymentToken: PAYMENT_TOKEN_NEW }
+          }
+        );
+        assert.fail();
+      } catch (err) {
+        assert.deepEqual(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE);
+        assert.equal(db.createAccountSubscription.callCount, 0);
+      }
+    });
+
+    it('should correctly handle payment token rejection', async () => {
+      subhub.updateCustomer = sinon.spy(async (uid, token) => {
+        throw error.rejectedSubscriptionPaymentToken(token);
+      });
+      try {
+        await runTest(
+          '/oauth/subscriptions/updatePayment',
+          {
+            ...requestOptions,
+            method: 'POST',
+            payload: { paymentToken: PAYMENT_TOKEN_BAD }
+          }
+        );
+        assert.fail();
+      } catch (err) {
+        assert.deepEqual(
+          subhub.updateCustomer.args,
+          [ [ UID, PAYMENT_TOKEN_BAD ] ]
+        );
+        assert.equal(err.errno, error.ERRNO.REJECTED_SUBSCRIPTION_PAYMENT_TOKEN);
+      }
+    });
+  });
+
+  describe('DELETE /oauth/subscriptions/active/{subscriptionId}', () => {
+    it('should support cancellation of an existing subscription', async () => {
+      const res = await runTest(
+        '/oauth/subscriptions/active/{subscriptionId}',
+        {
+          ...requestOptions,
+          method: 'DELETE',
+          params: { subscriptionId: SUBSCRIPTION_ID_1 }
+        }
+      );
+      assert.equal(customs.check.callCount, 1, 'calls customs.check');
+      assert.deepEqual(
+        subhub.cancelSubscription.args,
+        [ [ UID, SUBSCRIPTION_ID_1 ] ]
+      );
+      assert.deepEqual(
+        db.deleteAccountSubscription.args,
+        [ [ UID, SUBSCRIPTION_ID_1 ] ]
+      );
+      assert.deepEqual( res, {});
+
+      assert.equal(push.notifyProfileUpdated.callCount, 1,
+        'call push.notifyProfileUpdated');
+      assert.equal(log.notifyAttachedServices.callCount, 1,
+        'logs verified');
+      assert.equal(log.notifyAttachedServices.args[0][0], 'profileDataChanged');
+      assert.deepEqual(log.notifyAttachedServices.args[0][2],
+        { uid: UID, email: TEST_EMAIL });
+    });
+
+    it('should report error for unknown subscription', async () => {
+      const badSub = 'notasub';
+      try {
+        await runTest(
+          '/oauth/subscriptions/active/{subscriptionId}',
+          {
+            ...requestOptions,
+            method: 'DELETE',
+            params: { subscriptionId: badSub }
+          }
+        );
+        assert.fail();
+      } catch (err) {
+        assert.deepEqual(db.getAccountSubscription.args, [ [ UID, badSub ] ]);
+        assert.deepEqual(subhub.cancelSubscription.args, []);
+        assert.deepEqual(db.deleteAccountSubscription.args, []);
+        assert.deepEqual(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION);
+      }
+    });
+
+    it('should not delete subscription from DB after payment backend failure', async () => {
+      subhub.cancelSubscription = sinon.spy(async () => {
+        throw error.backendServiceFailure();
+      });
+      try {
+        await runTest(
+          '/oauth/subscriptions/active/{subscriptionId}',
+          {
+            ...requestOptions,
+            method: 'DELETE',
+            params: { subscriptionId: SUBSCRIPTION_ID_1 }
+          }
+        );
+        assert.fail();
+      } catch (err) {
+        assert.deepEqual(db.getAccountSubscription.args,
+          [ [ UID, SUBSCRIPTION_ID_1 ] ]);
+        assert.deepEqual(subhub.cancelSubscription.args,
+          [ [ UID, SUBSCRIPTION_ID_1 ] ]);
+        assert.deepEqual(db.deleteAccountSubscription.args, []);
+        assert.deepEqual(err.errno,
+          error.ERRNO.BACKEND_SERVICE_FAILURE);
+      }
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const sinon = require('sinon');
+const assert = require('chai').assert;
+const mocks = require('../../../mocks');
+
+const {
+  PRODUCT_SUBSCRIBED,
+  PRODUCT_REGISTERED,
+  determineClientVisibleSubscriptionCapabilities
+} = require('../../../../lib/routes/utils/subscriptions');
+
+const UID = 'uid8675309';
+const NOW = Date.now();
+const MOCK_SUBSCRIPTIONS = [
+  {
+    uid: UID,
+    subscriptionId: 'sub1',
+    productName: 'p1',
+    createdAt: NOW,
+  },
+  {
+    uid: UID,
+    subscriptionId: 'sub2',
+    productName: 'p2',
+    createdAt: NOW,
+  }
+];
+const MOCK_CONFIG = {
+  subscriptions: {
+    productCapabilities: {
+      p1: ['cap1', 'cap2', 'cap3'],
+      p2: ['cap4', 'cap5', 'cap6'],
+      p3: ['cap7', 'cap8', 'cap9'],
+      [PRODUCT_SUBSCRIBED]: ['capSubscribed'],
+      [PRODUCT_REGISTERED]: ['capRegistered']
+    },
+    clientCapabilities: {
+      c1: ['cap1', 'cap5', 'cap9'],
+      c2: ['capSubscribed'],
+      c3: ['capRegistered']
+    }
+  }
+};
+
+describe('routes/utils/subscriptions', () => {
+  let auth, db;
+
+  beforeEach(async () => {
+    auth = { strategy: 'oauthToken' };
+    db = mocks.mockDB();
+    db.fetchAccountSubscriptions = sinon.spy(
+      async (uid) => MOCK_SUBSCRIPTIONS
+      .filter(s => s.uid === uid)
+    );
+  });
+
+  describe('determineClientVisibleSubscriptionCapabilities', () => {
+    afterEach(() => {
+      // Each of these tests should cause a fetch of subscriptions
+      assert.deepEqual(
+        db.fetchAccountSubscriptions.args,
+        [ [ UID ] ]
+      );
+    });
+
+    it('should reveal all subscribed capabilities to a sessionToken client', async () => {
+      auth.strategy = 'sessionToken';
+      const result =
+        await determineClientVisibleSubscriptionCapabilities(MOCK_CONFIG, auth, db, UID, null);
+      assert.deepEqual(
+        result,
+        [ 'capRegistered', 'cap1', 'cap2', 'cap3', 'cap4', 'cap5', 'cap6', 'capSubscribed' ]
+      );
+    });
+
+    it('should only reveal capabilities relevant to the client', async () => {
+      const client = 'c1';
+      const result =
+        await determineClientVisibleSubscriptionCapabilities(MOCK_CONFIG, auth, db, UID, client);
+      assert.deepEqual(result, [ 'cap1', 'cap5' ]);
+    });
+
+    it('should return undefined if no capabilities are visible to client', async () => {
+      const client = 'someRando';
+      const result =
+        await determineClientVisibleSubscriptionCapabilities(MOCK_CONFIG, auth, db, UID, client);
+      assert.deepEqual(result, undefined);
+    });
+
+    it('should implicitly include subscribed default product for users with at least one subscription', async () => {
+      const client = 'c2';
+      const result =
+        await determineClientVisibleSubscriptionCapabilities(MOCK_CONFIG, auth, db, UID, client);
+      assert.deepEqual(result, ['capSubscribed']);
+    });
+
+    it('should implicitly include registered default product for all users', async () => {
+      const client = 'c3';
+      db.fetchAccountSubscriptions = sinon.spy(async (uid) => []);
+      const result =
+        await determineClientVisibleSubscriptionCapabilities(MOCK_CONFIG, auth, db, UID, client);
+      assert.deepEqual(result, ['capRegistered']);
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/local/subhub.js
+++ b/packages/fxa-auth-server/test/local/subhub.js
@@ -1,0 +1,400 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const nock = require('nock');
+const error = require('../../lib/error');
+const { mockLog } = require('../mocks');
+
+const subhubModule = require('../../lib/subhub');
+
+const mockConfig = {
+  publicUrl: 'https://accounts.example.com',
+  subhub: {
+    enabled: true,
+    url: 'https://foo.bar',
+    key: 'foo',
+  }
+};
+
+const mockServer = nock(mockConfig.subhub.url, {
+  reqheaders: {
+    Authorization: `Bearer ${mockConfig.subhub.key}`
+  }
+}).defaultReplyHeaders({
+  'Content-Type': 'application/json'
+});
+
+describe('subscriptions', () => {
+  const UID = '8675309';
+  const EMAIL = 'foo@example.com';
+  const PLAN_ID = 'plan12345';
+  const SUBSCRIPTION_ID = 'sub12345';
+  const PAYMENT_TOKEN_GOOD = 'foobarbaz';
+  const PAYMENT_TOKEN_NEW = 'quuxxyzzy';
+  const PAYMENT_TOKEN_BAD = 'badf00d';
+
+  const makeSubject = (subhubConfig = {}) => {
+    const log = mockLog();
+    const subhub = subhubModule(log, {
+      ...mockConfig,
+      subhub: {
+        ...mockConfig.subhub,
+        ...subhubConfig
+      }
+    });
+    return { log, subhub };
+  };
+
+  afterEach(() => {
+    assert.ok(nock.isDone(), 'there should be no pending request mocks at the end of a test');
+  });
+
+  it('should build stub API when configured to do so', async () => {
+    const { subhub } = makeSubject();
+    assert.equal(subhub.isStubAPI, false);
+
+    const { subhub: subhubWithStubs } = makeSubject({ useStubs: true });
+    assert.equal(subhubWithStubs.isStubAPI, true);
+  });
+
+  it('should throw errors when feature not enabled', async () => {
+    const { subhub } = makeSubject({ enabled: false });
+    const names = [
+      'listPlans',
+      'listSubscriptions',
+      'createSubscription',
+      'getCustomer',
+      'updateCustomer',
+      'cancelSubscription',
+    ];
+    for (const name of names) {
+      try {
+        await subhub[name]();
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.message, 'Feature not enabled');
+      }
+    }
+  });
+
+  describe('listPlans', () => {
+    it('should list plans', async () => {
+      const expected = [
+        {
+          'plan_id': 'firefox_pro_basic_823',
+          'product_id': 'firefox_pro_basic',
+          'interval': 'month',
+          'amount': 500,
+          'currency': 'usd'
+        }
+      ];
+      mockServer.get('/plans').reply(200, expected);
+      const { subhub } = makeSubject();
+      const resp = await subhub.listPlans();
+      assert.deepEqual(resp, expected);
+    });
+
+    it('should throw on backend service failure', async () => {
+      mockServer.get('/plans').reply(500, 'Internal Server Error');
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.listPlans();
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.listPlans.1');
+      }
+    });
+  });
+
+  describe('listSubscriptions', () => {
+    it('should list subscriptions for account', async () => {
+      const expected = [
+        {
+          'plan_id': 'firefox_pro_basic_823',
+          'product_id': 'firefox_pro_basic',
+          'current_period_end': 1557361022,
+          'end_at': 1557361022
+        }
+      ];
+      mockServer.get(`/customer/${UID}/subscriptions`).reply(200, expected);
+      const { subhub } = makeSubject();
+      const resp = await subhub.listSubscriptions(UID);
+      assert.deepEqual(resp, expected);
+    });
+
+    it('should throw on unknown user', async () => {
+      mockServer.get(`/customer/${UID}/subscriptions`)
+        .reply(404, { message: 'invalid uid' });
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.listSubscriptions(UID);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION_CUSTOMER);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.listSubscriptions.1');
+      }
+    });
+
+    it('should throw on invalid response', async () => {
+      const expected = { 'this is not right': true };
+      mockServer.get(`/customer/${UID}/subscriptions`).reply(200, expected);
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.listSubscriptions(UID);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.INTERNAL_VALIDATION_ERROR);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.listSubscriptions');
+        assert.equal(log.error.getCall(0).args[1].error, 'response schema validation failed');
+      }
+    });
+
+    it('should throw on backend service failure', async () => {
+      mockServer.get(`/customer/${UID}/subscriptions`)
+        .reply(500, 'Internal Server Error');
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.listSubscriptions(UID);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.listSubscriptions.1');
+      }
+    });
+  });
+
+  describe('createSubscription', () => {
+    it('should subscribe to a plan with valid payment token', async () => {
+      const expected = {
+        sub_id: SUBSCRIPTION_ID
+      };
+      const expectedBody = {
+        pmt_token: PAYMENT_TOKEN_GOOD,
+        plan_id: PLAN_ID,
+        email: EMAIL
+      };
+      let requestBody;
+      mockServer
+        .post(`/customer/${UID}/subscriptions`, body => requestBody = body)
+        .reply(201, expected);
+      const { subhub } = makeSubject();
+      const resp =
+        await subhub.createSubscription(UID, PAYMENT_TOKEN_GOOD, PLAN_ID, EMAIL);
+      assert.deepEqual(requestBody, expectedBody);
+      assert.deepEqual(resp, expected);
+    });
+
+    it('should throw on unknown plan ID', async () => {
+      mockServer
+        .post(`/customer/${UID}/subscriptions`)
+        // TODO: update with subhub createSubscription error response for invalid plan ID
+        .reply(400, { message: 'invalid plan id' });
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.createSubscription(UID, PAYMENT_TOKEN_BAD, PLAN_ID, EMAIL);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION_PLAN);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.createSubscription.1');
+      }
+    });
+
+    it('should throw on invalid payment token', async () => {
+      mockServer
+        .post(`/customer/${UID}/subscriptions`)
+        // TODO: update with subhub createSubscription error response for invalid payment token
+        .reply(400, { message: 'invalid payment token' });
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.createSubscription(UID, PAYMENT_TOKEN_BAD, PLAN_ID, EMAIL);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.REJECTED_SUBSCRIPTION_PAYMENT_TOKEN);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.createSubscription.1');
+      }
+    });
+
+    it('should throw on backend service failure', async () => {
+      mockServer.post(`/customer/${UID}/subscriptions`)
+        .reply(500, 'Internal Server Error');
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.createSubscription(UID, PAYMENT_TOKEN_GOOD, PLAN_ID, EMAIL);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.createSubscription.1');
+      }
+    });
+  });
+
+  describe('cancelSubscription', () => {
+    it('should cancel an existing subscription', async () => {
+      // TODO: update with subhub cancelSubscription response format
+      const expected = {};
+      mockServer
+        .delete(`/customer/${UID}/subscriptions/${SUBSCRIPTION_ID}`)
+        // TODO: subhub specifies 201 for cancelSubscription success - maybe 204 would be better?
+        .reply(201, expected);
+      const { subhub } = makeSubject();
+      const result = await subhub.cancelSubscription(UID, SUBSCRIPTION_ID);
+      assert.deepEqual(result, expected);
+    });
+
+    it('should throw on unknown user', async () => {
+      mockServer
+        .delete(`/customer/${UID}/subscriptions/${SUBSCRIPTION_ID}`)
+        .reply(404, { message: 'invalid uid' });
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.cancelSubscription(UID, SUBSCRIPTION_ID);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION_CUSTOMER);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.cancelSubscription.1');
+      }
+    });
+
+    it('should throw on unknown subscription', async () => {
+      mockServer
+        .delete(`/customer/${UID}/subscriptions/${SUBSCRIPTION_ID}`)
+        .reply(400, { message: 'invalid subscription id' });
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.cancelSubscription(UID, SUBSCRIPTION_ID);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.cancelSubscription.1');
+      }
+    });
+
+    it('should throw on backend service failure', async () => {
+      mockServer
+        .delete(`/customer/${UID}/subscriptions/${SUBSCRIPTION_ID}`)
+        .reply(500, 'Internal Server Error');
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.cancelSubscription(UID, SUBSCRIPTION_ID);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.cancelSubscription.1');
+      }
+    });
+  });
+
+  describe('getCustomer', () => {
+    it('should yield customer details', async () => {
+      // TODO: update with final customer schema from subhub
+      const expected = {
+        this_is_a_customer: true
+      };
+      mockServer.get(`/customer/${UID}`).reply(200, expected);
+      const { subhub } = makeSubject();
+      const resp = await subhub.getCustomer(UID);
+      assert.deepEqual(resp, expected);
+    });
+
+    it('should throw on unknown user', async () => {
+      mockServer.get(`/customer/${UID}`)
+        .reply(404, { message: 'invalid uid' });
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.getCustomer(UID);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION_CUSTOMER);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.getCustomer.1');
+      }
+    });
+
+    it('should throw on backend service failure', async () => {
+      mockServer.get(`/customer/${UID}`).reply(500, 'Internal Server Error');
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.getCustomer(UID);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.getCustomer.1');
+      }
+    });
+  });
+
+  describe('updateCustomer', () => {
+    it('should update payment method', async () => {
+      // TODO: update with final customer schema from subhub
+      const expected = {};
+      const expectedBody = {
+        pmt_token: PAYMENT_TOKEN_NEW
+      };
+      let requestBody;
+      mockServer
+        .post(`/customer/${UID}`, body => requestBody = body)
+        .reply(201, expected);
+      const { subhub } = makeSubject();
+      const resp = await subhub.updateCustomer(UID, PAYMENT_TOKEN_NEW);
+      assert.deepEqual(requestBody, expectedBody);
+      assert.deepEqual(resp, expected);
+    });
+
+    it('should throw on unknown user', async () => {
+      mockServer.post(`/customer/${UID}`)
+        .reply(404, { message: 'invalid uid' });
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.updateCustomer(UID, PAYMENT_TOKEN_NEW);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION_CUSTOMER);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.updateCustomer.1');
+      }
+    });
+
+    it('should throw on invalid payment token', async () => {
+      mockServer.post(`/customer/${UID}`)
+        .reply(400, { message: 'invalid payment token' });
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.updateCustomer(UID, PAYMENT_TOKEN_NEW);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.REJECTED_SUBSCRIPTION_PAYMENT_TOKEN);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.updateCustomer.1');
+      }
+    });
+
+    it('should throw on backend service failure', async () => {
+      mockServer.post(`/customer/${UID}`).reply(500, 'Internal Server Error');
+      const { log, subhub } = makeSubject();
+      try {
+        await subhub.updateCustomer(UID, PAYMENT_TOKEN_NEW);
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE);
+        assert.equal(log.error.callCount, 1, 'an error was logged');
+        assert.equal(log.error.getCall(0).args[0], 'subhub.updateCustomer.1');
+      }
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -83,7 +83,11 @@ const DB_METHOD_NAMES = [
   'verifyEmail',
   'verifyTokens',
   'verifyTokenCode',
-  'verifyTokensWithMethod'
+  'verifyTokensWithMethod',
+  'createAccountSubscription',
+  'getAccountSubscription',
+  'deleteAccountSubscription',
+  'fetchAccountSubscriptions'
 ];
 
 const OAUTHDB_METHOD_NAMES = [
@@ -159,6 +163,15 @@ const PUSHBOX_METHOD_NAMES = [
   'store'
 ];
 
+const SUBHUB_METHOD_NAMES = [
+  'listPlans',
+  'getCustomer',
+  'updateCustomer',
+  'listSubscriptions',
+  'createSubscription',
+  'cancelSubscription'
+];
+
 module.exports = {
   MOCK_PUSH_KEY: 'BDLugiRzQCANNj5KI1fAqui8ELrE7qboxzfa5K_R0wnUoJ89xY1D_SOXI_QJKNmellykaW_7U2BZ7hnrPW3A3LM',
   generateMetricsContext: generateMetricsContext,
@@ -173,6 +186,7 @@ module.exports = {
   mockPush,
   mockPushbox,
   mockRequest,
+  mockSubHub,
   mockVerificationReminders,
 };
 
@@ -339,6 +353,8 @@ function mockDB (data, errors) {
     deleteSessionToken: sinon.spy(() => {
       return P.resolve();
     }),
+    deleteAccountSubscription:
+      sinon.spy(async (uid, subscriptionId) => true),
     emailRecord: sinon.spy(() => {
       if (errors.emailRecord) {
         return P.reject(errors.emailRecord);
@@ -461,6 +477,16 @@ function mockPushbox (methods) {
     }
   });
   return pushbox;
+}
+
+function mockSubHub(methods) {
+  const subscriptionsBackend = Object.assign({}, methods);
+  SUBHUB_METHOD_NAMES.forEach((name) => {
+    if (! subscriptionsBackend[name]) {
+      subscriptionsBackend[name] = sinon.spy(() => P.resolve());
+    }
+  });
+  return subscriptionsBackend;
 }
 
 function mockDevices (data, errors) {

--- a/packages/fxa-auth-server/test/remote/account_profile_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_profile_tests.js
@@ -10,21 +10,52 @@ const Client = require('../client')();
 
 const config = require('../../config').getProperties();
 
+const PRODUCT_ID = 'megaProductHooray';
+const CLIENT_ID = 'client8675309';
+const CLIENT_ID_FOR_DEFAULT = 'client5551212';
+const PLAN_ID = 'allDoneProMonthly';
+const PAYMENT_TOKEN = 'pay8675309';
+
 function makeMockOAuthHeader(opts) {
   const token = Buffer.from(JSON.stringify(opts)).toString('hex');
   return `Bearer ${  token}`;
+}
+
+function startTestServer(subscriptionsEnabled = true) {
+  config.oauth.url = 'http://localhost:9010';
+  config.subhub.useStubs = true;
+  config.subhub.stubs = {
+    plans: [
+      {
+        plan_id: PLAN_ID,
+        product_id: PRODUCT_ID,
+        interval: 'month',
+        amount: 50,
+        currency: 'usd'
+      }
+    ]
+  };
+  config.subscriptions = {
+    enabled: subscriptionsEnabled,
+    productCapabilities: {
+      'defaultRegistered': [ 'isRegistered' ],
+      'defaultSubscribed': [ 'isSubscribed' ],
+      [ PRODUCT_ID ]: [ '123donePro', '321donePro', 'FirefoxPlus', 'MechaMozilla' ],
+    },
+    clientCapabilities: {
+      [ CLIENT_ID ]: [ '123donePro', 'ILikePie', 'MechaMozilla', 'FooBar' ],
+      [ CLIENT_ID_FOR_DEFAULT ]: [ 'isRegistered', 'isSubscribed' ],
+    }
+  };
+  return TestServer.start(config);
 }
 
 describe('remote account profile', function() {
   this.timeout(15000);
 
   let server;
-  before(() => {
-    config.oauth.url = 'http://localhost:9010';
-    return TestServer.start(config)
-      .then(s => {
-        server = s;
-      });
+  before(async () => {
+    server = await startTestServer();
   });
 
   it(
@@ -284,7 +315,151 @@ describe('remote account profile', function() {
     }
   );
 
+  describe('subscription capabilities status', () => {
+    let email, client;
+    beforeEach(async () => {
+      email = server.uniqueEmail();
+      client = await Client.create(
+        config.publicUrl,
+        email,
+        'password',
+        { lang: 'en-US' }
+      );
+    });
+
+    it('should report default registered capability with session token', async () => {
+      const response = await client.api.accountProfile(client.sessionToken);
+      assert.deepEqual(response.subscriptions, [ 'isRegistered' ]);
+    });
+
+    it('should not include subscriptions at all if account has none for OAuth client', async () => {
+      const response = await client.api.accountProfile(null, {
+        Authorization: makeMockOAuthHeader({
+          user: client.uid,
+          client_id: CLIENT_ID,
+          scope: ['profile:subscriptions']
+        })
+      });
+      assert.isNotOk('subscriptions' in response);
+    });
+
+    it('should report default registered capability to OAuth client', async () => {
+      const response = await client.api.accountProfile(null, {
+        Authorization: makeMockOAuthHeader({
+          user: client.uid,
+          client_id: CLIENT_ID_FOR_DEFAULT,
+          scope: ['profile:subscriptions']
+        })
+      });
+      assert.deepEqual(response.subscriptions, [ 'isRegistered' ]);
+    });
+
+    describe('with a subscription', () => {
+      beforeEach(async () => {
+        await client.api.createSubscription(
+          PLAN_ID,
+          PAYMENT_TOKEN,
+          {
+            Authorization: makeMockOAuthHeader({
+              user: client.uid,
+              client_id: CLIENT_ID,
+              scope: ['profile', 'https://identity.mozilla.com/account/subscriptions']
+            })
+          }
+        );
+      });
+
+      it('should report all subscription capabilities to session token client', async () => {
+        const response = await client.api.accountProfile(client.sessionToken);
+        assert.deepEqual(response.subscriptions, [
+          'isRegistered',
+          '123donePro',
+          '321donePro',
+          'FirefoxPlus',
+          'MechaMozilla',
+          'isSubscribed'
+        ]);
+      });
+
+      it('should report default subscription capability to OAuth client', async () => {
+        const response = await client.api.accountProfile(null, {
+          Authorization: makeMockOAuthHeader({
+            user: client.uid,
+            client_id: CLIENT_ID_FOR_DEFAULT,
+            scope: ['profile:subscriptions']
+          })
+        });
+        assert.deepEqual(response.subscriptions, [ 'isRegistered', 'isSubscribed' ]);
+      });
+
+      it('should report subset of subscription capabilities relevant to OAuth client', async () => {
+        const response = await client.api.accountProfile(null, {
+          Authorization: makeMockOAuthHeader({
+            user: client.uid,
+            client_id: CLIENT_ID,
+            scope: ['profile:subscriptions']
+          })
+        });
+        assert.deepEqual(response.subscriptions,
+          [ '123donePro', 'MechaMozilla' ]);
+      });
+
+      it('should not include subscriptions for OAuth token without profile:subscriptions scope', async () => {
+        const response = await client.api.accountProfile(null, {
+          Authorization: makeMockOAuthHeader({
+            user: client.uid,
+            client_id: CLIENT_ID,
+            scope: ['foobar']
+          })
+        });
+        assert.isNotOk('subscriptions' in response);
+      });
+    });
+  });
+
   after(() => {
     return TestServer.stop(server);
+  });
+});
+
+describe('remote account profile with subscriptions disabled', function () {
+  this.timeout(15000);
+
+  let server;
+  before(async () => {
+    server = await startTestServer(false);
+  });
+
+  after(() => {
+    return TestServer.stop(server);
+  });
+
+  describe('subscription capabilities status', () => {
+    let email, client;
+    beforeEach(async () => {
+      email = server.uniqueEmail();
+      client = await Client.create(
+        config.publicUrl,
+        email,
+        'password',
+        { lang: 'en-US' }
+      );
+    });
+
+    it('should not include subscription status at all with session token', async () => {
+      const response = await client.api.accountProfile(client.sessionToken);
+      assert.isNotOk('subscriptions' in response);
+    });
+
+    it('should not include subscription status at all for OAuth client', async () => {
+      const response = await client.api.accountProfile(null, {
+        Authorization: makeMockOAuthHeader({
+          user: client.uid,
+          client_id: CLIENT_ID_FOR_DEFAULT,
+          scope: ['profile:subscriptions']
+        })
+      });
+      assert.isNotOk('subscriptions' in response);
+    });
   });
 });

--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -235,6 +235,22 @@ var ERRORS = {
     errno: 165,
     message: t('Failed due to a conflicting request, please try again.')
   },
+  UNKNOWN_SUBSCRIPTION_CUSTOMER: {
+    errno: 176,
+    message: t('Unknown customer for subscription.')
+  },
+  UNKNOWN_SUBSCRIPTION: {
+    errno: 177,
+    message: t('Unknown subscription.')
+  },
+  UNKNOWN_SUBSCRIPTION_PLAN: {
+    errno: 178,
+    message: t('Unknown plan for subscription.')
+  },
+  REJECTED_SUBSCRIPTION_PAYMENT_TOKEN: {
+    errno: 179,
+    message: t('Invalid payment token for subscription.')
+  },
   // Secondary Email errors end
   SERVER_BUSY: {
     errno: 201,

--- a/packages/fxa-profile-server/docs/API.md
+++ b/packages/fxa-profile-server/docs/API.md
@@ -57,6 +57,7 @@ The currently-defined error responses are:
 
 - [GET /v1/profile][profile]
 - [GET /v1/email][email]
+- [GET /v1/subscriptions][subscriptions]
 - [GET /v1/uid][uid]
 - [GET /v1/avatar][avatar]
 - [POST /v1/avatar/upload][upload]
@@ -89,7 +90,8 @@ curl -v \
   "twoFactorAuthentication": true,
   "displayName": "Max Power",
   "avatar": "https://firefoxusercontent.com/a9bff302615cd015692a099f691205cc",
-  "avatarDefault": false
+  "avatarDefault": false,
+  "subscriptions": ["foo", "bar", "baz"]
 }
 ```
 
@@ -124,6 +126,28 @@ curl -v \
 ```json
 {
   "email": "user@example.domain"
+}
+```
+
+### GET /v1/subscriptions
+
+- scope: `profile:email`
+
+Retrieves subscription capabilities for the user
+
+#### Request
+
+```sh
+curl -v \
+-H "Authorization: Bearer 558f9980ad5a9c279beb52123653967342f702e84d3ab34c7f80427a6a37e2c0" \
+"https://profile.accounts.firefox.com/v1/subscriptions"
+```
+
+#### Response
+
+```json
+{
+  "subscriptions": ["foo", "bar", "baz"]
 }
 ```
 

--- a/packages/fxa-profile-server/lib/routes/_core_profile.js
+++ b/packages/fxa-profile-server/lib/routes/_core_profile.js
@@ -20,7 +20,7 @@ module.exports = {
   isInternal: true,
   auth: {
     strategy: 'oauth',
-    scope: ['profile:email', 'profile:locale', 'profile:amr', /* openid-connect scope */'email' ]
+    scope: ['profile:email', 'profile:locale', 'profile:amr', 'profile:subscriptions', /* openid-connect scope */'email' ]
   },
   response: {
     schema: {
@@ -28,6 +28,7 @@ module.exports = {
       locale: Joi.string().optional(),
       amrValues: Joi.array().items(Joi.string().required()).optional(),
       twoFactorAuthentication: Joi.boolean().optional(),
+      subscriptions: Joi.array().items(Joi.string().required()).optional(),
       profileChangedAt: Joi.number().optional()
     }
   },
@@ -84,6 +85,9 @@ module.exports = {
       }
       if (typeof body.authenticatorAssuranceLevel !== 'undefined') {
         result.twoFactorAuthentication = body.authenticatorAssuranceLevel >= 2;
+      }
+      if (typeof body.subscriptions !== 'undefined') {
+        result.subscriptions = body.subscriptions;
       }
       if (typeof body.profileChangedAt !== 'undefined') {
         result.profileChangedAt = body.profileChangedAt;

--- a/packages/fxa-profile-server/lib/routes/profile.js
+++ b/packages/fxa-profile-server/lib/routes/profile.js
@@ -29,6 +29,7 @@ module.exports = {
       locale: Joi.string().allow(null),
       amrValues: Joi.array().items(Joi.string().required()).allow(null),
       twoFactorAuthentication: Joi.boolean().allow(null),
+      subscriptions: Joi.array().items(Joi.string().required()).optional(),
 
       //openid-connect
       sub: Joi.string().allow(null)

--- a/packages/fxa-profile-server/lib/routes/subscriptions.js
+++ b/packages/fxa-profile-server/lib/routes/subscriptions.js
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const Joi = require('joi');
+
+module.exports = {
+  auth: {
+    strategy: 'oauth',
+    scope: ['profile:subscriptions']
+  },
+  response: {
+    schema: {
+      subscriptions: Joi.array().items(Joi.string()).required()
+    }
+  },
+  handler: function subscriptions(req, reply) {
+    req.server.inject({
+      allowInternals: true,
+      method: 'get',
+      url: '/v1/_core_profile',
+      headers: req.headers,
+      credentials: req.auth.credentials
+    }, res => {
+      if (res.statusCode !== 200) {
+        return reply(res);
+      }
+      return reply({
+        // If auth server omits subscriptions, just use an empty list
+        subscriptions: res.result.subscriptions || []
+      });
+    });
+  }
+};
+

--- a/packages/fxa-profile-server/lib/routing.js
+++ b/packages/fxa-profile-server/lib/routing.js
@@ -46,6 +46,11 @@ module.exports = [
   },
   {
     method: 'GET',
+    path: v('/subscriptions'),
+    config: require('./routes/subscriptions')
+  },
+  {
+    method: 'GET',
     path: v('/uid'),
     config: require('./routes/uid')
   },

--- a/packages/fxa-profile-server/test/lib/mock.js
+++ b/packages/fxa-profile-server/test/lib/mock.js
@@ -149,6 +149,13 @@ module.exports = function mock(options) {
         });
     },
 
+    subscriptions: function mockSubscriptions(subscriptions) {
+      var parts = url.parse(config.get('authServer.url'));
+      return nock(parts.protocol + '//' + parts.host)
+        .get(parts.path + '/account/profile')
+        .reply(200, { subscriptions });
+    },
+
     profileChangedAt: function mockProfileChangedAt(email, profileChangedAt) {
       var parts = url.parse(config.get('authServer.url'));
       return nock(parts.protocol + '//' + parts.host)


### PR DESCRIPTION
TODOs:
- [x] Try to resolve TODOs around subhub integration - made some assertive assumptions, but issue #719 exists to finish this for real
- [x] Add OAuth token strategy to subscription CRUD methods for use by payment & management page on separate domain (#715)
- [x] Auth server method to issue OAuth token for payment pages from session token
- [x] Ensure all subscriptions are cancelled when account is deleted
- [x] Metrics events? (Present, but most probably incorrect in absence of a metrics spec.)
- [x] Customs server calls? (Present, but not sure if correct.)

~This is an embarassingly early draft pull request. But I'm opening it to let folks see where I'm at with auth (#714) & profile API (#708) additions that will be used by payment pages (epic #695) and RPs (epic #706).~

I'm of course also new to all these bits of the stack, so any & all advice & critique are gratefully welcomed 😅 
