### PR TITLE
feat(broker): define the event abstraction

### DIFF
--- a/packages/fxa-event-broker/src/types.rs
+++ b/packages/fxa-event-broker/src/types.rs
@@ -12,4 +12,5 @@ pub mod macros;
 pub mod aws;
 pub mod env;
 pub mod error;
+pub mod event;
 pub mod validate;

--- a/packages/fxa-event-broker/src/types/event.rs
+++ b/packages/fxa-event-broker/src/types/event.rs
@@ -1,0 +1,145 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Event types.
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+#[cfg(test)]
+mod test;
+
+/// SNS wrapper around events,
+/// to be discarded.
+#[derive(Debug, Deserialize)]
+pub struct Envelope {
+    /// JSON-serialised event body.
+    #[serde(alias = "Message")]
+    pub message: String,
+}
+
+/// The main event structure,
+/// as defined by the
+/// [FxA Attached Service Notifications spec][spec].
+///
+/// Contains only a subset of all the available properties,
+/// partly to restrict the data we send out
+/// but also to prevent confusion about
+/// the different timestamp names/formats.
+///
+/// [spec]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/docs/service_notifications.md
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Event {
+    /// Event type.
+    pub event: String,
+
+    /// Event timestamp, in epoch-seconds.
+    #[serde(alias = "ts")]
+    pub timestamp: Timestamp,
+
+    /// Event origin domain.
+    #[serde(alias = "iss")]
+    pub issuer: String,
+
+    /// User id.
+    #[serde(alias = "uid", skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+
+    /// User's primary email address.
+    #[serde(alias = "email", skip_serializing_if = "Option::is_none")]
+    pub email_address: Option<String>,
+
+    /// User's locale.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
+
+    /// Flag indicating whether the user has opted in to marketing emails.
+    #[serde(alias = "marketingOptIn", skip_serializing_if = "Option::is_none")]
+    pub marketing_opt_in: Option<bool>,
+
+    /// Service name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service: Option<String>,
+
+    /// Metrics metadata.
+    #[serde(
+        alias = "metricsContext",
+        skip_serializing_if = "MetricsContext::is_empty"
+    )]
+    pub metrics_context: MetricsContext,
+}
+
+/// Conversion type that marshals
+/// floating-point epoch-seconds to epoch-milliseconds.
+#[derive(Debug, PartialEq, Serialize)]
+pub struct Timestamp(u64);
+
+impl<'d> Deserialize<'d> for Timestamp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'d>,
+    {
+        let value: f64 = Deserialize::deserialize(deserializer)?;
+        return Ok(Self((value * 1000.0) as u64));
+    }
+}
+
+impl PartialEq<u64> for Timestamp {
+    fn eq(&self, rhs: &u64) -> bool {
+        self.0 == *rhs
+    }
+}
+
+/// Metrics metadata.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct MetricsContext {
+    /// Metrics device id, which is a different thing to the FxA device id.
+    #[serde(alias = "deviceId", skip_serializing_if = "Option::is_none")]
+    pub device_id: Option<String>,
+
+    /// Entrypoint to the flow.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entrypoint: Option<String>,
+
+    /// FxA flow id.
+    #[serde(alias = "flowId", skip_serializing_if = "Option::is_none")]
+    pub flow_id: Option<String>,
+
+    /// Timestamp for the beginning of the flow, in epoch-milliseconds.
+    #[serde(alias = "flowBeginTime", skip_serializing_if = "Option::is_none")]
+    pub flow_begin_time: Option<u64>,
+
+    /// Marketing campaign id.
+    #[serde(alias = "utmCampaign", skip_serializing_if = "Option::is_none")]
+    pub utm_campaign: Option<String>,
+
+    /// Marketing content id.
+    #[serde(alias = "utmContent", skip_serializing_if = "Option::is_none")]
+    pub utm_content: Option<String>,
+
+    /// Marketing medium.
+    #[serde(alias = "utmMedium", skip_serializing_if = "Option::is_none")]
+    pub utm_medium: Option<String>,
+
+    /// Traffic source.
+    #[serde(alias = "utmSource", skip_serializing_if = "Option::is_none")]
+    pub utm_source: Option<String>,
+
+    /// Search term.
+    #[serde(alias = "utmTerm", skip_serializing_if = "Option::is_none")]
+    pub utm_term: Option<String>,
+}
+
+impl MetricsContext {
+    pub fn is_empty(&self) -> bool {
+        self.device_id.is_none()
+            && self.entrypoint.is_none()
+            && self.flow_id.is_none()
+            && self.flow_begin_time.is_none()
+            && self.utm_campaign.is_none()
+            && self.utm_content.is_none()
+            && self.utm_medium.is_none()
+            && self.utm_source.is_none()
+            && self.utm_term.is_none()
+    }
+}

--- a/packages/fxa-event-broker/src/types/event/test-fixture.json
+++ b/packages/fxa-event-broker/src/types/event/test-fixture.json
@@ -1,0 +1,9 @@
+[
+  {
+    "wibble": "blee",
+    "Message": "{\"wibble\":\"blee\",\"event\":\"foo.bar\",\"ts\":1555076067.0,\"iss\":\"api.accounts.firefox.com\",\"uid\":\"deadbeef\",\"email\":\"fxa@example.com\",\"locale\":\"en-GB\",\"marketingOptIn\":true,\"service\":\"baadf00d\",\"metricsContext\":{\"wibble\":\"blee\",\"deviceId\":\"a\",\"entrypoint\":\"b\",\"flowId\":\"c\",\"flowBeginTime\":1555076910685,\"utmCampaign\":\"d\",\"utmContent\":\"e\",\"utmMedium\":\"f\",\"utmSource\":\"g\",\"utmTerm\":\"h\"}}"
+  },
+  {
+    "Message": "{\"event\":\"baz.qux\",\"ts\":1555077255.999,\"iss\":\"example.com\",\"metricsContext\":{}}"
+  }
+]

--- a/packages/fxa-event-broker/src/types/event/test.rs
+++ b/packages/fxa-event-broker/src/types/event/test.rs
@@ -1,0 +1,100 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+use serde_json::{self, Error, Value as JsonValue};
+
+use super::*;
+
+#[test]
+fn deserialize_events() -> Result<(), Error> {
+    let json = include_str!("test-fixture.json");
+    let envelopes: Vec<Envelope> = serde_json::from_str(json)?;
+
+    assert_eq!(envelopes.len(), 2);
+
+    let event: Event = serde_json::from_str(&envelopes[0].message)?;
+
+    assert_eq!(event.event, "foo.bar");
+    assert_eq!(event.timestamp, 1555076067000);
+    assert_eq!(event.issuer, "api.accounts.firefox.com");
+    assert_eq!(event.user_id.unwrap(), "deadbeef");
+    assert_eq!(event.email_address.unwrap(), "fxa@example.com");
+    assert_eq!(event.locale.unwrap(), "en-GB");
+    assert_eq!(event.marketing_opt_in.unwrap(), true);
+    assert_eq!(event.service.unwrap(), "baadf00d");
+    assert_eq!(event.metrics_context.device_id.unwrap(), "a");
+    assert_eq!(event.metrics_context.entrypoint.unwrap(), "b");
+    assert_eq!(event.metrics_context.flow_id.unwrap(), "c");
+    assert_eq!(
+        event.metrics_context.flow_begin_time.unwrap(),
+        1555076910685
+    );
+    assert_eq!(event.metrics_context.utm_campaign.unwrap(), "d");
+    assert_eq!(event.metrics_context.utm_content.unwrap(), "e");
+    assert_eq!(event.metrics_context.utm_medium.unwrap(), "f");
+    assert_eq!(event.metrics_context.utm_source.unwrap(), "g");
+    assert_eq!(event.metrics_context.utm_term.unwrap(), "h");
+
+    let event: Event = serde_json::from_str(&envelopes[1].message)?;
+
+    assert_eq!(event.event, "baz.qux");
+    assert_eq!(event.timestamp, 1555077255999);
+    assert_eq!(event.issuer, "example.com");
+    assert!(event.user_id.is_none());
+    assert!(event.email_address.is_none());
+    assert!(event.locale.is_none());
+    assert!(event.marketing_opt_in.is_none());
+    assert!(event.service.is_none());
+    assert!(event.metrics_context.device_id.is_none());
+    assert!(event.metrics_context.entrypoint.is_none());
+    assert!(event.metrics_context.flow_id.is_none());
+    assert!(event.metrics_context.flow_begin_time.is_none());
+    assert!(event.metrics_context.utm_campaign.is_none());
+    assert!(event.metrics_context.utm_content.is_none());
+    assert!(event.metrics_context.utm_medium.is_none());
+    assert!(event.metrics_context.utm_source.is_none());
+    assert!(event.metrics_context.utm_term.is_none());
+
+    Ok(())
+}
+
+#[test]
+fn serialize_event() -> Result<(), Error> {
+    let json = include_str!("test-fixture.json");
+    let envelopes: Vec<Envelope> = serde_json::from_str(json)?;
+    let event: Event = serde_json::from_str(&envelopes[0].message)?;
+    let json = serde_json::to_string(&event)?;
+    let event: JsonValue = serde_json::from_str(&json)?;
+
+    assert_eq!(event["event"], "foo.bar");
+    assert_eq!(event["timestamp"], 1555076067000u64);
+    assert_eq!(event["issuer"], "api.accounts.firefox.com");
+    assert_eq!(event["user_id"], "deadbeef");
+    assert_eq!(event["email_address"], "fxa@example.com");
+    assert_eq!(event["locale"], "en-GB");
+    assert_eq!(event["marketing_opt_in"], true);
+    assert_eq!(event["service"], "baadf00d");
+    assert_eq!(event["metrics_context"]["device_id"], "a");
+    assert_eq!(event["metrics_context"]["entrypoint"], "b");
+    assert_eq!(event["metrics_context"]["flow_id"], "c");
+    assert_eq!(
+        event["metrics_context"]["flow_begin_time"],
+        1555076910685u64
+    );
+    assert_eq!(event["metrics_context"]["utm_campaign"], "d");
+    assert_eq!(event["metrics_context"]["utm_content"], "e");
+    assert_eq!(event["metrics_context"]["utm_medium"], "f");
+    assert_eq!(event["metrics_context"]["utm_source"], "g");
+    assert_eq!(event["metrics_context"]["utm_term"], "h");
+
+    let event: Event = serde_json::from_str(&envelopes[1].message)?;
+    let json = serde_json::to_string(&event)?;
+
+    assert_eq!(
+        json,
+        "{\"event\":\"baz.qux\",\"timestamp\":1555077255999,\"issuer\":\"example.com\"}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Because the event-broker work is off the agenda for train 136, I'm tidying up my in-progress loose ends so they can be reviewed and landed while they're fresh in mind. Otherwise they'll just be confusing local branches when I come back to them for train 137. This was the start of my branch for #682, containing definitions and tests for the event type that will arrive on the incoming queue.

It contains a useful subset of the available properties, partly for need-to-know reasons but also because the different timestamps available on some of the events would likely be confusing if we propagate them all to reliers.

For instance, the [`device:create` event](https://github.com/mozilla/fxa-auth-server/blob/master/docs/service_notifications.md#device-connection-event) contains it's own `timestamp` property that is set to the `createdAt` property from the db. That value is in integer milliseconds, but the main `ts` property on all events is in floating point seconds, and the two would only be milliseconds apart in this case. Let's stick to one consistent property everywhere and eliminate the possibility of confusion in the future.

@mozilla/fxa-devs r?