### PR TITLE
refactor(broker): pull string_type! macro out to the types directory

### DIFF
--- a/packages/fxa-event-broker/Cargo.lock
+++ b/packages/fxa-event-broker/Cargo.lock
@@ -432,6 +432,7 @@ dependencies = [
  "rusoto_sqs 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sentry 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/packages/fxa-event-broker/Cargo.toml
+++ b/packages/fxa-event-broker/Cargo.toml
@@ -19,3 +19,4 @@ rusoto_credential = ">=0.16.0"
 rusoto_sqs = ">=0.37.0"
 sentry = ">=0.15.2"
 serde = { version = ">=1.0.90", features = ["derive"] }
+serde_json = ">=1.0.39"

--- a/packages/fxa-event-broker/src/settings/test.rs
+++ b/packages/fxa-event-broker/src/settings/test.rs
@@ -24,13 +24,13 @@ fn env_vars_take_precedence() {
         Ok(settings) => {
             let aws_keys = if let Some(ref keys) = settings.aws.keys {
                 AwsKeys {
-                    access: AwsAccess(format!("{}A", keys.access)),
-                    secret: AwsSecret(format!("{}s", keys.secret)),
+                    access: AccessKey(format!("{}A", keys.access)),
+                    secret: SecretKey(format!("{}s", keys.secret)),
                 }
             } else {
                 AwsKeys {
-                    access: AwsAccess(String::from("A")),
-                    secret: AwsSecret(String::from("s")),
+                    access: AccessKey(String::from("A")),
+                    secret: SecretKey(String::from("s")),
                 }
             };
             let aws_region = if settings.aws.region.0 == "us-east-1" {
@@ -66,7 +66,7 @@ fn env_vars_take_precedence() {
 
             match Settings::new() {
                 Ok(env_settings) => {
-                    assert_eq!(env_settings.aws.region, AwsRegion(aws_region.to_string()));
+                    assert_eq!(env_settings.aws.region, Region(aws_region.to_string()));
 
                     if let Some(env_keys) = env_settings.aws.keys {
                         assert_eq!(env_keys.access, aws_keys.access);

--- a/packages/fxa-event-broker/src/types.rs
+++ b/packages/fxa-event-broker/src/types.rs
@@ -6,71 +6,10 @@
 //! for modules that implement
 //! miscellaneous generally-used types.
 
-macro_rules! enum_boilerplate {
-    ($name:ident ($description:expr, $default:ident, $error:ident) {
-        $($variant:ident => $serialization:expr,)+
-    }) => {
-        #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-        pub enum $name {
-            $($variant,
-            )+
-        }
+#[macro_use]
+pub mod macros;
 
-        impl AsRef<str> for $name {
-            fn as_ref(&self) -> &str {
-                match *self {
-                    $($name::$variant => $serialization,
-                    )+
-                }
-            }
-        }
-
-        impl std::default::Default for $name {
-            fn default() -> Self {
-                $name::$default
-            }
-        }
-
-        impl std::fmt::Display for $name {
-            fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(formatter, "{}", self.as_ref())
-            }
-        }
-
-        impl<'d> serde::de::Deserialize<'d> for $name {
-            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where
-                D: serde::de::Deserializer<'d>,
-            {
-                let value: String = serde::de::Deserialize::deserialize(deserializer)?;
-                std::convert::TryFrom::try_from(value.as_str())
-                    .map_err(|_| D::Error::invalid_value(serde::de::Unexpected::Str(&value), &$description))
-            }
-        }
-
-        impl serde::ser::Serialize for $name {
-            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-            where
-                S: serde::ser::Serializer,
-            {
-                serializer.serialize_str(self.as_ref())
-            }
-        }
-
-        impl<'v> std::convert::TryFrom<&'v str> for $name {
-            type Error = AppError;
-
-            fn try_from(value: &str) -> Result<Self, Self::Error> {
-                match value {
-                    $($serialization => Ok($name::$variant),
-                    )+
-                    _ => Err(AppErrorKind::$error(value.to_owned()))?,
-                }
-            }
-        }
-    }
-}
-
+pub mod aws;
 pub mod env;
 pub mod error;
 pub mod validate;

--- a/packages/fxa-event-broker/src/types/aws.rs
+++ b/packages/fxa-event-broker/src/types/aws.rs
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! AWS-related types.
+
+#[cfg(test)]
+mod test;
+
+use serde::{de::Error, Serialize};
+
+string_types! {
+    /// AWS region.
+    Region (aws_region, "AWS region", InvalidAwsRegion),
+
+    /// AWS access key.
+    AccessKey (aws_access_key, "AWS access key", InvalidAwsAccessKey),
+
+    /// AWS secret key.
+    SecretKey (aws_secret_key, "AWS secret key", InvalidAwsSecretKey),
+
+    /// SQS URL.
+    SqsUrl (sqs_url, "SQS queue URL", InvalidSqsUrl),
+}

--- a/packages/fxa-event-broker/src/types/aws/test.rs
+++ b/packages/fxa-event-broker/src/types/aws/test.rs
@@ -1,0 +1,129 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::convert::TryFrom;
+
+use serde_json::{self, Error as JsonError};
+
+use super::*;
+use crate::types::error::AppResult;
+
+#[test]
+fn region_try_from() -> AppResult<()> {
+    let region: Region = TryFrom::try_from("us-east-1")?;
+    assert_eq!(region.as_ref(), "us-east-1");
+
+    let result: AppResult<Region> = TryFrom::try_from("us-east-7");
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Invalid AWS region: us-east-7"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn region_serialize_deserialize() -> Result<(), JsonError> {
+    let region = Region("eu-west-1".to_owned());
+    let serialized = serde_json::to_string(&region)?;
+    assert_eq!(serialized, "\"eu-west-1\"");
+
+    let region: Region = serde_json::from_str(&serialized)?;
+    assert_eq!(region.as_ref(), "eu-west-1");
+
+    Ok(())
+}
+
+#[test]
+fn access_key_try_from() -> AppResult<()> {
+    let access_key: AccessKey = TryFrom::try_from("0123456789ABCDEF")?;
+    assert_eq!(access_key.as_ref(), "0123456789ABCDEF");
+
+    let result: AppResult<AccessKey> = TryFrom::try_from("0123456789 ABCDEF");
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Invalid AWS access key: 0123456789 ABCDEF"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn access_key_serialize_deserialize() -> Result<(), JsonError> {
+    let access_key = AccessKey("ABC".to_owned());
+    let serialized = serde_json::to_string(&access_key)?;
+    assert_eq!(serialized, "\"ABC\"");
+
+    let access_key: AccessKey = serde_json::from_str(&serialized)?;
+    assert_eq!(access_key.as_ref(), "ABC");
+
+    Ok(())
+}
+
+#[test]
+fn secret_key_try_from() -> AppResult<()> {
+    let secret_key: SecretKey = TryFrom::try_from("0123456789ABCabc+/=")?;
+    assert_eq!(secret_key.as_ref(), "0123456789ABCabc+/=");
+
+    let result: AppResult<SecretKey> = TryFrom::try_from("0123456789_ABC");
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Invalid AWS secret key: 0123456789_ABC"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn secret_key_serialize_deserialize() -> Result<(), JsonError> {
+    let secret_key = SecretKey("+/=".to_owned());
+    let serialized = serde_json::to_string(&secret_key)?;
+    assert_eq!(serialized, "\"+/=\"");
+
+    let secret_key: SecretKey = serde_json::from_str(&serialized)?;
+    assert_eq!(secret_key.as_ref(), "+/=");
+
+    Ok(())
+}
+
+#[test]
+fn sqs_url_try_from() -> AppResult<()> {
+    let sqs_url: SqsUrl =
+        TryFrom::try_from("https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue")?;
+    assert_eq!(
+        sqs_url.as_ref(),
+        "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue"
+    );
+
+    let result: AppResult<SqsUrl> =
+        TryFrom::try_from("http://sqs.us-east-1.amazonaws.com/123456789012/MyQueue");
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Invalid SQS URL: http://sqs.us-east-1.amazonaws.com/123456789012/MyQueue"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn sqs_url_serialize_deserialize() -> Result<(), JsonError> {
+    let sqs_url = SqsUrl("https://sqs.us-west-2.amazonaws.com/42/wibble".to_owned());
+    let serialized = serde_json::to_string(&sqs_url)?;
+    assert_eq!(
+        serialized,
+        "\"https://sqs.us-west-2.amazonaws.com/42/wibble\""
+    );
+
+    let sqs_url: SqsUrl = serde_json::from_str(&serialized)?;
+    assert_eq!(
+        sqs_url.as_ref(),
+        "https://sqs.us-west-2.amazonaws.com/42/wibble"
+    );
+
+    Ok(())
+}

--- a/packages/fxa-event-broker/src/types/env.rs
+++ b/packages/fxa-event-broker/src/types/env.rs
@@ -9,11 +9,11 @@ mod test;
 
 use serde::de::Error;
 
-use crate::types::error::{AppError, AppErrorKind};
-
-enum_boilerplate!(Env ("env", Dev, InvalidEnv) {
-    // These values are consistent with the conventions followed by other FxA repos.
-    Dev => "dev",
-    Prod => "production",
-    Test => "test",
-});
+enum_type! {
+    /// Environment enumerated type.
+    Env ("environment", Dev, InvalidEnv) {
+      Dev => "dev",
+      Prod => "production",
+      Test => "test",
+  }
+}

--- a/packages/fxa-event-broker/src/types/env/test.rs
+++ b/packages/fxa-event-broker/src/types/env/test.rs
@@ -4,22 +4,39 @@
 
 use std::convert::TryFrom;
 
+use serde_json::{self, Error as JsonError};
+
 use super::*;
+use crate::types::error::AppResult;
 
 #[test]
-fn try_from() {
-    let result: Result<Env, AppError> = TryFrom::try_from("dev");
-    assert!(result.is_ok());
+fn try_from() -> AppResult<()> {
+    let env: Env = TryFrom::try_from("dev")?;
+    assert_eq!(env, Env::Dev);
 
-    let result: Result<Env, AppError> = TryFrom::try_from("production");
-    assert!(result.is_ok());
+    let env: Env = TryFrom::try_from("production")?;
+    assert_eq!(env, Env::Prod);
 
-    let result: Result<Env, AppError> = TryFrom::try_from("test");
-    assert!(result.is_ok());
+    let env: Env = TryFrom::try_from("test")?;
+    assert_eq!(env, Env::Test);
 
-    let result: Result<Env, AppError> = TryFrom::try_from("prod");
+    let result: AppResult<Env> = TryFrom::try_from("prod");
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().to_string(), "Invalid environment: prod");
+
+    Ok(())
+}
+
+#[test]
+fn serialize_deserialize() -> Result<(), JsonError> {
+    let env = Env::Prod;
+    let serialized = serde_json::to_string(&env)?;
+    assert_eq!(serialized, "\"production\"");
+
+    let env: Env = serde_json::from_str(&serialized)?;
+    assert_eq!(env, Env::Prod);
+
+    Ok(())
 }
 
 #[test]

--- a/packages/fxa-event-broker/src/types/error.rs
+++ b/packages/fxa-event-broker/src/types/error.rs
@@ -97,6 +97,18 @@ pub enum AppErrorKind {
 
     #[fail(display = "Invalid environment: {}", _0)]
     InvalidEnv(String),
+
+    #[fail(display = "Invalid AWS region: {}", _0)]
+    InvalidAwsRegion(String),
+
+    #[fail(display = "Invalid AWS access key: {}", _0)]
+    InvalidAwsAccessKey(String),
+
+    #[fail(display = "Invalid AWS secret key: {}", _0)]
+    InvalidAwsSecretKey(String),
+
+    #[fail(display = "Invalid SQS URL: {}", _0)]
+    InvalidSqsUrl(String),
 }
 
 impl AppErrorKind {
@@ -105,7 +117,11 @@ impl AppErrorKind {
             AppErrorKind::NotImplemented(_) => Some(100),
             AppErrorKind::QueueError(_) => Some(101),
             AppErrorKind::InvalidEvent(_) => Some(102),
-            AppErrorKind::InvalidEnv { .. } => Some(103),
+            AppErrorKind::InvalidEnv(_) => Some(103),
+            AppErrorKind::InvalidAwsRegion(_) => Some(104),
+            AppErrorKind::InvalidAwsAccessKey(_) => Some(105),
+            AppErrorKind::InvalidAwsSecretKey(_) => Some(106),
+            AppErrorKind::InvalidSqsUrl(_) => Some(107),
         }
     }
 }

--- a/packages/fxa-event-broker/src/types/macros.rs
+++ b/packages/fxa-event-broker/src/types/macros.rs
@@ -1,0 +1,132 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Type definition macros.
+
+/// Defines an `enum`,
+/// with implementations for
+/// `AsRef<str>`, `Default`, `Deserialize`, `Display`, `Serialize` and `TryFrom`.
+macro_rules! enum_type {
+    (#[$docs:meta] $type:ident ($description:expr, $default:ident, $error:ident) {
+        $($variant:ident => $serialization:expr,)+
+    }) => {
+        #[$docs]
+        #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+        pub enum $type {
+            $($variant,
+            )+
+        }
+
+        impl AsRef<str> for $type {
+            fn as_ref(&self) -> &str {
+                match *self {
+                    $($type::$variant => $serialization,
+                    )+
+                }
+            }
+        }
+
+        impl std::default::Default for $type {
+            fn default() -> Self {
+                $type::$default
+            }
+        }
+
+        impl<'d> serde::de::Deserialize<'d> for $type {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::de::Deserializer<'d>,
+            {
+                let value: String = serde::de::Deserialize::deserialize(deserializer)?;
+                std::convert::TryFrom::try_from(value.as_str())
+                    .map_err(|_| D::Error::invalid_value(serde::de::Unexpected::Str(&value), &$description))
+            }
+        }
+
+        impl std::fmt::Display for $type {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str(self.as_ref())
+            }
+        }
+
+        impl serde::ser::Serialize for $type {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::ser::Serializer,
+            {
+                serializer.serialize_str(self.as_ref())
+            }
+        }
+
+        impl<'v> std::convert::TryFrom<&'v str> for $type {
+            type Error = crate::types::error::AppError;
+
+            fn try_from(value: &str) -> Result<Self, Self::Error> {
+                match value {
+                    $($serialization => Ok($type::$variant),
+                    )+
+                    _ => Err(crate::types::error::AppErrorKind::$error(value.to_owned()))?,
+                }
+            }
+        }
+    }
+}
+
+/// Defines a newtype `String` wrapper,
+/// with implementations for
+/// `AsRef<str>`, `Deserialize`, `Display` and `TryFrom`.
+macro_rules! string_type {
+    (#[$docs:meta] $type:ident ($validator:ident, $description:expr, $error:ident)) => {
+        #[$docs]
+        #[derive(Clone, Debug, Default, Eq, Hash, Serialize, PartialEq)]
+        pub struct $type(pub String);
+
+        impl AsRef<str> for $type {
+            fn as_ref(&self) -> &str {
+                self.0.as_str()
+            }
+        }
+
+        impl<'d> serde::de::Deserialize<'d> for $type {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::de::Deserializer<'d>,
+            {
+                let value: String = serde::de::Deserialize::deserialize(deserializer)?;
+                //let expected = $description;
+                std::convert::TryFrom::try_from(value.as_str()).map_err(|_| {
+                    D::Error::invalid_value(serde::de::Unexpected::Str(&value), &$description)
+                })
+            }
+        }
+
+        impl std::fmt::Display for $type {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str(self.as_ref())
+            }
+        }
+
+        impl<'v> std::convert::TryFrom<&'v str> for $type {
+            type Error = crate::types::error::AppError;
+
+            fn try_from(value: &str) -> Result<Self, Self::Error> {
+                if crate::types::validate::$validator(value) {
+                    Ok($type(value.to_owned()))
+                } else {
+                    Err(crate::types::error::AppErrorKind::$error(value.to_owned()))?
+                }
+            }
+        }
+    };
+}
+
+/// Aggregates multiple `string_type!` invocations.
+macro_rules! string_types {
+    ($(#[$docs:meta] $type:ident ($validator:ident, $description:expr, $error:ident),)+) => ($(
+        string_type! {
+            #[$docs]
+            $type ($validator, $description, $error)
+        }
+    )+)
+}

--- a/packages/fxa-event-broker/src/types/validate.rs
+++ b/packages/fxa-event-broker/src/types/validate.rs
@@ -33,12 +33,12 @@ pub fn aws_region(value: &str) -> bool {
 }
 
 /// Validate an AWS access key.
-pub fn aws_access(value: &str) -> bool {
+pub fn aws_access_key(value: &str) -> bool {
     AWS_ACCESS_FORMAT.is_match(value)
 }
 
 /// Validate an AWS secret key.
-pub fn aws_secret(value: &str) -> bool {
+pub fn aws_secret_key(value: &str) -> bool {
     AWS_SECRET_FORMAT.is_match(value)
 }
 

--- a/packages/fxa-event-broker/src/types/validate/test.rs
+++ b/packages/fxa-event-broker/src/types/validate/test.rs
@@ -27,34 +27,36 @@ fn invalid_aws_region() {
 
 #[test]
 fn aws_access() {
-    assert!(validate::aws_access("A0"));
-    assert!(validate::aws_access("Z9"));
-    assert!(validate::aws_access("ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"));
+    assert!(validate::aws_access_key("A0"));
+    assert!(validate::aws_access_key("Z9"));
+    assert!(validate::aws_access_key(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    ));
 }
 
 #[test]
 fn invalid_aws_access() {
-    assert_eq!(validate::aws_access("a0"), false);
-    assert_eq!(validate::aws_access("z9"), false);
-    assert_eq!(validate::aws_access("A0 "), false);
-    assert_eq!(validate::aws_access(" Z9"), false);
-    assert_eq!(validate::aws_access("A+"), false);
-    assert_eq!(validate::aws_access("Z/"), false);
-    assert_eq!(validate::aws_access("A="), false);
+    assert_eq!(validate::aws_access_key("a0"), false);
+    assert_eq!(validate::aws_access_key("z9"), false);
+    assert_eq!(validate::aws_access_key("A0 "), false);
+    assert_eq!(validate::aws_access_key(" Z9"), false);
+    assert_eq!(validate::aws_access_key("A+"), false);
+    assert_eq!(validate::aws_access_key("Z/"), false);
+    assert_eq!(validate::aws_access_key("A="), false);
 }
 
 #[test]
 fn aws_secret() {
-    assert!(validate::aws_secret("09"));
-    assert!(validate::aws_secret("AZ"));
-    assert!(validate::aws_secret("az"));
-    assert!(validate::aws_secret("09AZaz+/=="));
+    assert!(validate::aws_secret_key("09"));
+    assert!(validate::aws_secret_key("AZ"));
+    assert!(validate::aws_secret_key("az"));
+    assert!(validate::aws_secret_key("09AZaz+/=="));
 }
 
 #[test]
 fn invalid_aws_secret() {
-    assert_eq!(validate::aws_secret("AZ "), false);
-    assert_eq!(validate::aws_secret(" az"), false);
+    assert_eq!(validate::aws_secret_key("AZ "), false);
+    assert_eq!(validate::aws_secret_key(" az"), false);
 }
 
 #[test]


### PR DESCRIPTION
The motivation for this refactoring was that I wanted to use the `SqsUrl` type from `settings/` more generally, so it needed to move to the `types/` directory.

Along with it came the `string_type!` macro, previously called `settings_strings!`, and the other types that were being defined with it. Then, to make the type macros more uniform, I renamed `enum_boilerplate!` to `enum_type!` and put both of them inside a new `types/macros` module.

So no functionality has been changed or added, just moved about and some extra tests have been written.

@mozilla/fxa-devs r?