### PR TITLE
fix(events): Include issuer in all service notification events.

### DIFF
--- a/packages/fxa-auth-server/docs/service_notifications.md
+++ b/packages/fxa-auth-server/docs/service_notifications.md
@@ -43,6 +43,7 @@ All notifications will include the following properties
 in their JSON body object:
 
 * `event`: A string identifier for the type of event that occurred.
+* `iss`: The API server that issued the event ("api.accounts.firefox.com" in production environments)
 * `ts`: Integer timestamp when the event occurred, in seconds.
 * `metricsContext`: optional object containing metrics parameters such as
   `utm_campaign` and `utm_source`.
@@ -95,7 +96,6 @@ Message Properties:
 
 * `event`: The string "delete"
 * `uid`: The userid of the account being deleted
-* `iss`: The API server that issued the event ("api.accounts.firefox.com" in production environments)
 
 Services receiving this event
 should delete any data
@@ -104,7 +104,7 @@ taking particular care to purge
 any PII such as email address.
 
 Since the `uid` is an opaque identifier with no PII,
-esrvices *may* keep the account uid
+services *may* keep the account uid
 after deleting the user's data
 if that simplifies their internal implementation.
 
@@ -115,7 +115,6 @@ Message Properties:
 
 * `event`: The string "reset".
 * `uid`: The userid of the account that was reset.
-* `iss`: The API server that issued the event ("api.accounts.firefox.com" in production environments)
 * `generation`: A monotonically increasing integer for de-duping events (ok ok, it's a timestamp).
 
 Services receiving this event should
@@ -141,7 +140,6 @@ Message Properties:
 
 * `event`: The string "passwordChange".
 * `uid`: The userid of the account that had its password changed.
-* `iss`: The API server that issued the event ("api.accounts.firefox.com" in production environments)
 * `generation`: A monotonically increasing integer for de-duping events (ok ok, it's a timestamp).
 
 As with the "reset" event above,

--- a/packages/fxa-auth-server/lib/log.js
+++ b/packages/fxa-auth-server/lib/log.js
@@ -10,6 +10,7 @@ const mozlog = require('mozlog');
 const config = require('../config');
 const logConfig = config.get('log');
 
+const ISSUER = config.get('domain') || '';
 const CLIENT_ID_TO_SERVICE_NAMES = config.get('oauth.clientIds') || {};
 
 function Lug(options) {
@@ -133,6 +134,9 @@ Lug.prototype.notifyAttachedServices = function (name, request, data) {
         // Add a timestamp that this event occurred to help attached services resolve any
         // potential timing issues
         data.ts = data.ts || Date.now() / 1000; // Convert to float seconds
+
+        // Tag all events with the issuing service.
+        data.iss = ISSUER;
 
         // convert an oauth client-id to a human readable format, if a name is available.
         // If no name is available, continue to use the client_id.

--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -1021,7 +1021,6 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push,
                 }),
                 log.notifyAttachedServices('reset', request, {
                   uid: account.uid,
-                  iss: config.domain,
                   generation: account.verifierSetAt
                 }),
                 customs.reset(account.email)
@@ -1248,7 +1247,6 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push,
                 return P.all([
                   log.notifyAttachedServices('delete', request, {
                     uid,
-                    iss: config.domain
                   }),
                   request.emitMetricsEvent('account.deleted', {uid})
                 ]);

--- a/packages/fxa-auth-server/lib/routes/password.js
+++ b/packages/fxa-auth-server/lib/routes/password.js
@@ -275,7 +275,6 @@ module.exports = function (
 
                 log.notifyAttachedServices('passwordChange', request, {
                   uid: passwordChangeToken.uid,
-                  iss: config.domain,
                   generation: account.verifierSetAt
                 });
                 return db.accountEmails(passwordChangeToken.uid);

--- a/packages/fxa-auth-server/test/local/log.js
+++ b/packages/fxa-auth-server/test/local/log.js
@@ -30,6 +30,8 @@ describe('log', () => {
               return {
                 fmt: 'mozlog'
               };
+            case 'domain':
+              return 'example.com';
             case 'oauth.clientIds':
               return {
                 clientid: 'human readable name'
@@ -628,6 +630,7 @@ describe('log', () => {
         data: {
           service: 'human readable name',
           ts: now,
+          iss: 'example.com',
           metricsContext: {
             time: now,
             entrypoint: 'wibble',
@@ -679,6 +682,7 @@ describe('log', () => {
         data: {
           service: 'unknown-clientid',
           ts: now,
+          iss: 'example.com',
           metricsContext: {
             time: now,
             entrypoint: 'wibble',
@@ -730,6 +734,7 @@ describe('log', () => {
         data: {
           service: 'sync',
           ts: now,
+          iss: 'example.com',
           metricsContext: {
             time: now,
             entrypoint: 'wibble',

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -1653,7 +1653,6 @@ describe('/account/destroy', () => {
       assert.equal(args[0], 'delete', 'first argument was event name');
       assert.equal(args[1], mockRequest, 'second argument was request object');
       assert.equal(args[2].uid, uid, 'third argument was event data with a uid');
-      assert.equal(args[2].iss, 'wibble', 'third argument was event data with an issuer field');
 
       assert.equal(mockLog.activityEvent.callCount, 1, 'log.activityEvent was called once');
       args = mockLog.activityEvent.args[0];

--- a/packages/fxa-auth-server/test/local/routes/password.js
+++ b/packages/fxa-auth-server/test/local/routes/password.js
@@ -423,7 +423,6 @@ describe('/password', () => {
           assert.equal(notifyArgs[0], 'passwordChange', 'first argument was event name');
           assert.equal(notifyArgs[1], mockRequest, 'second argument was request object');
           assert.equal(notifyArgs[2].uid, uid, 'third argument was event data with a uid');
-          assert.equal(notifyArgs[2].iss, 'wibble', 'third argument was event data with an issuer field');
 
           assert.equal(mockDB.account.callCount, 1);
           assert.equal(mockMailer.sendPasswordChangedNotification.callCount, 1);


### PR DESCRIPTION
As noted in [Bug 1533257](https://bugzilla.mozilla.org/show_bug.cgi?id=1533257), some of the service notification events sent by FxA contain an "iss" field while others do not. The logic behind which do and which do not is highly inscrutable - basically it's "only the events that sync tokenserver cares about have an issuer field".

Since it seems valuable to be able to sanity-check the issuer for any type of event, I suggest we just include it by default in all of them.

An alternative could be to remove it from all of them, and have the downstream consumer infer this information from the SQS queue that it's pulling events out of.  This assumes that we never have multiple issuers of such events writing into a single SQS queue, which is probably the case but would require double-checking.