### PR TITLE
fix(ci): prevent the docs step from failing private builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,12 +258,8 @@ jobs:
           fingerprints:
             - "08:fc:2b:fb:06:0e:8f:0f:01:1f:28:86:83:89:11:28"
       - run: |
-          # From https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
-          # CIRCLE_PR_REPONAME - The name of the GitHub or Bitbucket repository where the pull request was created.
-          # Only available on forked PRs.
-          # We only want gh-ph pages to be generated on PRs opened
-          # on the mozilla/fxa repo
-          if [ -z "$CIRCLE_PR_REPONAME" ]; then
+          # Docs won't build on forks or the private repo because they don't have the deploy key.
+          if [ "$CIRCLE_PR_REPONAME" = "" ] && [ "$CIRCLE_REPOSITORY_URL" = "git@github.com:mozilla/fxa.git" ]; then
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             . .circleci/install-rust.sh
             ./_scripts/gh-pages.sh


### PR DESCRIPTION
#829 fixed the build on forks but broke it on the private repo. This tweak works in both places.

Example private build:

https://circleci.com/workflow-run/96bd4ef9-8839-4b3d-8f2f-e9f0fbd77858

Example fork build:

https://circleci.com/workflow-run/5c76de03-92ed-4132-b59b-570ef8ecaee7

@mozilla/fxa-devs r?