### PR TITLE
fix(scripts): make build and deploy scripts work with private repo

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -18,21 +18,15 @@ if grep -e "$MODULE" -e 'all' $DIR/../packages/test.list; then
     "$DIR/../_scripts/clone-authdb.sh"
   fi
 
-  if [ "$MODULE_SUFFIX" = "" ]; then
-    MODULE_QUALIFIED="$MODULE"
-  else
-    MODULE_QUALIFIED="${MODULE}-${MODULE_SUFFIX}"
-  fi
-
   if [ "${MODULE}" == 'fxa-oauth-server' ]; then
     cp $DIR/../packages/version.json fxa-oauth-server/config
-    docker build -f Dockerfile-oauth-build -t ${MODULE_QUALIFIED}:build .
+    docker build -f Dockerfile-oauth-build -t ${MODULE}:build .
   elif [[ -e Dockerfile ]]; then
-    docker build -f Dockerfile -t ${MODULE_QUALIFIED}:build .
-    # docker run --rm -it ${MODULE_QUALIFIED}:build npm ls --production
+    docker build -f Dockerfile -t ${MODULE}:build .
+    # docker run --rm -it ${MODULE}:build npm ls --production
   elif [[ -e Dockerfile-build ]]; then
-    docker build -f Dockerfile-build -t ${MODULE_QUALIFIED}:build .
-    # docker run --rm -it ${MODULE_QUALIFIED}:build npm ls --production
+    docker build -f Dockerfile-build -t ${MODULE}:build .
+    # docker run --rm -it ${MODULE}:build npm ls --production
   fi
 
   # docker save -o "../${MODULE}.tar" ${MODULE}:build

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -16,13 +16,16 @@ if grep -e "$MODULE" -e 'all' $DIR/../packages/test.list; then
     DOCKER_TAG="$CIRCLE_TAG"
   fi
 
-  if [ "$MODULE_SUFFIX" != "" ]; then
-    MODULE="${MODULE}-${MODULE_SUFFIX}"
+  if [ "$MODULE_SUFFIX" = "" ]; then
+    MODULE_QUALIFIED="$MODULE"
+  else
+    MODULE_QUALIFIED="${MODULE}-${MODULE_SUFFIX}"
   fi
+
   REPO=$(echo ${MODULE} | sed 's/-/_/g')
   DOCKER_USER=DOCKER_USER_${REPO}
   DOCKER_PASS=DOCKER_PASS_${REPO}
-  DOCKERHUB_REPO=mozilla/${MODULE}
+  DOCKERHUB_REPO=mozilla/${MODULE_QUALIFIED}
 
   if [ -n "${DOCKER_TAG}" ] && [ -n "${!DOCKER_PASS}" ] && [ -n "${!DOCKER_USER}" ]; then
     echo "${!DOCKER_PASS}" | docker login -u "${!DOCKER_USER}" --password-stdin


### PR DESCRIPTION
Some of the changes from the last PR were unnecessary and were actually breaking the test builds, because those Dockerfiles use hard-coded names for the `:build` images. So this puts things back to how they were, just with the change to `DOCKERHUB_REPO` in `deploy.sh`.

Working build: https://circleci.com/workflow-run/ff879f78-c433-4280-ae0b-ec2579ff7347

Sorry for the messing about! 😕

@jrgm r?