### PR TITLE
feat(deps): Use the fxa-js-client that's in the repo rather than the published version.

### DIFF
--- a/packages/fxa-content-server/npm-shrinkwrap.json
+++ b/packages/fxa-content-server/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "1.134.2",
+  "version": "1.135.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5855,23 +5855,6 @@
         }
       }
     },
-    "fxa-js-client": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/fxa-js-client/-/fxa-js-client-1.0.8.tgz",
-      "integrity": "sha512-1Nq8FtlF0Xb5V/4oKmJuKLKD2nGnM4DuhWCdY5obZEIDtBUHgPb0CUf9FVLY54rHJGzfoItFqrVI+SNpY1GAdw==",
-      "requires": {
-        "es6-promise": "4.1.1",
-        "sjcl": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8e",
-        "xhr2": "0.0.7"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
-          "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
-        }
-      }
-    },
     "fxa-mustache-loader": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/fxa-mustache-loader/-/fxa-mustache-loader-0.0.2.tgz",
@@ -8322,7 +8305,7 @@
       }
     },
     "legal-docs": {
-      "version": "git://github.com/mozilla/legal-docs.git#afc8e66552560bd6f9a598c2f02a8d7e91e3b31c",
+      "version": "git://github.com/mozilla/legal-docs.git#9ecbbcc2a06cceb3ae2a277551b9f709a5bda8cd",
       "from": "git://github.com/mozilla/legal-docs.git#master"
     },
     "levn": {
@@ -11891,10 +11874,6 @@
         }
       }
     },
-    "sjcl": {
-      "version": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8ef32329bc8d7bc28a438372b5acb46616b",
-      "from": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8e"
-    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -13369,11 +13348,6 @@
         "parse-headers": "^2.0.0",
         "xtend": "^4.0.0"
       }
-    },
-    "xhr2": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.0.7.tgz",
-      "integrity": "sha1-/LYfcE6Aw6q+QkKVR5QHxgctJbM="
     },
     "xml-parse-from-string": {
       "version": "1.0.1",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -59,7 +59,6 @@
     "fxa-common-password-list": "0.0.2",
     "fxa-crypto-relier": "2.3.0",
     "fxa-geodb": "1.0.4",
-    "fxa-js-client": "1.0.8",
     "fxa-mustache-loader": "0.0.2",
     "fxa-pairing-channel": "1.0.1",
     "fxa-shared": "1.0.20",

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -15,8 +15,9 @@ const assert = intern.getPlugin('chai').assert;
 const otplib = require('otplib');
 otplib.authenticator.options = {encoding: 'hex'};
 
-
-const FxaClient = require('fxa-js-client');
+const path = require('path');
+// Use the fxa-js-client that's in the fxa repo rather than the published version.
+const FxaClient = require(path.resolve(__dirname, '..', '..', '..', '..', 'fxa-js-client'));
 const got = require('got');
 const config = intern._config;
 

--- a/packages/fxa-content-server/tests/functional/reset_password.js
+++ b/packages/fxa-content-server/tests/functional/reset_password.js
@@ -5,14 +5,11 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const nodeXMLHttpRequest = require('xmlhttprequest');
-const FxaClient = require('fxa-js-client');
 const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
 const config = intern._config;
-const AUTH_SERVER_ROOT = config.fxaAuthRoot;
 const SIGNIN_PAGE_URL = config.fxaContentRoot + 'signin';
 const RESET_PAGE_URL = config.fxaContentRoot + 'reset_password';
 const CONFIRM_PAGE_URL = config.fxaContentRoot + 'confirm_reset_password';
@@ -54,9 +51,7 @@ const createRandomHexString = TestHelpers.createRandomHexString;
 
 function ensureFxaJSClient() {
   if (! client) {
-    client = new FxaClient(AUTH_SERVER_ROOT, {
-      xhr: nodeXMLHttpRequest.XMLHttpRequest
-    });
+    client = FunctionalHelpers.getFxaClient();
   }
 }
 

--- a/packages/fxa-content-server/tests/functional/settings_common.js
+++ b/packages/fxa-content-server/tests/functional/settings_common.js
@@ -5,12 +5,9 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const nodeXMLHttpRequest = require('xmlhttprequest');
-const FxaClient = require('fxa-js-client');
 const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 var config = intern._config;
-var AUTH_SERVER_ROOT = config.fxaAuthRoot;
 var SETTINGS_URL = config.fxaContentRoot + 'settings';
 var SIGNIN_URL = config.fxaContentRoot + 'signin';
 var AUTOMATED = '&automatedBrowser=true';
@@ -66,9 +63,7 @@ var verifiedSuite = {
   beforeEach: function () {
     email = TestHelpers.createEmail();
 
-    client = new FxaClient(AUTH_SERVER_ROOT, {
-      xhr: nodeXMLHttpRequest.XMLHttpRequest
-    });
+    client = FunctionalHelpers.getFxaClient();
 
     return this.remote
       .then(clearBrowserState())

--- a/packages/fxa-content-server/webpack.config.js
+++ b/packages/fxa-content-server/webpack.config.js
@@ -61,7 +61,7 @@ const webpackConfig = {
       draggable: path.resolve(__dirname, 'node_modules/jquery-ui/ui/widgets/draggable'),
       duration: path.resolve(__dirname, 'node_modules/duration-js/duration'),
       'es6-promise': path.resolve(__dirname, 'node_modules/es6-promise/dist/es6-promise'),
-      fxaClient: 'fxa-js-client/client/FxAccountClient',
+      fxaClient: path.resolve(__dirname, '..', 'fxa-js-client/client/FxAccountClient'),
       fxaCryptoDeriver: path.resolve(__dirname, 'node_modules/fxa-crypto-relier/dist/fxa-crypto-relier/fxa-crypto-deriver'),
       fxaPairingChannel: path.resolve(__dirname, 'node_modules/fxa-pairing-channel/dist/FxAccountsPairingChannel.babel.umd.js'),
       'base32-decode': path.resolve(__dirname, 'node_modules/base32-decode/index'),


### PR DESCRIPTION
It's a bit of a PITA to develop when udpates to the fxa-js-client are required.
The workflow is currently: Update the fxa-js-client, publish the new version to npm,
and then install it in the content server. npm link never worked for me with WebPack
to avoid this awfulness. The other way of doing things is to make changes to the
fxa-js-client, copy the source over to node_modules/fxa-js-client, and rebuild..

This avoids that hackery by just using the version that's built into the repo.

Not sure if it's a good idea or not, but it seems like a benefit of the monorepo
to be able to do stuff like this.

Not attached to an issue.

Thoughts?