### PR TITLE
fix(version): content-server version.json goes in server/config/version.json

### DIFF
--- a/.circleci/install-content-server.sh
+++ b/.circleci/install-content-server.sh
@@ -6,7 +6,7 @@ if grep -e "fxa-content-server" -e 'all' $DIR/../packages/test.list; then
   sudo apt-get install -y graphicsmagick
   mkdir -p config
   cp ../version.json ./
-  cp ../version.json config
+  cp ../version.json server/config
   cd $DIR/..
   CIRCLECI=false npm install
   npx pm2 kill


### PR DESCRIPTION
r? - @mozilla/fxa-devs 

Absent this change, `/__version__` shows `unknown` instead of the git sha