### PR TITLE
fix(scripts): conditionally show diff size warning at end of release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -130,6 +130,8 @@ else
   fi
 fi
 
+COMMIT_COUNT=0
+
 # 8. For each of the "main" packages...
 bump() {
   # 8.1. List commits since the last tag.
@@ -137,6 +139,7 @@ bump() {
 
   # 8.2. For each commit...
   while read -r COMMIT; do
+    COMMIT_COUNT=`expr $COMMIT_COUNT + 1`
     HASH=`echo "$COMMIT" | cut -d ' ' -f 1`
     MESSAGE=`echo "$COMMIT" | cut -d ':' -f 2- | awk '{$1=$1};1'`
     TYPE=`echo "$COMMIT" | cut -d ' ' -f 2 | awk '{$1=$1};1' | cut -d ':' -f 1 | cut -d '(' -f 1 | awk '{$1=$1};1'`
@@ -361,18 +364,23 @@ echo
 echo "  https://github.com/mozilla/fxa/compare/$TRAIN_BRANCH?expand=1"
 echo "  https://github.com/mozilla/fxa-private/compare/$PRIVATE_BRANCH?expand=1"
 echo
-echo "The diff for the private release may be pretty huge. If so, you may want to add the following comment to that PR:"
-echo
-echo "> There's no need to review every line of this diff, since it includes every commit from the train."
-echo ">"
-echo "> Instead you can do the following:"
-echo ">"
-echo '> ```'
-echo "> git fetch origin $TRAIN_BRANCH"
-echo "> git fetch $PRIVATE_REMOTE $PRIVATE_BRANCH"
-echo "> git checkout -b $PRIVATE_BRANCH $PRIVATE_REMOTE/$PRIVATE_BRANCH"
-echo "> git diff origin/$TRAIN_BRANCH"
-echo '> ```'
-echo ">"
-echo "> That diff should show only the changes from the private repo, proving that the $TRAIN_BRANCH branches are equal in other respects."
-echo
+
+expr $COMMIT_COUNT \> 5 > /dev/null
+IS_BIG_RELEASE="$?"
+if [ "$IS_BIG_RELEASE" = "1" ]; then
+  echo "The diff for the private release may be pretty huge. If so, you may want to add the following comment to that PR:"
+  echo
+  echo "> There's no need to review every line of this diff, since it includes every commit from the train."
+  echo ">"
+  echo "> Instead you can do the following:"
+  echo ">"
+  echo '> ```'
+  echo "> git fetch origin $TRAIN_BRANCH"
+  echo "> git fetch $PRIVATE_REMOTE $PRIVATE_BRANCH"
+  echo "> git checkout -b $PRIVATE_BRANCH $PRIVATE_REMOTE/$PRIVATE_BRANCH"
+  echo "> git diff origin/$TRAIN_BRANCH"
+  echo '> ```'
+  echo ">"
+  echo "> That diff should show only the changes from the private repo, proving that the $TRAIN_BRANCH branches are equal in other respects."
+  echo
+fi


### PR DESCRIPTION
Yesterday, in #841, I add a comment to the end of the release script about the size of the private diff. It occurred to me this morning there's no need to show that warning when there's only a handful of commits, it's more there for the big train releases.

So this PR just adds a little condition around that warning, dependent on the number of commits. I chose 5 as the arbitrary threshold, but happy to go higher or lower. The other condition I considered using instead was on the command-line argument, whether this was a `patch` release or not. But since patch releases could be big too, I decided this way was better.

@mozilla/fxa-devs r?