### PR TITLE
feat(metrics): add entrypoint_experiment and entrypoint_variation params

### DIFF
--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -431,6 +431,8 @@ those common validations are defined here.
 * `SCHEMA`: object({
     * `deviceId`: string, length(32), regex(HEX_STRING), optional
     * `entrypoint`: ENTRYPOINT_SCHEMA.optional
+    * `entrypointExperiment`: ENTRYPOINT_SCHEMA.optional
+    * `entrypointVariation`: ENTRYPOINT_SCHEMA.optional
     * `flowId`: string, length(64), regex(HEX_STRING), optional
     * `flowBeginTime`: number, integer, positive, optional
     * `utmCampaign`: UTM_CAMPAIGN_SCHEMA.optional
@@ -438,7 +440,6 @@ those common validations are defined here.
     * `utmMedium`: UTM_SCHEMA.optional
     * `utmSource`: UTM_SCHEMA.optional
     * `utmTerm`: UTM_SCHEMA.optional
-
   }), unknown(false), and('flowId', 'flowBeginTime')
 * `schema`: SCHEMA.optional
 * `requiredSchema`: SCHEMA.required

--- a/packages/fxa-auth-server/docs/metrics-events.md
+++ b/packages/fxa-auth-server/docs/metrics-events.md
@@ -90,6 +90,8 @@ contains the following fields:
 |`ua_os`|The user's operating system, e.g. 'Windows 10' or 'Android'.|
 |`context`|FxA auth broker context. This is related to browser platform and version |
 |`entrypoint`|The entrypoint of the first flow in the session. Typically a UI touchpoint like "preferences".|
+|`entrypoint_experiment`|Identifier for the experiment the user is part of at the entrypoint (if any).|
+|`entrypoint_variation`|Identifier for the experiment variation the user is part of at the entrypoint (if any).|
 |`migration`|Sync migration.|
 |`service`|The service identifier. For Sync it may be empty or `sync`. For OAuth reliers it is their hex client id.|
 |`utm_campaign`|Marketing campaign identifier for the first flow in the session. Not stored if the `DNT` request header was `1`.|

--- a/packages/fxa-auth-server/lib/metrics/context.js
+++ b/packages/fxa-auth-server/lib/metrics/context.js
@@ -25,6 +25,8 @@ const SCHEMA = isA.object({
   // only Sync creates records in the devices table.
   deviceId: isA.string().length(32).regex(HEX_STRING).optional(),
   entrypoint: ENTRYPOINT_SCHEMA.optional(),
+  entrypointExperiment: ENTRYPOINT_SCHEMA.optional(),
+  entrypointVariation: ENTRYPOINT_SCHEMA.optional(),
   flowId: isA.string().length(64).regex(HEX_STRING).optional(),
   flowBeginTime: isA.number().integer().positive().optional(),
   utmCampaign: UTM_CAMPAIGN_SCHEMA.optional(),
@@ -150,6 +152,8 @@ module.exports = function (log, config) {
       const doNotTrack = this.headers && this.headers.dnt === '1';
       if (! doNotTrack) {
         data.entrypoint = metadata.entrypoint;
+        data.entrypoint_experiment = metadata.entrypointExperiment;
+        data.entrypoint_variation = metadata.entrypointVariation;
         data.utm_campaign = metadata.utmCampaign;
         data.utm_content = metadata.utmContent;
         data.utm_medium = metadata.utmMedium;

--- a/packages/fxa-auth-server/test/local/log.js
+++ b/packages/fxa-auth-server/test/local/log.js
@@ -612,6 +612,8 @@ describe('log', () => {
         service: 'clientid',
         metricsContext: {
           entrypoint: 'wibble',
+          entrypointExperiment: 'blee-experiment',
+          entrypointVariation: 'blee-variation',
           flowBeginTime: now - 23,
           flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
           utmCampaign: 'utm campaign',
@@ -636,6 +638,8 @@ describe('log', () => {
           metricsContext: {
             time: now,
             entrypoint: 'wibble',
+            entrypoint_experiment: 'blee-experiment',
+            entrypoint_variation: 'blee-variation',
             flow_id: request.payload.metricsContext.flowId,
             flow_time: now - request.payload.metricsContext.flowBeginTime,
             flowBeginTime: request.payload.metricsContext.flowBeginTime,
@@ -688,6 +692,8 @@ describe('log', () => {
           metricsContext: {
             time: now,
             entrypoint: 'wibble',
+            entrypoint_experiment: undefined,
+            entrypoint_variation: undefined,
             flow_id: request.payload.metricsContext.flowId,
             flow_time: now - request.payload.metricsContext.flowBeginTime,
             flowBeginTime: request.payload.metricsContext.flowBeginTime,
@@ -740,6 +746,8 @@ describe('log', () => {
           metricsContext: {
             time: now,
             entrypoint: 'wibble',
+            entrypoint_experiment: undefined,
+            entrypoint_variation: undefined,
             flow_id: request.payload.metricsContext.flowId,
             flow_time: now - request.payload.metricsContext.flowBeginTime,
             flowBeginTime: request.payload.metricsContext.flowBeginTime,

--- a/packages/fxa-auth-server/test/local/metrics/context.js
+++ b/packages/fxa-auth-server/test/local/metrics/context.js
@@ -425,6 +425,8 @@ describe('metricsContext', () => {
             flowType: 'mock flow type',
             context: 'mock context',
             entrypoint: 'mock entry point',
+            entrypointExperiment: 'mock entrypoint experiment',
+            entrypointVariation: 'mock entrypoint experiment variation',
             migration: 'mock migration',
             service: 'mock service',
             utmCampaign: 'mock utm_campaign',
@@ -436,27 +438,28 @@ describe('metricsContext', () => {
           })
         }
       }, {}).then((result) => {
-        assert.equal(typeof result, 'object', 'result is object');
-        assert.notEqual(result, null, 'result is not null');
-        assert.equal(Object.keys(result).length, 14, 'result has 14 properties');
-        assert.ok(result.time > time, 'result.time seems correct');
-        assert.equal(result.device_id, 'mock device id', 'result.device_id is correct');
+        assert.isObject(result);
+        assert.lengthOf(Object.keys(result), 16);
+        assert.isAbove(result.time, time);
+        assert.equal(result.device_id, 'mock device id');
         assert.equal(result.entrypoint, 'mock entry point');
-        assert.equal(result.flow_id, 'mock flow id', 'result.flow_id is correct');
-        assert.ok(result.flow_time > 0, 'result.flow_time is greater than zero');
-        assert.ok(result.flow_time < time, 'result.flow_time is less than the current time');
-        assert.equal(result.flowBeginTime, time, 'result.flowBeginTime is correct');
-        assert.equal(result.flowCompleteSignal, 'mock flow complete signal', 'result.flowCompleteSignal is correct');
-        assert.equal(result.flowType, 'mock flow type', 'result.flowType is correct');
-        assert.equal(result.service, 'mock service', 'result.service is correct');
-        assert.equal(result.utm_campaign, 'mock utm_campaign', 'result.utm_campaign is correct');
-        assert.equal(result.utm_content, 'mock utm_content', 'result.utm_content is correct');
-        assert.equal(result.utm_medium, 'mock utm_medium', 'result.utm_medium is correct');
-        assert.equal(result.utm_source, 'mock utm_source', 'result.utm_source is correct');
-        assert.equal(result.utm_term, 'mock utm_term', 'result.utm_term is correct');
+        assert.equal(result.entrypoint_experiment, 'mock entrypoint experiment');
+        assert.equal(result.entrypoint_variation, 'mock entrypoint experiment variation');
+        assert.equal(result.flow_id, 'mock flow id');
+        assert.isAbove(result.flow_time, 0);
+        assert.isBelow(result.flow_time, time);
+        assert.equal(result.flowBeginTime, time);
+        assert.equal(result.flowCompleteSignal, 'mock flow complete signal');
+        assert.equal(result.flowType, 'mock flow type');
+        assert.equal(result.service, 'mock service');
+        assert.equal(result.utm_campaign, 'mock utm_campaign');
+        assert.equal(result.utm_content, 'mock utm_content');
+        assert.equal(result.utm_medium, 'mock utm_medium');
+        assert.equal(result.utm_source, 'mock utm_source');
+        assert.equal(result.utm_term, 'mock utm_term');
 
-        assert.equal(cache.get.callCount, 0, 'cache.get was not called');
-        assert.equal(log.error.callCount, 0, 'log.error was not called');
+        assert.equal(cache.get.callCount, 0);
+        assert.equal(log.error.callCount, 0);
       });
     }
   );
@@ -477,6 +480,8 @@ describe('metricsContext', () => {
             flowType: 'mock flow type',
             context: 'mock context',
             entrypoint: 'mock entry point',
+            entrypointExperiment: 'mock entrypoint experiment',
+            entrypointVariation: 'mock entrypoint experiment variation',
             migration: 'mock migration',
             service: 'mock service',
             utmCampaign: 'mock utm_campaign',
@@ -488,15 +493,17 @@ describe('metricsContext', () => {
           })
         }
       }, {}).then((result) => {
-        assert.equal(Object.keys(result).length, 8, 'result has 8 properties');
+        assert.lengthOf(Object.keys(result), 8);
         assert.isUndefined(result.entrypoint);
-        assert.equal(result.utm_campaign, undefined, 'result.utm_campaign is undefined');
-        assert.equal(result.utm_content, undefined, 'result.utm_content is undefined');
-        assert.equal(result.utm_medium, undefined, 'result.utm_medium is undefined');
-        assert.equal(result.utm_source, undefined, 'result.utm_source is undefined');
-        assert.equal(result.utm_term, undefined, 'result.utm_term is undefined');
+        assert.isUndefined(result.entrypoint_experiment);
+        assert.isUndefined(result.entrypoint_variation);
+        assert.isUndefined(result.utm_campaign);
+        assert.isUndefined(result.utm_content);
+        assert.isUndefined(result.utm_medium);
+        assert.isUndefined(result.utm_source);
+        assert.isUndefined(result.utm_term);
 
-        assert.equal(log.error.callCount, 0, 'log.error was not called');
+        assert.equal(log.error.callCount, 0);
       });
     }
   );

--- a/packages/fxa-auth-server/test/local/metrics/events.js
+++ b/packages/fxa-auth-server/test/local/metrics/events.js
@@ -173,6 +173,8 @@ describe('metrics/events', () => {
       payload: {
         metricsContext: {
           entrypoint: 'wibble',
+          entrypointExperiment: 'exp',
+          entrypointVariation: 'var',
           flowId: 'bar',
           flowBeginTime: time - 1000,
           flowCompleteSignal: 'account.signed',
@@ -201,6 +203,8 @@ describe('metrics/events', () => {
           country: 'United States',
           event: 'email.verification.sent',
           entrypoint: 'wibble',
+          entrypoint_experiment: 'exp',
+          entrypoint_variation: 'var',
           flow_id: 'bar',
           flow_time: 1000,
           flowBeginTime: time - 1000,

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -350,6 +350,8 @@ describe('/account/create', () => {
         metricsContext: {
           deviceId: 'wibble',
           entrypoint: 'blee',
+          entrypointExperiment: 'exp',
+          entrypointVariation: 'var',
           flowBeginTime: Date.now(),
           flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
           utmCampaign: 'utm campaign',
@@ -473,6 +475,8 @@ describe('/account/create', () => {
       assert.ok(eventData.data.ts, 'timestamp of event set');
       assert.deepEqual(eventData.data.metricsContext, {
         entrypoint: 'blee',
+        entrypoint_experiment: 'exp',
+        entrypoint_variation: 'var',
         flowBeginTime: mockRequest.payload.metricsContext.flowBeginTime,
         flowCompleteSignal: 'account.signed',
         flowType: undefined,
@@ -504,6 +508,8 @@ describe('/account/create', () => {
       assert.deepEqual(args[0], {
         country: 'United States',
         entrypoint: 'blee',
+        entrypoint_experiment: 'exp',
+        entrypoint_variation: 'var',
         event: 'account.created',
         flowBeginTime: mockRequest.payload.metricsContext.flowBeginTime,
         flowCompleteSignal: 'account.signed',
@@ -707,6 +713,8 @@ describe('/account/login', () => {
       metricsContext: {
         deviceId: 'blee',
         entrypoint: 'flub',
+        entrypointExperiment: 'exp',
+        entrypointVariation: 'var',
         flowBeginTime: Date.now(),
         flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
         utmCampaign: 'utm campaign',

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -528,6 +528,8 @@ function mockMetricsContext (methods) {
               flowType: this.payload.metricsContext.flowType
             }, this.headers && this.headers.dnt === '1' ? {} : {
               entrypoint: this.payload.metricsContext.entrypoint,
+              entrypoint_experiment: this.payload.metricsContext.entrypointExperiment,
+              entrypoint_variation: this.payload.metricsContext.entrypointVariation,
               utm_campaign: this.payload.metricsContext.utmCampaign,
               utm_content: this.payload.metricsContext.utmContent,
               utm_medium: this.payload.metricsContext.utmMedium,

--- a/packages/fxa-auth-server/test/remote/account_create_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_tests.js
@@ -381,12 +381,24 @@ describe('remote account create', function() {
     const options = {
       metricsContext: {
         entrypoint: 'foo',
+        entrypointExperiment: 'exp',
+        entrypointVariation: 'var',
         utmCampaign: 'bar',
         utmContent: 'baz',
         utmMedium: 'qux',
         utmSource: 'wibble',
         utmTerm: 'blee',
       }
+    };
+    return api.accountCreate(email, authPW, options);
+  });
+
+  it('empty metricsContext', () => {
+    const api = new Client.Api(config.publicUrl);
+    const email = server.uniqueEmail();
+    const authPW = '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+    const options = {
+      metricsContext: {},
     };
     return api.accountCreate(email, authPW, options);
   });
@@ -398,12 +410,54 @@ describe('remote account create', function() {
     const options = {
       metricsContext: {
         entrypoint: ';',
+        entrypointExperiment: 'exp',
+        entrypointVariation: 'var',
         utmCampaign: 'foo',
         utmContent: 'bar',
         utmMedium: 'baz',
         utmSource: 'qux',
         utmTerm: 'wibble',
       }
+    };
+    return api.accountCreate(email, authPW, options)
+      .then(assert.fail, err => assert.equal(err.errno, 107));
+  });
+
+  it('invalid entrypointExperiment', () => {
+    const api = new Client.Api(config.publicUrl);
+    const email = server.uniqueEmail();
+    const authPW = '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+    const options = {
+      metricsContext: {
+        entrypoint: 'foo',
+        entrypointExperiment: ';',
+        entrypointVariation: 'var',
+        utmCampaign: 'bar',
+        utmContent: 'baz',
+        utmMedium: 'qux',
+        utmSource: 'wibble',
+        utmTerm: 'blee',
+      },
+    };
+    return api.accountCreate(email, authPW, options)
+      .then(assert.fail, err => assert.equal(err.errno, 107));
+  });
+
+  it('invalid entrypointVariation', () => {
+    const api = new Client.Api(config.publicUrl);
+    const email = server.uniqueEmail();
+    const authPW = '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+    const options = {
+      metricsContext: {
+        entrypoint: 'foo',
+        entrypointExperiment: 'exp
+        entrypointVariation: ';',
+        utmCampaign: 'bar',
+        utmContent: 'baz',
+        utmMedium: 'qux',
+        utmSource: 'wibble',
+        utmTerm: 'blee',
+      },
     };
     return api.accountCreate(email, authPW, options)
       .then(assert.fail, err => assert.equal(err.errno, 107));
@@ -416,6 +470,8 @@ describe('remote account create', function() {
     const options = {
       metricsContext: {
         entrypoint: 'foo',
+        entrypointExperiment: 'exp',
+        entrypointVariation: 'var',
         utmCampaign: ';',
         utmContent: 'bar',
         utmMedium: 'baz',
@@ -434,6 +490,8 @@ describe('remote account create', function() {
     const options = {
       metricsContext: {
         entrypoint: 'foo',
+        entrypointExperiment: 'exp',
+        entrypointVariation: 'var',
         utmCampaign: 'bar',
         utmContent: ';',
         utmMedium: 'baz',
@@ -452,6 +510,8 @@ describe('remote account create', function() {
     const options = {
       metricsContext: {
         entrypoint: 'foo',
+        entrypointExperiment: 'exp',
+        entrypointVariation: 'var',
         utmCampaign: 'bar',
         utmContent: 'baz',
         utmMedium: ';',
@@ -470,6 +530,8 @@ describe('remote account create', function() {
     const options = {
       metricsContext: {
         entrypoint: 'foo',
+        entrypointExperiment: 'exp',
+        entrypointVariation: 'var',
         utmCampaign: 'bar',
         utmContent: 'baz',
         utmMedium: 'qux',
@@ -488,6 +550,8 @@ describe('remote account create', function() {
     const options = {
       metricsContext: {
         entrypoint: 'foo',
+        entrypointExperiment: 'exp',
+        entrypointVariation: 'var',
         utmCampaign: 'bar',
         utmContent: 'baz',
         utmMedium: 'qux',

--- a/packages/fxa-content-server/app/scripts/lib/metrics.js
+++ b/packages/fxa-content-server/app/scripts/lib/metrics.js
@@ -39,6 +39,8 @@ const ALLOWED_FIELDS = [
   'duration',
   'emailDomain',
   'entrypoint',
+  'entrypointExperiment',
+  'entrypointVariation',
   'events',
   'experiments',
   'flowBeginTime',
@@ -127,6 +129,8 @@ function Metrics (options = {}) {
   this._devicePixelRatio = options.devicePixelRatio || NOT_REPORTED_VALUE;
   this._emailDomain = NOT_REPORTED_VALUE;
   this._entrypoint = options.entrypoint || NOT_REPORTED_VALUE;
+  this._entrypointExperiment = options.entrypointExperiment || NOT_REPORTED_VALUE;
+  this._entrypointVariation = options.entrypointVariation || NOT_REPORTED_VALUE;
   this._env = options.environment || new Environment(this._window);
   this._eventMemory = {};
   this._inactivityFlushMs = options.inactivityFlushMs || DEFAULT_INACTIVITY_TIMEOUT_MS;
@@ -350,6 +354,8 @@ _.extend(Metrics.prototype, Backbone.Events, {
       deviceId: flowData.deviceId || NOT_REPORTED_VALUE,
       emailDomain: this._emailDomain,
       entrypoint: this._entrypoint,
+      entrypointExperiment: this._entrypointExperiment,
+      entrypointVariation: this._entrypointVariation,
       experiments: flattenHashIntoArrayOfObjects(this._activeExperiments),
       flowBeginTime: flowData.flowBeginTime,
       flowId: flowData.flowId,
@@ -655,6 +661,8 @@ _.extend(Metrics.prototype, Backbone.Events, {
     return {
       deviceId: metadata.deviceId,
       entrypoint: marshallProperty(this._entrypoint),
+      entrypointExperiment: marshallProperty(this._entrypointExperiment),
+      entrypointVariation: marshallProperty(this._entrypointVariation),
       flowBeginTime: metadata.flowBegin,
       flowId: metadata.flowId,
       utmCampaign: marshallProperty(this._utmCampaign),

--- a/packages/fxa-content-server/app/scripts/models/reliers/relier.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/relier.js
@@ -21,6 +21,8 @@ import Vat from '../../lib/vat';
 
 const RELIER_FIELDS_IN_RESUME_TOKEN = [
   'entrypoint',
+  'entrypointExperiment',
+  'entrypointVariation',
   'resetPasswordConfirm',
   'utmCampaign',
   'utmContent',
@@ -39,6 +41,8 @@ const QUERY_PARAMETER_SCHEMA = {
   // `entrypoint` (lowcase p). Normalize to `entrypoint`.
   entryPoint: Vat.string(),
   entrypoint: Vat.string(),
+  entrypoint_experiment: Vat.string().renameTo('entrypointExperiment'),
+  entrypoint_variation: Vat.string().renameTo('entrypointVariation'),
   migration: Vat.string().valid(Constants.AMO_MIGRATION, Constants.SYNC11_MIGRATION),
   reset_password_confirm: Vat.boolean().renameTo('resetPasswordConfirm'),
   setting: Vat.string(),
@@ -79,6 +83,8 @@ var Relier = BaseRelier.extend({
     context: Constants.CONTENT_SERVER_CONTEXT,
     email: null,
     entrypoint: null,
+    entrypointExperiment: null,
+    entrypointVariation: null,
     migration: null,
     resetPasswordConfirm: true,
     setting: null,

--- a/packages/fxa-content-server/app/scripts/models/resume-token.js
+++ b/packages/fxa-content-server/app/scripts/models/resume-token.js
@@ -15,6 +15,8 @@ var ResumeToken = Backbone.Model.extend({
     deviceId: undefined,
     email: undefined,
     entrypoint: undefined,
+    entrypointExperiment: undefined,
+    entrypointVariation: undefined,
     flowBegin: undefined,
     flowId: undefined,
     needsOptedInToMarketingEmail: undefined,

--- a/packages/fxa-content-server/app/scripts/views/mixins/signed-out-notification-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signed-out-notification-mixin.js
@@ -23,6 +23,8 @@ var Mixin = {
     const queryString = Url.objToSearchString({
       context: this.relier.get('context'),
       entrypoint: this.relier.get('entrypoint'),
+      entrypoint_experiment: this.relier.get('entrypointExperiment'),
+      entrypoint_variation: this.relier.get('entrypointVariation'),
       service: this.relier.get('service'),
       /* eslint-disable camelcase */
       utm_campaign: this.relier.get('utmCampaign'),

--- a/packages/fxa-content-server/app/tests/spec/lib/metrics.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/metrics.js
@@ -39,6 +39,8 @@ describe('lib/metrics', function () {
       context: 'fx_desktop_v3',
       devicePixelRatio: 2,
       entrypoint: 'menupanel',
+      entrypointExperiment: 'wibble',
+      entrypointVariation: 'blee',
       isSampledUser: true,
       lang: 'db_LB',
       notifier,
@@ -86,6 +88,8 @@ describe('lib/metrics', function () {
     assert.deepEqual(metrics.getFlowEventMetadata(), {
       deviceId: undefined,
       entrypoint: 'menupanel',
+      entrypointExperiment: 'wibble',
+      entrypointVariation: 'blee',
       flowBeginTime: undefined,
       flowId: undefined,
       utmCampaign: 'utm_campaign',
@@ -191,6 +195,8 @@ describe('lib/metrics', function () {
       assert.equal(filteredData.lang, 'db_LB');
       assert.equal(filteredData.emailDomain, 'none');
       assert.equal(filteredData.entrypoint, 'menupanel');
+      assert.equal(filteredData.entrypointExperiment, 'wibble');
+      assert.equal(filteredData.entrypointVariation, 'blee');
       assert.equal(filteredData.migration, 'none');
       assert.equal(filteredData.uniqueUserId, '0ae7fe2b-244f-4a78-9857-dff3ae263927');
       assert.equal(filteredData.startTime, 1439233336187);
@@ -330,13 +336,15 @@ describe('lib/metrics', function () {
             assert.equal(windowMock.navigator.sendBeacon.getCall(0).args[0], '/metrics');
 
             var data = JSON.parse(windowMock.navigator.sendBeacon.getCall(0).args[1]);
-            assert.lengthOf(Object.keys(data), 30);
+            assert.lengthOf(Object.keys(data), 32);
             assert.equal(data.broker, 'none');
             assert.equal(data.context, Constants.CONTENT_SERVER_CONTEXT);
             assert.match(data.deviceId, /^[0-9a-f]{32}$/);
             assert.isNumber(data.duration);
             assert.equal(data.emailDomain, 'none');
             assert.equal(data.entrypoint, 'none');
+            assert.equal(data.entrypointExperiment, 'none');
+            assert.equal(data.entrypointVariation, 'none');
             assert.isArray(data.events);
             assert.lengthOf(data.events, 4);
             assert.equal(data.events[0].type, 'foo');
@@ -503,7 +511,7 @@ describe('lib/metrics', function () {
             assert.equal(settings.contentType, 'application/json');
 
             var data = JSON.parse(settings.data);
-            assert.lengthOf(Object.keys(data), 29);
+            assert.lengthOf(Object.keys(data), 31);
             assert.match(data.deviceId, /^[0-9a-f]{32}$/);
             assert.isArray(data.events);
             assert.lengthOf(data.events, 5);
@@ -583,7 +591,7 @@ describe('lib/metrics', function () {
           assert.isTrue(metrics._send.getCall(0).args[1]);
 
           var data = metrics._send.getCall(0).args[0];
-          assert.lengthOf(Object.keys(data), 29);
+          assert.lengthOf(Object.keys(data), 31);
           assert.lengthOf(data.events, 5);
           assert.equal(data.events[0].type, 'foo');
           assert.equal(data.events[1].type, 'flow.bar');
@@ -608,7 +616,7 @@ describe('lib/metrics', function () {
           assert.isTrue(metrics._send.getCall(0).args[1]);
 
           var data = metrics._send.getCall(0).args[0];
-          assert.lengthOf(Object.keys(data), 29);
+          assert.lengthOf(Object.keys(data), 31);
           assert.lengthOf(data.events, 5);
           assert.equal(data.events[0].type, 'foo');
           assert.equal(data.events[1].type, 'flow.bar');

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
@@ -583,6 +583,8 @@ describe('models/reliers/oauth', () => {
 
       relier.set({
         entrypoint: ENTRYPOINT,
+        entrypointExperiment: ITEM,
+        entrypointVariation: ITEM,
         notPassed: 'this should not be picked',
         resetPasswordConfirm: false,
         state: STATE,
@@ -597,6 +599,8 @@ describe('models/reliers/oauth', () => {
         // ensure campaign and entrypoint from
         // the Relier are still passed.
         entrypoint: ENTRYPOINT,
+        entrypointExperiment: ITEM,
+        entrypointVariation: ITEM,
         resetPasswordConfirm: false,
         utmCampaign: UTM_CAMPAIGN,
         utmContent: ITEM,

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/relier.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/relier.js
@@ -17,6 +17,8 @@ describe('models/reliers/relier', function () {
 
   var EMAIL = 'email@moz.org';
   var ENTRYPOINT = 'preferences';
+  var ENTRYPOINT_EXPERIMENT = 'wibble';
+  var ENTRYPOINT_VARIATION = 'blee';
   var SETTING = 'avatar';
   var UID = TestHelpers.createRandomHexString(Constants.UID_LENGTH);
   var UTM_CAMPAIGN = 'utm_campaign';
@@ -49,6 +51,8 @@ describe('models/reliers/relier', function () {
       coppa: 'false',
       email: EMAIL,
       entrypoint: ENTRYPOINT,
+      entrypoint_experiment: ENTRYPOINT_EXPERIMENT,
+      entrypoint_variation: ENTRYPOINT_VARIATION,
       ignored: 'ignored',
       setting: SETTING,
       uid: UID,
@@ -71,6 +75,8 @@ describe('models/reliers/relier', function () {
         assert.equal(relier.get('setting'), SETTING);
         assert.equal(relier.get('uid'), UID);
         assert.equal(relier.get('entrypoint'), ENTRYPOINT);
+        assert.equal(relier.get('entrypointExperiment'), ENTRYPOINT_EXPERIMENT);
+        assert.equal(relier.get('entrypointVariation'), ENTRYPOINT_VARIATION);
 
         assert.equal(relier.get('utmCampaign'), UTM_CAMPAIGN);
         assert.equal(relier.get('utmContent'), UTM_CONTENT);
@@ -235,6 +241,8 @@ describe('models/reliers/relier', function () {
 
     relier.set({
       entrypoint: ENTRYPOINT,
+      entrypointExperiment: ITEM,
+      entrypointVariation: ITEM,
       notPassed: 'this should not be picked',
       resetPasswordConfirm: true,
       utmCampaign: UTM_CAMPAIGN,
@@ -246,6 +254,8 @@ describe('models/reliers/relier', function () {
 
     assert.deepEqual(relier.pickResumeTokenInfo(), {
       entrypoint: ENTRYPOINT,
+      entrypointExperiment: ITEM,
+      entrypointVariation: ITEM,
       resetPasswordConfirm: true,
       utmCampaign: UTM_CAMPAIGN,
       utmContent: ITEM,

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/signed-out-notification-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/signed-out-notification-mixin.js
@@ -89,6 +89,8 @@ describe('views/mixins/signed-out-notification-mixin', () => {
         assert.equal(view.navigateAway.args[0][0], '/signin?' + [
           'context=mock_context',
           'entrypoint=mock_entrypoint',
+          'entrypoint_experiment=mock_entrypointExperiment',
+          'entrypoint_variation=mock_entrypointVariation',
           'service=mock_service',
           'utm_campaign=mock_utmCampaign',
           'utm_content=mock_utmContent',

--- a/packages/fxa-content-server/docs/client-metrics.md
+++ b/packages/fxa-content-server/docs/client-metrics.md
@@ -41,6 +41,14 @@ The known values of `entrypoint` are:
 * fxa:signup: user clicked the "Looking for Sync" text from the signup page
 * fxa:signup-complete: TODO: we need to track down what's sending this value
 
+### entrypoint_experiment and entrypoint_variation
+
+If an experiment is running at the entrypoint,
+these properties will be set
+with the name of the experiment
+and the variation that
+the user is part of.
+
 ### events
 The event stream, see [Event Stream](#event_stream)
 

--- a/packages/fxa-content-server/docs/query-params.md
+++ b/packages/fxa-content-server/docs/query-params.md
@@ -146,6 +146,14 @@ Only available if `context` equals `fx_fennec_v1`, or `fx_ios_v1` and `service` 
 ### `entrypoint`
 If they user arrived at Firefox Accounts from within Firefox browser chrome, specify where in Firefox the user came from.
 
+### `entrypoint_experiment` and `entrypoint_variation`
+
+If an experiment is running at the entrypoint,
+set these properties to
+the name of the experiment
+and the variation that
+the user is part of.
+
 #### When to specify
 * /signin
 * /signup

--- a/packages/fxa-content-server/server/lib/routes/get-metrics-flow.js
+++ b/packages/fxa-content-server/server/lib/routes/get-metrics-flow.js
@@ -50,6 +50,8 @@ module.exports = function (config) {
     // Not passed by the Firefox Concert Series.
     // See https://github.com/mozilla/bedrock/issues/6839
     entrypoint: STRING_TYPE.regex(ENTRYPOINT_PATTERN).optional(),
+    'entrypoint_experiment': STRING_TYPE.regex(ENTRYPOINT_PATTERN).optional(),
+    'entrypoint_variation': STRING_TYPE.regex(ENTRYPOINT_PATTERN).optional(),
     // Not passed by the Firefox Concert Series.
     // See https://github.com/mozilla/bedrock/issues/6839
     'form_type': STRING_TYPE.regex(FORM_TYPE_PATTERN).optional(),

--- a/packages/fxa-content-server/server/lib/routes/get-update-firefox.js
+++ b/packages/fxa-content-server/server/lib/routes/get-update-firefox.js
@@ -28,6 +28,8 @@ const QUERY_PARAM_SCHEMA = {
   action: ACTION_TYPE.optional(),
   context: STRING_TYPE.regex(CONTEXT_PATTERN).required(),
   entrypoint: STRING_TYPE.regex(ENTRYPOINT_PATTERN).optional(),
+  'entrypoint_experiment': STRING_TYPE.regex(ENTRYPOINT_PATTERN).optional(),
+  'entrypoint_variation': STRING_TYPE.regex(ENTRYPOINT_PATTERN).optional(),
   service: STRING_TYPE.regex(SERVICE_PATTERN).optional(),
   'utm_campaign': UTM_CAMPAIGN_TYPE.optional(),
   'utm_content': UTM_TYPE.optional(),

--- a/packages/fxa-content-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-content-server/server/lib/routes/post-metrics.js
@@ -55,6 +55,8 @@ const BODY_SCHEMA = {
   emailDomain: DOMAIN_TYPE.optional(),
   entryPoint: STRING_TYPE.regex(ENTRYPOINT_PATTERN).optional(),
   entrypoint: STRING_TYPE.regex(ENTRYPOINT_PATTERN).optional(),
+  entrypointExperiment: STRING_TYPE.regex(ENTRYPOINT_PATTERN).optional(),
+  entrypointVariation: STRING_TYPE.regex(ENTRYPOINT_PATTERN).optional(),
   events: joi.array().items(joi.object().keys({
     offset: OFFSET_TYPE.max(MAX_EVENT_OFFSET).required(),
     type: STRING_TYPE.regex(EVENT_TYPE_PATTERN).required()

--- a/packages/fxa-content-server/server/lib/routes/redirect-download-firefox.js
+++ b/packages/fxa-content-server/server/lib/routes/redirect-download-firefox.js
@@ -35,6 +35,8 @@ const QUERY_PARAM_SCHEMA = {
   context: STRING_TYPE.regex(CONTEXT_PATTERN).required(),
   deviceId: HEX32_TYPE.required(),
   entrypoint: STRING_TYPE.regex(ENTRYPOINT_PATTERN).optional(),
+  'entrypoint_experiment': STRING_TYPE.regex(ENTRYPOINT_PATTERN).optional(),
+  'entrypoint_variation': STRING_TYPE.regex(ENTRYPOINT_PATTERN).optional(),
   flowBeginTime: OFFSET_TYPE.required(),
   flowId: FLOW_ID_TYPE.required(),
   service: STRING_TYPE.regex(SERVICE_PATTERN).optional(),

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -95,6 +95,8 @@ registerSuite('amplitude', {
       }, {
         deviceId: 'bar',
         entrypoint: 'baz',
+        entrypoint_experiment: 'exp',
+        entrypoint_variation: 'var',
         experiments: [
           {choice: 'FirstExperiment', group: 'groupOne'},
           {choice: 'second-experiment', group: 'Group-Two'},
@@ -141,6 +143,8 @@ registerSuite('amplitude', {
         user_id: 'soop',
         user_properties: {
           entrypoint: 'baz',
+          entrypoint_experiment: 'exp',
+          entrypoint_variation: 'var',
           flow_id: 'wibble',
           ua_browser: 'Firefox',
           ua_version: '65.0',

--- a/packages/fxa-content-server/tests/server/metrics.js
+++ b/packages/fxa-content-server/tests/server/metrics.js
@@ -33,6 +33,8 @@ suite.tests['#post /metrics - returns 200 with valid data'] = {
   'valid entrypoint (fxa:connect_another_device)': testValidMetricsField('entrypoint', 'fxa:connect_another_device'),
   'valid entrypoint (fxa:signup)': testValidMetricsField('entrypoint', 'fxa:signup'),
   'valid entrypoint (fxa:signup-complete)': testValidMetricsField('entrypoint', 'fxa:signup-complete'),
+  'valid entrypoint_experiment (wibble)': testValidMetricsField('entrypoint_experiment', 'wibble'),
+  'valid entrypoint_variation (blee)': testValidMetricsField('entrypoint_variation', 'blee'),
   'valid error-type (error.unknown context.auth.108)':
       testValidMetricsEvent('type', 'error.unknown context.auth.108'),
   'valid error-type (signin-permissions.checkbox.change.profile:display_name.unchecked)':
@@ -63,6 +65,8 @@ suite.tests['#post /metrics - returns 400 with invalid data'] = {
   'invalid duration (-1)': testInvalidMetricsField('duration', -1),
   'invalid entryPoint (15612!$@%%asdf<>)': testInvalidMetricsField('entrypoint', '15612!$@%%asdf<>'),
   'invalid entrypoint (!%!%)': testInvalidMetricsField('entrypoint', '!%!%'),
+  'invalid entrypoint_experiment (wibble!)': testInvalidMetricsField('entrypoint_experiment', 'wibble!'),
+  'invalid entrypoint_variation (blee;)': testInvalidMetricsField('entrypoint_variation', 'blee;'),
   'invalid event offset (<FLUSH_TIME_START_TIME_DIFF + 1>)': testInvalidMetricsField('events', [{ offset: FLUSH_TIME_START_TIME_DIFF + 1, type: 'offset-too-high-nono'}]), //eslint-disable-line max-len
   'invalid event offset (<MAX_EVENT_OFFSET + 1>)': testInvalidMetricsField('events', [{ offset: MAX_EVENT_OFFSET + 1, type: 'more-than-two-days-nono'}]),
   'invalid event offset (a)': testInvalidMetricsField('events', [{ offset: 'a', type: 'allgood'}]),

--- a/packages/fxa-content-server/tests/server/routes/get-metrics-flow.js
+++ b/packages/fxa-content-server/tests/server/routes/get-metrics-flow.js
@@ -94,6 +94,8 @@ registerSuite('routes/get-metrics-flow', {
         query: {
           context: 'blee',
           entrypoint: 'zoo',
+          'entrypoint_experiment': 'herf',
+          'entrypoint_variation': 'menk',
           'form_type': 'other',
           'service': 'sync',
           'utm_campaign': 'foo',
@@ -114,6 +116,8 @@ registerSuite('routes/get-metrics-flow', {
       assert.ok(args[0].time);
       assert.equal(args[0].type, 'flow.begin');
       assert.equal(args[2].entrypoint, 'zoo');
+      assert.equal(args[2].entrypoint_experiment, 'herf');
+      assert.equal(args[2].entrypoint_variation, 'menk');
       assert.ok(args[2].flowId);
       assert.ok(args[2].deviceId);
       assert.notEqual(args[2].deviceId, args[2].flowId);
@@ -313,6 +317,8 @@ registerSuite('routes/get-metrics-flow remote request', {
     const query = {
       context: 'blee',
       entrypoint: 'zoo',
+      'entrypoint_experiment': 'herf',
+      'entrypoint_variation': 'menk',
       'form_type': 'other',
       'service': 'sync',
       'utm_campaign': 'foo',
@@ -331,6 +337,14 @@ registerSuite('routes/get-metrics-flow remote request', {
 
   'invalid entrypoint query parameter': function() {
     return testInvalidFlowQueryParam('entrypoint', 'foo bar');
+  },
+
+  'invalid entrypoint_experiment query parameter': function() {
+    return testInvalidFlowQueryParam('entrypoint_experiment', 'herf menk');
+  },
+
+  'invalid entrypoint_variation query parameter': function() {
+    return testInvalidFlowQueryParam('entrypoint_variation', 'menk herf');
   },
 
   'invalid form_type query parameter': function() {

--- a/packages/fxa-content-server/tests/server/validation.js
+++ b/packages/fxa-content-server/tests/server/validation.js
@@ -13,6 +13,8 @@ const METRICS_DOCS_URL = 'https://raw.githubusercontent.com/mozilla/application-
 const UTM_REGEX = validation.TYPES.UTM._tests[1].arg.pattern;
 const REGEXES = new Map([
   [ 'entrypoint', validation.PATTERNS.ENTRYPOINT ],
+  [ 'entrypoint_experiment', validation.PATTERNS.ENTRYPOINT ],
+  [ 'entrypoint_variation', validation.PATTERNS.ENTRYPOINT ],
   [ 'utm_campaign', UTM_REGEX ],
   [ 'utm_content', UTM_REGEX ],
   [ 'utm_medium', UTM_REGEX ],

--- a/packages/fxa-js-client/client/lib/metricsContext.js
+++ b/packages/fxa-js-client/client/lib/metricsContext.js
@@ -13,6 +13,8 @@ define([], function () {
       return {
         deviceId: data.deviceId,
         entrypoint: data.entrypoint,
+        entrypointExperiment: data.entrypointExperiment,
+        entrypointVariation: data.entrypointVariation,
         flowId: data.flowId,
         flowBeginTime: data.flowBeginTime,
         utmCampaign: data.utmCampaign,

--- a/packages/fxa-js-client/tests/lib/account.js
+++ b/packages/fxa-js-client/tests/lib/account.js
@@ -235,6 +235,8 @@ define([
               metricsContext: {
                 deviceId: '0123456789abcdef0123456789abcdef',
                 entrypoint: 'mock-entrypoint',
+                entrypointExperiment: 'mock-entrypoint-experiment',
+                entrypointVariation: 'mock-entrypoint-variation',
                 flowBeginTime: 1480615985437,
                 flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
                 utmCampaign: 'mock-campaign',

--- a/packages/fxa-js-client/tests/lib/metricsContext.js
+++ b/packages/fxa-js-client/tests/lib/metricsContext.js
@@ -21,6 +21,8 @@ define([
         context: 'fx_desktop_v3',
         deviceId: '0123456789abcdef0123456789abcdef',
         entrypoint: 'menupanel',
+        entrypointExperiment: 'wibble',
+        entrypointVariation: 'blee',
         flowBeginTime: 1479815991573,
         flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
         migration: 'sync11',
@@ -35,6 +37,8 @@ define([
       assert.deepEqual(metricsContext.marshall(input), {
         deviceId: input.deviceId,
         entrypoint: 'menupanel',
+        entrypointExperiment: 'wibble',
+        entrypointVariation: 'blee',
         flowBeginTime: input.flowBeginTime,
         flowId: input.flowId,
         utmCampaign: 'foo',

--- a/packages/fxa-js-client/tests/lib/session.js
+++ b/packages/fxa-js-client/tests/lib/session.js
@@ -293,6 +293,8 @@ define([
               keys: true,
               metricsContext: {
                 entrypoint: 'mock-entrypoint',
+                entrypointExperiment: 'mock-entrypoint-experiment',
+                entrypointVariation: 'mock-entrypoint-variation',
                 utmCampaign: 'mock-utm-campaign',
                 utmContent: 'mock-utm-content',
                 utmMedium: 'mock-utm-medium',

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -232,6 +232,8 @@ module.exports = {
       return Object.assign(
         pruneUnsetValues({
           entrypoint: data.entrypoint,
+          entrypoint_experiment: data.entrypoint_experiment,
+          entrypoint_variation: data.entrypoint_variation,
           flow_id: data.flowId,
           ua_browser: data.browser,
           ua_version: data.browserVersion,

--- a/packages/fxa-shared/package-lock.json
+++ b/packages/fxa-shared/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Shared module for FxA repositories",
   "main": "index.js",
   "scripts": {

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -113,6 +113,8 @@ describe('metrics/amplitude:', () => {
           ],
           emailDomain: 'e',
           entrypoint: 'f',
+          entrypoint_experiment: 'exp',
+          entrypoint_variation: 'var',
           experiments: [
             { choice: 'g', group: 'h' },
             { choice: 'iI', group: 'jJ-J' }
@@ -138,6 +140,7 @@ describe('metrics/amplitude:', () => {
 
       it('returned the correct result', () => {
         assert.deepEqual(result, {
+          app_version: '0',
           country: 'c',
           device_id: 'd',
           device_model: 'm',
@@ -160,6 +163,8 @@ describe('metrics/amplitude:', () => {
               fxa_services_used: 'qux'
             },
             entrypoint: 'f',
+            entrypoint_experiment: 'exp',
+            entrypoint_variation: 'var',
             flow_id: 'l',
             sync_active_devices_day: 1,
             sync_active_devices_month: 5,
@@ -194,6 +199,7 @@ describe('metrics/amplitude:', () => {
 
       it('returned the correct result', () => {
         assert.deepEqual(result, {
+          app_version: '0',
           device_id: 'a',
           event_properties: {},
           event_type: 'fxa_login - targetEvent3',


### PR DESCRIPTION
Fixes #693.

The nice thing about the monorepo is that I can update all these metrics touchpoints in a single commit. The not-nice thing about it is that because we still require `fxa-shared` and `fxa-js-client` as external dependencies, some of the tests will fail until I publish new versions. Not the end of the world, but I look forward to this being a genuine one-step process.

Anyway, draft for now.