### PR TITLE
chore(ui): Lowercased the S on Manage subscriptions button

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/communication_preferences.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/communication_preferences.mustache
@@ -37,7 +37,7 @@
         {{/isOptedIn}}
         {{#isOptedIn}}
           <button id="marketing-email-manage" class="marketing-email-optin settings-button primary-button" autofocus>
-            {{#t}}Manage Subscriptions{{/t}}
+            {{#t}}Manage subscriptions{{/t}}
           </button>
           <button class="settings-button secondary-button cancel" id="marketing-email-done">{{#t}}Done{{/t}}</button>
         {{/isOptedIn}}


### PR DESCRIPTION
Lowercase on S on Manage subscriptions button because we don't use title case on buttons on fxa currently