### PR TITLE
fix(version): content looks for /app/config/version.json. Always create ./config directory.

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -7,20 +7,14 @@ if grep -e "$MODULE" -e 'all' $DIR/../packages/test.list; then
   docker -v
 
   # Place version.json so it is available as `/app/version.json` in the
-  # container, and also as `/app/config/version.json` if `/app/config` is a
-  # directory.
+  # container, and also as `/app/config/version.json`, creating /app/config
+  # if needed.
   cp $DIR/../packages/version.json .
-  if [[ -d config ]]; then
-    cp $DIR/../packages/version.json config
-  fi
+  mkdir -p config
+  cp $DIR/../packages/version.json config
 
   if [ "${MODULE}" == "fxa-auth-server" ]; then
     "$DIR/../_scripts/clone-authdb.sh"
-  elif [ "${MODULE}" == "fxa-content-server" ]; then
-    # HACK: This duplicates logic from .circleci/install-content-server.sh,
-    #       we should eliminate the duplication at some point.
-    mkdir -p server/config
-    cp $DIR/../packages/version.json server/config
   fi
 
   if [ "${MODULE}" == 'fxa-oauth-server' ]; then

--- a/.circleci/install-content-server.sh
+++ b/.circleci/install-content-server.sh
@@ -4,9 +4,9 @@ DIR=$(dirname "$0")
 
 if grep -e "fxa-content-server" -e 'all' $DIR/../packages/test.list; then
   sudo apt-get install -y graphicsmagick
-  mkdir -p server/config
+  mkdir -p config
   cp ../version.json ./
-  cp ../version.json server/config
+  cp ../version.json config
   cd $DIR/..
   CIRCLECI=false npm install
   npx pm2 kill


### PR DESCRIPTION
Ugh. So content-server, looking at lib/version.js, is looking for version.json in /app/config. My earlier fix was wrong, .circleci/install-content-server.js was always right, and the real fix is just to always `mkdir -p config` and put version.json there. [Almost all other packages have a ./config; content-server is the wildcard, but it always looked in ./config/version.json for the sha to be similar to the other packages].

r? - @philbooth 