### PR TITLE
chore(styles): Remove all references to trustedUI and resonableUI

### DIFF
--- a/packages/fxa-content-server/app/styles/_base.scss
+++ b/packages/fxa-content-server/app/styles/_base.scss
@@ -15,15 +15,7 @@ body {
   color: $text-color;
   font-size: $base-font;
   font-weight: 300;
-
-  @include respond-to('reasonableUI') {
-    padding-bottom: 20px;
-  }
-
-  @include respond-to('trustedUI') {
-    margin: 0;
-    padding: 0;
-  }
+  padding-bottom: 20px;
 }
 
 noscript {

--- a/packages/fxa-content-server/app/styles/_breakpoints.scss
+++ b/packages/fxa-content-server/app/styles/_breakpoints.scss
@@ -1,8 +1,6 @@
 // Breakpoint management
 // http://www.sitepoint.com/managing-responsive-breakpoints-sass/
 $breakpoints: (
-  trustedUI: '(max-width: 319px)',
-  reasonableUI: '(min-width: 320px)',
   small: '(max-width: 520px), (orientation:landscape) and (min-width:481px) and (max-height: 480px)',
   big: '(min-width: 521px) and (min-height: 481px)',
   balloonSmall: '(max-width: 927px)',

--- a/packages/fxa-content-server/app/styles/_layout.scss
+++ b/packages/fxa-content-server/app/styles/_layout.scss
@@ -42,14 +42,6 @@
     position: relative;
     width: 94%;
   }
-
-  @include respond-to('trustedUI') {
-    margin: 10px auto 0 auto;
-    min-width: 250px;
-    padding: 0;
-    top: 0;
-    width: 250px;
-  }
 }
 
 #fxa-settings-content {

--- a/packages/fxa-content-server/app/styles/modules/_avatar.scss
+++ b/packages/fxa-content-server/app/styles/modules/_avatar.scss
@@ -11,22 +11,12 @@
     border-radius: 4px;
   }
 
-  @include respond-to('trustedUI') {
-    box-shadow: none;
-    height: 65px;
-    padding: 0 0 0 55px;
-  }
-
   .user-info {
     flex: 1;
     flex-basis: 60px;
     height: 111px;
     margin-top: 20px;
     text-align: center;
-
-    @include respond-to('trustedUI') {
-      height: 55px;
-    }
   }
 
   a {
@@ -57,51 +47,25 @@
       width: 70px;
     }
 
-    @include respond-to('trustedUI') {
-      height: 55px;
-      margin-left: -55px;
-      margin-top: 0;
-      width: 55px;
-    }
-
     img {
       display: block;
       height: 71px;
       width: 71px;
-
-      @include respond-to('trustedUI') {
-        height: 55px;
-        width: 55px;
-      }
     }
   }
 
   &.avatar-view {
+    background-size: 120px auto;
     display: block;
+    height: 120px;
     margin: 0 auto 16px auto;
-
-    @include respond-to('reasonableUI') {
-      background-size: 120px auto;
-      height: 120px;
-      width: 120px;
-    }
+    width: 120px;
 
     img,
     .change-avatar {
         display: block;
         height: 120px;
         width: 120px;
-    }
-
-    @include respond-to('trustedUI') {
-      background-size: 100px auto;
-      height: 100px;
-      width: 100px;
-
-      img {
-        height: 100px;
-        width: 100px;
-      }
     }
 
     small {

--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -27,10 +27,6 @@
     }
   }
 
-  @include respond-to('trustedUI') {
-    display: none;
-  }
-
   .static & {
     opacity: 1;
   }

--- a/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
+++ b/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
@@ -237,10 +237,6 @@ input[type='checkbox'] {
   @include respond-to('small') {
     column-width: 150px;
   }
-
-  @include respond-to('trustedUI') {
-    column-width: 118px;
-  }
 }
 
 .pair-auth {

--- a/packages/fxa-content-server/app/styles/modules/_graphic.scss
+++ b/packages/fxa-content-server/app/styles/modules/_graphic.scss
@@ -35,10 +35,6 @@
   @include respond-to('small') {
     height: 100px;
   }
-
-  @include respond-to('trustedUI') {
-    margin: 0 auto 0 auto;
-  }
 }
 
 .graphic-connect-another-device {

--- a/packages/fxa-content-server/app/styles/modules/_input-row.scss
+++ b/packages/fxa-content-server/app/styles/modules/_input-row.scss
@@ -103,13 +103,7 @@
   }
 
   .input-help-focused {
-    @include respond-to('reasonableUI') {
-      opacity: 0;
-    }
-
-    @include respond-to('trustedUI') {
-      opacity: 1;
-    }
+    opacity: 0;
   }
 
   input:focus ~ .input-help-focused,

--- a/packages/fxa-content-server/app/styles/modules/_legal.scss
+++ b/packages/fxa-content-server/app/styles/modules/_legal.scss
@@ -12,17 +12,10 @@
 
 #legal-footer {
   bottom: 0;
+  margin: 10px 0;
   position: relative;
   text-align: center;
   width: 100%;
-
-  @include respond-to('reasonableUI') {
-    margin: 10px 0;
-  }
-
-  @include respond-to('trustedUI') {
-    margin: 0;
-  }
 
   .terms,
   .privacy {
@@ -47,14 +40,6 @@
 #legal-copy {
   line-height: 24px;
   text-align: left;
-
-  @include respond-to('trustedUI') {
-    margin-bottom: 10px;
-
-    h2 {
-      font-size: $base-font;
-    }
-  }
 
   p {
     font-size: $base-font;

--- a/packages/fxa-content-server/app/styles/modules/_marketing-ios.scss
+++ b/packages/fxa-content-server/app/styles/modules/_marketing-ios.scss
@@ -35,8 +35,4 @@
     padding: 15px 50px 20px 50px;
     text-align: center;
   }
-
-  @include respond-to('trustedUI') {
-    display: none;
-  }
 }

--- a/packages/fxa-content-server/app/styles/modules/_spinner.scss
+++ b/packages/fxa-content-server/app/styles/modules/_spinner.scss
@@ -50,10 +50,6 @@
     @include respond-to('small') {
       top: -1px;
     }
-
-    @include respond-to('trustedUI') {
-      top: -4px;
-    }
   }
 
   &.spinner-settings-fetch {

--- a/packages/fxa-content-server/app/styles/modules/_tooltip.scss
+++ b/packages/fxa-content-server/app/styles/modules/_tooltip.scss
@@ -86,10 +86,6 @@
       background-color: $warning-background-color;
     }
   }
-
-  @include respond-to('trustedUI') {
-    font-size: $small-font;
-  }
 }
 
 /**


### PR DESCRIPTION
Deprecates trustedUI and reasonableUI breakpoints and all mentions
of them from content-server.

fixes: #827