### PR TITLE
chore(docs): Update README/CONTRIBUTING for monorepo/commit signing.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,15 @@ mailing list or through issues here on GitHub.
 
 - IRC: `#fxa` on `irc.mozilla.org`
 - Mailing list: <https://mail.mozilla.org/listinfo/dev-fxacct>
-- and of course, [the issues list](https://github.com/mozilla/fxa-content-server/issues)
+- and of course, [the issues list](https://github.com/mozilla/fxa/issues)
+
+## Code of Conduct
+
+You must agree to abide by the [Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/)
 
 ## Bug Reports ##
 
-You can file issues here on GitHub. Please try to include as much information as you can and under what conditions
+You can [file issues on GitHub](https://github.com/mozilla/fxa/issues/new). Please try to include as much information as you can and under what conditions
 you saw the issue.
 
 ## Sending Pull Requests ##
@@ -17,14 +21,13 @@ you saw the issue.
 Patches should be submitted as pull requests (PR).
 
 Before submitting a PR:
-- Your code must run and pass all the automated tests before you submit your PR for review. "Work in progress" pull requests are allowed to be submitted, but should be clearly labeled as such and should not be merged until all tests pass and the code has been reviewed. 
-  - Run `grunt lint` to make sure your code passes linting.
-  - Run `npm test` to make sure all tests still pass.
+- Your code must run and pass all the automated tests before you submit your PR for review. "Work in progress" pull requests are allowed to be submitted, but should be clearly labeled as such and should not be merged until all tests pass and the code has been reviewed.
 - Your patch should include new tests that cover your changes. It is your and your reviewer's responsibility to ensure your patch includes adequate tests.
+- Your patch must be [GPG signed](https://help.github.com/articles/managing-commit-signature-verification) to ensure the commits come from a trusted source.
 
 When submitting a PR:
 - You agree to license your code under the project's open source license ([MPL 2.0](/LICENSE)).
-- Base your branch off the current `master` (see below for an example workflow).
+- Base your branch off the current `master`.
 - Add both your code and new tests if relevant.
 - Run `grunt lint` and `npm test` to make sure your code passes linting and tests.
 - Please do not include merge commits in pull requests; include only commits with the new relevant code.
@@ -35,7 +38,7 @@ See the main [README.md](/README.md) for information on prerequisites, installin
 
 ## Code Review ##
 
-This project is production Mozilla code and subject to our [engineering practices and quality standards](https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Committing_Rules_and_Responsibilities). Every patch must be peer reviewed. This project is part of the [Firefox Accounts module](https://wiki.mozilla.org/Modules/Other#Firefox_Accounts), and your patch must be reviewed by one of the listed module owners or peers. 
+This project is production Mozilla code and subject to our [engineering practices and quality standards](https://developer.mozilla.org/docs/Mozilla/Developer_guide/Committing_Rules_and_Responsibilities). Every patch must be peer reviewed. This project is part of the [Firefox Accounts module](https://wiki.mozilla.org/Modules/Other#Firefox_Accounts), and your patch must be reviewed by one of the listed module owners or peers.
 
 ## Git Commit Guidelines
 
@@ -72,34 +75,9 @@ You can also write a detailed description of the commit:
 Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes"
 It should include the motivation for the change and contrast this with previous behavior.
 
-###Footer
+### Footer
 The footer should contain any information about **Breaking Changes** and is also the place to
 reference GitHub issues that this commit **Closes**.
-
-## Grunt Commands
-
-[Grunt](http://gruntjs.com/) is used to run common tasks to build, test, and run local servers.
-
-| Task | Description |
-|------|-------------|
-| `grunt lint` | run ESLint, Sass-lint, amdcheck and JSONLint on client side and testing JavaScript. |
-| `grunt build` | build production resources. |
-| `grunt clean` | remove any built production resources. |
-| `grunt test` | run local Intern tests. |
-| `grunt server` | run a local server running on port 3030 with development resources. |
-| `grunt server:dist` | run a local server running on port 3030 with production resources. Production resources will be built as part of the task. |
-| `grunt version` | stamp a new version. Updates the version number and creates a new CHANGELOG.md file. |
-
-## Test Options
-
-| Command | Description |
-|------|-------------|
-| `npm test` | Run unit and functional tests locally. |
-| `npm run test-functional` | Run functional tests locally. |
-| `npm run test-functional-oauth` | Run OAuth functional tests locally. |
-| `npm run test-sauce` | Run functional tests on Sauce Labs. Requires credentials. |
-| `npm run test-server` | Run server tests. |
-| `npm run test-latest` | Run full functional tests (OAuth, Firefox Sync UI) against http://latest.dev.lcip.org. |
 
 ## Servers
 
@@ -112,12 +90,12 @@ reference GitHub issues that this commit **Closes**.
 
 ### npm
 
-We use [npm](http://npmjs.com/) to manage all dependencies. These components are [automatically
-installed](https://github.com/mozilla/fxa-content-server/blob/master/package.json#L7) when you install this project.
+We use [npm](http://npmjs.com/) to manage dependencies. Required components are [automatically
+installed](https://github.com/mozilla/fxa/blob/master/package.json#L6) when you install this project.
 
 ### L10N
 
-To contribute translations visit [mozilla/fxa-content-server-l10n](https://github.com/mozilla/fxa-content-server-l10n). 
+To contribute translations visit [mozilla/fxa-content-server-l10n](https://github.com/mozilla/fxa-content-server-l10n).
 Use the `FXA_L10N_SHA` to pin L10N files to certain Git SHA. If not set then the `master` branch SHA will be used.
 
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ When you want to [fetch the latest changes](_scripts/update_all.sh) to all serve
 
 *******
 
+### Contributing
+
+See the separate [CONTRIBUTING.md](https://github.com/mozilla/fxa/blob/master/CONTRIBUTING.md) to learn how to contribute.
+
+
 ### Workflow
 > This is an example workflow for **fxa**.
 


### PR DESCRIPTION
I moved the CONTRIBUTING.md file from the content server package to
the top level so that it easily discoverable. The README now
contains a link to CONTRIBUTING.md. CONTRIBUTING.md now mentions
GPG signatures as a requirement for opening PRs.

Not attached to an issue.

@mozilla/fxa-devs - r?