### PR TITLE
fix(ci): ensure redis and memcached docker images run in pm2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,8 +132,6 @@ jobs:
     parallelism: 6
     docker:
       - image: circleci/node:10-stretch-browsers
-      - image: redis
-      - image: memcached
       - image: pafortin/goaws
 
     working_directory: ~/project/packages/fxa-content-server
@@ -141,13 +139,13 @@ jobs:
       - attach_workspace:
           at: ~/
 
+      - setup_remote_docker
+
       - run: ../../.circleci/test-content-server.sh
 
       # run pairing tests on one node
       - deploy:
           command: ../../.circleci/test-content-server.sh pairing
-
-      - setup_remote_docker
 
       - deploy:
           command: ../../.circleci/build.sh fxa-content-server


### PR DESCRIPTION
Fixes #904.

The `setup-remote-docker` step was being run after the `.circleci/test-content-server.sh` step in the `test-content-server` job, causing `pm2` to fail for some services. Additionally I've removed memcached and redis from the `test-content-server` docker image, because pm2 runs them inside separate containers anyway.

The linked issue was intermittent so it's difficult to be certain that it's gone away, but I can point to the key differences in the logs that are due to this fix.

The linked [failing build](https://circleci.com/gh/mozilla/fxa/9304) shows that a number of processes started by `pm2` were aborted:

```
┌────────────────────────────────────────────────┬────┬─────────┬──────┬─────┬─────────┬─────────┬────────┬─────┬───────────┬──────────┬──────────┐
│ App name                                       │ id │ version │ mode │ pid │ status  │ restart │ uptime │ cpu │ mem       │ user     │ watching │
├────────────────────────────────────────────────┼────┼─────────┼──────┼─────┼─────────┼─────────┼────────┼─────┼───────────┼──────────┼──────────┤
│ 123done PORT 8080                              │ 10 │ 0.0.2   │ fork │ 652 │ online  │ 0       │ 1s     │ 0%  │ 36.4 MB   │ circleci │ disabled │
│ 321done UNTRUSTED PORT 10139                   │ 11 │ 0.0.2   │ fork │ 660 │ online  │ 0       │ 1s     │ 0%  │ 36.3 MB   │ circleci │ disabled │
│ Fake SQS/SNS PORT 4100                         │ 16 │ 2.0.0   │ fork │ 699 │ errored │ 0       │ 0      │ 0%  │ 0 B       │ circleci │ disabled │
│ auth-server db memory PORT 8000                │ 1  │ 1.135.1 │ fork │ 585 │ online  │ 0       │ 1s     │ 0%  │ 42.4 MB   │ circleci │ disabled │
│ auth-server key server PORT 9000               │ 2  │ 1.135.1 │ fork │ 596 │ online  │ 0       │ 1s     │ 0%  │ 44.0 MB   │ circleci │ disabled │
│ auth-server local mail helper                  │ 0  │ 1.135.1 │ fork │ 583 │ online  │ 0       │ 1s     │ 0%  │ 42.2 MB   │ circleci │ disabled │
│ browserid-verifier PORT 5050                   │ 12 │ 0.10.1  │ fork │ 661 │ online  │ 0       │ 1s     │ 0%  │ 36.4 MB   │ circleci │ disabled │
│ content-server PORT 3030                       │ 3  │ 1.135.1 │ fork │ 603 │ online  │ 0       │ 1s     │ 0%  │ 48.9 MB   │ circleci │ disabled │
│ email-service PORT 8001                        │ 17 │ 2.0.0   │ fork │ 691 │ online  │ 0       │ 0s     │ 0%  │ 3.0 MB    │ circleci │ disabled │
│ fxa-basket-proxy PORT 1114                     │ 4  │ 1.134.0 │ fork │ 611 │ online  │ 0       │ 1s     │ 0%  │ 40.2 MB   │ circleci │ disabled │
│ fxa-basket-proxy fake basket server PORT 10140 │ 5  │ 1.134.0 │ fork │ 618 │ online  │ 0       │ 1s     │ 0%  │ 44.4 MB   │ circleci │ disabled │
│ memcached PORT 11211                           │ 15 │ 2.0.0   │ fork │ 685 │ errored │ 0       │ 0      │ 0%  │ 0 B       │ circleci │ disabled │
│ oauth-server PORT 9010                         │ 6  │ 1.135.1 │ fork │ 625 │ online  │ 0       │ 1s     │ 0%  │ 41.2 MB   │ circleci │ disabled │
│ pairing channelserver PORT 8058                │ 20 │ 2.0.0   │ fork │ 743 │ errored │ 0       │ 0      │ 0%  │ 0 B       │ circleci │ disabled │
│ profile-server PORT 1111                       │ 7  │ 1.135.1 │ fork │ 626 │ online  │ 0       │ 1s     │ 0%  │ 37.9 MB   │ circleci │ disabled │
│ profile-server static dev PORT 1112            │ 8  │ 1.135.1 │ fork │ 639 │ online  │ 0       │ 1s     │ 0%  │ 37.8 MB   │ circleci │ disabled │
│ profile-server worker PORT 1113                │ 9  │ 1.135.1 │ fork │ 645 │ online  │ 0       │ 1s     │ 0%  │ 38.0 MB   │ circleci │ disabled │
│ pushbox PORT 8002                              │ 19 │ 2.0.0   │ fork │ 718 │ online  │ 0       │ 0s     │ 0%  │ 3.1 MB    │ circleci │ disabled │
│ pushbox db PORT 4306                           │ 18 │ 2.0.0   │ fork │ 711 │ online  │ 0       │ 0s     │ 0%  │ 3.1 MB    │ circleci │ disabled │
│ redis PORT 6379                                │ 14 │ 2.0.0   │ fork │ 675 │ errored │ 0       │ 0      │ 0%  │ 0 B       │ circleci │ disabled │
│ sync server PORT 5000                          │ 13 │ 2.0.0   │ fork │ 667 │ errored │ 0       │ 0      │ 0%  │ 0 B       │ circleci │ disabled │
└────────────────────────────────────────────────┴────┴─────────┴──────┴─────┴─────────┴─────────┴────────┴─────┴───────────┴──────────┴──────────┘
```

Whereas the [build for this branch](https://circleci.com/gh/mozilla/fxa/9928) shows them all started cleanly:

```
┌────────────────────────────────────────────────┬────┬─────────┬──────┬─────┬────────┬─────────┬────────┬─────┬───────────┬──────────┬──────────┐
│ App name                                       │ id │ version │ mode │ pid │ status │ restart │ uptime │ cpu │ mem       │ user     │ watching │
├────────────────────────────────────────────────┼────┼─────────┼──────┼─────┼────────┼─────────┼────────┼─────┼───────────┼──────────┼──────────┤
│ 123done PORT 8080                              │ 10 │ 0.0.2   │ fork │ 648 │ online │ 0       │ 0s     │ 0%  │ 36.2 MB   │ circleci │ disabled │
│ 321done UNTRUSTED PORT 10139                   │ 11 │ 0.0.2   │ fork │ 655 │ online │ 0       │ 0s     │ 0%  │ 33.9 MB   │ circleci │ disabled │
│ Fake SQS/SNS PORT 4100                         │ 16 │ 2.0.0   │ fork │ 700 │ online │ 0       │ 0s     │ 0%  │ 3.1 MB    │ circleci │ disabled │
│ auth-server db memory PORT 8000                │ 1  │ 1.135.3 │ fork │ 584 │ online │ 0       │ 0s     │ 0%  │ 47.9 MB   │ circleci │ disabled │
│ auth-server key server PORT 9000               │ 2  │ 1.135.3 │ fork │ 592 │ online │ 0       │ 0s     │ 0%  │ 48.7 MB   │ circleci │ disabled │
│ auth-server local mail helper                  │ 0  │ 1.135.3 │ fork │ 578 │ online │ 0       │ 0s     │ 0%  │ 49.6 MB   │ circleci │ disabled │
│ browserid-verifier PORT 5050                   │ 12 │ 0.10.1  │ fork │ 656 │ online │ 0       │ 0s     │ 0%  │ 35.1 MB   │ circleci │ disabled │
│ content-server PORT 3030                       │ 3  │ 1.135.3 │ fork │ 599 │ online │ 0       │ 0s     │ 0%  │ 49.1 MB   │ circleci │ disabled │
│ email-service PORT 8001                        │ 17 │ 2.0.0   │ fork │ 714 │ online │ 0       │ 0s     │ 0%  │ 3.2 MB    │ circleci │ disabled │
│ fxa-basket-proxy PORT 1114                     │ 4  │ 1.134.0 │ fork │ 605 │ online │ 0       │ 0s     │ 0%  │ 46.4 MB   │ circleci │ disabled │
│ fxa-basket-proxy fake basket server PORT 10140 │ 5  │ 1.134.0 │ fork │ 613 │ online │ 0       │ 0s     │ 0%  │ 36.7 MB   │ circleci │ disabled │
│ memcached PORT 11211                           │ 15 │ 2.0.0   │ fork │ 694 │ online │ 0       │ 0s     │ 0%  │ 3.2 MB    │ circleci │ disabled │
│ oauth-server PORT 9010                         │ 6  │ 1.135.3 │ fork │ 619 │ online │ 0       │ 0s     │ 0%  │ 39.1 MB   │ circleci │ disabled │
│ pairing channelserver PORT 8058                │ 20 │ 2.0.0   │ fork │ 744 │ online │ 0       │ 0s     │ 0%  │ 3.2 MB    │ circleci │ disabled │
│ profile-server PORT 1111                       │ 7  │ 1.135.3 │ fork │ 627 │ online │ 0       │ 0s     │ 0%  │ 36.6 MB   │ circleci │ disabled │
│ profile-server static dev PORT 1112            │ 8  │ 1.135.3 │ fork │ 634 │ online │ 0       │ 0s     │ 0%  │ 37.4 MB   │ circleci │ disabled │
│ profile-server worker PORT 1113                │ 9  │ 1.135.3 │ fork │ 641 │ online │ 0       │ 0s     │ 0%  │ 35.8 MB   │ circleci │ disabled │
│ pushbox PORT 8002                              │ 19 │ 2.0.0   │ fork │ 733 │ online │ 0       │ 0s     │ 0%  │ 3.1 MB    │ circleci │ disabled │
│ pushbox db PORT 4306                           │ 18 │ 2.0.0   │ fork │ 721 │ online │ 0       │ 0s     │ 0%  │ 3.1 MB    │ circleci │ disabled │
│ redis PORT 6379                                │ 14 │ 2.0.0   │ fork │ 671 │ online │ 0       │ 0s     │ 0%  │ 3.1 MB    │ circleci │ disabled │
│ sync server PORT 5000                          │ 13 │ 2.0.0   │ fork │ 668 │ online │ 0       │ 0s     │ 0%  │ 3.2 MB    │ circleci │ disabled │
└────────────────────────────────────────────────┴────┴─────────┴──────┴─────┴────────┴─────────┴────────┴─────┴───────────┴──────────┴──────────┘
```

You can also see that the log artifacts [for memcached]() and [for redis]() previously showed that the Docker daemon wasn't running:

```
docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.
See 'docker run --help'.
```

The artifacts no longer include that error.

So I'm sure this change definitely fixes something. Is it the same something described by the linked issue though?

@mozilla/fxa-devs r?