### PR TITLE
fix(emails): reverse engineer partials for verification reminders

### DIFF
--- a/packages/fxa-auth-server/lib/senders/partials/verification_reminder_first.html
+++ b/packages/fxa-auth-server/lib/senders/partials/verification_reminder_first.html
@@ -1,27 +1,6 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title>{{t "Firefox Accounts"}}</title>
-</head>
+<% extends "partials/base/base.html" %>
 
-<body style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; margin: 0; padding: 0;">
-<table align="center" border="0" cellpadding="0" cellspacing="0" width="310" style="-webkit-text-size-adjust: 100%; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 310px; margin: 0 auto;">
-
-<!--Logo-->
-<tr style="page-break-before: always">
-  <td align="center" id="firefox-logo" style="padding: 20px 0;">
-    {{^if sync}}
-      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="88" width="85" alt="" style="-ms-interpolation-mode: bicubic;" />
-    {{/if}}
-
-    {{#if sync}}
-      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
-    {{/if}}
-  </td>
-</tr>
-
-
+<% block content %>
 <!--Header Area-->
 <tr style="page-break-before: always">
   <td valign="top">
@@ -66,18 +45,9 @@
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #737373; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
   </td>
 </tr>
+<% endblock %>
 
-
-<tr style="page-break-before: always">
-  <td valign="top">
-    <p style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #737373; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">Mozilla. 331 E Evelyn Ave, Mountain View, CA 94041
-    <br />
-    <a href="{{{privacyUrl}}}" style="color: #0a84ff; text-decoration: none; font-family: sans-serif; font-size: 11px; line-height: 18px;">{{t "Mozilla Privacy Policy" }}</a></p>
-  </td>
-</tr>
-
-</table>
-
+<% block after_table %>
 <script type="application/ld+json">
 {
   "@context": "http://schema.org",
@@ -96,6 +66,4 @@
   }
 }
 </script>
-
-</body>
-</html>
+<% endblock %>

--- a/packages/fxa-auth-server/lib/senders/partials/verification_reminder_second.html
+++ b/packages/fxa-auth-server/lib/senders/partials/verification_reminder_second.html
@@ -1,38 +1,17 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title>{{t "Firefox Accounts"}}</title>
-</head>
+<% extends "partials/base/base.html" %>
 
-<body style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; margin: 0; padding: 0;">
-<table align="center" border="0" cellpadding="0" cellspacing="0" width="310" style="-webkit-text-size-adjust: 100%; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 310px; margin: 0 auto;">
-
-<!--Logo-->
-<tr style="page-break-before: always">
-  <td align="center" id="firefox-logo" style="padding: 20px 0;">
-    {{^if sync}}
-      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/firefox57-logo.png" height="88" width="85" alt="" style="-ms-interpolation-mode: bicubic;" />
-    {{/if}}
-
-    {{#if sync}}
-      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
-    {{/if}}
-  </td>
-</tr>
-
-
+<% block content %>
 <!--Header Area-->
 <tr style="page-break-before: always">
   <td valign="top">
     <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">
-      {{t "Hello again."}}
+      {{t "Still there?"}}
     </h1>
     <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">
-      {{t "You recently created a Firefox Account but haven't confirmed your email yet."}}
+      {{t "Almost a week ago you created a Firefox Account but never verified it. We’re worried about you."}}
     </p>
     <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
-      {{t "Confirm your email so that you can start using Firefox Sync, Pocket, Lockbox, Firefox Send, Monitor and more."}}
+      {{t "Confirm this email address to activate your account and let us know you're okay."}}
     </p>
   </td>
 </tr>
@@ -66,18 +45,9 @@
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #737373; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
   </td>
 </tr>
+<% endblock %>
 
-
-<tr style="page-break-before: always">
-  <td valign="top">
-    <p style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #737373; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">Mozilla. 331 E Evelyn Ave, Mountain View, CA 94041
-    <br />
-    <a href="{{{privacyUrl}}}" style="color: #0a84ff; text-decoration: none; font-family: sans-serif; font-size: 11px; line-height: 18px;">{{t "Mozilla Privacy Policy" }}</a></p>
-  </td>
-</tr>
-
-</table>
-
+<% block after_table %>
 <script type="application/ld+json">
 {
   "@context": "http://schema.org",
@@ -96,6 +66,4 @@
   }
 }
 </script>
-
-</body>
-</html>
+<% endblock %>

--- a/packages/fxa-auth-server/lib/senders/templates/verification_reminder_second.html
+++ b/packages/fxa-auth-server/lib/senders/templates/verification_reminder_second.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <title>{{t "Final reminder: Confirm your email to activate your Firefox Account"}}</title>
+  <title>{{t "Firefox Accounts"}}</title>
 </head>
 
 <body style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; margin: 0; padding: 0;">
@@ -58,6 +58,7 @@
     </table>
   </td>
 </tr>
+
 <!--Button Area-->
 <tr style="page-break-before: always">
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">


### PR DESCRIPTION
I didn't realise the email templates are generated from partials, so I created the verification reminder templates by hand. This change creates partials for them, so that they can be updated with `grunt templates`. I then ran `grunt templates` to check my work, which explains the changed `<title>` elements.

@mozilla/fxa-devs r?