### PR TITLE
chore(test): Add "signin token code" tests to the normal functional test suite.

### DIFF
--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -10,6 +10,7 @@ module.exports = [
   'tests/functional/sign_in.js',
   'tests/functional/sign_in_cached.js',
   'tests/functional/sign_in_blocked.js',
+  'tests/functional/sign_in_token_code.js',
   'tests/functional/sign_in_totp.js',
   'tests/functional/sign_in_recovery_code.js',
   'tests/functional/sync_v1.js',


### PR DESCRIPTION
ref #915 that adds the tests to circle, they were also missing from the normal functional test suite.

@mozilla/fxa-devs - r?