### PR TITLE
fix(scripts): stop release script failing in diff size logic

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -365,9 +365,8 @@ echo "  https://github.com/mozilla/fxa/compare/$TRAIN_BRANCH?expand=1"
 echo "  https://github.com/mozilla/fxa-private/compare/$PRIVATE_BRANCH?expand=1"
 echo
 
-PRIVATE_DIFF_SIZE=`git diff "$PRIVATE_BRANCH..$PRIVATE_DIFF_FROM" | wc -l`
-expr "$PRIVATE_DIFF_SIZE" \> 300 > /dev/null
-IS_BIG_RELEASE="$?"
+PRIVATE_DIFF_SIZE=`git diff "$PRIVATE_BRANCH..$PRIVATE_DIFF_FROM" | wc -l | awk '{$1=$1};1'`
+IS_BIG_RELEASE=`expr "$PRIVATE_DIFF_SIZE" \> 300`
 if [ "$IS_BIG_RELEASE" = "1" ]; then
   echo "The diff for the private release is pretty big. You may want to add the following comment to that PR:"
   echo


### PR DESCRIPTION
Testing my changes for #857, I realised I'd previously broken the release script with my changes for #856.

I tested that logic in the `PRIVATE_DIFF_SIZE` <= 300 case, but evidently failed to do so in the > 300 case.

There were two problems with it:

* It used the return code rather than the result string from the `expr` command. This meant the positive branch of the test was never entered.

* It didn't trim whitespace from the `wc -l` result.

This PR fixes both of those issues.

@mozilla/fxa-devs r?