### PR TITLE
feat(email): include flowId and flowBeginTime in reminder metrics

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -258,7 +258,7 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push,
               service: form.service || query.service,
               redirectTo: form.redirectTo,
               resume: form.resume,
-              acceptLanguage: request.app.acceptLanguage,
+              acceptLanguage: locale,
               deviceId,
               flowId,
               flowBeginTime,
@@ -280,7 +280,7 @@ module.exports = (log, db, mailer, Password, config, customs, signinUtils, push,
                   });
                 }
 
-                return verificationReminders.create(account.uid);
+                return verificationReminders.create(account.uid, flowId, flowBeginTime);
               })
               .catch((err) => {
                 log.error('mailer.sendVerifyCode.1', { err: err});

--- a/packages/fxa-auth-server/scripts/verification-reminders.js
+++ b/packages/fxa-auth-server/scripts/verification-reminders.js
@@ -56,14 +56,14 @@ async function run () {
 
     log.info('verificationReminders.processing', { count: reminders.length, key });
 
-    const failedReminders = await reminders.reduce(async (promise, { timestamp, uid }) => {
+    const failedReminders = await reminders.reduce(async (promise, { timestamp, uid, flowId, flowBeginTime }) => {
       const failed = await promise;
 
       try {
         if (sent[uid]) {
           // Don't send e.g. first and second reminders to the same email from a single batch
           log.info('verificationReminders.skipped.alreadySent', { uid });
-          failed.push({ timestamp, uid });
+          failed.push({ timestamp, uid, flowId, flowBeginTime });
           return failed;
         }
 
@@ -72,6 +72,8 @@ async function run () {
           acceptLanguage: account.locale,
           code: account.emailCode,
           email: account.email,
+          flowBeginTime,
+          flowId,
           uid,
         });
         sent[uid] = true;
@@ -90,7 +92,7 @@ async function run () {
             break;
           default:
             log.error('verificationReminders.error', { err });
-            failed.push({ timestamp, uid });
+            failed.push({ timestamp, uid, flowId, flowBeginTime });
         }
       }
 

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -569,8 +569,10 @@ describe('/account/create', () => {
 
       assert.equal(verificationReminders.create.callCount, 1);
       args = verificationReminders.create.args[0];
-      assert.lengthOf(args, 1);
+      assert.lengthOf(args, 3);
       assert.equal(args[0], uid);
+      assert.equal(args[1], mockRequest.payload.metricsContext.flowId);
+      assert.equal(args[2], mockRequest.payload.metricsContext.flowBeginTime);
 
       assert.equal(mockLog.error.callCount, 0);
     }).finally(() => Date.now.restore());


### PR DESCRIPTION
Related to https://github.com/mozilla/fxa/issues/866#issuecomment-486437969.

We weren't storing `flowId` and `flowBeginTime` with the verification reminders, so those properties were missing on the email events. This change writes them to Redis under a different key, removing them when the reminder records are removed.

A different key was used for a few reasons:

* We need to delete reminders by value when accounts are verified, and we can't guarantee we'll have the `flowId` and `flowBeginTime` to use at that point (they're only kept in memcached for 2 hours). So  the value inside the Redis sorted sets needs to stay as being just the `uid`.

* Even if we could include them in the sorted set value, we might not want to because that would duplicate them on both the first and second reminders, doubling the size of data that we write to Redis. Putting them under a different key effectively normalises that relationship.

To test this locally, you'll want to set your `verifcationReminders.firstInterval` and `verificationReminders.secondInterval` to suitably low values in the auth server config first. Typically I use `10 seconds` and `1 minute` respectively. Then sign up for an account but don't verify.

Running `node scripts/verificationReminders` after 10 seconds should show you logs like this (note the presence of `flowId`  in the `emailEvent` and the `X-Flow-*` headers in the mailer log):

```
fxa-auth-server.INFO: redis.enabled {"config":{"host":"127.0.0.1","port":6379,"sessionTokens":{"enabled":true,"prefix":"fxa-auth-session","maxConnections":200,"minConnections":2},"email":{"enabled":true,"prefix":"email:","maxConnections":10,"minConnections":1},"maxPending":1000,"retryCount":5,"initialBackoff":100,"prefix":"verificationReminders:","maxConnections":10,"minConnections":1,"enabled":true}}
fxa-auth-server.INFO: redis.enabled {"config":{"host":"127.0.0.1","port":6379,"sessionTokens":{"enabled":true,"prefix":"fxa-auth-session","maxConnections":200,"minConnections":2},"email":{"enabled":true,"prefix":"email:","maxConnections":10,"minConnections":1},"maxPending":1000,"retryCount":5,"initialBackoff":100,"enabled":true,"prefix":"email:","maxConnections":10,"minConnections":1}}
fxa-auth-server.INFO: redis.enabled {"config":{"host":"127.0.0.1","port":6379,"sessionTokens":{"enabled":true,"prefix":"fxa-auth-session","maxConnections":200,"minConnections":2},"email":{"enabled":true,"prefix":"email:","maxConnections":10,"minConnections":1},"maxPending":1000,"retryCount":5,"initialBackoff":100,"prefix":"verificationReminders:","maxConnections":10,"minConnections":1,"enabled":true}}
fxa-auth-server.INFO: verificationReminders.process {"key":"first","now":1556182974367,"cutoff":1556182964367}
fxa-auth-server.INFO: verificationReminders.process {"key":"second","now":1556182974367,"cutoff":1556182914367}
fxa-auth-server.INFO: redis.enabled {"config":{"host":"127.0.0.1","port":6379,"sessionTokens":{"enabled":true,"prefix":"fxa-auth-session","maxConnections":200,"minConnections":2},"email":{"enabled":true,"prefix":"email:","maxConnections":10,"minConnections":1},"maxPending":1000,"retryCount":5,"initialBackoff":100,"enabled":true,"prefix":"fxa-auth-session","maxConnections":200,"minConnections":2}}
(node:39786) DeprecationWarning: mozlog.config() is deprecated. Use mozlog(opts) to receive a specific mozlog instance.
fxa-auth-server.INFO: verificationReminders.processing {"count":1,"key":"first"}
fxa-auth-server.INFO: mailer.send {"email":"pmbooth@gmail.com","template":"verificationReminderFirstEmail","headers":"Content-Language,X-Template-Name,X-Template-Version,X-Link,X-Verify-Code,X-Flow-Id,X-Flow-Begin-Time,X-Uid,X-Email-Service,X-Email-Sender"}
fxa-auth-server.INFO: mailer.send.1 {"id":"smtp:250","to":"pmbooth@gmail.com","emailSender":"ses","emailService":"fxa-email-service"}
fxa-auth-server.INFO: emailEvent {"template":"verificationReminderFirstEmail","templateVersion":4,"type":"sent","flow_id":"f5f31369a4e42909bece4a204b6cc2cf20f577f3691db747501c3c8221355707","locale":"en","domain":"gmail.com"}
fxa-auth-server.INFO: redis.enabled {"config":{"host":"127.0.0.1","port":6379,"sessionTokens":{"enabled":true,"prefix":"fxa-auth-session","maxConnections":200,"minConnections":2},"email":{"enabled":true,"prefix":"email:","maxConnections":10,"minConnections":1},"maxPending":1000,"retryCount":5,"initialBackoff":100,"prefix":"verificationReminders:","maxConnections":10,"minConnections":1,"enabled":true}}
fxa-auth-server.INFO: amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_email - sent","time":1556182974912,"user_id":"181d58d0c1f74b1f8c1dcb9a66faa9d9","session_id":1556182880669,"app_version":"135","language":"en","event_properties":{"email_type":"registration","email_provider":"gmail.com","email_sender":"ses","email_service":"fxa-email-service","email_template":"verificationReminderFirstEmail","email_version":4},"user_properties":{"flow_id":"f5f31369a4e42909bece4a204b6cc2cf20f577f3691db747501c3c8221355707","sync_device_count":0,"sync_active_devices_day":0,"sync_active_devices_week":0,"sync_active_devices_month":0}}
fxa-auth-server.INFO: verificationReminders.processing {"count":0,"key":"second"}
fxa-auth-server.INFO: verificationReminders.done {}
```

Running it again a minute later should show logs like this:
```
fxa-auth-server.INFO: redis.enabled {"config":{"host":"127.0.0.1","port":6379,"sessionTokens":{"enabled":true,"prefix":"fxa-auth-session","maxConnections":200,"minConnections":2},"email":{"enabled":true,"prefix":"email:","maxConnections":10,"minConnections":1},"maxPending":1000,"retryCount":5,"initialBackoff":100,"prefix":"verificationReminders:","maxConnections":10,"minConnections":1,"enabled":true}}
fxa-auth-server.INFO: redis.enabled {"config":{"host":"127.0.0.1","port":6379,"sessionTokens":{"enabled":true,"prefix":"fxa-auth-session","maxConnections":200,"minConnections":2},"email":{"enabled":true,"prefix":"email:","maxConnections":10,"minConnections":1},"maxPending":1000,"retryCount":5,"initialBackoff":100,"enabled":true,"prefix":"email:","maxConnections":10,"minConnections":1}}
fxa-auth-server.INFO: redis.enabled {"config":{"host":"127.0.0.1","port":6379,"sessionTokens":{"enabled":true,"prefix":"fxa-auth-session","maxConnections":200,"minConnections":2},"email":{"enabled":true,"prefix":"email:","maxConnections":10,"minConnections":1},"maxPending":1000,"retryCount":5,"initialBackoff":100,"prefix":"verificationReminders:","maxConnections":10,"minConnections":1,"enabled":true}}
fxa-auth-server.INFO: verificationReminders.process {"key":"first","now":1556183057746,"cutoff":1556183047746}
fxa-auth-server.INFO: verificationReminders.process {"key":"second","now":1556183057746,"cutoff":1556182997746}
fxa-auth-server.INFO: redis.enabled {"config":{"host":"127.0.0.1","port":6379,"sessionTokens":{"enabled":true,"prefix":"fxa-auth-session","maxConnections":200,"minConnections":2},"email":{"enabled":true,"prefix":"email:","maxConnections":10,"minConnections":1},"maxPending":1000,"retryCount":5,"initialBackoff":100,"enabled":true,"prefix":"fxa-auth-session","maxConnections":200,"minConnections":2}}
(node:39834) DeprecationWarning: mozlog.config() is deprecated. Use mozlog(opts) to receive a specific mozlog instance.
fxa-auth-server.INFO: verificationReminders.processing {"count":0,"key":"first"}
fxa-auth-server.INFO: verificationReminders.processing {"count":1,"key":"second"}
fxa-auth-server.INFO: mailer.send {"email":"pmbooth@gmail.com","template":"verificationReminderSecondEmail","headers":"Content-Language,X-Template-Name,X-Template-Version,X-Link,X-Verify-Code,X-Flow-Id,X-Flow-Begin-Time,X-Uid,X-Email-Service,X-Email-Sender"}
fxa-auth-server.INFO: mailer.send.1 {"id":"smtp:250","to":"pmbooth@gmail.com","emailSender":"ses","emailService":"fxa-email-service"}
fxa-auth-server.INFO: emailEvent {"template":"verificationReminderSecondEmail","templateVersion":4,"type":"sent","flow_id":"f5f31369a4e42909bece4a204b6cc2cf20f577f3691db747501c3c8221355707","locale":"en","domain":"gmail.com"}
fxa-auth-server.INFO: redis.enabled {"config":{"host":"127.0.0.1","port":6379,"sessionTokens":{"enabled":true,"prefix":"fxa-auth-session","maxConnections":200,"minConnections":2},"email":{"enabled":true,"prefix":"email:","maxConnections":10,"minConnections":1},"maxPending":1000,"retryCount":5,"initialBackoff":100,"prefix":"verificationReminders:","maxConnections":10,"minConnections":1,"enabled":true}}
fxa-auth-server.INFO: amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_email - sent","time":1556183058186,"user_id":"181d58d0c1f74b1f8c1dcb9a66faa9d9","session_id":1556182880669,"app_version":"135","language":"en","event_properties":{"email_type":"registration","email_provider":"gmail.com","email_sender":"ses","email_service":"fxa-email-service","email_template":"verificationReminderSecondEmail","email_version":4},"user_properties":{"flow_id":"f5f31369a4e42909bece4a204b6cc2cf20f577f3691db747501c3c8221355707","sync_device_count":0,"sync_active_devices_day":0,"sync_active_devices_week":0,"sync_active_devices_month":0}}
fxa-auth-server.INFO: verificationReminders.done {}
```

Opened against `train-135` for a point release, because it affects metrics.

@mozilla/fxa-devs r?