### PR TITLE
feat(content-server settings): add button for payments/subscription management to /settings

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -65,7 +65,6 @@
   },
   "subscriptions": {
     "enabled": true,
-    "managementClientId": "3c49430b43dfba77",
     "productCapabilities": {
       "123doneProProduct": [ "123donePro" ],
       "321doneProProduct": [ "321donePro" ],

--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -610,18 +610,6 @@ const conf = convict({
       env: 'SUBSCRIPTIONS_ENABLED',
       default: false
     },
-    managementClientId: {
-      doc: 'OAuth client ID for subscriptions management pages',
-      format: String,
-      env: 'SUBSCRIPTIONS_MANAGEMENT_CLIENT_ID',
-      default:  'YOU MUST CHANGE ME'
-    },
-    managementTokenTTL: {
-      doc: 'OAuth token time-to-live (in seconds) for subscriptions management pages',
-      format: 'nat',
-      env: 'SUBSCRIPTIONS_MANAGEMENT_TOKEN_TTL',
-      default: 900
-    },
     productCapabilities: {
       doc: 'Mappings from product names to subscription capability names',
       format: Object,

--- a/packages/fxa-auth-server/fxa-oauth-server/config/dev.json
+++ b/packages/fxa-auth-server/fxa-oauth-server/config/dev.json
@@ -163,6 +163,18 @@
       "trusted": true,
       "allowedScopes": "https://identity.mozilla.com/apps/oldsync",
       "publicClient": true
+    },
+    {
+      "id": "59cceb6f8c32317c",
+      "name": "Firefox Accounts Subscriptions",
+      "hashedSecret": "220e560d48cf91dbba0219b986ca242a0b278eab8467bb07442fdfed1b245788",
+      "redirectUri": "http://127.0.0.1:3031/",
+      "imageUri": "",
+      "canGrant": true,
+      "termsUri": "",
+      "privacyUri": "",
+      "trusted": true,
+      "publicClient": false
     }
   ],
   "localRedirects": true,

--- a/packages/fxa-content-server/app/scripts/lib/app-start.js
+++ b/packages/fxa-content-server/app/scripts/lib/app-start.js
@@ -428,6 +428,13 @@ Start.prototype = {
   },
 
   createView (Constructor, options = {}) {
+    const {
+      subscriptions: {
+        allowedLanguages: subscriptionsManagementLanguages,
+        enabled: subscriptionsEnabled,
+      } = {},
+    } = this._config;
+
     const viewOptions = _.extend({
       broker: this._authenticationBroker,
       config: this._config,
@@ -443,6 +450,8 @@ Start.prototype = {
       relier: this._relier,
       sentryMetrics: this._sentryMetrics,
       session: Session,
+      subscriptionsManagementEnabled: subscriptionsEnabled,
+      subscriptionsManagementLanguages,
       translator: this._translator,
       user: this._user,
       window: this._window

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -235,14 +235,14 @@ const Account = Backbone.Model.extend({
               assertionPromise.__expiresAt >= Date.now());
   },
 
-  createOAuthToken (scope) {
+  createOAuthToken (scope, paramsIn = {}) {
     return this._generateAssertion()
       .then((assertion) => {
-        const params = {
+        const params = _.assign({
           assertion: assertion,
           client_id: this._oAuthClientId, //eslint-disable-line camelcase
-          scope: scope
-        };
+          scope: scope,
+        }, paramsIn);
         return this._oAuthClient.getToken(params);
       })
       .then((result) => {

--- a/packages/fxa-content-server/app/scripts/templates/settings/subscription.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/subscription.mustache
@@ -1,0 +1,10 @@
+<div id="manage-subscription" class="settings-unit">
+  <div class="settings-unit-stub">
+    <header class="settings-unit-summary">
+      <h2 class="settings-unit-title">{{#t}}Subscriptions{{/t}}</h2>
+    </header>
+    <button class="settings-button primary-button settings-unit-toggle">
+      <span class="change-button">{{#t}}Manage…{{/t}}</span>
+    </button>
+  </div>
+</div>

--- a/packages/fxa-content-server/app/scripts/views/settings.js
+++ b/packages/fxa-content-server/app/scripts/views/settings.js
@@ -30,6 +30,7 @@ import Session from '../lib/session';
 import SettingsHeaderTemplate from 'templates/partial/settings-header.mustache';
 import SignedOutNotificationMixin from './mixins/signed-out-notification-mixin';
 import SubPanels from './sub_panels';
+import SubscriptionView from './settings/subscription';
 import Template from 'templates/settings.mustache';
 import UserAgentMixin from '../lib/user-agent-mixin';
 
@@ -39,6 +40,7 @@ import RecoveryCodesView from './settings/recovery_codes';
 var PANEL_VIEWS = [
   AvatarView,
   DisplayNameView,
+  SubscriptionView,
   EmailsView,
   AccountRecoveryView,
   AccountRecoveryConfirmPasswordView,
@@ -69,7 +71,10 @@ const View = BaseView.extend({
     this._childView = options.childView;
     this._createView = options.createView;
     this._experimentGroupingRules = options.experimentGroupingRules;
+    this._language = options.config.lang;
     this._marketingEmailEnabled = options.marketingEmailEnabled !== false;
+    this._subscriptionsManagementEnabled = options.subscriptionsManagementEnabled !== false;
+    this._subscriptionsManagementLanguages = options.subscriptionsManagementLanguages;
 
     const uid = this.relier.get('uid');
     this.notifier.trigger('set-uid', uid);
@@ -220,8 +225,27 @@ const View = BaseView.extend({
       if (ChildView === CommunicationPreferencesView) {
         return areCommunicationPrefsVisible;
       }
+      if (ChildView === SubscriptionView) {
+        return this._isSubscriptionsManagementVisible();
+      }
       return true;
     });
+  },
+
+  /**
+   * Should the subscriptions management panel be displayed?
+   *
+   * @returns {Boolean}
+   * @private
+   */
+  _isSubscriptionsManagementVisible () {
+    if (! this._subscriptionsManagementEnabled) {
+      return false;
+    }
+    if (! this._subscriptionsManagementLanguages.includes(this._language)) {
+      return false;
+    }
+    return true;
   },
 
   /**

--- a/packages/fxa-content-server/app/scripts/views/settings/subscription.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/subscription.js
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+import Cocktail from 'cocktail';
+import FormView from '../form';
+import SettingsPanelMixin from '../mixins/settings-panel-mixin';
+import Template from 'templates/settings/subscription.mustache';
+
+const View = FormView.extend({
+  template: Template,
+  className: 'subscription',
+  viewName: 'settings.subscription',
+
+  events: {
+    'click button': 'submit',
+  },
+
+  initialize (options) {
+    this._config = {};
+    if (options && options.config && options.config.subscriptions) {
+      this._config = options.config.subscriptions;
+    }
+  },
+
+  submit () {
+    const {
+      managementClientId,
+      managementScopes,
+      managementTokenTTL,
+      managementUrl,
+    } = this._config;
+    return this.getSignedInAccount()
+      .createOAuthToken(managementScopes, {
+        client_id: managementClientId, //eslint-disable-line camelcase
+        ttl: managementTokenTTL,
+      })
+      .then((accessToken) => {
+        const url = `${managementUrl}/#accessToken=${encodeURIComponent(accessToken.get('token'))}`;
+        this.navigateAway(url);
+      });
+  }
+});
+
+Cocktail.mixin(View, SettingsPanelMixin);
+
+export default View;

--- a/packages/fxa-content-server/app/tests/spec/views/settings.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings.js
@@ -9,6 +9,7 @@ import AuthErrors from 'lib/auth-errors';
 import BaseView from 'views/base';
 import Cocktail from 'cocktail';
 import CommunicationPreferencesView from 'views/settings/communication_preferences';
+import SubscriptionView from 'views/settings/subscription';
 import ExperimentGroupingRules from 'lib/experiments/grouping-rules/index';
 import FormPrefill from 'models/form-prefill';
 import Metrics from 'lib/metrics';
@@ -41,6 +42,8 @@ describe('views/settings', function () {
   var formPrefill;
   var initialChildView;
   var marketingEmailEnabled;
+  var subscriptionsManagementEnabled;
+  var subscriptionsManagementLanguages;
   var metrics;
   var notifier;
   var profileClient;
@@ -60,6 +63,7 @@ describe('views/settings', function () {
     subPanelRenderSpy = sinon.spy(() => Promise.resolve());
     view = new View({
       childView: initialChildView,
+      config: { lang: 'en' },
       createView,
       experimentGroupingRules,
       formPrefill,
@@ -67,6 +71,8 @@ describe('views/settings', function () {
       metrics,
       notifier,
       relier,
+      subscriptionsManagementEnabled,
+      subscriptionsManagementLanguages,
       user,
       viewName: 'settings'
     });
@@ -87,6 +93,8 @@ describe('views/settings', function () {
     marketingEmailEnabled = true;
     metrics = new Metrics({ notifier });
     profileClient = new ProfileClient();
+    subscriptionsManagementEnabled = false;
+    subscriptionsManagementLanguages = ['en'];
     relier = new Relier();
     relier.set('uid', 'wibble');
 
@@ -468,6 +476,41 @@ describe('views/settings', function () {
         sinon.stub(view, '_areCommunicationPrefsVisible').callsFake(() => false);
         const panelsToDisplay = view._getPanelsToDisplay();
         assert.notInclude(panelsToDisplay, CommunicationPreferencesView);
+      });
+
+      it('SubscriptionView is visible if enabled', function () {
+        sinon.stub(view, '_isSubscriptionsManagementVisible').callsFake(() => true);
+        const panelsToDisplay = view._getPanelsToDisplay();
+        assert.include(panelsToDisplay, SubscriptionView);
+      });
+
+      it('SubscriptionView is not visible if disabled', function () {
+        sinon.stub(view, '_isSubscriptionsManagementVisible').callsFake(() => false);
+        const panelsToDisplay = view._getPanelsToDisplay();
+        assert.notInclude(panelsToDisplay, SubscriptionView);
+      });
+    });
+
+    describe('_isSubscriptionsManagementVisible', () => {
+      it('returns `false` if subscriptionsManagementEnabled is false', () => {
+        subscriptionsManagementEnabled = false;
+        subscriptionsManagementLanguages = ['en'];
+        createSettingsView();
+        assert.isFalse(view._isSubscriptionsManagementVisible());
+      });
+
+      it('returns `false` if subscriptionsManagementLanguages does not contain browser languages', () => {
+        subscriptionsManagementEnabled = true;
+        subscriptionsManagementLanguages = ['de'];
+        createSettingsView();
+        assert.isFalse(view._isSubscriptionsManagementVisible());
+      });
+
+      it('returns `true` if all conditions are met', () => {
+        subscriptionsManagementEnabled = true;
+        subscriptionsManagementLanguages = ['en'];
+        createSettingsView();
+        assert.isTrue(view._isSubscriptionsManagementVisible());
       });
     });
 

--- a/packages/fxa-content-server/app/tests/spec/views/settings/subscription.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/subscription.js
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import $ from 'jquery';
+import Account from 'models/account';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import User from 'models/user';
+import View from 'views/settings/subscription';
+import WindowMock from '../../../mocks/window';
+
+describe('views/settings/subscription', function () {
+  var account;
+  var user;
+  var view;
+  var tokenMock;
+  var windowMock;
+  var config;
+
+  function render() {
+    return view.render()
+      .then(() => view.afterVisible());
+  }
+
+  beforeEach(function () {
+    user = new User();
+    account = new Account();
+    windowMock = new WindowMock();
+    config = {
+      subscriptions: {
+        managementClientId: 'MOCK_CLIENT_ID',
+        managementScopes: 'MOCK_SCOPES',
+        managementTokenTTL: 900,
+        managementUrl: 'http://example.com',
+      }
+    };
+    tokenMock = {
+      get: () => 'MOCK_TOKEN'
+    };
+
+    sinon.stub(account, 'createOAuthToken').callsFake(() => Promise.resolve(tokenMock));
+
+    view = new View({ config, user, window: windowMock });
+
+    sinon.stub(view, 'getSignedInAccount').callsFake(() => account);
+    sinon.stub(view, 'navigateAway');
+
+    return render();
+  });
+
+  afterEach(function () {
+    $(view.el).remove();
+    view.destroy();
+    view = null;
+  });
+
+  describe('render', () => {
+    it('renders correctly', () => {
+      assert.lengthOf(view.$('#manage-subscription'), 1);
+    });
+  });
+
+  describe('submit', () => {
+    it('creates an OAuth token on submit', () => {
+      return view.submit().then(() => {
+        assert.lengthOf(view.getSignedInAccount.args, 1);
+        assert.deepEqual(
+          account.createOAuthToken.args[0],
+          [
+            config.subscriptions.managementScopes,
+            {
+              //eslint-disable-next-line camelcase
+              client_id: config.subscriptions.managementClientId,
+              ttl: config.subscriptions.managementTokenTTL
+            }
+          ]
+        );
+        assert.deepEqual(
+          view.navigateAway.args[0],
+          [ `${config.subscriptions.managementUrl}/#accessToken=MOCK_TOKEN` ]
+        );
+      });
+    });
+  });
+
+});

--- a/packages/fxa-content-server/app/tests/test_start.js
+++ b/packages/fxa-content-server/app/tests/test_start.js
@@ -240,6 +240,7 @@ require('./spec/views/settings/change_password');
 require('./spec/views/settings/clients');
 require('./spec/views/settings/client_disconnect');
 require('./spec/views/settings/communication_preferences');
+require('./spec/views/settings/subscription');
 require('./spec/views/settings/delete_account');
 require('./spec/views/settings/display_name');
 require('./spec/views/settings/emails');

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -594,6 +594,44 @@ const conf = module.exports = convict({
     env: 'STATIC_RESOURCE_URL',
     format: 'url'
   },
+  subscriptions: {
+    allowedLanguages: {
+      default: ['en'],
+      doc: 'Which languages are allowed to access subscription features?',
+      env: 'SUBSCRIPTIONS_ALLOWED_LANGUAGES',
+      format: Array,
+    },
+    enabled: {
+      default: false,
+      doc: 'Indicates whether subscriptions APIs are enabled',
+      env: 'SUBSCRIPTIONS_ENABLED',
+      format: Boolean,
+    },
+    managementClientId: {
+      default: '59cceb6f8c32317c',
+      doc: 'OAuth client ID for subscriptions management pages',
+      env: 'SUBSCRIPTIONS_MANAGEMENT_CLIENT_ID',
+      format: String,
+    },
+    managementScopes: {
+      default: 'profile https://identity.mozilla.com/account/subscriptions',
+      doc: 'OAuth scopes needed for the subscription management pages to access auth server APIs',
+      env: 'SUBSCRIPTIONS_MANAGEMENT_SCOPES',
+      format: String,
+    },
+    managementTokenTTL: {
+      default: 900,
+      doc: 'OAuth token time-to-live (in seconds) for subscriptions management pages',
+      env: 'SUBSCRIPTIONS_MANAGEMENT_TOKEN_TTL',
+      format: 'nat',
+    },
+    managementUrl: {
+      default: 'http://127.0.0.1:3031',
+      doc: 'The publicly visible URL of the subscription management server',
+      env: 'SUBSCRIPTIONS_MANAGEMENT_URL',
+      format: String,
+    },
+  },
   sync_tokenserver_url: {
     default: 'http://127.0.0.1:5000/token',
     doc: 'The url of the Firefox Sync tokenserver',

--- a/packages/fxa-content-server/server/lib/routes/get-index.js
+++ b/packages/fxa-content-server/server/lib/routes/get-index.js
@@ -31,6 +31,7 @@ module.exports = function (config) {
   const STATIC_RESOURCE_URL = config.get('static_resource_url');
   const SCOPED_KEYS_ENABLED = config.get('scopedKeys.enabled');
   const SCOPED_KEYS_VALIDATION = config.get('scopedKeys.validation');
+  const SUBSCRIPTIONS = config.get('subscriptions');
   // add version from package.json to config
   const RELEASE = require('../../../package.json').version;
   const WEBPACK_PUBLIC_PATH = `${STATIC_RESOURCE_URL}/${config.get('jsResourcePath')}/`;
@@ -51,6 +52,7 @@ module.exports = function (config) {
     scopedKeysEnabled: SCOPED_KEYS_ENABLED,
     scopedKeysValidation: SCOPED_KEYS_VALIDATION,
     staticResourceUrl: STATIC_RESOURCE_URL,
+    subscriptions: SUBSCRIPTIONS,
     webpackPublicPath: WEBPACK_PUBLIC_PATH,
   }));
 

--- a/packages/fxa-content-server/tests/server/routes/get-index.js
+++ b/packages/fxa-content-server/tests/server/routes/get-index.js
@@ -77,6 +77,7 @@ registerSuite('routes/get-index', {
               assert.equal(sentConfig.profileUrl, config.get('profile_url'));
               assert.equal(sentConfig.scopedKeysEnabled, config.get('scopedKeys.enabled'));
               assert.ok(sentConfig.scopedKeysValidation, 'config validation is present');
+              assert.deepEqual(sentConfig.subscriptions, config.get('subscriptions'));
               assert.equal(sentConfig.webpackPublicPath, `${config.get('static_resource_url')}/${config.get('jsResourcePath')}/`, 'correct webpackPublicPath');
             }
           }


### PR DESCRIPTION
This pulls out the button from PR #907, and the auth token generation from [Les's commit](https://github.com/lmorchard/fxa/commit/47e632b5020381082cdc3331f3398f4513e43ff8).

~There's some FIXMEs about enabling the feature, with a feature flag and possibly also a config setting; I didn't get a chance to do those, but I will be out Friday and wanted to get something up for feedback.~

@lmorchard took a shot at config & feature flags stuff here

Fixes #924 