### PR TITLE
feat(session): Allow verified sessions before TOTP became enabled to remove TOTP

### DIFF
--- a/packages/fxa-auth-db-mysql/db-server/test/backend/remote.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/remote.js
@@ -1669,6 +1669,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(result.epoch, user.totp.epoch, 'epoch set')
             assert.equal(result.verified, user.totp.verified, 'verified set')
             assert.equal(result.enabled, user.totp.enabled, 'enabled set')
+            assert.ok(result.createdAt, 'createdAt set')
           })
       })
 

--- a/packages/fxa-auth-db-mysql/lib/db/mem.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mem.js
@@ -1291,7 +1291,8 @@ module.exports = function (log, error) {
       sharedSecret: data.sharedSecret,
       epoch: data.epoch || 0,
       verified: false,
-      enabled: true
+      enabled: true,
+      createdAt: Date.now()
     }
 
     return Promise.resolve({})

--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -1412,7 +1412,7 @@ module.exports = function (log, error) {
     return this.write(CREATE_TOTP_TOKEN, [uid, data.sharedSecret, data.epoch, Date.now()])
   }
 
-  const GET_TOTP_TOKEN = 'CALL totpToken_2(?)'
+  const GET_TOTP_TOKEN = 'CALL totpToken_3(?)'
   MySql.prototype.totpToken = function (uid) {
     return this.readFirstResult(GET_TOTP_TOKEN, [uid])
   }

--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 98
+module.exports.level = 99

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-098-099.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-098-099.sql
@@ -1,0 +1,14 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('98');
+
+CREATE PROCEDURE `totpToken_3` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+
+  SELECT sharedSecret, epoch, verified, enabled, createdAt FROM `totp` WHERE uid = uidArg;
+
+END;
+
+UPDATE dbMetadata SET value = '99' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-099-098.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-099-098.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE totpToken_3;
+
+-- UPDATE dbMetadata SET value = '98' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-server/test/local/routes/totp-delete.js
+++ b/packages/fxa-auth-server/test/local/routes/totp-delete.js
@@ -1,0 +1,236 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const {assert} = require('chai');
+const mocks = require('../../mocks');
+const P = require('../../../lib/promise');
+const sinon = require('sinon');
+const hawk = require('hawk');
+const config = require('../../../config').getProperties();
+const error = require('../../../lib/error');
+const translator = {
+  getTranslator: sinon.spy(() => ({
+    en: {
+      format: () => {
+      }, language: 'en'
+    }
+  })),
+  getLocale: sinon.spy(() => 'en')
+};
+
+let log, db, customs, routes, server, requestOptions, mailer, sessionToken, response;
+const UID = 'abc';
+const EMAIL = 'abc@123.com';
+const defaultRequestOptions = {
+  headers: {},
+  method: 'POST',
+  payload: {
+    metricsContext: {
+      flowBeginTime: Date.now(),
+      flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+    }
+  }
+};
+
+describe('/totp/destroy', () => {
+  describe('should delete unverified TOTP token', () => {
+    before(async () => {
+      requestOptions = Object.assign(defaultRequestOptions, {url: '/totp/destroy'});
+      response = await runTest({
+        verified: false,
+        enabled: false
+      }, {}, requestOptions);
+    });
+
+    it('should return successful response', () => {
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(response.result, {}, 'empty response');
+    });
+
+    it('should call deleteTotpToken', () => {
+      assert.equal(db.deleteTotpToken.callCount, 1, 'called delete TOTP token');
+    });
+
+    it('should notify attached services', () => {
+      assert.equal(log.notifyAttachedServices.callCount, 1, 'called notifyAttachedServices');
+      const args = log.notifyAttachedServices.args[0];
+      assert.equal(args.length, 3, 'log.notifyAttachedServices was passed three arguments');
+      assert.equal(args[0], 'profileDataChanged', 'first argument was event name');
+      assert.equal(args[1]['path'], '/totp/destroy', 'second argument was request object');
+      assert.equal(args[2]['uid'], UID, 'third argument was event data with a uid');
+    });
+
+    it('should send email notifications', () => {
+      assert.equal(mailer.sendPostRemoveTwoStepAuthNotification.callCount, 1, 'called sendPostRemoveTwoStepAuthNotification');
+      const args = mailer.sendPostRemoveTwoStepAuthNotification.args[0];
+      assert.equal(args.length, 3, 'mailer.sendPostRemoveTwoStepAuthNotification was passed three arguments');
+      assert.equal(args[1]['email'], EMAIL, 'email address passed');
+    });
+  });
+
+  describe('should delete TOTP token in older verified session', () => {
+    before(async () => {
+      requestOptions = Object.assign(defaultRequestOptions, {url: '/totp/destroy'});
+      response = await runTest({
+        verified: true,
+        enabled: true
+      }, {}, requestOptions);
+    });
+
+    it('should return successful response', () => {
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(response.result, {}, 'empty response');
+    });
+
+    it('should call deleteTotpToken', () => {
+      assert.equal(db.deleteTotpToken.callCount, 1, 'called delete TOTP token');
+    });
+
+    it('should notify attached services', () => {
+      assert.equal(log.notifyAttachedServices.callCount, 1, 'called notifyAttachedServices');
+      const args = log.notifyAttachedServices.args[0];
+      assert.equal(args.length, 3, 'log.notifyAttachedServices was passed three arguments');
+      assert.equal(args[0], 'profileDataChanged', 'first argument was event name');
+      assert.equal(args[1]['path'], '/totp/destroy', 'second argument was request object');
+      assert.equal(args[2]['uid'], UID, 'third argument was event data with a uid');
+    });
+
+    it('should send email notifications', () => {
+      assert.equal(mailer.sendPostRemoveTwoStepAuthNotification.callCount, 1, 'called sendPostRemoveTwoStepAuthNotification');
+      const args = mailer.sendPostRemoveTwoStepAuthNotification.args[0];
+      assert.equal(args.length, 3, 'mailer.sendPostRemoveTwoStepAuthNotification was passed three arguments');
+      assert.equal(args[1]['email'], EMAIL, 'email address passed');
+    });
+  });
+
+  describe('should delete TOTP token in newer TOTP verified session', () => {
+    before(async () => {
+      requestOptions = Object.assign(defaultRequestOptions, {url: '/totp/destroy'});
+      response = await runTest({
+        verified: true,
+        enabled: true,
+        verificationMethod: 2,
+        createdAt: Date.now() + 100000 // Create a session with a timestamp older than TOTP token
+      }, {}, requestOptions);
+    });
+
+    it('should return successful response', () => {
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(response.result, {}, 'empty response');
+    });
+
+    it('should call deleteTotpToken', () => {
+      assert.equal(db.deleteTotpToken.callCount, 1, 'called delete TOTP token');
+    });
+
+    it('should notify attached services', () => {
+      assert.equal(log.notifyAttachedServices.callCount, 1, 'called notifyAttachedServices');
+      const args = log.notifyAttachedServices.args[0];
+      assert.equal(args.length, 3, 'log.notifyAttachedServices was passed three arguments');
+      assert.equal(args[0], 'profileDataChanged', 'first argument was event name');
+      assert.equal(args[1]['path'], '/totp/destroy', 'second argument was request object');
+      assert.equal(args[2]['uid'], UID, 'third argument was event data with a uid');
+    });
+
+    it('should send email notifications', () => {
+      assert.equal(mailer.sendPostRemoveTwoStepAuthNotification.callCount, 1, 'called sendPostRemoveTwoStepAuthNotification');
+      const args = mailer.sendPostRemoveTwoStepAuthNotification.args[0];
+      assert.equal(args.length, 3, 'mailer.sendPostRemoveTwoStepAuthNotification was passed three arguments');
+      assert.equal(args[1]['email'], EMAIL, 'email address passed');
+    });
+  });
+
+  describe('should not delete TOTP token in older unverified session', () => {
+    before(async () => {
+      requestOptions = Object.assign(defaultRequestOptions, {url: '/totp/destroy'});
+      response = await runTest({
+        verified: true,
+        enabled: true,
+        tokenVerificationId: 'notverifiedsession'
+      }, {}, requestOptions);
+    });
+
+    it('should return error response', () => {
+      assert.equal(response.statusCode, 400);
+      assert.equal(response.result.errno, 138, 'unverified session error');
+    });
+  });
+
+  describe('should not delete TOTP token in newer unverified session', () => {
+    before(async () => {
+      requestOptions = Object.assign(defaultRequestOptions, {url: '/totp/destroy'});
+      response = await runTest({
+        verified: true,
+        enabled: true,
+        createdAt: Date.now() + 100000,
+        tokenVerificationId: 'notverifiedsession'
+      }, {}, requestOptions);
+    });
+
+    it('should return error response', () => {
+      assert.equal(response.statusCode, 400);
+      assert.equal(response.result.errno, 138, 'unverified session error');
+    });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+});
+
+async function runTest (results, errors, requestOptions) {
+  // Perform custom setup for the required mocks and overrides to
+  // handle the request
+  log = mocks.mockLog();
+  customs = mocks.mockCustoms(errors.customs);
+  mailer = mocks.mockMailer();
+  db = mocks.mockDB({uid: UID, email: EMAIL}, errors.db);
+
+  // Create a valid session token to be used with Hawk Authentication
+  const Token = require('../../../lib/tokens')(log, config);
+  sessionToken = await Token.SessionToken.create({
+    uid: UID,
+    tokenVerificationId: results.tokenVerificationId,
+    createdAt: results.createdAt || Date.now(),
+    verificationMethod: results.verificationMethod || '0'
+  });
+  db.sessionToken = sinon.spy(async () => sessionToken);
+  db.totpToken = sinon.spy(() => {
+    return P.resolve({
+      verified: !! results.verified,
+      enabled: !! results.enabled,
+      createdAt: Date.now()
+    });
+  });
+  routes = require('../../../lib/routes/totp')(log, db, mailer, customs, config);
+  const authHeader = hawkHeader(sessionToken, 'POST', `${config.publicUrl}${requestOptions.url}`, requestOptions.payload);
+
+  const Server = require('../../../lib/server');
+  server = await Server.create(log, error, config, routes, db, {}, translator, Token);
+
+  const injectRequest = {
+    headers: {
+      authorization: authHeader
+    },
+    method: requestOptions.method || 'POST',
+    url: requestOptions.url,
+    payload: requestOptions.payload
+  };
+
+  await server.start();
+  return server.inject(injectRequest);
+}
+
+function hawkHeader (token, method, url, payload, offset) {
+  const verify = {
+    credentials: token
+  };
+  if (payload) {
+    verify.contentType = 'application/json';
+    verify.payload = JSON.stringify(payload);
+  }
+  return hawk.client.header(url, method, verify).header;
+}

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -61,42 +61,6 @@ describe('totp', () => {
     });
   });
 
-  describe('/totp/destroy', () => {
-    it('should delete TOTP token', () => {
-      requestOptions.credentials.authenticatorAssuranceLevel = 2;
-      return setup({db: {email: TEST_EMAIL}}, {}, '/totp/destroy', requestOptions)
-        .then((response) => {
-          assert.ok(response);
-          assert.equal(db.deleteTotpToken.callCount, 1, 'called delete TOTP token');
-
-          assert.equal(log.notifyAttachedServices.callCount, 1, 'called notifyAttachedServices');
-          const args = log.notifyAttachedServices.args[0];
-          assert.equal(args.length, 3, 'log.notifyAttachedServices was passed three arguments');
-          assert.equal(args[0], 'profileDataChanged', 'first argument was event name');
-          assert.equal(args[1], request, 'second argument was request object');
-          assert.equal(args[2].uid, 'uid', 'third argument was event data with a uid');
-        });
-    });
-
-    it('should not delete TOTP token in non-totp verified session', () => {
-      requestOptions.credentials.authenticatorAssuranceLevel = 1;
-      return setup({db: {email: TEST_EMAIL}}, {}, '/totp/destroy', requestOptions)
-        .then(assert.fail, (err) => {
-          assert.deepEqual(err.errno, 138, 'unverified session error');
-          assert.equal(log.notifyAttachedServices.callCount, 0, 'did not call notifyAttachedServices');
-        });
-    });
-
-    it('should be disabled in unverified session', () => {
-      requestOptions.credentials.tokenVerificationId = 'notverified';
-      return setup({db: {email: TEST_EMAIL}}, {}, '/totp/destroy', requestOptions)
-        .then(assert.fail, (err) => {
-          assert.deepEqual(err.errno, 138, 'unverified session error');
-          assert.equal(log.notifyAttachedServices.callCount, 0, 'did not call notifyAttachedServices');
-        });
-    });
-  });
-
   describe('/totp/exists', () => {
     it('should check for TOTP token', () => {
       return setup({db: {email: TEST_EMAIL}}, {}, '/totp/exists', requestOptions)

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -409,6 +409,7 @@ function mockDB (data, errors) {
     sessionToken: sinon.spy(() => {
       const res = {
         id: data.sessionTokenId || 'fake session token id',
+        data: data.sessionTokenData || crypto.randomBytes(32).toString('hex'),
         uid: data.uid || 'fake uid',
         tokenVerified: true,
         uaBrowser: data.uaBrowser,


### PR DESCRIPTION
Connects with #575 

Opening this up for some feedback. I don't believe that this will fully fix the issue above but it should make things a little better. Quick notes on what is in the PR.

* Sessions that were fully verified before TOTP can remove TOTP tokens.
* Adds a new authentication stragey `sessionTokenRequireMaximumAssuranceLevel`
  * This requires the route to have the maximum authentication level for the account. 
* Only added to `/totp/destroy` route
  * To reduce the risk, I thought it was better to add this to one route and see if we should incorpate in others. I didn't want this PR to get outta hand.
* Includes a db migration to return the `createdAt` then token was created. This is compared against the timestamp the session was created. 
* Testing was a bit of a challenge with the way our existing local auth-server tests work. I opted to use Hapi `server.inject` to simulate the requests verses using the `route.handler` methods. Using `route.handler` automagically skips authentication strategy validation.

@mozilla/fxa-devs Thoughts on this approach or any downsides?
