### PR TITLE
fix(ci): run eslint in ci

### DIFF
--- a/.circleci/test-content-server.sh
+++ b/.circleci/test-content-server.sh
@@ -33,6 +33,8 @@ function test_suite() {
 }
 
 if grep -e "$MODULE" -e 'all' $DIR/../packages/test.list; then
+  node_modules/.bin/grunt eslint
+
   sudo apt-get install -y python-setuptools python-dev build-essential graphicsmagick &> /dev/null
   sudo easy_install pip &> /dev/null
   sudo pip install mozdownload mozinstall &> /dev/null

--- a/.circleci/test-js-client.sh
+++ b/.circleci/test-js-client.sh
@@ -8,6 +8,7 @@ if grep -e "$MODULE" -e 'all' $DIR/../packages/test.list; then
   # for some reason js-client tests fail if we cache node_modules
   npm install
   npx grunt sjcl
+  node_modules/.bin/grunt eslint
   npm test
   # TODO ./tests/ci/travis-auth-server-test.sh
 else

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -10,7 +10,14 @@ if grep -e "$MODULE" -e 'all' $DIR/../packages/test.list; then
     docker run --net="host" -e DB="mysql" ${MODULE}:test npm run test-oauth
   elif [[ -e Dockerfile-test ]]; then
     docker build -f Dockerfile-test -t ${MODULE}:test .
+
     docker run --net="host" ${MODULE}:test npm run ${TEST:-test}
+
+    if grep eslint "$DIR/../packages/$MODULE/Gruntfile.js"; then
+      docker run --net="host" ${MODULE}:test /app/node_modules/.bin/grunt eslint
+    elif grep '"eslint"' "$DIR/../packages/$MODULE/package.json"; then
+      docker run --net="host" ${MODULE}:test npm run lint
+    fi
   fi
 else
   exit 0;


### PR DESCRIPTION
Fixes #959.

`eslint` was not running for any packages in CI. This change invokes it everywhere it finds it, based on grepping in `Gruntfile.js` and `package.json`.

@mozilla/fxa-devs r?