### PR TITLE
feat(metrics): add new entrypoint params to common amplitude logic

### DIFF
--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -232,6 +232,8 @@ module.exports = {
       return Object.assign(
         pruneUnsetValues({
           entrypoint: data.entrypoint,
+          entrypoint_experiment: data.entrypoint_experiment,
+          entrypoint_variation: data.entrypoint_variation,
           flow_id: data.flowId,
           ua_browser: data.browser,
           ua_version: data.browserVersion,

--- a/packages/fxa-shared/package-lock.json
+++ b/packages/fxa-shared/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -864,9 +864,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Shared module for FxA repositories",
   "main": "index.js",
   "scripts": {

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -113,6 +113,8 @@ describe('metrics/amplitude:', () => {
           ],
           emailDomain: 'e',
           entrypoint: 'f',
+          entrypoint_experiment: 'exp',
+          entrypoint_variation: 'var',
           experiments: [
             { choice: 'g', group: 'h' },
             { choice: 'iI', group: 'jJ-J' }
@@ -137,6 +139,10 @@ describe('metrics/amplitude:', () => {
       });
 
       it('returned the correct result', () => {
+        // HACK: app_version is set if the tests are run in the monorepo but not if
+        //       they're run inside a container, due to the resolution or otherwise
+        //       of `require('../../../package.json')` in metrics/amplitude.js
+        delete result.app_version;
         assert.deepEqual(result, {
           country: 'c',
           device_id: 'd',
@@ -160,6 +166,8 @@ describe('metrics/amplitude:', () => {
               fxa_services_used: 'qux'
             },
             entrypoint: 'f',
+            entrypoint_experiment: 'exp',
+            entrypoint_variation: 'var',
             flow_id: 'l',
             sync_active_devices_day: 1,
             sync_active_devices_month: 5,
@@ -193,6 +201,10 @@ describe('metrics/amplitude:', () => {
       });
 
       it('returned the correct result', () => {
+        // HACK: app_version is set if the tests are run in the monorepo but not if
+        //       they're run inside a container, due to the resolution or otherwise
+        //       of `require('../../../package.json')` in metrics/amplitude.js
+        delete result.app_version;
         assert.deepEqual(result, {
           device_id: 'a',
           event_properties: {},


### PR DESCRIPTION
Related to #693.

To pave the way for the new entrypoint params in the auth and content servers, we must first add them in `fxa-shared`. Here they are.

Opened against the `train-136` branch for a point release, because I'd previously committed to getting this out in that release.

@mozilla/fxa-devs r?