### PR TITLE
refactor(totp): can delete TOTP in verified sessions

### DIFF
--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -130,7 +130,10 @@ module.exports = (log, db, mailer, customs, config) => {
         }
 
         function deleteTotpToken() {
-          if (hasEnabledToken && (sessionToken.tokenVerificationId || sessionToken.authenticatorAssuranceLevel <= 1)) {
+          // To help prevent users from getting locked out of their account, sessions created and verified
+          // before TOTP was enabled, can remove TOTP. Any new sessions after TOTP is enabled, are only considered
+          // verified *if and only if* they have verified a TOTP code.
+          if (! sessionToken.tokenVerified) {
             throw errors.unverifiedSession();
           }
 

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -62,8 +62,8 @@ describe('totp', () => {
   });
 
   describe('/totp/destroy', () => {
-    it('should delete TOTP token', () => {
-      requestOptions.credentials.authenticatorAssuranceLevel = 2;
+    it('should delete TOTP token in verified session', () => {
+      requestOptions.credentials.tokenVerified = true;
       return setup({db: {email: TEST_EMAIL}}, {}, '/totp/destroy', requestOptions)
         .then((response) => {
           assert.ok(response);
@@ -78,17 +78,8 @@ describe('totp', () => {
         });
     });
 
-    it('should not delete TOTP token in non-totp verified session', () => {
-      requestOptions.credentials.authenticatorAssuranceLevel = 1;
-      return setup({db: {email: TEST_EMAIL}}, {}, '/totp/destroy', requestOptions)
-        .then(assert.fail, (err) => {
-          assert.deepEqual(err.errno, 138, 'unverified session error');
-          assert.equal(log.notifyAttachedServices.callCount, 0, 'did not call notifyAttachedServices');
-        });
-    });
-
-    it('should be disabled in unverified session', () => {
-      requestOptions.credentials.tokenVerificationId = 'notverified';
+    it('should not delete TOTP token in unverified session', () => {
+      requestOptions.credentials.tokenVerified = false;
       return setup({db: {email: TEST_EMAIL}}, {}, '/totp/destroy', requestOptions)
         .then(assert.fail, (err) => {
           assert.deepEqual(err.errno, 138, 'unverified session error');


### PR DESCRIPTION
This is a new PR that only checks for a session being verified before deleting a user's TOTP token, ref https://github.com/mozilla/fxa/pull/948#issuecomment-488135939. 

This approach wouldn't help everyone that get https://github.com/mozilla/fxa/issues/575 (users that logged in but never verified a session are still stuck), but I think it is still worthwhile because there is a strong likely hood that a user has some verified session on their account (it is required to sync).

@mozilla/fxa-devs r?