### PR TITLE
fix(caching): Add Cache-Control header to profile images uploaded to S3

### DIFF
--- a/packages/fxa-profile-server/lib/config.js
+++ b/packages/fxa-profile-server/lib/config.js
@@ -81,6 +81,11 @@ const conf = convict({
       }
     },
     uploads: {
+      cacheControlSeconds: {
+        doc: 'Number of seconds in Cache-Control: max-age=seconds header',
+        default: '31536000', // One year
+        env: 'IMG_UPLOADS_CACHE_CONTROL_SECONDS'
+      },
       dest: {
         public: {
           doc: 'Path or bucket name for images to be served publicly.',

--- a/packages/fxa-profile-server/lib/img/aws.js
+++ b/packages/fxa-profile-server/lib/img/aws.js
@@ -9,6 +9,7 @@ const config = require('../config');
 const logger = require('../logging')('img.aws');
 
 const PUBLIC_BUCKET = config.get('img.uploads.dest.public');
+const CACHE_CONTROL_HEADER = `immutable,public,max-age=${config.get('img.uploads.cacheControlSeconds')}`;
 const CONTENT_TYPE_PNG = 'image/png';
 
 if (! /^[a-zA-Z0-9_\-]+$/.test(PUBLIC_BUCKET)) {
@@ -35,6 +36,7 @@ AwsDriver.prototype = {
         Body: buf,
         Bucket: bucket,
         Key: key,
+        CacheControl: CACHE_CONTROL_HEADER,
         ContentType: contentType || CONTENT_TYPE_PNG
       }, function(err, data) {
         if (err) {


### PR DESCRIPTION
This PR adds a Cache-Control header to profile images uploaded to S3 reported by [Bug 1542031](https://bugzilla.mozilla.org/show_bug.cgi?id=1542031). This should improve caching performance on the CDN and client, especially if the client supports the immutable Cache-Control header.