### PR TITLE
feat(oauth): add back `profileChangedAt` migration for oauth tokens table

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/db/memory.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/db/memory.js
@@ -247,7 +247,8 @@ MemoryStore.prototype = {
       createdAt: now,
       // ttl is in seconds
       expiresAt: new Date(+now + (vals.ttl * 1000 || MAX_TTL)),
-      token: encrypt.hash(token)
+      token: encrypt.hash(token),
+      profileChangedAt: vals.profileChangedAt || 0
     };
     var ret = clone(t);
     this.tokens[unbuf(t.token)] = t;

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/db/mysql/index.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/db/mysql/index.js
@@ -177,7 +177,7 @@ const QUERY_CODE_INSERT =
   'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
 const QUERY_ACCESS_TOKEN_INSERT =
   'INSERT INTO tokens (clientId, userId, email, scope, type, expiresAt, ' +
-  'token) VALUES (?, ?, ?, ?, ?, ?, ?)';
+  'token, profileChangedAt) VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
 const QUERY_REFRESH_TOKEN_INSERT =
   'INSERT INTO refreshTokens (clientId, userId, email, scope, token, profileChangedAt) VALUES ' +
   '(?, ?, ?, ?, ?, ?)';
@@ -450,9 +450,6 @@ MysqlStore.prototype = {
       token: unique.token(),
       type: 'bearer',
       expiresAt: vals.expiresAt || new Date(Date.now() + (vals.ttl  * 1000 || MAX_TTL)),
-      // We're not yet able to persist this value into the db
-      // for operational reasons, but it's here for consistency
-      // with the other token types.
       profileChangedAt: vals.profileChangedAt || 0
     };
     return this._write(QUERY_ACCESS_TOKEN_INSERT, [
@@ -463,6 +460,7 @@ MysqlStore.prototype = {
       t.type,
       t.expiresAt,
       encrypt.hash(t.token),
+      t.profileChangedAt
     ]).then(function() {
       return t;
     });

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/db/mysql/patch.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/db/mysql/patch.js
@@ -6,4 +6,4 @@
 // Update this if you add a new patch, and don't forget to update
 // the documentation for the current schema in ../schema.sql.
 
-module.exports.level = 26;
+module.exports.level = 27;

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/db/mysql/patches/patch-026-027.sql
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/db/mysql/patches/patch-026-027.sql
@@ -1,0 +1,7 @@
+-- The `profileChangedAt` column was removed in patch-023-024 because
+-- it caused migration issues. Now that we have resolved our migration
+-- issues, it is safe to add this column back.
+ALTER TABLE tokens ADD COLUMN profileChangedAt BIGINT DEFAULT NULL,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+ UPDATE dbMetadata SET value = '27' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/db/mysql/patches/patch-027-026.sql
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/db/mysql/patches/patch-027-026.sql
@@ -1,0 +1,4 @@
+-- ALTER TABLE tokens DROP COLUMN profileChangedAt,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- UPDATE dbMetadata SET value = '26' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/db/mysql/schema.sql
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/db/mysql/schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE IF NOT EXISTS tokens (
   scope VARCHAR(256) NOT NULL,
   createdAt TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   expiresAt TIMESTAMP NOT NULL,
+  profileChangedAt BIGINT DEFAULT NULL,
   INDEX idx_expiresAt(expiresAt)
 ) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 

--- a/packages/fxa-auth-server/fxa-oauth-server/test/api.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/api.js
@@ -3022,11 +3022,7 @@ describe('/v1', function() {
           assert.equal(res.result.client_id, clientId);
           assert.equal(res.result.scope[0], 'profile');
           assert.equal(res.result.email, undefined);
-
-          // profileChangedAt (profile_changed_at) was introduced on the tokens table to
-          // help detect stale profile data, but we couldn't complete the migration at the time.
-          // If/when migration gets sorted out, we can check for actual value.
-          assert.equal(res.result.profile_changed_at, undefined, 'profile changed at is not set');
+          assert.equal(res.result.profile_changed_at, PROFILE_CHANGED_AT_LATER_TIME, 'profile changed at is set');
         });
       });
     });


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/498

This brings back `profileChangedAt` and reverses https://github.com/mozilla/fxa-oauth-server/pull/621.