### PR TITLE
fix(pooling): Change request payload default from {} to null

### DIFF
--- a/packages/fxa-auth-server/lib/backendService.js
+++ b/packages/fxa-auth-server/lib/backendService.js
@@ -173,7 +173,8 @@ module.exports = function createBackendServiceAPI(log, config, serviceName, meth
       // Next are query params as a dict, if any.
       const query = validation.query ? await validate('query', args[i++], querySchema) : {};
       // Next is request payload as a dict, if any.
-      const payload = validation.payload ? await validate('request', args[i++], payloadSchema) : {};
+      const payload = validation.payload ? await validate('request', args[i++], payloadSchema) :
+        opts.method === 'GET' ? null : {};
       // Unexpected extra fields in the service response should not be a fatal error,
       // but we also don't want them polluting our code. So, stripUnknown=true.
       const response = await sendRequest(this._pool, opts.method, path, params, query, payload, this._headers);

--- a/packages/fxa-auth-server/test/local/backendService.js
+++ b/packages/fxa-auth-server/test/local/backendService.js
@@ -87,7 +87,7 @@ describe('createBackendServiceAPI', () => {
   });
 
   it('can make a simple GET request and return the response', async () => {
-    mockService.get('/test_get/one/two')
+    mockService.get('/test_get/one/two', '')
     .reply(200, {
       hello: 'world'
     });
@@ -98,7 +98,7 @@ describe('createBackendServiceAPI', () => {
   });
 
   it('can make a simple POST request and return the response', async () => {
-    mockService.post('/test_post/abc')
+    mockService.post('/test_post/abc', { foo: 'bar' })
     .reply(200, {
       hello: 'world'
     });


### PR DESCRIPTION
Some HTTP software (notably GCLB) does not permit request bodies in
GET/HEAD HTTP methods. When you attempt to send one, it will respond
with an HTTP 400 Bad Request.

https://cloud.google.com/load-balancing/docs/https/#illegal_request_handling

> The load balancer also blocks the request if any of the following are true:
> * The combination of request URL and headers is longer than about 15KB.
> * *The request method does not allow a body, but the request has one.*
> * The request contains an upgrade header.
> * The HTTP version is unknown.
