### PR TITLE
fix(text): Sentence case on details

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/emails.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/emails.mustache
@@ -23,10 +23,10 @@
                                     <div class="address {{#verified}}verified{{/verified}}">{{email}}</div>
                                     <div class="details {{#verified}}verified{{/verified}}{{^verified}}not-verified{{/verified}}">
                                         {{#verified}}
-                                            <div>{{#t}}verified{{/t}}</div>
+                                            <div>{{#t}}Verified{{/t}}</div>
                                         {{/verified}}
                                         {{^verified}}
-                                            <div>{{#t}}verification required{{/t}}</div>
+                                            <div>{{#t}}Verification required{{/t}}</div>
                                         {{/verified}}
                                     </div>
                                 </div>


### PR DESCRIPTION
Capitalized the first word of this sentence like we do elsewhere. Lowercase style is too English-centric.