### PR TITLE
fix(signin): allow email first users w/ invalid sessions to sign in

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/models/user.js
+++ b/packages/fxa-content-server/app/tests/spec/models/user.js
@@ -88,6 +88,7 @@ describe('models/user', function () {
   it('isSyncAccount', function () {
     const account = user.initAccount({
       email: EMAIL,
+      sessionToken: 'session token',
       sessionTokenContext: Constants.SESSION_TOKEN_USED_FOR_SYNC
     });
 

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in.js
@@ -149,11 +149,7 @@ describe('views/sign_in', () => {
         return view.render()
           .then(() => view.afterVisible())
           .then(() => {
-            account.set({
-              accessToken: null,
-              sessionToken: null,
-              sessionTokenContext: null
-            });
+            account.discardSessionToken();
           });
       });
 


### PR DESCRIPTION
Users that sign into Sync in one browser and disconnect the session
in another browser were unable to sign in using the email-first flow
because the sessionToken was removed from the account but the
sessionTokenContext was not. The user wasn't asked for their
password and had no way to remedy the situation. This ensures
that when we remove the sessionToken, we also remove the
sessionTokenContext and any accessTokens.

This also provides a remedy for users already in this state. If
we find that an account has a sessionTokenContext but no
sessionToken, then remove the sessionTokenContext so
they can sign in.

Opened against train-135.

fixes #999

@vladikoff, @philbooth, @vbudhram - r?