### PR TITLE
refactor(pairing): Simplify vlad's approach to pairing slightly.

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/app-start.js
+++ b/packages/fxa-content-server/app/scripts/lib/app-start.js
@@ -374,7 +374,7 @@ Start.prototype = {
           }
 
           const browserAccountData  = this._authenticationBroker.get('browserSignedInAccount');
-          if (user.shouldSetSignedInAccountFromBrowser(this._relier.get('service'))) {
+          if (user.shouldSetSignedInAccountFromBrowser(this._relier.get('service'), this.isDevicePairingAsAuthority())) {
             return user.setSignedInAccountFromBrowserAccountData(browserAccountData);
           }
         });
@@ -572,7 +572,11 @@ Start.prototype = {
     // if FXA_STATUS is supported. Don't even bother
     // with localStorage.
     const shouldUseMemoryStorage =
-      this._authenticationBroker.hasCapability('fxaStatus') && this._relier.isSync();
+      this._authenticationBroker.hasCapability('fxaStatus')
+      && (
+        this._relier.isSync() ||
+        this.isDevicePairingAsAuthority()
+      );
 
     const storageType = shouldUseMemoryStorage ? undefined : 'localStorage';
     return Storage.factory(storageType, this._window);

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -1298,11 +1298,12 @@ const Account = Backbone.Model.extend({
   /**
      * Check to see if the current user has a verified TOTP token.
      *
-     * @param {String} [sessionToken] Optional sessionToken to verify
      * @returns {Promise}
      */
-  checkTotpTokenExists (sessionToken = this.get('sessionToken')) {
-    return this._fxaClient.checkTotpTokenExists(sessionToken);
+  checkTotpTokenExists () {
+    return this._fxaClient.checkTotpTokenExists(
+      this.get('sessionToken')
+    );
   },
 
   /**

--- a/packages/fxa-content-server/app/scripts/models/user.js
+++ b/packages/fxa-content-server/app/scripts/models/user.js
@@ -715,14 +715,18 @@ var User = Backbone.Model.extend({
    * Should the model be initialized using browser data?
    *
    * @param {Object} service service being signed into.
+   * @param {Boolean} isDevicePairingAsAuthority
    * @returns {Boolean}
    */
-  shouldSetSignedInAccountFromBrowser (service) {
-    // If service=sync, always use the browser's state of the world.
+  shouldSetSignedInAccountFromBrowser (service, isDevicePairingAsAuthority) {
+    // If service=sync or the device is pairing as the authority,
+    // always use the browser's state of the world.
     // If trying to sign in to an OAuth relier, prefer any users that are
     // stored in localStorage and only use the browser's state if no
     // user is stored.
-    return service === Constants.SYNC_SERVICE || this.getSignedInAccount().isDefault();
+    return service === Constants.SYNC_SERVICE
+           || isDevicePairingAsAuthority
+           || this.getSignedInAccount().isDefault();
   },
 
   /**

--- a/packages/fxa-content-server/app/scripts/views/pair/index.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/index.js
@@ -27,22 +27,19 @@ class PairIndexView extends FormView {
       return this.replaceCurrentPage('pair/unsupported');
     }
 
-    const account = this.broker.get('browserSignedInAccount');
     // If we reach this point that means we are in Firefox Desktop
-    if (! account) {
+    const account = this.getSignedInAccount();
+    if (account.isDefault()) {
       // if we are not logged into Sync then we offer to connect
       return this.replaceCurrentPage('connect_another_device');
     }
 
-    if (! account.verified || ! account.sessionToken) {
+    if (! account.get('verified') || ! account.get('sessionToken')) {
       // if account is not verified or missing sessionToken then offer to sign in or confirm
       return this.navigateAway(this.getEscapedSyncUrl('signin', 'fxa:pair'));
     }
 
-    // here we pass a token from the 'browserSignedInAccount'. This token has a device
-    // attached to it and is the one we want to check. We want to avoid using the
-    // "web" session token because it may disappear, expire or get pruned.
-    return this.checkTotpStatus(account.sessionToken);
+    return this.checkTotpStatus();
   }
 
   setInitialContext (context) {

--- a/packages/fxa-content-server/app/scripts/views/pair/pairing-totp-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/pairing-totp-mixin.js
@@ -6,7 +6,7 @@ import AuthErrors from '../../lib/auth-errors';
 
 export default function () {
   return {
-    checkTotpStatus(sessionToken) {
+    checkTotpStatus() {
       const account = this.getSignedInAccount();
 
       if (! account) {
@@ -15,8 +15,7 @@ export default function () {
         });
       }
 
-      // Use the browser sessionToken to check TOTP
-      return account.checkTotpTokenExists(sessionToken).then((result) => {
+      return account.checkTotpTokenExists().then((result) => {
         // pairing is disabled for accounts with 2FA
         if (result.exists) {
           this.replaceCurrentPage('pair/failure', {

--- a/packages/fxa-content-server/app/tests/spec/lib/app-start.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/app-start.js
@@ -747,11 +747,12 @@ describe('lib/app-start', () => {
           isSync: () => true
         }
       });
+      sinon.stub(appStart, 'isDevicePairingAsAuthority').callsFake(() => false);
       const storage = appStart._getUserStorageInstance();
       assert.instanceOf(storage._backend, NullStorage);
     });
 
-    it('returns a localStorage store if fxaccounts:fxa_status is supported and not Sync', () => {
+    it('returns a memory store if fxaccounts:fxa_status is supported and pairing as authority', () => {
       appStart = new AppStart({
         broker: {
           hasCapability: (name) => name === 'fxaStatus'
@@ -760,6 +761,21 @@ describe('lib/app-start', () => {
           isSync: () => false
         }
       });
+      sinon.stub(appStart, 'isDevicePairingAsAuthority').callsFake(() => true);
+      const storage = appStart._getUserStorageInstance();
+      assert.instanceOf(storage._backend, NullStorage);
+    });
+
+    it('returns a localStorage store if fxaccounts:fxa_status is supported and not Sync or pairing', () => {
+      appStart = new AppStart({
+        broker: {
+          hasCapability: (name) => name === 'fxaStatus'
+        },
+        relier: {
+          isSync: () => false
+        }
+      });
+      sinon.stub(appStart, 'isDevicePairingAsAuthority').callsFake(() => false);
       const storage = appStart._getUserStorageInstance();
       assert.strictEqual(storage._backend, localStorage);
     });

--- a/packages/fxa-content-server/app/tests/spec/models/user.js
+++ b/packages/fxa-content-server/app/tests/spec/models/user.js
@@ -1397,6 +1397,12 @@ describe('models/user', function () {
       assert.isTrue(user.shouldSetSignedInAccountFromBrowser('sync'));
     });
 
+    it('returns true if pairing as the authority', () => {
+      sinon.stub(user, 'getSignedInAccount').callsFake(() => user.initAccount({ email: 'already-signed-in@testuser.com' }));
+
+      assert.isTrue(user.shouldSetSignedInAccountFromBrowser(null, true));
+    });
+
     it('returns true if no local user, not sync', () => {
       sinon.stub(user, 'getSignedInAccount').callsFake(() => user.initAccount({}));
 

--- a/packages/fxa-content-server/app/tests/spec/views/pair/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/index.js
@@ -68,6 +68,21 @@ describe('views/pair/index', () => {
       });
     });
 
+    it('redirects to unsupported if no capability', () => {
+      windowMock.navigator.userAgent = UA_FIREFOX;
+      broker.unsetCapability('supportsPairing');
+
+      account.set({
+        email: 'testuser@testuser.com',
+        sessionToken: 'abc123',
+        uid: 'uid'
+      });
+      return view.render().then(() => {
+        console.log('args', view.replaceCurrentPage.args[0])
+        assert.isTrue(view.replaceCurrentPage.calledOnceWith('pair/unsupported'));
+      });
+    });
+
     it('redirects to CAD if not signed in', () => {
       windowMock.navigator.userAgent = UA_FIREFOX;
       broker.setCapability('supportsPairing', true);
@@ -77,16 +92,9 @@ describe('views/pair/index', () => {
       });
     });
 
-    it('redirects to unsupported if no capability', () => {
-      broker.set('browserSignedInAccount', { email: 'testuser@testuser.com', uid: 'uid' });
-      return view.render().then(() => {
-        assert.isTrue(view.replaceCurrentPage.calledOnceWith('pair/unsupported'));
-      });
-    });
-
     it('shows the code button', () => {
       windowMock.navigator.userAgent = UA_FIREFOX;
-      broker.set('browserSignedInAccount', {
+      account.set({
         email: 'testuser@testuser.com',
         sessionToken: 'abc123',
         uid: 'uid',
@@ -100,13 +108,13 @@ describe('views/pair/index', () => {
         assert.ok(view.$el.find('#pair-header').text(), 'Connect another device');
         assert.ok(view.$el.find('#start-pairing').length);
         assert.ok(view.$el.find('.graphic').length);
-        assert.isTrue(view.checkTotpStatus.calledOnceWith('abc123'));
+        assert.isTrue(view.checkTotpStatus.calledOnce);
       });
     });
 
     it('navigates away to sync signin for unverified accounts', () => {
       windowMock.navigator.userAgent = UA_FIREFOX;
-      broker.set('browserSignedInAccount', {
+      account.set({
         email: 'testuser@testuser.com',
         sessionToken: 'abc123',
         uid: 'uid',
@@ -122,7 +130,7 @@ describe('views/pair/index', () => {
 
     it('navigates away to sync signin for accounts with no sessionToken', () => {
       windowMock.navigator.userAgent = UA_FIREFOX;
-      broker.set('browserSignedInAccount', {
+      account.set({
         email: 'testuser@testuser.com',
         uid: 'uid',
         verified: true,


### PR DESCRIPTION
Instead of using the account stored in user.signedInAccount as a sort
of dumb pipe and passing in a custom sessionToken from the browser's
account, just ensure the account returned by user.getSignedInAccount
is the same as the browser's account.

Hey @vladikoff, this is what I meant by my comments. Conceptually it
seems to me a tad bit less confusing because it makes sure to use
the browser's view of the world if we are pairing.