### PR TITLE
feat(broker): add new entrypoint params to metrics context

### DIFF
--- a/packages/fxa-event-broker/src/types/event.rs
+++ b/packages/fxa-event-broker/src/types/event.rs
@@ -101,6 +101,17 @@ pub struct MetricsContext {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entrypoint: Option<String>,
 
+    /// Experiment running at the entrypoint.
+    #[serde(
+        alias = "entrypointExperiment",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub entrypoint_experiment: Option<String>,
+
+    /// Experiment variation at the entrypoint.
+    #[serde(alias = "entrypointVariation", skip_serializing_if = "Option::is_none")]
+    pub entrypoint_variation: Option<String>,
+
     /// FxA flow id.
     #[serde(alias = "flowId", skip_serializing_if = "Option::is_none")]
     pub flow_id: Option<String>,
@@ -134,6 +145,8 @@ impl MetricsContext {
     pub fn is_empty(&self) -> bool {
         self.device_id.is_none()
             && self.entrypoint.is_none()
+            && self.entrypoint_experiment.is_none()
+            && self.entrypoint_variation.is_none()
             && self.flow_id.is_none()
             && self.flow_begin_time.is_none()
             && self.utm_campaign.is_none()

--- a/packages/fxa-event-broker/src/types/event.rs
+++ b/packages/fxa-event-broker/src/types/event.rs
@@ -94,7 +94,7 @@ impl PartialEq<u64> for Timestamp {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct MetricsContext {
     /// Metrics device id, which is a different thing to the FxA device id.
-    #[serde(alias = "deviceId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub device_id: Option<String>,
 
     /// Entrypoint to the flow.
@@ -102,18 +102,15 @@ pub struct MetricsContext {
     pub entrypoint: Option<String>,
 
     /// Experiment running at the entrypoint.
-    #[serde(
-        alias = "entrypointExperiment",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub entrypoint_experiment: Option<String>,
 
     /// Experiment variation at the entrypoint.
-    #[serde(alias = "entrypointVariation", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub entrypoint_variation: Option<String>,
 
     /// FxA flow id.
-    #[serde(alias = "flowId", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub flow_id: Option<String>,
 
     /// Timestamp for the beginning of the flow, in epoch-milliseconds.
@@ -121,23 +118,23 @@ pub struct MetricsContext {
     pub flow_begin_time: Option<u64>,
 
     /// Marketing campaign id.
-    #[serde(alias = "utmCampaign", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub utm_campaign: Option<String>,
 
     /// Marketing content id.
-    #[serde(alias = "utmContent", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub utm_content: Option<String>,
 
     /// Marketing medium.
-    #[serde(alias = "utmMedium", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub utm_medium: Option<String>,
 
     /// Traffic source.
-    #[serde(alias = "utmSource", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub utm_source: Option<String>,
 
     /// Search term.
-    #[serde(alias = "utmTerm", skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub utm_term: Option<String>,
 }
 

--- a/packages/fxa-event-broker/src/types/event/test-fixture.json
+++ b/packages/fxa-event-broker/src/types/event/test-fixture.json
@@ -1,7 +1,7 @@
 [
   {
     "wibble": "blee",
-    "Message": "{\"wibble\":\"blee\",\"event\":\"foo.bar\",\"ts\":1555076067.0,\"iss\":\"api.accounts.firefox.com\",\"uid\":\"deadbeef\",\"email\":\"fxa@example.com\",\"locale\":\"en-GB\",\"marketingOptIn\":true,\"service\":\"baadf00d\",\"metricsContext\":{\"wibble\":\"blee\",\"deviceId\":\"a\",\"entrypoint\":\"b\",\"flowId\":\"c\",\"flowBeginTime\":1555076910685,\"utmCampaign\":\"d\",\"utmContent\":\"e\",\"utmMedium\":\"f\",\"utmSource\":\"g\",\"utmTerm\":\"h\"}}"
+    "Message": "{\"wibble\":\"blee\",\"event\":\"foo.bar\",\"ts\":1555076067.0,\"iss\":\"api.accounts.firefox.com\",\"uid\":\"deadbeef\",\"email\":\"fxa@example.com\",\"locale\":\"en-GB\",\"marketingOptIn\":true,\"service\":\"baadf00d\",\"metricsContext\":{\"wibble\":\"blee\",\"deviceId\":\"a\",\"entrypoint\":\"b\",\"entrypoint_experiment\":\"c\",\"entrypoint_variation\":\"d\",\"flowId\":\"e\",\"flowBeginTime\":1555076910685,\"utmCampaign\":\"f\",\"utmContent\":\"g\",\"utmMedium\":\"h\",\"utmSource\":\"i\",\"utmTerm\":\"j\"}}"
   },
   {
     "Message": "{\"event\":\"baz.qux\",\"ts\":1555077255.999,\"iss\":\"example.com\",\"metricsContext\":{}}"

--- a/packages/fxa-event-broker/src/types/event/test-fixture.json
+++ b/packages/fxa-event-broker/src/types/event/test-fixture.json
@@ -1,7 +1,7 @@
 [
   {
     "wibble": "blee",
-    "Message": "{\"wibble\":\"blee\",\"event\":\"foo.bar\",\"ts\":1555076067.0,\"iss\":\"api.accounts.firefox.com\",\"uid\":\"deadbeef\",\"email\":\"fxa@example.com\",\"locale\":\"en-GB\",\"marketingOptIn\":true,\"service\":\"baadf00d\",\"metricsContext\":{\"wibble\":\"blee\",\"deviceId\":\"a\",\"entrypoint\":\"b\",\"entrypoint_experiment\":\"c\",\"entrypoint_variation\":\"d\",\"flowId\":\"e\",\"flowBeginTime\":1555076910685,\"utmCampaign\":\"f\",\"utmContent\":\"g\",\"utmMedium\":\"h\",\"utmSource\":\"i\",\"utmTerm\":\"j\"}}"
+    "Message": "{\"wibble\":\"blee\",\"event\":\"foo.bar\",\"ts\":1555076067.0,\"iss\":\"api.accounts.firefox.com\",\"uid\":\"deadbeef\",\"email\":\"fxa@example.com\",\"locale\":\"en-GB\",\"marketingOptIn\":true,\"service\":\"baadf00d\",\"metricsContext\":{\"wibble\":\"blee\",\"device_id\":\"a\",\"entrypoint\":\"b\",\"entrypoint_experiment\":\"c\",\"entrypoint_variation\":\"d\",\"flow_id\":\"e\",\"flowBeginTime\":1555076910685,\"utm_campaign\":\"f\",\"utm_content\":\"g\",\"utm_medium\":\"h\",\"utm_source\":\"i\",\"utm_term\":\"j\"}}"
   },
   {
     "Message": "{\"event\":\"baz.qux\",\"ts\":1555077255.999,\"iss\":\"example.com\",\"metricsContext\":{}}"

--- a/packages/fxa-event-broker/src/types/event/test.rs
+++ b/packages/fxa-event-broker/src/types/event/test.rs
@@ -25,16 +25,18 @@ fn deserialize_events() -> Result<(), Error> {
     assert_eq!(event.service.unwrap(), "baadf00d");
     assert_eq!(event.metrics_context.device_id.unwrap(), "a");
     assert_eq!(event.metrics_context.entrypoint.unwrap(), "b");
-    assert_eq!(event.metrics_context.flow_id.unwrap(), "c");
+    assert_eq!(event.metrics_context.entrypoint_experiment.unwrap(), "c");
+    assert_eq!(event.metrics_context.entrypoint_variation.unwrap(), "d");
+    assert_eq!(event.metrics_context.flow_id.unwrap(), "e");
     assert_eq!(
         event.metrics_context.flow_begin_time.unwrap(),
         1555076910685
     );
-    assert_eq!(event.metrics_context.utm_campaign.unwrap(), "d");
-    assert_eq!(event.metrics_context.utm_content.unwrap(), "e");
-    assert_eq!(event.metrics_context.utm_medium.unwrap(), "f");
-    assert_eq!(event.metrics_context.utm_source.unwrap(), "g");
-    assert_eq!(event.metrics_context.utm_term.unwrap(), "h");
+    assert_eq!(event.metrics_context.utm_campaign.unwrap(), "f");
+    assert_eq!(event.metrics_context.utm_content.unwrap(), "g");
+    assert_eq!(event.metrics_context.utm_medium.unwrap(), "h");
+    assert_eq!(event.metrics_context.utm_source.unwrap(), "i");
+    assert_eq!(event.metrics_context.utm_term.unwrap(), "j");
 
     let event: Event = serde_json::from_str(&envelopes[1].message)?;
 
@@ -48,6 +50,8 @@ fn deserialize_events() -> Result<(), Error> {
     assert!(event.service.is_none());
     assert!(event.metrics_context.device_id.is_none());
     assert!(event.metrics_context.entrypoint.is_none());
+    assert!(event.metrics_context.entrypoint_experiment.is_none());
+    assert!(event.metrics_context.entrypoint_variation.is_none());
     assert!(event.metrics_context.flow_id.is_none());
     assert!(event.metrics_context.flow_begin_time.is_none());
     assert!(event.metrics_context.utm_campaign.is_none());
@@ -77,16 +81,18 @@ fn serialize_event() -> Result<(), Error> {
     assert_eq!(event["service"], "baadf00d");
     assert_eq!(event["metrics_context"]["device_id"], "a");
     assert_eq!(event["metrics_context"]["entrypoint"], "b");
-    assert_eq!(event["metrics_context"]["flow_id"], "c");
+    assert_eq!(event["metrics_context"]["entrypoint_experiment"], "c");
+    assert_eq!(event["metrics_context"]["entrypoint_variation"], "d");
+    assert_eq!(event["metrics_context"]["flow_id"], "e");
     assert_eq!(
         event["metrics_context"]["flow_begin_time"],
         1555076910685u64
     );
-    assert_eq!(event["metrics_context"]["utm_campaign"], "d");
-    assert_eq!(event["metrics_context"]["utm_content"], "e");
-    assert_eq!(event["metrics_context"]["utm_medium"], "f");
-    assert_eq!(event["metrics_context"]["utm_source"], "g");
-    assert_eq!(event["metrics_context"]["utm_term"], "h");
+    assert_eq!(event["metrics_context"]["utm_campaign"], "f");
+    assert_eq!(event["metrics_context"]["utm_content"], "g");
+    assert_eq!(event["metrics_context"]["utm_medium"], "h");
+    assert_eq!(event["metrics_context"]["utm_source"], "i");
+    assert_eq!(event["metrics_context"]["utm_term"], "j");
 
     let event: Event = serde_json::from_str(&envelopes[1].message)?;
     let json = serde_json::to_string(&event)?;


### PR DESCRIPTION
`entrypoint_experiment` and `entrypoint_variation` were added to `metricsContext` in the auth server in #979. We should probably include them in the `metrics_context` in the event broker too I guess.

@mozilla/fxa-devs r?