### PR TITLE
feat(metrics): add country and user agent to notifyAttachedServices

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -187,12 +187,16 @@ module.exports = (log, db, mailer, Password, config, customs, subhub, signinUtil
             uid: account.uid
           });
 
+          const geoData = request.app.geo;
+          const country =  geoData.location && geoData.location.country;
           if (account.emailVerified) {
             await log.notifyAttachedServices('verified', request, {
               email: account.email,
               locale: account.locale,
               service,
               uid: account.uid,
+              userAgent: userAgentString,
+              country
             });
           }
 
@@ -202,6 +206,7 @@ module.exports = (log, db, mailer, Password, config, customs, subhub, signinUtil
             service,
             uid: account.uid,
             userAgent: userAgentString,
+            country
           });
         }
 

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -243,12 +243,15 @@ module.exports = (log, config, customs, db, mailer)  => {
         });
 
         if (request.payload.reason === 'signin') {
+          const geoData = request.app.geo;
+          const country = geoData.location && geoData.location.country;
           await log.notifyAttachedServices('login', request, {
             deviceCount: sessions.length,
             email: accountRecord.primaryEmail.email,
             service,
             uid: accountRecord.uid,
-            userAgent: request.headers['user-agent']
+            userAgent: request.headers['user-agent'],
+            country
           });
         }
       }

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -472,6 +472,8 @@ describe('/account/create', () => {
       assert.equal(eventData.event, 'login', 'it was a login event');
       assert.equal(eventData.data.service, 'sync', 'it was for sync');
       assert.equal(eventData.data.email, TEST_EMAIL, 'it was for the correct email');
+      assert.equal(eventData.data.userAgent, 'test user-agent', 'correct user agent');
+      assert.equal(eventData.data.country, 'United States', 'correct country');
       assert.ok(eventData.data.ts, 'timestamp of event set');
       assert.deepEqual(eventData.data.metricsContext, {
         entrypoint: 'blee',

--- a/packages/fxa-auth-server/test/local/routes/utils/signin.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/signin.js
@@ -519,7 +519,8 @@ describe('sendSigninNotifications', () => {
         email: TEST_EMAIL,
         service: 'testservice',
         uid: TEST_UID,
-        userAgent: 'test user-agent'
+        userAgent: 'test user-agent',
+        country: 'United States'
       });
 
       assert.notCalled(mailer.sendVerifyCode);
@@ -634,7 +635,8 @@ describe('sendSigninNotifications', () => {
           email: TEST_EMAIL,
           service: 'testservice',
           uid: TEST_UID,
-          userAgent: 'test user-agent'
+          userAgent: 'test user-agent',
+          country: 'United States'
         });
       });
     });
@@ -667,7 +669,8 @@ describe('sendSigninNotifications', () => {
           email: TEST_EMAIL,
           service: 'testservice',
           uid: TEST_UID,
-          userAgent: 'test user-agent'
+          userAgent: 'test user-agent',
+          country: 'United States'
         });
 
         assert.notCalled(mailer.sendVerifyCode);
@@ -809,7 +812,8 @@ describe('sendSigninNotifications', () => {
         email: TEST_EMAIL,
         service: 'testservice',
         uid: TEST_UID,
-        userAgent: 'test user-agent'
+        userAgent: 'test user-agent',
+        country: 'United States'
       });
       assert.calledOnce(db.securityEvent);
     });
@@ -842,7 +846,8 @@ describe('sendSigninNotifications', () => {
           uid: TEST_UID,
           email: TEST_EMAIL,
           deviceCount: 1,
-          userAgent: 'test user-agent'
+          userAgent: 'test user-agent',
+          country: 'United States'
         });
       });
     });
@@ -856,7 +861,8 @@ describe('sendSigninNotifications', () => {
           uid: TEST_UID,
           email: TEST_EMAIL,
           deviceCount: 4,
-          userAgent: 'test user-agent'
+          userAgent: 'test user-agent',
+          country: 'United States'
         });
       });
     });


### PR DESCRIPTION
This PR adds missing attributes from https://github.com/mozilla/fxa/issues/971, namely the country and user agent on account verified. Services that are setup to recieve these events will get access to the new data.

Fixes https://github.com/mozilla/fxa/issues/971