### PR TITLE
fix: setup missing packages and include natives

### DIFF
--- a/_scripts/install_all.sh
+++ b/_scripts/install_all.sh
@@ -32,6 +32,14 @@ cd fxa-event-broker; cargo build; cd ..
 
 cd browserid-verifier; npm ci; cd ..
 
+cd fxa-js-client; npm ci; cd ..
+
+cd fxa-customs-server; npm ci; cd ..
+
+cd fxa-oauth-console; npm ci; cd ..
+
+cd fxa-payments-server; npm ci; cd ..
+
 # cd fxa-auth-server/fxa-oauth-server; npm ci; cd ../..
 
 cd fxa-profile-server; npm ci; mkdir -p var/public/; cd ..

--- a/packages/fxa-oauth-console/package-lock.json
+++ b/packages/fxa-oauth-console/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-oauth-console",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8165,9 +8165,9 @@
       }
     },
     "natives": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/packages/fxa-oauth-console/package.json
+++ b/packages/fxa-oauth-console/package.json
@@ -63,6 +63,7 @@
     "grunt-copyright": "0.3.0",
     "grunt-eslint": "19.0.0",
     "load-grunt-tasks": "3.5.2",
+    "natives": "1.1.6",
     "nodemon": "^1.2.1",
     "xmlhttprequest": "git://github.com/zaach/node-XMLHttpRequest.git#onerror"
   },


### PR DESCRIPTION
Several packages were not having npm ci run in them, so their grunt tasks were not found when running `npm test`. The natives package also apparently must be required at 1.1.6 due to gulpjs/gulp#2280.