### PR TITLE
fix(metrics): include deviceId in GET /metrics-flow response

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/flow.js
+++ b/packages/fxa-content-server/app/scripts/models/flow.js
@@ -52,7 +52,11 @@ var Model = Backbone.Model.extend({
     }
 
     if (! this.has('deviceId')) {
-      this.set('deviceId', uuid.v4().replace(/-/g, ''));
+      if (urlParams.device_id) {
+        this.set('deviceId', urlParams.device_id);
+      } else {
+        this.set('deviceId', uuid.v4().replace(/-/g, ''));
+      }
     }
   },
 

--- a/packages/fxa-content-server/app/tests/spec/models/flow.js
+++ b/packages/fxa-content-server/app/tests/spec/models/flow.js
@@ -98,6 +98,7 @@ describe('models/flow', function () {
 
     windowMock.location.search = Url.objToSearchString({
       /*eslint-disable camelcase*/
+      device_id: DEVICE_ID,
       flow_begin_time: QUERY_FLOW_BEGIN,
       flow_id: QUERY_FLOW_ID
       /*eslint-enable camelcase*/
@@ -105,7 +106,7 @@ describe('models/flow', function () {
 
     createFlow();
 
-    assert.match(flow.get('deviceId'), /^[0-9a-f]{32}$/);
+    assert.equal(flow.get('deviceId'), DEVICE_ID);
     assert.equal(flow.get('flowId'), QUERY_FLOW_ID);
     assert.equal(flow.get('flowBegin'), QUERY_FLOW_BEGIN);
     assert.ok(metricsMock.markEventLogged.calledOnce);

--- a/packages/fxa-content-server/server/lib/routes/get-metrics-flow.js
+++ b/packages/fxa-content-server/server/lib/routes/get-metrics-flow.js
@@ -73,8 +73,7 @@ module.exports = function (config) {
 
   route.process = function (req, res) {
     const flowEventData = flowMetrics.create(FLOW_ID_KEY, req.headers['user-agent']);
-    const flowBeginTime = flowEventData.flowBeginTime;
-    const flowId = flowEventData.flowId;
+    const { flowBeginTime, flowId } = flowEventData;
     const metricsData = req.query || {};
     const beginEvent = {
       flowTime: flowBeginTime,
@@ -86,7 +85,7 @@ module.exports = function (config) {
     // Amplitude-specific device id, like the client-side equivalent
     // created in app/scripts/lib/app-start.js. Transient for now,
     // but will become persistent in due course.
-    metricsData.deviceId = uuid.v4().replace(/-/g, '');
+    const deviceId = metricsData.deviceId = uuid.v4().replace(/-/g, '');
 
     amplitude(beginEvent, req, metricsData);
     logFlowEvent(beginEvent, metricsData, req);
@@ -107,8 +106,9 @@ module.exports = function (config) {
     // charset must be set on json responses.
     res.charset = 'utf-8';
     res.json({
-      flowBeginTime: flowEventData.flowBeginTime,
-      flowId: flowId
+      deviceId,
+      flowBeginTime,
+      flowId
     });
   };
 

--- a/packages/fxa-content-server/tests/server/routes/get-metrics-flow.js
+++ b/packages/fxa-content-server/tests/server/routes/get-metrics-flow.js
@@ -80,8 +80,10 @@ registerSuite('routes/get-metrics-flow', {
       assert.equal(response.json.callCount, 1);
       const args = response.json.args[0];
       assert.lengthOf(args, 1);
-      assert.ok(args[0].flowBeginTime);
-      assert.ok(args[0].flowId);
+      assert.match(args[0].deviceId, /^[0-9a-f]{32}$/);
+      assert.isAbove(args[0].flowBeginTime, Date.now() - 1000);
+      assert.isAtMost(args[0].flowBeginTime, Date.now());
+      assert.match(args[0].flowId, /^[0-9a-f]{64}$/);
 
       assert.equal(mocks.flowEvent.logFlowEvent.callCount, 1);
       const argsFlowEvent = mocks.flowEvent.logFlowEvent.args[0];


### PR DESCRIPTION
Fixes #1018. Re-applies #1053 on top of the 136.4 release.

We need to include `deviceId` in the response from `GET /metrics-flow` so that Amplitude can link up events correctly. In addition to the changes here, it will need any consuming code to pass it to us in a `device_id` query parameter.

@mozilla/fxa-devs r?