### PR TITLE
fix(oauth:introspect): fix introspect endpoint

### DIFF
--- a/packages/fxa-auth-server/lib/oauthdb/check-refresh-token.js
+++ b/packages/fxa-auth-server/lib/oauthdb/check-refresh-token.js
@@ -14,7 +14,7 @@ module.exports = (config) => {
     validate: {
       payload: {
         token: Joi.string().required(),
-        token_type_hint: Joi.string().allow('refresh_token')
+        token_type_hint: Joi.string().allow('refresh_token').default('refresh_token')
       },
       response: {
         // https://tools.ietf.org/html/rfc7662#section-2.2


### PR DESCRIPTION
* jti is optional, it's not returned if the token doesn't exist
* active logic was reversed, now returns active: true if expiresAt is in the future
* Only return fields if they are defined.
* Set the default token_type_hint in check-refresh-token to `refresh_token`
* Use token_type_hint from the payload rather than token_type

fixes #1066
fixes #1067
fixes #1068
fixes #1069

@mozilla/fxa-devs, @vladikoff - r?

Blocks mozilla/fxa-private#18