### PR TITLE
Cherry-pick auth server changes from 136.6 to `master`

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/test/api.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/api.js
@@ -124,9 +124,7 @@ function authParams(params, options) {
   return defaults;
 }
 
-function newToken(payload, options) {
-  payload = payload || {};
-  options = options || {};
+function newToken(payload={}, options={}) {
   var ttl = payload.ttl || MAX_TTL_S;
   delete payload.ttl;
   mockAssertion().reply(200, options.verifierResponse || VERIFY_GOOD);
@@ -3719,6 +3717,138 @@ describe('/v1', function() {
         });
       });
 
+    });
+  });
+
+  describe('/introspect', () => {
+    let accessToken;
+
+    before(async () => {
+      const res = await newToken({
+        access_type: 'online',
+      });
+      accessToken = res.result.access_token;
+    });
+
+
+    it('should return { active: false } if token is not found', async () => {
+      const res = await Server.api.post({
+        url: '/introspect',
+        payload: {
+          token: 'not a known token'
+        }
+      });
+      assert.strictEqual(res.statusCode, 200);
+      assert.isFalse(res.result.active);
+    });
+
+    it('should succeed if token is an access token', async () => {
+      const res = await Server.api.post({
+        url: '/introspect',
+        payload: {
+          token: accessToken
+        }
+      });
+      assert.strictEqual(res.statusCode, 200);
+      const { result } = res;
+      assert.isTrue(result.active);
+      assert.strictEqual(result.scope, 'a');
+      assert.strictEqual(result.client_id, 'dcdb5ae7add825d2');
+      assert.strictEqual(result.token_type, 'access_token');
+      assert.isNumber(result.exp);
+      assert.isAbove(result.exp, Date.now());
+      assert.isNumber(result.iat);
+      assert.isBelow(result.iat, Date.now());
+      assert.strictEqual(result.sub, USERID);
+      assert.isUndefined(result['fxa-lastUsedAt']);
+    });
+
+    it('should return { active: false } if token is an access token, but token_type_hint=refresh_token', async () => {
+      const res = await Server.api.post({
+        url: '/introspect',
+        payload: {
+          token: accessToken,
+          token_type_hint: 'refresh_token'
+        }
+      });
+      assert.strictEqual(res.statusCode, 200);
+      assert.isFalse(res.result.active);
+    });
+
+    it('should return a `not a public client` error if not a public client and using a refresh token', async () => {
+      const tokenRes = await newToken({
+        access_type: 'offline',
+      });
+
+      const res = await Server.api.post({
+        url: '/introspect',
+        payload: {
+          token: tokenRes.result.refresh_token
+        }
+      });
+      assert.strictEqual(res.statusCode, 400);
+      assert.strictEqual(res.result.errno, 116);
+    });
+
+
+    it('should succeed if token is a refresh token', async () => {
+      const clientId = '38a6b9b3a65a1872';
+      const tokenRes = await newToken({
+        access_type: 'offline',
+        response_type: 'code',
+        code_challenge_method: 'S256',
+        code_challenge: 'SWac3rF5sKcyAtsXGMO9feaKqpzgCoA2zowbi20F_0c'
+      }, {
+        clientId: clientId,
+        codeVerifier: 'WLjNEANMbRNUSG0uQsUZMQGgIL5FUknGz2jRipY79ZC',
+      });
+
+      const res = await Server.api.post({
+        url: '/introspect',
+        payload: {
+          token: tokenRes.result.refresh_token
+        }
+      });
+
+      assert.strictEqual(res.statusCode, 200);
+      const { result } = res;
+
+      assert.isTrue(result.active);
+      assert.strictEqual(result.scope, 'a');
+      assert.strictEqual(result.client_id, '38a6b9b3a65a1872');
+      assert.strictEqual(result.token_type, 'refresh_token');
+      assert.isUndefined(result.exp);
+      assert.isNumber(result.iat);
+      assert.isBelow(result.iat, Date.now());
+      assert.strictEqual(result.sub, USERID);
+      assert.isNumber(result['fxa-lastUsedAt']);
+      assert.isBelow(result['fxa-lastUsedAt'], Date.now());
+    });
+
+    it('should return { active: false } if token is an refresh token, but token_type_hint=access_token', async () => {
+      const clientId = '38a6b9b3a65a1872';
+      const tokenRes = await newToken({
+        access_type: 'offline',
+        response_type: 'code',
+        code_challenge_method: 'S256',
+        code_challenge: 'SWac3rF5sKcyAtsXGMO9feaKqpzgCoA2zowbi20F_0c'
+      }, {
+        clientId: clientId,
+        codeVerifier: 'WLjNEANMbRNUSG0uQsUZMQGgIL5FUknGz2jRipY79ZC',
+      });
+
+      const res = await Server.api.post({
+        url: '/introspect',
+        payload: {
+          token: tokenRes.result.refresh_token,
+          token_type_hint: 'access_token'
+        }
+      });
+
+      assert.strictEqual(res.statusCode, 200);
+      const { result } = res;
+
+      assert.isFalse(result.active);
     });
   });
 });

--- a/packages/fxa-auth-server/lib/oauthdb/check-refresh-token.js
+++ b/packages/fxa-auth-server/lib/oauthdb/check-refresh-token.js
@@ -14,7 +14,7 @@ module.exports = (config) => {
     validate: {
       payload: {
         token: Joi.string().required(),
-        token_type_hint: Joi.string().allow('refresh_token')
+        token_type_hint: Joi.string().allow('refresh_token').default('refresh_token')
       },
       response: {
         // https://tools.ietf.org/html/rfc7662#section-2.2

--- a/packages/fxa-auth-server/lib/scheme-refresh-token.js
+++ b/packages/fxa-auth-server/lib/scheme-refresh-token.js
@@ -30,7 +30,7 @@ module.exports = function schemeRefreshTokenScheme(db, oauthdb) {
 
         const refreshTokenInfo = await oauthdb.checkRefreshToken(refreshToken);
         if (! refreshTokenInfo || ! refreshTokenInfo.active) {
-          return h.unauthenticated();
+          return h.unauthenticated(new AppError.invalidToken());
         }
 
         const credentials = {
@@ -43,7 +43,7 @@ module.exports = function schemeRefreshTokenScheme(db, oauthdb) {
 
         if (! scopeSet.intersects(ALLOWED_REFRESH_TOKEN_SCHEME_SCOPES)) {
           // unauthenticated if refreshToken is missing the required scope
-          return h.unauthenticated();
+          return h.unauthenticated(AppError.invalidScopes(refreshTokenInfo.scope));
         }
 
         credentials.client = await oauthdb.getClientInfo(refreshTokenInfo.client_id);

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -278,6 +278,46 @@ module.exports = config => {
     );
   };
 
+  ClientApi.prototype.deviceCommandsWithRefreshToken = function (refreshTokenHex, index, limit) {
+    // eslint-disable-next-line no-undef
+    const queryParams = new URLSearchParams({
+      index,
+      limit
+    });
+    const url = `${this.baseURL  }/account/device/commands?${queryParams.toString()}`;
+
+    return this.doRequestWithBearerToken(
+      'GET',
+      url,
+      refreshTokenHex
+    );
+  };
+
+  ClientApi.prototype.devicesInvokeCommandWithRefreshToken = function (refreshTokenHex, target, command, payload, ttl) {
+    return this.doRequestWithBearerToken(
+      'POST',
+      `${this.baseURL  }/account/devices/invoke_command`,
+      refreshTokenHex,
+      {
+        command,
+        payload,
+        target,
+        ttl,
+      }
+    );
+  };
+
+  ClientApi.prototype.accountDevicesNotifyWithRefreshToken = function (refreshTokenHex, notifyDeviceId) {
+    return this.doRequestWithBearerToken(
+      'POST',
+      `${this.baseURL}/account/devices/notify`,
+      refreshTokenHex,
+      {
+        to: notifyDeviceId
+      }
+    );
+  };
+
   ClientApi.prototype.accountStatusByEmail = function (email) {
     if (email) {
       return this.doRequest(

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -409,6 +409,10 @@ module.exports = config => {
     return this.api.accountDevicesWithRefreshToken(refreshToken);
   };
 
+  Client.prototype.devicesNotifyWithRefreshToken = function(refreshToken, notifyDeviceId) {
+    return this.api.accountDevicesNotifyWithRefreshToken(refreshToken, notifyDeviceId);
+  };
+
   Client.prototype.updateDevice = function (info) {
     const o = this.sessionToken ? P.resolve(null) : this.login();
     return o.then(
@@ -454,6 +458,14 @@ module.exports = config => {
 
   Client.prototype.destroyDeviceWithRefreshToken = function (refreshTokenId, id) {
     return this.api.deviceDestroyWithRefreshToken(refreshTokenId, id);
+  };
+
+  Client.prototype.deviceCommandsWithRefreshToken = function (refreshTokenId, index, limit) {
+    return this.api.deviceCommandsWithRefreshToken(refreshTokenId, index, limit);
+  };
+
+  Client.prototype.devicesInvokeCommandWithRefreshToken = function (refreshTokenId, target, command, payload, ttl) {
+    return this.api.devicesInvokeCommandWithRefreshToken(refreshTokenId, target, command, payload, ttl);
   };
 
   Client.prototype.sessionStatus = function () {

--- a/packages/fxa-auth-server/test/remote/device_tests_refresh_tokens.js
+++ b/packages/fxa-auth-server/test/remote/device_tests_refresh_tokens.js
@@ -30,6 +30,7 @@ const Token = require('../../lib/tokens')(log, {
 const PUBLIC_CLIENT_ID = '3c49430b43dfba77';
 const NON_PUBLIC_CLIENT_ID = 'dcdb5ae7add825d2';
 const OAUTH_CLIENT_NAME = 'Android Components Reference Browser';
+const UNKNOWN_REFRESH_TOKEN = 'B53DF2CE2BDB91820CB0A5D68201EF87D8D8A0DFC11829FB074B6426F537EE78';
 
 describe('remote device with refresh tokens', function () {
   this.timeout(15000);
@@ -74,6 +75,75 @@ describe('remote device with refresh tokens', function () {
     return Client.create(config.publicUrl, email, password).then((c) => {
       client = c;
     });
+  });
+
+  it('device registration with unknown refresh token', async () => {
+    const deviceInfo = {
+      name: 'test device 🍓🔥在𝌆',
+      type: 'mobile',
+      availableCommands: {'foo': 'bar'},
+      pushCallback: '',
+      pushPublicKey: '',
+      pushAuthKey: ''
+    };
+
+    try {
+      await client.updateDeviceWithRefreshToken(UNKNOWN_REFRESH_TOKEN, deviceInfo);
+      assert.fail();
+    } catch (err) {
+      assert.strictEqual(err.code, 401);
+      assert.strictEqual(err.errno, 110);
+    }
+  });
+
+  it('devicesWithRefreshToken fails with unknown refresh token', async () => {
+    try {
+      await client.devicesWithRefreshToken(UNKNOWN_REFRESH_TOKEN);
+      assert.fail();
+    } catch (err) {
+      assert.strictEqual(err.code, 401);
+      assert.strictEqual(err.errno, 110);
+    }
+  });
+
+  it('destroyDeviceWithRefreshToken fails with unknown refresh token', async () => {
+    try {
+      await client.destroyDeviceWithRefreshToken(UNKNOWN_REFRESH_TOKEN, '1');
+      assert.fail();
+    } catch (err) {
+      assert.strictEqual(err.code, 401);
+      assert.strictEqual(err.errno, 110);
+    }
+  });
+
+  it('deviceCommandsWithRefreshToken fails with unknown refresh token', async () => {
+    try {
+      await client.deviceCommandsWithRefreshToken(UNKNOWN_REFRESH_TOKEN, 0, 50);
+      assert.fail();
+    } catch (err) {
+      assert.strictEqual(err.code, 401);
+      assert.strictEqual(err.errno, 110);
+    }
+  });
+
+  it('devicesInvokeCommandWithRefreshToken fails with unknown refresh token', async () => {
+    try {
+      await client.devicesInvokeCommandWithRefreshToken(UNKNOWN_REFRESH_TOKEN, 'target', 'command', {}, 5);
+      assert.fail();
+    } catch (err) {
+      assert.strictEqual(err.code, 401);
+      assert.strictEqual(err.errno, 110);
+    }
+  });
+
+  it('devicesNotifyWithRefreshToken fails with unknown refresh token', async () => {
+    try {
+      await client.devicesNotifyWithRefreshToken(UNKNOWN_REFRESH_TOKEN, '123');
+      assert.fail();
+    } catch (err) {
+      assert.strictEqual(err.code, 401);
+      assert.strictEqual(err.errno, 110);
+    }
   });
 
   it('device registration after account creation', () => {


### PR DESCRIPTION
Ref: https://github.com/mozilla/fxa-private/pull/19

An unfortunate side-effect of the monorepo is that we can't merge stuff back from `private` any more, because the base branch includes all stuff that is permanently private. Or we can if we refactor that stuff to config, which has been previously mooted.

In the meantime, cherry-picking seems like the only way to land this change in the public repo. I fear it might make the train 137 release script fail with a merge conflict, but I'm not sure what else we can do about that.

@mozilla/fxa-devs r?