### PR TITLE
feat(content:trailhead): Signup breadcrumb

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/create-account-breadcrumb.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/create-account-breadcrumb.mustache
@@ -1,0 +1,30 @@
+<aside class="signup-breadcrumb">
+  <ul>
+    <li class="{{#isCreateActive}}active{{/isCreateActive}}">
+      {{#t}}Create account{{/t}}
+    </li>
+    <li class="{{#isChooseSetupActive}}active{{/isChooseSetupActive}}">
+      {{#t}}Choose your set-up{{/t}}
+    </li>
+    <li class="{{#isConfirmActive}}active{{/isConfirmActive}}">
+      {{#t}}Confirm your account{{/t}}
+    </li>
+    <li class="{{#isConnectDeviceActive}}active{{/isConnectDeviceActive}}">
+      {{#t}}Connect another device{{/t}}
+    </li>
+    <li class="{{#isSendFirstTabActive}}active{{/isSendFirstTabActive}}">
+      {{#t}}Send your first tab{{/t}}
+    </li>
+  </ul>
+
+  <div>
+    <div class="logo lockwise"></div>
+    <div class="logo monitor"></div>
+    <div class="logo send"></div>
+  </div>
+
+  <header>
+    {{#t}}Firefox Account Services{{/t}}
+    <div>{{#t}}Your life on every device.{{/t}}</div>
+  </header>
+</aside>

--- a/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
@@ -8,6 +8,7 @@ import BackMixin from './mixins/back-mixin';
 import Cocktail from 'cocktail';
 import FormView from './form';
 import SessionVerificationPollMixin from './mixins/session-verification-poll-mixin';
+import SignupBreadcrumbMixin, { CHOOSE_WHAT_TO_SYNC } from './mixins/create-account-breadcrumb-mixin';
 import Template from 'templates/choose_what_to_sync.mustache';
 
 const SCREEN_CLASS = 'screen-choose-what-to-sync';
@@ -154,7 +155,10 @@ const View = FormView.extend({
 Cocktail.mixin(
   View,
   BackMixin,
-  SessionVerificationPollMixin
+  SessionVerificationPollMixin,
+  SignupBreadcrumbMixin({
+    active: CHOOSE_WHAT_TO_SYNC
+  }),
 );
 
 export default View;

--- a/packages/fxa-content-server/app/scripts/views/confirm.js
+++ b/packages/fxa-content-server/app/scripts/views/confirm.js
@@ -14,6 +14,7 @@ import ResendMixin from './mixins/resend-mixin';
 import ResumeTokenMixin from './mixins/resume-token-mixin';
 import ServiceMixin from './mixins/service-mixin';
 import SessionVerificationPollMixin from './mixins/session-verification-poll-mixin';
+import SignupBreadcrumbMixin, { CONFIRM } from './mixins/create-account-breadcrumb-mixin';
 import Template from 'templates/confirm.mustache';
 
 const proto = BaseView.prototype;
@@ -120,7 +121,10 @@ Cocktail.mixin(
   ResendMixin(),
   ResumeTokenMixin,
   ServiceMixin,
-  SessionVerificationPollMixin
+  SessionVerificationPollMixin,
+  SignupBreadcrumbMixin({
+    active: CONFIRM
+  }),
 );
 
 export default View;

--- a/packages/fxa-content-server/app/scripts/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/scripts/views/connect_another_device.js
@@ -21,6 +21,7 @@ import {
 } from '../lib/constants';
 import MarketingMixin from './mixins/marketing-mixin';
 import MarketingSnippet from './marketing_snippet';
+import SignupBreadcrumbMixin, { CONNECT_ANOTHER_DEVICE } from './mixins/create-account-breadcrumb-mixin';
 import SyncAuthMixin from './mixins/sync-auth-mixin';
 import Template from 'templates/connect_another_device.mustache';
 import UserAgentMixin from '../lib/user-agent-mixin';
@@ -267,6 +268,9 @@ Cocktail.mixin(
     // even if not specified on the URL. This makes manual testing slightly
     // easier where sometimes ?service=sync is forgotten. See #4948.
     service: SYNC_SERVICE
+  }),
+  SignupBreadcrumbMixin({
+    active: CONNECT_ANOTHER_DEVICE
   }),
   SyncAuthMixin,
   UserAgentMixin,

--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -18,6 +18,7 @@ import FlowBeginMixin from './mixins/flow-begin-mixin';
 import FormPrefillMixin from './mixins/form-prefill-mixin';
 import FormView from './form';
 import ServiceMixin from './mixins/service-mixin';
+import SignupBreadcrumbMixin, { CREATE_ACCOUNT } from './mixins/create-account-breadcrumb-mixin';
 import Template from 'templates/index.mustache';
 
 const EMAIL_SELECTOR = 'input[type=email]';
@@ -158,7 +159,10 @@ Cocktail.mixin(
   TokenCodeExperimentMixin,
   FlowBeginMixin,
   FormPrefillMixin,
-  ServiceMixin
+  ServiceMixin,
+  SignupBreadcrumbMixin({
+    active: CREATE_ACCOUNT
+  }),
 );
 
 export default IndexView;

--- a/packages/fxa-content-server/app/scripts/views/mixins/create-account-breadcrumb-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/create-account-breadcrumb-mixin.js
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A mixin to display the signup breadcrumb UI.
+ * See https://github.com/mozilla/fxa/issues/1084
+ */
+
+import Template from 'templates/partial/create-account-breadcrumb.mustache';
+
+export const CREATE_ACCOUNT = 'isCreateActive';
+export const CHOOSE_WHAT_TO_SYNC = 'isChooseSetupActive';
+export const CONFIRM = 'isConfirmActive';
+export const CONNECT_ANOTHER_DEVICE = 'isConnectDeviceActive';
+export const SEND_TAB = 'isSendFirstTabActive';
+
+export default function (config = {}) {
+  return {
+    isBreadcrumbEnabled () {
+      // If the isSignUp method is not available, assume feature is enabled.
+      // If the isSignUp method is available, only show if actually signing up.
+      return ! this.isSignUp || this.isSignUp();
+    },
+
+    afterRender () {
+      if (this.isBreadcrumbEnabled()) {
+        const breadcrumbHtml = this.renderTemplate(Template, {
+          [config.active]: true
+        });
+
+        this.$el.find('section').after(breadcrumbHtml);
+      }
+    },
+  };
+}

--- a/packages/fxa-content-server/app/scripts/views/sign_up.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_up.js
@@ -18,6 +18,7 @@ import ServiceMixin from './mixins/service-mixin';
 import SignedInNotificationMixin from './mixins/signed-in-notification-mixin';
 import SignInMixin from './mixins/signin-mixin';
 import SignUpMixin from './mixins/signup-mixin';
+import SignupBreadcrumbMixin, { CREATE_ACCOUNT } from './mixins/create-account-breadcrumb-mixin';
 import SyncSuggestionMixin from './mixins/sync-suggestion-mixin';
 import Template from 'templates/sign_up.mustache';
 
@@ -307,6 +308,9 @@ Cocktail.mixin(
   SignInMixin,
   SignUpMixin,
   SignedInNotificationMixin,
+  SignupBreadcrumbMixin({
+    active: CREATE_ACCOUNT
+  }),
   SyncSuggestionMixin({
     entrypoint: View.ENTRYPOINT,
     flowEvent: 'link.signin',

--- a/packages/fxa-content-server/app/scripts/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_up_password.js
@@ -15,6 +15,7 @@ import PasswordStrengthMixin from './mixins/password-strength-mixin';
 import preventDefaultThen from './decorators/prevent_default_then';
 import ServiceMixin from './mixins/service-mixin';
 import SignUpMixin from './mixins/signup-mixin';
+import SignupBreadcrumbMixin, { CREATE_ACCOUNT } from './mixins/create-account-breadcrumb-mixin';
 import Template from 'templates/sign_up_password.mustache';
 
 function selectAutoFocusEl(password, vPassword) {
@@ -124,6 +125,9 @@ Cocktail.mixin(
     passwordEl: '#password'
   }),
   ServiceMixin,
+  SignupBreadcrumbMixin({
+    active: CREATE_ACCOUNT
+  }),
   SignUpMixin
 );
 

--- a/packages/fxa-content-server/app/styles/_modules.scss
+++ b/packages/fxa-content-server/app/styles/_modules.scss
@@ -17,3 +17,4 @@
 @import 'modules/graphic';
 @import 'modules/marketing';
 @import 'modules/marketing-ios';
+@import 'modules/signup-breadcrumb';

--- a/packages/fxa-content-server/app/styles/modules/_signup-breadcrumb.scss
+++ b/packages/fxa-content-server/app/styles/modules/_signup-breadcrumb.scss
@@ -1,0 +1,78 @@
+$breadcrumb-size: 30px;
+$breadcrumb-border-width: 3px;
+$breadcrumb-logo-size: 40px;
+
+.signup-breadcrumb {
+  color: $grey-50;
+  left: calc(100% + 30px);
+  position: absolute;
+  text-align: left;
+  top: 75px;
+  width: 200px;
+
+  > ul {
+    border-left: $breadcrumb-border-width solid $grey-30;
+    font-size: 13px;
+    list-style: none;
+    margin: 0 0 0 $breadcrumb-size / 2;
+    padding: 0;
+
+    > li {
+      line-height: $breadcrumb-size;
+      margin-left: -($breadcrumb-size / 2) - ($breadcrumb-border-width / 2);
+      padding-bottom: 20px;
+
+      &::before {
+        // add the background color to draw over the border that
+        // connects the circles
+        background-color: $html-background-color;
+        border-radius: $breadcrumb-size;
+        border: $breadcrumb-border-width solid $grey-30;
+        content: '.';
+        display: inline-block;
+        float: left;
+        height: $breadcrumb-size;
+        margin: 0 10px 0 0;
+        text-indent: -9999px;
+        width: $breadcrumb-size;
+      }
+
+      &:last-of-type {
+        padding-bottom: 0;
+      }
+
+      &.active::before {
+        // Make the breadcrumb a solid color
+        border-width: $breadcrumb-size / 2;
+      }
+    }
+  }
+
+  > header {
+    color: $grey-60;
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  .logo {
+    background-repeat: no-repeat;
+    background-size: $breadcrumb-logo-size;
+    display: inline-block;
+    height: $breadcrumb-logo-size;
+    margin: 50px 3px 10px 0;
+    opacity: 0.3;
+    width: $breadcrumb-logo-size;
+
+    &.lockwise {
+      background-image: url('/images/icon-service-lockwise.svg');
+    }
+
+    &.monitor {
+      background-image: url('/images/icon-service-monitor.svg');
+    }
+
+    &.send {
+      background-image: url('/images/icon-service-send.svg');
+    }
+  }
+}


### PR DESCRIPTION
TODO:

* [ ] - Ensure the styles are as @ryanfeeley wants
* [ ] - Only show for Trailhead styles
* [ ] - Ensure it only displays for signup
* [ ] - Should not show on mobile
* [ ] - Make it look good on email-first
* [ ] - Make it look good on the confirm your account screen (can flexbox be used w/ absolutely positioned elements?)
* [ ] - How to handle the pw strength meter?
* [ ] - Do we show this on the send SMS screen or no?
* [ ] - Tests

fixes #1084

<img width="830" alt="Screenshot 2019-05-13 at 13 58 09" src="https://user-images.githubusercontent.com/848085/57623275-5c3c4800-7587-11e9-9d7c-f6f00f3d3360.png">

<img width="797" alt="Screenshot 2019-05-13 at 14 00 00" src="https://user-images.githubusercontent.com/848085/57623400-960d4e80-7587-11e9-8d70-629c15998a59.png">

<img width="830" alt="Screenshot 2019-05-13 at 14 00 34" src="https://user-images.githubusercontent.com/848085/57623407-99083f00-7587-11e9-9a06-9eef753a7607.png">

cc @ryanfeeley 