### PR TITLE
fix(scripts): use train number rather than full version in deploy bug

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -342,7 +342,7 @@ else
 fi
 
 if [ -f "$SCRIPT_DIR/create-deploy-bug.url" ]; then
-  DEPLOY_BUG_URL=`cat "$SCRIPT_DIR/create-deploy-bug.url" | sed "s/TRAIN_NUMBER/$NEW_VERSION/"`
+  DEPLOY_BUG_URL=`cat "$SCRIPT_DIR/create-deploy-bug.url" | sed "s/TRAIN_NUMBER/$TRAIN/"`
 fi
 
 # 13. Merge train branch into the private train branch.


### PR DESCRIPTION
Spotted this in the release just now, the link to create the deploy bug was using the full version string in the description rather than just the train number.

@mozilla/fxa-devs r?