### PR TITLE
refactor(tests): switch from insist to chai for assertions

### DIFF
--- a/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
@@ -3,7 +3,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const crypto = require('crypto')
 const P = require('bluebird')
 const util = require('../../../lib/db/util')
@@ -289,7 +289,7 @@ module.exports = function (config, DB) {
         return db.checkPassword(accountData.uid, {verifyHash: zeroBuffer32})
           .then((account) => {
             assert.deepEqual(account.uid, account.uid, 'uid')
-            assert.equal(Object.keys(account).length, 1, 'Only one field (uid) was returned, nothing else')
+            assert.lengthOf(Object.keys(account), 1)
           })
       })
     })
@@ -304,10 +304,10 @@ module.exports = function (config, DB) {
       it('should get sessions', () => {
         return db.sessions(accountData.uid)
           .then((sessions) => {
-            assert(Array.isArray(sessions), 'sessions is an array')
-            assert.equal(sessions.length, 1, 'sessions has one item')
+            assert.isArray(sessions)
+            assert.lengthOf(sessions, 1)
 
-            assert.equal(Object.keys(sessions[0]).length, 20, 'session has correct properties')
+            assert.lengthOf(Object.keys(sessions[0]), 20)
             assert.equal(sessions[0].tokenId.toString('hex'), sessionTokenData.tokenId.toString('hex'), 'tokenId is correct')
             assert.equal(sessions[0].uid.toString('hex'), accountData.uid.toString('hex'), 'uid is correct')
             assert.equal(sessions[0].createdAt, sessionTokenData.createdAt, 'createdAt is correct')
@@ -332,15 +332,15 @@ module.exports = function (config, DB) {
             return db.sessions(accountData.uid)
           })
           .then((sessions) => {
-            assert(Array.isArray(sessions), 'sessions is an array')
-            assert.equal(sessions.length, 1, 'sessions has one item')
+            assert.isArray(sessions)
+            assert.lengthOf(sessions, 1)
           })
       })
 
       it('should get session token', () => {
         return db.sessionToken(sessionTokenData.tokenId)
           .then((token) => {
-            assert.equal(token.hasOwnProperty('tokenId'), false, 'tokenId is not returned')
+            assert.isFalse(token.hasOwnProperty('tokenId'))
             assert.deepEqual(token.tokenData, sessionTokenData.data, 'token data matches')
             assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
             assert.equal(token.createdAt, sessionTokenData.createdAt, 'createdAt is correct')
@@ -484,7 +484,7 @@ module.exports = function (config, DB) {
           }, assert.fail)
           .then((token) => {
             assert.equal(!! token.mustVerify, false, 'mustVerify is null')
-            assert.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
+            assert.isNull(token.tokenVerificationId)
           })
       })
 
@@ -498,14 +498,14 @@ module.exports = function (config, DB) {
         it('should get device count', () => {
           return db.accountDevices(accountData.uid)
             .then((results) => {
-              assert.equal(results.length, 1, 'Account has one device')
+              assert.lengthOf(results, 1)
             })
         })
 
         it('db.sessions should contain device data', () => {
           return db.sessions(accountData.uid)
             .then((sessions) => {
-              assert.equal(sessions.length, 1, 'sessions contains correct number of items')
+              assert.lengthOf(sessions, 1)
               // the next session has a device attached to it
               assert.equal(sessions[0].deviceId.toString('hex'), deviceData.deviceId.toString('hex'))
               assert.equal(sessions[0].deviceName, 'Test Device')
@@ -521,12 +521,12 @@ module.exports = function (config, DB) {
         it('db.deleteSessionToken should delete device', () => {
           return db.accountDevices(accountData.uid)
             .then((results) => {
-              assert.equal(results.length, 1, 'Account has one device')
+              assert.lengthOf(results, 1)
               return db.deleteSessionToken(sessionTokenData.tokenId)
             })
             .then(() => db.accountDevices(accountData.uid))
             .then((results) => {
-              assert.equal(results.length, 0, 'Account has no devices')
+              assert.lengthOf(results, 0)
             })
         })
       })
@@ -572,15 +572,15 @@ module.exports = function (config, DB) {
             return db.keyFetchToken(keyFetchTokenData.tokenId)
           })
           .then((token) => {
-            assert.equal(token.tokenId, undefined, 'tokenId is not returned')
+            assert.isUndefined(token.tokenId)
             assert.deepEqual(token.authKey, keyFetchTokenData.authKey, 'authKey matches')
             assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
             assert.equal(token.createdAt, keyFetchTokenData.createdAt, 'createdAt is ok')
             assert.equal(!! token.emailVerified, accountData.emailVerified, 'emailVerified is correct')
-            assert.equal(token.email, undefined, 'tokenId is not returned')
-            assert.equal(token.emailCode, undefined, 'tokenId is not returned')
+            assert.isUndefined(token.email)
+            assert.isUndefined(token.emailCode)
             assert.equal(token.verifierSetAt, accountData.verifierSetAt, 'verifierSetAt is correct')
-            assert.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
+            assert.isUndefined(token.tokenVerificationId)
           })
       })
 
@@ -592,13 +592,13 @@ module.exports = function (config, DB) {
             return db.keyFetchTokenWithVerificationStatus(keyFetchTokenData.tokenId)
           })
           .then((token) => {
-            assert.equal(token.tokenId, undefined, 'tokenId is not returned')
+            assert.isUndefined(token.tokenId)
             assert.deepEqual(token.authKey, keyFetchTokenData.authKey, 'authKey matches')
             assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
             assert.equal(token.createdAt, keyFetchTokenData.createdAt, 'createdAt is ok')
             assert.equal(!! token.emailVerified, accountData.emailVerified, 'emailVerified is correct')
-            assert.equal(token.email, undefined, 'tokenId is not returned')
-            assert.equal(token.emailCode, undefined, 'tokenId is not returned')
+            assert.isUndefined(token.email)
+            assert.isUndefined(token.emailCode)
             assert.equal(token.verifierSetAt, accountData.verifierSetAt, 'verifierSetAt is correct')
             assert.equal(token.tokenVerificationId, keyFetchTokenData.tokenVerificationId, 'tokenVerificationId is undefined')
           })
@@ -643,7 +643,7 @@ module.exports = function (config, DB) {
             return db.keyFetchTokenWithVerificationStatus(keyFetchTokenData.tokenId)
           })
           .then((token) => {
-            assert.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
+            assert.isNull(token.tokenVerificationId)
           })
       })
 
@@ -774,7 +774,7 @@ module.exports = function (config, DB) {
         .then(function (account) {
           assert(account.emailVerified, 'account should now be emailVerified (truthy)')
           assert.equal(account.emailVerified, 1, 'account should now be emailVerified (1)')
-          assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
+          assert.isAbove(account.profileChangedAt, account.createdAt)
         })
     })
 
@@ -808,7 +808,7 @@ module.exports = function (config, DB) {
       it('db.accountResetToken should create token', () => {
         return db.accountResetToken(accountResetTokenData.tokenId)
           .then((token) => {
-            assert.equal(token.hasOwnProperty('tokenId'), false, 'tokenId is not returned')
+            assert.isFalse(token.hasOwnProperty('tokenId'))
             assert.deepEqual(token.uid, accountData.uid, 'token belongs to this account')
             assert.deepEqual(token.tokenData, accountResetTokenData.data, 'token data matches')
             assert.equal(token.createdAt, accountResetTokenData.createdAt, 'createdAt is correct')
@@ -997,11 +997,11 @@ module.exports = function (config, DB) {
       it('should get all devices', () => {
         return db.accountDevices(accountData.uid)
           .then((devices) => {
-            assert.equal(devices.length, 2, 'devices length 2')
+            assert.lengthOf(devices, 2)
 
             let device = devices.find(matchById('sessionTokenId', sessionTokenData.tokenId))
             assert.deepEqual(device.sessionTokenId, sessionTokenData.tokenId, 'sessionTokenId')
-            assert.deepEqual(device.refreshTokenId, null, 'refreshTokenId')
+            assert.isNull(device.refreshTokenId)
             assert.equal(device.name, sessionDeviceInfo.name, 'name')
             assert.deepEqual(device.id, sessionDeviceInfo.deviceId, 'id')
             assert.equal(device.createdAt, sessionDeviceInfo.createdAt, 'createdAt')
@@ -1011,10 +1011,10 @@ module.exports = function (config, DB) {
             assert.equal(device.callbackAuthKey, sessionDeviceInfo.callbackAuthKey, 'callbackAuthKey')
             assert.equal(device.callbackIsExpired, sessionDeviceInfo.callbackIsExpired, 'callbackIsExpired')
             assert.deepEqual(device.availableCommands, sessionDeviceInfo.availableCommands, 'availableCommands')
-            assert(device.lastAccessTime > 0, 'has a lastAccessTime')
+            assert.isAbove(device.lastAccessTime, 0)
 
             device = devices.find(matchById('refreshTokenId', refreshTokenData.tokenId))
-            assert.deepEqual(device.sessionTokenId, null, 'sessionTokenId')
+            assert.isNull(device.sessionTokenId)
             assert.deepEqual(device.refreshTokenId, refreshTokenData.tokenId, 'refreshTokenId')
             assert.equal(device.name, oauthDeviceInfo.name, 'name')
             assert.deepEqual(device.id, oauthDeviceInfo.deviceId, 'id')
@@ -1025,7 +1025,7 @@ module.exports = function (config, DB) {
             assert.equal(device.callbackAuthKey, oauthDeviceInfo.callbackAuthKey, 'callbackAuthKey')
             assert.equal(device.callbackIsExpired, oauthDeviceInfo.callbackIsExpired, 'callbackIsExpired')
             assert.deepEqual(device.availableCommands, oauthDeviceInfo.availableCommands, 'availableCommands')
-            assert.equal(device.lastAccessTime, null, 'does not have lastAccessTime')
+            assert.isNull(device.lastAccessTime)
           })
       })
 
@@ -1050,7 +1050,7 @@ module.exports = function (config, DB) {
             return db.accountDevices(accountData.uid)
           })
           .then((devices) => {
-            assert.equal(devices.length, 2, 'devices length 2')
+            assert.lengthOf(devices, 2)
             const device = devices.find(matchById('sessionTokenId', newSessionTokenData.tokenId))
             assert.ok(device, 'device found under new token id')
             assert.equal(device.name, 'New New Device', 'name updated')
@@ -1081,7 +1081,7 @@ module.exports = function (config, DB) {
             return db.accountDevices(accountData.uid)
           })
           .then((devices) => {
-            assert.equal(devices.length, 2, 'devices length 2')
+            assert.lengthOf(devices, 2)
             const device = devices.find(matchById('refreshTokenId', newRefreshTokenData.tokenId))
             assert.ok(device, 'device found under new token id')
             assert.equal(device.name, 'New New Device', 'name updated')
@@ -1103,8 +1103,8 @@ module.exports = function (config, DB) {
             return db.accountDevices(accountData.uid)
           })
           .then((devices) => {
-            assert.equal(devices.length, 1, 'devices length 1')
-            assert.equal(devices[0].sessionTokenId, null, 'sessionTokenId')
+            assert.lengthOf(devices, 1)
+            assert.isNull(devices[0].sessionTokenId)
             assert.deepEqual(devices[0].refreshTokenId, refreshTokenData.tokenId, 'refreshTokenId')
           })
       })
@@ -1135,7 +1135,7 @@ module.exports = function (config, DB) {
             return db.accountDevices(accountData.uid)
           })
           .then((devices) => {
-            assert.equal(devices.length, 2, 'devices length 2')
+            assert.lengthOf(devices, 2)
             const comboDeviceInfo = devices.find(matchById('sessionTokenId', sessionTokenData.tokenId))
             assert.ok(comboDeviceInfo, 'found device record')
             assert.deepEqual(comboDeviceInfo.refreshTokenId, anotherRefreshToken.tokenId)
@@ -1221,7 +1221,7 @@ module.exports = function (config, DB) {
           .then(() => db.createDevice(accountData.uid, sessionDeviceInfo3.deviceId, sessionDeviceInfo3))
           .then(() => db.accountDevices(accountData.uid))
           .then(devices => {
-            assert.equal(devices.length, 4, 'devices length 4')
+            assert.lengthOf(devices, 4)
 
             const device1 = devices.find(matchById('sessionTokenId', sessionTokenData.tokenId))
             assert.ok(device1, 'found first device')
@@ -1256,7 +1256,7 @@ module.exports = function (config, DB) {
           .then(() => db.createSessionToken(sessionToken3.tokenId, sessionToken3))
           .then(() => db.sessions(accountData.uid))
           .then(sessions => {
-            assert.equal(sessions.length, 3, 'sessions length 3')
+            assert.lengthOf(sessions, 3)
 
             const session1 = sessions.find(s => s.tokenId.equals(sessionTokenData.tokenId))
             assert.ok(session1, 'found first session')
@@ -1281,7 +1281,7 @@ module.exports = function (config, DB) {
             // Fetch all of the devices for the account
             return db.accountDevices(accountData.uid)
           })
-          .then((devices) => assert.equal(devices.length, 1, 'devices length 1'))
+          .then((devices) => assert.lengthOf(devices, 1))
           .then(() => db.sessionToken(sessionTokenData.tokenId))
           .then(assert.fail, (err) => {
             assert.equal(err.code, 404, 'err.code')
@@ -1297,7 +1297,7 @@ module.exports = function (config, DB) {
             // Fetch all of the devices for the account
             return db.accountDevices(accountData.uid)
           })
-          .then((devices) => assert.equal(devices.length, 1, 'devices length 1'))
+          .then((devices) => assert.lengthOf(devices, 1))
       })
     })
 
@@ -1317,7 +1317,7 @@ module.exports = function (config, DB) {
         return db.accountEmails(accountData.uid)
           .then((emails) => {
             // Account should be unverified
-            assert.equal(emails.length, 1, 'correct number of emails')
+            assert.lengthOf(emails, 1)
             assert.equal(!! emails[0].isVerified, false, 'email is not verified')
             assert.equal(!! emails[0].isPrimary, true, 'email is primary')
 
@@ -1326,7 +1326,7 @@ module.exports = function (config, DB) {
           .then(() => db.accountEmails(accountData.uid))
           .then((emails) => {
             // Account should be verified
-            assert.equal(emails.length, 1, 'correct number of emails')
+            assert.lengthOf(emails, 1)
             assert.equal(!! emails[0].isVerified, true, 'email is verified')
             assert.equal(!! emails[0].isPrimary, true, 'email is primary')
           })
@@ -1335,12 +1335,12 @@ module.exports = function (config, DB) {
       it('should remove devices after account reset', () => {
         return db.accountDevices(accountData.uid)
           .then((devices) => {
-            assert.equal(devices.length, 1, 'The devices length should be one')
+            assert.lengthOf(devices, 1)
             return db.resetAccount(accountData.uid, accountData)
           })
           .then(() => db.accountDevices(accountData.uid))
           .then((devices) => {
-            assert.equal(devices.length, 0, 'The devices length should be zero')
+            assert.lengthOf(devices, 0)
           })
       })
 
@@ -1411,17 +1411,17 @@ module.exports = function (config, DB) {
       it('should get security event', () => {
         return db.securityEvents({id: uid1, ipAddr: addr1})
           .then((results) => {
-            assert.equal(results.length, 3, 'three events for uid and addr')
+            assert.lengthOf(results, 3)
             // The most recent event is returned first.
             assert.equal(results[0].name, evC, 'correct event name')
             assert.equal(!! results[0].verified, true, 'event without a session is already verified')
-            assert(results[0].createdAt < Date.now(), 'createdAt is set')
+            assert.isBelow(results[0].createdAt, Date.now())
             assert.equal(results[1].name, evB, 'correct event name')
             assert.equal(!! results[1].verified, false, 'second session is not verified yet')
-            assert(results[1].createdAt < results[0].createdAt, 'createdAt is lower than previous event')
+            assert.isBelow(results[1].createdAt, results[0].createdAt)
             assert.equal(results[2].name, evA, 'correct event name')
             assert.equal(!! results[2].verified, true, 'first session is already verified')
-            assert(results[2].createdAt < results[1].createdAt, 'createdAt is lower than previous event')
+            assert.isBelow(results[2].createdAt, results[1].createdAt)
           })
       })
 
@@ -1429,19 +1429,19 @@ module.exports = function (config, DB) {
         return db.verifyTokens(session1.tokenVerificationId, {uid: uid1})
           .then(() => db.securityEvents({id: uid1, ipAddr: addr1}))
           .then((results) => {
-            assert.equal(results.length, 3, 'three events for uid and addr')
-            assert.equal(!! results[0].verified, true, 'first session verified')
-            assert.equal(!! results[1].verified, true, 'second session verified')
-            assert.equal(!! results[2].verified, true, 'third session verified')
+            assert.lengthOf(results, 3)
+            assert.isTrue(!! results[0].verified)
+            assert.isTrue(!! results[1].verified)
+            assert.isTrue(!! results[2].verified)
           })
       })
 
       it('should get second address', () => {
         return db.securityEvents({id: uid1, ipAddr: addr2})
           .then((results) => {
-            assert.equal(results.length, 1, 'one event for addr2')
+            assert.lengthOf(results, 1)
             assert.equal(results[0].name, evA)
-            assert.equal(!! results[0].verified, false, 'session3 not verified yet')
+            assert.isFalse(!! results[0].verified)
           })
       })
 
@@ -1449,27 +1449,27 @@ module.exports = function (config, DB) {
         return db.deleteSessionToken(session3.tokenId)
           .then(() => db.securityEvents({id: uid1, ipAddr: addr2}))
           .then((results) => {
-            assert.equal(results.length, 1, 'one event for addr2')
+            assert.lengthOf(results, 1)
             assert.equal(results[0].name, evA)
-            assert.equal(!! results[0].verified, false, 'session3 not verified yet')
+            assert.isFalse(!! results[0].verified)
           })
       })
 
       it('should get with IPv6', () => {
         return db.securityEvents({id: uid1, ipAddr: '::' + addr1})
-          .then((results) => assert.equal(results.length, 3, 'three events for ipv6 addr'))
+          .then((results) => assert.lengthOf(results, 3))
       })
 
       it('should fail with unknown uid', () => {
         return db.securityEvents({id: newUuid(), ipAddr: addr1})
-          .then((results) => assert.equal(results.length, 0, 'no events for unknown uid'))
+          .then((results) => assert.lengthOf(results, 0))
       })
 
       it('should delete events when account is deleted', () => {
         return db.deleteAccount(accountData.uid)
           .then(() => db.securityEvents({id: uid1, ipAddr: addr1}))
           .then((res) => {
-            assert.equal(res.length, 0, 'no events returned')
+            assert.lengthOf(res, 0)
           })
       })
     })
@@ -1535,7 +1535,7 @@ module.exports = function (config, DB) {
             assert.equal(result[0].uid.toString('hex'), accountData.uid.toString('hex'), 'correct uid')
             return db.fetchReminders({}, fetchQuery)
           })
-          .then((result) => assert.equal(result.length, 0, 'no more reminders'))
+          .then((result) => assert.lengthOf(result, 0))
       })
 
       it('multiple accounts', () => {
@@ -1553,12 +1553,12 @@ module.exports = function (config, DB) {
           .then(() => P.delay(20))
           .then(() => db.fetchReminders({}, fetchQuery))
           .then((result) => {
-            assert.equal(result.length, 2, 'correct size of result')
+            assert.lengthOf(result, 2)
             assert.equal(result[0].type, 'first', 'correct type')
             assert.equal(result[1].type, 'first', 'correct type')
             return db.fetchReminders({}, fetchQuery)
           })
-          .then((result) => assert.equal(result.length, 0, 'no more first reminders'))
+          .then((result) => assert.lengthOf(result, 0))
       })
 
       it('multi fetch', () => {
@@ -1636,14 +1636,14 @@ module.exports = function (config, DB) {
       it('should consume unblock code', () => {
         return db.consumeUnblockCode(uid1, code1)
           .then((code) => {
-            assert(code.createdAt <= Date.now(), 'returns unblock code timestamp')
+            assert.isAtMost(code.createdAt, Date.now())
           })
       })
 
       it('should fail to consume code twice', () => {
         return db.consumeUnblockCode(uid1, code1)
           .then((code) => {
-            assert(code.createdAt <= Date.now(), 'returns unblock code timestamp')
+            assert.isAtMost(code.createdAt, Date.now())
             return db.consumeUnblockCode(uid1, code1)
               .then(assert.fail, (err) => {
                 assert.equal(err.code, 404, 'err.code')
@@ -1660,7 +1660,7 @@ module.exports = function (config, DB) {
             return db.consumeUnblockCode(uid1, code1)
           })
           .then((code) => {
-            assert(code.createdAt <= Date.now(), 'returns unblock code timestamp')
+            assert.isAtMost(code.createdAt, Date.now())
             return db.consumeUnblockCode(uid1, code2)
           }, assert.fail)
           .then(assert.fail, (err) => {
@@ -1686,7 +1686,7 @@ module.exports = function (config, DB) {
           }))
           .then(() => db.fetchEmailBounces(email))
           .then(bounces => {
-            assert.equal(bounces.length, 2)
+            assert.lengthOf(bounces, 2)
             assert.equal(bounces[0].email, email)
             assert.equal(bounces[0].bounceType, 2)
             assert.equal(bounces[0].bounceSubType, 2)
@@ -1720,11 +1720,11 @@ module.exports = function (config, DB) {
         return db.createAccount(anotherAccountData.uid, anotherAccountData)
           .then(() => db.accountEmails(anotherAccountData.uid))
           .then((result) => {
-            assert.equal(result.length, 1, 'one email returned')
+            assert.lengthOf(result, 1)
 
             // Check first email is email from accounts table
             assert.equal(result[0].email, anotherAccountData.email, 'matches account email')
-            assert.equal(!! result[0].isPrimary, true, 'isPrimary is true on account email')
+            assert.isTrue(!! result[0].isPrimary)
             assert.equal(!! result[0].isVerified, anotherAccountData.emailVerified, 'matches account emailVerified')
           })
       })
@@ -1732,16 +1732,16 @@ module.exports = function (config, DB) {
       it('should return secondary emails', () => {
         return db.accountEmails(accountData.uid)
           .then((result) => {
-            assert.equal(result.length, 2, 'two emails returned')
+            assert.lengthOf(result, 2)
 
             // Check first email is email from accounts table
             assert.equal(result[0].email, accountData.email, 'matches account email')
-            assert.equal(!! result[0].isPrimary, true, 'isPrimary is true on account email')
+            assert.isTrue(!! result[0].isPrimary)
             assert.equal(!! result[0].isVerified, accountData.emailVerified, 'matches account emailVerified')
 
             // Check second email is from emails table
             assert.equal(result[1].email, secondEmail.email, 'matches secondEmail email')
-            assert.equal(!! result[1].isPrimary, false, 'isPrimary is false on secondEmail email')
+            assert.isFalse(!! result[1].isPrimary)
             assert.equal(!! result[1].isVerified, secondEmail.isVerified, 'matches secondEmail isVerified')
           })
       })
@@ -1750,7 +1750,7 @@ module.exports = function (config, DB) {
         return db.getSecondaryEmail(secondEmail.email)
           .then((result) => {
             assert.equal(result.email, secondEmail.email, 'matches secondEmail email')
-            assert.equal(!! result.isPrimary, false, 'isPrimary is false on secondEmail email')
+            assert.isFalse(!! result.isPrimary)
             assert.equal(!! result.isVerified, secondEmail.isVerified, 'matches secondEmail isVerified')
           })
       })
@@ -1762,16 +1762,16 @@ module.exports = function (config, DB) {
             return db.accountEmails(accountData.uid)
           })
           .then((result) => {
-            assert.equal(result.length, 2, 'two email returned')
+            assert.lengthOf(result, 2)
 
             // Check second email is from emails table and verified
             assert.equal(result[1].email, secondEmail.email, 'matches secondEmail email')
-            assert.equal(!! result[1].isPrimary, false, 'isPrimary is false on secondEmail email')
-            assert.equal(!! result[1].isVerified, true, 'secondEmail isVerified is true')
+            assert.isFalse(!! result[1].isPrimary)
+            assert.isTrue(!! result[1].isVerified)
 
             return db.account(accountData.uid)
               .then((account) => {
-                assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
+                assert.isAbove(account.profileChangedAt, account.createdAt)
               })
           })
       })
@@ -1786,16 +1786,16 @@ module.exports = function (config, DB) {
           })
           .then((result) => {
             // Verify that the email has been removed
-            assert.equal(result.length, 1, 'one email returned')
+            assert.lengthOf(result, 1)
 
             // Only email returned should be from users account
             assert.equal(result[0].email, accountData.email, 'matches account email')
-            assert.equal(!! result[0].isPrimary, true, 'isPrimary is true on account email')
+            assert.isTrue(!! result[0].isPrimary)
             assert.equal(!! result[0].isVerified, accountData.emailVerified, 'matches account emailVerified')
 
             return db.account(accountData.uid)
               .then((account) => {
-                assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
+                assert.isAbove(account.profileChangedAt, account.createdAt)
               })
           })
       })
@@ -1941,7 +1941,7 @@ module.exports = function (config, DB) {
         .spread(function (emails, account) {
           assert.equal(emails[0].email, account.email, 'correct email returned')
           assert.equal(!! emails[0].isVerified, !! account.emailVerified, 'correct email verification')
-          assert.equal(!! emails[0].isPrimary, true, 'correct email primary')
+          assert.isTrue(!! emails[0].isPrimary)
 
           // Verify account email
           return db.verifyEmail(account.uid, account.emailCode)
@@ -1953,7 +1953,7 @@ module.exports = function (config, DB) {
         .spread(function (emails, account) {
           assert.equal(emails[0].email, account.email, 'correct email returned')
           assert.equal(!! emails[0].isVerified, !! account.emailVerified, 'correct email verification')
-          assert.equal(!! emails[0].isPrimary, true, 'correct email primary')
+          assert.isTrue(!! emails[0].isPrimary)
         })
     })
 
@@ -2033,16 +2033,16 @@ module.exports = function (config, DB) {
             return db.accountEmails(account.uid)
           })
           .then(function (res) {
-            assert.deepEqual(res.length, 2, 'Returns correct amount of emails')
+            assert.lengthOf(res, 2)
             assert.equal(res[0].email, account.email, 'primary email is the address that was used to create account')
             assert.deepEqual(res[0].emailCode, account.emailCode, 'correct emailCode')
-            assert.equal(!! res[0].isVerified, true, 'correct verification set')
-            assert.equal(!! res[0].isPrimary, true, 'isPrimary is true')
+            assert.isTrue(!! res[0].isVerified)
+            assert.isTrue(!! res[0].isPrimary)
 
             assert.equal(res[1].email, secondEmail.email, 'primary email is the address that was used to create account')
             assert.deepEqual(res[1].emailCode, secondEmail.emailCode, 'correct emailCode')
-            assert.equal(!! res[1].isVerified, true, 'correct verification set')
-            assert.equal(!! res[1].isPrimary, false, 'isPrimary is false')
+            assert.isTrue(!! res[1].isVerified)
+            assert.isFalse(!! res[1].isPrimary)
           })
       })
 
@@ -2054,17 +2054,17 @@ module.exports = function (config, DB) {
             return db.accountEmails(account.uid)
           })
           .then(function (res) {
-            assert.deepEqual(res.length, 2, 'Returns correct amount of emails')
+            assert.lengthOf(res, 2)
 
             assert.equal(res[0].email, secondEmail.email, 'primary email is the secondary email address')
             assert.deepEqual(res[0].emailCode, secondEmail.emailCode, 'correct emailCode')
             assert.equal(!! res[0].isVerified, secondEmail.isVerified, 'correct verification set')
-            assert.equal(!! res[0].isPrimary, true, 'isPrimary is true')
+            assert.isTrue(!! res[0].isPrimary)
 
             assert.equal(res[1].email, account.email, 'should equal account email')
             assert.deepEqual(res[1].emailCode, account.emailCode, 'correct emailCode')
             assert.equal(!! res[1].isVerified, account.emailVerified, 'correct verification set')
-            assert.equal(!! res[1].isPrimary, false, 'isPrimary is false')
+            assert.isFalse(!! res[1].isPrimary)
 
             // Verify correct email set in session
             sessionTokenData = makeMockSessionToken(account.uid)
@@ -2084,7 +2084,7 @@ module.exports = function (config, DB) {
             assert.deepEqual(res[0].primaryEmail, secondEmail.email, 'primary email should be set to update email')
             assert.ok(res[0].createdAt, 'should set createdAt')
             assert.deepEqual(res[0].createdAt, res[1].createdAt, 'account records should have the same createdAt')
-            assert.equal(res[0].profileChangedAt >= res[0].createdAt, true, 'profileChangedAt updated')
+            assert.isAtLeast(res[0].profileChangedAt, res[0].createdAt)
           })
       })
 
@@ -2137,10 +2137,10 @@ module.exports = function (config, DB) {
           })
           .then((session) => {
             // Returns verified session
-            assert.equal(!! session.mustVerify, false, 'mustVerify is false')
-            assert.equal(session.tokenVerificationId, null, 'tokenVerificationId is not set')
-            assert.equal(session.tokenVerificationCodeHash, null, 'tokenVerificationCodeHash is not set')
-            assert.equal(session.tokenVerificationCodeExpiresAt, null, 'tokenVerificationCodeExpiresAt is not set')
+            assert.isFalse(!! session.mustVerify)
+            assert.isNull(session.tokenVerificationId)
+            assert.notOk(session.tokenVerificationCodeHash)
+            assert.notOk(session.tokenVerificationCodeExpiresAt)
           })
       })
 
@@ -2211,8 +2211,8 @@ module.exports = function (config, DB) {
           .then((token) => {
             assert.equal(token.sharedSecret, sharedSecret, 'correct sharedSecret')
             assert.equal(token.epoch, epoch, 'correct epoch')
-            assert.equal(token.verified, false, 'correct verified')
-            assert.equal(token.enabled, true, 'correct enabled')
+            assert.isFalse(!! token.verified)
+            assert.isTrue(!! token.enabled)
           })
       })
 
@@ -2241,7 +2241,7 @@ module.exports = function (config, DB) {
                 return db.account(accountData.uid)
               })
               .then((account) => {
-                assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
+                assert.isAbove(account.profileChangedAt, account.createdAt)
               })
           })
       })
@@ -2254,13 +2254,13 @@ module.exports = function (config, DB) {
               .then((token) => {
                 assert.equal(token.sharedSecret, sharedSecret, 'correct sharedSecret')
                 assert.equal(token.epoch, epoch, 'correct epoch')
-                assert.equal(token.verified, true, 'correct verified')
-                assert.equal(token.enabled, true, 'correct enable')
+                assert.isTrue(!! token.verified)
+                assert.isTrue(!! token.enabled)
 
                 return db.account(accountData.uid)
               })
               .then((account) => {
-                assert.equal(account.profileChangedAt > account.createdAt, true, 'profileChangedAt updated')
+                assert.isAbove(account.profileChangedAt, account.createdAt)
               })
           })
       })
@@ -2294,7 +2294,7 @@ module.exports = function (config, DB) {
           .then((session) => {
             // Returns unverified session
             assert.equal(session.tokenVerificationId.toString('hex'), sessionToken.tokenVerificationId.toString('hex'), 'tokenVerificationId must match sessionToken')
-            assert.equal(session.verificationMethod, undefined, 'verificationMethod not set')
+            assert.isNull(session.verificationMethod)
           })
       })
 
@@ -2317,17 +2317,17 @@ module.exports = function (config, DB) {
             return db.sessionToken(tokenId)
           }, assert.fail)
           .then((token) => {
-            assert.equal(token.mustVerify, false, 'mustVerify is false')
-            assert.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
-            assert.equal(token.verificationMethod, null, 'verificationMethod is null')
+            assert.isFalse(!! token.mustVerify)
+            assert.isNull(token.tokenVerificationId)
+            assert.isNull(token.verificationMethod)
             return db.verifyTokensWithMethod(tokenId, verifyOptions)
           })
           .then(() => {
             return db.sessionToken(tokenId)
           }, assert.fail)
           .then((token) => {
-            assert.equal(token.mustVerify, false, 'mustVerify is false')
-            assert.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
+            assert.isFalse(!! token.mustVerify)
+            assert.isNull(token.tokenVerificationId)
             assert.equal(token.verificationMethod, 2, 'verificationMethod is set')
           })
       })
@@ -2354,7 +2354,7 @@ module.exports = function (config, DB) {
             return db.sessionToken(tokenId)
           })
           .then((session) => {
-            assert.equal(session.tokenVerificationId, undefined, 'tokenVerificationId must be undefined')
+            assert.isNull(session.tokenVerificationId)
             assert.equal(session.verificationMethod, 2, 'verificationMethod set')
             assert.ok(session.verifiedAt, 'verifiedAt set')
           })
@@ -2382,11 +2382,10 @@ module.exports = function (config, DB) {
         it('should generate ' + num + ' recovery codes', () => {
           return db.replaceRecoveryCodes(account.uid, num)
             .then((codes) => {
-              assert.equal(codes.length, num, 'correct number of codes')
+              assert.lengthOf(codes, num)
               codes.forEach((code) => {
-                assert.equal(codeTest.test(code), true, 'matches recovery code format')
+                assert.match(code, codeTest)
               })
-              assert.equal()
             }, (err) => {
               assert.equal(err.errno, 116, 'correct errno, not found')
             })
@@ -2398,12 +2397,12 @@ module.exports = function (config, DB) {
         return db.replaceRecoveryCodes(account.uid, 2)
           .then((codes) => {
             firstCodes = codes
-            assert.equal(firstCodes.length, 2, 'correct number of codes')
+            assert.lengthOf(firstCodes, 2)
 
             return db.replaceRecoveryCodes(account.uid, 3)
           })
           .then((codes) => {
-            assert.equal(codes.length, 3, 'correct number of codes')
+            assert.lengthOf(codes, 3)
             assert.notDeepEqual(codes, firstCodes, 'codes are different')
           })
       })
@@ -2431,7 +2430,7 @@ module.exports = function (config, DB) {
           return db.replaceRecoveryCodes(account.uid, 2)
             .then((codes) => {
               recoveryCodes = codes
-              assert.equal(recoveryCodes.length, 2, 'correct number of recovery codes')
+              assert.lengthOf(recoveryCodes, 2)
             })
         })
 
@@ -2562,7 +2561,7 @@ module.exports = function (config, DB) {
       it('should return true if recovery key exists', () => {
         return db.recoveryKeyExists(account.uid)
           .then((res) => {
-            assert.equal(res.exists, true, 'key exists')
+            assert.isTrue(res.exists)
           })
       })
 
@@ -2572,7 +2571,7 @@ module.exports = function (config, DB) {
           .then(() => {
             return db.recoveryKeyExists(account.uid)
               .then((res) => {
-                assert.equal(res.exists, false, 'key doesn\'t exist')
+                assert.isFalse(res.exists)
               })
           })
       })
@@ -2580,7 +2579,7 @@ module.exports = function (config, DB) {
       it('should throw when checking for recovery key on non-existent user', () => {
         return db.recoveryKeyExists('nonexistent')
           .then((res) => {
-            assert.equal(res.exists, false, 'key doesn\'t exist')
+            assert.isFalse(res.exists)
           })
       })
 
@@ -2652,7 +2651,7 @@ module.exports = function (config, DB) {
 
         const result = await db.fetchAccountSubscriptions(account.uid)
 
-        assert.equal(result.length, 3)
+        assert.lengthOf(result, 3)
         assert.deepEqual(
           pickSet(result, 'subscriptionId'),
           new Set([ subscriptionIds[3], subscriptionIds[4], subscriptionIds[5] ])
@@ -2671,7 +2670,7 @@ module.exports = function (config, DB) {
 
         const result = await db.fetchAccountSubscriptions(account.uid)
 
-        assert.equal(result.length, 2)
+        assert.lengthOf(result, 2)
         assert.deepEqual(
           pickSet(result, 'subscriptionId'),
           new Set([ subscriptionIds[6], subscriptionIds[8] ])
@@ -2691,7 +2690,7 @@ module.exports = function (config, DB) {
 
         const result = await db.fetchAccountSubscriptions(account.uid)
 
-        assert.equal(result.length, 3)
+        assert.lengthOf(result, 3)
         assert.deepEqual(
           pickSet(result, 'subscriptionId'),
           new Set([ subscriptionIds[12], subscriptionIds[13], subscriptionIds[14] ])
@@ -2712,7 +2711,7 @@ module.exports = function (config, DB) {
 
         const result = await db.fetchAccountSubscriptions(account.uid)
 
-        assert.equal(result.length, 2)
+        assert.lengthOf(result, 2)
         assert.deepEqual(
           pickSet(result, 'subscriptionId'),
           new Set([ subscriptionIds[15], subscriptionIds[17] ])

--- a/packages/fxa-auth-db-mysql/db-server/test/backend/remote.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/remote.js
@@ -3,7 +3,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const crypto = require('crypto')
 const fake = require('../fake')
 const P = require('../../../lib/promise')
@@ -79,10 +79,8 @@ function testVersionResponse(client, route) {
   return client.getThen(route)
     .then(function (r) {
       assert.equal(r.res.statusCode, 200, 'version returns 200 OK')
-      assert(r.obj.version.match(/\d+\.\d+\.\d+/),
-           'Version has a semver version property')
-      assert(['Memory', 'MySql'].indexOf(r.obj.implementation) !== -1,
-           'Version has a known implementation  property')
+      assert.match(r.obj.version, /\d+\.\d+\.\d+/)
+      assert.include(['Memory', 'MySql'], r.obj.implementation)
     })
 }
 
@@ -148,7 +146,7 @@ module.exports = function(cfg, makeServer) {
             respOk(r)
 
             var result = r.obj
-            assert.equal(result.length, 2, 'two emails returned')
+            assert.lengthOf(result, 2)
 
             // Verify first email is email from accounts table
             assert.equal(result[0].email, user.account.email, 'matches account email')
@@ -171,7 +169,7 @@ module.exports = function(cfg, makeServer) {
             respOk(r)
 
             var result = r.obj
-            assert.equal(result.length, 2, 'two emails returned')
+            assert.lengthOf(result, 2)
             assert.equal(result[1].email, secondEmailRecord.email, 'matches secondEmail email')
             assert.equal(!! result[1].isPrimary, false, 'isPrimary is false on secondEmail email')
             assert.equal(!! result[1].isVerified, true, 'matches secondEmail isVerified')
@@ -187,7 +185,7 @@ module.exports = function(cfg, makeServer) {
             respOk(r)
 
             var result = r.obj
-            assert.equal(result.length, 3, 'three emails returned')
+            assert.lengthOf(result, 3)
             assert.equal(result[2].email, thirdEmailRecord.email, 'matches thirdEmailRecord email')
             assert.equal(!! result[2].isPrimary, false, 'isPrimary is false on thirdEmailRecord email')
             assert.equal(!! result[2].isVerified, false, 'matches secondEmail thirdEmailRecord')
@@ -202,7 +200,7 @@ module.exports = function(cfg, makeServer) {
             respOk(r)
 
             var result = r.obj
-            assert.equal(result.length, 2, 'two emails returned')
+            assert.lengthOf(result, 2)
             assert.equal(result[0].email, user.account.email, 'matches account email')
             assert.equal(!! result[0].isPrimary, true, 'isPrimary is true on account email')
             assert.equal(!! result[0].isVerified, !! user.account.emailVerified, 'matches account emailVerified')
@@ -300,8 +298,8 @@ module.exports = function(cfg, makeServer) {
         return client.getThen('/account/' + user.accountId + '/sessions')
           .then(function(r) {
             respOk(r)
-            assert(Array.isArray(r.obj), 'sessions is array')
-            assert.equal(r.obj.length, 0, 'sessions is empty')
+            assert.isArray(r.obj)
+            assert.lengthOf(r.obj, 0)
 
             // Create accounts
             return P.all([
@@ -314,7 +312,7 @@ module.exports = function(cfg, makeServer) {
             return client.getThen('/account/' + user.accountId + '/sessions')
           })
           .then(function(r) {
-            assert.equal(r.obj.length, 0, 'sessions is empty')
+            assert.lengthOf(r.obj, 0)
 
             // Attempt to fetch a non-existent session token
             return client.getThen('/sessionToken/' + user.sessionTokenId)
@@ -337,7 +335,7 @@ module.exports = function(cfg, makeServer) {
           .then(function(r) {
             respOk(r)
             var sessions = r.obj
-            assert.equal(sessions.length, 1, 'sessions contains one item')
+            assert.lengthOf(sessions, 1)
             assert.equal(Object.keys(sessions[0]).length, 20, 'session has correct properties')
             assert.equal(sessions[0].tokenId, user.sessionTokenId, 'tokenId is correct')
             assert.equal(sessions[0].uid, user.accountId, 'uid is correct')
@@ -372,7 +370,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(token.email, user.account.email, 'token.email same as account email')
             assert.deepEqual(token.emailCode, user.account.emailCode, 'token emailCode same as account emailCode')
             assert(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
-            assert(token.accountCreatedAt > 0, 'accountCreatedAt is positive number')
+            assert.isAbove(token.accountCreatedAt, 0)
             assert.equal(token.mustVerify, user.sessionToken.mustVerify, 'mustVerify is correct')
             assert.equal(token.tokenVerificationId, user.sessionToken.tokenVerificationId, 'tokenVerificationId is correct')
 
@@ -403,9 +401,9 @@ module.exports = function(cfg, makeServer) {
             assert.equal(token.email, verifiedUser.account.email, 'token.email same as account email')
             assert.deepEqual(token.emailCode, verifiedUser.account.emailCode, 'token emailCode same as account emailCode')
             assert(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
-            assert(token.accountCreatedAt > 0, 'accountCreatedAt is positive number')
-            assert.equal(token.mustVerify, true, 'mustVerify is true')
-            assert.equal(token.tokenVerificationId, null, 'tokenVerificationId is null')
+            assert.isAbove(token.accountCreatedAt, 0)
+            assert.isTrue(!! token.mustVerify)
+            assert.isNull(token.tokenVerificationId)
 
             // Attempt to verify a non-existent session token
             return client.postThen('/tokens/' + crypto.randomBytes(16).toString('hex') + '/verify', {
@@ -440,7 +438,7 @@ module.exports = function(cfg, makeServer) {
           })
           .then(function(r) {
             assert.equal(!! r.obj.mustVerify, true, 'mustVerify is true')
-            assert.equal(r.obj.tokenVerificationId, null, 'tokenVerificationId is null')
+            assert.isNull(r.obj.tokenVerificationId)
 
             // Attempt to verify the session token again
             return client.postThen('/tokens/' + user.sessionToken.tokenVerificationId + '/verify', {
@@ -473,7 +471,7 @@ module.exports = function(cfg, makeServer) {
           .then(function(r) {
             respOk(r)
             var sessions = r.obj
-            assert.equal(sessions.length, 1, 'sessions still contains one item')
+            assert.lengthOf(sessions, 1)
             assert.equal(sessions[0].tokenId, user.sessionTokenId, 'tokenId is correct')
             assert.equal(sessions[0].uid, user.accountId, 'uid is correct')
             assert.equal(sessions[0].createdAt, user.sessionToken.createdAt, 'createdAt is correct')
@@ -513,7 +511,7 @@ module.exports = function(cfg, makeServer) {
           })
           .then(function(r) {
             respOk(r)
-            assert.equal(r.obj.length, 1, 'account has one device')
+            assert.lengthOf(r.obj, 1)
 
             // Fetch the session again to make sure device info is included
             return client.getThen('/account/' + user.accountId + '/sessions')
@@ -521,7 +519,7 @@ module.exports = function(cfg, makeServer) {
           .then(function(r) {
             respOk(r)
             var sessions = r.obj
-            assert.equal(sessions.length, 1, 'sessions still contains one item')
+            assert.lengthOf(sessions, 1)
             var s = sessions[0]
             assert(s.createdAt)
             assert.equal(s.deviceCallbackAuthKey.length, 22)
@@ -548,7 +546,7 @@ module.exports = function(cfg, makeServer) {
             ])
           })
           .then(function(results) {
-            assert.equal(results.length, 2)
+            assert.lengthOf(results, 2)
             results.forEach(function (result) {
               respOk(result)
             })
@@ -558,14 +556,14 @@ module.exports = function(cfg, makeServer) {
           })
           .then(function(r) {
             respOk(r)
-            assert.equal(r.obj.length, 0, 'account has no devices')
+            assert.lengthOf(r.obj, 0)
 
             // Fetch all of the session tokens for the account
             return client.getThen('/account/' + user.accountId + '/sessions')
           })
           .then(function(r) {
             respOk(r)
-            assert.equal(r.obj.length, 0, 'sessions is empty')
+            assert.lengthOf(r.obj, 0)
 
             // Attempt to fetch a deleted session token
             return client.getThen('/sessionToken/' + user.sessionTokenId)
@@ -585,8 +583,8 @@ module.exports = function(cfg, makeServer) {
         return client.getThen('/account/' + user.accountId + '/devices')
           .then(function(r) {
             respOk(r)
-            assert(Array.isArray(r.obj), 'devices is array')
-            assert.equal(r.obj.length, 0, 'devices is empty')
+            assert.isArray(r.obj)
+            assert.lengthOf(r.obj, 0)
             return client.putThen('/account/' + user.accountId, user.account)
           })
           .then(function() {
@@ -596,7 +594,7 @@ module.exports = function(cfg, makeServer) {
             return client.getThen('/account/' + user.accountId + '/devices')
           })
           .then(function(r) {
-            assert.equal(r.obj.length, 0, 'devices is empty')
+            assert.lengthOf(r.obj, 0)
             return client.putThen('/account/' + user.accountId + '/device/' + user.deviceId, user.device)
           })
           .then(function(r) {
@@ -605,8 +603,8 @@ module.exports = function(cfg, makeServer) {
           .then(function(r) {
             respOk(r)
             var devices = r.obj
-            assert.equal(devices.length, 1, 'devices contains one item')
-            assert.equal(Object.keys(devices[0]).length, 19, 'device has nineteen properties')
+            assert.lengthOf(devices, 1)
+            assert.lengthOf(Object.keys(devices[0]), 19)
             assert.equal(devices[0].uid, user.accountId, 'uid is correct')
             assert.equal(devices[0].id, user.deviceId, 'id is correct')
             assert.equal(devices[0].sessionTokenId, user.sessionTokenId, 'sessionTokenId is correct')
@@ -676,7 +674,7 @@ module.exports = function(cfg, makeServer) {
           .then(function(r) {
             respOk(r)
             var devices = r.obj
-            assert.equal(devices.length, 1, 'devices still contains one item')
+            assert.lengthOf(devices, 1)
             assert.equal(devices[0].uid, user.accountId, 'uid is correct')
             assert.equal(devices[0].id, user.deviceId, 'id is correct')
             assert.equal(devices[0].sessionTokenId, user.sessionTokenId, 'sessionTokenId is correct')
@@ -707,7 +705,7 @@ module.exports = function(cfg, makeServer) {
           .then(function(r) {
             respOk(r)
             var devices = r.obj
-            assert.equal(devices.length, 0, 'devices is empty')
+            assert.lengthOf(devices, 0)
 
             return client.postThen('/account/' + user.accountId + '/device/' + user.deviceId + '/update', {
               sessionTokenId: user.sessionTokenId
@@ -720,7 +718,7 @@ module.exports = function(cfg, makeServer) {
           .then(function(r) {
             respOk(r)
             var devices = r.obj
-            assert.equal(devices.length, 1, 'devices contains one item again')
+            assert.lengthOf(devices, 1)
 
             return client.postThen('/account/' + user.accountId + '/device/' + user.deviceId + '/update', {
               name: '4a6f686e'
@@ -733,7 +731,7 @@ module.exports = function(cfg, makeServer) {
           .then(function(r) {
             respOk(r)
             var devices = r.obj
-            assert.equal(devices.length, 1, 'devices contains one item again')
+            assert.lengthOf(devices, 1)
             assert.equal(devices[0].name, '4a6f686e', 'name was not automagically bufferized')
 
             return client.putThen('/account/' + user.accountId + '/device/' + user.oauthDeviceId, user.oauthDevice)
@@ -744,7 +742,7 @@ module.exports = function(cfg, makeServer) {
           .then(function (r) {
             respOk(r)
             var devices = r.obj
-            assert.equal(devices.length, 2, 'devices now contains two items')
+            assert.lengthOf(devices, 2)
             const sessionDevice = devices.find(d => d.sessionTokenId)
             const oauthDevice = devices.find(d => d.refreshTokenId)
 
@@ -752,7 +750,7 @@ module.exports = function(cfg, makeServer) {
             assert.equal(sessionDevice.sessionTokenId, user.sessionTokenId, 'sessionTokenId is correct')
             assert.equal(sessionDevice.refreshTokenId, null, 'refreshTokenId is correct')
 
-            assert.equal(Object.keys(oauthDevice).length, 19, 'device has nineteen properties')
+            assert.lengthOf(Object.keys(oauthDevice), 19)
             assert.equal(oauthDevice.uid, user.accountId, 'uid is correct')
             assert.equal(oauthDevice.id, user.oauthDeviceId, 'id is correct')
             assert.equal(oauthDevice.sessionTokenId, null, 'sessionTokenId is correct')
@@ -765,13 +763,13 @@ module.exports = function(cfg, makeServer) {
             assert.equal(oauthDevice.callbackAuthKey, user.oauthDevice.callbackAuthKey, 'callbackAuthKey is correct')
             assert.equal(oauthDevice.callbackIsExpired, user.oauthDevice.callbackIsExpired, 'callbackIsExpired is correct')
             assert.deepEqual(oauthDevice.availableCommands, {}, 'availableCommands is correct')
-            assert.equal(oauthDevice.uaBrowser, null, 'uaBrowser is correct')
-            assert.equal(oauthDevice.uaBrowserVersion, null, 'uaBrowserVersion is correct')
-            assert.equal(oauthDevice.uaOS, null, 'uaOS is correct')
-            assert.equal(oauthDevice.uaOSVersion, null, 'uaOSVersion is correct')
-            assert.equal(oauthDevice.uaDeviceType, null, 'uaDeviceType is correct')
-            assert.equal(oauthDevice.uaFormFactor, null, 'uaFormFactor is correct')
-            assert.equal(oauthDevice.lastAccessTime, null, 'lastAccessTime is correct')
+            assert.isNull(oauthDevice.uaBrowser)
+            assert.isNull(oauthDevice.uaBrowserVersion)
+            assert.isNull(oauthDevice.uaOS)
+            assert.isNull(oauthDevice.uaOSVersion)
+            assert.isNull(oauthDevice.uaDeviceType)
+            assert.isNull(oauthDevice.uaFormFactor)
+            assert.isNull(oauthDevice.lastAccessTime)
 
             return client.postThen('/account/' + user.accountId + '/device/' + oauthDevice.id + '/update', {
               name: 'a new device name'
@@ -783,14 +781,14 @@ module.exports = function(cfg, makeServer) {
           .then(function (r) {
             respOk(r)
             var devices = r.obj
-            assert.equal(devices.length, 2, 'devices still contains two items')
+            assert.lengthOf(devices, 2)
             const sessionDevice = devices.find(d => d.sessionTokenId)
             const oauthDevice = devices.find(d => d.refreshTokenId)
 
             assert.equal(sessionDevice.sessionTokenId, user.sessionTokenId, 'sessionTokenId is correct')
-            assert.equal(sessionDevice.refreshTokenId, null, 'refreshTokenId is correct')
+            assert.isNull(sessionDevice.refreshTokenId)
 
-            assert.equal(oauthDevice.sessionTokenId, null, 'sessionTokenId is correct')
+            assert.isNull(oauthDevice.sessionTokenId)
             assert.equal(oauthDevice.refreshTokenId, oauthDevice.refreshTokenId, 'refreshTokenId is correct')
             assert.equal(oauthDevice.name, 'a new device name', 'name is correct')
 
@@ -809,7 +807,7 @@ module.exports = function(cfg, makeServer) {
           })
           .then(function(r) {
             respOk(r)
-            assert.equal(r.obj.length, 0, 'devices is empty')
+            assert.lengthOf(r.obj, 0)
 
             return client.getThen('/account/' + user.accountId + '/device' + user.deviceId)
               .then(function () {
@@ -876,7 +874,7 @@ module.exports = function(cfg, makeServer) {
             assert(token.createdAt, 'Got a createdAt')
             assert.equal(!! token.emailVerified, user.account.emailVerified)
             assert(token.verifierSetAt, 'verifierSetAt is set to a truthy value')
-            assert.equal(token.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
+            assert.isUndefined(token.tokenVerificationId)
 
             // Fetch the key fetch token with its verification state
             return client.getThen('/keyFetchToken/' + user.keyFetchTokenId + '/verified')
@@ -930,19 +928,19 @@ module.exports = function(cfg, makeServer) {
             return client.getThen('/keyFetchToken/' + user.keyFetchTokenId)
           })
           .then(function (r) {
-            assert.equal(r.obj.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
+            assert.isUndefined(r.obj.tokenVerificationId)
 
             // Fetch the key fetch token with its verification state
             return client.getThen('/keyFetchToken/' + user.keyFetchTokenId + '/verified')
           })
           .then(function (r) {
-            assert.equal(r.obj.tokenVerificationId, null, 'tokenVerificationId is null')
+            assert.isNull(r.obj.tokenVerificationId)
 
             // Fetch the session token with its verification state
             return client.getThen('/sessionToken/' + user.sessionTokenId)
           })
           .then(function (r) {
-            assert.equal(r.obj.tokenVerificationId, null, 'tokenVerificationId is null')
+            assert.isNull(r.obj.tokenVerificationId)
 
             // Attempt to verify the key fetch token again
             return client.postThen('/tokens/' + user.keyFetchToken.tokenVerificationId + '/verify', {
@@ -963,13 +961,13 @@ module.exports = function(cfg, makeServer) {
             return client.getThen('/keyFetchToken/' + verifiedUser.keyFetchTokenId)
           })
           .then(function (r) {
-            assert.equal(r.obj.tokenVerificationId, undefined, 'tokenVerificationId is undefined')
+            assert.isUndefined(r.obj.tokenVerificationId)
 
             // Fetch the verified key fetch token with its verification state
             return client.getThen('/keyFetchToken/' + verifiedUser.keyFetchTokenId + '/verified')
           })
           .then(function (r) {
-            assert.equal(r.obj.tokenVerificationId, null, 'tokenVerificationId is null')
+            assert.isNull(r.obj.tokenVerificationId)
             // Delete both key fetch tokens
             return P.all([
               client.delThen('/keyFetchToken/' + user.keyFetchTokenId),
@@ -977,7 +975,7 @@ module.exports = function(cfg, makeServer) {
             ])
           })
           .then(function (results) {
-            assert.equal(results.length, 2)
+            assert.lengthOf(results, 2)
             results.forEach(function (result) {
               respOk(result)
             })
@@ -1263,7 +1261,7 @@ module.exports = function(cfg, makeServer) {
           .then(
             function (r) {
               respOk(r)
-              assert(r.obj.createdAt <= Date.now(), 'returns { createdAt: Number }')
+              assert.isAtMost(r.obj.createdAt, Date.now())
               return client.delThen('/account/' + uid + '/unblock/' + unblockCode)
               .then(
                 function (r) {
@@ -1298,9 +1296,9 @@ module.exports = function(cfg, makeServer) {
           .then(
             function (r) {
               respOk(r)
-              assert.equal(r.obj.length, 1)
+              assert.lengthOf(r.obj, 1)
               assert.equal(r.obj[0].email, email)
-              assert(r.obj[0].createdAt <= Date.now(), 'returns { createdAt: Number }')
+              assert.isAtMost(r.obj[0].createdAt, Date.now())
             }
           )
       }
@@ -1640,10 +1638,10 @@ module.exports = function(cfg, makeServer) {
               respOk(keyFetchTokenResp)
               const sessionToken = sessionTokenResp.obj
               const keyFetchToken = keyFetchTokenResp.obj
-              assert.equal(sessionToken.tokenVerificationId, null, 'tokenVerificationCodeHash not set')
-              assert.equal(sessionToken.tokenVerificationCodeHash, null, 'tokenVerificationCodeHash not set')
-              assert.equal(sessionToken.tokenVerificationCodeExpiresAt, null, 'tokenVerificationCodeExpiresAt not set')
-              assert.equal(keyFetchToken.tokenVerificationId, null, 'tokenVerificationId not set')
+              assert.isNull(sessionToken.tokenVerificationId)
+              assert.notOk(sessionToken.tokenVerificationCodeHash)
+              assert.notOk(sessionToken.tokenVerificationCodeExpiresAt)
+              assert.isNull(keyFetchToken.tokenVerificationId)
             })
         })
       }
@@ -1766,7 +1764,7 @@ module.exports = function(cfg, makeServer) {
         return client.postThen('/account/' + user.accountId + '/recoveryCodes', {count: 8})
           .then((res) => {
             const codes = res.obj
-            assert.equal(codes.length, 8, 'correct number of codes')
+            assert.lengthOf(codes, 8)
           })
       })
 
@@ -1781,7 +1779,7 @@ module.exports = function(cfg, makeServer) {
         return client.postThen('/account/' + user.accountId + '/recoveryCodes', {count: 8})
           .then((res) => {
             const codes = res.obj
-            assert.equal(codes.length, 8, 'correct number of codes')
+            assert.lengthOf(codes, 8)
             return client.postThen('/account/' + user.accountId + '/recoveryCodes/' + codes[0])
           })
           .then((res) => {
@@ -1832,7 +1830,7 @@ module.exports = function(cfg, makeServer) {
         return client.getThen('/account/' + user.accountId + '/recoveryKey')
           .then((res) => {
             const result = res.obj
-            assert.equal(result.exists, true, 'recovery key exists')
+            assert.isTrue(result.exists)
           })
       })
     })
@@ -1889,7 +1887,7 @@ module.exports = function(cfg, makeServer) {
         const { obj } =
           await client.getThen(`/account/${user.accountId}/subscriptions`)
 
-        assert.equal(obj.length, 3)
+        assert.lengthOf(obj, 3)
         assert.deepEqual(
           pick(obj, 'subscriptionId'),
           [ subs[2], subs[3], subs[4] ]
@@ -1918,7 +1916,7 @@ module.exports = function(cfg, makeServer) {
         const { obj } =
             await client.getThen(`/account/${user.accountId}/subscriptions`)
 
-        assert.equal(obj.length, 2)
+        assert.lengthOf(obj, 2)
         assert.deepEqual(
           pick(obj, 'subscriptionId'),
           [ subs[5], subs[7] ]

--- a/packages/fxa-auth-db-mysql/db-server/test/local/bufferize.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/local/bufferize.js
@@ -3,7 +3,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const sinon = require('sinon')
 
 describe('bufferize', () => {
@@ -12,19 +12,19 @@ describe('bufferize', () => {
     () => {
 
       var bufferize = require('../../lib/bufferize')
-      assert.equal(typeof bufferize, 'object', 'bufferize exports object')
-      assert.equal(Object.keys(bufferize).length, 4, 'bufferize exports four functions')
-      assert.equal(typeof bufferize.unbuffer, 'function', 'bufferize exports unbuffer function')
-      assert.equal(typeof bufferize.bufferize, 'function', 'bufferize exports bufferize function')
-      assert.equal(typeof bufferize.bufferizeRequest, 'function', 'bufferize exports bufferizeRequest function')
-      assert.equal(typeof bufferize.hexToUtf8, 'function', 'bufferize exports hexToUtf8 function')
+      assert.isObject(bufferize)
+      assert.lengthOf(Object.keys(bufferize), 4)
+      assert.isFunction(bufferize.unbuffer)
+      assert.isFunction(bufferize.bufferize)
+      assert.isFunction(bufferize.bufferizeRequest)
+      assert.isFunction(bufferize.hexToUtf8)
 
       var result = bufferize.unbuffer({
         foo: Buffer.from('42', 'hex'),
         bar: '42'
       })
-      assert.equal(typeof result, 'object', 'bufferize.unbuffer returned object')
-      assert.equal(Object.keys(result).length, 2, 'bufferize.unbuffer returned correct number of properties')
+      assert.isObject(result)
+      assert.lengthOf(Object.keys(result), 2)
       assert.equal(result.foo, '42', 'bufferize.unbuffer unbuffered correctly')
       assert.equal(result.foo, '42', 'bufferize.unbuffer preserved string')
 
@@ -33,13 +33,13 @@ describe('bufferize', () => {
         bar: 'ffff',
       })
 
-      assert.equal(typeof result, 'object', 'bufferize.bufferize returned object')
-      assert.equal(Object.keys(result).length, 2, 'bufferize.bufferize returned correct number of properties')
+      assert.isObject(result)
+      assert.lengthOf(Object.keys(result), 2)
       assert(Buffer.isBuffer(result.foo), 'bufferize.bufferize returned buffer for 00')
-      assert.equal(result.foo.length, 1, 'bufferize.bufferize returned correct length for 00')
+      assert.lengthOf(result.foo, 1)
       assert.equal(result.foo[0], 0x00, 'bufferize.bufferize returned correct data for 00')
       assert(Buffer.isBuffer(result.bar), 'bufferize.bufferize returned buffer for ffff')
-      assert.equal(result.bar.length, 2, 'bufferize.bufferize returned correct length for ffff')
+      assert.lengthOf(result.bar, 2)
       assert.equal(result.bar[0], 0xff, 'bufferize.bufferize returned correct first byte for ffff')
       assert.equal(result.bar[1], 0xff, 'bufferize.bufferize returned correct second byte for ffff')
 
@@ -49,13 +49,13 @@ describe('bufferize', () => {
         wibble: '00'
       }, new Set(['foo', 'bar']))
 
-      assert.equal(typeof result, 'object', 'bufferize.bufferize returned object')
-      assert.equal(Object.keys(result).length, 3, 'bufferize.bufferize returned correct number of properties')
+      assert.isObject(result)
+      assert.lengthOf(Object.keys(result), 3)
       assert(Buffer.isBuffer(result.foo), 'bufferize.bufferize returned buffer for 00')
-      assert.equal(result.foo.length, 1, 'bufferize.bufferize returned correct length for 00')
+      assert.lengthOf(result.foo, 1)
       assert.equal(result.foo[0], 0x00, 'bufferize.bufferize returned correct data for 00')
       assert(Buffer.isBuffer(result.bar), 'bufferize.bufferize returned buffer for ffff')
-      assert.equal(result.bar.length, 2, 'bufferize.bufferize returned correct length for ffff')
+      assert.lengthOf(result.bar, 2)
       assert.equal(result.bar[0], 0xff, 'bufferize.bufferize returned correct first byte for ffff')
       assert.equal(result.bar[1], 0xff, 'bufferize.bufferize returned correct second byte for ffff')
       assert.equal(result.wibble, '00', 'bufferize.bufferize ignored property not in match list')
@@ -66,13 +66,13 @@ describe('bufferize', () => {
         baz: undefined
       }, new Set(['foo', 'bar', 'baz']))
 
-      assert.equal(typeof result, 'object', 'bufferize.bufferize returned object')
-      assert.equal(Object.keys(result).length, 3, 'bufferize.bufferize returned correct number of properties')
+      assert.isObject(result)
+      assert.lengthOf(Object.keys(result), 3)
       assert(Buffer.isBuffer(result.foo), 'bufferize.bufferize returned buffer for 00')
-      assert.equal(result.foo.length, 1, 'bufferize.bufferize returned correct length for 00')
+      assert.lengthOf(result.foo, 1)
       assert.equal(result.foo[0], 0x00, 'bufferize.bufferize returned correct data for 00')
-      assert.equal(result.bar, null, 'bufferize.bufferize ignored property that was set to null')
-      assert.equal(result.baz, undefined, 'bufferize.bufferize ignored property that was undefined')
+      assert.isNull(result.bar)
+      assert.isUndefined(result.baz)
 
       var request = {
         body: {
@@ -89,26 +89,26 @@ describe('bufferize', () => {
       var keys = new Set(['yes', 'y'])
       bufferize.bufferizeRequest(keys, request, {}, next)
 
-      assert.equal(Object.keys(request).length, 2, 'bufferize.bufferizeRequest did not mess with request')
+      assert.lengthOf(Object.keys(request), 2)
 
-      assert.equal(Object.keys(request.body).length, 3, 'bufferize.bufferizeRequest did not mess with request.body')
+      assert.lengthOf(Object.keys(request.body), 3)
       assert.equal(request.body.no, 'badf00d', 'bufferize.bufferizeRequest preserved body string badf00d')
       assert.equal(request.body.nope, 'f00d', 'bufferize.bufferizeRequest ignored body property not in matchlist')
       assert(Buffer.isBuffer(request.body.yes), 'bufferize.bufferizeRequest returned buffer for body f00d')
-      assert.equal(request.body.yes.length, 2, 'bufferize.bufferizeRequest returned correct length for body f00d')
+      assert.lengthOf(request.body.yes, 2)
       assert.equal(request.body.yes[0], 0xf0, 'bufferize.bufferizeRequest returned correct first byte for body f00d')
       assert.equal(request.body.yes[1], 0x0d, 'bufferize.bufferizeRequest returned correct second byte for body f00d')
 
-      assert.equal(Object.keys(request.params).length, 2, 'bufferize.bufferizeRequest did not mess with request.params')
+      assert.lengthOf(Object.keys(request.params), 2)
       assert(Buffer.isBuffer(request.params.y), 'bufferize.bufferizeRequest returned buffer for params deadbeef')
-      assert.equal(request.params.y.length, 4, 'bufferize.bufferizeRequest returned correct length for params deadbeef')
+      assert.lengthOf(request.params.y, 4)
       assert.equal(request.params.y[0], 0xde, 'bufferize.bufferizeRequest returned correct first byte for params deadbeef')
       assert.equal(request.params.y[1], 0xad, 'bufferize.bufferizeRequest returned correct second byte for params deadbeef')
       assert.equal(request.params.y[2], 0xbe, 'bufferize.bufferizeRequest returned correct third byte for params deadbeef')
       assert.equal(request.params.y[3], 0xef, 'bufferize.bufferizeRequest returned correct fourth byte for params deadbeef')
       assert.equal(request.params.n, 'deadbeef', 'bufferize.bufferizeRequest ignored params not in matchlist')
       assert(next.calledOnce, 'bufferize.bufferizeRequest called next')
-      assert.equal(next.getCall(0).args.length, 0, 'bufferize.bufferizeRequest called next with no arguments')
+      assert.lengthOf(next.getCall(0).args, 0)
 
       request = {
         body: {
@@ -118,11 +118,11 @@ describe('bufferize', () => {
       next = sinon.spy()
       bufferize.bufferizeRequest(null, request, {}, next)
 
-      assert.equal(Object.keys(request).length, 1, 'bufferize.bufferizeRequest did not mess with request')
-      assert.equal(Object.keys(request.body).length, 1, 'bufferize.bufferizeRequest did not mess with request.body')
+      assert.lengthOf(Object.keys(request), 1)
+      assert.lengthOf(Object.keys(request.body), 1)
       assert.equal(request.body.buf, 'invalid', 'bufferize.bufferizeRequest did not overwrite invalid field in body')
       assert(next.calledOnce, 'bufferize.bufferizeRequest called next')
-      assert.equal(next.getCall(0).args.length, 1, 'bufferize.bufferizeRequest called next with one argument')
+      assert.lengthOf(next.getCall(0).args, 1)
       assert.equal(next.getCall(0).args[0].statusCode, 400, 'bufferize.bufferizeRequest called next with a 400 error')
     }
   )

--- a/packages/fxa-auth-db-mysql/db-server/test/local/error.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/local/error.js
@@ -3,17 +3,17 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 
 describe('error', () => {
   it(
     'error module',
     () => {
       const error = require('../../lib/error')
-      assert.equal(typeof error, 'function', 'error module returns a function')
+      assert.isFunction(error)
 
       const duplicate = error.duplicate()
-      assert.equal(typeof duplicate, 'object', 'duplicate returns an object')
+      assert.isObject(duplicate)
       assert(duplicate instanceof error, 'is an instance of error')
       assert.equal(duplicate.code, 409)
       assert.equal(duplicate.errno, 101)
@@ -22,7 +22,7 @@ describe('error', () => {
       assert.equal(duplicate.toString(), 'Error: Record already exists')
 
       const notFound = error.notFound()
-      assert.equal(typeof notFound, 'object', 'notFound returns an object')
+      assert.isObject(notFound)
       assert(notFound instanceof error, 'is an instance of error')
       assert.equal(notFound.code, 404)
       assert.equal(notFound.errno, 116)
@@ -34,7 +34,7 @@ describe('error', () => {
       err.code = 'ER_QUERY_INTERRUPTED'
       err.errno = 1317
       const wrap = error.wrap(err)
-      assert.equal(typeof wrap, 'object', 'wrap returns an object')
+      assert.isObject(wrap)
       assert(wrap instanceof error, 'is an instance of error')
       assert.equal(wrap.code, 500)
       assert.equal(wrap.errno, 1317)

--- a/packages/fxa-auth-db-mysql/db-server/test/local/safeJsonFormatter.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/local/safeJsonFormatter.js
@@ -3,12 +3,12 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const safeJsonFormatter = require('../../lib/safeJsonFormatter')
 
 describe('safeJsonFormatter module', () => {
   it('safeJsonFormatter function exported', () => {
-    assert.equal(typeof safeJsonFormatter === 'function', true)
+    assert.isFunction(safeJsonFormatter)
   })
 
   it('escapes input', () => {

--- a/packages/fxa-auth-db-mysql/npm-shrinkwrap.json
+++ b/packages/fxa-auth-db-mysql/npm-shrinkwrap.json
@@ -14,12 +14,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
-      "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.0",
+        "@babel/types": "^7.4.4",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.11",
         "source-map": "^0.5.0",
@@ -47,12 +47,12 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
-      "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.4.0"
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/highlight": {
@@ -98,34 +98,34 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
-      "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
+      "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
-      "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.4.0",
-        "@babel/types": "^7.4.0"
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4"
       }
     },
     "@babel/traverse": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
-      "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
+      "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.4.0",
+        "@babel/generator": "^7.4.4",
         "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.4.0",
-        "@babel/parser": "^7.4.3",
-        "@babel/types": "^7.4.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.11"
@@ -141,17 +141,17 @@
           }
         },
         "globals": {
-          "version": "11.11.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
         }
       }
     },
     "@babel/types": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
-      "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -477,14 +477,17 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chalk": {
@@ -503,6 +506,12 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
@@ -570,9 +579,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -712,20 +721,12 @@
       "dev": true
     },
     "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "0.1.1"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-          "dev": true
-        }
+        "type-detect": "^4.0.0"
       }
     },
     "deep-equal": {
@@ -739,6 +740,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -806,10 +816,35 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "es5-ext": {
-      "version": "0.10.49",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.49.tgz",
-      "integrity": "sha512-3NMEhi57E31qdzmYp2jwRArIUsj1HI/RxbQ4bgnSB+AIKIxsAmTiK83bYMifIcpWvEc3P1X30DhUKOqEtF/kvg==",
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
       "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
@@ -963,9 +998,9 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -1182,9 +1217,9 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -1241,6 +1276,12 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "fxa-jwtool": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/fxa-jwtool/-/fxa-jwtool-0.7.2.tgz",
@@ -1275,6 +1316,12 @@
       "requires": {
         "is-property": "^1.0.0"
       }
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -1393,9 +1440,9 @@
           },
           "dependencies": {
             "glob": {
-              "version": "7.1.3",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-              "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+              "version": "7.1.4",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+              "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
               "dev": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
@@ -1527,6 +1574,15 @@
         "har-schema": "^2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -1539,6 +1595,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "he": {
@@ -1658,30 +1720,6 @@
         "through": "^2.3.6"
       }
     },
-    "insist": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/insist/-/insist-1.0.0.tgz",
-      "integrity": "sha1-W+Sa55tzM3XgsXLxhLklxfxETHc=",
-      "dev": true,
-      "requires": {
-        "esprima": "^2.0.0",
-        "stack-trace": "^0.0.7"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true
-        },
-        "stack-trace": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.7.tgz",
-          "integrity": "sha1-xy4Il0T8Nln1CM3ONiGvVjTsD/8=",
-          "dev": true
-        }
-      }
-    },
     "intel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/intel/-/intel-1.2.0.tgz",
@@ -1700,6 +1738,12 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+      "dev": true
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1710,6 +1754,18 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -1729,6 +1785,12 @@
         "number-is-nan": "^1.0.0"
       }
     },
+    "is-generator-function": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
+      "dev": true
+    },
     "is-my-ip-valid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
@@ -1736,9 +1798,9 @@
       "dev": true
     },
     "is-my-json-valid": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
+      "integrity": "sha512-XTHBZSIIxNsIsZXg7XB5l8z/OBFosl1Wao4tXLpeC7eKU4Vm/kdop2azkPqULwnfGQjmeDIyey9g7afMMtdWAA==",
       "dev": true,
       "requires": {
         "generate-function": "^2.0.0",
@@ -1760,11 +1822,29 @@
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1794,24 +1874,32 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-lib-coverage": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
-      "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
       "dev": true,
       "requires": {
-        "@babel/generator": "^7.0.0",
-        "@babel/parser": "^7.0.0",
-        "@babel/template": "^7.0.0",
-        "@babel/traverse": "^7.0.0",
-        "@babel/types": "^7.0.0",
-        "istanbul-lib-coverage": "^2.0.3",
-        "semver": "^5.5.0"
+        "@babel/generator": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "istanbul-lib-coverage": "^2.0.5",
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+          "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+          "dev": true
+        }
       }
     },
     "js-tokens": {
@@ -2033,16 +2121,16 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
-      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
     "mime-types": {
-      "version": "2.1.22",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
-      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "requires": {
-        "mime-db": "~1.38.0"
+        "mime-db": "1.40.0"
       }
     },
     "minimalistic-assert": {
@@ -2234,9 +2322,9 @@
       "optional": true
     },
     "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "newrelic": {
       "version": "4.10.0",
@@ -2287,6 +2375,17 @@
         "qs": "^6.0.2"
       },
       "dependencies": {
+        "chai": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+          "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+          "dev": true,
+          "requires": {
+            "assertion-error": "^1.0.1",
+            "deep-eql": "^0.1.3",
+            "type-detect": "^1.0.0"
+          }
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2296,10 +2395,33 @@
             "ms": "2.0.0"
           }
         },
+        "deep-eql": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+          "dev": true,
+          "requires": {
+            "type-detect": "0.1.1"
+          },
+          "dependencies": {
+            "type-detect": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+              "dev": true
+            }
+          }
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "type-detect": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
           "dev": true
         }
       }
@@ -3382,6 +3504,24 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
     "obuf": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
@@ -3466,6 +3606,12 @@
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pem-jwk": {
       "version": "1.5.1",
@@ -3710,9 +3856,9 @@
       }
     },
     "resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
+      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -4281,9 +4427,9 @@
       }
     },
     "type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "typedarray": {
@@ -4324,12 +4470,16 @@
       "integrity": "sha1-Qw/VEKt/yVtdWRDJAteYgMIIQ2s="
     },
     "util": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
-      "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.0.tgz",
+      "integrity": "sha512-pPSOFl7VLhZ7LO/SFABPraZEEurkJUWSMn3MuA/r3WQZc+Z1fqou2JqLSOZbCLl73EUIxuUVX8X4jkX2vfJeAA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "object.entries": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "util-deprecate": {

--- a/packages/fxa-auth-db-mysql/package.json
+++ b/packages/fxa-auth-db-mysql/package.json
@@ -43,11 +43,11 @@
     "restify": "7.2.2"
   },
   "devDependencies": {
+    "chai": "4.2.0",
     "eslint-plugin-fxa": "git+https://github.com/mozilla/eslint-plugin-fxa#master",
     "grunt": "1.0.4",
     "grunt-copyright": "0.3.0",
     "grunt-eslint": "18.0.0",
-    "insist": "1.0.0",
     "load-grunt-tasks": "3.5.0",
     "mocha": "5.2.0",
     "nock": "8.0.0",

--- a/packages/fxa-auth-db-mysql/scripts/createAccounts.js
+++ b/packages/fxa-auth-db-mysql/scripts/createAccounts.js
@@ -6,7 +6,7 @@
 
 // For testing purposes only, generate traffic and table size for fxa.accounts.
 
-const assert = require('insist')
+const { assert } = require('chai')
 const dbServer = require('../db-server')
 const log = require('../test/lib/log')
 const DB = require('../lib/db/mysql')(log, dbServer.errors)

--- a/packages/fxa-auth-db-mysql/test/local/constants_test.js
+++ b/packages/fxa-auth-db-mysql/test/local/constants_test.js
@@ -1,7 +1,7 @@
 /* Any copyright is dedicated to the Public Domain.
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
-const assert = require('insist')
+const { assert } = require('chai')
 const constants = require('../../lib/constants')
 describe('constants', () => {
   it(

--- a/packages/fxa-auth-db-mysql/test/local/incorrect-patch-level.js
+++ b/packages/fxa-auth-db-mysql/test/local/incorrect-patch-level.js
@@ -3,7 +3,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const dbServer = require('../../db-server')
 const log = require('../lib/log')
 const DB = require('../../lib/db/mysql')(log, dbServer.errors)
@@ -26,8 +26,7 @@ describe('DB patch', () => {
           assert(false, 'DB.connect should have failed on an incorrect patchVersion')
         },
         err => {
-          assert.equal(typeof err, 'object')
-          assert(err instanceof Error)
+          assert.instanceOf(err, Error)
           assert.equal(err.message, 'dbIncorrectPatchLevel')
         }
       )

--- a/packages/fxa-auth-db-mysql/test/local/log-stats.js
+++ b/packages/fxa-auth-db-mysql/test/local/log-stats.js
@@ -3,7 +3,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const dbServer = require('../../db-server')
 const P = require('../../lib/promise')
 const config = require('../../config')
@@ -36,7 +36,7 @@ describe('DB statInterval', () => {
   it('should log stats periodically', () => {
     return dfd.promise
       .then(stats => {
-        assert.equal(typeof stats, 'object')
+        assert.isObject(stats)
         assert.equal(stats.stat, 'mysql')
         assert.equal(stats.errors, 0)
         assert.equal(stats.connections, 1)

--- a/packages/fxa-auth-db-mysql/test/local/metrics_tests.js
+++ b/packages/fxa-auth-db-mysql/test/local/metrics_tests.js
@@ -3,7 +3,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const log = require('../lib/log')
 const DB = require('../../lib/db/mysql')(log, require('../../db-server').errors)
 const config = require('../../config')
@@ -34,12 +34,12 @@ describe('DB metrics', () => {
         Date.now()
       ]
 
-      assert.equal(typeof metrics.run, 'function', 'run function was exported')
-      assert.equal(typeof metrics.countAccounts, 'string', 'countAccounts string was exported')
-      assert.equal(typeof metrics.countVerifiedAccounts, 'string', 'countVerifiedAccounts string was exported')
-      assert.equal(typeof metrics.countAccountsWithTwoOrMoreDevices, 'string', 'countAccountsWithTwoOrMoreDevices string was exported')
-      assert.equal(typeof metrics.countAccountsWithThreeOrMoreDevices, 'string', 'countAccountsWithThreeOrMoreDevices string was exported')
-      assert.equal(typeof metrics.countAccountsWithMobileDevice, 'string', 'countAccountsWithMobileDevice string was exported')
+      assert.isFunction(metrics.run)
+      assert.isString(metrics.countAccounts)
+      assert.isString(metrics.countVerifiedAccounts)
+      assert.isString(metrics.countAccountsWithTwoOrMoreDevices)
+      assert.isString(metrics.countAccountsWithThreeOrMoreDevices)
+      assert.isString(metrics.countAccountsWithMobileDevice)
 
       return P.all([
         db.readAllResults(metrics.countAccounts, times[0]),
@@ -50,7 +50,7 @@ describe('DB metrics', () => {
       ])
       .then(function (results) {
         results.forEach(function (result, index) {
-          assert(result.count >= 0, 'returned non-negative count [' + index + ']')
+          assert.isAtLeast(result.count, 0)
         })
         lastResults = results
         uid = crypto.randomBytes(16)
@@ -226,17 +226,17 @@ describe('DB metrics', () => {
       .then(function () {
 
         assert.equal(connect.callCount, 1, 'mysql.connect was called once')
-        assert.equal(connect.getCall(0).args.length, 1, 'mysql.connect was passed one argument')
+        assert.lengthOf(connect.getCall(0).args, 1)
         var options = connect.getCall(0).args[0]
-        assert.equal(Object.keys(options).length, 3, 'mysql.connect options had correct number of properties')
-        assert.equal(typeof options.master, 'object', 'mysql.connect master option was object')
-        assert.equal(Object.keys(options.master).length, 4, 'mysql.connect master option had correct number of properties')
+        assert.lengthOf(Object.keys(options), 3)
+        assert.isObject(options.master)
+        assert.lengthOf(Object.keys(options.master), 4)
         assert.equal(options.master.host, 'foo', 'mysql.connect master.host option was correct')
         assert.equal(options.master.user, 'bar', 'mysql.connect master.user option was correct')
         assert.equal(options.master.password, 'baz', 'mysql.connect master.password option was correct')
         assert.equal(options.master.database, 'fxa', 'mysql.connect master.database option was correct')
-        assert.equal(typeof options.slave, 'object', 'mysql.connect slave option was object')
-        assert.equal(Object.keys(options.slave).length, 4, 'mysql.connect slave option had correct number of properties')
+        assert.isObject(options.slave)
+        assert.lengthOf(Object.keys(options.slave), 4)
         assert.equal(options.slave.host, 'foo', 'mysql.connect slave.host option was correct')
         assert.equal(options.slave.user, 'bar', 'mysql.connect slave.user option was correct')
         assert.equal(options.slave.password, 'baz', 'mysql.connect slave.password option was correct')
@@ -244,19 +244,19 @@ describe('DB metrics', () => {
         assert.equal(options.patchKey, 'schema-patch-level', 'mysql.connect patchKey option was correct')
 
         assert.equal(readMultiple.callCount, 1, 'readMultiple was called once')
-        assert.equal(readMultiple.getCall(0).args.length, 2, 'readMultiple was passed two arguments')
+        assert.lengthOf(readMultiple.getCall(0).args, 2)
         var queries = readMultiple.getCall(0).args[0]
-        assert(Array.isArray(queries), 'readMultiple was passed queries array')
-        assert.equal(queries.length, 7, 'query array was correct length')
+        assert.isArray(queries)
+        assert.lengthOf(queries, 7)
 
         queries.forEach(function (query, index) {
-          assert.equal(typeof query, 'object', 'query item was object [' + index + ']')
+          assert.isObject(query)
           if (index <= 1) {
-            assert.equal(Object.keys(query).length, 1, 'query item had correct number of properties [' + index + ']')
+            assert.lengthOf(Object.keys(query), 1)
           } else {
-            assert.equal(Object.keys(query).length, 2, 'query item had correct number of properties [' + index + ']')
-            assert(Array.isArray(query.params), 'query item had params array [' + index + ']')
-            assert.equal(query.params.length, 1, 'query item had correct number of params [' + index + ']')
+            assert.lengthOf(Object.keys(query), 2)
+            assert.isArray(query.params)
+            assert.lengthOf(query.params, 1)
             assert.equal(query.params[0], Date.UTC(1977, 5, 10, 0, 0, 0, 0), 'query item had correct param [' + index + ']')
           }
         })
@@ -268,18 +268,18 @@ describe('DB metrics', () => {
         assert.equal(queries[5].sql, metrics.countAccountsWithThreeOrMoreDevices, 'sixth query had correct SQL')
         assert.equal(queries[6].sql, metrics.countAccountsWithMobileDevice, 'seventh query had correct SQL')
         var finalQuery = readMultiple.getCall(0).args[1]
-        assert.equal(Object.keys(finalQuery).length, 1, 'final query had correct number of properties')
+        assert.lengthOf(Object.keys(finalQuery), 1)
         assert.equal(finalQuery.sql, 'COMMIT', 'final query had correct SQL')
 
         assert.equal(mocks.fs.appendFileSync.callCount, 1, 'fs.appendFileSync was called once')
         var args = mocks.fs.appendFileSync.getCall(0).args
-        assert.equal(args.length, 2, 'fs.appendFileSync was passed two arguments')
+        assert.lengthOf(args, 2)
         assert.equal(args[0], '/media/ephemeral0/fxa-admin/basic_metrics.log', 'log file path was correct')
-        assert.equal(typeof args[1], 'string', 'log file data was string')
+        assert.isString(args[1])
         var delimiterIndex = args[1].length - 1
         assert.equal(args[1][delimiterIndex], '\n', 'log file data was correctly delimited')
         var data = JSON.parse(args[1].substr(0, delimiterIndex))
-        assert.equal(Object.keys(data).length, 10, 'log file data had correct number of properties')
+        assert.lengthOf(Object.keys(data), 10)
         assert.equal(data.hostname, 'fake hostname', 'log file hostname property was correct')
         assert.equal(data.pid, process.pid, 'log file pid property was correct')
         assert.equal(data.op, 'account_totals', 'log file op property was correct')
@@ -288,7 +288,7 @@ describe('DB metrics', () => {
         assert.equal(data.total_accounts_with_two_or_more_devices, 3, 'log file total_accounts_with_two_or_more_devices property was correct')
         assert.equal(data.total_accounts_with_three_or_more_devices, 4, 'log file total_accounts_with_three_or_more_devices property was correct')
         assert.equal(data.total_accounts_with_mobile_device, 5, 'log file total_accounts_with_mobile_device property was correct')
-        assert.equal(typeof data.time, 'string', 'log file time property was a string')
+        assert.isString(data.time)
         var time = new Date(data.time)
         assert.equal(time.getUTCFullYear(), 1977, 'log file time property had correct year')
         assert.equal(time.getUTCMonth(), 5, 'log file time property had correct month')
@@ -300,7 +300,7 @@ describe('DB metrics', () => {
         assert.equal(data.v, 0, 'log file v property was correct')
 
         assert.equal(close.callCount, 1, 'connection.close was called once')
-        assert.equal(close.getCall(0).args.length, 0, 'connection.close was passed no arguments')
+        assert.lengthOf(close.getCall(0).args, 0)
       })
     }
   )

--- a/packages/fxa-auth-db-mysql/test/local/mysql_tests.js
+++ b/packages/fxa-auth-db-mysql/test/local/mysql_tests.js
@@ -3,7 +3,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const dbServer = require('../../db-server')
 const log = require('../lib/log')
 const DB = require('../../lib/db/mysql')(log, dbServer.errors)
@@ -278,15 +278,15 @@ describe('MySQL', () => {
       ])
       .then(
         function(results) {
-          assert(Array.isArray(results), 'results array was returned')
-          assert.equal(results.length, 2, 'results array contained two items')
-          assert(Array.isArray(results[0]), 'first result was an array')
-          assert(results[0].length <= 1, 'first result contained zero or one items')
-          assert(Array.isArray(results[1]), 'second result was an array')
-          assert.equal(results[1].length, 1, 'second result contained one item')
-          assert.equal(typeof results[1][0], 'object', 'second result item was object')
-          assert.equal(Object.keys(results[1][0]).length, 1, 'second result item had one property')
-          assert(results[1][0].count >= 0, 'count property was non-negative number')
+          assert.isArray(results)
+          assert.lengthOf(results, 2)
+          assert.isArray(results[0])
+          assert.isAtMost(results[0].length, 1)
+          assert.isArray(results[1])
+          assert.lengthOf(results[1], 1)
+          assert.isObject(results[1][0])
+          assert.lengthOf(Object.keys(results[1][0]), 1)
+          assert.isAtLeast(results[1][0].count, 0)
         }
       )
     }
@@ -301,7 +301,7 @@ describe('MySQL', () => {
       ], { sql: 'SELECT * FROM accounts LIMIT 1' })
       .then(
         function(results) {
-          assert.equal(results.length, 2, 'results array contained two items')
+          assert.lengthOf(results, 2)
         }
       )
     }
@@ -347,7 +347,7 @@ describe('MySQL', () => {
       return db._connectionConfig('MASTER')
         .then(
           function(config) {
-            assert.equal(typeof config, 'object')
+            assert.isObject(config)
             assert.equal(config.protocol41, true, 'protocol41 is true')
             assert.equal(config.charsetNumber, 46, 'charsetNumber must be 46 (UTF8MB4_BIN)')
             assert.equal(config.multipleStatements, false, 'multipleStatements should normally be false')
@@ -362,7 +362,7 @@ describe('MySQL', () => {
       return db._showVariables('MASTER')
         .then(
           function(vars) {
-            assert.equal(typeof vars, 'object')
+            assert.isObject(vars)
             assert.equal(vars['character_set_client'], 'utf8mb4', 'character_set_connection is utf8mb4')
             assert.equal(vars['character_set_connection'], 'utf8mb4', 'character_set_client is utf8mb4')
             assert.equal(vars['character_set_results'], 'utf8mb4', 'character_set_results is utf8mb4')

--- a/packages/fxa-auth-db-mysql/test/local/prune_tokens.js
+++ b/packages/fxa-auth-db-mysql/test/local/prune_tokens.js
@@ -7,7 +7,7 @@ const TOKEN_PRUNE_AGE = 24 * 60 * 60 * 1000 * 2 // two days
 
 const ROOT_DIR = '../..'
 
-const assert = require('insist')
+const { assert } = require('chai')
 const crypto = require('crypto')
 const dbServer = require(`${ROOT_DIR}/db-server`)
 const log = require('../lib/log')
@@ -145,13 +145,13 @@ describe('prune tokens', () => {
           return db.read(sql, [user.accountId])
         })
         .then(function(res) {
-          assert.equal(res.length, 0, 'no unblock codes for that user')
+          assert.lengthOf(res, 0)
         })
         .then(() => {
           return db.read('SELECT * FROM signinCodes WHERE hash = ?', [signinCodeHash])
         })
         .then(res => {
-          assert.equal(res.length, 0, 'db.read should return an empty recordset')
+          assert.lengthOf(res, 0)
         })
         // The unprunable session token should still exist
         .then(() => db.sessionToken(unprunableSessionTokenId))
@@ -167,17 +167,17 @@ describe('prune tokens', () => {
           return db.read(sql)
         })
         .then((res) => {
-          assert.equal(res.length, 1, 'sessionTokensPrunedUntil still exists')
+          assert.lengthOf(res, 1)
           assert.ok(res[0].value, 'sessionTokensPrunedUntil is not falsy')
           const updatedPrunedUntilValue = parseInt(res[0].value, 10)
-          assert.ok(updatedPrunedUntilValue >  initialPrunedUntilValue, 'sessionTokensPrunedUntil increased')
+          assert.isAbove(updatedPrunedUntilValue, initialPrunedUntilValue)
           // Prune again, so we can check that it gracefully handles
           // the case when there's nothing to prune.
           return db.pruneTokens().then(() => {
             const sql = 'SELECT value FROM dbMetadata WHERE name = \'sessionTokensPrunedUntil\''
             return db.read(sql)
           }).then((res) => {
-            assert.equal(res.length, 1, 'sessionTokensPrunedUntil still exists')
+            assert.lengthOf(res, 1)
             assert.ok(res[0].value, 'sessionTokensPrunedUntil is not falsy')
             assert.equal(parseInt(res[0].value, 10), updatedPrunedUntilValue, 'sessionTokensPrunedUntil did not change')
           })

--- a/packages/fxa-auth-db-mysql/test/local/random.js
+++ b/packages/fxa-auth-db-mysql/test/local/random.js
@@ -3,7 +3,7 @@
 
 'use strict'
 
-const assert = require('insist')
+const { assert } = require('chai')
 
 const base32 = require('../../lib/db/random')
 
@@ -11,11 +11,11 @@ describe('random', () => {
   it('should generate random code', () => {
     return base32(10)
       .then(code => {
-        assert.equal(code.length, 10)
-        assert.equal(code.indexOf('i'), -1, 'should not contain i')
-        assert.equal(code.indexOf('l'), -1, 'should not contain l')
-        assert.equal(code.indexOf('o'), -1, 'should not contain o')
-        assert.equal(code.indexOf('u'), -1, 'should not contain u')
+        assert.lengthOf(code, 10)
+        assert.notInclude(code, 'i')
+        assert.notInclude(code, 'l')
+        assert.notInclude(code, 'o')
+        assert.notInclude(code, 'u')
       })
   })
 })

--- a/packages/fxa-auth-db-mysql/test/local/utils.js
+++ b/packages/fxa-auth-db-mysql/test/local/utils.js
@@ -2,7 +2,7 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 
 const dbUtils = require('../../lib/db/util')
-const assert = require('insist')
+const { assert } = require('chai')
 const P = require('bluebird')
 
 describe('utils', () => {
@@ -12,8 +12,8 @@ describe('utils', () => {
       .then((result) => {
         assert.ok(result.hash, 'hash exists')
         assert.ok(result.salt, 'salt exists')
-        assert.equal(result.hash.length, 32)
-        assert.equal(result.salt.length, 32)
+        assert.lengthOf(result.hash, 32)
+        assert.lengthOf(result.salt, 32)
       })
   })
 
@@ -32,18 +32,18 @@ describe('utils', () => {
     it('should fail for different input', () => {
       return dbUtils.compareHashScrypt(inputA, resultB.hash, resultB.salt)
         .then((result) => {
-          assert.equal(result, false, 'strings do not match')
+          assert.isFalse(result)
           return dbUtils.compareHashScrypt(inputB, resultA.hash, resultA.salt)
         })
         .then((result) => {
-          assert.equal(result, false, 'strings do not match')
+          assert.isFalse(result)
         })
     })
 
     it('should succeed for same input', () => {
       return dbUtils.compareHashScrypt(inputA, resultA.hash, resultA.salt)
         .then((result) => {
-          assert.equal(result, true, 'strings do match')
+          assert.isTrue(result)
         })
     })
   })
@@ -57,19 +57,19 @@ describe('utils', () => {
     })
 
     it('should generate correct count of codes', () => {
-      assert.equal(codes.length, codeCount, 'correct number of codees generated')
+      assert.lengthOf(codes, codeCount)
     })
 
     it('should generate correct length of code', () => {
       codes.forEach((code) => {
-        assert.equal(code.length, codeLength, 'code is correct length')
+        assert.lengthOf(code, codeLength)
       })
     })
 
     it('should generate code in keyspace', () => {
       const reg = /[a-z0-9]/
       codes.forEach((code) => {
-        assert.equal(reg.test(code), true, 'code is in correct keyspace')
+        assert.match(code, reg)
       })
     })
   })


### PR DESCRIPTION
Fixes #1104.

This annoyed me enough to fix right away, because I'm writing tests for another PR that would benefit from chai. And consistency between packages is something we've discussed previously too.

In addition to updating the dependency, I also did a non-exhaustive search-and-replace for some of the common patterns to replace them with new assertion styles. In a few places, the conversion to `isTrue` or `isFalse` wasn't clean because the db returns `1` or `0` on those columns, so I coerced them with `!!`. And in a couple of places I couldn't use `isNull` because of a discrepancy between the returned values from the MySQL and memory backends, so I used `notOk` instead.

@mozilla/fxa-devs r?