### PR TITLE
feat(subscriptions): support deferred cancellation of subscriptions

### DIFF
--- a/packages/fxa-auth-db-mysql/db-server/index.js
+++ b/packages/fxa-auth-db-mysql/db-server/index.js
@@ -269,6 +269,13 @@ function createServer(db) {
       req.params.subscriptionId
     ))
   )
+  api.post('/account/:uid/subscriptions/:subscriptionId/cancel',
+    op(req => db.cancelAccountSubscription(
+      req.params.uid,
+      req.params.subscriptionId,
+      req.body.cancelledAt
+    ))
+  )
   api.get('/account/:id/subscriptions', withIdAndBody(db.fetchAccountSubscriptions))
 
   api.get(

--- a/packages/fxa-auth-db-mysql/docs/API.md
+++ b/packages/fxa-auth-db-mysql/docs/API.md
@@ -110,7 +110,8 @@ The following datatypes are used throughout this document:
     * createAccountSubscription : `PUT /account/:id/subscriptions/:subscriptionId`
     * fetchAccountSubscriptions : `GET /account/:id/subscriptions`
     * getAccountSubscription    : `GET /account/:id/subscriptions/:subscriptionId`
-    * deleteAccountSubscriptions : `DELETE /account/:id/subscriptions/:subscriptionId`
+    * deleteAccountSubscription : `DELETE /account/:id/subscriptions/:subscriptionId`
+    * cancelAccountSubscription : `POST /account/:id/subscriptions/:subscriptionId/cancel`
 
 ## Ping : `GET /`
 
@@ -1992,6 +1993,9 @@ curl \
 * Method : `POST`
 * Path : `/totp/<uid>/update`
     * `uid` : hex
+* Params:
+    * verified : boolean
+    * enable : boolean
 
 ### Response
 
@@ -2024,7 +2028,7 @@ curl \
     -H "Content-Type: application/json" \
     -d '{
         "count" : 8
-    }'
+    }' \
     http://localhost:8000/account/1234567890ab/recoveryCodes
 ```
 
@@ -2033,7 +2037,8 @@ curl \
 * Method : `POST`
 * Path : `/account/<uid>/recoveryCodes`
     * `uid` : hex
-*
+* Params:
+    * count : int
 
 ### Response
 
@@ -2404,7 +2409,7 @@ Content-Length: 2
     * Content-Type : `application/json`
     * Body : `{"code":"InternalError","message":"..."}`
 
-## deleteAccountSubscriptions : `DELETE /account/:id/subscriptions/:subscriptionId`
+## deleteAccountSubscription : `DELETE /account/:id/subscriptions/:subscriptionId`
 
 ### Example
 
@@ -2419,7 +2424,7 @@ curl \
 ### Request
 
 * Method : `DELETE`
-* Path : `/account/<uid>/subscriptions`
+* Path : `/account/<uid>/subscriptions/<subscriptionId>`
     * `uid` : hex
 
 ### Response
@@ -2440,3 +2445,42 @@ Content-Length: 2
     * Content-Type : `application/json`
     * Body : `{"code":"InternalError","message":"..."}`
 
+## cancelAccountSubscription : `POST /account/:id/subscriptions/:subscriptionId/cancel`
+
+### Example
+
+```
+curl \
+    -v \
+    -X DELETE \
+    -H "Content-Type: application/json" \
+    -d '{"cancelledAt":1557844225547}' \
+    http://localhost:8000/account/6044486dd15b42e08b1fb9167415b9ac/subscriptions/sub8675309/cancel
+```
+
+### Request
+
+* Method : `POST`
+* Path : `/account/<uid>/subscriptions/<subscriptionId>`
+    * `uid` : hex
+    * `subscriptionId` : string255
+* Params:
+    * `cancelledAt`: uint64
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+{}
+```
+
+* Status Code : `200 OK`
+    * Content-Type : `application/json`
+    * Body : `{}`
+* Status Code : `500 Internal Server Error`
+    * Conditions: if something goes wrong on the server
+    * Content-Type : `application/json`
+    * Body : `{"code":"InternalError","message":"..."}`

--- a/packages/fxa-auth-db-mysql/docs/DB_API.md
+++ b/packages/fxa-auth-db-mysql/docs/DB_API.md
@@ -80,6 +80,7 @@ There are a number of methods that a DB storage backend should implement:
     * .fetchAccountSubscriptions(uid)
     * .getAccountSubscription(uid, subscriptionId)
     * .deleteAccountSubscription(uid, subscriptionId)
+    * .cancelAccountSubscription(uid, subscriptionId, cancelledAt)
 * General
     * .ping()
     * .close()
@@ -1100,6 +1101,28 @@ Parameters:
   The uid of the owning account
 * `subscriptionId` (String):
   The subscription ID from the upstream payment system
+
+Returns:
+
+* Resolves with:
+  * Empty object `{}`
+* Rejects with:
+  * Any error from the underlying storage system (wrapped in `error.wrap()`)
+
+## .cancelAccountSubscription(uid, subscriptionId, cancelledAt)
+
+Cancel a product subscription for this user.
+A cancelled subscription is still active,
+but will be deleted later when it expires.
+
+Parameters:
+
+* `uid` (Buffer16):
+  The uid of the owning account
+* `subscriptionId` (String):
+  The subscription ID from the upstream payment system
+* `cancelledAt` (number):
+  Cancellation timestamp, epoch-milliseconds
 
 Returns:
 

--- a/packages/fxa-auth-db-mysql/lib/db/mem.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mem.js
@@ -1517,7 +1517,8 @@ module.exports = function (log, error) {
       uid,
       subscriptionId,
       productName,
-      createdAt
+      createdAt,
+      cancelledAt: null
     }
     return {}
   }
@@ -1556,6 +1557,29 @@ module.exports = function (log, error) {
       .filter(([key, s]) => s.uid === uid && s.subscriptionId === subscriptionId)
       .map(([key, s]) => key)
     toDelete.forEach(key => delete accountSubscriptions[key])
+    return {}
+  }
+
+  Memory.prototype.cancelAccountSubscription = async function (uid, subscriptionId, cancelledAt) {
+    uid = uid.toString('hex')
+
+    // Ensure user account exists
+    await getAccountByUid(uid)
+
+    const cancelled = Object.values(accountSubscriptions)
+      .some(subscription => {
+        if (subscription.uid === uid && subscription.subscriptionId === subscriptionId && ! subscription.cancelledAt) {
+          subscription.cancelledAt = cancelledAt
+          return true
+        }
+
+        return false
+      })
+
+    if (! cancelled) {
+      throw error.notFound()
+    }
+
     return {}
   }
 

--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -1635,7 +1635,7 @@ module.exports = function (log, error) {
     return this.readFirstResult(GET_ACCOUNT_SUBSCRIPTION, [ uid, subscriptionId ])
   }
 
-  const FETCH_ACCOUNT_SUBSCRIPTIONS = 'CALL fetchAccountSubscriptions_1(?)'
+  const FETCH_ACCOUNT_SUBSCRIPTIONS = 'CALL fetchAccountSubscriptions_2(?)'
   MySql.prototype.fetchAccountSubscriptions = function (uid) {
     return this.readAllResults(FETCH_ACCOUNT_SUBSCRIPTIONS, [ uid ])
   }
@@ -1644,6 +1644,18 @@ module.exports = function (log, error) {
   MySql.prototype.deleteAccountSubscription = function (uid, subscriptionId) {
     return this.write(DELETE_ACCOUNT_SUBSCRIPTION, [ uid, subscriptionId ])
       .then(result => ({}))
+  }
+
+  const CANCEL_ACCOUNT_SUBSCRIPTION = 'CALL cancelAccountSubscription_1(?,?,?)'
+  MySql.prototype.cancelAccountSubscription = async function (uid, subscriptionId, cancelledAt) {
+    const result = await this.read(CANCEL_ACCOUNT_SUBSCRIPTION, [ uid, subscriptionId, cancelledAt ])
+
+    if (result.affectedRows === 0) {
+      log.error('MySql.cancelAccountSubscription.notUpdated', { result })
+      throw error.notFound()
+    }
+
+    return {}
   }
 
   return MySql

--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -4,4 +4,4 @@
 
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
-module.exports.level = 98
+module.exports.level = 99

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-098-099.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-098-099.sql
@@ -1,0 +1,42 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('98');
+
+-- Add a `cancelledAt` column to `accountSubscriptions` and a
+-- `cancelAccountSubscription_1` stored procedure for setting it.
+
+ALTER TABLE `accountSubscriptions`
+ADD COLUMN `cancelledAt` BIGINT UNSIGNED DEFAULT NULL,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+CREATE PROCEDURE `cancelAccountSubscription_1` (
+  IN uidArg BINARY(16),
+  IN subscriptionIdArg VARCHAR(191),
+  IN cancelledAtArg BIGINT UNSIGNED
+)
+BEGIN
+  UPDATE accountSubscriptions
+    SET cancelledAt = cancelledAtArg
+  WHERE uid = uidArg
+    AND subscriptionId = subscriptionIdArg
+    AND cancelledAt IS NULL;
+END;
+
+CREATE PROCEDURE `fetchAccountSubscriptions_2` (
+  IN uidArg BINARY(16)
+)
+BEGIN
+  SELECT
+    asi.uid,
+    asi.subscriptionId,
+    asi.productName,
+    asi.createdAt,
+    asi.cancelledAt
+  FROM accountSubscriptions asi
+  WHERE
+    asi.uid = uidArg
+  ORDER BY
+    asi.createdAt asc;
+END;
+
+UPDATE dbMetadata SET value = '99' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-099-098.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-099-098.sql
@@ -1,0 +1,10 @@
+--SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+--DROP PROCEDURE `fetchAccountSubscriptions_2`;
+--DROP PROCEDURE `cancelAccountSubscription_1`;
+
+--ALTER TABLE `accountSubscriptions`
+--DROP COLUMN `cancelledAt`,
+--ALGORITHM = INPLACE, LOCK = NONE;
+
+--UPDATE dbMetadata SET value = '98' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -1393,6 +1393,15 @@ module.exports = (
     return this.pool.del(SAFE_URLS.deleteAccountSubscription, { uid, subscriptionId });
   };
 
+  SAFE_URLS.cancelAccountSubscription = new SafeUrl(
+    '/account/:uid/subscriptions/:subscriptionId/cancel',
+    'db.cancelAccountSubscription'
+  );
+  DB.prototype.cancelAccountSubscription = function (uid, subscriptionId, cancelledAt) {
+    log.trace('DB.deleteAccountSubscription', { uid, subscriptionId, cancelledAt });
+    return this.pool.del(SAFE_URLS.deleteAccountSubscription, { uid, subscriptionId }, { cancelledAt });
+  };
+
   SAFE_URLS.fetchAccountSubscriptions = new SafeUrl(
     '/account/:uid/subscriptions',
     'db.fetchAccountSubscriptions'

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -90,6 +90,7 @@ const ERRNO = {
   UNKNOWN_SUBSCRIPTION: 177,
   UNKNOWN_SUBSCRIPTION_PLAN: 178,
   REJECTED_SUBSCRIPTION_PAYMENT_TOKEN: 179,
+  SUBSCRIPTION_ALREADY_CANCELLED: 180,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -1079,6 +1080,15 @@ AppError.rejectedSubscriptionPaymentToken = (token) => {
     message: 'Rejected subscription payment token'
   }, {
     token
+  });
+};
+
+AppError.subscriptionAlreadyCancelled = (token) => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.SUBSCRIPTION_ALREADY_CANCELLED,
+    message: 'Subscription has already been cancelled'
   });
 };
 

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -216,7 +216,14 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
         }
 
         await subhub.cancelSubscription(uid, subscriptionId);
-        await db.deleteAccountSubscription(uid, subscriptionId);
+
+        try {
+          await db.cancelAccountSubscription(uid, subscriptionId, Date.now());
+        } catch (err) {
+          if (err.statusCode === 404 && err.errno === 116) {
+            throw error.subscriptionAlreadyCancelled();
+          }
+        }
 
         const devices = await request.app.devices;
         await push.notifyProfileUpdated(uid, devices);

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -87,6 +87,7 @@ const DB_METHOD_NAMES = [
   'createAccountSubscription',
   'getAccountSubscription',
   'deleteAccountSubscription',
+  'cancelAccountSubscription',
   'fetchAccountSubscriptions'
 ];
 


### PR DESCRIPTION
Related to #981.

Changes the behaviour of `DELETE /oauth/subscriptions/active/:subscriptionId` so that it marks a subscription as cancelled rather than deletes it from the db. If the subscription can't be found or has already been cancelled, the db method will fail.

Doesn't include any remote tests because #1110.

I think this ticks off the first two checkboxes in the description for #981, but it doesn't make any attempt to tackle the second two.

@lmorchard r?