### PR TITLE
feat(payments): Fix #713, update subscriptions from SubHub SQS events

### DIFF
--- a/packages/fxa-auth-server/bin/subhub_messaging.js
+++ b/packages/fxa-auth-server/bin/subhub_messaging.js
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+'use strict';
+
+// This MUST be the first require in the program.
+// Only `require()` the newrelic module if explicity enabled.
+// If required, modules will be instrumented.
+require('../lib/newrelic')();
+
+const config = require('../config').getProperties();
+const log = require('../lib/log')(config.log.level, 'subhub-messaging');
+const Token = require('../lib/tokens')(log, config);
+const SQSReceiver = require('../lib/sqs')(log);
+// FIXME: import a different module:
+const subhubUpdates = require('../lib/subhub/updates')(log);
+
+const DB = require('../lib/db')(
+  config,
+  log,
+  Token
+);
+
+const subhubUpdatesQueue = new SQSReceiver(config.subhubServerMessaging.region, [
+  config.subhubServerMessaging.subhubUpdatesQueueUrl
+]);
+
+DB.connect(config[config.db.backend])
+  .then(
+    (db) => {
+      subhubUpdates(subhubUpdatesQueue, db);
+    }
+  );

--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -431,6 +431,20 @@ const conf = convict({
       doc: 'Initial backoff for Redis connection retries, increases exponentially with each attempt'
     }
   },
+  subhubServerMessaging: {
+    region: {
+      doc: 'The region where the queues live',
+      format: String,
+      env: 'SUBHUB_REGION',
+      default: ''
+    },
+    profileUpdatesQueueUrl: {
+      doc: 'The queue URL to use (should include https://sqs.<region>.amazonaws.com/<account-id>/<queue-name>)',
+      format: String,
+      env: 'SUBHUB_QUEUE_URL',
+      default: ''
+    }
+  },
   tokenLifetimes: {
     accountResetToken: {
       format: 'duration',

--- a/packages/fxa-auth-server/lib/subhub/updates.js
+++ b/packages/fxa-auth-server/lib/subhub/updates.js
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+*/
+
+'use strict';
+
+const Joi = require('joi');
+
+const MESSAGE_SCHEMA = Joi.object().keys({
+  uid: Joi.string().required(),
+  active: Joi.boolean().required(),
+  subscriptionId: Joi.string().required(),
+  productName: Joi.string(),
+  eventId: Joi.string(),
+  eventCreatedAt: Joi.number().integer(),
+  messageCreatedAt: Joi.number().integer().required(),
+  del: Joi.any(), // a method (function) that's added to messages
+});
+
+function validateMessage(message) {
+  return Joi.validate(message, MESSAGE_SCHEMA);
+}
+
+module.exports = function (log) {
+
+  return function start(messageQueue, db) {
+
+    async function handleSubHubUpdates(message) {
+      const uid = message && message.uid;
+
+      log.info('handleSubHubUpdated', { uid, action: 'notify' });
+
+      const result = validateMessage(message);
+      if (result.error) {
+        log.error('handleSubHubUpdates', { uid, action: 'validate', validationError: result.error });
+        message.del();
+        return;
+      }
+
+      try {
+        if (message.active) {
+          await db.createAccountSubscription(uid, message.subscriptionId, message.productName, message.eventCreatedAt);
+        } else {
+          const existing = await db.getAccountSubscription(uid, message.subscriptionId);
+          if (existing && existing.createdAt >= message.eventCreatedAt) {
+            log.warn('handleSubHubUpdate', {
+              uid,
+              action: 'ignoreDelete',
+              eventCreatedAt: message.eventCreatedAt,
+              subscriptionCreatedAt: existing.createdAt,
+            });
+          } else {
+            await db.deleteAccountSubscription(uid, message.subscriptionId);
+            log.info('handleSubHubUpdated', { uid, action: 'delete' });
+          }
+        }
+        message.del();
+      } catch (err) {
+        log.error('handleSubHubUpdated', { uid, action: 'error', err, stack: err && err.stack });
+        throw err;
+      }
+    }
+
+    messageQueue.on('data', handleSubHubUpdates);
+    messageQueue.start();
+
+    return {
+      messageQueue,
+      handleSubHubUpdates,
+    };
+  };
+};

--- a/packages/fxa-auth-server/test/local/subhub/updates.js
+++ b/packages/fxa-auth-server/test/local/subhub/updates.js
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const sinon = require('sinon');
+const assert = { ...sinon.assert, ...require('chai').assert };
+
+const EventEmitter = require('events').EventEmitter;
+const { mockDB, mockLog } = require('../../mocks');
+const subhubUpdates = require('../../../lib/subhub/updates');
+
+const mockDeliveryQueue = new EventEmitter();
+mockDeliveryQueue.start = function start() { };
+
+const baseMessage = {
+  uid: '1e2122ba',
+  subscriptionId: '1234',
+  productName: 'fx_pro',
+  eventId: 'st_ev_1234',
+  eventCreatedAt: 1557265730749,
+  messageCreatedAt: 1557265730949
+};
+
+
+function mockMessage(messageOverrides) {
+  const message = Object.assign({}, baseMessage, messageOverrides);
+  message.del = sinon.spy();
+  return message;
+}
+
+function mockSubHubUpdates(log, db) {
+  return subhubUpdates(log)(mockDeliveryQueue, db);
+}
+
+describe('subhub updates', () => {
+  let db;
+  let log;
+
+  beforeEach(() => {
+    db = mockDB();
+    log = mockLog();
+  });
+
+  it(
+    'should log validation errors',
+    async () => {
+      await mockSubHubUpdates(log, db).handleSubHubUpdates(mockMessage({subscriptionId: null, active: true}));
+      assert.equal(log.error.callCount, 1);
+    }
+  );
+
+  it(
+    'should activate an account',
+    async () => {
+      await mockSubHubUpdates(log, db).handleSubHubUpdates(mockMessage({active: true}));
+      // FIXME: figure out what side effect we expect
+      assert.equal(log.error.callCount, 0, `Got error: ${log.error.lastCall ? JSON.stringify(log.error.lastCall.args) : ''}`);
+      assert.calledWithExactly(
+        db.createAccountSubscription,
+        baseMessage.uid, baseMessage.subscriptionId, baseMessage.productName, baseMessage.eventCreatedAt);
+    }
+  );
+
+  it(
+    'should de-activate an account',
+    async () => {
+      await mockSubHubUpdates(log, db).handleSubHubUpdates(mockMessage({active: false}));
+      // FIXME: figure out what side effect we expect
+      assert.calledWithExactly(db.deleteAccountSubscription, baseMessage.uid, baseMessage.subscriptionId);
+      assert.equal(log.error.callCount, 0);
+    }
+  );
+
+  it(
+    'should ignore an UNSUBSCRIBE message that is out of order',
+    async () => {
+      const message = mockMessage({eventCreatedAt: baseMessage.eventCreatedAt, active: false});
+      db.getAccountSubscription = sinon.spy(
+        async (uid, subscriptionId) => {
+          return {
+            uid,
+            subscriptionId,
+            productName: message.productName,
+            // It's a subscription FROM THE FUTURE!
+            createdAt: message.eventCreatedAt + 1000,
+          };
+        }
+      );
+      await mockSubHubUpdates(log, db).handleSubHubUpdates(message);
+      assert.equal(db.getAccountSubscription.callCount, 1, 'db.getAccountSubscription() should be called');
+      assert.equal(db.deleteAccountSubscription.callCount, 0, 'db.deleteAccountSubscription() should not be called');
+    }
+  );
+
+  // FIXME: because we don't keep timestamps of unsubscribes, we can't implement this:
+  it.skip(
+    'should ignore a SUBSCRIBE message that is out of order',
+    async () => {
+      const message = mockMessage({eventCreatedAt: baseMessage.eventCreatedAt, active: true});
+      db.getAccountSubscription = sinon.spy(
+        async (uid, subscriptionId) => {
+          return {
+            uid,
+            subscriptionId,
+            productName: message.productName,
+            // It's a subscription FROM THE FUTURE!
+            createdAt: message.eventCreatedAt + 1000,
+          };
+        }
+      );
+      await mockSubHubUpdates(log, db).handleSubHubUpdates(message);
+      assert.equal(db.getAccountSubscription.callCount, 1, 'db.getAccountSubscription() should be called');
+      assert.equal(db.createAccountSubscription.callCount, 0, 'db.createAccountSubscription() should not be called');
+    }
+  );
+
+});


### PR DESCRIPTION
This adds a new SQS listening script to bin/subhub_messaging.js

I didn't see any tests elsewhere for the actual SQS setup, so `bin/subhub_messaging.js` is built on hope and copying `bin/profile_server_messaging.js`