### PR TITLE
feat(api): report authenticationMethods and authenticatorAssuranceLevel for sessionTokens in account/status

### DIFF
--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -789,6 +789,13 @@ Gets the status of an account.
   
   <!--end-query-param-get-accountstatus-uid-->
 
+##### Response Body
+
+* `authenticationMethods`: *isA.array().items(isA.string().required()).optional()*
+* `authenticatorAssuranceLevel`: *isA.number().min(0).optional()*
+* `exists`: *isA.boolean().required()*
+* `locale`: *isA.string().optional()*
+
 ##### Error responses
 
 Failing requests may be caused

--- a/packages/fxa-auth-server/test/remote/account_status_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_status_tests.js
@@ -48,11 +48,33 @@ describe('remote account status', function() {
         )
         .then(
           (response) => {
+            assert.deepEqual(response.authenticationMethods, ['pwd', 'email']);
+            assert.equal(response.authenticatorAssuranceLevel, '1');
             assert.equal(response.locale, 'en-US', 'locale is stored');
           }
         );
     }
   );
+
+  it(
+    'account status includes locale when authenticated',
+    () => {
+      return Client.createAndVerifyAndTOTP(config.publicUrl, server.uniqueEmail(), 'password', server.mailbox, { lang: 'en-US' })
+        .then(
+          (c) => {
+            return c.api.accountStatus(c.uid, c.sessionToken);
+          }
+        )
+        .then(
+          (response) => {
+            assert.deepEqual(response.authenticationMethods, ['pwd', 'email', 'otp']);
+            assert.equal(response.authenticatorAssuranceLevel, '2');
+            assert.equal(response.locale, 'en-US', 'locale is stored');
+          }
+        );
+    }
+  );
+
 
   it(
     'account status does not include locale when unauthenticated',
@@ -65,6 +87,8 @@ describe('remote account status', function() {
         )
         .then(
           (response) => {
+            assert.ok(! response.authenticationMethods);
+            assert.ok(! response.authenticatorAssuranceLevel);
             assert.ok(! response.locale, 'locale is not present');
           }
         );


### PR DESCRIPTION
We need this for pairing to be able to present a 2FA form. This could also simplify things in the future!