### PR TITLE
feat(js-client): add /account/profile support

### DIFF
--- a/packages/fxa-js-client/client/FxAccountClient.js
+++ b/packages/fxa-js-client/client/FxAccountClient.js
@@ -837,6 +837,27 @@ define([
   };
 
   /**
+   * Gets the account profile
+   *
+   * @method accountProfile
+   * @param {String} sessionToken User session token
+   * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
+   */
+  FxAccountClient.prototype.accountProfile = function(sessionToken) {
+    var self = this;
+
+    return Promise.resolve()
+      .then(function () {
+        required(sessionToken, 'sessionToken');
+
+        return hawkCredentials(sessionToken, 'sessionToken',  HKDF_SIZE);
+      })
+      .then(function(creds) {
+        return self.request.send('/account/profile', 'GET', creds);
+      });
+  };
+
+  /**
    * Destroys this session, by invalidating the sessionToken.
    *
    * @method sessionDestroy

--- a/packages/fxa-js-client/tests/lib/account.js
+++ b/packages/fxa-js-client/tests/lib/account.js
@@ -351,6 +351,21 @@ define([
           );
       });
 
+      test('#accountProfile', function () {
+
+        return accountHelper.newVerifiedAccount()
+          .then(function (account) {
+
+            return respond(client.accountProfile(account.signIn.sessionToken), RequestMocks.accountProfile);
+          })
+          .then(
+            function(res) {
+              assert.isNotNull(res);
+            },
+            assert.notOk
+          );
+      });
+
       test('#accountStatus with wrong uid', function () {
 
         return respond(client.accountStatus('00047f01e387498e8ccc7fede1a74000'), RequestMocks.accountStatusFalse)

--- a/packages/fxa-js-client/tests/lib/session.js
+++ b/packages/fxa-js-client/tests/lib/session.js
@@ -67,6 +67,7 @@ define([
           );
       });
 
+
       test('#status error with a false token', function () {
 
         return accountHelper.newVerifiedAccount()

--- a/packages/fxa-js-client/tests/mocks/request.js
+++ b/packages/fxa-js-client/tests/mocks/request.js
@@ -177,6 +177,10 @@ define([
       status: 200,
       body: '{"uid": "5d576e2cd3604981a8c05f6ea67fce5b", "sessionToken": "9c1fe2a0643ce23aa1b44afbe30e28d33e5726558cab215314980fc85875684f","keyFetchToken": "b1f4182d7e072567a1dbe682043a16932a84b7f4ca3b95e471a34806c87e4130","verified": true}'
     },
+    accountProfile: {
+      status: 200,
+      body: '{"email": "a@a.com", "locale": "en", "authenticationMethods": ["pwd", "email"], "authenticatorAssuranceLevel": 2, "profileChangedAt": 1539002077704}'
+    },
     sessionDestroy: {
       status: 200,
       body: '{}'


### PR DESCRIPTION
Route is here: https://github.com/mozilla/fxa/blob/0ff422dfb48308307f712e4a5c74b4b9452a2a20/packages/fxa-auth-server/lib/routes/account.js#L814

We need it to get the `authenticationMethods` and `authenticatorAssuranceLevel` values