### PR TITLE
refactor(views): Extract a modal-child-view-mixin

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/scripts/views/connect_another_device.js
@@ -13,6 +13,7 @@ import ConnectAnotherDeviceMixin from './mixins/connect-another-device-mixin';
 import ExperimentMixin from './mixins/experiment-mixin';
 import FlowEventsMixin from './mixins/flow-events-mixin';
 import FormView from './form';
+import HasModalChildViewMixin from './mixins/has-modal-child-view-mixin';
 import PairingGraphicsMixin from './mixins/pairing-graphics-mixin';
 import {
   MARKETING_ID_AUTUMN_2016,
@@ -27,23 +28,7 @@ import UserAgentMixin from '../lib/user-agent-mixin';
 import VerificationReasonMixin from './mixins/verification-reason-mixin';
 
 class ConnectAnotherDeviceView extends FormView {
-  initialize (options = {}) {
-    this._createView = options.createView;
-    this.template = Template;
-
-    return super.initialize(options);
-  }
-
-  showChildView (ChildView, options = {}) {
-    // an extra element is needed to attach the child view to, the extra element
-    // is removed from the DOM when the view is destroyed. Without it, .child-view
-    // is removed from the DOM and a 2nd child view cannot be displayed.
-    this.$('.child-view').append('<div>');
-    options.el = this.$('.child-view > div');
-    const childView = this._createView(ChildView, options);
-    return childView.render()
-      .then(() => this.trackChildView(childView));
-  }
+  template = Template;
 
   beforeRender () {
     const account = this.getAccount();
@@ -259,6 +244,7 @@ Cocktail.mixin(
   ConnectAnotherDeviceMixin,
   ExperimentMixin,
   FlowEventsMixin,
+  HasModalChildViewMixin,
   PairingGraphicsMixin,
   MarketingMixin({
     // The marketing area is manually created to which badges are displayed.

--- a/packages/fxa-content-server/app/scripts/views/mixins/has-modal-child-view-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/has-modal-child-view-mixin.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Mix into views that have a modal child view. Overrides showChildView
+ * to show the child view in a modal.
+ */
+export default {
+  initialize (options = {}) {
+    this._createView = options.createView;
+  },
+
+  showChildView (ChildView, options = {}) {
+    // an extra element is needed to attach the child view to, the extra element
+    // is removed from the DOM when the view is destroyed. Without it, .child-view
+    // is removed from the DOM and a 2nd child view cannot be displayed.
+    this.$('.child-view').append('<div>');
+    options.el = this.$('.child-view > div');
+    const childView = this._createView(ChildView, options);
+    return childView.render()
+      .then(() => this.trackChildView(childView));
+  }
+}
+;

--- a/packages/fxa-content-server/app/scripts/views/sms_send.js
+++ b/packages/fxa-content-server/app/scripts/views/sms_send.js
@@ -14,6 +14,7 @@ import SmsMessageIds from '../lib/sms-message-ids';
 import FlowEventsMixin from './mixins/flow-events-mixin';
 import FormPrefillMixin from './mixins/form-prefill-mixin';
 import FormView from './form';
+import HasModalChildViewMixin from './mixins/has-modal-child-view-mixin';
 import PairingGraphicsMixin from './mixins/pairing-graphics-mixin';
 import { MARKETING_ID_AUTUMN_2016, SYNC_SERVICE } from '../lib/constants';
 import MarketingMixin from './mixins/marketing-mixin';
@@ -27,14 +28,8 @@ const { FIREFOX_MOBILE_INSTALL } = SmsMessageIds;
 const SELECTOR_PHONE_NUMBER = 'input[type=tel]';
 
 class SmsSendView extends FormView {
-  initialize (options) {
-    super.initialize(options);
-
-    this.mustAuth = true;
-    this.template = Template;
-
-    this._createView = options.createView;
-  }
+  mustAuth = true;
+  template = Template;
 
   getAccount () {
     // TODO - remove the `|| ...` when done with development
@@ -73,19 +68,6 @@ class SmsSendView extends FormView {
       phoneNumber,
       showSuccessMessage: this.model.get('showSuccessMessage')
     });
-  }
-
-  showChildView (ChildView, options = {}) {
-    // TODO remove the duplication between here and connect_another_device
-
-    // an extra element is needed to attach the child view to, the extra element
-    // is removed from the DOM when the view is destroyed. Without it, .child-view
-    // is removed from the DOM and a 2nd child view cannot be displayed.
-    this.$('.child-view').append('<div>');
-    options.el = this.$('.child-view > div');
-    const childView = this._createView(ChildView, options);
-    return childView.render()
-      .then(() => this.trackChildView(childView));
   }
 
   submit () {
@@ -188,6 +170,7 @@ Cocktail.mixin(
   SmsSendView,
   FlowEventsMixin,
   FormPrefillMixin,
+  HasModalChildViewMixin,
   PairingGraphicsMixin,
   MarketingMixin({
     marketingId: MARKETING_ID_AUTUMN_2016,

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/has-modal-child-view-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/has-modal-child-view-mixin.js
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import HasModalChildViewMixin from 'views/mixins/has-modal-child-view-mixin';
+import { assert } from 'chai';
+import BaseView from 'views/base';
+import Cocktail from 'cocktail';
+import sinon from 'sinon';
+
+const HasModalChildView = BaseView.extend({
+  template: () => '<div><div class="child-view"></div></div>'
+});
+Cocktail.mixin(
+  HasModalChildView,
+  HasModalChildViewMixin
+);
+
+describe('views/mixins/has-modal-child-view-mixin', () => {
+  let view;
+  let childView;
+  let createViewSpy;
+
+  beforeEach(() => {
+    childView = new BaseView();
+    sinon.stub(childView, 'render').callsFake(() => Promise.resolve());
+    createViewSpy = sinon.spy(() => childView);
+
+    view = new HasModalChildView({
+      createView: createViewSpy
+    });
+  });
+
+  it('showChildView renders and tracks the child view.', () => {
+    sinon.spy(view, 'trackChildView');
+
+    return view.showChildView(BaseView)
+      .then(() => {
+        assert.isTrue(createViewSpy.calledOnceWith(BaseView));
+        assert.isTrue(childView.render.calledOnce);
+        assert.isTrue(view.trackChildView.calledOnceWith(childView));
+      });
+  });
+});

--- a/packages/fxa-content-server/app/tests/test_start.js
+++ b/packages/fxa-content-server/app/tests/test_start.js
@@ -176,6 +176,7 @@ require('./spec/views/mixins/external-links-mixin');
 require('./spec/views/mixins/flow-begin-mixin');
 require('./spec/views/mixins/flow-events-mixin');
 require('./spec/views/mixins/form-prefill-mixin');
+require('./spec/views/mixins/has-modal-child-view-mixin');
 require('./spec/views/mixins/last-checked-time-mixin');
 require('./spec/views/mixins/loading-mixin');
 require('./spec/views/mixins/marketing-mixin');


### PR DESCRIPTION
Logic to manage modal child views in normal views was duplicated
in a couple of views. This creates a mixin to share the logic.

extraction from #1098

@mozilla/fxa-devs - r?