### PR TITLE
feat(oidc): Basic support for OIDC prompt=none

### DIFF
--- a/packages/123done/static/index.html
+++ b/packages/123done/static/index.html
@@ -23,26 +23,36 @@
         Choose my sign-in flow for me
       </button>
 
-      <a href="//127.0.0.1:3030/subscriptions/products/123doneProProduct" class="btn btn-persona btn-subscribe">Subscribe for Pro</a>
+      <a
+        href="//127.0.0.1:3030/subscriptions/products/123doneProProduct"
+        class="btn btn-persona btn-subscribe"
+        >Subscribe for Pro</a
+      >
 
       <button
         class="btn btn-large btn-info btn-persona signin-pkce"
         type="submit"
-        >
+      >
         Sign In with PKCE
       </button>
       <div class="pkce-data"></div>
       <button
         class="btn btn-large btn-info btn-persona email-first-button email-first"
         type="submit"
-        >
+      >
         Email first
       </button>
       <button
         class="btn btn-large btn-info btn-persona two-step-authentication"
         type="submit"
-        >
+      >
         Sign In (Require 2FA)
+      </button>
+      <button
+        class="btn btn-large btn-info btn-persona prompt-none"
+        type="submit"
+      >
+        Sign In (prompt=none)
       </button>
     </div>
 
@@ -111,17 +121,32 @@
     <div id="lists">
       <header id="header-main">
         <div class="container">
-          <h1><span class="logo"></span><span class="title">123done <span class="pro-status">Pro!</span></span></h1>
+          <h1>
+            <span class="logo"></span
+            ><span class="title"
+              >123done <span class="pro-status">Pro!</span></span
+            >
+          </h1>
           <button id="logout">logout</button>
           <div id="loggedin"><span></span></div>
           <div id="subscriptionCTA">
-            <a href="//127.0.0.1:3030/subscriptions/products/123doneProProduct" class="btn btn-persona btn-subscribe">Subscribe for Pro</a>
+            <a
+              href="//127.0.0.1:3030/subscriptions/products/123doneProProduct"
+              class="btn btn-persona btn-subscribe"
+              >Subscribe for Pro</a
+            >
           </div>
         </div>
       </header>
       <section class="todo">
         <div class="container">
           <div class="preroll">
+            <div id="subscriptionCTA">
+              <span
+                >Subscribe for pro! LINK TBD!
+                productId=123doneProProduct&amp;</span
+              >
+            </div>
             <ul id="signinhere" style="font-size: 15pt">
               <p>Sign in to get started making todo lists!</p>
             </ul>

--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -111,7 +111,10 @@ $(document).ready(function() {
     };
 
     function authenticate(endpoint) {
-      window.location.href = '/api/' + endpoint;
+      // propagate query parameters to the authorization request.
+      // This is used by the functional tests to, e.g., override
+      // the client_id or propagate an email.
+      window.location.href = `/api/${endpoint}${window.location.search}`;
     }
 
     $('button.signin').click(function(ev) {
@@ -136,6 +139,17 @@ $(document).ready(function() {
 
     $('button.two-step-authentication').click(function(ev) {
       authenticate('two_step_authentication');
+    });
+
+    $('button.prompt-none').click(function(ev) {
+      if (
+        !window.location.search.includes('login_hint=') &&
+        !navigator.userAgent.includes('FxATester')
+      ) {
+        alert('prompt=none requires a `login_hint` query parameter');
+        return;
+      }
+      authenticate('prompt_none');
     });
 
     // upon click of logout link navigator.id.logout()

--- a/packages/fxa-auth-server/fxa-oauth-server/docs/api.md
+++ b/packages/fxa-auth-server/fxa-oauth-server/docs/api.md
@@ -303,7 +303,7 @@ content-server page.
   - `signup` triggers the signup flow. (will become deprecated and replaced by `email`)
   - `force_auth` requires the user to sign in using the address specified in `email`.
 - `email`: Optional if `action` is `email`, `signup` or `signin`. Required if `action`
-  is `force_auth`.
+  is `force_auth` or `prompt=none`.
   - if `action` is `email`, the email address will be used to determine whether to display the signup or signin form, but the user is free to change it.
   - If `action` is `signup` or `signin`, the email address will be pre-filled into the account form, but the user is free to change it.
   - If `action` is `signin`, the literal string `blank` will force the user to enter an email address and the last signed in email address will be ignored.
@@ -311,6 +311,10 @@ content-server page.
     signed in email address will be used as the default.
   - If `action` is `force_auth`, the user is unable to modify the email
     address and is unable to sign up if the address is not registered.
+- `login_hint`: An alias to `email`
+- `prompt`: Specifies whether the Authorization Server prompts the End-User for reauthentication and consent.
+  - `consent`: The Authorization Server SHOULD prompt the End-User for consent before returning information to the Client.
+  - `none`: The Authorization Server MUST NOT display any authentication or consent user interface pages. See the [prompt=none doc][prompt-none] for more info.
 
 **Example:**
 
@@ -797,3 +801,4 @@ A valid 200 response will return an empty JSON object.
 [authorized-clients-destroy]: #post-v1authorized-clientsdestroy
 [client-tokens]: #get-v1client-tokens
 [client-tokens-delete]: #delete-v1client-tokensid
+[prompt-none]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/prompt-none.md

--- a/packages/fxa-auth-server/fxa-oauth-server/docs/prompt-none.md
+++ b/packages/fxa-auth-server/fxa-oauth-server/docs/prompt-none.md
@@ -1,0 +1,114 @@
+# prompt=none
+
+`prompt=none` is a flow described by the [OpenID Connect spec][#oidc-spec] as:
+
+> The Authorization Server MUST NOT display any authentication or consent user interface pages. An error is returned if an End-User is not already authenticated or the Client does not have pre-configured consent for the requested Claims or does not fulfill other conditions for processing the request. The error code will typically be login_required, interaction_required, or another code defined in Section 3.1.2.6. This can be used as a method to check for existing authentication and/or consent.
+
+`prompt=none` enables authorized RPs to check a user's authentication state and receive an OAuth grant or access token without requiring user interaction.
+
+## prompt=none usage is controlled
+
+Usage of `prompt=none` is controlled to an authorized list of RPs since
+it bypasses the normal authorization flow and use could easily fall afoul of user expectations.
+
+## Requesting `prompt=none` during authorization
+
+[`prompt=none` and `login_hint=<email>`][#authorization-api-doc] are appended onto the query parameters when opening the `/authorization` endpoint.
+
+```
+GET https://accounts.firefox.com/authorization?client_id=ea3ca969f8c6bb0d&state=2sfas415FSSF@A5f&scope=profile&prompt=none&login_hint=conscious.chooser%40mozilla.com
+```
+
+If a different user is currently signed in to the email specified by `login_hint`, an [`account_selection_required` error will be returned](#handling-errors).
+
+## Handling errors
+
+Most `prompt=none` failures cause the user to be redirected back to the RP's `redirectURI` with `state` and `error` query parameters.
+
+The following is a table of [OIDC compliant error codes][#oidc-error-codes] &rarr; reasons
+
+| error                          | reason                                    |
+| ------------------------------ | ----------------------------------------- |
+| `invalid_request`              | prompt=none is not enabled                |
+| &nbsp;                         | OR `login_hint` is missing                |
+| &nbsp;                         | OR scoped keys are requested              |
+| `unauthorized_client`          | prompt=none is not enabled for the client |
+| `* interaction_required`       | account or session is not verified        |
+| `* login_required`             | user is not signed in                     |
+| `* account_selection_required` | a different user is signed in             |
+
+`*` indicates the user must take some form of action to recover
+
+As an example, suppose the `authorization` request from the previous section failed because the user is not signed in and assume the `redirectURI` for client `ea3ca969f8c6bb0d` is `https://service.firefox.com/oauth/complete`. The user would
+be redirected to:
+
+```
+GET https://service.firefox.com/oauth/complete?state=2sfas415FSSF@A5f&error=login_required
+```
+
+### Recovering from errors
+
+At this point, the RP knows the user must authenticate to Firefox Accounts before OAuth codes or access tokens are returned. The RP can generate a new `state` and try again without the `prompt=none` query parameter:
+
+```
+GET https://accounts.firefox.com/authorization?client_id=ea3ca969f8c6bb0d&state=gASDF-3df@A5f&scope=profile&login_hint=conscious.chooser%40mozilla.com
+```
+
+**WARNING** When `prompt=none` is not specified, FxA handles `login_hint` as a suggestion, users are still able to authenticate/authorize using a different email. If the user specified in `login_hint` _MUST_ be used, specify [`action=force_auth`][#authorization-api-doc] when redirecting back to FxA.
+
+If a different user is allowed to sign in, it may be necessary to clear locally held session state before redirecting back to FxA.
+
+## Handling user logout
+
+Whenever the user terminates a session at the RP, any access and refresh tokens held by the RP for that session should be destroyed. Destroying the access and refresh tokens will ensure an entry for the session no longer appears in the [Devices and Apps][#fxa-devices-and-apps] list.
+
+### Destroying an access token
+
+```
+POST https://oauth.accounts.firefox.com/v1/destroy
+{
+  access_token: <access_token>
+}
+```
+
+### Destroying a refresh token
+
+```
+POST https://oauth.accounts.firefox.com/v1/destroy
+{
+  refresh_token: <refresh_token>
+}
+```
+
+More information on destroying tokens can be found on the [OAuth server's API docs][#oauth-server-api-destroy].
+
+### SSO logout
+
+[Several concerns are noted][#sso-logout], most importantly:
+
+> ...there's potentially confusing behaviour around logging out of an FxA relier. If I use FxA to sign in to AMO, and then I sign out in AMO, I could reasonably expect to have to enter my password again if I want to sign back in. But we don't have a way for AMO to signal back to FxA that the user signed out.
+
+This concern is not currently addressed as none of the [OIDC logout flows][#oidc-logout-flows] are currently supported.
+
+RPs can protect themselves a little bit here by not using `prompt=none` unless they still have a valid local login session for that user. If the users signs out of the RP, they will always see some UI when trying to sign back in, even if it's just the "Continue as X" button rather than a password prompt.
+
+## prompt=none and security
+
+For users that are already authenticated to Firefox Accounts, `prompt=none` bypasses the FxA authorization screen and redirects back to the RP without any user interaction. This behavior applies equally to users with 2FA enabled and could easily cause confusion with users. The Firefox Accounts team only enables the use of `prompt=none` for a service if both a good use case exists and the integration has been audited.
+
+## Future directions
+
+Once FxA [accepts the id_token_hint query parameter][#oidc-id-token-hint-github-issue], support for `prompt=none` may be expanded to allow any RP to check the user's FxA login state. Since RPs not on the [authorized list](#prompt=none-usage-is-controlled) can only obtain an [id_token][#oidc-id-token] by going through the normal authorization flow, it is safe to assume an RP presenting the `id_token` as part of a `prompt=none` flow has already been granted authorization.
+
+Support for [OIDC RP Initiated Logout][#oidc-rp-initiated-logout-github-issue] may go some way to reducing user confusion on what it means to sign out of an RP and whether they should have to enter their password again. Upon signing out of the RP, RPs that support the OIDC RP Initiated Logout protocol will redirect the user to FxA where they are given the option to destroy their FxA session as well.
+
+[#authorization-api-doc]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/api.md#get-v1authorization
+[#fxa-devices-and-apps]: https://accounts.firefox.com/settings/clients
+[#oauth-server-api-destroy]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/api.md#post-v1destroy
+[#oidc-error-codes]: https://openid.net/specs/openid-connect-core-1_0.html#AuthError
+[#oidc-id-token-hint-github-issue]: https://github.com/mozilla/fxa/issues/590#issuecomment-506153249
+[#oidc-id-token]: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
+[#oidc-logout-flows]: https://medium.com/@robert.broeckelmann/openid-connect-logout-eccc73df758f
+[#oidc-rp-initiated-logout-github-issue]: https://github.com/mozilla/fxa/issues/1979
+[#oidc-spec]: https://openid.net/specs/openid-connect-core-1_0.html
+[#sso-logout]: https://github.com/mozilla/fxa-content-server/issues/5916#issuecomment-369777880

--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -53,7 +53,6 @@ module.exports = {
   OAUTH_ACTION_SIGNIN: 'signin',
   OAUTH_ACTION_SIGNUP: 'signup',
 
-  OAUTH_PROMPT_CONSENT: 'consent',
   OAUTH_TRUSTED_PROFILE_SCOPE: 'profile',
   OAUTH_TRUSTED_PROFILE_SCOPE_EXPANSION: [
     'profile:uid',

--- a/packages/fxa-content-server/app/scripts/lib/error-utils.js
+++ b/packages/fxa-content-server/app/scripts/lib/error-utils.js
@@ -29,7 +29,20 @@ export default {
       OAuthErrors.is(error, 'INVALID_PARAMETER') ||
       OAuthErrors.is(error, 'INVALID_PAIRING_CLIENT') ||
       OAuthErrors.is(error, 'MISSING_PARAMETER') ||
-      OAuthErrors.is(error, 'UNKNOWN_CLIENT')
+      OAuthErrors.is(error, 'UNKNOWN_CLIENT') ||
+      // By default the prompt=none errors cause a redirect
+      // back to the RP with the response_error_code from
+      // the error entry. If the RP specifies `return_on_error=false`,
+      // the FxA 400 page will be displayed instead. This
+      // is used by the functional tests to ensure the
+      // expected error case is being invoked when
+      // checking whether prompt=none can be used.
+      OAuthErrors.is(error, 'PROMPT_NONE_NOT_ENABLED') ||
+      OAuthErrors.is(error, 'PROMPT_NONE_NOT_ENABLED_FOR_CLIENT') ||
+      OAuthErrors.is(error, 'PROMPT_NONE_WITH_KEYS') ||
+      OAuthErrors.is(error, 'PROMPT_NONE_NOT_SIGNED_IN') ||
+      OAuthErrors.is(error, 'PROMPT_NONE_DIFFERENT_USER_SIGNED_IN') ||
+      OAuthErrors.is(error, 'PROMPT_NONE_UNVERIFIED')
     ) {
       return FourHundredTemplate;
     }

--- a/packages/fxa-content-server/app/scripts/lib/errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/errors.js
@@ -121,7 +121,18 @@ export default {
     const message = this.toMessage(errno);
     const err = _.isString(message) ? new Error(message) : message;
 
-    if (typeof type === 'object') {
+    // copy over any fields from the error entry.
+    // errno, message, etc, are be overridden below.
+    const entry = this.find(errno);
+    // copy over any fields from the error entry,
+    // some fields may be overridden. This allows
+    // custom fields like response_error_code
+    // to be propagated out without any additional work.
+    if (_.isObject(entry)) {
+      _.extendOwn(err, entry);
+    }
+
+    if (_.isObject(type)) {
       // copy over any fields from the original object,
       // some fields may be overridden. This allows
       // AuthServer fields like `code` or `retryAfter`

--- a/packages/fxa-content-server/app/scripts/lib/oauth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/oauth-errors.js
@@ -141,10 +141,41 @@ var ERRORS = {
   MISSING_PARAMETER: {
     errno: 1005,
     message: t('Missing OAuth parameter: %(param)s'),
+    response_error_code: 'invalid_request',
   },
   INVALID_PAIRING_CLIENT: {
     errno: 1006,
     message: 'Invalid pairing client',
+  },
+  PROMPT_NONE_NOT_ENABLED: {
+    errno: 1007,
+    message: 'prompt=none is not enabled',
+    response_error_code: 'invalid_request',
+  },
+  PROMPT_NONE_NOT_ENABLED_FOR_CLIENT: {
+    errno: 1008,
+    message: 'prompt=none is not enabled for this client',
+    response_error_code: 'unauthorized_client',
+  },
+  PROMPT_NONE_WITH_KEYS: {
+    errno: 1009,
+    message: 'prompt=none cannot be used when requesting keys',
+    response_error_code: 'invalid_request',
+  },
+  PROMPT_NONE_NOT_SIGNED_IN: {
+    errno: 1010,
+    message: t('User is not signed in'),
+    response_error_code: 'login_required',
+  },
+  PROMPT_NONE_DIFFERENT_USER_SIGNED_IN: {
+    errno: 1011,
+    message: t('A different user is signed in'),
+    response_error_code: 'account_selection_required',
+  },
+  PROMPT_NONE_UNVERIFIED: {
+    errno: 1012,
+    message: t('Unverified user or session'),
+    response_error_code: 'interaction_required',
   },
 };
 /*eslint-enable sorting/sort-object-props*/

--- a/packages/fxa-content-server/app/scripts/lib/oauth-prompt.ts
+++ b/packages/fxa-content-server/app/scripts/lib/oauth-prompt.ts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * List of valid `prompt` query parameters
+ */
+
+enum OAuthPrompt {
+    CONSENT = 'consent',
+    NONE = 'none',
+}
+
+export default OAuthPrompt;

--- a/packages/fxa-content-server/app/scripts/lib/validate.js
+++ b/packages/fxa-content-server/app/scripts/lib/validate.js
@@ -7,6 +7,7 @@
 import _ from 'underscore';
 import Constants from './constants';
 import Newsletters from './newsletters';
+import OAuthPrompt from './oauth-prompt';
 
 const UNBLOCK_CODE_LENGTH = Constants.UNBLOCK_CODE_LENGTH;
 
@@ -149,7 +150,7 @@ var Validate = {
    * @returns {Boolean}
    */
   isPromptValid(prompt) {
-    var valid = [Constants.OAUTH_PROMPT_CONSENT];
+    const valid = [OAuthPrompt.CONSENT, OAuthPrompt.NONE];
 
     return _.contains(valid, prompt);
   },

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
@@ -88,16 +88,28 @@ export default BaseAuthenticationBroker.extend({
   DELAY_BROKER_RESPONSE_MS: 100,
 
   sendOAuthResultToRelier(result) {
-    var win = this.window;
-    return this._metrics.flush().then(function() {
+    return this._metrics.flush().then(() => {
       var extraParams = {};
       if (result.error) {
-        extraParams['error'] = result.error;
+        extraParams.error = result.error;
       }
       if (result.action) {
-        extraParams['action'] = result.action;
+        extraParams.action = result.action;
       }
-      win.location.href = Url.updateSearchString(result.redirect, extraParams);
+      // Always use the state the RP passed in.
+      // This is necessary to complete the prompt=none
+      // flow error cases where no interaction with
+      // the server occurs to get the state from
+      // the redirect_uri returned when creating
+      // the token or code.
+      const state = this.relier.get('state');
+      if (state) {
+        extraParams.state = state;
+      }
+      this.window.location.href = Url.updateSearchString(
+        result.redirect,
+        extraParams
+      );
     });
   },
 

--- a/packages/fxa-content-server/app/scripts/views/authorization.js
+++ b/packages/fxa-content-server/app/scripts/views/authorization.js
@@ -5,10 +5,23 @@
 /**
  * OAuth authorization view, redirects based on requested OAuth actions.
  */
+import AuthErrors from '../lib/auth-errors';
 import BaseView from './base';
+import Cocktail from 'cocktail';
+import OAuthErrors from '../lib/oauth-errors';
+import OAuthPrompt from '../lib/oauth-prompt';
+import SignInMixin from './mixins/signin-mixin';
 
 class AuthorizationView extends BaseView {
   beforeRender() {
+    if (this.relier.get('prompt') === OAuthPrompt.NONE) {
+      return (
+        this._doPromptNone()
+          // false prevents the view from rendering
+          .then(() => false)
+      );
+    }
+
     const action = this.relier.get('action');
     if (action) {
       const pathname = action === 'email' ? '/oauth/' : action;
@@ -19,6 +32,59 @@ class AuthorizationView extends BaseView {
       this.replaceCurrentPage('/oauth/');
     }
   }
+
+  _doPromptNone() {
+    const account = this.getSignedInAccount();
+
+    return (
+      this.relier
+        .validatePromptNoneRequest(account)
+        .then(() => this.signIn(account, null))
+        // Both validatePromptNoneRequest and signIn can
+        // reject, .catch handles both cases.
+        .catch(err => {
+          const normalizedErr = this._normalizePromptNoneError(err);
+          return this._handlePromptNoneError(normalizedErr);
+        })
+    );
+  }
+
+  _normalizePromptNoneError(err) {
+    if (AuthErrors.is(err, 'INVALID_TOKEN')) {
+      err = OAuthErrors.toError('PROMPT_NONE_NOT_SIGNED_IN');
+    }
+
+    return err;
+  }
+
+  _handlePromptNoneError(err) {
+    return Promise.resolve().then(() => {
+      if (this._shouldSendErrorToRP(err)) {
+        // Unless the RP overrides this behavior, errors with a `response_error_code`
+        // redirect back to the RP with `response_error_code` as the `error` parameter.
+        // The override is used by the functional tests to ensure the expected error
+        // case is being invoked when checking whether prompt=none can be used.
+        return this.broker.sendOAuthResultToRelier({
+          error: err.response_error_code,
+          redirect: this.relier.get('redirectUri'),
+        });
+      }
+
+      // All other errors are handled at a higher level. If
+      // the error should be displayed as a 400 to the user,
+      // add the error to the list in error-utils.js, otherwise
+      // the error will be displayed as a 500.
+      throw err;
+    });
+  }
+
+  _shouldSendErrorToRP(err) {
+    return (
+      err.response_error_code && this.relier.get('returnOnError') !== false
+    );
+  }
 }
+
+Cocktail.mixin(AuthorizationView, SignInMixin);
 
 export default AuthorizationView;

--- a/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
@@ -4,9 +4,10 @@
 
 import AuthErrors from '../../lib/auth-errors';
 import FormPrefillMixin from './form-prefill-mixin';
+import SigninMixin from './signin-mixin';
 
 export default {
-  dependsOn: [FormPrefillMixin],
+  dependsOn: [FormPrefillMixin, SigninMixin],
 
   /**
    * Get the prefill email.

--- a/packages/fxa-content-server/app/scripts/views/mixins/form-prefill-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/form-prefill-mixin.js
@@ -40,22 +40,24 @@ export default {
   },
 
   fillPrefillableValues() {
-    this.getFormElements().each((index, el) => {
-      const $el = this.$(el);
-      if (isElementFillable($el, this.formPrefill)) {
-        const key = getKey($el);
-        $el.val(this.formPrefill.get(key));
-      }
-    });
+    this.getFormElements &&
+      this.getFormElements().each((index, el) => {
+        const $el = this.$(el);
+        if (isElementFillable($el, this.formPrefill)) {
+          const key = getKey($el);
+          $el.val(this.formPrefill.get(key));
+        }
+      });
   },
 
   beforeDestroy() {
-    this.getFormElements().each((index, el) => {
-      const $el = this.$(el);
-      const key = getKey($el);
-      if (key) {
-        this.formPrefill.set(key, $el.__val());
-      }
-    });
+    this.getFormElements &&
+      this.getFormElements().each((index, el) => {
+        const $el = this.$(el);
+        const key = getKey($el);
+        if (key) {
+          this.formPrefill.set(key, $el.__val());
+        }
+      });
   },
 };

--- a/packages/fxa-content-server/app/tests/spec/lib/error-utils.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/error-utils.js
@@ -56,6 +56,19 @@ describe('lib/error-utils', function() {
       OAuthErrors.toInvalidParameterError('paramName'),
       OAuthErrors.toMissingParameterError('paramName'),
       OAuthErrors.toError('UNKNOWN_CLIENT'),
+      // By default the prompt=none errors cause a redirect
+      // back to the RP with the response_error_code from
+      // the error entry. If the RP specifies `return_on_error=false`,
+      // the FxA 400 page will be displayed instead. This
+      // is used by the functional tests to ensure the
+      // expected error case is being invoked when
+      // checking whether prompt=none can be used.
+      OAuthErrors.toError('PROMPT_NONE_NOT_ENABLED'),
+      OAuthErrors.toError('PROMPT_NONE_NOT_ENABLED_FOR_CLIENT'),
+      OAuthErrors.toError('PROMPT_NONE_WITH_KEYS'),
+      OAuthErrors.toError('PROMPT_NONE_NOT_SIGNED_IN'),
+      OAuthErrors.toError('PROMPT_NONE_DIFFERENT_USER_SIGNED_IN'),
+      OAuthErrors.toError('PROMPT_NONE_UNVERIFIED'),
     ];
 
     badRequestPageErrors.forEach(function(err) {

--- a/packages/fxa-content-server/app/tests/spec/lib/validate.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/validate.js
@@ -237,6 +237,12 @@ describe('lib/validate', function() {
       });
     });
 
+    describe('none', function() {
+      it('returns true', function() {
+        assert.isTrue(Validate.isPromptValid('none'));
+      });
+    });
+
     describe('other values', function() {
       it('returns false', function() {
         assert.isFalse(Validate.isPromptValid('unrecognized'));

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-redirect.js
@@ -269,7 +269,10 @@ describe('models/auth_brokers/oauth-redirect', () => {
           .then(() => {
             assert.isTrue(metrics.flush.calledOnce);
             assert.lengthOf(metrics.flush.getCall(0).args, 0);
-            assert.equal(windowMock.location.href, REDIRECT_TO);
+            assert.equal(
+              windowMock.location.href,
+              `${REDIRECT_TO}?state=state`
+            );
           });
       });
     });
@@ -286,6 +289,7 @@ describe('models/auth_brokers/oauth-redirect', () => {
             assert.lengthOf(metrics.flush.getCall(0).args, 0);
             assert.include(windowMock.location.href, REDIRECT_TO);
             assert.include(windowMock.location.href, 'error=error');
+            assert.include(windowMock.location.href, 'state=state');
           });
       });
     });
@@ -303,6 +307,7 @@ describe('models/auth_brokers/oauth-redirect', () => {
             assert.lengthOf(metrics.flush.getCall(0).args, 0);
             assert.include(windowMock.location.href, REDIRECT_TO);
             assert.include(windowMock.location.href, 'action=' + action);
+            assert.include(windowMock.location.href, 'state=state');
           });
       });
     });
@@ -320,6 +325,7 @@ describe('models/auth_brokers/oauth-redirect', () => {
             assert.include(windowMock.location.href, REDIRECT_TO);
             assert.include(windowMock.location.href, 'test=param');
             assert.include(windowMock.location.href, 'error=error');
+            assert.include(windowMock.location.href, 'state=state');
           });
       });
     });

--- a/packages/fxa-content-server/docs/query-params.md
+++ b/packages/fxa-content-server/docs/query-params.md
@@ -32,18 +32,22 @@ When signing up a user.
 
 ### `prompt`
 
-Specifies whether the content server prompts for permissions consent. Only applicable for `trusted` reliers.
-Untrusted reliers always show the prompt.
+Specifies whether the content server prompts for permissions consent. Only applicable for `trusted` relying parties.
+Untrusted relying parties always show the prompt.
 
 #### Options
 
 -   `consent` - Show the permissions prompt if any additional
-    permissions are required.
+    permissions are required. Only applicable for `trusted` relying parties.
+    Untrusted relying parties always show the prompt.
+-   `none` - Require no user interaction if the user is signed in.
+    Only applicable for authorized relying parties that are not requesting
+    keys. An error is returned to the RP for all others.
+    See the [prompt=none doc][#prompt-none] for more info.
 
 #### When to specify
 
-When authenticating a user for OAuth. Only applicable for `trusted` reliers.
-Untrusted reliers always show the prompt.
+When authenticating a user for OAuth.
 
 -   /oauth/signin
 -   /oauth/signup
@@ -330,18 +334,18 @@ Used in the verification flows to specify the verification code.
 
 #### When to use
 
-Should not be used by reliers.
+Should not be used by relying parties.
 
 ### `uid`
 
 Used in two cases:
 
 1. By the verification flows to specify the user id of the user being verified.
-1. By reliers when loading a settings page to specify which account should be used.
+1. By relying parties when loading a settings page to specify which account should be used.
 
 #### When to use
 
-Reliers who send users to a settings page to e.g., set an avatar, can pass a uid to
+Relying parties who send users to a settings page to e.g., set an avatar, can pass a uid to
 ensure users with multiple accounts update the avatar for the correct account.
 
 ## Experimental/development parameters
@@ -366,7 +370,7 @@ Used by functional tests to synthesize localStorage being disabled.
 
 #### When to use
 
-Should not be used by reliers. Should only be used by functional tests.
+Should not be used by relying parties. Should only be used by functional tests.
 
 ### `forceAboutAccounts`
 
@@ -378,7 +382,7 @@ Force Sync brokers to act as if the user opened FxA from within about:accounts.
 
 #### When to use
 
-Should not be used by reliers. Should only be used for Sync based functional tests.
+Should not be used by relying parties. Should only be used for Sync based functional tests.
 
 ### `forceExperiment`
 
@@ -413,7 +417,7 @@ Used to skip the confirmation form to reset a password
 
 #### When to use
 
-Should not be used by reliers.
+Should not be used by relying parties.
 Should only be used for accounts that must be reset.
 
 ### `emailToHashWith`
@@ -439,3 +443,5 @@ if they perform a reset password.
 #### When to specify
 
 -   /settings/emails
+
+[#prompt-none]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/prompt-none.md

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -399,6 +399,23 @@ const conf = (module.exports = convict({
     env: 'FXA_OAUTH_URL',
     format: 'url',
   },
+  oauth: {
+    prompt_none: {
+      enabled: {
+        default: true,
+        doc: 'Is prompt=none enabled globally?',
+        env: 'OAUTH_PROMPT_NONE_ENABLED',
+        format: Boolean,
+      },
+      enabled_client_ids: {
+        // 123done enabled for functional tests, 321done is not.
+        default: ['dcdb5ae7add825d2', '7f368c6886429f19'],
+        doc: 'client_ids for which prompt=none is enabled',
+        env: 'OAUTH_PROMPT_NONE_ENABLED_CLIENT_IDS',
+        format: Array,
+      },
+    },
+  },
   openid_configuration: {
     claims_supported: ['aud', 'exp', 'iat', 'iss', 'sub'],
     id_token_signing_alg_values_supported: ['RS256'],

--- a/packages/fxa-content-server/server/lib/routes/get-index.js
+++ b/packages/fxa-content-server/server/lib/routes/get-index.js
@@ -36,32 +36,36 @@ module.exports = function(config) {
   const SCOPED_KEYS_ENABLED = config.get('scopedKeys.enabled');
   const SCOPED_KEYS_VALIDATION = config.get('scopedKeys.validation');
   const SUBSCRIPTIONS = config.get('subscriptions');
+  const PROMPT_NONE_ENABLED = config.get('oauth.prompt_none.enabled');
+  const PROMPT_NONE_ENABLED_CLIENT_IDS = new Set(
+    config.get('oauth.prompt_none.enabled_client_ids')
+  );
+
   // add version from package.json to config
   const RELEASE = require('../../../package.json').version;
   const WEBPACK_PUBLIC_PATH = `${STATIC_RESOURCE_URL}/${config.get(
     'jsResourcePath'
   )}/`;
 
-  const serializedConfig = encodeURIComponent(
-    JSON.stringify({
-      authServerUrl: AUTH_SERVER_URL,
-      env: ENV,
-      isCoppaEnabled: COPPA_ENABLED,
-      marketingEmailEnabled: MARKETING_EMAIL_ENABLED,
-      marketingEmailPreferencesUrl: MARKETING_EMAIL_PREFERENCES_URL,
-      oAuthClientId: CLIENT_ID,
-      oAuthUrl: OAUTH_SERVER_URL,
-      pairingChannelServerUri: PAIRING_CHANNEL_URI,
-      pairingClients: PAIRING_CLIENTS,
-      profileUrl: PROFILE_SERVER_URL,
-      release: RELEASE,
-      scopedKeysEnabled: SCOPED_KEYS_ENABLED,
-      scopedKeysValidation: SCOPED_KEYS_VALIDATION,
-      staticResourceUrl: STATIC_RESOURCE_URL,
-      subscriptions: SUBSCRIPTIONS,
-      webpackPublicPath: WEBPACK_PUBLIC_PATH,
-    })
-  );
+  const configForFrontEnd = {
+    authServerUrl: AUTH_SERVER_URL,
+    env: ENV,
+    isCoppaEnabled: COPPA_ENABLED,
+    isPromptNoneEnabled: PROMPT_NONE_ENABLED,
+    marketingEmailEnabled: MARKETING_EMAIL_ENABLED,
+    marketingEmailPreferencesUrl: MARKETING_EMAIL_PREFERENCES_URL,
+    oAuthClientId: CLIENT_ID,
+    oAuthUrl: OAUTH_SERVER_URL,
+    pairingChannelServerUri: PAIRING_CHANNEL_URI,
+    pairingClients: PAIRING_CLIENTS,
+    profileUrl: PROFILE_SERVER_URL,
+    release: RELEASE,
+    scopedKeysEnabled: SCOPED_KEYS_ENABLED,
+    scopedKeysValidation: SCOPED_KEYS_VALIDATION,
+    staticResourceUrl: STATIC_RESOURCE_URL,
+    subscriptions: SUBSCRIPTIONS,
+    webpackPublicPath: WEBPACK_PUBLIC_PATH,
+  };
 
   const NO_LONGER_SUPPORTED_CONTEXTS = new Set([
     'fx_desktop_v1',
@@ -90,10 +94,21 @@ module.exports = function(config) {
         logger.error('featureFlags.error', err);
         flags = {};
       }
+
+      const isPromptNoneEnabledForClient =
+        req.query.client_id &&
+        PROMPT_NONE_ENABLED_CLIENT_IDS.has(req.query.client_id);
+
       res.render('index', {
         // Note that bundlePath is added to templates as a build step
         bundlePath: '/bundle',
-        config: serializedConfig,
+        config: encodeURIComponent(
+          JSON.stringify({
+            ...configForFrontEnd,
+            isPromptNoneEnabled: PROMPT_NONE_ENABLED,
+            isPromptNoneEnabledForClient,
+          })
+        ),
         featureFlags: encodeURIComponent(JSON.stringify(flags)),
         flowBeginTime: flowEventData.flowBeginTime,
         flowId: flowEventData.flowId,

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -41,6 +41,7 @@ module.exports = [
   'tests/functional/oauth_force_auth.js',
   'tests/functional/oauth_handshake.js',
   'tests/functional/oauth_permissions.js',
+  'tests/functional/oauth_prompt_none.js',
   'tests/functional/oauth_query_param_validation.js',
   'tests/functional/oauth_reset_password.js',
   'tests/functional/oauth_settings_clients.js',

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -1408,7 +1408,7 @@ const reOpenWithAdditionalQueryParams = thenify(function(
  * @param {object} [options]
  * @param {string} [options.header] - element selector that indicates
  *  "page is loaded". Defaults to `#fxa-force-auth-header`
- * @param {object} [options.query] - query strings to open page with
+ * @param {object} [options.query] - query parameters to open page with
  * @param {boolean} [options.untrusted] - if `true`, opens the Untrusted
  * relier. Defaults to `true`
  */
@@ -1472,13 +1472,33 @@ const openFxaFromRp = thenify(function(page, options = {}) {
  * @param {object} [options]
  * @param {string} [options.header] - element selector that indicates
  *  "page is loaded". Defaults to `#fxa-force-auth-header`
- * @param {object} [options.query] - query strings to open page with
+ * @param {object} [options.query] - query parameters to open page with
  */
 function openFxaFromUntrustedRp(page, options) {
   options = options || {};
   options.untrusted = true;
   return openFxaFromRp(page, options);
 }
+
+/**
+ * Open 123done.
+ *
+ * @param {object} [options={}]
+ * @param {string} [options.header=selectors['123DONE'].BUTTON_SIGNIN] - element selector that indicates the page is loaded
+ * @param {object} [options.query={}] - query parameters to open the page with
+ */
+const openRP = thenify(function(options = {}) {
+  const app = options.untrusted ? UNTRUSTED_OAUTH_APP : OAUTH_APP;
+  let queryString = '';
+  if (options.query) {
+    queryString = '?' + Querystring.stringify(options.query);
+  }
+
+  const endpoint = `${app}${queryString}`;
+  return this.parent.then(
+    openPage(endpoint, options.header || selectors['123DONE'].BUTTON_SIGNIN)
+  );
+});
 
 const fillOutSignIn = thenify(function(email, password, alwaysLoad) {
   return this.parent
@@ -2432,6 +2452,7 @@ module.exports = {
   openFxaFromUntrustedRp,
   openPage,
   openPasswordResetLinkInDifferentBrowser,
+  openRP,
   openSettingsInNewTab,
   openSignInInNewTab,
   openSignUpInNewTab,

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -27,6 +27,7 @@ module.exports = {
     AUTHENTICATED_TOTP: '#loggedin span:first-child',
     BUTTON_SIGNIN: '.sign-in-button.signin',
     BUTTON_SIGNIN_CHOOSE_FLOW_FOR_ME: '.ready .sign-choose',
+    BUTTON_PROMPT_NONE: '.ready .prompt-none',
     BUTTON_SIGNUP: '.sign-in-button.signup',
     LINK_LOGOUT: '#logout',
   },

--- a/packages/fxa-content-server/tests/functional/oauth_prompt_none.js
+++ b/packages/fxa-content-server/tests/functional/oauth_prompt_none.js
@@ -1,0 +1,215 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { registerSuite } = intern.getInterface('object');
+const { createEmail } = require('../lib/helpers');
+const FunctionalHelpers = require('./lib/helpers');
+const config = intern._config;
+const selectors = require('./lib/selectors');
+
+const EMAIL_FIRST_URL = `${config.fxaContentRoot}?action=email`;
+
+const PASSWORD = 'passwordzxcv';
+
+let email;
+
+const {
+  clearBrowserState,
+  click,
+  createUser,
+  destroySessionForEmail,
+  fillOutEmailFirstSignIn,
+  openPage,
+  openRP,
+  testElementExists,
+  testElementTextInclude,
+} = FunctionalHelpers;
+
+registerSuite('oauth prompt=none', {
+  beforeEach: function() {
+    email = createEmail();
+
+    return this.remote.then(
+      clearBrowserState({
+        '123done': true,
+        contentServer: true,
+      })
+    );
+  },
+
+  afterEach: function() {
+    return this.remote.then(
+      clearBrowserState({
+        '123done': true,
+        contentServer: true,
+      })
+    );
+  },
+
+  tests: {
+    'fails RP that is not allowed': function() {
+      return this.remote
+        .then(
+          openRP({
+            untrusted: true,
+            query: { login_hint: email, return_on_error: false },
+          })
+        )
+        .then(click(selectors['123DONE'].BUTTON_PROMPT_NONE))
+        .then(testElementExists(selectors['400'].HEADER))
+        .then(
+          testElementTextInclude(
+            selectors['400'].ERROR,
+            'prompt=none is not enabled for this client'
+          )
+        );
+    },
+
+    'fails if requesting keys': function() {
+      return this.remote
+        .then(
+          openRP({
+            query: {
+              client_id: '7f368c6886429f19', // eslint-disable-line camelcase
+              forceUA:
+                'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36',
+              keys_jwk:
+                'eyJrdHkiOiJFQyIsImtpZCI6Im9DNGFudFBBSFZRX1pmQ09RRUYycTRaQlZYblVNZ2xISGpVRzdtSjZHOEEiLCJjcnYiOi' +
+                'JQLTI1NiIsIngiOiJDeUpUSjVwbUNZb2lQQnVWOTk1UjNvNTFLZVBMaEg1Y3JaQlkwbXNxTDk0IiwieSI6IkJCWDhfcFVZeHpTaldsdX' +
+                'U5MFdPTVZwamIzTlpVRDAyN0xwcC04RW9vckEifQ',
+              login_hint: email,
+              redirect_uri:
+                'https://mozilla.github.io/notes/fxa/android-redirect.html', // eslint-disable-line camelcase
+              return_on_error: false,
+              scope: 'profile https://identity.mozilla.com/apps/notes',
+            },
+          })
+        )
+        .then(click(selectors['123DONE'].BUTTON_PROMPT_NONE))
+        .then(
+          testElementTextInclude(
+            selectors['400'].ERROR,
+            'prompt=none cannot be used when requesting keys'
+          )
+        );
+    },
+
+    'fails if no login_hint': function() {
+      return this.remote
+        .then(
+          openRP({
+            query: { return_on_error: false },
+          })
+        )
+        .then(click(selectors['123DONE'].BUTTON_PROMPT_NONE))
+        .then(testElementExists(selectors['400'].HEADER))
+        .then(
+          testElementTextInclude(
+            selectors['400'].ERROR,
+            'missing oauth parameter'
+          )
+        );
+    },
+
+    'fails if no user logged in': function() {
+      return this.remote
+        .then(
+          openRP({
+            query: {
+              login_hint: email,
+              return_on_error: false,
+            },
+          })
+        )
+        .then(click(selectors['123DONE'].BUTTON_PROMPT_NONE))
+        .then(testElementExists(selectors['400'].HEADER))
+        .then(
+          testElementTextInclude(
+            selectors['400'].ERROR,
+            'User is not signed in'
+          )
+        );
+    },
+
+    'fails if account is not verified': function() {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: false }))
+
+        .then(openPage(EMAIL_FIRST_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+        .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
+
+        .then(openRP({ query: { login_hint: email, return_on_error: false } }))
+        .then(click(selectors['123DONE'].BUTTON_PROMPT_NONE))
+        .then(testElementExists(selectors['400'].HEADER))
+        .then(
+          testElementTextInclude(
+            selectors['400'].ERROR,
+            'Unverified user or session'
+          )
+        );
+    },
+
+    'fails if login_hint is different to logged in user': function() {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+
+        .then(openPage(EMAIL_FIRST_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+        .then(testElementExists(selectors.SETTINGS.HEADER))
+
+        .then(
+          openRP({
+            query: { login_hint: createEmail(), return_on_error: false },
+          })
+        )
+        .then(click(selectors['123DONE'].BUTTON_PROMPT_NONE))
+        .then(testElementExists(selectors['400'].HEADER))
+        .then(
+          testElementTextInclude(
+            selectors['400'].ERROR,
+            'a different user is signed in'
+          )
+        );
+    },
+
+    'fails if session is no longer valid': function() {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+
+        .then(openPage(EMAIL_FIRST_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+        .then(testElementExists(selectors.SETTINGS.HEADER))
+        .then(destroySessionForEmail(email))
+        .then(
+          openRP({
+            query: { login_hint: email, return_on_error: false },
+          })
+        )
+        .then(click(selectors['123DONE'].BUTTON_PROMPT_NONE))
+        .then(testElementExists(selectors['400'].HEADER))
+        .then(
+          testElementTextInclude(
+            selectors['400'].ERROR,
+            'User is not signed in'
+          )
+        );
+    },
+
+    'succeeds if login_hint same as logged in user': function() {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+
+        .then(openPage(EMAIL_FIRST_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+        .then(testElementExists(selectors.SETTINGS.HEADER))
+
+        .then(openRP({ query: { login_hint: email } }))
+        .then(click(selectors['123DONE'].BUTTON_PROMPT_NONE))
+        .then(testElementExists(selectors['123DONE'].AUTHENTICATED));
+    },
+  },
+});

--- a/packages/fxa-content-server/tests/functional/oauth_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sign_in.js
@@ -29,6 +29,7 @@ let secret;
 const thenify = FunctionalHelpers.thenify;
 
 const {
+  cleanMemory,
   clearBrowserState,
   click,
   closeCurrentWindow,
@@ -81,6 +82,12 @@ registerSuite('oauth signin', {
     );
   },
   tests: {
+    'clear memory': function() {
+      // tests fail on this suite very often on Circle because Firefox
+      // crashes here. Clear memory and hope that helps.
+      return this.remote.then(cleanMemory());
+    },
+
     'with missing client_id': function() {
       return this.remote.then(
         openPage(SIGNIN_ROOT + '?scope=profile', selectors['400'].HEADER)

--- a/packages/fxa-content-server/tests/functional/reset_password.js
+++ b/packages/fxa-content-server/tests/functional/reset_password.js
@@ -28,6 +28,7 @@ let email;
 let token;
 
 const {
+  cleanMemory,
   clearBrowserState,
   click,
   closeCurrentWindow,
@@ -117,6 +118,12 @@ registerSuite('reset_password', {
       .then(clearBrowserState());
   },
   tests: {
+    'clear memory': function() {
+      // tests fail on this suite very often on Circle because Firefox
+      // crashes here. Clear memory and hope that helps.
+      return this.remote.then(cleanMemory());
+    },
+
     'visit confirmation screen without initiating reset_password, user is redirected to /reset_password': function() {
       // user is immediately redirected to /reset_password if they have no
       // sessionToken.


### PR DESCRIPTION
Loads of caveats:

* Does not have a good 2FA story
* Only works for authorized relying parties that do not request keys
* Makes no effort at "single log out"
* Does not use "id_token_hint"


To make testing this simpler, I updated 123done to propagate any query parameters on the URL to FxA. This allows us to open 123done with query parameters like alternate client_ids or a login_hint and have those propagated. 123done now also handles OAuth errors that are returned as part of the process, including `interaction_required`, `login_required`, and `account_selection_required`. If these errors are returned as part of a prompt=none flow, then FxA is re-opened w/o prompt=none to simulate how a normal RP should work.

fixes #640
