### PR TITLE
 feat(trailhead): Add new ui to legacy /signup page 

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sign_up.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up.mustache
@@ -1,13 +1,18 @@
 <div id="main-content" class="card">
   <header>
     <h1 id="fxa-signup-header">
-      {{#serviceName}}
-        <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-        {{#t}}Create a Firefox Account{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
-      {{/serviceName}}
-      {{^serviceName}}
-        {{#t}}Create a Firefox Account{{/t}}
-      {{/serviceName}}
+      {{#isTrailhead}}
+        {{#t}}Create your Firefox account{{/t}}
+      {{/isTrailhead}}
+      {{^isTrailhead}}
+        {{#serviceName}}
+          <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
+          {{#t}}Create a Firefox Account{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+        {{/serviceName}}
+        {{^serviceName}}
+          {{#t}}Create a Firefox Account{{/t}}
+        {{/serviceName}}
+      {{/isTrailhead}}
     </h1>
   </header>
 
@@ -54,11 +59,13 @@
         {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
       </div>
 
-      {{#isEmailOptInEnabled}}
-      <div class="input-row marketing-email-optin-row">
-        <input id="marketing-email-optin" type="checkbox" class="marketing-email-optin" /><label for="marketing-email-optin">{{#t}}Get the latest news about Mozilla and Firefox{{/t}}</label>
-      </div>
-      {{/isEmailOptInEnabled}}
+      {{^isTrailhead}}
+        {{#isEmailOptInEnabled}}
+        <div class="input-row marketing-email-optin-row">
+          <input id="marketing-email-optin" type="checkbox" class="marketing-email-optin" /><label for="marketing-email-optin">{{#t}}Get the latest news about Mozilla and Firefox{{/t}}</label>
+        </div>
+        {{/isEmailOptInEnabled}}
+      {{/isTrailhead}}
 
       <div class="button-row">
         <button id="submit-btn" type="submit">{{#t}}Create account{{/t}}</button>
@@ -79,6 +86,9 @@
       {{/isSignInEnabled}}
     </div>
 
+    {{#isTrailhead}}
+      {{{ unsafeFirefoxFamilyHTML }}}
+    {{/isTrailhead}}
     {{/error}}
   </section>
 </div>

--- a/packages/fxa-content-server/app/scripts/views/sign_up.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_up.js
@@ -9,6 +9,7 @@ import CoppaMixin from './mixins/coppa-mixin';
 import EmailFirstExperimentMixin from './mixins/email-first-experiment-mixin';
 import EmailOptInMixin from './mixins/email-opt-in-mixin';
 import ExperimentMixin from './mixins/experiment-mixin';
+import FirefoxFamilyServicesTemplate from '../templates/partial/firefox-family-services.mustache';
 import FlowBeginMixin from './mixins/flow-begin-mixin';
 import FormPrefillMixin from './mixins/form-prefill-mixin';
 import FormView from './form';
@@ -41,6 +42,9 @@ const proto = FormView.prototype;
 
 var View = FormView.extend({
   template: Template,
+  partialTemplates: {
+    unsafeFirefoxFamilyHTML: FirefoxFamilyServicesTemplate
+  },
   className: 'sign-up',
 
   beforeRender () {

--- a/packages/fxa-content-server/app/styles/modules/_marketing.scss
+++ b/packages/fxa-content-server/app/styles/modules/_marketing.scss
@@ -33,6 +33,7 @@
 
   > h2 {
     font-size: 18px;
+    margin-top: 0;
   }
 
   > ul {
@@ -59,5 +60,11 @@
         margin-left: -5px;
       }
     }
+  }
+}
+
+.links + .firefox-family-services {
+  @include respond-to('big') {
+    margin-top: 20px;
   }
 }

--- a/packages/fxa-content-server/app/tests/spec/views/sign_up.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_up.js
@@ -9,6 +9,7 @@ import { assert } from 'chai';
 import AuthErrors from 'lib/auth-errors';
 import Backbone from 'backbone';
 import Broker from 'models/auth_brokers/base';
+import { SIGNUP } from '../../../../tests/functional/lib/selectors';
 import ExperimentGroupingRules from 'lib/experiments/grouping-rules/index';
 import ExperimentInterface from 'lib/experiment';
 import FormPrefill from 'models/form-prefill';
@@ -24,6 +25,8 @@ import Translator from 'lib/translator';
 import User from 'models/user';
 import View from 'views/sign_up';
 import WindowMock from '../../mocks/window';
+
+const Selectors = SIGNUP;
 
 describe('views/sign_up', function () {
   var broker;
@@ -46,7 +49,7 @@ describe('views/sign_up', function () {
     if (arguments.length < 3) {
       passwordConfirm = password;
     }
-    view.$('#vpassword').val(passwordConfirm);
+    view.$(Selectors.VPASSWORD).val(passwordConfirm);
   }
 
   function createView(options) {
@@ -151,6 +154,7 @@ describe('views/sign_up', function () {
           assert.equal(view.$('[type=email]').val(), 'testuser@testuser.com');
           assert.equal(view.$('[type=email]').attr('spellcheck'), 'false');
           assert.equal(view.$('[type=password]').val(), 'prefilled password');
+          assert.lengthOf(view.$(Selectors.FIREFOX_FAMILY_SERVICES), 0);
         });
     });
 
@@ -170,7 +174,7 @@ describe('views/sign_up', function () {
       return view.render()
         .then(() => {
           view.highlightSignupPasswordHelper({
-            target: '#vpassword'
+            target: Selectors.VPASSWORD
           });
           assert.equal(view.$('.input-help-balloon').css('top'), '-10px');
         });
@@ -241,7 +245,7 @@ describe('views/sign_up', function () {
     });
 
     describe('email opt in', function () {
-      it('is visible if enabled', function () {
+      it('is visible if enabled, not trailhead', function () {
         sinon.stub(experimentGroupingRules, 'choose').callsFake(function () {
           return true;
         });
@@ -264,16 +268,40 @@ describe('views/sign_up', function () {
             assert.equal(view.$('#marketing-email-optin').length, 0);
           });
       });
+
+      it('is not visible for trailhead', () => {
+        sinon.stub(experimentGroupingRules, 'choose').callsFake(function () {
+          return true;
+        });
+
+        sinon.stub(view, 'isTrailhead').callsFake(() => true);
+        return view.render()
+          .then(() => {
+            assert.lengthOf(view.$('.marketing-email-optin'), 0);
+          });
+      });
     });
+
 
     describe('password confirm', function() {
       it('is visible', function () {
         return view.render()
           .then(function () {
-            assert.equal(view.$('#vpassword').length, 1);
+            assert.equal(view.$(Selectors.VPASSWORD).length, 1);
           });
       });
     });
+
+
+    it('renders the firefox-family services for trailhead', () => {
+      relier.set('style', 'trailhead');
+
+      return view.render()
+        .then(() => {
+          assert.lengthOf(view.$(Selectors.FIREFOX_FAMILY_SERVICES), 1);
+        });
+    });
+
   });
 
   describe('afterVisible', function () {
@@ -315,7 +343,7 @@ describe('views/sign_up', function () {
       formPrefill.set('password', 'password');
       return view.render()
         .then(() => {
-          assert.ok(view.$('#vpassword').attr('autofocus'));
+          assert.ok(view.$(Selectors.VPASSWORD).attr('autofocus'));
         });
     });
 

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -284,6 +284,7 @@ module.exports = {
     CUSTOMIZE_SYNC_CHECKBOX: '#customize-sync',
     EMAIL: 'input[type=email]',
     ERROR: '.error',
+    FIREFOX_FAMILY_SERVICES: '.firefox-family-services',
     HEADER: '#fxa-signup-header',
     LINK_SIGN_IN: 'a#have-account',
     LINK_SUGGEST_EMAIL_DOMAIN_CORRECTION: '#email-suggestion',


### PR DESCRIPTION
Added this because someone surely is going to link directly
to this page. Getting it prepared.

extraction from #1098
Builds on #1162 and should be reviewed afterwards

Spec'd here: https://mozilla.invisionapp.com/share/3GRZJ9J65A9#/screens/363518307

### Desktop

<img width="531" alt="Screenshot 2019-05-20 at 20 50 59" src="https://user-images.githubusercontent.com/848085/58047834-08120480-7b41-11e9-8f66-0440c34d5621.png">

### Mobile

<img width="422" alt="Screenshot 2019-05-20 at 20 51 04" src="https://user-images.githubusercontent.com/848085/58047840-0c3e2200-7b41-11e9-8534-cf3c973f9fa3.png">


@mozilla/fxa-devs - r?

