### PR TITLE
feat(trailhead): Add new UI to signin pages

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sign_in.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in.mustache
@@ -1,13 +1,18 @@
 <div id="main-content" class="card">
   <header>
     <h1 id="fxa-signin-header">
-      {{#serviceName}}
-        <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-        {{{ headerSignInText }}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
-      {{/serviceName}}
-      {{^serviceName}}
-        {{{ headerSignInText }}}
-      {{/serviceName}}
+      {{#isTrailhead}}
+        {{#unsafeTranslate}}Sign in <span class="service">to your Firefox account</span>{{/unsafeTranslate}}
+      {{/isTrailhead}}
+      {{^isTrailhead}}
+        {{#serviceName}}
+          <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
+          {{{ headerSignInText }}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+        {{/serviceName}}
+        {{^serviceName}}
+          {{{ headerSignInText }}}
+        {{/serviceName}}
+      {{/isTrailhead}}
     </h1>
   </header>
 

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -1,13 +1,18 @@
 <div id="main-content" class="card">
   <header>
     <h1 id="fxa-signin-password-header">
-      {{#serviceName}}
-        <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-        {{#t}}Sign in{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
-      {{/serviceName}}
-      {{^serviceName}}
-        {{#t}}Sign in{{/t}}
-      {{/serviceName}}
+      {{#isTrailhead}}
+        {{#unsafeTranslate}}Sign in <span class="service">to your Firefox account</span>{{/unsafeTranslate}}
+      {{/isTrailhead}}
+      {{^isTrailhead}}
+        {{#serviceName}}
+          <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
+          {{#t}}Sign in{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+        {{/serviceName}}
+        {{^serviceName}}
+          {{#t}}Sign in{{/t}}
+        {{/serviceName}}
+      {{/isTrailhead}}
     </h1>
   </header>
 

--- a/packages/fxa-content-server/app/styles/modules/_avatar.scss
+++ b/packages/fxa-content-server/app/styles/modules/_avatar.scss
@@ -156,6 +156,7 @@
 .with-default {
   background: image-url('default-profile.svg') center;
   background-repeat: no-repeat;
+  background-size: 100% 100%;
 }
 
 .change-avatar-text {


### PR DESCRIPTION
* Add to both the legacy sign in page and the new sign in page.
* Fix the default avatar size on the signin page
* Change to header text specified here: https://docs.google.com/presentation/d/1fv1EdAxmtHt6jypDgp8UQt0tN9K_WQW2sRdlfLss9GI/edit#slide=id.g5781b6e478_0_46

issue #1084
Extraction from #1098
fixes #1125

### New /signin page desktop
<img width="555" alt="Screenshot 2019-05-20 at 22 48 50" src="https://user-images.githubusercontent.com/848085/58054380-5a0f5600-7b52-11e9-9cfb-587c06319f13.png">

### New /signin page mobile

<img width="381" alt="Screenshot 2019-05-20 at 22 48 56" src="https://user-images.githubusercontent.com/848085/58054381-5a0f5600-7b52-11e9-9b2c-f3300dc4d51e.png">

### Old /signin page desktop

<img width="606" alt="Screenshot 2019-05-20 at 22 44 09" src="https://user-images.githubusercontent.com/848085/58054405-68f60880-7b52-11e9-84d7-957e0bc3dc7c.png">

### Old /signin page mobile

<img width="448" alt="Screenshot 2019-05-20 at 22 44 15" src="https://user-images.githubusercontent.com/848085/58054406-68f60880-7b52-11e9-84cf-9fcb8ca6c3b2.png">

@mozilla/fxa-devs - r?