### PR TITLE
 feat(payments): auth API changes for better subhub interop 

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -41,35 +41,45 @@
       "plans": [
         {
           "plan_id": "123doneProMonthly",
+          "plan_name": "123done Pro Monthly",
           "product_id": "123doneProProduct",
+          "product_name": "123done Pro",
           "interval": "month",
           "amount": 50,
           "currency": "usd"
         },
         {
           "plan_id": "321doneProMonthly",
+          "plan_name": "321done Pro Monthly",
           "product_id": "321doneProProduct",
+          "product_name": "321done Pro",
           "interval": "month",
           "amount": 50,
           "currency": "usd"
         },
         {
           "plan_id": "allDoneProMonthly",
+          "plan_name": "123done Pro and 321done Pro Monthly",
           "product_id": "allDoneProProduct",
+          "product_name": "123done Pro and 321done Pro",
           "interval": "month",
           "amount": 50,
           "currency": "usd"
         },
         {
           "plan_id": "321doneProWeekly",
+          "plan_name": "321done Pro Weekly",
           "product_id": "321doneProProduct",
+          "product_name": "321done Pro",
           "interval": "week",
           "amount": 5,
           "currency": "usd"
         },
         {
           "plan_id": "allDoneProWeekly",
+          "plan_name": "123done Pro and 321done Pro Weekly",
           "product_id": "allDoneProProduct",
+          "product_name": "123done Pro and 321done Pro",
           "interval": "week",
           "amount": 5,
           "currency": "usd"

--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -1249,6 +1249,10 @@ module.exports = (log, db, mailer, Password, config, customs, subhub, signinUtil
                 }
 
                 if (config.subscriptions && config.subscriptions.enabled) {
+                  // TODO: We should probably delete the upstream customer for
+                  // subscriptions, but no such API exists in subhub yet.
+                  // https://github.com/mozilla/subhub/issues/61
+
                   // Cancel all subscriptions before deletion, if any exist
                   // Subscription records will be deleted from DB as part of account
                   // deletion, but we have to trigger cancellation in payment systems

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -21,7 +21,7 @@ module.exports = function (
   // Various extra helpers.
   const push = require('../push')(log, db, config);
   const pushbox = require('../pushbox')(log, config);
-  const subhub = require('../subhub')(log, config);
+  const subhub = require('../subhub/client')(log, config);
   const devicesImpl = require('../devices')(log, db, push);
   const signinUtils = require('./utils/signin')(log, config, customs, db, mailer);
   const verificationReminders = require('../verification-reminders')(log, config);

--- a/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
@@ -25,6 +25,9 @@ module.exports = {
       // All accounts get this product
       PRODUCT_REGISTERED,
       // Other products come from actual subscriptions
+      // TODO: The FxA DB has a column `productName` that we're using for
+      // product_id. We might want to rename that someday.
+      // https://github.com/mozilla/fxa/issues/1187
       ...subscriptions.map(({ productName }) => productName)
     ];
     // Accounts with at least one subscription get this product

--- a/packages/fxa-auth-server/lib/subhub/stubAPI.js
+++ b/packages/fxa-auth-server/lib/subhub/stubAPI.js
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ 'use strict';
+
+ const error = require('../error');
+
+ module.exports.buildStubAPI = function buildStubAPI(log, config) {
+  const {
+    subhub: {
+      stubs: {
+        plans = []
+      } = {}
+    } = {}
+  } = config;
+
+  const getPlanById = plan_id => plans
+    .filter(plan => plan.plan_id === plan_id)[0];
+
+  const storage = { subscriptions: {} };
+  const subscriptionsKey = (uid, sub_id) => `${uid}|${sub_id}`;
+
+  const customer = {
+    payment_type: 'card',
+    last4: 8675,
+    exp_month: 8,
+    exp_year: 2020
+  };
+
+  return {
+    isStubAPI: true,
+
+    async listPlans() {
+      return plans;
+    },
+
+    async listSubscriptions(uid) {
+      return Object
+        .values(storage.subscriptions)
+        .filter(subscription => subscription.uid === uid);
+    },
+
+    async createSubscription(uid, pmt_token, plan_id, email) {
+      const plan = getPlanById(plan_id);
+      if (! plan) {
+        throw error.unknownSubscriptionPlan(plan_id);
+      }
+      const product_id = plan.product_id;
+      const subscription_id = `sub${Math.random()}`;
+      const key = subscriptionsKey(uid, subscription_id);
+      storage.subscriptions[key] = {
+        uid,
+        plan_id,
+        product_id,
+        email
+      };
+      return {
+        subscriptions: [
+          {
+            subscription_id,
+            plan_id
+          }
+        ]
+      };
+    },
+
+    async cancelSubscription(uid, sub_id) {
+      const key = subscriptionsKey(uid, sub_id);
+      /*
+      FIXME: since FxA subs can be in the DB but mock subhub subs are in RAM,
+      this can throw after a local dev server restart.
+
+      if (! storage.subscriptions[key]) {throw
+        error.unknownSubscription(sub_id);
+      }
+      */
+      delete storage.subscriptions[key];
+      return {};
+    },
+
+    async getCustomer(uid) {
+      return customer;
+    },
+
+    async updateCustomer(uid, pmt_token) {
+      // HACK: Update the payment_type to at least show some change
+      customer.payment_type = pmt_token;
+      return {};
+    },
+  };
+};

--- a/packages/fxa-auth-server/scripts/delete-account.js
+++ b/packages/fxa-auth-server/scripts/delete-account.js
@@ -25,7 +25,7 @@ const P = require('../lib/promise');
 const config = require('../config').getProperties();
 const log = require('../lib/log')(config.log.level);
 const Token = require('../lib/tokens')(log, config);
-const subhub = require('../lib/subhub')(log, config);
+const subhub = require('../lib/subhub/client')(log, config);
 const mailer = null;
 
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -29,17 +29,21 @@ const CUSTOMER = {
 const PLANS = [
   {
     plan_id: 'firefox_pro_basic_823',
+    plan_name: 'Firefox Pro Basic Weekly',
     product_id: 'firefox_pro_basic',
-    interval: 'month',
+    product_name: 'Firefox Pro Basic',
+    interval: 'week',
     amount: '123',
-    currency: 'usd'
+    currency: 'usd',
   },
   {
     plan_id: 'firefox_pro_basic_999',
+    plan_name: 'Firefox Pro Pro Monthly',
     product_id: 'firefox_pro_pro',
+    product_name: 'Firefox Pro Pro',
     interval: 'month',
     amount: '456',
-    currency: 'usd'
+    currency: 'usd',
   }
 ];
 const SUBSCRIPTION_ID_1 = 'sub-8675309';
@@ -121,7 +125,11 @@ describe('subscriptions', () => {
       getCustomer: sinon.spy(async () => CUSTOMER),
       listPlans: sinon.spy(async () => PLANS),
       createSubscription: sinon.spy(
-        async (uid, token, plan_id) => ({ sub_id: SUBSCRIPTION_ID_1 })
+        async (uid, token, plan_id) => ({
+          subscriptions: [
+            { subscription_id: SUBSCRIPTION_ID_1 }
+          ]
+        })
       ),
       cancelSubscription: sinon.spy(
         async (uid, subscriptionId) => true
@@ -241,7 +249,7 @@ describe('subscriptions', () => {
       assert.deepEqual(
         subhub.createSubscription.args,
         [
-          [ UID, PAYMENT_TOKEN_VALID, PLANS[0].plan_id ]
+          [ UID, PAYMENT_TOKEN_VALID, PLANS[0].plan_id, TEST_EMAIL ]
         ]
       );
       assert.equal(db.createAccountSubscription.callCount, 1);
@@ -252,6 +260,9 @@ describe('subscriptions', () => {
         {
           uid: UID,
           subscriptionId: SUBSCRIPTION_ID_1,
+          // TODO: The FxA DB has a column `productName` that we're using for
+          // product_id. We might want to rename that someday.
+          // https://github.com/mozilla/fxa/issues/1187
           productName: PLANS[0].product_id,
           createdAt: createArgs.createdAt
         }

--- a/packages/fxa-auth-server/test/local/subhub/client.js
+++ b/packages/fxa-auth-server/test/local/subhub/client.js
@@ -6,10 +6,10 @@
 
 const { assert } = require('chai');
 const nock = require('nock');
-const error = require('../../lib/error');
-const { mockLog } = require('../mocks');
+const error = require('../../../lib/error');
+const { mockLog } = require('../../mocks');
 
-const subhubModule = require('../../lib/subhub');
+const subhubModule = require('../../../lib/subhub/client');
 
 const mockConfig = {
   publicUrl: 'https://accounts.example.com',
@@ -22,13 +22,14 @@ const mockConfig = {
 
 const mockServer = nock(mockConfig.subhub.url, {
   reqheaders: {
-    Authorization: `Bearer ${mockConfig.subhub.key}`
+    Authorization: mockConfig.subhub.key
   }
 }).defaultReplyHeaders({
   'Content-Type': 'application/json'
 });
 
-describe('subscriptions', () => {
+describe('subhub client', () => {
+  const ORIG_SYSTEM = 'Firefox Accounts';
   const UID = '8675309';
   const EMAIL = 'foo@example.com';
   const PLAN_ID = 'plan12345';
@@ -86,20 +87,22 @@ describe('subscriptions', () => {
       const expected = [
         {
           'plan_id': 'firefox_pro_basic_823',
+          'plan_name': 'Firefox Pro Basic Monthly',
           'product_id': 'firefox_pro_basic',
+          'product_name': 'Firefox Pro Basic',
           'interval': 'month',
           'amount': 500,
-          'currency': 'usd'
+          'currency': 'usd',
         }
       ];
-      mockServer.get('/plans').reply(200, expected);
+      mockServer.get('/v1/plans').reply(200, expected);
       const { subhub } = makeSubject();
       const resp = await subhub.listPlans();
       assert.deepEqual(resp, expected);
     });
 
     it('should throw on backend service failure', async () => {
-      mockServer.get('/plans').reply(500, 'Internal Server Error');
+      mockServer.get('/v1/plans').reply(500, 'Internal Server Error');
       const { log, subhub } = makeSubject();
       try {
         await subhub.listPlans();
@@ -112,24 +115,44 @@ describe('subscriptions', () => {
     });
   });
 
+  const mockSubscriptions = () => {
+    const mockBody = {
+      subscriptions: [
+        {
+          current_period_start: 1557161022,
+          current_period_end: 1557361022,
+          ended_at: null,
+          nickname: 'Example',
+          plan_id: 'firefox_pro_basic_823',
+          status: 'active',
+          subscription_id: 'sub_8675309'
+        }
+      ]
+    };
+
+    // These unix timestamps get converted to Date along the way.
+    const expected = {
+      subscriptions: mockBody.subscriptions.map(subscription => ({
+        ...subscription,
+        current_period_start: new Date(subscription.current_period_start * 1000),
+        current_period_end: new Date(subscription.current_period_end * 1000),
+      }))
+    };
+
+    return { mockBody, expected };
+  };
+
   describe('listSubscriptions', () => {
     it('should list subscriptions for account', async () => {
-      const expected = [
-        {
-          'plan_id': 'firefox_pro_basic_823',
-          'product_id': 'firefox_pro_basic',
-          'current_period_end': 1557361022,
-          'end_at': 1557361022
-        }
-      ];
-      mockServer.get(`/customer/${UID}/subscriptions`).reply(200, expected);
+      const { mockBody, expected } = mockSubscriptions();
+      mockServer.get(`/v1/customer/${UID}/subscriptions`).reply(200, mockBody);
       const { subhub } = makeSubject();
       const resp = await subhub.listSubscriptions(UID);
       assert.deepEqual(resp, expected);
     });
 
     it('should throw on unknown user', async () => {
-      mockServer.get(`/customer/${UID}/subscriptions`)
+      mockServer.get(`/v1/customer/${UID}/subscriptions`)
         .reply(404, { message: 'invalid uid' });
       const { log, subhub } = makeSubject();
       try {
@@ -143,8 +166,8 @@ describe('subscriptions', () => {
     });
 
     it('should throw on invalid response', async () => {
-      const expected = { 'this is not right': true };
-      mockServer.get(`/customer/${UID}/subscriptions`).reply(200, expected);
+      const mockBody = { 'subscriptions': 'this is not right' };
+      mockServer.get(`/v1/customer/${UID}/subscriptions`).reply(200, mockBody);
       const { log, subhub } = makeSubject();
       try {
         await subhub.listSubscriptions(UID);
@@ -158,7 +181,7 @@ describe('subscriptions', () => {
     });
 
     it('should throw on backend service failure', async () => {
-      mockServer.get(`/customer/${UID}/subscriptions`)
+      mockServer.get(`/v1/customer/${UID}/subscriptions`)
         .reply(500, 'Internal Server Error');
       const { log, subhub } = makeSubject();
       try {
@@ -174,18 +197,17 @@ describe('subscriptions', () => {
 
   describe('createSubscription', () => {
     it('should subscribe to a plan with valid payment token', async () => {
-      const expected = {
-        sub_id: SUBSCRIPTION_ID
-      };
+      const { mockBody, expected } = mockSubscriptions();
       const expectedBody = {
+        orig_system: ORIG_SYSTEM,
         pmt_token: PAYMENT_TOKEN_GOOD,
         plan_id: PLAN_ID,
         email: EMAIL
       };
       let requestBody;
       mockServer
-        .post(`/customer/${UID}/subscriptions`, body => requestBody = body)
-        .reply(201, expected);
+        .post(`/v1/customer/${UID}/subscriptions`, body => requestBody = body)
+        .reply(201, mockBody);
       const { subhub } = makeSubject();
       const resp =
         await subhub.createSubscription(UID, PAYMENT_TOKEN_GOOD, PLAN_ID, EMAIL);
@@ -195,7 +217,7 @@ describe('subscriptions', () => {
 
     it('should throw on unknown plan ID', async () => {
       mockServer
-        .post(`/customer/${UID}/subscriptions`)
+        .post(`/v1/customer/${UID}/subscriptions`)
         // TODO: update with subhub createSubscription error response for invalid plan ID
         .reply(400, { message: 'invalid plan id' });
       const { log, subhub } = makeSubject();
@@ -211,7 +233,7 @@ describe('subscriptions', () => {
 
     it('should throw on invalid payment token', async () => {
       mockServer
-        .post(`/customer/${UID}/subscriptions`)
+        .post(`/v1/customer/${UID}/subscriptions`)
         // TODO: update with subhub createSubscription error response for invalid payment token
         .reply(400, { message: 'invalid payment token' });
       const { log, subhub } = makeSubject();
@@ -226,7 +248,7 @@ describe('subscriptions', () => {
     });
 
     it('should throw on backend service failure', async () => {
-      mockServer.post(`/customer/${UID}/subscriptions`)
+      mockServer.post(`/v1/customer/${UID}/subscriptions`)
         .reply(500, 'Internal Server Error');
       const { log, subhub } = makeSubject();
       try {
@@ -242,11 +264,9 @@ describe('subscriptions', () => {
 
   describe('cancelSubscription', () => {
     it('should cancel an existing subscription', async () => {
-      // TODO: update with subhub cancelSubscription response format
-      const expected = {};
+      const expected = { message: 'Subscription cancellation successful' };
       mockServer
-        .delete(`/customer/${UID}/subscriptions/${SUBSCRIPTION_ID}`)
-        // TODO: subhub specifies 201 for cancelSubscription success - maybe 204 would be better?
+        .delete(`/v1/customer/${UID}/subscriptions/${SUBSCRIPTION_ID}`)
         .reply(201, expected);
       const { subhub } = makeSubject();
       const result = await subhub.cancelSubscription(UID, SUBSCRIPTION_ID);
@@ -255,7 +275,7 @@ describe('subscriptions', () => {
 
     it('should throw on unknown user', async () => {
       mockServer
-        .delete(`/customer/${UID}/subscriptions/${SUBSCRIPTION_ID}`)
+        .delete(`/v1/customer/${UID}/subscriptions/${SUBSCRIPTION_ID}`)
         .reply(404, { message: 'invalid uid' });
       const { log, subhub } = makeSubject();
       try {
@@ -270,7 +290,7 @@ describe('subscriptions', () => {
 
     it('should throw on unknown subscription', async () => {
       mockServer
-        .delete(`/customer/${UID}/subscriptions/${SUBSCRIPTION_ID}`)
+        .delete(`/v1/customer/${UID}/subscriptions/${SUBSCRIPTION_ID}`)
         .reply(400, { message: 'invalid subscription id' });
       const { log, subhub } = makeSubject();
       try {
@@ -285,7 +305,7 @@ describe('subscriptions', () => {
 
     it('should throw on backend service failure', async () => {
       mockServer
-        .delete(`/customer/${UID}/subscriptions/${SUBSCRIPTION_ID}`)
+        .delete(`/v1/customer/${UID}/subscriptions/${SUBSCRIPTION_ID}`)
         .reply(500, 'Internal Server Error');
       const { log, subhub } = makeSubject();
       try {
@@ -301,21 +321,21 @@ describe('subscriptions', () => {
 
   describe('getCustomer', () => {
     it('should yield customer details', async () => {
-      // TODO: update with final customer schema from subhub
       const expected = {
         payment_type: 'card',
-        last4: 8675,
+        last4: '8675',
         exp_month: 8,
-        exp_year: 2020
+        exp_year: 2020,
+        subscriptions: []
       };
-      mockServer.get(`/customer/${UID}`).reply(200, expected);
+      mockServer.get(`/v1/customer/${UID}`).reply(200, expected);
       const { subhub } = makeSubject();
       const resp = await subhub.getCustomer(UID);
       assert.deepEqual(resp, expected);
     });
 
     it('should throw on unknown user', async () => {
-      mockServer.get(`/customer/${UID}`)
+      mockServer.get(`/v1/customer/${UID}`)
         .reply(404, { message: 'invalid uid' });
       const { log, subhub } = makeSubject();
       try {
@@ -329,7 +349,7 @@ describe('subscriptions', () => {
     });
 
     it('should throw on backend service failure', async () => {
-      mockServer.get(`/customer/${UID}`).reply(500, 'Internal Server Error');
+      mockServer.get(`/v1/customer/${UID}`).reply(500, 'Internal Server Error');
       const { log, subhub } = makeSubject();
       try {
         await subhub.getCustomer(UID);
@@ -344,14 +364,19 @@ describe('subscriptions', () => {
 
   describe('updateCustomer', () => {
     it('should update payment method', async () => {
-      // TODO: update with final customer schema from subhub
-      const expected = {};
+      const expected = {
+        exp_month: 12,
+        exp_year: 2020,
+        last4: '8675',
+        payment_type: 'credit',
+        subscriptions: []
+      };
       const expectedBody = {
         pmt_token: PAYMENT_TOKEN_NEW
       };
       let requestBody;
       mockServer
-        .post(`/customer/${UID}`, body => requestBody = body)
+        .post(`/v1/customer/${UID}`, body => requestBody = body)
         .reply(201, expected);
       const { subhub } = makeSubject();
       const resp = await subhub.updateCustomer(UID, PAYMENT_TOKEN_NEW);
@@ -360,7 +385,7 @@ describe('subscriptions', () => {
     });
 
     it('should throw on unknown user', async () => {
-      mockServer.post(`/customer/${UID}`)
+      mockServer.post(`/v1/customer/${UID}`)
         .reply(404, { message: 'invalid uid' });
       const { log, subhub } = makeSubject();
       try {
@@ -374,7 +399,7 @@ describe('subscriptions', () => {
     });
 
     it('should throw on invalid payment token', async () => {
-      mockServer.post(`/customer/${UID}`)
+      mockServer.post(`/v1/customer/${UID}`)
         .reply(400, { message: 'invalid payment token' });
       const { log, subhub } = makeSubject();
       try {
@@ -388,7 +413,7 @@ describe('subscriptions', () => {
     });
 
     it('should throw on backend service failure', async () => {
-      mockServer.post(`/customer/${UID}`).reply(500, 'Internal Server Error');
+      mockServer.post(`/v1/customer/${UID}`).reply(500, 'Internal Server Error');
       const { log, subhub } = makeSubject();
       try {
         await subhub.updateCustomer(UID, PAYMENT_TOKEN_NEW);

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -16,7 +16,9 @@ const CLIENT_ID = 'client8675309';
 const CLIENT_ID_FOR_DEFAULT = 'client5551212';
 const PAYMENT_TOKEN = 'pay8675309';
 const PLAN_ID = 'allDoneProMonthly';
+const PLAN_NAME = 'All Done Pro Monthly';
 const PRODUCT_ID = 'megaProductHooray';
+const PRODUCT_NAME = 'All Done Pro';
 
 describe('remote subscriptions:', function () {
   this.timeout(10000);
@@ -27,7 +29,9 @@ describe('remote subscriptions:', function () {
       plans: [
         {
           plan_id: PLAN_ID,
+          plan_name: PLAN_NAME,
           product_id: PRODUCT_ID,
+          product_name: PRODUCT_NAME,
           interval: 'month',
           amount: 50,
           currency: 'usd'


### PR DESCRIPTION
~FYI: This PR depends on landing #1174 first.~

Withdrew #1174, tweaked this PR to no longer rely on those changes.

- General tweaks to better match current subhub API schemas

- Use both productId & productName in creating subscriptions

- Start using plan_name & product_name properties from subhub GET /plans

- Split `lib/subhub.js` into `lib/subhub/client.js` and
  `lib/subhub/stubAPI.js`

- Update and reorganize some subhub & subscriptions validators into
  `lib/route/validators.js`

- Bugfix for subhub API paths by adding a /v1/

- Test updates and a few TODOs

Issue #719