### PR TITLE
feat(trailhead): add support for multiple newletters

### DIFF
--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -279,14 +279,21 @@ module.exports = (log, db, mailer, config, customs, push, verificationReminders)
             reminder: isA.string().regex(REMINDER_PATTERN).optional(),
             type: isA.string().max(32).alphanum().optional(),
             style: isA.string().allow(['trailhead']).optional(),
-            marketingOptIn: isA.boolean()
+            marketingOptIn: isA.boolean(),
+            newsletters: isA.array().items(isA.string().valid(
+              'firefox-accounts-journey',
+              'knowledge-is-power',
+              'take-action-for-the-internet',
+              'test-pilot',
+              )).default([]).optional()
           }
         }
       },
       handler: async function (request) {
         log.begin('Account.RecoveryEmailVerify', request);
 
-        const { code, marketingOptIn, reminder, service, type, uid, style } = request.payload;
+        const { code, marketingOptIn, newsletters, reminder, service, style, type, uid } = request.payload;
+
 
         // verify_code because we don't know what type this is yet, but
         // we want to record right away before anything could fail, so
@@ -431,6 +438,7 @@ module.exports = (log, db, mailer, config, customs, push, verificationReminders)
                         email: account.email,
                         locale: account.locale,
                         marketingOptIn: marketingOptIn ? true : undefined,
+                        newsletters,
                         service,
                         uid,
                         userAgent: request.headers['user-agent'],
@@ -439,6 +447,7 @@ module.exports = (log, db, mailer, config, customs, push, verificationReminders)
                         // The content server omits marketingOptIn in the false case.
                         // Force it so that we emit the appropriate newsletter state.
                         marketingOptIn: marketingOptIn || false,
+                        newsletters,
                         uid
                       }),
                       reminder ? request.emitMetricsEvent(`account.reminder.${reminder}`, { uid }) : null,

--- a/packages/fxa-auth-server/npm-shrinkwrap.json
+++ b/packages/fxa-auth-server/npm-shrinkwrap.json
@@ -2458,9 +2458,9 @@
       }
     },
     "fxa-shared": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.24.tgz",
-      "integrity": "sha512-xrAB4sIRhwWcZoxWjwrRoDCDCEo7TzKxlGpkG1CKQDCpbO7uT5ddWEiDYfbOxfe17621fy/VWm8n+8TUOFJddg==",
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.25.tgz",
+      "integrity": "sha512-P+Mr/nZyQ3I2KA3ldONKk9L4i4k2nnWDytR4OPXh1kjehmFpJJql62wIdvxtAnDHVClqlXDotOOMfI8FhxkoIg==",
       "requires": {
         "accept-language": "2.0.17",
         "ajv": "6.10.0",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -51,7 +51,7 @@
     "fxa-geodb": "1.0.4",
     "fxa-jwtool": "0.7.2",
     "fxa-notifier-aws": "1.0.0",
-    "fxa-shared": "1.0.24",
+    "fxa-shared": "1.0.25",
     "generic-pool": "3.2.0",
     "google-libphonenumber": "2.0.10",
     "grunt-nunjucks-2-html": "3.1.0",

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -485,7 +485,8 @@ module.exports = config => {
         service: options.service || undefined,
         type: options.type || undefined,
         verifiedEmail: options.verifiedEmail || undefined,
-        style: options.style || undefined
+        style: options.style || undefined,
+        newsletters: options.newsletters || undefined
       },
       {
         'accept-language': options.lang

--- a/packages/fxa-auth-server/test/local/metrics/amplitude.js
+++ b/packages/fxa-auth-server/test/local/metrics/amplitude.js
@@ -400,6 +400,44 @@ describe('metrics/amplitude', () => {
       });
     });
 
+    describe('account.verified, newsletters is empty', () => {
+      beforeEach(() => {
+        return amplitude('account.verified', mocks.mockRequest({}), {
+          newsletters: []
+        });
+      });
+
+      it('did not call log.error', () => {
+        assert.equal(log.error.callCount, 0);
+      });
+
+      it('called log.amplitudeEvent correctly', () => {
+        assert.equal(log.amplitudeEvent.callCount, 1);
+        const args = log.amplitudeEvent.args[0];
+        assert.equal(args[0].event_type, 'fxa_reg - email_confirmed');
+        assert.deepEqual(args[0].user_properties.newsletters, []);
+      });
+    });
+
+    describe('account.verified, subscribe to beta newsletters', () => {
+      beforeEach(() => {
+        return amplitude('account.verified', mocks.mockRequest({}), {
+          newsletters: ['test-pilot']
+        });
+      });
+
+      it('did not call log.error', () => {
+        assert.equal(log.error.callCount, 0);
+      });
+
+      it('called log.amplitudeEvent correctly', () => {
+        assert.equal(log.amplitudeEvent.callCount, 1);
+        const args = log.amplitudeEvent.args[0];
+        assert.equal(args[0].event_type, 'fxa_reg - email_confirmed');
+        assert.deepEqual(args[0].user_properties.newsletters, ['test_pilot']);
+      });
+    });
+
     describe('flow.complete (sign-up)', () => {
       beforeEach(() => {
         return amplitude('flow.complete', mocks.mockRequest({}), {}, {

--- a/packages/fxa-auth-server/test/local/routes/emails.js
+++ b/packages/fxa-auth-server/test/local/routes/emails.js
@@ -510,6 +510,7 @@ describe('/recovery_email/verify_code', () => {
           country: 'United States',
           event: 'account.verified',
           marketingOptIn: false,
+          newsletters: undefined,
           region: 'California',
           service: 'sync',
           uid: uid.toString('hex'),
@@ -555,6 +556,25 @@ describe('/recovery_email/verify_code', () => {
         args = mockLog.amplitudeEvent.args[1];
         assert.equal(args[0].event_type, 'fxa_reg - email_confirmed', 'second call to amplitudeEvent was email_confirmed event');
         assert.equal(args[0].user_properties.newsletter_state, 'subscribed', 'newsletter_state was correct');
+
+        assert.equal(JSON.stringify(response), '{}');
+      });
+    });
+
+    it('with newsletters', () => {
+      mockRequest.payload.newsletters = ['test-pilot', 'firefox-pilot'];
+      return runTest(route, mockRequest, (response) => {
+        assert.equal(mockLog.notifyAttachedServices.callCount, 1, 'logs verified');
+        let args = mockLog.notifyAttachedServices.args[0];
+        assert.equal(args[0], 'verified');
+        assert.equal(args[2].uid, uid);
+        assert.deepEqual(args[2].newsletters, ['test-pilot', 'firefox-pilot']);
+        assert.equal(args[2].service, 'sync');
+
+        assert.equal(mockLog.amplitudeEvent.callCount, 3, 'amplitudeEvent was called 3 times');
+        args = mockLog.amplitudeEvent.args[2];
+        assert.equal(args[0].event_type, 'fxa_reg - email_confirmed', 'second call to amplitudeEvent was email_confirmed event');
+        assert.deepEqual(args[0].user_properties.newsletters, ['test_pilot', 'firefox_pilot'], 'newsletters was correct');
 
         assert.equal(JSON.stringify(response), '{}');
       });

--- a/packages/fxa-js-client/client/FxAccountClient.js
+++ b/packages/fxa-js-client/client/FxAccountClient.js
@@ -304,6 +304,8 @@ define([
    *   Type of code being verified, only supports `secondary` otherwise will verify account/sign-in
    *   @param {Boolean} [options.marketingOptIn]
    *   If `true`, notifies marketing of opt-in intent.
+   *   @param {Array} [options.newsletters]
+   *   Array of newsletters to opt in or out of.
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
    */
   FxAccountClient.prototype.verifyCode = function(uid, code, options) {
@@ -334,6 +336,10 @@ define([
 
           if (options.marketingOptIn) {
             data.marketingOptIn = true;
+          }
+
+          if (options.newsletters) {
+            data.newsletters = options.newsletters;
           }
         }
 

--- a/packages/fxa-js-client/tests/lib/verifyCode.js
+++ b/packages/fxa-js-client/tests/lib/verifyCode.js
@@ -195,6 +195,38 @@ define([
             assert.notOk
           );
       });
+
+      test('#verifyEmail with newsletters param', function () {
+        var user = 'test7' + new Date().getTime();
+        var email = user + '@restmail.net';
+        var password = 'iliketurtles';
+        var uid;
+
+        return respond(client.signUp(email, password), RequestMocks.signUp)
+          .then(function (result) {
+            uid = result.uid;
+            assert.ok(uid, 'uid is returned');
+
+            return respond(mail.wait(user), RequestMocks.mail);
+          })
+          .then(function (emails) {
+            var code = emails[0].html.match(/code=([A-Za-z0-9]+)/)[1];
+            assert.ok(code, 'code is returned');
+
+            return respond(client.verifyCode(uid, code, { newsletters: ['test-pilot'] }),
+              RequestMocks.verifyCode);
+          })
+          .then(
+            function (result) {
+              assert.ok(result);
+              assert.equal(xhrOpen.args[2][0], 'POST', 'method is correct');
+              assert.include(xhrOpen.args[2][1], '/recovery_email/verify_code', 'path is correct');
+              var sentData = JSON.parse(xhrSend.args[2][0]);
+              assert.deepEqual(sentData.newsletters, ['test-pilot']);
+            },
+            assert.notOk
+          );
+      });
     });
   }
 });


### PR DESCRIPTION
Opening this PR up as a draft for https://github.com/mozilla/fxa/issues/1102.

This has added initial support for subscribing to multiple email newsletters. When a user verifies an account via `/verify_code` endpoint, they can pass an additional array `newsletters` that contains the newsletter slug names defined in https://docs.google.com/spreadsheets/d/1CdsuwXBhXhJ9LBMthRMDx9ATEGWDiKXlZoPFWLjjKzI/edit#gid=0. 

- [x] Update tests
- [x] Upate JS client
- [x] Verfiy correct metrics emitted