### PR TITLE
fix(clients): Include refresh tokens when determining active OAuth clients

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/db/helpers.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/db/helpers.js
@@ -46,7 +46,7 @@ module.exports = {
 
       activeClients[clientIdHex].scope.add(clientTokenObj.scope);
 
-      var clientTokenTime = clientTokenObj.createdAt;
+      var clientTokenTime = clientTokenObj.lastUsedAt || clientTokenObj.createdAt;
       if (clientTokenTime > activeClients[clientIdHex].lastAccessTime) {
         // only update the createdAt if it is newer
         activeClients[clientIdHex].lastAccessTime = clientTokenTime;


### PR DESCRIPTION
This is related to https://github.com/mozilla/fxa/issues/946, but is not a complete fix.

Currently, OAuth clients can "hide" from the devices-and-apps list by creating a refresh token and either (a) being a "can grant" client, or (b) destroying all their access tokens after they use them. As @callahad notes [here](https://github.com/mozilla/fxa/issues/946#issuecomment-492332246), that can be scary for the user because they lack visibility into what's connected to their account.

This is a first step to improving the situation, by examining active refresh tokens as well as access tokens when generating the list of connected clients.

It's far from perfect. If you have two separate instances of Lockbox connected they will appear as a single "Lockbox" entry. When Fenix ships support for registering a device record, we might end up listing it twice, once for the device record and once for its refresh token. But I think in all cases the new behaviour is better than the current behaviour, so I'm posting this as an incremental improvement while we continue working on https://github.com/mozilla/fxa/issues/466.

(I have a work-in-progress patch for https://github.com/mozilla/fxa/issues/466 FWIW, but it's going to take me a few more days to polish it).