### PR TITLE
feat(trailhead): add support for multiple newletters in amplitude

### DIFF
--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -245,7 +245,8 @@ module.exports = {
         }),
         mapAppendProperties(data),
         mapSyncDevices(data),
-        mapNewsletterState(eventCategory, data)
+        mapNewsletterState(eventCategory, data),
+        mapNewsletters(data),
       );
     }
 
@@ -333,5 +334,15 @@ function mapNewsletterState (eventCategory, data) {
 
   if (newsletter_state) {
     return { newsletter_state };
+  }
+}
+
+function mapNewsletters (data) {
+  let {newsletters} = data;
+  if (newsletters) {
+    newsletters = newsletters.map((newsletter) => {
+      return toSnakeCase(newsletter);
+    });
+    return {newsletters};
   }
 }

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -86,7 +86,11 @@ describe('metrics/amplitude:', () => {
         [ /newsletter\.(\w+)\.(\w+)/, {
           group: amplitude.GROUPS.settings,
           event: 'newsletterEvent'
-        } ]
+        } ],
+        [ /newsletters\.(\w+)\.(\w+)/, {
+          group: amplitude.GROUPS.settings,
+          event: 'newsletters'
+        } ],
       ]));
     });
 
@@ -301,7 +305,7 @@ describe('metrics/amplitude:', () => {
       });
     });
 
-    describe('transform an event with newsletter properties:', () => {
+    describe('transform an event with newsletter optIn properties:', () => {
       let result;
 
       before(() => {
@@ -311,6 +315,24 @@ describe('metrics/amplitude:', () => {
       it('returned the correct event data', () => {
         assert.equal(result.event_type, 'fxa_pref - newsletterEvent');
         assert.deepEqual(result.user_properties, { newsletter_state: 'subscribed' });
+      });
+    });
+
+    describe('transform an event with newsletters optIn properties:', () => {
+      let result;
+
+      before(() => {
+        result = transform({ type: 'newsletters.optIn.wibble' }, {
+          newsletters: ['test-pilot']
+        });
+      });
+
+      it('returned the correct event data', () => {
+        assert.equal(result.event_type, 'fxa_pref - newsletters');
+        assert.deepEqual(result.user_properties, {
+          newsletter_state: "subscribed",
+          newsletters: ['test_pilot']
+        });
       });
     });
 


### PR DESCRIPTION
Extracted from https://github.com/mozilla/fxa/pull/1177, since this would need a new fxa-shared version.

This sets new user properties `newsletters` in amplitude if a user has specified newsletter subscriptions. I don't have a lot of experience in this part of the code, so I could be doing things bonkers. 

In the new property, the keys are the email subscription slugs defined at https://docs.google.com/spreadsheets/d/1CdsuwXBhXhJ9LBMthRMDx9ATEGWDiKXlZoPFWLjjKzI/edit#gid=0, with `-` replaced with `_`.

@philbooth @shane-tomlinson Mind a sanity check and if this makes sense?