### PR TITLE
feat(trailhead): Update UI for force_auth

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
@@ -1,13 +1,18 @@
 <div id="main-content" class="card">
   <header>
     <h1 id="fxa-force-auth-header">
-      {{#serviceName}}
-        <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-        {{#t}}Sign in{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
-      {{/serviceName}}
-      {{^serviceName}}
-        {{#t}}Sign in to continue{{/t}}
-      {{/serviceName}}
+      {{#isTrailhead}}
+        {{#unsafeTranslate}}Sign in <span class="service">to your Firefox account</span>{{/unsafeTranslate}}
+      {{/isTrailhead}}
+      {{^isTrailhead}}
+        {{#serviceName}}
+          <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
+          {{#t}}Sign in{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+        {{/serviceName}}
+        {{^serviceName}}
+          {{#t}}Sign in to continue{{/t}}
+        {{/serviceName}}
+      {{/isTrailhead}}
     </h1>
   </header>
 
@@ -18,8 +23,9 @@
     {{^fatalError}}
 
     <div class="error"></div>
-    <div class="avatar-wrapper avatar-view"></div>
-    <p class="prefillEmail">{{ email }}</p>
+
+    {{{ userCardHTML }}}
+
     <form novalidate>
       <input type="email" class="email hidden" value="{{ email }}" disabled />
       <div class="input-row password-row">

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -22,7 +22,6 @@
 
     {{{ userCardHTML }}}
 
-
     <form novalidate>
       <input type="email" class="email hidden" value="{{ email }}" disabled />
 

--- a/packages/fxa-content-server/app/scripts/views/force_auth.js
+++ b/packages/fxa-content-server/app/scripts/views/force_auth.js
@@ -6,13 +6,13 @@ import _ from 'underscore';
 import AuthErrors from '../lib/auth-errors';
 import cancelEventThen from './decorators/cancel_event_then';
 import Cocktail from 'cocktail';
-import FormView from './form';
 import NullBehavior from './behaviors/null';
 import PasswordResetMixin from './mixins/password-reset-mixin';
 import SignInView from './sign_in';
 import ServiceMixin from './mixins/service-mixin';
 import Template from 'templates/force_auth.mustache';
 import Transform from '../lib/transform';
+import UserCardMixin from './mixins/user-card-mixin';
 import Vat from '../lib/vat';
 
 const t = msg => msg;
@@ -177,27 +177,16 @@ var View = SignInView.extend({
     return proto.onSignInError.call(this, account, password, error);
   },
 
-  /**
-     * Displays the account's avatar
-     *
-     * @returns {Promise}
-     */
-  afterVisible () {
-    var email = this.relier.get('email');
-    var account = this.user.getAccountByEmail(email);
-
-    // Use FormView's afterVisible because SignIn attempts to
-    // display a profile image for the "suggested" account.
-    FormView.prototype.afterVisible.call(this);
-    // Display the profile image if possible, otherwise show a placeholder.
-    return this.displayAccountProfileImage(account, { spinner: true });
+  getAccount () {
+    return this.user.getAccountByEmail(this.relier.get('email'));
   }
 });
 
 Cocktail.mixin(
   View,
   PasswordResetMixin,
-  ServiceMixin
+  ServiceMixin,
+  UserCardMixin,
 );
 
 export default View;

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
@@ -9,11 +9,14 @@ import Broker from 'models/auth_brokers/base';
 import FormPrefill from 'models/form-prefill';
 import Notifier from 'lib/channels/notifier';
 import Relier from 'models/reliers/relier';
+import { SIGNIN_PASSWORD } from '../../../../tests/functional/lib/selectors';
 import sinon from 'sinon';
 import User from 'models/user';
 import View from 'views/sign_in_password';
 
 const EMAIL = 'testuser@testuser.com';
+
+const Selectors = SIGNIN_PASSWORD;
 
 describe('views/sign_in_password', () => {
   let account;
@@ -83,12 +86,25 @@ describe('views/sign_in_password', () => {
 
   describe('render', () => {
     it('renders as expected, initializes flow events', () => {
-      assert.include(view.$('.service').text(), 'Firefox Sync');
+      assert.include(view.$(Selectors.SUB_HEADER).text(), 'Firefox Sync');
       assert.lengthOf(view.$('input[type=email]'), 1);
       assert.equal(view.$('input[type=email]').val(), EMAIL);
       assert.lengthOf(view.$('input[type=password]'), 1);
       assert.isTrue(notifier.trigger.calledOnce);
       assert.isTrue(notifier.trigger.calledWith('flow.initialize'));
+    });
+
+    it('renders as expected for trailhead', () => {
+      relier.set({
+        serviceName: 'Firefox Sync'
+      });
+
+      sinon.stub(view, 'isTrailhead').callsFake(() => true);
+
+      return view.render().then(() => {
+        assert.equal(view.$(Selectors.SUB_HEADER).text(), 'to your Firefox account');
+        assert.lengthOf(view.$(Selectors.PROGRESS_INDICATOR), 0);
+      });
     });
   });
 

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -146,7 +146,9 @@ module.exports = {
   },
   FORCE_AUTH: {
     EMAIL: 'input[type=email]',
-    HEADER: '#fxa-force-auth-header'
+    HEADER: '#fxa-force-auth-header',
+    PROGRESS_INDICATOR: '.step',
+    SUB_HEADER: '#fxa-force-auth-header .service',
   },
   MOZILLA_ORG_SYNC: {
     HEADER: '.mzp-c-navigation'
@@ -231,6 +233,7 @@ module.exports = {
     LINK_USE_DIFFERENT: '.use-different',
     MIGRATION_NUDGE: '#suggest-sync',
     PASSWORD: 'input[type=password]',
+    PROGRESS_INDICATOR: '.step',
     RESET_PASSWORD: 'a[href^="/reset_password"]',
     SUB_HEADER: '#fxa-signin-header .service',
     SUBMIT: 'button[type=submit]',
@@ -254,7 +257,9 @@ module.exports = {
     LINK_FORGOT_PASSWORD: 'a[href^="/reset_password"]',
     LINK_MISTYPED_EMAIL: '.use-different',
     PASSWORD: 'input[type=password]',
+    PROGRESS_INDICATOR: '.step',
     SHOW_PASSWORD: '#password ~ .show-password-label',
+    SUB_HEADER: '#fxa-signin-password-header .service',
     SUBMIT: 'button[type="submit"]',
   },
   SIGNIN_RECOVERY_CODE: {


### PR DESCRIPTION
Wireframe: https://docs.google.com/presentation/d/1fv1EdAxmtHt6jypDgp8UQt0tN9K_WQW2sRdlfLss9GI/edit#slide=id.g5781b6e478_0_46

### force_auth desktop
<img width="584" alt="Screenshot 2019-05-21 at 16 02 01" src="https://user-images.githubusercontent.com/848085/58107462-cedda100-7be1-11e9-95f3-c897e0c09233.png">

### force_auth mobile
<img width="381" alt="Screenshot 2019-05-21 at 16 02 07" src="https://user-images.githubusercontent.com/848085/58107463-cedda100-7be1-11e9-842e-215e85edebf9.png">

Also added a test to the legacy sign_in and sign_in_password tests to ensure "to your Firefox account" is displayed instead of "to continue to Firefox Sync"

Extraction from #1098
issue #1084

@mozilla/fxa-devs - r?