### PR TITLE
chore(version): bump fxa-shared version 1.0.25

### DIFF
--- a/packages/fxa-shared/package-lock.json
+++ b/packages/fxa-shared/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Shared module for FxA repositories",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Version 1.0.25 published via np, ref https://www.npmjs.com/package/fxa-shared

@mozilla/fxa-devs r?