### PR TITLE
WIP feat(clients): Add API for listing all active client authorizations.

### DIFF
--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -33,6 +33,8 @@ see [`mozilla/fxa-js-client`](https://github.com/mozilla/fxa-js-client).
     * [GET /account/device/commands (:lock: sessionToken, refreshToken)](#get-accountdevicecommands)
     * [POST /account/devices/invoke_command (:lock: sessionToken, refreshToken)](#post-accountdevicesinvoke_command)
     * [POST /account/devices/notify (:lock: sessionToken, refreshToken)](#post-accountdevicesnotify)
+    * [GET /account/connected_clients (:lock: sessionToken)](#get-accountconnected_clients)
+    * [POST /account/connected_clients/destroy (:lock: sessionToken)](#get-accountconnected_clientsdestroy)
     * [GET /account/devices (:lock: sessionToken, refreshToken)](#get-accountdevices)
     * [GET /account/sessions (:lock: sessionToken)](#get-accountsessions)
     * [POST /account/device/destroy (:lock: sessionToken, refreshToken)](#post-accountdevicedestroy)
@@ -1355,6 +1357,67 @@ by the following errors
 
 * `code: 503, errno: 202`:
   Feature not enabled
+
+
+
+#### GET /account/connected_clients
+
+:lock: HAWK-authenticated with session token
+<!--begin-route-get-accountsessions-->
+Returns an array listing all the clients connected to the authenticated user's account,
+including devices, OAuth clients, and web sessions.
+
+This endpoint is primarily designed to power the "devices and apps" view
+on the user's account settings page. Depending on the type of client, it will have
+at least one and possibly several of the following properties:
+
+* `clientId`: The OAuth client_id of the connected application.
+* `sessionTokenId`: The id of the `sessionToken` held by that client, if any.
+* `refreshTokenId`: The id of the OAuth `refreshToken` held by that client, if any.
+* `deviceId`: The id of the client's device record, if it has registered one.
+
+These identifiers can be passed to TODO:destroy in order to disconnect the client.
+
+<!--end-route-get-accountsessions-->
+
+##### Response body
+
+* `clientId`: *string, regex(HEX_STRING), optional*
+* `sessionTokenId`: *string, regex(HEX_STRING), optional*
+* `refreshTokenId`: *string, regex(HEX_STRING), optional*
+* `deviceId`: *string, regex(HEX_STRING), optional*
+* `deviceName`: *DEVICES_SCHEMA.nameResponse.allow('').allow(null).required*
+* `deviceType`: *DEVICES_SCHEMA.type.allow(null).required*
+* `isCurrentDevice`: *boolean, required*
+* `createdTime`: *number, min(0), required, allow(null)*
+* `createdTimeFormatted`: *string, optional, allow('')*
+* `lastAccessTime`: *number, min(0), required, allow(null)*
+* `lastAccessTimeFormatted`: *string, optional, allow('')*
+* `approximateLastAccessTime`: *number, min(earliestSaneTimestamp), optional*
+* `approximateLastAccessTimeFormatted`: *string, optional, allow('')*
+* `location`: *DEVICES_SCHEMA.location, optional*
+  Object containing the client's last-known geolocation info (state and country) if available.
+* `userAgent`: *string, max(255), required, allow('')*
+* `os`: *string, max(255), allow(''), allow(null)*
+
+
+#### POST /account/connected_client/destroy
+
+:lock: HAWK-authenticated with session token
+<!--begin-route-post-accountdevicedestroy-->
+Destroy all tokens held by a connected client, disconnecting it from the user's account.
+
+This endpoint is designed to be used in conjunction with TODO:connected.
+It accepts as the request body an object in the same format as returned by that endpoing,
+and will disconnect that client from the user's account.
+<!--end-route-post-accountdevicedestroy-->
+
+##### Request body
+
+* `clientId`: *string, regex(HEX_STRING), optional*
+* `sessionTokenId`: *string, regex(HEX_STRING), optional*
+* `refreshTokenId`: *string, regex(HEX_STRING), optional*
+* `deviceId`: *string, regex(HEX_STRING), optional*
 
 
 #### GET /account/devices

--- a/packages/fxa-auth-server/fxa-oauth-server/docs/api.md
+++ b/packages/fxa-auth-server/fxa-oauth-server/docs/api.md
@@ -74,8 +74,10 @@ The currently-defined error responses are:
   - [POST /v1/developer/activate][developer-activate]
 - [POST /v1/verify][verify]
 - [POST /v1/key-data][key-data]
-- [GET /v1/client-tokens][client-tokens]
-- [DELETE /v1/client-tokens/:id][client-tokens-delete]
+- [POST /v1/authorized-clients][authorized-clients]
+- [POST /v1/authorized-clients/destroy][authorized-clients-destroy]
+- (**DEPRECATED**) [GET /v1/client-tokens][client-tokens]
+- (**DEPRECATED**) [DELETE /v1/client-tokens/:id][client-tokens-delete]
 
 ### GET /v1/client/:id
 
@@ -598,7 +600,113 @@ A valid response will return JSON the scoped key information for every scope tha
 }
 ```
 
+### GET /v1/authorized-clients
+
+This endpoint returns a list of all OAuth client instances connected to the user's account,
+including the the scopes granted to each client instance
+and the time at which it was last active, if available.
+It must be authenticated with an identity assertion for the user's account.
+
+#### Request Parameters
+
+- `assertion`: A FxA assertion for the signed-in user.
+
+**Example:**
+
+```sh
+curl -X POST \
+  https://oauth.accounts.firefox.com/v1/authorized-clients \
+  -H 'cache-control: no-cache' \
+  -H 'content-type: application/json' \
+  -d '{
+ "assertion": "eyJhbGciOiJSUzI1NiJ9.eyJwdWJsaWMta2V5Ijp7Imt0eSI6IlJTQSIsIm4iOiJvWmdsNkpwM0Iwcm5BVXppNThrdS1iT0RvR3ZuUGNnWU1UdXQ1WkpyQkJiazBCdWU4VUlRQ0dnYVdrYU5Xb29INkktMUZ6SXU0VFpZYnNqWGJ1c2JRRlQxOGREUkN6VVRubFlXdVZXUzhoSWhKc3lhZHJwSHJOVkI1VndmSlRKZVgwTjFpczBXcU1qdUdOc2VMLXluYnFjOVhueElncFJaai05QnZqY2ZKYXNOUTNZdHR3VHZVaFJOLVFGNWgxQkY1MnA2QmdOTVBvWmQ5MC1EU0xydlpseXp6MEh0Q2tFZnNsc013czVkR0ExTlZ1dEwtcGVDeU50VTFzOEtFaDlzcGxXeF9lQlFybTlYQU1kYXp5ZWR6VUpJU1UyMjZmQzhEUHh5c0ZreXpCbjlDQnFDQUpTNjQzTGFydUVDaS1rMGhKOWFmM2JXTmJnWmpSNVJ2NXF4THciLCJlIjoiQVFBQiJ9LCJwcmluY2lwYWwiOnsiZW1haWwiOiIwNjIxMzM0YzIwNjRjNmYzNmJlOGFkOWE0N2M1NTliY2FwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9LCJpYXQiOjE1MDY5Njk2OTU0MzksImV4cCI6MTUwNjk2OTY5NjQzOSwiZnhhLXZlcmlmaWVkRW1haWwiOiIzMjM2NzJiZUBtb3ppbGxhLmNvbSIsImlzcyI6ImFwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9.hFZd5zFheXOFrXKkJvw6Vpv2l7ctlxuBTvuh5f_jLPAjZoJ9ri-vaJjL_WYBFUvS2xHzfx3-ldxLddyTKwCDAJeB_NkOFL_WJSrMet9C7_Z1hH9HmydeXIT82xJmhrwzW-WOO4ibQvRbocEFiNujynKsg1gS8v0iiYjIX-0cXCrlkxkbVx_8EXJFKDDOGzK9v7Zq6D7gkhP-CHEaNYaTHMn65tLQtBS6snGdaXlxoGHMWmDL6STbnJzWa7sa4QwHf-AgT1rUkQQAUHNa_XLZ0FEzqiCPctMadlihiUZL2V6vxIDBS4mHUF4qj0FvIMJflivDnJVkRNijDuP-h-Lh_A~eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJvYXV0aC5meGEiLCJleHAiOjE1MDY5Njk2OTY0MzksImlzcyI6ImFwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9.M5xyk3RffucgaavjbUm7Eqnt47hzeGbGa2VR3jnVEIlRHfz5S25Qf3ngejwee7XECvIywbaKWeijXFOwS-EkB-7qP1gl4oNJjPmbnCk7S1lgckLWvdMIU-HLGKjrN6Mw76__LzvAbsusSeGmsvTCIVuOJ49Xs3tC1fLyB_re0QNpCcS6AUnJ1KOxIMEM3Om7ysNO5F_AqcD3PwlEti5lbwSk8iP5TWL12C2Nkb_6Hxze_mA1NZNAHOips9bF2J7oy1hqGoMYj1XYZrsyjpPWEuZQATAPlKSjbh1hq-UtDeT7DlwEmIbIUd3JA8qh1MkHKGgavd4fIMap0IPmr9rs4A",
+}'
+```
+
+#### Response
+
+A valid 200 response will be a JSON array
+where each item has the following properties:
+
+- `client_id`: The hex id of the client.
+- `refresh_token_id`: (optional) The ID of the refresh token held the client instance
+- `client_name`: The string name of the client.
+- `creation_time`: Integer time of token creation.
+- `creation_time_formatted`: Localized string time of token creation.
+- `last_access_time`: Integer last-access time for the token.
+- `last_access_time_formatted`: Localized string last-access time for the token.
+- `scope`: Sorted list of all scopes granted to the client instance.
+
+For clients that use refresh tokens, each refresh token is taken to represent
+a separate instance of that client and is returned as a separate entry in the list,
+with the `refresh_token_id` field distinguishing each.
+
+For clients that only use access tokens, all active access tokens are combined
+into a single entry in the list, and the `refresh_token_id` field will not be present.
+
+**Example:**
+
+```json
+[
+  {
+    "client_id": "5901bd09376fadaa",
+    "refresh_token_id": "6e8c38f6a9c27dc0e4df698dc3e3e8b101ad6d79e87842b1ca96ad9b3cd8ed28",
+    "name": "Example Sync Client",
+    "last_access_time": 1528334748000,
+    "last_access_time_formatted": "13 days ago",
+    "scope": ["profile", "https://identity.mozilla.com/apps/oldsync"]
+  },
+  {
+    "client_id": "5901bd09376fadaa",
+    "refresh_token_id": "eb5e17f246a6b0937356412118ea12b67a638232d6b376e2511cf38a0c4eecf9",
+    "name": "Example Sync Client",
+    "last_access_time": 1528334834000,
+    "last_access_time_formatted": "18 days ago",
+    "scope": ["profile", "https://identity.mozilla.com/apps/oldsync"]
+  },
+  {
+    "client_id": "23d10a14f474ca41",
+    "name": "Example Website",
+    "last_access_time": 1476677854037,
+    "last_access_time_formatted": "2 years ago",
+    "scope": ["profile:email", "profile:uid"]
+  }
+]
+```
+
+### POST /v1/authorized-clients/destroy
+
+This endpoint revokes tokens granted to a given client.
+It must be authenticated with an identity assertion for the user's account.
+
+#### Request Parameters
+
+- `client_id`: The `client_id` of the client whose tokens should be deleted.
+- `refresh_token_id`: (Optional) The specific `refresh_token_id` to be destroyed.
+- `assertion`: A FxA assertion for the signed-in user.
+
+
+**Example:**
+
+```sh
+curl -X POST \
+  https://oauth.accounts.firefox.com/v1/authorized-clients/destroy \
+  -H 'cache-control: no-cache' \
+  -H 'content-type: application/json' \
+  -d '{
+ "client_id": "5901bd09376fadaa",
+ "refresh_token_id": "6e8c38f6a9c27dc0e4df698dc3e3e8b101ad6d79e87842b1ca96ad9b3cd8ed28",
+ "assertion": "eyJhbGciOiJSUzI1NiJ9.eyJwdWJsaWMta2V5Ijp7Imt0eSI6IlJTQSIsIm4iOiJvWmdsNkpwM0Iwcm5BVXppNThrdS1iT0RvR3ZuUGNnWU1UdXQ1WkpyQkJiazBCdWU4VUlRQ0dnYVdrYU5Xb29INkktMUZ6SXU0VFpZYnNqWGJ1c2JRRlQxOGREUkN6VVRubFlXdVZXUzhoSWhKc3lhZHJwSHJOVkI1VndmSlRKZVgwTjFpczBXcU1qdUdOc2VMLXluYnFjOVhueElncFJaai05QnZqY2ZKYXNOUTNZdHR3VHZVaFJOLVFGNWgxQkY1MnA2QmdOTVBvWmQ5MC1EU0xydlpseXp6MEh0Q2tFZnNsc013czVkR0ExTlZ1dEwtcGVDeU50VTFzOEtFaDlzcGxXeF9lQlFybTlYQU1kYXp5ZWR6VUpJU1UyMjZmQzhEUHh5c0ZreXpCbjlDQnFDQUpTNjQzTGFydUVDaS1rMGhKOWFmM2JXTmJnWmpSNVJ2NXF4THciLCJlIjoiQVFBQiJ9LCJwcmluY2lwYWwiOnsiZW1haWwiOiIwNjIxMzM0YzIwNjRjNmYzNmJlOGFkOWE0N2M1NTliY2FwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9LCJpYXQiOjE1MDY5Njk2OTU0MzksImV4cCI6MTUwNjk2OTY5NjQzOSwiZnhhLXZlcmlmaWVkRW1haWwiOiIzMjM2NzJiZUBtb3ppbGxhLmNvbSIsImlzcyI6ImFwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9.hFZd5zFheXOFrXKkJvw6Vpv2l7ctlxuBTvuh5f_jLPAjZoJ9ri-vaJjL_WYBFUvS2xHzfx3-ldxLddyTKwCDAJeB_NkOFL_WJSrMet9C7_Z1hH9HmydeXIT82xJmhrwzW-WOO4ibQvRbocEFiNujynKsg1gS8v0iiYjIX-0cXCrlkxkbVx_8EXJFKDDOGzK9v7Zq6D7gkhP-CHEaNYaTHMn65tLQtBS6snGdaXlxoGHMWmDL6STbnJzWa7sa4QwHf-AgT1rUkQQAUHNa_XLZ0FEzqiCPctMadlihiUZL2V6vxIDBS4mHUF4qj0FvIMJflivDnJVkRNijDuP-h-Lh_A~eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJvYXV0aC5meGEiLCJleHAiOjE1MDY5Njk2OTY0MzksImlzcyI6ImFwaS5hY2NvdW50cy5maXJlZm94LmNvbSJ9.M5xyk3RffucgaavjbUm7Eqnt47hzeGbGa2VR3jnVEIlRHfz5S25Qf3ngejwee7XECvIywbaKWeijXFOwS-EkB-7qP1gl4oNJjPmbnCk7S1lgckLWvdMIU-HLGKjrN6Mw76__LzvAbsusSeGmsvTCIVuOJ49Xs3tC1fLyB_re0QNpCcS6AUnJ1KOxIMEM3Om7ysNO5F_AqcD3PwlEti5lbwSk8iP5TWL12C2Nkb_6Hxze_mA1NZNAHOips9bF2J7oy1hqGoMYj1XYZrsyjpPWEuZQATAPlKSjbh1hq-UtDeT7DlwEmIbIUd3JA8qh1MkHKGgavd4fIMap0IPmr9rs4A",
+}'
+```
+
+#### Response
+
+A valid 200 response will return an empty JSON object.
+
 ### GET /v1/client-tokens
+
+**DEPRECATED**: Please use [POST /v1/authorized-clients][authorized-clients] instead.
 
 This endpoint returns a list of all clients with active OAuth tokens for the user,
 including the the scopes granted to each client
@@ -619,7 +727,7 @@ curl -X GET \
 #### Response
 
 A valid 200 response will be a JSON array
-where each item as the following properties:
+where each item has the following properties:
 
 - `id`: The hex id of the client.
 - `name`: The string name of the client.
@@ -649,6 +757,8 @@ where each item as the following properties:
 ```
 
 ### DELETE /v1/client-tokens/:id
+
+**DEPRECATED**: Please use [POST /v1/authorized-clients/destroy][authorized-clients-destroy] instead.
 
 This endpoint deletes all tokens granted to a given client.
 It must be authenticated with an OAuth token bearing scope "clients:write".
@@ -684,5 +794,7 @@ A valid 200 response will return an empty JSON object.
 [developer-activate]: #post-v1developeractivate
 [jwks]: #get-v1jwks
 [key-data]: #post-v1post-keydata
+[authorized-clients]: #post-v1authorized-clients
+[authorized-clients-destroy]: #post-v1authorized-clientsdestroy
 [client-tokens]: #get-v1client-tokens
 [client-tokens-delete]: #delete-v1client-tokensid

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/db/memory.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/db/memory.js
@@ -174,7 +174,7 @@ MemoryStore.prototype = {
       } else if (key === 'hashedSecret') {
         old.hashedSecret = buf(client[key]);
       } else if (key === 'hashedSecretPrevious') {
-        old.hashedSecretPrevious = buf(client[key]);
+        old.hashedSecretPrevious = client[key] === null ? null : buf(client[key]);
       } else if (client[key] !== undefined) {
         old[key] = client[key];
       }
@@ -310,6 +310,63 @@ MemoryStore.prototype = {
   },
 
   /**
+   * Get all access tokens for a given user.
+   * @param {String} uid User ID as hex
+   * @returns {Promise}
+   */
+  getAccessTokensByUid: async function getAccessTokensByUid(uid) {
+    if (! uid) {
+      return P.reject(new Error('Uid is required'));
+    }
+    const accessTokens = [];
+    Object.keys(this.tokens).forEach(id => {
+      const token = this.tokens[id];
+      if (token.userId.toString('hex') === uid) {
+        var clientIdHex = unbuf(token.clientId);
+        var client = this.clients[clientIdHex];
+        accessTokens.push({
+          accessTokenId: buf(id),
+          clientId: token.clientId,
+          createdAt: token.createdAt,
+          clientName: client.name,
+          clientCanGrant: client.canGrant,
+          scope: this.tokens[id].scope
+        });
+      }
+    });
+    return accessTokens;
+  },
+
+  /**
+   * Get all refresh tokens for a given user.
+   * @param {String} uid User ID as hex
+   * @returns {Promise}
+   */
+  getRefreshTokensByUid: async function getRefreshTokensByUid(uid) {
+    if (! uid) {
+      return P.reject(new Error('Uid is required'));
+    }
+    const refreshTokens = [];
+    Object.keys(this.refreshTokens).forEach(id => {
+      const token = this.refreshTokens[id];
+      if (token.userId.toString('hex') === uid) {
+        var clientIdHex = unbuf(token.clientId);
+        var client = this.clients[clientIdHex];
+        refreshTokens.push({
+          refreshTokenId: buf(id),
+          clientId: token.clientId,
+          createdAt: token.createdAt,
+          lastUsedAt: token.lastUsedAt,
+          clientName: client.name,
+          clientCanGrant: client.canGrant,
+          scope: token.scope
+        });
+      }
+    });
+    return refreshTokens;
+  },
+
+  /**
    * Delete all authorization grants for some clientId and uid.
    *
    * @param {String} clientId Client ID
@@ -338,6 +395,29 @@ MemoryStore.prototype = {
 
     return P.resolve({});
   },
+
+  /**
+   * Delete a specific refresh token, for some clientId and uid.
+   * We don't actually need to know the clientId or uid in order to delete a refresh token,
+   * but since they're available we use them a an additional check.
+   *
+   * @param {String} refreshTokenId Refresh Token ID as Hex
+   * @param {String} clientId Client ID as Hex
+   * @param {String} uid User Id as Hex
+   * @returns {Promise} `true` if the token was found and deleted, `false` otherwise
+   */
+  deleteClientRefreshToken: async function deleteClientRefreshToken(refreshTokenId, clientId, uid) {
+    const token = this.refreshTokens[refreshTokenId];
+    if (token.clientId.toString('hex') !== clientId) {
+      return false;
+    }
+    if (token.userId.toString('hex') !== uid) {
+      return false;
+    }
+    delete this.refreshTokens[refreshTokenId];
+    return true;
+  },
+
   generateRefreshToken: function generateRefreshToken(vals) {
     var token = unique.token();
     var t = {

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/error.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/error.js
@@ -295,4 +295,13 @@ AppError.invalidGrantType = function invalidGrantType() {
   });
 };
 
+AppError.unknownToken = function unknownToken() {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: 122,
+    message: 'Unknown token'
+  });
+};
+
 module.exports = AppError;

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/authorized-clients/destroy.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/authorized-clients/destroy.js
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const validators = require('../../validators');
+const db = require('../../db');
+const error = require('../../error');
+const verifyAssertion = require('../../assertion');
+
+module.exports = {
+  validate: {
+    payload: {
+      client_id: validators.clientId,
+      refresh_token_id: validators.token.optional(),
+      assertion: validators.assertion,
+    }
+  },
+  handler: async function(req) {
+    const claims = await verifyAssertion(req.payload.assertion);
+    if (req.payload.refresh_token_id) {
+      if (! await db.deleteClientRefreshToken(req.payload.refresh_token_id, req.payload.client_id, claims.uid)) {
+        throw error.unknownToken();
+      }
+    } else {
+      await db.deleteClientAuthorization(req.payload.client_id, claims.uid);
+    }
+    return {};
+  }
+};

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/authorized-clients/list.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/authorized-clients/list.js
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const hex = require('buf').to.hex;
+const Joi = require('joi');
+
+const config = require('../../config');
+const db = require('../../db');
+const validators = require('../../validators');
+const verifyAssertion = require('../../assertion');
+const ScopeSet = require('fxa-shared').oauth.scopes;
+const localizeTimestamp = require('fxa-shared').l10n.localizeTimestamp({
+  supportedLanguages: config.get('i18n.supportedLanguages'),
+  defaultLanguage: config.get('i18n.defaultLanguage')
+});
+
+
+// Helper function to render each returned record in the expected form.
+function serialize(clientIdHex, token, acceptLanguage) {
+  var creationTime = token.createdAt.getTime();
+  var creationTimeFormatted = localizeTimestamp.format(creationTime, acceptLanguage);
+  var lastAccessTime = token.lastUsedAt.getTime();
+  var lastAccessTimeFormatted = localizeTimestamp.format(lastAccessTime, acceptLanguage);
+  return {
+    client_id: clientIdHex,
+    refresh_token_id: token.refreshTokenId ? hex(token.refreshTokenId) : undefined,
+    client_name: token.clientName,
+    creation_time: creationTime,
+    creation_time_formatted: creationTimeFormatted,
+    last_access_time: lastAccessTime,
+    last_access_time_formatted: lastAccessTimeFormatted,
+    // Sort the scopes alphabetically, for consistent output.
+    scope: token.scope.getScopeValues().sort(),
+  };
+}
+
+
+module.exports = {
+  validate: {
+    payload: {
+      assertion: validators.assertion.required(),
+    }
+  },
+  response: {
+    schema: Joi.array().items(Joi.object({
+      client_id: validators.clientId,
+      refresh_token_id: validators.token.optional(),
+      client_name: Joi.string().required(),
+      creation_time: Joi.number().min(0).required(),
+      creation_time_formatted: Joi.string().optional().allow(''),
+      last_access_time: Joi.number().min(0).required().allow(null),
+      last_access_time_formatted: Joi.string().optional().allow(''),
+      scope: Joi.array().items(Joi.string()).required(),
+    }))
+  },
+  handler: async function(req) {
+    const claims = await verifyAssertion(req.payload.assertion);
+    const authorizedClients = [];
+
+    // First, enumerate all the refresh tokens.
+    // Each of these is a separate instance of an authorized client
+    // and should be displayed to the user as such. Nice and simple!
+    const seenClientIds = new Set();
+    for (const token of await db.getRefreshTokensByUid(claims.uid)) {
+      const clientId = hex(token.clientId);
+      authorizedClients.push(serialize(clientId, token, req.headers['accept-language']));
+      seenClientIds.add(clientId);
+    }
+
+    // Next, enumerate all the access tokens. In the interests of giving the user a
+    // complete-yet-comprehensible list of all the things attached to their account,
+    // we want to:
+    //
+    //  1. Show a single unified record for any client that is not using refresh tokens.
+    //  2. Avoid showing access tokens for `canGrant` clients; such clients will always
+    //     hold some other sort of token, and we don't want them to appear in the list twice.
+    const accessTokenRecordsByClientId = new Map();
+    for (const token of await db.getAccessTokensByUid(claims.uid)) {
+      const clientId = hex(token.clientId);
+      if (! seenClientIds.has(clientId) && ! token.clientCanGrant) {
+        let record = accessTokenRecordsByClientId.get(clientId);
+        if (typeof record === 'undefined') {
+          record = {
+            clientId,
+            clientName: token.clientName,
+            createdAt: token.createdAt,
+            lastUsedAt: token.createdAt,
+            scope: ScopeSet.fromArray([]),
+          };
+          accessTokenRecordsByClientId.set(clientId, record);
+        }
+        // Merge details of all access tokens into a single record.
+        record.scope.add(token.scope);
+        if (token.createdAt < record.createdAt) {
+          record.createdAt = token.createdAt;
+        }
+        if (record.lastUsedAt < token.createdAt) {
+          record.lastUsedAt = token.createdAt;
+        }
+      }
+    }
+    for (const [clientId, record] of accessTokenRecordsByClientId.entries()) {
+      authorizedClients.push(serialize(clientId, record, req.headers['accept-language']));
+    }
+
+    // Sort the final list first by last_access_time, then by client_name, then by creation_time.
+    authorizedClients.sort(function (a, b) {
+      if (b.last_access_time > a.last_access_time) {
+        return 1;
+      }
+      if (b.last_access_time < a.last_access_time) {
+        return -1;
+      }
+      if (a.client_name > b.client_name) {
+        return 1;
+      }
+      if (a.client_name < b.client_name) {
+        return -1;
+      }
+      if (a.creation_time > b.creation_time) {
+        return 1;
+      }
+      if (a.creation_time < b.creation_time) {
+        return -1;
+      }
+      // To help provide a deterministic result order to simplify testing, also sort of scope values.
+      if (a.scope < b.scope) {
+        return 1;
+      }
+      if (a.scope > b.scope) {
+        return -1;
+      }
+      return 0;
+    });
+    return authorizedClients;
+  }
+};

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routing.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routing.js
@@ -83,6 +83,16 @@ exports.routes = [
     config: require('./routes/jwks')
   },
   {
+    method: 'POST',
+    path: v('/authorized-clients'),
+    config: require('./routes/authorized-clients/list')
+  },
+  {
+    method: 'POST',
+    path: v('/authorized-clients/destroy'),
+    config: require('./routes/authorized-clients/destroy')
+  },
+  {
     method: 'GET',
     path: v('/client-tokens'),
     config: require('./routes/client-tokens/list')

--- a/packages/fxa-auth-server/fxa-oauth-server/test/api.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/api.js
@@ -50,6 +50,8 @@ function mockVerifierResult(opts) {
 
 const VERIFY_GOOD = mockVerifierResult();
 const VERIFY_GOOD_BUT_UNVERIFIED = mockVerifierResult({ tokenVerified: false });
+const VERIFY_FAILURE = '{"status": "failure"}';
+
 
 const MAX_TTL_S = config.get('expiration.accessToken') / 1000;
 
@@ -428,7 +430,7 @@ describe('/v1', function() {
       });
 
       it('errors correctly if invalid', function() {
-        mockAssertion().reply(400, '{"status":"failure"}');
+        mockAssertion().reply(400, VERIFY_FAILURE);
         return Server.api.post({
           url: '/authorization',
           payload: authParams()
@@ -1949,7 +1951,7 @@ describe('/v1', function() {
       });
 
       it('rejects invalid assertions', async () => {
-        mockAssertion().reply(400, '{"status":"failure"}');
+        mockAssertion().reply(400, VERIFY_FAILURE);
         const res = await Server.api.post({
           url: '/token',
           payload: {
@@ -3762,6 +3764,369 @@ describe('/v1', function() {
         });
       });
 
+    });
+  });
+
+
+  describe('/authorized-clients', () => {
+    let user1, user2, client1Id, client2Id, client1, client2;
+
+    function withMockAssertion(user, params) {
+      mockAssertion().reply(200, mockVerifierResult({
+        uid: user.uid,
+        vemail: user.email,
+      }));
+      return {
+        assertion: AN_ASSERTION,
+        ...params,
+      };
+    }
+
+    async function makeAccessToken(client, user, scope) {
+      const token = await db.generateAccessToken({
+        clientId: client.id,
+        userId: buf(user.uid),
+        email: user.email,
+        scope: ScopeSet.fromArray(scope),
+      });
+      return encrypt.hash(token.token).toString('hex');
+    }
+
+    async function makeRefreshToken(client, user, scope) {
+      const token = await db.generateRefreshToken({
+        clientId: client.id,
+        userId: buf(user.uid),
+        email: user.email,
+        scope: ScopeSet.fromArray(scope),
+      });
+      return encrypt.hash(token.token).toString('hex');
+    }
+
+    beforeEach(async () => {
+      user1 = {
+        uid: unique(16).toString('hex'),
+        email: unique(10).toString('hex') + '@example.com'
+      };
+
+      user2 = {
+        uid: unique(16).toString('hex'),
+        email: unique(10).toString('hex') + '@example.com'
+      };
+
+      client1Id = unique.id();
+      client1 = {
+        name: 'test/api/authorized-clients/bbb-one',
+        id: client1Id,
+        hashedSecret: encrypt.hash(unique.secret()),
+        redirectUri: 'https://example.domain',
+        imageUri: 'https://example.com/logo.png',
+        trusted: true
+      };
+      await db.registerClient(client1);
+
+      client2Id = unique.id();
+      client2 = {
+        name: 'test/api/authorized-clients/aaa-two',
+        id: client2Id,
+        hashedSecret: encrypt.hash(unique.secret()),
+        redirectUri: 'https://example.domain',
+        imageUri: 'https://example.com/logo.png',
+        trusted: false
+      };
+      await db.registerClient(client2);
+    });
+
+    describe('POST /authorized-clients', () => {
+
+      it('should list authorized clients in a specific order', async () => {
+        await makeAccessToken(client1, user1, ['profile']);
+        await makeAccessToken(client2, user1, ['bb_scope', 'aa_scope']);
+        const res = await Server.api.post({
+          url: '/authorized-clients',
+          payload: withMockAssertion(user1, {}),
+        });
+        assert.equal(res.statusCode, 200);
+        assertSecurityHeaders(res);
+        const clients = res.result;
+        assert.equal(clients.length, 2);
+        // The API sorts the results by last-used time and then by name.
+        // Since we create the token for client2 after that of client1,
+        // either way we'll end up with client2 at the start of the list.
+        assert.equal(clients[0].client_id, client2Id.toString('hex'));
+        assert.ok(clients[0].last_access_time);
+        assert.equal(clients[0].last_access_time_formatted, 'a few seconds ago');
+        assert.equal(clients[0].client_name, 'test/api/authorized-clients/aaa-two');
+        assert.deepEqual(clients[0].scope, ['aa_scope', 'bb_scope']);
+
+        assert.equal(clients[1].client_id, client1Id.toString('hex'));
+        assert.ok(clients[1].last_access_time);
+        assert.equal(clients[1].last_access_time_formatted, 'a few seconds ago');
+        assert.equal(clients[1].client_name, 'test/api/authorized-clients/bbb-one');
+        assert.deepEqual(clients[1].scope, ['profile']);
+      });
+
+      it('should not list tokens of different users', async ()  => {
+        await makeAccessToken(client1, user1, ['profile']);
+        await makeAccessToken(client2, user2, ['bb_scope', 'aa_scope']);
+
+        const res1 = await Server.api.post({
+          url: '/authorized-clients',
+          payload: withMockAssertion(user1, {}),
+        });
+        assert.equal(res1.statusCode, 200);
+        assertSecurityHeaders(res1);
+        const clients1 = res1.result;
+        assert.equal(clients1.length, 1);
+        assert.equal(clients1[0].client_id, client1Id.toString('hex'));
+
+        const res2 = await Server.api.post({
+          url: '/authorized-clients',
+          payload: withMockAssertion(user2, {}),
+        });
+        assert.equal(res2.statusCode, 200);
+        assertSecurityHeaders(res2);
+        const clients2 = res2.result;
+        assert.equal(clients2.length, 1);
+        assert.equal(clients2[0].client_id, client2Id.toString('hex'));
+      });
+
+      it('should seperately list different refresh tokens from the same client', async () => {
+        await makeAccessToken(client1, user1, ['profile']);
+        await makeAccessToken(client1, user1, ['other', 'scope']);
+        await makeRefreshToken(client2, user1, ['profile']);
+        await makeRefreshToken(client2, user1, ['other', 'scope']);
+        await makeAccessToken(client2, user1, ['profile']);
+        const res = await Server.api.post({
+          url: '/authorized-clients',
+          payload: withMockAssertion(user1, {}),
+        });
+        assert.equal(res.statusCode, 200);
+        assertSecurityHeaders(res);
+        const clients = res.result;
+        assert.equal(clients.length, 3);
+        assert.equal(clients[0].client_id, client2Id.toString('hex'));
+        assert.deepEqual(clients[0].scope, ['profile']);
+        assert.ok(clients[0].refresh_token_id);
+        assert.equal(clients[1].client_id, client2Id.toString('hex'));
+        assert.deepEqual(clients[1].scope, ['other', 'scope']);
+        assert.ok(clients[1].refresh_token_id);
+        assert.equal(clients[2].client_id, client1Id.toString('hex'));
+        assert.deepEqual(clients[2].scope, ['other', 'profile', 'scope']);
+        assert.ok(! clients[2].refresh_token_id);
+      });
+
+      it('should not list canGrant=1 clients that only have access tokens', async () => {
+        await db.updateClient({
+          ...client2,
+          canGrant: true,
+        });
+        await makeAccessToken(client1, user1, ['profile']);
+        await makeAccessToken(client2, user1, ['profile']);
+        const res = await Server.api.post({
+          url: '/authorized-clients',
+          payload: withMockAssertion(user1, {}),
+        });
+        assert.equal(res.statusCode, 200);
+        assertSecurityHeaders(res);
+        const clients = res.result;
+        assert.equal(clients.length, 1);
+        assert.equal(clients[0].client_id, client1Id.toString('hex'));
+      });
+
+      it('should list canGrant=1 clients that have refresh tokens', async () => {
+        await db.updateClient({
+          ...client2,
+          canGrant: true,
+        });
+        await makeAccessToken(client1, user1, ['profile']);
+        await makeRefreshToken(client2, user1, ['profile']);
+        const res = await Server.api.post({
+          url: '/authorized-clients',
+          payload: withMockAssertion(user1, {}),
+        });
+        assert.equal(res.statusCode, 200);
+        assertSecurityHeaders(res);
+        const clients = res.result;
+        assert.equal(clients.length, 2);
+        assert.equal(clients[0].client_id, client2Id.toString('hex'));
+        assert.equal(clients[1].client_id, client1Id.toString('hex'));
+      });
+
+      it('requires a valid assertion', async () => {
+        await makeAccessToken(client1, user1, ['profile']);
+        mockAssertion().reply(400, VERIFY_FAILURE);
+
+        let res = await Server.api.post({
+          url: '/authorized-clients',
+          payload: {
+            assertion: AN_ASSERTION,
+          }
+        });
+        assert.equal(res.statusCode, 401);
+        assert.equal(res.result.message, 'Invalid assertion');
+        assertSecurityHeaders(res);
+
+        // Check that it didn't delete the token.
+        res = await Server.api.post({
+          url: '/authorized-clients',
+          payload: withMockAssertion(user1, {}),
+        });
+        assert.equal(res.statusCode, 200);
+        assertSecurityHeaders(res);
+        const clients = res.result;
+        assert.equal(clients.length, 1);
+        assert.equal(clients[0].client_id, client1Id.toString('hex'));
+      });
+    });
+
+    describe('POST /authorized-clients/destroy', function () {
+
+      it('can delete all tokens a target client id', async () => {
+        await makeAccessToken(client1, user1, ['profile']);
+        await makeRefreshToken(client2, user1, ['profile']);
+        await makeRefreshToken(client2, user1, ['profile']);
+
+        let res = await Server.api.post({
+          url: '/authorized-clients/destroy',
+          payload: withMockAssertion(user1, {
+            client_id: client1Id.toString('hex'),
+          })
+        });
+        assert.equal(res.statusCode, 200);
+        assertSecurityHeaders(res);
+
+        res = await Server.api.post({
+          url: '/authorized-clients',
+          payload: withMockAssertion(user1, {}),
+        });
+        assert.equal(res.statusCode, 200);
+        assert.equal(res.result.length, 2);
+        assert.equal(res.result[0].client_id, client2Id.toString('hex'));
+
+        res = await Server.api.post({
+          url: '/authorized-clients/destroy',
+          payload: withMockAssertion(user1, {
+            client_id: client2Id.toString('hex'),
+          })
+        });
+        assert.equal(res.statusCode, 200);
+        assertSecurityHeaders(res);
+
+        res = await Server.api.post({
+          url: '/authorized-clients',
+          payload: withMockAssertion(user1, {}),
+        });
+        assert.equal(res.statusCode, 200);
+        assert.equal(res.result.length, 0);
+      });
+
+      it('deletes outstanding authorization codes for the client', async () => {
+        mockAssertion().reply(200, mockVerifierResult({ uid: user1.uid }));
+        let res = await Server.api.post({
+          url: '/authorization',
+          payload: authParams({
+            scope: 'profile',
+          })
+        });
+        const code = res.result.code;
+        assert.ok(code, 'an authorization code was generated');
+        await Server.api.post({
+          url: '/authorized-clients/destroy',
+          payload: withMockAssertion(user1, {
+            client_id: clientId,
+          })
+        });
+        assert.equal(res.statusCode, 200);
+        res = await Server.api.post({
+          url: '/token',
+          payload: {
+            client_id: clientId,
+            client_secret: secret,
+            code,
+          }
+        });
+        assert.equal(res.statusCode, 400);
+        assert.equal(res.result.code, 400);
+        assert.equal(res.result.errno, 105);
+        assert.equal(res.result.message, 'Unknown code');
+        assertSecurityHeaders(res);
+      });
+
+      it('can delete a specific token of a target client id', async () => {
+        await makeAccessToken(client1, user1, ['profile']);
+        await makeRefreshToken(client2, user1, ['profile']);
+        const tokenId = await makeRefreshToken(client2, user1, ['other', 'scope']);
+
+        let res = await Server.api.post({
+          url: '/authorized-clients/destroy',
+          payload: withMockAssertion(user1, {
+            client_id: client2Id.toString('hex'),
+            refresh_token_id: tokenId,
+          })
+        });
+        assert.equal(res.statusCode, 200);
+        assertSecurityHeaders(res);
+
+        res = await Server.api.post({
+          url: '/authorized-clients',
+          payload: withMockAssertion(user1, {}),
+        });
+        assert.equal(res.statusCode, 200);
+        assert.equal(res.result.length, 2);
+        assert.equal(res.result[0].client_id, client2Id.toString('hex'));
+        assert.deepEqual(res.result[0].scope, ['profile']);
+        assert.notEqual(res.result[0].refresh_token_id, tokenId);
+        assert.equal(res.result[1].client_id, client1Id.toString('hex'));
+        assert.deepEqual(res.result[1].scope, ['profile']);
+      });
+
+      it('refuses to delete token for wrong client_id', async () => {
+        await makeAccessToken(client1, user1, ['profile']);
+        await makeRefreshToken(client2, user1, ['profile']);
+        const tokenId = await makeRefreshToken(client2, user1, ['other', 'scope']);
+        const res = await Server.api.post({
+          url: '/authorized-clients/destroy',
+          payload: withMockAssertion(user1, {
+            client_id: client1Id.toString('hex'),
+            refresh_token_id: tokenId,
+          })
+        });
+        assert.equal(res.statusCode, 400);
+        assert.equal(res.result.errno, 122);
+        assert.equal(res.result.message, 'Unknown token');
+        assertSecurityHeaders(res);
+      });
+
+      it('refuses to delete token for wrong user', async () => {
+        await makeAccessToken(client1, user1, ['profile']);
+        await makeRefreshToken(client2, user1, ['profile']);
+        const tokenId = await makeRefreshToken(client2, user1, ['other', 'scope']);
+        const res = await Server.api.post({
+          url: '/authorized-clients/destroy',
+          payload: withMockAssertion(user2, {
+            client_id: client2Id.toString('hex'),
+            refresh_token_id: tokenId,
+          })
+        });
+        assert.equal(res.statusCode, 400);
+        assert.equal(res.result.errno, 122);
+        assert.equal(res.result.message, 'Unknown token');
+        assertSecurityHeaders(res);
+      });
+
+      it('requires a valid assertion', async () => {
+        mockAssertion().reply(400, VERIFY_FAILURE);
+        const res = await Server.api.post({
+          url: '/authorized-clients/destroy',
+          payload: {
+            assertion: AN_ASSERTION,
+            client_id: client1Id.toString('hex'),
+          }
+        });
+        assert.equal(res.statusCode, 401);
+        assert.equal(res.result.message, 'Invalid assertion');
+        assertSecurityHeaders(res);
+      });
     });
   });
 

--- a/packages/fxa-auth-server/lib/oauthdb/index.js
+++ b/packages/fxa-auth-server/lib/oauthdb/index.js
@@ -33,6 +33,8 @@ module.exports = (log, config) => {
     grantTokensFromRefreshToken: require('./grant-tokens-from-refresh-token')(config),
     grantTokensFromCredentials: require('./grant-tokens-from-credentials')(config),
     checkAccessToken: require('./check-access-token')(config),
+    listAuthorizedClients: require('./list-authorized-clients')(config),
+    revokeAuthorizedClient: require('./revoke-authorized-client')(config),
   });
 
   const api = new OAuthAPI(config.oauth.url, config.oauth.poolee);
@@ -122,22 +124,26 @@ module.exports = (log, config) => {
       } catch (err) {
         throw mapOAuthError(log, err);
       }
-    }
-
-    /* As we work through the process of merging oauth-server
-     * into auth-server, future methods we might want to include
-     * here will be things like the following:
-
-    async getClientInstances(account) {
     },
 
-    async revokeAccessToken(token) {
-    }
+    async listAuthorizedClients(sessionToken) {
+      const oauthParams = {
+        assertion: await makeAssertionJWT(config, sessionToken)
+      };
+      try {
+        return await api.listAuthorizedClients(oauthParams);
+      } catch (err) {
+        throw mapOAuthError(log, err);
+      }
+    },
 
-     * But in the interests of landing small manageable changes,
-     * let's only add those as we need them.
-     *
-     */
-
+    async revokeAuthorizedClient(sessionToken, oauthParams) {
+      oauthParams.assertion = await makeAssertionJWT(config, sessionToken);
+      try {
+        return await api.revokeAuthorizedClient(oauthParams);
+      } catch (err) {
+        throw mapOAuthError(log, err);
+      }
+    },
   };
 };

--- a/packages/fxa-auth-server/lib/oauthdb/list-authorized-clients.js
+++ b/packages/fxa-auth-server/lib/oauthdb/list-authorized-clients.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const Joi = require('joi');
+const validators = require('../routes/validators');
+
+module.exports = (config) => {
+  return {
+    path: '/v1/authorized-clients',
+    method: 'POST',
+    validate: {
+      payload: {
+        assertion: validators.assertion.required(),
+      },
+      response: Joi.array().items(Joi.object({
+        client_id: validators.clientId,
+        refresh_token_id: validators.refreshToken.optional(),
+        client_name: Joi.string().max(255).regex(validators.DISPLAY_SAFE_UNICODE).required(),
+        creation_time: Joi.number().min(0).required(),
+        creation_time_formatted: Joi.string().optional().allow(''),
+        last_access_time: Joi.number().min(0).required().allow(null),
+        last_access_time_formatted: Joi.string().optional().allow(''),
+        scope: Joi.array().items(validators.scope).required(),
+      }))
+    }
+  };
+};

--- a/packages/fxa-auth-server/lib/oauthdb/revoke-authorized-client.js
+++ b/packages/fxa-auth-server/lib/oauthdb/revoke-authorized-client.js
@@ -9,18 +9,15 @@ const validators = require('../routes/validators');
 
 module.exports = (config) => {
   return {
-    path: '/v1/verify',
+    path: '/v1/authorized-clients/destroy',
     method: 'POST',
     validate: {
       payload: {
-        token: validators.accessToken.required(),
+        assertion: validators.assertion.required(),
+        client_id: validators.clientId.required(),
+        refresh_token_id: validators.refreshToken.optional().allow(null),
       },
-      response: {
-        user: Joi.string().required(),
-        client_id: Joi.string().required(),
-        scope: Joi.array().items(validators.scope),
-        profile_changed_at: Joi.number().min(0)
-      }
+      response: Joi.object({}),
     }
   };
 };

--- a/packages/fxa-auth-server/lib/routes/connected-clients.js
+++ b/packages/fxa-auth-server/lib/routes/connected-clients.js
@@ -1,0 +1,280 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const i18n = require('i18n-abide');
+const isA = require('joi');
+const validators = require('./validators');
+
+const HEX_STRING = validators.HEX_STRING;
+const DEVICES_SCHEMA = require('../devices').schema;
+
+module.exports = (log, db, config, customs, push, pushbox, devices, oauthdb) => {
+
+  const earliestSaneAccessTime = config.lastAccessTimeUpdates.earliestSaneTimestamp;
+  const { supportedLanguages, defaultLanguage } = config.i18n;
+
+  const localizeTimestamp = require('fxa-shared').l10n.localizeTimestamp({
+    supportedLanguages,
+    defaultLanguage
+  });
+
+  function formatTimestamps(client, request) {
+    const languages = request.app.acceptLanguage;
+    if (client.lastAccessTime < earliestSaneAccessTime) {
+      client.lastAccessTime = earliestSaneAccessTime;
+    }
+    client.createdTimeFormatted = localizeTimestamp.format(client.createdTime, languages);
+    client.lastAccessTimeFormatted = localizeTimestamp.format(client.lastAccessTime, languages);
+  }
+
+  function formatLocation(client, request) {
+    let language;
+    if (client.location) {
+      const location = client.location;
+      try {
+        const languages = i18n.parseAcceptLanguage(request.app.acceptLanguage);
+        language = i18n.bestLanguage(languages, supportedLanguages, defaultLanguage);
+        // For English, we can just leave all the location components intact.
+        // For other languages, only return what we can translate
+        if (language[0] !== 'e' || language[1] !== 'n') {
+          const territories = require(`cldr-localenames-full/main/${language}/territories.json`);
+          client.location = {
+            country: territories.main[language].localeDisplayNames.territories[location.countryCode]
+          }
+        }
+      } catch (err) {
+        log.warn('connected-clients.formatLocation.warning', {
+          err: err.message,
+          languages: request.app.acceptLanguage,
+          language,
+          location,
+        });
+      }
+    }
+  }
+
+  return [
+    {
+      method: 'GET',
+      path: '/account/connected_clients',
+      options: {
+        auth: {
+          strategy : 'sessionToken'
+        },
+        response: {
+          schema: isA.array().items(isA.object({
+            clientId: isA.string().regex(HEX_STRING).allow(null).required(),
+            sessionTokenId: isA.string().regex(HEX_STRING).allow(null).required(),
+            refreshTokenId: isA.string().regex(HEX_STRING).allow(null).required(),
+            deviceId: DEVICES_SCHEMA.id.allow(null).required(),
+            deviceName: DEVICES_SCHEMA.nameResponse.allow('').allow(null).required(),
+            deviceType: DEVICES_SCHEMA.type.allow(null).required(),
+            isCurrentDevice: isA.boolean().required(),
+            createdTime: isA.number().min(0).required().allow(null),
+            createdTimeFormatted: isA.string().optional().allow(''),
+            lastAccessTime: isA.number().min(0).required().allow(null),
+            lastAccessTimeFormatted: isA.string().optional().allow(''),
+            approximateLastAccessTime: isA.number().min(0).optional(),
+            approximateLastAccessTimeFormatted: isA.string().optional().allow(''),
+            location: DEVICES_SCHEMA.location,
+            userAgent: isA.string().max(255).required().allow(''),
+            os: isA.string().max(255).allow('').allow(null),
+          }))
+        }
+      },
+      handler: async function (request) {
+        log.begin('Account.connectedClients', request);
+
+        const sessionToken = request.auth.credentials;
+        const uid = sessionToken.uid;
+
+        const connectedClients = [];
+
+        const defaultFields = {
+          clientId: null,
+          sessionTokenId: null,
+          refreshTokenId: null,
+          deviceId: null,
+          deviceName: null,
+          deviceType: null,
+          isCurrentDevice: false,
+          createdTime: null,
+          lastAccessTime: null,
+          location: null,
+          userAgent: null,
+          os: null,
+        };
+
+        // To generate the full list of connected clients, we have to merge three lists:
+        //  * The auth-server's list of active session tokens
+        //  * The auth-server's list of active device records
+        //  * The oauth-server's list of authorized clients
+        // Fetch them in parallel.
+        // XXX TODO: we could obtain `sessions` and `devices` in a single query,
+        // but would need to add a new endpoint because each set can contain items
+        // that the other does not.
+        const devicesP = request.app.devices;
+        const sessionsP = db.sessions(uid);
+        const oauthClientsP = oauthdb.listAuthorizedClients(sessionToken);
+
+        // Let's start with the devices, since each device is annotated with
+        // the appropriate `sessionTokenId` and/or `refreshTokenId` to merge
+        // with the other lists.
+        const clientsBySessionTokenId = new Map();
+        const clientsByRefreshTokenId = new Map();
+        for (const device of await devicesP) {
+          const client = {
+            ...defaultFields,
+            sessionTokenId: device.sessionTokenId || null,
+            refreshTokenId: device.refreshTokenId || null,
+            deviceId: device.id,
+            deviceName: device.name,
+            deviceType: device.type,
+            isCurrentDevice: device.sessionTokenId === sessionToken.id,
+            createdTime: device.createdAt,
+          };
+          connectedClients.push(client);
+          if (device.sessionTokenId) {
+            clientsBySessionTokenId.set(device.sessionTokenId, client);
+          }
+          if (device.refreshTokenId) {
+            clientsByRefreshTokenId.set(device.refreshTokenId, client);
+          }
+        }
+
+        // Merge with sessions, which may or may not be linked
+        // to a device record.
+        for (const session of await sessionsP) {
+          let client = clientsBySessionTokenId.get(session.id);
+          if (! client) {
+            client = {
+              ...defaultFields,
+              sessionTokenId: session.id,
+              isCurrentDevice: session.id === sessionToken.id,
+              createdTime: session.createdAt,
+            };
+            connectedClients.push(client);
+          }
+          client.createdTime = Math.min(client.createdTime, session.createdTime);
+          client.lastAccessTime = Math.max(client.lastAccessTime, session.lastAccessTime);
+          // Location, OS and UA are currently only available on sessionTokens
+          // so we can copy across without worrying about merging.
+          client.location = session.location ? { ...session.location } : null;
+          client.os = session.uaOS;
+          if (! session.uaBrowser) {
+            client.userAgent = '';
+          } else if (! session.uaBrowserVersion) {
+            client.userAgent = session.uaBrowser;
+          } else {
+            const { uaBrowser: browser, uaBrowserVersion: version } = session;
+            client.userAgent = `${browser} ${version.split('.')[0]}`;
+          }
+        }
+
+        // Merge with OAuth clients, which may or may not be linked
+        // to a device record.
+        for (const oauthClient in await oauthClientsP) {
+          let client = clientsBySessionTokenId.get(oauthClient.refresh_token_id);
+          if (! client) {
+            client = {
+              ...defaultFields,
+              refreshTokenId: oauthClient.refresh_token_id,
+              createdTime: oauthClient.creation_time,
+            };
+            connectedClients.push(client);
+          }
+          client.clientId = oauthClient.client_id;
+          client.createdTime = Math.min(client.createdTime, oauthClient.createdTime);
+          client.lastAccessTime = Math.max(client.lastAccessTime, oauthClient.lastAccessTime);
+        }
+
+        // Now we can do some final tweaks of each item for display.
+        for (const client of connectedClients) {
+          formatTimestamps(client, request);
+          formatLocation(client, request);
+        }
+
+        return connectedClients;
+      }
+    },
+    {
+      method: 'POST',
+      path: '/account/connected_clients/destroy',
+      options: {
+        auth: {
+          strategy: 'sessionToken'
+        },
+        validate: {
+          payload: isA.object({
+            clientId: validators.clientId.allow(null).optional(),
+            sessionTokenId: isA.string().regex(HEX_STRING).allow(null).optional(),
+            refreshTokenId: validators.refreshToken.allow(null).optional(),
+            deviceId: DEVICES_SCHEMA.id.allow(null).optional(),
+          })
+          .or('clientId', 'sessionTokenId', 'refreshTokenId', 'deviceId')
+          .with('refreshTokenId', ['clientId'])
+        },
+        response: {
+          schema: {}
+        }
+      },
+      handler: async function (request) {
+        log.begin('Account.connectedClientsDestroy', request);
+
+        const sessionToken = request.auth.credentials;
+        const uid = sessionToken.uid;
+
+        if (request.payload.deviceId) {
+          // If we got a `deviceId`, then deleting that should also delete the sessionToken
+          // and should return the refreshToken. It's fishy if the values returned here don't
+          // match ones we were given in the request.
+          // XXX TODO: needs to trigger notifications, like `/account/device/destroy`.
+          const device = await db.deleteDevice(uid, request.payload.deviceId);
+          if (device && device.refreshTokenId) {
+            await oauthdb.revokeRefreshTokenById(device.refreshTokenId);
+          }
+          // XXX TODO: check that sessionToken and refreshToken matched the ones in the request.
+        } else if (request.payload.refreshTokenId) {
+          // We've got device-less refreshToken. There should be no sessionToken.
+          await oauthdb.revokeAuthorizedClient(request.auth.credentials, {
+            client_id: request.payload.clientId,
+            refresh_token_id: request.payload.refreshTokenId,
+          });
+        } else if (request.payload.clientId) {
+          // We've got an OAuth client that isn't using refresh tokens. There should be no sessionToken.
+          await oauthdb.revokeAuthorizedClient(request.auth.credentials, {
+            client_id: request.payload.clientId,
+          });
+        } else if (request.payload.sessionTokenId) {
+          // We've got a web session on our hands.
+          // XXX TODO: 
+          await
+        }
+
+        const refreshTokenId = request.payload.refreshTokenId;
+        if (request.payload.clientId) {
+          if (! refreshTokenId) {
+            await oauthdb.revokeAuthorizedClient(request.auth.credentials, {
+              client_id: request.payload.clientId
+            });
+          } else if (refreshTokenId !== device.refreshTokenId) {
+            // What if we got a refresh token that's different to the one on the device record.
+            // That shouldn't really happen...should we error out or what?
+
+          }
+        }
+
+        const sessionTokenId = request.payload.sessionTokenId;
+        if (sessionTokenId && sessionTokenId !== device.sessionTokenId) {
+
+        }
+
+
+        return {};
+      }
+    },
+  ];
+};


### PR DESCRIPTION
The existing `/client-tokens` endpoint merges all access tokens held by a particular `client_id` into a single record. This is not appropriate for clients that use refresh tokens, where each refresh token should appear to the user as a separate instance of that client.

This adds a new oauth-server endpoint, `/authorized-clients`, which lists each refresh token separately while preserving the existing merge behaviour for access tokens. It's very much a work-in-progress, but posting early for comment/comparison with https://github.com/mozilla/fxa/pull/1178.

We'll probably want to use this from the auth-server to implement the endpoint suggested in https://github.com/mozilla/fxa/issues/466, but I'm not far enough along to know whether it makes sense to do that inline in this PR.