### PR TITLE
fix(trailhead): Ensure logos display on prod, better mobile alignment

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/firefox-family-services.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/firefox-family-services.mustache
@@ -2,19 +2,19 @@
   <h2>{{#t}}Get more from these features:{{/t}}</h2>
   <ul>
     <li class="firefox-service">
-      <img alt="{{#t}}Firefox browser{{/t}}" src="/images/trailhead/graphic-logo-firefox.svg" height=40 width=180 decoding=async/>
+      <span class="logo logo-firefox-browser">{{#t}}Firefox browser{{/t}}</span>
       {{#t}}Travel the internet with protection, on every device.{{/t}}
     </li>
     <li class="firefox-service service-lockwise">
-      <img alt="{{#t}}Firefox Lockwise{{/t}}" src="/images/trailhead/graphic-logo-lockwise.svg" height=40 width=180 decoding=async />
+      <span class="logo logo-lockwise">{{#t}}Firefox Lockwise{{/t}}</span>
       {{#t}}Keep your passwords protected and portable.{{/t}}
     </li>
     <li class="firefox-service">
-      <img alt="{{#t}}Firefox Monitor{{/t}}" src="/images/trailhead/graphic-logo-monitor.svg" height=40 width=180 decoding=async/>
+      <span class="logo logo-monitor">{{#t}}Firefox Monitor{{/t}}</span>
       {{#t}}Get a lookout for data breaches.{{/t}}
     </li>
     <li class="firefox-service">
-      <img alt="{{#t}}Firefox Send{{/t}}" src="/images/trailhead/graphic-logo-send.svg" height=40 width=153 decoding=async />
+      <span class="logo logo-send">{{#t}}Firefox Send{{/t}}</span>
       {{#t}}Share large files without prying eyes.{{/t}}
     </li>
   </ul>

--- a/packages/fxa-content-server/app/styles/modules/_marketing.scss
+++ b/packages/fxa-content-server/app/styles/modules/_marketing.scss
@@ -37,27 +37,63 @@
   }
 
   > ul {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
     list-style: none;
     padding: 0;
+
+    @include respond-to('big') {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @include respond-to('small') {
+      margin: auto;
+      text-align: center;
+    }
 
     > .firefox-service {
       color: $grey-50;
       font-size: 11.5px;
       line-height: 1.7em;
       padding: 0 10px 20px 0;
-      text-align: left;
 
-      img {
-        display: block;
-        height: 40px;
-        max-width: 180px;
-        margin: 0 0 0 -10px;
+      @include respond-to('big') {
+        text-align: left;
       }
 
-      &.service-lockwise img {
-        margin-left: -5px;
+      .logo {
+        background-position: -10px top;
+        background-repeat: no-repeat;
+        display: block;
+        height: 40px;
+        text-indent: -9999px;
+        width: 180px;
+
+        @include respond-to('big') {
+          margin: 0;
+        }
+
+        @include respond-to('small') {
+          margin: 0 auto;
+        }
+
+        &.logo-firefox-browser {
+          background-image: image-url('trailhead/graphic-logo-firefox.svg');
+        }
+
+        &.logo-lockwise {
+          background-position-x: -5px;
+          background-image: image-url('trailhead/graphic-logo-lockwise.svg');
+        }
+
+        &.logo-monitor {
+          background-image: image-url('trailhead/graphic-logo-monitor.svg');
+        }
+
+        &.logo-send {
+          background-image: image-url('trailhead/graphic-logo-send.svg');
+          background-position-x: -8px;
+          width: 153px;
+        }
       }
     }
   }


### PR DESCRIPTION
The Firefox family service logos were displayed using `img` tags
rather than background-images. The build script does not know how
to transform img tag src. img tags are replaced with background
images.

Also fixed is the layout on mobile. Instead of taking up
two columns on mobile, use one center aligned column.

fixes #1196

### desktop layout
<img width="531" alt="Screenshot 2019-05-22 at 09 14 40" src="https://user-images.githubusercontent.com/848085/58158292-0c8a0a80-7c72-11e9-99ef-effa55c08222.png">

### mobile layout

<img width="332" alt="Screenshot 2019-05-22 at 09 11 28" src="https://user-images.githubusercontent.com/848085/58158260-fb40fe00-7c71-11e9-9a5b-af522f9d2c44.png">

@mozilla/fxa-devs - r?