### PR TITLE
fix(trailhead): Fix the layout on the CWTS page

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/sync-engines.js
+++ b/packages/fxa-content-server/app/scripts/models/sync-engines.js
@@ -31,23 +31,23 @@ const AVAILABLE_ENGINES = [
   },
   {
     checked: true,
-    id: 'passwords',
-    text: t('Logins')
-  },
-  {
-    checked: true,
-    id: 'tabs',
-    text: t('Open tabs')
-  },
-  {
-    checked: true,
     id: 'history',
     text: t('History')
   },
   {
     checked: true,
+    id: 'passwords',
+    text: t('Logins')
+  },
+  {
+    checked: true,
     id: 'addons',
     text: t('Add-ons')
+  },
+  {
+    checked: true,
+    id: 'tabs',
+    text: t('Open tabs')
   },
   {
     checked: true,

--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -127,12 +127,18 @@
 
   .trailhead & {
     h2, h3 {
+      font-weight: 700;
+
       html[dir='ltr'] & {
         text-align: left;
       }
       html[dir='rtl'] & {
         text-align: right;
       }
+    }
+
+    h2 {
+      font-size: 17px;
     }
 
     h3 {

--- a/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
+++ b/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
@@ -248,8 +248,12 @@ input[type='checkbox'] {
 }
 
 .two-col-items {
-  column-width: 160px;
+  display: grid;
   margin: 20px 0 10px 0;
+
+  @include respond-to('big') {
+    grid-template-columns: repeat(2, 1fr);
+  }
 
   .trailhead & {
     margin-bottom: 0;
@@ -265,6 +269,10 @@ input[type='checkbox'] {
 
   .fxa-checkbox__label {
     color: $color-grey-faint-text;
+
+    .trailhead & {
+      color: $text-color;
+    }
   }
 
   @include respond-to('small') {


### PR DESCRIPTION
* Change to display: grid to better control layout.
* Ensure the checkbox label color matches.
* Ensure the headers match the spec

Note: this does *not* update the strings. The string freeze has passed.
If we decide to change the strings anyways, we'll do it
in another PR.

Note 2: Not all the newsletters are displayed, they will be [with 1102](https://github.com/mozilla/fxa/issues/1102).

issue #1197

### Desktop
<img width="563" alt="Screenshot 2019-05-22 at 09 49 34" src="https://user-images.githubusercontent.com/848085/58161235-cc2d8b00-7c77-11e9-9e9e-050c53652634.png">

### Mobile

<img width="424" alt="Screenshot 2019-05-22 at 09 49 27" src="https://user-images.githubusercontent.com/848085/58161241-ce8fe500-7c77-11e9-9fa7-b7fdcf737ea1.png">

@mozilla/fxa-devs - r?