### PR TITLE
feat(subscriptions): add endpoint to return client capabilities

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -624,6 +624,12 @@ const conf = convict({
       env: 'SUBSCRIPTIONS_ENABLED',
       default: false
     },
+    sharedSecret: {
+      doc: 'Shared secret for authentication between backend subscription services',
+      format: String,
+      default: 'YOU MUST CHANGE ME',
+      env: 'SUBSCRIPTIONS_SHARED_SECRET',
+    },
     productCapabilities: {
       doc: 'Mappings from product names to subscription capability names',
       format: Object,

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -126,6 +126,13 @@ module.exports = config => {
     return d.promise;
   };
 
+  ClientApi.prototype.doRequestWithSecret = function (method, url, secret, payload, headers = {}) {
+    return this.doRequest(method, url, null, payload, {
+      ...headers,
+      Authorization: secret,
+    });
+  };
+
   /*
    *  Creates a user account.
    *
@@ -1061,6 +1068,10 @@ module.exports = config => {
       null,
       oauthParams
     );
+  };
+
+  ClientApi.prototype.getSubscriptionClients = function (secret) {
+    return this.doRequestWithSecret('GET', `${this.baseURL}/oauth/subscriptions/clients`, secret);
   };
 
   ClientApi.prototype.getSubscriptionPlans = function (refreshToken) {

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -704,6 +704,10 @@ module.exports = config => {
     return this.api.grantOAuthTokens(oauthParams);
   };
 
+  Client.prototype.getSubscriptionClients = function (secret) {
+    return this.api.getSubscriptionClients(secret);
+  };
+
   Client.prototype.getSubscriptionPlans = function (refreshToken) {
     return this.api.getSubscriptionPlans(refreshToken);
   };

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -84,7 +84,8 @@ describe('subscriptions', () => {
       subscriptions: {
         enabled: true,
         managementClientId: MOCK_CLIENT_ID,
-        managementTokenTTL: MOCK_TTL
+        managementTokenTTL: MOCK_TTL,
+        clientCapabilities: {},
       }
     };
 


### PR DESCRIPTION
Fixes #1159.

Returns the client capabilities, marshalled to an array because that seems to match the consuming use case better. The caller will iterate through every item rather than indexing into a particular one, so the response may as well be iterable.

Authentication is literally the simplest thing I could think of that would work, a plain old constant-time comparison of two secrets. I figured that's fine because there's no payload to validate so we're literally just verifying that the caller knows the magic word.

@lmorchard / @bbangert r?