### PR TITLE
fix(services): send country code instead of country on login and verified events

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -189,6 +189,7 @@ module.exports = (log, db, mailer, Password, config, customs, subhub, signinUtil
 
           const geoData = request.app.geo;
           const country =  geoData.location && geoData.location.country;
+          const countryCode =  geoData.location && geoData.location.countryCode;
           if (account.emailVerified) {
             await log.notifyAttachedServices('verified', request, {
               email: account.email,
@@ -196,17 +197,19 @@ module.exports = (log, db, mailer, Password, config, customs, subhub, signinUtil
               service,
               uid: account.uid,
               userAgent: userAgentString,
-              country
+              country,
+              countryCode
             });
           }
 
           await log.notifyAttachedServices('login', request, {
             deviceCount: 1,
+            country,
+            countryCode,
             email: account.email,
             service,
             uid: account.uid,
             userAgent: userAgentString,
-            country
           });
         }
 

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -417,13 +417,19 @@ module.exports = (log, db, mailer, config, customs, push, verificationReminders)
                 // Any matching code verifies the account
                 return db.verifyEmail(account, account.emailCode)
                   .then(() => {
+                    const geoData = request.app.geo;
+                    const country =  geoData.location && geoData.location.country;
+                    const countryCode =  geoData.location && geoData.location.countryCode;
                     return P.all([
                       log.notifyAttachedServices('verified', request, {
+                        country,
+                        countryCode,
                         email: account.email,
                         locale: account.locale,
                         marketingOptIn: marketingOptIn ? true : undefined,
                         service,
                         uid,
+                        userAgent: request.headers['user-agent'],
                       }),
                       request.emitMetricsEvent('account.verified', {
                         // The content server omits marketingOptIn in the false case.

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -245,13 +245,15 @@ module.exports = (log, config, customs, db, mailer)  => {
         if (request.payload.reason === 'signin') {
           const geoData = request.app.geo;
           const country = geoData.location && geoData.location.country;
+          const countryCode = geoData.location && geoData.location.countryCode;
           await log.notifyAttachedServices('login', request, {
+            country,
+            countryCode,
             deviceCount: sessions.length,
             email: accountRecord.primaryEmail.email,
             service,
             uid: accountRecord.uid,
             userAgent: request.headers['user-agent'],
-            country
           });
         }
       }

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -474,6 +474,7 @@ describe('/account/create', () => {
       assert.equal(eventData.data.email, TEST_EMAIL, 'it was for the correct email');
       assert.equal(eventData.data.userAgent, 'test user-agent', 'correct user agent');
       assert.equal(eventData.data.country, 'United States', 'correct country');
+      assert.equal(eventData.data.countryCode, 'US', 'correct country code');
       assert.ok(eventData.data.ts, 'timestamp of event set');
       assert.deepEqual(eventData.data.metricsContext, {
         entrypoint: 'blee',

--- a/packages/fxa-auth-server/test/local/routes/emails.js
+++ b/packages/fxa-auth-server/test/local/routes/emails.js
@@ -495,6 +495,9 @@ describe('/recovery_email/verify_code', () => {
         assert.equal(args[2].uid, uid);
         assert.equal(args[2].marketingOptIn, undefined);
         assert.equal(args[2].service, 'sync');
+        assert.equal(args[2].country, 'United States', 'set country');
+        assert.equal(args[2].countryCode, 'US', 'set country code');
+        assert.equal(args[2].userAgent, 'test user-agent');
 
         assert.equal(mockMailer.sendPostVerifyEmail.callCount, 1, 'sendPostVerifyEmail was called once');
         assert.equal(mockMailer.sendPostVerifyEmail.args[0][2].service, mockRequest.payload.service);

--- a/packages/fxa-auth-server/test/local/routes/utils/signin.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/signin.js
@@ -520,7 +520,8 @@ describe('sendSigninNotifications', () => {
         service: 'testservice',
         uid: TEST_UID,
         userAgent: 'test user-agent',
-        country: 'United States'
+        country: 'United States',
+        countryCode: 'US'
       });
 
       assert.notCalled(mailer.sendVerifyCode);
@@ -636,7 +637,8 @@ describe('sendSigninNotifications', () => {
           service: 'testservice',
           uid: TEST_UID,
           userAgent: 'test user-agent',
-          country: 'United States'
+          country: 'United States',
+          countryCode: 'US',
         });
       });
     });
@@ -670,7 +672,8 @@ describe('sendSigninNotifications', () => {
           service: 'testservice',
           uid: TEST_UID,
           userAgent: 'test user-agent',
-          country: 'United States'
+          country: 'United States',
+          countryCode: 'US',
         });
 
         assert.notCalled(mailer.sendVerifyCode);
@@ -813,7 +816,8 @@ describe('sendSigninNotifications', () => {
         service: 'testservice',
         uid: TEST_UID,
         userAgent: 'test user-agent',
-        country: 'United States'
+        country: 'United States',
+        countryCode: 'US',
       });
       assert.calledOnce(db.securityEvent);
     });
@@ -847,7 +851,8 @@ describe('sendSigninNotifications', () => {
           email: TEST_EMAIL,
           deviceCount: 1,
           userAgent: 'test user-agent',
-          country: 'United States'
+          country: 'United States',
+          countryCode: 'US',
         });
       });
     });
@@ -862,7 +867,8 @@ describe('sendSigninNotifications', () => {
           email: TEST_EMAIL,
           deviceCount: 4,
           userAgent: 'test user-agent',
-          country: 'United States'
+          country: 'United States',
+          countryCode: 'US',
         });
       });
     });


### PR DESCRIPTION
From https://github.com/mozilla/fxa/pull/1177#issuecomment-494439836 and a converstion with pmac, we should actually be sending the country code not the country. Targeting train 137 since this originally landed in that.

@mozilla/fxa-devs r?

cc @pmac