### PR TITLE
feat(notifications): include client id in outgoing service notifications

### DIFF
--- a/packages/fxa-auth-server/docs/service_notifications.md
+++ b/packages/fxa-auth-server/docs/service_notifications.md
@@ -60,6 +60,7 @@ Message Properties:
 
 * `event`: The string "verified".
 * `service`: The name of the service that was logged in to.
+* `clientId`: The client id of the service that was logged in to.
 * `uid`: The userid of the account being that was created.
 * `email`: The primary email address that was verified for the account.
 * `locale`: The accept-language header supplies by the user at account creation.
@@ -80,6 +81,7 @@ Message Properties:
 
 * `event`: The string "login".
 * `service`: The name of the service that was logged in to.
+* `clientId`: The client id of the service that was logged in to.
 * `uid`: The userid of the account being that was used to log in.
 * `email`: The primary email address of the account.
 * `deviceCount`: The number of active sessions on the user's account.

--- a/packages/fxa-auth-server/lib/log.js
+++ b/packages/fxa-auth-server/lib/log.js
@@ -140,6 +140,7 @@ Lug.prototype.notifyAttachedServices = function (name, request, data) {
         // convert an oauth client-id to a human readable format, if a name is available.
         // If no name is available, continue to use the client_id.
         if (data.service && data.service !== 'sync') {
+          data.clientId = data.service;
           data.service = CLIENT_ID_TO_SERVICE_NAMES[data.service] || data.service;
         }
 

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -19,7 +19,7 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
     'https://identity.mozilla.com/account/subscriptions';
 
   const CLIENT_CAPABILITIES = Object.entries(config.subscriptions.clientCapabilities)
-    .map(([ clientId, capabilities ]) => ({ client_id: clientId, capabilities }));
+    .map(([ clientId, capabilities ]) => ({ clientId, capabilities }));
 
   async function handleAuth(auth, fetchEmail = false) {
     const scope = ScopeSet.fromArray(auth.credentials.scope);
@@ -49,7 +49,7 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
         response: {
           schema: isA.array().items(
             isA.object().keys({
-              client_id: isA.string(),
+              clientId: isA.string(),
               capabilities: isA.array().items(isA.string()),
             })
           )

--- a/packages/fxa-auth-server/test/local/log.js
+++ b/packages/fxa-auth-server/test/local/log.js
@@ -632,6 +632,7 @@ describe('log', () => {
       assert.deepEqual(log.notifier.send.args[0][0], {
         event: 'login',
         data: {
+          clientId: 'clientid',
           service: 'human readable name',
           ts: now,
           iss: 'example.com',
@@ -686,6 +687,7 @@ describe('log', () => {
       assert.deepEqual(log.notifier.send.args[0][0], {
         event: 'login',
         data: {
+          clientId: 'unknown-clientid',
           service: 'unknown-clientid',
           ts: now,
           iss: 'example.com',

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -74,11 +74,11 @@ describe('remote subscriptions:', function () {
       const response = await client.getSubscriptionClients('wibble');
       assert.deepEqual(response, [
         {
-          client_id: CLIENT_ID,
+          clientId: CLIENT_ID,
           capabilities: [ '123donePro', 'ILikePie', 'MechaMozilla', 'FooBar' ],
         },
         {
-          client_id: CLIENT_ID_FOR_DEFAULT,
+          clientId: CLIENT_ID_FOR_DEFAULT,
           capabilities: [ 'isRegistered', 'isSubscribed' ],
         },
       ]);


### PR DESCRIPTION
Fixes #1210.

Adds `clientId` to the auth server outgoing notifications.

While doing that, I realised I'd contributed to our inconsistent nomenclature by using snake case for `client_id` in the response payload in #1208. So there's a secondary change included where I rename that to `clientId` too (it only just landed so nothing is using it yet).

@bbangert r?