### PR TITLE
fix(trailhead): Update CWTS wording to match the spec

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/choose_what_to_sync.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/choose_what_to_sync.mustache
@@ -41,8 +41,7 @@
       {{#isTrailhead}}
         {{#isAnyNewsletterEnabled}}
         <header class="get-involved">
-          <h2>{{#t}}Practical knowledge is coming to your inbox{{/t}}</h2>
-          <h3>{{#t}}Sign up for more:{{/t}}</h3>
+          <h2>{{#t}}Practical knowledge is coming to your inbox. Sign up for more:{{/t}}</h2>
         </header>
         {{/isAnyNewsletterEnabled}}
         {{#isOnlineSafetyNewsletterEnabled}}
@@ -52,7 +51,7 @@
         {{/isOnlineSafetyNewsletterEnabled}}
         {{#isBetaNewsletterEnabled}}
         <div class="input-row marketing-email-optin-row">
-          <input id="consumer-beta-optin" type="checkbox" class="consumer-beta-optin"><label for="consumer-beta-optin">{{#t}}Invite me to test new Mozilla products{{/t}}</label>
+          <input id="consumer-beta-optin" type="checkbox" class="consumer-beta-optin"><label for="consumer-beta-optin">{{#t}}Test new Firefox products{{/t}}</label>
         </div>
         {{/isBetaNewsletterEnabled}}
         {{#isEmailOptInEnabled}}

--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -126,7 +126,8 @@
   }
 
   .trailhead & {
-    h2, h3 {
+    h2 {
+      font-size: 17px;
       font-weight: 700;
 
       html[dir='ltr'] & {
@@ -135,15 +136,6 @@
       html[dir='rtl'] & {
         text-align: right;
       }
-    }
-
-    h2 {
-      font-size: 17px;
-    }
-
-    h3 {
-      font-size: 14px;
-      margin-top: 15px;
     }
 
     #main-content {


### PR DESCRIPTION
* Move "Sign up for more:" in with the h2, remove the h3 it was in.
* Remove the CSS for the now removed H3
* Update the beta text to "Test new Firefox products"

fixes #1197

@mozilla/fxa-devs - r?