### PR TITLE
feat(trailhead): add the trailhead style hooks to js-client

### DIFF
--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -124,13 +124,13 @@ module.exports = (log, db, mailer, config, customs, push, verificationReminders)
           query: {
             service: validators.service,
             type: isA.string().max(32).alphanum().allow(['upgradeSession']).optional(),
-            style: isA.string().allow(['trailhead']).optional()
           },
           payload: {
             email: validators.email().optional(),
             service: validators.service,
             redirectTo: validators.redirectTo(config.smtp.redirectDomain).optional(),
             resume: isA.string().max(2048).optional(),
+            style: isA.string().allow(['trailhead']).optional(),
             type: isA.string().max(32).alphanum().allow(['upgradeSession']).optional()
           }
         }
@@ -144,7 +144,7 @@ module.exports = (log, db, mailer, config, customs, push, verificationReminders)
         const type = request.payload.type || request.query.type;
         const ip = request.app.clientAddress;
         const geoData = request.app.geo;
-        const style = request.query.style;
+        const style = request.payload.style;
 
         // This endpoint can resend multiple types of codes, set these values once it
         // is known what is being verified.

--- a/packages/fxa-auth-server/test/local/routes/emails.js
+++ b/packages/fxa-auth-server/test/local/routes/emails.js
@@ -296,7 +296,8 @@ describe('/recovery_email/resend_code', () => {
         metricsContext: {
           flowBeginTime: Date.now(),
           flowId: 'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103'
-        }
+        },
+        style: 'trailhead'
       }
     });
 
@@ -320,6 +321,7 @@ describe('/recovery_email/resend_code', () => {
       assert.equal(args[2].flowBeginTime, mockRequest.payload.metricsContext.flowBeginTime);
       assert.equal(args[2].service, mockRequest.payload.service);
       assert.equal(args[2].uid, mockRequest.auth.credentials.uid);
+      assert.equal(args[2].style, 'trailhead');
     })
       .then(() => {
         mockMailer.sendVerifyCode.resetHistory();

--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -393,6 +393,7 @@ FxaClientWrapper.prototype = {
    *   @param {String} [options.sessionTokenContext] - The context for
    *                   which the session token is being created.
    *                   Defaults to the relier's context.
+   *   @param {String} [options.style] - Specify the style for emails
    * @returns {Promise}
    */
   signUp: withClient(function (client, originalEmail, password, relier, options = {}) {
@@ -418,6 +419,10 @@ FxaClientWrapper.prototype = {
       signUpOptions.resume = options.resume;
     }
 
+    if (relier.has('style')) {
+      signUpOptions.style = relier.get('style');
+    }
+
     setMetricsContext(signUpOptions, options);
 
     return client.signUp(email, password, signUpOptions)
@@ -434,6 +439,8 @@ FxaClientWrapper.prototype = {
    *   Opaque url-encoded string that will be included in the verification link
    *   as a querystring parameter, useful for continuing an OAuth flow for
    *   example.
+   *   @param {String} [options.style]
+   *   Specify the style for the email
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
    */
   signUpResend: withClient((client, relier, sessionToken, options = {}) => {
@@ -444,6 +451,10 @@ FxaClientWrapper.prototype = {
 
     if (options.resume) {
       clientOptions.resume = options.resume;
+    }
+
+    if (relier.has('style')) {
+      clientOptions.style = relier.get('style');
     }
 
     return client.recoveryEmailResendCode(sessionToken, clientOptions);
@@ -491,6 +502,8 @@ FxaClientWrapper.prototype = {
    *   Reminder that was used to verify the account
    *   @param {String} [options.type]
    *   Type of code being verified, only supports `secondary` otherwise will verify account/sign-in
+   *   @param {String} [options.style]
+   *   Specify the style of confirmation email to be sent
    * @return {Promise} resolves when complete
    */
   verifyCode: createClientDelegate('verifyCode'),

--- a/packages/fxa-content-server/app/scripts/views/complete_sign_up.js
+++ b/packages/fxa-content-server/app/scripts/views/complete_sign_up.js
@@ -76,6 +76,7 @@ const CompleteSignUpView = BaseView.extend({
       reminder: verificationInfo.get('reminder'),
       secondaryEmailVerified: this.getSearchParam('secondary_email_verified') || null,
       service: this.relier.get('service') || null,
+      style: this.relier.get('style') || null,
       type: verificationInfo.get('type')
     };
 

--- a/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
@@ -21,6 +21,7 @@ var NON_SYNC_SERVICE = 'chronicle';
 var REDIRECT_TO = 'https://sync.firefox.com';
 var STATE = 'state';
 var SYNC_SERVICE = 'sync';
+const STYLE = 'trailhead';
 
 var assert = chai.assert;
 var client;
@@ -222,6 +223,28 @@ describe('lib/fxa-client', function () {
         }));
       });
     });
+
+    it('passes along an optional `style`', function () {
+      sinon.stub(realClient, 'signUp').callsFake(function () {
+        return Promise.resolve({});
+      });
+
+      relier.set('service', 'chronicle');
+      relier.set('style', STYLE);
+
+      return client.signUp(email, password, relier, {
+        resume: resumeToken,
+        style: STYLE,
+      }).then(function () {
+        assert.isTrue(realClient.signUp.calledWith(trim(email), password, {
+          keys: false,
+          redirectTo: REDIRECT_TO,
+          resume: resumeToken,
+          service: 'chronicle',
+          style: STYLE
+        }));
+      });
+    });
   });
 
   describe('recoveryEmailStatus', function () {
@@ -346,20 +369,21 @@ describe('lib/fxa-client', function () {
     });
   });
 
-  describe('signUpResend', function () {
-    it('resends the validation email', function () {
+  describe('signUpResend', () => {
+    it('resends the validation email', () => {
       var sessionToken = 'session token';
 
-      sinon.stub(realClient, 'recoveryEmailResendCode').callsFake(function () {
-        return Promise.resolve();
-      });
+      sinon.stub(realClient, 'recoveryEmailResendCode').callsFake(() => Promise.resolve());
 
-      return client.signUpResend(relier, sessionToken, { resume: resumeToken })
-        .then(function () {
-          var params = {
+      relier.set('style', STYLE);
+
+      return client.signUpResend(relier, sessionToken, {resume: resumeToken})
+        .then(() => {
+          const params = {
             redirectTo: REDIRECT_TO,
             resume: resumeToken,
-            service: SYNC_SERVICE
+            service: SYNC_SERVICE,
+            style: STYLE
           };
           assert.isTrue(
             realClient.recoveryEmailResendCode.calledWith(
@@ -379,6 +403,22 @@ describe('lib/fxa-client', function () {
       return client.verifyCode('uid', 'code')
         .then(function () {
           assert.isTrue(realClient.verifyCode.calledWith('uid', 'code'));
+        });
+    });
+
+    it('can successfully complete with optional `style`', () => {
+      sinon.stub(realClient, 'verifyCode').callsFake(() => {
+        return Promise.resolve({});
+      });
+
+      relier.set('style', STYLE);
+
+      return client.verifyCode('uid', 'code', {style: STYLE})
+        .then(() => {
+          const params = {
+            style: STYLE
+          };
+          assert.isTrue(realClient.verifyCode.calledWith('uid', 'code', params));
         });
     });
 

--- a/packages/fxa-content-server/app/tests/spec/views/complete_sign_up.js
+++ b/packages/fxa-content-server/app/tests/spec/views/complete_sign_up.js
@@ -224,6 +224,7 @@ describe('views/complete_sign_up', function () {
           reminder: null,
           secondaryEmailVerified: null,
           service: validService,
+          style: null,
           type: null
         });
       });
@@ -250,6 +251,7 @@ describe('views/complete_sign_up', function () {
           reminder: validReminder,
           secondaryEmailVerified: null,
           service: null,
+          style: null,
           type: null
         });
       });
@@ -277,6 +279,7 @@ describe('views/complete_sign_up', function () {
           reminder: validReminder,
           secondaryEmailVerified: null,
           service: validService,
+          style: null,
           type: null
         });
       });
@@ -304,6 +307,7 @@ describe('views/complete_sign_up', function () {
           reminder: null,
           secondaryEmailVerified: null,
           service: null,
+          style: null,
           type: 'secondary'
         });
       });
@@ -332,6 +336,7 @@ describe('views/complete_sign_up', function () {
           reminder: null,
           secondaryEmailVerified: 'some@email.com',
           service: null,
+          style: null,
           type: null
         });
       });
@@ -359,6 +364,35 @@ describe('views/complete_sign_up', function () {
           reminder: null,
           secondaryEmailVerified: null,
           service: null,
+          style: null,
+          type: null
+        });
+      });
+    });
+
+    describe('if style is in the url', () => {
+      beforeEach(function () {
+        windowMock.location.search = '?code=' + validCode + '&uid=' + validUid +
+          '&style=trailhead';
+        relier = new Relier({}, {
+          window: windowMock
+        });
+        relier.fetch();
+        initView(account);
+        sinon.stub(view, '_notifyBrokerAndComplete').callsFake(() => Promise.resolve());
+        return view.render();
+      });
+
+      it('attempt to pass style to verifySignUp', () => {
+        const { args } = account.verifySignUp.getCall(0);
+        assert.isTrue(account.verifySignUp.called);
+        assert.ok(args[0]);
+        assert.deepEqual(args[1], {
+          primaryEmailVerified: null,
+          reminder: null,
+          secondaryEmailVerified: null,
+          service: null,
+          style: 'trailhead',
           type: null
         });
       });

--- a/packages/fxa-js-client/client/FxAccountClient.js
+++ b/packages/fxa-js-client/client/FxAccountClient.js
@@ -96,6 +96,8 @@ define([
    *   example.
    *   @param {String} [options.lang]
    *   set the language for the 'Accept-Language' header
+   *   @param {String} [options.style]
+   *   Specify the style of confirmation emails
    *   @param {Object} [options.metricsContext={}] Metrics context metadata
    *     @param {String} options.metricsContext.deviceId identifier for the current device
    *     @param {String} options.metricsContext.flowId identifier for the current event flow
@@ -157,6 +159,10 @@ define([
 
             if (options.metricsContext) {
               data.metricsContext = metricsContext.marshall(options.metricsContext);
+            }
+
+            if (options.style) {
+              data.style = options.style;
             }
           }
 
@@ -306,6 +312,8 @@ define([
    *   If `true`, notifies marketing of opt-in intent.
    *   @param {Array} [options.newsletters]
    *   Array of newsletters to opt in or out of.
+   *   @param {String} [options.style]
+   *   Specify the style of email to send.
    * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
    */
   FxAccountClient.prototype.verifyCode = function(uid, code, options) {
@@ -340,6 +348,10 @@ define([
 
           if (options.newsletters) {
             data.newsletters = options.newsletters;
+          }
+
+          if (options.style) {
+            data.style = options.style;
           }
         }
 
@@ -444,6 +456,10 @@ define([
             requestOpts.headers = {
               'Accept-Language': options.lang
             };
+          }
+
+          if (options.style) {
+            data.style = options.style;
           }
         }
 

--- a/packages/fxa-js-client/tests/lib/recoveryEmail.js
+++ b/packages/fxa-js-client/tests/lib/recoveryEmail.js
@@ -50,12 +50,13 @@ define([
           );
       });
 
-      test('#recoveryEmailResendCode with service, redirectTo, type, and resume', function () {
+      test('#recoveryEmailResendCode with service, redirectTo, type, style and resume', function () {
         var user;
         var opts = {
           service: 'sync',
           redirectTo: 'https://sync.127.0.0.1/after_reset',
           resume: 'resumejwt',
+          style: 'trailhead',
           type: 'upgradeSession'
         };
 
@@ -82,11 +83,14 @@ define([
             assert.ok(redirectTo, 'redirectTo found');
             var resume = emails[2].html.match(/resume=([A-Za-z0-9]+)/);
             assert.ok(resume, 'resume found');
+            var style = emails[2].html.match(/style=trailhead/)[0];
+            assert.ok(style, 'style found');
 
             assert.ok(code[1], 'code is returned');
             assert.equal(service[1], 'sync', 'service is returned');
             assert.equal(redirectTo[1], 'https', 'redirectTo is returned');
             assert.equal(resume[1], 'resumejwt', 'resume is returned');
+            assert.ok(style, 'style is returned');
           },
           assert.notOk
         );

--- a/packages/fxa-js-client/tests/lib/signUp.js
+++ b/packages/fxa-js-client/tests/lib/signUp.js
@@ -83,14 +83,15 @@ define([
           );
       });
 
-      test('#create account with service, redirectTo, and resume', function () {
+      test('#create account with service, redirectTo, style, and resume', function () {
         var user = 'test' + new Date().getTime();
         var email = user + '@restmail.net';
         var password = 'iliketurtles';
         var opts = {
           service: 'sync',
           redirectTo: 'https://sync.127.0.0.1/after_reset',
-          resume: 'resumejwt'
+          resume: 'resumejwt',
+          style: 'trailhead'
         };
 
         return respond(client.signUp(email, password, opts), RequestMocks.signUp)
@@ -104,20 +105,23 @@ define([
               var service = emails[0].html.match(/service=([A-Za-z0-9]+)/)[1];
               var redirectTo = emails[0].html.match(/redirectTo=([A-Za-z0-9]+)/)[1];
               var resume = emails[0].html.match(/resume=([A-Za-z0-9]+)/)[1];
+              var style = emails[0].html.match(/style=trailhead/)[0];
 
               assert.ok(code, 'code is returned');
               assert.ok(service, 'service is returned');
               assert.ok(redirectTo, 'redirectTo is returned');
               assert.ok(resume, 'resume is returned');
+              assert.ok(style, 'style is returned');
 
               assert.include(xhrOpen.args[0][1], '/account/create', 'path is correct');
               var sentData = JSON.parse(xhrSend.args[0][0]);
-              assert.equal(Object.keys(sentData).length, 5);
+              assert.equal(Object.keys(sentData).length, 6);
               assert.equal(sentData.email, email, 'email is correct');
               assert.equal(sentData.authPW.length, 64, 'length of authPW');
               assert.equal(sentData.service, opts.service);
               assert.equal(sentData.resume, opts.resume);
               assert.equal(sentData.redirectTo, opts.redirectTo);
+              assert.equal(sentData.style, opts.style);
             },
             assert.notOk
           );
@@ -216,6 +220,28 @@ define([
           .then(function(res) {
             assert.equal(res.verified, true, '== account is verified');
           });
+      });
+
+      test('#withStyle', function () {
+        var user = 'test' + new Date().getTime();
+        var email = user + '@restmail.net';
+        var password = 'iliketurtles';
+        var opts = {
+          style: 'trailhead'
+        };
+
+        return respond(client.signUp(email, password, opts), RequestMocks.signUp)
+          .then(function (res) {
+            assert.ok(res.uid);
+            return respond(mail.wait(user), RequestMocks.mailServiceAndRedirect);
+          })
+          .then(
+            function (emails) {
+              var style = emails[0].html.match(/style=trailhead/)[0];
+              assert.ok(style, 'style is returned');
+            },
+            assert.notOk
+          );
       });
 
       test('#accountExists', function () {

--- a/packages/fxa-js-client/tests/lib/verifyCode.js
+++ b/packages/fxa-js-client/tests/lib/verifyCode.js
@@ -164,6 +164,38 @@ define([
           );
       });
 
+      test('#verifyEmail with style param', function () {
+        var user = 'test7' + new Date().getTime();
+        var email = user + '@restmail.net';
+        var password = 'iliketurtles';
+        var uid;
+
+        return respond(client.signUp(email, password), RequestMocks.signUp)
+          .then(function (result) {
+            uid = result.uid;
+            assert.ok(uid, 'uid is returned');
+
+            return respond(mail.wait(user), RequestMocks.mail);
+          })
+          .then(function (emails) {
+            var code = emails[0].html.match(/code=([A-Za-z0-9]+)/)[1];
+            assert.ok(code, 'code is returned');
+
+            return respond(client.verifyCode(uid, code, { style: 'trailhead' }),
+              RequestMocks.verifyCode);
+          })
+          .then(
+            function (result) {
+              assert.ok(result);
+              assert.equal(xhrOpen.args[2][0], 'POST', 'method is correct');
+              assert.include(xhrOpen.args[2][1], '/recovery_email/verify_code', 'path is correct');
+              var sentData = JSON.parse(xhrSend.args[2][0]);
+              assert.equal(sentData.style, 'trailhead');
+            },
+            assert.notOk
+          );
+      });
+
       test('#verifyEmail with marketingOptIn param', function () {
         var user = 'test7' + new Date().getTime();
         var email = user + '@restmail.net';

--- a/packages/fxa-js-client/tests/mocks/request.js
+++ b/packages/fxa-js-client/tests/mocks/request.js
@@ -95,7 +95,7 @@ define([
     },
     mailServiceAndRedirect: {
       status: 200,
-      body: '[{"html":"Mocked code=9001 service=sync redirectTo=https resume=resumejwt"}]'
+      body: '[{"html":"Mocked code=9001 service=sync redirectTo=https resume=resumejwt style=trailhead"}]'
     },
     resetMail: {
       status: 200,
@@ -119,7 +119,7 @@ define([
     },
     resetMailWithServiceAndRedirectNoSignup: {
       status: 200,
-      body: '[{"html":"Mocked code=9001"}, {"html":"Mocked code=9001"}, {"html":"Mocked code=9001 service=sync redirectTo=https resume=resumejwt"}]'
+      body: '[{"html":"Mocked code=9001"}, {"html":"Mocked code=9001"}, {"html":"Mocked code=9001 service=sync redirectTo=https resume=resumejwt style=trailhead"}]'
     },
     resetMailWithServiceAndRedirect: {
       status: 200,


### PR DESCRIPTION
Connects with https://github.com/mozilla/fxa/issues/1073
Connects with #1152 

This updates the content-server and js-client to accept and pass the style param to the auth-server.

~~Marking this as a draft since I need to add a few more things.~~

I've updated the js-client and content-server to send the new style param for account signup, resending verification email and verifying account.

- [x] Add content server tests for new style param
- [x] Add js-client tests