### PR TITLE
fix(trailhead): Use new Firefox logo globally in the content server.

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -1,48 +1,33 @@
 #main-content::before {
-  background-image: image-url('firefox-logo.svg');
-  background-position: center -1px;
+  $firefox-standalone-logo-size-large: 82px;
+  $firefox-standalone-logo-size-small: 56px;
+
+  background-image: image-url('trailhead/firefox-logo.svg');
+  background-position: center center;
   background-repeat: no-repeat;
   content: '';
+  left: 0;
   position: absolute;
+  width: 100%;
   z-index: $fox-logo-zindex;
 
-  $large-logo: 72px;
   @include respond-to('big') {
-    background-size: auto $large-logo;
-    height: $large-logo;
-    margin-top: -$large-logo;
-    top: .5 * $large-logo;
-    width: $large-logo;
-
-    html[dir='ltr'] & {
-      margin-left: .5 * -$large-logo;
-    }
-
-    html[dir='rtl'] & {
-      margin-right: .5 * -$large-logo;
-    }
+    background-size: auto $firefox-standalone-logo-size-large;
+    height: $firefox-standalone-logo-size-large;
+    margin-top: -$firefox-standalone-logo-size-large;
+    top: $firefox-standalone-logo-size-large/2;
+    opacity: 1 !important; // !important overrides the !important in _branding.scss
   }
 
-  $small-logo: 56px;
   @include respond-to('small') {
-    background-size: auto $small-logo;
-    height: $small-logo;
-    margin-left: .5 * -$small-logo;
-    margin-top: -$small-logo;
-    top: 10 + $small-logo;
-    width: $small-logo;
+    background-size: auto $firefox-standalone-logo-size-small;
+    height: $firefox-standalone-logo-size-small;
+    margin-top: -$firefox-standalone-logo-size-small;
+    top: 10 + $firefox-standalone-logo-size-small;
+  }
 
-    html[dir='ltr'] & {
-      margin-left: .5 * -$small-logo;
-    }
-
-    html[dir='rtl'] & {
-      margin-right: .5 * -$small-logo;
-    }
-
-    .screen-choose-what-to-sync & {
-      display: none;
-    }
+  .screen-choose-what-to-sync & {
+    display: none;
   }
 
   .static & {
@@ -62,31 +47,6 @@
     // where we want to hide the logo and not animate it
     // it uses `!important` to avoid the fade-in effect and inline styles.
     opacity: 0 !important;
-  }
-
-  .trailhead &{
-    $firefox-standalone-logo-size-large: 82px;
-    $firefox-standalone-logo-size-small: 56px;
-
-    background-image: image-url('trailhead/firefox-logo.svg');
-    background-position: center center;
-
-    @include respond-to('big') {
-      background-size: auto $firefox-standalone-logo-size-large;
-      height: $firefox-standalone-logo-size-large;
-      margin-top: -$firefox-standalone-logo-size-large;
-      top: $firefox-standalone-logo-size-large/2;
-      width: $firefox-standalone-logo-size-large;
-      opacity: 1 !important; // !important overrides the !important in _branding.scss
-    }
-
-    @include respond-to('small') {
-      background-size: auto $firefox-standalone-logo-size-small;
-      height: $firefox-standalone-logo-size-small;
-      margin-top: -$firefox-standalone-logo-size-small;
-      top: 10 + $firefox-standalone-logo-size-small;
-      width: $firefox-standalone-logo-size-small;
-    }
   }
 }
 

--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -57,21 +57,27 @@ body.settings #stage .settings {
   }
 
   #fxa-manage-account {
-    background-image: image-url('firefox-logo.svg');
+    background-image: image-url('trailhead/firefox-logo.svg');
     background-repeat: no-repeat;
     margin: 0;
+
+    html[dir='ltr'] & {
+      background-position: left center;
+    }
+
+    html[dir='rtl'] & {
+      background-position: right center;
+    }
 
     @include respond-to('big') {
       background-size: 36px auto;
       line-height: 63px;
 
       html[dir='ltr'] & {
-        background-position: left 11px;
         padding-left: 48px;
       }
 
       html[dir='rtl'] & {
-        background-position: right 11px;
         padding-right: 48px;
       }
     }
@@ -86,12 +92,10 @@ body.settings #stage .settings {
       }
 
       html[dir='ltr'] & {
-        background-position: left 8px;
         padding-left: 36px;
       }
 
       html[dir='rtl'] & {
-        background-position: right 8px;
         padding-right: 36px;
       }
     }


### PR DESCRIPTION
`?style=trailhead` is not needed to see the new logo. Just show it
everywhere, including the settings page where we missed it previously.

Does not update the email templates globally.

issue #1223

@mozilla/fxa-devs - r?

### settings desktop
<img width="1070" alt="Screenshot 2019-05-23 at 11 14 54" src="https://user-images.githubusercontent.com/848085/58245420-a920db00-7d4c-11e9-9a87-0de3f205b310.png">

### settings mobile

<img width="468" alt="Screenshot 2019-05-23 at 11 14 59" src="https://user-images.githubusercontent.com/848085/58245431-afaf5280-7d4c-11e9-8418-ec8af82ab327.png">


### signin desktop

<img width="523" alt="Screenshot 2019-05-23 at 11 19 08" src="https://user-images.githubusercontent.com/848085/58245442-b4740680-7d4c-11e9-94ed-83f755b4ca55.png">

### signin mobile

<img width="298" alt="Screenshot 2019-05-23 at 11 19 13" src="https://user-images.githubusercontent.com/848085/58245448-b6d66080-7d4c-11e9-9793-506d36ae773a.png">


@mozilla/fxa-devs - r?