### PR TITLE
fix(settings): Better left alignment of panels.

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -207,7 +207,7 @@ body.settings #stage .settings {
   }
 
   @include respond-to('small') {
-    padding: 0 8px;
+    padding: 0 16px;
   }
 }
 
@@ -250,7 +250,13 @@ body.settings #stage .settings {
   align-items: center;
   display: flex;
   height: 72px;
-  padding: 0 16px;
+
+  @include respond-to('big') {
+    padding: 0 32px;
+  }
+  @include respond-to('small') {
+    padding: 0 16px;
+  }
 
   .settings-unit-summary {
     margin: 0;


### PR DESCRIPTION
Makes sure the left/right gutters are consistent between
the Fx logo, the avatar, and the settings panels.

fixes #1142

### Desktop

<img width="871" alt="Screenshot 2019-05-23 at 11 28 36" src="https://user-images.githubusercontent.com/848085/58246080-12edb480-7d4e-11e9-83f6-6e3971c3eac7.png">

### Mobile


<img width="407" alt="Screenshot 2019-05-23 at 11 28 50" src="https://user-images.githubusercontent.com/848085/58246073-0ff2c400-7d4e-11e9-9768-ac3eb0ac381c.png">


@mozilla/fxa-devs - r?