### PR TITLE
feat(trailhead): use updated firefox logo on all emails

### DIFF
--- a/packages/fxa-auth-server/lib/senders/templates/password_reset_required.html
+++ b/packages/fxa-auth-server/lib/senders/templates/password_reset_required.html
@@ -18,7 +18,7 @@
 <!--Logo-->
 <tr style="page-break-before: always">
   <td align="center" id="firefox-logo" style="padding: 20px 0;">
-    <img src="http://image.e.mozilla.org/lib/fe9915707361037e75/m/2/fxlogojg.gif" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
+    <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/4/11c1e411-7dfe-4e04-914c-0f098edac96c.png" height="95" width="88" alt="" style="-ms-interpolation-mode: bicubic;" />
   </td>
 </tr>
 


### PR DESCRIPTION
I did this as part of https://github.com/mozilla/fxa/pull/1087#issuecomment-493133406. After an audit looks like I missed a template. It isn't used anywhere but still might be worthwhile to update.

Connect to https://github.com/mozilla/fxa/issues/1223

@mozilla/fxa-devs r?