### PR TITLE
chore(version): bump fxa-js-client version to 1.0.12

### DIFF
--- a/packages/fxa-content-server/npm-shrinkwrap.json
+++ b/packages/fxa-content-server/npm-shrinkwrap.json
@@ -6232,12 +6232,12 @@
       }
     },
     "fxa-js-client": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fxa-js-client/-/fxa-js-client-1.0.11.tgz",
-      "integrity": "sha512-CwSkZi9CKzJPMVoW8OMPFTxQHF7B4qlM+hXoRZd4axs/XdSePdP89HuCDXR4omcjQCjjjXQBrGfbL1JWOfopHQ==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fxa-js-client/-/fxa-js-client-1.0.12.tgz",
+      "integrity": "sha512-lmaElBDO6wiWQa4CV8097TPE5uRY0R4cOJhOmsY3hbHTGZAo2Jyu6SQ2FUbzANOj0IzAVBYaKX+xLhwvhock2w==",
       "requires": {
         "es6-promise": "4.1.1",
-        "sjcl": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8e",
+        "sjcl": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8ef32329bc8d7bc28a438372b5acb46616b",
         "xhr2": "0.0.7"
       },
       "dependencies": {

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -60,7 +60,7 @@
     "fxa-common-password-list": "0.0.2",
     "fxa-crypto-relier": "2.3.0",
     "fxa-geodb": "1.0.4",
-    "fxa-js-client": "1.0.11",
+    "fxa-js-client": "1.0.12",
     "fxa-mustache-loader": "0.0.2",
     "fxa-pairing-channel": "1.0.1",
     "fxa-shared": "1.0.24",

--- a/packages/fxa-js-client/package-lock.json
+++ b/packages/fxa-js-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-js-client",
-  "version": "1.0.9",
+  "version": "1.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fxa-js-client/package.json
+++ b/packages/fxa-js-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-js-client",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Web client that talks to the Firefox Accounts API server",
   "author": "Mozilla",
   "license": "MPL-2.0",


### PR DESCRIPTION
Our release scripts got broken during the mono repo transition. I've published and manually bumped this version.