### PR TITLE
chore(tests): add more remote tests for subscription endpoints

### DIFF
--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -1101,7 +1101,7 @@ module.exports = config => {
   };
 
   ClientApi.prototype.cancelSubscription = function (refreshToken, subscriptionId) {
-    return this.doRequestWithBearerToken('DELETE', `${this.baseURL}/oauth/subscriptions/active/${subscriptionId}`, refreshToken);
+    return this.doRequestWithBearerToken('POST', `${this.baseURL}/oauth/subscriptions/subscriptionId}/cancel`, refreshToken);
   };
 
   ClientApi.heartbeat = function (origin) {


### PR DESCRIPTION
Fixes #1110.

Adds some remote tests for `cancelSubscription` and `getActiveSubscriptions`, I figured that would do for now and I'm not sure I understand some of the others properly yet. Also fixes a bug in the test client, where I'd called the wrong db endpoint for `cancelSubscriptions`.

@lmorchard r?

