### PR TITLE
fix(metrics): add geolocation to get-metrics-flow

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/get-metrics-flow.js
+++ b/packages/fxa-content-server/server/lib/routes/get-metrics-flow.js
@@ -6,6 +6,7 @@
 
 const amplitude = require('../amplitude');
 const flowMetrics = require('../flow-metrics');
+const geolocate = require('../geo-locate');
 const logFlowEvent = require('../flow-event').logFlowEvent;
 const logger = require('../logging/log')('server.get-metrics-flow');
 const uuid = require('node-uuid');
@@ -82,6 +83,7 @@ module.exports = function (config) {
     };
 
     metricsData.flowId = flowId;
+    metricsData.location = geolocate(req);
     // Amplitude-specific device id, like the client-side equivalent
     // created in app/scripts/lib/app-start.js. Transient for now,
     // but will become persistent in due course.

--- a/packages/fxa-content-server/tests/server/routes/get-metrics-flow.js
+++ b/packages/fxa-content-server/tests/server/routes/get-metrics-flow.js
@@ -34,6 +34,7 @@ registerSuite('routes/get-metrics-flow', {
       flowEvent: {
         logFlowEvent: sandbox.spy()
       },
+      geolocate: sandbox.spy(() => ({ country: 'United States', state: 'California' })),
       log: {
         info: sandbox.spy()
       }
@@ -41,6 +42,7 @@ registerSuite('routes/get-metrics-flow', {
     route = proxyquire('../../../server/lib/routes/get-metrics-flow', {
       '../amplitude': mocks.amplitude,
       '../flow-event': mocks.flowEvent,
+      '../geolocate': mocks.geolocate,
       '../logging/log': () => mocks.log
     });
     instance = route(mocks.config);
@@ -120,6 +122,8 @@ registerSuite('routes/get-metrics-flow', {
       assert.equal(args[2].entrypoint, 'zoo');
       assert.equal(args[2].entrypoint_experiment, 'herf');
       assert.equal(args[2].entrypoint_variation, 'menk');
+      assert.equal(args[2].location.country, 'United States');
+      assert.equal(args[2].location.state, 'California');
       assert.ok(args[2].flowId);
       assert.ok(args[2].deviceId);
       assert.notEqual(args[2].deviceId, args[2].flowId);
@@ -278,6 +282,8 @@ registerSuite('routes/get-metrics-flow', {
       assert.ok(args[0].time);
       assert.equal(args[0].type, 'screen.enter-email');
       assert.equal(args[2].entrypoint, 'bar');
+      assert.equal(args[2].location.country, 'United States');
+      assert.equal(args[2].location.state, 'California');
       assert.ok(args[2].flowId);
 
       assert.equal(mocks.flowEvent.logFlowEvent.callCount, 2);
@@ -392,4 +398,3 @@ async function testInvalidFlowQueryParam(paramName, paramValue) {
     assert.include(JSON.parse(err.response.body).validation.keys, paramName);
   }
 }
-


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/1224

I couldn't actually test this locally bcs for the life of me I can't get fxa-email-service to build on `npm install`

<details>
  <summary>Click for example error msg i was seeing</summary>
`error: Could not compile `security-framework-sys`.
warning: build failed, waiting for other jobs to finish...
error: could not exec the linker `cc`
  |
  = note: Not a directory (os error 20)
  = note: "cc" "-m64" "-L" "/Users/loines/.rustup/toolchains/nightly-2018-11-09-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.0.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.1.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.10.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.11.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.12.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.13.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.14.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.15.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.2.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.3.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.4.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.5.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.6.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.7.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.8.rcgu.o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.build_script_build.cun14r2b-cgu.9.rcgu.o" "-o" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/build/core-foundation-sys-2c2efb62155710fc/build_script_build-2c2efb62155710fc.5g2ajhe5khvqws1c.rcgu.o" "-Wl,-dead_strip" "-nodefaultlibs" "-L" "/Users/loines/Documents/GitHub/fxa/packages/fxa-email-service/target/debug/deps" "-L" "/Users/loines/.rustup/toolchains/nightly-2018-11-09-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib" "/Users/loines/.rustup/toolchains/nightly-2018-11-09-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libstd-9e5a69db4dc01737.rlib" "/Users/loines/.rustup/toolchains/nightly-2018-11-09-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libpanic_unwind-5a2cb5c752e3ae9c.rlib" "/Users/loines/.rustup/toolchains/nightly-2018-11-09-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libunwind-88ee0f866cc5107b.rlib" "/Users/loines/.rustup/toolchains/nightly-2018-11-09-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/liballoc_system-418f733d0e05a87c.rlib" "/Users/loines/.rustup/toolchains/nightly-2018-11-09-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/liblibc-faa0a0baebb4269f.rlib" "/Users/loines/.rustup/toolchains/nightly-2018-11-09-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/liballoc-c18bb86c34490d18.rlib" "/Users/loines/.rustup/toolchains/nightly-2018-11-09-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libcore-291d1e3476ad529e.rlib" "/Users/loines/.rustup/toolchains/nightly-2018-11-09-x86_64-apple-darwin/lib/rustlib/x86_64-apple-darwin/lib/libcompiler_builtins-d676450268a06e1b.rlib" "-lSystem" "-lresolv" "-lc" "-lm"
error: aborting due to previous error
error: Could not compile `core-foundation-sys`.
warning: build failed, waiting for other jobs to finish...
error: build failed
npm ERR! code ELIFECYCLE
npm ERR! errno 101
npm ERR! fxa@2.0.0 postinstall: `_scripts/postinstall.sh`
npm ERR! Exit status 101
npm ERR! 
npm ERR! Failed at the fxa@2.0.0 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/loines/.npm/_logs/2019-05-23T19_41_29_164Z-debug.log
MacBook-Pro:fxa loines$ cc --version
Apple LLVM version 10.0.1 (clang-1001.0.46.4)
Target: x86_64-apple-darwin18.5.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin`
</details>

So if someone could check this branch to see if country is being added to the amplitude events, I would appreciate it (or if you know what's going on above lmk and I'll do it),  (edit) but iiuc what i did add to the tests *should* check for a country field in the amplitude event.

however I'm also not sure I'm modifying the tests correctly or if I need to add other things