### PR TITLE
chore(content:csp): Remove the CSP rule for the default png's inline style

### DIFF
--- a/packages/fxa-content-server/server/lib/csp/blocking.js
+++ b/packages/fxa-content-server/server/lib/csp/blocking.js
@@ -36,8 +36,6 @@ module.exports = function (config) {
   // Double quoted values
   //
   const NONE = "'none'";
-  // The sha of the embedded <style> tag in default-profile.svg.
-  const EMBEDDED_STYLE_SHA = "'sha256-9n6ek6ecEYlqel7uDyKLy6fdGNo3vw/uScXSq9ooQlk='";
   // keyword sources - https://www.w3.org/TR/CSP2/#keyword_source
   // Note: "'unsafe-inline'" and "'unsafe-eval'" are not used in this module.
   const SELF = "'self'";
@@ -83,8 +81,7 @@ module.exports = function (config) {
         SELF
       ]),
       styleSrc: addCdnRuleIfRequired([
-        SELF,
-        EMBEDDED_STYLE_SHA
+        SELF
       ])
     },
     reportOnly: false,
@@ -94,7 +91,6 @@ module.exports = function (config) {
       BLOB,
       CDN_URL,
       DATA,
-      EMBEDDED_STYLE_SHA,
       GRAVATAR,
       MARKETING_EMAIL_SERVER,
       NONE,

--- a/packages/fxa-content-server/tests/server/csp.js
+++ b/packages/fxa-content-server/tests/server/csp.js
@@ -86,9 +86,8 @@ suite.tests['blockingRules'] = function () {
   assert.include(scriptSrc, CDN_SERVER);
 
   const styleSrc = directives.styleSrc;
-  assert.lengthOf(styleSrc, 3);
+  assert.lengthOf(styleSrc, 2);
   assert.include(styleSrc, Sources.SELF);
-  assert.include(styleSrc, Sources.EMBEDDED_STYLE_SHA);
   assert.include(styleSrc, CDN_SERVER);
 };
 


### PR DESCRIPTION
The SHA embedded in the CSP rule allowed the inline style element in
the old default avatar. When @johngruen replaced the default avatar,
that style element went away, so we can safely remove the SHA.

@mozilla/fxa-devs - r?