### PR TITLE
fix(build): Speed up dev webpack compilation

### DIFF
--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -26,6 +26,7 @@
   },
   "allowed_metrics_flow_cors_origins": ["http://127.0.0.1:8001"],
   "allowed_parent_origins": ["http://127.0.0.1:8080"],
+  "sourceMapType": "cheap-source-map",
   "csp": {
     "enabled": true,
     "reportUri": "/_/csp-violation"

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -576,6 +576,12 @@ const conf = module.exports = convict({
       }
     }
   },
+  sourceMapType: {
+    default: 'source-map',
+    doc: 'Type of source maps created. See https://webpack.js.org/configuration/devtool/',
+    env: 'SOURCE_MAP_TYPE',
+    format: String
+  },
   static_directory: {
     default: 'app',
     doc: 'Directory that static files are served from.',

--- a/packages/fxa-content-server/webpack.config.js
+++ b/packages/fxa-content-server/webpack.config.js
@@ -187,9 +187,7 @@ const webpackConfig = {
     crypto: 'empty'
   },
 
-  // See https://webpack.js.org/configuration/devtool/ to
-  // configure source maps to personal preferences.
-  devtool: 'source-map'
+  devtool: config.sourceMapType
 };
 
 if (ENV === 'development') {


### PR DESCRIPTION
For local dev use `cheap-source-map`s instead of `source-map`. This
speeds up the compilation from 15 seconds to 1 second. The source maps
are not as good, but they are configurable in local.json for
those that want better maps.

fixes #1205

@mozilla/fxa-devs - r?