### PR TITLE
fix(settings): padding for Firefox icon

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -45,8 +45,9 @@ body.settings #stage .settings {
 // settings header controls
 #fxa-settings-header-wrapper {
   align-items: center;
+  align-self: center;
   display: flex;
-  width: 100%;
+  width: 100vw;
 
   @include respond-to('big') {
     height: 96px;


### PR DESCRIPTION
Fixes #1115 