### PR TITLE
chore(deps): Update to the latest Backbone

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/pairing/state.js
+++ b/packages/fxa-content-server/app/scripts/models/pairing/state.js
@@ -17,11 +17,6 @@ export class State extends Model {
     this.relier = options.relier;
   }
 
-  destroy () {
-    this.stopListening();
-    super.destroy();
-  }
-
   gotoState (NextState, attrs) {
     this.trigger('goto.state', NextState, attrs);
   }

--- a/packages/fxa-content-server/app/tests/spec/lib/channels/notifier-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/channels/notifier-mixin.js
@@ -119,7 +119,7 @@ describe('lib/channels/notifier-mixin', () => {
 
     beforeEach(() => {
       callback = sinon.spy();
-      sinon.spy(notifier, 'once');
+      sinon.spy(view, 'listenToOnce');
 
       view.notifier.once('handle-once', callback);
       notifier.trigger('handle-once');
@@ -128,9 +128,7 @@ describe('lib/channels/notifier-mixin', () => {
     });
 
     it('registers a message with the notifier', () => {
-      assert.isTrue(notifier.once.calledWith('handle-once'));
-      // A second argument is passed, but it's opaque to us.
-      assert.isFunction(notifier.once.args[0][1]);
+      assert.isTrue(view.listenToOnce.calledWith(notifier, 'handle-once', callback));
       assert.isTrue(callback.calledOnce);
     });
   });

--- a/packages/fxa-content-server/npm-shrinkwrap.json
+++ b/packages/fxa-content-server/npm-shrinkwrap.json
@@ -2609,11 +2609,11 @@
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "backbone": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.1.1.tgz",
-      "integrity": "sha1-gJEZf+86WP3q4k3nDZbiPOQy85k=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
       "requires": {
-        "underscore": ">=1.5.0"
+        "underscore": ">=1.8.3"
       }
     },
     "backbone.cocktail": {
@@ -6237,7 +6237,7 @@
       "integrity": "sha512-lmaElBDO6wiWQa4CV8097TPE5uRY0R4cOJhOmsY3hbHTGZAo2Jyu6SQ2FUbzANOj0IzAVBYaKX+xLhwvhock2w==",
       "requires": {
         "es6-promise": "4.1.1",
-        "sjcl": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8ef32329bc8d7bc28a438372b5acb46616b",
+        "sjcl": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8e",
         "xhr2": "0.0.7"
       },
       "dependencies": {

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -37,7 +37,7 @@
     "@babel/preset-env": "7.4.4",
     "autoprefixer": "9.0.1",
     "babel-loader": "8.0.5",
-    "backbone": "1.1.1",
+    "backbone": "^1.4.0",
     "backbone.cocktail": "git://github.com/onsi/cocktail.git#87971c88e2e4f904a0984b5f236ee5dbb21ddb4a",
     "base32-decode": "1.0.0",
     "base64url": "3.0.0",


### PR DESCRIPTION
A couple of tests needed to be updated
because:

* notifier-mixin was testing deep internals of how once was hooked up.
* Backbone.Model.destroy now calls `stopListening` itself, no need to do it again.

This is in support of adding Typescript. Backbone updated the way Views initialize that work better with ES2015 classes, which work better with Typescript than View.extend.

Not attached to an issue