### PR TITLE
fix(scripts): use version sort to get last tag for train bump

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -76,7 +76,11 @@ if [ "$STATUS" != "" ]; then
 fi
 
 # 3. Find the last tag.
-LAST_TAG=`git describe --tags --abbrev=0`
+if [ "$BUILD_TYPE" = "Train" ]; then
+  LAST_TAG=`git tag -l --sort=version:refname | tail -1`
+else
+  LAST_TAG=`git describe --tags --abbrev=0`
+fi
 
 # 4. Check there have been some commits since the last tag.
 COMMITS=`git log $LAST_TAG..HEAD --pretty=oneline --abbrev-commit`


### PR DESCRIPTION
Fixes #1270.

Currently the release script fails when tagging `138.0` because the most recent tag chronologically is `136.6`. This changes it so that path uses git's version-sort ordering instead.

@mozilla/fxa-devs r?