### PR TITLE
feat(payments): add configuration to payments index.html

### DIFF
--- a/packages/fxa-payments-server/public/index.html
+++ b/packages/fxa-payments-server/public/index.html
@@ -10,6 +10,8 @@
     <meta name=robots content=noindex,nofollow>
     <meta name=viewport content="width=device-width,initial-scale=1,maximum-scale=2,user-scalable=yes">
     <meta name=apple-itunes-app content="app-id=989804926, affiliate-data=ct=smartbanner-fxa">
+    <meta name="fxa-content-server/config" content="__SERVER_CONFIG__">
+    <meta name="fxa-feature-flags" content="__FEATURE_FLAGS__">
 
     <script src="https://js.stripe.com/v3/"></script>
 </head>

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -85,7 +85,7 @@ const conf = convict({
     },
   },
   proxyStaticResourcesFrom: {
-    default: null,
+    default: '',
     doc: 'Instead of loading static resources from disk, get them by proxy from this URL (typically a special reloading dev server)',
     env: 'PROXY_STATIC_RESOURCES_FROM',
     format: String,

--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -6,6 +6,7 @@
 
 module.exports = () => {
   const path = require('path');
+  const fs = require('fs');
 
   // setup version first for the rest of the modules
   const logger = require('./logging/log')('server.main');
@@ -21,6 +22,21 @@ module.exports = () => {
   const serveStatic = require('serve-static');
 
   const app = express();
+
+  // Each of these config values (e.g., 'servers.content') will be exposed as the given
+  // variable to the client/browser (via fxa-content-server/config)
+  const CLIENT_CONFIG_MAP = {
+    contentUrl: 'servers.content',
+    oAuthUrl: 'servers.oauth',
+    profileUrl: 'servers.profile',
+  };
+
+  // This is a list of all the paths that should resolve to index.html:
+  const INDEX_ROUTES = [
+    '/',
+    '/subscriptions',
+    '/products/:productId',
+  ];
 
   app.disable('x-powered-by');
 
@@ -57,20 +73,58 @@ module.exports = () => {
       .get(require('cors')(corsOptions));
   }
 
+  function injectHtmlConfig(html, config, featureFlags) {
+    const encodedConfig = encodeURIComponent(JSON.stringify(config));
+    let result = html.replace('__SERVER_CONFIG__', encodedConfig);
+    const encodedFeatureFlags = encodeURIComponent(JSON.stringify(featureFlags));
+    result = result.replace('__FEATURE_FLAGS__', encodedFeatureFlags);
+    return result;
+  }
+
+  function getClientConfig() {
+    // See also packages/fxa-content-server/server/lib/routes/get-index.js
+    const clientConfig = {};
+    for (const exportVariable in CLIENT_CONFIG_MAP) {
+      clientConfig[exportVariable] = config.get(CLIENT_CONFIG_MAP[exportVariable]);
+    }
+    return clientConfig;
+  }
+
   const STATIC_DIRECTORY =
     path.join(__dirname, '..', '..', config.get('staticResources.directory'));
+
+  const STATIC_INDEX_HTML = fs.readFileSync(path.join(STATIC_DIRECTORY, 'index.html'), {encoding: 'UTF-8'});
 
   const proxyUrl = config.get('proxyStaticResourcesFrom');
   if (proxyUrl) {
     logger.info('static.proxying', { url: proxyUrl });
     const proxy = require('express-http-proxy');
-    app.use('/', proxy(proxyUrl));
+    app.use('/', proxy(proxyUrl, {
+      userResDecorator: function(proxyRes, proxyResData, userReq, userRes) {
+        const contentType = proxyRes.headers['content-type'];
+        if (! contentType || ! contentType.startsWith('text/html')) {
+          return proxyResData;
+        }
+        if (userReq.url.startsWith('/sockjs-node/')) {
+          // This is a development WebPack channel that we don't want to modify
+          return proxyResData;
+        }
+        const body = proxyResData.toString('utf8');
+        return injectHtmlConfig(body, getClientConfig(), {});
+      }
+    }));
   } else {
     logger.info('static.directory', { directory: STATIC_DIRECTORY });
+    const renderedStaticHtml = injectHtmlConfig(STATIC_INDEX_HTML, getClientConfig(), {});
+    for (const route of INDEX_ROUTES) {
+      // FIXME: should set ETag, Not-Modified:
+      app.get(route, (req, res) => {
+        res.send(renderedStaticHtml);
+      });
+    }
     app.use(serveStatic(STATIC_DIRECTORY, {
       maxAge: config.get('staticResources.maxAge')
     }));
-    // TODO routes
   }
 
   // it's a four-oh-four not found.

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -24,7 +24,7 @@ type AppProps = {
   store: Store,
 };
 
-export const App = ({ 
+export const App = ({
   accessToken,
   config,
   store
@@ -36,6 +36,7 @@ export const App = ({
       (props: object) =>
         <Component {...{ accessToken, config, ...props }} />;
 
+  // Note: every Route below should also be listed in INDEX_ROUTES in server/lib/server.js
   return (
     <StripeProvider apiKey={config.STRIPE_API_KEY}>
       <Provider store={store}>


### PR DESCRIPTION
This injects some whitelisted config values into <meta name=fxa-content-server/config> (and a stubbed feature flag tag). The misnomer is to allow a shared library to load that config.

The config is both injected into the development server (which is proxied to) and the production server (which is based on a static file)

Also this adds routes to the production server, which should serve the standard index.html on all routes (e.g., /subscriptions).

Some followups that would be called for:
* Move `config-loader.js` into shared
* Actually read the config!
* Add feature flags
* Add ETag to the production index.html serving
