### PR TITLE
feat(payment): use subhub for current subscriptions list

### DIFF
--- a/packages/fxa-payments-server/src/components/ProductValueProposition/index.tsx
+++ b/packages/fxa-payments-server/src/components/ProductValueProposition/index.tsx
@@ -22,9 +22,10 @@ const ProductValueProposition = ({
     ? availableDetails[plan.product_id]
     : DefaultDetails;
 
+  const { currency, amount, interval, plan_name } = plan;
   return (
     <div className="productDetails">
-      <p>For {plan.currency} {plan.amount} per {plan.interval}, your {plan.product_id} includes:</p>
+      <p>For {currency} {amount} per {interval}, your {plan_name} includes:</p>
       <Details plan={plan} />
     </div>
   );

--- a/packages/fxa-payments-server/src/routes/Home.tsx
+++ b/packages/fxa-payments-server/src/routes/Home.tsx
@@ -1,41 +1,41 @@
 import React, { useEffect } from 'react';
-import { connect, useDispatch } from 'react-redux';
-import { actions, selectorsFromState } from '../store';
-import { PlansFetchState } from '../store/types';
+import { connect } from 'react-redux';
+import { actions, selectors } from '../store';
+import { State, PlansFetchState, Plan } from '../store/types';
 import { Link } from 'react-router-dom';
 
 type IndexProps = {
   accessToken: string,
-  isLoading: boolean,
   plans: PlansFetchState,
-  products: Array<string>
+  fetchPlans: Function,
 };
 
 export const Index = ({
   accessToken,
-  isLoading,
   plans,
-  products,
+  fetchPlans,
 }: IndexProps) => {
-  const dispatch = useDispatch();
-
   useEffect(() => {
     if (accessToken) {
-      dispatch(actions.fetchPlans(accessToken));
+      fetchPlans(accessToken);
     }
-  }, [ dispatch, accessToken ]);
+  }, [ fetchPlans, accessToken ]);
 
   return (
     <div>
       <p>TODO: This should probably not be a useful page that links anywhere.</p>
       <p><Link to="/subscriptions">Manage subscriptions</Link></p>
-      <h2>Available Products</h2>
+      <h2>Available Plans</h2>
       <ul>
         {plans.loading && <li>(plans loading...)</li>}
         {plans.error && <h1>(plans error! {'' + plans.error})</h1>}
         {plans.result && (
-          products.map(productId =>
-            <li key={productId}><Link to={`/products/${productId}`}>{productId}</Link></li>
+          plans.result.map(({
+            plan_id,
+            plan_name,
+            product_id,
+          }: Plan) =>
+            <li key={plan_id}><Link to={`/products/${product_id}?plan=${plan_id}`}>{plan_name}</Link></li>
           )
         )}
       </ul>
@@ -45,5 +45,10 @@ export const Index = ({
 
 // TODO: replace this with a useSelector hook
 export default connect(
-  selectorsFromState('plans', 'products')
+  (state: State) => ({
+    plans: selectors.plans(state),
+  }),
+  {
+    fetchPlans: actions.fetchPlans
+  }
 )(Index);

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Subscription.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Subscription.tsx
@@ -1,32 +1,35 @@
 import React, { useCallback } from 'react';
 import { useBooleanState, useCheckboxState } from '../../lib/hooks';
-import { Subscription as SubscriptionType } from '../../store/types';
+import { CustomerSubscription } from '../../store/types';
 
 type SubscriptionProps = {
   accessToken: string,
-  subscription: SubscriptionType,
+  subscription: CustomerSubscription,
   cancelSubscription: Function,
 };
 export const Subscription = ({
   accessToken,
   cancelSubscription,
   subscription: {
-    subscriptionId,
-    productName,
-    createdAt
+    subscription_id,
+    plan_id,
+    nickname,
+    status,
+    current_period_start,
+    current_period_end,
   },
 }: SubscriptionProps) => {
   const [ cancelRevealed, revealCancel, hideCancel ] = useBooleanState();
   const [ confirmationChecked, onConfirmationChanged ] = useCheckboxState();
   const confirmCancellation = useCallback(
-    () => cancelSubscription(accessToken, subscriptionId),
-    [ accessToken, cancelSubscription, subscriptionId ]
+    () => cancelSubscription(accessToken, subscription_id),
+    [ accessToken, cancelSubscription, subscription_id ]
   );
 
   return (
     <div className="subscription">
-      <h3>{productName}</h3>
-      <p>{subscriptionId} - {productName} - {'' + new Date(createdAt)}</p>
+      <h3>{nickname} ({status})</h3>
+      <p>{subscription_id} - {plan_id} - {current_period_start} - {current_period_end}</p>
       <div>
         {! cancelRevealed ? <>
           <h3>Cancel subscription <button onClick={revealCancel}>Cancel...</button></h3>

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -1,39 +1,44 @@
-import React, { useCallback, useEffect } from 'react';
-import { connect, useDispatch } from 'react-redux';
-import { selectorsFromState, actions } from '../../store';
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import { actions, selectors } from '../../store';
 import { Elements } from 'react-stripe-elements';
-import { SubscriptionsFetchState, UpdatePaymentFetchState, CustomerFetchState } from '../../store/types';
-import AlertBar from '../../components/AlertBar';
 
+import {
+  State,
+  CustomerSubscription,
+  SubscriptionsFetchState,
+  UpdatePaymentFetchState,
+  CustomerFetchState
+} from '../../store/types';
+
+import AlertBar from '../../components/AlertBar';
 import Subscription from './Subscription';
 import PaymentUpdateForm from './PaymentUpdateForm';
 
 type SubscriptionsProps = {
   accessToken: string,
-  isLoading: boolean,
   customer: CustomerFetchState,
   subscriptions: SubscriptionsFetchState,
+  customerSubscriptions: Array<CustomerSubscription>,
+  fetchCustomerAndSubscriptions: Function,
   cancelSubscription: Function,
   resetUpdatePayment: Function,
+  resetCancelSubscription: Function,
   updatePayment: Function,
   updatePaymentStatus: UpdatePaymentFetchState,
 };
 export const Subscriptions = ({
   accessToken,
-  isLoading,
   customer,
   subscriptions,
+  customerSubscriptions,
+  fetchCustomerAndSubscriptions,
   cancelSubscription,
   updatePayment,
   resetUpdatePayment,
+  resetCancelSubscription,
   updatePaymentStatus,
 }: SubscriptionsProps) => {
-  const dispatch = useDispatch();
-
-  const resetCancelSubscription = useCallback(() => {
-    dispatch(actions.resetCancelSubscription());
-  }, [ dispatch ]);
-
   // Reset subscription cancel status on initial render.
   useEffect(() => {
     resetCancelSubscription();
@@ -42,10 +47,9 @@ export const Subscriptions = ({
   // Fetch subscriptions and customer on initial render or auth change.
   useEffect(() => {
     if (accessToken) {
-      dispatch(actions.fetchSubscriptions(accessToken));
-      dispatch(actions.fetchCustomer(accessToken));
+      fetchCustomerAndSubscriptions(accessToken);
     }
-  }, [ dispatch, accessToken ]);
+  }, [ fetchCustomerAndSubscriptions, accessToken ]);
 
   if (subscriptions.loading) {
     return <div>(subscriptions loading...)</div>;
@@ -98,19 +102,24 @@ export const Subscriptions = ({
         }} />
       </Elements>
 
-      {subscriptions.result.map((subscription, idx) =>
+      {customerSubscriptions.map((subscription, idx) =>
         <Subscription key={idx} {...{ accessToken, cancelSubscription, subscription }} />)}
     </div>
   );
 };
 
 export default connect(
-  // TODO: replace this with a useSelector hook
-  selectorsFromState('customer', 'subscriptions', 'updatePaymentStatus'),
-  // TODO: replace this with a useDispatch hook
+  (state: State) => ({
+    customer: selectors.customer(state),
+    customerSubscriptions: selectors.customerSubscriptions(state),
+    subscriptions: selectors.subscriptions(state),
+    updatePaymentStatus: selectors.updatePaymentStatus(state),
+  }),
   { 
+    fetchCustomerAndSubscriptions: actions.fetchCustomerAndSubscriptions,
     updatePayment: actions.updatePaymentAndRefresh,
     resetUpdatePayment: actions.resetUpdatePayment,
+    resetCancelSubscription: actions.resetCancelSubscription,
     cancelSubscription: actions.cancelSubscriptionAndRefresh,
   }
 )(Subscriptions);

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -9,13 +9,6 @@ export interface Profile {
   uid: string;
 }
 
-export interface Customer {
-  payment_type: string;
-  last4: string;
-  exp_month: string;
-  exp_year: string;
-}
-
 export interface Token {
   active: boolean;
   scope: string;
@@ -29,7 +22,9 @@ export interface Token {
 
 export interface Plan {
   plan_id: string;
+  plan_name: string;
   product_id: string;
+  product_name: string;
   currency: string;
   amount: number;
   interval: string;
@@ -37,8 +32,29 @@ export interface Plan {
 
 export interface Subscription {
   subscriptionId: string;
+  // TODO: Rename `productName` column to `productId`
+  // https://github.com/mozilla/fxa/issues/1187
   productName: string;
   createdAt: number;
+  cancelledAt: number | null;
+}
+
+export interface CustomerSubscription {
+  current_period_end: string;
+  current_period_start:  string;
+  ended_at: string | null,
+  nickname: string;
+  plan_id: string;
+  status: string;
+  subscription_id: string;
+}
+
+export interface Customer {
+  payment_type: string;
+  last4: string;
+  exp_month: string;
+  exp_year: string;
+  subscriptions: Array<CustomerSubscription>;
 }
 
 export interface FetchState<T> {


### PR DESCRIPTION
- switch to subhub data as a better source of truth for plans and
  current subscriptions

- refactor out some store helpers for better typescript coverage
  (e.g. selectorsFromState)

- refactor out react-redux hooks for now

Issue #719
Issue #718