### PR TITLE
fix(trailhead): Fix the vertical alignment on sync selection area

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -92,18 +92,13 @@
     form h2 {
       font-size: 18px;
       font-weight: 700;
+      padding: 0 15px;
 
       html[dir='ltr'] & {
         text-align: left;
       }
       html[dir='rtl'] & {
         text-align: right;
-      }
-    }
-
-    .firefox-family-services {
-      @include respond-to('big') {
-        margin-top: 25px;
       }
     }
   }

--- a/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
+++ b/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
@@ -257,6 +257,7 @@ input[type='checkbox'] {
 
   .trailhead & {
     margin-bottom: 0;
+    padding: 0 15px;
   }
 
   .choose-what-to-sync-row {


### PR DESCRIPTION
Add a 15px padding to the sync selection area, including both the h2
and the checkbox elements.

fixes https://github.com/mozilla/fxa-bugzilla-mirror/issues/663

### Desktop

<img width="567" alt="Screenshot 2019-05-29 at 11 35 47" src="https://user-images.githubusercontent.com/848085/58550671-31e4be80-8206-11e9-9263-f95a7c48bdbd.png">

### Mobile
<img width="327" alt="Screenshot 2019-05-29 at 11 35 53" src="https://user-images.githubusercontent.com/848085/58550672-31e4be80-8206-11e9-87d1-0c0bce1f42c8.png">

@mozilla/fxa-devs - r?

