### PR TITLE
fix(trailhead): Increase the send button right/left padding

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -128,7 +128,6 @@
       border-radius: 0 $inner-button-border-radius $inner-button-border-radius 0;
       height: $input-height - 2px;
       min-width: 55px;
-      padding: 0 7px;
       position: absolute;
       top: 1px;
       width: auto;
@@ -145,10 +144,15 @@
         left: 1px;
       }
 
+      @include respond-to('big') {
+        padding: 0 20px;
+      }
+
       @include respond-to('small') {
         border-radius: 0 $inner-button-border-radius $inner-button-border-radius 0;
         height: 38px;
         line-height: 38px;
+        padding: 0 7px;
       }
     }
   }


### PR DESCRIPTION
Set left/right padding to 20px on desktop to match the mocks.

The left/right padding on mobile is kept at 7px so that the placeholder on "long" languages has less of a chance of being obscured by the button.

### Desktop
<img width="540" alt="Screenshot 2019-05-29 at 11 54 32" src="https://user-images.githubusercontent.com/848085/58551763-bcc6b880-8208-11e9-9450-e0175d5b4046.png">

### mobile
<img width="319" alt="Screenshot 2019-05-29 at 11 54 28" src="https://user-images.githubusercontent.com/848085/58551764-bcc6b880-8208-11e9-954d-81b056fd2101.png">


fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1554757
fixes https://github.com/mozilla/fxa-bugzilla-mirror/issues/666

@mozilla/fxa-devs - r?