### PR TITLE
fix: install gcloud for circleci

### DIFF
--- a/.circleci/install-content-server.sh
+++ b/.circleci/install-content-server.sh
@@ -3,6 +3,10 @@
 DIR=$(dirname "$0")
 
 if grep -e "fxa-content-server" -e 'all' $DIR/../packages/test.list; then
+  CLOUD_SDK_REPO="cloud-sdk-$(grep VERSION_CODENAME /etc/os-release | cut -d '=' -f 2)"
+  echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+  sudo apt-get update -y && sudo apt-get install google-cloud-sdk -y
   sudo apt-get install -y graphicsmagick
   mkdir -p config
   cp ../version.json ./


### PR DESCRIPTION
I'll admit I don't entirely understand why 'install-content-server' actually installs everything in the FxA repo, but it does, so here we are.