### PR TITLE
fix(script): use correct permissions for /etc/apt file

### DIFF
--- a/.circleci/install-content-server.sh
+++ b/.circleci/install-content-server.sh
@@ -3,10 +3,9 @@
 DIR=$(dirname "$0")
 
 if grep -e "fxa-content-server" -e 'all' $DIR/../packages/test.list; then
-  CLOUD_SDK_REPO="cloud-sdk-$(grep VERSION_CODENAME /etc/os-release | cut -d '=' -f 2)"
-  echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-  sudo apt-get update -y && sudo apt-get install google-cloud-sdk -y
+  curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-248.0.0-linux-x86_64.tar.gz
+  tar zxvf google-cloud-sdk-248.0.0-linux-x86_64.tar.gz google-cloud-sdk
+  ./google-cloud-sdk/install.sh
   sudo apt-get install -y graphicsmagick
   mkdir -p config
   cp ../version.json ./


### PR DESCRIPTION
My prior fix worked because the file didn't exist yet, now that it does, it has the wrong permissions. Not to mention it doesn't properly work on the circleci system for unknown reasons.

As a result, I'm switching to just grabbing the binary.