### PR TITLE
fix(deps): Remove duplicate @babel/core from devDependencies

### DIFF
--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -125,7 +125,6 @@
   },
   "devDependencies": {
     "@babel/cli": "7.4.4",
-    "@babel/core": "7.4.4",
     "audit-filter": "0.3.0",
     "babel-eslint": "9.0.0",
     "babel-plugin-dynamic-import-webpack": "1.0.2",


### PR DESCRIPTION
@babel/core is already in "dependencies", no need to have it in "devDependencies" too.

Saw this error in https://circleci.com/gh/mozilla/fxa/25869#queue-placeholder/containers/0

> npm WARN The package @babel/core is included as both a dev and production dependency.

@philbooth - r?