### PR TITLE
fix: add gcloud to path for test-content-server pm2 run

### DIFF
--- a/.circleci/test-content-server.sh
+++ b/.circleci/test-content-server.sh
@@ -44,6 +44,7 @@ if grep -e "$MODULE" -e 'all' $DIR/../packages/test.list; then
     PATH=$PATH:$HOME/.cargo/bin
   fi
 
+  source google-cloud-sdk/path.bash.inc
   cd ../../
   npx pm2 delete servers.json && npx pm2 start servers.json
   # ensure email-service is ready


### PR DESCRIPTION
This should be the final place this is needed. The tests don't run from build changes which makes the PR check somewhat difficult to gauge.