### PR TITLE
fix(trailhead): Show better warning if user cancels merge in email first

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/error-utils.js
+++ b/packages/fxa-content-server/app/scripts/lib/error-utils.js
@@ -23,6 +23,7 @@ export default {
   getErrorPageTemplate (error) {
     if (AuthErrors.is(error, 'INVALID_PARAMETER') ||
         AuthErrors.is(error, 'MISSING_PARAMETER') ||
+        AuthErrors.is(error, 'USER_CANCELED_LOGIN') ||
         OAuthErrors.is(error, 'INCORRECT_REDIRECT') ||
         OAuthErrors.is(error, 'INVALID_PARAMETER') ||
         OAuthErrors.is(error, 'INVALID_PAIRING_CLIENT') ||

--- a/packages/fxa-content-server/app/tests/spec/lib/error-utils.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/error-utils.js
@@ -52,6 +52,7 @@ describe('lib/error-utils', function () {
     var badRequestPageErrors = [
       AuthErrors.toInvalidParameterError('paramName'),
       AuthErrors.toMissingParameterError('paramName'),
+      AuthErrors.toError('USER_CANCELED_LOGIN'),
       OAuthErrors.toInvalidParameterError('paramName'),
       OAuthErrors.toMissingParameterError('paramName'),
       OAuthErrors.toError('UNKNOWN_CLIENT')

--- a/packages/fxa-content-server/tests/functional/sync_v3_email_first.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_email_first.js
@@ -323,6 +323,19 @@ registerSuite('Firefox Desktop Sync v3 email first', {
         .then(testElementValueEquals(selectors.ENTER_EMAIL.EMAIL, email));
     },
 
+    'email specified by relier, cancel merge': function () {
+      return this.remote
+        .then(openPage(INDEX_PAGE_URL, selectors['400'].HEADER, {
+          query: {
+            email
+          },
+          webChannelResponses: {
+            'fxaccounts:can_link_account': {ok: false}
+          }
+        }))
+        .then(testElementTextInclude(selectors['400'].ERROR, 'Login attempt cancelled'));
+    },
+
     'cached credentials': function () {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))


### PR DESCRIPTION
This now looks like:

<img width="564" alt="Screenshot 2019-05-30 at 18 28 19" src="https://user-images.githubusercontent.com/848085/58652040-94bf7e00-830a-11e9-9566-ecce3508d589.png">

fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1555681

@dannycoates - r?