### PR TITLE
fix(test): Fix the first-run v2 tests

### DIFF
--- a/packages/fxa-content-server/tests/functional/fx_firstrun_v2.js
+++ b/packages/fxa-content-server/tests/functional/fx_firstrun_v2.js
@@ -9,10 +9,10 @@ const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const config = intern._config;
 
-const FORCE_AUTH_PAGE_URL = `${config.fxaContentRoot}force_auth?context=fx_iframe_v2&service=sync`;
-const SIGNIN_PAGE_URL = `${config.fxaContentRoot}signin?context=fx_iframe_v2&service=sync`;
-const SIGNUP_PAGE_URL = `${config.fxaContentRoot}signin?context=fx_iframe_v2&service=sync`;
-const RESET_PASSWORD_PAGE_URL = `${config.fxaContentRoot}reset_password?context=fx_iframe_v2&service=sync`;
+const FORCE_AUTH_PAGE_URL = `${config.fxaContentRoot}force_auth?context=fx_firstrun_v2&service=sync`;
+const SIGNIN_PAGE_URL = `${config.fxaContentRoot}signin?context=fx_firstrun_v2&service=sync`;
+const SIGNUP_PAGE_URL = `${config.fxaContentRoot}signin?context=fx_firstrun_v2&service=sync`;
+const RESET_PASSWORD_PAGE_URL = `${config.fxaContentRoot}reset_password?context=fx_firstrun_v2&service=sync`;
 
 const {
   clearBrowserState,

--- a/packages/fxa-content-server/tests/functional_circle.js
+++ b/packages/fxa-content-server/tests/functional_circle.js
@@ -49,6 +49,7 @@ module.exports = selectCircleTests([
   'tests/functional/fx_fennec_v1_force_auth.js',
   'tests/functional/fx_fennec_v1_sign_in.js',
   'tests/functional/fx_fennec_v1_sign_up.js',
+  'tests/functional/fx_firstrun_v2.js',
   'tests/functional/fx_ios_v1_email_first.js',
   'tests/functional/fx_ios_v1_sign_in.js',
   'tests/functional/fx_ios_v1_sign_up.js',


### PR DESCRIPTION
The context in the fx_firstrun_v2 tests was incorrectly
set to fx_iframe_v2. Because these tests were not run on
Circle, we did not know.

Now running the tests on Circle and using the correct context.

issue #642

Found because of the [PR to run all tests on Circle](https://circleci.com/gh/mozilla/fxa/26931#queue-placeholder/containers/5).

@mozilla/fxa-devs - r?