### PR TITLE
fix(force_auth): Ensure the email always displays

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/force_auth.js
+++ b/packages/fxa-content-server/app/scripts/views/force_auth.js
@@ -178,7 +178,20 @@ var View = SignInView.extend({
   },
 
   getAccount () {
-    return this.user.getAccountByEmail(this.relier.get('email'));
+    const email = this.relier.get('email');
+    const account = this.user.getAccountByEmail(email);
+
+    // if no account is in localStorage for the email address,
+    // the returned account will be the default. Set the email
+    // so that the user-card displays correctly.
+    if (account.isDefault()) {
+      account.set({
+        email,
+        uid: this.relier.get('uid')
+      });
+    }
+
+    return account;
   }
 });
 

--- a/packages/fxa-content-server/app/tests/spec/views/force_auth.js
+++ b/packages/fxa-content-server/app/tests/spec/views/force_auth.js
@@ -148,11 +148,10 @@ describe('/views/force_auth', function () {
         return view.render();
       });
 
-      it('does not navigate', function () {
+      it('renders as expected', () => {
         assert.isFalse(view.navigate.called);
-      });
-
-      it('does not error', function () {
+        assert.equal(view.$(Selectors.EMAIL).val(), email);
+        assert.equal(view.$(Selectors.EMAIL_NOT_EDITABLE).text(), email);
         assert.lengthOf(view.$('.error.visible'), 0);
       });
     });
@@ -168,15 +167,11 @@ describe('/views/force_auth', function () {
         return view.render();
       });
 
-      it('does not navigate', function () {
+      it('renders as expected', () => {
         assert.isFalse(view.navigate.called);
-      });
-
-      it('has no service name', function () {
         assert.lengthOf(view.$(Selectors.SUB_HEADER), 0);
-      });
-
-      it('does not error', function () {
+        assert.equal(view.$(Selectors.EMAIL).val(), email);
+        assert.equal(view.$(Selectors.EMAIL_NOT_EDITABLE).text(), email);
         assert.lengthOf(view.$('.error.visible'), 0);
       });
     });
@@ -205,6 +200,8 @@ describe('/views/force_auth', function () {
         return view.render().then(() => {
           assert.equal(view.$(Selectors.SUB_HEADER).text(), 'to your Firefox account');
           assert.lengthOf(view.$(Selectors.PROGRESS_INDICATOR), 0);
+          assert.equal(view.$(Selectors.EMAIL).val(), email);
+          assert.equal(view.$(Selectors.EMAIL_NOT_EDITABLE).text(), email);
         });
       });
     });

--- a/packages/fxa-content-server/tests/functional/force_auth.js
+++ b/packages/fxa-content-server/tests/functional/force_auth.js
@@ -8,27 +8,30 @@ const { registerSuite } = intern.getInterface('object');
 const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
-var clearBrowserState = FunctionalHelpers.clearBrowserState;
-var click = FunctionalHelpers.click;
-var createUser = FunctionalHelpers.createUser;
-var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
-var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-var openForceAuth = FunctionalHelpers.openForceAuth;
-var testElementDisabled = FunctionalHelpers.testElementDisabled;
-var testElementExists = FunctionalHelpers.testElementExists;
-var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
-var testElementValueEquals = FunctionalHelpers.testElementValueEquals;
-var testErrorTextInclude = FunctionalHelpers.testErrorTextInclude;
-var type = FunctionalHelpers.type;
-var visibleByQSA = FunctionalHelpers.visibleByQSA;
+
+const {
+  clearBrowserState,
+  click,
+  createUser,
+  fillOutForceAuth,
+  fillOutSignUp,
+  openForceAuth,
+  testElementDisabled,
+  testElementExists,
+  testElementTextInclude,
+  testElementValueEquals,
+  testErrorTextInclude,
+  type,
+  visibleByQSA,
+} = FunctionalHelpers;
 
 function testAccountNoLongerExistsErrorShown() {
   return this.parent
     .then(testErrorTextInclude('no longer exists'));
 }
 
-var PASSWORD = 'password';
-var email;
+const PASSWORD = 'password';
+let email;
 
 registerSuite('force_auth', {
   beforeEach: function () {
@@ -40,7 +43,7 @@ registerSuite('force_auth', {
     'with a missing email': function () {
       return this.remote
         .then(openForceAuth({
-          header: '#fxa-400-header'
+          header: selectors['400'].HEADER
         }))
         .then(testErrorTextInclude('missing'))
         .then(testErrorTextInclude('email'));
@@ -49,7 +52,7 @@ registerSuite('force_auth', {
     'with an invalid email': function () {
       return this.remote
         .then(openForceAuth({
-          header: '#fxa-400-header',
+          header: selectors['400'].HEADER,
           query: {
             email: 'invalid'
           }
@@ -64,7 +67,7 @@ registerSuite('force_auth', {
         .then(openForceAuth({query: {email: email}}))
         .then(fillOutForceAuth(PASSWORD))
 
-        .then(testElementExists('#fxa-settings-header'));
+        .then(testElementExists(selectors.SETTINGS.HEADER));
     },
 
     'with a registered email, invalid uid': function () {
@@ -72,7 +75,7 @@ registerSuite('force_auth', {
         .then(createUser(email, PASSWORD, {preVerified: true}))
         .then(function (accountInfo) {
           return openForceAuth({
-            header: '#fxa-400-header',
+            header: selectors['400'].HEADER,
             query: {
               email: email,
               uid: 'a' + accountInfo.uid
@@ -96,7 +99,7 @@ registerSuite('force_auth', {
         })
         .then(fillOutForceAuth(PASSWORD))
 
-        .then(testElementExists('#fxa-settings-header'));
+        .then(testElementExists(selectors.SETTINGS.HEADER));
     },
 
     'with a registered email, unregistered uid': function () {
@@ -114,18 +117,18 @@ registerSuite('force_auth', {
     'with an unregistered email, no uid': function () {
       return this.remote
         .then(openForceAuth({
-          header: '#fxa-signup-header',
+          header: selectors.SIGNUP.HEADER,
           query: {email: email}
         }))
         .then(visibleByQSA('.error'))
         .then(testErrorTextInclude('recreate'))
 
         // ensure the email is filled in, and not editible.
-        .then(testElementValueEquals('input[type=email]', email))
-        .then(testElementDisabled('input[type=email]'))
+        .then(testElementValueEquals(selectors.SIGNUP.EMAIL, email))
+        .then(testElementDisabled(selectors.SIGNUP.EMAIL))
 
         .then(fillOutSignUp(email, PASSWORD, {enterEmail: false}))
-        .then(testElementExists('#fxa-confirm-header'));
+        .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER));
     },
 
     'with an unregistered email, registered uid': function () {
@@ -164,32 +167,32 @@ registerSuite('force_auth', {
         .then(createUser(email, PASSWORD, {preVerified: true}))
         .then(openForceAuth({query: {email: email}}))
 
-        .then(click('.reset-password'))
+        .then(click(selectors.FORCE_AUTH.LINK_RESET_PASSWORD))
 
-        .then(testElementExists('#fxa-reset-password-header'))
-        .then(testElementValueEquals('input[type=email]', email))
-        .then(testElementDisabled('input[type=email]'))
-        .then(testElementTextInclude('.prefillEmail', email))
+        .then(testElementExists(selectors.RESET_PASSWORD.HEADER))
+        .then(testElementValueEquals(selectors.FORCE_AUTH.EMAIL, email))
+        .then(testElementDisabled(selectors.FORCE_AUTH.EMAIL))
+        .then(testElementTextInclude(selectors.FORCE_AUTH.EMAIL_NOT_EDITABLE, email))
         // User thinks they have remembered their password, clicks the
         // "sign in" link. Go back to /force_auth.
         .then(click(selectors.RESET_PASSWORD.LINK_SIGNIN))
 
-        .then(testElementExists('#fxa-force-auth-header'))
+        .then(testElementExists(selectors.FORCE_AUTH.HEADER))
         // User goes back to reset password to submit.
-        .then(click('.reset-password'))
+        .then(click(selectors.FORCE_AUTH.LINK_RESET_PASSWORD))
 
-        .then(testElementExists('#fxa-reset-password-header'))
-        .then(click('button[type=submit]'))
+        .then(testElementExists(selectors.RESET_PASSWORD.HEADER))
+        .then(click(selectors.RESET_PASSWORD.SUBMIT))
 
-        .then(testElementExists('#fxa-confirm-reset-password-header'))
+        .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
         // User has remembered their password, for real this time.
         // Go back to /force_auth.
-        .then(click('.sign-in'))
+        .then(click(selectors.CONFIRM_RESET_PASSWORD.LINK_SIGNIN))
 
-        .then(testElementExists('#fxa-force-auth-header'))
-        .then(testElementValueEquals('input[type=email]', email))
-        .then(testElementDisabled('input[type=email]'))
-        .then(testElementTextInclude('.prefillEmail', email));
+        .then(testElementExists(selectors.FORCE_AUTH.HEADER))
+        .then(testElementValueEquals(selectors.FORCE_AUTH.EMAIL, email))
+        .then(testElementDisabled(selectors.FORCE_AUTH.EMAIL))
+        .then(testElementTextInclude(selectors.FORCE_AUTH.EMAIL_NOT_EDITABLE, email));
     },
 
     'visiting the tos/pp links saves information for return': function () {
@@ -205,11 +208,11 @@ registerSuite('force_auth', {
         .then(openForceAuth({query: {email: email}}))
         .then(fillOutForceAuth(PASSWORD))
 
-        .then(testElementExists('#fxa-settings-header'))
+        .then(testElementExists(selectors.SETTINGS.HEADER))
         .then(click('#signout'))
 
-        .then(testElementExists('#fxa-signin-header'))
-        .then(testElementValueEquals('input[type=password]', ''));
+        .then(testElementExists(selectors.SIGNIN.HEADER))
+        .then(testElementValueEquals(selectors.SIGNIN.PASSWORD, ''));
     }
   }
 });
@@ -218,14 +221,14 @@ function testRepopulateFields(dest, header) {
   return function () {
     return this.parent
       .then(openForceAuth({ query: { email: email }}))
-      .then(type('input[type=password]', PASSWORD))
+      .then(type(selectors.FORCE_AUTH.PASSWORD, PASSWORD))
       .then(click('a[href="' + dest + '"]'))
 
       .then(testElementExists('#' + header))
       .then(click('.back'))
 
-      .then(testElementExists('#fxa-force-auth-header'))
+      .then(testElementExists(selectors.FORCE_AUTH.HEADER))
       // check the email address was re-populated
-      .then(testElementValueEquals('input[type=password]', PASSWORD));
+      .then(testElementValueEquals(selectors.FORCE_AUTH.PASSWORD, PASSWORD));
   };
 }

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -84,6 +84,7 @@ module.exports = {
   CONFIRM_RESET_PASSWORD: {
     HEADER: '#fxa-confirm-reset-password-header',
     LINK_RESEND: '#resend',
+    LINK_SIGNIN: '.sign-in',
     RESEND_SUCCESS: '.success'
   },
   CONFIRM_SIGNIN: {
@@ -147,7 +148,10 @@ module.exports = {
   },
   FORCE_AUTH: {
     EMAIL: 'input[type=email]',
+    EMAIL_NOT_EDITABLE: '.prefillEmail',
     HEADER: '#fxa-force-auth-header',
+    LINK_RESET_PASSWORD: '.reset-password',
+    PASSWORD: 'input[type=password]',
     PROGRESS_INDICATOR: '.step',
     SUB_HEADER: '#fxa-force-auth-header .service',
   },

--- a/packages/fxa-content-server/tests/functional_circle.js
+++ b/packages/fxa-content-server/tests/functional_circle.js
@@ -53,6 +53,7 @@ module.exports = selectCircleTests([
   'tests/functional/fx_ios_v1_email_first.js',
   'tests/functional/fx_ios_v1_sign_in.js',
   'tests/functional/fx_ios_v1_sign_up.js',
+  'tests/functional/force_auth.js',
   'tests/functional/mocha.js',
   'tests/functional/password_strength.js',
   'tests/functional/password_visibility.js',


### PR DESCRIPTION
If the user's email address was not stored in localStorage,
no email address would be displayed in the user-card.

This happened because user.getAccountByEmail returns the
"default" account if no user is stored for the given
email address.

When this happens, set the relier's email/uid on the account.

Added the /force_auth suite to the Circle run and
used this as an opportunity to modernize the suite
to use the selectors module.

fixes #1341

I opened this against train-138 because this is a regression due to Trailhead work. If this doesn't seem important, we can add it to train-139.

@mozilla/fxa-devs - r?