### PR TITLE
fix(test): Fix the sync_v3_force_auth tests

### DIFF
--- a/packages/fxa-content-server/tests/functional/sync_v3_force_auth.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_force_auth.js
@@ -14,6 +14,7 @@ let email;
 const PASSWORD = '12345678';
 
 const {
+  clearBrowserState,
   click,
   closeCurrentWindow,
   createUser,
@@ -38,6 +39,9 @@ const {
 registerSuite('Firefox Desktop Sync v3 force_auth', {
   beforeEach: function () {
     email = TestHelpers.createEmail('sync{id}');
+
+    return this.remote
+      .then(clearBrowserState({ force: true }));
   },
 
   tests: {'with a registered email, no uid, verify same browser': function () {


### PR DESCRIPTION
Over in #1337 I change the order of the functional tests when run on Circle.
The Sync v3 force_auth tests start failing, I'm assuming because the order
changed and the suite does not clear browser state.

Ensure browser state is cleared between test runs.

fixes #1345

@mozilla/fxa-devs - r?