### PR TITLE
feat(email): add download email for subscription services

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -641,7 +641,19 @@ const conf = convict({
       format: Object,
       env: 'SUBSCRIPTIONS_CLIENT_CAPABILITIES',
       default: {}
-    }
+    },
+    clientDownloadUrls: {
+      default: {},
+      doc: 'Mappings from OAuth client IDs to download URLs for inclusion in emails',
+      env: 'SUBSCRIPTIONS_CLIENT_DOWNLOAD_URLS',
+      format: Object,
+    },
+    clientIcons: {
+      default: {},
+      doc: 'Mappings from OAuth client IDs to service icons URLs for inclusion in emails',
+      env: 'SUBSCRIPTIONS_CLIENT_ICONS',
+      format: Object,
+    },
   },
   oauth: {
     url: {

--- a/packages/fxa-auth-server/lib/senders/partials/download_service.html
+++ b/packages/fxa-auth-server/lib/senders/partials/download_service.html
@@ -1,0 +1,69 @@
+<% extends "partials/base/base.html" %>
+
+<% block content %>
+<!--Header Area-->
+<tr style="page-break-before: always">
+  <td valign="top">
+    <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">
+      {{t "Welcome to %(serviceName)s!"}}
+    </h1>
+    <p class="primary" style="margin: 0 auto 11px; text-align: center;">
+      <img src="{{serviceIcon}}" alt="" style="width: 100px; height: 100px; -ms-interpolation-mode: bicubic;" />
+    </p>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
+      {{t "If you haven’t already downloaded %(serviceName)s, let’s get started using all the features included in your subscription."}}
+    </p>
+  </td>
+</tr>
+
+<!--Button Area-->
+<tr height="50">
+  <td align="center" valign="top">
+    <table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="email-button" style="-webkit-text-size-adjust: 100%; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #0a84ff; border-radius: 4px; height: 50px; width: 310px !important;">
+      <tr style="page-break-before: always">
+        <td align="center" valign="middle" id="button-content" style="font-family: sans-serif; font-weight: normal; text-align: center; margin: 0; color: #ffffff; font-size: 20px; line-height: 100%;">
+          <!--[if mso]>
+          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{{link}}}" style="width:280px;height:40px;v-text-anchor:middle;" arcsize="10%" stroke="f" fillcolor="#0a84ff">
+            <w:anchorlock/>
+            <center>
+          <![endif]-->
+          <a href="{{link}}" id="button-link" style="font-family:sans-serif; color: #fff; display: block; padding: 15px; text-decoration: none; width: 280px; font-size: 18px; line-height: 26px;">{{t "Download %(serviceName)s"}}</a>
+          <!--[if mso]>
+          </center>
+          </v:roundrect>
+          <![endif]-->
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+
+<tr style="page-break-before: always">
+  <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
+    <br/>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #737373; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">{{{t "Questions about your subscription? Our <a %(supportLinkAttributes)s>support team</a> is here to help you."}}}</p>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #737373; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}}
+  </td>
+</tr>
+<% endblock %>
+
+<% block after_table %>
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "description": "Download",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "name": "{{t "Download"}}",
+    "target": "{{oneClickLink}}",
+    "url": "{{oneClickLink}}"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Firefox Accounts",
+    "url": "https://accounts.firefox.com"
+  }
+}
+</script>
+<% endblock %>

--- a/packages/fxa-auth-server/lib/senders/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/templates/_versions.json
@@ -1,4 +1,5 @@
 {
+  "downloadServiceEmail": 1,
   "lowRecoveryCodesEmail": 2,
   "newDeviceLoginEmail": 2,
   "passwordChangedEmail": 1,

--- a/packages/fxa-auth-server/lib/senders/templates/download_service.html
+++ b/packages/fxa-auth-server/lib/senders/templates/download_service.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>{{t "Firefox Accounts"}}</title>
+</head>
+
+<body style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; margin: 0; padding: 0;">
+<table align="center" border="0" cellpadding="0" cellspacing="0" width="310" style="-webkit-text-size-adjust: 100%; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 310px; margin: 0 auto;">
+
+<!--Logo-->
+<tr style="page-break-before: always">
+  <td align="center" id="firefox-logo" style="padding: 20px 0;">
+    {{^if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/4/11c1e411-7dfe-4e04-914c-0f098edac96c.png" height="88" width="85" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+
+    {{#if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/fxa_july2017_v2.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+  </td>
+</tr>
+
+
+<!--Header Area-->
+<tr style="page-break-before: always">
+  <td valign="top">
+    <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">
+      {{t "Welcome to %(serviceName)s!"}}
+    </h1>
+    <p class="primary" style="margin: 0 auto 11px; text-align: center;">
+      <img src="{{serviceIcon}}" alt="" style="width: 100px; height: 100px; -ms-interpolation-mode: bicubic;" />
+    </p>
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
+      {{t "If you haven’t already downloaded %(serviceName)s, let’s get started using all the features included in your subscription."}}
+    </p>
+  </td>
+</tr>
+
+<!--Button Area-->
+<tr height="50">
+  <td align="center" valign="top">
+    <table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="email-button" style="-webkit-text-size-adjust: 100%; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #0a84ff; border-radius: 4px; height: 50px; width: 310px !important;">
+      <tr style="page-break-before: always">
+        <td align="center" valign="middle" id="button-content" style="font-family: sans-serif; font-weight: normal; text-align: center; margin: 0; color: #ffffff; font-size: 20px; line-height: 100%;">
+          <!--[if mso]>
+          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="{{{link}}}" style="width:280px;height:40px;v-text-anchor:middle;" arcsize="10%" stroke="f" fillcolor="#0a84ff">
+            <w:anchorlock/>
+            <center>
+          <![endif]-->
+          <a href="{{link}}" id="button-link" style="font-family:sans-serif; color: #fff; display: block; padding: 15px; text-decoration: none; width: 280px; font-size: 18px; line-height: 26px;">{{t "Download %(serviceName)s"}}</a>
+          <!--[if mso]>
+          </center>
+          </v:roundrect>
+          <![endif]-->
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+
+<tr style="page-break-before: always">
+  <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
+    <br/>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #737373; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">{{{t "Questions about your subscription? Our <a %(supportLinkAttributes)s>support team</a> is here to help you."}}}</p>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #737373; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}}
+  </td>
+</tr>
+
+
+<tr style="page-break-before: always">
+  <td valign="top">
+    <p style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #737373; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">Mozilla. 331 E Evelyn Ave, Mountain View, CA 94041
+    <br />
+    <a href="{{{privacyUrl}}}" style="color: #0a84ff; text-decoration: none; font-family: sans-serif; font-size: 11px; line-height: 18px;">{{t "Mozilla Privacy Policy" }}</a></p>
+  </td>
+</tr>
+
+</table>
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "description": "Download",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "name": "{{t "Download"}}",
+    "target": "{{oneClickLink}}",
+    "url": "{{oneClickLink}}"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Firefox Accounts",
+    "url": "https://accounts.firefox.com"
+  }
+}
+</script>
+
+</body>
+</html>

--- a/packages/fxa-auth-server/lib/senders/templates/download_service.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/download_service.txt
@@ -1,0 +1,16 @@
+{{t "Welcome to %(serviceName)s!"}}
+
+{{t "If you haven’t already downloaded %(serviceName)s, let’s get started using all the features included in your subscription."}}
+
+{{t "Download %(serviceName)s:"}}
+
+{{{link}}}
+
+{{t "Questions about your subscription? Our support team is here to help you:"}}
+
+{{{supportUrl}}}
+
+Mozilla. 331 E Evelyn Ave, Mountain View, CA 94041
+
+{{t "Mozilla Privacy Policy"}}
+{{{privacyUrl}}}

--- a/packages/fxa-auth-server/lib/senders/templates/index.js
+++ b/packages/fxa-auth-server/lib/senders/templates/index.js
@@ -59,6 +59,7 @@ module.exports = {
   generateTemplateName,
   init: () => P.all(
     [
+      'download_service',
       'low_recovery_codes',
       'new_device_login',
       'password_changed',


### PR DESCRIPTION
Fixes #927.

In-progress work for the `Welcome to ${serviceName}!` download email. Need to check my assumptions about fetching the icon and download URL from config, plus the icon sizes being constant. Oh, and tests, I haven't written any tests yet.