### PR TITLE
fix(test): Fix the recovery codes tests

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -101,5 +101,10 @@
       "dcdb5ae7add825d2": [ "123donePro", "exampleCap1", "exampleCap3", "exampleCap5" ],
       "325b4083e32fe8e7": [ "321donePro", "exampleCap2", "exampleCap4", "exampleCap6" ]
     }
+  },
+  "totp": {
+    "recoveryCodes": {
+      "count": 3
+    }
   }
 }

--- a/packages/fxa-content-server/tests/functional_circle.js
+++ b/packages/fxa-content-server/tests/functional_circle.js
@@ -67,6 +67,7 @@ module.exports = selectCircleTests([
   'tests/functional/sign_in.js',
   'tests/functional/sign_in_blocked.js',
   'tests/functional/sign_in_cached.js',
+  'tests/functional/sign_in_recovery_code.js',
   'tests/functional/sign_up.js',
   'tests/functional/sync_v3_email_first.js',
   'tests/functional/sync_v3_force_auth.js',


### PR DESCRIPTION
The recovery codes tests assumes 3 recovery codes
are generated whereas by default 8 are.

This updates the default dev config to generate
3 recovery codes as well as add the recovery_codes
tests to the circle run.

fixes #1347

@mozilla/fxa-devs - r?