### PR TITLE
fix(test): Fix the password visibility test

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -2024,6 +2024,26 @@ const testAttributeExists = thenify(function (selector, attributeName) {
 });
 
 /**
+ * Ensure `attributeName` does not exist on element
+ * selected by `selector`.
+ *
+ * @param {string} selector CSS selector for the element
+ * @param {string} attributeName Name of attribute
+ * @returns {promise} resolves if attribute does not exist, rejects otherwise.
+ */
+const noSuchAttribute = thenify(function (selector, attributeName) {
+  return this.parent
+    .findByCssSelector(selector)
+    .getAttribute(attributeName)
+    .then(function (attributeValue) {
+      // Older Firefoxes return an attribute value of `null`,
+      // Newer Firefoxes return an attribute value of ''.
+      assert.isTrue(attributeValue === '' || attributeValue === null);
+    })
+    .end();
+});
+
+/**
  * Get some memory back
  *
  */
@@ -2224,6 +2244,7 @@ module.exports = {
   mouseup,
   noEmailExpected,
   noPageTransition,
+  noSuchAttribute,
   noSuchBrowserNotification,
   noSuchElement,
   noSuchElementDisplayed,

--- a/packages/fxa-content-server/tests/functional/password_visibility.js
+++ b/packages/fxa-content-server/tests/functional/password_visibility.js
@@ -6,18 +6,21 @@
 
 const { registerSuite } = intern.getInterface('object');
 const FunctionalHelpers = require('./lib/helpers');
-var config = intern._config;
-var SIGNIN_URL = config.fxaContentRoot + 'signin';
+const config = intern._config;
+const SIGNIN_URL = config.fxaContentRoot + 'signin';
 
-var clearBrowserState = FunctionalHelpers.clearBrowserState;
-var mousedown = FunctionalHelpers.mousedown;
-var mouseup = FunctionalHelpers.mouseup;
-var noSuchElement = FunctionalHelpers.noSuchElement;
-var openPage = FunctionalHelpers.openPage;
-var testAttributeEquals = FunctionalHelpers.testAttributeEquals;
-var testElementExists = FunctionalHelpers.testElementExists;
-var type = FunctionalHelpers.type;
-var visibleByQSA = FunctionalHelpers.visibleByQSA;
+const {
+  clearBrowserState,
+  mousedown,
+  mouseup,
+  noSuchAttribute,
+  noSuchElement,
+  openPage,
+  testAttributeEquals,
+  testElementExists,
+  type,
+  visibleByQSA,
+} = FunctionalHelpers;
 
 registerSuite('password visibility', {
   beforeEach: function () {
@@ -43,7 +46,7 @@ registerSuite('password visibility', {
         .then(mouseup('.show-password-label'))
 
         .then(testAttributeEquals('#password', 'type', 'password'))
-        .then(testAttributeEquals('#password', 'autocomplete', ''))
+        .then(noSuchAttribute('#password', 'autocomplete'))
 
         // \u0008 is unicode for backspace char. By default `type` clears the
         // element value before typing, we want the character to do so.

--- a/packages/fxa-content-server/tests/functional_circle.js
+++ b/packages/fxa-content-server/tests/functional_circle.js
@@ -55,6 +55,7 @@ module.exports = selectCircleTests([
   'tests/functional/fx_ios_v1_sign_up.js',
   'tests/functional/mocha.js',
   'tests/functional/password_strength.js',
+  'tests/functional/password_visibility.js',
   'tests/functional/refreshes_metrics.js',
   'tests/functional/reset_password.js',
   'tests/functional/robots_txt.js',


### PR DESCRIPTION
The way we were checking the `autocomplete` attribute was
removed was not browser independent.

Older Firefoxes return an attribute value of `null`,
Newer Firefoxes return an attribute value of ''.

Allow both.

fixes #1351

@mozilla/fxa-devs - r?