### PR TITLE
feat(metrics): emit view, engage and submit events for CWTS

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/choose_what_to_sync.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/choose_what_to_sync.mustache
@@ -47,7 +47,7 @@
         {{/isTrailhead}}
         </div>
       <div class="links">
-        <a href="#" id="back">{{#t}}Back{{/t}}</a>
+        <a href="#" id="back" data-flow-event="back">{{#t}}Back{{/t}}</a>
       </div>
     </form>
   </section>

--- a/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
@@ -6,6 +6,7 @@ import _ from 'underscore';
 import $ from 'jquery';
 import BackMixin from './mixins/back-mixin';
 import Cocktail from 'cocktail';
+import FlowEventsMixin from './mixins/flow-events-mixin';
 import FormView from './form';
 import SessionVerificationPollMixin from './mixins/session-verification-poll-mixin';
 import Template from 'templates/choose_what_to_sync.mustache';
@@ -154,6 +155,7 @@ const View = FormView.extend({
 Cocktail.mixin(
   View,
   BackMixin,
+  FlowEventsMixin,
   SessionVerificationPollMixin
 );
 

--- a/packages/fxa-content-server/app/tests/spec/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/tests/spec/views/choose_what_to_sync.js
@@ -7,10 +7,11 @@ import Account from 'models/account';
 import { assert } from 'chai';
 import Backbone from 'backbone';
 import Broker from 'models/auth_brokers/base';
+import { CHOOSE_WHAT_TO_SYNC } from '../../../../tests/functional/lib/selectors';
 import Metrics from 'lib/metrics';
 import Notifier from 'lib/channels/notifier';
 import sinon from 'sinon';
-import { CHOOSE_WHAT_TO_SYNC } from '../../../../tests/functional/lib/selectors';
+import SentryMetrics from 'lib/sentry';
 import SessionVerificationPoll from 'models/polls/session-verification';
 import SyncEngines from 'models/sync-engines';
 import TestHelpers from '../../lib/helpers';
@@ -58,7 +59,7 @@ describe('views/choose_what_to_sync', () => {
     email = TestHelpers.createEmail();
     model = new Backbone.Model();
     notifier = new Notifier();
-    metrics = new Metrics({ notifier });
+    metrics = new Metrics({ notifier, sentryMetrics: new SentryMetrics() });
     onSubmitComplete = sinon.spy();
     user = new User({});
 
@@ -106,6 +107,17 @@ describe('views/choose_what_to_sync', () => {
 
     return view.render();
   }
+
+  it('registers for the expected events', () => {
+    return initView()
+      .then(() => {
+        assert.isFunction(view.events['click a']);
+        assert.isFunction(view.events['click input']);
+        assert.isFunction(view.events['input input']);
+        assert.isFunction(view.events['keyup input']);
+        assert.isFunction(view.events['submit']);
+      });
+  });
 
   describe('renders', () => {
     it('coming from sign up, redirects to /signup when email accound data missing', () => {

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -34,6 +34,18 @@ const EVENTS = {
     group: GROUPS.login,
     event: 'forgot_submit'
   },
+  'flow.choose-what-to-sync.back': {
+    group: GROUPS.registration,
+    event: 'cwts_back'
+  },
+  'flow.choose-what-to-sync.engage': {
+    group: GROUPS.registration,
+    event: 'cwts_engage'
+  },
+  'flow.choose-what-to-sync.submit': {
+    group: GROUPS.registration,
+    event: 'cwts_submit'
+  },
   'flow.update-firefox.engage': {
     group: GROUPS.notify,
     event: 'update_firefox_engage'
@@ -41,6 +53,10 @@ const EVENTS = {
   'flow.update-firefox.view': {
     group: GROUPS.notify,
     event: 'update_firefox_view'
+  },
+  'screen.choose-what-to-sync': {
+    group: GROUPS.registration,
+    event: 'cwts_view'
   },
   'settings.change-password.success': {
     group: GROUPS.settings,

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -34,14 +34,6 @@ const EVENTS = {
     group: GROUPS.login,
     event: 'forgot_submit'
   },
-  'settings.change-password.success': {
-    group: GROUPS.settings,
-    event: 'password'
-  },
-  'settings.signout.success': {
-    group: GROUPS.settings,
-    event: 'logout'
-  },
   'flow.update-firefox.engage': {
     group: GROUPS.notify,
     event: 'update_firefox_engage'
@@ -49,6 +41,14 @@ const EVENTS = {
   'flow.update-firefox.view': {
     group: GROUPS.notify,
     event: 'update_firefox_view'
+  },
+  'settings.change-password.success': {
+    group: GROUPS.settings,
+    event: 'password'
+  },
+  'settings.signout.success': {
+    group: GROUPS.settings,
+    event: 'logout'
   },
 };
 

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -375,6 +375,25 @@ registerSuite('amplitude', {
       assert.equal(logger.info.args[0][1].event_type, 'fxa_reg - password_blocked');
     },
 
+    'flow.choose-what-to-sync.engage': () => {
+      amplitude({
+        time: 'a',
+        type: 'flow.choose-what-to-sync.engage'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '63.245.221.32'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      });
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(logger.info.args[0][1].event_type, 'fxa_reg - cwts_engage');
+    },
+
     'flow.enter-email.engage': () => {
       amplitude({
         time: 'a',
@@ -615,6 +634,26 @@ registerSuite('amplitude', {
       assert.equal(arg.event_properties.connect_device_os, 'foo');
     },
 
+    'flow.choose-what-to-sync.back': () => {
+      amplitude({
+        time: 'a',
+        type: 'flow.choose-what-to-sync.back'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '63.245.221.32'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      });
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_reg - cwts_back');
+    },
+
     'flow.signin.forgot-password': () => {
       amplitude({
         time: 'a',
@@ -651,6 +690,25 @@ registerSuite('amplitude', {
 
       assert.equal(logger.info.callCount, 1);
       assert.equal(logger.info.args[0][1].event_type, 'fxa_reg - have_account');
+    },
+
+    'flow.choose-what-to-sync.submit': () => {
+      amplitude({
+        time: 'a',
+        type: 'flow.choose-what-to-sync.submit'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '63.245.221.32'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      });
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(logger.info.args[0][1].event_type, 'fxa_reg - cwts_submit');
     },
 
     'flow.enter-email.submit': () => {
@@ -785,6 +843,25 @@ registerSuite('amplitude', {
         uid: 'd'
       });
       assert.equal(logger.info.callCount, 0);
+    },
+
+    'screen.choose-what-to-sync': () => {
+      amplitude({
+        time: 'a',
+        type: 'screen.choose-what-to-sync'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '63.245.221.32'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      });
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(logger.info.args[0][1].event_type, 'fxa_reg - cwts_view');
     },
 
     'screen.enter-email': () => {


### PR DESCRIPTION
Related to #938.

This hooks up view, engage, submit and back events for CWTS. It's not a complete fix for the linked issue because I'm going to add a user property for the selected Sync engines in a follow-up PR.

Sample flows showing the new events.

* Flow events:
  
  ```
  {"event":"flow.signup.view","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":2142,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:17:19.127Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.signup.engage","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":2994,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:17:19.979Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.signup.submit","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":10102,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:17:27.087Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.signup.attempt","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":10135,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:17:27.120Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.choose-what-to-sync.view","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":10728,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:17:27.713Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.performance.auth.network","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":1,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:17:16.986Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.performance.auth.server","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":42,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:17:17.027Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.performance.auth.client","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":288,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:17:17.273Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.choose-what-to-sync.engage","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":49892,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:18:06.877Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.choose-what-to-sync.back","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":55988,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:18:12.973Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.signup.view","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":56017,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:18:13.002Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.signup.submit","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":61598,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:18:18.583Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.signup.attempt","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":61605,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:18:18.590Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.choose-what-to-sync.view","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":61991,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:18:18.976Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.choose-what-to-sync.submit","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":77762,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:18:34.747Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  {"event":"flow.confirm.view","flow_id":"50fd6c525cb33e8f47e46ae513cf0457af8be04e7f89a91b8301d363d444e615","flow_time":77811,"hostname":"philbooth-5ejhd3.local","locale":"en","op":"flowEvent","pid":78120,"time":"2019-06-04T14:18:34.796Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:65.0) Gecko/20100101 Firefox/65.0","v":1,"context":"fx_desktop_v3","entrypoint":"menupanel","service":"sync"}
  ```

* Amplitude events:
  
  ```
  {"op":"amplitudeEvent","event_type":"fxa_reg - view","time":1559658263108,"device_id":"8db533fed9424a9ea2ff94bc4194de90","session_id":1559658259881,"app_version":"138","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"menupanel","flow_id":"f5b80296462173cb3a6b0a01fd7b759c7a3d4491dc632202780e8aa4b12a1be3","ua_browser":"Firefox","ua_version":"65.0","$append":{"fxa_services_used":"sync","experiments":["email_first_control"]}}}
  {"op":"amplitudeEvent","event_type":"fxa_reg - view","time":1559658268378,"device_id":"7a8bfc08d567465d832ed2a6d38da400","session_id":1559658267974,"app_version":"138","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"menupanel","flow_id":"83a71e95982d44e870b61d2e51f21fd1909aed2c044b8c964643489257d283c6","ua_browser":"Firefox","ua_version":"65.0","$append":{"fxa_services_used":"sync","experiments":["email_first_control"]}}}
  {"op":"amplitudeEvent","event_type":"fxa_reg - engage","time":1559658271873,"device_id":"7a8bfc08d567465d832ed2a6d38da400","session_id":1559658267974,"app_version":"138","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"menupanel","flow_id":"83a71e95982d44e870b61d2e51f21fd1909aed2c044b8c964643489257d283c6","ua_browser":"Firefox","ua_version":"65.0","$append":{"fxa_services_used":"sync","experiments":["email_first_control"]}}}
  {"op":"amplitudeEvent","event_type":"fxa_reg - submit","time":1559658281012,"device_id":"7a8bfc08d567465d832ed2a6d38da400","session_id":1559658267974,"app_version":"138","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"menupanel","flow_id":"83a71e95982d44e870b61d2e51f21fd1909aed2c044b8c964643489257d283c6","ua_browser":"Firefox","ua_version":"65.0","$append":{"fxa_services_used":"sync","experiments":["email_first_control"]}}}
  {"op":"amplitudeEvent","event_type":"fxa_reg - cwts_view","time":1559658281587,"device_id":"7a8bfc08d567465d832ed2a6d38da400","session_id":1559658267974,"app_version":"138","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"menupanel","flow_id":"83a71e95982d44e870b61d2e51f21fd1909aed2c044b8c964643489257d283c6","ua_browser":"Firefox","ua_version":"65.0","$append":{"fxa_services_used":"sync","experiments":["email_first_control"]}}}
  {"op":"amplitudeEvent","event_type":"fxa_reg - cwts_engage","time":1559658284324,"device_id":"7a8bfc08d567465d832ed2a6d38da400","session_id":1559658267974,"app_version":"138","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"menupanel","flow_id":"83a71e95982d44e870b61d2e51f21fd1909aed2c044b8c964643489257d283c6","ua_browser":"Firefox","ua_version":"65.0","$append":{"fxa_services_used":"sync","experiments":["email_first_control"]}}}
  {"op":"amplitudeEvent","event_type":"fxa_reg - cwts_back","time":1559658288693,"device_id":"7a8bfc08d567465d832ed2a6d38da400","session_id":1559658267974,"app_version":"138","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"menupanel","flow_id":"83a71e95982d44e870b61d2e51f21fd1909aed2c044b8c964643489257d283c6","ua_browser":"Firefox","ua_version":"65.0","$append":{"fxa_services_used":"sync","experiments":["email_first_control"]}}}
  {"op":"amplitudeEvent","event_type":"fxa_reg - view","time":1559658288719,"device_id":"7a8bfc08d567465d832ed2a6d38da400","session_id":1559658267974,"app_version":"138","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"menupanel","flow_id":"83a71e95982d44e870b61d2e51f21fd1909aed2c044b8c964643489257d283c6","ua_browser":"Firefox","ua_version":"65.0","$append":{"fxa_services_used":"sync","experiments":["email_first_control"]}}}
  {"op":"amplitudeEvent","event_type":"fxa_reg - submit","time":1559658289909,"device_id":"7a8bfc08d567465d832ed2a6d38da400","session_id":1559658267974,"app_version":"138","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"menupanel","flow_id":"83a71e95982d44e870b61d2e51f21fd1909aed2c044b8c964643489257d283c6","ua_browser":"Firefox","ua_version":"65.0","$append":{"fxa_services_used":"sync","experiments":["email_first_control"]}}}
  {"op":"amplitudeEvent","event_type":"fxa_reg - cwts_view","time":1559658290310,"device_id":"7a8bfc08d567465d832ed2a6d38da400","session_id":1559658267974,"app_version":"138","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"menupanel","flow_id":"83a71e95982d44e870b61d2e51f21fd1909aed2c044b8c964643489257d283c6","ua_browser":"Firefox","ua_version":"65.0","$append":{"fxa_services_used":"sync","experiments":["email_first_control"]}}}
  {"op":"amplitudeEvent","event_type":"fxa_reg - cwts_submit","time":1559658296177,"device_id":"7a8bfc08d567465d832ed2a6d38da400","session_id":1559658267974,"app_version":"138","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"menupanel","flow_id":"83a71e95982d44e870b61d2e51f21fd1909aed2c044b8c964643489257d283c6","ua_browser":"Firefox","ua_version":"65.0","$append":{"fxa_services_used":"sync","experiments":["email_first_control"]}}}
  ```

@mozilla/fxa-devs r?