### PR TITLE
feat(metrics): add optional sync_engines user property to amplitude

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/choose_what_to_sync.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/choose_what_to_sync.mustache
@@ -47,7 +47,7 @@
         {{/isTrailhead}}
         </div>
       <div class="links">
-        <a href="#" id="back">{{#t}}Back{{/t}}</a>
+        <a href="#" id="back" data-flow-event="back">{{#t}}Back{{/t}}</a>
       </div>
     </form>
   </section>

--- a/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
@@ -6,6 +6,7 @@ import _ from 'underscore';
 import $ from 'jquery';
 import BackMixin from './mixins/back-mixin';
 import Cocktail from 'cocktail';
+import FlowEventsMixin from './mixins/flow-events-mixin';
 import FormView from './form';
 import SessionVerificationPollMixin from './mixins/session-verification-poll-mixin';
 import Template from 'templates/choose_what_to_sync.mustache';
@@ -154,6 +155,7 @@ const View = FormView.extend({
 Cocktail.mixin(
   View,
   BackMixin,
+  FlowEventsMixin,
   SessionVerificationPollMixin
 );
 

--- a/packages/fxa-content-server/app/tests/spec/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/tests/spec/views/choose_what_to_sync.js
@@ -7,10 +7,11 @@ import Account from 'models/account';
 import { assert } from 'chai';
 import Backbone from 'backbone';
 import Broker from 'models/auth_brokers/base';
+import { CHOOSE_WHAT_TO_SYNC } from '../../../../tests/functional/lib/selectors';
 import Metrics from 'lib/metrics';
 import Notifier from 'lib/channels/notifier';
 import sinon from 'sinon';
-import { CHOOSE_WHAT_TO_SYNC } from '../../../../tests/functional/lib/selectors';
+import SentryMetrics from 'lib/sentry';
 import SessionVerificationPoll from 'models/polls/session-verification';
 import SyncEngines from 'models/sync-engines';
 import TestHelpers from '../../lib/helpers';
@@ -58,7 +59,7 @@ describe('views/choose_what_to_sync', () => {
     email = TestHelpers.createEmail();
     model = new Backbone.Model();
     notifier = new Notifier();
-    metrics = new Metrics({ notifier });
+    metrics = new Metrics({ notifier, sentryMetrics: new SentryMetrics() });
     onSubmitComplete = sinon.spy();
     user = new User({});
 
@@ -106,6 +107,17 @@ describe('views/choose_what_to_sync', () => {
 
     return view.render();
   }
+
+  it('registers for the expected events', () => {
+    return initView()
+      .then(() => {
+        assert.isFunction(view.events['click a']);
+        assert.isFunction(view.events['click input']);
+        assert.isFunction(view.events['input input']);
+        assert.isFunction(view.events['keyup input']);
+        assert.isFunction(view.events['submit']);
+      });
+  });
 
   describe('renders', () => {
     it('coming from sign up, redirects to /signup when email accound data missing', () => {

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -34,6 +34,18 @@ const EVENTS = {
     group: GROUPS.login,
     event: 'forgot_submit'
   },
+  'flow.choose-what-to-sync.back': {
+    group: GROUPS.registration,
+    event: 'cwts_back'
+  },
+  'flow.choose-what-to-sync.engage': {
+    group: GROUPS.registration,
+    event: 'cwts_engage'
+  },
+  'flow.choose-what-to-sync.submit': {
+    group: GROUPS.registration,
+    event: 'cwts_submit'
+  },
   'flow.update-firefox.engage': {
     group: GROUPS.notify,
     event: 'update_firefox_engage'
@@ -41,6 +53,10 @@ const EVENTS = {
   'flow.update-firefox.view': {
     group: GROUPS.notify,
     event: 'update_firefox_view'
+  },
+  'screen.choose-what-to-sync': {
+    group: GROUPS.registration,
+    event: 'cwts_view'
   },
   'settings.change-password.success': {
     group: GROUPS.settings,

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -34,14 +34,6 @@ const EVENTS = {
     group: GROUPS.login,
     event: 'forgot_submit'
   },
-  'settings.change-password.success': {
-    group: GROUPS.settings,
-    event: 'password'
-  },
-  'settings.signout.success': {
-    group: GROUPS.settings,
-    event: 'logout'
-  },
   'flow.update-firefox.engage': {
     group: GROUPS.notify,
     event: 'update_firefox_engage'
@@ -49,6 +41,14 @@ const EVENTS = {
   'flow.update-firefox.view': {
     group: GROUPS.notify,
     event: 'update_firefox_view'
+  },
+  'settings.change-password.success': {
+    group: GROUPS.settings,
+    event: 'password'
+  },
+  'settings.signout.success': {
+    group: GROUPS.settings,
+    event: 'logout'
   },
 };
 

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -375,6 +375,25 @@ registerSuite('amplitude', {
       assert.equal(logger.info.args[0][1].event_type, 'fxa_reg - password_blocked');
     },
 
+    'flow.choose-what-to-sync.engage': () => {
+      amplitude({
+        time: 'a',
+        type: 'flow.choose-what-to-sync.engage'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '63.245.221.32'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      });
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(logger.info.args[0][1].event_type, 'fxa_reg - cwts_engage');
+    },
+
     'flow.enter-email.engage': () => {
       amplitude({
         time: 'a',
@@ -615,6 +634,26 @@ registerSuite('amplitude', {
       assert.equal(arg.event_properties.connect_device_os, 'foo');
     },
 
+    'flow.choose-what-to-sync.back': () => {
+      amplitude({
+        time: 'a',
+        type: 'flow.choose-what-to-sync.back'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '63.245.221.32'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      });
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_reg - cwts_back');
+    },
+
     'flow.signin.forgot-password': () => {
       amplitude({
         time: 'a',
@@ -651,6 +690,25 @@ registerSuite('amplitude', {
 
       assert.equal(logger.info.callCount, 1);
       assert.equal(logger.info.args[0][1].event_type, 'fxa_reg - have_account');
+    },
+
+    'flow.choose-what-to-sync.submit': () => {
+      amplitude({
+        time: 'a',
+        type: 'flow.choose-what-to-sync.submit'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '63.245.221.32'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      });
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(logger.info.args[0][1].event_type, 'fxa_reg - cwts_submit');
     },
 
     'flow.enter-email.submit': () => {
@@ -785,6 +843,25 @@ registerSuite('amplitude', {
         uid: 'd'
       });
       assert.equal(logger.info.callCount, 0);
+    },
+
+    'screen.choose-what-to-sync': () => {
+      amplitude({
+        time: 'a',
+        type: 'screen.choose-what-to-sync'
+      }, {
+        connection: {},
+        headers: {
+          'x-forwarded-for': '63.245.221.32'
+        }
+      }, {
+        flowBeginTime: 'b',
+        flowId: 'c',
+        uid: 'd'
+      });
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(logger.info.args[0][1].event_type, 'fxa_reg - cwts_view');
     },
 
     'screen.enter-email': () => {

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -245,6 +245,7 @@ module.exports = {
         }),
         mapAppendProperties(data),
         mapSyncDevices(data),
+        mapSyncEngines(data),
         mapNewsletterState(eventCategory, data),
         mapNewsletters(data),
       );
@@ -319,6 +320,14 @@ function mapSyncDevices (data) {
 
 function countDevices (devices, period) {
   return devices.filter(device => device.lastAccessTime >= Date.now() - period).length;
+}
+
+function mapSyncEngines (data) {
+  const { syncEngines: sync_engines } = data;
+
+  if (Array.isArray(sync_engines) && sync_engines.length > 0) {
+    return { sync_engines };
+  }
 }
 
 function mapNewsletterState (eventCategory, data) {

--- a/packages/fxa-shared/package-lock.json
+++ b/packages/fxa-shared/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Shared module for FxA repositories",
   "main": "index.js",
   "scripts": {

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -132,6 +132,7 @@ describe('metrics/amplitude:', () => {
           osVersion: 'q',
           region: 'r',
           service: 'baz',
+          syncEngines: [ 'wibble', 'blee' ],
           templateVersion: 's',
           uid: 't',
           utm_campaign: 'u',
@@ -177,6 +178,7 @@ describe('metrics/amplitude:', () => {
             sync_active_devices_month: 5,
             sync_active_devices_week: 3,
             sync_device_count: 6,
+            sync_engines: [ 'wibble', 'blee' ],
             ua_browser: 'a',
             ua_version: 'b',
             utm_campaign: 'u',
@@ -200,6 +202,7 @@ describe('metrics/amplitude:', () => {
           deviceId: 'a',
           flowBeginTime: 'b',
           flowId: 'c',
+          syncEngines: [],
           uid: 'd'
         });
       });


### PR DESCRIPTION
Related to #938. Depends on #1380.

Adds a new user property to Amplitude, `sync_engines`. Ignored unless it's populated, because of the way it defaults to the empty array in the content server (as it's a user property, we don't want it to be clobbered by the default value). Opened as draft because it includes commits from #1380, which hasn't landed yet.