### PR TITLE
feat(metrics): pass selected sync engines to amplitude

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/metrics.js
+++ b/packages/fxa-content-server/app/scripts/lib/metrics.js
@@ -56,6 +56,7 @@ const ALLOWED_FIELDS = [
   'referrer',
   'screen',
   'service',
+  'syncEngines',
   'startTime',
   'timers',
   'uid',
@@ -149,6 +150,7 @@ function Metrics (options = {}) {
   // if navigationTiming is supported, the baseTime will be from
   // navigationTiming.navigationStart, otherwise Date.now().
   this._startTime = options.startTime || this._speedTrap.baseTime;
+  this._syncEngines = options.syncEngines || [];
   this._uid = options.uid || NOT_REPORTED_VALUE;
   this._uniqueUserId = options.uniqueUserId || NOT_REPORTED_VALUE;
   this._utmCampaign = options.utmCampaign || NOT_REPORTED_VALUE;
@@ -188,6 +190,7 @@ _.extend(Metrics.prototype, Backbone.Events, {
     'flow.initialize': '_initializeFlowModel',
     'flow.event': '_logFlowEvent',
     'set-email-domain': '_setEmailDomain',
+    'set-sync-engines': '_setSyncEngines',
     'set-uid': '_setUid',
     'clear-uid': '_clearUid',
     'once!view-shown': '_setInitialView'
@@ -376,6 +379,7 @@ _.extend(Metrics.prototype, Backbone.Events, {
       },
       service: this._service,
       startTime: this._startTime,
+      syncEngines: this._syncEngines,
       uid: this._uid,
       uniqueUserId: this._uniqueUserId,
       utm_campaign: this._utmCampaign, //eslint-disable-line camelcase
@@ -690,6 +694,12 @@ _.extend(Metrics.prototype, Backbone.Events, {
     const domain = marshallEmailDomain(email);
     if (domain) {
       this._emailDomain = domain;
+    }
+  },
+
+  _setSyncEngines (engines) {
+    if (engines) {
+      this._syncEngines = engines;
     }
   },
 

--- a/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
@@ -92,7 +92,10 @@ const View = FormView.extend({
     });
 
     return this.user.setAccount(account)
-      .then(this.onSubmitComplete);
+      .then(account => {
+        this.notifier.trigger('set-sync-engines', offeredSyncEngines);
+        return this.onSubmitComplete(account);
+      });
   },
 
   /**

--- a/packages/fxa-content-server/app/tests/spec/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/tests/spec/views/choose_what_to_sync.js
@@ -248,6 +248,7 @@ describe('views/choose_what_to_sync', () => {
   describe('submit', () => {
     beforeEach(() => {
       sinon.stub(user, 'setAccount').callsFake(() => Promise.resolve(account));
+      sinon.spy(notifier, 'trigger');
     });
 
     it('updates and saves the account, logs metrics, calls onSubmitComplete', () => {
@@ -265,6 +266,11 @@ describe('views/choose_what_to_sync', () => {
           assert.sameMembers(offered, DISPLAYED_ENGINE_IDS);
 
           assert.isTrue(user.setAccount.calledWith(account));
+
+          assert.equal(notifier.trigger.callCount, 2);
+          const args = notifier.trigger.args[1];
+          assert.equal(args[0], 'set-sync-engines');
+          assert.deepEqual(args[1], DISPLAYED_ENGINE_IDS);
 
           assert.isTrue(view.onSubmitComplete.calledOnce);
           assert.instanceOf(view.onSubmitComplete.args[0][0], Account);

--- a/packages/fxa-content-server/npm-shrinkwrap.json
+++ b/packages/fxa-content-server/npm-shrinkwrap.json
@@ -5672,9 +5672,9 @@
       }
     },
     "fxa-shared": {
-      "version": "1.0.24",
-      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.24.tgz",
-      "integrity": "sha512-xrAB4sIRhwWcZoxWjwrRoDCDCEo7TzKxlGpkG1CKQDCpbO7uT5ddWEiDYfbOxfe17621fy/VWm8n+8TUOFJddg==",
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.26.tgz",
+      "integrity": "sha512-JlLmvoQ8UZ5OasFro9JUTsfabATlDUS/411EZxznvQJtmBCZQ8URNcpJAadsUlu2cAA8i0DO/LcPztZSoCaxBQ==",
       "requires": {
         "accept-language": "2.0.17",
         "ajv": "6.10.0",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -63,7 +63,7 @@
     "fxa-js-client": "1.0.12",
     "fxa-mustache-loader": "0.0.2",
     "fxa-pairing-channel": "1.0.1",
-    "fxa-shared": "1.0.24",
+    "fxa-shared": "1.0.26",
     "got": "6.7.1",
     "grunt": "1.0.4",
     "grunt-babel": "6.0.0",

--- a/packages/fxa-content-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-content-server/server/lib/routes/post-metrics.js
@@ -37,6 +37,7 @@ const {
   OFFSET: OFFSET_TYPE,
   REFERRER: REFERRER_TYPE,
   STRING: STRING_TYPE,
+  SYNC_ENGINES: SYNC_ENGINES_TYPE,
   TIME: TIME_TYPE,
   URL: URL_TYPE,
   UTM: UTM_TYPE,
@@ -111,6 +112,7 @@ const BODY_SCHEMA = {
   }).required(),
   service: STRING_TYPE.regex(SERVICE_PATTERN).required(),
   startTime: TIME_TYPE.required(),
+  syncEngines: SYNC_ENGINES_TYPE.optional(),
   timers: joi.object().optional(), // this is never consumed.
   uid: HEX32_TYPE.allow('none').required(),
   uniqueUserId: STRING_TYPE.regex(UNIQUE_USER_ID_PATTERN).allow('none').required(),

--- a/packages/fxa-content-server/server/lib/validation.js
+++ b/packages/fxa-content-server/server/lib/validation.js
@@ -24,6 +24,7 @@ const PATTERNS = {
   FORM_TYPE: /^(email|other)$/,
   MIGRATION: /^(sync11|amo|none)$/,
   SERVICE: /^(sync|content-server|none|[0-9a-f]{16})$/,
+  SYNC_ENGINE: /^[a-z]+$/,
   UNIQUE_USER_ID: /^[0-9a-z-]{36}$/
 };
 
@@ -42,6 +43,7 @@ const TYPES = {
   RESUME: joi.string().regex(PATTERNS.BASE64),
   SIGNIN_CODE: joi.string().regex(PATTERNS.BASE64_URL_SAFE).length(8),
   STRING: joi.string().max(1024), // 1024 is arbitrary, seems like it should give CSP reports plenty of space.
+  SYNC_ENGINES: joi.array().items(joi.string().regex(PATTERNS.SYNC_ENGINE)),
   TIME: joi.number().integer().min(0),
   URL: joi.string().max(2048).uri({ scheme: [ 'http', 'https' ]}), // 2048 is also arbitrary, the same limit we use on the front end.
   UTM: joi.string().max(128).regex(/^[\w\/.%-]+$/) // values here can be 'firefox/sync'

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -392,6 +392,7 @@ registerSuite('amplitude', {
 
       assert.equal(logger.info.callCount, 1);
       assert.equal(logger.info.args[0][1].event_type, 'fxa_reg - cwts_engage');
+      assert.isUndefined(logger.info.args[0][1].user_properties.sync_engines);
     },
 
     'flow.enter-email.engage': () => {
@@ -652,6 +653,7 @@ registerSuite('amplitude', {
       assert.equal(logger.info.callCount, 1);
       const arg = logger.info.args[0][1];
       assert.equal(arg.event_type, 'fxa_reg - cwts_back');
+      assert.isUndefined(logger.info.args[0][1].user_properties.sync_engines);
     },
 
     'flow.signin.forgot-password': () => {
@@ -704,11 +706,13 @@ registerSuite('amplitude', {
       }, {
         flowBeginTime: 'b',
         flowId: 'c',
+        syncEngines: [ 'wibble', 'blee' ],
         uid: 'd'
       });
 
       assert.equal(logger.info.callCount, 1);
       assert.equal(logger.info.args[0][1].event_type, 'fxa_reg - cwts_submit');
+      assert.deepEqual(logger.info.args[0][1].user_properties.sync_engines, [ 'wibble', 'blee' ]);
     },
 
     'flow.enter-email.submit': () => {
@@ -862,6 +866,7 @@ registerSuite('amplitude', {
 
       assert.equal(logger.info.callCount, 1);
       assert.equal(logger.info.args[0][1].event_type, 'fxa_reg - cwts_view');
+      assert.isUndefined(logger.info.args[0][1].user_properties.sync_engines);
     },
 
     'screen.enter-email': () => {

--- a/packages/fxa-content-server/tests/server/routes/post-metrics.js
+++ b/packages/fxa-content-server/tests/server/routes/post-metrics.js
@@ -138,6 +138,7 @@ registerSuite('routes/post-metrics', {
                 ],
                 isSampledUser: true,
                 startTime: 10,
+                syncEngines: [ 'foo', 'bar' ],
                 flushTime: 20
               },
               userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:47.0) Gecko/20100101 Firefox/47.0'
@@ -191,7 +192,8 @@ registerSuite('routes/post-metrics', {
                     ],
                     flushTime: 20,
                     isSampledUser: true,
-                    startTime: 10
+                    startTime: 10,
+                    syncEngines: [ 'foo', 'bar' ],
                   });
                 },
 


### PR DESCRIPTION
Fixes #938. Depends on #1384.

Passes the selected Sync engines from the CWTS view through to `POST /metrics`, from which point they're propagated to Amplitude automatically. Opened as draft because it includes commits from #1380 and #1384, which haven't landed yet, and it needs shrinkwrap regenerating after I publish a new release of `fxa-shared`.