### PR TITLE
feat(metrics): add optional sync_engines user property to amplitude

### DIFF
--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -245,6 +245,7 @@ module.exports = {
         }),
         mapAppendProperties(data),
         mapSyncDevices(data),
+        mapSyncEngines(data),
         mapNewsletterState(eventCategory, data),
         mapNewsletters(data),
       );
@@ -319,6 +320,14 @@ function mapSyncDevices (data) {
 
 function countDevices (devices, period) {
   return devices.filter(device => device.lastAccessTime >= Date.now() - period).length;
+}
+
+function mapSyncEngines (data) {
+  const { syncEngines: sync_engines } = data;
+
+  if (Array.isArray(sync_engines) && sync_engines.length > 0) {
+    return { sync_engines };
+  }
 }
 
 function mapNewsletterState (eventCategory, data) {

--- a/packages/fxa-shared/package-lock.json
+++ b/packages/fxa-shared/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Shared module for FxA repositories",
   "main": "index.js",
   "scripts": {

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -132,6 +132,7 @@ describe('metrics/amplitude:', () => {
           osVersion: 'q',
           region: 'r',
           service: 'baz',
+          syncEngines: [ 'wibble', 'blee' ],
           templateVersion: 's',
           uid: 't',
           utm_campaign: 'u',
@@ -177,6 +178,7 @@ describe('metrics/amplitude:', () => {
             sync_active_devices_month: 5,
             sync_active_devices_week: 3,
             sync_device_count: 6,
+            sync_engines: [ 'wibble', 'blee' ],
             ua_browser: 'a',
             ua_version: 'b',
             utm_campaign: 'u',
@@ -200,6 +202,7 @@ describe('metrics/amplitude:', () => {
           deviceId: 'a',
           flowBeginTime: 'b',
           flowId: 'c',
+          syncEngines: [],
           uid: 'd'
         });
       });


### PR DESCRIPTION
Related to #938. Depends on #1380.

Adds a new user property to Amplitude, `sync_engines`. Ignored unless it's populated, because of the way it defaults to the empty array in the content server (as it's a user property, we don't want it to be clobbered by the default value). Opened as draft because it includes commits from #1380, which hasn't landed yet.