### PR TITLE
feat(payments): fix #1280, consume configuration in payments frontend

### DIFF
--- a/packages/fxa-payments-server/.storybook/components/MockApp.tsx
+++ b/packages/fxa-payments-server/.storybook/components/MockApp.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, ReactNode } from 'react';
-import config from '../../src/lib/config';
+import { config } from '../../src/lib/config';
 import { StripeProvider } from 'react-stripe-elements';
 import { MockLoader } from './MockLoader';
 
@@ -20,7 +20,7 @@ export const MockApp = ({
   }, []);
 
   return (
-    <StripeProvider apiKey={config.STRIPE_API_KEY}>
+    <StripeProvider apiKey={config.stripe.apiKey}>
       <MockLoader>
         {children}
       </MockLoader>

--- a/packages/fxa-payments-server/public/index.html
+++ b/packages/fxa-payments-server/public/index.html
@@ -10,7 +10,7 @@
     <meta name=robots content=noindex,nofollow>
     <meta name=viewport content="width=device-width,initial-scale=1,maximum-scale=2,user-scalable=yes">
     <meta name=apple-itunes-app content="app-id=989804926, affiliate-data=ct=smartbanner-fxa">
-    <meta name="fxa-content-server/config" content="__SERVER_CONFIG__">
+    <meta name="fxa-config" content="__SERVER_CONFIG__">
     <meta name="fxa-feature-flags" content="__FEATURE_FLAGS__">
 
     <script src="https://js.stripe.com/v3/"></script>

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -97,6 +97,14 @@ const conf = convict({
     format: 'String',
   },
   servers: {
+    auth: {
+      url: {
+        default: 'http://127.0.0.1:9000',
+        doc: 'The url of the fxa-auth-server instance',
+        env: 'AUTH_SERVER_URL',
+        format: 'url',
+      }
+    },
     content: {
       url: {
         default: 'http://127.0.0.1:3030',
@@ -140,6 +148,14 @@ const conf = convict({
       doc: 'The origin of the static resources',
       env: 'STATIC_RESOURCE_URL',
       format: 'url'
+    }
+  },
+  stripe: {
+    apiKey: {
+      default: 'pk_test_FL2cOisOukoCQUZsrochvTlk00ff4IakfE',
+      doc: 'API key for Stripe',
+      env: 'STRIP_API_KEY',
+      format: String,
     }
   },
 });

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -35,7 +35,7 @@ export const App = ({
 }: AppProps) => {
   // Note: every Route below should also be listed in INDEX_ROUTES in server/lib/server.js
   return (
-    <StripeProvider apiKey={config.STRIPE_API_KEY}>
+    <StripeProvider apiKey={config.stripe.apiKey}>
       <Provider store={store}>
         <LoadingOverlay />
         <Router>

--- a/packages/fxa-payments-server/src/index.tsx
+++ b/packages/fxa-payments-server/src/index.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { render } from 'react-dom';
 import { createAppStore, actions } from './store';
 
-import config from './lib/config';
+import { config, readConfigFromMeta } from './lib/config';
 import './index.scss';
 import App from './App';
 
 async function init() {
+  readConfigFromMeta();
+
   const store = createAppStore();
 
   const queryParams = parseParams(window.location.search);
@@ -20,11 +22,11 @@ async function init() {
       actions.fetchToken(accessToken),
       actions.fetchProfile(accessToken),
     ].map(store.dispatch);
-  
+
     render(
       <App {...{ accessToken, config, store, queryParams }} />,
       document.getElementById('root')
-    );  
+    );
   }
 }
 
@@ -58,7 +60,7 @@ async function getVerifiedAccessToken({
 
   try {
     const result = await fetch(
-      `${config.OAUTH_API_ROOT}/verify`,
+      `${config.servers.oauth.url}/v1/verify`,
       {
         body: JSON.stringify({ token: accessToken }),
         headers: { 'Content-Type': 'application/json' },
@@ -76,7 +78,7 @@ async function getVerifiedAccessToken({
 
   if (! accessToken) {
     // TODO: bounce through a login redirect to get back here with a token
-    window.location.href = `${config.CONTENT_SERVER_ROOT}/settings`;
+    window.location.href = `${config.servers.content.url}/settings`;
     return accessToken;
   }
 

--- a/packages/fxa-payments-server/src/lib/config.js
+++ b/packages/fxa-payments-server/src/lib/config.js
@@ -1,8 +1,0 @@
-// TODO: make this dynamic based on host and/or config injected by server
-export default {
-  AUTH_API_ROOT: 'http://127.0.0.1:9000/v1',
-  CONTENT_SERVER_ROOT: 'http://127.0.0.1:3030',
-  OAUTH_API_ROOT: 'http://127.0.0.1:9010/v1',
-  PROFILE_API_ROOT: 'http://127.0.0.1:1111/v1',
-  STRIPE_API_KEY: 'pk_test_FL2cOisOukoCQUZsrochvTlk00ff4IakfE',
-};

--- a/packages/fxa-payments-server/src/lib/config.ts
+++ b/packages/fxa-payments-server/src/lib/config.ts
@@ -1,0 +1,89 @@
+// This configuration is a subset of the configuration declared in server/config/index.js
+// Which config is copied over is defined in server/lib/server.js
+export interface Config {
+  featureFlags: {[key: string]: any}
+  servers: {
+    auth: {
+      url: string
+    }
+    content: {
+      url: string
+    }
+    oauth: {
+      url: string
+    }
+    profile: {
+      url: string
+    }
+  }
+  stripe: {
+    apiKey: string
+  }
+  lang: string
+}
+
+export const config: Config = {
+  featureFlags: {},
+  servers: {
+    auth: {
+      url: '',
+    },
+    content: {
+      url: '',
+    },
+    oauth: {
+      url: '',
+    },
+    profile: {
+      url: '',
+    },
+  },
+  stripe: {
+    apiKey: '',
+  },
+  lang: '',
+};
+
+function decodeConfig(content: string|null) {
+  if (!content) {
+    throw new Error('Configuration is empty');
+  }
+  const decoded = decodeURIComponent(content);
+  try {
+    return JSON.parse(decoded);
+  } catch (e) {
+    throw new Error(`Invalid configuration ${JSON.stringify(content)}: ${decoded}`);
+  }
+}
+
+export function readConfigFromMeta() {
+  const configEl = document.head.querySelector('meta[name="fxa-config"]');
+  if (!configEl) {
+    throw new Error('<meta name="fxa-config"> is missing');
+  }
+  updateConfig(decodeConfig(configEl.getAttribute('content')));
+  const featureEl = document.head.querySelector('meta[name="fxa-feature-flags"]');
+  if (!featureEl) {
+    throw new Error('<meta name="fxa-feature-flags"> is missing');
+  }
+  updateConfig({featureFlags: decodeConfig(featureEl.getAttribute('content'))});
+  updateConfig({lang: document.documentElement.lang});
+}
+
+function merge(obj: any, data: any) {
+  for (const [key, value] of Object.entries(data)) {
+    if (value === null || typeof value !== "object") {
+      obj[key] = value;
+    } else {
+      if (!obj[key]) {
+        obj[key] = {};
+      }
+      merge(obj[key], value);
+    }
+  }
+  return obj;
+}
+
+export function updateConfig(newData: any) {
+  merge(config, newData);
+}

--- a/packages/fxa-payments-server/src/store/index.tsx
+++ b/packages/fxa-payments-server/src/store/index.tsx
@@ -4,7 +4,7 @@ import ReduxThunk from 'redux-thunk';
 import { createPromise as promiseMiddleware } from 'redux-promise-middleware';
 import typeToReducer from 'type-to-reducer';
 
-import config from '../lib/config';
+import { config } from '../lib/config';
 
 import {
   apiGet,
@@ -34,7 +34,7 @@ export const defaultState: State = {
     profile: fetchDefault({}),
     updatePayment: fetchDefault(false),
     subscriptions: fetchDefault([]),
-    token: fetchDefault({}),  
+    token: fetchDefault({}),
   }
 };
 
@@ -76,30 +76,30 @@ export const actions: ActionCreators = {
   ...createActions(
     {
       fetchProfile: accessToken =>
-        apiGet(accessToken, `${config.PROFILE_API_ROOT}/profile`),
+        apiGet(accessToken, `${config.servers.profile.url}/v1/profile`),
       fetchPlans: accessToken =>
-        apiGet(accessToken, `${config.AUTH_API_ROOT}/oauth/subscriptions/plans`),
+        apiGet(accessToken, `${config.servers.auth.url}/v1/oauth/subscriptions/plans`),
       fetchSubscriptions: accessToken =>
-        apiGet(accessToken, `${config.AUTH_API_ROOT}/oauth/subscriptions/active`),
+        apiGet(accessToken, `${config.servers.auth.url}/v1/oauth/subscriptions/active`),
       fetchToken: accessToken =>
-        apiPost(accessToken, `${config.OAUTH_API_ROOT}/introspect`, { token: accessToken }),
+        apiPost(accessToken, `${config.servers.oauth.url}/v1/introspect`, { token: accessToken }),
       fetchCustomer: accessToken =>
-        apiGet(accessToken, `${config.AUTH_API_ROOT}/oauth/subscriptions/customer`),
+        apiGet(accessToken, `${config.servers.auth.url}/v1/oauth/subscriptions/customer`),
       createSubscription: (accessToken, params) =>
         apiPost(
           accessToken,
-          `${config.AUTH_API_ROOT}/oauth/subscriptions/active`,
+          `${config.servers.auth.url}/v1/oauth/subscriptions/active`,
           params
         ),
       cancelSubscription: (accessToken, subscriptionId) =>
         apiDelete(
           accessToken,
-          `${config.AUTH_API_ROOT}/oauth/subscriptions/active/${subscriptionId}`
+          `${config.servers.auth.url}/v1/oauth/subscriptions/active/${subscriptionId}`
         ),
       updatePayment: (accessToken, { paymentToken }) =>
         apiPost(
           accessToken,
-          `${config.AUTH_API_ROOT}/oauth/subscriptions/updatePayment`,
+          `${config.servers.auth.url}/v1/oauth/subscriptions/updatePayment`,
           { paymentToken }
         ),
     },
@@ -115,16 +115,16 @@ export const actions: ActionCreators = {
     async (dispatch: Function, getState: Function) => {
       await Promise.all([
         dispatch(actions.fetchCustomer(accessToken)),
-        dispatch(actions.fetchSubscriptions(accessToken))  
+        dispatch(actions.fetchSubscriptions(accessToken))
       ])
     },
-  
+
   fetchPlansAndSubscriptions: (accessToken: string) =>
     async (dispatch: Function, getState: Function) => {
       await Promise.all([
         dispatch(actions.fetchPlans(accessToken)),
         dispatch(actions.fetchCustomer(accessToken)),
-        dispatch(actions.fetchSubscriptions(accessToken))  
+        dispatch(actions.fetchSubscriptions(accessToken))
       ])
     },
 
@@ -134,12 +134,12 @@ export const actions: ActionCreators = {
       await dispatch(actions.fetchCustomerAndSubscriptions(accessToken));
     },
 
-  cancelSubscriptionAndRefresh: (accessToken: string, subscriptionId: object) => 
+  cancelSubscriptionAndRefresh: (accessToken: string, subscriptionId: object) =>
     async (dispatch: Function, getState: Function) => {
       await dispatch(actions.cancelSubscription(accessToken, subscriptionId));
       await dispatch(actions.fetchCustomerAndSubscriptions(accessToken));
     },
-  
+
   updatePaymentAndRefresh: (accessToken: string, params: object) =>
     async (dispatch: Function, getState: Function) => {
       await dispatch(actions.updatePayment(accessToken, params));
@@ -156,9 +156,9 @@ export const reducers = {
     {
       [actions.fetchProfile.toString()]:
         fetchReducer('profile'),
-      [actions.fetchPlans.toString()]: 
+      [actions.fetchPlans.toString()]:
         fetchReducer('plans'),
-      [actions.fetchSubscriptions.toString()]: 
+      [actions.fetchSubscriptions.toString()]:
         fetchReducer('subscriptions'),
       [actions.fetchToken.toString()]:
         fetchReducer('token'),
@@ -183,7 +183,7 @@ export const reducers = {
   ),
 };
 
-export const selectorsFromState = 
+export const selectorsFromState =
   (...names: Array<string>) =>
     (state: State) =>
       mapToObject(names, (name: string) => selectors[name](state));


### PR DESCRIPTION
This also changes the config naming on the frontend to match the server configuration.

I started this out trying to do the "right thing" and move `packages/fxa-content-server/app/scripts/lib/config-loader.js` to fxa-shared, but that became complex and awkward, and the actual code is only 25 lines of real functionality. So I switched back to the simple thing and just reimplemented the functionality.

Also a bunch of automatic whitespace trimming happened to the files I touched.