### PR TITLE
feat(payments): Tooltip component to reuse styles from content server

### DIFF
--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -41,6 +41,7 @@
     "@storybook/addon-links": "^5.0.11",
     "@storybook/addons": "^5.0.11",
     "@storybook/react": "^5.0.11",
+    "@types/classnames": "^2.2.8",
     "@types/jsdom": "^12.2.3",
     "@types/react-redux": "^7.0.8",
     "@types/react-router": "^4.4.5",

--- a/packages/fxa-payments-server/src/components/Tooltip.stories.tsx
+++ b/packages/fxa-payments-server/src/components/Tooltip.stories.tsx
@@ -1,0 +1,108 @@
+import React, { useRef, useState, useCallback } from 'react';
+import { storiesOf } from '@storybook/react';
+import MockApp from '../../.storybook/components/MockApp';
+import ScreenInfo from '../lib/screen-info';
+import { SignInLayout } from './AppLayout';
+import { Tooltip } from './Tooltip';
+
+function init() {
+  storiesOf('components/Tooltip', module)
+    .add('default', () =>
+      <MockPage>
+        <Field>default</Field>
+      </MockPage>
+    )
+    .add('dismissible', () =>
+      <MockPage>
+        <FieldWithDismissible
+          message={<>Did you mean <a href="https://mozilla.org">mozilla.org</a>?</>}
+          extraClassNames="tooltip-error tooltip-suggest"
+          dismissible
+        >dismissible = true</FieldWithDismissible>
+      </MockPage>
+    )
+    .add('showBelow', () =>
+      <MockPage>
+        <Field showBelow={false}>showBelow = false</Field>
+        <Field showBelow>showBelow default</Field>
+        <Field showBelow={true}>showBelow = true</Field>
+      </MockPage>
+    )
+    .add('clientHeight', () =>
+      <MockPage>
+        <Field clientHeight={300}>clientHeight = 300</Field>
+        <Field showBelow={false} clientHeight={300}>clientHeight = 300, showBelow = false</Field>
+        <Field clientHeight={1000}>clientHeight = 1000</Field>
+      </MockPage>
+    );
+}
+
+type FieldProps = {
+  children: string | React.ReactNode,
+  message?: string | React.ReactNode,
+  showTooltip?: boolean,
+  dismissible?: boolean,
+  onDismiss?: (ev: React.MouseEvent) => void,
+  onFocus?: (ev: React.FocusEvent) => void,
+  showBelow?: boolean,
+  clientHeight?: number,
+  extraClassNames?: string,
+};
+
+const Field = ({
+  children,
+  message = 'Valid email required',
+  showTooltip = true,
+  dismissible = false,
+  onDismiss = () => {},
+  onFocus = () => {},
+  showBelow = undefined,
+  clientHeight = undefined,
+  extraClassNames = 'tooltip-error',
+}: FieldProps) => {
+  const screenInfo = new ScreenInfo(window);
+  if (typeof clientHeight !== 'undefined') {
+    screenInfo.clientHeight = clientHeight;
+  }
+  const parentRef = useRef(null);
+  return (
+    <div className="input-row">
+      <label>
+        <span className="label-text">{children}</span>
+        <input ref={parentRef} onFocus={onFocus} name="name" type="text" className="name tooltip-below invalid" defaultValue="" required autoFocus aria-invalid="true" />
+        {showTooltip && <Tooltip {...{ parentRef, showBelow, dismissible, onDismiss, extraClassNames, screenInfo }}>{message}</Tooltip>}
+      </label>
+    </div>
+  );
+};
+
+const FieldWithDismissible = (props: FieldProps) => {
+  const [ showTooltip, setShowTooltip ] = useState(true);
+  const onFocus = useCallback(() => setShowTooltip(true), [ setShowTooltip ]);
+  const onDismiss = useCallback(
+    (ev: React.MouseEvent) => {
+      ev.preventDefault();
+      setShowTooltip(false);
+    },
+    [ setShowTooltip ]
+  );
+  return <Field {...{ ...props, showTooltip, onFocus, onDismiss }} />;
+};
+
+type MockPageProps = {
+  children: React.ReactNode,
+};
+
+const MockPage = ({ children }: MockPageProps) => {
+  return (
+    <MockApp>
+      <SignInLayout>
+        <form className="payment">
+          {children}
+        </form>
+      </SignInLayout>
+    </MockApp>
+  );
+};
+
+init();

--- a/packages/fxa-payments-server/src/components/Tooltip.test.tsx
+++ b/packages/fxa-payments-server/src/components/Tooltip.test.tsx
@@ -1,0 +1,133 @@
+import React, { useRef } from 'react';
+import { render, cleanup, fireEvent, } from '@testing-library/react';
+import 'jest-dom/extend-expect';
+import { Omit } from '../lib/types';
+import ScreenInfo from '../lib/screen-info';
+import {
+  Tooltip,
+  TooltipProps,
+  MIN_HEIGHT_TO_SHOW_TOOLTIP_BELOW,
+  MIN_WIDTH_TO_SHOW_TOOLTIP_BELOW,
+} from './Tooltip';
+
+const LABEL_TEXT = 'Valid frobnitz required.';
+
+afterEach(cleanup);
+
+type SubjectProps = {
+  clientHeight?: number,
+  clientWidth?: number,
+} & Omit<TooltipProps, "parentRef">;
+
+const Subject = (props: SubjectProps) => {
+  const {
+    clientHeight = 2000,
+    clientWidth = 2000,
+    ...tooltipProps
+  } = props;
+
+  const parentRef = useRef(null);
+  
+  const screenInfo = new ScreenInfo(window);
+  Object.assign(screenInfo, { clientHeight, clientWidth });
+  
+  return (
+    <div className="input-row">
+      <input ref={parentRef} name="name" type="text" className="name tooltip-below invalid" />
+      <Tooltip {...{ ...tooltipProps, screenInfo, parentRef }} />
+    </div>
+  );
+};
+
+it('renders children as label', () => {
+  const { queryByText } = render(
+    <Subject>{LABEL_TEXT}</Subject>
+  );
+  const result = queryByText(LABEL_TEXT);
+  expect(result).toBeInTheDocument();
+  if (result) {
+    expect(result).toHaveClass('tooltip');
+    expect(result).toHaveClass('tooltip-below');
+    expect(result).toHaveClass('fade-up-tt');
+    expect(result.style.top).not.toContain('-');  
+  }
+});
+
+it('renders with expected id and class names', () => {
+  const { getByText } = render(
+    <Subject id="xyzzy" extraClassNames="frobnitz">{LABEL_TEXT}</Subject>
+  );
+  const result = getByText(LABEL_TEXT);
+  expect(result).toHaveAttribute('id', 'xyzzy');
+  expect(result).toHaveClass('tooltip');
+  expect(result).toHaveClass('tooltip-below');
+  expect(result).toHaveClass('fade-up-tt');
+  expect(result).toHaveClass('frobnitz');
+});
+
+it('handles being dismissible', () => {
+  const onDismiss = jest.fn();
+  const { queryByTestId } = render(
+    <Subject dismissible onDismiss={onDismiss}>{LABEL_TEXT}</Subject>
+  );
+  const control = queryByTestId('dismiss-button');
+  expect(control).toBeInTheDocument();
+  fireEvent.click(control as Element);
+  expect(onDismiss.mock.calls.length).toBe(1);
+});
+
+it('displays label above with showBelow=false', () => {
+  const { getByText } = render(
+    <Subject showBelow={false}>{LABEL_TEXT}</Subject>
+  );
+  const result = getByText(LABEL_TEXT);
+  expect(result).not.toHaveClass('tooltip-below');
+  expect(result).toHaveClass('fade-down-tt');
+  expect(result.style.top).toContain('-');
+});
+
+it('displays label above on short window', () => {
+  const { getByText } = render(
+    <Subject clientHeight={MIN_HEIGHT_TO_SHOW_TOOLTIP_BELOW - 10}>{LABEL_TEXT}</Subject>
+  );
+  const result = getByText(LABEL_TEXT);
+  expect(result).not.toHaveClass('tooltip-below');
+  expect(result).toHaveClass('fade-down-tt');
+  expect(result.style.top).toContain('-');
+});
+
+it('overrides showBelow={true} on short window', () => {
+  const { getByText } = render(
+    <Subject
+      showBelow={true}
+      clientHeight={MIN_HEIGHT_TO_SHOW_TOOLTIP_BELOW - 10}>{LABEL_TEXT}</Subject>
+  );
+  const result = getByText(LABEL_TEXT);
+  expect(result).not.toHaveClass('tooltip-below');
+  expect(result).toHaveClass('fade-down-tt');
+  expect(result.style.top).toContain('-');
+});
+
+it('displays label above on narrow window', () => {
+  const { getByText } = render(
+    <Subject
+      showBelow={true}
+      clientWidth={MIN_WIDTH_TO_SHOW_TOOLTIP_BELOW - 10}>{LABEL_TEXT}</Subject>
+  );
+  const result = getByText(LABEL_TEXT);
+  expect(result).not.toHaveClass('tooltip-below');
+  expect(result).toHaveClass('fade-down-tt');
+  expect(result.style.top).toContain('-');
+});
+
+it('overrides showBelow={true} on narrow window', () => {
+  const { getByText } = render(
+    <Subject
+      showBelow={true}
+      clientWidth={MIN_WIDTH_TO_SHOW_TOOLTIP_BELOW - 10}>{LABEL_TEXT}</Subject>
+  );
+  const result = getByText(LABEL_TEXT);
+  expect(result).not.toHaveClass('tooltip-below');
+  expect(result).toHaveClass('fade-down-tt');
+  expect(result.style.top).toContain('-');
+});

--- a/packages/fxa-payments-server/src/components/Tooltip.tsx
+++ b/packages/fxa-payments-server/src/components/Tooltip.tsx
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This is a React version of this Bootstrap view:
+// https://github.com/mozilla/fxa/blob/master/packages/fxa-content-server/app/scripts/views/tooltip.js
+
+import React, { useEffect, useRef } from 'react';
+import classNames from 'classnames';
+import ScreenInfo from '../lib/screen-info';
+
+export const PADDING_BELOW_TOOLTIP_PX = 2;
+export const PADDING_ABOVE_TOOLTIP_PX = 4;
+
+// These values should be the same as
+// https://github.com/mozilla/fxa-content-server/blob/0eab619612897dcda43e8074dafdf55e8cbe11ee/app/styles/_breakpoints.scss#L6
+export const MIN_HEIGHT_TO_SHOW_TOOLTIP_BELOW = 480;
+export const MIN_WIDTH_TO_SHOW_TOOLTIP_BELOW = 520;
+
+export type TooltipProps = {
+  children: string | React.ReactNode,
+  parentRef: React.RefObject<HTMLInputElement | HTMLDivElement>,
+  id?: string,
+  showBelow?: boolean,
+  dismissible?: boolean,
+  onDismiss?: (ev: React.MouseEvent) => void,
+  extraClassNames?: string,
+  screenInfo?: ScreenInfo,
+};
+
+export const Tooltip = ({
+  children,
+  parentRef,
+  id = '',
+  showBelow = true,
+  dismissible = false,
+  onDismiss = () => {},
+  extraClassNames = '',
+  screenInfo,
+}: TooltipProps) => {
+  const { clientHeight, clientWidth } =
+    screenInfo || { clientHeight: 1000, clientWidth: 1000 };
+
+  const doShowBelow =
+    showBelow &&
+    (clientHeight >= MIN_HEIGHT_TO_SHOW_TOOLTIP_BELOW) &&
+    (clientWidth >= MIN_WIDTH_TO_SHOW_TOOLTIP_BELOW);
+
+  const tooltipRef = useRef<HTMLElement>(null);
+
+  // After initial render, nudge tooltip position relative to parent element
+  useEffect(() => {
+    const tooltipEl = tooltipRef.current;
+    const parentEl = parentRef.current;
+    if (tooltipEl && parentEl) {
+      tooltipEl.style.top = doShowBelow
+        ? parentEl.offsetTop + parentEl.offsetHeight + PADDING_ABOVE_TOOLTIP_PX + 'px'
+        : parentEl.offsetTop + (0 - tooltipEl.offsetHeight - PADDING_BELOW_TOOLTIP_PX) + 'px';
+    }
+  }, [ doShowBelow, tooltipRef, parentRef ]);
+
+  const asideClassNames = [
+    'tooltip',
+    extraClassNames,
+    doShowBelow
+      ? 'tooltip-below fade-up-tt'
+      : 'fade-down-tt',
+  ]; 
+
+  return (
+    <aside ref={tooltipRef} id={id} className={classNames(...asideClassNames)}>
+      {children}
+      {dismissible &&
+        <span data-testid="dismiss-button" onClick={onDismiss} className="dismiss" tabIndex={2}>&#10005;</span>}
+    </aside>
+  );
+};
+
+export default Tooltip;

--- a/packages/fxa-payments-server/src/lib/screen-info.ts
+++ b/packages/fxa-payments-server/src/lib/screen-info.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This is a port to TypeScript of this fxa-content-server library:
+// https://github.com/mozilla/fxa/blob/master/packages/fxa-content-server/app/scripts/lib/screen-info.js
+
+// module to calculate screen dimentions given a window.
+
+enum ScreenInfoOther {
+  NOT_REPORTED_VALUE = 'none',
+}
+
+class ScreenInfo {
+  clientHeight: number | ScreenInfoOther;
+  clientWidth: number | ScreenInfoOther;
+  devicePixelRatio: number | ScreenInfoOther;
+  screenHeight: number | ScreenInfoOther;
+  screenWidth: number | ScreenInfoOther;
+
+  constructor(win: Window) {
+    var documentElement = win.document.documentElement || {};
+    var screen = win.screen || {};
+  
+    // for more information:
+    // http://quirksmode.org/mobile/viewports.html and
+    // http://quirksmode.org/mobile/viewports2.html
+    this.clientHeight = documentElement.clientHeight || ScreenInfoOther.NOT_REPORTED_VALUE;
+    this.clientWidth = documentElement.clientWidth || ScreenInfoOther.NOT_REPORTED_VALUE;
+    this.devicePixelRatio = win.devicePixelRatio || ScreenInfoOther.NOT_REPORTED_VALUE;
+    this.screenHeight = screen.height || ScreenInfoOther.NOT_REPORTED_VALUE;
+    this.screenWidth = screen.width || ScreenInfoOther.NOT_REPORTED_VALUE;
+  }  
+}
+
+export default ScreenInfo;

--- a/packages/fxa-payments-server/src/lib/types.tsx
+++ b/packages/fxa-payments-server/src/lib/types.tsx
@@ -10,3 +10,6 @@ export interface QueryParams {
 export interface GenericObject {
   [propName: string]: any
 }
+
+// https://stackoverflow.com/questions/48215950/exclude-property-from-type
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;


### PR DESCRIPTION
issue #1365

Things to do and see:
* `cd packages/fxa-payments-server`
* `npm install`
* `CI=yes npm run test` - should pass
* `npm run storybook` - http://localhost:6006/?path=/story/components-tooltip--default