### PR TITLE
feat(oauth): Add a config option to disable particular OAuth clients.

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/config.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/config.js
@@ -72,6 +72,12 @@ const conf = convict({
     default: {},
     env: 'OAUTH_CLIENT_IDS'
   },
+  disabledClients: {
+    doc: 'Comma-separated list of client ids for which service should be temporarily refused',
+    env: 'OAUTH_DISABLED_CLIENTS',
+    format: Array,
+    default: []
+  },
   scopes: {
     doc: 'Some pre-defined list of scopes that will be inserted into the DB',
     env: 'OAUTH_SCOPES',

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/error.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/error.js
@@ -295,4 +295,29 @@ AppError.invalidGrantType = function invalidGrantType() {
   });
 };
 
+AppError.disabledClient = function disabledClient(clientId) {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: 122,
+    message: 'This client has been temporarily disabled'
+  }, { clientId });
+};
+
+AppError.serviceUnavailable = function serviceUnavailable(retryAfter) {
+  if (! retryAfter) {
+    retryAfter = 30;
+  }
+  return new AppError({
+    code: 503,
+    error: 'Service Unavailable',
+    errno: 201,
+    message: 'Service unavailable'
+  }, {
+    retryAfter: retryAfter
+  }, {
+    'retry-after': retryAfter
+  });
+};
+
 module.exports = AppError;

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/client/get.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/client/get.js
@@ -6,9 +6,12 @@ const hex = require('buf').to.hex;
 const Joi = require('joi');
 
 const AppError = require('../../error');
+const config = require('../../config');
 const db = require('../../db');
 const logger = require('../../logging')('routes.client.get');
 const validators = require('../../validators');
+
+const DISABLED_CLIENTS = new Set(config.get('disabledClients'));
 
 module.exports = {
   validate: {
@@ -20,6 +23,7 @@ module.exports = {
     schema: {
       id: validators.clientId,
       name: Joi.string().required(),
+      disabled: Joi.boolean().required(),
       trusted: Joi.boolean().required(),
       image_uri: Joi.any(),
       redirect_uri: Joi.string().required().allow('')
@@ -36,6 +40,7 @@ module.exports = {
         return {
           id: hex(client.id),
           name: client.name,
+          disabled: DISABLED_CLIENTS.has(params.client_id),
           trusted: client.trusted,
           image_uri: client.imageUri,
           redirect_uri: client.redirectUri

--- a/packages/fxa-auth-server/fxa-oauth-server/test/api.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/api.js
@@ -3375,7 +3375,7 @@ describe('/v1', function() {
 
       it('should list canGrant=1 clients that have refresh tokens', function () {
         return db.registerClient({
-          name: 'test/api/client-tokens/z-list-can-grant',
+          name: 'test/api/client-tokens/aaa-list-can-grant',
           id: client2Id,
           hashedSecret: encrypt.hash(unique.secret()),
           redirectUri: 'https://example.domain',
@@ -3410,10 +3410,10 @@ describe('/v1', function() {
           .then(function (res) {
             var result = res.result;
             assert.equal(result.length, 2);
-            assert.equal(result[0].id, client1Id.toString('hex'));
-            assert.deepEqual(result[0].scope, ['clients:write', 'profile']);
-            assert.equal(result[1].id, client2Id.toString('hex'));
-            assert.deepEqual(result[1].scope, ['scopeFromRefreshToken']);
+            assert.equal(result[0].id, client2Id.toString('hex'));
+            assert.deepEqual(result[0].scope, ['scopeFromRefreshToken']);
+            assert.equal(result[1].id, client1Id.toString('hex'));
+            assert.deepEqual(result[1].scope, ['clients:write', 'profile']);
             assertSecurityHeaders(res);
           });
       });

--- a/packages/fxa-auth-server/fxa-oauth-server/test/lib/mocks.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/lib/mocks.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const path = require('path');
+const proxyquire = require('proxyquire');
 
 module.exports = {
   require: requireDependencies,
@@ -41,29 +42,12 @@ function requireDependency(dependency, modulePath, basePath) {
     return dependency.ctor;
   }
 
-  var localPath = dependency.path;
-
-  if (localPath[0] === '.') {
-    // attempt to find something like ./patch.js from mysql/index.js
-    localPath = path.relative(
-      basePath,
-      path.resolve(basePath, modulePath, localPath)
-    );
+  if (dependency.path[0] !== '.') {
+    return proxyquire(dependency.path, {});
   }
-
-  try {
-    return require(localPath);
-  } catch (e) {
-    // if above require fails, attempt to find the module as a sibling of `modulePath`
-    // this takes care of cases like: ./token.js being a sibling of the given module
-    localPath = path.relative(
-      basePath,
-      path.resolve(basePath, '..', modulePath, '..', dependency.path)
-    );
-
-    return require(localPath);
-  }
-
+  const moduleUnderTest = require.resolve(modulePath, { paths: [basePath] });
+  const dependencyPath = require.resolve(dependency.path, { paths: [path.dirname(moduleUnderTest)] });
+  return proxyquire(dependencyPath, {});
 }
 
 function mockLog(logger, cb) {

--- a/packages/fxa-auth-server/fxa-oauth-server/test/routes/authorization.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/routes/authorization.js
@@ -6,8 +6,15 @@
 
 const { assert } = require('chai');
 const Joi = require('joi');
-const route = require('../../lib/routes/authorization');
-const validation = route.validate.payload;
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+const mocks = require('../lib/mocks');
+const realConfig = require('../../lib/config');
+
+const routeModulePath = '../../lib/routes/authorization';
+var dependencies = mocks.require([
+  { path: '../config' },
+], routeModulePath, __dirname);
 
 const CLIENT_ID = '98e6508e88680e1b';
 // jscs:disable
@@ -15,106 +22,159 @@ const BASE64URL_STRING = 'TG9yZW0gSXBzdW0gaXMgc2ltcGx5IGR1bW15IHRleHQgb2YgdGhlIH
 // jscs:enable
 const PKCE_CODE_CHALLENGE = 'iyW5ScKr22v_QL-rcW_EGlJrDSOymJvrlXlw4j7JBiQ';
 const PKCE_CODE_CHALLENGE_METHOD = 'S256';
-
-function joiAssertFail(req, param, messagePostfix) {
-  messagePostfix = messagePostfix || 'is required';
-  let fail = null;
-
-  try {
-    Joi.assert(req, validation);
-  } catch (err) {
-    fail = true;
-    assert.ok(err.isJoi);
-    assert.ok(err.name, 'ValidationError');
-    assert.equal(err.details[0].message, `"${param}" ${messagePostfix}`);
-  }
-
-  if (! fail) {
-    throw new Error('Did not throw!');
-  }
-}
+const DISABLED_CLIENT_ID = 'd15ab1edd15ab1ed';
 
 describe('/authorization POST', function () {
-  it('fails with no client_id', () => {
-    joiAssertFail({
-      foo: 1
-    }, 'client_id');
-  });
 
-  it('fails with no assertion', () => {
-    joiAssertFail({
-      client_id: CLIENT_ID
-    }, 'assertion');
-  });
+  describe('input validation', () => {
+    const route = require(routeModulePath);
+    const validation = route.validate.payload;
 
-  it('fails with no state', () => {
-    joiAssertFail({
-      client_id: CLIENT_ID,
-      assertion: BASE64URL_STRING,
-    }, 'state');
-  });
+    function joiAssertFail(req, param, messagePostfix) {
+      messagePostfix = messagePostfix || 'is required';
+      let fail = null;
 
-  it('fails with no state', () => {
-    Joi.assert({
-      client_id: CLIENT_ID,
-      assertion: BASE64URL_STRING,
-      state: 'foo'
-    }, validation);
-  });
+      try {
+        Joi.assert(req, validation);
+      } catch (err) {
+        fail = true;
+        assert.ok(err.isJoi);
+        assert.ok(err.name, 'ValidationError');
+        assert.equal(err.details[0].message, `"${param}" ${messagePostfix}`);
+      }
 
-  describe('PKCE params', function () {
-    it('accepts code_challenge and code_challenge_method', () => {
+      if (! fail) {
+        throw new Error('Did not throw!');
+      }
+    }
+
+    it('fails with no client_id', () => {
+      joiAssertFail({
+        foo: 1
+      }, 'client_id');
+    });
+
+    it('fails with no assertion', () => {
+      joiAssertFail({
+        client_id: CLIENT_ID
+      }, 'assertion');
+    });
+
+    it('fails with no state', () => {
+      joiAssertFail({
+        client_id: CLIENT_ID,
+        assertion: BASE64URL_STRING,
+      }, 'state');
+    });
+
+    it('fails with no state', () => {
       Joi.assert({
         client_id: CLIENT_ID,
         assertion: BASE64URL_STRING,
-        state: 'foo',
-        code_challenge: PKCE_CODE_CHALLENGE,
-        code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
+        state: 'foo'
       }, validation);
     });
 
-    it('accepts code_challenge and code_challenge_method', () => {
-      joiAssertFail({
-        client_id: CLIENT_ID,
-        assertion: BASE64URL_STRING,
-        state: 'foo',
-        code_challenge: PKCE_CODE_CHALLENGE,
-        code_challenge_method: 'bad_method',
-      }, 'code_challenge_method', 'must be one of [S256]');
+    describe('PKCE params', function () {
+      it('accepts code_challenge and code_challenge_method', () => {
+        Joi.assert({
+          client_id: CLIENT_ID,
+          assertion: BASE64URL_STRING,
+          state: 'foo',
+          code_challenge: PKCE_CODE_CHALLENGE,
+          code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
+        }, validation);
+      });
+
+      it('accepts code_challenge and code_challenge_method', () => {
+        joiAssertFail({
+          client_id: CLIENT_ID,
+          assertion: BASE64URL_STRING,
+          state: 'foo',
+          code_challenge: PKCE_CODE_CHALLENGE,
+          code_challenge_method: 'bad_method',
+        }, 'code_challenge_method', 'must be one of [S256]');
+      });
+
+      it('validates code_challenge', () => {
+        joiAssertFail({
+          client_id: CLIENT_ID,
+          assertion: BASE64URL_STRING,
+          state: 'foo',
+          code_challenge: 'foo',
+          code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
+        }, 'code_challenge', 'length must be 43 characters long');
+      });
+
+      it('works with response_type code (non-default)', () => {
+        Joi.assert({
+          client_id: CLIENT_ID,
+          assertion: BASE64URL_STRING,
+          state: 'foo',
+          code_challenge: PKCE_CODE_CHALLENGE,
+          code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
+          response_type: 'code'
+        }, validation);
+      });
+
+      it('fails with response_type token', () => {
+        joiAssertFail({
+          client_id: CLIENT_ID,
+          assertion: BASE64URL_STRING,
+          state: 'foo',
+          code_challenge: PKCE_CODE_CHALLENGE,
+          code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
+          response_type: 'token'
+        }, 'code_challenge', 'is not allowed');
+      });
+
+    });
+  });
+
+
+  describe('config handling', () => {
+    let sandbox, route, request;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(dependencies['../config'], 'get').callsFake((key) => {
+        if (key === 'disabledClients') {
+          return [DISABLED_CLIENT_ID];
+        }
+        return realConfig.get(key);
+      });
+      route = proxyquire(routeModulePath, dependencies);
+      request = {
+        headers: {},
+        payload: {
+          client_id: CLIENT_ID,
+        },
+      };
     });
 
-    it('validates code_challenge', () => {
-      joiAssertFail({
-        client_id: CLIENT_ID,
-        assertion: BASE64URL_STRING,
-        state: 'foo',
-        code_challenge: 'foo',
-        code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
-      }, 'code_challenge', 'length must be 43 characters long');
+    afterEach(() => {
+      sandbox.restore();
     });
 
-    it('works with response_type code (non-default)', () => {
-      Joi.assert({
-        client_id: CLIENT_ID,
-        assertion: BASE64URL_STRING,
-        state: 'foo',
-        code_challenge: PKCE_CODE_CHALLENGE,
-        code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
-        response_type: 'code'
-      }, validation);
+    it('allows clients that have not been disabled via config', async () => {
+      try {
+        await route.handler(request);
+        assert.fail('should have errored');
+      } catch (err) {
+        assert.equal(err.errno, 104); // Invalid assertion.
+      }
     });
 
-    it('fails with response_type token', () => {
-      joiAssertFail({
-        client_id: CLIENT_ID,
-        assertion: BASE64URL_STRING,
-        state: 'foo',
-        code_challenge: PKCE_CODE_CHALLENGE,
-        code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
-        response_type: 'token'
-      }, 'code_challenge', 'is not allowed');
+    it('returns an error for clients that have been disabled via config', async () => {
+      request.payload.client_id = DISABLED_CLIENT_ID;
+      try {
+        await route.handler(request);
+        assert.fail('should have errored');
+      } catch (err) {
+        assert.equal(err.output.statusCode, 400);
+        assert.equal(err.errno, 122); // Disabled client
+      }
     });
-
   });
 
 });

--- a/packages/fxa-auth-server/fxa-oauth-server/test/routes/client-get.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/routes/client-get.js
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { assert } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+const mocks = require('../lib/mocks');
+const realConfig = require('../../lib/config');
+
+const routeModulePath = '../../lib/routes/client/get';
+var dependencies = mocks.require([
+  { path: '../../config' },
+], routeModulePath, __dirname);
+
+const CLIENT_ID = '98e6508e88680e1b';
+
+describe('/client/:id', function () {
+
+  describe('config handling', () => {
+    let sandbox, route, request;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      request = {
+        params: {
+          client_id: CLIENT_ID
+        },
+      };
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('clients that have not been disabled via config are not reported as disabled', async () => {
+      route = proxyquire(routeModulePath, dependencies);
+      const client = await route.handler(request);
+      assert.equal(client.id, CLIENT_ID);
+      assert.ok(! client.disabled);
+    });
+
+    it('clients that have been disabled via config are reported as disabled', async () => {
+      sandbox.stub(dependencies['../../config'], 'get').callsFake((key) => {
+        if (key === 'disabledClients') {
+          return [CLIENT_ID];
+        }
+        return realConfig.get(key);
+      });
+      route = proxyquire(routeModulePath, dependencies);
+      const client = await route.handler(request);
+      assert.equal(client.id, CLIENT_ID);
+      assert.ok(client.disabled);
+    });
+  });
+});

--- a/packages/fxa-auth-server/fxa-oauth-server/test/routes/token.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/routes/token.js
@@ -4,12 +4,21 @@
 
 const { assert } = require('chai');
 const Joi = require('joi');
-const route = require('../../lib/routes/token');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+const mocks = require('../lib/mocks');
+const realConfig = require('../../lib/config');
+
+const routeModulePath = '../../lib/routes/token';
+var dependencies = mocks.require([
+  { path: '../config' },
+], routeModulePath, __dirname);
 
 const CLIENT_SECRET = 'b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8';
 const CLIENT_ID = '98e6508e88680e1b';
 const CODE = 'df6dcfe7bf6b54a65db5742cbcdce5c0a84a5da81a0bb6bdf5fc793eef041fc6';
 const PKCE_CODE_VERIFIER = 'au3dqDz2dOB0_vSikXCUf4S8Gc-37dL-F7sGxtxpR3R';
+const DISABLED_CLIENT_ID = 'd15ab1edd15ab1ed';
 
 function joiRequired(err, param) {
   assert.ok(err.isJoi);
@@ -23,79 +32,35 @@ function joiNotAllowed(err, param) {
   assert.equal(err.details[0].message, `"${param}" is not allowed`);
 }
 
+
 describe('/token POST', function () {
-  // route validation function
-  function v(req, ctx, cb) {
-    if (typeof ctx === 'function' && ! cb) {
-      cb = ctx;
-      ctx = undefined;
+
+  describe('input validation', () => {
+    const route = require(routeModulePath);
+
+    // route validation function
+    function v(req, ctx, cb) {
+      if (typeof ctx === 'function' && ! cb) {
+        cb = ctx;
+        ctx = undefined;
+      }
+      Joi.validate(req, route.validate.payload, { context: ctx }, cb);
     }
-    Joi.validate(req, route.validate.payload, {context: ctx}, cb);
-  }
 
-  it('fails with no client_id', (done) => {
-    v({
-      client_secret: CLIENT_SECRET,
-      code: CODE
-    }, (err) => {
-      joiRequired(err, 'client_id');
-      done();
+    it('fails with no client_id', (done) => {
+      v({
+        client_secret: CLIENT_SECRET,
+        code: CODE
+      }, (err) => {
+        joiRequired(err, 'client_id');
+        done();
+      });
     });
-  });
 
-  it('valid client_secret scheme', (done) => {
-    v({
-      client_id: CLIENT_ID,
-      client_secret: CLIENT_SECRET,
-      code: CODE
-    }, (err) => {
-      assert.equal(err, null);
-      done();
-    });
-  });
-
-  it('requires client_secret', (done) => {
-    v({
-      client_id: CLIENT_ID,
-      code: CODE
-    }, (err) => {
-      joiRequired(err, 'client_secret');
-      done();
-    });
-  });
-
-  it('forbids client_id when authz header provided', (done) => {
-    v({
-      client_id: CLIENT_ID
-    }, {
-      headers: {
-        authorization: 'Basic ABCDEF'
-      }
-    }, (err) => {
-      joiNotAllowed(err, 'client_id');
-      done();
-    });
-  });
-
-  it('forbids client_secret when authz header provided', (done) => {
-    v({
-      client_secret: CLIENT_SECRET,
-      code: CODE // If we don't send `code`, then the missing `code` will fail validation first.
-    }, {
-      headers: {
-        authorization: 'Basic ABCDEF'
-      }
-    }, (err) => {
-      joiNotAllowed(err, 'client_secret');
-      done();
-    });
-  });
-
-  describe('pkce', () => {
-    it('accepts pkce code_verifier instead of client_secret', (done) => {
+    it('valid client_secret scheme', (done) => {
       v({
         client_id: CLIENT_ID,
-        code_verifier: PKCE_CODE_VERIFIER,
+        client_secret: CLIENT_SECRET,
         code: CODE
       }, (err) => {
         assert.equal(err, null);
@@ -103,47 +68,166 @@ describe('/token POST', function () {
       });
     });
 
-    it('rejects pkce code_verifier that is too small', (done) => {
-      const bad_code_verifier = PKCE_CODE_VERIFIER.substring(0, 32);
+    it('requires client_secret', (done) => {
       v({
         client_id: CLIENT_ID,
-        code_verifier: bad_code_verifier,
         code: CODE
       }, (err) => {
-        assert.ok(err.isJoi);
-        assert.ok(err.name, 'ValidationError');
-        assert.equal(err.details[0].message, `"code_verifier" length must be at least 43 characters long`); // eslint-disable-line quotes
+        joiRequired(err, 'client_secret');
         done();
       });
     });
 
-    it('rejects pkce code_verifier that is too big', (done) => {
-      const bad_code_verifier = PKCE_CODE_VERIFIER + PKCE_CODE_VERIFIER + PKCE_CODE_VERIFIER + PKCE_CODE_VERIFIER;
+    it('forbids client_id when authz header provided', (done) => {
       v({
-        client_id: CLIENT_ID,
-        code_verifier: bad_code_verifier,
-        code: CODE
+        client_id: CLIENT_ID
+      }, {
+        headers: {
+          authorization: 'Basic ABCDEF'
+        }
       }, (err) => {
-        assert.ok(err.isJoi);
-        assert.ok(err.name, 'ValidationError');
-        assert.equal(err.details[0].message, `"code_verifier" length must be less than or equal to 128 characters long`);  // eslint-disable-line quotes
+        joiNotAllowed(err, 'client_id');
         done();
       });
     });
 
-    it('rejects pkce code_verifier that contains invalid characters', (done) => {
-      const bad_code_verifier = PKCE_CODE_VERIFIER + ' :.';
+    it('forbids client_secret when authz header provided', (done) => {
       v({
-        client_id: CLIENT_ID,
-        code_verifier: bad_code_verifier,
-        code: CODE
+        client_secret: CLIENT_SECRET,
+        code: CODE // If we don't send `code`, then the missing `code` will fail validation first.
+      }, {
+        headers: {
+          authorization: 'Basic ABCDEF'
+        }
       }, (err) => {
-        assert.ok(err.isJoi);
-        assert.ok(err.name, 'ValidationError');
-        assert.equal(err.details[0].message, `"code_verifier" with value "${bad_code_verifier}" fails to match the required pattern: /^[A-Za-z0-9-_]+$/`);
+        joiNotAllowed(err, 'client_secret');
         done();
+      });
+    });
+
+    describe('pkce', () => {
+      it('accepts pkce code_verifier instead of client_secret', (done) => {
+        v({
+          client_id: CLIENT_ID,
+          code_verifier: PKCE_CODE_VERIFIER,
+          code: CODE
+        }, (err) => {
+          assert.equal(err, null);
+          done();
+        });
+      });
+
+      it('rejects pkce code_verifier that is too small', (done) => {
+        const bad_code_verifier = PKCE_CODE_VERIFIER.substring(0, 32);
+        v({
+          client_id: CLIENT_ID,
+          code_verifier: bad_code_verifier,
+          code: CODE
+        }, (err) => {
+          assert.ok(err.isJoi);
+          assert.ok(err.name, 'ValidationError');
+          assert.equal(err.details[0].message, `"code_verifier" length must be at least 43 characters long`); // eslint-disable-line quotes
+          done();
+        });
+      });
+
+      it('rejects pkce code_verifier that is too big', (done) => {
+        const bad_code_verifier = PKCE_CODE_VERIFIER + PKCE_CODE_VERIFIER + PKCE_CODE_VERIFIER + PKCE_CODE_VERIFIER;
+        v({
+          client_id: CLIENT_ID,
+          code_verifier: bad_code_verifier,
+          code: CODE
+        }, (err) => {
+          assert.ok(err.isJoi);
+          assert.ok(err.name, 'ValidationError');
+          assert.equal(err.details[0].message, `"code_verifier" length must be less than or equal to 128 characters long`);  // eslint-disable-line quotes
+          done();
+        });
+      });
+
+      it('rejects pkce code_verifier that contains invalid characters', (done) => {
+        const bad_code_verifier = PKCE_CODE_VERIFIER + ' :.';
+        v({
+          client_id: CLIENT_ID,
+          code_verifier: bad_code_verifier,
+          code: CODE
+        }, (err) => {
+          assert.ok(err.isJoi);
+          assert.ok(err.name, 'ValidationError');
+          assert.equal(err.details[0].message, `"code_verifier" with value "${bad_code_verifier}" fails to match the required pattern: /^[A-Za-z0-9-_]+$/`);
+          done();
+        });
       });
     });
   });
 
+  describe('config handling', () => {
+    let sandbox, route, request;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(dependencies['../config'], 'get').callsFake((key) => {
+        if (key === 'disabledClients') {
+          return [DISABLED_CLIENT_ID];
+        }
+        return realConfig.get(key);
+      });
+      route = proxyquire(routeModulePath, dependencies);
+      request = {
+        headers: {},
+        payload: {
+          client_id: CLIENT_ID,
+          client_secret: CLIENT_SECRET,
+        },
+      };
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('allows clients that have not been disabled via config', async () => {
+      try {
+        await route.handler(request);
+        assert.fail('should have errored');
+      } catch (err) {
+        assert.equal(err.errno, 102); // Incorrect client secret.
+      }
+    });
+
+    it('allows code grants for clients that have been disabled via config', async () => {
+      request.payload.client_id = DISABLED_CLIENT_ID;
+      request.payload.grant_type = 'authorization_code';
+      try {
+        await route.handler(request);
+        assert.fail('should have errored');
+      } catch (err) {
+        assert.equal(err.errno, 101); // Unknown client.
+      }
+    });
+
+    it('returns an error on refresh_token grants for clients that have been disabled via config', async () => {
+      request.payload.client_id = DISABLED_CLIENT_ID;
+      request.payload.grant_type = 'refresh_token';
+      try {
+        await route.handler(request);
+        assert.fail('should have errored');
+      } catch (err) {
+        assert.equal(err.output.statusCode, 400);
+        assert.equal(err.errno, 122); // Disabled client.
+      }
+    });
+
+    it('returns an error on fxa-credentials grants for clients that have been disabled via config', async () => {
+      request.payload.client_id = DISABLED_CLIENT_ID;
+      request.payload.grant_type = 'fxa-credentials';
+      try {
+        await route.handler(request);
+        assert.fail('should have errored');
+      } catch (err) {
+        assert.equal(err.output.statusCode, 400);
+        assert.equal(err.errno, 122); // Disabled client.
+      }
+    });
+  });
 });

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -85,13 +85,13 @@ const ERRNO = {
   MISMATCH_AUTHORIZATION_CODE: 173,
   EXPIRED_AUTHORIZATION_CODE: 174,
   INVALID_PKCE_CHALLENGE: 175,
-
   UNKNOWN_SUBSCRIPTION_CUSTOMER: 176,
   UNKNOWN_SUBSCRIPTION: 177,
   UNKNOWN_SUBSCRIPTION_PLAN: 178,
   REJECTED_SUBSCRIPTION_PAYMENT_TOKEN: 179,
   SUBSCRIPTION_ALREADY_CANCELLED: 180,
   REJECTED_CUSTOMER_UPDATE: 181,
+  DISABLED_CLIENT_ID: 182,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -1111,6 +1111,17 @@ AppError.insufficientACRValues = (foundValue) => {
   }, {
     foundValue
   });
+};
+
+AppError.disabledClientId = (clientId) => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.DISABLED_CLIENT_ID,
+    message: 'This client has been temporarily disabled'
+  }, {
+      clientId
+    });
 };
 
 AppError.backendServiceFailure = (service, operation) => {

--- a/packages/fxa-auth-server/lib/oauthdb/utils.js
+++ b/packages/fxa-auth-server/lib/oauthdb/utils.js
@@ -58,6 +58,10 @@ module.exports = {
       return error.staleAuthAt(err.authAt);
     case 120:
       return error.insufficientACRValues(err.foundValue);
+    case 122:
+      return error.disabledClientId(err.clientId);
+    case 201:
+      return error.serviceUnavailable(err.retryAfter);
     default:
       log.warn('oauthdb.mapOAuthError', {
         err: err,

--- a/packages/fxa-auth-server/test/local/oauthdb.js
+++ b/packages/fxa-auth-server/test/local/oauthdb.js
@@ -235,6 +235,28 @@ describe('oauthdb', () => {
       }
     });
 
+    it('returns correct error for disabled client_id', async () => {
+      mockOAuthServer.post('/v1/authorization', body => true)
+        .reply(400, {
+          code: 400,
+          errno: 122,
+          message: 'This client has been temporarily disabled',
+          clientId: MOCK_CLIENT_ID
+        });
+      oauthdb = oauthdbModule(mockLog(), mockConfig);
+      try {
+        await oauthdb.createAuthorizationCode(MOCK_CREDENTIALS, {
+          client_id: MOCK_CLIENT_ID,
+          scope: MOCK_SCOPES,
+          state: 'xyz',
+        });
+        assert.fail('should have thrown');
+      } catch (err) {
+        assert.equal(err.errno, error.ERRNO.DISABLED_CLIENT_ID);
+        assert.equal(err.output.payload.clientId, MOCK_CLIENT_ID);
+      }
+    });
+
     it('validates its input parameters', async () => {
       oauthdb = oauthdbModule(mockLog(), mockConfig);
       try {

--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -249,6 +249,10 @@ var ERRORS = {
     errno: 179,
     message: t('Invalid payment token for subscription.')
   },
+  DISABLED_CLIENT_ID: {
+    errno: 182,
+    message: t('Client has been temporarily disabled.')
+  },
   // Secondary Email errors end
   SERVER_BUSY: {
     errno: 201,

--- a/packages/fxa-content-server/app/scripts/lib/oauth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/oauth-errors.js
@@ -97,6 +97,10 @@ var ERRORS = {
     errno: 121,
     message: 'Invalid grant_type'
   },
+  DISABLED_CLIENT_ID: {
+    errno: 122,
+    message: t('Client has been temporarily disabled.')
+  },
   SERVICE_UNAVAILABLE: {
     errno: 998,
     message: t('System unavailable, try again soon')


### PR DESCRIPTION
If we discover something busted with the Account or Sync integration in Fenix, we may find ourselves wanting to forcibly disable it - particularly if some unexpected client misbehaviour means it is destabilizing our service for other clients.

Here's a blunt instrument which would allow us to do so.  By adding the Fenix OAuth clent_id to a server-side config option, we could prevent new users from signing in to Fenix and prevent already-signed-in users from renewing their access tokens. That's sad for those users, but it may be better than a service outage for everyone.

By returning a 503, clients *should* treat this as a transient server-side error, so clients that already have a refresh_token will stay signed in and will be able to sync again once we re-enable the client.

@shane-tomlinson @vladikoff @jbuck what do you think, worth having something like this in our pocket just in case?