### PR TITLE
Add a route for listing all attached clients.

### DIFF
--- a/packages/fxa-auth-db-mysql/lib/db/mem.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mem.js
@@ -224,6 +224,7 @@ module.exports = function (log, error) {
           var device = {
             uid: uid,
             id: deviceId,
+            createdAt: Date.now(),
             availableCommands: {}
           }
           deviceInfo.callbackIsExpired = false // mimic the db behavior assigning a default false value

--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -33,8 +33,10 @@ see [`mozilla/fxa-js-client`](https://github.com/mozilla/fxa-js-client).
     * [GET /account/device/commands (:lock: sessionToken, refreshToken)](#get-accountdevicecommands)
     * [POST /account/devices/invoke_command (:lock: sessionToken, refreshToken)](#post-accountdevicesinvoke_command)
     * [POST /account/devices/notify (:lock: sessionToken, refreshToken)](#post-accountdevicesnotify)
+    * [GET /account/attached_clients (:lock: sessionToken)](#get-accountattached_clients)
+    * [POST /account/attached_client/destroy (:lock: sessionToken)](#post-accountattached_clientdestroy)
     * [GET /account/devices (:lock: sessionToken, refreshToken)](#get-accountdevices)
-    * [GET /account/sessions (:lock: sessionToken)](#get-accountsessions)
+    * **DEPRECATED** [GET /account/sessions (:lock: sessionToken)](#get-accountsessions)
     * [POST /account/device/destroy (:lock: sessionToken, refreshToken)](#post-accountdevicedestroy)
   * [Emails](#emails)
     * [GET /recovery_email/status (:lock: sessionToken)](#get-recovery_emailstatus)
@@ -1357,6 +1359,66 @@ by the following errors
   Feature not enabled
 
 
+
+#### GET /account/attached_clients
+
+:lock: HAWK-authenticated with session token
+
+Returns an array listing all the clients connected to the authenticated user's account,
+including devices, OAuth clients, and web sessions.
+
+This endpoint is primarily designed to power the "devices and apps" view
+on the user's account settings page. Depending on the type of client, it will have
+at least one and possibly several of the following properties:
+
+* `clientId`: The OAuth client_id of the connected application.
+* `sessionTokenId`: The id of the `sessionToken` held by that client, if any.
+* `refreshTokenId`: The id of the OAuth `refreshToken` held by that client, if any.
+* `deviceId`: The id of the client's device record, if it has registered one.
+
+These identifiers can be passed to [/account/attached_client/destroy](#post-accountattached_clientdestroy)
+in order to disconnect the client.
+
+##### Response body
+
+* `clientId`: *string, regex(HEX_STRING), optional*
+* `sessionTokenId`: *string, regex(HEX_STRING), optional*
+* `refreshTokenId`: *string, regex(HEX_STRING), optional*
+* `deviceId`: *string, regex(HEX_STRING), optional*
+* `deviceType`: *DEVICES_SCHEMA.type.allow(null).required*
+* `isCurrentSession`: *boolean, required*
+* `name`: *DEVICES_SCHEMA.nameResponse.allow('').allow(null).required*
+* `createdTime`: *number, min(0), required, allow(null)*
+* `createdTimeFormatted`: *string, optional, allow('')*
+* `lastAccessTime`: *number, min(0), required, allow(null)*
+* `lastAccessTimeFormatted`: *string, optional, allow('')*
+* `approximateLastAccessTime`: *number, min(earliestSaneTimestamp), optional*
+* `approximateLastAccessTimeFormatted`: *string, optional, allow('')*
+* `scope`: *array(string), required, allow(null)*
+* `location`: *DEVICES_SCHEMA.location, optional*
+  Object containing the client's last-known geolocation info (state and country) if available.
+* `userAgent`: *string, max(255), required, allow('')*
+* `os`: *string, max(255), allow(''), allow(null)*
+
+
+#### POST /account/attached_client/destroy
+
+:lock: HAWK-authenticated with session token
+
+Destroy all tokens held by a connected client, disconnecting it from the user's account.
+
+This endpoint is designed to be used in conjunction with [/account/attached_clients](#get-accountattached_clients).
+It accepts as the request body an object in the same format as returned by that endpoing,
+and will disconnect that client from the user's account.
+
+##### Request body
+
+* `clientId`: *string, regex(HEX_STRING), optional*
+* `sessionTokenId`: *string, regex(HEX_STRING), optional*
+* `refreshTokenId`: *string, regex(HEX_STRING), optional*
+* `deviceId`: *string, regex(HEX_STRING), optional*
+
+
 #### GET /account/devices
 
 :lock: HAWK-authenticated with session token or authenticated with OAuth refresh token
@@ -1454,6 +1516,8 @@ for the authenticated user.
 
 
 #### GET /account/sessions
+
+**DEPRECATED**: Please use [/account/attached_clients](#get-accountattached_clients) instead.
 
 :lock: HAWK-authenticated with session token
 <!--begin-route-get-accountsessions-->

--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -761,7 +761,7 @@ module.exports = (
                       return true;
                     }
 
-                    if (sessionTokenId && device.sessionToken === sessionTokenId ||
+                    if (sessionTokenId && device.sessionTokenId === sessionTokenId ||
                       deviceInfo.refreshTokenId && device.refreshTokenId === deviceInfo.refreshTokenId) {
                       conflictingDeviceId = device.id;
                     }
@@ -815,7 +815,7 @@ module.exports = (
             .then(devices => {
               let conflictingDeviceId;
               devices.some(device => {
-                if (device.sessionToken === sessionTokenId) {
+                if (device.sessionTokenId === sessionTokenId) {
                   conflictingDeviceId = device.id;
                   return true;
                 }
@@ -1469,12 +1469,13 @@ module.exports = (
     const mergedInfo = Object.assign({}, device, token);
     return {
       id: mergedInfo.id,
-      sessionToken: mergedInfo.sessionTokenId,
+      sessionTokenId: mergedInfo.sessionTokenId,
       refreshTokenId: mergedInfo.refreshTokenId,
       lastAccessTime: lastAccessTimeEnabled ? mergedInfo.lastAccessTime : null,
       location: mergedInfo.location,
       name: mergedInfo.name,
       type: mergedInfo.type,
+      createdAt: mergedInfo.createdAt,
       pushCallback: mergedInfo.callbackURL,
       pushPublicKey: mergedInfo.callbackPublicKey,
       pushAuthKey: mergedInfo.callbackAuthKey,

--- a/packages/fxa-auth-server/lib/oauthdb/index.js
+++ b/packages/fxa-auth-server/lib/oauthdb/index.js
@@ -33,6 +33,8 @@ module.exports = (log, config) => {
     grantTokensFromRefreshToken: require('./grant-tokens-from-refresh-token')(config),
     grantTokensFromCredentials: require('./grant-tokens-from-credentials')(config),
     checkAccessToken: require('./check-access-token')(config),
+    listAuthorizedClients: require('./list-authorized-clients')(config),
+    revokeAuthorizedClient: require('./revoke-authorized-client')(config),
   });
 
   const api = new OAuthAPI(config.oauth.url, config.oauth.poolee);
@@ -122,22 +124,26 @@ module.exports = (log, config) => {
       } catch (err) {
         throw mapOAuthError(log, err);
       }
-    }
-
-    /* As we work through the process of merging oauth-server
-     * into auth-server, future methods we might want to include
-     * here will be things like the following:
-
-    async getClientInstances(account) {
     },
 
-    async revokeAccessToken(token) {
-    }
+    async listAuthorizedClients(sessionToken) {
+      const oauthParams = {
+        assertion: await makeAssertionJWT(config, sessionToken)
+      };
+      try {
+        return await api.listAuthorizedClients(oauthParams);
+      } catch (err) {
+        throw mapOAuthError(log, err);
+      }
+    },
 
-     * But in the interests of landing small manageable changes,
-     * let's only add those as we need them.
-     *
-     */
-
+    async revokeAuthorizedClient(sessionToken, oauthParams) {
+      oauthParams.assertion = await makeAssertionJWT(config, sessionToken);
+      try {
+        return await api.revokeAuthorizedClient(oauthParams);
+      } catch (err) {
+        throw mapOAuthError(log, err);
+      }
+    },
   };
 };

--- a/packages/fxa-auth-server/lib/oauthdb/list-authorized-clients.js
+++ b/packages/fxa-auth-server/lib/oauthdb/list-authorized-clients.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const Joi = require('joi');
+const validators = require('../routes/validators');
+
+module.exports = (config) => {
+  return {
+    path: '/v1/authorized-clients',
+    method: 'POST',
+    validate: {
+      payload: {
+        assertion: validators.assertion.required(),
+      },
+      response: Joi.array().items(Joi.object({
+        client_id: validators.clientId,
+        refresh_token_id: validators.refreshToken.optional(),
+        client_name: Joi.string().max(255).regex(validators.DISPLAY_SAFE_UNICODE).required(),
+        created_time: Joi.number().min(0).required(),
+        last_access_time: Joi.number().min(0).required().allow(null),
+        scope: Joi.array().items(validators.scope).required(),
+      }))
+    }
+  };
+};

--- a/packages/fxa-auth-server/lib/oauthdb/revoke-authorized-client.js
+++ b/packages/fxa-auth-server/lib/oauthdb/revoke-authorized-client.js
@@ -9,18 +9,15 @@ const validators = require('../routes/validators');
 
 module.exports = (config) => {
   return {
-    path: '/v1/verify',
+    path: '/v1/authorized-clients/destroy',
     method: 'POST',
     validate: {
       payload: {
-        token: validators.accessToken.required(),
+        assertion: validators.assertion.required(),
+        client_id: validators.clientId.required(),
+        refresh_token_id: validators.refreshToken.optional().allow(null),
       },
-      response: {
-        user: Joi.string().required(),
-        client_id: Joi.string().required(),
-        scope: Joi.array().items(validators.scope),
-        profile_changed_at: Joi.number().min(0)
-      }
+      response: Joi.object({}),
     }
   };
 };

--- a/packages/fxa-auth-server/lib/routes/attached-clients.js
+++ b/packages/fxa-auth-server/lib/routes/attached-clients.js
@@ -1,0 +1,253 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const isA = require('joi');
+const validators = require('./validators');
+const error = require('../error');
+
+const HEX_STRING = validators.HEX_STRING;
+const DEVICES_SCHEMA = require('../devices').schema;
+
+module.exports = (log, db, oauthdb, devices, clientUtils) => {
+
+  return [
+    {
+      method: 'GET',
+      path: '/account/attached_clients',
+      options: {
+        auth: {
+          strategy : 'sessionToken'
+        },
+        response: {
+          schema: isA.array().items(isA.object({
+            clientId: isA.string().regex(HEX_STRING).allow(null).required(),
+            deviceId: DEVICES_SCHEMA.id.allow(null).required(),
+            sessionTokenId: isA.string().regex(HEX_STRING).allow(null).required(),
+            refreshTokenId: isA.string().regex(HEX_STRING).allow(null).required(),
+            isCurrentSession: isA.boolean().required(),
+            deviceType: DEVICES_SCHEMA.type.allow(null).required(),
+            name: DEVICES_SCHEMA.nameResponse.allow('').allow(null).required(),
+            createdTime: isA.number().min(0).required().allow(null),
+            createdTimeFormatted: isA.string().optional().allow(''),
+            lastAccessTime: isA.number().min(0).required().allow(null),
+            lastAccessTimeFormatted: isA.string().optional().allow(''),
+            approximateLastAccessTime: isA.number().min(0).optional(),
+            approximateLastAccessTimeFormatted: isA.string().optional().allow(''),
+            scope: isA.array().items(validators.scope).required().allow(null),
+            location: DEVICES_SCHEMA.location,
+            userAgent: isA.string().max(255).required().allow(''),
+            os: isA.string().max(255).allow('').allow(null),
+          }))
+        }
+      },
+      handler: async function (request) {
+        log.begin('Account.attachedClients', request);
+
+        const uid = request.auth.credentials.uid;
+
+        const attachedClients = [];
+
+        const defaultFields = {
+          clientId: null,
+          deviceId: null,
+          sessionTokenId: null,
+          refreshTokenId: null,
+          isCurrentSession: false,
+          deviceType: null,
+          name: null,
+          createdTime: Infinity,
+          lastAccessTime: 0,
+          scope: null,
+          location: null,
+          userAgent: '',
+          os: null,
+        };
+
+        // To generate the full list of attached clients, we have to merge three lists:
+        //  * The auth-server's list of active session tokens
+        //  * The auth-server's list of active device records
+        //  * The oauth-server's list of authorized clients
+        // Fetch them in parallel.
+        // XXX TODO: we could obtain `sessions` and `devices` in a single query to the DB,
+        // but would need to add a new db-server endpoint because each set can contain items
+        // that the other does not.
+        const devicesP = request.app.devices;
+        const oauthClientsP = oauthdb.listAuthorizedClients(request.auth.credentials);
+        const sessionsP = db.sessions(uid);
+
+        // Let's start with the devices, since each device is annotated with
+        // the appropriate `sessionTokenId` and/or `refreshTokenId` to merge
+        // with the other lists.
+        const clientsBySessionTokenId = new Map();
+        const clientsByRefreshTokenId = new Map();
+        for (const device of await devicesP) {
+          const client = {
+            ...defaultFields,
+            sessionTokenId: device.sessionTokenId || null,
+            refreshTokenId: device.refreshTokenId || null,
+            deviceId: device.id,
+            deviceType: device.type,
+            name: device.name,
+            createdTime: device.createdAt,
+            lastAccessTime: device.createdAt,
+          };
+          attachedClients.push(client);
+          if (device.sessionTokenId) {
+            clientsBySessionTokenId.set(device.sessionTokenId, client);
+          }
+          if (device.refreshTokenId) {
+            clientsByRefreshTokenId.set(device.refreshTokenId, client);
+          }
+        }
+
+        // Merge with OAuth clients, which may or may not be linked to a device record.
+        for (const oauthClient of await oauthClientsP) {
+          let client = clientsByRefreshTokenId.get(oauthClient.refresh_token_id);
+          if (! client) {
+            client = {
+              ...defaultFields,
+              refreshTokenId: oauthClient.refresh_token_id || null,
+              createdTime: oauthClient.created_time,
+              lastAccessTime: oauthClient.last_access_time,
+            };
+            attachedClients.push(client);
+          }
+          client.clientId = oauthClient.client_id;
+          client.scope = oauthClient.scope;
+          client.createdTime = Math.min(client.createdTime, oauthClient.created_time);
+          client.lastAccessTime = Math.max(client.lastAccessTime, oauthClient.last_access_time);
+          // We fill in a default device name from the OAuth client name,
+          // but indidivual clients can override this in their device record registration.
+          if (! client.name) {
+            client.name = oauthClient.client_name;
+          }
+          // For now we assume that all oauth clients that register a device record are mobile apps.
+          // Ref https://github.com/mozilla/fxa/issues/449
+          if (client.deviceId && ! client.deviceType) {
+            client.deviceType = 'mobile';
+          }
+        }
+
+        // Merge with sessions, which may or may not be linked to a device record.
+        for (const session of await sessionsP) {
+          let client = clientsBySessionTokenId.get(session.id);
+          if (! client) {
+            client = {
+              ...defaultFields,
+              sessionTokenId: session.id,
+              createdTime: session.createdAt,
+            };
+            attachedClients.push(client);
+          }
+          client.createdTime = Math.min(client.createdTime, session.createdAt);
+          client.lastAccessTime = Math.max(client.lastAccessTime, session.lastAccessTime);
+          if (client.sessionTokenId === request.auth.credentials.id) {
+            client.isCurrentSession = true;
+          }
+          // Any client holding a sessionToken can grant themselves any scope.
+          client.scope = null;
+          // Location, OS and UA are currently only available on sessionTokens, so we can
+          // copy across without worrying about merging with data from the device record.
+          client.location = session.location ? { ...session.location } : null;
+          client.os = session.uaOS || null;
+          if (! session.uaBrowser) {
+            client.userAgent = '';
+          } else if (! session.uaBrowserVersion) {
+            client.userAgent = session.uaBrowser;
+          } else {
+            const { uaBrowser: browser, uaBrowserVersion: version } = session;
+            client.userAgent = `${browser} ${version.split('.')[0]}`;
+          }
+          if (! client.name) {
+            client.name = devices.synthesizeName(session);
+          }
+        }
+
+        // Now we can do some final tweaks of each item for display.
+        for (const client of attachedClients) {
+          clientUtils.formatTimestamps(client, request);
+          clientUtils.formatLocation(client, request);
+          if (client.deviceId && ! client.deviceType) {
+             client.deviceType = 'desktop';
+          }
+        }
+
+        return attachedClients;
+      }
+    },
+    {
+      method: 'POST',
+      path: '/account/attached_client/destroy',
+      options: {
+        auth: {
+          strategy: 'sessionToken'
+        },
+        validate: {
+          payload: isA.object({
+            clientId: validators.clientId.allow(null).optional(),
+            sessionTokenId: isA.string().regex(HEX_STRING).allow(null).optional(),
+            refreshTokenId: validators.refreshToken.allow(null).optional(),
+            deviceId: DEVICES_SCHEMA.id.allow(null).optional(),
+          })
+          .or('clientId', 'sessionTokenId', 'refreshTokenId', 'deviceId')
+          .with('refreshTokenId', ['clientId'])
+        },
+        response: {
+          schema: {}
+        }
+      },
+      handler: async function (request) {
+        log.begin('Account.attachedClientDestroy', request);
+
+        const credentials = request.auth.credentials;
+        const payload = request.payload;
+
+        if (payload.deviceId) {
+          // If we got a `deviceId`, then deleting that should also delete `sessionTokenId` and `refreshTokenId`,
+          // assuming that they match the ones that were actually on the device record.
+          const destroyedDevice = await devices.destroy(request, payload.deviceId);
+          if (payload.sessionTokenId && destroyedDevice.sessionTokenId !== payload.sessionTokenId) {
+            throw error.invalidRequestParameter('sessionTokenId did not match device record');
+          }
+          if (payload.refreshTokenId && destroyedDevice.refreshTokenId !== payload.refreshTokenId) {
+            throw error.invalidRequestParameter('refreshTokenId did not match device record');
+          }
+        } else if (payload.refreshTokenId) {
+          // We've got device-less refreshToken. There should be no sessionToken.
+          if (payload.sessionTokenId) {
+            throw error.invalidRequestParameter('sessionTokenId cannot be present for non-device OAuth client');
+          }
+          await oauthdb.revokeAuthorizedClient(credentials, {
+            client_id: payload.clientId,
+            refresh_token_id: payload.refreshTokenId,
+          });
+        } else if (payload.clientId) {
+          // We've got an OAuth client that isn't using refresh tokens. There should be no sessionToken.
+          if (payload.sessionTokenId) {
+            throw error.invalidRequestParameter('sessionTokenId cannot be present for non-device OAuth client');
+          }
+          await oauthdb.revokeAuthorizedClient(credentials, {
+            client_id: payload.clientId,
+          });
+        } else if (payload.sessionTokenId) {
+          // We've got a plain web session on our hands.
+          // Need to check that it actually belongs to this user, unless it's the current session.
+          if (payload.sessionTokenId === credentials.id) {
+            await db.deleteSessionToken(credentials);
+          } else {
+            const sessionToken = await db.sessionToken(payload.sessionTokenId);
+            if (! sessionToken || sessionToken.uid !== credentials.uid) {
+              throw error.invalidRequestParameter('sessionTokenId');
+            }
+            await db.deleteSessionToken(sessionToken);
+          }
+        }
+
+        return {};
+      }
+    },
+  ];
+};

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -22,8 +22,9 @@ module.exports = function (
   const push = require('../push')(log, db, config);
   const pushbox = require('../pushbox')(log, config);
   const subhub = require('../subhub/client')(log, config);
-  const devicesImpl = require('../devices')(log, db, push);
+  const devicesImpl = require('../devices')(log, db, oauthdb, push);
   const signinUtils = require('./utils/signin')(log, config, customs, db, mailer);
+  const clientUtils = require('./utils/clients')(log, config);
   const verificationReminders = require('../verification-reminders')(log, config);
   // The routing modules themselves.
   const defaults = require('./defaults')(log, db);
@@ -41,7 +42,8 @@ module.exports = function (
     verificationReminders,
   );
   const oauth = require('./oauth')(log, config, oauthdb, db, mailer, devicesImpl);
-  const devicesSessions = require('./devices-and-sessions')(log, db, config, customs, push, pushbox, devicesImpl, oauthdb);
+  const devicesSessions = require('./devices-and-sessions')(log, db, config, customs, push, pushbox, devicesImpl, clientUtils);
+  const attachedClients = require('./attached-clients')(log, db, oauthdb, devicesImpl, clientUtils);
   const emails = require('./emails')(log, db, mailer, config, customs, push, verificationReminders);
   const password = require('./password')(
     log,
@@ -78,6 +80,7 @@ module.exports = function (
     account,
     oauth,
     devicesSessions,
+    attachedClients,
     emails,
     password,
     recoveryCodes,

--- a/packages/fxa-auth-server/lib/routes/utils/clients.js
+++ b/packages/fxa-auth-server/lib/routes/utils/clients.js
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const i18n = require('i18n-abide');
+
+module.exports = (log, config) => {
+
+  const earliestSaneAccessTime = config.lastAccessTimeUpdates.earliestSaneTimestamp;
+  const { supportedLanguages, defaultLanguage } = config.i18n;
+
+  const localizeTimestamp = require('fxa-shared').l10n.localizeTimestamp({
+    supportedLanguages,
+    defaultLanguage
+  });
+
+  return {
+
+    formatLocation(client, request) {
+      let language;
+      if (! client.location) {
+        client.location = {};
+      } else {
+        const location = client.location;
+        try {
+          const languages = i18n.parseAcceptLanguage(request.app.acceptLanguage);
+          language = i18n.bestLanguage(languages, supportedLanguages, defaultLanguage);
+          // For English, we can leave all the location components intact.
+          // For other languages, only return what we can translate
+          if (language[0] === 'e' || language[1] === 'n') {
+            client.location = {
+              city: location.city,
+              country: location.country,
+              state: location.state,
+              stateCode: location.stateCode,
+            };
+          } else {
+            const territories = require(`cldr-localenames-full/main/${language}/territories.json`);
+            client.location = {
+              country: territories.main[language].localeDisplayNames.territories[location.countryCode]
+            };
+          }
+        } catch (err) {
+          log.warn('attached-clients.formatLocation.warning', {
+            err: err.message,
+            languages: request.app.acceptLanguage,
+            language,
+            location,
+          });
+        }
+      }
+      return client;
+    },
+
+    formatTimestamps(client, request) {
+      const languages = request.app.acceptLanguage;
+      if (client.createdTime) {
+        client.createdTimeFormatted = localizeTimestamp.format(client.createdTime, languages);
+      }
+      if (client.lastAccessTime) {
+        client.lastAccessTimeFormatted = localizeTimestamp.format(client.lastAccessTime, languages);
+        if (client.lastAccessTime < earliestSaneAccessTime) {
+          client.approximateLastAccessTime = earliestSaneAccessTime;
+          client.approximateLastAccessTimeFormatted = localizeTimestamp.format(earliestSaneAccessTime, languages);
+
+        }
+      }
+      return client;
+    }
+
+  };
+};

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -650,6 +650,20 @@ module.exports = config => {
     );
   };
 
+  ClientApi.prototype.attachedClientDestroy = function (sessionTokenHex, clientData) {
+    return tokens.SessionToken.fromHex(sessionTokenHex)
+      .then(
+        (token) => {
+          return this.doRequest(
+            'POST',
+            `${this.baseURL}/account/attached_client/destroy`,
+            token,
+            clientData,
+          );
+        }
+      );
+  };
+
   ClientApi.prototype.sessionDestroy = function (sessionTokenHex, options) {
     let data = null;
 
@@ -714,6 +728,19 @@ module.exports = config => {
           return this.doRequest(
             'GET',
             `${this.baseURL  }/account/sessions`,
+            token
+          );
+        }
+      );
+  };
+
+  ClientApi.prototype.attachedClients = function (sessionTokenHex) {
+    return tokens.SessionToken.fromHex(sessionTokenHex)
+      .then(
+        (token) => {
+          return this.doRequest(
+            'GET',
+            `${this.baseURL}/account/attached_clients`,
             token
           );
         }

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -396,6 +396,24 @@ module.exports = config => {
     );
   };
 
+  Client.prototype.attachedClients = function () {
+    const o = this.sessionToken ? P.resolve(null) : this.login();
+    return o.then(
+      () => {
+        return this.api.attachedClients(this.sessionToken);
+      }
+    );
+  };
+
+  Client.prototype.destroyAttachedClient = function (clientData) {
+    const o = this.sessionToken ? P.resolve(null) : this.login();
+    return o.then(
+      () => {
+        return this.api.attachedClientDestroy(this.sessionToken, clientData);
+      }
+    );
+  };
+
   Client.prototype.devices = function () {
     const o = this.sessionToken ? P.resolve(null) : this.login();
     return o.then(

--- a/packages/fxa-auth-server/test/local/db.js
+++ b/packages/fxa-auth-server/test/local/db.js
@@ -477,7 +477,8 @@ describe('redis enabled, token-pruning enabled:', () => {
       .then(result => assert.deepEqual(result, [
         {
           id: 'device-id',
-          sessionToken: 'oldFormat',
+          sessionTokenId: 'oldFormat',
+          createdAt: undefined,
           name: undefined,
           type: undefined,
           pushCallback: undefined,
@@ -503,7 +504,8 @@ describe('redis enabled, token-pruning enabled:', () => {
         },
         {
           id: 'device-id',
-          sessionToken: 'newFormat',
+          sessionTokenId: 'newFormat',
+          createdAt: undefined,
           name: undefined,
           type: undefined,
           availableCommands: {},

--- a/packages/fxa-auth-server/test/local/routes/attached-clients.js
+++ b/packages/fxa-auth-server/test/local/routes/attached-clients.js
@@ -1,0 +1,463 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const sinon = require('sinon');
+const assert = { ...sinon.assert, ...require('chai').assert };
+const crypto = require('crypto');
+const getRoute = require('../../routes_helpers').getRoute;
+const mocks = require('../../mocks');
+const error = require('../../../lib/error');
+const proxyquire = require('proxyquire');
+const uuid = require('uuid');
+
+const EARLIEST_SANE_TIMESTAMP = 31536000000;
+
+
+function makeRoutes (options = {}, requireMocks) {
+  const config = options.config || {};
+  config.smtp = config.smtp ||  {};
+  config.memcached = config.memcached || {
+    address: '127.0.0.1:1121',
+    idle: 500,
+    lifetime: 30
+  };
+  config.i18n = {
+    supportedLanguages: [ 'en', 'fr' ],
+    defaultLanguage: 'en'
+  };
+  config.push = {
+    allowedServerRegex: /^https:\/\/updates\.push\.services\.mozilla\.com(\/.*)?$/
+  };
+  config.lastAccessTimeUpdates = {
+    earliestSaneTimestamp: EARLIEST_SANE_TIMESTAMP
+  };
+  config.publicUrl = 'https://public.url';
+
+  const log = options.log || mocks.mockLog();
+  const db = options.db || mocks.mockDB();
+  const oauthdb = options.oauthdb || mocks.mockOAuthDB(log, config);
+  const push = options.push || require('../../../lib/push')(log, db, {});
+  const devices = options.devices || require('../../../lib/devices')(log, db, oauthdb, push);
+  const clientUtils = options.clientUtils || require('../../../lib/routes/utils/clients')(log, config);
+  return proxyquire('../../../lib/routes/attached-clients', requireMocks || {})(
+    log, db, oauthdb, devices, clientUtils
+  );
+}
+
+function newId(size=32) {
+  return crypto.randomBytes(size).toString('hex');
+}
+
+function locFields(obj) {
+  // Set fields explicitly to `undefined`, for deepEqual testing.
+  return Object.assign({
+    city: undefined,
+    country: undefined,
+    state: undefined,
+    stateCode: undefined
+  }, obj);
+}
+
+describe('/account/attached_clients', () => {
+
+  let config, uid, log, db, oauthdb, request, route;
+
+  beforeEach(() => {
+    config = {};
+    uid = uuid.v4('binary').toString('hex');
+    log = mocks.mockLog();
+    db = mocks.mockDB();
+    oauthdb = mocks.mockOAuthDB(log, config);
+    request = mocks.mockRequest({
+      credentials: {
+        id: crypto.randomBytes(16).toString('hex'),
+        uid: uid
+      }
+    });
+    const accountRoutes = makeRoutes({
+      config, log, db, oauthdb
+    });
+    route = getRoute(accountRoutes, '/account/attached_clients').handler;
+  });
+
+  it('creates a merged list of all the things attached to the account', async () => {
+    const now = Date.now();
+    const DEVICES = [
+      // A device with a sessionToken.
+      { id: newId(), sessionTokenId: newId(), type: 'desktop', name: 'device 1', createdAt: now - 5 },
+      // An OAuth device.
+      { id: newId(), refreshTokenId: newId(), type: 'desktop', name: 'oauthy device-o', createdAt: now - 2000 },
+      // A newfangled device with both kinds of token.
+      { id: newId(), sessionTokenId: newId(), refreshTokenId: newId(), createdAt: now - 4000 },
+    ];
+    const OAUTH_CLIENTS = [
+      // A non-public oauth client that's *not* using refresh tokens.
+      { client_id: newId(16), client_name: 'Legacy OAuth Service', created_time: now - 1600, last_access_time: now - 200, scope: ['a', 'b'] },
+      // A non-public oauth client using refresh tokens.
+      { client_id: newId(16), client_name: 'OAuth Service', refresh_token_id: newId(), created_time: now - 1600, last_access_time: now - 200, scope: ['profile'] },
+      // An OAuth device.
+      { client_id: newId(16), client_name: 'OAuth Device', refresh_token_id: DEVICES[1].refreshTokenId, created_time: now - 2600, last_access_time: now - 200, scope: ['foo'] },
+      // The newfangled device with both kinds of token.
+      { client_id: newId(16), client_name: 'OAuth Mega-Device', refresh_token_id: DEVICES[2].refreshTokenId, created_time: now - 1600, last_access_time: now - 200, scope: ['bar'] },
+    ];
+    const SESSIONS = [
+      // A web session
+      { id: newId(), createdAt: now - 1234, lastAccessTime: now, location: { country: 'USA' }, uaOS: 'Windows', uaBrowser: 'Firefox', uaBrowserVersion: '67' },
+      // The sessionToken device
+      { id: DEVICES[0].sessionTokenId, createdAt: now, lastAccessTime: now, location: { country: 'Australia' } },
+      // The oauth+session device.
+      { id: DEVICES[2].sessionTokenId, createdAt: now, lastAccessTime: now, location: { country: 'Germany' } },
+    ];
+
+    request.app.devices = (async () => {
+      return DEVICES;
+    })();
+    oauthdb.listAuthorizedClients = sinon.spy(async () => {
+      return OAUTH_CLIENTS;
+    });
+    db.sessions = sinon.spy(async () => {
+      return SESSIONS;
+    });
+
+    request.auth.credentials.id = SESSIONS[0].id;
+    const result = await route(request);
+
+    assert.equal(result.length, 6);
+
+    // The device with just a sessionToken.
+    assert.deepEqual(result[0], {
+      clientId: null,
+      deviceId: DEVICES[0].id,
+      sessionTokenId: SESSIONS[1].id,
+      refreshTokenId: null,
+      isCurrentSession: false,
+      deviceType: 'desktop',
+      name: 'device 1',
+      createdTime: now - 5,
+      createdTimeFormatted: 'a few seconds ago',
+      lastAccessTime: now,
+      lastAccessTimeFormatted: 'a few seconds ago',
+      scope: null,
+      location: locFields({ country: 'Australia' }),
+      userAgent: '',
+      os: null,
+    });
+    // The device with just a refreshToken.
+    assert.deepEqual(result[1], {
+      clientId: OAUTH_CLIENTS[2].client_id,
+      deviceId: DEVICES[1].id,
+      sessionTokenId: null,
+      refreshTokenId: OAUTH_CLIENTS[2].refresh_token_id,
+      isCurrentSession: false,
+      deviceType: 'desktop',
+      name: 'oauthy device-o',
+      createdTime: now - 2600,
+      createdTimeFormatted: 'a few seconds ago',
+      lastAccessTime: now - 200,
+      lastAccessTimeFormatted: 'a few seconds ago',
+      scope: ['foo'],
+      location: {},
+      userAgent: '',
+      os: null,
+    });
+    // The newfangled device with both kinds of token.
+    assert.deepEqual(result[2], {
+      clientId: OAUTH_CLIENTS[3].client_id,
+      deviceId: DEVICES[2].id,
+      sessionTokenId: SESSIONS[2].id,
+      refreshTokenId: OAUTH_CLIENTS[3].refresh_token_id,
+      isCurrentSession: false,
+      deviceType: 'mobile',
+      name: 'OAuth Mega-Device',
+      createdTime: now - 4000,
+      createdTimeFormatted: 'a few seconds ago',
+      lastAccessTime: now,
+      lastAccessTimeFormatted: 'a few seconds ago',
+      scope: null, // Having a sessionToken means you can grant yourself any scope!
+      location: locFields({ country: 'Germany' }),
+      userAgent: '',
+      os: null,
+    });
+    // The cloud OAuth service using only access tokens.
+    assert.deepEqual(result[3], {
+      clientId: OAUTH_CLIENTS[0].client_id,
+      deviceId: null,
+      sessionTokenId: null,
+      refreshTokenId: null,
+      isCurrentSession: false,
+      deviceType: null,
+      name: 'Legacy OAuth Service',
+      createdTime: now - 1600,
+      createdTimeFormatted: 'a few seconds ago',
+      lastAccessTime: now - 200,
+      lastAccessTimeFormatted: 'a few seconds ago',
+      scope: ['a', 'b'],
+      location: {},
+      userAgent: '',
+      os: null,
+    });
+    // The cloud OAuth service using a refresh token.
+    assert.deepEqual(result[4], {
+      clientId: OAUTH_CLIENTS[1].client_id,
+      deviceId: null,
+      sessionTokenId: null,
+      refreshTokenId: OAUTH_CLIENTS[1].refresh_token_id,
+      isCurrentSession: false,
+      deviceType: null,
+      name: 'OAuth Service',
+      createdTime: now - 1600,
+      createdTimeFormatted: 'a few seconds ago',
+      lastAccessTime: now - 200,
+      lastAccessTimeFormatted: 'a few seconds ago',
+      scope: ['profile'],
+      location: {},
+      userAgent: '',
+      os: null,
+    });
+    // The web-only login session.
+    assert.deepEqual(result[5], {
+      clientId: null,
+      deviceId: null,
+      sessionTokenId: SESSIONS[0].id,
+      refreshTokenId: null,
+      isCurrentSession: true,
+      deviceType: null,
+      name: 'Firefox 67, Windows',
+      createdTime: now - 1234,
+      createdTimeFormatted: 'a few seconds ago',
+      lastAccessTime: now,
+      lastAccessTimeFormatted: 'a few seconds ago',
+      location: locFields({ country: 'USA' }),
+      scope: null,
+      userAgent: 'Firefox 67',
+      os: 'Windows',
+    });
+  });
+
+});
+
+
+describe('/account/attached_client/destroy', () => {
+
+  let config, uid, log, db, oauthdb, devices, request, route;
+
+  beforeEach(() => {
+    config = {};
+    uid = uuid.v4('binary').toString('hex');
+    log = mocks.mockLog();
+    db = mocks.mockDB();
+    oauthdb = mocks.mockOAuthDB(log, config);
+    devices = mocks.mockDevices({});
+    request = mocks.mockRequest({
+      credentials: {
+        id: crypto.randomBytes(16).toString('hex'),
+        uid: uid
+      },
+      payload: {},
+    });
+    const accountRoutes = makeRoutes({
+      config, log, db, oauthdb, devices
+    });
+    route = getRoute(accountRoutes, '/account/attached_client/destroy').handler;
+  });
+
+  it('can destroy by deviceId', async () => {
+    const deviceId = newId();
+    request.payload = {
+      deviceId,
+    };
+
+    const res = await route(request);
+    assert.deepEqual(res, {});
+
+    assert.equal(devices.destroy.callCount, 1);
+    assert.ok(devices.destroy.calledOnceWith(request, deviceId));
+    assert.equal(db.deleteSessionToken.callCount, 0);
+    assert.equal(oauthdb.revokeAuthorizedClient.callCount, 0);
+  });
+
+  it('checks that sessionTokenId matches device record, if given', async () => {
+    const deviceId = newId();
+    request.payload = {
+      deviceId,
+      sessionTokenId: newId(),
+    };
+    devices.destroy = sinon.spy(async () => {
+      return {
+        sessionTokenId: newId(),
+        refreshTokenId: null,
+      };
+    });
+
+    try {
+      await route(request);
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.errno, error.ERRNO.INVALID_PARAMETER);
+    }
+
+    assert.ok(devices.destroy.calledOnceWith(request, deviceId));
+    assert.ok(db.deleteSessionToken.notCalled);
+    assert.ok(oauthdb.revokeAuthorizedClient.notCalled);
+  });
+
+  it('checks that refreshTokenId matches device record, if given', async () => {
+    const deviceId = newId();
+    request.payload = {
+      deviceId,
+      sessionTokenId: newId(),
+      refreshTokenId: newId(),
+    };
+    devices.destroy = sinon.spy(async () => {
+      return {
+        sessionTokenId: request.payload.sessionTokenId,
+        refreshTokenId: newId(),
+      };
+    });
+
+    try {
+      await route(request);
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.errno, error.ERRNO.INVALID_PARAMETER);
+    }
+
+    assert.ok(devices.destroy.calledOnceWith(request, deviceId));
+    assert.ok(db.deleteSessionToken.notCalled);
+    assert.ok(oauthdb.revokeAuthorizedClient.notCalled);
+  });
+
+  it('can destroy by refreshTokenId', async () => {
+    const clientId = newId(16);
+    const refreshTokenId = newId();
+    request.payload = {
+      clientId,
+      refreshTokenId,
+    };
+
+    const res = await route(request);
+    assert.deepEqual(res, {});
+
+    assert.ok(devices.destroy.notCalled);
+    assert.ok(db.deleteSessionToken.notCalled);
+    assert.ok(oauthdb.revokeAuthorizedClient.calledOnceWith(request.auth.credentials, {
+      client_id: clientId,
+      refresh_token_id: refreshTokenId,
+    }));
+  });
+
+  it('wont accept refreshTokenId and sessionTokenId without deviceId', async () => {
+    const clientId = newId(16);
+    const refreshTokenId = newId();
+    request.payload = {
+      clientId,
+      refreshTokenId,
+      sessionTokenId: newId(),
+    };
+
+    try {
+      await route(request);
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.errno, error.ERRNO.INVALID_PARAMETER);
+    }
+
+    assert.ok(devices.destroy.notCalled);
+    assert.ok(db.deleteSessionToken.notCalled);
+    assert.ok(oauthdb.revokeAuthorizedClient.notCalled);
+  });
+
+  it('can destroy by just clientId', async () => {
+    const clientId = newId(16);
+    request.payload = {
+      clientId,
+    };
+
+    const res = await route(request);
+    assert.deepEqual(res, {});
+
+    assert.ok(devices.destroy.notCalled);
+    assert.ok(db.deleteSessionToken.notCalled);
+    assert.ok(oauthdb.revokeAuthorizedClient.calledOnceWith(request.auth.credentials, {
+      client_id: clientId,
+    }));
+  });
+
+  it('wont accept clientId and sessionTokenId without deviceId', async () => {
+    const clientId = newId(16);
+    request.payload = {
+      clientId,
+      sessionTokenId: newId(),
+    };
+
+    try {
+      await route(request);
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.errno, error.ERRNO.INVALID_PARAMETER);
+    }
+
+    assert.ok(devices.destroy.notCalled);
+    assert.ok(db.deleteSessionToken.notCalled);
+    assert.ok(oauthdb.revokeAuthorizedClient.notCalled);
+  });
+
+  it('can destroy by sessionTokenId when given the current session', async () => {
+    const sessionTokenId = newId(16);
+    request.payload = {
+      sessionTokenId,
+    };
+    request.auth.credentials.id = sessionTokenId;
+
+    const res = await route(request);
+    assert.deepEqual(res, {});
+
+    assert.ok(devices.destroy.notCalled);
+    assert.ok(db.sessionToken.notCalled);
+    assert.ok(db.deleteSessionToken.calledOnceWith(request.auth.credentials));
+    assert.ok(oauthdb.revokeAuthorizedClient.notCalled);
+  });
+
+  it('can destroy by sessionTokenId when given a different session', async () => {
+    const sessionTokenId = newId(16);
+    request.payload = {
+      sessionTokenId,
+    };
+    db.sessionToken = sinon.spy(async () => {
+      return { id: sessionTokenId, uid };
+    });
+
+    const res = await route(request);
+    assert.deepEqual(res, {});
+
+    assert.ok(devices.destroy.notCalled);
+    assert.ok(db.sessionToken.calledOnceWith(sessionTokenId));
+    assert.ok(db.deleteSessionToken.calledOnceWith({ id: sessionTokenId, uid }));
+    assert.ok(oauthdb.revokeAuthorizedClient.notCalled);
+  });
+
+  it('errors if the sessionToken does not belong to the current user', async () => {
+    const sessionTokenId = newId(16);
+    request.payload = {
+      sessionTokenId,
+    };
+    db.sessionToken = sinon.spy(async () => {
+      return { uid: newId() };
+    });
+
+    try {
+      await route(request);
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.errno, error.ERRNO.INVALID_PARAMETER);
+    }
+
+    assert.ok(devices.destroy.notCalled);
+    assert.ok(db.sessionToken.calledOnceWith(sessionTokenId));
+    assert.ok(db.deleteSessionToken.notCalled);
+    assert.ok(oauthdb.revokeAuthorizedClient.notCalled);
+  });
+});

--- a/packages/fxa-auth-server/test/local/routes/utils/clients.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/clients.js
@@ -1,0 +1,181 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const sinon = require('sinon');
+const assert = { ...sinon.assert, ...require('chai').assert };
+const mocks = require('../../../mocks');
+const moment = require('fxa-shared/node_modules/moment');
+
+const EARLIEST_SANE_TIMESTAMP = 31536000000;
+
+const makeClientUtils = (options) => {
+  const log = options.log || mocks.mockLog();
+  const config = options.config || {};
+  config.lastAccessTimeUpdates = config.lastAccessTimeUpdates || {
+    earliestSaneTimestamp: EARLIEST_SANE_TIMESTAMP
+  };
+  config.i18n = config.i18n || {
+    supportedLanguages: ['en', 'fr'],
+    defaultLanguage: 'en'
+  };
+  return require('../../../../lib/routes/utils/clients')(log, config);
+};
+
+
+describe('clientUtils.formatLocation', () => {
+  let log, clientUtils, request;
+
+  beforeEach(() => {
+    log = mocks.mockLog();
+    clientUtils = makeClientUtils({ log });
+    request = mocks.mockRequest({});
+  });
+
+  it ('sets empty location if no info is available', () => {
+    const client = {};
+    clientUtils.formatLocation(client, request);
+    assert.deepEqual(client.location, {});
+    assert.equal(log.warn.callCount, 0);
+  });
+
+  it('sets empty location if location is null', () => {
+    const client = {
+      location: null
+    };
+    clientUtils.formatLocation(client, request);
+    assert.deepEqual(client.location, {});
+    assert.equal(log.warn.callCount, 0);
+  });
+
+  it('leaves location info untranslated by default', () => {
+    const client = {
+      location: {
+        city: 'Testville',
+        state: 'Testachusetts',
+        stateCode: '1234',
+        country: 'USA',
+        countryCode: '9876',
+      }
+    };
+    clientUtils.formatLocation(client, request);
+    assert.deepEqual(client.location, {
+      city: 'Testville',
+      state: 'Testachusetts',
+      country: 'USA',
+      stateCode: '1234',
+    });
+    assert.equal(log.warn.callCount, 0);
+  });
+
+  it('leaves location info untranslated for english', () => {
+    request.app.acceptLanguage = 'en;q=0.95';
+    const client = {
+      location: {
+        city: 'Testville',
+        state: 'Testachusetts',
+        stateCode: '1234',
+        country: 'USA',
+        countryCode: '9876',
+      }
+    };
+    clientUtils.formatLocation(client, request);
+    assert.deepEqual(client.location, {
+      city: 'Testville',
+      state: 'Testachusetts',
+      country: 'USA',
+      stateCode: '1234',
+    });
+    assert.equal(log.warn.callCount, 0);
+  });
+
+  it('translates only the country name for other languages', () => {
+    request.app.acceptLanguage = 'en;q=0.5, fr;q=0.51';
+    const client = {
+      location: {
+        city: 'Bournemouth',
+        state: 'England',
+        stateCode: 'EN',
+        country: 'United Kingdom',
+        countryCode: 'GB'
+      }
+    };
+    clientUtils.formatLocation(client, request);
+    assert.deepEqual(client.location, {
+      country: 'Royaume-Uni',
+    });
+    assert.equal(log.warn.callCount, 0);
+  });
+});
+
+
+describe('clientUtils.formatTimestamps', () => {
+  let log, clientUtils, request;
+
+  beforeEach(() => {
+    log = mocks.mockLog();
+    clientUtils = makeClientUtils({ log });
+    request = mocks.mockRequest({});
+  });
+
+  it('formats timestamps in english by default', () => {
+    const now = Date.now();
+    const client = {
+      createdTime: now - (2 * 60 * 1000),
+      lastAccessTime: now,
+    };
+    clientUtils.formatTimestamps(client, request);
+    assert.equal(client.createdTime, now - (2 * 60 * 1000));
+    assert.equal(client.createdTimeFormatted, '2 minutes ago');
+    assert.equal(client.lastAccessTime, now);
+    assert.equal(client.lastAccessTimeFormatted, 'a few seconds ago');
+    assert.equal(client.approximateLastAccessTime, undefined);
+    assert.equal(client.approximateLastAccessTimeFormatted, undefined);
+  });
+
+  it('ignores missing timestamps', () => {
+    const now = Date.now();
+    const client = {
+      lastAccessTime: now,
+    };
+    clientUtils.formatTimestamps(client, request);
+    assert.equal(client.createdTime, undefined);
+    assert.equal(client.createdTimeFormatted, undefined);
+    assert.equal(client.lastAccessTime, now);
+    assert.equal(client.lastAccessTimeFormatted, 'a few seconds ago');
+    assert.equal(client.approximateLastAccessTime, undefined);
+    assert.equal(client.approximateLastAccessTimeFormatted, undefined);
+  });
+
+  it('sets approximateLastAccessTime if lastAccessTime is too early', () => {
+    const client = {
+      lastAccessTime: EARLIEST_SANE_TIMESTAMP - 20,
+    };
+    clientUtils.formatTimestamps(client, request);
+    assert.equal(client.createdTime, undefined);
+    assert.equal(client.createdTimeFormatted, undefined);
+    assert.equal(client.lastAccessTime, EARLIEST_SANE_TIMESTAMP - 20);
+    assert.equal(client.lastAccessTimeFormatted, moment(EARLIEST_SANE_TIMESTAMP - 20).locale('en').fromNow());
+    assert.equal(client.approximateLastAccessTime, EARLIEST_SANE_TIMESTAMP);
+    assert.equal(client.approximateLastAccessTimeFormatted, moment(EARLIEST_SANE_TIMESTAMP).locale('en').fromNow());
+  });
+
+  it('formats timestamps according to accept-language header', () => {
+    const now = Date.now();
+    const client = {
+      createdTime: now - (2 * 60 * 1000),
+      lastAccessTime: now,
+    };
+    request.app.acceptLanguage = 'en;q=0.5, fr;q=0.51';
+    clientUtils.formatTimestamps(client, request);
+    assert.equal(client.createdTime, now - (2 * 60 * 1000));
+    assert.equal(client.createdTimeFormatted, 'il y a 2 minutes');
+    assert.equal(client.lastAccessTime, now);
+    assert.equal(client.lastAccessTimeFormatted, 'il y a quelques secondes');
+    assert.equal(client.approximateLastAccessTime, undefined);
+    assert.equal(client.approximateLastAccessTimeFormatted, undefined);
+  });
+
+});

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -101,6 +101,8 @@ const OAUTHDB_METHOD_NAMES = [
   'grantTokensFromAuthorizationCode',
   'grantTokensFromRefreshToken',
   'grantTokensFromSessionToken',
+  'listAuthorizedClients',
+  'revokeAuthorizedClient'
 ];
 
 const LOG_METHOD_NAMES = [
@@ -505,6 +507,9 @@ function mockDevices (data, errors) {
         name: data.deviceName || 'mock device name',
         type: data.deviceType || 'desktop'
       });
+    }),
+    destroy: sinon.spy(async () => {
+      return data;
     }),
     synthesizeName: sinon.spy(() => {
       return data.deviceName || null;

--- a/packages/fxa-auth-server/test/remote/attached_clients_tests.js
+++ b/packages/fxa-auth-server/test/remote/attached_clients_tests.js
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const TestServer = require('../test_server');
+const Client = require('../client')();
+const config = require('../../config').getProperties();
+const tokens = require('../../lib/tokens')({ trace: () => {} }, config);
+const testUtils = require('../lib/util');
+const oauthServerModule = require('../../fxa-oauth-server/lib/server');
+const ScopeSet = require('fxa-shared').oauth.scopes;
+const buf = require('buf').hex;
+const hashRefreshToken = require('../../fxa-oauth-server/lib/encrypt').hash;
+
+
+const PUBLIC_CLIENT_ID = '3c49430b43dfba77';
+
+describe('attached clients listing', function () {
+  this.timeout(15000);
+  let server, oauthServer, oauthServerDb;
+  before(async () => {
+    config.lastAccessTimeUpdates = {
+      enabled: true,
+      sampleRate: 1,
+      earliestSaneTimestamp: config.lastAccessTimeUpdates.earliestSaneTimestamp
+    };
+    testUtils.disableLogs();
+    oauthServer = await oauthServerModule.create();
+    oauthServerDb = require('../../fxa-oauth-server/lib/db');
+    await oauthServer.start();
+    server = await TestServer.start(config, false, {oauthServer});
+  });
+
+  it('correctly lists a variety of attached clients', async () => {
+    const email = server.uniqueEmail();
+    const password = 'test password';
+    const client = await Client.createAndVerify(config.publicUrl, email, password, server.mailbox);
+    const mySessionTokenId = (await tokens.SessionToken.fromHex(client.sessionToken)).id;
+    const deviceInfo = {
+      name: 'test device 🍓🔥在𝌆',
+      type: 'mobile',
+      availableCommands: { 'foo': 'bar' },
+      pushCallback: '',
+      pushPublicKey: '',
+      pushAuthKey: ''
+    };
+
+    let allClients = await client.attachedClients();
+
+    assert.equal(allClients.length, 1);
+    assert.equal(allClients[0].sessionTokenId, mySessionTokenId);
+    assert.equal(allClients[0].deviceId, null);
+    assert.equal(allClients[0].lastAccessTimeFormatted, 'a few seconds ago');
+
+    const device = await client.updateDevice(deviceInfo);
+
+    allClients = await client.attachedClients();
+    assert.equal(allClients.length, 1);
+    assert.equal(allClients[0].sessionTokenId, mySessionTokenId);
+    assert.equal(allClients[0].deviceId, device.id);
+    assert.equal(allClients[0].name, deviceInfo.name);
+
+    const refreshToken = await oauthServerDb.generateRefreshToken({
+      clientId: buf(PUBLIC_CLIENT_ID),
+      userId: buf(client.uid),
+      email: client.email,
+      scope: ScopeSet.fromArray(['profile', 'https://identity.mozilla.com/apps/oldsync']),
+    });
+    const refreshTokenId = hashRefreshToken(refreshToken.token).toString('hex');
+
+    allClients = await client.attachedClients();
+    assert.equal(allClients.length, 2);
+    assert.equal(allClients[0].sessionTokenId, mySessionTokenId);
+    assert.equal(allClients[1].sessionTokenId, null);
+    assert.equal(allClients[1].refreshTokenId, refreshTokenId);
+    assert.equal(allClients[1].lastAccessTimeFormatted, 'a few seconds ago');
+    assert.equal(allClients[1].name, 'Android Components Reference Browser');
+
+    const device2 = await client.updateDeviceWithRefreshToken(refreshToken.token.toString('hex'), { name: 'test device', type: 'mobile' });
+    allClients = await client.attachedClients();
+    assert.equal(allClients.length, 2);
+    assert.equal(allClients[0].sessionTokenId, mySessionTokenId);
+    assert.equal(allClients[0].deviceId, device.id);
+    assert.equal(allClients[1].refreshTokenId, refreshTokenId);
+    assert.equal(allClients[1].deviceId, device2.id);
+    assert.equal(allClients[1].name, 'test device');
+  });
+
+  it('correctly deletes by device id', async () => {
+    const email = server.uniqueEmail();
+    const password = 'test password';
+    const client = await Client.createAndVerify(config.publicUrl, email, password, server.mailbox);
+    const mySessionTokenId = (await tokens.SessionToken.fromHex(client.sessionToken)).id;
+
+    const client2 = await Client.login(config.publicUrl, email, password);
+    const device = await client2.updateDevice({ name: 'test', type: 'desktop' });
+
+    let allClients = await client.attachedClients();
+    assert.equal(allClients.length, 2);
+
+    await client.destroyAttachedClient({
+      deviceId: device.id
+    });
+
+    allClients = await client.attachedClients();
+    assert.equal(allClients.length, 1);
+    assert.equal(allClients[0].sessionTokenId, mySessionTokenId);
+  });
+
+  it('correctly deletes by sessionTokenId', async () => {
+    const email = server.uniqueEmail();
+    const password = 'test password';
+    const client = await Client.createAndVerify(config.publicUrl, email, password, server.mailbox);
+    const mySessionTokenId = (await tokens.SessionToken.fromHex(client.sessionToken)).id;
+
+    const client2 = await Client.login(config.publicUrl, email, password);
+    const otherSessionTokenId = (await tokens.SessionToken.fromHex(client2.sessionToken)).id;
+
+    let allClients = await client.attachedClients();
+    assert.equal(allClients.length, 2);
+
+    await client.destroyAttachedClient({
+      sessionTokenId: otherSessionTokenId
+    });
+
+    allClients = await client.attachedClients();
+    assert.equal(allClients.length, 1);
+    assert.equal(allClients[0].sessionTokenId, mySessionTokenId);
+  });
+
+  it('correctly deletes by refreshTokenId', async () => {
+    const email = server.uniqueEmail();
+    const password = 'test password';
+    const client = await Client.createAndVerify(config.publicUrl, email, password, server.mailbox);
+    const mySessionTokenId = (await tokens.SessionToken.fromHex(client.sessionToken)).id;
+
+    const refreshToken = await oauthServerDb.generateRefreshToken({
+      clientId: buf(PUBLIC_CLIENT_ID),
+      userId: buf(client.uid),
+      email: client.email,
+      scope: ScopeSet.fromArray(['profile', 'https://identity.mozilla.com/apps/oldsync']),
+    });
+    const refreshTokenId = hashRefreshToken(refreshToken.token).toString('hex');
+
+    let allClients = await client.attachedClients();
+    assert.equal(allClients.length, 2);
+
+    await client.destroyAttachedClient({
+      refreshTokenId,
+      clientId: PUBLIC_CLIENT_ID,
+    });
+
+    allClients = await client.attachedClients();
+    assert.equal(allClients.length, 1);
+    assert.equal(allClients[0].sessionTokenId, mySessionTokenId);
+    assert.equal(allClients[0].refreshTokenId, null);
+
+  });
+
+  after(async () => {
+    await TestServer.stop(server);
+    await oauthServer.stop();
+    testUtils.restoreStdoutWrite();
+  });
+});


### PR DESCRIPTION
This is an extraction of part of https://github.com/mozilla/fxa/pull/1262, and depends on https://github.com/mozilla/fxa/pull/1551. Review https://github.com/mozilla/fxa/pull/1551 first because this PR includes that commit.

This adds a new route `/account/attached_clients` that can be used to get the canonical list of all the things connected to the user's account. It combines web sessions, oauth apps, and device records into a single coherent list which should correspond directly to what we want to show the user in their "devices and apps" view.

Fixes #466.