### PR TITLE
fix(copy): Sentence case links

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/pair/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/index.mustache
@@ -16,7 +16,7 @@
     </form>
 
     <div class="links">
-      <a href="{{downloadAppLink}}" rel="noopener noreferrer" target="_blank">{{#t}}Get App{{/t}}</a>
+      <a href="{{downloadAppLink}}" rel="noopener noreferrer" target="_blank">{{#t}}Get app{{/t}}</a>
     </div>
 
   </section>


### PR DESCRIPTION
Lowercased the A on **Get app** to match our current sentence case style