### PR TITLE
updated some trailhead styles for mobile

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_marketing.scss
+++ b/packages/fxa-content-server/app/styles/modules/_marketing.scss
@@ -24,11 +24,12 @@
 .firefox-family-services {
   border-radius: 0 0 16px 16px;
   margin: 0 -40px -40px -40px;
-  padding: 20px 40px;
+  padding: 0 40px;
 
 
   @include respond-to('big') {
     background-color: #f8f9fc;
+    padding: 20px 40px;
   }
 
   > h2 {
@@ -36,6 +37,8 @@
     margin-top: 0;
 
     @include respond-to('small') {
+      font-size: 16px;
+
       html[dir='ltr'] & {
         text-align: left;
       }
@@ -59,7 +62,11 @@
       color: $grey-50;
       font-size: 11.5px;
       line-height: 1.7em;
-      padding: 0 10px 20px 0;
+      padding: 0 10px 10px 0;
+
+      @include respond-to('big') {
+        padding: 0 10px 20px 0;
+      }
 
       html[dir='ltr'] & {
         text-align: left;
@@ -110,7 +117,7 @@
     padding: 0;
     width: 185px;
 
-    @include respond-to('small') {
+    @media screen and (max-width: 720px) {
       display: none;
     }
 


### PR DESCRIPTION
closes #1306

## iPhone 6
<img width="487" alt="Screen Shot 2019-06-11 at 11 54 32 AM" src="https://user-images.githubusercontent.com/87619/59303637-74b58600-8c4b-11e9-9a7b-f000db1baae5.png">
<img width="487" alt="Screen Shot 2019-06-11 at 11 55 53 AM" src="https://user-images.githubusercontent.com/87619/59303791-cfe77880-8c4b-11e9-96c7-eea81757e450.png">

## Tablet size
<img width="704" alt="Screen Shot 2019-06-11 at 1 22 41 PM" src="https://user-images.githubusercontent.com/87619/59303889-091fe880-8c4c-11e9-8dec-53802bf8807b.png">
