### PR TITLE
feat(payments): Add storybook deployment to _scripts/gh-pages.sh

### DIFF
--- a/_scripts/gh-pages.sh
+++ b/_scripts/gh-pages.sh
@@ -18,12 +18,22 @@ node_modules/.bin/grunt yuidoc:compile
 cd ../../packages/fxa-email-service
 cargo doc --no-deps
 
+# fxa-payments-server relies on fxa-content-server .scss styles, which in turn
+# rely on some modules in package.json
+cd ../../packages/fxa-content-server
+npm ci
+
+cd ../../packages/fxa-payments-server
+npm ci
+npm run build-storybook
+
 cd ../..
 git clone --branch gh-pages git@github.com:mozilla/fxa.git docs-build
 cd docs-build
 rm -rf *
 mv ../packages/fxa-js-client/docs fxa-js-client
 mv ../packages/fxa-email-service/target/doc fxa-email-service
+mv ../packages/fxa-payments-server/storybook-static fxa-payments-server
 
 CHANGES=`git status --porcelain`
 


### PR DESCRIPTION
Reworked this PR to add storybook deployment to `_scripts/gh-pages.sh`.

Hard to exactly test, since it looks like this script only runs on merges to master. But, if it works, we should end up with Storybook deployments for `fxa-payments-server` here:

https://mozilla.github.io/fxa/fxa-payments-server/