### PR TITLE
use 2 columns for engines in cwts on mobile

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
+++ b/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
@@ -250,10 +250,7 @@ input[type='checkbox'] {
 .two-col-items {
   display: grid;
   margin: 20px 0 10px 0;
-
-  @include respond-to('big') {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  grid-template-columns: repeat(2, 1fr);
 
   .trailhead & {
     margin-bottom: 0;
@@ -261,7 +258,10 @@ input[type='checkbox'] {
   }
 
   .choose-what-to-sync-row {
+    line-break: anywhere;
     margin-bottom: 10px;
+    padding-right: 4px;
+    word-break: break-all;
 
     .trailhead & {
       margin-bottom: 20px;


### PR DESCRIPTION
closes #1201 

## Mobile
<img width="598" alt="Screen Shot 2019-06-12 at 10 54 44 AM" src="https://user-images.githubusercontent.com/87619/59374877-ba348a80-8d01-11e9-91af-c5ac40bb024e.png">

## Desktop
<img width="880" alt="Screen Shot 2019-06-12 at 10 55 12 AM" src="https://user-images.githubusercontent.com/87619/59374887-c4568900-8d01-11e9-86f9-4f5cf1ab6730.png">
