### PR TITLE
Feature Flags for First Fenix Flight

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -662,6 +662,28 @@ const conf = convict({
       default: {},
       env: 'OAUTH_CLIENT_IDS'
     },
+    // A safety switch for disabling new signins/signups from particular clients,
+    // as a hedge against unexpected client behaviour.
+    disableNewConnectionsForClients: {
+      doc: 'Comma-separated list of oauth client ids for which new connections should be temporarily refused',
+      env: 'OAUTH_DISABLE_NEW_CONNECTIONS_FOR_CLIENTS',
+      format: Array,
+      default: []
+    },
+    // Some safety switches to disable oauth-based device API operations,
+    // in case problems with the client logic cause server overload.
+    deviceAccessEnabled: {
+      doc: 'Is oauth-based access to the devices API allowed at all?',
+      format: Boolean,
+      env: 'OAUTH_DEVICE_ACCESS_ENABLED',
+      default: true
+    },
+    deviceCommandsEnabled: {
+      doc: 'Are oauth-based devices allowed to use  device commands?',
+      format: Boolean,
+      env: 'OAUTH_DEVICE_COMMANDS_ENABLED',
+      default: true
+    },
     clientInfoCacheTTL: {
       doc: 'TTL for OAuth client details (in milliseconds)',
       format: 'duration',

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/config.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/config.js
@@ -72,6 +72,12 @@ const conf = convict({
     default: {},
     env: 'OAUTH_CLIENT_IDS'
   },
+  disabledClients: {
+    doc: 'Comma-separated list of client ids for which service should be temporarily refused',
+    env: 'OAUTH_CLIENTS_DISABLED',
+    format: Array,
+    default: []
+  },
   scopes: {
     doc: 'Some pre-defined list of scopes that will be inserted into the DB',
     env: 'OAUTH_SCOPES',

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/error.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/error.js
@@ -295,4 +295,16 @@ AppError.invalidGrantType = function invalidGrantType() {
   });
 };
 
+// N.B. `errno: 201` is traditionally our generic "service unavailable" error,
+// so let's reserve it for that purpose here as well.
+
+AppError.disabledClient = function disabledClient(clientId) {
+  return new AppError({
+    code: 503,
+    error: 'Client Disabled',
+    errno: 202,
+    message: 'This client has been temporarily disabled'
+  }, { clientId });
+};
+
 module.exports = AppError;

--- a/packages/fxa-auth-server/fxa-oauth-server/test/api.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/api.js
@@ -3375,7 +3375,7 @@ describe('/v1', function() {
 
       it('should list canGrant=1 clients that have refresh tokens', function () {
         return db.registerClient({
-          name: 'test/api/client-tokens/z-list-can-grant',
+          name: 'test/api/client-tokens/aaa-list-can-grant',
           id: client2Id,
           hashedSecret: encrypt.hash(unique.secret()),
           redirectUri: 'https://example.domain',
@@ -3410,10 +3410,10 @@ describe('/v1', function() {
           .then(function (res) {
             var result = res.result;
             assert.equal(result.length, 2);
-            assert.equal(result[0].id, client1Id.toString('hex'));
-            assert.deepEqual(result[0].scope, ['clients:write', 'profile']);
-            assert.equal(result[1].id, client2Id.toString('hex'));
-            assert.deepEqual(result[1].scope, ['scopeFromRefreshToken']);
+            assert.equal(result[0].id, client2Id.toString('hex'));
+            assert.deepEqual(result[0].scope, ['scopeFromRefreshToken']);
+            assert.equal(result[1].id, client1Id.toString('hex'));
+            assert.deepEqual(result[1].scope, ['clients:write', 'profile']);
             assertSecurityHeaders(res);
           });
       });

--- a/packages/fxa-auth-server/fxa-oauth-server/test/lib/mocks.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/lib/mocks.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const path = require('path');
+const proxyquire = require('proxyquire');
 
 module.exports = {
   require: requireDependencies,
@@ -41,29 +42,12 @@ function requireDependency(dependency, modulePath, basePath) {
     return dependency.ctor;
   }
 
-  var localPath = dependency.path;
-
-  if (localPath[0] === '.') {
-    // attempt to find something like ./patch.js from mysql/index.js
-    localPath = path.relative(
-      basePath,
-      path.resolve(basePath, modulePath, localPath)
-    );
+  if (dependency.path[0] !== '.') {
+    return proxyquire(dependency.path, {});
   }
-
-  try {
-    return require(localPath);
-  } catch (e) {
-    // if above require fails, attempt to find the module as a sibling of `modulePath`
-    // this takes care of cases like: ./token.js being a sibling of the given module
-    localPath = path.relative(
-      basePath,
-      path.resolve(basePath, '..', modulePath, '..', dependency.path)
-    );
-
-    return require(localPath);
-  }
-
+  const moduleUnderTest = require.resolve(modulePath, { paths: [basePath] });
+  const dependencyPath = require.resolve(dependency.path, { paths: [path.dirname(moduleUnderTest)] });
+  return proxyquire(dependencyPath, {});
 }
 
 function mockLog(logger, cb) {

--- a/packages/fxa-auth-server/fxa-oauth-server/test/routes/authorization.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/routes/authorization.js
@@ -6,8 +6,15 @@
 
 const { assert } = require('chai');
 const Joi = require('joi');
-const route = require('../../lib/routes/authorization');
-const validation = route.validate.payload;
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+const mocks = require('../lib/mocks');
+const realConfig = require('../../lib/config');
+
+const routeModulePath = '../../lib/routes/authorization';
+var dependencies = mocks.require([
+  { path: '../config' },
+], routeModulePath, __dirname);
 
 const CLIENT_ID = '98e6508e88680e1b';
 // jscs:disable
@@ -15,106 +22,159 @@ const BASE64URL_STRING = 'TG9yZW0gSXBzdW0gaXMgc2ltcGx5IGR1bW15IHRleHQgb2YgdGhlIH
 // jscs:enable
 const PKCE_CODE_CHALLENGE = 'iyW5ScKr22v_QL-rcW_EGlJrDSOymJvrlXlw4j7JBiQ';
 const PKCE_CODE_CHALLENGE_METHOD = 'S256';
-
-function joiAssertFail(req, param, messagePostfix) {
-  messagePostfix = messagePostfix || 'is required';
-  let fail = null;
-
-  try {
-    Joi.assert(req, validation);
-  } catch (err) {
-    fail = true;
-    assert.ok(err.isJoi);
-    assert.ok(err.name, 'ValidationError');
-    assert.equal(err.details[0].message, `"${param}" ${messagePostfix}`);
-  }
-
-  if (! fail) {
-    throw new Error('Did not throw!');
-  }
-}
+const DISABLED_CLIENT_ID = 'd15ab1edd15ab1ed';
 
 describe('/authorization POST', function () {
-  it('fails with no client_id', () => {
-    joiAssertFail({
-      foo: 1
-    }, 'client_id');
-  });
 
-  it('fails with no assertion', () => {
-    joiAssertFail({
-      client_id: CLIENT_ID
-    }, 'assertion');
-  });
+  describe('input validation', () => {
+    const route = require(routeModulePath);
+    const validation = route.validate.payload;
 
-  it('fails with no state', () => {
-    joiAssertFail({
-      client_id: CLIENT_ID,
-      assertion: BASE64URL_STRING,
-    }, 'state');
-  });
+    function joiAssertFail(req, param, messagePostfix) {
+      messagePostfix = messagePostfix || 'is required';
+      let fail = null;
 
-  it('fails with no state', () => {
-    Joi.assert({
-      client_id: CLIENT_ID,
-      assertion: BASE64URL_STRING,
-      state: 'foo'
-    }, validation);
-  });
+      try {
+        Joi.assert(req, validation);
+      } catch (err) {
+        fail = true;
+        assert.ok(err.isJoi);
+        assert.ok(err.name, 'ValidationError');
+        assert.equal(err.details[0].message, `"${param}" ${messagePostfix}`);
+      }
 
-  describe('PKCE params', function () {
-    it('accepts code_challenge and code_challenge_method', () => {
+      if (! fail) {
+        throw new Error('Did not throw!');
+      }
+    }
+
+    it('fails with no client_id', () => {
+      joiAssertFail({
+        foo: 1
+      }, 'client_id');
+    });
+
+    it('fails with no assertion', () => {
+      joiAssertFail({
+        client_id: CLIENT_ID
+      }, 'assertion');
+    });
+
+    it('fails with no state', () => {
+      joiAssertFail({
+        client_id: CLIENT_ID,
+        assertion: BASE64URL_STRING,
+      }, 'state');
+    });
+
+    it('accepts state parameter', () => {
       Joi.assert({
         client_id: CLIENT_ID,
         assertion: BASE64URL_STRING,
-        state: 'foo',
-        code_challenge: PKCE_CODE_CHALLENGE,
-        code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
+        state: 'foo'
       }, validation);
     });
 
-    it('accepts code_challenge and code_challenge_method', () => {
-      joiAssertFail({
-        client_id: CLIENT_ID,
-        assertion: BASE64URL_STRING,
-        state: 'foo',
-        code_challenge: PKCE_CODE_CHALLENGE,
-        code_challenge_method: 'bad_method',
-      }, 'code_challenge_method', 'must be one of [S256]');
+    describe('PKCE params', function () {
+      it('accepts code_challenge and code_challenge_method', () => {
+        Joi.assert({
+          client_id: CLIENT_ID,
+          assertion: BASE64URL_STRING,
+          state: 'foo',
+          code_challenge: PKCE_CODE_CHALLENGE,
+          code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
+        }, validation);
+      });
+
+      it('validates code_challenge_method', () => {
+        joiAssertFail({
+          client_id: CLIENT_ID,
+          assertion: BASE64URL_STRING,
+          state: 'foo',
+          code_challenge: PKCE_CODE_CHALLENGE,
+          code_challenge_method: 'bad_method',
+        }, 'code_challenge_method', 'must be one of [S256]');
+      });
+
+      it('validates code_challenge', () => {
+        joiAssertFail({
+          client_id: CLIENT_ID,
+          assertion: BASE64URL_STRING,
+          state: 'foo',
+          code_challenge: 'foo',
+          code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
+        }, 'code_challenge', 'length must be 43 characters long');
+      });
+
+      it('works with response_type code (non-default)', () => {
+        Joi.assert({
+          client_id: CLIENT_ID,
+          assertion: BASE64URL_STRING,
+          state: 'foo',
+          code_challenge: PKCE_CODE_CHALLENGE,
+          code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
+          response_type: 'code'
+        }, validation);
+      });
+
+      it('fails with response_type token', () => {
+        joiAssertFail({
+          client_id: CLIENT_ID,
+          assertion: BASE64URL_STRING,
+          state: 'foo',
+          code_challenge: PKCE_CODE_CHALLENGE,
+          code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
+          response_type: 'token'
+        }, 'code_challenge', 'is not allowed');
+      });
+
+    });
+  });
+
+
+  describe('config handling', () => {
+    let sandbox, route, request;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(dependencies['../config'], 'get').callsFake((key) => {
+        if (key === 'disabledClients') {
+          return [DISABLED_CLIENT_ID];
+        }
+        return realConfig.get(key);
+      });
+      route = proxyquire(routeModulePath, dependencies);
+      request = {
+        headers: {},
+        payload: {
+          client_id: CLIENT_ID,
+        },
+      };
     });
 
-    it('validates code_challenge', () => {
-      joiAssertFail({
-        client_id: CLIENT_ID,
-        assertion: BASE64URL_STRING,
-        state: 'foo',
-        code_challenge: 'foo',
-        code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
-      }, 'code_challenge', 'length must be 43 characters long');
+    afterEach(() => {
+      sandbox.restore();
     });
 
-    it('works with response_type code (non-default)', () => {
-      Joi.assert({
-        client_id: CLIENT_ID,
-        assertion: BASE64URL_STRING,
-        state: 'foo',
-        code_challenge: PKCE_CODE_CHALLENGE,
-        code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
-        response_type: 'code'
-      }, validation);
+    it('allows clients that have not been disabled via config', async () => {
+      try {
+        await route.handler(request);
+        assert.fail('should have errored');
+      } catch (err) {
+        assert.equal(err.errno, 104); // Invalid assertion.
+      }
     });
 
-    it('fails with response_type token', () => {
-      joiAssertFail({
-        client_id: CLIENT_ID,
-        assertion: BASE64URL_STRING,
-        state: 'foo',
-        code_challenge: PKCE_CODE_CHALLENGE,
-        code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
-        response_type: 'token'
-      }, 'code_challenge', 'is not allowed');
+    it('returns an error for clients that have been disabled via config', async () => {
+      request.payload.client_id = DISABLED_CLIENT_ID;
+      try {
+        await route.handler(request);
+        assert.fail('should have errored');
+      } catch (err) {
+        assert.equal(err.output.statusCode, 503);
+        assert.equal(err.errno, 202); // Disabled client
+      }
     });
-
   });
 
 });

--- a/packages/fxa-auth-server/fxa-oauth-server/test/routes/token.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/routes/token.js
@@ -4,12 +4,21 @@
 
 const { assert } = require('chai');
 const Joi = require('joi');
-const route = require('../../lib/routes/token');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+const mocks = require('../lib/mocks');
+const realConfig = require('../../lib/config');
+
+const routeModulePath = '../../lib/routes/token';
+var dependencies = mocks.require([
+  { path: '../config' },
+], routeModulePath, __dirname);
 
 const CLIENT_SECRET = 'b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8';
 const CLIENT_ID = '98e6508e88680e1b';
 const CODE = 'df6dcfe7bf6b54a65db5742cbcdce5c0a84a5da81a0bb6bdf5fc793eef041fc6';
 const PKCE_CODE_VERIFIER = 'au3dqDz2dOB0_vSikXCUf4S8Gc-37dL-F7sGxtxpR3R';
+const DISABLED_CLIENT_ID = 'd15ab1edd15ab1ed';
 
 function joiRequired(err, param) {
   assert.ok(err.isJoi);
@@ -23,79 +32,35 @@ function joiNotAllowed(err, param) {
   assert.equal(err.details[0].message, `"${param}" is not allowed`);
 }
 
+
 describe('/token POST', function () {
-  // route validation function
-  function v(req, ctx, cb) {
-    if (typeof ctx === 'function' && ! cb) {
-      cb = ctx;
-      ctx = undefined;
+
+  describe('input validation', () => {
+    const route = require(routeModulePath);
+
+    // route validation function
+    function v(req, ctx, cb) {
+      if (typeof ctx === 'function' && ! cb) {
+        cb = ctx;
+        ctx = undefined;
+      }
+      Joi.validate(req, route.validate.payload, { context: ctx }, cb);
     }
-    Joi.validate(req, route.validate.payload, {context: ctx}, cb);
-  }
 
-  it('fails with no client_id', (done) => {
-    v({
-      client_secret: CLIENT_SECRET,
-      code: CODE
-    }, (err) => {
-      joiRequired(err, 'client_id');
-      done();
+    it('fails with no client_id', (done) => {
+      v({
+        client_secret: CLIENT_SECRET,
+        code: CODE
+      }, (err) => {
+        joiRequired(err, 'client_id');
+        done();
+      });
     });
-  });
 
-  it('valid client_secret scheme', (done) => {
-    v({
-      client_id: CLIENT_ID,
-      client_secret: CLIENT_SECRET,
-      code: CODE
-    }, (err) => {
-      assert.equal(err, null);
-      done();
-    });
-  });
-
-  it('requires client_secret', (done) => {
-    v({
-      client_id: CLIENT_ID,
-      code: CODE
-    }, (err) => {
-      joiRequired(err, 'client_secret');
-      done();
-    });
-  });
-
-  it('forbids client_id when authz header provided', (done) => {
-    v({
-      client_id: CLIENT_ID
-    }, {
-      headers: {
-        authorization: 'Basic ABCDEF'
-      }
-    }, (err) => {
-      joiNotAllowed(err, 'client_id');
-      done();
-    });
-  });
-
-  it('forbids client_secret when authz header provided', (done) => {
-    v({
-      client_secret: CLIENT_SECRET,
-      code: CODE // If we don't send `code`, then the missing `code` will fail validation first.
-    }, {
-      headers: {
-        authorization: 'Basic ABCDEF'
-      }
-    }, (err) => {
-      joiNotAllowed(err, 'client_secret');
-      done();
-    });
-  });
-
-  describe('pkce', () => {
-    it('accepts pkce code_verifier instead of client_secret', (done) => {
+    it('valid client_secret scheme', (done) => {
       v({
         client_id: CLIENT_ID,
-        code_verifier: PKCE_CODE_VERIFIER,
+        client_secret: CLIENT_SECRET,
         code: CODE
       }, (err) => {
         assert.equal(err, null);
@@ -103,47 +68,166 @@ describe('/token POST', function () {
       });
     });
 
-    it('rejects pkce code_verifier that is too small', (done) => {
-      const bad_code_verifier = PKCE_CODE_VERIFIER.substring(0, 32);
+    it('requires client_secret', (done) => {
       v({
         client_id: CLIENT_ID,
-        code_verifier: bad_code_verifier,
         code: CODE
       }, (err) => {
-        assert.ok(err.isJoi);
-        assert.ok(err.name, 'ValidationError');
-        assert.equal(err.details[0].message, `"code_verifier" length must be at least 43 characters long`); // eslint-disable-line quotes
+        joiRequired(err, 'client_secret');
         done();
       });
     });
 
-    it('rejects pkce code_verifier that is too big', (done) => {
-      const bad_code_verifier = PKCE_CODE_VERIFIER + PKCE_CODE_VERIFIER + PKCE_CODE_VERIFIER + PKCE_CODE_VERIFIER;
+    it('forbids client_id when authz header provided', (done) => {
       v({
-        client_id: CLIENT_ID,
-        code_verifier: bad_code_verifier,
-        code: CODE
+        client_id: CLIENT_ID
+      }, {
+        headers: {
+          authorization: 'Basic ABCDEF'
+        }
       }, (err) => {
-        assert.ok(err.isJoi);
-        assert.ok(err.name, 'ValidationError');
-        assert.equal(err.details[0].message, `"code_verifier" length must be less than or equal to 128 characters long`);  // eslint-disable-line quotes
+        joiNotAllowed(err, 'client_id');
         done();
       });
     });
 
-    it('rejects pkce code_verifier that contains invalid characters', (done) => {
-      const bad_code_verifier = PKCE_CODE_VERIFIER + ' :.';
+    it('forbids client_secret when authz header provided', (done) => {
       v({
-        client_id: CLIENT_ID,
-        code_verifier: bad_code_verifier,
-        code: CODE
+        client_secret: CLIENT_SECRET,
+        code: CODE // If we don't send `code`, then the missing `code` will fail validation first.
+      }, {
+        headers: {
+          authorization: 'Basic ABCDEF'
+        }
       }, (err) => {
-        assert.ok(err.isJoi);
-        assert.ok(err.name, 'ValidationError');
-        assert.equal(err.details[0].message, `"code_verifier" with value "${bad_code_verifier}" fails to match the required pattern: /^[A-Za-z0-9-_]+$/`);
+        joiNotAllowed(err, 'client_secret');
         done();
+      });
+    });
+
+    describe('pkce', () => {
+      it('accepts pkce code_verifier instead of client_secret', (done) => {
+        v({
+          client_id: CLIENT_ID,
+          code_verifier: PKCE_CODE_VERIFIER,
+          code: CODE
+        }, (err) => {
+          assert.equal(err, null);
+          done();
+        });
+      });
+
+      it('rejects pkce code_verifier that is too small', (done) => {
+        const bad_code_verifier = PKCE_CODE_VERIFIER.substring(0, 32);
+        v({
+          client_id: CLIENT_ID,
+          code_verifier: bad_code_verifier,
+          code: CODE
+        }, (err) => {
+          assert.ok(err.isJoi);
+          assert.ok(err.name, 'ValidationError');
+          assert.equal(err.details[0].message, `"code_verifier" length must be at least 43 characters long`); // eslint-disable-line quotes
+          done();
+        });
+      });
+
+      it('rejects pkce code_verifier that is too big', (done) => {
+        const bad_code_verifier = PKCE_CODE_VERIFIER + PKCE_CODE_VERIFIER + PKCE_CODE_VERIFIER + PKCE_CODE_VERIFIER;
+        v({
+          client_id: CLIENT_ID,
+          code_verifier: bad_code_verifier,
+          code: CODE
+        }, (err) => {
+          assert.ok(err.isJoi);
+          assert.ok(err.name, 'ValidationError');
+          assert.equal(err.details[0].message, `"code_verifier" length must be less than or equal to 128 characters long`);  // eslint-disable-line quotes
+          done();
+        });
+      });
+
+      it('rejects pkce code_verifier that contains invalid characters', (done) => {
+        const bad_code_verifier = PKCE_CODE_VERIFIER + ' :.';
+        v({
+          client_id: CLIENT_ID,
+          code_verifier: bad_code_verifier,
+          code: CODE
+        }, (err) => {
+          assert.ok(err.isJoi);
+          assert.ok(err.name, 'ValidationError');
+          assert.equal(err.details[0].message, `"code_verifier" with value "${bad_code_verifier}" fails to match the required pattern: /^[A-Za-z0-9-_]+$/`);
+          done();
+        });
       });
     });
   });
 
+  describe('config handling', () => {
+    let sandbox, route, request;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(dependencies['../config'], 'get').callsFake((key) => {
+        if (key === 'disabledClients') {
+          return [DISABLED_CLIENT_ID];
+        }
+        return realConfig.get(key);
+      });
+      route = proxyquire(routeModulePath, dependencies);
+      request = {
+        headers: {},
+        payload: {
+          client_id: CLIENT_ID,
+          client_secret: CLIENT_SECRET,
+        },
+      };
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('allows clients that have not been disabled via config', async () => {
+      try {
+        await route.handler(request);
+        assert.fail('should have errored');
+      } catch (err) {
+        assert.equal(err.errno, 102); // Incorrect client secret.
+      }
+    });
+
+    it('allows code grants for clients that have been disabled via config', async () => {
+      request.payload.client_id = DISABLED_CLIENT_ID;
+      request.payload.grant_type = 'authorization_code';
+      try {
+        await route.handler(request);
+        assert.fail('should have errored');
+      } catch (err) {
+        assert.equal(err.errno, 101); // Unknown client.
+      }
+    });
+
+    it('returns an error on refresh_token grants for clients that have been disabled via config', async () => {
+      request.payload.client_id = DISABLED_CLIENT_ID;
+      request.payload.grant_type = 'refresh_token';
+      try {
+        await route.handler(request);
+        assert.fail('should have errored');
+      } catch (err) {
+        assert.equal(err.output.statusCode, 503);
+        assert.equal(err.errno, 202); // Disabled client.
+      }
+    });
+
+    it('returns an error on fxa-credentials grants for clients that have been disabled via config', async () => {
+      request.payload.client_id = DISABLED_CLIENT_ID;
+      request.payload.grant_type = 'fxa-credentials';
+      try {
+        await route.handler(request);
+        assert.fail('should have errored');
+      } catch (err) {
+        assert.equal(err.output.statusCode, 503);
+        assert.equal(err.errno, 202); // Disabled client.
+      }
+    });
+  });
 });

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -85,7 +85,6 @@ const ERRNO = {
   MISMATCH_AUTHORIZATION_CODE: 173,
   EXPIRED_AUTHORIZATION_CODE: 174,
   INVALID_PKCE_CHALLENGE: 175,
-
   UNKNOWN_SUBSCRIPTION_CUSTOMER: 176,
   UNKNOWN_SUBSCRIPTION: 177,
   UNKNOWN_SUBSCRIPTION_PLAN: 178,
@@ -96,6 +95,7 @@ const ERRNO = {
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
   BACKEND_SERVICE_FAILURE: 203,
+  DISABLED_CLIENT_ID: 204,
 
   INTERNAL_VALIDATION_ERROR: 998,
   UNEXPECTED_ERROR: 999
@@ -1123,6 +1123,17 @@ AppError.backendServiceFailure = (service, operation) => {
     service,
     operation
   });
+};
+
+AppError.disabledClientId = (clientId) => {
+  return new AppError({
+    code: 503,
+    error: 'Client Disabled',
+    errno: ERRNO.DISABLED_CLIENT_ID,
+    message: 'This client has been temporarily disabled'
+  }, {
+      clientId
+    });
 };
 
 AppError.internalValidationError = (op, data) => {

--- a/packages/fxa-auth-server/lib/oauthdb/utils.js
+++ b/packages/fxa-auth-server/lib/oauthdb/utils.js
@@ -58,6 +58,10 @@ module.exports = {
       return error.staleAuthAt(err.authAt);
     case 120:
       return error.insufficientACRValues(err.foundValue);
+    case 201:
+      return error.serviceUnavailable(err.retryAfter);
+    case 202:
+      return error.disabledClientId(err.clientId);
     default:
       log.warn('oauthdb.mapOAuthError', {
         err: err,

--- a/packages/fxa-auth-server/lib/scheme-refresh-token.js
+++ b/packages/fxa-auth-server/lib/scheme-refresh-token.js
@@ -15,10 +15,14 @@ const ScopeSet = require('fxa-shared').oauth.scopes;
 // so we limit to the scope below as a safety mechanism
 const ALLOWED_REFRESH_TOKEN_SCHEME_SCOPES = ScopeSet.fromArray(['https://identity.mozilla.com/apps/oldsync']);
 
-module.exports = function schemeRefreshTokenScheme(db, oauthdb) {
+module.exports = function schemeRefreshTokenScheme(config, db, oauthdb) {
   return function schemeRefreshToken(server, options) {
     return {
       async authenticate (request, h) {
+        if (config.oauth.deviceAccessEnabled === false) {
+          throw new AppError.featureNotEnabled();
+        }
+
         const bearerMatch = BEARER_AUTH_REGEX.exec(request.headers.authorization);
         const bearerMatchErr = new AppError.invalidRequestParameter('authorization');
         const refreshToken = bearerMatch && bearerMatch[1];

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -342,7 +342,7 @@ async function create (log, error, config, routes, db, oauthdb, translator) {
 
   server.auth.strategy('oauthToken', 'fxa-oauth', config.oauth);
 
-  server.auth.scheme('fxa-oauth-refreshToken', schemeRefreshToken(db, oauthdb));
+  server.auth.scheme('fxa-oauth-refreshToken', schemeRefreshToken(config, db, oauthdb));
 
   server.auth.strategy('refreshToken', 'fxa-oauth-refreshToken');
 

--- a/packages/fxa-auth-server/test/local/ip_profiling.js
+++ b/packages/fxa-auth-server/test/local/ip_profiling.js
@@ -19,6 +19,7 @@ const UID = uuid.v4('binary').toString('hex');
 function makeRoutes (options = {}, requireMocks) {
   const { db, mailer } = options;
   const config = {
+    oauth: {},
     securityHistory: {
       ipProfiling: {
         allowedRecency: MS_ONE_DAY

--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -262,6 +262,10 @@ var ERRORS = {
     errno: 203,
     message: t('System unavailable, try again soon')
   },
+  DISABLED_CLIENT_ID: {
+    errno: 204,
+    message: t('System unavailable, try again soon')
+  },
   ENDPOINT_NOT_SUPPORTED: {
     errno: 116,
     message: t('This endpoint is no longer supported')

--- a/packages/fxa-content-server/app/scripts/lib/oauth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/oauth-errors.js
@@ -97,6 +97,14 @@ var ERRORS = {
     errno: 121,
     message: 'Invalid grant_type'
   },
+  SERVER_UNAVAILABLE: {
+    errno: 201,
+    message: t('System unavailable, try again soon')
+  },
+  DISABLED_CLIENT_ID: {
+    errno: 202,
+    message: t('System unavailable, try again soon')
+  },
   SERVICE_UNAVAILABLE: {
     errno: 998,
     message: t('System unavailable, try again soon')

--- a/packages/fxa-payments-server/package-lock.json
+++ b/packages/fxa-payments-server/package-lock.json
@@ -2905,6 +2905,12 @@
         "@types/node": "*"
       }
     },
+    "@types/classnames": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.8.tgz",
+      "integrity": "sha512-3UrLzPnz8u+MMXuJTF++389IfLSQUbl5F3ry9WCxva0BKG5H/oo5NuPRXk+HrpPU1+5pVHSWhnVWRzIaFQ7QuQ==",
+      "dev": true
+    },
     "@types/enzyme": {
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.9.3.tgz",
@@ -4374,6 +4380,7 @@
       "resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-8.0.0.tgz",
       "integrity": "sha512-6Dmj7e8l7eWE+R6sKKLRrGEQXMfcBqBYlphaAgT1ml8qT1NEP+CyTZyfjmgKGqHZfwH3RQCUOuP6y4mpGc7tgg==",
       "requires": {
+        "@babel/core": "7.4.3",
         "@babel/plugin-proposal-class-properties": "7.4.0",
         "@babel/plugin-proposal-decorators": "7.4.0",
         "@babel/plugin-proposal-object-rest-spread": "7.4.3",
@@ -4393,6 +4400,27 @@
         "babel-plugin-transform-react-remove-prop-types": "0.4.24"
       },
       "dependencies": {
+        "@babel/core": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
+          "integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.0",
+            "@babel/helpers": "^7.4.3",
+            "@babel/parser": "^7.4.3",
+            "@babel/template": "^7.4.0",
+            "@babel/traverse": "^7.4.3",
+            "@babel/types": "^7.4.0",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.11",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          }
+        },
         "@babel/plugin-proposal-object-rest-spread": {
           "version": "7.4.3",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
@@ -4487,6 +4515,27 @@
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -5244,7 +5293,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -5609,7 +5659,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -5657,6 +5708,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -5695,11 +5747,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -10999,7 +11053,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -11364,7 +11419,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -11412,6 +11468,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -11450,11 +11507,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }
@@ -12726,8 +12785,7 @@
     "lodash.unescape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-      "dev": true
+      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -16251,7 +16309,10 @@
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-3.0.0.tgz",
       "integrity": "sha512-F4HegoBuUKZvEzXYksQu05Y6vJqallhHkQUEL6M7OQ5rYLBQC/4MTK6km9ZZvEK9TqMy1XA8SSEJGJgTEr6bSQ==",
       "requires": {
+        "@babel/core": "7.4.3",
         "@svgr/webpack": "4.1.0",
+        "@typescript-eslint/eslint-plugin": "1.6.0",
+        "@typescript-eslint/parser": "1.6.0",
         "babel-eslint": "10.0.1",
         "babel-jest": "24.7.1",
         "babel-loader": "8.0.5",
@@ -16301,6 +16362,79 @@
         "workbox-webpack-plugin": "4.2.0"
       },
       "dependencies": {
+        "@babel/core": {
+          "version": "7.4.3",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.3.tgz",
+          "integrity": "sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.0",
+            "@babel/helpers": "^7.4.3",
+            "@babel/parser": "^7.4.3",
+            "@babel/template": "^7.4.0",
+            "@babel/traverse": "^7.4.3",
+            "@babel/types": "^7.4.0",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.11",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+              "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+            }
+          }
+        },
+        "@typescript-eslint/eslint-plugin": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.6.0.tgz",
+          "integrity": "sha512-U224c29E2lo861TQZs6GSmyC0OYeRNg6bE9UVIiFBxN2MlA0nq2dCrgIVyyRbC05UOcrgf2Wk/CF2gGOPQKUSQ==",
+          "requires": {
+            "@typescript-eslint/parser": "1.6.0",
+            "@typescript-eslint/typescript-estree": "1.6.0",
+            "requireindex": "^1.2.0",
+            "tsutils": "^3.7.0"
+          }
+        },
+        "@typescript-eslint/parser": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.6.0.tgz",
+          "integrity": "sha512-VB9xmSbfafI+/kI4gUK3PfrkGmrJQfh0N4EScT1gZXSZyUxpsBirPL99EWZg9MmPG0pzq/gMtgkk7/rAHj4aQw==",
+          "requires": {
+            "@typescript-eslint/typescript-estree": "1.6.0",
+            "eslint-scope": "^4.0.0",
+            "eslint-visitor-keys": "^1.0.0"
+          }
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.6.0.tgz",
+          "integrity": "sha512-A4CanUwfaG4oXobD5y7EXbsOHjCwn8tj1RDd820etpPAjH+Icjc2K9e/DQM1Hac5zH2BSy+u6bjvvF2wwREvYA==",
+          "requires": {
+            "lodash.unescape": "4.0.1",
+            "semver": "5.5.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+            }
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "doctrine": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -16323,6 +16457,14 @@
             "resolve": "^1.9.0"
           }
         },
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
         "resolve": {
           "version": "1.10.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
@@ -16335,6 +16477,11 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
           "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
@@ -16863,8 +17010,7 @@
     "requireindex": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
-      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
-      "dev": true
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="
     },
     "requires-port": {
       "version": "1.0.0",
@@ -19082,7 +19228,6 @@
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.0.tgz",
       "integrity": "sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==",
-      "dev": true,
       "requires": {
         "tslib": "^1.8.1"
       }


### PR DESCRIPTION
Opening this as a point-release to train-139, in the hope of having it in production before Fenix launch.

We have a new relier coming online with unknown but potentially significant volume, and it's going to be exercising our API in new and interesting ways. This adds some feature-flags that we can use to engage a graceful degradation of service if client behaviour causes unexpected problems:

* `OAUTH_DISABLE_NEW_CONNECTIONS_FOR_CLIENTS` on fxa-auth-server -- lets us refuse new signins or signups from a particular OAuth client, while leaving existing users connected.
  * This will be useful if we feel like current server load is sustainable but we don't want to increase it any further.
* `OAUTH_CLIENTS_DISABLED` on fxa-oauth-server -- lets us refuse to generate any tokens for particular oauth clients.
  * This will prevent new client instances from connecting, and additionally prevent connected instances from issuing new tokens. It's a big hammer!
  * Due to a client-side limitation, enabling this for Fenix will [sign users out](https://github.com/mozilla-mobile/android-components/issues/3347) even though we don't technically need to.
* ` OAUTH_DEVICE_COMMANDS_ENABLED` on fxa-auth-server -- lets us prevent OAuth clients from using the device-commands infrastructure (aka send-tab).
  * This lets the clients continue to do basic device registration and show up in the "devices and apps" list, but prevents them from using send-tab.
* `OAUTH_DEVICE_ACCESS_ENABLED` on fxa-auth-server -- lets us deny OAuth clients access to the entire devices API.
  * They will still be able to sync successfully (unless the broader disablement options above are also enabled)

Much of the diff here is tests, because I did a bit of cleanup as I went. It works better if you view without whitespace changes.

Using a local stack, I have manually tested that each of these have the desired effect on Fenix client behaviour when enabled via the instructions in the [Fenix Rollout Gameplan](https://docs.google.com/document/d/1doYLD7p6DnxAPLb-KYWSKUsi85M4JWbhJgnG6HOIstU/edit?ts=5d014545#heading=h.iyydstq02om).