### PR TITLE
feat(trailhead): update links and trailhead verification page

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/ready.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/ready.mustache
@@ -10,6 +10,11 @@
 
     {{#isSync}}
       <p class="account-ready-service">{{{escapedReadyToSyncText}}}</p>
+        {{#isTrailhead}}
+            <div class="button-row">
+                <button class="primary-button btn-start-browsing">{{#t}}Start browsing{{/t}}</button>
+            </div>
+        {{/isTrailhead}}
     {{/isSync}}
 
     {{^isSync}}

--- a/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
@@ -50,7 +50,7 @@
     <div class="links">
       {{#isTrailhead}}
         <a href="/sms/why" data-flow-event="link.why" class="left">{{#t}}Why sign in on another device?{{/t}}</a>
-        <a href="https://www.mozilla.org" data-flow-event="link.mozilla.org" class="right">{{#t}}Start browsing{{/t}}</a>
+        <a href="https://www.mozilla.org/firefox/accounts" data-flow-event="link.mozilla.org" class="right">{{#t}}Start browsing{{/t}}</a>
       {{/isTrailhead}}
       {{^isTrailhead}}
         <a href="/sms/why" data-flow-event="link.why">{{#t}}Why is more than one device required?{{/t}}</a>

--- a/packages/fxa-content-server/app/scripts/templates/sms_sent.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sms_sent.mustache
@@ -30,7 +30,7 @@
 
       <div class="links">
         <a href="/sms/sent/why" data-flow-event="link.why" class="left">{{#t}}Why sign in on another device?{{/t}}</a>
-        <a href="https://www.mozilla.org" data-flow-event="link.mozilla.org" class="right">{{#t}}Start browsing{{/t}}</a>
+        <a href="https://www.mozilla.org/firefox/accounts" data-flow-event="link.mozilla.org" class="right">{{#t}}Start browsing{{/t}}</a>
       </div>
 
     {{/isTrailhead}}

--- a/packages/fxa-content-server/app/scripts/views/ready.js
+++ b/packages/fxa-content-server/app/scripts/views/ready.js
@@ -72,6 +72,8 @@ const TEMPLATE_INFO = {
   }
 };
 
+const FXA_PRODUCT_PAGE_URL = 'https://www.mozilla.org/firefox/accounts';
+
 /*eslint-enable camelcase*/
 const View = FormView.extend({
   template: Template,
@@ -80,7 +82,8 @@ const View = FormView.extend({
   events: _.extend({}, FormView.prototype.events, {
     'click .btn-continue': preventDefaultThen('continue'),
     'click .btn-create-recovery-key': preventDefaultThen('createRecoveryKey'),
-    'click .btn-goto-account': preventDefaultThen('gotoSettings')
+    'click .btn-goto-account': preventDefaultThen('gotoSettings'),
+    'click .btn-start-browsing': preventDefaultThen('gotoProductPage'),
   }),
 
   initialize (options = {}) {
@@ -113,6 +116,10 @@ const View = FormView.extend({
 
   createRecoveryKey() {
     this.navigate('settings/account_recovery/confirm_password');
+  },
+
+  gotoProductPage() {
+    this.window.location.href = FXA_PRODUCT_PAGE_URL;
   },
 
   gotoSettings() {

--- a/packages/fxa-content-server/app/tests/spec/views/ready.js
+++ b/packages/fxa-content-server/app/tests/spec/views/ready.js
@@ -161,6 +161,17 @@ describe('views/ready', function () {
         });
     });
 
+    it('shows the `Start browsing` for Sync and trailhead style', () => {
+      createView(VerificationReasons.SIGN_UP);
+      sinon.stub(relier, 'isSync').callsFake(() => true);
+      sinon.stub(relier, 'get').callsFake(() => 'trailhead');
+
+      return view.render()
+        .then(() => {
+          assert.lengthOf(view.$('.btn-start-browsing'), 1);
+        });
+    });
+
     it('does not show the `Continue` for Sync', () => {
       createView(VerificationReasons.SIGN_UP);
       sinon.stub(relier, 'isSync').callsFake(() => true);

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -337,7 +337,7 @@ module.exports = {
     LINK_MARKETING: '.marketing-link',
     LINK_MARKETING_ANDROID: '.marketing-link-android',
     LINK_MARKETING_IOS: '.marketing-link-ios',
-    LINK_START_BROWSING: 'a[href="https://www.mozilla.org"]',
+    LINK_START_BROWSING: 'a[href="https://www.mozilla.org/firefox/accounts"]',
     LINK_WHY_IS_THIS_REQUIRED: 'a[href="/sms/why"]',
     PHONE_NUMBER: 'input[type="tel"]',
     PHONE_NUMBER_TOOLTIP: 'input[type="tel"] ~ .tooltip',
@@ -349,7 +349,7 @@ module.exports = {
     HEADER: '#fxa-sms-sent-header',
     LINK_BACK: '#back',
     LINK_RESEND: '#resend',
-    LINK_START_BROWSING: 'a[href="https://www.mozilla.org"]',
+    LINK_START_BROWSING: 'a[href="https://www.mozilla.org/firefox/accounts"]',
     PHONE_NUMBER_SENT_TO: '#send-success',
     RESEND_SUCCESS: '#resend-success'
   },


### PR DESCRIPTION
Connects with https://github.com/mozilla/fxa/issues/1306

Updates the account confirmed page (when viewed on mobile) to show a `Start browsing` button. It also updates our exisiting start browsing links to goto `https://www.mozilla.org/firefox/accounts`.

<img width="410" alt="Screen Shot 2019-06-13 at 3 52 24 PM" src="https://user-images.githubusercontent.com/1295288/59463136-45417d80-8df3-11e9-9878-9f64265435c5.png">
