### PR TITLE
fix(settings): Use the same padding for settings panel body as the header

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -321,7 +321,13 @@ body.settings #stage .settings {
 .settings-unit-details {
   clear: both;
   display: none;
-  padding: 0 16px;
+
+  @include respond-to('big') {
+    padding: 0 32px;
+  }
+  @include respond-to('small') {
+    padding: 0 16px;
+  }
 
   p {
     clear: both;


### PR DESCRIPTION
Use a left/right padding of 32px in "big" mode, 16px in "small"

fixes #1555

### Desktop

<img width="677" alt="Screenshot 2019-06-14 at 14 40 52" src="https://user-images.githubusercontent.com/848085/59513322-86e52d80-8eb2-11e9-8aa6-f1f14af9414a.png">

### Mobile

<img width="504" alt="Screenshot 2019-06-14 at 14 41 00" src="https://user-images.githubusercontent.com/848085/59513331-8c427800-8eb2-11e9-836d-6bff947be138.png">

@hritvi - r? (your first FxA review!)

