### PR TITLE
fix(payments): subhub integration tweaks for auth and payments servers

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -36,6 +36,9 @@
     "maxTTL": "28 days"
   },
   "subhub": {
+    "enabled": true,
+    "url": "http://127.0.0.1:8012/",
+    "key": "abcde",
     "useStubs": true,
     "stubs": {
       "plans": [

--- a/packages/fxa-auth-server/fxa-oauth-server/config/dev.json
+++ b/packages/fxa-auth-server/fxa-oauth-server/config/dev.json
@@ -175,7 +175,7 @@
       "termsUri": "",
       "privacyUri": "",
       "trusted": true,
-      "publicClient": false
+      "publicClient": true
     }
   ],
   "localRedirects": true,

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -1141,7 +1141,7 @@ AppError.unknownSubscriptionPlan = planId => {
   );
 };
 
-AppError.rejectedSubscriptionPaymentToken = (token, message) => {
+AppError.rejectedSubscriptionPaymentToken = (message, paymentError) => {
   return new AppError(
     {
       code: 400,
@@ -1149,19 +1149,20 @@ AppError.rejectedSubscriptionPaymentToken = (token, message) => {
       errno: ERRNO.REJECTED_SUBSCRIPTION_PAYMENT_TOKEN,
       message,
     },
-    {
-      token,
-    }
+    paymentError
   );
 };
 
-AppError.rejectedCustomerUpdate = message => {
-  return new AppError({
-    code: 400,
-    error: 'Bad Request',
-    errno: ERRNO.REJECTED_CUSTOMER_UPDATE,
-    message,
-  });
+AppError.rejectedCustomerUpdate = (message, paymentError) => {
+  return new AppError(
+    {
+      code: 400,
+      error: 'Bad Request',
+      errno: ERRNO.REJECTED_CUSTOMER_UPDATE,
+      message,
+    },
+    paymentError
+  );
 };
 
 AppError.subscriptionAlreadyCancelled = () => {

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -273,7 +273,7 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
           subscriptionId,
         });
 
-        return {};
+        return { subscriptionId };
       },
     },
   ];

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -293,11 +293,14 @@ module.exports.subscriptionsSubscriptionValidator = isA.object({
     .date()
     .timestamp('unix')
     .required(),
+  cancel_at_period_end: isA
+    .boolean()
+    .required(),
   ended_at: isA.alternatives(
     isA.date().timestamp('unix'),
     isA.any().allow(null)
   ),
-  nickname: isA.string().required(),
+  plan_name: isA.string().required(),
   plan_id: module.exports.subscriptionsPlanId.required(),
   status: isA.string().required(),
   subscription_id: module.exports.subscriptionsSubscriptionId.required(),

--- a/packages/fxa-auth-server/lib/subhub/client.js
+++ b/packages/fxa-auth-server/lib/subhub/client.js
@@ -180,7 +180,7 @@ module.exports = function(log, config) {
           orig_system: ORIG_SYSTEM,
         });
       } catch (err) {
-        if (err.statusCode === 400) {
+        if (err.statusCode === 400 || err.statusCode === 402 || err.statusCode === 404) {
           log.error('subhub.createSubscription.1', {
             uid,
             pmt_token,
@@ -188,13 +188,11 @@ module.exports = function(log, config) {
             email,
             err,
           });
-          // TODO: update with subhub createSubscription error response for invalid payment token
-          if (err.message === 'invalid payment token') {
-            throw error.rejectedSubscriptionPaymentToken(pmt_token);
-          }
-          // TODO: update with subhub createSubscription error response for invalid plan ID
-          if (err.message === 'invalid plan id') {
+          if (err.statusCode === 404) {
             throw error.unknownSubscriptionPlan(plan_id);
+          }
+          if (err.statusCode === 400 || err.statusCode === 402) {
+            throw error.rejectedSubscriptionPaymentToken(err.message, err);
           }
         }
         throw err;
@@ -236,13 +234,13 @@ module.exports = function(log, config) {
       try {
         return await api.updateCustomer(uid, { pmt_token });
       } catch (err) {
-        if (err.statusCode === 400 || err.statusCode === 404) {
+        if (err.statusCode === 400 || err.statusCode === 402 || err.statusCode === 404) {
           log.error('subhub.updateCustomer.1', { uid, pmt_token, err });
           if (err.statusCode === 404) {
             throw error.unknownCustomer(uid);
           }
-          if (err.statusCode === 400) {
-            throw error.rejectedCustomerUpdate(err.message);
+          if (err.statusCode === 400 || err.statusCode === 402) {
+            throw error.rejectedCustomerUpdate(err.message, err);
           }
         }
         throw err;

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -454,7 +454,7 @@ describe('subscriptions', () => {
       assert.equal(args[1], SUBSCRIPTION_ID_1);
       assert.isAbove(args[2], Date.now() - 1000);
       assert.isAtMost(args[2], Date.now());
-      assert.deepEqual(res, {});
+      assert.deepEqual(res, { subscriptionId: 'sub-8675309' });
 
       assert.equal(
         push.notifyProfileUpdated.callCount,

--- a/packages/fxa-auth-server/test/local/subhub/client.js
+++ b/packages/fxa-auth-server/test/local/subhub/client.js
@@ -124,8 +124,9 @@ describe('subhub client', () => {
         {
           current_period_start: 1557161022,
           current_period_end: 1557361022,
+          cancel_at_period_end: false,
           ended_at: null,
-          nickname: 'Example',
+          plan_name: 'Example',
           plan_id: 'firefox_pro_basic_823',
           status: 'active',
           subscription_id: 'sub_8675309',
@@ -133,16 +134,7 @@ describe('subhub client', () => {
       ],
     };
 
-    // These unix timestamps get converted to Date along the way.
-    const expected = {
-      subscriptions: mockBody.subscriptions.map(subscription => ({
-        ...subscription,
-        current_period_start: new Date(
-          subscription.current_period_start * 1000
-        ),
-        current_period_end: new Date(subscription.current_period_end * 1000),
-      })),
-    };
+    const expected = mockBody;
 
     return { mockBody, expected };
   };
@@ -239,7 +231,7 @@ describe('subhub client', () => {
       mockServer
         .post(`/v1/customer/${UID}/subscriptions`)
         // TODO: update with subhub createSubscription error response for invalid plan ID
-        .reply(400, { message: 'invalid plan id' });
+        .reply(404, { message: 'invalid plan id' });
       const { log, subhub } = makeSubject();
       try {
         await subhub.createSubscription(UID, PAYMENT_TOKEN_BAD, PLAN_ID, EMAIL);

--- a/packages/fxa-payments-server/src/components/AppLayout/index.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.tsx
@@ -31,7 +31,7 @@ export const SignInLayout = ({
     </div>
   </AppLayout>
   <div id="static-footer">
-    <a id="about-mozilla" rel="author" target="_blank" href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"></a>
+    <a id="about-mozilla" rel="author noopener noreferrer" target="_blank" href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral">&nbsp;</a>
   </div>
 </>;
 

--- a/packages/fxa-payments-server/src/components/DialogMessage.stories.tsx
+++ b/packages/fxa-payments-server/src/components/DialogMessage.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { storiesOf } from '@storybook/react';
 import MockApp from '../../.storybook/components/MockApp';
 import LoremIpsum from '../../.storybook/components/LoremIpsum';

--- a/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
@@ -7,9 +7,7 @@ import { QueryParams } from '../../lib/types';
 import { APIError } from '../../store/utils';
 import { SignInLayout } from '../../components/AppLayout';
 import {
-  Validator,
   State as ValidatorState,
-  MiddlewareReducer as ValidatorMiddlewareReducer,
 } from '../../lib/validator';
 import { Product, ProductProps } from './index';
 
@@ -28,6 +26,7 @@ function init() {
           {
             current_period_end: (Date.now() + 86400) / 1000,
             current_period_start: (Date.now() - 86400) / 1000,
+            cancel_at_period_end: false,
             ended_at: null,
             nickname: 'Example Plan',
             plan_id: 'plan_123',
@@ -51,7 +50,7 @@ function init() {
         profile: {
           loading: false,
           result: null,
-          error: new APIError({ code: 500, message: 'Internal Server Error' }),
+          error: new APIError({ statusCode: 500, message: 'Internal Server Error' }),
         }
       }} />
     ))
@@ -67,7 +66,7 @@ function init() {
         customer: {
           loading: false,
           result: null,
-          error: new APIError({ code: 500, message: 'Internal Server Error' }),
+          error: new APIError({ statusCode: 500, message: 'Internal Server Error' }),
         }
       }} />
     ))
@@ -83,7 +82,7 @@ function init() {
         plans: {
           loading: false,
           result: null,
-          error: new APIError({ code: 500, message: 'Internal Server Error' }),
+          error: new APIError({ statusCode: 500, message: 'Internal Server Error' }),
         }
       }} />
     ))
@@ -96,8 +95,13 @@ function init() {
           result: null,
           loading: false,
           error: {
-            code: 'card_declined',
-            message: 'Your card has insufficient funds.',
+            // Copy / paste of error content from API
+            "code": "expired_card",
+            "message": "Your card has expired.",
+            "errno": 181,
+            "error": "Bad Request",
+            "info": "https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/docs/api.md#response-format",
+            "statusCode": 402,
           }
         }
       }} />
@@ -111,7 +115,6 @@ function init() {
           error: {
             code: '',
             message: 'Payment server request failed.',
-            params: ''
           }
         }
       }} />

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -109,11 +109,11 @@ export const Product = ({
       const error: any = { message: 'No token response received from Stripe' };
       setCreateTokenError(error);
     }
-  }, [ accessToken, selectedPlan ]);
+  }, [ accessToken, selectedPlan, createSubscription, setCreateTokenError ]);
 
   const onPaymentError = useCallback((error: any) => {
     setCreateTokenError(error);
-  }, [ setCreateTokenError, accessToken, selectedPlan ]);
+  }, [ setCreateTokenError ]);
 
   if (customer.loading || plans.loading || profile.loading) {
     return <LoadingOverlay isLoading={true} />;
@@ -264,7 +264,7 @@ const ProfileBanner = ({
   }
 }: ProfileProps) => (
   <div className="profile-banner">
-    <img className="avatar hoisted" src={avatar} />
+    <img className="avatar hoisted" src={avatar} alt={displayName || email} />
     {displayName && <h2 className="displayName">{displayName}</h2>}
     <h3 className="name email">{email}</h3>
     {/* TODO: what does "switch account" do? need to re-login and redirect eventually back here?

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -1,11 +1,15 @@
-import React, { useCallback, useEffect, useState, useContext } from 'react';
-import { useBooleanState } from '../../lib/hooks';
-import { Customer, UpdatePaymentFetchState, CustomerFetchState, CustomerSubscription, PlansFetchState, Plan } from '../../store/types';
+import React, { useCallback, useState } from 'react';
 import dayjs from 'dayjs';
-
+import { useBooleanState } from '../../lib/hooks';
+import {
+  Customer,
+  UpdatePaymentFetchState,
+  CustomerFetchState,
+  CustomerSubscription,
+  Plan
+} from '../../store/types';
 import PaymentForm from '../../components/PaymentForm';
 import DialogMessage from '../../components/DialogMessage';
-import AppContext from '../../lib/AppContext';
 
 type PaymentUpdateFormProps = {
   accessToken: string,
@@ -44,11 +48,15 @@ export const PaymentUpdateForm = ({
       const error: any = { message: 'No token response received from Stripe' };
       setCreateTokenError(error);
     }
-  }, [ accessToken ]);
+  }, [ accessToken, updatePayment, setCreateTokenError ]);
 
   const onPaymentError = useCallback((error: any) => {
     setCreateTokenError(error);
-  }, [ setCreateTokenError, accessToken ]);
+  }, [ setCreateTokenError ]);
+
+  const onTokenErrorDismiss = useCallback(() => {
+    setCreateTokenError({ message: null });
+  }, [ setCreateTokenError ]);
 
   const inProgress =
     updatePaymentStatus.loading
@@ -67,6 +75,14 @@ export const PaymentUpdateForm = ({
 
   return (
     <div className="payment-update">
+
+      {createTokenError.message && (
+        <DialogMessage className="dialog-error" onDismiss={onTokenErrorDismiss}>
+          <h4>Payment submission failed</h4>
+          <p>{createTokenError.message}</p>
+        </DialogMessage>
+      )}
+
       <h3 className="billing-title"><span>Billing information</span></h3>
       <p className="billing-description">
         You'll be billed ${plan.amount / 100} per {plan.interval} for {plan.plan_name}.

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -68,7 +68,7 @@ export const SubscriptionItem = ({
         <h2>{plan.plan_name}</h2>
       </header>
 
-      {customerSubscription.status === 'active' ? <>
+      {! customerSubscription.cancel_at_period_end ? <>
         <PaymentUpdateForm {...{
           plan,
           customerSubscription,

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -84,7 +84,18 @@ function init() {
     .add('payment update', () => (
       <SubscriptionsRoute routeProps={{
         ...subscribedProps,
-        updatePaymentStatus: errorFetchState(),
+        updatePaymentStatus: {
+          loading: false,
+          result: null,
+          error: new APIError({
+            // Copy / paste of error content from API
+            "code": "expired_card",
+            "message": "Your card has expired.",
+            "errno": 181,
+            "error": "Bad Request",
+            "info": "https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/docs/api.md#response-format",
+          })
+        },
         resetUpdatePayment: linkTo('routes/Subscriptions', 'subscribed'),
       }} />
     ))
@@ -102,7 +113,7 @@ const errorFetchState = (): FetchState<any> => ({
   loading: false,
   result: null,
   error: new APIError({
-    code: 500,
+    statusCode: 500,
     message: 'Internal Server Error',
   })
 });
@@ -219,6 +230,7 @@ const subscribedProps: SubscriptionsProps = {
     {
       current_period_end: (Date.now() + 86400) / 1000,
       current_period_start: (Date.now() - 86400) / 1000,
+      cancel_at_period_end: false,
       ended_at: null,
       nickname: 'Example Plan',
       plan_id: PLAN_ID,
@@ -245,7 +257,7 @@ const cancelledProps: SubscriptionsProps = {
   customerSubscriptions: [
     {
       ...subscribedProps.customerSubscriptions[0],
-      status: 'cancelled',
+      cancel_at_period_end: true,
     }
   ],
   subscriptions: {
@@ -268,7 +280,7 @@ const reactivationErrorProps = {
     loading: false,
     result: false,
     error: new APIError({
-      code: 500,
+      statusCode: 500,
       message: 'reactivateSubscription API not implemented',
     })
   }

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext, useCallback, useState } from 'react';
+import React, { useEffect, useContext, useCallback } from 'react';
 import { connect } from 'react-redux';
 import dayjs from 'dayjs';
 
@@ -81,7 +81,7 @@ export const Subscriptions = ({
 
   const onSupportClick = useCallback(
     () => navigateToUrl(SUPPORT_PANEL_URL),
-    [ SUPPORT_PANEL_URL, navigateToUrl ]
+    [ navigateToUrl ]
   );
 
   if (customer.loading || subscriptions.loading || profile.loading || plans.loading) {
@@ -312,7 +312,7 @@ const ProfileBanner = ({
 }: ProfileProps) => (
   <header id="fxa-settings-profile-header-wrapper">
     <div className="avatar-wrapper avatar-settings-view">
-      <img src={avatar} className="profile-image" />
+      <img src={avatar} alt={displayName || email} className="profile-image" />
     </div>
     <div id="fxa-settings-profile-header">
       {displayName && <h1 className="card-header">{displayName}</h1>}

--- a/packages/fxa-payments-server/src/store/index.tsx
+++ b/packages/fxa-payments-server/src/store/index.tsx
@@ -28,15 +28,15 @@ const RESET_PAYMENT_DELAY = 2000;
 
 export const defaultState: State = {
   api: {
-    cancelSubscription: fetchDefault(false),
-    reactivateSubscription: fetchDefault(false),
-    createSubscription: fetchDefault(false),
-    customer: fetchDefault({}),
+    cancelSubscription: fetchDefault(null),
+    reactivateSubscription: fetchDefault(null),
+    createSubscription: fetchDefault(null),
+    customer: fetchDefault(null),
     plans: fetchDefault(null),
-    profile: fetchDefault({}),
-    updatePayment: fetchDefault(false),
-    subscriptions: fetchDefault([]),
-    token: fetchDefault({}),
+    profile: fetchDefault(null),
+    updatePayment: fetchDefault(null),
+    subscriptions: fetchDefault(null),
+    token: fetchDefault(null),
   }
 };
 
@@ -69,9 +69,10 @@ export const selectors: Selectors = {
 
   customerSubscriptions: state => {
     const customer = selectors.customer(state);
-    return ! customer || ! customer.result
-      ? []
-      : customer.result.subscriptions;
+    if (customer && customer.result && customer.result.subscriptions) {
+      return customer.result.subscriptions;
+    }
+    return [];
   },
 };
 
@@ -98,13 +99,17 @@ export const actions: ActionCreators = {
         apiDelete(
           accessToken,
           `${config.servers.auth.url}/v1/oauth/subscriptions/active/${subscriptionId}`
-        ),
-      reactivateSubscription: (accessToken, subscriptionId) => 
-        // TODO: https://github.com/mozilla/fxa/issues/1273
-        Promise.reject(new APIError({
-          code: 500,
+        ).then(result => {
+          // HACK: cancellation response does not include subscriptionId, but we want it.
+          return { ...result, subscriptionId };
+        }),
+      // TODO: https://github.com/mozilla/fxa/issues/1273
+      reactivateSubscription: async (accessToken, subscriptionId) => {
+        throw new APIError({
+          statusCode: 500,
           message: 'reactivateSubscription API not implemented',
-        })),
+        })
+      },
       updatePayment: (accessToken, { paymentToken }) =>
         apiPost(
           accessToken,
@@ -127,6 +132,7 @@ export const actions: ActionCreators = {
         dispatch(actions.fetchPlans(accessToken)),
         dispatch(actions.fetchProfile(accessToken)),
         dispatch(actions.fetchCustomer(accessToken)),
+        dispatch(actions.fetchSubscriptions(accessToken)),
       ])
     },
 
@@ -136,6 +142,15 @@ export const actions: ActionCreators = {
         dispatch(actions.fetchPlans(accessToken)),
         dispatch(actions.fetchProfile(accessToken)),
         dispatch(actions.fetchCustomer(accessToken)),
+        dispatch(actions.fetchSubscriptions(accessToken)),
+      ])
+    },
+  
+  fetchCustomerAndSubscriptions: (accessToken: string) =>
+    async (dispatch: Function, getState: Function) => {
+      await Promise.all([
+        dispatch(actions.fetchCustomer(accessToken)),
+        dispatch(actions.fetchSubscriptions(accessToken)),
       ])
     },
 
@@ -185,18 +200,20 @@ export const reducers = {
         fetchReducer('createSubscription'),
       [actions.cancelSubscription.toString()]:
         fetchReducer('cancelSubscription'),
+      [actions.reactivateSubscription.toString()]:
+        fetchReducer('reactivateSubscription'),
       [actions.updatePayment.toString()]:
         fetchReducer('updatePayment'),
       [actions.updateApiData.toString()]:
         (state, { payload }) => ({ ...state, ...payload }),
       [actions.resetCreateSubscription.toString()]:
-        setStatic({ createSubscription: fetchDefault(false) }),
+        setStatic({ createSubscription: fetchDefault(null) }),
       [actions.resetCancelSubscription.toString()]:
-        setStatic({ cancelSubscription: fetchDefault(false) }),
+        setStatic({ cancelSubscription: fetchDefault(null) }),
       [actions.resetReactivateSubscription.toString()]:
-        setStatic({ reactivateSubscription: fetchDefault(false) }),
+        setStatic({ reactivateSubscription: fetchDefault(null) }),
       [actions.resetUpdatePayment.toString()]:
-        setStatic({ updatePayment: fetchDefault(false) }),
+        setStatic({ updatePayment: fetchDefault(null) }),
     },
     defaultState.api
   ),

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -42,6 +42,7 @@ export interface Subscription {
 }
 
 export interface CustomerSubscription {
+  cancel_at_period_end: boolean;
   current_period_end: number;
   current_period_start: number;
   ended_at: string | null,
@@ -71,7 +72,10 @@ export interface CreateSubscriptionResult {
 export type CreateSubscriptionError = {
   code: string,
   message: string,
-  params?: string,
+  error?: string,
+  errno?: number,
+  info?: string,
+  statusCode?: number,
 };
 export type CreateSubscriptionFetchState =
   FetchState<CreateSubscriptionResult, CreateSubscriptionError>;

--- a/packages/fxa-payments-server/src/store/utils.tsx
+++ b/packages/fxa-payments-server/src/store/utils.tsx
@@ -11,7 +11,8 @@ export const mapToObject = (list: Array<string>, mapFn: Function): MappedObject 
 };
 
 type ErrorResponseBody = {
-  code?: number;
+  code?: string;
+  statusCode?: number,
   errno?: number;
   error?: string;
   message?: string;
@@ -21,28 +22,31 @@ type ErrorResponseBody = {
 export class APIError extends Error {
   body: ErrorResponseBody | null;
   response: Response | null;
-  code: number | null;
+  code: string | null;
+  statusCode: number | null;
   errno: number | null;
   error: string | null;
 
   constructor(
     body?: ErrorResponseBody,
     response?: Response,
-    code?: number,
+    code?: string,
     errno?: number,
     error?: string,
+    statusCode?: number,
     ...params: Array<any>
 ) {
     super(...params);
     this.response = response || null;
     this.body = body || null;
     this.code = code || null;
+    this.statusCode = statusCode || null;
     this.errno = errno || null;
     this.error = error || null;
 
     if (this.body) {
-      const { code, errno, error, message } = this.body;
-      Object.assign(this, { code, errno, error, message });
+      const { code, errno, error, message, statusCode } = this.body;
+      Object.assign(this, { code, errno, error, message, statusCode });
     }
   }
 }


### PR DESCRIPTION
(Note: this PR moved to #1656)

- add example local subhub server config to auth-server

- stub out subscription reactivate button (pending Issue #1273)

- handle & display errors in calling Stripe createToken API

- change OAuth client for payment pages to publicClient: true

- properly handle 402 errors on subscribe & payment update

- include more payment error info in payment form errors

- add cancel_at_period_end in customer data for cancelled subscriptions

- rename nickname field to plan_name in customer subscriptions data

- tweaks to subhub stubAPI to better reflect subscription cancellation

- default result for fetch states in Redux set to null

- misc tweaks to address lint warnings