### PR TITLE
fix(docker): Run `npm run build` steps within image

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -20,6 +20,10 @@ if grep -e "$MODULE" -e 'all' $DIR/../packages/test.list; then
   if [ "${MODULE}" == 'fxa-oauth-server' ]; then
     cp $DIR/../packages/version.json fxa-oauth-server/config
     docker build -f Dockerfile-oauth-build -t ${MODULE}:build .
+  elif [ "${MODULE}" == 'fxa-payments-server' ]; then
+    cd ..
+    docker build -f fxa-payments-server/Dockerfile -t ${MODULE}:build .
+    cd fxa-payments-server
   elif [[ -e Dockerfile ]]; then
     docker build -f Dockerfile -t ${MODULE}:build .
     # docker run --rm -it ${MODULE}:build npm ls --production

--- a/packages/fxa-payments-server/Dockerfile
+++ b/packages/fxa-payments-server/Dockerfile
@@ -1,13 +1,22 @@
 FROM node:12 AS node-builder
 USER node
-RUN mkdir /home/node/fxa-payments-server
+RUN mkdir /home/node/fxa-payments-server /home/node/fxa-content-server
 WORKDIR /home/node/fxa-payments-server
-COPY package*.json ./
-RUN npm install
+COPY ["fxa-payments-server/package*.json", "./"]
+RUN npm ci
+COPY ["fxa-payments-server/.storybook", ".storybook/"]
+COPY ["fxa-payments-server/public", "public/"]
+COPY ["fxa-payments-server/src", "src/"]
+COPY ["fxa-content-server", "../fxa-content-server/"]
+WORKDIR /home/node/fxa-content-server
+RUN npm ci
+WORKDIR /home/node/fxa-payments-server
+RUN npm run build
 
 FROM node:12-slim
 USER node
 RUN mkdir /home/node/fxa-payments-server
 WORKDIR /home/node/fxa-payments-server
 COPY --chown=node:node --from=node-builder /home/node/fxa-payments-server .
-COPY --chown=node:node . .
+COPY --chown=node:node [ "fxa-payments-server/", "./" ]
+CMD [ "/usr/local/bin/node", "server/bin/fxa-payments-server.js" ]


### PR DESCRIPTION
The problem I'm running into is that the payments server is attempting to use the `fxa-content-server` SCSS for shared styles.

```
Step 9/15 : RUN npm run build
 ---> Running in f678d372525d

> fxa-payments-server@0.0.1 build /home/node/fxa-payments-server
> react-scripts build

We detected TypeScript in your project (src/App.tsx) and created a tsconfig.json file for you.

Your tsconfig.json has been populated with default values.

Creating an optimized production build...
... repeated ...
BrowserslistError: Unknown browser query `android all`
Failed to compile.

./src/index.scss
@import '../../fxa-content-server/app/styles/main.scss';
^
      File to import not found or unreadable: ../../fxa-content-server/app/styles/main.scss.
      in /home/node/fxa-payments-server/src/index.scss (line 1, column 1)


npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! fxa-payments-server@0.0.1 build: `react-scripts build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the fxa-payments-server@0.0.1 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/node/.npm/_logs/2019-06-24T22_59_25_266Z-debug.log
The command '/bin/sh -c npm run build' returned a non-zero code: 1
```

However if I try to copy in the fxa-content-server via `COPY ["../fxa-content-server", "../fxa-content-server"]` it'll fail with:

```
Step 9/16 : COPY ["../fxa-content-server", "../fxa-content-server"]
COPY failed: Forbidden path outside the build context: ../fxa-content-server ()
```

Anybody have any ideas to fix this?