### PR TITLE
fix(event-broker): use proper types and correct in-memory datastore args

### DIFF
--- a/packages/fxa-event-broker/bin/workerDev.ts
+++ b/packages/fxa-event-broker/bin/workerDev.ts
@@ -33,7 +33,7 @@ delete firestoreConfig.enabled;
 
 let db = firestoreEnabled
   ? createDatastore(FirestoreDatastore, firestoreConfig)
-  : createDatastore(InMemoryDatastore, { webhooks: Config.get('clientWebhooks') });
+  : createDatastore(InMemoryDatastore, { clientWebhooks: Config.get('clientWebhooks') });
 
 /**
  * Verify the topic configuration is setup properly to route subscriptions locally

--- a/packages/fxa-event-broker/lib/db/firestore.ts
+++ b/packages/fxa-event-broker/lib/db/firestore.ts
@@ -6,9 +6,9 @@ import { Firestore, Settings } from '@google-cloud/firestore';
 import { ClientWebhooks } from '../selfUpdatingService/clientWebhookService';
 import { Datastore } from './index';
 
-type FirestoreDbSettings = Settings & {
+interface FirestoreDbSettings extends Settings {
   prefix: string;
-};
+}
 
 class FirestoreDatastore implements Datastore {
   private db: Firestore;

--- a/packages/fxa-event-broker/lib/db/index.ts
+++ b/packages/fxa-event-broker/lib/db/index.ts
@@ -24,9 +24,9 @@ interface Datastore {
   fetchClientIdWebhooks(): Promise<{ [clientId: string]: string }>;
 }
 
-type DatastoreConstructor = new (config: object) => Datastore;
+type DatastoreConstructor<T> = new (config: T) => Datastore;
 
-function createDatastore(constructor: DatastoreConstructor, config: object): Datastore {
+function createDatastore<T>(constructor: DatastoreConstructor<T>, config: T): Datastore {
   return new constructor(config);
 }
 


### PR DESCRIPTION
I noticed TypeScript complaining about how I goofed the signature of the db constructor, when I fixed it by using a generic Config, it pointed out that I passed the wrong args to the in-memory constructor, which this also fixes.