### PR TITLE
feat(oauth): Reject new authorizations for disabled OAuth clients.

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -1125,15 +1125,25 @@ AppError.backendServiceFailure = (service, operation) => {
   });
 };
 
-AppError.disabledClientId = (clientId) => {
-  return new AppError({
-    code: 503,
-    error: 'Client Disabled',
-    errno: ERRNO.DISABLED_CLIENT_ID,
-    message: 'This client has been temporarily disabled'
-  }, {
-      clientId
-    });
+AppError.disabledClientId = (clientId, retryAfter) => {
+  if (! retryAfter) {
+    retryAfter = 30;
+  }
+  return new AppError(
+    {
+      code: 503,
+      error: 'Client Disabled',
+      errno: ERRNO.DISABLED_CLIENT_ID,
+      message: 'This client has been temporarily disabled',
+    },
+    {
+      clientId,
+      retryAfter,
+    },
+    {
+      'retry-after': retryAfter,
+    }
+  );
 };
 
 AppError.internalValidationError = (op, data) => {

--- a/packages/fxa-auth-server/lib/routes/oauth.js
+++ b/packages/fxa-auth-server/lib/routes/oauth.js
@@ -21,6 +21,18 @@ const error = require('../error');
 const oauthRouteUtils = require('./utils/oauth');
 
 module.exports = (log, config, oauthdb, db, mailer, devices) => {
+
+  const OAUTH_DISABLE_NEW_CONNECTIONS_FOR_CLIENTS = new Set(
+    config.oauth.disableNewConnectionsForClients || []
+  );
+
+  function checkDisabledClientId(payload) {
+    const clientId = payload.client_id;
+    if (OAUTH_DISABLE_NEW_CONNECTIONS_FOR_CLIENTS.has(clientId)) {
+      throw error.disabledClientId(clientId);
+    }
+  }
+
   const routes = [
     {
       method: 'GET',
@@ -53,7 +65,8 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
           schema: oauthdb.api.getScopedKeyData.opts.validate.response
         }
       },
-      handler: async function (request) {
+      handler: async function(request) {
+        checkDisabledClientId(request.payload);
         const sessionToken = request.auth.credentials;
         return oauthdb.getScopedKeyData(sessionToken, request.payload);
       }
@@ -74,7 +87,8 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
           schema: oauthdb.api.createAuthorizationCode.opts.validate.response
         }
       },
-      handler: async function (request) {
+      handler: async function(request) {
+        checkDisabledClientId(request.payload);
         const sessionToken = request.auth.credentials;
         return oauthdb.createAuthorizationCode(sessionToken, request.payload);
       }

--- a/packages/fxa-auth-server/test/local/routes/oauth.js
+++ b/packages/fxa-auth-server/test/local/routes/oauth.js
@@ -26,10 +26,14 @@ const MOCK_TOKEN_RESPONSE = {
 };
 
 describe('/oauth/ routes', () => {
-  let mockOAuthDB, mockLog, sessionToken;
+  let mockOAuthDB, mockLog, mockConfig, sessionToken;
 
   async function loadAndCallRoute(path, request) {
-    const routes = require('../../../lib/routes/oauth')(mockLog, {}, mockOAuthDB);
+    const routes = require('../../../lib/routes/oauth')(
+      mockLog,
+      mockConfig,
+      mockOAuthDB
+    );
     const route = await getRoute(routes, path);
     if (route.options.validate.payload) {
       request.payload = await Joi.validate(request.payload, route.options.validate.payload);
@@ -58,6 +62,9 @@ describe('/oauth/ routes', () => {
 
   beforeEach(() => {
     mockLog = mocks.mockLog();
+    mockConfig = {
+      oauth: {}
+    };
   });
 
   describe('/oauth/client/{client_id}', () => {
@@ -107,6 +114,27 @@ describe('/oauth/ routes', () => {
       assert.deepEqual(resp, { key: 'data' });
     });
 
+    it('can refuse to return scoped-key data for selected OAuth clients', async () => {
+      mockOAuthDB = mocks.mockOAuthDB();
+      mockConfig.oauth.disableNewConnectionsForClients = [MOCK_CLIENT_ID];
+      sessionToken = await mockSessionToken();
+      const mockRequest = mocks.mockRequest({
+        credentials: sessionToken,
+        payload: {
+          client_id: MOCK_CLIENT_ID,
+          scope: MOCK_SCOPES,
+        },
+      });
+      try {
+        await loadAndCallRoute('/account/scoped-key-data', mockRequest);
+        assert.fail('should have thrown');
+      } catch (err) {
+        assert.equal(err.output.statusCode, 503);
+        assert.equal(err.output.headers['retry-after'], '30');
+        assert.equal(err.errno, error.ERRNO.DISABLED_CLIENT_ID);
+      }
+      assert.notCalled(mockOAuthDB.getScopedKeyData);
+    });
   });
 
   describe('/oauth/authorization', () => {
@@ -146,6 +174,28 @@ describe('/oauth/ routes', () => {
       });
     });
 
+    it('can refuse to authorize new grants for selected OAuth clients', async () => {
+      mockOAuthDB = mocks.mockOAuthDB();
+      mockConfig.oauth.disableNewConnectionsForClients = [MOCK_CLIENT_ID];
+      sessionToken = await mockSessionToken();
+      const mockRequest = mocks.mockRequest({
+        credentials: sessionToken,
+        payload: {
+          client_id: MOCK_CLIENT_ID,
+          scope: MOCK_SCOPES,
+          state: 'xyz',
+        },
+      });
+      try {
+        await loadAndCallRoute('/oauth/authorization', mockRequest);
+        assert.fail('should have thrown');
+      } catch (err) {
+        assert.equal(err.output.statusCode, 503);
+        assert.equal(err.output.headers['retry-after'], '30');
+        assert.equal(err.errno, error.ERRNO.DISABLED_CLIENT_ID);
+      }
+      assert.notCalled(mockOAuthDB.createAuthorizationCode);
+    });
   });
 
   describe('/oauth/token', () => {

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -442,7 +442,7 @@ function mockDB (data, errors) {
   });
 }
 
-function mockOAuthDB(methods) {
+function mockOAuthDB(methods={}) {
   // For OAuthDB, the mock object needs to expose a `.api` property
   // with route validation info, so we load the module directly.
   const log = methods.log || module.exports.mockLog();


### PR DESCRIPTION
The `$OAUTH_DISABLE_NEW_CONNECTIONS_FOR_CLIENTS` added in https://github.com/mozilla/fxa/pull/1577 does not cover the pairing flow, which allows clients to get connected from an already-connected client.  This PR adds additional checks of that flag so that it also covers the pairing flow.

Not sure if it's worth a point-release, but wanted to put it up for completeness.