### PR TITLE
chore(pm2): build payment server content before starting

### DIFF
--- a/servers.json
+++ b/servers.json
@@ -193,6 +193,7 @@
       "script": "npm",
       "args": [
         "run",
+        "build",
         "start-dev"
       ],
       "max_restarts": "1",


### PR DESCRIPTION
`npm run build` before starting the dev payment server with pm2.  Otherwise the server would error out with `uncaughtException Error: ENOENT: no such file or directory, open '/home/chenba/dev/fxa/packages/fxa-payments-server/build/index.html'`

Fixes #1378