### PR TITLE
fix(style): Fixes #1258 - remove back link from CWTS on email first flow

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/choose_what_to_sync.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/choose_what_to_sync.mustache
@@ -46,9 +46,6 @@
           <button id="submit-btn" type="submit" tabindex="1" autofocus>{{#t}}Save selections{{/t}}</button>
         {{/isTrailhead}}
         </div>
-      <div class="links">
-        <a href="#" id="back" data-flow-event="back">{{#t}}Back{{/t}}</a>
-      </div>
     </form>
   </section>
 </div>


### PR DESCRIPTION
First PR! 🎉 Thanks to @dannycoates for walking me through the process. :D

---

Removes the back link and container div from CWTS email first flow.

Fixes #1258 