### PR TITLE
feat(clients): Add methods for handling attached clients in fxa-js-client

### DIFF
--- a/packages/fxa-js-client/client/FxAccountClient.js
+++ b/packages/fxa-js-client/client/FxAccountClient.js
@@ -1626,6 +1626,63 @@ define([
   };
 
   /**
+   * Get a list of user's attached clients
+   *
+   * @method attachedClients
+   * @param {String} sessionToken sessionToken obtained from signIn
+   * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
+   */
+  FxAccountClient.prototype.attachedClients = function(sessionToken) {
+    var request = this.request;
+
+    return Promise.resolve()
+      .then(function() {
+        required(sessionToken, 'sessionToken');
+
+        return hawkCredentials(sessionToken, 'sessionToken', HKDF_SIZE);
+      })
+      .then(function(creds) {
+        return request.send('/account/attached_clients', 'GET', creds);
+      });
+  };
+
+  /**
+   * Destroys all tokens held by an attached client.
+   *
+   * @method attachedClientDestroy
+   * @param {String} sessionToken User session token
+   * @param {Object} clientInfo Attached client info, as returned by `attachedClients` method
+   * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
+   */
+  FxAccountClient.prototype.attachedClientDestroy = function(
+    sessionToken,
+    clientInfo
+  ) {
+    var self = this;
+    var data = {
+      clientId: clientInfo.clientId,
+      deviceId: clientInfo.deviceId,
+      refreshTokenId: clientInfo.refreshTokenId,
+      sessionTokenId: clientInfo.sessionTokenId,
+    };
+
+    return Promise.resolve()
+      .then(function() {
+        required(sessionToken, 'sessionToken');
+
+        return hawkCredentials(sessionToken, 'sessionToken', HKDF_SIZE);
+      })
+      .then(function(creds) {
+        return self.request.send(
+          '/account/attached_client/destroy',
+          'POST',
+          creds,
+          data
+        );
+      });
+  };
+
+  /**
    * Send an unblock code
    *
    * @method sendUnblockCode

--- a/packages/fxa-js-client/tests/lib/attachedClients.js
+++ b/packages/fxa-js-client/tests/lib/attachedClients.js
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!tdd',
+  'intern/chai!assert',
+  'tests/addons/environment',
+  'tests/addons/sinon',
+], function(tdd, assert, Environment, sinon) {
+  with (tdd) {
+    suite('session', function() {
+      var accountHelper;
+      var respond;
+      var requests;
+      var client;
+      var RequestMocks;
+      var ErrorMocks;
+      var xhr;
+
+      beforeEach(function() {
+        var env = new Environment();
+        accountHelper = env.accountHelper;
+        respond = env.respond;
+        requests = env.requests;
+        client = env.client;
+        RequestMocks = env.RequestMocks;
+        ErrorMocks = env.ErrorMocks;
+        xhr = env.xhr;
+        sinon.spy(xhr.prototype, 'open');
+        sinon.spy(xhr.prototype, 'send');
+      });
+
+      afterEach(function() {
+        xhr.prototype.open.restore();
+        xhr.prototype.send.restore();
+      });
+
+      test('#attachedClients', function() {
+        return accountHelper
+          .newVerifiedAccount()
+          .then(function(account) {
+            return respond(
+              client.attachedClients(account.signIn.sessionToken),
+              RequestMocks.attachedClients
+            );
+          })
+          .then(function(res) {
+            assert.equal(res.length, 2);
+            var s = res[0];
+            assert.ok(s.deviceId);
+            assert.ok(s.deviceType);
+            assert.ok(s.lastAccessTime);
+            assert.ok(s.lastAccessTimeFormatted);
+            assert.ok(s.sessionTokenId);
+            s = res[1];
+            assert.ok(s.deviceId);
+            assert.ok(s.deviceType);
+            assert.ok(s.lastAccessTime);
+            assert.ok(s.lastAccessTimeFormatted);
+            assert.ok(s.sessionTokenId);
+          }, assert.notOk);
+      });
+
+      test('#attachedClients error', function() {
+        return accountHelper
+          .newVerifiedAccount()
+          .then(function(account) {
+            var fakeToken =
+              'e838790265a45f6ee1130070d57d67d9bb20953706f73af0e34b0d4d92f10000';
+
+            return respond(
+              client.attachedClients(fakeToken),
+              ErrorMocks.invalidAuthToken
+            );
+          })
+          .then(assert.notOk, function(err) {
+            assert.equal(err.code, 401);
+            assert.equal(err.errno, 110);
+          });
+      });
+
+      test('#destroy', function() {
+        return accountHelper
+          .newVerifiedAccount()
+          .then(function(account) {
+            return respond(
+              client.attachedClientDestroy(account.signIn.sessionToken),
+              RequestMocks.attachedClientDestroy
+            );
+          })
+          .then(function(res) {
+            assert.ok(res, 'got response');
+          }, assert.notOk);
+      });
+    });
+  }
+});

--- a/packages/fxa-js-client/tests/mocks/request.js
+++ b/packages/fxa-js-client/tests/mocks/request.js
@@ -250,6 +250,35 @@ define(['client/lib/errors', 'tests/lib/push-constants'], function(
         },
       ]),
     },
+    attachedClients: {
+      status: 200,
+      body: JSON.stringify([
+        {
+          deviceId: 'device1',
+          deviceType: 'desktop',
+          isDevice: false,
+          lastAccessTime: 100,
+          lastAccessTimeFormatted: 'a few seconds ago',
+          name: 'name1',
+          sessionToken: 'session1',
+          userAgent: 'agent1',
+        },
+        {
+          deviceId: 'device2',
+          deviceType: 'desktop',
+          isDevice: false,
+          lastAccessTime: 101,
+          lastAccessTimeFormatted: 'a few seconds ago',
+          name: 'name2',
+          sessionToken: 'session2',
+          userAgent: 'agent2',
+        },
+      ]),
+    },
+    attachedClientDestroy: {
+      status: 200,
+      body: '{}',
+    },
     accountDestroy: {
       status: 200,
       body: '{}',


### PR DESCRIPTION
The tests in https://github.com/mozilla/fxa/pull/1262/ are failing because it adds new methods to fxa-js-client, but fxa-content-server uses the latest published version rather than the version from the repo. I guess I need to gut a new fxa-js-client release before I can land that PR?  Here's just the fxa-js-client changes as a separate PR in order to facilitate that.