### PR TITLE
fix(deploy): ensure built paths are generated correctly in container

### DIFF
--- a/packages/fxa-payments-server/Dockerfile
+++ b/packages/fxa-payments-server/Dockerfile
@@ -11,6 +11,7 @@ COPY ["fxa-content-server", "../fxa-content-server/"]
 WORKDIR /home/node/fxa-content-server
 RUN npm ci
 WORKDIR /home/node/fxa-payments-server
+ENV PUBLIC_URL /
 RUN npm run build
 
 FROM node:12-slim


### PR DESCRIPTION
Fixes #1632.

Figured this out through a combination of trial-and-error and looking at the output of `npm run build`, so I don't fully understand all the ins and outs of this. But fwiw, running it with `PUBLIC_URL` set to `/` generates the `build` directory with the correct paths for me.

@jbuck, can you try this out just to make sure it works for you too?