### PR TITLE
chore(version) bump fxa-js-client version to 1.0.14

### DIFF
--- a/packages/fxa-content-server/npm-shrinkwrap.json
+++ b/packages/fxa-content-server/npm-shrinkwrap.json
@@ -5710,9 +5710,9 @@
             }
         },
         "fxa-js-client": {
-            "version": "1.0.13",
-            "resolved": "https://registry.npmjs.org/fxa-js-client/-/fxa-js-client-1.0.13.tgz",
-            "integrity": "sha512-9oppS4QjKW66HO8J2CWjQvr67Yzif+qf70E0Ivyvq2xgROip8tE/ZlvdiTSQSXIidk5iyxnRtsFYlWvGlHAF5w==",
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/fxa-js-client/-/fxa-js-client-1.0.14.tgz",
+            "integrity": "sha512-Yh5OhC+/WS3fAdWpLC/4zlRGDXRaB86lom72+aqUqMQ2/Rz+0vhdS1dWQKfofkfg5IYkPTULump+r36e/pGvMw==",
             "requires": {
                 "es6-promise": "4.1.1",
                 "sjcl": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8e",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -63,7 +63,7 @@
         "fxa-common-password-list": "0.0.2",
         "fxa-crypto-relier": "2.3.0",
         "fxa-geodb": "1.0.4",
-        "fxa-js-client": "^1.0.13",
+        "fxa-js-client": "^1.0.14",
         "fxa-mustache-loader": "0.0.2",
         "fxa-pairing-channel": "1.0.1",
         "fxa-shared": "1.0.26",

--- a/packages/fxa-js-client/package-lock.json
+++ b/packages/fxa-js-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-js-client",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fxa-js-client/package.json
+++ b/packages/fxa-js-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-js-client",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Web client that talks to the Firefox Accounts API server",
   "author": "Mozilla",
   "license": "MPL-2.0",


### PR DESCRIPTION
What is says on the tin.