### PR TITLE
fix(metrics): remove declined sync engines from amplitude events

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
@@ -93,7 +93,10 @@ const View = FormView.extend({
 
     return this.user.setAccount(account)
       .then(account => {
-        this.notifier.trigger('set-sync-engines', offeredSyncEngines);
+        this.notifier.trigger(
+          'set-sync-engines',
+          offeredSyncEngines.filter(e => declinedSyncEngines.indexOf(e) === -1)
+        );
         return this.onSubmitComplete(account);
       });
   },

--- a/packages/fxa-content-server/app/tests/spec/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/tests/spec/views/choose_what_to_sync.js
@@ -270,7 +270,14 @@ describe('views/choose_what_to_sync', () => {
           assert.equal(notifier.trigger.callCount, 2);
           const args = notifier.trigger.args[1];
           assert.equal(args[0], 'set-sync-engines');
-          assert.deepEqual(args[1], DISPLAYED_ENGINE_IDS);
+          assert.deepEqual(args[1], [
+            'bookmarks',
+            'addons',
+            'passwords',
+            'history',
+            'prefs',
+            'creditcards'
+          ]);
 
           assert.isTrue(view.onSubmitComplete.calledOnce);
           assert.instanceOf(view.onSubmitComplete.args[0][0], Account);


### PR DESCRIPTION
Fixes #938.

Targeted at `train-140` for a patch release. I did a rush job on #1384 and failed to notice the data I was sending to Amplitude included every displayed Sync engine, not just the ones the user had actually selected. This fixes that.

Note there is a quadratic nested loop, where I use `indexOf` inside `filter`. I do this knowingly, because the maximum combined nested iteration count is 36 and we only iterate it once, on submission. It's an imperceptible chunk of time and although I could refactor the auth broker to return a map instead, it didn't seem worth the effort. I'll be happy to oblige if there's disagreement however.

@mozilla/fxa-devs r?
