### PR TITLE
fix(db): delete account subscriptions inside db transaction

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -1436,7 +1436,6 @@ module.exports = (
                     for (const subscription of subscriptions) {
                       const { subscriptionId } = subscription;
                       await subhub.cancelSubscription(uid, subscriptionId);
-                      await db.deleteAccountSubscription(uid, subscriptionId);
                     }
                   }
 

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -2741,11 +2741,7 @@ describe('/account/destroy', () => {
         cancelArgs,
         'active subscriptions were all cancelled'
       );
-      assert.deepEqual(
-        mockDB.deleteAccountSubscription.args,
-        cancelArgs,
-        'active subscriptions were all deleted'
-      );
+      assert.equal(mockDB.deleteAccountSubscription.callCount, 0);
 
       assert.equal(mockPush.notifyAccountDestroyed.callCount, 1);
       assert.equal(mockPush.notifyAccountDestroyed.firstCall.args[0], uid);


### PR DESCRIPTION
This isn't attached to any issue, I just noticed it while I was perusing the code.

The `deleteAccount` stored procedure already deletes all of the subscriptions for an account, inside the same transaction where the account record itself is deleted:

https://github.com/mozilla/fxa/blob/84dc39debf9f65fc07185fd6db8fac0d1de3ac4d/packages/fxa-auth-db-mysql/lib/db/schema/patch-097-098.sql#L143

So there's no need for us to separately call `db.deleteAccountSubscription` in the route handler for `POST /account/destroy` and doing so opens the possibility of independently failing db operations, which seems sub-optimal.

Ergo, this change removes the call to `db.deleteAccountSubscription`.

@mozilla/fxa-devs r?