### PR TITLE
fix(style): fixes #1258 - remove back link from CWTS on email first flow

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/choose_what_to_sync.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/choose_what_to_sync.mustache
@@ -38,7 +38,7 @@
           </div>
         {{/engines}}
       </div>
-      <div class="button-row">
+      <div>
         {{#isTrailhead}}
           <button id="submit-btn" type="submit" tabindex="1" autofocus>{{#t}}Continue{{/t}}</button>
         {{/isTrailhead}}
@@ -46,9 +46,6 @@
           <button id="submit-btn" type="submit" tabindex="1" autofocus>{{#t}}Save selections{{/t}}</button>
         {{/isTrailhead}}
         </div>
-      <div class="links">
-        <a href="#" id="back" data-flow-event="back">{{#t}}Back{{/t}}</a>
-      </div>
     </form>
   </section>
 </div>

--- a/packages/fxa-content-server/app/tests/spec/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/tests/spec/views/choose_what_to_sync.js
@@ -134,8 +134,6 @@ describe('views/choose_what_to_sync', () => {
     it('renders email info, adds SCREEN_CLASS to body', () => {
       return initView().then(() => {
         assert.include(view.$('.success-email-created').text(), email);
-        const $backEls = view.$('#back');
-        assert.lengthOf($backEls, 1);
 
         assert.isTrue($('body').hasClass(View.SCREEN_CLASS));
 


### PR DESCRIPTION
First PR to be merged🎉
Closed https://github.com/mozilla/fxa/pull/1631 in favor of this one due to my commit not yet being GPG verified.

Fixes #1258 - Removes the back link and container div from CWTS email first flow.

With this commit, I've also updated the test that now passes. However, I ran the tests locally and am seeing 4 failed tests in `fxa-content-server` unrelated to my change here, 3 centered around avatars/profile images and 1 around `oauth query parameter`. I'm curious if these will pass in CircleCI and if so I'd like to determine why they're failing locally for me.

I've also removed the class `button-row` on the previous adjacent div due to `padding-bottom` the class added, here's a screenshot requested from the closed PR:
<img width="636" alt="image" src="https://user-images.githubusercontent.com/13018240/60443942-d41b0c00-9be1-11e9-8ffa-1c5d79761350.png">