### PR TITLE
feat(subscriptions): implement reactivation of cancelled subscriptions

### DIFF
--- a/packages/fxa-auth-db-mysql/db-server/index.js
+++ b/packages/fxa-auth-db-mysql/db-server/index.js
@@ -349,6 +349,12 @@ function createServer(db) {
       )
     )
   );
+  api.post(
+    '/account/:uid/subscriptions/:subscriptionId/reactivate',
+    op(req =>
+      db.reactivateAccountSubscription(req.params.uid, req.params.subscriptionId)
+    )
+  );
   api.get(
     '/account/:id/subscriptions',
     withIdAndBody(db.fetchAccountSubscriptions)

--- a/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
@@ -4180,7 +4180,7 @@ module.exports = function(config, DB) {
     });
 
     describe('account subscriptions', () => {
-      const subscriptionIds = [...Array(25)].map(() => 'sub-' + Math.random());
+      const subscriptionIds = [...Array(26)].map(() => 'sub-' + Math.random());
       let account;
 
       beforeEach(async () => {
@@ -4468,6 +4468,100 @@ module.exports = function(config, DB) {
         } catch (err) {
           assert.equal(err.errno, 116);
         }
+      });
+
+      it('should reactivate subscriptions', async () => {
+        await db.createAccountSubscription(
+          account.uid,
+          subscriptionIds[22],
+          'prod0',
+          Date.now()
+        );
+        await db.cancelAccountSubscription(
+          account.uid,
+          subscriptionIds[22],
+          Date.now()
+        );
+        await db.reactivateAccountSubscription(account.uid, subscriptionIds[22]);
+
+        const subscriptions = await db.fetchAccountSubscriptions(account.uid);
+
+        assert.lengthOf(subscriptions, 1);
+        assert.deepEqual(
+          pickSet(subscriptions, 'subscriptionId'),
+          new Set([subscriptionIds[22]])
+        );
+        assert.deepEqual(
+          pickSet(subscriptions, 'cancelledAt'),
+          new Set([null])
+        );
+      });
+
+      it('should fail to reactivate a non-existent subscription', async () => {
+        let failed = false;
+        try {
+          await db.reactivateAccountSubscription(
+            account.uid,
+            subscriptionIds[23],
+            Date.now()
+          );
+        } catch (err) {
+          failed = true;
+          assert.equal(err.errno, 116);
+        }
+        assert(failed);
+      });
+
+      it('should fail to reactivate a non-cancelled subscription', async () => {
+        await db.createAccountSubscription(
+          account.uid,
+          subscriptionIds[24],
+          'prod0',
+          Date.now()
+        );
+
+        let failed = false;
+        try {
+          await db.reactivateAccountSubscription(
+            account.uid,
+            subscriptionIds[24],
+            Date.now()
+          );
+        } catch (err) {
+          failed = true;
+          assert.equal(err.errno, 116);
+        }
+        assert(failed);
+      });
+
+      it('should fail to reactivate a reactivated subscription', async () => {
+        await db.createAccountSubscription(
+          account.uid,
+          subscriptionIds[25],
+          'prod0',
+          Date.now()
+        );
+        await db.cancelAccountSubscription(
+          account.uid,
+          subscriptionIds[25],
+          Date.now()
+        );
+        await db.reactivateAccountSubscription(
+          account.uid,
+          subscriptionIds[25],
+        );
+
+        let failed = false;
+        try {
+          await db.reactivateAccountSubscription(
+            account.uid,
+            subscriptionIds[25],
+          );
+        } catch (err) {
+          failed = true;
+          assert.equal(err.errno, 116);
+        }
+        assert(failed);
       });
 
       it('should support fetching one subscription', async () => {

--- a/packages/fxa-auth-db-mysql/docs/API.md
+++ b/packages/fxa-auth-db-mysql/docs/API.md
@@ -112,6 +112,7 @@ The following datatypes are used throughout this document:
   - getAccountSubscription : `GET /account/:id/subscriptions/:subscriptionId`
   - deleteAccountSubscription : `DELETE /account/:id/subscriptions/:subscriptionId`
   - cancelAccountSubscription : `POST /account/:id/subscriptions/:subscriptionId/cancel`
+  - reactivateAccountSubscription : `POST /account/:id/subscriptions/:subscriptionId/reactivate`
 
 ## Ping : `GET /`
 
@@ -2543,20 +2544,18 @@ Content-Length: 2
 ### Example
 
 ```
-
 curl \
  -v \
  -X DELETE \
  -H "Content-Type: application/json" \
  -d '{"cancelledAt":1557844225547}' \
  http://localhost:8000/account/6044486dd15b42e08b1fb9167415b9ac/subscriptions/sub8675309/cancel
-
 ```
 
 ### Request
 
 * Method : `POST`
-* Path : `/account/<uid>/subscriptions/<subscriptionId>`
+* Path : `/account/<uid>/subscriptions/<subscriptionId>/cancel`
     * `uid` : hex
     * `subscriptionId` : string255
 * Params:
@@ -2565,20 +2564,62 @@ curl \
 ### Response
 
 ```
-
 HTTP/1.1 200 OK
 Content-Type: application/json
 Content-Length: 2
 
 {}
-
 ```
 
 * Status Code : `200 OK`
     * Content-Type : `application/json`
     * Body : `{}`
+* Status Code : 404 Not Found
+    * Conditions: if subscription(uid,subscriptionId) is not found in the database
+    * Content-Type : 'application/json'
+    * Body : `{"errno":116,"message":"Not Found"}`
 * Status Code : `500 Internal Server Error`
     * Conditions: if something goes wrong on the server
     * Content-Type : `application/json`
     * Body : `{"code":"InternalError","message":"..."}`
+
+## reactivateAccountSubscription : `POST /account/:id/subscriptions/:subscriptionId/reactivate`
+
+### Example
+
 ```
+curl \
+ -v \
+ -X DELETE \
+ -H "Content-Type: application/json" \
+ http://localhost:8000/account/6044486dd15b42e08b1fb9167415b9ac/subscriptions/sub8675309/reactivate
+```
+
+### Request
+
+* Method : `POST`
+* Path : `/account/<uid>/subscriptions/<subscriptionId>/reactivate`
+    * `uid` : hex
+    * `subscriptionId` : string255
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+{}
+```
+
+* Status Code : `200 OK`
+    * Content-Type : `application/json`
+    * Body : `{}`
+* Status Code : 404 Not Found
+    * Conditions: if subscription(uid,subscriptionId) is not found in the database or is not in the cancelled state
+    * Content-Type : 'application/json'
+    * Body : `{"errno":116,"message":"Not Found"}`
+* Status Code : `500 Internal Server Error`
+    * Conditions: if something goes wrong on the server
+    * Content-Type : `application/json`
+    * Body : `{"code":"InternalError","message":"..."}`

--- a/packages/fxa-auth-db-mysql/docs/DB_API.md
+++ b/packages/fxa-auth-db-mysql/docs/DB_API.md
@@ -81,6 +81,7 @@ There are a number of methods that a DB storage backend should implement:
   - .getAccountSubscription(uid, subscriptionId)
   - .deleteAccountSubscription(uid, subscriptionId)
   - .cancelAccountSubscription(uid, subscriptionId, cancelledAt)
+  - .reactivateAccountSubscription(uid, subscriptionId)
 - General
   - .ping()
   - .close()
@@ -1140,4 +1141,24 @@ Returns:
 - Resolves with:
   - Empty object `{}`
 - Rejects with:
+  - `error.notFound()` if the subscription does not exist
+  - Any error from the underlying storage system (wrapped in `error.wrap()`)
+
+## .reactivateAccountSubscription(uid, subscriptionId)
+
+Reactivate a cancelled product subscription.
+
+Parameters:
+
+- `uid` (Buffer16):
+  The uid of the owning account
+- `subscriptionId` (String):
+  The subscription ID from the upstream payment system
+
+Returns:
+
+- Resolves with:
+  - Empty object `{}`
+- Rejects with:
+  - `error.notFound()` if the subscription does not exist or is not cancelled
   - Any error from the underlying storage system (wrapped in `error.wrap()`)

--- a/packages/fxa-auth-db-mysql/lib/db/mem.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mem.js
@@ -1700,6 +1700,35 @@ module.exports = function(log, error) {
     return {};
   };
 
+  Memory.prototype.reactivateAccountSubscription = async function(
+    uid,
+    subscriptionId,
+  ) {
+    uid = uid.toString('hex');
+
+    // Ensure user account exists
+    await getAccountByUid(uid);
+
+    const reactivated = Object.values(accountSubscriptions).some(subscription => {
+      if (
+        subscription.uid === uid &&
+        subscription.subscriptionId === subscriptionId &&
+        subscription.cancelledAt > 0
+      ) {
+        subscription.cancelledAt = null;
+        return true;
+      }
+
+      return false;
+    });
+
+    if (!reactivated) {
+      throw error.notFound();
+    }
+
+    return {};
+  };
+
   // UTILITY FUNCTIONS
 
   Memory.prototype.ping = function() {

--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -1701,5 +1701,23 @@ module.exports = function(log, error) {
     return {};
   };
 
+  const REACTIVATE_ACCOUNT_SUBSCRIPTION = 'CALL reactivateAccountSubscription_1(?,?)';
+  MySql.prototype.reactivateAccountSubscription = async function(
+    uid,
+    subscriptionId,
+  ) {
+    const result = await this.read(REACTIVATE_ACCOUNT_SUBSCRIPTION, [
+      uid,
+      subscriptionId,
+    ]);
+
+    if (result.affectedRows === 0) {
+      log.error('MySql.reactivateAccountSubscription.notUpdated', { result });
+      throw error.notFound();
+    }
+
+    return {};
+  };
+
   return MySql;
 };

--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 100;
+module.exports.level = 101;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-100-101.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-100-101.sql
@@ -1,0 +1,19 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('100');
+
+-- Add a reactivateAccountSubscription stored procedure.
+
+CREATE PROCEDURE `reactivateAccountSubscription_1` (
+  IN uidArg BINARY(16),
+  IN subscriptionIdArg VARCHAR(191)
+)
+BEGIN
+  UPDATE accountSubscriptions
+    SET cancelledAt = NULL
+  WHERE uid = uidArg
+    AND subscriptionId = subscriptionIdArg
+    AND cancelledAt IS NOT NULL;
+END;
+
+UPDATE dbMetadata SET value = '101' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-101-100.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-101-100.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+--DROP PROCEDURE `reactivateAccountSubscription_1`;
+
+-- UPDATE dbMetadata SET value = '100' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -1553,6 +1553,18 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     );
   };
 
+  SAFE_URLS.reactivateAccountSubscription = new SafeUrl(
+    '/account/:uid/subscriptions/:subscriptionId/reactivate',
+    'db.reactivateAccountSubscription'
+  );
+  DB.prototype.reactivateAccountSubscription = function(uid, subscriptionId) {
+    log.trace('DB.reactivateAccountSubscription', { uid, subscriptionId });
+    return this.pool.post(
+      SAFE_URLS.reactivateAccountSubscription,
+      { uid, subscriptionId },
+    );
+  };
+
   SAFE_URLS.fetchAccountSubscriptions = new SafeUrl(
     '/account/:uid/subscriptions',
     'db.fetchAccountSubscriptions'

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -276,5 +276,53 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
         return { subscriptionId };
       },
     },
+    {
+      method: 'POST',
+      path: '/oauth/subscriptions/reactivate',
+      options: {
+        auth: {
+          payload: false,
+          strategy: 'oauthToken',
+        },
+        validate: {
+          payload: {
+            subscriptionId: validators.subscriptionsSubscriptionId.required(),
+          },
+        },
+      },
+      handler: async function(request) {
+        log.begin('subscriptions.reactivateSubscription', request);
+
+        const { uid, email } = await handleAuth(request.auth, true);
+
+        await customs.check(request, email, 'reactivateSubscription');
+
+        const { subscriptionId } = request.payload;
+
+        const subscription = await db.getAccountSubscription(
+          uid,
+          subscriptionId
+        );
+        if (!subscription) {
+          throw error.unknownSubscription();
+        }
+
+        await subhub.reactivateSubscription(uid, subscriptionId);
+        await db.reactivateAccountSubscription(uid, subscriptionId);
+
+        await push.notifyProfileUpdated(uid, await request.app.devices);
+        log.notifyAttachedServices('profileDataChanged', request, {
+          uid,
+          email,
+        });
+
+        log.info('subscriptions.reactivateSubscription.success', {
+          uid,
+          subscriptionId,
+        });
+
+        return {};
+      },
+    },
   ];
 };

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -1136,6 +1136,18 @@ module.exports = config => {
     );
   };
 
+  ClientApi.prototype.reactivateSubscription = function(
+    refreshToken,
+    subscriptionId
+  ) {
+    return this.doRequestWithBearerToken(
+      'POST',
+      `${this.baseURL}/oauth/subscriptions/reactivate`,
+      refreshToken,
+      { subscriptionId },
+    );
+  };
+
   ClientApi.heartbeat = function(origin) {
     return new ClientApi(origin).doRequest('GET', `${origin}/__heartbeat__`);
   };

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -786,5 +786,9 @@ module.exports = config => {
     return this.api.cancelSubscription(refreshToken, subscriptionId);
   };
 
+  Client.prototype.reactivateSubscription = function(refreshToken, subscriptionId) {
+    return this.api.reactivateSubscription(refreshToken, subscriptionId);
+  };
+
   return Client;
 };

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -528,4 +528,124 @@ describe('subscriptions', () => {
       }
     });
   });
+
+  describe('POST /oauth/subscriptions/reactivate', () => {
+    it('should reactivate cancelled subscriptions', async () => {
+      const res = await runTest(
+        '/oauth/subscriptions/reactivate',
+        {
+          ...requestOptions,
+          method: 'POST',
+          payload: { subscriptionId: SUBSCRIPTION_ID_1 },
+        }
+      );
+
+      assert.equal(customs.check.callCount, 1);
+
+      assert.equal(db.reactivateAccountSubscription.callCount, 1);
+      let args = db.reactivateAccountSubscription.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], UID);
+      assert.equal(args[1], SUBSCRIPTION_ID_1);
+
+      assert.equal(push.notifyProfileUpdated.callCount, 1);
+      args = push.notifyProfileUpdated.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], UID);
+      assert.isArray(args[1]);
+
+      assert.equal(log.notifyAttachedServices.callCount, 1);
+      args = log.notifyAttachedServices.args[0];
+      assert.lengthOf(args, 3);
+      assert.equal(args[0], 'profileDataChanged');
+      assert.isObject(args[1]);
+      assert.deepEqual(args[2], {
+        uid: UID,
+        email: TEST_EMAIL,
+      });
+
+      assert.deepEqual(res, {});
+    });
+
+    it('should fail to reactivate non-existent subscriptions', async () => {
+      let failed = false;
+
+      try {
+        await runTest('/oauth/subscriptions/reactivate', {
+          ...requestOptions,
+          method: 'POST',
+          payload: { subscriptionId: 'notasub' },
+        });
+      } catch (err) {
+        failed = true;
+
+        assert.equal(subhub.reactivateSubscription.callCount, 0);
+        assert.equal(db.reactivateAccountSubscription.callCount, 0);
+        assert.equal(push.notifyProfileUpdated.callCount, 0);
+        assert.equal(log.notifyAttachedServices.callCount, 0);
+
+        assert.equal(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION);
+      }
+
+      assert.isTrue(failed);
+    });
+
+    it('should propagate errors from subhub', async () => {
+      let failed = false;
+
+      try {
+        subhub.reactivateSubscription = sinon.spy(async () => {
+          throw error.backendServiceFailure();
+        });
+        await runTest(
+          '/oauth/subscriptions/reactivate',
+          {
+            ...requestOptions,
+            method: 'POST',
+            payload: { subscriptionId: SUBSCRIPTION_ID_1 },
+          }
+        );
+      } catch (err) {
+        failed = true;
+
+        assert.equal(subhub.reactivateSubscription.callCount, 1);
+        assert.equal(db.reactivateAccountSubscription.callCount, 0);
+        assert.equal(push.notifyProfileUpdated.callCount, 0);
+        assert.equal(log.notifyAttachedServices.callCount, 0);
+
+        assert.equal(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE);
+      }
+
+      assert.isTrue(failed);
+    });
+
+    it('should propagate errors from db', async () => {
+      let failed = false;
+
+      try {
+        db.reactivateAccountSubscription = sinon.spy(async () => {
+          throw error.unknownSubscription();
+        });
+        await runTest(
+          '/oauth/subscriptions/reactivate',
+          {
+            ...requestOptions,
+            method: 'POST',
+            payload: { subscriptionId: SUBSCRIPTION_ID_1 },
+          }
+        );
+      } catch (err) {
+        failed = true;
+
+        assert.equal(subhub.reactivateSubscription.callCount, 1);
+        assert.equal(db.reactivateAccountSubscription.callCount, 1);
+        assert.equal(push.notifyProfileUpdated.callCount, 0);
+        assert.equal(log.notifyAttachedServices.callCount, 0);
+
+        assert.equal(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION);
+      }
+
+      assert.isTrue(failed);
+    });
+  });
 });

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -88,6 +88,7 @@ const DB_METHOD_NAMES = [
   'getAccountSubscription',
   'deleteAccountSubscription',
   'cancelAccountSubscription',
+  'reactivateAccountSubscription',
   'fetchAccountSubscriptions',
 ];
 
@@ -170,6 +171,7 @@ const SUBHUB_METHOD_NAMES = [
   'listSubscriptions',
   'createSubscription',
   'cancelSubscription',
+  'reactivateSubscription',
 ];
 
 module.exports = {

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -252,6 +252,50 @@ describe('remote subscriptions:', function() {
           assert.equal(result[0].productName, PRODUCT_ID);
           assert.equal(result[0].uid, client.uid);
         });
+
+        describe('reactivateSubscription:', () => {
+          beforeEach(async () => {
+            await client.reactivateSubscription(tokens[2], subscriptionId);
+          });
+
+          it('should return subscription capabilities with session token', async () => {
+            const response = await client.accountProfile();
+            assert.deepEqual(response.subscriptions, [
+              'isRegistered',
+              '123donePro',
+              '321donePro',
+              'FirefoxPlus',
+              'MechaMozilla',
+              'isSubscribed',
+            ]);
+          });
+
+          it('should return default capability with refresh token', async () => {
+            const response = await client.accountProfile(tokens[0]);
+            assert.deepEqual(response.subscriptions, [
+              'isRegistered',
+              'isSubscribed',
+            ]);
+          });
+
+          it('should return relevant capabilities with refresh token', async () => {
+            const response = await client.accountProfile(tokens[1]);
+            assert.deepEqual(response.subscriptions, [
+              '123donePro',
+              'MechaMozilla',
+            ]);
+          });
+
+          it('should return reactivated subscriptions', async () => {
+            const result = await client.getActiveSubscriptions(tokens[2]);
+            assert.isArray(result);
+            assert.lengthOf(result, 1);
+            assert.isAbove(result[0].createdAt, Date.now() - 1000);
+            assert.isNull(result[0].cancelledAt);
+            assert.equal(result[0].productName, PRODUCT_ID);
+            assert.equal(result[0].uid, client.uid);
+          });
+        });
       });
     });
   });

--- a/packages/fxa-payments-server/src/store/index.tsx
+++ b/packages/fxa-payments-server/src/store/index.tsx
@@ -103,13 +103,12 @@ export const actions: ActionCreators = {
           // HACK: cancellation response does not include subscriptionId, but we want it.
           return { ...result, subscriptionId };
         }),
-      // TODO: https://github.com/mozilla/fxa/issues/1273
-      reactivateSubscription: async (accessToken, subscriptionId) => {
-        throw new APIError({
-          statusCode: 500,
-          message: 'reactivateSubscription API not implemented',
-        })
-      },
+      reactivateSubscription: async (accessToken, subscriptionId) =>
+        apiPost(
+          accessToken,
+          `${config.servers.auth.url}/v1/oauth/subscriptions/reactivate`,
+          { subscriptionId },
+        ),
       updatePayment: (accessToken, { paymentToken }) =>
         apiPost(
           accessToken,


### PR DESCRIPTION
Fixes #1273.

This is the backend for subscription reactivation. ~~Opening as a draft, I haven't looked at any of the front-end stuff yet so I don't know where the new button is supposed to live.~~ It seems like the front-end was already in place, so I just hooked into it by cargo-culting what I saw elsewhere in `fxa-payments-server`.