### PR TITLE
feat(routes): securityEvents GET and DELETE added with uid

### DIFF
--- a/packages/fxa-auth-db-mysql/db-server/index.js
+++ b/packages/fxa-auth-db-mysql/db-server/index.js
@@ -218,6 +218,18 @@ function createServer(db) {
 
   api.get('/securityEvents/:id/ip/:ipAddr', withParams(db.securityEvents));
   api.post('/securityEvents', withBodyAndQuery(db.createSecurityEvent));
+  api.get(
+    '/securityEvents/:id',
+    op(req => {
+      return db.securityEventsByUid(req.params.id);
+    })
+  );
+  api.del(
+    '/securityEvents/:id',
+    op(req => {
+      return db.deleteSecurityEventsByUid(req.params.id);
+    })
+  );
 
   api.get('/emailBounces/:id', withIdAndBody(db.fetchEmailBounces));
   api.post('/emailBounces', withBodyAndQuery(db.createEmailBounce));

--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -69,6 +69,9 @@ see [`mozilla/fxa-js-client`](https://github.com/mozilla/fxa-js-client).
     - [GET /recoveryKey/{recoveryKeyId} (:lock: accountResetToken)](#get-recoverykeyrecoverykeyid)
     - [POST /recoveryKey/exists (:lock::unlock: sessionToken)](#post-recoverykeyexists)
     - [DELETE /recoveryKey (:lock: sessionToken)](#delete-recoverykey)
+  - [Security events](#security-events)
+    - [GET /securityEvents (:lock: securityEvents)](#get-securityEvents)
+    - [DELETE /securityEvents (:lock: securityEvents)](#delete-securityEvents)
   - [Session](#session)
     - [POST /session/destroy (:lock: sessionToken)](#post-sessiondestroy)
     - [POST /session/reauth (:lock: sessionToken)](#post-sessionreauth)
@@ -2890,6 +2893,31 @@ This route remove an account's recovery key. When the key is
 removed, it can no longer be used to restore an account's kB.
 
 <!--end-route-delete-recoverykey-->
+
+### Security events
+
+#### GET /securityEvents
+
+:lock: HAWK-authenticated with session token
+
+<!--begin-route-get-securityEvents-->
+
+Returns a list of all security events
+for a signed in account having
+`account.create, account.login, account.reset` events.
+
+<!--end-route-get-securityEvents-->
+
+#### DELETE /securityEvents
+
+:lock: HAWK-authenticated with session token
+
+<!--begin-route-delete-securityEvents-->
+
+Deletes all the security events
+of a signed in account.
+
+<!--end-route-delete-securityEvents-->
 
 ### Session
 

--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -1156,6 +1156,30 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     return this.pool.get(SAFE_URLS.securityEvents, { ipAddr, uid });
   };
 
+  SAFE_URLS.securityEventsByUid = new SafeUrl(
+    '/securityEvents/:uid',
+    'db.securityEventsByUid'
+  );
+  DB.prototype.securityEventsByUid = function(params) {
+    log.trace('DB.securityEventsByUid', {
+      params: params,
+    });
+    const { uid } = params;
+    return this.pool.get(SAFE_URLS.securityEventsByUid, { uid });
+  };
+
+  SAFE_URLS.deleteSecurityEvents = new SafeUrl(
+    '/securityEvents/:uid',
+    'db.deleteSecurityEventsByUid'
+  );
+  DB.prototype.deleteSecurityEvents = function(params) {
+    log.trace('DB.deleteSecurityEvents', {
+      params: params,
+    });
+    const { uid } = params;
+    return this.pool.del(SAFE_URLS.deleteSecurityEvents, { uid });
+  };
+
   SAFE_URLS.createUnblockCode = new SafeUrl(
     '/account/:uid/unblock/:unblock',
     'db.createUnblockCode'

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -98,6 +98,7 @@ module.exports = function(
     config
   );
   const tokenCodes = require('./token-codes')(log, db, config, customs);
+  const securityEvents = require('./security-events')(log, db, config);
   const session = require('./session')(log, db, Password, config, signinUtils);
   const sign = require('./sign')(log, signer, db, config.domain, devicesImpl);
   const signinCodes = require('./signin-codes')(log, db, customs);
@@ -150,6 +151,7 @@ module.exports = function(
     emails,
     password,
     recoveryCodes,
+    securityEvents,
     session,
     signinCodes,
     sign,

--- a/packages/fxa-auth-server/lib/routes/security-events.js
+++ b/packages/fxa-auth-server/lib/routes/security-events.js
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+module.exports = (log, db, config) => {
+  return [
+    {
+      method: 'GET',
+      path: '/securityEvents',
+      options: {
+        auth: {
+          strategy: 'sessionToken',
+        },
+      },
+      handler: async function(request) {
+        log.begin('SecurityEventsGet', request);
+        const { uid } = request.auth.credentials;
+
+        const events = await db.securityEventsByUid({ uid });
+        return events;
+      },
+    },
+    {
+      method: 'DELETE',
+      path: '/securityEvents',
+      options: {
+        auth: {
+          strategy: 'sessionToken',
+        },
+      },
+      handler: async function(request) {
+        log.begin('SecurityEventsDelete', request);
+        const { uid } = request.auth.credentials;
+
+        await db.deleteSecurityEvents({ uid });
+        return {};
+      },
+    },
+  ];
+};

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -772,6 +772,18 @@ module.exports = config => {
     });
   };
 
+  ClientApi.prototype.securityEvents = function(sessionTokenHex) {
+    return tokens.SessionToken.fromHex(sessionTokenHex).then(token => {
+      return this.doRequest('GET', `${this.baseURL}/securityEvents`, token);
+    });
+  };
+
+  ClientApi.prototype.deleteSecurityEvents = function(sessionTokenHex) {
+    return tokens.SessionToken.fromHex(sessionTokenHex).then(token => {
+      return this.doRequest('DELETE', `${this.baseURL}/securityEvents`, token);
+    });
+  };
+
   ClientApi.prototype.accountProfile = function(sessionTokenHex, headers) {
     const o = sessionTokenHex
       ? tokens.SessionToken.fromHex(sessionTokenHex)

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -498,6 +498,20 @@ module.exports = config => {
     });
   };
 
+  Client.prototype.securityEvents = function() {
+    const o = this.sessionToken ? P.resolve(null) : this.login();
+    return o.then(() => {
+      return this.api.securityEvents(this.sessionToken);
+    });
+  };
+
+  Client.prototype.deleteSecurityEvents = function() {
+    const o = this.sessionToken ? P.resolve(null) : this.login();
+    return o.then(() => {
+      return this.api.deleteSecurityEvents(this.sessionToken);
+    });
+  };
+
   Client.prototype.accountProfile = function(oauthToken) {
     if (oauthToken) {
       return this.api.accountProfile(null, {

--- a/packages/fxa-auth-server/test/local/routes/security-events.js
+++ b/packages/fxa-auth-server/test/local/routes/security-events.js
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const getRoute = require('../../routes_helpers').getRoute;
+const mocks = require('../../mocks');
+const uuid = require('uuid');
+
+let route, routes, request;
+const TEST_EMAIL = 'foo@gmail.com';
+const UID = uuid.v4('binary').toString('hex');
+
+function makeRoutes(options = {}) {
+  const log = options.log || mocks.mockLog();
+  const config = options.config || {};
+  const db = options.db || mocks.mockDB();
+  return require('../../../lib/routes/security-events')(log, db, config);
+}
+
+function runTest(route, request) {
+  return route.handler(request);
+}
+
+function setup(path, requestOptions) {
+  routes = makeRoutes({});
+  route = getRoute(routes, path, requestOptions.method);
+  request = mocks.mockRequest(requestOptions);
+  return runTest(route, request);
+}
+
+describe('GET /securityEvents', () => {
+  it('gets the security events', () => {
+    const requestOptions = {
+      credentials: {
+        email: TEST_EMAIL,
+        uid: UID,
+      },
+      method: 'GET',
+    };
+    return setup('/securityEvents', requestOptions).then(res => {
+      assert.equal(res.length, 3);
+      assert.equal(res[0].name, 'account.create');
+      assert.equal(res[0].verified, 1);
+      assert.isBelow(res[0].createdAt, new Date().getTime());
+
+      assert.equal(res[1].name, 'account.login');
+      assert.equal(res[1].verified, 1);
+      assert.isBelow(res[1].createdAt, new Date().getTime());
+
+      assert.equal(res[2].name, 'account.reset');
+      assert.equal(res[2].verified, 1);
+      assert.isBelow(res[2].createdAt, new Date().getTime());
+    });
+  });
+});
+
+describe('DELETE /securityEvents', () => {
+  it('deletes the security events', () => {
+    const requestOptions = {
+      credentials: {
+        email: TEST_EMAIL,
+        uid: UID,
+      },
+      method: 'DELETE',
+    };
+    return setup('/securityEvents', requestOptions).then(res => {
+      assert.deepEqual(res, {});
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -49,6 +49,7 @@ const DB_METHOD_NAMES = [
   'deleteEmail',
   'deleteKeyFetchToken',
   'deletePasswordChangeToken',
+  'deleteSecurityEvents',
   'deleteSessionToken',
   'deviceFromTokenVerificationId',
   'deleteRecoveryKey',
@@ -71,6 +72,7 @@ const DB_METHOD_NAMES = [
   'resetAccountTokens',
   'securityEvent',
   'securityEvents',
+  'securityEventsByUid',
   'sessions',
   'sessionToken',
   'setPrimaryEmail',
@@ -390,6 +392,9 @@ function mockDB(data, errors) {
       assert.ok(device);
       return P.resolve(device);
     }),
+    deleteSecurityEvents: sinon.spy(() => {
+      return P.resolve({});
+    }),
     deleteSessionToken: sinon.spy(() => {
       return P.resolve();
     }),
@@ -448,6 +453,25 @@ function mockDB(data, errors) {
     }),
     securityEvents: sinon.spy(() => {
       return P.resolve([]);
+    }),
+    securityEventsByUid: sinon.spy(() => {
+      return P.resolve([
+        {
+          name: 'account.create',
+          verified: 1,
+          createdAt: new Date().getTime(),
+        },
+        {
+          name: 'account.login',
+          verified: 1,
+          createdAt: new Date().getTime(),
+        },
+        {
+          name: 'account.reset',
+          verified: 1,
+          createdAt: new Date().getTime(),
+        },
+      ]);
     }),
     sessions: sinon.spy(uid => {
       assert.ok(typeof uid === 'string');

--- a/packages/fxa-auth-server/test/remote/db_tests.js
+++ b/packages/fxa-auth-server/test/remote/db_tests.js
@@ -1288,6 +1288,46 @@ describe('remote db', function() {
       });
   });
 
+  it('db.securityEventsByUid', () => {
+    return db
+      .securityEvent({
+        ipAddr: '127.0.0.1',
+        name: 'account.create',
+        uid: account.uid,
+      })
+      .then(() => {
+        return db.securityEventsByUid({
+          uid: account.uid,
+        });
+      })
+      .then(events => {
+        assert.equal(events.length, 1);
+      });
+  });
+
+  it('db.deleteSecurityEvents', () => {
+    return db
+      .securityEvent({
+        ipAddr: '127.0.0.1',
+        name: 'account.create',
+        uid: account.uid,
+      })
+      .then(() => {
+        return db.deleteSecurityEvents({
+          uid: account.uid,
+        });
+      })
+      .then(events => {
+        assert.deepEqual(events, {});
+        return db.securityEventsByUid({
+          uid: account.uid,
+        });
+      })
+      .then(events => {
+        assert.equal(events.length, 0);
+      });
+  });
+
   it('unblock code', () => {
     let unblockCode;
     return db

--- a/packages/fxa-auth-server/test/remote/security_events.js
+++ b/packages/fxa-auth-server/test/remote/security_events.js
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const Client = require('../client')();
+const TestServer = require('../test_server');
+const config = require('../../config').getProperties();
+
+function resetPassword(client, code, newPassword, options) {
+  return client.verifyPasswordResetCode(code).then(() => {
+    return client.resetPassword(newPassword, {}, options);
+  });
+}
+
+describe('remote securityEvents', () => {
+  let server;
+
+  before(function() {
+    this.timeout(15000);
+    config.securityHistory.ipProfiling.allowedRecency = 0;
+    config.signinConfirmation.skipForNewAccounts.enabled = false;
+    return TestServer.start(config).then(s => {
+      server = s;
+    });
+  });
+
+  it('returns securityEvents on creating and login into an account', () => {
+    const email = server.uniqueEmail();
+    const password = 'abcdef';
+    let client;
+
+    return Client.createAndVerify(
+      config.publicUrl,
+      email,
+      password,
+      server.mailbox
+    )
+      .then(x => {
+        client = x;
+        return client.login().then(() => {
+          return client.securityEvents();
+        });
+      })
+      .then(events => {
+        assert.equal(events.length, 2);
+        assert.equal(events[0].name, 'account.login');
+        assert.isBelow(events[0].createdAt, new Date().getTime());
+        assert.equal(events[0].verified, false);
+
+        assert.equal(events[1].name, 'account.create');
+        assert.isBelow(events[1].createdAt, new Date().getTime());
+        assert.equal(events[1].verified, true);
+      });
+  });
+
+  it('returns no securityEvents after deleting them', () => {
+    const email = server.uniqueEmail();
+    const password = 'abcdef';
+    let client;
+
+    return Client.createAndVerify(
+      config.publicUrl,
+      email,
+      password,
+      server.mailbox
+    )
+      .then(x => {
+        client = x;
+        return client.login().then(() => {
+          return client.securityEvents();
+        });
+      })
+      .then(events => {
+        assert.equal(events.length, 2);
+        assert.equal(events[0].name, 'account.login');
+        assert.isBelow(events[0].createdAt, new Date().getTime());
+        assert.equal(events[0].verified, false);
+
+        assert.equal(events[1].name, 'account.create');
+        assert.isBelow(events[1].createdAt, new Date().getTime());
+        assert.equal(events[1].verified, true);
+      })
+      .then(() => client.deleteSecurityEvents())
+      .then(events => {
+        assert.deepEqual(events, {});
+      });
+  });
+
+  it('returns security events after account reset w/o keys, with sessionToken', () => {
+    const email = server.uniqueEmail();
+    const password = 'oldPassword';
+    const newPassword = 'newPassword';
+    let client;
+
+    return Client.createAndVerify(
+      config.publicUrl,
+      email,
+      password,
+      server.mailbox
+    )
+      .then(x => {
+        client = x;
+      })
+      .then(() => {
+        return client.forgotPassword();
+      })
+      .then(() => {
+        return server.mailbox.waitForCode(email);
+      })
+      .then(code => {
+        assert.throws(() => {
+          client.resetPassword(newPassword);
+        });
+        return resetPassword(client, code, newPassword);
+      })
+      .then(response => {
+        assert.ok(response.sessionToken, 'session token is in response');
+        assert(
+          !response.keyFetchToken,
+          'keyFetchToken token is not in response'
+        );
+        assert.equal(response.verified, true, 'verified is true');
+      })
+      .then(() => {
+        return client.securityEvents();
+      })
+      .then(events => {
+        assert.equal(events.length, 2);
+        assert.equal(events[0].name, 'account.reset');
+        assert.isBelow(events[0].createdAt, new Date().getTime());
+        assert.equal(events[0].verified, true);
+
+        assert.equal(events[1].name, 'account.create');
+        assert.isBelow(events[1].createdAt, new Date().getTime());
+        assert.equal(events[1].verified, true);
+      });
+  });
+
+  after(() => {
+    return TestServer.stop(server);
+  });
+});


### PR DESCRIPTION
Working on `securityEvents` routes for the Firefox Security Dashboard with @vbudhram 