### PR TITLE
fix(subs): Add display_name field to subhub create subscription API

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -109,6 +109,7 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
           payload: {
             planId: validators.subscriptionsPlanId.required(),
             paymentToken: validators.subscriptionsPaymentToken.required(),
+            displayName: isA.string().required(),
           },
         },
         response: {
@@ -124,7 +125,7 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
 
         await customs.check(request, email, 'createSubscription');
 
-        const { planId, paymentToken } = request.payload;
+        const { planId, paymentToken, displayName } = request.payload;
 
         // Find the selected plan and get its product ID
         const plans = await subhub.listPlans();
@@ -141,6 +142,7 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
           uid,
           paymentToken,
           planId,
+          displayName,
           email
         );
 

--- a/packages/fxa-auth-server/lib/subhub/client.js
+++ b/packages/fxa-auth-server/lib/subhub/client.js
@@ -122,6 +122,7 @@ module.exports = function(log, config) {
           plan_id: isA.string().required(),
           email: isA.string().required(),
           orig_system: isA.string().required(),
+          display_name: isA.string().required(),
         },
         response: isA.alternatives(
           validators.subscriptionsSubscriptionListValidator,
@@ -184,20 +185,26 @@ module.exports = function(log, config) {
       }
     },
 
-    async createSubscription(uid, pmt_token, plan_id, email) {
+    async createSubscription(uid, pmt_token, plan_id, display_name, email) {
       try {
         return await api.createSubscription(uid, {
           pmt_token,
           plan_id,
+          display_name,
           email,
           orig_system: ORIG_SYSTEM,
         });
       } catch (err) {
-        if (err.statusCode === 400 || err.statusCode === 402 || err.statusCode === 404) {
+        if (
+          err.statusCode === 400 ||
+          err.statusCode === 402 ||
+          err.statusCode === 404
+        ) {
           log.error('subhub.createSubscription.1', {
             uid,
             pmt_token,
             plan_id,
+            display_name,
             email,
             err,
           });
@@ -267,7 +274,11 @@ module.exports = function(log, config) {
       try {
         return await api.updateCustomer(uid, { pmt_token });
       } catch (err) {
-        if (err.statusCode === 400 || err.statusCode === 402 || err.statusCode === 404) {
+        if (
+          err.statusCode === 400 ||
+          err.statusCode === 402 ||
+          err.statusCode === 404
+        ) {
           log.error('subhub.updateCustomer.1', { uid, pmt_token, err });
           if (err.statusCode === 404) {
             throw error.unknownCustomer(uid);

--- a/packages/fxa-auth-server/lib/subhub/stubAPI.js
+++ b/packages/fxa-auth-server/lib/subhub/stubAPI.js
@@ -37,7 +37,7 @@ module.exports.buildStubAPI = function buildStubAPI(log, config) {
       );
     },
 
-    async createSubscription(uid, pmt_token, plan_id, email) {
+    async createSubscription(uid, pmt_token, plan_id, display_name, email) {
       const plan = getPlanById(plan_id);
       if (!plan) {
         throw error.unknownSubscriptionPlan(plan_id);

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -1093,7 +1093,8 @@ module.exports = config => {
   ClientApi.prototype.createSubscription = function(
     refreshToken,
     planId,
-    paymentToken
+    paymentToken,
+    displayName
   ) {
     return this.doRequestWithBearerToken(
       'POST',
@@ -1102,6 +1103,7 @@ module.exports = config => {
       {
         planId,
         paymentToken,
+        displayName,
       }
     );
   };
@@ -1144,7 +1146,7 @@ module.exports = config => {
       'POST',
       `${this.baseURL}/oauth/subscriptions/reactivate`,
       refreshToken,
-      { subscriptionId },
+      { subscriptionId }
     );
   };
 

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -769,9 +769,15 @@ module.exports = config => {
   Client.prototype.createSubscription = function(
     refreshToken,
     planId,
-    paymentToken
+    paymentToken,
+    displayName
   ) {
-    return this.api.createSubscription(refreshToken, planId, paymentToken);
+    return this.api.createSubscription(
+      refreshToken,
+      planId,
+      paymentToken,
+      displayName
+    );
   };
 
   Client.prototype.updatePayment = function(refreshToken, paymentToken) {
@@ -786,7 +792,10 @@ module.exports = config => {
     return this.api.cancelSubscription(refreshToken, subscriptionId);
   };
 
-  Client.prototype.reactivateSubscription = function(refreshToken, subscriptionId) {
+  Client.prototype.reactivateSubscription = function(
+    refreshToken,
+    subscriptionId
+  ) {
     return this.api.reactivateSubscription(refreshToken, subscriptionId);
   };
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -69,6 +69,7 @@ const ACTIVE_SUBSCRIPTIONS = [
     cancelledAt: null,
   },
 ];
+const DISPLAY_NAME = 'Foo Bar';
 
 const MOCK_CLIENT_ID = '3c49430b43dfba77';
 const MOCK_TTL = 3600;
@@ -257,6 +258,7 @@ describe('subscriptions', () => {
         payload: {
           ...requestOptions.payload,
           planId: PLANS[0].plan_id,
+          displayName: DISPLAY_NAME,
           paymentToken: PAYMENT_TOKEN_VALID,
         },
       });
@@ -265,7 +267,7 @@ describe('subscriptions', () => {
 
       assert.equal(subhub.listPlans.callCount, 1);
       assert.deepEqual(subhub.createSubscription.args, [
-        [UID, PAYMENT_TOKEN_VALID, PLANS[0].plan_id, TEST_EMAIL],
+        [UID, PAYMENT_TOKEN_VALID, PLANS[0].plan_id, DISPLAY_NAME, TEST_EMAIL],
       ]);
       assert.equal(db.createAccountSubscription.callCount, 1);
 

--- a/packages/fxa-auth-server/test/local/subhub/client.js
+++ b/packages/fxa-auth-server/test/local/subhub/client.js
@@ -32,6 +32,7 @@ describe('subhub client', () => {
   const ORIG_SYSTEM = 'Firefox Accounts';
   const UID = '8675309';
   const EMAIL = 'foo@example.com';
+  const DISPLAY_NAME = 'Foo Barbaz';
   const PLAN_ID = 'plan12345';
   const SUBSCRIPTION_ID = 'sub12345';
   const PAYMENT_TOKEN_GOOD = 'foobarbaz';
@@ -211,6 +212,7 @@ describe('subhub client', () => {
         orig_system: ORIG_SYSTEM,
         pmt_token: PAYMENT_TOKEN_GOOD,
         plan_id: PLAN_ID,
+        display_name: DISPLAY_NAME,
         email: EMAIL,
       };
       let requestBody;
@@ -222,6 +224,7 @@ describe('subhub client', () => {
         UID,
         PAYMENT_TOKEN_GOOD,
         PLAN_ID,
+        DISPLAY_NAME,
         EMAIL
       );
       assert.deepEqual(requestBody, expectedBody);
@@ -235,7 +238,13 @@ describe('subhub client', () => {
         .reply(404, { message: 'invalid plan id' });
       const { log, subhub } = makeSubject();
       try {
-        await subhub.createSubscription(UID, PAYMENT_TOKEN_BAD, PLAN_ID, EMAIL);
+        await subhub.createSubscription(
+          UID,
+          PAYMENT_TOKEN_BAD,
+          PLAN_ID,
+          DISPLAY_NAME,
+          EMAIL
+        );
         assert.fail();
       } catch (err) {
         assert.equal(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION_PLAN);
@@ -254,7 +263,13 @@ describe('subhub client', () => {
         .reply(400, { message: 'invalid payment token' });
       const { log, subhub } = makeSubject();
       try {
-        await subhub.createSubscription(UID, PAYMENT_TOKEN_BAD, PLAN_ID, EMAIL);
+        await subhub.createSubscription(
+          UID,
+          PAYMENT_TOKEN_BAD,
+          PLAN_ID,
+          DISPLAY_NAME,
+          EMAIL
+        );
         assert.fail();
       } catch (err) {
         assert.equal(
@@ -279,6 +294,7 @@ describe('subhub client', () => {
           UID,
           PAYMENT_TOKEN_GOOD,
           PLAN_ID,
+          DISPLAY_NAME,
           EMAIL
         );
         assert.fail();

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -14,6 +14,7 @@ const testServerFactory = require('../test_server');
 
 const CLIENT_ID = 'client8675309';
 const CLIENT_ID_FOR_DEFAULT = 'client5551212';
+const DISPLAY_NAME = 'Example User';
 const PAYMENT_TOKEN = 'pay8675309';
 const PLAN_ID = 'allDoneProMonthly';
 const PLAN_NAME = 'All Done Pro Monthly';
@@ -161,7 +162,8 @@ describe('remote subscriptions:', function() {
         ({ subscriptionId } = await client.createSubscription(
           tokens[2],
           PLAN_ID,
-          PAYMENT_TOKEN
+          PAYMENT_TOKEN,
+          DISPLAY_NAME
         ));
       });
 

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -102,6 +102,7 @@ export const Product = ({
       createSubscription(accessToken, {
         paymentToken: tokenResponse.token.id,
         planId: selectedPlan.plan_id,
+        displayName: profile.result ? profile.result.displayName : '',
       });  
     } else {
       // This shouldn't happen with a successful createToken() call, but let's


### PR DESCRIPTION
Fixes #1597.

-----

original WIP description:

* Not yet able to get tests running locally; pushing to CI to see if the
tests run there.

* Looks like the payments-server already gets the full profile from the
profile-server, so it's just a matter of passing the display name field
from payments-server to auth-server, and then from auth-server to
subhub.