### PR TITLE
fix(jwks): Set explicit cache-control header on jwks_uri

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/jwks.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/jwks.js
@@ -34,6 +34,10 @@ const KEYS = (function() {
 })();
 
 module.exports = {
+  cache: {
+    privacy: 'public',
+    expiresIn: 10000,
+  },
   handler: async function jwks() {
     return KEYS;
   },

--- a/packages/fxa-auth-server/fxa-oauth-server/test/api.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/api.js
@@ -3509,7 +3509,9 @@ describe('/v1', function() {
         })
         .then(function(res) {
           assert.equal(res.statusCode, 200);
-          assertSecurityHeaders(res);
+          assertSecurityHeaders(res, {
+            'cache-control': 'max-age=10, must-revalidate, public',
+          });
 
           var key = res.result.keys[0];
           assert(key.n);
@@ -3525,7 +3527,9 @@ describe('/v1', function() {
         })
         .then(function(res) {
           assert.equal(res.statusCode, 200);
-          assertSecurityHeaders(res);
+          assertSecurityHeaders(res, {
+            'cache-control': 'max-age=10, must-revalidate, public',
+          });
 
           var keys = res.result.keys;
           assert.equal(keys.length, 2);

--- a/packages/fxa-auth-server/fxa-oauth-server/test/lib/util.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/lib/util.js
@@ -5,19 +5,19 @@
 const { assert } = require('chai');
 const config = require('../../lib/config').getProperties();
 
-function assertSecurityHeaders(res) {
-  const expect = {
+function assertSecurityHeaders(res, expect = {}) {
+  expect = {
     'strict-transport-security': 'max-age=15552000; includeSubDomains',
     'x-content-type-options': 'nosniff',
     'x-xss-protection': '1; mode=block',
     'x-frame-options': 'DENY',
+    'cache-control': config.cacheControl,
+    ...expect,
   };
 
   Object.keys(expect).forEach(function(header) {
     assert.equal(res.headers[header], expect[header]);
   });
-
-  assert.equal(res.headers['cache-control'], config.cacheControl);
 }
 
 module.exports = {


### PR DESCRIPTION
We intend for RPs to fetch and cache the contents of this URL, so we should really give them some instructions on how to do so. This brings https://oauth.accounts.firefox.com/v1/jwks in line with the existing cache-control settings on https://api.accounts.firefox.com/.well-known/browserid. @shane-tomlinson r?