### PR TITLE
Add scripts and docs for rotating the signing key

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/.gitignore
+++ b/packages/fxa-auth-server/fxa-oauth-server/.gitignore
@@ -4,4 +4,5 @@ Thumbs.db
 /coverage.html
 config/key.json
 config/oldKey.json
+config/newKey.json
 .nyc_output

--- a/packages/fxa-auth-server/fxa-oauth-server/config/dev.json
+++ b/packages/fxa-auth-server/fxa-oauth-server/config/dev.json
@@ -195,7 +195,8 @@
   "openid": {
     "issuer": "http://127.0.0.1:3030",
     "keyFile": "../config/key.json",
-    "key": {}
+    "newKeyFile": "../config/newKey.json",
+    "oldKeyFile": "../config/oldKey.json"
   },
   "ppid": {
     "enabled": true,

--- a/packages/fxa-auth-server/fxa-oauth-server/config/test.json
+++ b/packages/fxa-auth-server/fxa-oauth-server/config/test.json
@@ -131,9 +131,8 @@
   },
   "openid": {
     "issuer": "http://127.0.0.1:3030",
-    "key": {},
     "keyFile": "../config/key.json",
-    "oldKey": {},
+    "newKeyFile": "../config/newKey.json",
     "oldKeyFile": "../config/oldKey.json"
   },
   "ppid": {

--- a/packages/fxa-auth-server/fxa-oauth-server/docs/signing-key-management.md
+++ b/packages/fxa-auth-server/fxa-oauth-server/docs/signing-key-management.md
@@ -1,0 +1,58 @@
+# Management of JWT Signing Keys
+
+This server uses signed [JWTs](https://jwt.io/) to represent various kinds of security token,
+including:
+
+- `id_token`s as defined by [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html)
+- `access_token`s as defined by [JWT Profile for OAuth 2.0 Access
+  Tokens](https://datatracker.ietf.org/doc/draft-bertocci-oauth-access-token-jwt/)
+- Security Event Tokens as defined by [RFC8417](https://tools.ietf.org/html/rfc8417)
+
+RPs are expected to verify the signatures on these JWTs by fetching our public keys via the
+[OpenID Connect Discovery Protocol](https://openid.net/specs/openid-connect-discovery-1_0.html),
+which involves:
+
+1. Fetching our main OpenID metadata document at https://accounts.firefox.com/.well-known/openid-configuration
+2. Extracting the contained `"jwks_uri"` entry
+3. Fetching a [JWK Set](https://tools.ietf.org/html/rfc7517) document from that URI
+4. Respecting standard HTTP cache-control headers on those resources
+
+We thus have a coordination problem between this server and its RPs when it comes to changing our
+JWT signing keys. Let `T_cache` be the max age in the cache-control headers of our metadata documents,
+and `T_tokens` be the maximum lifetime of any token issued by this service. Then:
+
+- We must advertise a new signing key in our JWK Set for at least `T_cache` seconds before we start
+  using it to sign tokens. If we don't, RPs with a cached copy of our JWK Set may not know to trust
+  the new key, resulting in spurious verification failures and/or fragile logic to refresh the cached
+  copy on-demand when verification fails.
+- We must continue to advertise an old signing key in our JWK Set for at least `T_tokens` seconds
+  after we stop using it to sign tokens. If we don't, RPs who refresh their cache of our JWK Set may
+  treat tokens signed with that key as invalid before they expire, resulting in spurious verification
+  failures.
+
+To help manage this, the server config has slots for three different keys, one required and the others
+optional:
+
+- `openid.key`: The private key that is actively being used to sign tokens. This key is required.
+- `openid.newKey`: A new private key that we intend to start using to sign tokens in the future.
+  This key is optional, but can be specified in order to start advertising it before use.
+- `openid.oldKey`: The _public_ component of a key we previously used to sign tokens. This key is
+  optional, but can be specified in order to continue advertising it while tokens bearing its signature
+  may be active.
+
+The procedure for rotating the active signing key is:
+
+- Create the new signing key and configure it as `openid.newKey`, while leaving the existing `openid.key` intact.
+  - This can be performed using `../scripts/prepare-new-signing-key.js`.
+- Deploy to all server instances, then wait for at least `T_cache` seconds plus some margin for clock error.
+- Take the public component of `openid.key` and configure it as `openid.oldKey`, then move `openid.newKey`
+  to `openid.key`.
+  - This can be performed using `../scripts/activate-new-signing-key.js`.
+- Deploy to all server instances, then wait for at least `T_tokens` seconds plus some margin for clock error.
+- Remove `openid.oldKey` from the configuration.
+  - This can be performed using `../scripts/retire-old-signing-key.js`.
+- Deploy to all server instances, then celebrate a job well done.
+
+This scheme keeps things fairly simple, but it also means that each key rotation event must be at least
+`T_cache + T_tokens` seconds apart. If this proves to be a problem in practice, we could reduce the limit
+to `T_cache` by keeping a _list_ of old signing keys rather than a single key.

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/keys.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/keys.js
@@ -2,11 +2,137 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const assert = require('assert');
 const config = require('./config');
-const { jwk2pem } = require('pem-jwk');
+const { jwk2pem, pem2jwk } = require('pem-jwk');
+const crypto = require('crypto');
+const Joi = require('joi');
 
+const BASE64URL = /^[A-Za-z0-9-_]+$/;
 
-function pub(key) {
+const PUBLIC_KEY_SCHEMA = (exports.PUBLIC_KEY_SCHEMA = Joi.object({
+  kty: Joi.string()
+    .only('RSA')
+    .required(),
+  kid: Joi.string().required(),
+  n: Joi.string()
+    .regex(BASE64URL)
+    .required(),
+  e: Joi.string()
+    .regex(BASE64URL)
+    .required(),
+  alg: Joi.string()
+    .only('RS256')
+    .optional(),
+  use: Joi.string()
+    .only('sig')
+    .optional(),
+  'fxa-createdAt': Joi.number()
+    .integer()
+    .min(0)
+    .optional(),
+}));
+
+const PRIVATE_KEY_SCHEMA = (exports.PRIVATE_KEY_SCHEMA = Joi.object({
+  kty: Joi.string()
+    .only('RSA')
+    .required(),
+  kid: Joi.string().required(),
+  n: Joi.string()
+    .regex(BASE64URL)
+    .required(),
+  e: Joi.string()
+    .regex(BASE64URL)
+    .required(),
+  d: Joi.string()
+    .regex(BASE64URL)
+    .required(),
+  alg: Joi.string()
+    .only('RS256')
+    .optional(),
+  use: Joi.string()
+    .only('sig')
+    .optional(),
+  p: Joi.string()
+    .regex(BASE64URL)
+    .required(),
+  q: Joi.string()
+    .regex(BASE64URL)
+    .required(),
+  dp: Joi.string()
+    .regex(BASE64URL)
+    .required(),
+  dq: Joi.string()
+    .regex(BASE64URL)
+    .required(),
+  qi: Joi.string()
+    .regex(BASE64URL)
+    .required(),
+  'fxa-createdAt': Joi.number()
+    .integer()
+    .min(0)
+    .optional(),
+}));
+
+const PRIVATE_JWKS_MAP = new Map();
+const PUBLIC_JWK_MAP = new Map();
+const PUBLIC_PEM_MAP = new Map();
+
+// The active signing key should be a proper RSA private key,
+// and should always exist (unless we're initializing the keys for the first time).
+const currentPrivJWK = config.get('openid.key');
+if (currentPrivJWK) {
+  assert.strictEqual(
+    PRIVATE_KEY_SCHEMA.validate(currentPrivJWK).error,
+    null,
+    'openid.key must be a valid private key'
+  );
+  PRIVATE_JWKS_MAP.set(currentPrivJWK.kid, currentPrivJWK);
+} else if (!config.get('openid.unsafelyAllowMissingActiveKey')) {
+  assert.fail('openid.key is missing; bailing out in a cowardly fashion...');
+}
+
+// The pending signing key, if present, should be a proper RSA private key
+// and must be different from the active key..
+const newPrivJWK = config.get('openid.newKey');
+if (newPrivJWK) {
+  assert.strictEqual(
+    PRIVATE_KEY_SCHEMA.validate(newPrivJWK).error,
+    null,
+    'openid.newKey must be a valid private key'
+  );
+  assert.notEqual(
+    currentPrivJWK.kid,
+    newPrivJWK.kid,
+    'openid.key.kid must differ from openid.newKey.id'
+  );
+  PRIVATE_JWKS_MAP.set(newPrivJWK.kid, newPrivJWK);
+}
+
+// The retired signing key, if present, should be a proper RSA *public* key.
+// We will never again sign anything with it, so no need to keep the private component.
+const oldPubJWK = config.get('openid.oldKey');
+if (oldPubJWK) {
+  assert.strictEqual(
+    PUBLIC_KEY_SCHEMA.validate(oldPubJWK).error,
+    null,
+    'openid.oldKey must be a valid public key'
+  );
+  assert.notEqual(
+    currentPrivJWK.kid,
+    oldPubJWK.kid,
+    'openid.key.kid must differ from openid.oldKey.id'
+  );
+  PRIVATE_JWKS_MAP.set(oldPubJWK.kid, oldPubJWK);
+}
+
+/**
+ * Extract the public portion of a key.
+ *
+ * @param {JWK} The private key.
+ * @returns {JWK} Its corresponding public key.
+ */
+exports.extractPublicKey = function extractPublicKey(key) {
   // Hey, this is important. Listen up.
   //
   // This function pulls out only the **PUBLIC** pieces of this key.
@@ -15,37 +141,58 @@ function pub(key) {
   // BE CAREFUL IF YOU REFACTOR THIS. Thanks.
   return {
     kty: key.kty,
-    alg: 'RS256',
+    alg: key.alg || 'RS256',
     kid: key.kid,
     'fxa-createdAt': key['fxa-createdAt'],
-    use: 'sig',
+    use: key.use || 'sig',
     n: key.n,
     e: key.e,
   };
-}
+};
 
-const PRIVATE_JWKS_MAP = new Map();
-
-const currentPrivJWK = config.get('openid.key');
-PRIVATE_JWKS_MAP.set(currentPrivJWK.kid, currentPrivJWK);
-
-const oldPrivJWK = config.get('openid.oldKey');
-if (oldPrivJWK && Object.keys(oldPrivJWK).length) {
-  PRIVATE_JWKS_MAP.set(oldPrivJWK.kid, oldPrivJWK);
-}
-
-const SIGNING_JWK = config.get('openid.key');
-const SIGNING_PEM = jwk2pem(SIGNING_JWK);
-
-const PUBLIC_JWK_MAP = new Map();
-const PUBLIC_PEM_MAP = new Map();
-
-PRIVATE_JWKS_MAP.forEach((privJWK, kid) => {
-  const publicJWK = pub(privJWK);
-
-  PUBLIC_JWK_MAP.set(kid, publicJWK);
-  PUBLIC_PEM_MAP.set(kid, jwk2pem(publicJWK));
-});
+/**
+ * Generate a new, random private key.
+ *
+ * @returns {JWK}
+ */
+exports.generatePrivateKey = function generatePrivateKey() {
+  const PEM_ENCODING = {
+    type: 'pkcs1',
+    format: 'pem',
+  };
+  const kp = crypto.generateKeyPairSync('rsa', {
+    modulusLength: 256 * 8,
+    publicKeyEncoding: PEM_ENCODING,
+    privateKeyEncoding: PEM_ENCODING,
+  });
+  // We tag our keys with their creation time, and a unique key id
+  // based on a hash of the public key and the timestamp.  The result
+  // comes out like:
+  //  {
+  //    kid: "20170316-ebe69008"
+  //    "fxa-createdAt": 1489716000,
+  //  }
+  const now = new Date();
+  const pubKeyFingerprint = crypto
+    .createHash('sha256')
+    .update(kp.publicKey)
+    .digest('hex')
+    .slice(0, 8);
+  const privKey = Object.assign(pem2jwk(kp.privateKey), {
+    kid:
+      now
+        .toISOString()
+        .slice(0, 10)
+        .replace(/-/g, '') +
+      '-' +
+      pubKeyFingerprint,
+    alg: 'RS256',
+    use: 'sig',
+    // Timestamp to nearest hour; consumers don't need to know the precise time.
+    'fxa-createdAt': Math.floor(now / 1000 / 3600) * 3600,
+  });
+  return privKey;
+};
 
 /**
  * Get a public PEM by `kid`.
@@ -62,11 +209,25 @@ exports.publicPEM = function publicPEM(kid) {
   return pem;
 };
 
+PRIVATE_JWKS_MAP.forEach((privJWK, kid) => {
+  const publicJWK = exports.extractPublicKey(privJWK);
+
+  PUBLIC_JWK_MAP.set(kid, publicJWK);
+  PUBLIC_PEM_MAP.set(kid, jwk2pem(publicJWK));
+});
+
 // An array of raw public keys that can be fetched
 // by remote services to locally verify.
 exports.PUBLIC_KEYS = Array.from(PUBLIC_JWK_MAP.values());
 
-// The PEM to sign with
-exports.SIGNING_PEM = SIGNING_PEM;
-exports.SIGNING_KID = SIGNING_JWK.kid;
-exports.SIGNING_ALG = 'RS256';
+// The PEM to sign with, and related details.
+// This won't be present if we're unsafely allowing the module to load without
+// keys property configured.
+if (currentPrivJWK) {
+  const SIGNING_JWK = currentPrivJWK;
+  const SIGNING_PEM = jwk2pem(SIGNING_JWK);
+
+  exports.SIGNING_PEM = SIGNING_PEM;
+  exports.SIGNING_KID = SIGNING_JWK.kid;
+  exports.SIGNING_ALG = 'RS256';
+}

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/introspect.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/introspect.js
@@ -47,7 +47,7 @@ module.exports = {
       tokenId = await getTokenId(req.payload.token);
     } catch (err) {
       return {
-        active: false
+        active: false,
       };
     }
     if (tokenTypeHint === 'access_token' || !tokenTypeHint) {

--- a/packages/fxa-auth-server/fxa-oauth-server/scripts/activate-new-signing-key.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/scripts/activate-new-signing-key.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+
+ Usage:
+ scripts/activate-new-signing-key.js
+
+ Will copy the existing signing key from ./config/key.json into ./config/oldKey.json,
+ then move the new signing key from ./config/newKey.json into ./config/key.json.
+
+ */
+
+//eslint-disable no-console
+
+const fs = require('fs');
+const assert = require('assert');
+const keys = require('../lib/keys');
+const config = require('../lib/config');
+
+function main(cb) {
+  cb = cb || (() => {});
+
+  const keyPath = config.get('openid.keyFile');
+  const key = config.get('openid.key');
+
+  const newKeyPath = config.get('openid.newKeyFile');
+  const newKey = config.get('openid.newKey');
+  assert(newKey, 'missing new signing key');
+
+  const oldKeyPath = config.get('openid.oldKeyFile');
+  const oldKey = keys.extractPublicKey(key);
+  fs.writeFileSync(oldKeyPath, JSON.stringify(oldKey, undefined, 2));
+  console.log('OldKey saved:', keyPath);
+
+  fs.writeFileSync(keyPath, JSON.stringify(newKey, undefined, 2));
+  console.log('Key saved:', keyPath);
+
+  fs.unlinkSync(newKeyPath);
+  console.log('NewKey wiped:', keyPath);
+
+  console.log('Please restart the server to begin using the new signing key');
+  return cb();
+}
+
+module.exports = main;
+
+if (require.main === module) {
+  main();
+}

--- a/packages/fxa-auth-server/fxa-oauth-server/scripts/gen_keys.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/scripts/gen_keys.js
@@ -12,75 +12,78 @@
  Will create these files
 
  ./config/key.json
+ ./config/newKey.json
  ./config/oldKey.json
 
+ This script is used for initializing keys in a dev environment.
  If these files already exist, this script will show an error message
- and exit. You must remove both keys if you want to generate a new
- keypair.
+ and exit. If you want to generate a new keypair, either use one of
+ the key-rotation scripts (e.g. 'prepare-new-signing-key.js') or just
+ delete the existing key file (hey, only it's a dev environment!).
  */
 
+//eslint-disable no-console
+
+// If you're running this script, you probably don't have keys created yet.
+// This bypasses config checks that would otherwise prevent us from running
+// without a properly-configured active key.
+process.env.FXA_OPENID_UNSAFELY_ALLOW_MISSING_ACTIVE_KEY = true;
+
 const fs = require('fs');
-const assert = require('assert');
-const crypto = require('crypto');
-const generateRSAKeypair = require('keypair');
-const JwTool = require('fxa-jwtool');
+const path = require('path');
+const keys = require('../lib/keys');
+const config = require('../lib/config');
 
-const keyPath = './fxa-oauth-server/config/key.json';
-const oldKeyPath = './fxa-oauth-server/config/oldKey.json';
-
-try {
-  var keysExist = fs.existsSync(keyPath) && fs.existsSync(oldKeyPath);
-  assert(!keysExist, 'keys already exists');
-} catch (e) {
-  process.exit();
-}
-
-// We tag our keys with their creation time, and a unique key id
-// based on a hash of the public key and the timestamp.  The result
-// comes out like:
-//  {
-//    kid: "2017-03-16-ebe69008de771d62cd1cadf9faa6daae"
-//    "fxa-createdAt": 1489716000,
-//  }
-function makeKeyProperties(kp) {
-  var now = new Date();
-  return {
-    // Key id based on timestamp and hash of public key.
-    kid:
-      now.toISOString().slice(0, 10) +
-      '-' +
-      crypto
-        .createHash('sha256')
-        .update(kp.public)
-        .digest('hex')
-        .slice(0, 32),
-    // Timestamp to nearest hour; consumers don't need to know the precise time.
-    'fxa-createdAt': Math.round(now / 1000 / 3600) * 3600,
-  };
+function writeJSONFile(filePath, data) {
+  try {
+    fs.mkdirSync(filePath.dirname(filePath));
+  } catch (accessEx) {}
+  fs.writeFileSync(filePath, JSON.stringify(data, undefined, 2));
 }
 
 function main(cb) {
-  var kp = generateRSAKeypair();
-  var privKey = JwTool.JWK.fromPEM(kp.private, makeKeyProperties(kp));
-  try {
-    fs.mkdirSync('./fxa-oauth-server/config');
-  } catch (accessEx) {}
+  cb = cb || (() => {});
 
-  fs.writeFileSync(keyPath, JSON.stringify(privKey.toJSON(), undefined, 2));
-  console.log('Key saved:', keyPath); //eslint-disable-line no-console
+  let keyPath = config.get('openid.keyFile');
+  const newKeyPath = config.get('openid.newKeyFile');
+  let oldKeyPath = config.get('openid.oldKeyFile');
+
+  // Default fallbacks for running in various dev environments.
+  if (!keyPath) {
+    keyPath = path.resolve(__dirname, '../config/key.json');
+  }
+  if (!oldKeyPath) {
+    oldKeyPath = path.resolve(__dirname, '../config/oldKey.json');
+  }
+
+  var keysExist =
+    (keyPath && fs.existsSync(keyPath)) ||
+    (newKeyPath && fs.existsSync(newKeyPath)) ||
+    (oldKeyPath && fs.existsSync(oldKeyPath));
+  if (keysExist) {
+    return cb();
+  }
+
+  const privKey = keys.generatePrivateKey();
+  writeJSONFile(keyPath, privKey);
+  console.log('Key saved:', keyPath);
 
   // The "old key" is not used to sign anything, so we don't need to store
   // the private component, we just need to serve the public component
-  // so that old signatures can be verified correctly.
-  kp = generateRSAKeypair();
-  var pubKey = JwTool.JWK.fromPEM(kp.public, makeKeyProperties(kp));
-  fs.writeFileSync(oldKeyPath, JSON.stringify(pubKey.toJSON(), undefined, 2));
-  console.log('OldKey saved:', oldKeyPath); //eslint-disable-line no-console
-  cb();
+  // so that old signatures can be verified correctly.  In dev we just
+  // write a fake one for testing purposes.
+  if (oldKeyPath) {
+    const pubKey = keys.extractPublicKey(keys.generatePrivateKey());
+    writeJSONFile(oldKeyPath, pubKey);
+    console.log('OldKey saved:', oldKeyPath);
+  }
+
+  console.log('Please restart the server to begin using the new keys');
+  return cb();
 }
 
 module.exports = main;
 
 if (require.main === module) {
-  main(function() {});
+  main();
 }

--- a/packages/fxa-auth-server/fxa-oauth-server/scripts/prepare-new-signing-key.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/scripts/prepare-new-signing-key.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+
+ Usage:
+ scripts/prepare-new-signing-key.js
+
+ Will generate a new signing key and write it into ./config/newKey.json.
+
+ */
+
+//eslint-disable no-console
+
+const fs = require('fs');
+const assert = require('assert');
+const keys = require('../lib/keys');
+const config = require('../lib/config');
+
+function main(cb) {
+  cb = cb || (() => {});
+
+  const newKeyPath = config.get('openid.newKeyFile');
+  if (!newKeyPath) {
+    assert(false, 'openid.newKeyFile not specified');
+  }
+
+  if (config.get('openid.newKey')) {
+    assert(false, 'new key already exists; perhaps you meant to activate it?');
+  }
+
+  const privKey = keys.generatePrivateKey();
+  fs.writeFileSync(newKeyPath, JSON.stringify(privKey, undefined, 2));
+  console.log('NewKey saved:', newKeyPath);
+
+  console.log(
+    'Please restart the server to begin advertising the incoming signing key'
+  );
+  return cb();
+}
+
+module.exports = main;
+
+if (require.main === module) {
+  main();
+}

--- a/packages/fxa-auth-server/fxa-oauth-server/scripts/retire-old-signing-key.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/scripts/retire-old-signing-key.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+
+ Usage:
+ scripts/retire-new-signing-key.js
+
+ Will zero out the old signing key in ./config/oldKey.json.
+
+ */
+
+//eslint-disable no-console
+
+const fs = require('fs');
+const config = require('../lib/config');
+
+// We don't use this, but we load it to check key config.
+require('../lib/keys');
+
+function main(cb) {
+  cb = cb || (() => {});
+
+  const oldKeyPath = config.get('openid.oldKeyFile');
+  fs.unlinkSync(oldKeyPath);
+  console.log('OldKey wiped:', oldKeyPath);
+
+  console.log(
+    'Please restart the server to stop advertising the old signing key'
+  );
+  return cb();
+}
+
+module.exports = main;
+
+if (require.main === module) {
+  main();
+}

--- a/packages/fxa-auth-server/fxa-oauth-server/test/api.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/api.js
@@ -3564,6 +3564,10 @@ describe('/v1', function() {
     });
 
     it('should include the oldKey if present', function() {
+      assert.ok(
+        config.get('openid.oldKey'),
+        'openid.oldKey should be present by default during tests'
+      );
       return Server.api
         .get({
           url: '/jwks',

--- a/packages/fxa-auth-server/fxa-oauth-server/test/key-management-scripts.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/key-management-scripts.js
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { assert } = require('chai');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const crypto = require('crypto');
+const rimraf = require('rimraf');
+
+describe('the signing-key management scripts', () => {
+  let runScript;
+  let workDir, keyFile, newKeyFile, oldKeyFile;
+
+  beforeEach(() => {
+    const uniqName = crypto.randomBytes(8).toString('hex');
+    workDir = path.join(os.tmpdir(), `fxa-oauth-server-tests-${uniqName}`);
+    fs.mkdirSync(workDir);
+    keyFile = path.join(workDir, 'key.json');
+    newKeyFile = path.join(workDir, 'newKey.json');
+    oldKeyFile = path.join(workDir, 'oldKey.json');
+    runScript = name => {
+      const script = path.resolve(__dirname, '../scripts/', name);
+      return execFileSync(process.execPath, [script], {
+        env: {
+          FXA_OPENID_KEYFILE: keyFile,
+          FXA_OPENID_NEWKEYFILE: newKeyFile,
+          FXA_OPENID_OLDKEYFILE: oldKeyFile,
+        },
+        stdio: [0, 'pipe', 'pipe'],
+      });
+    };
+  });
+
+  afterEach(() => {
+    rimraf.sync(workDir);
+  });
+
+  it('work as intended', () => {
+    // Initially, the directory is empty.
+    assert.deepEqual(fs.readdirSync(workDir), []);
+
+    // We can't run any of the other management scripts until we generate initial set of keys.
+    assert.throws(
+      () => runScript('prepare-new-signing-key.js'),
+      /openid\.key is missing/
+    );
+    assert.throws(
+      () => runScript('activate-new-signing-key.js'),
+      /openid\.key is missing/
+    );
+    assert.throws(
+      () => runScript('retire-old-signing-key.js'),
+      /openid\.key is missing/
+    );
+
+    // Need to initialize some keys
+    runScript('gen_keys.js');
+    assert.equal(fs.readdirSync(workDir).length, 2);
+    assert.ok(fs.existsSync(keyFile));
+    assert.ok(!fs.existsSync(newKeyFile));
+    assert.ok(fs.existsSync(oldKeyFile));
+
+    const kid = JSON.parse(fs.readFileSync(keyFile)).kid;
+    assert.ok(kid);
+
+    // That generated a fake old key, which we can retire.
+    runScript('retire-old-signing-key.js');
+    assert.equal(fs.readdirSync(workDir).length, 1);
+    assert.ok(fs.existsSync(keyFile));
+    assert.ok(!fs.existsSync(newKeyFile));
+    assert.ok(!fs.existsSync(oldKeyFile));
+
+    // But it didn't generate a new key, so we can't activate it.
+    assert.throws(
+      () => runScript('activate-new-signing-key.js'),
+      /missing new signing key/
+    );
+
+    // Generate new signing key.
+    runScript('prepare-new-signing-key.js');
+    assert.equal(fs.readdirSync(workDir).length, 2);
+    assert.ok(fs.existsSync(keyFile));
+    assert.ok(fs.existsSync(newKeyFile));
+    assert.ok(!fs.existsSync(oldKeyFile));
+
+    const newKid = JSON.parse(fs.readFileSync(newKeyFile)).kid;
+    assert.ok(newKid);
+    assert.notEqual(newKid, kid);
+
+    // Now we can activate it.
+    runScript('activate-new-signing-key.js');
+    assert.equal(fs.readdirSync(workDir).length, 2);
+    assert.ok(fs.existsSync(keyFile));
+    assert.ok(!fs.existsSync(newKeyFile));
+    assert.ok(fs.existsSync(oldKeyFile));
+
+    const activatedKid = JSON.parse(fs.readFileSync(keyFile)).kid;
+    assert.equal(activatedKid, newKid);
+
+    // Which should have moved the previous key to old-key.
+    const retiringKid = JSON.parse(fs.readFileSync(oldKeyFile)).kid;
+    assert.equal(retiringKid, kid);
+
+    // From where we can retire it completely.
+    runScript('retire-old-signing-key.js');
+    assert.equal(fs.readdirSync(workDir).length, 1);
+    assert.ok(fs.existsSync(keyFile));
+    assert.ok(!fs.existsSync(newKeyFile));
+    assert.ok(!fs.existsSync(oldKeyFile));
+  });
+});

--- a/packages/fxa-auth-server/fxa-oauth-server/test/keys.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/keys.js
@@ -5,46 +5,62 @@
 const { assert } = require('chai');
 const config = require('../lib/config');
 const proxyquire = require('proxyquire');
+const keys = require('../lib/keys');
+
+const MOCK_PRIVATE_KEY = {
+  kty: 'RSA',
+  n:
+    'gtZICzk-mbbsIf8LTrTDaog3lYzyDNGWwZvklM0euIWnkXfXDoracZAe5E3XV-PYNyT8OOwvf3LxX7zlzVjZ6Ew1PucUafXbjweHFPQy307qEWhJjJl-KYmcD7VXS1IYQ-BVzSKYBAWtCHiRb9f37mkAbITwes-dwm0nM8W0c2BtND-KKCFE5mhZTkBtbOcti-QHglRvEftoLo_7nqYu2tU3VqKDbRuv7lRzCgSPlpLbQMNoE_I190JxMOHOVUrj9GSfXNcuoR_3DqpfAEG8I0OR1RaAWq_-ZbIZJw380DZDN007r5w5oiiff_fG-DLFB9jY67eh7Mv1vpuZ7Q6tFQ',
+  e: 'AQAB',
+  d:
+    'ahFhsoej8mXTJPRorFPrIJBxz3HGQRIgz7CcLO3le94OrOWkmQuEcBBQmvFoJL536Ky5NUR0dTQv7ldrTYA8mBBAElCvwf8pEdkeb6RRIawOIjKTfcJp_y6qMCnpLQzO0ygpJvZmmswnLPjhnvRM8SB60X8sncN2t8pZv6UF14opwOOh6HRUCZIwk_qsVj3FFF2Kbof6zMGZeja2SNw2syRho8JunvLGj7i1EfNY_hCtfuKJQFgqnNGc6UkvvQow7biv8hoXmjAfuSfsll-YUMI0tizg8Qe6EhH34m0YcnW-iZjA6-VNDXcQpQG8Wey2r-t0Xf5IUZ0EaF2RTvJqeQ',
+  p:
+    'vqtEjuvKMtqATKajIFUmU0u2Ak0qgseTVSzLXA1DhyV4JBVguGXDOKCqEkomwB-WwudH2KWY0A22FP73KS7tFiEvPDjPPBnBrK2fNPYqBIMEoSW1Q5IKTwvuWyqbAMFEilGm4Or83Mzz7VGnokcsiKAqsKNFVnVvky0iflKfk4M',
+  q:
+    'r6rJ_nauB7J3fdjaJ9emM1nyBx2KyPzblraP4QhH9C3Ytfh4aYvh772vwFyu3_woDOc4PMNKTWa88yth5RQzlenAL9S4chk9sJvtAKEAzDy7_6saZHL0P30EAAjRaSrtq4ZCV4vXffhK6vXSFpW_TAXqNk6e2AwqPD70K6pMIYc',
+  dp:
+    'Kn2meKdJV03kW7CjF9iCAvwTYq3ptF1fkxK5exklnF-YR4pQFKfw-pSrcgn-WsBva535H-m_hVYY5tLvJ8liYpUgnq4WWNFwnNfQbBATyw-bn4H0xEsuavFAvCZhhqiLarvJkcQsd9Rg49lXn013OjdfbB_mmt7u74CWeEpXb5s',
+  dq:
+    'XKpAMZ5TQTYweE9LDRdh0dbRqFU6H7na8A7PqQpgQntoxN0UT8D9ZyTtsBB0Iy11xxC1hsAR0vCuHaw10MyuRZdvzQtuXKnZ8-7cv6cur44eMckFfBVzqIX-9TGxncOKah_BoULgYs_2XSldMJK_vY-lNA6XFiqcoPkoflwwGsM',
+  qi:
+    'Qgpo8CVYFvjpjni53XjVwrSTtD-zbT_COS3-1bs4h1zKinpruX7asvrwaAk1gpxG5Sz79zuaOyoKUzj7z3p3j9TYW7bILlP0WhIGmI5W_z0ZjdnYUCZa2j0JMcSY1iySuzGkp44Bllt8b19WYUnW5IrooGaJALaVL5YQmSKF5kc',
+  kid: '20190403-4c56c912',
+  'fxa-createdAt': 1554278400,
+};
+
+const MOCK_PUBLIC_KEY = {
+  kty: 'RSA',
+  n:
+    'm9Iych6X-w5_vc1G0Ds_c1sD0KCwM1yGcyGbEn1XnJoNLMY0UqVbG0n6QQRSK841y9mVK88iaLgBjAfhHa4D3Ahvq5vzkoKbu1Ui0-_W0EilbqAMciUX9wi3spvlENzgwWtXqlPgDTlKwoTfx0blqUh-8RVJCkP147vQnDzQzYbl30oMIB_swzRFRkz87t02AE3iOHlBLDJqn4hS9Jgw1l9xcGTD17ZhPVpRqrbw63l9phUTHaIqUX2B1s-q9qJSi_16I-BV1C4r7TCtW6bAD9KH86upBUczOPakSmzydsWoj1fQllfBkl-d5E5s0llWGOr_geXtMZWa-DxzoTgllw',
+  e: 'AQAB',
+  kid: '20190402-33e2bd19',
+  'fxa-createdAt': 1554278401,
+};
 
 describe('lib/keys', () => {
-  let keys;
   let mockConfig;
+  let currentKey, newKey, oldKey, unsafelyAllowMissingActiveKey;
+  let loadMockedModule;
 
   beforeEach(() => {
+    currentKey = MOCK_PRIVATE_KEY;
+    newKey = null;
+    oldKey = MOCK_PUBLIC_KEY;
+    unsafelyAllowMissingActiveKey = false;
     mockConfig = {
       get(key) {
         switch (key) {
           case 'openid.key': {
-            return {
-              kty: 'RSA',
-              n:
-                'gtZICzk-mbbsIf8LTrTDaog3lYzyDNGWwZvklM0euIWnkXfXDoracZAe5E3XV-PYNyT8OOwvf3LxX7zlzVjZ6Ew1PucUafXbjweHFPQy307qEWhJjJl-KYmcD7VXS1IYQ-BVzSKYBAWtCHiRb9f37mkAbITwes-dwm0nM8W0c2BtND-KKCFE5mhZTkBtbOcti-QHglRvEftoLo_7nqYu2tU3VqKDbRuv7lRzCgSPlpLbQMNoE_I190JxMOHOVUrj9GSfXNcuoR_3DqpfAEG8I0OR1RaAWq_-ZbIZJw380DZDN007r5w5oiiff_fG-DLFB9jY67eh7Mv1vpuZ7Q6tFQ',
-              e: 'AQAB',
-              d:
-                'ahFhsoej8mXTJPRorFPrIJBxz3HGQRIgz7CcLO3le94OrOWkmQuEcBBQmvFoJL536Ky5NUR0dTQv7ldrTYA8mBBAElCvwf8pEdkeb6RRIawOIjKTfcJp_y6qMCnpLQzO0ygpJvZmmswnLPjhnvRM8SB60X8sncN2t8pZv6UF14opwOOh6HRUCZIwk_qsVj3FFF2Kbof6zMGZeja2SNw2syRho8JunvLGj7i1EfNY_hCtfuKJQFgqnNGc6UkvvQow7biv8hoXmjAfuSfsll-YUMI0tizg8Qe6EhH34m0YcnW-iZjA6-VNDXcQpQG8Wey2r-t0Xf5IUZ0EaF2RTvJqeQ',
-              p:
-                'vqtEjuvKMtqATKajIFUmU0u2Ak0qgseTVSzLXA1DhyV4JBVguGXDOKCqEkomwB-WwudH2KWY0A22FP73KS7tFiEvPDjPPBnBrK2fNPYqBIMEoSW1Q5IKTwvuWyqbAMFEilGm4Or83Mzz7VGnokcsiKAqsKNFVnVvky0iflKfk4M',
-              q:
-                'r6rJ_nauB7J3fdjaJ9emM1nyBx2KyPzblraP4QhH9C3Ytfh4aYvh772vwFyu3_woDOc4PMNKTWa88yth5RQzlenAL9S4chk9sJvtAKEAzDy7_6saZHL0P30EAAjRaSrtq4ZCV4vXffhK6vXSFpW_TAXqNk6e2AwqPD70K6pMIYc',
-              dp:
-                'Kn2meKdJV03kW7CjF9iCAvwTYq3ptF1fkxK5exklnF-YR4pQFKfw-pSrcgn-WsBva535H-m_hVYY5tLvJ8liYpUgnq4WWNFwnNfQbBATyw-bn4H0xEsuavFAvCZhhqiLarvJkcQsd9Rg49lXn013OjdfbB_mmt7u74CWeEpXb5s',
-              dq:
-                'XKpAMZ5TQTYweE9LDRdh0dbRqFU6H7na8A7PqQpgQntoxN0UT8D9ZyTtsBB0Iy11xxC1hsAR0vCuHaw10MyuRZdvzQtuXKnZ8-7cv6cur44eMckFfBVzqIX-9TGxncOKah_BoULgYs_2XSldMJK_vY-lNA6XFiqcoPkoflwwGsM',
-              qi:
-                'Qgpo8CVYFvjpjni53XjVwrSTtD-zbT_COS3-1bs4h1zKinpruX7asvrwaAk1gpxG5Sz79zuaOyoKUzj7z3p3j9TYW7bILlP0WhIGmI5W_z0ZjdnYUCZa2j0JMcSY1iySuzGkp44Bllt8b19WYUnW5IrooGaJALaVL5YQmSKF5kc',
-              kid: '2019-04-03-4c56c912afb12a573f2ccc8474b9bfbf',
-              'fxa-createdAt': 1554278400,
-            };
+            return currentKey;
+          }
+          case 'openid.newKey': {
+            return newKey;
           }
           case 'openid.oldKey': {
-            return {
-              kty: 'RSA',
-              n:
-                'm9Iych6X-w5_vc1G0Ds_c1sD0KCwM1yGcyGbEn1XnJoNLMY0UqVbG0n6QQRSK841y9mVK88iaLgBjAfhHa4D3Ahvq5vzkoKbu1Ui0-_W0EilbqAMciUX9wi3spvlENzgwWtXqlPgDTlKwoTfx0blqUh-8RVJCkP147vQnDzQzYbl30oMIB_swzRFRkz87t02AE3iOHlBLDJqn4hS9Jgw1l9xcGTD17ZhPVpRqrbw63l9phUTHaIqUX2B1s-q9qJSi_16I-BV1C4r7TCtW6bAD9KH86upBUczOPakSmzydsWoj1fQllfBkl-d5E5s0llWGOr_geXtMZWa-DxzoTgllw',
-              e: 'AQAB',
-              kid: '2019-04-03-33e2bd199f5e624cfe13c73f74d5baef',
-              'fxa-createdAt': 1554278401,
-            };
+            return oldKey;
+          }
+          case 'unsafelyAllowMissingActiveKey': {
+            return unsafelyAllowMissingActiveKey;
           }
           default: {
             return config.get(key);
@@ -52,30 +68,36 @@ describe('lib/keys', () => {
         }
       },
     };
-    keys = proxyquire('../lib/keys', {
-      './config': mockConfig,
-    });
+    loadMockedModule = () =>
+      proxyquire('../lib/keys', {
+        './config': mockConfig,
+      });
   });
 
   it('has the expected interface', () => {
-    assert.lengthOf(Object.keys(keys), 5);
+    const keys = loadMockedModule();
+    assert.lengthOf(Object.keys(keys), 9);
     assert.isFunction(keys.publicPEM);
+    assert.isFunction(keys.extractPublicKey);
+    assert.isFunction(keys.generatePrivateKey);
     assert.isArray(keys.PUBLIC_KEYS);
+    assert.isObject(keys.PUBLIC_KEY_SCHEMA);
+    assert.isFunction(keys.PUBLIC_KEY_SCHEMA.validate);
+    assert.isObject(keys.PRIVATE_KEY_SCHEMA);
+    assert.isFunction(keys.PRIVATE_KEY_SCHEMA.validate);
     assert.isString(keys.SIGNING_PEM);
     assert.isString(keys.SIGNING_KID);
     assert.isString(keys.SIGNING_ALG);
   });
 
   it('exports raw PUBLIC_KEYS', () => {
+    const keys = loadMockedModule();
     assert.lengthOf(keys.PUBLIC_KEYS, 2);
 
     const rawPublicKey0 = keys.PUBLIC_KEYS[0];
     assert.strictEqual(rawPublicKey0.kty, 'RSA');
     assert.strictEqual(rawPublicKey0.alg, 'RS256');
-    assert.strictEqual(
-      rawPublicKey0.kid,
-      '2019-04-03-4c56c912afb12a573f2ccc8474b9bfbf'
-    );
+    assert.strictEqual(rawPublicKey0.kid, '20190403-4c56c912');
     assert.strictEqual(rawPublicKey0['fxa-createdAt'], 1554278400);
     assert.strictEqual(rawPublicKey0.use, 'sig');
     assert.strictEqual(
@@ -87,10 +109,7 @@ describe('lib/keys', () => {
     const rawPublicKey1 = keys.PUBLIC_KEYS[1];
     assert.strictEqual(rawPublicKey1.kty, 'RSA');
     assert.strictEqual(rawPublicKey1.alg, 'RS256');
-    assert.strictEqual(
-      rawPublicKey1.kid,
-      '2019-04-03-33e2bd199f5e624cfe13c73f74d5baef'
-    );
+    assert.strictEqual(rawPublicKey1.kid, '20190402-33e2bd19');
     assert.strictEqual(rawPublicKey1['fxa-createdAt'], 1554278401);
     assert.strictEqual(rawPublicKey1.use, 'sig');
     assert.strictEqual(
@@ -100,14 +119,147 @@ describe('lib/keys', () => {
     assert.strictEqual(rawPublicKey1.e, 'AQAB');
   });
 
+  it('exports the current key if that is the only one configured', () => {
+    oldKey = null;
+    const keys = loadMockedModule();
+    assert.lengthOf(keys.PUBLIC_KEYS, 1);
+
+    const rawPublicKey0 = keys.PUBLIC_KEYS[0];
+    assert.strictEqual(rawPublicKey0.kid, '20190403-4c56c912');
+  });
+
+  it('exports both new and current keys, if configured', () => {
+    oldKey = null;
+    newKey = keys.generatePrivateKey();
+    const mockedKeys = loadMockedModule();
+    assert.lengthOf(mockedKeys.PUBLIC_KEYS, 2);
+    const rawPublicKey0 = mockedKeys.PUBLIC_KEYS[0];
+    assert.strictEqual(rawPublicKey0.kid, '20190403-4c56c912');
+    const rawPublicKey1 = mockedKeys.PUBLIC_KEYS[1];
+    assert.strictEqual(rawPublicKey1.kid, newKey.kid);
+  });
+
+  it('exports new and current and old keys if all three are configured', () => {
+    newKey = keys.generatePrivateKey();
+    const mockedKeys = loadMockedModule();
+    assert.lengthOf(mockedKeys.PUBLIC_KEYS, 3);
+    const rawPublicKey0 = mockedKeys.PUBLIC_KEYS[0];
+    assert.strictEqual(rawPublicKey0.kid, '20190403-4c56c912');
+    const rawPublicKey1 = mockedKeys.PUBLIC_KEYS[1];
+    assert.strictEqual(rawPublicKey1.kid, newKey.kid);
+    const rawPublicKey2 = mockedKeys.PUBLIC_KEYS[2];
+    assert.strictEqual(rawPublicKey2.kid, '20190402-33e2bd19');
+  });
+
+  describe('if the current signing key is not present', () => {
+    beforeEach(() => {
+      currentKey = null;
+    });
+
+    it('refuses to load by default', () => {
+      try {
+        loadMockedModule();
+        assert.fail('should have thrown');
+      } catch (err) {
+        assert.equal(
+          err.message,
+          'openid.key is missing; bailing out in a cowardly fashion...'
+        );
+      }
+    });
+
+    it('loads if a special config option is to to allow it', () => {
+      unsafelyAllowMissingActiveKey = true;
+      try {
+        loadMockedModule();
+        assert.fail('should have thrown');
+      } catch (err) {
+        assert.equal(
+          err.message,
+          'openid.key is missing; bailing out in a cowardly fashion...'
+        );
+      }
+    });
+  });
+
+  it('refuses to load if the current signing key does not contain the private key component', () => {
+    currentKey = oldKey;
+    try {
+      loadMockedModule();
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.message, 'openid.key must be a valid private key');
+    }
+  });
+
+  it('refuses to load if the new signing key is set but does not contain the private key component', () => {
+    newKey = oldKey;
+    try {
+      loadMockedModule();
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.message, 'openid.newKey must be a valid private key');
+    }
+  });
+
+  it('refuses to load if the new signing key is set but matches the current signing key', () => {
+    newKey = currentKey;
+    try {
+      loadMockedModule();
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(
+        err.message,
+        'openid.key.kid must differ from openid.newKey.id'
+      );
+    }
+  });
+
+  it('refuses to load if the old signing key is set but still contains the private key component', () => {
+    oldKey = keys.generatePrivateKey();
+    try {
+      loadMockedModule();
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.message, 'openid.oldKey must be a valid public key');
+    }
+  });
+
+  it('refuses to load if the old signing key is set but matches the current signing key', () => {
+    oldKey = keys.extractPublicKey(currentKey);
+    try {
+      loadMockedModule();
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(
+        err.message,
+        'openid.key.kid must differ from openid.oldKey.id'
+      );
+    }
+  });
+
   it('can get a public PEM by kid', () => {
-    assert.ok(keys.publicPEM('2019-04-03-4c56c912afb12a573f2ccc8474b9bfbf'));
-    assert.ok(keys.publicPEM('2019-04-03-33e2bd199f5e624cfe13c73f74d5baef'));
+    const keys = loadMockedModule();
+    assert.ok(keys.publicPEM('20190403-4c56c912'));
+    assert.ok(keys.publicPEM('20190402-33e2bd19'));
     try {
       keys.publicPEM('bing');
       assert.fail();
     } catch (err) {
       assert.equal(err.message, 'PEM not found');
     }
+  });
+
+  it('can generate new private keys', () => {
+    const key = keys.generatePrivateKey();
+    assert.strictEqual(keys.PRIVATE_KEY_SCHEMA.validate(key).error, null);
+    assert.ok(key['fxa-createdAt'] <= Date.now() / 1000);
+    assert.ok(key['fxa-createdAt'] >= Date.now() / 1000 - 3600);
+  });
+
+  it('can extract public keys', () => {
+    const key = keys.extractPublicKey(keys.generatePrivateKey());
+    assert.strictEqual(keys.PUBLIC_KEY_SCHEMA.validate(key).error, null);
+    assert.notEqual(keys.PRIVATE_KEY_SCHEMA.validate(key).error, null);
   });
 });

--- a/packages/fxa-auth-server/fxa-oauth-server/test/routes/jwks.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/routes/jwks.js
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { assert } = require('chai');
+const proxyquire = require('proxyquire');
+const mocks = require('../lib/mocks');
+const keys = require('../../lib/keys');
+
+const routeModulePath = '../../lib/routes/jwks';
+var dependencies = mocks.require(
+  [{ path: '../keys' }],
+  routeModulePath,
+  __dirname
+);
+
+describe('/jwks GET', function() {
+  describe('config handling', () => {
+    let PUBLIC_KEYS, getRoute;
+
+    beforeEach(() => {
+      PUBLIC_KEYS = [];
+      getRoute = () => {
+        dependencies['../keys'].PUBLIC_KEYS = PUBLIC_KEYS;
+        return proxyquire(routeModulePath, dependencies);
+      };
+    });
+
+    it('returns the configured public keys', async () => {
+      PUBLIC_KEYS = [
+        keys.extractPublicKey(keys.generatePrivateKey()),
+        keys.extractPublicKey(keys.generatePrivateKey()),
+      ];
+      const resp = await getRoute().handler();
+      assert.deepEqual(Object.keys(resp), ['keys']);
+      assert.deepEqual(resp.keys[0], PUBLIC_KEYS[0]);
+      assert.deepEqual(resp.keys[1], PUBLIC_KEYS[1]);
+    });
+  });
+});

--- a/packages/fxa-auth-server/npm-shrinkwrap.json
+++ b/packages/fxa-auth-server/npm-shrinkwrap.json
@@ -4153,11 +4153,6 @@
       "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
       "integrity": "sha1-RIR8o5TOjWtSGuhYFr1kUJlCs4U="
     },
-    "keypair": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.1.tgz",
-      "integrity": "sha1-dgNxknCvtlZO04oiCHoG/Jqk6hs="
-    },
     "keyv": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -66,7 +66,6 @@
     "jed": "0.5.4",
     "joi": "14.0.0",
     "jsonwebtoken": "^8.4.0",
-    "keypair": "1.0.1",
     "keyv": "3.0.0",
     "memcached": "2.2.2",
     "moment-timezone": "0.5.11",

--- a/packages/fxa-auth-server/scripts/start-local.sh
+++ b/packages/fxa-auth-server/scripts/start-local.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 node ./scripts/gen_keys.js
-node ./fxa-oauth-server/scripts/gen_keys.js
+NODE_ENV=dev node ./fxa-oauth-server/scripts/gen_keys.js
 node ./scripts/gen_vapid_keys.js
 node ./test/mail_helper.js &
 MH=$!


### PR DESCRIPTION
In recent conversation, @shane-tomlinson mentioned that we didn't have very good docs written down for how to rotate the `id_token` (and soon `access_token`) signing key. I started to write one and then realized that our current facilities for actually doing the rotation were inadequate, and could allow a brief window where RPs with a cached copy of our JWK Set would get spurious validation failures.

So, here we have:

* A doc describing the intended mechanics of key rotation, and why we need two "staging" periods in the process - one for introducing the new key, and one for phasing out the old key.
* An extra config value to be used for staging the new signing key *before* we actually start using it to sign things.
* A set of scripts for automating the stages of this process.

I don't know if we'd use the scripts verbatim in production, but would be happy to modify them as needed so they're useful, if that's how we want to proceed here.

Rendered explainer doc [here](https://github.com/mozilla/fxa/blob/scripted-key-rotation/packages/fxa-auth-server/fxa-oauth-server/docs/signing-key-management.md).

(I'm also not thrilled that we're doing a bunch of hand-massaging of the components of the keys like this, and I wonder if the node JWX ecosystem has evolved sufficiently that we could use an existing library. But that's a bigger topic, and this PR doesn't cause us to do anything that we weren't doing already).

@shane-tomlinson @dannycoates @bbangert @jbuck @jrgm thoughts?