### PR TITLE
chore(subs): remove `|| []` from call to db.fetchAccountSubscriptions

### DIFF
--- a/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
@@ -2538,101 +2538,134 @@ module.exports = function(config, DB) {
     });
 
     describe('db.securityEventsByUid', () => {
-      let session1, session2, session3, anotherAccountSession, uid, anotherUid
-      const evA = 'account.login', evB = 'account.create', evC = 'account.reset'
-      const addr = '127.0.0.1'
+      let session1, session2, session3, anotherAccountSession, uid, anotherUid;
+      const evA = 'account.login',
+        evB = 'account.create',
+        evC = 'account.reset';
+      const addr = '127.0.0.1';
 
       function insert(uid, addr, name, session) {
         return db.createSecurityEvent({
           uid: uid,
           ipAddr: addr,
           name: name,
-          tokenId: session
-        })
+          tokenId: session,
+        });
       }
 
-      beforeEach( () => {
-        const anotherAccountData = createAccount()
+      beforeEach(() => {
+        const anotherAccountData = createAccount();
 
-        session1 = makeMockSessionToken(accountData.uid)
-        session2 = makeMockSessionToken(accountData.uid)
+        session1 = makeMockSessionToken(accountData.uid);
+        session2 = makeMockSessionToken(accountData.uid);
         // Make session verified
-        delete session2.tokenVerificationId
+        delete session2.tokenVerificationId;
 
-        session3 = makeMockSessionToken(accountData.uid)
-        anotherAccountSession = makeMockSessionToken(anotherAccountData.uid)
+        session3 = makeMockSessionToken(accountData.uid);
+        anotherAccountSession = makeMockSessionToken(anotherAccountData.uid);
 
-        uid = accountData.uid
-        anotherUid = anotherAccountData.uid
+        uid = accountData.uid;
+        anotherUid = anotherAccountData.uid;
 
-        return P.all([
-          db.createSessionToken(session1.tokenId, session1),
-          db.createSessionToken(session2.tokenId, session2),
-          db.createSessionToken(session3.tokenId, session3),
-          db.createSessionToken(anotherAccountSession.tokenId, anotherAccountSession)
-        ])
-        // Don't parallelize these, the order of them matters
-        // because they record timestamps in the db.
-          .then(() => insert(uid, addr, evA, session2.tokenId).delay(10))
-          .then(() => insert(uid, addr, evB, session1.tokenId).delay(10))
-          .then(() => insert(uid, addr, evC).delay(10))
-          .then(() => insert(anotherUid, addr, evA, anotherAccountSession.tokenId).delay(10))
+        return (
+          P.all([
+            db.createSessionToken(session1.tokenId, session1),
+            db.createSessionToken(session2.tokenId, session2),
+            db.createSessionToken(session3.tokenId, session3),
+            db.createSessionToken(
+              anotherAccountSession.tokenId,
+              anotherAccountSession
+            ),
+          ])
+            // Don't parallelize these, the order of them matters
+            // because they record timestamps in the db.
+            .then(() => insert(uid, addr, evA, session2.tokenId).delay(10))
+            .then(() => insert(uid, addr, evB, session1.tokenId).delay(10))
+            .then(() => insert(uid, addr, evC).delay(10))
+            .then(() =>
+              insert(
+                anotherUid,
+                addr,
+                evA,
+                anotherAccountSession.tokenId
+              ).delay(10)
+            )
 
-          // create an account in db with anotherAccountData
-          .then(() => db.createAccount(anotherAccountData.uid, anotherAccountData))
-      })
+            // create an account in db with anotherAccountData
+            .then(() =>
+              db.createAccount(anotherAccountData.uid, anotherAccountData)
+            )
+        );
+      });
 
       it('should get security event', () => {
-        return db.securityEventsByUid(uid)
-          .then(results => {
-            assert.lengthOf(results, 3)
-            // The most recent event is returned first.
-            assert.equal(results[0].name, evC, 'correct event name')
-            assert.equal(!! results[0].verified, true, 'event without a session is already verified')
-            assert.isBelow(results[0].createdAt, Date.now())
-            assert.equal(results[1].name, evB, 'correct event name')
-            assert.equal(!! results[1].verified, false, 'second session is not verified yet')
-            assert.isBelow(results[1].createdAt, results[0].createdAt)
-            assert.equal(results[2].name, evA, 'correct event name')
-            assert.equal(!! results[2].verified, true, 'first session is already verified')
-            assert.isBelow(results[2].createdAt, results[1].createdAt)
-          })
-      })
+        return db.securityEventsByUid(uid).then(results => {
+          assert.lengthOf(results, 3);
+          // The most recent event is returned first.
+          assert.equal(results[0].name, evC, 'correct event name');
+          assert.equal(
+            !!results[0].verified,
+            true,
+            'event without a session is already verified'
+          );
+          assert.isBelow(results[0].createdAt, Date.now());
+          assert.equal(results[1].name, evB, 'correct event name');
+          assert.equal(
+            !!results[1].verified,
+            false,
+            'second session is not verified yet'
+          );
+          assert.isBelow(results[1].createdAt, results[0].createdAt);
+          assert.equal(results[2].name, evA, 'correct event name');
+          assert.equal(
+            !!results[2].verified,
+            true,
+            'first session is already verified'
+          );
+          assert.isBelow(results[2].createdAt, results[1].createdAt);
+        });
+      });
 
       it('should get security event for another account', () => {
-        return db.securityEventsByUid(anotherUid)
-          .then(results => {
-            assert.lengthOf(results, 1)
-            assert.equal(results[0].name, evA, 'correct event name')
-            assert.equal(results[0].verified, false, 'this session is not verified')
-            assert.isBelow(results[0].createdAt, Date.now())
-          })
-      })
+        return db.securityEventsByUid(anotherUid).then(results => {
+          assert.lengthOf(results, 1);
+          assert.equal(results[0].name, evA, 'correct event name');
+          assert.equal(
+            results[0].verified,
+            false,
+            'this session is not verified'
+          );
+          assert.isBelow(results[0].createdAt, Date.now());
+        });
+      });
 
       it('should get event after session verified', () => {
-        return db.verifyTokens(session1.tokenVerificationId, { uid })
+        return db
+          .verifyTokens(session1.tokenVerificationId, { uid })
           .then(() => db.securityEventsByUid(uid))
           .then(results => {
-            assert.lengthOf(results, 3)
-            assert.isTrue(!! results[0].verified)
-            assert.isTrue(!! results[1].verified)
-            assert.isTrue(!! results[2].verified)
-          })
-      })
+            assert.lengthOf(results, 3);
+            assert.isTrue(!!results[0].verified);
+            assert.isTrue(!!results[1].verified);
+            assert.isTrue(!!results[2].verified);
+          });
+      });
 
       it('should give no securityEvent with new unknown uid', () => {
-        const unknownUid = newUuid()
-        return db.securityEventsByUid(unknownUid)
-          .then(results => assert.lengthOf(results, 0))
-      })
+        const unknownUid = newUuid();
+        return db
+          .securityEventsByUid(unknownUid)
+          .then(results => assert.lengthOf(results, 0));
+      });
 
       it('should get no events when events are deleted', () => {
-        return db.deleteSecurityEventsByUid(accountData.uid)
-          .then((result) => assert.deepEqual(result, {}))
+        return db
+          .deleteSecurityEventsByUid(accountData.uid)
+          .then(result => assert.deepEqual(result, {}))
           .then(() => db.securityEventsByUid(uid))
-          .then(result => assert.lengthOf(result, 0))
-      })
-    })
+          .then(result => assert.lengthOf(result, 0));
+      });
+    });
 
     describe('db.deleteAccount', () => {
       let sessionTokenData;
@@ -4254,6 +4287,12 @@ module.exports = function(config, DB) {
         }
       });
 
+      it('should fetch an empty array when there are no subscriptions', async () => {
+        const result = await db.fetchAccountSubscriptions(account.uid);
+        assert.isArray(result);
+        assert.lengthOf(result, 0);
+      });
+
       const pickSet = (list, name) => new Set(list.map(x => x[name]));
 
       it('should support fetching all subscriptions', async () => {
@@ -4482,7 +4521,10 @@ module.exports = function(config, DB) {
           subscriptionIds[22],
           Date.now()
         );
-        await db.reactivateAccountSubscription(account.uid, subscriptionIds[22]);
+        await db.reactivateAccountSubscription(
+          account.uid,
+          subscriptionIds[22]
+        );
 
         const subscriptions = await db.fetchAccountSubscriptions(account.uid);
 
@@ -4548,14 +4590,14 @@ module.exports = function(config, DB) {
         );
         await db.reactivateAccountSubscription(
           account.uid,
-          subscriptionIds[25],
+          subscriptionIds[25]
         );
 
         let failed = false;
         try {
           await db.reactivateAccountSubscription(
             account.uid,
-            subscriptionIds[25],
+            subscriptionIds[25]
           );
         } catch (err) {
           failed = true;

--- a/packages/fxa-auth-db-mysql/db-server/test/backend/remote.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/remote.js
@@ -2950,6 +2950,14 @@ module.exports = function(cfg, makeServer) {
         return client.putThen('/account/' + user.accountId, user.account);
       });
 
+      it('should list no subscriptions', async () => {
+        const { obj } = await client.getThen(
+          `/account/${user.accountId}/subscriptions`
+        );
+        assert.isArray(obj);
+        assert.lengthOf(obj, 0);
+      });
+
       it('should create a new subscription', async () => {
         const result = await client.putThen(
           `/account/${user.accountId}/subscriptions/${subs[0]}`,

--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -1431,8 +1431,9 @@ module.exports = (
                     // Subscription records will be deleted from DB as part of account
                     // deletion, but we have to trigger cancellation in payment systems
                     const uid = emailRecord.uid;
-                    const subscriptions =
-                      (await db.fetchAccountSubscriptions(uid)) || [];
+                    const subscriptions = await db.fetchAccountSubscriptions(
+                      uid
+                    );
                     for (const subscription of subscriptions) {
                       const { subscriptionId } = subscription;
                       await subhub.cancelSubscription(uid, subscriptionId);


### PR DESCRIPTION
Not connected to an issue, I noticed this while looking at someone else.

There was an unnecessary and misleading `|| []` after a call to `db.fetchAccountSubscriptions`, so I just removed it and added some test coverage to assert that the db does indeed return the empty array in the default case.

@mozilla/fxa-devs r?