### PR TITLE
feat(payments): add sentry to client-side

### DIFF
--- a/packages/fxa-payments-server/package-lock.json
+++ b/packages/fxa-payments-server/package-lock.json
@@ -1490,6 +1490,65 @@
         "warning": "^3.0.0"
       }
     },
+    "@sentry/browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.5.0.tgz",
+      "integrity": "sha512-QZw4EXK47Qp9Q+vNpL5H4P4tYyfAN8qpWWeLIM0RDiNLlOugTVUdkfkeNTEJZ9VlqJ5RLx/2G/PITG4R6pwh/A==",
+      "requires": {
+        "@sentry/core": "5.5.0",
+        "@sentry/types": "5.5.0",
+        "@sentry/utils": "5.5.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.5.0.tgz",
+          "integrity": "sha512-xOcBud0t5mfhFdyd2tQQti4uuWSrLiJihpXzxeRpdCfk2ic+xmpeQs3G4UqnluvQDc48ug/Igt7LXfSBRBx4eg==",
+          "requires": {
+            "@sentry/hub": "5.5.0",
+            "@sentry/minimal": "5.5.0",
+            "@sentry/types": "5.5.0",
+            "@sentry/utils": "5.5.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.5.0.tgz",
+          "integrity": "sha512-+jKh5U1nv8ufoquGciWoZPOmKuEjFPH5m0VifCs6t3NcEbAq2qnfF26KUGqhUNznlUN/PkbWB4qMfKn14uNE2Q==",
+          "requires": {
+            "@sentry/types": "5.5.0",
+            "@sentry/utils": "5.5.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.5.0.tgz",
+          "integrity": "sha512-o6O30+/pNrO7fTgwKxgZynHB7cMScJlw9HXgnNXgLXS6LBiqjYCQfVnWAgV//SyyG0uUlcjH3P6PnV6TsJOmVQ==",
+          "requires": {
+            "@sentry/hub": "5.5.0",
+            "@sentry/types": "5.5.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.5.0.tgz",
+          "integrity": "sha512-3otF/miVDth91o+iign00x0o31McUPeyIFbMjLbgeTRRW9rXpu2jGrcRrvHfofECtoqCf5Y734hwvvlBvFZeIw=="
+        },
+        "@sentry/utils": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.5.0.tgz",
+          "integrity": "sha512-gO8Bs/QcKDn7ncc2f2fIOTPx2AiZKrGj4us1Yxu6mBU8JZqMQRl9XjDMFAUECJQvquBAta+TFJyYj71ZedeQUQ==",
+          "requires": {
+            "@sentry/types": "5.5.0",
+            "tslib": "^1.9.3"
+          }
+        }
+      }
+    },
     "@sentry/core": {
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.4.2.tgz",
@@ -5185,7 +5244,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -5203,11 +5263,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5220,15 +5282,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -5331,7 +5396,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -5341,6 +5407,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -5353,17 +5420,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -5380,6 +5450,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -5452,7 +5523,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -5462,6 +5534,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -5537,7 +5610,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -5567,6 +5641,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5584,6 +5659,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -5622,11 +5698,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -10971,7 +11049,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -10989,11 +11068,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -11006,15 +11087,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -11117,7 +11201,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -11127,6 +11212,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -11139,17 +11225,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -11166,6 +11255,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -11238,7 +11328,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -11248,6 +11339,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -11323,7 +11415,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -11353,6 +11446,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -11370,6 +11464,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -11408,11 +11503,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -71,6 +71,7 @@
     "ts-node": "^8.1.0"
   },
   "dependencies": {
+    "@sentry/browser": "^5.5.0",
     "@sentry/node": "^5.3.0",
     "@types/nock": "^10.0.1",
     "@types/node": "^12.0.0",

--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -27,6 +27,7 @@ module.exports = () => {
   // Each of these config values (e.g., 'servers.content') will be exposed as the given
   // variable to the client/browser (via fxa-content-server/config)
   const CLIENT_CONFIG = {
+    sentryDsn: config.get('sentryDsn'),
     servers: {
       auth: {
         url: config.get('servers.auth.url'),

--- a/packages/fxa-payments-server/src/index.tsx
+++ b/packages/fxa-payments-server/src/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from 'react-dom';
 import { createAppStore, actions } from './store';
+import * as Sentry from '@sentry/browser';
 
 import { config, readConfigFromMeta } from './lib/config';
 import './index.scss';
@@ -9,6 +10,11 @@ import ScreenInfo from './lib/screen-info';
 
 async function init() {
   readConfigFromMeta();
+  if (config.sentryDsn) {
+    Sentry.init({
+      dsn: config.sentryDsn,
+    });
+  }
 
   const store = createAppStore();
 

--- a/packages/fxa-payments-server/src/lib/config.ts
+++ b/packages/fxa-payments-server/src/lib/config.ts
@@ -2,6 +2,7 @@
 // Which config is copied over is defined in server/lib/server.js
 export interface Config {
   featureFlags: {[key: string]: any}
+  sentryDsn: string
   servers: {
     auth: {
       url: string
@@ -24,6 +25,7 @@ export interface Config {
 
 export const config: Config = {
   featureFlags: {},
+  sentryDsn: '',
   servers: {
     auth: {
       url: '',


### PR DESCRIPTION
Fixes #1299.

Adds sentry to the client-side of the payments server. Uses all the default options, which seem like they should be fine:

https://github.com/getsentry/sentry-javascript/blob/master/packages/types/src/options.ts

Only a draft for now because `prettier` has made some unexpected changes on commit. Ref: #1673