### PR TITLE
chore(lint): use fxa eslint plugin in payments server

### DIFF
--- a/packages/fxa-payments-server/src/.eslintrc
+++ b/packages/fxa-payments-server/src/.eslintrc
@@ -1,4 +1,5 @@
 plugins:
+  - fxa
   - react
 
 extends: ../.eslintrc


### PR DESCRIPTION
Fixes #1673.

Turns out the payments server was missing the `fxa` eslint plugin. Adding this stops prettier being uglier.

@mozilla/fxa-devs r?