### PR TITLE
fix(openid): fix the openid at_hash calculation

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/grant.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/grant.js
@@ -157,7 +157,7 @@ module.exports.generateTokens = async function generateTokens(grant) {
   }
   // Maybe also generate an idToken?
   if (grant.scope && grant.scope.contains(SCOPE_OPENID)) {
-    result.id_token = await generateIdToken(grant, access);
+    result.id_token = await generateIdToken(grant, result.access_token);
   }
 
   amplitude('token.created', {
@@ -168,7 +168,7 @@ module.exports.generateTokens = async function generateTokens(grant) {
   return result;
 };
 
-function generateIdToken(grant, access) {
+function generateIdToken(grant, accessToken) {
   var now = Math.floor(Date.now() / 1000);
   var claims = {
     sub: hex(grant.userId),
@@ -176,7 +176,7 @@ function generateIdToken(grant, access) {
     //iss set in jwt.sign
     iat: now,
     exp: now + ID_TOKEN_EXPIRATION,
-    at_hash: util.generateTokenHash(access.token),
+    at_hash: util.generateTokenHash(accessToken),
   };
   if (grant.amr) {
     claims.amr = grant.amr;

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/util.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/util.js
@@ -29,15 +29,15 @@ const base64URLEncode = function base64URLEncode(buf) {
  * Generates a hash of the access token based on
  * http://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken
  *
- * This value is the hash of the ascii value of the access token, then the base64url
+ * This hash of the access token, then the base64url
  * value of the left half.
  *
- * @param {Buffer} accessTokenBuf
+ * @param {Buffer} accessToken The access token as seen by the client (hex form)
  * @returns {String}
  * @api public
  */
-const generateTokenHash = function generateTokenHash(accessTokenBuf) {
-  const hash = encrypt.hash(accessTokenBuf.toString('ascii'));
+const generateTokenHash = function generateTokenHash(accessToken) {
+  const hash = encrypt.hash(accessToken);
   return base64URLEncode(hash.slice(0, hash.length / 2));
 };
 

--- a/packages/fxa-auth-server/fxa-oauth-server/test/api.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/api.js
@@ -2266,9 +2266,7 @@ describe('/v1', function() {
           assert.equal(claims.acr, ACR);
           assert.equal(claims['fxa-aal'], AAL);
 
-          const at_hash = util.generateTokenHash(
-            Buffer.from(res.result.access_token, 'hex')
-          );
+          const at_hash = util.generateTokenHash(res.result.access_token);
           assert.equal(claims.at_hash, at_hash);
         });
       });


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/1678

This simplifies the `at_hash` calculation for the access token by calculating the hash based on what the client sees.

When I originally read the spec, I suspect the ASCII part threw me off

> Its value is the base64url encoding of the left-most half of the hash of the octets of the ASCII representation of the access_token value

@shane-tomlinson @rfk Does this match what you were thinking?