### PR TITLE
refactor(api): prefer async/await in POST /account/destroy route

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -2703,9 +2703,8 @@ describe('/account/destroy', () => {
         'db.emailRecord was called once'
       );
       let args = mockDB.accountRecord.args[0];
-      assert.equal(args.length, 2, 'db.emailRecord was passed two arguments');
-      assert.equal(args[0], email, 'first argument was email address');
-      assert.equal(args[1], true, 'second argument was customs.check result');
+      assert.equal(args.length, 1);
+      assert.equal(args[0], email);
 
       assert.equal(
         mockDB.deleteAccount.callCount,


### PR DESCRIPTION
It was pointed out in https://github.com/mozilla/fxa/pull/1671#discussion_r300750165 that the route handler for `POST /account/destroy` is an ugly mix of `.then` chains and `async`/`await`. This refactors it to use `async`/`await` across the board.

Opened as a separate PR because it makes a mess of the diff, so I'll rebase #1671 after this lands.

@mozilla/fxa-devs r?