### PR TITLE
fix(tests): use correct module name in get-metrics-flow tests

### DIFF
--- a/packages/fxa-content-server/tests/server/routes/get-metrics-flow.js
+++ b/packages/fxa-content-server/tests/server/routes/get-metrics-flow.js
@@ -46,7 +46,7 @@ registerSuite('routes/get-metrics-flow', {
     route = proxyquire('../../../server/lib/routes/get-metrics-flow', {
       '../amplitude': mocks.amplitude,
       '../flow-event': mocks.flowEvent,
-      '../geolocate': mocks.geolocate,
+      '../geo-locate': mocks.geolocate,
       '../logging/log': () => mocks.log,
     });
     instance = route(mocks.config);


### PR DESCRIPTION
The content server `get-metrics-flow` tests are failing because of a typo in a module name. This fixes it.

@mozilla/fxa-devs r?