### PR TITLE
Revert "fix(subs): Add display_name field to subhub create subscription API"

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -109,7 +109,6 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
           payload: {
             planId: validators.subscriptionsPlanId.required(),
             paymentToken: validators.subscriptionsPaymentToken.required(),
-            displayName: isA.string().required(),
           },
         },
         response: {
@@ -125,7 +124,7 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
 
         await customs.check(request, email, 'createSubscription');
 
-        const { planId, paymentToken, displayName } = request.payload;
+        const { planId, paymentToken } = request.payload;
 
         // Find the selected plan and get its product ID
         const plans = await subhub.listPlans();
@@ -142,7 +141,6 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
           uid,
           paymentToken,
           planId,
-          displayName,
           email
         );
 

--- a/packages/fxa-auth-server/lib/subhub/client.js
+++ b/packages/fxa-auth-server/lib/subhub/client.js
@@ -122,7 +122,6 @@ module.exports = function(log, config) {
           plan_id: isA.string().required(),
           email: isA.string().required(),
           orig_system: isA.string().required(),
-          display_name: isA.string().required(),
         },
         response: isA.alternatives(
           validators.subscriptionsSubscriptionListValidator,
@@ -185,26 +184,20 @@ module.exports = function(log, config) {
       }
     },
 
-    async createSubscription(uid, pmt_token, plan_id, display_name, email) {
+    async createSubscription(uid, pmt_token, plan_id, email) {
       try {
         return await api.createSubscription(uid, {
           pmt_token,
           plan_id,
-          display_name,
           email,
           orig_system: ORIG_SYSTEM,
         });
       } catch (err) {
-        if (
-          err.statusCode === 400 ||
-          err.statusCode === 402 ||
-          err.statusCode === 404
-        ) {
+        if (err.statusCode === 400 || err.statusCode === 402 || err.statusCode === 404) {
           log.error('subhub.createSubscription.1', {
             uid,
             pmt_token,
             plan_id,
-            display_name,
             email,
             err,
           });
@@ -274,11 +267,7 @@ module.exports = function(log, config) {
       try {
         return await api.updateCustomer(uid, { pmt_token });
       } catch (err) {
-        if (
-          err.statusCode === 400 ||
-          err.statusCode === 402 ||
-          err.statusCode === 404
-        ) {
+        if (err.statusCode === 400 || err.statusCode === 402 || err.statusCode === 404) {
           log.error('subhub.updateCustomer.1', { uid, pmt_token, err });
           if (err.statusCode === 404) {
             throw error.unknownCustomer(uid);

--- a/packages/fxa-auth-server/lib/subhub/stubAPI.js
+++ b/packages/fxa-auth-server/lib/subhub/stubAPI.js
@@ -37,7 +37,7 @@ module.exports.buildStubAPI = function buildStubAPI(log, config) {
       );
     },
 
-    async createSubscription(uid, pmt_token, plan_id, display_name, email) {
+    async createSubscription(uid, pmt_token, plan_id, email) {
       const plan = getPlanById(plan_id);
       if (!plan) {
         throw error.unknownSubscriptionPlan(plan_id);

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -1093,8 +1093,7 @@ module.exports = config => {
   ClientApi.prototype.createSubscription = function(
     refreshToken,
     planId,
-    paymentToken,
-    displayName
+    paymentToken
   ) {
     return this.doRequestWithBearerToken(
       'POST',
@@ -1103,7 +1102,6 @@ module.exports = config => {
       {
         planId,
         paymentToken,
-        displayName,
       }
     );
   };
@@ -1146,7 +1144,7 @@ module.exports = config => {
       'POST',
       `${this.baseURL}/oauth/subscriptions/reactivate`,
       refreshToken,
-      { subscriptionId }
+      { subscriptionId },
     );
   };
 

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -769,15 +769,9 @@ module.exports = config => {
   Client.prototype.createSubscription = function(
     refreshToken,
     planId,
-    paymentToken,
-    displayName
+    paymentToken
   ) {
-    return this.api.createSubscription(
-      refreshToken,
-      planId,
-      paymentToken,
-      displayName
-    );
+    return this.api.createSubscription(refreshToken, planId, paymentToken);
   };
 
   Client.prototype.updatePayment = function(refreshToken, paymentToken) {
@@ -792,10 +786,7 @@ module.exports = config => {
     return this.api.cancelSubscription(refreshToken, subscriptionId);
   };
 
-  Client.prototype.reactivateSubscription = function(
-    refreshToken,
-    subscriptionId
-  ) {
+  Client.prototype.reactivateSubscription = function(refreshToken, subscriptionId) {
     return this.api.reactivateSubscription(refreshToken, subscriptionId);
   };
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -69,7 +69,6 @@ const ACTIVE_SUBSCRIPTIONS = [
     cancelledAt: null,
   },
 ];
-const DISPLAY_NAME = 'Foo Bar';
 
 const MOCK_CLIENT_ID = '3c49430b43dfba77';
 const MOCK_TTL = 3600;
@@ -258,7 +257,6 @@ describe('subscriptions', () => {
         payload: {
           ...requestOptions.payload,
           planId: PLANS[0].plan_id,
-          displayName: DISPLAY_NAME,
           paymentToken: PAYMENT_TOKEN_VALID,
         },
       });
@@ -267,7 +265,7 @@ describe('subscriptions', () => {
 
       assert.equal(subhub.listPlans.callCount, 1);
       assert.deepEqual(subhub.createSubscription.args, [
-        [UID, PAYMENT_TOKEN_VALID, PLANS[0].plan_id, DISPLAY_NAME, TEST_EMAIL],
+        [UID, PAYMENT_TOKEN_VALID, PLANS[0].plan_id, TEST_EMAIL],
       ]);
       assert.equal(db.createAccountSubscription.callCount, 1);
 

--- a/packages/fxa-auth-server/test/local/subhub/client.js
+++ b/packages/fxa-auth-server/test/local/subhub/client.js
@@ -32,7 +32,6 @@ describe('subhub client', () => {
   const ORIG_SYSTEM = 'Firefox Accounts';
   const UID = '8675309';
   const EMAIL = 'foo@example.com';
-  const DISPLAY_NAME = 'Foo Barbaz';
   const PLAN_ID = 'plan12345';
   const SUBSCRIPTION_ID = 'sub12345';
   const PAYMENT_TOKEN_GOOD = 'foobarbaz';
@@ -212,7 +211,6 @@ describe('subhub client', () => {
         orig_system: ORIG_SYSTEM,
         pmt_token: PAYMENT_TOKEN_GOOD,
         plan_id: PLAN_ID,
-        display_name: DISPLAY_NAME,
         email: EMAIL,
       };
       let requestBody;
@@ -224,7 +222,6 @@ describe('subhub client', () => {
         UID,
         PAYMENT_TOKEN_GOOD,
         PLAN_ID,
-        DISPLAY_NAME,
         EMAIL
       );
       assert.deepEqual(requestBody, expectedBody);
@@ -238,13 +235,7 @@ describe('subhub client', () => {
         .reply(404, { message: 'invalid plan id' });
       const { log, subhub } = makeSubject();
       try {
-        await subhub.createSubscription(
-          UID,
-          PAYMENT_TOKEN_BAD,
-          PLAN_ID,
-          DISPLAY_NAME,
-          EMAIL
-        );
+        await subhub.createSubscription(UID, PAYMENT_TOKEN_BAD, PLAN_ID, EMAIL);
         assert.fail();
       } catch (err) {
         assert.equal(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION_PLAN);
@@ -263,13 +254,7 @@ describe('subhub client', () => {
         .reply(400, { message: 'invalid payment token' });
       const { log, subhub } = makeSubject();
       try {
-        await subhub.createSubscription(
-          UID,
-          PAYMENT_TOKEN_BAD,
-          PLAN_ID,
-          DISPLAY_NAME,
-          EMAIL
-        );
+        await subhub.createSubscription(UID, PAYMENT_TOKEN_BAD, PLAN_ID, EMAIL);
         assert.fail();
       } catch (err) {
         assert.equal(
@@ -294,7 +279,6 @@ describe('subhub client', () => {
           UID,
           PAYMENT_TOKEN_GOOD,
           PLAN_ID,
-          DISPLAY_NAME,
           EMAIL
         );
         assert.fail();

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -14,7 +14,6 @@ const testServerFactory = require('../test_server');
 
 const CLIENT_ID = 'client8675309';
 const CLIENT_ID_FOR_DEFAULT = 'client5551212';
-const DISPLAY_NAME = 'Example User';
 const PAYMENT_TOKEN = 'pay8675309';
 const PLAN_ID = 'allDoneProMonthly';
 const PLAN_NAME = 'All Done Pro Monthly';
@@ -162,8 +161,7 @@ describe('remote subscriptions:', function() {
         ({ subscriptionId } = await client.createSubscription(
           tokens[2],
           PLAN_ID,
-          PAYMENT_TOKEN,
-          DISPLAY_NAME
+          PAYMENT_TOKEN
         ));
       });
 

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -102,7 +102,6 @@ export const Product = ({
       createSubscription(accessToken, {
         paymentToken: tokenResponse.token.id,
         planId: selectedPlan.plan_id,
-        displayName: profile.result ? profile.result.displayName : '',
       });  
     } else {
       // This shouldn't happen with a successful createToken() call, but let's


### PR DESCRIPTION
Reverts mozilla/fxa#1664.

Turns out the display name from the credit card input form, not the user's fxa display name, is what's needed. Following up in #1690.