### PR TITLE
fix(api): prevent raw location object being returned in clients list

### DIFF
--- a/packages/fxa-auth-server/lib/routes/utils/clients.js
+++ b/packages/fxa-auth-server/lib/routes/utils/clients.js
@@ -49,6 +49,7 @@ module.exports = (log, config) => {
             language,
             location,
           });
+          client.location = {};
         }
       }
       return client;

--- a/packages/fxa-auth-server/test/local/routes/utils/clients.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/clients.js
@@ -18,7 +18,7 @@ const makeClientUtils = (options) => {
     earliestSaneTimestamp: EARLIEST_SANE_TIMESTAMP
   };
   config.i18n = config.i18n || {
-    supportedLanguages: ['en', 'fr'],
+    supportedLanguages: ['en', 'fr', 'wibble'],
     defaultLanguage: 'en'
   };
   return require('../../../../lib/routes/utils/clients')(log, config);
@@ -107,6 +107,38 @@ describe('clientUtils.formatLocation', () => {
       country: 'Royaume-Uni',
     });
     assert.equal(log.warn.callCount, 0);
+  });
+
+  it('unsets location if it fails', () => {
+    request.app.acceptLanguage = 'wibble';
+    const client = {
+      location: {
+        city: 'Bournemouth',
+        state: 'England',
+        stateCode: 'EN',
+        country: 'United Kingdom',
+        countryCode: 'GB',
+      },
+    };
+    clientUtils.formatLocation(client, request);
+    assert.deepEqual(client.location, {});
+
+    assert.equal(log.warn.callCount, 1);
+    const args = log.warn.args[0];
+    assert.lengthOf(args, 2);
+    assert.equal(args[0], 'attached-clients.formatLocation.warning');
+    assert.deepEqual(args[1], {
+      err: "Cannot find module 'cldr-localenames-full/main/wibble/territories.json'",
+      language: 'wibble',
+      languages: 'wibble',
+      location: {
+        city: 'Bournemouth',
+        state: 'England',
+        stateCode: 'EN',
+        country: 'United Kingdom',
+        countryCode: 'GB',
+      }
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #1698.

There was a subtle change to the marshalling logic for client locations, introduced in #1552. The old `marshallLocation` function used to return the empty object in the error case, but the new `formatLocation` function leaves the raw `location` object in place instead.

Indirectly, this was the cause of:

https://sentry.prod.mozaws.net/operations/auth-prod/issues/6027903/?environment=prod

The alternative fix, to just add `countryCode` to the response schema, would mean showing English location data instead of omitting it if no acceptable translation is available. Since that's a behavioural change and presumably not what we want, I opted for consistency with the old approach.

Opened against the `train-140` branch for a patch release.

@mozilla/fxa-devs r?