### PR TITLE
fix(css): #1562 - display proper Firefox Send icon for Android

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -544,7 +544,7 @@ section.modal-panel {
     background-image: url('/images/icon-device-phone-android.svg');
   }
 
-  &[data-name='Firefox Send'] {
+  &[data-name^='Firefox Send'] {
     background-image: url('/images/icon-service-send.svg');
   }
 }


### PR DESCRIPTION
fixes https://github.com/mozilla/fxa/issues/1562

The `data-name` for this comes up as `'Firefox Send for Android'`. Updating the CSS to include the "starts with" selector fixes the problem.

Thanks @6a68 for the screenshot. I was able to see the fix by changing some stuff around client-side.

<img width="1298" alt="image" src="https://user-images.githubusercontent.com/13018240/60839606-2a182280-a193-11e9-84ed-52f4c64d21a8.png">
