### PR TITLE
fix(css): update trailhead progress bar to support rtl

### DIFF
--- a/packages/fxa-content-server/app/images/trailhead/step-2-rtl.svg
+++ b/packages/fxa-content-server/app/images/trailhead/step-2-rtl.svg
@@ -1,0 +1,15 @@
+<svg width="141" height="18" xmlns="http://www.w3.org/2000/svg">
+    <g transform="translate(3 3)" fill="none" fill-rule="evenodd">
+        <circle stroke="#E0E0E6" stroke-width="3" cx="6" cy="6" r="7.5"/>
+        <circle fill="#0090ED" cx="67.75" cy="6" r="3.75"/>
+        <circle stroke="#E0E0E6" stroke-width="3" cx="67.5" cy="6" r="7.5"/>
+        <circle stroke="#E0E0E6" stroke-width="3" cx="129" cy="6" r="7.5"/>
+        <path d="M13.5 6.375H60M75 6.375h46.5" stroke="#E0E0E6" stroke-width="3"/>
+        <g transform="translate(123)">
+            <circle stroke="#005CE3" stroke-width="3" fill="#005CE3" cx="6" cy="6" r="7.5"/>
+            <path
+                d="M4.746 9.75a.626.626 0 0 1-.442-.184L2.426 7.69a.625.625 0 0 1 .885-.884l1.35 1.349 3.953-5.643a.626.626 0 0 1 1.026.717L5.26 9.482a.626.626 0 0 1-.458.267.54.54 0 0 1-.055 0z"
+                fill="#FFF" fill-rule="nonzero"/>
+        </g>
+    </g>
+</svg>

--- a/packages/fxa-content-server/app/images/trailhead/step-3-rtl.svg
+++ b/packages/fxa-content-server/app/images/trailhead/step-3-rtl.svg
@@ -1,0 +1,22 @@
+<svg width="141" height="18" xmlns="http://www.w3.org/2000/svg">
+    <g transform="translate(3 3)" fill="none" fill-rule="evenodd">
+        <circle fill="#0090ED" cx="6" cy="6" r="3.75"/>
+        <circle stroke="#E0E0E6" stroke-width="3" cx="6" cy="6" r="7.5"/>
+        <circle stroke="#E0E0E6" stroke-width="3" cx="67.5" cy="6" r="7.5"/>
+        <circle stroke="#E0E0E6" stroke-width="3" cx="129" cy="6" r="7.5"/>
+        <path d="M13.5 6.375H60" stroke="#E0E0E6" stroke-width="3"/>
+        <path d="M75 6.375h46.5" stroke="#E0E0E6" stroke-width="3"/>
+        <g transform="translate(62)">
+            <circle stroke="#005CE3" stroke-width="3" fill="#005CE3" cx="6" cy="6" r="7.5"/>
+            <path
+                d="M4.746 9.75a.626.626 0 0 1-.442-.184L2.426 7.69a.625.625 0 0 1 .885-.884l1.35 1.349 3.953-5.643a.626.626 0 0 1 1.026.717L5.26 9.482a.626.626 0 0 1-.458.267.54.54 0 0 1-.055 0z"
+                fill="#FFF" fill-rule="nonzero"/>
+        </g>
+        <g transform="translate(123)">
+            <circle stroke="#005CE3" stroke-width="3" fill="#005CE3" cx="6" cy="6" r="7.5"/>
+            <path
+                d="M4.746 9.75a.626.626 0 0 1-.442-.184L2.426 7.69a.625.625 0 0 1 .885-.884l1.35 1.349 3.953-5.643a.626.626 0 0 1 1.026.717L5.26 9.482a.626.626 0 0 1-.458.267.54.54 0 0 1-.055 0z"
+                fill="#FFF" fill-rule="nonzero"/>
+        </g>
+    </g>
+</svg>

--- a/packages/fxa-content-server/app/styles/_base.scss
+++ b/packages/fxa-content-server/app/styles/_base.scss
@@ -275,14 +275,26 @@ a[data-visible-url^='http']::after {
 
 .step-1 {
   background-image: image-url('trailhead/step-1.svg');
+
+  html[dir='rtl'] & {
+    transform: scaleX(-1);
+  }
 }
 
 .step-2 {
   background-image: image-url('trailhead/step-2.svg');
+
+  html[dir='rtl'] & {
+    background-image: image-url('trailhead/step-2-rtl.svg');
+  }
 }
 
 .step-3 {
   background-image: image-url('trailhead/step-3.svg');
+
+  html[dir='rtl'] & {
+    background-image: image-url('trailhead/step-3-rtl.svg');
+  }
 }
 
 .step-4 {


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/1307

This PR updates our trailhead progress bar to support RTL. I opted to create and modify our existing images to put the checkmarks in the right spot. There might be a better way to do this so open to suggestions!

<img width="446" alt="Screen Shot 2019-07-08 at 4 53 24 PM" src="https://user-images.githubusercontent.com/1295288/60842396-07413a80-a1a2-11e9-8472-4a23f8d39875.png">
<img width="466" alt="Screen Shot 2019-07-08 at 4 53 32 PM" src="https://user-images.githubusercontent.com/1295288/60842400-09a39480-a1a2-11e9-80d7-6adcf444a8b5.png">
<img width="444" alt="Screen Shot 2019-07-08 at 4 53 39 PM" src="https://user-images.githubusercontent.com/1295288/60842403-0b6d5800-a1a2-11e9-857b-774c46b99f77.png">

This was moved to Train 142, so no rush on reviews.
