### PR TITLE
fix(subs): SubHub display_name should be CC name, not FxA name 

### DIFF
--- a/packages/fxa-payments-server/README.md
+++ b/packages/fxa-payments-server/README.md
@@ -8,6 +8,10 @@ This project uses [Storybook](https://storybook.js.org/) to show each screen wit
 
 You can view the Storybook built from the most recent master at http://mozilla.github.io/fxa/fxa-payments-server/
 
+## Installation notes
+
+On Mac OS, `npm run test` may trigger an `EMFILE` error. In this case, to get tests running, you may need to `brew install watchman`. (If the watchman postinstall step fails, follow the instructions [here](https://stackoverflow.com/a/41320226) to change `/usr/local` ownership from root to your user account.)
+
 ## License
 
 MPL-2.0

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -32,7 +32,7 @@ export type PaymentFormProps = {
   confirm?: boolean,
   plan?: Plan,
   onCancel?: () => void,
-  onPayment: (tokenResponse: stripe.TokenResponse) => void,
+  onPayment: (tokenResponse: stripe.TokenResponse, name: string) => void,
   onPaymentError: (error: any) => void,
   validatorInitialState?: ValidatorState,
   validatorMiddlewareReducer?: ValidatorMiddlewareReducer,
@@ -63,7 +63,7 @@ export const PaymentForm = ({
     if (stripe) {
       stripe
         .createToken({ name, address_zip: zip })
-        .then(onPayment)
+        .then((tokenResponse: stripe.TokenResponse) => onPayment(tokenResponse, name))
         .catch(onPaymentError);
     }
   }, [ validator, onPayment, onPaymentError, stripe ]);

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -97,12 +97,12 @@ export const Product = ({
     selectedPlan = productPlans[0];
   }
 
-  const onPayment = useCallback((tokenResponse: stripe.TokenResponse) => {
+  const onPayment = useCallback((tokenResponse: stripe.TokenResponse, name: string) => {
     if (tokenResponse && tokenResponse.token) {
       createSubscription(accessToken, {
         paymentToken: tokenResponse.token.id,
         planId: selectedPlan.plan_id,
-        displayName: profile.result ? profile.result.displayName : '',
+        displayName: name,
       });  
     } else {
       // This shouldn't happen with a successful createToken() call, but let's


### PR DESCRIPTION
OK, think I've got this setup correctly, and tests pass.

I'm not yet sure how much of the previous change (#1664) should be reverted. I think we need the change in the subhub API wrapper, but not elsewhere in the auth server?

~~Can't get payments tests running locally; leaning on CI again~~