### PR TITLE
docs(root): Add OSX Rust install and 'npm test' info

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you get an `error` status for any of the servers please verify that you insta
 > [libgmp](https://gmplib.org/),
 > [graphicsmagick](http://www.graphicsmagick.org/),
 > [docker](https://docs.docker.com/),
-> [grunt](https://github.com/gruntjs/grunt-cli)
+> [grunt](https://github.com/gruntjs/grunt-cli),
 > [gcloud CLI](https://cloud.google.com/sdk/)
 
 ##### OS X (with [Brew](http://brew.sh/)):
@@ -170,7 +170,7 @@ Download from [java.com/en/download/](https://www.java.com/en/download/)
 
 > Rust Nightly is used for the fxa-email-service
 
-#### Ubuntu
+##### Ubuntu and OS X
 
 ```
 curl https://sh.rustup.rs -sSf | sh
@@ -213,7 +213,19 @@ Available options:
 
 **The following requires [the JDK](http://www.oracle.com/technetwork/java/javase/downloads/index-jsp-138363.html#javasejdk) and tests the local servers only.**
 
-**Use `npm test` - all functional tests**
+To run all functional tests:
+
+```
+npm test
+```
+
+Note that as of 2019-07-08, running this command at the project root will fail ([see issue #725](https://github.com/mozilla/fxa/issues/725)). Instead, run the command in the server that needs to be tested.
+
+To run a specific test or tests whose name matches part of a search string:
+
+```
+node tests/intern.js --suites=all --grep="Test string to search for"
+```
 
 ---
 


### PR DESCRIPTION
Adds:
1. Adds "or OS X" to "Ubuntu" instructions for Rust installation
2. `npm test` info about failing at root-level with a link to the issue Danny created, and a helper command for searching for tests (thanks @vbudhram!)

Prettier did the rest of the formatting and changes here. Please let me know if you think anything should be tweaked, even if it's minor, since this is my first doc contribution.

After approval but before merging this in, as a reminder to remove my "not working at root level" addition when it's no longer applicable, I'm going to add a comment about this PR in #725 to ensure docs are updated.