### PR TITLE
fix(scripts): run grunt sjcl after npm ci for fxa-js-client

### DIFF
--- a/_scripts/install_all.sh
+++ b/_scripts/install_all.sh
@@ -30,7 +30,7 @@ cd ..
 
 cd browserid-verifier; npm ci; cd ..
 
-cd fxa-js-client; npm ci; cd ..
+cd fxa-js-client; npm ci; npx grunt sjcl; cd ..
 
 cd fxa-customs-server; npm ci; cd ..
 


### PR DESCRIPTION
Previously I tried to fix this by adding `grunt sjcl` as a post-install step in #977, but that caused npm install to fail for the js client package and was backed out in #1192.

So, this is take 2, do it explicitly in scripting instead.

@mozilla/fxa-devs r?