### PR TITLE
fix(ui): translate alt text

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/avatar_crop.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/avatar_crop.mustache
@@ -6,7 +6,7 @@
       <div class="wrapper">
         <div class="mask"></div>
         <div class="drag-overlay"></div>
-        <img src="" class="avatar" alt="Avatar" />
+        <img src="" class="avatar" alt="{{#t}}Avatar{{/t}}" />
       </div>
 
       <p class="notice">{{#t}}Position and rotate your picture as needed{{/t}}</p>


### PR DESCRIPTION
While investigating a different l10n issue, I grepped to see whether we were localising all the `alt` text and found this one case where we weren't. Figured we may as well fix it.

Also wondering whether it would be possible for a linter to pick this up. Do we lint markup? Can we?

(note, we don't want to land this until train 141 has been cut)

@mozilla/fxa-devs r?