### PR TITLE
fix(test): No longer check haveibeenpwned.com

### DIFF
--- a/packages/fxa-content-server/tests/server/helpers/routesHelpers.js
+++ b/packages/fxa-content-server/tests/server/helpers/routesHelpers.js
@@ -140,6 +140,8 @@ const IGNORE_URL_REGEXPS = [
   /support\.mozilla\.org/,
   // skip the livereload link in the mocha tests
   /localhost:35729/,
+  // haveibeenpwned 403s.
+  /haveibeenpwned\.com/,
 ];
 
 function isUrlIgnored(url) {


### PR DESCRIPTION
haveibeenpwned.com returns a 403 to non-browser requests.

fixes #1689

@mozilla/fxa-devs - r?