### PR TITLE
fix(scripts): stop prettier messing with the changelogs

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -308,7 +308,7 @@ done
 npm run authors > /dev/null
 
 # 10. Commit changes.
-git commit -a -m "Release $NEW_VERSION"
+git commit --no-verify -a -m "Release $NEW_VERSION"
 
 # 11. Create a tag.
 git tag -a "$NEW_TAG" -m "$BUILD_TYPE release $NEW_VERSION"


### PR DESCRIPTION
`prettier` makes a right pig's ear of the changelogs when the release script runs, breaking every word of each commit message into it's own dedicated bullet point. It's completely unreadable.

I'm sure there's a proper fix that lets prettier do it's thing in a sane fashion but as this is blocking the tag for train 141, I've done the easy thing here and bypassed `prettier` completely. We can sort it out properly some other time.

@mozilla/fxa-devs r?

/cc @vbudhram