### PR TITLE
fix(scripts): fix splitting of commit messages in release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+IFS=$'\n'
 
 # This script will automatically update the changelogs and bump the version
 # strings for each of the "main" FxA packages in this tree. It assumes some


### PR DESCRIPTION
Fixes #1712.

Sets `IFS` so the commit history is split on newline character rather than any whitespace. It's not portable so probably won't work on WSL and maybe other places too. But it's good enough to unblock the release for now.

@mozilla/fxa-devs r?

/cc @vbudhram