### PR TITLE
feat(fxa-client): add active subscriptions and support ticket endpoints

### DIFF
--- a/packages/fxa-js-client/client/FxAccountClient.js
+++ b/packages/fxa-js-client/client/FxAccountClient.js
@@ -2472,6 +2472,69 @@ define([
   };
 
   /**
+   * Get a user's list of active subscriptions.
+   *
+   * @param {String} token A token from the OAuth server.
+   * @returns {Promise} A promise that will be fulfilled with a list of active
+   * subscriptions.
+   */
+  FxAccountClient.prototype.getActiveSubscriptions = function(token) {
+    var self = this;
+
+    return Promise.resolve().then(function() {
+      required(token, 'token');
+      const requestOptions = {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      };
+      return self.request.send(
+        '/oauth/subscriptions/active',
+        'GET',
+        null,
+        null,
+        requestOptions
+      );
+    });
+  };
+
+  /**
+   * Submit a support ticket.
+   *
+   * @param {String} authorizationHeader A token from the OAuth server.
+   * @param {Object} [supportTicket={}]
+   *   @param {String} [supportTicket.topic]
+   *   @param {String} [supportTicket.subject] Optional subject
+   *   @param {String} [supportTicket.message]
+   * @returns {Promise} A promise that will be fulfilled with:
+   *   - `success`
+   *   - `ticket` OR `error`
+   */
+  FxAccountClient.prototype.createSupportTicket = function(
+    token,
+    supportTicket
+  ) {
+    var self = this;
+
+    return Promise.resolve().then(function() {
+      required(token, 'token');
+      required(supportTicket, 'supportTicket');
+      const requestOptions = {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      };
+      return self.request.send(
+        '/support/ticket',
+        'POST',
+        null,
+        supportTicket,
+        requestOptions
+      );
+    });
+  };
+
+  /**
    * Check for a required argument. Exposed for unit testing.
    *
    * @param {Value} val - value to check

--- a/packages/fxa-js-client/package.json
+++ b/packages/fxa-js-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-js-client",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Web client that talks to the Firefox Accounts API server",
   "author": "Mozilla",
   "license": "MPL-2.0",

--- a/packages/fxa-js-client/tests/all.js
+++ b/packages/fxa-js-client/tests/all.js
@@ -25,6 +25,7 @@ define([
   'tests/lib/signIn',
   'tests/lib/signinCodes',
   'tests/lib/signUp',
+  'tests/lib/subscriptions',
   'tests/lib/totp',
   'tests/lib/tokenCodes',
   'tests/lib/sms',

--- a/packages/fxa-js-client/tests/lib/subscriptions.js
+++ b/packages/fxa-js-client/tests/lib/subscriptions.js
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+define([
+  'intern!tdd',
+  'intern/chai!assert',
+  'tests/addons/environment',
+], function(tdd, assert, Environment) {
+  var env = new Environment();
+  if (env.useRemoteServer) {
+    return;
+  }
+
+  with (tdd) {
+    suite('subscriptions', function() {
+      var accountHelper;
+      var respond;
+      var client;
+      var RequestMocks;
+
+      beforeEach(function() {
+        env = new Environment();
+        accountHelper = env.accountHelper;
+        respond = env.respond;
+        client = env.client;
+        RequestMocks = env.RequestMocks;
+      });
+
+      test('#getActiveSubscriptions - missing token', function() {
+        return accountHelper
+          .newVerifiedAccount()
+          .then(function(account) {
+            return respond(
+              client.getActiveSubscriptions(),
+              RequestMocks.getActiveSubscriptions
+            );
+          })
+          .then(assert.notOk, function(error) {
+            assert.include(error.message, 'Missing token');
+          });
+      });
+      test('#getActiveSubscriptions', function() {
+        return accountHelper
+          .newVerifiedAccount()
+          .then(function(account) {
+            return respond(
+              client.getActiveSubscriptions('saynomore'),
+              RequestMocks.getActiveSubscriptions
+            );
+          })
+          .then(function(resp) {
+            assert.ok(resp);
+          }, assert.notOk);
+      });
+
+      test('#createSupportTicket - missing token', function() {
+        return accountHelper
+          .newVerifiedAccount()
+          .then(function(account) {
+            return respond(
+              client.createSupportTicket(),
+              RequestMocks.createSupportTicket
+            );
+          })
+          .then(assert.notOk, function(error) {
+            assert.include(error.message, 'Missing token');
+          });
+      });
+      test('#createSupportTicket - missing supportTicket', function() {
+        return accountHelper
+          .newVerifiedAccount()
+          .then(function(account) {
+            return respond(
+              client.createSupportTicket('redpandas'),
+              RequestMocks.createSupportTicket
+            );
+          })
+          .then(assert.notOk, function(error) {
+            assert.include(error.message, 'Missing supportTicket');
+          });
+      });
+      test('#createSupportTicket', function() {
+        return accountHelper
+          .newVerifiedAccount()
+          .then(function(account) {
+            return respond(
+              client.createSupportTicket('redpandas', {
+                topic: 'Species',
+                subject: 'Cute & Rare',
+                message: 'Need moar',
+              }),
+              RequestMocks.createSupportTicket
+            );
+          })
+          .then(function(resp) {
+            assert.ok(resp);
+          }, assert.notOk);
+      });
+    });
+  }
+});

--- a/packages/fxa-js-client/tests/mocks/request.js
+++ b/packages/fxa-js-client/tests/mocks/request.js
@@ -509,5 +509,13 @@ define(['client/lib/errors', 'tests/lib/push-constants'], function(
       status: 200,
       body: '{"exists": true}',
     },
+    getActiveSubscriptions: {
+      status: 200,
+      body: '[{"subscriptionId": 9},{"subscriptionId": 12}]',
+    },
+    createSupportTicket: {
+      status: 200,
+      body: '{"success": true, "ticket": "abc123xyz"}',
+    },
   };
 });


### PR DESCRIPTION
fxa-content-server needs to know if a user has any active subscriptions
and to able to submit a support ticket.

Issues #797 and #1078

@mozilla/fxa-devs r?