### PR TITLE
fix(payments): correct payment form field names and error punctuation

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
@@ -16,7 +16,8 @@ function init() {
     .add('in progress', () => <Subject inProgress={true} />)
     .add('all invalid', () => {
       const state = mockValidatorState();
-      
+
+      // HACK: pre-seed with some error messages for display purposes
       state.fields.name.valid = false;
       state.fields.name.error = 'Please enter your name';
       state.fields.zip.valid = false;
@@ -24,10 +25,10 @@ function init() {
       state.fields.creditCardNumber.valid = false;
       state.fields.creditCardNumber.error = 'Your card number is incomplete';
       state.fields.expDate.valid = false;
-      state.fields.expDate.error = 'Your card\'s expiration date is incomplete.';
+      state.fields.expDate.error = 'Your card\'s expiration date is incomplete';
       state.fields.cvc.valid = false;
-      state.fields.cvc.error = 'Your card\'s security code is incomplete.';
-      
+      state.fields.cvc.error = 'Your card\'s security code is incomplete';
+
       return<Subject validatorInitialState={state} />;
     });
 }

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -85,19 +85,19 @@ export const PaymentForm = ({
       <FieldGroup>
 
         <StripeElement component={CardNumberElement}
-          name="creditCardNumber" label="Credit Card Number"
+          name="creditCardNumber" label="Card number"
           style={STRIPE_ELEMENT_STYLES}
           className="input-row input-row--xl" required />
 
         <StripeElement component={CardExpiryElement}
-          name="expDate" label="Exp. Date"
+          name="expDate" label="Exp. date"
           style={STRIPE_ELEMENT_STYLES} required />
 
         <StripeElement component={CardCVCElement}
           name="cvc" label="CVC"
           style={STRIPE_ELEMENT_STYLES} required />
 
-        <Input type="number" name="zip" label="Zip Code" maxLength={5} required
+        <Input type="number" name="zip" label="Zip code" maxLength={5} required
           data-testid="zip"
           onValidate={value => {
             let error = null;

--- a/packages/fxa-payments-server/src/components/fields.tsx
+++ b/packages/fxa-payments-server/src/components/fields.tsx
@@ -157,7 +157,13 @@ export const StripeElement = (props: StripeElementProps) => {
     (value: stripe.elements.ElementChangeResponse) => {
       if (value !== null) {
         if (value.error && value.error.message) {
-          validator.updateField({ name, value, valid: false, error: value.error.message });
+          let error = value.error.message;
+          // Issue #1718 - remove periods from error messages from Stripe
+          // for consistency with our own errors
+          if (error.endsWith('.')) {
+            error = error.slice(0, -1);
+          }
+          validator.updateField({ name, value, valid: false, error });
         } else if (value.complete) {
           validator.updateField({ name, value, valid: true });
         }


### PR DESCRIPTION
fixes #1718

Should be able to exercise the tweak to Stripe error messages here from Storybook. Try `npm run storybook` inside `packages/fxa-payments-server`, view [PaymentForm, all invalid](http://localhost:6006/?path=/story/components-paymentform--all-invalid), and try entering different values in the credit card fields. Stripe errors should have periods trimmed off.