### PR TITLE
fix(api): prevent /account/destroy failing due to subhub errors

### DIFF
--- a/packages/fxa-auth-server/lib/subhub/client.js
+++ b/packages/fxa-auth-server/lib/subhub/client.js
@@ -307,11 +307,12 @@ module.exports = function(log, config) {
       try {
         return await api.deleteCustomer(uid);
       } catch (err) {
-        log.error('subhub.deleteCustomer.failed', { uid, err });
-
         if (err.statusCode === 404) {
-          throw error.unknownCustomer(uid);
+          // This method is called optimistically, so swallow `unknownCustomer` errors.
+          return { message: 'unknown customer' };
         }
+
+        log.error('subhub.deleteCustomer.failed', { uid, err });
 
         throw err;
       }

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -2780,6 +2780,19 @@ describe('/account/destroy', () => {
     });
   });
 
+  it('should fail if subhub.deleteCustomer fails', async () => {
+    mockSubhub.deleteCustomer = sinon.spy(async function() {
+      throw new Error('wibble');
+    });
+    let failed = false;
+    try {
+      await runTest(buildRoute(), mockRequest);
+    } catch (err) {
+      failed = true;
+    }
+    assert.isTrue(failed);
+  });
+
   it('should not attempt to cancel subscriptions with config.subscriptions.enabled = false', async () => {
     const route = buildRoute(false);
     return runTest(route, mockRequest, () => {

--- a/packages/fxa-auth-server/test/local/subhub/client.js
+++ b/packages/fxa-auth-server/test/local/subhub/client.js
@@ -567,10 +567,19 @@ describe('subhub client', () => {
       assert.deepEqual(response, { message: 'wibble' });
     });
 
-    it('should throw on unknown user', async () => {
+    it('should not fail for unknown user', async () => {
       mockServer
         .delete(`/v1/customer/${UID}`)
         .reply(404, { message: 'invalid uid' });
+      const { subhub } = makeSubject();
+      const response = await subhub.deleteCustomer(UID);
+      assert.deepEqual(response, { message: 'unknown customer' });
+    });
+
+    it('should fail for other errors', async () => {
+      mockServer
+        .delete(`/v1/customer/${UID}`)
+        .reply(400, { message: 'wibble' });
       const { subhub } = makeSubject();
 
       let failed = false;
@@ -580,7 +589,7 @@ describe('subhub client', () => {
       } catch (err) {
         failed = true;
 
-        assert.equal(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION_CUSTOMER);
+        assert.equal(err.message, 'wibble');
       }
 
       assert.isTrue(failed);


### PR DESCRIPTION
Fixes #1740.

I didn't think #1671 through at all, and foolishly left errors from subhub to abort the `/account/destroy` endpoint. Given that it's called optimistically, `unknownCustomer` errors are expected to come back as a matter of course. This change prevents them causing a problem.

Opened against the `train-141` branch for a point release.

@mozilla/fxa-devs r?