### PR TITLE
fix(cdn): Ensure JS files are fetched from the CDN

### DIFF
--- a/packages/fxa-content-server/.prettierignore
+++ b/packages/fxa-content-server/.prettierignore
@@ -18,3 +18,8 @@ app/scripts/vendor/*
 tests/teamcity/*
 tests/tools/certs/*
 server/templates/pages/dist/*
+# The way prettier reformats the HTML causes
+# grunt-cdn to break & JS files are served
+# from nginx rather than the CDN
+server/templates/pages/src/index.html
+server/templates/pages/src/update_firefox.html

--- a/packages/fxa-content-server/server/templates/pages/src/index.html
+++ b/packages/fxa-content-server/server/templates/pages/src/index.html
@@ -24,10 +24,7 @@
         <link rel="stylesheet" href="/styles/main.css" />
         <!-- endbuild -->
 
-        <script
-            type="text/javascript"
-            src="{{ bundlePath }}/head.bundle.js"
-        ></script>
+        <script type="text/javascript" src="{{ bundlePath }}/head.bundle.js"></script>
     </head>
     <body
         data-flow-id="{{flowId}}"
@@ -57,13 +54,7 @@
             {{#t}}Firefox Accounts requires JavaScript.{{/t}}
         </noscript>
 
-        <script
-            type="text/javascript"
-            src="{{ bundlePath }}/appDependencies.bundle.js"
-        ></script>
-        <script
-            type="text/javascript"
-            src="{{ bundlePath }}/app.bundle.js"
-        ></script>
+        <script type="text/javascript" src="{{ bundlePath }}/appDependencies.bundle.js"></script>
+        <script type="text/javascript" src="{{ bundlePath }}/app.bundle.js"></script>
     </body>
 </html>

--- a/packages/fxa-content-server/server/templates/pages/src/update_firefox.html
+++ b/packages/fxa-content-server/server/templates/pages/src/update_firefox.html
@@ -22,10 +22,7 @@
         <link rel="stylesheet" href="/styles/main.css" />
         <!-- endbuild -->
 
-        <script
-            type="text/javascript"
-            src="{{ bundlePath }}/head.bundle.js"
-        ></script>
+        <script type="text/javascript" src="{{ bundlePath }}/head.bundle.js"></script>
     </head>
     <body class="static">
         <div id="stage">


### PR DESCRIPTION
The way Prettify updated the files messed with the parser
used by grunt-cdn. Putting the entire script tag on a single
line fixes the problem by ensuring that `{{{ staticResourceUrl }}}`
is prefixed on the JS URLs.

fixes #1729

Now, I'm not sure how we should ensure this doesn't happen in the future. Is it p
@jrgm - r?