### PR TITLE
feat(fxa-client): support sessionToken in getActiveSubscriptions

### DIFF
--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -1082,12 +1082,25 @@ module.exports = config => {
     );
   };
 
-  ClientApi.prototype.getActiveSubscriptions = function(refreshToken) {
-    return this.doRequestWithBearerToken(
-      'GET',
-      `${this.baseURL}/oauth/subscriptions/active`,
-      refreshToken
-    );
+  ClientApi.prototype.getActiveSubscriptions = function(
+    refreshToken,
+    sessionTokenHex = null
+  ) {
+    if (refreshToken) {
+      return this.doRequestWithBearerToken(
+        'GET',
+        `${this.baseURL}/oauth/subscriptions/active`,
+        refreshToken
+      );
+    } else {
+      return tokens.SessionToken.fromHex(sessionTokenHex).then(token => {
+        return this.doRequest(
+          'GET',
+          `${this.baseURL}/oauth/subscriptions/active`,
+          token
+        );
+      });
+    }
   };
 
   ClientApi.prototype.createSubscription = function(

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -763,7 +763,14 @@ module.exports = config => {
   };
 
   Client.prototype.getActiveSubscriptions = function(refreshToken) {
-    return this.api.getActiveSubscriptions(refreshToken);
+    if (refreshToken) {
+      return this.api.getActiveSubscriptions(refreshToken);
+    } else {
+      const o = this.sessionToken ? P.resolve(null) : this.login();
+      return o.then(() => {
+        return this.api.getActiveSubscriptions(null, this.sessionToken);
+      });
+    }
   };
 
   Client.prototype.createSubscription = function(

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -152,6 +152,7 @@ describe('subscriptions', () => {
     requestOptions = {
       metricsContext: mocks.mockMetricsContext(),
       credentials: {
+        strategy: 'oauthToken',
         user: UID,
         email: TEST_EMAIL,
         scope: MOCK_SCOPES,

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -150,8 +150,13 @@ describe('remote subscriptions:', function() {
       ]);
     });
 
-    it('should return no active subscriptions', async () => {
+    it('should return no active subscriptions with refresh token', async () => {
       const result = await client.getActiveSubscriptions(tokens[2]);
+      assert.deepEqual(result, []);
+    });
+
+    it('should return no active subscriptions with session token', async () => {
+      const result = await client.getActiveSubscriptions();
       assert.deepEqual(result, []);
     });
 
@@ -200,8 +205,7 @@ describe('remote subscriptions:', function() {
         ]);
       });
 
-      it('should return active subscriptions', async () => {
-        const result = await client.getActiveSubscriptions(tokens[2]);
+      function assertActiveSubscriptions(result) {
         assert.isArray(result);
         assert.lengthOf(result, 1);
         assert.isAbove(result[0].createdAt, Date.now() - 1000);
@@ -209,6 +213,16 @@ describe('remote subscriptions:', function() {
         assert.equal(result[0].productName, PRODUCT_ID);
         assert.equal(result[0].uid, client.uid);
         assert.isNull(result[0].cancelledAt);
+      }
+
+      it('should return active subscriptions with refresh token', async () => {
+        const result = await client.getActiveSubscriptions(tokens[2]);
+        assertActiveSubscriptions(result);
+      });
+
+      it('should return active subscriptions with session token', async () => {
+        const result = await client.getActiveSubscriptions();
+        assertActiveSubscriptions(result);
       });
 
       describe('cancelSubscription:', () => {

--- a/packages/fxa-js-client/package-lock.json
+++ b/packages/fxa-js-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-js-client",
-  "version": "1.0.14",
+  "version": "1.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fxa-js-client/package.json
+++ b/packages/fxa-js-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-js-client",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Web client that talks to the Firefox Accounts API server",
   "author": "Mozilla",
   "license": "MPL-2.0",

--- a/packages/fxa-js-client/tests/lib/subscriptions.js
+++ b/packages/fxa-js-client/tests/lib/subscriptions.js
@@ -37,15 +37,28 @@ define([
             );
           })
           .then(assert.notOk, function(error) {
-            assert.include(error.message, 'Missing token');
+            assert.include(error.message, 'Missing oauthToken or sessionToken');
           });
       });
-      test('#getActiveSubscriptions', function() {
+      test('#getActiveSubscriptions with oauth token', function() {
         return accountHelper
           .newVerifiedAccount()
           .then(function(account) {
             return respond(
               client.getActiveSubscriptions('saynomore'),
+              RequestMocks.getActiveSubscriptions
+            );
+          })
+          .then(function(resp) {
+            assert.ok(resp);
+          }, assert.notOk);
+      });
+      test('#getActiveSubscriptions with session token', function() {
+        return accountHelper
+          .newVerifiedAccount()
+          .then(function(account) {
+            return respond(
+              client.getActiveSubscriptions(null, account.signIn.sessionToken),
               RequestMocks.getActiveSubscriptions
             );
           })


### PR DESCRIPTION
This depends on PR #1757 - review & merge that first.

This adds support for `sessionToken` alongside `oauthToken` for `getActiveSubscriptions`.

Per discussion in Issue #1753, we might only need `sessionToken` and not `oauthToken` - but I was most of the way there with both, so here's a PR 🤷‍♂  We can remove `oauthToken` support if necessary