### PR TITLE
fix(events): compile typescript dist in docker build image

### DIFF
--- a/packages/fxa-event-broker/Dockerfile
+++ b/packages/fxa-event-broker/Dockerfile
@@ -16,9 +16,11 @@ USER app
 COPY package.json package.json
 COPY package-lock.json package-lock.json
 
-RUN npm ci --production && rm -rf ~app/.npm /tmp/*
+RUN npm ci && rm -rf ~app/.npm /tmp/*
 
 COPY . /app
+RUN npm run build 
+
 USER root
 RUN chown app:app /app/config
 


### PR DESCRIPTION
Might want to refine this later so we don't have all devDependencies in the docker image, and I'll leave it to @bbangert to choose the right pattern, but this will work for now.

r? - @bbangert 