### PR TITLE
fix(scripts): switch the release script shebang to bash

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 IFS=$'\n'


### PR DESCRIPTION
In #1714 I broke portability of the release script by using the `IFS` env var. I don't know the correct portable way to fix the loop over commit messages, so let's just force it to use bash instead. I admit my defeat. 😞

@mozilla/fxa-devs r?

