### PR TITLE
fix(fxa-payments-server): Style updates in payment form

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_button-row.scss
+++ b/packages/fxa-content-server/app/styles/modules/_button-row.scss
@@ -48,7 +48,7 @@ button {
     background: $button-background-color-primary;
     color: $button-text-color-primary;
 
-    &:hover {
+    &:hover:not:disabled {
       background: $button-background-color-primary-hover;
     }
 

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -22,8 +22,9 @@ const STRIPE_ELEMENT_STYLES = {
   base: {
     //TODO: Figure out what this really should be - I just copied it from computed styles because CSS can't apply through the iframe
     fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
-    fontSize: '16px',
-    lineHeight: '48px',
+    fontSize: '13px',
+    fontWeight: '500',
+    lineHeight: '45px',
   }
 };
 
@@ -103,10 +104,9 @@ export const PaymentForm = ({
             let error = null;
             if (value !== null) {
               value = ('' + value).substr(0, 5);
-              if (! value) {
+              if (!value) {
                 error = 'Zip code is required';
-              }
-              if (value.length !== 5) {
+              } else if (value.length !== 5) {
                 error = 'Zip code is too short';
               }
             }


### PR DESCRIPTION
refs #1666
- no hover styles on disabled buttons
- tweak input font size and line height
- fix typo and logic to show proper error msg for zip fields

Updates to form, sans zip error:
![no-errors-fresh-form](https://user-images.githubusercontent.com/1844554/61243616-5c3afe80-a716-11e9-9535-56cefe931827.png)

Filled in form, with correct empty zip error:
![updated-error](https://user-images.githubusercontent.com/1844554/61243614-5c3afe80-a716-11e9-9fac-fb9789c44b97.png)