### PR TITLE
fix(oauth): Ignore unknown refresh_token_id when destroying attached client.

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -91,6 +91,7 @@ const ERRNO = {
   REJECTED_SUBSCRIPTION_PAYMENT_TOKEN: 179,
   SUBSCRIPTION_ALREADY_CANCELLED: 180,
   REJECTED_CUSTOMER_UPDATE: 181,
+  REFRESH_TOKEN_UNKNOWN: 182,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -1187,6 +1188,15 @@ AppError.insufficientACRValues = foundValue => {
       foundValue,
     }
   );
+};
+
+AppError.unknownRefreshToken = () => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.REFRESH_TOKEN_UNKNOWN,
+    message: 'Unknown refresh token',
+  });
 };
 
 AppError.backendServiceFailure = (service, operation) => {

--- a/packages/fxa-auth-server/lib/oauthdb/utils.js
+++ b/packages/fxa-auth-server/lib/oauthdb/utils.js
@@ -57,6 +57,8 @@ module.exports = {
         return error.staleAuthAt(err.authAt);
       case 120:
         return error.insufficientACRValues(err.foundValue);
+      case 122:
+        return error.unknownRefreshToken();
       case 201:
         return error.serviceUnavailable(err.retryAfter);
       case 202:

--- a/packages/fxa-auth-server/test/local/oauthdb/revoke-authorized-client.js
+++ b/packages/fxa-auth-server/test/local/oauthdb/revoke-authorized-client.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const nock = require('nock');
+const oauthdbModule = require('../../../lib/oauthdb');
+const error = require('../../../lib/error');
+const { mockLog } = require('../../mocks');
+
+const MOCK_CLIENT_ID = '0123456789ABCDEF';
+const mockSessionToken = {
+  emailVerified: true,
+  tokenVerified: true,
+  uid: 'ABCDEF123456',
+  lastAuthAt: () => Date.now(),
+  authenticationMethods: ['pwd', 'email'],
+};
+const mockConfig = {
+  publicUrl: 'https://accounts.example.com',
+  oauth: {
+    url: 'https://oauth.server.com',
+    secretKey: 'secret-key-oh-secret-key',
+  },
+  domain: 'accounts.example.com',
+};
+const mockOAuthServer = nock(mockConfig.oauth.url).defaultReplyHeaders({
+  'Content-Type': 'application/json',
+});
+
+describe('oauthdb/revokeAuthorizedClient', () => {
+  let oauthdb;
+
+  afterEach(async () => {
+    assert.ok(
+      nock.isDone(),
+      'there should be no pending request mocks at the end of a test'
+    );
+    if (oauthdb) {
+      await oauthdb.close();
+    }
+  });
+
+  it('correctly maps errno 122 to "unknown refresh token"', async () => {
+    mockOAuthServer
+      .post('/v1/authorized-clients/destroy', body => true)
+      .reply(400, {
+        errno: 122,
+      });
+    oauthdb = oauthdbModule(mockLog(), mockConfig);
+    try {
+      await oauthdb.revokeAuthorizedClient(mockSessionToken, {
+        client_id: MOCK_CLIENT_ID,
+        refresh_token_id:
+          '1234567890123456789012345678901234567890123456789012345678901234',
+      });
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.equal(err.errno, error.ERRNO.REFRESH_TOKEN_UNKNOWN);
+    }
+  });
+});

--- a/packages/fxa-auth-server/test/local/routes/attached-clients.js
+++ b/packages/fxa-auth-server/test/local/routes/attached-clients.js
@@ -425,6 +425,26 @@ describe('/account/attached_client/destroy', () => {
     );
   });
 
+  it('silently succeeds if given an invalid refreshTokenId', async () => {
+    const clientId = newId(16);
+    const refreshTokenId = newId();
+    request.payload = {
+      clientId,
+      refreshTokenId,
+    };
+
+    db.revokeAuthorizedClient = sinon.spy(async () => {
+      throw error.unknownRefreshToken();
+    });
+
+    const res = await route(request);
+    assert.deepEqual(res, {});
+
+    assert.ok(devices.destroy.notCalled);
+    assert.ok(db.deleteSessionToken.notCalled);
+    assert.ok(oauthdb.revokeAuthorizedClient.calledOnce);
+  });
+
   it('wont accept refreshTokenId and sessionTokenId without deviceId', async () => {
     const clientId = newId(16);
     const refreshTokenId = newId();


### PR DESCRIPTION
Fixes #1784.

If we get an "unknown token" error when trying to destroy an authorized client record, it almost certainly indicates some sort of race in deleting the refresh token. There is nothing useful we can tell the user, and the account is in the state they wanted anyway, so just ignore it.

(In practice, I think we'll see these when we've got a device record in the auth-server db, but the corresponding refresh token has been deleted from the oauth-server db).