### PR TITLE
chore(package): include more debug info in release build

### DIFF
--- a/packages/fxa-email-service/Cargo.toml
+++ b/packages/fxa-email-service/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/bin/queues.rs"
 
 [profile.release]
 # Include debug symbols to make Sentry errors richer
-debug = 1
+debug = true
 
 [dependencies]
 base64 = ">=0.6.0"


### PR DESCRIPTION
It's tricky to match up [line numbers from Sentry](https://sentry.prod.mozaws.net/operations/email-service/issues/6054356/?environment=release) against actual code, because you have to checkout the correct tag in git and then manually find the correct module based on contextual info like namespace and method names.

This change includes full debug info in the release build instead, so Sentry can just present that information inline. We previously turned it down in mozilla/fxa-email-service#250 to reduce the binary size, but the old binary size wasn't actually causing any problems afaik.

@mozilla/fxa-devs r?