### PR TITLE
feat(email): send new subscribers a product download link

### DIFF
--- a/packages/fxa-auth-server/bin/subhub_messaging.js
+++ b/packages/fxa-auth-server/bin/subhub_messaging.js
@@ -5,25 +5,51 @@
 
 'use strict';
 
+const LIB_DIR = '../lib';
+
 // This MUST be the first require in the program.
 // Only `require()` the newrelic module if explicity enabled.
 // If required, modules will be instrumented.
-require('../lib/newrelic')();
+require(`${LIB_DIR}/newrelic`)();
 
 const config = require('../config').getProperties();
-const log = require('../lib/log')(config.log.level, 'subhub-messaging');
-const Token = require('../lib/tokens')(log, config);
-const SQSReceiver = require('../lib/sqs')(log);
-// FIXME: import a different module:
-const subhubUpdates = require('../lib/subhub/updates')(log, config);
+const log = require(`${LIB_DIR}/log`)(config.log.level, 'subhub-messaging');
+const Promise = require(`${LIB_DIR}/promise`);
+const Token = require(`${LIB_DIR}/tokens`)(log, config);
+const SQSReceiver = require(`${LIB_DIR}/sqs`)(log);
+const subhubUpdates = require(`${LIB_DIR}/subhub/updates`)(log, config);
 
-const DB = require('../lib/db')(config, log, Token);
+run();
 
-const subhubUpdatesQueue = new SQSReceiver(
-  config.subhubServerMessaging.region,
-  [config.subhubServerMessaging.subhubUpdatesQueueUrl]
-);
+async function run() {
+  try {
+    const subhubUpdatesQueue = new SQSReceiver(
+      config.subhubServerMessaging.region,
+      [config.subhubServerMessaging.subhubUpdatesQueueUrl]
+    );
 
-DB.connect(config[config.db.backend]).then(db => {
-  subhubUpdates(subhubUpdatesQueue, db);
-});
+    const [db, translator] = await Promise.all([
+      require(`${LIB_DIR}/lib/db`)(config, log, Token).connect(
+        config[config.db.backend]
+      ),
+      require(`${LIB_DIR}/senders/translator`)(
+        config.i18n.supportedLanguages,
+        config.i18n.defaultLanguage
+      ),
+    ]);
+
+    const { email: mailer } = await require(`${LIB_DIR}/senders`)(
+      log,
+      config,
+      require(`${LIB_DIR}/error`),
+      require(`${LIB_DIR}/bounces`)(config, db),
+      translator,
+      require(`${LIB_DIR}/oauthdb`)(log, config)
+    );
+
+    subhubUpdates(subhubUpdatesQueue, db, mailer);
+  } catch (err) {
+    log.error('bin.subhub.error', { err });
+    process.exit(1);
+  }
+}

--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -290,6 +290,24 @@ const conf = convict({
       default:
         'https://support.mozilla.org/kb/password-manager-remember-delete-change-and-import#w_viewing-and-deleting-passwords',
     },
+    subscriptionDownloadUrl: {
+      default: 'https://accounts.firefox.com/subscriptions/download',
+      doc: 'Subscription download URL',
+      env: 'SUBSCRIPTION_DOWNLOAD_URL',
+      format: String,
+    },
+    subscriptionSettingsUrl: {
+      default: 'https://accounts.firefox.com/subscriptions',
+      doc: 'Subscription settings URL',
+      env: 'SUBSCRIPTION_SETTINGS_URL',
+      format: String,
+    },
+    subscriptionTermsUrl: {
+      default: 'https://accounts.firefox.com/legal/subscription_terms',
+      doc: 'Subscription terms and cancellation policy URL',
+      env: 'SUBSCRIPTION_TERMS_URL',
+      format: String,
+    },
     sesConfigurationSet: {
       doc:
         'AWS SES Configuration Set for SES Event Publishing. If defined, ' +

--- a/packages/fxa-auth-server/grunttasks/l10n-extract.js
+++ b/packages/fxa-auth-server/grunttasks/l10n-extract.js
@@ -51,19 +51,34 @@ module.exports = function(grunt) {
       });
 
       walker.on('end', () => {
-        const jsWalker = extract({
-          'input-dir': path.join(pkgroot, 'lib/senders'),
+        const subscriptionWalker = extract({
+          'input-dir': path.join(pkgroot, 'lib/senders/subscription-templates'),
           outputDir: pkgroot,
           output: 'server.pot',
           joinExisting: true,
-          keyword: ['gettext'],
+          keyword: ['t'],
           parsers: {
-            '.js': 'javascript',
+            '.txt': 'handlebars',
+            '.html': 'handlebars',
           },
         });
 
-        jsWalker.on('end', () => {
-          done();
+        subscriptionWalker.on('end', () => {
+          const jsWalker = extract({
+            'input-dir': path.join(pkgroot, 'lib/senders'),
+            outputDir: pkgroot,
+            output: 'server.pot',
+            joinExisting: true,
+            keyword: ['gettext'],
+            parsers: {
+              '.js': 'javascript',
+            },
+            parserOptions: '{"ecmaVersion":"2018"}',
+          });
+
+          jsWalker.on('end', () => {
+            done();
+          });
         });
       });
     }

--- a/packages/fxa-auth-server/lib/senders/subscription-templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/subscription-templates/_versions.json
@@ -1,0 +1,3 @@
+{
+  "downloadSubscription": 1
+}

--- a/packages/fxa-auth-server/lib/senders/subscription-templates/downloadSubscription.html
+++ b/packages/fxa-auth-server/lib/senders/subscription-templates/downloadSubscription.html
@@ -1,0 +1,27 @@
+{{> icon}}
+
+<tr style="page-break-before: always">
+  <td align="center" valign="top" style="padding: 20px 30px 0;">
+    <h1 style="font-size: 1.1em; line-height: 1.5;">
+      {{t subject}}
+    </h1>
+  </td>
+</tr>
+
+<tr style="page-break-before: always">
+  <td align="left" valign="top" style="padding: 0 30px 30px;">
+    <p style="font-size: 0.9em; line-height: 1.8;">
+      {{t "If you haven't already downloaded %(product)s, let's gets started using all the features included in your subscription."}}
+    </p>
+  </td>
+</tr>
+
+{{> button}}
+
+<tr style="page-break-before: always">
+  <td align="left" valign="top" style="padding: 30px 30px 15px;">
+    <p style="font-size: 0.9em; line-height: 1.8;">
+      {{{t "Questions about your subscription? Our <a %(supportLinkAttributes)s>support team</a> is here to help you."}}}
+    </p>
+  </td>
+</tr>

--- a/packages/fxa-auth-server/lib/senders/subscription-templates/downloadSubscription.txt
+++ b/packages/fxa-auth-server/lib/senders/subscription-templates/downloadSubscription.txt
@@ -1,0 +1,9 @@
+{{{t subject}}}
+
+{{{t "If you haven't already downloaded %(product)s, let's gets started using all the features included in your subscription:"}}}
+
+{{{link}}}
+
+{{{t "Questions about your subscription? Our support team is here to help you:"}}}
+
+{{{supportUrl}}}

--- a/packages/fxa-auth-server/lib/senders/subscription-templates/index.js
+++ b/packages/fxa-auth-server/lib/senders/subscription-templates/index.js
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const LIB_DIR = '../..';
+
+const error = require(`${LIB_DIR}/error`);
+const fs = require('fs');
+const handlebars = {
+  html: require('handlebars').create(),
+  txt: require('handlebars').create(),
+};
+const path = require('path');
+const Promise = require(`${LIB_DIR}/promise`);
+
+const readDir = Promise.promisify(fs.readdir);
+const readFile = Promise.promisify(fs.readFile);
+
+const TEMPLATE_FILE = /(.+)\.(html|txt)$/;
+const TEMPLATES_DIR = __dirname;
+const LAYOUTS_DIR = path.join(TEMPLATES_DIR, 'layouts');
+const PARTIALS_DIR = path.join(TEMPLATES_DIR, 'partials');
+
+module.exports = init;
+
+async function init(log) {
+  if (!log) {
+    throw error.unexpectedError();
+  }
+
+  handlebars.html.registerHelper('t', translate);
+  handlebars.txt.registerHelper('t', translate);
+
+  await forEachTemplate(PARTIALS_DIR, (template, name, type) => {
+    handlebars[type].registerPartial(name, template);
+  });
+
+  const templates = new Map();
+  const layouts = new Map();
+
+  await Promise.all([
+    forEachTemplate(TEMPLATES_DIR, compile(templates)),
+    forEachTemplate(LAYOUTS_DIR, compile(layouts)),
+  ]);
+
+  return { render };
+
+  function translate(string) {
+    if (this.translator) {
+      return this.translator.format(this.translator.gettext(string), this);
+    }
+
+    return string;
+  }
+
+  function render(templateName, layoutName, data) {
+    const template = templates.get(templateName);
+    const layout = layouts.get(layoutName);
+
+    if (!template || !layout) {
+      log.error('templates.render.invalidArg', {
+        templateName,
+        layoutName,
+        data,
+      });
+      throw error.unexpectedError();
+    }
+
+    let html, text;
+
+    if (template.html && layout.html) {
+      html = layout.html({
+        ...data,
+        body: template.html(data),
+      });
+    }
+
+    if (template.txt && layout.txt) {
+      text = layout.txt({
+        ...data,
+        body: template.txt(data),
+      });
+    }
+
+    return { html, text };
+  }
+}
+
+async function forEachTemplate(dir, action) {
+  const files = await readDir(dir);
+  return Promise.all(
+    files.map(async file => {
+      const parts = TEMPLATE_FILE.exec(file);
+      if (parts) {
+        const template = await readFile(path.join(dir, file), {
+          encoding: 'utf8',
+        });
+        return action(template, parts[1], parts[2]);
+      }
+
+      return Promise.resolve();
+    })
+  );
+}
+
+function compile(map) {
+  return (template, name, type) => {
+    const item = map.get(name) || {};
+    item[type] = handlebars[type].compile(template);
+    map.set(name, item);
+  };
+}

--- a/packages/fxa-auth-server/lib/senders/subscription-templates/layouts/subscription.html
+++ b/packages/fxa-auth-server/lib/senders/subscription-templates/layouts/subscription.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="{{language}}" xml:lang="{{language}}">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>{{t subject}}</title>
+    {{> metadata}}
+  </head>
+
+  <body
+   style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; margin: 0; padding: 0; background: #fbfcfe; font-family: Helvetica, Geneva, Tahoma, Verdana, Arial, sans-serif; font-size: 1em; line-height: 1.2;"
+  >
+    <table
+     align="center"
+     width="550"
+     border="0"
+     cellpadding="0"
+     cellspacing="0"
+     style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: 0 auto;"
+    >
+      <tr style="page-break-before: always">
+        <td align="left" style="padding: 30px 0 20px;">
+          <a href="https://www.mozilla.org/firefox/new">
+            <img
+             src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/4/db272056-b844-4c8b-9827-da275d2335de.png"
+             width="130"
+             height="43"
+             alt="Firefox"
+             style="-ms-interpolation-mode: bicubic;"
+            />
+          </a>
+        </td>
+      </tr>
+    </table>
+
+    <table
+     align="center"
+     width="550"
+     border="0"
+     cellpadding="0"
+     cellspacing="0"
+     style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: 0 auto; background: #fff; border-radius: 9px; box-shadow: 0 0 30px #c7cbd6; page-break-before: always;"
+    >
+      {{{body}}}
+    </table>
+
+    <table
+     align="center"
+     width="550"
+     border="0"
+     cellpadding="0"
+     cellspacing="0"
+     style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: 0 auto;"
+    >
+      <tr style="page-break-before: always">
+        <td align="center" valign="top" style="padding: 30px 0 0;">
+          <p style="font-weight: normal; margin: 0; color: #888; font-size: 0.75em; word-wrap: break-word;">
+            {{t "This is an automated email; if you received it in error, no action is required."}}
+          </p>
+        </td>
+      </tr>
+
+      <tr style="page-break-before: always">
+        <td align="center" valign="top" style="padding: 12px 0 0;">
+          <p style="font-weight: normal; margin: 0; color: #888; font-size: 0.75em; word-wrap: break-word;">
+            <a
+             href="{{{subscriptionTermsUrl}}}"
+             style="color: #888;"
+            >
+              {{t "Terms and cancellation policy"}}
+            </a>
+            &bull;
+            <a
+             href="{{{privacyUrl}}}"
+             style="color: #888;"
+            >
+              {{t "Privacy notice"}}
+            </a>
+            &bull;
+            <a
+             href="{{{cancelSubscriptionUrl}}}"
+             style="color: #888;"
+            >
+              {{t "Cancel subscription"}}
+            </a>
+            &bull;
+            <a
+             href="{{{updateBillingUrl}}}"
+             style="color: #888;"
+            >
+              {{t "Update billing information"}}
+            </a>
+          </p>
+        </td>
+      </tr>
+
+      <tr style="page-break-before: always">
+        <td align="center" valign="top" style="padding: 15px 0 0;">
+          <img
+           src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/3/moz-social-bw-rgb.png"
+           height="30"
+           width="30"
+           alt=""
+           style="-ms-interpolation-mode: bicubic;"
+          />
+        </td>
+      </tr>
+
+      <tr style="page-break-before: always">
+        <td align="center" valign="top" style="padding: 8px 0 0;">
+          <p style="font-weight: normal; margin: 0; color: #888; font-size: 0.75em; word-wrap: break-word;">
+            Mozilla
+          </p>
+        </td>
+      </tr>
+
+      <tr style="page-break-before: always">
+        <td align="center" valign="top" style="padding: 6px 0 0;">
+          <p style="font-weight: normal; margin: 0; color: #888; font-size: 0.75em; word-wrap: break-word;">
+            331 E Evelyn Ave, Mountain View, CA 94041
+          </p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/packages/fxa-auth-server/lib/senders/subscription-templates/layouts/subscription.txt
+++ b/packages/fxa-auth-server/lib/senders/subscription-templates/layouts/subscription.txt
@@ -1,0 +1,18 @@
+{{{body}}}
+
+{{{t "This is an automated email; if you received it in error, no action is required."}}}
+
+{{{t "Terms and cancellation policy:"}}}
+{{{subscriptionTermsUrl}}}
+
+{{{t "Privacy notice:"}}}
+{{{privacyUrl}}}
+
+{{{t "Cancel subscription:"}}}
+{{{cancelSubscriptionUrl}}}
+
+{{{t "Update billing information:"}}}
+{{{updateBillingUrl}}}
+
+Mozilla
+331 E Evelyn Ave, Mountain View, CA 94041

--- a/packages/fxa-auth-server/lib/senders/subscription-templates/partials/button.html
+++ b/packages/fxa-auth-server/lib/senders/subscription-templates/partials/button.html
@@ -1,0 +1,25 @@
+<tr style="page-break-before: always">
+  <td align="center" valign="middle">
+    <!--[if mso]>
+    <v:roundrect
+     xmlns:v="urn:schemas-microsoft-com:vml"
+     xmlns:w="urn:schemas-microsoft-com:office:word"
+     href="{{{link}}}"
+     style="width:280px;height:40px;v-text-anchor:middle;"
+     arcsize="10%"
+     stroke="f"
+     fillcolor="#005de8"
+    >
+      <w:anchorlock />
+      <center>
+    <![endif]-->
+    <a
+     href="{{{link}}}"
+     style="background: #005de8; color: #fff; padding: 18px; text-decoration: none; font-size: 0.9em; font-weight: bold; line-height: 1.8; border-radius: 5px;"
+     >{{t action}}</a>
+    <!--[if mso]>
+      </center>
+    </v:roundrect>
+    <![endif]-->
+  </td>
+</tr>

--- a/packages/fxa-auth-server/lib/senders/subscription-templates/partials/icon.html
+++ b/packages/fxa-auth-server/lib/senders/subscription-templates/partials/icon.html
@@ -1,0 +1,7 @@
+{{#if icon}}
+<tr style="page-break-before: always">
+  <td align="center" style="padding: 20px 0;">
+    <img src="{{{icon}}}" width="58" height="58" alt="" style="-ms-interpolation-mode: bicubic;" />
+  </td>
+</tr>
+{{/if}}

--- a/packages/fxa-auth-server/lib/senders/subscription-templates/partials/metadata.html
+++ b/packages/fxa-auth-server/lib/senders/subscription-templates/partials/metadata.html
@@ -1,0 +1,20 @@
+{{#if oneClickLink}}
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "EmailMessage",
+  "description": "{{t subject}}",
+  "potentialAction": {
+    "@type": "ViewAction",
+    "name": "{{t action}}",
+    "target": "{{{oneClickLink}}}",
+    "url": "{{{oneClickLink}}}"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Firefox Accounts",
+    "url": "https://accounts.firefox.com/"
+  }
+}
+</script>
+{{/if}}

--- a/packages/fxa-auth-server/lib/subhub/updates.js
+++ b/packages/fxa-auth-server/lib/subhub/updates.js
@@ -29,7 +29,7 @@ function validateMessage(message) {
 }
 
 module.exports = function(log, config) {
-  return function start(messageQueue, db) {
+  return function start(messageQueue, db, mailer) {
     async function handleSubHubUpdates(message) {
       const uid = message && message.uid;
 
@@ -56,6 +56,12 @@ module.exports = function(log, config) {
             message.productName,
             message.eventCreatedAt
           );
+          const account = await db.account(uid);
+          await mailer.sendDownloadSubscription(account.emails, {
+            acceptLanguage: account.locale,
+            productId: message.productName,
+            uid: account.uid,
+          });
         } else {
           const existing = await db.getAccountSubscription(
             uid,

--- a/packages/fxa-auth-server/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/scripts/write-emails-to-disk.js
@@ -123,6 +123,7 @@ function sendMail(mailer, messageToSend) {
       country: 'Spain',
     },
     locations: [],
+    productId: '0123456789abcdef',
     redirectTo: 'https://redirect.com/',
     resume:
       'eyJjYW1wYWlnbiI6bnVsbCwiZW50cnlwb2ludCI6bnVsbCwiZmxvd0lkIjoiM2Q1ODZiNzY4Mzc2NGJhOWFiNzhkMzMxMTdjZDU4Y2RmYjk3Mzk5MWU5NTk0NjgxODBlMDUyMmY2MThhNmEyMSIsInJlc2V0UGFzc3dvcmRDb25maXJtIjp0cnVlLCJ1bmlxdWVVc2VySWQiOiI1ODNkOGFlYS00NzU3LTRiZTQtYWJlNC0wZWQ2NWZhY2Y2YWQiLCJ1dG1DYW1wYWlnbiI6bnVsbCwidXRtQ29udGVudCI6bnVsbCwidXRtTWVkaXVtIjpudWxsLCJ1dG1Tb3VyY2UiOm51bGwsInV0bVRlcm0iOm51bGx9',

--- a/packages/fxa-auth-server/test/local/senders/index.js
+++ b/packages/fxa-auth-server/test/local/senders/index.js
@@ -364,6 +364,32 @@ describe('lib/senders/index', () => {
       });
     });
 
+    describe('sendDownloadSubscription:', () => {
+      it('called mailer.downloadSubscriptionEmail', async () => {
+        const mailer = await createSender(config, bounces);
+        mailer._ungatedMailer.downloadSubscriptionEmail = sinon.spy(() =>
+          P.resolve({})
+        );
+        await mailer.sendDownloadSubscription(EMAILS, {
+          acceptLanguage: 'wibble',
+          productId: 'blee',
+        });
+
+        assert.equal(
+          mailer._ungatedMailer.downloadSubscriptionEmail.callCount,
+          1
+        );
+        const args = mailer._ungatedMailer.downloadSubscriptionEmail.args[0];
+        assert.lengthOf(args, 1);
+        assert.deepEqual(args[0], {
+          acceptLanguage: 'wibble',
+          ccEmails: EMAILS.slice(1, 2).map(e => e.email),
+          email: EMAIL,
+          productId: 'blee',
+        });
+      });
+    });
+
     describe('gated on bounces', () => {
       const code = crypto.randomBytes(8).toString('hex');
 

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -122,6 +122,7 @@ const LOG_METHOD_NAMES = [
 ];
 
 const MAILER_METHOD_NAMES = [
+  'sendDownloadSubscription',
   'sendNewDeviceLoginNotification',
   'sendPasswordChangedNotification',
   'sendPasswordResetNotification',
@@ -225,6 +226,7 @@ function mockDB(data, errors) {
         email: data.email,
         emailCode: data.emailCode,
         emailVerified: data.emailVerified,
+        locale: data.locale,
         primaryEmail: {
           normalizedEmail: data.email.toLowerCase(),
           email: data.email,


### PR DESCRIPTION
Fixes #927.

When we're notified of a new subscription, send that user an email containing a product download link.

The designs for the subscription emails are completely different to the normal FxA emails, so I've implemented this as a separate pipeline with its own set of templates and so on. That also represented an opportunity to make a step towards #1779, so you'll notice some differences in the new pipeline:

* It doesn't use nunjucks, only handlebars. That allows us to drop a dependency and stops the templates from being a confusing mix of two different template syntaxes.
* The templates are refactored to use partials for common elements like buttons, icons and metadata. That reduces the amount of duplication in our templates.
* The layouts and partials are applied dynamically without serialising the end result to disk in the source tree. That should eliminate the kind of confusion that led to #912.
* There is a common `render` function that works for all templates. That's the kind of re-use I had in mind when I opened #1779.

Opened as a draft because I've only implemented the structural parts so far, I haven't styled the emails or written any tests yet. I figured the above discussion might be interesting enough that people want to see this alternative approach early doors, so they can tell me why I'm a fool and it won't work. 😄
