### PR TITLE
fix(test): Fix the "fails with bad assertion" test.

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/test/api.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/api.js
@@ -3156,6 +3156,7 @@ describe('/v1', function() {
       });
 
       it('fails with bad assertion', () => {
+        mockAssertion().reply(200, VERIFY_FAILURE);
         return Server.api.post(genericRequest).then(res => {
           assert.equal(res.statusCode, 401);
           assertSecurityHeaders(res);


### PR DESCRIPTION
See https://circleci.com/gh/mozilla/fxa/44167

Up until now there was one test that always reported "pending"
in the OAuth server, I suspect this was it. I'm not sure how this
test ever passed.

The problem is no browserid-verifier runs on Circle. This test
does not mock out a verifier response, so an attempt is made at
calling a real browserid verifier, which fails because the
verifier cannot be reached. The 500 error is propagated back.

This can be seen locally by starting all of the servers, then
killing all the auth servers, the oauth-server, and the
browserid-verifier. Once all those are stopped, run the
oauth tests. Only this one fails.

With this fix, the problem goes away because the response is mocked 
out like all of the other tests.

fixes #1821

@mozilla/fxa-devs - r?