### PR TITLE
feat(api): add a GET /account endpoint

### DIFF
--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -787,6 +787,11 @@ module.exports = config => {
     });
   };
 
+  ClientApi.prototype.account = async function(sessionTokenHex) {
+    const token = await tokens.SessionToken.fromHex(sessionTokenHex);
+    return this.doRequest('GET', `${this.baseURL}/account`, token);
+  };
+
   ClientApi.prototype.smsSend = function(
     sessionTokenHex,
     phoneNumber,

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -511,6 +511,13 @@ module.exports = config => {
     }
   };
 
+  Client.prototype.account = async function() {
+    if (!this.sessionToken) {
+      await this.login();
+    }
+    return this.api.account(this.sessionToken);
+  };
+
   Client.prototype.destroyAccount = function() {
     if (this.sessionToken) {
       return this.api

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -151,8 +151,11 @@ describe('remote subscriptions:', function() {
     });
 
     it('should return no active subscriptions', async () => {
-      const result = await client.getActiveSubscriptions(tokens[2]);
+      let result = await client.getActiveSubscriptions(tokens[2]);
       assert.deepEqual(result, []);
+
+      result = await client.account();
+      assert.deepEqual(result.subscriptions, []);
     });
 
     describe('createSubscription:', () => {
@@ -201,7 +204,7 @@ describe('remote subscriptions:', function() {
       });
 
       it('should return active subscriptions', async () => {
-        const result = await client.getActiveSubscriptions(tokens[2]);
+        let result = await client.getActiveSubscriptions(tokens[2]);
         assert.isArray(result);
         assert.lengthOf(result, 1);
         assert.isAbove(result[0].createdAt, Date.now() - 1000);
@@ -209,6 +212,12 @@ describe('remote subscriptions:', function() {
         assert.equal(result[0].productName, PRODUCT_ID);
         assert.equal(result[0].uid, client.uid);
         assert.isNull(result[0].cancelledAt);
+
+        result = await client.account();
+        assert.isArray(result.subscriptions);
+        assert.lengthOf(result.subscriptions, 1);
+        assert.equal(result.subscriptions[0].subscription_id, subscriptionId);
+        assert.equal(result.subscriptions[0].plan_id, PLAN_ID);
       });
 
       describe('cancelSubscription:', () => {
@@ -334,6 +343,11 @@ describe('remote subscriptions:', function() {
 
     it('should not include subscriptions with refresh token', async () => {
       const response = await client.accountProfile(refreshToken);
+      assert.isUndefined(response.subscriptions);
+    });
+
+    it('should not return subscriptions from client.account', async () => {
+      const response = await client.account();
       assert.isUndefined(response.subscriptions);
     });
   });

--- a/packages/fxa-js-client/client/FxAccountClient.js
+++ b/packages/fxa-js-client/client/FxAccountClient.js
@@ -980,6 +980,28 @@ define([
   };
 
   /**
+   * Gets aggregated account data, to be used instead of making
+   * multiple calls to disparate `/status` endpoints.
+   *
+   * @method account
+   * @param {String} sessionToken User session token
+   * @return {Promise} A promise that will be fulfilled with JSON
+   */
+  FxAccountClient.prototype.account = function(sessionToken) {
+    var self = this;
+
+    return Promise.resolve()
+      .then(function() {
+        required(sessionToken, 'sessionToken');
+
+        return hawkCredentials(sessionToken, 'sessionToken', HKDF_SIZE);
+      })
+      .then(function(creds) {
+        return self.request.send('/account', 'GET', creds);
+      });
+  };
+
+  /**
    * Destroys this session, by invalidating the sessionToken.
    *
    * @method sessionDestroy

--- a/packages/fxa-js-client/package-lock.json
+++ b/packages/fxa-js-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-js-client",
-  "version": "1.0.14",
+  "version": "1.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fxa-js-client/package.json
+++ b/packages/fxa-js-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-js-client",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Web client that talks to the Firefox Accounts API server",
   "author": "Mozilla",
   "license": "MPL-2.0",

--- a/packages/fxa-js-client/tests/lib/account.js
+++ b/packages/fxa-js-client/tests/lib/account.js
@@ -600,6 +600,15 @@ define([
             assert.equal(error.errno, 127);
           });
       });
+
+      test('account()', async () => {
+        const account = await accountHelper.newVerifiedAccount();
+        const result = await respond(
+          client.account(account.signIn.sessionToken),
+          RequestMocks.account
+        );
+        assert.isArray(result.subscriptions);
+      });
     });
   }
 });

--- a/packages/fxa-js-client/tests/mocks/request.js
+++ b/packages/fxa-js-client/tests/mocks/request.js
@@ -219,6 +219,10 @@ define(['client/lib/errors', 'tests/lib/push-constants'], function(
       body:
         '{"email": "a@a.com", "locale": "en", "authenticationMethods": ["pwd", "email"], "authenticatorAssuranceLevel": 2, "profileChangedAt": 1539002077704}',
     },
+    account: {
+      status: 200,
+      body: '{"subscriptions":[{"foo":"bar"}]}',
+    },
     sessionDestroy: {
       status: 200,
       body: '{}',


### PR DESCRIPTION
Related to #970, #1801 and #1808. Not a fix for any issue.

For #970, we need a way to interrogate the `failure_code` property from the settings view. We can't add it to any of the existing endpoints that view makes requests to because they are our high-traffic, polling endpoints and we don't want to add more overhead for a minority case. And we don't really want to add yet another request to the backend for this one specific purpose, that's exactly what #1808 is trying to avoid.

So this change adds a new endpoint with a generic name, `GET /account`. The long-term plan is that it will return all the stuff needed by the settings view and we'll only have to make one back-end request instead of the 10 or so that we currently make. But for now all I'm doing is returning the subscriptions array to make the new UI for #970 possible.

I've opened it as a separate PR because @LZoog also needs access to the `plan_name` property for #1801, and I don't want to block her any longer while I finish off #970.

There's also a secondary fix here; the behaviour of the stubbed `subhub.listSubscriptions` method was broken because it assumed the presence of a `uid` property in the subscription data. There isn't any, so I hacked it with some extra storage.

@mozilla/fxa-devs r?