### PR TITLE
fix: default ppid enabled to false

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/config.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/config.js
@@ -280,7 +280,7 @@ const conf = convict({
     enabled: {
       doc: 'Whether pairwise pseudonymous identifiers (PPIDs) are enabled',
       format: Boolean,
-      default: true,
+      default: false,
       env: 'PPID_ENABLED',
     },
     enabledClientIds: {


### PR DESCRIPTION
This change disables ppid by default since it won't run in dev/stage environments without further changes.