### PR TITLE
chore(tests): run content server tests when 123done changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "fxa": {
     "moduleDependencies": {
       "fxa-content-server": [
+        "123done",
         "fxa-auth-server",
         "fxa-js-client",
         "fxa-shared",


### PR DESCRIPTION
Read about this in last night's scrollback on Slack, looks like we want changes to 123done to trigger tests in the content server. Those relationships are defined in the top-level `package.json` and implemented by `.circleci/modules-to-test.js`.

So adding `123done` here should do what we want, IIUC.

@mozilla/fxa-devs r?