### PR TITLE
fix(payments): payment server should not read production static assets in local dev

### DIFF
--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -103,11 +103,6 @@ module.exports = () => {
     return result;
   }
 
-  const STATIC_DIRECTORY =
-    path.join(__dirname, '..', '..', config.get('staticResources.directory'));
-
-  const STATIC_INDEX_HTML = fs.readFileSync(path.join(STATIC_DIRECTORY, 'index.html'), {encoding: 'UTF-8'});
-
   const proxyUrl = config.get('proxyStaticResourcesFrom');
   if (proxyUrl) {
     logger.info('static.proxying', { url: proxyUrl });
@@ -127,7 +122,14 @@ module.exports = () => {
       }
     }));
   } else {
+    const STATIC_DIRECTORY =
+      path.join(__dirname, '..', '..', config.get('staticResources.directory'));
+
     logger.info('static.directory', { directory: STATIC_DIRECTORY });
+
+    const STATIC_INDEX_HTML =
+      fs.readFileSync(path.join(STATIC_DIRECTORY, 'index.html'), {encoding: 'UTF-8'});
+
     const renderedStaticHtml = injectHtmlConfig(STATIC_INDEX_HTML, CLIENT_CONFIG, {});
     for (const route of INDEX_ROUTES) {
       // FIXME: should set ETag, Not-Modified:


### PR DESCRIPTION
Static resources from a production `npm run build` should only be expected when running the production-mode server. Looks like [we reverted](https://github.com/mozilla/fxa/commit/1c54e449a0f2effca8376a1d5526f05de7abc008#diff-d619f9f7310d2d6c71ffbce5b6fee2ceR108) the [earlier fix](https://github.com/mozilla/fxa/commit/ecc1def1c686e3556c30688b64f9d861acb2d7f7) to this on accident. 

To verify this worked, you can do something like this:
```
cd packages/fxa-payments-server
rm -rf build
cd ../..
./pm2 restart 18
./pm2 logs
```
I *think* number 18 is the payments-server for everyone? Anyway, payments server should start up without a build directory present. A more thorough way to verify this would be to start from a completely fresh checkout of FxA, but folks probably don't have time for that :)