### PR TITLE
feat(oauth): Support the `resource` parameter when fetching JWT access tokens.

### DIFF
--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -2290,6 +2290,9 @@ rather than with a BrowserID assertion.
   JWT access tokens/ID tokens for clients with [Pseudonymous Pairwise
   Identifiers (PPID)](https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/pairwise-pseudonymous-identifiers.md)
   enabled. Used to forcibly rotate the `sub` claim. If not specified, it will default to `0`.
+- `resource`: _url, optional_ Indicates the target service or resource at which access is being
+  requested. Its value must be an absolute URI, and may include a query component but
+  must not include a fragment component. Added to the `aud` claim of JWT access tokens.
 - `ttl`: _number.integer.min(0), optional_
   The desired lifetime of the issued access token, in seconds.
   The actual lifetime may be smaller than requested depending on server configuration,

--- a/packages/fxa-auth-server/fxa-oauth-server/docs/api.md
+++ b/packages/fxa-auth-server/fxa-oauth-server/docs/api.md
@@ -330,16 +330,17 @@ back to the client. This code will be traded for a token at the
 - `client_id`: The id returned from client registration.
 - `assertion`: A FxA assertion for the signed-in user.
 - `state`: A value that will be returned to the client as-is upon redirection, so that clients can verify the redirect is authentic.
-- `response_type`: Optional. If supplied, must be either `code` or `token`. `code` is the default. `token` means the implicit grant is desired, and requires that the client have special permission to do so.
-  - **Note: new implementations should not use `response_type=token`; instead use `grant_type=fxa-credentials` at the [token][] endpoint.**
-- `ttl`: Optional if `response_type=token`, forbidden if `response_type=code`. Indicates the requested lifespan in seconds for the implicit grant token. The value is subject to an internal maximum limit, so clients must check the `expires_in` result property for the actual TTL.
-- `redirect_uri`: Optional. If supplied, a string URL of where to redirect afterwards. Must match URL from registration.
-- `scope`: Optional. A string-separated list of scopes that the user has authorized. This could be pruned by the user at the confirmation dialog.
 - `access_type`: Optional. A value of `offline` will generate a refresh token along with the access token.
+- `acr_values`: Optional. A string-separated list of acr values that the token should have a claim for. Specifying `AAL2` will require the token to have an authentication assurance level >= 2 which corresponds to requiring 2FA.
 - `code_challenge_method`: Required if using [PKCE](pkce.md). Must be `S256`, no other value is accepted.
 - `code_challenge`: Required if using [PKCE](pkce.md). A minimum length of 43 characters and a maximum length of 128 characters string, encoded as `BASE64URL`.
 - `keys_jwe`: Optional. A JWE bundle to be returned to the client when it redeems the authorization code.
-- `acr_values`: Optional. A string-separated list of acr values that the token should have a claim for. Specifying `AAL2` will require the token to have an authentication assurance level >= 2 which corresponds to requiring 2FA.
+- `redirect_uri`: Optional. If supplied, a string URL of where to redirect afterwards. Must match URL from registration.
+- `resource`: Optional if `response_type=token`, forbidden if `response_type=code`. Indicates the target service or resource at which access is being requested. Its value must be an absolute URI, and may include a query component but must not include a fragment component. Added to the `aud` claim of JWT access tokens.
+- `response_type`: Optional. If supplied, must be either `code` or `token`. `code` is the default. `token` means the implicit grant is desired, and requires that the client have special permission to do so.
+  - **Note: new implementations should not use `response_type=token`; instead use `grant_type=fxa-credentials` at the [token][] endpoint.**
+- `scope`: Optional. A string-separated list of scopes that the user has authorized. This could be pruned by the user at the confirmation dialog.
+- `ttl`: Optional if `response_type=token`, forbidden if `response_type=code`. Indicates the requested lifespan in seconds for the implicit grant token. The value is subject to an internal maximum limit, so clients must check the `expires_in` result property for the actual TTL.
 
 **Example:**
 
@@ -398,6 +399,9 @@ The following types of grant are possible:
   Identifiers (PPID)](https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/pairwise-pseudonymous-identifiers.md)
   enabled. Used to forcibly rotate the `sub` claim. Must be an integer in the range 0-1024.
   Defaults to 0.
+- `resource`: (optional) Indicates the target service or resource at which access is being
+  requested. Its value must be an absolute URI, and may include a query component but
+  must not include a fragment component. Added to the `aud` claim of JWT access tokens.
 - `ttl`: (optional) Seconds that the access_token should be valid.
   If unspecified this will default to the maximum value allowed by the
   server, which is a configurable option but would typically be measured

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/grant.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/grant.js
@@ -171,9 +171,18 @@ module.exports.generateTokens = async function generateTokens(grant) {
 
 async function generateIdToken(grant, accessToken) {
   var now = Math.floor(Date.now() / 1000);
-  var claims = {
+  const clientId = hex(grant.clientId);
+  // The IETF spec for `aud` refers to https://openid.net/specs/openid-connect-core-1_0.html#IDToken
+  // > REQUIRED. Audience(s) that this ID Token is intended for. It MUST contain the
+  // > OAuth 2.0 client_id of the Relying Party as an audience value. It MAY also contain
+  // > identifiers for other audiences. In the general case, the aud value is an array of
+  // > case sensitive strings. In the common special case when there is one audience, the
+  // > aud value MAY be a single case sensitive string.
+  const audience = grant.resource ? [clientId, grant.resource] : clientId;
+
+  const claims = {
     sub: await sub(grant.userId, grant.clientId, grant.ppidSeed),
-    aud: hex(grant.clientId),
+    aud: audience,
     //iss set in jwt.sign
     iat: now,
     exp: now + ID_TOKEN_EXPIRATION,

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/jwt_access_token.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/jwt_access_token.js
@@ -14,20 +14,18 @@ const HEADER_TYP = 'at+JWT';
  */
 exports.create = async function generateJWTAccessToken(accessToken, grant) {
   const clientId = hex(grant.clientId);
+  // The IETF spec for `aud` refers to https://openid.net/specs/openid-connect-core-1_0.html#IDToken
+  // > REQUIRED. Audience(s) that this ID Token is intended for. It MUST contain the
+  // > OAuth 2.0 client_id of the Relying Party as an audience value. It MAY also contain
+  // > identifiers for other audiences. In the general case, the aud value is an array of
+  // > case sensitive strings. In the common special case when there is one audience, the
+  // > aud value MAY be a single case sensitive string.
+  const audience = grant.resource ? [clientId, grant.resource] : clientId;
 
   // Claims list from:
   // https://tools.ietf.org/html/draft-bertocci-oauth-access-token-jwt-00#section-2.2
   const claims = {
-    // The IETF spec for `aud` refers to https://openid.net/specs/openid-connect-core-1_0.html#IDToken
-    // > REQUIRED. Audience(s) that this ID Token is intended for. It MUST contain the
-    // > OAuth 2.0 client_id of the Relying Party as an audience value. It MAY also contain
-    // > identifiers for other audiences. In the general case, the aud value is an array of
-    // > case sensitive strings. In the common special case when there is one audience, the
-    // > aud value MAY be a single case sensitive string.
-
-    // We only specify the clientId because we do not yet accept
-    // a `resource` parameter which we could use as the audience.
-    aud: [clientId],
+    aud: audience,
     client_id: clientId,
     exp: Math.floor(accessToken.expiresAt / 1000),
     iat: Math.floor(Date.now() / 1000),

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/authorization.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/authorization.js
@@ -101,6 +101,12 @@ module.exports = {
         .max(256)
         .optional()
         .allow(null),
+
+      resource: validators.resourceUrl.when('response_type', {
+        is: RESPONSE_TYPE_TOKEN,
+        then: Joi.optional(),
+        otherwise: Joi.forbidden(),
+      }),
     },
   },
   response: {
@@ -208,11 +214,11 @@ async function generateImplicitGrant(client, payload, grant) {
     });
     throw AppError.invalidResponseType();
   }
-  return generateTokens(
-    Object.assign(grant, {
-      ttl: payload.ttl,
-    })
-  );
+  return generateTokens({
+    ...grant,
+    resource: payload.resource,
+    ttl: payload.ttl,
+  });
 }
 
 function validateClientDetails(client, payload) {

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/token.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/token.js
@@ -143,6 +143,8 @@ const PAYLOAD_SCHEMA = Joi.object({
   }),
 
   ppid_seed: validators.ppidSeed.optional(),
+
+  resource: validators.resourceUrl.optional(),
 });
 
 module.exports = {
@@ -276,8 +278,9 @@ async function validateGrantParameters(client, params) {
       logger.critical('joi.grant_type', { grant_type: params.grant_type });
       throw Error('unreachable');
   }
-  requestedGrant.ttl = params.ttl;
   requestedGrant.ppidSeed = params.ppid_seed;
+  requestedGrant.resource = params.resource;
+  requestedGrant.ttl = params.ttl;
   return requestedGrant;
 }
 

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/validators.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/validators.js
@@ -77,3 +77,5 @@ exports.jwt = Joi.string()
 exports.accessToken = Joi.alternatives().try([exports.token, exports.jwt]);
 
 exports.ppidSeed = authServerValidators.ppidSeed.default(0);
+
+exports.resourceUrl = authServerValidators.resourceUrl;

--- a/packages/fxa-auth-server/fxa-oauth-server/test/jwt_access_token.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/jwt_access_token.js
@@ -59,12 +59,23 @@ describe('lib/jwt_access_token', () => {
       assert.isTrue(mockJWT.sign.calledOnce);
 
       const signedClaims = mockJWT.sign.args[0][0];
-      assert.deepEqual(signedClaims.aud, ['deadbeef']);
+      assert.lengthOf(Object.keys(signedClaims), 7);
+      assert.strictEqual(signedClaims.aud, 'deadbeef');
       assert.strictEqual(signedClaims.client_id, 'deadbeef');
       assert.isAtLeast(signedClaims.exp, Math.floor(Date.now() / 1000));
       assert.isAtMost(signedClaims.iat, Math.floor(Date.now() / 1000));
       assert.strictEqual(signedClaims.scope, scope.toString());
       assert.strictEqual(signedClaims.sub, 'feedcafe');
+    });
+
+    it('should propagate `resource` and `clientId` in the `aud` claim', async () => {
+      requestedGrant.resource = 'https://resource.server1.com';
+      await JWTAccessToken.create(mockAccessToken, requestedGrant);
+      const signedClaims = mockJWT.sign.args[0][0];
+      assert.deepEqual(signedClaims.aud, [
+        'deadbeef',
+        'https://resource.server1.com',
+      ]);
     });
   });
 

--- a/packages/fxa-auth-server/lib/oauthdb/grant-tokens-from-authorization-code.js
+++ b/packages/fxa-auth-server/lib/oauthdb/grant-tokens-from-authorization-code.js
@@ -26,7 +26,8 @@ module.exports = config => {
         ttl: Joi.number()
           .positive()
           .optional(),
-        ppid_seed: validators.ppidSeed.optional()
+        ppid_seed: validators.ppidSeed.optional(),
+        resource: validators.resourceUrl.optional(),
       }).xor('client_secret', 'code_verifier'),
       response: Joi.object({
         access_token: validators.accessToken.required(),

--- a/packages/fxa-auth-server/lib/oauthdb/grant-tokens-from-credentials.js
+++ b/packages/fxa-auth-server/lib/oauthdb/grant-tokens-from-credentials.js
@@ -27,6 +27,7 @@ module.exports = config => {
         ttl: Joi.number()
           .positive()
           .optional(),
+        resource: validators.resourceUrl.optional(),
       }),
       response: Joi.object({
         access_token: validators.accessToken.required(),

--- a/packages/fxa-auth-server/lib/oauthdb/grant-tokens-from-refresh-token.js
+++ b/packages/fxa-auth-server/lib/oauthdb/grant-tokens-from-refresh-token.js
@@ -25,7 +25,8 @@ module.exports = config => {
         ttl: Joi.number()
           .positive()
           .optional(),
-        ppid_seed: validators.ppidSeed.optional()
+        ppid_seed: validators.ppidSeed.optional(),
+        resource: validators.resourceUrl.optional(),
       }),
       response: Joi.object({
         access_token: validators.accessToken.required(),

--- a/packages/fxa-auth-server/lib/routes/oauth.js
+++ b/packages/fxa-auth-server/lib/routes/oauth.js
@@ -83,6 +83,7 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
           payload: oauthdb.api.createAuthorizationCode.opts.validate.payload.keys(
             {
               assertion: Joi.forbidden(),
+              resource: Joi.forbidden(),
             }
           ),
         },

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -202,6 +202,10 @@ module.exports.url = function url(options) {
   return validator;
 };
 
+// resourceUrls must *not* contain a hash fragment.
+// See https://tools.ietf.org/html/draft-ietf-oauth-resource-indicators-02#section-2
+module.exports.resourceUrl = module.exports.url().regex(/#/, { invert: true });
+
 module.exports.pushCallbackUrl = function pushUrl(options) {
   const validator = isA.string().uri(options);
   validator._tests.push({
@@ -333,4 +337,8 @@ module.exports.subscriptionsCustomerValidator = isA.object({
     .optional(),
 });
 
-module.exports.ppidSeed = isA.number().integer().min(0).max(1024);
+module.exports.ppidSeed = isA
+  .number()
+  .integer()
+  .min(0)
+  .max(1024);

--- a/packages/fxa-auth-server/test/lib/util.js
+++ b/packages/fxa-auth-server/test/lib/util.js
@@ -28,7 +28,16 @@ function restoreStdoutWrite() {
   process.stdout.write = ORIGINAL_STDOUT_WRITE;
 }
 
+function decodeJWT(b64) {
+  const jwt = b64.split('.');
+  return {
+    header: JSON.parse(Buffer.from(jwt[0], 'base64').toString('utf-8')),
+    claims: JSON.parse(Buffer.from(jwt[1], 'base64').toString('utf-8')),
+  };
+}
+
 module.exports = {
+  decodeJWT,
   disableLogs,
   restoreStdoutWrite,
 };


### PR DESCRIPTION
Note, this only works with JWT access tokens and ID tokens. Whenever a `resource` is
specified, the `aud` claim of JWT access tokens or id tokens changes from a string
to an array of strings containing the client_id in position 0 and the `resource`
in position 1.

This PR does not yet return `aud` from either `/verify` or `/introspect` since
the field is not currently returned (see #1872).

Finally, this does not check the `resource` parameter against a pre-defined list
that is authorized for the given client_id.

fixes #1817