### PR TITLE
fix(tests): fix security events test to check for later date

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/security-events.js
+++ b/packages/fxa-auth-server/test/local/routes/security-events.js
@@ -44,15 +44,15 @@ describe('GET /securityEvents', () => {
       assert.equal(res.length, 3);
       assert.equal(res[0].name, 'account.create');
       assert.equal(res[0].verified, 1);
-      assert.isBelow(res[0].createdAt, new Date().getTime());
+      assert.isBelow(res[0].createdAt, Date.now());
 
       assert.equal(res[1].name, 'account.login');
       assert.equal(res[1].verified, 1);
-      assert.isBelow(res[1].createdAt, new Date().getTime());
+      assert.isBelow(res[1].createdAt, Date.now());
 
       assert.equal(res[2].name, 'account.reset');
       assert.equal(res[2].verified, 1);
-      assert.isBelow(res[2].createdAt, new Date().getTime());
+      assert.isBelow(res[2].createdAt, Date.now());
     });
   });
 });

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -462,17 +462,17 @@ function mockDB(data, errors) {
         {
           name: 'account.create',
           verified: 1,
-          createdAt: new Date().getTime(),
+          createdAt: Date.now() - 2000,
         },
         {
           name: 'account.login',
           verified: 1,
-          createdAt: new Date().getTime(),
+          createdAt: Date.now() - 2000,
         },
         {
           name: 'account.reset',
           verified: 1,
-          createdAt: new Date().getTime(),
+          createdAt: Date.now() - 2000,
         },
       ]);
     }),


### PR DESCRIPTION
Not attached to an issue, but fixes an intermittent test failure introduced in https://github.com/mozilla/fxa/pull/1661. This correctly checks for a later time.

@mozilla/fxa-devs r?