### PR TITLE
Fix flaky OAuth test

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/authorized-clients/list.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/authorized-clients/list.js
@@ -127,10 +127,10 @@ module.exports = {
         return -1;
       }
       // To help provide a deterministic result order to simplify testing, also sort of scope values.
-      if (a.scope < b.scope) {
+      if (a.scope > b.scope) {
         return 1;
       }
-      if (a.scope > b.scope) {
+      if (a.scope < b.scope) {
         return -1;
       }
       return 0;

--- a/packages/fxa-auth-server/fxa-oauth-server/test/api.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/api.js
@@ -4329,7 +4329,11 @@ describe('/v1', function() {
         await makeAccessToken(client1, user1, ['profile']);
         await makeAccessToken(client1, user1, ['other', 'scope']);
         await makeRefreshToken(client2, user1, ['profile']);
-        await makeRefreshToken(client2, user1, ['other', 'scope']);
+        await makeRefreshToken(client2, user1, [
+          'aaaSortMeFirst',
+          'other',
+          'scope',
+        ]);
         await makeAccessToken(client2, user1, ['profile']);
         const res = await Server.api.post({
           url: '/authorized-clients',
@@ -4340,10 +4344,14 @@ describe('/v1', function() {
         const clients = res.result;
         assert.equal(clients.length, 3);
         assert.equal(clients[0].client_id, client2Id.toString('hex'));
-        assert.deepEqual(clients[0].scope, ['profile']);
+        assert.deepEqual(clients[0].scope, [
+          'aaaSortMeFirst',
+          'other',
+          'scope',
+        ]);
         assert.ok(clients[0].refresh_token_id);
         assert.equal(clients[1].client_id, client2Id.toString('hex'));
-        assert.deepEqual(clients[1].scope, ['other', 'scope']);
+        assert.deepEqual(clients[1].scope, ['profile']);
         assert.ok(clients[1].refresh_token_id);
         assert.equal(clients[2].client_id, client1Id.toString('hex'));
         assert.deepEqual(clients[2].scope, ['other', 'profile', 'scope']);


### PR DESCRIPTION
Fixes #1837, in which a test would sometimes pass if two tokens had the same timestamp (causing them to be sorted by scope values) and would sometimes fail if they did not. The scope values now produce the same sort order as the timestamps.