### PR TITLE
fix(l10n): Only support the `bn` locale, `bn-BD` will be removed.

### DIFF
--- a/packages/fxa-shared/l10n/supportedLanguages.json
+++ b/packages/fxa-shared/l10n/supportedLanguages.json
@@ -3,7 +3,7 @@
   "ast",
   "az",
   "bg",
-  "bn-BD",
+  "bn",
   "ca",
   "cak",
   "cs",


### PR DESCRIPTION
fixes #1840

@mozilla/fxa-devs - r?