### PR TITLE
feat(payments): extend payment server session from 15 min to 30 min

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/lib/payment-server.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/payment-server.js
@@ -19,7 +19,7 @@ describe('lib/payment-server-redirect', () => {
       subscriptions: {
         managementClientId: 'MOCK_CLIENT_ID',
         managementScopes: 'MOCK_SCOPES',
-        managementTokenTTL: 900,
+        managementTokenTTL: 1800,
         managementUrl: 'http://example.com',
       },
     };

--- a/packages/fxa-content-server/app/tests/spec/views/settings/subscription.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/subscription.js
@@ -21,7 +21,7 @@ describe('views/settings/subscription', function() {
       subscriptions: {
         managementClientId: 'MOCK_CLIENT_ID',
         managementScopes: 'MOCK_SCOPES',
-        managementTokenTTL: 900,
+        managementTokenTTL: 1800,
         managementUrl: 'http://example.com',
       },
     };

--- a/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
@@ -38,7 +38,7 @@ describe('views/subscriptions_product_redirect', function() {
       subscriptions: {
         managementClientId: 'MOCK_CLIENT_ID',
         managementScopes: 'MOCK_SCOPES',
-        managementTokenTTL: 900,
+        managementTokenTTL: 1800,
         managementUrl: 'http://example.com',
       },
     };

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -625,7 +625,7 @@ const conf = (module.exports = convict({
       format: String,
     },
     managementTokenTTL: {
-      default: 900,
+      default: 1800,
       doc:
         'OAuth token time-to-live (in seconds) for subscriptions management pages',
       env: 'SUBSCRIPTIONS_MANAGEMENT_TOKEN_TTL',


### PR DESCRIPTION
Fixes #1694.

I think I've hit all the relevant configuration bits in the code, including the tests. Didn't see anything in the payments-server that seemed to need to be updated.