### PR TITLE
fix(support-panel): handle 404 correctly

### DIFF
--- a/packages/fxa-support-panel/lib/api.ts
+++ b/packages/fxa-support-panel/lib/api.ts
@@ -93,14 +93,21 @@ class SupportController {
       this.logger.debug('infoFetch', { err });
       return h.response('<h1>Unable to fetch user</h1>').code(404);
     }
-    const totpResponse: requests.FullResponse = await requests.get({
-      json: true,
-      resolveWithFullResponse: true,
-      url: `${this.config.authdb_url}/totp/${uid}`
-    });
-    let totpEnabled = false;
-    if (totpResponse.statusCode === 200) {
+    let totpResponse: requests.FullResponse;
+    let totpEnabled: boolean;
+    try {
+      totpResponse = await requests.get({
+        json: true,
+        resolveWithFullResponse: true,
+        url: `${this.config.authdb_url}/totp/${uid}`
+      });
       totpEnabled = (totpResponse.body as TotpTokenResponse).enabled;
+    } catch (err) {
+      if (err.response && err.response.statusCode === 404) {
+        totpEnabled = false;
+      } else {
+        throw err;
+      }
     }
     const hasSubscriptions = subscriptions.length > 0 ? true : false;
     const context = {

--- a/packages/fxa-support-panel/test/lib/api.spec.ts
+++ b/packages/fxa-support-panel/test/lib/api.spec.ts
@@ -103,6 +103,7 @@ describe('Support Controller', () => {
 
   afterEach(async () => {
     await server.stop();
+    nock.cleanAll();
   });
 
   it('has a heartbeat', async () => {
@@ -142,5 +143,7 @@ describe('Support Controller', () => {
       url: `/?uid=${uid}`
     });
     cassert.equal(result.statusCode, 200);
+    const payloadMatch = result.payload.match(/2FA enabled\?<\/th>\s*<td>\s*no/g);
+    cassert.isTrue(payloadMatch && payloadMatch.length === 1);
   });
 });


### PR DESCRIPTION
The prior fix failed to account for a leftover nock intercept.

Closes #1876