### PR TITLE
fix(fxa-shared): Use fxa-shared@1.0.27 in the content/auth servers.

### DIFF
--- a/packages/fxa-auth-server/npm-shrinkwrap.json
+++ b/packages/fxa-auth-server/npm-shrinkwrap.json
@@ -2590,9 +2590,9 @@
       }
     },
     "fxa-shared": {
-      "version": "1.0.25",
-      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.25.tgz",
-      "integrity": "sha512-P+Mr/nZyQ3I2KA3ldONKk9L4i4k2nnWDytR4OPXh1kjehmFpJJql62wIdvxtAnDHVClqlXDotOOMfI8FhxkoIg==",
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.27.tgz",
+      "integrity": "sha512-h6zY85SpPOYIcqNpitPrwWyvZTQIb5a99mknZbydAfkey6/z6gzj7/LXNrvLNPj/QsneNHQ/rNeWl8bPvwfL7g==",
       "requires": {
         "accept-language": "2.0.17",
         "ajv": "6.10.0",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -52,7 +52,7 @@
     "fxa-geodb": "1.0.4",
     "fxa-jwtool": "0.7.2",
     "fxa-notifier-aws": "1.0.0",
-    "fxa-shared": "1.0.25",
+    "fxa-shared": "^1.0.27",
     "generic-pool": "3.2.0",
     "google-libphonenumber": "2.0.10",
     "grunt-nunjucks-2-html": "3.1.0",

--- a/packages/fxa-content-server/npm-shrinkwrap.json
+++ b/packages/fxa-content-server/npm-shrinkwrap.json
@@ -5865,9 +5865,9 @@
             }
         },
         "fxa-shared": {
-            "version": "1.0.26",
-            "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.26.tgz",
-            "integrity": "sha512-JlLmvoQ8UZ5OasFro9JUTsfabATlDUS/411EZxznvQJtmBCZQ8URNcpJAadsUlu2cAA8i0DO/LcPztZSoCaxBQ==",
+            "version": "1.0.27",
+            "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.27.tgz",
+            "integrity": "sha512-h6zY85SpPOYIcqNpitPrwWyvZTQIb5a99mknZbydAfkey6/z6gzj7/LXNrvLNPj/QsneNHQ/rNeWl8bPvwfL7g==",
             "requires": {
                 "accept-language": "2.0.17",
                 "ajv": "6.10.0",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -67,7 +67,7 @@
         "fxa-js-client": "^1.0.15",
         "fxa-mustache-loader": "0.0.2",
         "fxa-pairing-channel": "1.0.1",
-        "fxa-shared": "1.0.26",
+        "fxa-shared": "^1.0.27",
         "got": "6.7.1",
         "grunt": "1.0.4",
         "grunt-babel": "6.0.0",

--- a/packages/fxa-shared/package-lock.json
+++ b/packages/fxa-shared/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "Shared module for FxA repositories",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This fixes a problem with `bn_BD` and `bn_IN` being merged into just `bn`. I updated fxa-shared but neglected to push a new version to npm and update package.json files where needed.

v1.0.27 is already pushed to npm from using the `np` command,
this updates all the package.json and lockfiles.

@mozilla/fxa-devs - r?