### PR TITLE
chore(deps): Restore `keypair` dependency

### DIFF
--- a/packages/fxa-auth-server/npm-shrinkwrap.json
+++ b/packages/fxa-auth-server/npm-shrinkwrap.json
@@ -4153,6 +4153,11 @@
       "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
       "integrity": "sha1-RIR8o5TOjWtSGuhYFr1kUJlCs4U="
     },
+    "keypair": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.1.tgz",
+      "integrity": "sha1-dgNxknCvtlZO04oiCHoG/Jqk6hs="
+    },
     "keyv": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -66,6 +66,7 @@
     "jed": "0.5.4",
     "joi": "14.0.0",
     "jsonwebtoken": "^8.4.0",
+    "keypair": "1.0.1",
     "keyv": "3.0.0",
     "memcached": "2.2.2",
     "moment-timezone": "0.5.11",


### PR DESCRIPTION
I attempted to remove this dependency in #1668 in favour of node's new built-in functions that do the same thing, but clearly failed to find all the uses of it, because CI is now busted. Restoring the dep, with apologies for not catching this before merge.