### PR TITLE
chore(config): Advertize auth-server /oauth/token endpoint in OIDC config

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/get-openid-configuration.js
+++ b/packages/fxa-content-server/server/lib/routes/get-openid-configuration.js
@@ -9,7 +9,7 @@ const config = require('../configuration');
 const authorizationEndpoint = config.get('public_url') + '/authorization';
 const issuer = config.get('public_url');
 const jwksEndpoint = config.get('oauth_url') + '/v1/jwks';
-const tokenEndpoint = config.get('oauth_url') + '/v1/token';
+const tokenEndpoint = config.get('fxaccount_url') + '/v1/oauth/token';
 const userInfoEndpoint = config.get('profile_url') + '/v1/profile';
 
 const openidConfig = {


### PR DESCRIPTION
We intend for the auth-server endpoint to replace the oauth-server version, so might as well start telling clients to use it.

@shane-tomlinson any reason we wouldn't want to do this?