### PR TITLE
WIP add support for ES256 JWT signatures.

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/test-es256-keys.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test-es256-keys.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+
+const keys = require('./lib/keys');
+const jwt = require('jsonwebtoken');
+
+async function run() {
+  const k1 = await keys.generatePrivateKey('RS256');
+  const k2 = await keys.generatePrivateKey('ES256');
+  const k3 = await keys.generatePrivateKey('ES256');
+
+  const k1PrivatePEM = await keys.jwk2pem(k1, true);
+  const k2PrivatePEM = await keys.jwk2pem(k2, true);
+  const k3PrivatePEM = await keys.jwk2pem(k3, true);
+
+  const k1PublicPEM = await keys.jwk2pem(await keys.extractPublicKey(k1));
+  const k2PublicPEM = await keys.jwk2pem(await keys.extractPublicKey(k2));
+  const k3PublicPEM = await keys.jwk2pem(await keys.extractPublicKey(k3));
+
+  const tok1 = jwt.sign({ hello: 'world' }, k1PrivatePEM, {
+    algorithm: 'RS256',
+  });
+  assert.ok(jwt.verify(tok1, k1PublicPEM, { algorithms: ['RS256', 'ES256'] }));
+  assert.throws(() => {
+    jwt.verify(tok1, k2PublicPEM, { algorithms: ['RS256', 'ES256'] });
+  });
+  assert.throws(() => {
+    jwt.verify(tok1, k3PublicPEM, { algorithms: ['RS256', 'ES256'] });
+  });
+
+  const tok2 = jwt.sign({ hello: 'world' }, k2PrivatePEM, {
+    algorithm: 'ES256',
+  });
+  assert.ok(jwt.verify(tok2, k2PublicPEM, { algorithms: ['RS256', 'ES256'] }));
+  assert.throws(() => {
+    jwt.verify(tok2, k1PublicPEM, { algorithms: ['RS256', 'ES256'] });
+  });
+  assert.throws(() => {
+    jwt.verify(tok2, k3PublicPEM, { algorithms: ['RS256', 'ES256'] });
+  });
+
+  const tok3 = jwt.sign({ hello: 'world' }, k3PrivatePEM, {
+    algorithm: 'ES256',
+  });
+  assert.ok(jwt.verify(tok3, k3PublicPEM, { algorithms: ['RS256', 'ES256'] }));
+  assert.throws(() => {
+    jwt.verify(tok3, k1PublicPEM, { algorithms: ['RS256', 'ES256'] });
+  });
+  assert.throws(() => {
+    jwt.verify(tok3, k2PublicPEM, { algorithms: ['RS256', 'ES256'] });
+  });
+
+  console.log(k3);
+  console.log(tok3);
+}
+
+run().then(() => {
+  console.log('OK!');
+});

--- a/packages/fxa-auth-server/npm-shrinkwrap.json
+++ b/packages/fxa-auth-server/npm-shrinkwrap.json
@@ -4329,6 +4329,11 @@
       "integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
       "dev": true
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -4990,6 +4995,36 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
+        }
+      }
+    },
+    "node-forge": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+      "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
+    },
+    "node-jose": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-1.1.3.tgz",
+      "integrity": "sha512-kupfi4uGWhRjnOmtie2T64cLge5a1TZyalEa8uWWWBgtKBcu41A4IGKpI9twZAxRnmviamEUQRK7LSyfFb2w8A==",
+      "requires": {
+        "base64url": "^3.0.1",
+        "es6-promise": "^4.2.6",
+        "lodash": "^4.17.11",
+        "long": "^4.0.0",
+        "node-forge": "^0.8.1",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "base64url": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+          "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         }
       }
     },

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -74,6 +74,7 @@
     "mysql": "2.15.0",
     "mysql-patcher": "0.7.0",
     "newrelic": "4.10.0",
+    "node-jose": "^1.1.3",
     "node-uap": "git+https://github.com/vladikoff/node-uap.git#9cdd16247",
     "node-zendesk": "^1.4.0",
     "nodemailer": "2.7.2",


### PR DESCRIPTION
@shane-tomlinson I did a little spike on integrating `ES256` JWT signatures, here's my very very rough code. Connects to #1769 

The hardest part here is that `pem-jwk` only supports RSA keys. I've switched to using `node-jose` for translating between PEM and JWK here, but the APIs it exposes for that are Promise-based, so that resulted in some flow-on changes and some "XXX TODO" notes. There may be a better way to achieve what we need here.

I *think* this works; at least the tokens it produces can be verified successfully using https://jwt.io. Definitely a lot of cleanup required before we could use this for real, but hopefully it will help unblock you.  I don't think I'll have any more time to work on it this week, but you're very welcome to pick it up or scavenge it for parts.