### PR TITLE
chore(docs): add note warning that api docs are wrong

### DIFF
--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -1,5 +1,11 @@
 # Firefox Accounts authentication server API
 
+**WARNING:**
+Some of this information is wrong,
+use it at your own risk.
+It may be worth verifying things in the source code
+before acting on anything you read here.
+
 <!--begin-abstract-->
 
 This document provides protocol-level details


### PR DESCRIPTION
Related to #1845.

My argument for deleting `packages/fxa-auth-server/docs/api.md` was not popular, nor was my attempt to fix it using the old generator script.

If we're going to replace it with swagger docs, in the meantime should we at least make it explicit that it's wrong?

@mozilla/fxa-devs r?