### PR TITLE
feat(signup): Fix #1723, redirect to original page after signup

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -578,6 +578,10 @@ var ERRORS = {
     message: t('Accounts with two-step authentication do not support pairing at this time')
   },
    */
+  INVALID_REDIRECT_TO: {
+    errno: 1062,
+    message: t('Invalid redirect'),
+  },
 };
 /*eslint-enable sorting/sort-object-props*/
 

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/base.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/base.js
@@ -13,6 +13,7 @@ import Cocktail from 'cocktail';
 import Environment from '../../lib/environment';
 import NotifierMixin from '../../lib/channels/notifier-mixin';
 import NavigateBehavior from '../../views/behaviors/navigate';
+import NavigateOrRedirectBehavior from '../../views/behaviors/navigate-or-redirect';
 import NullBehavior from '../../views/behaviors/null';
 import SameBrowserVerificationModel from '../verification/same-browser';
 import UrlMixin from '../mixins/url';
@@ -97,14 +98,16 @@ const BaseAuthenticationBroker = Backbone.Model.extend({
     ),
     afterCompleteSignIn: new NavigateBehavior('signin_verified'),
     afterCompleteSignInWithCode: new NavigateBehavior('settings'),
-    afterCompleteSignUp: new NavigateBehavior('signup_verified'),
+    afterCompleteSignUp: new NavigateOrRedirectBehavior('signup_verified'),
     afterDeleteAccount: new NullBehavior(),
     afterForceAuth: new NavigateBehavior('signin_confirmed'),
     afterResetPasswordConfirmationPoll: new NullBehavior(),
     afterSignIn: new NavigateBehavior('signin_confirmed'),
     afterSignInConfirmationPoll: new NavigateBehavior('signin_confirmed'),
     afterSignUp: new NavigateBehavior('confirm'),
-    afterSignUpConfirmationPoll: new NavigateBehavior('signup_confirmed'),
+    afterSignUpConfirmationPoll: new NavigateOrRedirectBehavior(
+      'signup_confirmed'
+    ),
     afterSignUpRequireTOTP: new NavigateBehavior('signin'),
     beforeSignIn: new NullBehavior(),
     beforeSignUpConfirmationPoll: new NullBehavior(),

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/web.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/web.js
@@ -10,12 +10,13 @@ import _ from 'underscore';
 import BaseBroker from '../auth_brokers/base';
 import { CONTENT_SERVER_CONTEXT } from '../../lib/constants';
 import NavigateBehavior from '../../views/behaviors/navigate';
+import NavigateOrRedirectBehavior from '../../views/behaviors/navigate-or-redirect';
 import SettingsIfSignedInBehavior from '../../views/behaviors/settings';
 const t = msg => msg;
 
 const proto = BaseBroker.prototype;
 
-const redirectToSettingsBehavior = new NavigateBehavior('settings', {
+const redirectToSettingsBehavior = new NavigateOrRedirectBehavior('settings', {
   success: t('Account verified successfully'),
 });
 

--- a/packages/fxa-content-server/app/scripts/views/base.js
+++ b/packages/fxa-content-server/app/scripts/views/base.js
@@ -381,6 +381,9 @@ var BaseView = Backbone.View.extend({
         err => {
           if (AuthErrors.is(err, 'INVALID_TOKEN')) {
             this.logError(AuthErrors.toError('SESSION_EXPIRED'));
+            // The redirectTo in .navigate() is lost if there's later navigations, so by saving it here
+            // we can get it later (e.g., in case of a signUp):
+            this.relier.set('redirectTo', this.window.location.href);
             this.navigate(this._reAuthPage(), {
               redirectTo: this.currentPage,
             });

--- a/packages/fxa-content-server/app/scripts/views/behaviors/navigate-or-redirect.js
+++ b/packages/fxa-content-server/app/scripts/views/behaviors/navigate-or-redirect.js
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A behavior that navigates to the relier's redirectTo value if present, or navigates to a fixed endpoint
+ */
+
+import _ from 'underscore';
+import AuthErrors from '../../lib/auth-errors';
+import NavigationBehavior from './navigate.js';
+
+const NavigateOrRedirectBehavior = function(endpoint, options = {}) {
+  const behavior = function(view, account) {
+    let redirectTo = view.relier.get('redirectTo');
+    if (redirectTo) {
+      redirectTo = new URL(redirectTo, location.href);
+      if (redirectTo.origin !== location.origin) {
+        const err = AuthErrors.toError('INVALID_REDIRECT_TO');
+        this.logError(err);
+        throw err;
+      }
+      redirectTo = redirectTo.pathname + redirectTo.search;
+    }
+    const redirectEndpoint = redirectTo || endpoint;
+    const navigateBehavior = new NavigationBehavior(redirectEndpoint, options);
+    return navigateBehavior(view, account);
+  };
+
+  // used for testing
+  _.assign(behavior, options, {
+    endpoint: endpoint,
+    halt: true,
+    type: 'navigateOrRedirect',
+  });
+
+  return behavior;
+};
+
+export default NavigateOrRedirectBehavior;

--- a/packages/fxa-content-server/app/scripts/views/behaviors/settings.js
+++ b/packages/fxa-content-server/app/scripts/views/behaviors/settings.js
@@ -32,14 +32,20 @@ export default function(defaultBehavior, options = {}) {
 
         // Check the `redirectTo` param sent from server, if it matches
         // a known path redirect there, else just go to settings.
-        const redirectTo = view.relier.get('redirectTo');
+        let redirectTo = view.relier.get('redirectTo');
         if (redirectTo) {
-          if (redirectTo.indexOf('/settings/emails') > 0) {
-            endpoint = '/settings/emails';
-          } else if (
-            redirectTo.indexOf('/settings/two_step_authentication') > 0
-          ) {
-            endpoint = '/settings/two_step_authentication';
+          redirectTo = new URL(redirectTo, window.location.origin);
+          if (redirectTo.origin === window.location.origin) {
+            redirectTo = redirectTo.pathname + redirectTo.search;
+            if (redirectTo.indexOf('/settings/emails') >= 0) {
+              endpoint = '/settings/emails';
+            } else if (
+              redirectTo.indexOf('/settings/two_step_authentication') >= 0
+            ) {
+              endpoint = '/settings/two_step_authentication';
+            } else if (redirectTo.indexOf('/subscriptions/products') === 0) {
+              endpoint = redirectTo;
+            }
           }
         }
 

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/base.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/base.js
@@ -373,7 +373,7 @@ describe('models/auth_brokers/base', function() {
       sinon.spy(broker, 'unpersistVerificationData');
       return broker.afterCompleteSignUp(account).then(behavior => {
         assert.isTrue(broker.unpersistVerificationData.calledWith(account));
-        assert.equal(behavior.type, 'navigate');
+        assert.equal(behavior.type, 'navigateOrRedirect');
         assert.equal(behavior.endpoint, 'signup_verified');
       });
     });

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/web.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/web.js
@@ -21,6 +21,15 @@ describe('models/auth_brokers/web', function() {
     });
   }
 
+  function testRedirectsToSettingsOrRedirectTo(brokerMethod) {
+    it(`${brokerMethod} returns a NavigateOrRedirectBehavior to settings`, () => {
+      return broker[brokerMethod]({ get: () => {} }).then(behavior => {
+        assert.equal(behavior.type, 'navigateOrRedirect');
+        assert.equal(behavior.endpoint, 'settings');
+      });
+    });
+  }
+
   function testRedirectsToSettingsIfSignedIn(brokerMethod) {
     it(`${brokerMethod} returns a SettingsIfSignedInBehavior`, () => {
       return broker[brokerMethod]({ get: () => {} }).then(behavior => {
@@ -31,10 +40,10 @@ describe('models/auth_brokers/web', function() {
 
   testRedirectsToSettings('afterCompleteResetPassword');
   testRedirectsToSettings('afterForceAuth');
-  testRedirectsToSettings('afterResetPasswordConfirmationPoll');
+  testRedirectsToSettingsOrRedirectTo('afterResetPasswordConfirmationPoll');
   testRedirectsToSettings('afterSignIn');
-  testRedirectsToSettings('afterSignInConfirmationPoll');
-  testRedirectsToSettings('afterSignUpConfirmationPoll');
+  testRedirectsToSettingsOrRedirectTo('afterSignInConfirmationPoll');
+  testRedirectsToSettingsOrRedirectTo('afterSignUpConfirmationPoll');
 
   testRedirectsToSettingsIfSignedIn('afterCompleteSignIn');
   testRedirectsToSettingsIfSignedIn('afterCompleteSignUp');

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -2278,13 +2278,13 @@ function noSuchStoredAccountByEmail(email) {
 /**
  * Wait for the given `url`
  *
- * @param {string} url - url to wait for
+ * @param {string|function} url - url to wait for, or a function that takes the URL and returns true when ready to continue
  * @returns {promise} resolves when true
  */
 
 const waitForUrl = thenify(function(url) {
   return this.parent.getCurrentUrl().then(function(currentUrl) {
-    if (currentUrl !== url) {
+    if (typeof url === 'function' ? url(currentUrl) : currentUrl !== url) {
       return this.parent.sleep(500).then(waitForUrl(url));
     }
   });


### PR DESCRIPTION
This adds a redirectTo property to the relier, which is already used to add a redirectTo query parameter to verification links, though it wasn't previously being read after signup.

Out of caution, we ensure the redirect can only be to a location local to the content-server (relying party signups go through a different path).

Additionally the confirmation page will redirect based on the in-memory value of `relier.get('redirectTo')`

Re: tests: I wasn't able to figure out how to test the confirmation page redirect. The testing process (which doesn't exactly match the manual process) seems to load a new page, losing the value of redirectTo. There doesn't seem to be any special testing logic about the confirmation page, so I'm not sure why it navigates differently in testing.

We may want to revert part of this patch once payments is a relying party; or maybe this is functionality worth preserving, I'm not sure.