### PR TITLE
fix(fxa-content-server): fixes #1219 - add margin-top to 404 home button

### DIFF
--- a/packages/fxa-content-server/app/styles/_layout.scss
+++ b/packages/fxa-content-server/app/styles/_layout.scss
@@ -84,6 +84,10 @@
   }
 }
 
+#fxa-404-home {
+  margin-top: 24px;
+}
+
 #static-footer {
   align-items: center;
   display: flex;


### PR DESCRIPTION
fixes #1219 

This seemed like the proper spot to stick this style.

I've seen this a couple of times and it bothered me enough to find the issue and fix it. :P
![image](https://user-images.githubusercontent.com/13018240/61910993-bf3d4a00-aefb-11e9-87c6-e548ed083b95.png)
