### PR TITLE
feat(config): Add script for extracting/inserting secret keys from SOPS config

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/docs/signing-key-management.md
+++ b/packages/fxa-auth-server/fxa-oauth-server/docs/signing-key-management.md
@@ -56,3 +56,17 @@ The procedure for rotating the active signing key is:
 This scheme keeps things fairly simple, but it also means that each key rotation event must be at least
 `T_cache + T_tokens` seconds apart. If this proves to be a problem in practice, we could reduce the limit
 to `T_cache` by keeping a _list_ of old signing keys rather than a single key.
+
+For our main production environment, secret keys are managed via [SOPS](https://github.com/mozilla/sops).
+If you're working in such an environment you can do this to extract the keys from SOPS into local files:
+
+```
+./scripts/sops-key-config.js extract path/to/encrypted/config.yaml
+```
+
+Then, after operating on them locally using the above key-rotation scripts, you can insert the modified
+values back into SOPS via:
+
+```
+./scripts/sops-key-config.js insert path/to/encrypted/config.yaml
+```

--- a/packages/fxa-auth-server/fxa-oauth-server/scripts/sops-key-config.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/scripts/sops-key-config.js
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+
+ Usage:
+ scripts/sops-key-config.js [extract|insert] path/to/encrypted/config.yaml
+
+ This script can be used to manage OpenID key configuration in a config file encrypted
+ via SOPS [1], like we use for production deploys.
+
+ When `extract` is specified, this will extract the OpenID `key`, `newKey` and `oldKey`
+ config entries from the specified SOPS-encrypted config file, and write them into the
+ files specified by `keyFile`, `newKeyFile` and `oldKeyFile` where they can be operated
+ on locally.
+
+ When `insert` is specified, this will write the contents of `keyFile`, `newKeyFile` and
+ `oldKeyFile` into the specified SOPS-encrypted config file, where they can be committed
+ to the production config store.
+
+ [1] https://github.com/mozilla/sops
+
+ */
+
+//eslint-disable no-console
+
+const fs = require('fs');
+const assert = require('assert');
+const config = require('../lib/config');
+const yaml = require('js-yaml');
+const { execFileSync } = require('child_process');
+
+const SOPS_ITEM_KEY = 'fxa_oauth::oauth_openid_key';
+const SOPS_ITEM_NEWKEY = 'fxa_oauth::oauth_openid_new_key';
+const SOPS_ITEM_OLDKEY = 'fxa_oauth::oauth_openid_old_key';
+
+function main(cb) {
+  cb = cb || (() => {});
+
+  const mode = process.argv[2];
+  assert(
+    mode === 'extract' || mode === 'insert',
+    'Please specify either "extract" or "insert" as command-line argument'
+  );
+
+  const configFile = process.argv[3];
+  assert(
+    configFile,
+    'Please specify SOPS config file as command-line argument'
+  );
+
+  const keyFilePath = config.get('openid.keyFile');
+  const newKeyFilePath = config.get('openid.newKeyFile');
+  const oldKeyFilePath = config.get('openid.oldKeyFile');
+
+  assert(keyFilePath, 'openid.keyFile not specified');
+  assert(newKeyFilePath, 'openid.newKeyFile not specified');
+  assert(oldKeyFilePath, 'openid.oldKeyFile not specified');
+
+  // Load the encrypted yaml so we can check which keys exist.
+  const encryptedConfig = yaml.safeLoad(fs.readFileSync(configFile));
+
+  if (mode === 'extract') {
+    extractFileFromSOPS(
+      configFile,
+      encryptedConfig,
+      SOPS_ITEM_KEY,
+      keyFilePath
+    );
+    extractFileFromSOPS(
+      configFile,
+      encryptedConfig,
+      SOPS_ITEM_NEWKEY,
+      newKeyFilePath
+    );
+    extractFileFromSOPS(
+      configFile,
+      encryptedConfig,
+      SOPS_ITEM_OLDKEY,
+      oldKeyFilePath
+    );
+  } else if (mode === 'insert') {
+    insertFileIntoSOPS(configFile, SOPS_ITEM_KEY, keyFilePath);
+    insertFileIntoSOPS(configFile, SOPS_ITEM_NEWKEY, newKeyFilePath);
+    insertFileIntoSOPS(configFile, SOPS_ITEM_OLDKEY, oldKeyFilePath);
+  } else {
+    assert(
+      false,
+      'Eh? Did we somehow mess up checking `mode` argument above??'
+    );
+  }
+}
+
+function extractFileFromSOPS(
+  configFile,
+  encryptedConfig,
+  itemPath,
+  outputFilePath
+) {
+  if (dottedLookup(encryptedConfig, itemPath)) {
+    fs.writeFileSync(
+      outputFilePath,
+      JSON.stringify(extractValueFromSOPS(configFile, itemPath))
+    );
+    console.log(`Item ${itemPath} extracted to ${outputFilePath}.`);
+  } else if (fs.existsSync(outputFilePath)) {
+    fs.unlinkSync(outputFilePath);
+    console.log(`Item ${itemPath} does not exist, deleted ${outputFilePath}.`);
+  } else {
+    console.log(`Item ${itemPath} does not exist.`);
+  }
+}
+
+function extractValueFromSOPS(configFile, itemPath) {
+  const treePath = dottedPathToTreePath(itemPath);
+  const output = execFileSync('sops', [
+    '-d',
+    '--extract',
+    treePath,
+    configFile,
+  ]);
+  return yaml.safeLoad(output);
+}
+
+function insertFileIntoSOPS(configFile, itemPath, inputFilePath) {
+  if (fs.existsSync(inputFilePath)) {
+    const value = JSON.parse(fs.readFileSync(inputFilePath));
+    insertValueIntoSOPS(configFile, itemPath, value);
+    console.log(`Item ${itemPath} updated from ${inputFilePath}`);
+  } else {
+    // I don't see a specific option to tell SOPS to delete an item,
+    // so instead we explicitly set it to `null`.
+    insertValueIntoSOPS(configFile, itemPath, null);
+    console.log(`Item ${itemPath} cleared.`);
+  }
+}
+
+function insertValueIntoSOPS(configFile, itemPath, value) {
+  const treePath = dottedPathToTreePath(itemPath);
+  const setValue = JSON.stringify(value);
+  execFileSync('sops', ['--set', treePath + ' ' + setValue, configFile]);
+}
+
+// Walk an object to return a nested property.
+// `dottedLookup(obj, "a.b.c") === obj.a.b.c`
+function dottedLookup(obj, path) {
+  const bits = path.split('.');
+  while (bits.length > 0 && obj !== undefined) {
+    obj = obj[bits.shift()];
+  }
+  return obj;
+}
+
+// Turns a simple dotted name like 'x.y.z' into the tree path
+// syntax required by SOPS, like '["x"]["y"]["z"]'.
+function dottedPathToTreePath(path) {
+  return path
+    .split('.')
+    .map(bit => {
+      return JSON.stringify([bit]);
+    })
+    .join('');
+}
+
+module.exports = main;
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
Here's my initial attempt at #1897.  Given a `.yaml` file encrypted with SOPS, I can do the following to extract the various OpenID secret keys to local files:

```
./scripts/sops-key-config.js extract path/to/config.yaml
```

Then I can operate on them locally using `prepare-new-signing-key.ks`, `activate-new-signing-key.js`, etc. Finally I can write them back to the encrypted SOPS file via:

```
./scripts/sops-key-config.js insert path/to/config.yaml
```

The resulting SOPS file looks like:

```
openid:
    key:
        kty: ENC[AES256_GCM,data:TGCb,iv:Wjymx0Ev5XWmPJ8reqv2KNyhihL/ODQJeHRLIdxzXJs=,tag:wNcIYXGHiun0kXP8C8Mrmg==,type:str]
        "n": ENC[AES256_GCM,data:cVEKFlw50kLKdZvPMec6I4aMhy2nCly7iwspcgEvfjoB77iTjdBIbjdr/OyFs/U/I9xU1E5wBwEHygvaaY66nFWohC0Eo6OuuHcx4Kvq7zonAlKBWIqBWVLr60jU5QwI5D/0F6sWQwcSNbYlBiOX5GgaEQnRu9UOu+wCZTvod947pjO7v/ljAVxj54ibpHW8Z3jVOCtS6BsJDq/vt+aEkFsy+WUHa394Lcs3TjPL2QBENhsRtV4Uy1Ih/s2PCdtUTrT+EzYQR2wdqnKtDlg6AW9RPE3FDF3QJrpLd/308RABnzSJMIOfYdlDyhxB/S+5EJMFyoyQSsgn6TxOZn2prMHBy4jdMJmBbSXppXhgdwj527fonU0TrK/ZEJan5pOkyTaQ/ti9ctQvkp3/ovcbiLysrXZD2v2FAcdf9C+baMlAGeSYGS70TDJG/zpRzJJwbXiXQP3f,iv:A+0ucIQjXXPlUMK18DgRkVAbmCNXFOD1f/l/nTfJduA=,tag:A0xD9M0YO1z6xJ1R5rrUxQ==,type:str]
        e: ENC[AES256_GCM,data:ZoqVBQ==,iv:DW0xQ8g62aiXuKi8vdcuO0ReIQR9Wd65PinTQ7VWFe4=,tag:RH1oPrnQ35+51+xojIFh4Q==,type:str]
        d: ENC[AES256_GCM,data:h9YcQ0n4p1/P/gworjGa/gZwqwdhxOY3ihFRpZpZByJ0o6XjO0IJPiPD8TBzSnUYlQrnkjfkD+6As2Qcn/RGxyQ8tI8oKluPib7tZwCVJ7xsT/PFmxQJm/OMaNnipR8uahM44vtqgevXcFTIt4e0qnEF8DvXcI/BcxAbLPAlm5RtLibVKXdlb3GRQIND40U7fHZvhK9pI1zaKaMTtFRYHLTUU4L0+lj3TjHqX2VlMTCRSRYxyUVE3GUm8t5UUQEIrBzdvvh380bWJHChoD38/eU+zDwrju0O8RNT7lpd3mP2Ch+Ba3GiHkfJESvQKj9GY/w+uc/ix+Mizfx4Hc7g7XItTvn4Gqo1myVQ4nb+e0AJBaBbk4YEpR975xQQ4oyjpc6mLY7KUcINMpwy2boZBgZa1vl4yGOdVAPsXMWRSweGRe1jqSdmdauriZOhizZBjOsS8OL5,iv:NDNrHsXZEXIlhp6de9uTIEO2NIj+r+KgomHtJ8exSJ0=,tag:d2ZuSmFGuN7PF1WzOd7ftg==,type:str]
        p: ENC[AES256_GCM,data:vR/HNiMZwCUcPJgw6QrBDxqVyvafASpEp9H8GVvfVOggzYmUQX1Il4hj+yHu6AM+Bg94fEz5XHd3XHilLDCdjzbTAy4azT/R7rsDb6UZ+M3yL6w5foKE3raT9qZYfyE8EFXOGFL4J9th4QYgHoOIWziX3UIYPUZtQ9eSIecvi5Z7o8Pt9qpPpaeNBhwBHIlD2gNQKNOEzCLuO3/Ad2db1kCD6aF1hhebl3Ua,iv:Q40PEa7C0wCjf3rVFBX9NaTaPXYeCuXtdRfmMlqwAv0=,tag:9/Zphc8m/R2xVVDoG39MhA==,type:str] 
        q: ENC[AES256_GCM,data:t6IN1a/0/Wws+al0Appji4Gl8n1LZrlizAFFEIcUL7Mb9UyyTWwi0j/NlvepmT3NN0DRgooydfdvYOj0T5GJ9qyGuf6mwEpLxX7T2WoPaDUlMoLgEj4OXmazWp9wtlymC1ICcwRJoWn/7Jg41NfI0jZjqORDZfI9h5obJA4L9xavsShfTC83gttnLzI1ZO7sOjsiZrYOvvA975uS7gV9AwyXT9+LoLmU5+z6,iv:5B33mGdTZbSux7YK2Wu30X0ithjewAJsL58+swDr/7U=,tag:pce0M4WcQew220RABwEwRQ==,type:str] 
        dp: ENC[AES256_GCM,data:OOEWi5jBH3HtCq2g7FM/xlzJ2do/vdL+qd6T9hnO+7LDKOYT3K9C06p2QWa0QqgqzPl9CbMDWnmCDX2YY1DY5aVyE7wA/DOZzBZv71PbkG4Wwzj4QJ3Jcq8va8wM3SyNByaE/t9uAqxwB3QuRIOkXavGZX/vNXgAbPdcUL337OYvoTkFsLf3ogYyrF9vNOUCa1DfZXU3A52dYxYOv93WN19dNQcNxKMamvrE,iv:mOpYbPvBlgPBjw4NS+R+0bfoR8aN/BnBmfQHCGPo7OI=,tag:HwGlKBIwozY0AhSe5adqRQ==,type:str]
        dq: ENC[AES256_GCM,data:ZIDOaqXofMkhFG+6oktGDdZEqVDGpsgLcGVg4cfWb4rydAOfZq1Akg20KL3YzWFQUNcaInQf90GtfYUd0hVQvollvv4GA9YqG4jt8EjqsybRQB4NEtWA4XaGrXutv8Md6JYcv41Mmtr6uGSCb9qj+LEVbh7CWhcnaEzZsj4Owne6EI+mVsb4KGygzXwvGYAKizXQfQBzH1zlWOW3sK6NCVhfXYeuCbXTPVRR,iv:XG06PKBKUYN0EvVtoCDVn8sguSoXHJZKEkf0G/AA+b0=,tag:iN0LyeFs5UifdYlUm8Y2OA==,type:str]
        qi: ENC[AES256_GCM,data:yGOQBTv6Xk0DsFEjdw1yN7krw62hOw94Ysa/ijmKSQ5x9u8DBMT7tFmtar6b2VRZ2NPGa6vld4+IQKOr7jMgNuIdFlqoHOU95W6evSUUCZlIKRxU4PZp6/Mjq9MvR5+XAC7+e0Ej5ChGxaIfeFv+cnlKZ3WDYt1XbRVW16+fI0Wxl1/j9ZkWhX8EFz5+oHOHpw9g0lH6ruRIjFkN2KBqt+B151t9PO8E8sO4,iv:N3g9sb1PlBsMz6ppbO+KMelPf/USdtbBKAuELCM4qm4=,tag:WOE0mHjbiQC6+ZJNrrzQ9A==,type:str]
        kid: ENC[AES256_GCM,data:qFYZPtS/jik+FpA6Fea9Jdw=,iv:PjQJZMiUp19cSPzabhgeUy6+4fPW4wuPVbHD7uvhLWk=,tag:Nfa9hxTkFjMA7ymkZsxFyA==,type:str]
        alg: ENC[AES256_GCM,data:tMztG+g=,iv:F20V/lnkkhodMrWRYBPP+B7whG3Yha1P5MkUeJ2UDGk=,tag:jo3cQkUe5KrIJiQz7faiOg==,type:str]
        use: ENC[AES256_GCM,data:/4LZ,iv:lprVlWHZ3sx2GdkAakgClCgZpEhjMSmE67MuA5Ivz+w=,tag:Okz280Bi5hJMOcr9BPu7UQ==,type:str]
        fxa-createdAt: ENC[AES256_GCM,data:78RVBzFgf6/13Q==,iv:dbuGETEUgcaLOGShrZAgj6HANwTa8tfkpvNzJ+zJdZM=,tag:XVy2T6mb1Usy0rrj+VqtGQ==,type:float]
    newKey: null
    oldKey:
        kty: ENC[AES256_GCM,data:teZu,iv:8b/FSZHn+xtWchz/r3yEHcv2RqK08cpRhkC1R1uymks=,tag:URFPEW962NkQD4YLEAaBiw==,type:str]
        alg: ENC[AES256_GCM,data:dS5jAJs=,iv:TOrHA19aeDwCF/U5besbGishVVk3qUsEoz2uTC9v0dQ=,tag:jFHAjwRkVjtI3ZcpxFCjSA==,type:str]
        kid: ENC[AES256_GCM,data:Epuv+6nfO2r9jcHClrHyX7k=,iv:i4gOTw2vRofShp/8+zsI+kGCK1oRk/al14cNw8ICp5k=,tag:Nm/4yI9OZ+EssyBV0N0fCw==,type:str]
        fxa-createdAt: ENC[AES256_GCM,data:bXkD99gQ99Smgw==,iv:2h5h7pE5IjyG5K4LFjWnmFO5QHaQ6uZHYZJNbNgC5x0=,tag:KS7zQxRSBAX6TXiTMeR39Q==,type:float]
        use: ENC[AES256_GCM,data:Wuwo,iv:vphbdg1sDzvIH5e2MxVe84awJCha+bX0VN1ItYsnct0=,tag:0mprk2blliInaZEcdSe+Zw==,type:str]
        "n": ENC[AES256_GCM,data:GKWZIG0FOrL97zn2Q3UbygccpGGFSAPsUu9gassRhJRSJ6VosJX/cLLHVeQCM+0DsqJpS9Cti1b6nJn3Y/y94ABI/g0KrwLs66Q526zYb3aM4WK3FdW6IRwbkTOEzmhglYSLC7M9zah4Jrp76/vNw0iipT+bKhrKX825PTTuou0cK5L5wtmTh5WX8OzUzjATe6yQVe9xFd0im9/aS1eRu63qa36t2a0v0kuzS4/NqGdgHlUUJ6MefVXolhVgW6ubE1zW3XnwdvKDhK4Jtw8UIOS7i5WqrSVWkSFVijAFfo5/Hy0Q/5SXgoHm30f3ZRgG/StQEetEnEnhAjrKP87ELaj1iJAMbG/oq6czAvL6dG3DQGOBxdgZtRd4EN+NRElrUSMqDCD2vvTcEbC2suuikwjq0OpRz03DdEaQwj6YjHTy3KhrVSYC3XgpBo5GRHz7/RuJH1gi,iv:SkGEjK5khVStCPcdD9RyLQIYSLQheqHzkUw++L/nUeQ=,tag:QtPKnkfIvqbdgrX/u9PPgw==,type:str]
        e: ENC[AES256_GCM,data:KNAtNw==,iv:y/Pvjpxd8WS7KrhDYNS2kTh+PEsZeKW3WwInVi7EVAc=,tag:GqR+g6+Bb9H/CynCKwQK0w==,type:str]
```

Which...I think it would be better to encrypt the key as a single blob rather than encrypting each individual field, but it'll do the job, and I assume that the current production keys are encrypted similarly.

@jrgm @jbuck what do you think, is this a step in the right direction?