### PR TITLE
fix(fxa-content-server): dump scopedKeys.validation at startup

### DIFF
--- a/packages/fxa-content-server/server/bin/fxa-content-server.js
+++ b/packages/fxa-content-server/server/bin/fxa-content-server.js
@@ -252,6 +252,11 @@ function listen(theApp) {
   }
   if (isMain) {
     logger.info('Firefox Account Content server listening on port', port);
+    logger.info(
+      `Config scopedKeys.validation: ${JSON.stringify(
+        config.get('scopedKeys.validation')
+      )}`
+    );
   }
   return true;
 }


### PR DESCRIPTION
Fixes #1970 

r? - @vladikoff 