### PR TITLE
fix(api): don't return empty locales from GET /account/profile

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -973,7 +973,7 @@ module.exports = (
         if (scope.contains('profile:email')) {
           res.email = account.primaryEmail.email;
         }
-        if (scope.contains('profile:locale')) {
+        if (scope.contains('profile:locale') && account.locale) {
           res.locale = account.locale;
         }
         if (scope.contains('profile:amr')) {

--- a/packages/fxa-auth-server/test/remote/account_profile_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_profile_tests.js
@@ -325,6 +325,23 @@ describe('remote account profile', function() {
       });
   });
 
+  it('handles empty locale', () => {
+    return Client.create(config.publicUrl, server.uniqueEmail(), 'password', {
+      lang: '',
+    })
+      .then(client => {
+        return client.api.accountProfile(null, {
+          Authorization: makeMockOAuthHeader({
+            user: client.uid,
+            scope: ['profile:locale'],
+          }),
+        });
+      })
+      .then(response => {
+        assert.isUndefined(response.locale);
+      });
+  });
+
   after(() => {
     return TestServer.stop(server);
   });


### PR DESCRIPTION
Fixes [Sentry error 6094009](https://sentry.prod.mozaws.net/operations/auth-prod/issues/6094009/?environment=prod). **EDIT:** Fixes #1978.

Not sure if this is the right fix, but I took the approach of not setting `response.locale` if it's the empty string.

Alternatives include adding `allow('')` to the response schema or possibly doing something to prevent empty locales getting into the database in the first place, although the cat is already out of the bag on that one of course so it would also require updating existing records in prod.

@mozilla/fxa-devs r?