### PR TITLE
fix(payments): allow undefined subscriptions from auth-server /v1/account

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -1480,7 +1480,7 @@ module.exports = (
 
         const { uid } = request.auth.credentials;
 
-        let subscriptions;
+        let subscriptions = [];
 
         if (config.subscriptions.enabled) {
           try {

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -2871,7 +2871,7 @@ describe('/account', () => {
 
     return runTest(buildRoute(), request, result => {
       assert.deepEqual(result, {
-        subscriptions: undefined,
+        subscriptions: [],
       });
 
       assert.equal(log.begin.callCount, 1);
@@ -2898,7 +2898,7 @@ describe('/account', () => {
   it('should not return subhub.listSubscriptions result when subscriptions are disabled', () => {
     return runTest(buildRoute(false), request, result => {
       assert.deepEqual(result, {
-        subscriptions: undefined,
+        subscriptions: [],
       });
 
       assert.equal(log.begin.callCount, 1);

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -348,7 +348,7 @@ describe('remote subscriptions:', function() {
 
     it('should not return subscriptions from client.account', async () => {
       const response = await client.account();
-      assert.isUndefined(response.subscriptions);
+      assert.deepEqual(response.subscriptions, []);
     });
   });
 });

--- a/packages/fxa-content-server/app/scripts/views/settings/delete_account.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/delete_account.js
@@ -86,7 +86,7 @@ var View = FormView.extend({
   _fetchActiveSubscriptions() {
     const account = this.getSignedInAccount();
     const start = Date.now();
-    return account.settingsData().then(({ subscriptions }) => {
+    return account.settingsData().then(({ subscriptions = [] } = {}) => {
       this.logFlowEvent(`timing.settings.fetch.${Date.now() - start}`);
       this._activeSubscriptions = subscriptions.filter(
         subscription => subscription.status === 'active'


### PR DESCRIPTION
fixes #1984

At least, I *think* this fixes it. The validator seems to be letting a missing or undefined `subscriptions` property on the accounts data response go by without error in my local stack. But, I think this is what the problem is on dev.