### PR TITLE
fix(content): clear up browser memory after most content-server tests

### DIFF
--- a/.circleci/test-content-server.sh
+++ b/.circleci/test-content-server.sh
@@ -46,14 +46,14 @@ if grep -e "$MODULE" -e 'all' $DIR/../packages/test.list; then
 
   cd ../../
   npx pm2 delete servers.json && npx pm2 start servers.json
-  # ensure email-service is ready
-  check 127.0.0.1:8001/__heartbeat__
   cd packages/fxa-content-server
   mozdownload --version 58.0 --destination firefox.tar.bz2
 
   if [ -n "${PAIRING}" ]; then
     wget https://s3-us-west-2.amazonaws.com/fxa-dev-bucket/fenix-pair/desktop/7f10c7614e9fa46-target.tar.bz2
     mozinstall 7f10c7614e9fa46-target.tar.bz2
+    # ensure email-service is ready
+    check 127.0.0.1:8001/__heartbeat__
     test_suite pairing
 
     mozinstall firefox.tar.bz2
@@ -61,6 +61,8 @@ if grep -e "$MODULE" -e 'all' $DIR/../packages/test.list; then
 
   else
     mozinstall firefox.tar.bz2
+    # ensure email-service is ready
+    check 127.0.0.1:8001/__heartbeat__
     test_suite circle
   fi
 else

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -437,6 +437,21 @@ const closeAllButFirstWindow = thenify(function() {
   });
 });
 
+/**
+ * Get some memory back
+ *
+ */
+const cleanMemory = thenify(function(selector, attributeName) {
+  return (
+    this.parent
+      .get('about:memory')
+      // Click the Minimize Memory Usage button
+      .then(click('div.opsRow:nth-child(3) > button:nth-child(4)'))
+      .then(testElementExists('.section'))
+      .end()
+  );
+});
+
 const clearBrowserState = thenify(function(options) {
   options = options || {};
   if (!('contentServer' in options)) {
@@ -467,6 +482,7 @@ const clearBrowserState = thenify(function(options) {
         return this.parent.then(clear123DoneState({ untrusted: true }));
       }
     })
+    .then(cleanMemory())
     .then(closeAllButFirstWindow());
 });
 
@@ -2186,21 +2202,6 @@ const noSuchAttribute = thenify(function(selector, attributeName) {
       assert.isTrue(attributeValue === '' || attributeValue === null);
     })
     .end();
-});
-
-/**
- * Get some memory back
- *
- */
-const cleanMemory = thenify(function(selector, attributeName) {
-  return (
-    this.parent
-      .get('about:memory')
-      // Click the Minimize Memory Usage button
-      .then(click('div.opsRow:nth-child(3) > button:nth-child(4)'))
-      .then(testElementExists('.section'))
-      .end()
-  );
 });
 
 /**


### PR DESCRIPTION
Many content-server tests call `clearBrowserState` in `beforeEach`. That seems like a lazy place to stick a call to `clearMemory`.

For more context: I'm not sure if this is the best solution, but I'm opening a PR to try kicking off CircleCI and see if it regularly makes it through the `test-content-server` task. Ran these tests manually in an ssh session and saw Firefox dying off regularly with a core dump, which went away when I started sprinkling in `clearMemory` calls.