### PR TITLE
fix(config): Make OIDC key file paths relative to project root.

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/config/dev.json
+++ b/packages/fxa-auth-server/fxa-oauth-server/config/dev.json
@@ -194,9 +194,9 @@
   },
   "openid": {
     "issuer": "http://127.0.0.1:3030",
-    "keyFile": "../config/key.json",
-    "newKeyFile": "../config/newKey.json",
-    "oldKeyFile": "../config/oldKey.json"
+    "keyFile": "config/key.json",
+    "newKeyFile": "config/newKey.json",
+    "oldKeyFile": "config/oldKey.json"
   },
   "ppid": {
     "enabled": true,

--- a/packages/fxa-auth-server/fxa-oauth-server/config/test.json
+++ b/packages/fxa-auth-server/fxa-oauth-server/config/test.json
@@ -131,9 +131,9 @@
   },
   "openid": {
     "issuer": "http://127.0.0.1:3030",
-    "keyFile": "../config/key.json",
-    "newKeyFile": "../config/newKey.json",
-    "oldKeyFile": "../config/oldKey.json"
+    "keyFile": "config/key.json",
+    "newKeyFile": "config/newKey.json",
+    "oldKeyFile": "config/oldKey.json"
   },
   "ppid": {
     "enabled": true,

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/config.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/config.js
@@ -421,9 +421,10 @@ conf.validate(options);
 
 // Load our various keys from files if specified,
 // resolving paths to absolute form to remove any ambiguity.
+// All paths are relative to the project root directory.
 
 if (conf.get('openid.keyFile')) {
-  const keyFile = path.resolve(__dirname, conf.get('openid.keyFile'));
+  const keyFile = path.resolve(__dirname, '..', conf.get('openid.keyFile'));
   conf.set('openid.keyFile', keyFile);
   // If the file doesnt exist, or contains an empty object, then there's no active key.
   conf.set('openid.key', null);
@@ -438,7 +439,11 @@ if (conf.get('openid.keyFile')) {
 }
 
 if (conf.get('openid.newKeyFile')) {
-  const newKeyFile = path.resolve(__dirname, conf.get('openid.newKeyFile'));
+  const newKeyFile = path.resolve(
+    __dirname,
+    '..',
+    conf.get('openid.newKeyFile')
+  );
   conf.set('openid.newKeyFile', newKeyFile);
   // If the file doesnt exist, or contains an empty object, then there's no new key.
   conf.set('openid.newKey', null);
@@ -453,7 +458,11 @@ if (conf.get('openid.newKeyFile')) {
 }
 
 if (conf.get('openid.oldKeyFile')) {
-  const oldKeyFile = path.resolve(__dirname, conf.get('openid.oldKeyFile'));
+  const oldKeyFile = path.resolve(
+    __dirname,
+    '..',
+    conf.get('openid.oldKeyFile')
+  );
   conf.set('openid.oldKeyFile', oldKeyFile);
   // If the file doesnt exist, or contains an empty object, then there's no old key.
   conf.set('openid.oldKey', null);


### PR DESCRIPTION
In https://github.com/mozilla/fxa/pull/1962#issuecomment-516103989 @jbuck noted that the config options for OIDC key file paths are not very intuitive; they're relative to the location of `./lib/config.js`.  This rejiggers things so that they're relative to the project root directory, which should be a little easier to explain and understand.

There's a small change this may break some tests or dev environments if they are explicitly setting these config values rather than taking the defaults, but let's see what happens in CI...