### PR TITLE
chore(test): Remove extra calls to `cleanMemory`

### DIFF
--- a/packages/fxa-content-server/tests/functional/refreshes_metrics.js
+++ b/packages/fxa-content-server/tests/functional/refreshes_metrics.js
@@ -10,7 +10,6 @@ var AUTOMATED = '?automatedBrowser=true';
 var SIGNUP_URL = intern._config.fxaContentRoot + 'signup' + AUTOMATED;
 var SIGNIN_URL = intern._config.fxaContentRoot + 'signin' + AUTOMATED;
 
-var cleanMemory = FunctionalHelpers.cleanMemory;
 var clearBrowserState = FunctionalHelpers.clearBrowserState;
 var openPage = FunctionalHelpers.openPage;
 var testAreEventsLogged = FunctionalHelpers.testAreEventsLogged;
@@ -24,7 +23,6 @@ registerSuite('refreshing a screen logs a refresh event', {
     'refreshing the signup screen': function() {
       return (
         this.remote
-          .then(cleanMemory())
           .then(openPage(SIGNUP_URL, '#fxa-signup-header'))
 
           .refresh()

--- a/packages/fxa-content-server/tests/functional/send_sms.js
+++ b/packages/fxa-content-server/tests/functional/send_sms.js
@@ -34,7 +34,6 @@ let formattedPhoneNumber;
 const {
   click,
   clearBrowserState,
-  cleanMemory,
   closeCurrentWindow,
   deleteAllSms,
   disableInProd,
@@ -87,7 +86,6 @@ const suite = {
     // no need to verify.
     return (
       this.remote
-        .then(cleanMemory())
         .then(clearBrowserState({ force: true }))
         .then(fillOutSignUp(email, PASSWORD))
         .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))

--- a/packages/fxa-content-server/tests/functional/settings.js
+++ b/packages/fxa-content-server/tests/functional/settings.js
@@ -15,7 +15,6 @@ var SIGNIN_URL = config.fxaContentRoot + 'signin';
 var SETTINGS_URL = config.fxaContentRoot + 'settings';
 
 const {
-  cleanMemory,
   clearBrowserState,
   click,
   closeCurrentWindow,
@@ -33,7 +32,7 @@ const {
   testElementTextEquals,
   testErrorTextInclude,
   type,
-  visibleByQSA
+  visibleByQSA,
 } = FunctionalHelpers;
 
 var FIRST_PASSWORD = 'password';
@@ -45,7 +44,6 @@ registerSuite('settings', {
     email = TestHelpers.createEmail();
 
     return this.remote
-      .then(cleanMemory())
       .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
       .then(function(result) {
         accountData = result;
@@ -181,23 +179,24 @@ registerSuite('settings', {
         .then(testElementExists('#avatar-options'));
     },
 
-    'sign in, go to settings and opening display_name panel autofocuses the first input element': function () {
-      return this.remote
-        .then(fillOutSignIn(email, FIRST_PASSWORD, true))
-        .then(click('[data-href="settings/display_name"]'))
-        .then(testElementExists('input.display-name'))
- 
-        // first element is focused
-        .getActiveElement()
-        .then(function (element) {
-          element.getAttribute('class')
-            .then(function (className) {
+    'sign in, go to settings and opening display_name panel autofocuses the first input element': function() {
+      return (
+        this.remote
+          .then(fillOutSignIn(email, FIRST_PASSWORD, true))
+          .then(click('[data-href="settings/display_name"]'))
+          .then(testElementExists('input.display-name'))
+
+          // first element is focused
+          .getActiveElement()
+          .then(function(element) {
+            element.getAttribute('class').then(function(className) {
               assert.isTrue(className.includes('display-name'));
             });
-        })
-        .end();
+          })
+          .end()
+      );
     },
- 
+
     'sign in, open settings and add a display name': function() {
       var name = 'joe';
       return this.remote


### PR DESCRIPTION
Now that `cleanMemory` is called from `clearBrowserState`,
it no longer needs to be called manually from the test suites.

Not attached to an issue.

@mozilla/fxa-devs - r?