### PR TITLE
feat(payments): add breadcrumb navigation to contact and sub list

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/support.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/support.mustache
@@ -3,6 +3,12 @@
     <h1 id="fxa-manage-account"><span class="fxa-account-title">{{#t}}Firefox Accounts{{/t}}</span></h1>
   </header>
 
+  <ol class="breadcrumbs">
+    <li><a href="/settings">Account Home</a></li>
+    <li><a href="/subscriptions">Subscriptions</a></li>
+    <li><a href="/support">Contact Us</a></li>
+  </ol>
+
   <div class="settings-success-wrapper">
     <div class="success settings-success"></div>
   </div>

--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -62,6 +62,7 @@ body.settings #stage .settings {
   align-items: center;
   align-self: center;
   display: flex;
+  flex-direction: column;
   width: 100%;
 
   @include respond-to('big') {
@@ -779,5 +780,28 @@ section.modal-panel {
   html[dir='rtl'] & {
     background-position: center left;
     padding-left: 25px;
+  }
+}
+
+.breadcrumbs {
+  width: 100%;
+  margin-top: 0px;
+  margin-left: 100px;
+
+  li {
+    list-style: none;
+    float: left;
+    margin: 0px;
+    padding: 0px;
+
+    &:before {
+      content: "\003E";
+      padding: 0px 10px;
+    }
+
+    &:first-child:before {
+      content: "";
+      padding: 0px;
+    }
   }
 }

--- a/packages/fxa-payments-server/src/components/AppLayout/index.scss
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.scss
@@ -5,8 +5,12 @@
   background-image: url('./images/firefox-logo.svg');
 }
 
-#fxa-settings-header-wrapper #fxa-manage-account {
-  background-image: url('./images/firefox-logo.svg');
+#fxa-settings-header-wrapper {
+  flex-direction: column;
+
+  #fxa-manage-account {
+    background-image: url('./images/firefox-logo.svg');
+  }
 }
 
 #about-mozilla {
@@ -23,5 +27,28 @@
 
   &.spinner-settings-fetch {
     background-image: url('./images/spinnergrey.png');
+  }
+}
+
+.breadcrumbs {
+  margin-left: 100px;
+  margin-top: 0;
+  width: 100%;
+
+  li {
+    float: left;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    &::before {
+      content: '\003E';
+      padding: 0 10px;
+    }
+
+    &:first-child::before {
+      content: '';
+      padding: 0;
+    }
   }
 }

--- a/packages/fxa-payments-server/src/components/AppLayout/index.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode, useEffect } from 'react';
+import React, { ReactNode, useEffect, useContext } from 'react';
+import { AppContext } from '../../lib/AppContext';
 
 import './index.scss';
 
@@ -47,6 +48,15 @@ export const SettingsLayout = ({
     return () => document.body.classList.remove('settings');
   }, [ children ]);
 
+  const { config } = useContext(AppContext);
+  const homeURL = `${config.servers.content.url}/settings`;
+  let breadcrumbs = (
+      <ol className="breadcrumbs">
+        <li><a href={homeURL}>Account Home</a></li>
+        <li><a href="/subscriptions">Subscriptions</a></li>
+      </ol>
+  );
+
   return (
     <AppLayout>
       <div className="settings">
@@ -58,6 +68,7 @@ export const SettingsLayout = ({
               <button id="signout" className="settings-button secondary-button">Sign out</button>
               */}
           </header>
+          {breadcrumbs}
         </div>
 
         <div id="fxa-settings">


### PR DESCRIPTION
- fixes #1693

Still need to find a way to detect which environment we are running in, so that in the breadcrumbs that are in the support form page (content  server) can link to the subscriptions list page (payments server) and vice versa.

![contact-breadcrumbs](https://user-images.githubusercontent.com/1844554/62154576-fbdebc00-b2d4-11e9-9cb5-26e27f111e6e.png)
![sub-list](https://user-images.githubusercontent.com/1844554/62154577-fbdebc00-b2d4-11e9-9fd0-66cbba6e6a2a.png)
