### PR TITLE
fix(security): update HSTS to 31536000

### DIFF
--- a/packages/browserid-verifier/lib/server.js
+++ b/packages/browserid-verifier/lib/server.js
@@ -53,7 +53,7 @@ app.use(function(req, res, next) {
   res.setHeader('X-XSS-Protection', '1; mode=block');
   res.setHeader('X-Content-Type-Options', 'nosniff');
   res.setHeader('X-Frame-Options', 'DENY');
-  res.setHeader('Strict-Transport-Security', 'max-age=15552000');
+  res.setHeader('Strict-Transport-Security', 'max-age=31536000');
   res.setHeader(
     'Content-Security-Policy',
     "default-src 'none'; frame-ancestors 'none'; report-uri /__cspreport__"

--- a/packages/browserid-verifier/tests/lib/should-return-security-headers.js
+++ b/packages/browserid-verifier/tests/lib/should-return-security-headers.js
@@ -6,7 +6,7 @@ var should = require('should');
 
 function shouldReturnSecurityHeaders(res) {
   var expect = {
-    'strict-transport-security': 'max-age=15552000',
+    'strict-transport-security': 'max-age=31536000',
     'x-content-type-options': 'nosniff',
     'x-xss-protection': '1; mode=block',
     'x-frame-options': 'DENY',

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/server/config.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/server/config.js
@@ -17,7 +17,7 @@ module.exports = {
     },
     security: {
       hsts: {
-        maxAge: 15552000,
+        maxAge: 31536000,
         includeSubdomains: true,
       },
       xframe: true,

--- a/packages/fxa-auth-server/fxa-oauth-server/test/lib/util.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/lib/util.js
@@ -7,7 +7,7 @@ const config = require('../../lib/config').getProperties();
 
 function assertSecurityHeaders(res, expect = {}) {
   expect = {
-    'strict-transport-security': 'max-age=15552000; includeSubDomains',
+    'strict-transport-security': 'max-age=31536000; includeSubDomains',
     'x-content-type-options': 'nosniff',
     'x-xss-protection': '1; mode=block',
     'x-frame-options': 'DENY',

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -147,7 +147,7 @@ async function create(log, error, config, routes, db, oauthdb, translator) {
       },
       security: {
         hsts: {
-          maxAge: 15552000,
+          maxAge: 31536000,
           includeSubdomains: true,
         },
       },

--- a/packages/fxa-auth-server/test/remote/misc_tests.js
+++ b/packages/fxa-auth-server/test/remote/misc_tests.js
@@ -179,7 +179,7 @@ describe('remote misc', function() {
     }).spread((res, body) => {
       assert.equal(
         res.headers['strict-transport-security'],
-        'max-age=15552000; includeSubDomains'
+        'max-age=31536000; includeSubDomains'
       );
     });
   });

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -269,7 +269,7 @@ const conf = (module.exports = convict({
     },
   },
   hsts_max_age: {
-    default: 15552000, // 180 days
+    default: 31536000, // a year
     doc: 'Max age of the STS directive in seconds',
     // Note: This format is a number because the value needs to be in seconds
     format: Number,

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -22,7 +22,7 @@ const conf = convict({
     format: [ 'development', 'production' ],
   },
   hstsMaxAge: {
-    default: 15552000, // 180 days
+    default: 31536000, // a year
     doc: 'Max age of the STS directive in seconds',
     // Note: This format is a number because the value needs to be in seconds
     format: Number

--- a/packages/fxa-profile-server/lib/server/web.js
+++ b/packages/fxa-profile-server/lib/server/web.js
@@ -52,7 +52,7 @@ exports.create = function createServer() {
         cors: true,
         security: {
           hsts: {
-            maxAge: 15552000,
+            maxAge: 31536000,
             includeSubdomains: true,
           },
           xframe: true,

--- a/packages/fxa-profile-server/test/lib/util.js
+++ b/packages/fxa-profile-server/test/lib/util.js
@@ -6,7 +6,7 @@ const assert = require('insist');
 
 function assertSecurityHeaders(res) {
   var expect = {
-    'strict-transport-security': 'max-age=15552000; includeSubDomains',
+    'strict-transport-security': 'max-age=31536000; includeSubDomains',
     'x-content-type-options': 'nosniff',
     'x-xss-protection': '1; mode=block',
     'x-frame-options': 'DENY',


### PR DESCRIPTION
Update HSTS to the value asked on the Security Checklist.

For consistency, I'm updating all the HSTS max-age values in the monorepo.

Part of #1128

@mozilla/fxa-devs r>