### PR TITLE
fix(subscriptions): properly handle subhub listSubscriptions response

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -1484,7 +1484,7 @@ module.exports = (
 
         if (config.subscriptions.enabled) {
           try {
-            subscriptions = await subhub.listSubscriptions(uid);
+            ({ subscriptions } = await subhub.listSubscriptions(uid));
           } catch (err) {
             if (err.errno !== error.ERRNO.UNKNOWN_SUBSCRIPTION_CUSTOMER) {
               throw err;

--- a/packages/fxa-auth-server/lib/subhub/stubAPI.js
+++ b/packages/fxa-auth-server/lib/subhub/stubAPI.js
@@ -32,7 +32,9 @@ module.exports.buildStubAPI = function buildStubAPI(log, config) {
     },
 
     async listSubscriptions(uid) {
-      return storage.subscriptionsByUid[uid] || [];
+      return {
+        subscriptions: storage.subscriptionsByUid[uid] || []
+      };
     },
 
     async createSubscription(uid, pmt_token, plan_id, display_name, email) {

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -2824,7 +2824,9 @@ describe('/account', () => {
   beforeEach(async () => {
     log = mocks.mockLog();
     subhub = mocks.mockSubHub({
-      listSubscriptions: sinon.spy(async () => [subscription]),
+      listSubscriptions: sinon.spy(async () => ({
+        subscriptions: [ subscription ]
+      })),
     });
     request = mocks.mockRequest({
       credentials: { uid },


### PR DESCRIPTION
fixes #2006

Okay, I think I got it: subhub does not respond with a plain list of subscriptions for `GET /v1/customer/:uid/subscriptions`. Instead, [it responds with an object `{ subscriptions: [] }` that contains a list of subscriptions](https://github.com/mozilla/subhub/issues/178).

On our side, we were erroneously expecting a plain list all the way through mocks, tests, client code, and the front end code. So... this should fix that.