### PR TITLE
Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,15 @@
 {
+  "automerge": false,
+  "branchPrefix": "renovate/",
   "extends": [
     "config:base"
   ],
-  "prConcurrentLimit": 2,
-  "schedule": "every weekend",
-  "automerge": false,
-  "branchPrefix": "renovate/",
   "includePaths": [
     "packages/fxa-payments-server/package.json",
-    "packages/fxa-payments-server/Dockerfile"
-  ]
+    "packages/fxa-payments-server/Dockerfile",
+    "packages/fxa-support-panel/package.json"
+  ],
+  "rangeStrategy": "replace",
+  "prConcurrentLimit": 2,
+  "schedule": "every weekend"
 }


### PR DESCRIPTION
This PR adds support-server to renovate's list of managed package.json files, and also updates the [`rangeStrategy`](https://renovatebot.com/docs/configuration-options/#rangestrategy) to `replace` old ranges with new ones when a package gets a major version bump.

I'm curious what factors led to the current FxA approach of using lockfiles and specifying ranges. Renovate provides a [lengthy article](https://renovatebot.com/docs/dependency-pinning/) on pros and cons of dependency pinning approaches, but I'm not sure what would be best for FxA.

Feedback welcome!