### PR TITLE
chore(legal): add a page for subplat terms of service

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -582,6 +582,10 @@ var ERRORS = {
     errno: 1062,
     message: t('Invalid redirect'),
   },
+  COULD_NOT_GET_SUBPLAT_TOS: {
+    errno: 1063,
+    message: t('Could not get Subscription Platform Terms of Service'),
+  },
 };
 /*eslint-enable sorting/sort-object-props*/
 

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -127,6 +127,7 @@ const Router = Backbone.Router.extend({
     'force_auth(/)': createViewHandler(ForceAuthView),
     'legal(/)': createViewHandler('legal'),
     'legal/privacy(/)': createViewHandler('pp'),
+    'legal/subscription_terms(/)': createViewHandler('subscription_terms'),
     'legal/terms(/)': createViewHandler('tos'),
     'oauth(/)': createViewHandler(OAuthIndexView),
     'oauth/force_auth(/)': createViewHandler(ForceAuthView),

--- a/packages/fxa-content-server/app/scripts/templates/subscription_terms.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/subscription_terms.mustache
@@ -1,0 +1,18 @@
+<div id="main-content" class="panel">
+  <header id="legal-header">
+    <h1 id="fxa-subscription-terms-header">{{#t}}Subscription Platform Terms of Service{{/t}}</h1>
+  </header>
+
+  <section class="hidden">
+    <div class="error"></div>
+
+    <article id="legal-copy">
+    </article>
+
+    {{#canGoBack}}
+      <div class="button-row">
+        <button id="fxa-subscription-terms-back" class="back primary-button">{{#t}}Back{{/t}}</button>
+      </div>
+    {{/canGoBack}}
+  </section>
+</div>

--- a/packages/fxa-content-server/app/scripts/views/subscription_terms.js
+++ b/packages/fxa-content-server/app/scripts/views/subscription_terms.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import AuthErrors from '../lib/auth-errors';
+import LegalCopyView from './legal_copy';
+import Template from 'templates/subscription_terms.mustache';
+
+const View = LegalCopyView.extend({
+  className: 'subscription-terms',
+  copyUrl: '/legal/subscription_terms',
+  events: {
+    'click #fxa-subscription-terms-back': 'back',
+    'keyup #fxa-subscription-terms-back': 'backOnEnter',
+  },
+  fetchError: AuthErrors.toError('COULD_NOT_GET_SUBPLAT_TOS'),
+  template: Template,
+});
+
+export default View;

--- a/packages/fxa-content-server/app/tests/spec/views/subscription_terms.js
+++ b/packages/fxa-content-server/app/tests/spec/views/subscription_terms.js
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import chai from 'chai';
+import sinon from 'sinon';
+import View from 'views/subscription_terms';
+import WindowMock from '../../mocks/window';
+
+var assert = chai.assert;
+
+var TEMPLATE_TEXT =
+  '<span id="fxa-subscription-terms-header"></span>' +
+  '<a id="data-visible-url-added" href="https://accounts.firefox.com">Firefox Accounts</a>' +
+  '<a id="data-visible-url-not-added" href="https://mozilla.org">https://mozilla.org</a>';
+
+describe('views/subscription_terms', function() {
+  var view;
+  var xhrMock;
+  var windowMock;
+
+  beforeEach(function() {
+    xhrMock = {
+      ajax() {
+        return Promise.resolve(TEMPLATE_TEXT);
+      },
+    };
+
+    windowMock = new WindowMock();
+    windowMock.location.pathname = '/legal/subscription_terms';
+
+    view = new View({
+      broker: {
+        hasCapability: () => true,
+      },
+      window: windowMock,
+      xhr: xhrMock,
+    });
+  });
+
+  afterEach(function() {
+    view.remove();
+    view.destroy();
+  });
+
+  it('Back button is displayed if there is a page to go back to', function() {
+    sinon.stub(view, 'canGoBack').callsFake(function() {
+      return true;
+    });
+
+    return view.render().then(function() {
+      assert.equal(view.$('#fxa-subscription-terms-back').length, 1);
+    });
+  });
+
+  it('sets a cookie that lets the server correctly handle page refreshes', function() {
+    return view.render().then(function() {
+      assert.isTrue(
+        /canGoBack=1; path=\/legal\/subscription_terms/.test(
+          windowMock.document.cookie
+        )
+      );
+    });
+  });
+
+  it('Back button is not displayed if there is no page to go back to', function() {
+    sinon.stub(view, 'canGoBack').callsFake(function() {
+      return false;
+    });
+
+    return view.render().then(function() {
+      assert.equal(view.$('#fxa-subscription-terms-back').length, 0);
+    });
+  });
+
+  it('fetches translated text from the backend', function() {
+    sinon.spy(xhrMock, 'ajax');
+
+    return view.render().then(function() {
+      assert.isTrue(xhrMock.ajax.called);
+      assert.ok(view.$('#fxa-subscription-terms-header').length);
+    });
+  });
+
+  it('shows an error if fetch fails', function() {
+    sinon.stub(xhrMock, 'ajax').callsFake(function() {
+      return Promise.reject(new Error('could not fetch resource'));
+    });
+
+    return view.render().then(function() {
+      assert.isTrue(xhrMock.ajax.called);
+      assert.isTrue(view.isErrorVisible());
+    });
+  });
+
+  it('adds a `data-visible-url` to an anchor if the href and the text differ', function() {
+    return view.render().then(function() {
+      assert.equal(
+        view.$('#data-visible-url-added').attr('data-visible-url'),
+        'https://accounts.firefox.com'
+      );
+    });
+  });
+
+  it('does not add a `data-visible-url` to an anchor if the href is the same as the text', function() {
+    return view.render().then(function() {
+      assert.equal(
+        typeof view.$('#data-visible-url-not-added').attr('data-visible-url'),
+        'undefined'
+      );
+    });
+  });
+});

--- a/packages/fxa-content-server/app/tests/test_start.js
+++ b/packages/fxa-content-server/app/tests/test_start.js
@@ -257,6 +257,7 @@ require('./spec/views/sign_up_password');
 require('./spec/views/sms_send');
 require('./spec/views/sms_sent');
 require('./spec/views/sub_panels');
+require('./spec/views/subscription_terms');
 require('./spec/views/subscriptions_management_redirect');
 require('./spec/views/subscriptions_product_redirect');
 require('./spec/views/support');

--- a/packages/fxa-content-server/server/lib/legal-templates.js
+++ b/packages/fxa-content-server/server/lib/legal-templates.js
@@ -8,11 +8,26 @@ const path = require('path');
 const logger = require('./logging/log')('legal-templates');
 
 module.exports = function(i18n, root) {
-  const TOS_ROOT_PATH = path.join(root, 'terms');
-  const PP_ROOT_PATH = path.join(root, 'privacy');
+  const TOS = 'terms';
+  const PP = 'privacy';
+  const SUBPLAT_TOS = 'subscription_terms';
+  const TOS_ROOT_PATH = path.join(root, TOS);
+  const PP_ROOT_PATH = path.join(root, PP);
+  // const SUBPLAT_TOS_ROOT_PATH = path.join(root, SUBPLAT_TOS);
 
   function getRoot(type) {
-    return type === 'terms' ? TOS_ROOT_PATH : PP_ROOT_PATH;
+    switch (type) {
+      case PP:
+        return PP_ROOT_PATH;
+      case SUBPLAT_TOS:
+        // TODO! Fix once we have legal copy template for the subplat tos
+        // return SUBPLAT_TOS_ROOT_PATH;
+        return TOS_ROOT_PATH;
+      case TOS:
+        return TOS_ROOT_PATH;
+      default:
+        return TOS_ROOT_PATH;
+    }
   }
 
   const templateCache = {};

--- a/packages/fxa-content-server/server/lib/routes/get-terms-privacy.js
+++ b/packages/fxa-content-server/server/lib/routes/get-terms-privacy.js
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /**
- * <locale>/legal/terms and <locale>/legal/privacy
+ * <locale>/legal/terms, <locale>/legal/privacy
+ * and <locale>/legal/subscription_terms
  * Translation done by fetching appropriate template for language.
  * If language is not found, fall back to en-US.
  *
@@ -43,7 +44,9 @@ module.exports = function verRoute(i18n) {
   // * /<locale>/legal/terms
   // * /legal/privacy
   // * /<locale>/legal/privacy
-  route.path = /^\/(?:([a-zA-Z-\_]*)\/)?legal\/(terms|privacy)(?:\/)?$/;
+  // * /legal/subscription_terms
+  // * /<locale>/legal/subscription_terms
+  route.path = /^\/(?:([a-zA-Z-\_]*)\/)?legal\/(terms|privacy|subscription_terms)(?:\/)?$/;
 
   route.process = function(req, res, next) {
     const lang = req.params[0] || req.lang;

--- a/packages/fxa-content-server/server/templates/pages/src/subscription_terms.html
+++ b/packages/fxa-content-server/server/templates/pages/src/subscription_terms.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html dir="{{ lang_dir }}" lang="{{ lang }}">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <title>
+            {{#t}}Firefox Accounts{{/t}}: {{#t}}Subscription Platform Terms of Service{{/t}}
+        </title>
+        <meta name="description" content="" />
+        <meta name="viewport" content="width=device-width" />
+        <meta name="referrer" content="origin" />
+        <meta name="robots" content="noindex,nofollow" />
+
+        <!-- build:css(.tmp) /styles/main.css -->
+        <link rel="stylesheet" href="/styles/main.css" />
+        <!-- endbuild -->
+    </head>
+    <body class="static" data-static-resource-host="{{{staticResourceUrl}}}">
+        <div id="stage">
+            <div id="main-content" class="panel">
+                <header id="legal-header">
+                    <h1 id="fxa-subscription-terms-header">{{#t}}Subscription Platform Terms of Service{{/t}}</h1>
+                </header>
+                <section>
+                    <article id="legal-copy">
+                        {{{ subscription_terms }}}
+                    </article>
+                </section>
+            </div>
+        </div>
+        <div id="static-footer">
+            <a
+                id="about-mozilla"
+                rel="author"
+                target="_blank"
+                href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"
+            ></a>
+        </div>
+    </body>
+</html>

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -68,6 +68,7 @@ module.exports = [
   'tests/functional/sign_in_token_code.js',
   'tests/functional/sign_in_totp.js',
   'tests/functional/sign_up.js',
+  'tests/functional/subscription_terms.js',
   'tests/functional/support.js',
   'tests/functional/sync_v1.js',
   'tests/functional/sync_v2.js',

--- a/packages/fxa-content-server/tests/functional/subscription_terms.js
+++ b/packages/fxa-content-server/tests/functional/subscription_terms.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { registerSuite } = intern.getInterface('object');
+const FunctionalHelpers = require('./lib/helpers');
+const PAGE_URL = intern._config.fxaContentRoot + 'legal/subscription_terms';
+const LEGAL_URL = intern._config.fxaContentRoot + 'legal';
+const subplatTosLinkSelector = '.links > a:nth-child(3)';
+const backButtonSelector = '#fxa-subscription-terms-back';
+const legalHeaderSelector = '#fxa-legal-header';
+
+const { click, noSuchElement, openPage } = FunctionalHelpers;
+
+/**
+ * Since the new page is not linked from anywhere at the time of writing, we
+ * cannot test its back button.
+ */
+
+registerSuite('subscription platform terms of service', {
+  beforeEach: function() {
+    return this.remote.then(FunctionalHelpers.clearBrowserState());
+  },
+  tests: {
+    'start at /legal': function() {
+      this.skip();
+      return this.remote
+        .then(openPage(LEGAL_URL, legalHeaderSelector))
+        .then(click(subplatTosLinkSelector, backButtonSelector))
+        .then(click(backButtonSelector, legalHeaderSelector))
+        .end();
+    },
+
+    'browse directly to page - no back button': function() {
+      return this.remote
+        .then(openPage(PAGE_URL, '#fxa-subscription-terms-header'))
+        .then(noSuchElement(backButtonSelector))
+        .end();
+    },
+
+    'refresh, back button is available': function() {
+      this.skip();
+      return this.remote
+        .then(openPage(LEGAL_URL, legalHeaderSelector))
+        .then(click(subplatTosLinkSelector, backButtonSelector))
+        .end()
+        .refresh()
+        .then(click(backButtonSelector, '#fxa-legal-header'))
+        .end();
+    },
+  },
+});


### PR DESCRIPTION
Add /legal/subscription_terms to the content server.  It serves the
regular ToS until the actual content is available.  (See TODO in
fxa-content-server/server/lib/legal-templates.js.)

Part of #1986

@mozilla/fxa-devs r?