### PR TITLE
fix(tv): fixed some ui glitches on Fire TV

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/complete_reset_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/complete_reset_password.mustache
@@ -59,7 +59,7 @@
 
       <div class="input-row password-row">
         <input type="password" class="password check-password tooltip-below" id="password" placeholder="{{#t}}New password{{/t}}" pattern=".{8,}" required autofocus data-synchronize-show="true"/>
-        <div class="helper-balloon"></div>
+        <div class="helper-balloon" tabindex="-1"></div>
       </div>
 
 

--- a/packages/fxa-content-server/app/scripts/templates/settings/change_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/change_password.mustache
@@ -27,7 +27,7 @@
 
       <div class="input-row password-row">
         <input type="password" class="password check-password tooltip-below" id="new_password" placeholder="{{#t}}New password{{/t}}" required pattern=".{8,}"  data-synchronize-show="true"/>
-        <div class="helper-balloon"></div>
+        <div class="helper-balloon" tabindex="-1"></div>
       </div>
 
       <div class="input-row password-row">
@@ -41,4 +41,3 @@
     </form>
   </div>
 </div>
-

--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -36,7 +36,7 @@
 
       <div class="input-row password-row">
         <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required data-form-prefill="password" data-synchronize-show="true" />
-        <div class="helper-balloon"></div>
+        <div class="helper-balloon" tabindex="-1"></div>
       </div>
 
       <div class="input-row password-row">

--- a/packages/fxa-content-server/app/scripts/views/form.js
+++ b/packages/fxa-content-server/app/scripts/views/form.js
@@ -383,14 +383,20 @@ var FormView = BaseView.extend({
 
     const markElementInvalidAndFocus = describedById => {
       this.markElementInvalid($invalidEl, describedById);
-      try {
-        // wait until next tick to focus otherwise
-        // on screen keyboard may cover message
-        setTimeout(() => $invalidEl.get(0).focus());
-      } catch (e) {
-        // IE can blow up if the element is not visible.
-      }
-
+      // wait to focus otherwise
+      // on screen keyboard may cover message
+      setTimeout(
+        () => {
+          try {
+            $invalidEl.get(0).focus();
+          } catch (e) {
+            // IE can blow up if the element is not visible.
+          }
+        },
+        // Create account page needs a bit more time than next tick
+        // for some unknown reason. Maybe investigate later...
+        200
+      );
       // used for testing
       this.trigger('validation_error', el, message);
     };

--- a/packages/fxa-content-server/app/scripts/views/mixins/coppa-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/coppa-mixin.js
@@ -121,6 +121,8 @@ export default function(config = {}) {
           keyCode === KeyCodes.TAB ||
           keyCode === KeyCodes.LEFT_ARROW ||
           keyCode === KeyCodes.RIGHT_ARROW ||
+          keyCode === KeyCodes.UP_ARROW ||
+          keyCode === KeyCodes.DOWN_ARROW ||
           keyCode === KeyCodes.ENTER ||
           (keyCode >= KeyCodes.NUM_0 && keyCode <= KeyCodes.NUM_9) ||
           (keyCode >= KeyCodes.NUMPAD_0 && keyCode <= KeyCodes.NUMPAD_9)

--- a/packages/fxa-content-server/app/scripts/views/mixins/password-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/password-mixin.js
@@ -5,6 +5,7 @@
 // helper functions for views with passwords. Meant to be mixed into views.
 
 import $ from 'jquery';
+import KeyCodes from '../../lib/key-codes';
 import AuthErrors from '../../lib/auth-errors';
 import showPasswordTemplate from 'templates/partial/show-password.mustache';
 
@@ -19,6 +20,7 @@ export default {
     'keyup input.password': 'onPasswordChanged',
     'mousedown .show-password-label': 'onShowPasswordMouseDown',
     'touchstart .show-password-label': 'onShowPasswordMouseDown',
+    'keydown input.show-password': 'onShowPasswordTV',
   },
 
   initialize() {
@@ -87,6 +89,18 @@ export default {
 
     $passwordEl.after(showPasswordLabelEl);
     this._updateShowPasswordLabel($passwordEl);
+  },
+
+  onShowPasswordTV(event) {
+    if (event.which === KeyCodes.ENTER) {
+      const $passwordEl = this.getAffectedPasswordInputs(this.$(event.target));
+      this.showPassword($passwordEl);
+      const hideVisiblePasswords = () => {
+        $(this.window).off('keyup', hideVisiblePasswords);
+        this.hideVisiblePasswords();
+      };
+      $(this.window).one('keyup', hideVisiblePasswords);
+    }
   },
 
   onShowPasswordMouseDown(event) {
@@ -185,9 +199,11 @@ export default {
    * @private
    */
   hideVisiblePasswords() {
+    const active = document.activeElement;
     this.$el.find('.password[type=text]').each((index, el) => {
       this.hidePassword(el);
     });
+    active.focus();
   },
 
   onPasswordChanged(event) {

--- a/packages/fxa-content-server/app/scripts/views/mixins/password-strength-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/password-strength-mixin.js
@@ -32,11 +32,6 @@ export default function(config = {}) {
           // problems in the reset-password screen when using the recovery key
           return;
         }
-        if (window.matchMedia('(max-width: 960px)').matches) {
-          // Temporarily disable balloon on small screens.
-          // Part of https://github.com/mozilla/fxa/issues/2013
-          return;
-        }
 
         const passwordModel = (this.passwordModel = this._createPasswordStrengthBalloonModel());
         // wait a short time after the last invalid event to log the invalid reason.

--- a/packages/fxa-content-server/app/scripts/views/mixins/password-strength-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/password-strength-mixin.js
@@ -32,6 +32,11 @@ export default function(config = {}) {
           // problems in the reset-password screen when using the recovery key
           return;
         }
+        if (window.matchMedia('(max-width: 960px)').matches) {
+          // Temporarily disable balloon on small screens.
+          // Part of https://github.com/mozilla/fxa/issues/2013
+          return;
+        }
 
         const passwordModel = (this.passwordModel = this._createPasswordStrengthBalloonModel());
         // wait a short time after the last invalid event to log the invalid reason.

--- a/packages/fxa-content-server/app/scripts/views/password_strength/password_strength_balloon.js
+++ b/packages/fxa-content-server/app/scripts/views/password_strength/password_strength_balloon.js
@@ -42,7 +42,7 @@ class PasswordStrengthBalloonView extends BaseView {
     const validationError = this.model.validationError;
 
     context.set({
-      escapedCommonPasswordLinkAttrs: `href="${ESCAPED_SUMO_ARTICLE_HREF}" target="_blank"`,
+      escapedCommonPasswordLinkAttrs: `href="${ESCAPED_SUMO_ARTICLE_HREF}" target="_blank" tabindex="-1"`,
       isCommon:
         validationError &&
         AuthErrors.is(validationError, 'PASSWORD_TOO_COMMON'),

--- a/packages/fxa-content-server/app/scripts/views/password_strength/password_with_strength_balloon.js
+++ b/packages/fxa-content-server/app/scripts/views/password_strength/password_with_strength_balloon.js
@@ -70,9 +70,10 @@ const PasswordWithStrengthBalloonView = FormView.extend({
       // which causes the check to occur a 2nd time.
       return !!this.model.validate({ password });
     }
-
-    // There is no prefilled password, yes, show the balloon.
-    return true;
+    // when css `respond-to('balloonSmall') wait until the password
+    // isn't blank to show in order to allow the user to see
+    // the form unobstructed
+    return window.matchMedia('(min-width: 960px)').matches;
   },
 
   createBalloon() {

--- a/packages/fxa-content-server/app/styles/_breakpoints.scss
+++ b/packages/fxa-content-server/app/styles/_breakpoints.scss
@@ -5,9 +5,9 @@ $breakpoints: (
     '(max-width: 520px), (max-height: 640px), (orientation: landscape) and (min-width: 641px) and (max-height: 640px)',
   big: '(min-width: 521px) and (min-height: 641px)',
   balloonSmall: '(max-width: 960px)',
-  balloonBig: '(min-width: 960px)',
+  balloonBig: '(min-width: 961px)',
   balloonSmallSettings: '(max-width: 1180px)',
-  balloonBigSettings: '(min-width: 1180px)',
+  balloonBigSettings: '(min-width: 1181px)',
 );
 
 @mixin respond-to($breakpoint) {

--- a/packages/fxa-content-server/app/styles/_breakpoints.scss
+++ b/packages/fxa-content-server/app/styles/_breakpoints.scss
@@ -4,8 +4,8 @@ $breakpoints: (
   small:
     '(max-width: 520px), (max-height: 640px), (orientation: landscape) and (min-width: 641px) and (max-height: 640px)',
   big: '(min-width: 521px) and (min-height: 641px)',
-  balloonSmall: '(max-width: 960px)',
-  balloonBig: '(min-width: 961px)',
+  balloonSmall: '(max-width: 959px)',
+  balloonBig: '(min-width: 960px)',
   balloonSmallSettings: '(max-width: 1180px)',
   balloonBigSettings: '(min-width: 1181px)',
 );

--- a/packages/fxa-content-server/app/styles/_layout.scss
+++ b/packages/fxa-content-server/app/styles/_layout.scss
@@ -91,7 +91,6 @@
 #static-footer {
   align-items: center;
   display: flex;
-  height: 96px;
   padding: 0 32px;
   width: 100%;
 }

--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -42,6 +42,7 @@
     cursor: pointer;
     display: block;
     height: 48px;
+    margin: 24px 0;
     transition: opacity $short-transition;
     width: 128px;
 

--- a/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
+++ b/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
@@ -201,6 +201,14 @@ input[type='checkbox'] {
   color: $show-password-label-color;
 }
 
+.show-password:focus + .show-password-label {
+  background-color: #d9d9d9;
+}
+
+input[type='text'] ~ .show-password:focus + .show-password-label {
+  background-color: #bdbdbe;
+}
+
 .password:focus ~ .show-password-label {
   color: $input-border-color-focus;
 }


### PR DESCRIPTION
This temporarily disables the password strength on small screens until a better design can be implemented.

@ryanfeeley I'm happy to re-enable and change the strength balloon once we have a solution. This is just a quick fix to unblock Fire TV.

fixes #2013