### PR TITLE
fix(tests): wait for 123done page after successful subscription

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -2392,7 +2392,7 @@ const subscribeToTestProduct = thenify(function() {
     .then(type('input[name=zip]', '12345'))
     .then(click('input[type=checkbox]'))
     .then(click('button[name=submit]'))
-    .then(testElementExists('.subscription-ready'));
+    .then(testElementTextEquals('#splash header h1', '123done'));
 });
 
 module.exports = {


### PR DESCRIPTION
This patch changes what the `subscribeToTestProduct` functional test
helper wait for after submitting the payment form.  Previously it waited
for the subscription ready successful message.  However, that produced
intermittent failures in CI.  Now it waits for the final redirect to the
product page.

Fixes #2031