### PR TITLE
fix(support panel): display correct email verified status

### DIFF
--- a/packages/fxa-support-panel/lib/api.ts
+++ b/packages/fxa-support-panel/lib/api.ts
@@ -122,7 +122,7 @@ class SupportController {
         return { name: d.name, type: d.type, created: String(new Date(d.createdAt)) };
       }),
       email: account.email,
-      emailVerified: account.emailVerified,
+      emailVerified: !!account.emailVerified,
       locale: account.locale,
       subscriptionStatus: hasSubscriptions,
       twoFactorAuth: totpEnabled,


### PR DESCRIPTION
Fixes #2046

Handlebars treat `0` and `false` differently.  This is a simple fix for that.