### PR TITLE
chore(fxa-payments-server): fixes #1923 - add CSP to the payments server

### DIFF
--- a/packages/fxa-content-server/tests/server/csp.js
+++ b/packages/fxa-content-server/tests/server/csp.js
@@ -5,8 +5,8 @@
 const { registerSuite } = intern.getInterface('object');
 const assert = intern.getPlugin('chai').assert;
 const config = require('../../server/lib/configuration');
-const BlockingRules = require('../../server/lib/csp/blocking');
 const path = require('path');
+const blockingRules = require('../../server/lib/csp/blocking');
 const proxyquire = require('proxyquire');
 
 const csp = proxyquire(path.join(process.cwd(), 'server', 'lib', 'csp'), {
@@ -34,15 +34,12 @@ suite.tests['blockingRules'] = function() {
   const CDN_SERVER = 'https://static.accounts.firefox.com';
   config.set('static_resource_url', CDN_SERVER);
 
-  const blockingRules = BlockingRules(config);
-  const Sources = blockingRules.Sources;
+  const { Sources, directives, reportOnly } = blockingRules(config);
 
-  // Ensure none of the Sources map to `undefined`G
+  // Ensure none of the Sources map to `undefined`
   assert.notProperty(Sources, 'undefined');
 
-  assert.isFalse(blockingRules.reportOnly);
-
-  const directives = blockingRules.directives;
+  assert.isFalse(reportOnly);
 
   const connectSrc = directives.connectSrc;
   assert.lengthOf(connectSrc, 7);

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -15,11 +15,35 @@ const conf = convict({
     env: 'CLIENT_ADDRESS_DEPTH',
     format: Number,
   },
+  csp: {
+    enabled: {
+      default: true,
+      doc: 'Send "Content-Security-Policy" header',
+      env: 'CSP_ENABLED',
+    },
+    /*eslint-disable sorting/sort-object-props*/
+    reportUri: {
+      default: 'https://accounts.firefox.com/_/csp-violation',
+      doc: 'Location of "report-uri" for full, blocking CSP rules',
+      env: 'CSP_REPORT_URI',
+    },
+    reportOnlyEnabled: {
+      default: false,
+      doc: 'Send "Content-Security-Policy-Report-Only" header',
+      env: 'CSP_REPORT_ONLY_ENABLED',
+    },
+    reportOnlyUri: {
+      default: 'https://accounts.firefox.com/_/csp-violation-report-only',
+      doc: 'Location of "report-uri" for report-only CSP rules',
+      env: 'CSP_REPORT_ONLY_URI',
+    },
+    /*eslint-enable sorting/sort-object-props*/
+  },
   env: {
     default: 'production',
     doc: 'The current node.js environment',
     env: 'NODE_ENV',
-    format: ['development', 'production'],
+    format: ['development', 'production', 'test'],
   },
   hstsMaxAge: {
     default: 31536000, // a year
@@ -130,6 +154,14 @@ const conf = convict({
         format: 'url',
       },
     },
+    profileImages: {
+      url: {
+        default: 'http://127.0.0.1:1112',
+        doc: 'The url of the Firefox Account Profile Image Server',
+        env: 'FXA_PROFILE_IMAGES_URL',
+        format: 'url',
+      },
+    },
   },
   staticResources: {
     directory: {
@@ -157,6 +189,24 @@ const conf = convict({
       doc: 'API key for Stripe',
       env: 'STRIPE_API_KEY',
       format: String,
+    },
+    apiUrl: {
+      default: 'https://api.stripe.com',
+      doc: 'The Stripe API url',
+      env: 'STRIPE_API_URL',
+      format: 'url',
+    },
+    hooksUrl: {
+      default: 'https://hooks.stripe.com',
+      doc: 'The Stripe hooks url',
+      env: 'STRIPE_HOOKS_URL',
+      format: 'url',
+    },
+    scriptUrl: {
+      default: 'https://js.stripe.com',
+      doc: 'The Stripe script url',
+      env: 'STRIPE_SCRIPT_URL',
+      format: 'url',
     },
   },
 });

--- a/packages/fxa-payments-server/server/lib/csp.js
+++ b/packages/fxa-payments-server/server/lib/csp.js
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Middleware to take care of CSP. CSP headers are not sent unless config
+// option 'csp.enabled' is set (default true).
+
+'use strict';
+const helmet = require('helmet');
+const htmlOnly = require('./html-middleware');
+
+module.exports = function(config) {
+  const cspMiddleware = helmet.contentSecurityPolicy(config.rules);
+
+  return htmlOnly((req, res, next) => {
+    cspMiddleware(req, res, next);
+  });
+};

--- a/packages/fxa-payments-server/server/lib/csp.test.js
+++ b/packages/fxa-payments-server/server/lib/csp.test.js
@@ -1,0 +1,91 @@
+const config = require('../config');
+const blockingRules = require('./csp/blocking');
+
+describe('CSP blocking rules', () => {
+  // force the CDN to be enabled for tests.
+  const CDN_SERVER = 'https://static.accounts.firefox.com';
+  config.set('staticResources.url', CDN_SERVER);
+  const { Sources, directives, reportOnly } = blockingRules(config);
+
+  it('does not have a Sources value equal `undefined`', () => {
+    expect(Sources).not.toHaveProperty('undefined');
+    expect(reportOnly).toBeFalsy();
+  });
+
+  it('has correct connectSrc directives', () => {
+    const { connectSrc } = directives;
+
+    expect(connectSrc).toHaveLength(5);
+    expect(connectSrc).toContain(Sources.SELF);
+    expect(connectSrc).toContain(Sources.AUTH_SERVER);
+    expect(connectSrc).toContain(Sources.OAUTH_SERVER);
+    expect(connectSrc).toContain(Sources.PROFILE_SERVER);
+    expect(connectSrc).toContain(Sources.STRIPE_API_URL);
+  });
+
+  it('has correct defaultSrc directives', () => {
+    const { defaultSrc } = directives;
+
+    expect(defaultSrc).toHaveLength(1);
+    expect(defaultSrc).toContain(Sources.SELF);
+  });
+
+  it('has correct fontSrc directives', () => {
+    const { fontSrc } = directives;
+
+    expect(fontSrc).toHaveLength(2);
+    expect(fontSrc).toContain(Sources.SELF);
+    expect(fontSrc).toContain(CDN_SERVER);
+  });
+
+  it('has correct frameSrc directives', () => {
+    const { frameSrc } = directives;
+
+    expect(frameSrc).toHaveLength(2);
+    expect(frameSrc).toContain(Sources.STRIPE_SCRIPT_URL);
+    expect(frameSrc).toContain(Sources.STRIPE_HOOKS_URL);
+  });
+
+  it('has correct imgSrc directives', () => {
+    const { imgSrc } = directives;
+
+    expect(imgSrc).toHaveLength(5);
+    expect(imgSrc).toContain(Sources.SELF);
+    expect(imgSrc).toContain(Sources.DATA);
+    expect(imgSrc).toContain(Sources.GRAVATAR);
+    expect(imgSrc).toContain(Sources.PROFILE_IMAGES_SERVER);
+    expect(imgSrc).toContain(CDN_SERVER);
+  });
+
+  it('has correct mediaSrc directives', () => {
+    const { mediaSrc } = directives;
+
+    expect(mediaSrc).toHaveLength(1);
+    expect(mediaSrc).toContain(Sources.NONE);
+  });
+
+  it('has correct objectSrc directives', () => {
+    const { mediaSrc } = directives;
+
+    expect(mediaSrc).toHaveLength(1);
+    expect(mediaSrc).toContain(Sources.NONE);
+  });
+
+  it('has correct scriptSrc directives', () => {
+    const { scriptSrc } = directives;
+
+    expect(scriptSrc).toHaveLength(3);
+    expect(scriptSrc).toContain(Sources.SELF);
+    expect(scriptSrc).toContain(Sources.STRIPE_SCRIPT_URL);
+    expect(scriptSrc).toContain(CDN_SERVER);
+  });
+
+  it('has correct styleSrc directives', () => {
+    const { styleSrc } = directives;
+
+    expect(styleSrc).toHaveLength(3);
+    expect(styleSrc).toContain(Sources.SELF);
+    expect(styleSrc).toContain(Sources.UNSAFE_INLINE);
+    expect(styleSrc).toContain(CDN_SERVER);
+  });
+});

--- a/packages/fxa-payments-server/server/lib/csp/blocking.js
+++ b/packages/fxa-payments-server/server/lib/csp/blocking.js
@@ -3,9 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // Middleware to take care of CSP. CSP headers are not sent unless config
-// option 'csp.enabled' is set (default true in development), with a special
-// exception for the /tests/index.html path, which are the frontend unit
-// tests.
+// option 'csp.enabled' is set (default true).
 
 const url = require('url');
 
@@ -19,36 +17,36 @@ function getOrigin(link) {
  * to be blocked if it runs afowl of a rule.
  */
 module.exports = function(config) {
-  const AUTH_SERVER = getOrigin(config.get('fxaccount_url'));
-  const BLOB = 'blob:';
-  const CDN_URL = config.get('static_resource_url');
+  const AUTH_SERVER = getOrigin(config.get('servers.auth.url'));
+  const CDN_URL = config.get('staticResources.url');
   const DATA = 'data:';
   const GRAVATAR = 'https://secure.gravatar.com';
-  const MARKETING_EMAIL_SERVER = getOrigin(
-    config.get('marketing_email.api_url')
+  const OAUTH_SERVER = getOrigin(config.get('servers.oauth.url'));
+  const PROFILE_SERVER = getOrigin(config.get('servers.profile.url'));
+  const PROFILE_IMAGES_SERVER = getOrigin(
+    config.get('servers.profileImages.url')
   );
-  const OAUTH_SERVER = getOrigin(config.get('oauth_url'));
-  const PROFILE_SERVER = getOrigin(config.get('profile_url'));
-  const PROFILE_IMAGES_SERVER = getOrigin(config.get('profile_images_url'));
-  const PUBLIC_URL = config.get('public_url');
-  const PAIRING_SERVER_WEBSOCKET = getOrigin(
-    config.get('pairing.server_base_uri')
-  );
-  const PAIRING_SERVER_HTTP = PAIRING_SERVER_WEBSOCKET.replace(/^ws/, 'http');
+  const PUBLIC_URL = config.get('listen.publicUrl');
+  const HOT_RELOAD_WEBSOCKET = PUBLIC_URL.replace(/^http/, 'ws');
+
+  const STRIPE_API_URL = getOrigin(config.get('stripe.apiUrl'));
+  const STRIPE_HOOKS_URL = getOrigin(config.get('stripe.hooksUrl'));
+  const STRIPE_SCRIPT_URL = getOrigin(config.get('stripe.scriptUrl'));
 
   //
   // Double quoted values
   //
   const NONE = "'none'";
   // keyword sources - https://www.w3.org/TR/CSP2/#keyword_source
-  // Note: "'unsafe-inline'" and "'unsafe-eval'" are not used in this module.
+  // Note: "'unsafe-eval'" is not used in this module, and "'unsafe-inline'" is
+  // needed for Stripe inline styles.
   const SELF = "'self'";
+  const UNSAFE_INLINE = "'unsafe-inline'";
 
   function addCdnRuleIfRequired(target) {
     if (CDN_URL !== PUBLIC_URL) {
       target.push(CDN_URL);
     }
-
     return target;
   }
 
@@ -59,12 +57,11 @@ module.exports = function(config) {
         AUTH_SERVER,
         OAUTH_SERVER,
         PROFILE_SERVER,
-        MARKETING_EMAIL_SERVER,
-        PAIRING_SERVER_WEBSOCKET,
-        PAIRING_SERVER_HTTP,
+        STRIPE_API_URL,
       ],
       defaultSrc: [SELF],
       fontSrc: addCdnRuleIfRequired([SELF]),
+      frameSrc: [STRIPE_SCRIPT_URL, STRIPE_HOOKS_URL],
       imgSrc: addCdnRuleIfRequired([
         SELF,
         DATA,
@@ -74,32 +71,36 @@ module.exports = function(config) {
         GRAVATAR,
         PROFILE_IMAGES_SERVER,
       ]),
-      mediaSrc: [BLOB],
+      mediaSrc: [NONE],
       objectSrc: [NONE],
       reportUri: config.get('csp.reportUri'),
-      scriptSrc: addCdnRuleIfRequired([SELF]),
-      styleSrc: addCdnRuleIfRequired([SELF]),
+      scriptSrc: addCdnRuleIfRequired([SELF, STRIPE_SCRIPT_URL]),
+      styleSrc: addCdnRuleIfRequired([SELF, UNSAFE_INLINE]),
     },
     reportOnly: false,
     // Sources are exported for unit tests
     Sources: {
       //eslint-disable-line sorting/sort-object-props
       AUTH_SERVER,
-      BLOB,
       CDN_URL,
       DATA,
       GRAVATAR,
-      MARKETING_EMAIL_SERVER,
       NONE,
       OAUTH_SERVER,
-      PAIRING_SERVER_HTTP,
-      PAIRING_SERVER_WEBSOCKET,
+      HOT_RELOAD_WEBSOCKET,
       PROFILE_IMAGES_SERVER,
       PROFILE_SERVER,
       PUBLIC_URL,
+      STRIPE_API_URL,
+      STRIPE_HOOKS_URL,
+      STRIPE_SCRIPT_URL,
       SELF,
+      UNSAFE_INLINE,
     },
   };
+
+  if (config.get('env') === 'development')
+    rules.directives.connectSrc.push(HOT_RELOAD_WEBSOCKET);
 
   return rules;
 };

--- a/packages/fxa-payments-server/server/lib/csp/report-only.js
+++ b/packages/fxa-payments-server/server/lib/csp/report-only.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * reportOnlyCspMiddleware is where to declare experimental rules that
+ * will not cause a resource to be blocked if it runs afowl of a rule, but
+ * will cause the resource to be reported.
+ *
+ * If no directives other than `reportUri` are declared, the CSP reportOnly
+ * middleware will not be added.
+ */
+module.exports = function(config) {
+  return {
+    directives: {
+      reportUri: config.get('csp.reportOnlyUri'),
+    },
+    reportOnly: true,
+  };
+};

--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -22,6 +22,11 @@ module.exports = () => {
   const sentry = require('@sentry/node');
   const serveStatic = require('serve-static');
 
+  const bodyParser = require('body-parser');
+  const csp = require('../lib/csp');
+  const cspRulesBlocking = require('../lib/csp/blocking')(config);
+  const cspRulesReportOnly = require('../lib/csp/report-only')(config);
+
   const app = express();
 
   // Each of these config values (e.g., 'servers.content') will be exposed as the given
@@ -77,15 +82,37 @@ module.exports = () => {
 
     helmet.noSniff(),
 
-    // TODO CSP
-    require('./no-robots')
+    require('./no-robots'),
+
+    bodyParser.text({
+      type: 'text/plain',
+    }),
+
+    bodyParser.json({
+      // the 3 entries:
+      // json file types,
+      // all json content-types
+      // csp reports
+      type: ['json', '*/json', 'application/csp-report'],
+    })
   );
+
+  if (config.get('csp.enabled')) {
+    app.use(csp({ rules: cspRulesBlocking }));
+  }
+  if (config.get('csp.reportOnlyEnabled')) {
+    // There has to be more than a `reportUri`
+    // to enable reportOnly CSP.
+    if (Object.keys(cspRulesReportOnly.directives).length > 1) {
+      app.use(csp({ rules: cspRulesReportOnly }));
+    }
+  }
 
   if (isCorsRequired()) {
     // JS, CSS and web font resources served from a CDN
     // will be ignored unless CORS headers are present.
     const corsOptions = {
-      origin: config.get('public_url'),
+      origin: config.get('listen.publicUrl'),
     };
 
     app


### PR DESCRIPTION
fixes #1923 

@shane-tomlinson and I met and agreed the CSP violation reporting should go to the content server rather than duplicate code or only moving this piece related to CSP into `fxa-shared`. The merge of this depends on getting the fix for #2176.

NOTE: TLDR below; went with option 3 and created https://github.com/mozilla/fxa/issues/2073

---
---

I believe I've got this mostly figured out, I would just like some input.

Files mentioned in this comment:
payment server config: `packages/fxa-payments-server/server/config/index.js`
content server config:`packages/fxa-content-server/server/lib/configuration.js`
shared file: `packages/fxa-shared/csp/blocking.js` (can I rename this to `middleware`?)

In the file shared between the content server and payment server mentioned above, we grab some data from the server config file. The payment server config is set up pretty differently than the content server config, and arguably much better - for example, the content server uses the `fxaccount_url` key for the same data that the payment server has set for `servers.auth.url`. The payment server schema seems clearer to me and better thought-out.

It seems to me the best thing to do is to get these configs to match up better, but that's going to require a lot of testing and time for the content server, and I don't really want to change the payment server config setup to one I feel is not as clear.

Even if this worked in the payment server config, it would be a temporary solution, but it doesn't work without adding `fxaccount_url` to the payments schema so it's 👎:
```
if (! conf.has('fxaccount_url')) {
  conf.set('fxaccount_url', conf.get('servers.auth.url'));
}
```

When retrieving the data, I can't use an `||` in the const declaration because it throws an error so I could do this, but it still is not ideal:
```
let authServer;
  try {
    authServer = getOrigin(config.get('fxaccount_url'))
  } catch(e) {
  authServer = getOrigin(config.get('servers.auth.url'));
}
```
However, I will need to do something like this anyway for a few vars due to needing to declare Stripe stuff in this file: https://stripe.com/docs/security#content-security-policy

It seems our options are:
1. Spend time getting the config files matching (there's also a `config` vs `configuration` file name difference)
2. Use try/catch like how I have it above, and create a new issue for the first option and to refactor this later
3. Create separate CSP middleware, despite a lot of reuse across them, and probably still create an issue for the first option and to refactor later

What's the preferred direction? I'd guess it'd be between 2/3.

Also, looks like we don't have a `prettier` file in `payments-server` - after committing, I have conflicts with eslint. I can open a separate PR to get that fixed and pull it in here.
Edit: relates to https://github.com/mozilla/fxa/issues/1673