### PR TITLE
feat(signin): Reduce the need to enter a password

### DIFF
--- a/docs/adr/0005-minimize-password-entry.md
+++ b/docs/adr/0005-minimize-password-entry.md
@@ -1,0 +1,109 @@
+# Minimizing password entry
+
+- Deciders: Shane Tomlinson, Alex Davis, Ryan Feeley, Ryan Kelly
+- Date: 2019-08-07
+
+## Context and Problem Statement
+
+See [Github Issue 1371][#gh-issue-1371]. The FxA authorization flow sometimes asks already authenticated users to enter their password, sometimes it does not. Password entry, especially on mobile devices, is difficult and a source of user dropoff. Minimizing the need for a password in an authorization flow should increase flow completion rates.
+
+When and where passwords are asked for has been a repeated source of confusion amongst both users and Firefox Accounts developers. If a user is signed into Sync, passwords are only _supposed_ to be required for authorization flows for RPs that require encryption keys. However, there is a bug in the state management logic that forces users to enter their password more often than expected.
+
+Technically, we _must always_ ask the user to enter their password any time encryption keys are needed by an RP, e.g., Sync, Lockwise, and Send. For RPs that do not require encryption keys, e.g., Monitor and AMO, there is no technical reason why authenticated users must enter their password again, the existing sessionToken is capable of requesting new OAuth tokens.
+
+## Decision Drivers
+
+- User happiness via fewer keystrokes, less confusion
+- Improved signin rates
+
+## Considered Options
+
+1. Keep the existing flow
+2. Only ask authenticated users for a password if encryption keys are required
+
+## Decision Outcome
+
+Chosen option: "option 2", because it minimizes the number of places the user must enter their password.
+
+### Positive Consequences
+
+- User will need to type their password in fewer places.
+- Signin completion rates should increase.
+
+### Negative Consequences
+
+- There may be user confusion around what it means to sign out.
+
+### [option 1] Keep the existing flow
+
+If a user signs in to Sync first and is not signing into an OAuth
+RP that requires encryption keys, then no password is required.
+
+If a user does not sign into Sync and instead signs into an
+OAuth RP, e.g., Send, and then visits a 2nd OAuth RP that does not
+require encryption keys, e.g., Monitor, then they must enter their password.
+
+**example 1** User performs the initial authorization flow for an OAuth RP, e.g., Send, and then visits a 2nd OAuth RP that does not require encryption keys, e.g., Monitor, then _ask_ for the password.
+
+**example 2** User performs the initial authorization flow for Sync, then a subsequent authorization flow for an OAuth RP that does not require encryption keys, e.g., Monitor, _do not_ ask for the password.
+
+**example 3** User performs the initial authorization flow for an OAuth RP, e.g., Monitor, and then a subsequent authorization flow for an OAuth RP that _does_ require encryption keys, e.g., Send, then _ask_ for the password.
+
+**example 4** User performs the initial authorization flow for Sync, then a subsequent authorization flow for an OAuth RP that _does_ require encryption keys, e.g., Send, then _ask_ for the password.
+
+**example 5** User performs the initial authorization flow for an OAuth RP that does not require keys, e.g., Monitor, and then performs an authorization flow for Sync, then _ask_ for the password.
+
+**example 6** User performs the initial authorization flow for an OAuth RP that does does require keys, e.g., Send, and then performs an authorization flow for Sync, then _ask_ for the password.
+
+- Good, because we already have it and no effort is required to keep it.
+- Bad because there is no technical reason why we cannot re-use existing sessionTokens created when signing into OAuth RPs to generate OAuth tokens for other non-key requesting OAuth RPs.
+- Bad, because users need to enter their password more than they need to.
+- Bad, because due to a bug in the code, users that are currently signed into Sync are sometimes asked for their password to sign into services such as Monitor that do not require keys.
+
+### [option 2] Only ask authenticated users for a password if encryption keys are required
+
+**example 1** User performs the initial authorization flow for an OAuth RP, e.g., Send, and then visits a 2nd OAuth RP that does not require encryption keys, e.g., Monitor, then _do not_ ask for the password.
+
+**example 2** User performs the initial authorization flow for Sync, then a subsequent authorization flow for an OAuth RP that does not require encryption keys, e.g., Monitor, _do not_ ask for the password.
+
+**example 3** User performs the initial authorization flow for an OAuth RP, e.g., Monitor, and then a subsequent authorization flow for an OAuth RP that _does_ require encryption keys, e.g., Send, then _ask_ for the password.
+
+**example 4** User performs the initial authorization flow for Sync, then a subsequent authorization flow for an OAuth RP that _does_ require encryption keys, e.g., Send, then _ask_ for the password.
+
+**example 5** User performs the initial authorization flow for an OAuth RP that does not require keys, e.g., Monitor, and then performs an authorization flow for Sync, then _ask_ for the password.
+
+**example 6** User performs the initial authorization flow for an OAuth RP that does does require keys, e.g., Send, and then performs an authorization flow for Sync, then _ask_ for the password.
+
+- Good, because case 1 _does not_ ask for a password whereas it _does_ with option 1.
+- Bad, because there is potential for user confusion about expected behavior when destroying the sessionToken - should destroying the sessionToken sign the user out of the RP too? See [Github issue 640][#gh-issue-640].
+  - Support for [RP initiated logout][#gh-issue-1979] will largely mitigate this.
+
+## Is a password needed for service &lt;X&gt;?
+
+| Service                 | Password needed if already authenticated to FxA? |
+| ----------------------- | ------------------------------------------------ |
+| Lockwise                | yes                                              |
+| Notes                   | yes                                              |
+| Send                    | yes                                              |
+| Sync                    | yes                                              |
+| AMO                     | no                                               |
+| Email preferences       | no                                               |
+| Firefox Private Network | no                                               |
+| Monitor                 | no                                               |
+| Mozilla IAM             | no?                                              |
+| Mozilla Support         | no                                               |
+| Pocket                  | no                                               |
+| Pontoon                 | no                                               |
+
+## Expired sessions
+
+Not mentioned above is how invalid sessions are handled. Sessions become invalid under a number of scenarios, including password change, password reset, and session revocation from the [FxA Devices & Apps panel][#fxa-devices-apps-panel]. FxA only knows when previously authenticated sessions are invalid when the user attempts to use the previously authenticated session. If a previously authenticated user attempts to sign into Monitor, FxA will not initially ask for their password. Once the user clicks "Submit", FxA will learn the session is invalid and ask the user for their password.
+
+## Future
+
+In the future some sort of "session freshness" heuristic may be used to force users who have not recently authenticated must re-enter their password. Support for [RP initiated logout][#gh-issue-1979] will largely mitigate user confusion around what it means to sign out of a service and whether destroying a sessionToken should also sign the user out of an RP.
+
+[#gh-issue-1371]: https://github.com/mozilla/fxa/issues/1371
+[#gh-issue-640]: https://github.com/mozilla/fxa/issues/640
+[#gh-issue-1979]: https://github.com/mozilla/fxa/issues/1979
+[#fxa-devices-apps-panel]: https://accounts.firefox.com/settings/clients

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -9,6 +9,7 @@ This log lists the architectural decisions for [project name].
 - [ADR-0002](0002-use-react-redux-and-typescript-for-subscription-management-pages.md) - Use React, Redux, and Typescript for subscription management pages
 - [ADR-0003](0003-event-broker-for-subscription-platform.md) - Event Broker for Subscription Platform
 - [ADR-0004](0004-product-capabilities-for-subscription-services.md) - Product Capabilities for Subscription Services
+- [ADR-0005](0005-minimize-password-entry.md) - Minimizing password entry
 
 <!-- adrlogstop -->
 

--- a/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
@@ -32,6 +32,11 @@ export default {
    * @returns {Boolean}
    */
   isPasswordNeededForAccount(account) {
+    // If the account doesn't have a sessionToken, we'll need a password
+    if (!account.get('sessionToken')) {
+      return true;
+    }
+
     // If the account doesn't yet have an email address, we'll need a password too.
     if (!account.get('email')) {
       return true;
@@ -40,13 +45,6 @@ export default {
     // If the relier wants keys, then the user must authenticate and the password must be requested.
     // This includes sync, which must skip the login chooser at all cost
     if (this.relier.wantsKeys()) {
-      return true;
-    }
-
-    // We need to ask the user again for their password unless the credentials came from Sync.
-    // Otherwise they aren't able to "fully" log out. Only Sync has a clear path to disconnect/log out
-    // your account that invalidates your sessionToken.
-    if (!this.user.isSyncAccount(account)) {
       return true;
     }
 

--- a/packages/fxa-content-server/app/scripts/views/sign_in.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in.js
@@ -52,11 +52,8 @@ const View = FormView.extend({
     // should be re-rendered with the default avatar.
     const account = this.getAccount();
     this.listenTo(account, 'change:accessToken', () => {
-      // if no access token and password is not visible we need to show the password field.
-      if (
-        !account.has('accessToken') &&
-        this.$(PASSWORD_SELECTOR).is(':hidden')
-      ) {
+      // if no access token we need to show the password field.
+      if (!account.has('accessToken')) {
         this.model.set('chooserAskForPassword', true);
         return this.render().then(() => this.setDefaultPlaceholderAvatar());
       }

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in.js
@@ -176,11 +176,9 @@ describe('views/sign_in', () => {
           });
       });
 
-      it('re-renders, keeps the original email, forces user to enter password', () => {
+      it('re-renders, forces user to enter password', () => {
         assert.equal(view.render.callCount, 2);
-        assert.equal(view.$('.prefillEmail').text(), 'a@a.com');
-        assert.equal(view.$('input[type=email]').val(), 'a@a.com');
-        assert.lengthOf(view.$('input[type=password]'), 1);
+        assert.isTrue(view.model.get('chooserAskForPassword'));
       });
     });
   });

--- a/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js
+++ b/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js
@@ -246,7 +246,8 @@ registerSuite('Firefox desktop user info handshake', {
             )
           )
           // User can sign in with cached credentials, no password needed.
-          .then(noSuchElement(selectors.SIGNIN.PASSWORD))
+          .then(click(selectors.SIGNIN.SUBMIT_USE_SIGNED_IN))
+          .then(testElementExists(selectors.SETTINGS.HEADER))
       );
     },
 
@@ -285,9 +286,8 @@ registerSuite('Firefox desktop user info handshake', {
               otherEmail
             )
           )
-          // normal email element is in the DOM to help password managers.
-          .then(testElementValueEquals(selectors.SIGNIN.EMAIL, otherEmail))
-          .then(testElementExists(selectors.SIGNIN.PASSWORD))
+          .then(click(selectors.SIGNIN.SUBMIT_USE_SIGNED_IN))
+          .then(testElementExists(selectors.SETTINGS.HEADER))
       );
     },
 

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -259,6 +259,8 @@ module.exports = {
   },
   SIGNIN_PASSWORD: {
     EMAIL: 'input[type=email]',
+    EMAIL_NOT_EDITABLE: '.prefillEmail',
+    ERROR: '.error',
     HEADER: '#fxa-signin-password-header',
     LINK_FORGOT_PASSWORD: 'a[href^="/reset_password"]',
     LINK_MISTYPED_EMAIL: '.use-different',
@@ -267,6 +269,7 @@ module.exports = {
     SHOW_PASSWORD: '#password ~ .show-password-label',
     SUB_HEADER: '#fxa-signin-password-header .service',
     SUBMIT: 'button[type="submit"]',
+    SUBMIT_USE_SIGNED_IN: '.use-logged-in',
   },
   SIGNIN_RECOVERY_CODE: {
     DONE_BUTTON: '.two-step-authentication-done',

--- a/packages/fxa-content-server/tests/functional/oauth_email_first.js
+++ b/packages/fxa-content-server/tests/functional/oauth_email_first.js
@@ -12,8 +12,6 @@ const config = intern._config;
 const OAUTH_APP = config.fxaOAuthApp;
 const selectors = require('./lib/selectors');
 
-const SYNC_SIGNIN_URL = `${config.fxaContentRoot}signin?context=fx_desktop_v3&service=sync&action=email`;
-
 const PASSWORD = 'passwordzxcv';
 let email;
 
@@ -21,9 +19,7 @@ const {
   clearBrowserState,
   click,
   createUser,
-  noSuchElement,
   openFxaFromRp,
-  openPage,
   openVerificationLinkInSameTab,
   testElementExists,
   testElementTextEquals,
@@ -279,245 +275,7 @@ registerSuite('oauth email first', {
       );
     },
 
-    'cached Sync credentials': function() {
-      return (
-        this.remote
-          .then(createUser(email, PASSWORD, { preVerified: true }))
-          .then(
-            openPage(SYNC_SIGNIN_URL, selectors.ENTER_EMAIL.HEADER, {
-              webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
-                'fxaccounts:fxa_status': {
-                  capabilities: null,
-                  signedInUser: null,
-                },
-              },
-            })
-          )
-
-          .then(type(selectors.ENTER_EMAIL.EMAIL, email))
-          .then(
-            click(
-              selectors.ENTER_EMAIL.SUBMIT,
-              selectors.SIGNIN_PASSWORD.HEADER
-            )
-          )
-
-          .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
-          .then(
-            click(
-              selectors.SIGNIN_PASSWORD.SUBMIT,
-              selectors.CONNECT_ANOTHER_DEVICE.HEADER
-            )
-          )
-
-          // user is signed into Sync, now try to sign into OAuth w/o entering password.
-          .then(
-            openFxaFromRp('email-first', {
-              header: selectors.SIGNIN_PASSWORD.HEADER,
-            })
-          )
-          .then(testElementValueEquals(selectors.SIGNIN_PASSWORD.EMAIL, email))
-          .then(noSuchElement(selectors.SIGNIN_PASSWORD.PASSWORD))
-          .then(click(selectors.SIGNIN_PASSWORD.SUBMIT))
-
-          .then(testAtOAuthApp())
-      );
-    },
-
-    'cached Sync credentials, user changes email': function() {
-      const oAuthEmail = createEmail();
-      return (
-        this.remote
-          .then(createUser(email, PASSWORD, { preVerified: true }))
-          .then(createUser(oAuthEmail, PASSWORD, { preVerified: true }))
-          .then(
-            openPage(SYNC_SIGNIN_URL, selectors.ENTER_EMAIL.HEADER, {
-              webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
-                'fxaccounts:fxa_status': {
-                  capabilities: null,
-                  signedInUser: null,
-                },
-              },
-            })
-          )
-
-          .then(type(selectors.ENTER_EMAIL.EMAIL, email))
-          .then(
-            click(
-              selectors.ENTER_EMAIL.SUBMIT,
-              selectors.SIGNIN_PASSWORD.HEADER
-            )
-          )
-
-          .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
-          .then(
-            click(
-              selectors.SIGNIN_PASSWORD.SUBMIT,
-              selectors.CONNECT_ANOTHER_DEVICE.HEADER
-            )
-          )
-
-          .then(
-            openFxaFromRp('email-first', {
-              header: selectors.SIGNIN_PASSWORD.HEADER,
-            })
-          )
-          .then(testElementValueEquals(selectors.SIGNIN_PASSWORD.EMAIL, email))
-
-          // user realizes they want to use a different account.
-          .then(
-            click(
-              selectors.SIGNIN_PASSWORD.LINK_MISTYPED_EMAIL,
-              selectors.ENTER_EMAIL.HEADER
-            )
-          )
-
-          .then(type(selectors.ENTER_EMAIL.EMAIL, oAuthEmail))
-          .then(
-            click(
-              selectors.ENTER_EMAIL.SUBMIT,
-              selectors.SIGNIN_PASSWORD.HEADER
-            )
-          )
-
-          .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
-          .then(click(selectors.SIGNIN_PASSWORD.SUBMIT))
-
-          .then(testAtOAuthApp())
-      );
-    },
-
-    'cached Sync credentials, login_hint specified by relier': function() {
-      const loginHintEmail = createEmail();
-
-      return this.remote
-        .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(createUser(loginHintEmail, PASSWORD, { preVerified: true }))
-        .then(
-          openPage(SYNC_SIGNIN_URL, selectors.ENTER_EMAIL.HEADER, {
-            webChannelResponses: {
-              'fxaccounts:can_link_account': { ok: true },
-              'fxaccounts:fxa_status': {
-                capabilities: null,
-                signedInUser: null,
-              },
-            },
-          })
-        )
-
-        .then(type(selectors.ENTER_EMAIL.EMAIL, email))
-        .then(
-          click(selectors.ENTER_EMAIL.SUBMIT, selectors.SIGNIN_PASSWORD.HEADER)
-        )
-
-        .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
-        .then(
-          click(
-            selectors.SIGNIN_PASSWORD.SUBMIT,
-            selectors.CONNECT_ANOTHER_DEVICE.HEADER
-          )
-        )
-
-        .then(
-          openFxaFromRp('email-first', {
-            header: selectors.SIGNIN_PASSWORD.HEADER,
-            query: {
-              login_hint: loginHintEmail,
-            },
-          })
-        )
-
-        .then(
-          testElementValueEquals(
-            selectors.SIGNIN_PASSWORD.EMAIL,
-            loginHintEmail
-          )
-        )
-        .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
-        .then(click(selectors.SIGNIN_PASSWORD.SUBMIT))
-
-        .then(testAtOAuthApp());
-    },
-
-    'cached Sync credentials, login_hint specified by relier, user changes email': function() {
-      const loginHintEmail = createEmail();
-      const oAuthEmail = createEmail();
-
-      return (
-        this.remote
-          .then(createUser(email, PASSWORD, { preVerified: true }))
-          .then(createUser(oAuthEmail, PASSWORD, { preVerified: true }))
-          .then(createUser(loginHintEmail, PASSWORD, { preVerified: true }))
-          .then(
-            openPage(SYNC_SIGNIN_URL, selectors.ENTER_EMAIL.HEADER, {
-              webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
-                'fxaccounts:fxa_status': {
-                  capabilities: null,
-                  signedInUser: null,
-                },
-              },
-            })
-          )
-
-          .then(type(selectors.ENTER_EMAIL.EMAIL, email))
-          .then(
-            click(
-              selectors.ENTER_EMAIL.SUBMIT,
-              selectors.SIGNIN_PASSWORD.HEADER
-            )
-          )
-
-          .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
-          .then(
-            click(
-              selectors.SIGNIN_PASSWORD.SUBMIT,
-              selectors.CONNECT_ANOTHER_DEVICE.HEADER
-            )
-          )
-
-          .then(
-            openFxaFromRp('email-first', {
-              header: selectors.SIGNIN_PASSWORD.HEADER,
-              query: {
-                login_hint: loginHintEmail,
-              },
-            })
-          )
-
-          .then(
-            testElementValueEquals(
-              selectors.SIGNIN_PASSWORD.EMAIL,
-              loginHintEmail
-            )
-          )
-
-          // user realizes they want to use a different account.
-          .then(
-            click(
-              selectors.SIGNIN_PASSWORD.LINK_MISTYPED_EMAIL,
-              selectors.ENTER_EMAIL.HEADER
-            )
-          )
-
-          .then(type(selectors.ENTER_EMAIL.EMAIL, oAuthEmail))
-          .then(
-            click(
-              selectors.ENTER_EMAIL.SUBMIT,
-              selectors.SIGNIN_PASSWORD.HEADER
-            )
-          )
-
-          .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
-          .then(click(selectors.SIGNIN_PASSWORD.SUBMIT))
-
-          .then(testAtOAuthApp())
-      );
-    },
-
-    'cached OAuth credentials': function() {
+    'cached credentials': function() {
       return (
         this.remote
           .then(createUser(email, PASSWORD, { preVerified: true }))
@@ -540,21 +298,20 @@ registerSuite('oauth email first', {
           .then(testAtOAuthApp())
           .then(click(selectors['123DONE'].LINK_LOGOUT))
 
-          // user is signed in, use cached credentials but a password is needed
+          // user is signed in, use cached credentials no password is needed
           .then(
             openFxaFromRp('email-first', {
               header: selectors.SIGNIN_PASSWORD.HEADER,
             })
           )
           .then(testElementValueEquals(selectors.SIGNIN_PASSWORD.EMAIL, email))
-          .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
           .then(click(selectors.SIGNIN_PASSWORD.SUBMIT))
 
           .then(testAtOAuthApp())
       );
     },
 
-    'cached OAuth credentials, login_hint specified by relier': function() {
+    'cached credentials, login_hint specified by relier': function() {
       const loginHintEmail = createEmail();
       const oAuthEmail = createEmail();
 
@@ -582,7 +339,7 @@ registerSuite('oauth email first', {
           .then(testAtOAuthApp())
           .then(click(selectors['123DONE'].LINK_LOGOUT))
 
-          // user is signed in, use cached credentials but a password is needed
+          // login_hint takes precedence over the signed in user
           .then(
             openFxaFromRp('email-first', {
               header: selectors.SIGNIN_PASSWORD.HEADER,
@@ -605,7 +362,7 @@ registerSuite('oauth email first', {
       );
     },
 
-    'cached OAuth credentials, login_hint specified by relier, user changes email': function() {
+    'cached credentials, login_hint specified by relier, user changes email': function() {
       const loginHintEmail = createEmail();
       const oAuthEmail = createEmail();
 

--- a/packages/fxa-content-server/tests/functional/oauth_handshake.js
+++ b/packages/fxa-content-server/tests/functional/oauth_handshake.js
@@ -20,17 +20,18 @@ let otherAccount;
 
 const PASSWORD = '12345678';
 
-const click = FunctionalHelpers.click;
-const clearBrowserState = FunctionalHelpers.clearBrowserState;
-const createUser = FunctionalHelpers.createUser;
-const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-const openFxaFromRp = FunctionalHelpers.openFxaFromRp;
-const noSuchElement = FunctionalHelpers.noSuchElement;
-const testElementExists = FunctionalHelpers.testElementExists;
-const testElementTextEquals = FunctionalHelpers.testElementTextEquals;
-const testElementValueEquals = FunctionalHelpers.testElementValueEquals;
-const thenify = FunctionalHelpers.thenify;
-const visibleByQSA = FunctionalHelpers.visibleByQSA;
+const {
+  click,
+  clearBrowserState,
+  createUser,
+  fillOutSignIn,
+  openFxaFromRp,
+  noSuchElement,
+  testElementExists,
+  testElementTextEquals,
+  thenify,
+  visibleByQSA,
+} = FunctionalHelpers;
 
 const ensureUsers = thenify(function() {
   return this.parent
@@ -103,6 +104,9 @@ registerSuite('Firefox desktop user info handshake - OAuth flows', {
           )
           // User can sign in with cached credentials, no password needed.
           .then(noSuchElement(selectors.SIGNIN.PASSWORD))
+          .then(click(selectors.SIGNIN_PASSWORD.SUBMIT_USE_SIGNED_IN))
+
+          .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
       );
     },
 
@@ -157,9 +161,11 @@ registerSuite('Firefox desktop user info handshake - OAuth flows', {
               otherEmail
             )
           )
-          // normal email element is in the DOM to help password managers.
-          .then(testElementValueEquals(selectors.SIGNIN.EMAIL, otherEmail))
-          .then(testElementExists(selectors.SIGNIN.PASSWORD))
+          // User can sign in with cached credentials, no password needed.
+          .then(noSuchElement(selectors.SIGNIN.PASSWORD))
+          .then(click(selectors.SIGNIN_PASSWORD.SUBMIT_USE_SIGNED_IN))
+
+          .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
       );
     },
   },

--- a/packages/fxa-content-server/tests/functional/oauth_permissions.js
+++ b/packages/fxa-content-server/tests/functional/oauth_permissions.js
@@ -88,10 +88,9 @@ registerSuite('oauth permissions for untrusted reliers', {
           .then(click(selectors['123DONE'].BUTTON_SIGNIN))
 
           // user signed in previously and should not need to enter
-          // their email address.
+          // either their email address or password
           .then(testElementExists(selectors.SIGNIN.HEADER))
-          .then(type(selectors.SIGNIN.PASSWORD, PASSWORD))
-          .then(click(selectors.SIGNIN.SUBMIT))
+          .then(click(selectors.SIGNIN.SUBMIT_USE_SIGNED_IN))
 
           // no permissions additional asked for
           .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
@@ -206,10 +205,9 @@ registerSuite('oauth permissions for untrusted reliers', {
           .then(click(selectors['123DONE'].BUTTON_SIGNIN))
 
           // user signed in previously and should not need to enter
-          // their email address.
+          // either their email address or password
           .then(testElementExists(selectors.SIGNIN.HEADER))
-          .then(type(selectors.SIGNIN.PASSWORD, PASSWORD))
-          .then(click(selectors.SIGNIN.SUBMIT))
+          .then(click(selectors.SIGNIN.SUBMIT_USE_SIGNED_IN))
 
           .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
           .then(testUrlEquals(UNTRUSTED_OAUTH_APP))
@@ -282,10 +280,9 @@ registerSuite('oauth permissions for untrusted reliers', {
 
           .then(closeCurrentWindow())
 
+          // user is already signed in, does not need to enter their password.
           .then(click(selectors['123DONE'].BUTTON_SIGNIN))
-
-          .then(type(selectors.SIGNIN.PASSWORD, PASSWORD))
-          .then(click(selectors.SIGNIN.SUBMIT))
+          .then(click(selectors.SIGNIN.SUBMIT_USE_SIGNED_IN))
 
           // display name is now available
           .then(
@@ -314,6 +311,7 @@ registerSuite('oauth permissions for untrusted reliers', {
               'test user'
             )
           )
+          // user is already signed in, does not need to enter their password.
           .then(click(selectors.SETTINGS_DISPLAY_NAME.SUBMIT))
           .then(visibleByQSA(selectors.SETTINGS.SUCCESS))
 
@@ -326,8 +324,7 @@ registerSuite('oauth permissions for untrusted reliers', {
             })
           )
 
-          .then(type(selectors.SIGNIN.PASSWORD, PASSWORD))
-          .then(click(selectors.SIGNIN.SUBMIT))
+          .then(click(selectors.SIGNIN.SUBMIT_USE_SIGNED_IN))
 
           .then(testElementExists(selectors.OAUTH_PERMISSIONS.HEADER))
           // display name is not available because it's not requested
@@ -346,8 +343,7 @@ registerSuite('oauth permissions for untrusted reliers', {
           .then(click(selectors['123DONE'].LINK_LOGOUT))
           .then(click(selectors['123DONE'].BUTTON_SIGNIN))
 
-          .then(type(selectors.SIGNIN.PASSWORD, PASSWORD))
-          .then(click(selectors.SIGNIN.SUBMIT))
+          .then(click(selectors.SIGNIN.SUBMIT_USE_SIGNED_IN))
 
           // the second time through, profile:email, profile:uid, and
           // profile:display_name will be asked for, so display_name is
@@ -383,8 +379,7 @@ registerSuite('oauth permissions for untrusted reliers', {
 
           .then(openFxaFromUntrustedRp('signin'))
 
-          .then(type(selectors.SIGNIN.PASSWORD, PASSWORD))
-          .then(click(selectors.SIGNIN.SUBMIT))
+          .then(click(selectors.SIGNIN.SUBMIT_USE_SIGNED_IN))
 
           .then(
             testElementExists(selectors.OAUTH_PERMISSIONS.CHECKBOX_DISPLAY_NAME)
@@ -404,9 +399,11 @@ registerSuite('oauth permissions for untrusted reliers', {
           // display_name was de-selected last time.
           .then(click(selectors['123DONE'].BUTTON_SIGNIN))
 
-          .then(type(selectors.SIGNIN.PASSWORD, PASSWORD))
           .then(
-            click(selectors.SIGNIN.SUBMIT, selectors['123DONE'].AUTHENTICATED)
+            click(
+              selectors.SIGNIN.SUBMIT_USE_SIGNED_IN,
+              selectors['123DONE'].AUTHENTICATED
+            )
           )
       );
     },
@@ -503,8 +500,7 @@ registerSuite('oauth permissions for trusted reliers', {
             openFxaFromTrustedRp('signin', { query: { prompt: 'consent' } })
           )
 
-          .then(type(selectors.SIGNIN.PASSWORD, PASSWORD))
-          .then(click(selectors.SIGNIN.SUBMIT))
+          .then(click(selectors.SIGNIN.SUBMIT_USE_SIGNED_IN))
 
           // since consent is now requested, user should see prompt
           .then(testElementExists(selectors.OAUTH_PERMISSIONS.HEADER))

--- a/packages/fxa-content-server/tests/functional/oauth_settings_clients.js
+++ b/packages/fxa-content-server/tests/functional/oauth_settings_clients.js
@@ -11,6 +11,7 @@ var config = intern._config;
 var CONTENT_SERVER = config.fxaContentRoot;
 var APPS_SETTINGS_URL = CONTENT_SERVER + 'settings/clients?forceDeviceList=1';
 var UNTRUSTED_OAUTH_APP = config.fxaUntrustedOauthApp;
+const selectors = require('./lib/selectors');
 
 var PASSWORD = 'password';
 
@@ -26,7 +27,6 @@ const {
   pollUntilGoneByQSA,
   switchToWindow,
   testElementExists,
-  type,
 } = FunctionalHelpers;
 
 var email;
@@ -51,9 +51,9 @@ registerSuite('oauth settings clients', {
         this.remote
           .then(openFxaFromRp('signup'))
           .then(fillOutSignUp(email, PASSWORD))
-          .then(testElementExists('#fxa-confirm-header'))
+          .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
           .then(openVerificationLinkInSameTab(email, 0))
-          .then(testElementExists('#loggedin'))
+          .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
 
           // lists the first client
           .then(openPage(APPS_SETTINGS_URL, '.client-disconnect'))
@@ -65,24 +65,19 @@ registerSuite('oauth settings clients', {
           // cannot use the helper method here, the helper method uses $ (jQuery)
           // 123Done loads jQuery in the <body> this leads to '$ is undefined' error
           // when running tests, because jQuery can be slow to load
-          .findByCssSelector('.ready')
-          .end()
 
-          .findByCssSelector('.signin')
-          .click()
-          .end()
+          .then(click(selectors['123DONE'].BUTTON_SIGNIN))
 
-          .then(type('#password', PASSWORD))
-          .then(click('#submit-btn'))
+          .then(click(selectors.SIGNIN.SUBMIT_USE_SIGNED_IN))
 
-          .then(testElementExists('#fxa-permissions-header'))
-          .then(click('#accept'))
-          .then(testElementExists('#loggedin'))
+          .then(testElementExists(selectors.OAUTH_PERMISSIONS.HEADER))
+          .then(click(selectors.OAUTH_PERMISSIONS.SUBMIT))
+          .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
 
           .then(closeCurrentWindow())
 
           // second app should show up using 'refresh'
-          .then(click('.clients-refresh'))
+          .then(click(selectors.SETTINGS_CLIENTS.BUTTON_REFRESH))
 
           .then(testElementExists('li.client-oAuthApp[data-name^="321"]'))
 

--- a/packages/fxa-content-server/tests/functional/reset_password.js
+++ b/packages/fxa-content-server/tests/functional/reset_password.js
@@ -28,7 +28,6 @@ let email;
 let token;
 
 const {
-  cleanMemory,
   clearBrowserState,
   click,
   closeCurrentWindow,
@@ -118,12 +117,6 @@ registerSuite('reset_password', {
       .then(clearBrowserState());
   },
   tests: {
-    'clear memory': function() {
-      // tests fail on this suite very often on Circle because Firefox
-      // crashes here. Clear memory and hope that helps.
-      return this.remote.then(cleanMemory());
-    },
-
     'visit confirmation screen without initiating reset_password, user is redirected to /reset_password': function() {
       // user is immediately redirected to /reset_password if they have no
       // sessionToken.


### PR DESCRIPTION
Do not ask for a password for users signing into a non-key
requesting RP if they already have an FxA session of any sort.

I removed a lot of tests that now seem duplicate, since there is
no longer a distinction between a "Sync" signin and an "OAuth" signin
when it comes to whether to display the password field.

I also added onto a bunch of the "cached session" tests
to actually click the "submit" button to ensure the user
is redirected where they are supposed to be. The idea
is to follow on with trying expired cached credentials
targeting the problems uncovered in #999.

fixes #1371