### PR TITLE
chore(deps): bump fxa-shared to 1.0.28

### DIFF
--- a/packages/fxa-auth-server/npm-shrinkwrap.json
+++ b/packages/fxa-auth-server/npm-shrinkwrap.json
@@ -2590,9 +2590,9 @@
       }
     },
     "fxa-shared": {
-      "version": "1.0.27",
-      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.27.tgz",
-      "integrity": "sha512-h6zY85SpPOYIcqNpitPrwWyvZTQIb5a99mknZbydAfkey6/z6gzj7/LXNrvLNPj/QsneNHQ/rNeWl8bPvwfL7g==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.28.tgz",
+      "integrity": "sha512-by3klXnB1gTawRsZofBexa+9OZKLcj97LNapZqtKHCkKmFqigSz2juXF4qcCYc9RRZ78xy+wRNB/FVPx4xDetg==",
       "requires": {
         "accept-language": "2.0.17",
         "ajv": "6.10.0",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -52,7 +52,7 @@
     "fxa-geodb": "1.0.4",
     "fxa-jwtool": "0.7.2",
     "fxa-notifier-aws": "1.0.0",
-    "fxa-shared": "^1.0.27",
+    "fxa-shared": "^1.0.28",
     "generic-pool": "3.2.0",
     "google-libphonenumber": "2.0.10",
     "grunt-nunjucks-2-html": "3.1.0",

--- a/packages/fxa-content-server/npm-shrinkwrap.json
+++ b/packages/fxa-content-server/npm-shrinkwrap.json
@@ -5818,9 +5818,9 @@
             }
         },
         "fxa-shared": {
-            "version": "1.0.27",
-            "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.27.tgz",
-            "integrity": "sha512-h6zY85SpPOYIcqNpitPrwWyvZTQIb5a99mknZbydAfkey6/z6gzj7/LXNrvLNPj/QsneNHQ/rNeWl8bPvwfL7g==",
+            "version": "1.0.28",
+            "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.28.tgz",
+            "integrity": "sha512-by3klXnB1gTawRsZofBexa+9OZKLcj97LNapZqtKHCkKmFqigSz2juXF4qcCYc9RRZ78xy+wRNB/FVPx4xDetg==",
             "requires": {
                 "accept-language": "2.0.17",
                 "ajv": "6.10.0",
@@ -11660,7 +11660,7 @@
         },
         "sjcl": {
             "version": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8ef32329bc8d7bc28a438372b5acb46616b",
-            "from": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8e"
+            "from": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8ef32329bc8d7bc28a438372b5acb46616b"
         },
         "slash": {
             "version": "1.0.0",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -68,7 +68,7 @@
         "fxa-js-client": "^1.0.17",
         "fxa-mustache-loader": "0.0.2",
         "fxa-pairing-channel": "1.0.1",
-        "fxa-shared": "^1.0.27",
+        "fxa-shared": "^1.0.28",
         "got": "6.7.1",
         "grunt": "1.0.4",
         "grunt-babel": "6.0.0",

--- a/packages/fxa-profile-server/npm-shrinkwrap.json
+++ b/packages/fxa-profile-server/npm-shrinkwrap.json
@@ -1474,14 +1474,44 @@
       }
     },
     "fxa-shared": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.13.tgz",
-      "integrity": "sha512-jy9FehibrocELTpXPEfr6cWMrac+N//7CBBPACAK17ZHuN/ZP5iJuIG3nB18ZIZKBSmJH0TgO8C6p3XocSx2mA==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/fxa-shared/-/fxa-shared-1.0.28.tgz",
+      "integrity": "sha512-by3klXnB1gTawRsZofBexa+9OZKLcj97LNapZqtKHCkKmFqigSz2juXF4qcCYc9RRZ78xy+wRNB/FVPx4xDetg==",
       "requires": {
         "accept-language": "2.0.17",
-        "moment": "2.20.1"
+        "ajv": "6.10.0",
+        "bluebird": "3.5.3",
+        "generic-pool": "3.6.1",
+        "moment": "2.20.1",
+        "redis": "2.8.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+          "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+          "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
         "moment": {
           "version": "2.20.1",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
@@ -1506,6 +1536,11 @@
       "requires": {
         "is-property": "^1.0.0"
       }
+    },
+    "generic-pool": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.6.1.tgz",
+      "integrity": "sha512-iMmD/pY4q0+V+f8o4twE9JPeqfNuX+gJAaIPB3B0W1lFkBOtTxBo6B0HxHPgGhzQA8jego7EWopcYq/UDJO2KA=="
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -4211,6 +4246,23 @@
         "esprima": "~3.0.0"
       }
     },
+    "redis": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
+      "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
+      "requires": {
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
+      },
+      "dependencies": {
+        "redis-parser": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-2.6.0.tgz",
+          "integrity": "sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs="
+        }
+      }
+    },
     "redis-commands": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.4.0.tgz",
@@ -4862,6 +4914,21 @@
       "requires": {
         "sprintf-js": "^1.0.3",
         "util-deprecate": "^1.0.2"
+      }
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
       }
     },
     "url": {

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -23,7 +23,7 @@
     "compute-cluster": "0.0.9",
     "convict": "4.0.2",
     "fxa-notifier-aws": "1.0.0",
-    "fxa-shared": "1.0.13",
+    "fxa-shared": "^1.0.28",
     "gm-reloaded": "1.24.0",
     "hapi": "16.7.0",
     "inert": "4.0.2",

--- a/packages/fxa-shared/package-lock.json
+++ b/packages/fxa-shared/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "description": "Shared module for FxA repositories",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This enables Belerusian `be` locale.

The fxa-shared 1.0.28 package has already been published to npm

@mozilla/fxa-devs - r?

fixes mozilla/fxa-content-server-l10n#364