### PR TITLE
fix(l10n): Parse server code using `ecmaVersion: 2018`

### DIFF
--- a/packages/fxa-content-server/grunttasks/l10n-extract.js
+++ b/packages/fxa-content-server/grunttasks/l10n-extract.js
@@ -19,7 +19,7 @@ var messagesOutputPath = path.join(
   'LC_MESSAGES'
 );
 var babelCmd =
-  'npx babel --plugins=@babel/plugin-syntax-dynamic-import,dynamic-import-webpack,@babel/plugin-proposal-class-properties --presets @babel/preset-react,@babel/env app/scripts --out-dir .es5';
+  'npx babel --plugins=@babel/plugin-syntax-dynamic-import,dynamic-import-webpack,@babel/plugin-proposal-class-properties --presets @babel/preset-react,@babel/env,@babel/preset-typescript app/scripts --out-dir .es5';
 var templateCmd = 'cp -r app/scripts/templates .es5/templates/';
 
 module.exports = function(grunt) {
@@ -73,6 +73,7 @@ module.exports = function(grunt) {
             '.js': 'javascript',
             '.txt': 'handlebars',
           },
+          parserOptions: '{"ecmaVersion":"2018"}',
         });
 
         authWalker.on('end', function() {


### PR DESCRIPTION
The acorn parser was blowing up trying to parse the spread
operator in the server code. Set the parser to use ecmaVersion: 2018
so that it can handle any new syntax we throw at it.

This is the approached used by the auth server.

fixes #2067

@philbooth - r?

