### PR TITLE
refactor(subscriptions): use account's settings data to check for active subscriptions

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -1015,6 +1015,19 @@ const Account = Backbone.Model.extend(
     },
 
     /**
+     * Check to see if the account has any subscriptions.
+     *
+     * @returns {Promise} resolves to a bool.
+     */
+    hasSubscriptions() {
+      return this.settingsData().then(
+        settingsData =>
+          Array.isArray(settingsData.subscriptions) &&
+          settingsData.subscriptions.length > 0
+      );
+    },
+
+    /**
      * Fetch the account's list of active subscriptions.
      *
      * @returns {Promise} - resolves with a list of subscription objects.

--- a/packages/fxa-content-server/app/scripts/views/settings/subscription.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/subscription.js
@@ -13,6 +13,7 @@ import PaymentServer from '../../lib/payment-server';
 const View = FormView.extend({
   className: 'subscription',
   viewName: 'settings.subscription',
+  template: Template,
 
   events: {
     'click button': 'submit',
@@ -25,27 +26,8 @@ const View = FormView.extend({
     }
   },
 
-  template() {
-    return '';
-  },
-
   afterRender() {
-    return this._hasActiveSubscriptions().then(hasSubs => {
-      if (hasSubs) {
-        this.$el.html(this.renderTemplate(Template));
-      }
-    });
-  },
-
-  /**
-   * Check to see if the account has any active subscriptions.
-   *
-   * @returns {Promise} resolves to a bool.
-   */
-  _hasActiveSubscriptions() {
-    return this.getSignedInAccount()
-      .fetchActiveSubscriptions()
-      .then(subscriptions => subscriptions.length > 0);
+    return this.getSignedInAccount().hasSubscriptions();
   },
 
   submit() {

--- a/packages/fxa-content-server/app/scripts/views/support.js
+++ b/packages/fxa-content-server/app/scripts/views/support.js
@@ -56,8 +56,8 @@ const SupportView = BaseView.extend({
   beforeRender() {
     const account = this.getSignedInAccount();
 
-    return account.fetchActiveSubscriptions().then(subscriptions => {
-      if (subscriptions.length > 0) {
+    return account.hasSubscriptions().then(hasSubs => {
+      if (hasSubs) {
         return account.fetchProfile().then(() => this.user.setAccount(account));
       } else {
         // Note that if a user landed here, it is because:

--- a/packages/fxa-content-server/app/tests/spec/models/account.js
+++ b/packages/fxa-content-server/app/tests/spec/models/account.js
@@ -2972,9 +2972,32 @@ describe('models/account', function() {
           return Promise.resolve(subs);
         });
 
-      account.fetchActiveSubscriptions().then(resp => {
+      return account.fetchActiveSubscriptions().then(resp => {
         assert.isTrue(subsStub.calledWith(token));
         assert.deepEqual(resp, subs);
+      });
+    });
+  });
+
+  describe('hasSubscriptions', () => {
+    it('resolves to false when settingsData has no subscriptions data', function() {
+      account._settingsData = {};
+      return account.hasSubscriptions().then(hasSub => {
+        assert.isFalse(hasSub);
+      });
+    });
+
+    it('resolves to false when settingsData has an empty subscriptions list', function() {
+      account._settingsData = { subscriptions: [] };
+      return account.hasSubscriptions().then(hasSub => {
+        assert.isFalse(hasSub);
+      });
+    });
+
+    it('resolves to true when settingsData has a subscription', function() {
+      account._settingsData = { subscriptions: [{ x: 'yz' }] };
+      return account.hasSubscriptions().then(hasSub => {
+        assert.isTrue(hasSub);
       });
     });
   });

--- a/packages/fxa-content-server/app/tests/spec/views/settings/subscription.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/subscription.js
@@ -14,6 +14,7 @@ import User from 'models/user';
 
 describe('views/settings/subscription', function() {
   var view;
+  var account;
   var config;
   var UID = TestHelpers.createUid();
 
@@ -36,7 +37,7 @@ describe('views/settings/subscription', function() {
       profileClient: profileClient,
     });
 
-    const account = user.initAccount({
+    account = user.initAccount({
       email: 'a@a.com',
       sessionToken: 'abc123',
       uid: UID,
@@ -59,19 +60,19 @@ describe('views/settings/subscription', function() {
 
   describe('render', () => {
     it('renders an empty container when there are no active subscriptions', () => {
-      sinon.stub(view, '_hasActiveSubscriptions').resolves(false);
+      sinon.stub(account, 'hasSubscriptions').resolves(false);
       view.render().then(() => {
         assert.lengthOf(view.$('#manage-subscription'), 0);
       });
-      view._hasActiveSubscriptions.restore();
+      account.hasSubscriptions.restore();
     });
 
     it('renders the content when there are active subscriptions', () => {
-      sinon.stub(view, '_hasActiveSubscriptions').resolves(true);
+      sinon.stub(account, 'hasSubscriptions').resolves(true);
       view.render().then(() => {
         assert.lengthOf(view.$('#manage-subscription'), 1);
       });
-      view._hasActiveSubscriptions.restore();
+      account.hasSubscriptions.restore();
     });
   });
 

--- a/packages/fxa-content-server/app/tests/spec/views/support.js
+++ b/packages/fxa-content-server/app/tests/spec/views/support.js
@@ -58,9 +58,7 @@ describe('views/support', function() {
       verified: true,
     });
     sinon.stub(account, 'fetchProfile').returns(Promise.resolve());
-    sinon
-      .stub(account, 'fetchActiveSubscriptions')
-      .returns(Promise.resolve([{ id: '123done' }]));
+    sinon.stub(account, 'hasSubscriptions').resolves(true);
     sinon.stub(user, 'getAccountByUid').returns(account);
     sinon.stub(user, 'setSignedInAccountByUid').returns(Promise.resolve());
     sinon.stub(user, 'getSignedInAccount').returns(account);


### PR DESCRIPTION
In the Support Form and the Subscriptions subpanel in Settings, we check
to see if the account has any active subscriptions.  Previously we were
fetching the subscriptions list directly from the active subscriptions
endpoint.  However, since a list of subscriptions is available in the
account model's settings data, we can make use of it, and save a few
requests.

Fixes #1921

@mozilla/fxa-devs r?