### PR TITLE
fix(payments): quick fix for BrowserslistError: Unknown browser query `android all`

### DIFF
--- a/packages/fxa-payments-server/package-lock.json
+++ b/packages/fxa-payments-server/package-lock.json
@@ -4937,12 +4937,12 @@
       }
     },
     "browserslist": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.3.tgz",
-      "integrity": "sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.2.tgz",
+      "integrity": "sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==",
       "requires": {
-        "caniuse-lite": "^1.0.30000975",
-        "electron-to-chromium": "^1.3.164",
+        "caniuse-lite": "^1.0.30000974",
+        "electron-to-chromium": "^1.3.150",
         "node-releases": "^1.1.23"
       }
     },
@@ -5145,9 +5145,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000975",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000975.tgz",
-      "integrity": "sha512-ZsXA9YWQX6ATu5MNg+Vx/cMQ+hM6vBBSqDeJs8ruk9z0ky4yIHML15MoxcFt088ST2uyjgqyUGRJButkptWf0w=="
+      "version": "1.0.30000974",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz",
+      "integrity": "sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -31,6 +31,10 @@
     "url": "https://github.com/mozilla/fxa/issues"
   },
   "homepage": "https://github.com/mozilla/fxa/tree/master/packages/fxa-payments-server#README.md",
+  "resolutions": {
+    "browserslist": "4.6.2",
+    "caniuse-lite": "1.0.30000974"
+  },
   "devDependencies": {
     "@babel/core": "^7.4.5",
     "@babel/register": "^7.4.4",
@@ -55,6 +59,8 @@
     "audit-filter": "^0.5.0",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.5",
+    "browserslist": "^4.6.2",
+    "caniuse-lite": "^1.0.30000974",
     "concurrently": "^4.1.0",
     "cross-env": "^5.2.0",
     "eslint": "^5.16.0",


### PR DESCRIPTION
This looks like the minimal fix to the issue. A better fix would be to upgrade everything in package.json, but that introduces some new TypeScript errors from dependencies. Will file a follow up for that.

See also:
https://github.com/browserslist/browserslist/issues/382#issuecomment-506236189

fixes #1760