### PR TITLE
feat: add firestore type-checking

### DIFF
--- a/packages/fxa-event-broker/package-lock.json
+++ b/packages/fxa-event-broker/package-lock.json
@@ -2442,9 +2442,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.at": {
       "version": "4.6.0",
@@ -2472,9 +2472,9 @@
       "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
     },
     "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.snakecase": {
       "version": "4.1.1",
@@ -3564,6 +3564,11 @@
         "@types/hapi__joi": "^15.0.1",
         "@types/node": "*"
       }
+    },
+    "typesafe-node-firestore": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typesafe-node-firestore/-/typesafe-node-firestore-1.0.0.tgz",
+      "integrity": "sha512-v31yXxz477zzhA3U9bkMRmVcVeDPgZaLQt14ch3ycK9S64y9WSys9HJ4sa87tHib2rmFOZlG7rUsWKCac5N1nw=="
     },
     "typescript": {
       "version": "3.5.1",

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -36,7 +36,8 @@
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
     "sqs-consumer": "^5.2.0",
-    "typesafe-joi": "^2.0.2"
+    "typesafe-joi": "^2.0.2",
+    "typesafe-node-firestore": "^1.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",


### PR DESCRIPTION
This uses a port of the browser-based typesafe-firestore that works with the Node version to provide strong typing of Firestore documents.