### PR TITLE
refactor(test): Simplify loading of 123done in the tests.

### DIFF
--- a/packages/123done/static/index.html
+++ b/packages/123done/static/index.html
@@ -54,6 +54,12 @@
       >
         Sign In (prompt=none)
       </button>
+      <button
+        class="btn btn-large btn-info btn-persona force-auth"
+        type="submit"
+      >
+        Force auth
+      </button>
     </div>
 
     <div id="splash">

--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -141,6 +141,18 @@ $(document).ready(function() {
       authenticate('two_step_authentication');
     });
 
+    $('button.force-auth').click(function(ev) {
+      if (
+        !window.location.search.includes('email=') &&
+        !window.location.search.includes('login_hint=') &&
+        !navigator.userAgent.includes('FxATester')
+      ) {
+        alert('force_auth requires an `email` or `login_hint` query parameter');
+        return;
+      }
+      authenticate('force_auth');
+    });
+
     $('button.prompt-none').click(function(ev) {
       if (
         !window.location.search.includes('login_hint=') &&

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -1081,6 +1081,39 @@ const respondToWebChannelMessage = thenify(function(expectedCommand, response) {
 });
 
 /**
+ * Respond to web channel messages
+ *
+ * @param {Object} webChannelMessages
+ *  key->value pairs of message->response. Example:
+ *    {
+ *      'fxaccounts:fxa_status`: {
+ *        signedInUser: {
+ *          uid: '132142sfecd',
+ *          email: 'testuser@testuser.com'
+ *        }
+ *      }
+ *    }
+ * @returns {Promise}
+ */
+const respondToWebChannelMessages = thenify(function(webChannelResponses) {
+  return this.parent.then(function() {
+    if (webChannelResponses) {
+      return Object.keys(webChannelResponses).reduce(
+        (parent, webChannelMessage) => {
+          return parent.then(
+            respondToWebChannelMessage(
+              webChannelMessage,
+              webChannelResponses[webChannelMessage]
+            )
+          );
+        },
+        this.parent
+      );
+    }
+  });
+});
+
+/**
  * Store the data sent for a WebChannel event into sessionStorage.
  *
  * @param {string} expectedCommand command to store data for.
@@ -1312,22 +1345,7 @@ const openPage = thenify(function(url, readySelector, options) {
       .get(url)
       .setFindTimeout(config.pageLoadTimeout)
 
-      .then(function() {
-        const webChannelResponses = options.webChannelResponses;
-        if (webChannelResponses) {
-          return Object.keys(webChannelResponses).reduce(
-            (parent, webChannelMessage) => {
-              return parent.then(
-                respondToWebChannelMessage(
-                  webChannelMessage,
-                  webChannelResponses[webChannelMessage]
-                )
-              );
-            },
-            this.parent
-          );
-        }
-      })
+      .then(respondToWebChannelMessages(options.webChannelResponses))
 
       // Wait until the `readySelector` element is found to return.
       .then(testElementExists(readySelector))
@@ -1383,25 +1401,6 @@ function addQueryParamsToLink(link, query) {
 }
 
 /**
- * Re-open the same page with additional query parameters.
- *
- * @param   {object} additionalQueryParams key/value pairs of query parameters
- * @param   {string} waitForSelector query selector that indicates load is complete
- * @returns {promise} resolves when complete.
- */
-const reOpenWithAdditionalQueryParams = thenify(function(
-  additionalQueryParams,
-  waitForSelector,
-  options
-) {
-  return this.parent.getCurrentUrl().then(function(url) {
-    var urlToOpen = addQueryParamsToLink(url, additionalQueryParams);
-
-    return this.parent.then(openPage(urlToOpen, waitForSelector, options));
-  });
-});
-
-/**
  * Open FxA from an OAuth relier.
  *
  * @param {string} page - page to open
@@ -1413,55 +1412,26 @@ const reOpenWithAdditionalQueryParams = thenify(function(
  * relier. Defaults to `true`
  */
 const openFxaFromRp = thenify(function(page, options = {}) {
-  var app = options.untrusted ? UNTRUSTED_OAUTH_APP : OAUTH_APP;
-  var expectedHeader =
-    options.header || '#fxa-' + page.replace('_', '-') + '-header';
-  var queryParams = options.query || {};
-
-  // force_auth does not have a button on 123done, instead this is
-  // only available programatically. Load the force_auth page
-  // with only the email initially, then reload with the full passed
-  // in urlSuffix so things like the webChannelId are correctly passed.
-  if (page === 'force_auth') {
-    var emailSearchString =
-      '?' + Querystring.stringify({ email: queryParams.email });
-    var endpoint = app + 'api/force_auth' + emailSearchString;
-    return this.parent
-      .then(openPage(endpoint, expectedHeader))
-      .then(function() {
-        var numQueryParams = Object.keys(queryParams).length;
-        if (!numQueryParams || (numQueryParams === 1 && queryParams.email)) {
-          // email will already have been added, if passed in. email is
-          // not passed in for some functional tests to ensure query parameter
-          // validation is working properly.
-          return;
-        }
-        return this.parent.then(
-          reOpenWithAdditionalQueryParams(queryParams, expectedHeader, options)
-        );
-      });
-  }
-
+  const expectedHeader =
+    options.header || `#fxa-${page.replace('_', '-')}-header`;
+  const buttonSelector = `.ready .${page}`;
   return (
     this.parent
-      .then(openPage(app, '.ready .' + page))
-      .then(click('.ready .' + page))
+      .then(
+        //eslint-disable-next-line no-use-before-define
+        openRP({
+          // any query parameters that are meant for FxA are added
+          // onto the RP URL, the RP propagates query parameters to FxA.
+          ...options,
+          header: buttonSelector,
+        })
+      )
+      .then(click(buttonSelector))
+      .then(respondToWebChannelMessages(options.webChannelResponses))
 
       // wait until the page fully loads or else the re-load with
       // the suffix will blow its lid when run against latest.
       .then(testElementExists(expectedHeader))
-
-      .then(function() {
-        if (Object.keys(queryParams).length) {
-          return this.parent.then(
-            reOpenWithAdditionalQueryParams(
-              queryParams,
-              expectedHeader,
-              options
-            )
-          );
-        }
-      })
   );
 });
 
@@ -1496,7 +1466,14 @@ const openRP = thenify(function(options = {}) {
 
   const endpoint = `${app}${queryString}`;
   return this.parent.then(
-    openPage(endpoint, options.header || selectors['123DONE'].BUTTON_SIGNIN)
+    openPage(endpoint, options.header || selectors['123DONE'].BUTTON_SIGNIN, {
+      ...options,
+      // never hook up web channel listeners on the RP.
+      // 123done doesn't send WebChannel messages to the browser,
+      // and we certainly don't expect a response. Hooking up
+      // webChannelMessages here just slows down the test.
+      webChannelResponses: null,
+    })
   );
 });
 
@@ -2463,7 +2440,6 @@ module.exports = {
   pollUntil,
   pollUntilGoneByQSA,
   pollUntilHiddenByQSA,
-  reOpenWithAdditionalQueryParams,
   respondToWebChannelMessage,
   storeWebChannelMessageData,
   subscribeToTestProduct,

--- a/packages/fxa-content-server/tests/functional/oauth_email_first.js
+++ b/packages/fxa-content-server/tests/functional/oauth_email_first.js
@@ -25,7 +25,6 @@ const {
   openFxaFromRp,
   openPage,
   openVerificationLinkInSameTab,
-  reOpenWithAdditionalQueryParams,
   testElementExists,
   testElementTextEquals,
   testElementValueEquals,
@@ -150,13 +149,12 @@ registerSuite('oauth email first', {
 
       return this.remote
         .then(
-          openFxaFromRp('email-first', { header: selectors.ENTER_EMAIL.HEADER })
-        )
-        .then(
-          reOpenWithAdditionalQueryParams(
-            { email: invalidEmail },
-            selectors.ENTER_EMAIL.HEADER
-          )
+          openFxaFromRp('email-first', {
+            header: selectors.ENTER_EMAIL.HEADER,
+            query: {
+              email: invalidEmail,
+            },
+          })
         )
         .then(testElementValueEquals(selectors.ENTER_EMAIL.EMAIL, invalidEmail))
         .then(testElementExists(selectors.ENTER_EMAIL.TOOLTIP))
@@ -173,14 +171,11 @@ registerSuite('oauth email first', {
         this.remote
           .then(
             openFxaFromRp('email-first', {
-              header: selectors.ENTER_EMAIL.HEADER,
+              header: selectors.SIGNUP_PASSWORD.HEADER,
+              query: {
+                email,
+              },
             })
-          )
-          .then(
-            reOpenWithAdditionalQueryParams(
-              { email },
-              selectors.SIGNUP_PASSWORD.HEADER
-            )
           )
           .then(testElementValueEquals(selectors.SIGNUP_PASSWORD.EMAIL, email))
           // user realizes it's the wrong email address.
@@ -200,16 +195,11 @@ registerSuite('oauth email first', {
         this.remote
           .then(
             openFxaFromRp('email-first', {
-              header: selectors.ENTER_EMAIL.HEADER,
-            })
-          )
-          .then(
-            reOpenWithAdditionalQueryParams(
-              {
+              header: selectors.SIGNUP_PASSWORD.HEADER,
+              query: {
                 login_hint: email,
               },
-              selectors.SIGNUP_PASSWORD.HEADER
-            )
+            })
           )
 
           .then(testElementValueEquals(selectors.SIGNUP_PASSWORD.EMAIL, email))
@@ -231,14 +221,11 @@ registerSuite('oauth email first', {
           .then(createUser(email, PASSWORD, { preVerified: true }))
           .then(
             openFxaFromRp('email-first', {
-              header: selectors.ENTER_EMAIL.HEADER,
+              header: selectors.SIGNIN_PASSWORD.HEADER,
+              query: {
+                email,
+              },
             })
-          )
-          .then(
-            reOpenWithAdditionalQueryParams(
-              { email },
-              selectors.SIGNIN_PASSWORD.HEADER
-            )
           )
           .then(testElementValueEquals(selectors.SIGNIN_PASSWORD.EMAIL, email))
           // user realizes it's the wrong email address.
@@ -257,15 +244,12 @@ registerSuite('oauth email first', {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(
-          openFxaFromRp('email-first', { header: selectors.ENTER_EMAIL.HEADER })
-        )
-        .then(
-          reOpenWithAdditionalQueryParams(
-            {
+          openFxaFromRp('email-first', {
+            header: selectors.SIGNIN_PASSWORD.HEADER,
+            query: {
               login_hint: email,
             },
-            selectors.SIGNIN_PASSWORD.HEADER
-          )
+          })
         )
         .then(testElementValueEquals(selectors.SIGNIN_PASSWORD.EMAIL, email));
     },
@@ -276,16 +260,11 @@ registerSuite('oauth email first', {
           .then(createUser(email, PASSWORD, { preVerified: true }))
           .then(
             openFxaFromRp('email-first', {
-              header: selectors.ENTER_EMAIL.HEADER,
-            })
-          )
-          .then(
-            reOpenWithAdditionalQueryParams(
-              {
+              header: selectors.SIGNIN_PASSWORD.HEADER,
+              query: {
                 login_hint: email,
               },
-              selectors.SIGNIN_PASSWORD.HEADER
-            )
+            })
           )
           .then(testElementValueEquals(selectors.SIGNIN_PASSWORD.EMAIL, email))
 
@@ -444,15 +423,10 @@ registerSuite('oauth email first', {
         .then(
           openFxaFromRp('email-first', {
             header: selectors.SIGNIN_PASSWORD.HEADER,
-          })
-        )
-        .then(
-          reOpenWithAdditionalQueryParams(
-            {
+            query: {
               login_hint: loginHintEmail,
             },
-            selectors.SIGNIN_PASSWORD.HEADER
-          )
+          })
         )
 
         .then(
@@ -507,15 +481,10 @@ registerSuite('oauth email first', {
           .then(
             openFxaFromRp('email-first', {
               header: selectors.SIGNIN_PASSWORD.HEADER,
-            })
-          )
-          .then(
-            reOpenWithAdditionalQueryParams(
-              {
+              query: {
                 login_hint: loginHintEmail,
               },
-              selectors.SIGNIN_PASSWORD.HEADER
-            )
+            })
           )
 
           .then(
@@ -617,15 +586,10 @@ registerSuite('oauth email first', {
           .then(
             openFxaFromRp('email-first', {
               header: selectors.SIGNIN_PASSWORD.HEADER,
-            })
-          )
-          .then(
-            reOpenWithAdditionalQueryParams(
-              {
+              query: {
                 login_hint: loginHintEmail,
               },
-              selectors.SIGNIN_PASSWORD.HEADER
-            )
+            })
           )
 
           .then(
@@ -673,15 +637,10 @@ registerSuite('oauth email first', {
           .then(
             openFxaFromRp('email-first', {
               header: selectors.SIGNIN_PASSWORD.HEADER,
-            })
-          )
-          .then(
-            reOpenWithAdditionalQueryParams(
-              {
+              query: {
                 login_hint: loginHintEmail,
               },
-              selectors.SIGNIN_PASSWORD.HEADER
-            )
+            })
           )
 
           .then(

--- a/packages/fxa-content-server/tests/functional/oauth_force_auth.js
+++ b/packages/fxa-content-server/tests/functional/oauth_force_auth.js
@@ -46,7 +46,7 @@ registerSuite('oauth force_auth', {
       return (
         this.remote
           .then(createUser(email, PASSWORD, { preVerified: true }))
-          .then(openFxaFromRp('force_auth', { query: { email: email } }))
+          .then(openFxaFromRp('force-auth', { query: { email: email } }))
           .then(fillOutForceAuth(PASSWORD))
 
           .then(testElementExists('#loggedin'))
@@ -63,7 +63,7 @@ registerSuite('oauth force_auth', {
       return (
         this.remote
           .then(
-            openFxaFromRp('force_auth', {
+            openFxaFromRp('force-auth', {
               header: '#fxa-signup-header',
               query: { email: email },
             })
@@ -100,7 +100,7 @@ registerSuite('oauth force_auth', {
       return (
         this.remote
           .then(createUser(email, PASSWORD, { preVerified: true }))
-          .then(openFxaFromRp('force_auth', { query: { email: email } }))
+          .then(openFxaFromRp('force-auth', { query: { email: email } }))
           .then(fillOutForceAuth(PASSWORD))
 
           .then(testElementExists('#fxa-signin-unblock-header'))

--- a/packages/fxa-content-server/tests/functional/oauth_permissions.js
+++ b/packages/fxa-content-server/tests/functional/oauth_permissions.js
@@ -518,7 +518,7 @@ registerSuite('oauth permissions for trusted reliers', {
       return (
         this.remote
           .then(createUser(email, PASSWORD, { preVerified: true }))
-          .then(openFxaFromTrustedRp('force_auth', { query: { email: email } }))
+          .then(openFxaFromTrustedRp('force-auth', { query: { email: email } }))
           .then(fillOutForceAuth(PASSWORD))
 
           // no permissions asked for, straight to relier
@@ -531,7 +531,7 @@ registerSuite('oauth permissions for trusted reliers', {
         this.remote
           .then(createUser(email, PASSWORD, { preVerified: true }))
           .then(
-            openFxaFromTrustedRp('force_auth', {
+            openFxaFromTrustedRp('force-auth', {
               query: {
                 email: email,
                 prompt: 'consent',

--- a/packages/fxa-content-server/tests/functional/oauth_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sign_in.js
@@ -46,7 +46,6 @@ const {
   openVerificationLinkInDifferentBrowser,
   openVerificationLinkInNewTab,
   openVerificationLinkInSameTab,
-  reOpenWithAdditionalQueryParams,
   switchToWindow,
   testElementExists,
   testElementTextInclude,
@@ -110,13 +109,11 @@ registerSuite('oauth signin', {
     },
 
     'with service=sync specified': function() {
-      return this.remote.then(openFxaFromRp('signin')).then(
-        reOpenWithAdditionalQueryParams(
-          {
-            service: 'sync',
-          },
-          selectors['400'].HEADER
-        )
+      return this.remote.then(
+        openFxaFromRp('signin', {
+          header: selectors['400'].HEADER,
+          query: { service: 'sync' },
+        })
       );
     },
 


### PR DESCRIPTION
* Add a force_auth button to 123done, hook up click logic
  so it redirects to FxA's /force_auth flow.
* This allows a simplification of the openRP functional test helper,
  force_auth is no longer special cased.
* This further allows us to no longer require a page reload
  to add query parameters in the force_auth flow.
* And *this* further allows us to simplify how webChannel responses
  are hooked up, only attempt to attach them once on FxA instead
  of once on the 123done, and another time on FxA.
* Since 123done propagates query parameters, the OAuth email-first
  and signin tests were simplified to no longer call
  reOpenWithAdditionalQueryParams, and we were finally able to
  remove this horrible call.

@mozilla/fxa-devs - r?

Extracted as a standalone refactor from #2056 