### PR TITLE
fix(payments): ensure storybook gets a properly mocked-out app config

### DIFF
--- a/packages/fxa-payments-server/.storybook/components/MockApp.tsx
+++ b/packages/fxa-payments-server/.storybook/components/MockApp.tsx
@@ -3,6 +3,7 @@ import { action } from '@storybook/addon-actions';
 import { StripeProvider } from 'react-stripe-elements';
 import { MockLoader } from './MockLoader';
 import { AppContext, AppContextType } from '../../src/lib/AppContext';
+import { config } from '../../src/lib/config';
 import ScreenInfo from '../../src/lib/screen-info';
 
 declare global {
@@ -20,7 +21,18 @@ type MockAppProps = {
 
 export const defaultAppContextValue: AppContextType = {
   accessToken: 'at_12345',
-  config: {},
+  config: {
+    ...config,
+    productRedirectURLs: {
+      product_8675309: 'https://example.com/product'
+    },
+    servers: {
+      ...config.servers,
+      content: {
+        url: 'https://accounts.firefox.com'
+      },
+    },
+  },
   queryParams: {},
   navigateToUrl: action('navigateToUrl'),
   getScreenInfo: () => new ScreenInfo(window),

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -4,7 +4,8 @@ import { Provider } from 'react-redux';
 import { StripeProvider } from 'react-stripe-elements';
 import { BrowserRouter as Router, Route, Redirect } from 'react-router-dom';
 
-import { Config, QueryParams } from './lib/types';
+import { QueryParams } from './lib/types';
+import { Config } from './lib/config';
 import { AppContext, AppContextType } from './lib/AppContext';
 
 import './App.scss';

--- a/packages/fxa-payments-server/src/lib/AppContext.tsx
+++ b/packages/fxa-payments-server/src/lib/AppContext.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Config, QueryParams } from './types';
+import { QueryParams } from './types';
+import { Config, config } from './config';
 import ScreenInfo from './screen-info';
 
 export type AppContextType = {
@@ -13,7 +14,7 @@ export type AppContextType = {
 
 export const defaultAppContext = {
   accessToken: '',
-  config: {},
+  config,
   queryParams: {},
   navigateToUrl: () => {},
   getScreenInfo: () => new ScreenInfo(),

--- a/packages/fxa-payments-server/src/lib/types.tsx
+++ b/packages/fxa-payments-server/src/lib/types.tsx
@@ -1,8 +1,3 @@
-// TODO: Maybe flesh this out to match a convict config definition?
-export interface Config {
-  [propName: string]: any;
-}
-
 export interface QueryParams {
   plan?: string;
   activated?: string;


### PR DESCRIPTION
fixes #2098

Looks like AppContext and storybook were using an older Config type that allowed missing values. We have a newer more descriptive type for config. This should fix things by switching over to that and should help catch similar issues in the future.