### PR TITLE
fix(signin): Better invalid cached credential handling

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -32,7 +32,7 @@
       {{/isPasswordNeeded}}
 
       <div class="button-row">
-        <button id="submit-btn" type="submit">{{#t}}Sign in{{/t}}</button>
+        <button id="submit-btn" {{^isPasswordNeeded}}class="use-logged-in"{{/isPasswordNeeded}} type="submit">{{#t}}Sign in{{/t}}</button>
       </div>
 
       <div class="links">

--- a/packages/fxa-content-server/app/scripts/views/base.js
+++ b/packages/fxa-content-server/app/scripts/views/base.js
@@ -226,6 +226,9 @@ var BaseView = Backbone.View.extend({
 
     this._boundCheckAuthorization = this.checkAuthorization.bind(this);
     $(this.window).on('focus', this._boundCheckAuthorization);
+
+    // batch re-renders so that it's only called once.
+    this.rerender = _.debounce(this.rerender, 50);
   },
 
   /**
@@ -570,6 +573,16 @@ var BaseView = Backbone.View.extend({
     this.focusAutofocusElement();
 
     return Promise.resolve();
+  },
+
+  /**
+   * Re-renders the view, assumes the view
+   * is still visible.
+   *
+   * @returns {Promise}
+   */
+  rerender() {
+    return this.render().then(() => this.afterVisible());
   },
 
   /**

--- a/packages/fxa-content-server/app/scripts/views/mixins/form-prefill-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/form-prefill-mixin.js
@@ -28,9 +28,13 @@ function isElementFillable($el, formPrefill) {
 }
 
 export default {
-  initialize(options = {}) {
+  preinitialize(options = {}) {
+    // this.formPrefill must be set in `preinitialize` so that it's
+    // ready for any other views to use in their `initialize`
     this.formPrefill = options.formPrefill;
+  },
 
+  initialize() {
     // NOTE: this assumes `rendered` will be triggered after
     // the view has been rendered, but before `afterRender`.
     // `afterRender` takes care of seeding the model that tracks

--- a/packages/fxa-content-server/app/scripts/views/sign_in.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in.js
@@ -120,8 +120,8 @@ const View = FormView.extend({
    * @private
    */
   _signIn(account, password) {
-    return this.signIn(account, password).catch(err =>
-      this.onSignInError(account, password, err)
+    return this.signIn(account, password).catch(
+      this.onSignInError.bind(this, account, password)
     );
   },
 

--- a/packages/fxa-content-server/app/scripts/views/sign_in.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in.js
@@ -39,9 +39,6 @@ const View = FormView.extend({
     // the sign_in view because these are the users that are most likely
     // to have stored accounts, users that visit /signup probably not.
     this.user.logNumStoredAccounts();
-  },
-
-  beforeRender() {
     this._account = this.suggestedAccount();
   },
 
@@ -123,8 +120,8 @@ const View = FormView.extend({
    * @private
    */
   _signIn(account, password) {
-    return this.signIn(account, password).catch(
-      this.onSignInError.bind(this, account, password)
+    return this.signIn(account, password).catch(err =>
+      this.onSignInError(account, password, err)
     );
   },
 
@@ -149,14 +146,12 @@ const View = FormView.extend({
    * Render to a basic sign in view, used with "Use a different account" button
    */
   useDifferentAccount: preventDefaultThen(function() {
-    // TODO when the UI allows removal of individual accounts,
-    // only clear the current account.
-    this.user.removeAllAccounts();
     Session.clear();
     this.formPrefill.clear();
     this.logViewEvent('use-different-account');
+    this._account = this.user.initAccount({});
 
-    return this.render();
+    return this.rerender();
   }),
 
   _suggestSignUp(err) {

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -17,8 +17,6 @@ import SignInMixin from './mixins/signin-mixin';
 import Template from 'templates/sign_in_password.mustache';
 import UserCardMixin from './mixins/user-card-mixin';
 
-const PASSWORD_SELECTOR = 'input[type=password]';
-
 const SignInPasswordView = FormView.extend({
   template: Template,
 
@@ -55,8 +53,8 @@ const SignInPasswordView = FormView.extend({
 
   submit() {
     const account = this.getAccount();
-    if (this.$(PASSWORD_SELECTOR).length) {
-      const password = this.getElementValue(PASSWORD_SELECTOR);
+    if (this.isPasswordNeededForAccount(account)) {
+      const password = this.getElementValue('input[type=password]');
       return this.signIn(account, password).catch(error =>
         this.onSignInError(account, password, error)
       );

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -17,6 +17,8 @@ import SignInMixin from './mixins/signin-mixin';
 import Template from 'templates/sign_in_password.mustache';
 import UserCardMixin from './mixins/user-card-mixin';
 
+const PASSWORD_SELECTOR = 'input[type=password]';
+
 const SignInPasswordView = FormView.extend({
   template: Template,
 
@@ -53,8 +55,8 @@ const SignInPasswordView = FormView.extend({
 
   submit() {
     const account = this.getAccount();
-    if (this.isPasswordNeededForAccount(account)) {
-      const password = this.getElementValue('input[type=password]');
+    if (this.$(PASSWORD_SELECTOR).length) {
+      const password = this.getElementValue(PASSWORD_SELECTOR);
       return this.signIn(account, password).catch(error =>
         this.onSignInError(account, password, error)
       );

--- a/packages/fxa-content-server/app/tests/spec/views/base.js
+++ b/packages/fxa-content-server/app/tests/spec/views/base.js
@@ -12,6 +12,7 @@ import BaseView from 'views/base';
 import ErrorUtils from 'lib/error-utils';
 import Metrics from 'lib/metrics';
 import Notifier from 'lib/channels/notifier';
+import P from 'lib/promise';
 import Relier from 'models/reliers/base';
 import sinon from 'sinon';
 import Template from 'templates/test_template.mustache';
@@ -402,6 +403,23 @@ describe('views/base', function() {
 
       it('displays the message, `isSuccessVisible` returns `true`', () => {
         assert.isTrue(view.isSuccessVisible());
+      });
+    });
+  });
+
+  describe('rerender', () => {
+    it('is debounced, calls render, afterVisible', () => {
+      sinon.stub(view, 'render').callsFake(() => Promise.resolve());
+      sinon.stub(view, 'afterVisible');
+
+      view.rerender();
+      view.rerender();
+      view.rerender();
+      view.rerender();
+
+      return P.delay(100).then(() => {
+        assert.isTrue(view.render.calledOnce);
+        assert.isTrue(view.afterVisible.calledOnce);
       });
     });
   });

--- a/packages/fxa-content-server/app/tests/spec/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/tests/spec/views/choose_what_to_sync.js
@@ -245,9 +245,7 @@ describe('views/choose_what_to_sync', () => {
   });
 
   describe('submit', () => {
-    beforeEach(() => {});
-
-    it('updatesthe account, logs metrics, calls onSubmitComplete', () => {
+    it('updates the account, logs metrics, calls onSubmitComplete', () => {
       return initView()
         .then(() => {
           view

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/user-card-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/user-card-mixin.js
@@ -10,36 +10,33 @@ import { Model } from 'backbone';
 import UserCardMixin from 'views/mixins/user-card-mixin';
 import sinon from 'sinon';
 
-class View extends BaseView {}
-
-Cocktail.mixin(View, UserCardMixin);
-
 describe('views/mixins/user-card-mixin', () => {
   let account;
   let view;
+  class View extends BaseView {
+    getAccount() {
+      return account;
+    }
+    displayAccountProfileImage() {}
+  }
+  Cocktail.mixin(View, UserCardMixin);
 
   beforeEach(() => {
-    account = new Account({ email: 'testuser@testuser.com' });
-    view = new View({});
+    account = new Account({
+      accessToken: 'access-token',
+      email: 'testuser@testuser.com',
+    });
 
-    sinon.stub(view, 'getAccount').callsFake(() => account);
-    sinon.stub(view, 'displayAccountProfileImage').callsFake(() => {});
+    view = new View({});
   });
 
-  describe('afterVisible', () => {
-    it('hooks up a `change:accessToken` listener, displays account profile photo', () => {
-      sinon.spy(view, 'listenTo');
+  describe('change:accessToken listener', () => {
+    it('rerenders if the accessToken is revoked', () => {
+      sinon.stub(view, 'rerender').callsFake(() => {});
 
-      view.afterVisible();
+      account.unset('accessToken');
 
-      assert.isTrue(
-        view.listenTo.calledOnceWith(account, 'change:accessToken')
-      );
-      assert.isTrue(
-        view.displayAccountProfileImage.calledOnceWith(account, {
-          spinner: true,
-        })
-      );
+      assert.isTrue(view.rerender.calledOnce);
     });
   });
 
@@ -48,20 +45,6 @@ describe('views/mixins/user-card-mixin', () => {
       const context = new Model({});
       view.setInitialContext(context);
       assert.ok(context.get('userCardHTML'));
-    });
-  });
-
-  describe('_onAccessTokenChange', () => {
-    it('sets the default placeholder if the account has no access token', () => {
-      sinon.stub(view, 'setDefaultPlaceholderAvatar');
-
-      account.set('accessToken', 'token');
-      view._onAccessTokenChange();
-      assert.isFalse(view.setDefaultPlaceholderAvatar.called);
-
-      account.unset('accessToken');
-      view._onAccessTokenChange();
-      assert.isTrue(view.setDefaultPlaceholderAvatar.calledOnce);
     });
   });
 });

--- a/packages/fxa-content-server/app/tests/spec/views/permissions.js
+++ b/packages/fxa-content-server/app/tests/spec/views/permissions.js
@@ -189,7 +189,6 @@ describe('views/permissions', function() {
           'profile:uid': true,
         })
       );
-
       assert.isTrue(onSubmitComplete.calledWith(account));
     });
   });

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -1348,7 +1348,11 @@ const openPage = thenify(function(url, readySelector, options) {
       .then(respondToWebChannelMessages(options.webChannelResponses))
 
       // Wait until the `readySelector` element is found to return.
-      .then(testElementExists(readySelector))
+      .then(() => {
+        if (readySelector) {
+          return this.parent.then(testElementExists(readySelector));
+        }
+      })
 
       .then(null, function errorOpenPage(err) {
         return this.parent

--- a/packages/fxa-content-server/tests/functional/oauth_require_totp.js
+++ b/packages/fxa-content-server/tests/functional/oauth_require_totp.js
@@ -58,6 +58,7 @@ registerSuite('oauth require totp', {
         clearBrowserState({
           '123done': true,
           contentServer: true,
+          force: true,
         })
       )
       .then(
@@ -93,17 +94,9 @@ registerSuite('oauth require totp', {
         clearBrowserState({
           '123done': true,
           contentServer: true,
+          force: true,
         })
       );
-  },
-
-  afterEach: function() {
-    return this.remote.then(
-      clearBrowserState({
-        '123done': true,
-        contentServer: true,
-      })
-    );
   },
 
   tests: {

--- a/packages/fxa-content-server/tests/functional/sign_in_cached.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_cached.js
@@ -134,37 +134,34 @@ registerSuite('cached signin', {
 
           .then(click(selectors.SIGNIN.LINK_USE_DIFFERENT))
           .then(testElementExists(selectors.SIGNIN.EMAIL))
-
-          .then(openPage(PAGE_SIGNIN, selectors.SIGNIN.HEADER))
           .then(testElementValueEquals(selectors.SIGNIN.EMAIL, ''))
+
+          .then(openPage(PAGE_SIGNIN, selectors.SIGNIN.HEADER))
+          .then(
+            testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email2)
+          )
       );
     },
 
-    'open signin page with expired cached credentials': function() {
-      return (
-        this.remote
-          .then(openPage(PAGE_SIGNIN, selectors.SIGNIN.HEADER))
-          .then(fillOutSignIn(email, PASSWORD))
+    'expired cached credentials': function() {
+      return this.remote
+        .then(openPage(PAGE_SIGNIN, selectors.SIGNIN.HEADER))
+        .then(fillOutSignIn(email, PASSWORD))
 
-          .then(testElementExists(selectors.SETTINGS.HEADER))
+        .then(testElementExists(selectors.SETTINGS.HEADER))
 
-          .then(destroySessionForEmail(email))
+        .then(destroySessionForEmail(email))
 
-          .then(openPage(PAGE_SIGNIN, selectors.SIGNIN.HEADER))
-          .then(click(selectors.SIGNIN.SUBMIT_USE_SIGNED_IN))
+        .then(openPage(PAGE_SIGNIN, selectors.SIGNIN.HEADER))
+        .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email))
+        .then(testElementValueEquals(selectors.SIGNIN.EMAIL, email))
+        .then(type(selectors.SIGNIN.PASSWORD, PASSWORD))
+        .then(click(selectors.SIGNIN.SUBMIT))
 
-          // Session expired error should show.
-          .then(visibleByQSA(selectors.SIGNIN_PASSWORD.ERROR))
-
-          .then(testElementValueEquals(selectors.SIGNIN.EMAIL, email))
-          .then(type(selectors.SIGNIN.PASSWORD, PASSWORD))
-          .then(click(selectors.SIGNIN.SUBMIT))
-
-          .then(testElementExists(selectors.SETTINGS.HEADER))
-      );
+        .then(testElementExists(selectors.SETTINGS.HEADER));
     },
 
-    'open signin page with valid cached credentials that expire': function() {
+    'cached credentials that expire while on page': function() {
       return (
         this.remote
           .then(openPage(PAGE_SIGNIN, selectors.SIGNIN.HEADER))
@@ -182,6 +179,9 @@ registerSuite('cached signin', {
           // Session expired error should show.
           .then(visibleByQSA(selectors.SIGNIN.ERROR))
 
+          .then(
+            testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email)
+          )
           .then(testElementValueEquals(selectors.SIGNIN.EMAIL, email))
           .then(type(selectors.SIGNIN.PASSWORD, PASSWORD))
           .then(click(selectors.SIGNIN.SUBMIT))
@@ -244,7 +244,7 @@ registerSuite('cached signin', {
       );
     },
 
-    'sign in with desktop context then no context, desktop credentials should not persist': function() {
+    'sign in with desktop context then no context, desktop credentials should persist': function() {
       return (
         this.remote
           .then(openPage(PAGE_SIGNIN_SYNC_DESKTOP, selectors.SIGNIN.HEADER))
@@ -261,7 +261,6 @@ registerSuite('cached signin', {
           // not be cleared by clicking .use-different
           .then(openPage(PAGE_SIGNIN, selectors.SIGNIN.LINK_USE_DIFFERENT))
           .then(visibleByQSA(selectors.SIGNIN.HEADER))
-          // This will clear the desktop credentials
           .then(click(selectors.SIGNIN.LINK_USE_DIFFERENT))
           // need to wait for the email field to be visible
           // before attempting to sign-in.
@@ -276,14 +275,14 @@ registerSuite('cached signin', {
           // testing to make sure cached signin comes back after a refresh
           .then(openPage(PAGE_SIGNIN, selectors.SIGNIN.HEADER))
           .then(
-            testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email2)
+            testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email)
           )
 
           .refresh()
 
           .then(testElementExists(selectors.SIGNIN.LINK_USE_DIFFERENT))
           .then(
-            testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email2)
+            testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email)
           )
       );
     },


### PR DESCRIPTION
If a cached credential is stored and used on the signin
page, check whether the sessionToken is valid before rendering.
If the sessionToken is invalid, re-render and ask for a password.

If the sessionToken expires while the user is on the page,
also re-render, asking the user for their password.

This slightly modifies cached signin behavior. If a user
clicks "use a different account", we no longer remove the
stored sessionToken from localStorage, allowing Sync
accounts to remain the default account displayed on
the signin page for the next service, with a side
goal of minimizing the number of new sessions that
are created.

Part of this refactor is to re-render whenever an accessToken
or a sessionToken is removed from an account. Because
both can happen at the same time, I added a new method
"rerender" that is debounced so it's only processed once
within a 50ms timeframe if `rerender` is called multiple times.

fixes #999