### PR TITLE
refactor(CWTS): Remove `customizeSync` and `chooseWhatToSyncCheckbox` capability

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -119,10 +119,6 @@ function getUpdatedSessionData(email, relier, accountData, options = {}) {
     updatedSessionData.keyFetchToken = accountData.keyFetchToken;
   }
 
-  if (relier.isSync()) {
-    updatedSessionData.customizeSync = options.customizeSync || false;
-  }
-
   return updatedSessionData;
 }
 
@@ -222,9 +218,6 @@ FxaClientWrapper.prototype = {
    * @param {String} password
    * @param {Relier} relier
    * @param {Object} [options]
-   *   @param {Boolean} [options.customizeSync] - If the relier is Sync,
-   *                   whether the user wants to customize which items will
-   *                   be synced. Defaults to `false`
    *   @param {String} [options.metricsContext] - context metadata for use in
    *                   flow events
    *   @param {String} [options.reason] - Reason for the sign in. See definitions
@@ -387,9 +380,6 @@ FxaClientWrapper.prototype = {
    * @param {String} password
    * @param {Relier} relier
    * @param {Object} [options]
-   *   @param {Boolean} [options.customizeSync] - If the relier is Sync,
-   *                    whether the user wants to customize which items
-   *                    will be synced. Defaults to `false`
    *   @param {String} [options.metricsContext] - Metrics context metadata
    *   @param {Boolean} [options.preVerified] - is the user preVerified
    *   @param {String} [options.resume] - Resume token, passed in the
@@ -533,9 +523,6 @@ FxaClientWrapper.prototype = {
    *                   flow events
    *   @param {String} [options.resume] - Resume token, passed in the
    *                   verification link if the user must verify their email.
-   *   @param {Boolean} [options.customizeSync] - If the relier is Sync,
-   *                   whether the user wants to customize which items will
-   *                   be synced. Defaults to `false`
    * @return {Promise} resolves when complete
    */
   passwordReset: withClient((client, originalEmail, relier, options = {}) => {

--- a/packages/fxa-content-server/app/scripts/lib/sentry.js
+++ b/packages/fxa-content-server/app/scripts/lib/sentry.js
@@ -11,7 +11,6 @@ var ALLOWED_QUERY_PARAMETERS = [
   'automatedBrowser',
   'client_id',
   'context',
-  'customizeSync',
   'entrypoint',
   'keys',
   'migration',

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -55,7 +55,6 @@ const PERSISTENT = {
 const DEFAULTS = _.extend(
   {
     accessToken: undefined,
-    customizeSync: undefined,
     declinedSyncEngines: undefined,
     keyFetchToken: undefined,
     // We should be able to remove `needsOptedInToMarketingEmail` after train-140 or so.
@@ -665,7 +664,6 @@ const Account = Backbone.Model.extend(
     signUp(password, relier, options = {}) {
       return this._fxaClient
         .signUp(this.get('email'), password, relier, {
-          customizeSync: this.get('customizeSync'),
           metricsContext: this._metrics.getFlowEventMetadata(),
           resume: options.resume,
         })

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/base.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/base.js
@@ -544,10 +544,6 @@ const BaseAuthenticationBroker = Backbone.Model.extend({
      */
     browserTransitionsAfterEmailVerification: true,
     /**
-     * Should the signup page show the `Choose what to sync` checkbox
-     */
-    chooseWhatToSyncCheckbox: true,
-    /**
      * Should external links be converted to text?
      */
     convertExternalLinksToText: false,

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-desktop-v2.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-desktop-v2.js
@@ -34,7 +34,6 @@ const FxDesktopV2AuthenticationBroker = FxSyncWebChannelAuthenticationBroker.ext
     }),
 
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
-      chooseWhatToSyncCheckbox: false,
       chooseWhatToSyncWebV1: true,
       openWebmailButtonVisible: true,
     }),

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-fennec-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-fennec-v1.js
@@ -15,7 +15,6 @@ const proto = FxSyncWebChannelAuthenticationBroker.prototype;
 export default FxSyncWebChannelAuthenticationBroker.extend({
   defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
     browserTransitionsAfterEmailVerification: false,
-    chooseWhatToSyncCheckbox: false,
     chooseWhatToSyncWebV1: true,
     emailFirst: true,
     emailVerificationMarketingSnippet: false,

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -46,7 +46,6 @@ export default FxSyncChannelAuthenticationBroker.extend({
   }),
 
   defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
-    chooseWhatToSyncCheckbox: false,
     chooseWhatToSyncWebV1: true,
     convertExternalLinksToText: true,
     emailFirst: true,
@@ -69,15 +68,6 @@ export default FxSyncChannelAuthenticationBroker.extend({
   },
 
   afterResetPasswordConfirmationPoll(account) {
-    // We wouldn't expect `customizeSync` to be set when completing
-    // a password reset, but the field must be present for the login
-    // message to be sent. false is the default value set in
-    // lib/fxa-client.js if the value is not present.
-    // See #5528
-    if (!account.has('customizeSync')) {
-      account.set('customizeSync', false);
-    }
-
     // fx-ios-v1 send a login message after reset password complete,
     // assuming the user verifies in the same browser. fx-ios-v1
     // do not support WebChannels, and the login message must be

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-sync-channel.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-sync-channel.js
@@ -18,7 +18,6 @@ import Logger from '../../lib/logger';
 const proto = FxSyncAuthenticationBroker.prototype;
 
 const ALLOWED_LOGIN_FIELDS = [
-  'customizeSync',
   'declinedSyncEngines',
   'email',
   'keyFetchToken',
@@ -30,7 +29,6 @@ const ALLOWED_LOGIN_FIELDS = [
 ];
 
 const REQUIRED_LOGIN_FIELDS = [
-  'customizeSync',
   'email',
   'keyFetchToken',
   'sessionToken',

--- a/packages/fxa-content-server/app/scripts/models/reliers/base.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/base.js
@@ -37,15 +37,6 @@ var Relier = Backbone.Model.extend({
   },
 
   /**
-   * Check if the relier forces the "customize sync" checkbox to be checked.
-   *
-   * @returns {Boolean}
-   */
-  isCustomizeSyncChecked() {
-    return false;
-  },
-
-  /**
    * Check if the relier wants access to the account encryption keys.
    *
    * @returns {Boolean}

--- a/packages/fxa-content-server/app/scripts/models/reliers/sync.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/sync.js
@@ -20,7 +20,6 @@ const QUERY_PARAMETER_SCHEMA = {
   // context is not available when verifying.
   context: Vat.string().min(1),
   country: Vat.string().valid(...AllowedCountries),
-  customizeSync: Vat.boolean(),
   service: Vat.string(),
   // signin code, from an SMS. Note, this is *not* validated
   // because users that open the verification link with an
@@ -35,7 +34,6 @@ const QUERY_PARAMETER_SCHEMA = {
 export default Relier.extend({
   defaults: _.extend({}, Relier.prototype.defaults, {
     action: undefined,
-    customizeSync: false,
     signinCode: undefined,
     tokenCode: false,
   }),
@@ -67,14 +65,5 @@ export default Relier.extend({
    */
   wantsKeys() {
     return true;
-  },
-
-  /**
-   * Check if the relier wants to force the customize sync checkbox on
-   *
-   * @returns {Boolean}
-   */
-  isCustomizeSyncChecked() {
-    return !!this.get('customizeSync');
   },
 });

--- a/packages/fxa-content-server/app/scripts/templates/sign_up.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up.mustache
@@ -89,14 +89,6 @@
       <div class="button-row">
         <button id="submit-btn" type="submit">{{#t}}Create account{{/t}}</button>
       </div>
-
-      {{#isSync}}
-      {{#chooseWhatToSyncCheckbox}}
-        <div class="input-row customize-sync-row">
-          <input id="customize-sync" type="checkbox" class="customize-sync customize-sync-bottom" {{#isCustomizeSyncChecked}}checked="checked"{{/isCustomizeSyncChecked}} /><label for="customize-sync">{{#t}}Choose what to sync{{/t}}</label>
-        </div>
-      {{/chooseWhatToSyncCheckbox}}
-      {{/isSync}}
     </form>
 
     <div class="links">

--- a/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
@@ -89,7 +89,6 @@ const View = FormView.extend(
       this._trackDeclinedEngineIds(declinedSyncEngines);
 
       account.set({
-        customizeSync: true,
         declinedSyncEngines,
         offeredSyncEngines,
       });

--- a/packages/fxa-content-server/app/scripts/views/sign_up.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_up.js
@@ -117,13 +117,9 @@ var View = FormView.extend(
       var isSync = relier.isSync();
 
       context.set({
-        chooseWhatToSyncCheckbox: this.broker.hasCapability(
-          'chooseWhatToSyncCheckbox'
-        ),
         email: prefillEmail,
         error: this.error,
         forceEmail: forceEmail,
-        isCustomizeSyncChecked: relier.isCustomizeSyncChecked(),
         isSignInEnabled: !forceEmail,
         isSync: isSync,
       });
@@ -302,7 +298,6 @@ var View = FormView.extend(
 
     _initAccount() {
       const account = this.user.initAccount({
-        customizeSync: this.$('.customize-sync').is(':checked'),
         email: this.getElementValue('.email'),
       });
 
@@ -310,11 +305,6 @@ var View = FormView.extend(
         account.set({
           newsletters: this.getOptedIntoNewsletters(),
         });
-      }
-
-      if (this.relier.isSync()) {
-        var customizeSync = account.get('customizeSync');
-        this.logViewEvent('customizeSync.' + String(customizeSync));
       }
 
       return account;

--- a/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
@@ -120,7 +120,6 @@ describe('lib/fxa-client', function() {
 
       return client
         .signUp(email, password, relier, {
-          customizeSync: true,
           resume: resumeToken,
         })
         .then(function(sessionData) {
@@ -136,7 +135,6 @@ describe('lib/fxa-client', function() {
           // The following should only be set for Sync
           assert.equal(sessionData.unwrapBKey, 'unwrapBKey');
           assert.equal(sessionData.keyFetchToken, 'keyFetchToken');
-          assert.equal(sessionData.customizeSync, true);
         });
     });
 
@@ -147,10 +145,8 @@ describe('lib/fxa-client', function() {
 
       relier.set('service', NON_SYNC_SERVICE);
       assert.isFalse(relier.wantsKeys());
-      // customizeSync should be ignored
       return client
         .signUp(email, password, relier, {
-          customizeSync: true,
           resume: resumeToken,
         })
         .then(function(sessionData) {
@@ -166,8 +162,6 @@ describe('lib/fxa-client', function() {
           // These should not be returned by default
           assert.isFalse('unwrapBKey' in sessionData);
           assert.isFalse('keyFetchToken' in sessionData);
-          // The following should only be set for Sync
-          assert.isFalse('customizeSync' in sessionData);
         });
     });
 
@@ -183,7 +177,6 @@ describe('lib/fxa-client', function() {
       sinon.stub(relier, 'wantsKeys').callsFake(() => true);
       return client
         .signUp(email, password, relier, {
-          customizeSync: true,
           resume: resumeToken,
         })
         .then(function(sessionData) {
@@ -198,8 +191,6 @@ describe('lib/fxa-client', function() {
 
           assert.equal(sessionData.unwrapBKey, 'unwrapBKey');
           assert.equal(sessionData.keyFetchToken, 'keyFetchToken');
-          // The following should only be set for Sync
-          assert.isFalse('customizeSync' in sessionData);
         });
     });
 
@@ -593,7 +584,6 @@ describe('lib/fxa-client', function() {
 
       return client
         .signIn(email, password, relier, {
-          customizeSync: true,
           resume: resumeToken,
         })
         .then(function(sessionData) {
@@ -607,8 +597,6 @@ describe('lib/fxa-client', function() {
             })
           );
 
-          // `customizeSync` should only be set for Sync
-          assert.isUndefined(sessionData.customizeSync);
           assert.equal(sessionData.keyFetchToken, 'keyFetchToken');
           assert.equal(sessionData.unwrapBKey, 'unwrapBKey');
           assert.isFalse(sessionData.verified);
@@ -629,7 +617,6 @@ describe('lib/fxa-client', function() {
       relier.set('service', NON_SYNC_SERVICE);
       sinon.stub(relier, 'wantsKeys').callsFake(() => false);
 
-      // customizeSync should be ignored.
       return client.signIn(email, password, relier).then(function(sessionData) {
         assert.isTrue(
           realClient.signIn.calledWith(trim(email), password, {
@@ -643,30 +630,7 @@ describe('lib/fxa-client', function() {
         // These should not be returned by default
         assert.isFalse('unwrapBKey' in sessionData);
         assert.isFalse('keyFetchToken' in sessionData);
-        // The following should only be set for Sync
-        assert.isFalse('customizeSync' in sessionData);
       });
-    });
-
-    it('Sync signIn informs browser of customizeSync option', function() {
-      sinon.stub(relier, 'isSync').callsFake(() => true);
-      sinon.stub(relier, 'wantsKeys').callsFake(() => true);
-      sinon.stub(realClient, 'signIn').callsFake(() => Promise.resolve({}));
-
-      return client
-        .signIn(email, password, relier, { customizeSync: true })
-        .then(function(sessionData) {
-          assert.isTrue(
-            realClient.signIn.calledWith(trim(email), password, {
-              keys: true,
-              reason: SignInReasons.SIGN_IN,
-              redirectTo: REDIRECT_TO,
-              service: SYNC_SERVICE,
-            })
-          );
-
-          assert.isTrue(sessionData.customizeSync);
-        });
     });
 
     it('passes along an optional `reason`', function() {

--- a/packages/fxa-content-server/app/tests/spec/models/account.js
+++ b/packages/fxa-content-server/app/tests/spec/models/account.js
@@ -1189,7 +1189,6 @@ describe('models/account', function() {
 
   describe('signUp', function() {
     beforeEach(function() {
-      account.set('customizeSync', true);
       account.set('needsOptedInToMarketingEmail', true);
       sinon.stub(fxaClient, 'signUp').callsFake(function() {
         return Promise.resolve({
@@ -1204,7 +1203,6 @@ describe('models/account', function() {
     it('delegates to the fxaClient', function() {
       assert.isTrue(
         fxaClient.signUp.calledWith(EMAIL, PASSWORD, relier, {
-          customizeSync: true,
           metricsContext: {
             baz: 'qux',
             foo: 'bar',

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -43,7 +43,6 @@ describe('models/auth_brokers/fx-desktop-v2', () => {
     assert.isTrue(
       broker.getCapability('browserTransitionsAfterEmailVerification')
     );
-    assert.isFalse(broker.getCapability('chooseWhatToSyncCheckbox'));
     assert.isTrue(broker.getCapability('chooseWhatToSyncWebV1'));
     assert.isTrue(broker.getCapability('openWebmailButtonVisible'));
     assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
@@ -156,12 +155,6 @@ describe('models/auth_brokers/fx-desktop-v2', () => {
       return broker.afterDeleteAccount(account).then(() => {
         assert.isTrue(channelMock.send.calledWith('fxaccounts:delete_account'));
       });
-    });
-  });
-
-  it('disables the `chooseWhatToSyncCheckbox` capability', () => {
-    return broker.fetch().then(() => {
-      assert.isFalse(broker.hasCapability('chooseWhatToSyncCheckbox'));
     });
   });
 

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
@@ -59,12 +59,6 @@ describe('models/auth_brokers/fx-fennec-v1', function() {
     );
   });
 
-  it('disables the `chooseWhatToSyncCheckbox` capability', function() {
-    return broker.fetch().then(function() {
-      assert.isFalse(broker.hasCapability('chooseWhatToSyncCheckbox'));
-    });
-  });
-
   describe('afterForceAuth', function() {
     it('notifies the channel of `login`', function() {
       return broker.afterForceAuth(account).then(function(behavior) {

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-ios-v1.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-ios-v1.js
@@ -94,7 +94,6 @@ describe('models/auth_brokers/fx-ios-v1', () => {
 
     it('has the expected capabilities', () => {
       assert.isTrue(broker.hasCapability('signup'));
-      assert.isFalse(broker.hasCapability('chooseWhatToSyncCheckbox'));
     });
 
     it('`broker.SIGNUP_DISABLED_REASON` is not set', () => {
@@ -244,16 +243,9 @@ describe('models/auth_brokers/fx-ios-v1', () => {
     it('notifies the channel of login, halts by default', () => {
       sinon.spy(broker, 'send');
 
-      // customizeSync is required to send the `login` message, but
-      // it won't be set because the user hasn't visited the signup/in
-      // page.
-      account.unset('customizeSync');
-
       return broker.afterResetPasswordConfirmationPoll(account).then(result => {
         assert.isTrue(broker.send.calledWith('login'));
         assert.isTrue(broker.send.calledOnce);
-        const loginData = broker.send.args[0][1];
-        assert.isFalse(loginData.customizeSync);
 
         assert.isTrue(result.halt);
       });

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync-channel.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync-channel.js
@@ -50,7 +50,6 @@ describe('models/auth_brokers/fx-sync-channel', () => {
 
     user = new User();
     account = user.initAccount({
-      customizeSync: true,
       declinedSyncEngines: ['addons'],
       email: 'testuser@testuser.com',
       keyFetchToken: 'key-fetch-token',
@@ -180,7 +179,6 @@ describe('models/auth_brokers/fx-sync-channel', () => {
         assert.isTrue(channelMock.send.calledWith('login'));
 
         const data = channelMock.send.args[0][1];
-        assert.isTrue(data.customizeSync);
         assert.sameMembers(data.declinedSyncEngines, ['addons']);
         assert.equal(data.email, 'testuser@testuser.com');
         assert.equal(data.keyFetchToken, 'key-fetch-token');
@@ -249,7 +247,6 @@ describe('models/auth_brokers/fx-sync-channel', () => {
   describe('afterSignIn', () => {
     it('notifies the channel of login, does not halt by default', () => {
       account.set({
-        customizeSync: true,
         declinedSyncEngines: ['bookmarks', 'passwords'],
         keyFetchToken: 'key_fetch_token',
         sessionToken: 'session_token',
@@ -262,7 +259,6 @@ describe('models/auth_brokers/fx-sync-channel', () => {
       return broker.afterSignIn(account).then(function(result) {
         const args = channelMock.send.args[0];
         assert.equal(args[0], 'login');
-        assert.equal(args[1].customizeSync, true);
         assert.deepEqual(args[1].declinedSyncEngines, [
           'bookmarks',
           'passwords',
@@ -377,7 +373,6 @@ describe('models/auth_brokers/fx-sync-channel', () => {
   describe('afterChangePassword', () => {
     it('notifies the channel of change_password with the new login info', () => {
       account.set({
-        customizeSync: true,
         keyFetchToken: 'key_fetch_token',
         sessionToken: 'session_token',
         sessionTokenContext: 'sync',
@@ -393,7 +388,6 @@ describe('models/auth_brokers/fx-sync-channel', () => {
         assert.equal(args[1].uid, 'uid');
         assert.equal(args[1].sessionToken, 'session_token');
         assert.equal(args[1].unwrapBKey, 'unwrap_b_key');
-        assert.equal(args[1].customizeSync, true);
         assert.equal(args[1].verified, true);
         assert.isUndefined(args[1].sessionTokenContext);
       });

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync-web-channel.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync-web-channel.js
@@ -38,7 +38,6 @@ describe('models/auth_brokers/fx-sync-web-channel', () => {
 
     user = new User();
     account = user.initAccount({
-      customizeSync: true,
       declinedSyncEngines: ['addons'],
       email: 'testuser@testuser.com',
       keyFetchToken: 'key-fetch-token',

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/base.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/base.js
@@ -38,12 +38,6 @@ describe('models/reliers/base', function() {
     });
   });
 
-  describe('isCustomizeSyncChecked', function() {
-    it('returns `false`', function() {
-      assert.isFalse(relier.isCustomizeSyncChecked());
-    });
-  });
-
   describe('pickResumeTokenInfo', function() {
     it('returns an empty object by default', function() {
       assert.deepEqual(relier.pickResumeTokenInfo(), {});

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/sync.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/sync.js
@@ -47,7 +47,6 @@ describe('models/reliers/sync', () => {
         action: ACTION,
         context: CONTEXT,
         country: COUNTRY,
-        customizeSync: 'true',
         service: SYNC_SERVICE,
         signin: 'signin-code',
       });
@@ -57,7 +56,6 @@ describe('models/reliers/sync', () => {
         assert.equal(relier.get('context'), CONTEXT);
         assert.equal(relier.get('country'), COUNTRY);
         assert.equal(relier.get('service'), SYNC_SERVICE);
-        assert.isTrue(relier.get('customizeSync'));
         assert.equal(relier.get('signinCode'), 'signin-code');
       });
     });
@@ -200,70 +198,6 @@ describe('models/reliers/sync', () => {
       });
     });
 
-    describe('customizeSync query parameter', () => {
-      describe('missing', () => {
-        beforeEach(() => {
-          windowMock.location.search = TestHelpers.toSearchString({
-            context: CONTEXT,
-          });
-
-          return relier.fetch();
-        });
-
-        it('succeeds', () => {
-          assert.isFalse(relier.get('customizeSync'));
-        });
-      });
-
-      describe('emtpy', () => {
-        beforeEach(() => {
-          windowMock.location.search = TestHelpers.toSearchString({
-            context: CONTEXT,
-            customizeSync: '',
-          });
-
-          return fetchExpectError();
-        });
-
-        it('errors correctly', () => {
-          assert.isTrue(AuthErrors.is(err, 'INVALID_PARAMETER'));
-          assert.equal(err.param, 'customizeSync');
-        });
-      });
-
-      describe('whitespace', () => {
-        beforeEach(() => {
-          windowMock.location.search = TestHelpers.toSearchString({
-            context: CONTEXT,
-            customizeSync: ' ',
-          });
-
-          return fetchExpectError();
-        });
-
-        it('errors correctly', () => {
-          assert.isTrue(AuthErrors.is(err, 'INVALID_PARAMETER'));
-          assert.equal(err.param, 'customizeSync');
-        });
-      });
-
-      describe('not a boolean', () => {
-        beforeEach(() => {
-          windowMock.location.search = TestHelpers.toSearchString({
-            context: CONTEXT,
-            customizeSync: 'not a boolean',
-          });
-
-          return fetchExpectError();
-        });
-
-        it('errors correctly', () => {
-          assert.isTrue(AuthErrors.is(err, 'INVALID_PARAMETER'));
-          assert.equal(err.param, 'customizeSync');
-        });
-      });
-    });
-
     describe('signin query parameter', () => {
       describe('missing', () => {
         beforeEach(() => {
@@ -340,30 +274,6 @@ describe('models/reliers/sync', () => {
   describe('isSync', () => {
     it('returns `true`', () => {
       assert.isTrue(relier.isSync());
-    });
-  });
-
-  describe('isCustomizeSyncChecked', () => {
-    it('returns true if `customizeSync=true`', () => {
-      windowMock.location.search = TestHelpers.toSearchString({
-        context: CONTEXT,
-        customizeSync: 'true',
-      });
-
-      return relier.fetch().then(() => {
-        assert.isTrue(relier.isCustomizeSyncChecked());
-      });
-    });
-
-    it('returns false if `customizeSync=false`', () => {
-      windowMock.location.search = TestHelpers.toSearchString({
-        context: CONTEXT,
-        customizeSync: 'false',
-      });
-
-      return relier.fetch().then(() => {
-        assert.isFalse(relier.isCustomizeSyncChecked());
-      });
     });
   });
 

--- a/packages/fxa-content-server/app/tests/spec/views/confirm.js
+++ b/packages/fxa-content-server/app/tests/spec/views/confirm.js
@@ -61,7 +61,6 @@ describe('views/confirm', function() {
     });
 
     account = user.initAccount({
-      customizeSync: true,
       email: 'a@a.com',
       sessionToken: 'fake session token',
       uid: 'uid',
@@ -201,10 +200,7 @@ describe('views/confirm', function() {
 
       sinon
         .stub(broker, 'beforeSignUpConfirmationPoll')
-        .callsFake(function(account) {
-          assert.isTrue(account.get('customizeSync'));
-          return Promise.resolve();
-        });
+        .callsFake(() => Promise.resolve());
 
       sinon.stub(view, 'waitForSessionVerification').callsFake(() => {});
 
@@ -332,7 +328,6 @@ describe('views/confirm', function() {
       broker.setCapability('openWebmailButtonVisible', true);
 
       account = user.initAccount({
-        customizeSync: true,
         email: 'a@gmail.com',
         sessionToken: 'fake session token',
         uid: 'uid',

--- a/packages/fxa-content-server/tests/functional/fx_fennec_v1_sign_up.js
+++ b/packages/fxa-content-server/tests/functional/fx_fennec_v1_sign_up.js
@@ -19,7 +19,6 @@ const {
   click,
   closeCurrentWindow,
   fillOutSignUp,
-  noSuchElement,
   noSuchBrowserNotification,
   openPage,
   openVerificationLinkInNewTab,
@@ -49,7 +48,6 @@ registerSuite('Fx Fennec Sync v1 sign_up', {
               ok: true,
             })
           )
-          .then(noSuchElement(selectors.SIGNUP.CUSTOMIZE_SYNC_CHECKBOX))
           .then(fillOutSignUp(email, PASSWORD))
 
           // user should be transitioned to the choose what to Sync page

--- a/packages/fxa-content-server/tests/functional/fx_ios_v1_sign_up.js
+++ b/packages/fxa-content-server/tests/functional/fx_ios_v1_sign_up.js
@@ -22,7 +22,6 @@ const {
   clearBrowserState,
   closeCurrentWindow,
   fillOutSignUp,
-  noSuchElement,
   openPage,
   openVerificationLinkInNewTab,
   switchToWindow,
@@ -53,7 +52,6 @@ registerSuite('FxiOS v1 sign_up', {
             })
           )
           .execute(listenForFxaCommands)
-          .then(noSuchElement(selectors.SIGNUP.CUSTOMIZE_SYNC_CHECKBOX))
           .then(fillOutSignUp(email, PASSWORD))
 
           // In Fx for iOS >= 11.0, user should be transitioned to the

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -1517,7 +1517,6 @@ const fillOutSignInTokenCode = thenify(function(email, number) {
 const fillOutSignUp = thenify(function(email, password, options) {
   options = options || {};
 
-  var customizeSync = options.customizeSync || false;
   var enterEmail = options.enterEmail !== false;
   var age = options.age || 24;
   var submit = options.submit !== false;
@@ -1544,12 +1543,6 @@ const fillOutSignUp = thenify(function(email, password, options) {
       return type(selectors.SIGNUP.VPASSWORD, vpassword).call(this);
     })
     .then(type(selectors.SIGNUP.AGE, age))
-
-    .then(function() {
-      if (customizeSync) {
-        return click(selectors.SIGNUP.CUSTOMIZE_SYNC_CHECKBOX).call(this);
-      }
-    })
 
     .then(function() {
       if (submit) {

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -295,7 +295,6 @@ module.exports = {
   },
   SIGNUP: {
     AGE: '#age',
-    CUSTOMIZE_SYNC_CHECKBOX: '#customize-sync',
     EMAIL: 'input[type=email]',
     ERROR: '.error',
     FIREFOX_FAMILY_SERVICES: '.firefox-family-services',


### PR DESCRIPTION
No longer send the field when signing into Sync, remove
traces of the UI element, remove it from everywhere.

fixes #2020
fixes #2133

@vladikoff - r?