### PR TITLE
fix(test): Fix the signup newsletter test

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/views/sign_up.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_up.js
@@ -843,6 +843,7 @@ describe('views/sign_up', function() {
         beforeEach(function() {
           sinon.stub(view, 'signUp').callsFake(() => Promise.resolve());
           sinon.stub(view, '_hasOptedIntoNewsletter').callsFake(() => true);
+          sinon.stub(view, 'isAnyNewsletterVisible').callsFake(() => true);
 
           return view.submit();
         });


### PR DESCRIPTION
`isAnyNewsletterVisible` was not stubbed to be `true`, and
it seems via some strange timing issue it sometimes passed
before, perhaps from a render in another view. Stub
out the method to ensure it always returns true and that
the expected newsletters are sent in the test.

fixes #2134

@mozilla/fxa-devs - r?