### PR TITLE
fix(support-panel): add CSP frame-ancestors

### DIFF
--- a/packages/fxa-support-panel/bin/worker.ts
+++ b/packages/fxa-support-panel/bin/worker.ts
@@ -10,7 +10,7 @@ import { init, ServerEnvironment } from '../lib/server';
 const logger = mozlog(Config.get('logging'))('supportPanel');
 
 async function main() {
-  const server = init(
+  const server = await init(
     { ...Config.getProperties(), env: Config.get('env') as ServerEnvironment },
     logger
   );

--- a/packages/fxa-support-panel/config/index.ts
+++ b/packages/fxa-support-panel/config/index.ts
@@ -66,6 +66,16 @@ const conf = convict({
         format: ['default_fxa', 'dev_fxa', 'default', 'dev', 'short', 'tiny']
       }
     }
+  },
+  security: {
+    csp: {
+      frameAncestors: {
+        default: 'none',
+        doc:
+          'https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors',
+        env: 'CSP_FRAME_ANCESTORS'
+      }
+    }
   }
 });
 

--- a/packages/fxa-support-panel/package-lock.json
+++ b/packages/fxa-support-panel/package-lock.json
@@ -270,6 +270,14 @@
         "@hapi/joi": "15.x.x"
       }
     },
+    "@hapi/scooter": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/scooter/-/scooter-5.1.0.tgz",
+      "integrity": "sha512-UdUxYGLiR/yfYUxJ97nxKLvSgGqReIn/keczcdn4dcsNQBIGt25JeuEDX7Vmrl+a3Y+X/w5t7iKhpt4MX/lsmw==",
+      "requires": {
+        "useragent": "2.x.x"
+      }
+    },
     "@hapi/shot": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-4.1.0.tgz",
@@ -677,6 +685,15 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "blankie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/blankie/-/blankie-4.1.1.tgz",
+      "integrity": "sha512-rV8BLrR5T7UkkSf27mPiRWGn8/peJs2FrcGodbXfxsg9R9fuOITih+balI6c7f2HmitR0Fe3MU5C6YpcUYsWwA==",
+      "requires": {
+        "@hapi/hoek": "^6.2.1",
+        "@hapi/joi": "^15.0.0"
       }
     },
     "bluebird": {
@@ -1622,6 +1639,15 @@
       "integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
       "dev": true
     },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
     "make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
@@ -1948,6 +1974,11 @@
         "mem": "^4.0.0"
       }
     },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -2045,6 +2076,11 @@
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
       "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
       "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "psl": {
       "version": "1.2.0",
@@ -2346,6 +2382,14 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -2539,6 +2583,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "useragent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
+      "requires": {
+        "lru-cache": "4.1.x",
+        "tmp": "0.0.x"
+      }
+    },
     "utcstring": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/utcstring/-/utcstring-0.1.0.tgz",
@@ -2636,6 +2689,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "13.2.2",

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -29,6 +29,8 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "@hapi/hapi": "^18.3.1",
+    "@hapi/scooter": "^5.1.0",
+    "blankie": "^4.1.1",
     "bluebird": "^3.5.5",
     "convict": "^5.0.0",
     "handlebars": "^4.1.2",

--- a/packages/fxa-support-panel/types/blankie/index.d.ts
+++ b/packages/fxa-support-panel/types/blankie/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'blankie';

--- a/packages/fxa-support-panel/types/scooter/index.d.ts
+++ b/packages/fxa-support-panel/types/scooter/index.d.ts
@@ -1,0 +1,1 @@
+declare module '@hapi/scooter';


### PR DESCRIPTION
Hapi's route security configurations by default set 'DENY' for
X-Frame-Options.  The 'frame-ancestors' CSP directive obsoletes the
X-Frame-Options header.

Note that the module/Hapi plugin used to generate the CSP header also
produces default values for other directives; those are _not_ configured
in this patch.

Fixes #2142