### PR TITLE
refactor(broker): Remove the `chooseWhatToSyncWebV1` capability

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-desktop-v2.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-desktop-v2.js
@@ -34,7 +34,6 @@ const FxDesktopV2AuthenticationBroker = FxSyncWebChannelAuthenticationBroker.ext
     }),
 
     defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
-      chooseWhatToSyncWebV1: true,
       openWebmailButtonVisible: true,
     }),
 

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-fennec-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-fennec-v1.js
@@ -15,7 +15,6 @@ const proto = FxSyncWebChannelAuthenticationBroker.prototype;
 export default FxSyncWebChannelAuthenticationBroker.extend({
   defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
     browserTransitionsAfterEmailVerification: false,
-    chooseWhatToSyncWebV1: true,
     emailFirst: true,
     emailVerificationMarketingSnippet: false,
   }),

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -12,7 +12,6 @@ import FxDesktopChannel from '../../lib/channels/fx-desktop-v1';
 import FxSyncChannelAuthenticationBroker from '../auth_brokers/fx-sync-channel';
 import HaltBehavior from '../../views/behaviors/halt';
 import NavigateBehavior from '../../views/behaviors/navigate';
-import UserAgent from '../../lib/user-agent';
 
 const proto = FxSyncChannelAuthenticationBroker.prototype;
 
@@ -46,7 +45,6 @@ export default FxSyncChannelAuthenticationBroker.extend({
   }),
 
   defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
-    chooseWhatToSyncWebV1: true,
     convertExternalLinksToText: true,
     emailFirst: true,
   }),
@@ -80,45 +78,6 @@ export default FxSyncChannelAuthenticationBroker.extend({
     return this._notifyRelierOfLogin(account).then(() =>
       proto.afterResetPasswordConfirmationPoll.call(this, account)
     );
-  },
-
-  initialize(options = {}) {
-    proto.initialize.call(this, options);
-
-    const userAgent = new UserAgent(this._getUserAgentString());
-    const version = userAgent.parseVersion();
-
-    // We enable then disable this capability if necessary and not the opposite,
-    // because initialize() sets chooseWhatToSyncWebV1Engines and
-    // new UserAgent() can't be called before initialize().
-    if (!this._supportsChooseWhatToSync(version)) {
-      this.setCapability('chooseWhatToSyncWebV1', false);
-    }
-  },
-
-  /**
-   * Get the user-agent string. For functional testing
-   * purposes, first attempts to fetch a UA string from the
-   * `forceUA` query parameter, if that is not found, use
-   * the browser's.
-   *
-   * @returns {String}
-   * @private
-   */
-  _getUserAgentString() {
-    return this.getSearchParam('forceUA') || this.window.navigator.userAgent;
-  },
-
-  /**
-   * Check if the browser supports Choose What To Sync
-   * for newly created accounts.
-   *
-   * @param {Object} version
-   * @returns {Boolean}
-   * @private
-   */
-  _supportsChooseWhatToSync(version) {
-    return version.major >= 11;
   },
 
   /**

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-sync.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-sync.js
@@ -36,10 +36,8 @@ export default BaseAuthenticationBroker.extend({
   initialize(options = {}) {
     proto.initialize.call(this, options);
 
-    if (this.hasCapability('chooseWhatToSyncWebV1')) {
-      const syncEngines = new SyncEngines(null, { window: this.window });
-      this.set('chooseWhatToSyncWebV1Engines', syncEngines);
-    }
+    const syncEngines = new SyncEngines(null, { window: this.window });
+    this.set('chooseWhatToSyncWebV1Engines', syncEngines);
 
     if (this.hasCapability('fxaStatus')) {
       this.on('fxa_status', response => this.onFxaStatus(response));

--- a/packages/fxa-content-server/app/scripts/views/mixins/signup-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signup-mixin.js
@@ -50,7 +50,7 @@ export default {
             // with an updated account
             onSubmitComplete: onSubmitComplete,
           });
-        } else if (this.broker.hasCapability('chooseWhatToSyncWebV1')) {
+        } else if (this.broker.get('chooseWhatToSyncWebV1Engines')) {
           return this.navigate('choose_what_to_sync', {
             account: account,
             // choose_what_to_sync screen will call onSubmitComplete

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-desktop-v2.js
@@ -43,7 +43,6 @@ describe('models/auth_brokers/fx-desktop-v2', () => {
     assert.isTrue(
       broker.getCapability('browserTransitionsAfterEmailVerification')
     );
-    assert.isTrue(broker.getCapability('chooseWhatToSyncWebV1'));
     assert.isTrue(broker.getCapability('openWebmailButtonVisible'));
     assert.isTrue(broker.hasCapability('emailVerificationMarketingSnippet'));
     assert.isTrue(broker.hasCapability('handleSignedInNotification'));

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
@@ -50,11 +50,10 @@ describe('models/auth_brokers/fx-fennec-v1', function() {
   it('has the expected capabilities', () => {
     assert.isTrue(broker.hasCapability('signup'));
     assert.isTrue(broker.hasCapability('handleSignedInNotification'));
-    assert.isTrue(broker.hasCapability('chooseWhatToSyncWebV1'));
     assert.isTrue(broker.hasCapability('emailFirst'));
     assert.isFalse(broker.hasCapability('emailVerificationMarketingSnippet'));
     assert.equal(
-      broker.defaultCapabilities.chooseWhatToSyncWebV1.engines,
+      broker.defaultCapabilities.chooseWhatToSyncWebV1Engines,
       Constants.DEFAULT_DECLINED_ENGINES
     );
   });

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-ios-v1.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-ios-v1.js
@@ -12,8 +12,6 @@ import WindowMock from '../../../mocks/window';
 
 const IMMEDIATE_UNVERIFIED_LOGIN_UA_STRING =
   'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/6.1 Mobile/12F69 Safari/600.1.4'; //eslint-disable-line max-len
-const CHOOSE_WHAT_TO_SYNC_UA_STRING =
-  'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/11.0 Mobile/12F69 Safari/600.1.4'; //eslint-disable-line max-len
 
 describe('models/auth_brokers/fx-ios-v1', () => {
   let account;
@@ -54,39 +52,6 @@ describe('models/auth_brokers/fx-ios-v1', () => {
 
   afterEach(() => {
     sandbox.restore();
-  });
-
-  describe('capabilities', () => {
-    describe('supports chooseWhatToSyncWebV1', () => {
-      it('has the expected capabilities and behaviors', () => {
-        initializeBroker(CHOOSE_WHAT_TO_SYNC_UA_STRING);
-
-        assert.isTrue(broker.hasCapability('signup'));
-        assert.isTrue(broker.hasCapability('handleSignedInNotification'));
-        assert.isTrue(
-          broker.hasCapability('emailVerificationMarketingSnippet')
-        );
-        assert.isTrue(broker.hasCapability('chooseWhatToSyncWebV1'));
-        assert.isTrue(broker.hasCapability('emailFirst'));
-
-        assert.equal(
-          broker.getBehavior('afterSignInConfirmationPoll').type,
-          'navigate'
-        );
-        assert.equal(
-          broker.getBehavior('afterSignInConfirmationPoll').endpoint,
-          'signin_confirmed'
-        );
-        assert.equal(
-          broker.getBehavior('afterSignUpConfirmationPoll').type,
-          'navigate'
-        );
-        assert.equal(
-          broker.getBehavior('afterSignUpConfirmationPoll').endpoint,
-          'signup_confirmed'
-        );
-      });
-    });
   });
 
   describe('`broker.fetch` is called', () => {

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -17,16 +17,9 @@ describe('models/auth_brokers/fx-sync', () => {
   let metrics;
   let notificationChannel;
   let relier;
-  let supportsChooseWhatToSyncWebV1;
   let windowMock;
 
-  const ChildBroker = FxSyncAuthenticationBroker.extend({
-    defaultCapabilities: {
-      get chooseWhatToSyncWebV1() {
-        return supportsChooseWhatToSyncWebV1;
-      },
-    },
-  });
+  const ChildBroker = FxSyncAuthenticationBroker.extend({});
 
   function createBroker() {
     if (broker) {
@@ -62,24 +55,6 @@ describe('models/auth_brokers/fx-sync', () => {
     windowMock = null;
   });
 
-  describe('initialize', () => {
-    describe('chooseWhatToSyncWebV1 not supported', () => {
-      it('does not set `chooseWhatToSyncWebV1Engines`', () => {
-        supportsChooseWhatToSyncWebV1 = false;
-        createBroker();
-        assert.notOk(broker.get('chooseWhatToSyncWebV1Engines'));
-      });
-    });
-
-    describe('chooseWhatToSyncWebV1 supported', () => {
-      it('sets `chooseWhatToSyncWebV1Engines`', () => {
-        supportsChooseWhatToSyncWebV1 = true;
-        createBroker();
-        assert.ok(broker.get('chooseWhatToSyncWebV1Engines'));
-      });
-    });
-  });
-
   describe('chooseWhatToSyncWebV1Engines', () => {
     let response;
     beforeEach(() => {
@@ -99,27 +74,12 @@ describe('models/auth_brokers/fx-sync', () => {
         .callsFake(() => true);
     });
 
-    describe('chooseWhatToSyncWebV1 not supported', () => {
-      it('does not add the additional engines', () => {
-        supportsChooseWhatToSyncWebV1 = false;
-        createBroker();
+    it('add the additional engines', () => {
+      createBroker();
 
-        return broker.fetch().then(() => {
-          const syncEngines = broker.get('chooseWhatToSyncWebV1Engines');
-          assert.notOk(syncEngines);
-        });
-      });
-    });
-
-    describe('chooseWhatToSyncWebV1 supported', () => {
-      it('add the additional engines', () => {
-        supportsChooseWhatToSyncWebV1 = true;
-        createBroker();
-
-        return broker.fetch().then(() => {
-          const syncEngines = broker.get('chooseWhatToSyncWebV1Engines');
-          assert.ok(syncEngines.get('creditcards'));
-        });
+      return broker.fetch().then(() => {
+        const syncEngines = broker.get('chooseWhatToSyncWebV1Engines');
+        assert.ok(syncEngines.get('creditcards'));
       });
     });
   });

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/signup-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/signup-mixin.js
@@ -5,6 +5,7 @@
 import Account from 'models/account';
 import { assert } from 'chai';
 import Broker from 'models/auth_brokers/base';
+import { Model } from 'backbone';
 import Relier from 'models/reliers/relier';
 import SignUpMixin from 'views/mixins/signup-mixin';
 import sinon from 'sinon';
@@ -99,11 +100,9 @@ describe('views/mixins/signup-mixin', function() {
       });
     });
 
-    describe('broker supports chooseWhatToSync', function() {
+    describe('sync', function() {
       beforeEach(function() {
-        sinon.stub(broker, 'hasCapability').callsFake(function(capabilityName) {
-          return capabilityName === 'chooseWhatToSyncWebV1';
-        });
+        broker.set('chooseWhatToSyncWebV1Engines', new Model());
 
         return view.signUp(account, 'password');
       });


### PR DESCRIPTION
All current Firefoxes support chooseWhatToSyncWebV1, removing
the capability and showing CWTS to all Sync users.

fixes #2136

@vladikoff - r?