### PR TITLE
refactor(account): Persist valid accounts to localStorage automatically on change

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
@@ -82,18 +82,18 @@ const View = FormView.extend(
     },
 
     submit() {
-      const account = this.getAccount();
-      const declinedSyncEngines = this._getDeclinedEngineIds();
-      const offeredSyncEngines = this._getOfferedEngineIds();
+      return Promise.resolve().then(() => {
+        const account = this.getAccount();
+        const declinedSyncEngines = this._getDeclinedEngineIds();
+        const offeredSyncEngines = this._getOfferedEngineIds();
 
-      this._trackDeclinedEngineIds(declinedSyncEngines);
+        this._trackDeclinedEngineIds(declinedSyncEngines);
 
-      account.set({
-        declinedSyncEngines,
-        offeredSyncEngines,
-      });
+        account.set({
+          declinedSyncEngines,
+          offeredSyncEngines,
+        });
 
-      return this.user.setAccount(account).then(account => {
         this.notifier.trigger(
           'set-sync-engines',
           offeredSyncEngines.filter(e => declinedSyncEngines.indexOf(e) === -1)

--- a/packages/fxa-content-server/app/scripts/views/complete_sign_up.js
+++ b/packages/fxa-content-server/app/scripts/views/complete_sign_up.js
@@ -119,10 +119,6 @@ const CompleteSignUpView = BaseView.extend({
       this.logEvent('signin.success');
     }
 
-    // Update the stored account data in case it was
-    // updated by completeAccountSignUp.
-    this.user.setAccount(account);
-
     const brokerMethod = this._getBrokerMethod();
     // The brokers handle all next steps.
     return this.invokeBrokerMethod(brokerMethod, account);

--- a/packages/fxa-content-server/app/scripts/views/confirm.js
+++ b/packages/fxa-content-server/app/scripts/views/confirm.js
@@ -80,8 +80,8 @@ const View = BaseView.extend({
   },
 
   _gotoNextScreen() {
-    const account = this.getAccount();
-    return this.user.setAccount(account).then(() => {
+    return Promise.resolve().then(() => {
+      const account = this.getAccount();
       this.logViewEvent('verification.success');
       this.notifier.trigger('verification.success');
 

--- a/packages/fxa-content-server/app/scripts/views/mixins/avatar-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/avatar-mixin.js
@@ -105,7 +105,6 @@ var Mixin = {
   _updateCachedProfileImage(profileImage, account) {
     if (!account.isDefault()) {
       account.setProfileImage(profileImage);
-      this.user.setAccount(account);
     }
   },
 
@@ -164,9 +163,9 @@ var Mixin = {
 
   updateProfileImage(profileImage, account) {
     account.setProfileImage(profileImage);
-    return this.user
-      .setAccount(account)
-      .then(_.bind(this._notifyProfileUpdate, this, account.get('uid')));
+    return Promise.resolve().then(
+      _.bind(this._notifyProfileUpdate, this, account.get('uid'))
+    );
   },
 
   deleteDisplayedAccountProfileImage(account) {
@@ -197,17 +196,17 @@ var Mixin = {
   updateDisplayName(displayName) {
     var account = this.getSignedInAccount();
     account.set('displayName', displayName);
-    return this.user
-      .setAccount(account)
-      .then(() => this._notifyProfileUpdate(account.get('uid')));
+    return Promise.resolve().then(() =>
+      this._notifyProfileUpdate(account.get('uid'))
+    );
   },
 
   updateDisplayEmail(email) {
     var account = this.getSignedInAccount();
     account.set('email', email);
-    return this.user
-      .setAccount(account)
-      .then(() => this._notifyProfileUpdate(account.get('uid')));
+    return Promise.resolve().then(() =>
+      this._notifyProfileUpdate(account.get('uid'))
+    );
   },
 
   _notifyProfileUpdate(uid) {

--- a/packages/fxa-content-server/app/scripts/views/permissions.js
+++ b/packages/fxa-content-server/app/scripts/views/permissions.js
@@ -267,16 +267,18 @@ var View = FormView.extend(
     },
 
     submit() {
-      var account = this.getAccount();
+      return Promise.resolve().then(() => {
+        var account = this.getAccount();
 
-      this.logViewEvent('accept');
+        this.logViewEvent('accept');
 
-      account.setClientPermissions(
-        this.relier.get('clientId'),
-        this._getFormPermissions()
-      );
+        account.setClientPermissions(
+          this.relier.get('clientId'),
+          this._getFormPermissions()
+        );
 
-      return this.user.setAccount(account).then(this.onSubmitComplete);
+        return this.onSubmitComplete(account);
+      });
     },
 
     _previousView() {

--- a/packages/fxa-content-server/app/scripts/views/settings.js
+++ b/packages/fxa-content-server/app/scripts/views/settings.js
@@ -123,12 +123,8 @@ const View = BaseView.extend({
   beforeRender() {
     const account = this.getSignedInAccount();
 
-    return Promise.all([
-      account.fetchProfile(),
-      this.user.setAccount(account),
-      account.settingsData(),
-    ])
-      .then(([, , data]) => {
+    return Promise.all([account.fetchProfile(), account.settingsData()])
+      .then(([, data]) => {
         if (data && Array.isArray(data.subscriptions)) {
           this._ccExpired = data.subscriptions.some(
             s => s.failure_code === Constants.CC_EXPIRED

--- a/packages/fxa-content-server/app/scripts/views/support.js
+++ b/packages/fxa-content-server/app/scripts/views/support.js
@@ -58,7 +58,7 @@ const SupportView = BaseView.extend({
 
     return account.hasSubscriptions().then(hasSubs => {
       if (hasSubs) {
-        return account.fetchProfile().then(() => this.user.setAccount(account));
+        return account.fetchProfile();
       } else {
         // Note that if a user landed here, it is because:
         // a) they accessed the page directly, as the button for this page is

--- a/packages/fxa-content-server/app/tests/spec/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/tests/spec/views/choose_what_to_sync.js
@@ -245,12 +245,9 @@ describe('views/choose_what_to_sync', () => {
   });
 
   describe('submit', () => {
-    beforeEach(() => {
-      sinon.stub(user, 'setAccount').callsFake(() => Promise.resolve(account));
-      sinon.spy(notifier, 'trigger');
-    });
+    beforeEach(() => {});
 
-    it('updates and saves the account, logs metrics, calls onSubmitComplete', () => {
+    it('updatesthe account, logs metrics, calls onSubmitComplete', () => {
       return initView()
         .then(() => {
           view
@@ -258,7 +255,8 @@ describe('views/choose_what_to_sync', () => {
             .first()
             .removeAttr('checked');
 
-          return view.validateAndSubmit();
+          sinon.spy(notifier, 'trigger');
+          return view.submit();
         })
         .then(() => {
           const declined = account.get('declinedSyncEngines');
@@ -267,10 +265,8 @@ describe('views/choose_what_to_sync', () => {
           const offered = account.get('offeredSyncEngines');
           assert.sameMembers(offered, DISPLAYED_ENGINE_IDS);
 
-          assert.isTrue(user.setAccount.calledWith(account));
-
-          assert.equal(notifier.trigger.callCount, 2);
-          const args = notifier.trigger.args[1];
+          assert.equal(notifier.trigger.callCount, 1);
+          const args = notifier.trigger.args[0];
           assert.equal(args[0], 'set-sync-engines');
           assert.deepEqual(args[1], [
             'bookmarks',
@@ -278,7 +274,7 @@ describe('views/choose_what_to_sync', () => {
             'passwords',
             'history',
             'prefs',
-            'creditcards'
+            'creditcards',
           ]);
 
           assert.isTrue(view.onSubmitComplete.calledOnce);

--- a/packages/fxa-content-server/app/tests/spec/views/complete_sign_up.js
+++ b/packages/fxa-content-server/app/tests/spec/views/complete_sign_up.js
@@ -83,7 +83,6 @@ describe('views/complete_sign_up', function() {
     user = new User({
       notifier: notifier,
     });
-    sinon.stub(user, 'setAccount').callsFake(() => {});
 
     verificationError = null;
     windowMock = new WindowMock();
@@ -653,9 +652,6 @@ describe('views/complete_sign_up', function() {
 
         assert.isTrue(view.logEvent.calledOnce);
         assert.isTrue(view.logEvent.calledWith('signin.success'));
-
-        assert.isTrue(user.setAccount.calledOnce);
-        assert.isTrue(user.setAccount.calledWith(account));
 
         assert.isTrue(view._getBrokerMethod.calledOnce);
 

--- a/packages/fxa-content-server/app/tests/spec/views/confirm.js
+++ b/packages/fxa-content-server/app/tests/spec/views/confirm.js
@@ -251,10 +251,8 @@ describe('views/confirm', function() {
       const notifySpy = sinon.spy(view.notifier, 'trigger');
 
       sinon.stub(broker, expectedBrokerCall).callsFake(() => Promise.resolve());
-      sinon.stub(user, 'setAccount').callsFake(() => Promise.resolve());
 
       return view._gotoNextScreen().then(function() {
-        assert.isTrue(user.setAccount.calledWith(account));
         assert.isTrue(broker[expectedBrokerCall].calledWith(account));
         assert.isTrue(
           TestHelpers.isEventLogged(metrics, 'confirm.verification.success')

--- a/packages/fxa-content-server/app/tests/spec/views/confirm_reset_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/confirm_reset_password.js
@@ -464,6 +464,7 @@ describe('views/confirm_reset_password', function() {
       });
 
       var account = user.initAccount({
+        email: 'email',
         uid: 'uid',
       });
 

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/avatar-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/avatar-mixin.js
@@ -59,7 +59,6 @@ describe('views/mixins/avatar-mixin', function() {
     sinon.stub(view, 'getSignedInAccount').callsFake(function() {
       return account;
     });
-    sinon.spy(user, 'setAccount');
 
     sinon.spy(notifier, 'trigger');
   });
@@ -216,7 +215,6 @@ describe('views/mixins/avatar-mixin', function() {
 
     return view.displayAccountProfileImage(account).then(function() {
       assert.isTrue(account.fetchCurrentProfileImage.called);
-      assert.isTrue(user.setAccount.calledWith(account));
       assert.isTrue(account.setProfileImage.calledWith(image));
     });
   });
@@ -227,7 +225,6 @@ describe('views/mixins/avatar-mixin', function() {
         .updateProfileImage(new ProfileImage({ url: 'url' }), account)
         .then(function() {
           assert.equal(account.get('profileImageUrl'), 'url');
-          assert.isTrue(user.setAccount.calledWith(account));
           assert.isTrue(
             notifier.trigger.calledWith(Notifier.PROFILE_CHANGE, { uid: UID })
           );
@@ -251,7 +248,6 @@ describe('views/mixins/avatar-mixin', function() {
         .then(function() {
           assert.isTrue(account.deleteAvatar.calledWith('foo'));
           assert.isFalse(account.has('profileImageUrl'));
-          assert.isTrue(user.setAccount.calledWith(account));
           assert.isTrue(
             notifier.trigger.calledWith(Notifier.PROFILE_CHANGE, { uid: UID })
           );
@@ -264,7 +260,6 @@ describe('views/mixins/avatar-mixin', function() {
       return view.updateDisplayName('joe').then(function() {
         assert.equal(account.get('displayName'), 'joe');
         assert.isTrue(view.getSignedInAccount.called);
-        assert.isTrue(user.setAccount.calledWith(account));
         assert.isTrue(
           notifier.trigger.calledWith(Notifier.PROFILE_CHANGE, { uid: UID })
         );

--- a/packages/fxa-content-server/app/tests/spec/views/permissions.js
+++ b/packages/fxa-content-server/app/tests/spec/views/permissions.js
@@ -62,10 +62,6 @@ describe('views/permissions', function() {
       uid: 'uid',
     });
 
-    sinon.stub(user, 'setAccount').callsFake(function() {
-      return Promise.resolve(account);
-    });
-
     sinon.stub(account, 'fetchProfile').callsFake(function() {
       return Promise.resolve();
     });
@@ -186,20 +182,14 @@ describe('views/permissions', function() {
       });
     });
 
-    it('saves the granted permissions', function() {
+    it('saves the granted permissions, calls onSubmitComplete', function() {
       assert.isTrue(
         account.setClientPermissions.calledWith(CLIENT_ID, {
           'profile:email': true,
           'profile:uid': true,
         })
       );
-    });
 
-    it('sets the account', function() {
-      assert.isTrue(user.setAccount.calledWith(account));
-    });
-
-    it('calls onSubmitComplete', function() {
       assert.isTrue(onSubmitComplete.calledWith(account));
     });
   });

--- a/packages/fxa-content-server/app/tests/spec/views/settings.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings.js
@@ -832,7 +832,7 @@ describe('views/settings', function() {
 
     describe('with cached relier specified uid', function() {
       it('sets the signed in account', function() {
-        return user.setAccount({ uid: 'uid' }).then(function() {
+        return user.setAccount({ email: 'email', uid: 'uid' }).then(function() {
           createSettingsView();
 
           assert.isTrue(user.setSignedInAccountByUid.calledWith('uid'));


### PR DESCRIPTION
There are a lot of `user.setAccount`s sprinkled around the code,
it's easy to forget one whenever an account is updated and
for the account stored in localStorage to be stale.

This automatically persists an account to localStorage
as long as the account has both an email and uid.

Extraction from #2122

@mozilla/fxa-devs - r?