### PR TITLE
refactor(signin): Legacy signin view uses user-card-mixin

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sign_in.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in.mustache
@@ -26,8 +26,7 @@
       <div class="success"></div>
 
       {{#suggestedAccount}}
-          <div class="avatar-wrapper avatar-view"></div>
-          <p class="prefillEmail">{{ email }}</p>
+        {{{ userCardHTML }}}
 
         {{#chooserAskForPassword}}
           <form novalidate>

--- a/packages/fxa-content-server/app/scripts/views/sign_in.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in.js
@@ -19,13 +19,13 @@ import Session from '../lib/session';
 import SignedInNotificationMixin from './mixins/signed-in-notification-mixin';
 import SignInMixin from './mixins/signin-mixin';
 import SignInTemplate from 'templates/sign_in.mustache';
+import UserCardMixin from './mixins/user-card-mixin';
 
 const t = msg => msg;
 
 const EMAIL_SELECTOR = 'input[type=email]';
 const PASSWORD_SELECTOR = 'input[type=password]';
 
-const proto = FormView.prototype;
 const View = FormView.extend({
   template: SignInTemplate,
   className: 'sign-in',
@@ -43,23 +43,6 @@ const View = FormView.extend({
 
   beforeRender() {
     this._account = this.suggestedAccount();
-  },
-
-  afterVisible() {
-    proto.afterVisible.call(this);
-    // this.displayAccountProfileImage could cause the existing
-    // accessToken to be invalidated, in which case the view
-    // should be re-rendered with the default avatar.
-    const account = this.getAccount();
-    this.listenTo(account, 'change:accessToken', () => {
-      // if no access token we need to show the password field.
-      if (!account.has('accessToken')) {
-        this.model.set('chooserAskForPassword', true);
-        return this.render().then(() => this.setDefaultPlaceholderAvatar());
-      }
-    });
-
-    return this.displayAccountProfileImage(account, { spinner: true });
   },
 
   getAccount() {
@@ -195,7 +178,8 @@ Cocktail.mixin(
   PasswordResetMixin,
   ServiceMixin,
   SignInMixin,
-  SignedInNotificationMixin
+  SignedInNotificationMixin,
+  UserCardMixin
 );
 
 export default View;

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in.js
@@ -150,37 +150,6 @@ describe('views/sign_in', () => {
         assert.equal(view.$('[type=email]').val(), 'testuser@testuser.com');
       });
     });
-
-    describe('with a cached account whose accessToken is invalidated after render', () => {
-      beforeEach(() => {
-        initView();
-
-        const account = user.initAccount({
-          accessToken: 'access token',
-          email: 'a@a.com',
-          sessionToken: 'session token',
-          sessionTokenContext: Constants.SYNC_SERVICE,
-        });
-
-        sinon.stub(view, 'suggestedAccount').callsFake(() => account);
-        sinon
-          .stub(view, 'displayAccountProfileImage')
-          .callsFake(() => Promise.resolve());
-        sinon.spy(view, 'render');
-
-        return view
-          .render()
-          .then(() => view.afterVisible())
-          .then(() => {
-            account.discardSessionToken();
-          });
-      });
-
-      it('re-renders, forces user to enter password', () => {
-        assert.equal(view.render.callCount, 2);
-        assert.isTrue(view.model.get('chooserAskForPassword'));
-      });
-    });
   });
 
   describe('destroy', () => {


### PR DESCRIPTION
This is to remove duplicate logic to display/update the
profile image.

The user card mixin already has logic to display profile
images, and to revert to the default image whenever an
access token is cleared.

extraction from #2122
issue #999

@mozilla/fxa-devs - r?