### PR TITLE
refactor(signin): Pull account verify into a helper function for reuse

### DIFF
--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -36,6 +36,13 @@ module.exports = function(
     log,
     config
   );
+  const signupUtils = require('./utils/signup')(
+    log,
+    db,
+    mailer,
+    push,
+    verificationReminders
+  );
   // The routing modules themselves.
   const defaults = require('./defaults')(log, db);
   const idp = require('./idp')(log, serverPublicKeys);
@@ -83,7 +90,8 @@ module.exports = function(
     config,
     customs,
     push,
-    verificationReminders
+    verificationReminders,
+    signupUtils
   );
   const password = require('./password')(
     log,

--- a/packages/fxa-auth-server/lib/routes/utils/signup.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signup.js
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const P = require('../../promise');
+
+module.exports = (log, db, mailer, push, verificationReminders) => {
+  return {
+    /**
+     * Verify the account with the specified options. This function takes
+     * care of verifying the account, emitting metrics, sending emails and
+     * notifying other devices.
+     */
+    verifyAccount: async (request, account, options) => {
+      const { uid } = account;
+      const { marketingOptIn, newsletters, service, reminder, style } = options;
+      await db.verifyEmail(account, account.primaryEmail.emailCode);
+
+      const geoData = request.app.geo;
+      const country = geoData.location && geoData.location.country;
+      const countryCode = geoData.location && geoData.location.countryCode;
+
+      await P.all([
+        log.notifyAttachedServices('verified', request, {
+          country,
+          countryCode,
+          email: account.primaryEmail.email,
+          locale: account.locale,
+          marketingOptIn: marketingOptIn ? true : undefined,
+          newsletters,
+          service,
+          uid,
+          userAgent: request.headers['user-agent'],
+        }),
+        request.emitMetricsEvent('account.verified', {
+          // The content server omits marketingOptIn in the false case.
+          // Force it so that we emit the appropriate newsletter state.
+          marketingOptIn: marketingOptIn || false,
+          newsletters,
+          uid,
+        }),
+
+        // Verification reminders can *only* be used in email links. We currently don't
+        // support them for email codes.
+        reminder
+          ? request.emitMetricsEvent(`account.reminder.${reminder}`, { uid })
+          : null,
+        verificationReminders.delete(uid),
+      ]);
+
+      // Send a push notification to all devices that the account changed
+      request.app.devices.then(devices =>
+        push.notifyAccountUpdated(uid, devices, 'accountVerify')
+      );
+
+      // Our post-verification email is very specific to sync,
+      // so only send it if we're sure this is for sync.
+      if (service === 'sync') {
+        const mailOptions = {
+          acceptLanguage: request.app.acceptLanguage,
+          service,
+          uid,
+        };
+
+        if (style) {
+          mailOptions.style = style;
+        }
+
+        return mailer.sendPostVerifyEmail([], account, mailOptions);
+      }
+
+      return {};
+    },
+  };
+};

--- a/packages/fxa-auth-server/test/local/routes/emails.js
+++ b/packages/fxa-auth-server/test/local/routes/emails.js
@@ -53,16 +53,27 @@ const makeRoutes = function(options = {}, requireMocks) {
     },
   };
   const push = options.push || require('../../../lib/push')(log, db, {});
+  const mailer = options.mailer || {};
   const verificationReminders =
     options.verificationReminders || mocks.mockVerificationReminders();
+  const signupUtils =
+    options.signupUtils ||
+    require('../../../lib/routes/utils/signup')(
+      log,
+      db,
+      mailer,
+      push,
+      verificationReminders
+    );
   return proxyquire('../../../lib/routes/emails', requireMocks || {})(
     log,
     db,
-    options.mailer || {},
+    mailer,
     config,
     customs,
     push,
-    verificationReminders
+    verificationReminders,
+    signupUtils
   );
 };
 

--- a/packages/fxa-auth-server/test/local/routes/utils/signup.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/signup.js
@@ -1,0 +1,132 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const sinon = require('sinon');
+const assert = { ...sinon.assert, ...require('chai').assert };
+const mocks = require('../../../mocks');
+
+const TEST_EMAIL = 'test@email.com';
+const TEST_UID = '123123';
+
+let db, log, mailer, push, request, verificationReminders, utils, account;
+
+async function setup(options) {
+  const log = options.log || mocks.mockLog();
+  const db = options.db || mocks.mockDB();
+  const mailer = options.mailer || {};
+  const verificationReminders =
+    options.verificationReminders || mocks.mockVerificationReminders();
+  const push = options.push || require('../../../lib/push')(log, db, {});
+  return require('../../../../lib/routes/utils/signup')(
+    log,
+    db,
+    mailer,
+    push,
+    verificationReminders
+  );
+}
+
+describe('verifyAccount', () => {
+  beforeEach(() => {
+    account = {
+      uid: TEST_UID,
+      primaryEmail: {
+        email: TEST_EMAIL,
+        isVerified: false,
+        emailCode: '123',
+      },
+    };
+    db = mocks.mockDB(account);
+    log = mocks.mockLog();
+    mailer = mocks.mockMailer();
+    push = mocks.mockPush();
+    verificationReminders = mocks.mockVerificationReminders();
+    request = mocks.mockRequest({
+      log,
+      metricsContext: mocks.mockMetricsContext({
+        async gather(data) {
+          return Object.assign(data, {
+            flowCompleteSignal: 'account.signed',
+            flow_time: 10000,
+            flow_id:
+              'F1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF1031DF103',
+            time: Date.now() - 10000,
+          });
+        },
+      }),
+    });
+  });
+
+  describe('can verify account', () => {
+    let args;
+    const options = {
+      service: 'sync',
+    };
+
+    beforeEach(async () => {
+      utils = await setup({ db, log, mailer, push, verificationReminders });
+      await utils.verifyAccount(request, account, options);
+    });
+
+    it('should verify the account', () => {
+      assert.calledOnce(db.verifyEmail);
+      assert.calledWithExactly(
+        db.verifyEmail,
+        account,
+        account.primaryEmail.emailCode
+      );
+    });
+
+    it('should notify attached services', () => {
+      assert.calledOnce(log.notifyAttachedServices);
+
+      args = log.notifyAttachedServices.args[0];
+      assert.equal(args[0], 'verified');
+      assert.equal(args[2].uid, TEST_UID);
+      assert.equal(args[2].marketingOptIn, undefined);
+      assert.equal(args[2].service, 'sync');
+      assert.equal(args[2].country, 'United States', 'set country');
+      assert.equal(args[2].countryCode, 'US', 'set country code');
+      assert.equal(args[2].userAgent, 'test user-agent');
+    });
+
+    it('should emit metrics', () => {
+      assert.calledOnce(log.activityEvent);
+      args = log.activityEvent.args[0];
+      assert.equal(args.length, 1, 'log.activityEvent was passed one argument');
+      assert.calledOnce(log.flowEvent);
+      assert.equal(
+        log.flowEvent.args[0][0].event,
+        'account.verified',
+        'event was event account.verified'
+      );
+    });
+
+    it('should delete verification reminders', () => {
+      assert.calledOnce(verificationReminders.delete);
+      assert.calledWithExactly(verificationReminders.delete, TEST_UID);
+    });
+
+    it('should send push notifications', () => {
+      assert.calledOnce(push.notifyAccountUpdated);
+      assert.calledWithExactly(
+        push.notifyAccountUpdated,
+        TEST_UID,
+        [],
+        'accountVerify'
+      );
+    });
+
+    it('should send post account verification email', () => {
+      assert.calledOnce(mailer.sendPostVerifyEmail);
+      assert.equal(
+        mailer.sendPostVerifyEmail.args[0][2].service,
+        options.service
+      );
+      assert.equal(mailer.sendPostVerifyEmail.args[0][2].uid, TEST_UID);
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -227,13 +227,14 @@ function mockDB(data, errors) {
       return P.resolve({
         email: data.email,
         emailCode: data.emailCode,
-        emailVerified: data.emailVerified,
+        emailVerified: data.emailVerified || false,
         locale: data.locale,
         primaryEmail: {
           normalizedEmail: data.email.toLowerCase(),
           email: data.email,
           isVerified: data.emailVerified || false,
           isPrimary: true,
+          emailCode: data.emailCode,
         },
         emails: [
           {


### PR DESCRIPTION
Connects with #457 

Pulling this into it's own commit to make the review process easier. This PR adds signup utils for verify account function. No tests were added/removed since no underlying feature functionally didn't changed.