### PR TITLE
feat(codes): Add routes and emails to verify account by otp code

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -1135,6 +1135,26 @@ const conf = convict({
       format: String,
     },
   },
+  otp: {
+    step: {
+      doc: 'Default time step size (seconds)',
+      default: 10 * 60,
+      format: 'nat',
+      env: 'OTP_SIGNUP_STEP_SIZE',
+    },
+    window: {
+      doc: 'Tokens in the previous x-windows that should be considered valid',
+      default: 1,
+      format: 'nat',
+      env: 'OTP_SIGNUP_WINDOW',
+    },
+    digits: {
+      doc: 'Number of digits in token',
+      default: 6,
+      format: 'nat',
+      env: 'OTP_SIGNUP_DIGIT',
+    },
+  },
 });
 
 // handle configuration files.  you can specify a CSV list of configuration

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -92,6 +92,7 @@ const ERRNO = {
   SUBSCRIPTION_ALREADY_CANCELLED: 180,
   REJECTED_CUSTOMER_UPDATE: 181,
   REFRESH_TOKEN_UNKNOWN: 182,
+  INVALID_EXPIRED_OTP_CODE: 183,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -1196,6 +1197,15 @@ AppError.unknownRefreshToken = () => {
     error: 'Bad Request',
     errno: ERRNO.REFRESH_TOKEN_UNKNOWN,
     message: 'Unknown refresh token',
+  });
+};
+
+AppError.invalidOrExpiredOtpCode = () => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.INVALID_EXPIRED_OTP_CODE,
+    message: 'Invalid or expired OTP code',
   });
 };
 

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -341,20 +341,7 @@ module.exports = (
               .allow(['trailhead'])
               .optional(),
             marketingOptIn: isA.boolean(),
-            newsletters: isA
-              .array()
-              .items(
-                isA
-                  .string()
-                  .valid(
-                    'firefox-accounts-journey',
-                    'knowledge-is-power',
-                    'take-action-for-the-internet',
-                    'test-pilot'
-                  )
-              )
-              .default([])
-              .optional(),
+            newsletters: validators.newsletters,
           },
         },
       },

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -107,7 +107,15 @@ module.exports = function(
   );
   const tokenCodes = require('./token-codes')(log, db, config, customs);
   const securityEvents = require('./security-events')(log, db, config);
-  const session = require('./session')(log, db, Password, config, signinUtils);
+  const session = require('./session')(
+    log,
+    db,
+    Password,
+    config,
+    signinUtils,
+    signupUtils,
+    mailer
+  );
   const sign = require('./sign')(log, signer, db, config.domain, devicesImpl);
   const signinCodes = require('./signin-codes')(log, db, customs);
   const smsRoute = require('./sms')(log, db, config, customs, smsImpl);

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -254,9 +254,13 @@ function isValidUrl(url, hostnameRegex) {
   return parsed.href;
 }
 
-module.exports.verificationMethod = isA
-  .string()
-  .valid(['email', 'email-2fa', 'email-captcha', 'totp-2fa']);
+module.exports.verificationMethod = isA.string().valid([
+  'email', // Verification by email link
+  'email-otp', // Verification by email otp code using account long code (`emailCode`) as secret
+  'email-2fa', // Verification by email code using randomly generated code (used in login flow)
+  'email-captcha', // Verification by email code using randomly generated code (used in unblock flow)
+  'totp-2fa', // Verification by TOTP authenticator device code, secret is randomly generated
+]);
 
 module.exports.authPW = isA
   .string()
@@ -342,3 +346,23 @@ module.exports.ppidSeed = isA
   .integer()
   .min(0)
   .max(1024);
+
+module.exports.style = isA
+  .string()
+  .allow(['trailhead'])
+  .optional();
+
+module.exports.newsletters = isA
+  .array()
+  .items(
+    isA
+      .string()
+      .valid(
+        'firefox-accounts-journey',
+        'knowledge-is-power',
+        'take-action-for-the-internet',
+        'test-pilot'
+      )
+  )
+  .default([])
+  .optional();

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -56,6 +56,7 @@ module.exports = function(log, config, oauthdb) {
     recoveryEmail: 'forgot-password',
     unblockCodeEmail: 'new-unblock',
     verifyEmail: 'welcome',
+    verifyShortCodeEmail: 'welcome',
     verifyLoginEmail: 'new-signin',
     verifyLoginCodeEmail: 'new-signin-verify-code',
     verifyPrimaryEmail: 'welcome-primary',
@@ -88,6 +89,7 @@ module.exports = function(log, config, oauthdb) {
     recoveryEmail: 'reset-password',
     unblockCode: 'unblock-code',
     verifyEmail: 'activate',
+    verifyShortCodeEmail: 'activate',
     verifyLoginEmail: 'confirm-signin',
     verifyLoginCodeEmail: 'new-signin-verify-code',
     verifyPrimaryEmail: 'activate',
@@ -509,6 +511,48 @@ module.exports = function(log, config, oauthdb) {
           serviceName: serviceName,
           style: message.style,
           sync: message.service === 'sync',
+          supportUrl: links.supportUrl,
+          supportLinkAttributes: links.supportLinkAttributes,
+        },
+        metricsTemplate: metricsTemplateName,
+      })
+    );
+  };
+
+  Mailer.prototype.verifyShortCodeEmail = async function(message) {
+    log.trace('mailer.verifyShortCodeEmail', {
+      email: message.email,
+      uid: message.uid,
+    });
+
+    const templateName = 'verifyShortCodeEmail';
+    const metricsTemplateName = 'verifyEmail';
+    const code = message.code;
+    const subject = gettext('Verification code: %(code)s');
+
+    const links = this._generateLinks(
+      this.verificationUrl,
+      message.email,
+      {},
+      templateName
+    );
+
+    const headers = {
+      'X-Verify-Short-Code': message.code,
+    };
+
+    return this.send(
+      Object.assign({}, message, {
+        headers,
+        subject,
+        template: templateName,
+        templateValues: {
+          code,
+          device: this._formatUserAgentInfo(message),
+          email: message.email,
+          ip: message.ip,
+          location: this._constructLocationString(message),
+          privacyUrl: links.privacyUrl,
           supportUrl: links.supportUrl,
           supportLinkAttributes: links.supportLinkAttributes,
         },

--- a/packages/fxa-auth-server/lib/senders/index.js
+++ b/packages/fxa-auth-server/lib/senders/index.js
@@ -115,6 +115,21 @@ module.exports = (log, config, error, bounces, translator, oauthdb, sender) => {
           );
         });
       },
+      sendVerifyShortCode: function(emails, account, opts) {
+        // This function differs from `sendVerifyCode` since it sends a code that
+        // is expected to be entered into a input field rather than a link to verify
+        // the account. It is expected to be much shorter than the `emailCode`.
+        const primaryEmail = account.email;
+        return getSafeMailer(primaryEmail).then(mailer => {
+          return mailer.verifyShortCodeEmail(
+            Object.assign({}, opts, {
+              acceptLanguage: opts.acceptLanguage || defaultLanguage,
+              email: primaryEmail,
+              uid: account.uid,
+            })
+          );
+        });
+      },
       sendVerifyLoginEmail: function(emails, account, opts) {
         return getSafeMailerWithEmails(emails).then(result => {
           const mailer = result.ungatedMailer;

--- a/packages/fxa-auth-server/lib/senders/partials/verify_short_code.html
+++ b/packages/fxa-auth-server/lib/senders/partials/verify_short_code.html
@@ -1,0 +1,32 @@
+<% extends "partials/base/base.html" %>
+
+<% block content %>
+<!--Header Area-->
+<tr style="page-break-before: always">
+  <td valign="top">
+    <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;"><% block verify_title %>{{t "Is this you signing up?" }}<% endblock %></h1>
+    <p style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
+      <% include "./location/location.html" %>
+  </td>
+</tr>
+<tr style="page-break-before: always">
+  <td valign="top">
+    <p style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
+      {{t "If yes, use this verification code:" }}
+    </p>
+    <p style="font-family: monospace !important; font-size: 32px; line-height: 26px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">
+      {{ code }}
+    </p>
+    <p style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
+      {{t "It expires in 20 minutes." }}
+    </p>
+  </td>
+</tr>
+<!--Button Area-->
+<tr style="page-break-before: always">
+  <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
+    <br/>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #737373; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
+  </td>
+</tr>
+<% endblock %>

--- a/packages/fxa-auth-server/lib/senders/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/templates/_versions.json
@@ -18,6 +18,7 @@
   "verifyPrimaryEmail": 5,
   "verifyLoginEmail": 3,
   "verifyLoginCodeEmail": 4,
+  "verifyShortCodeEmail": 1,
   "verifySecondaryEmail": 3,
   "verifySyncEmail": 3,
   "verifyTrailheadEmail": 3,

--- a/packages/fxa-auth-server/lib/senders/templates/index.js
+++ b/packages/fxa-auth-server/lib/senders/templates/index.js
@@ -77,6 +77,7 @@ module.exports = {
         'verify_login',
         'verify_login_code',
         'verify_primary',
+        'verify_short_code',
         'verify_sync',
         'verify_secondary',
         'verify_trailhead',

--- a/packages/fxa-auth-server/lib/senders/templates/verify_short_code.html
+++ b/packages/fxa-auth-server/lib/senders/templates/verify_short_code.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>{{t "Firefox Accounts"}}</title>
+</head>
+
+<body style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; margin: 0; padding: 0;">
+<table align="center" border="0" cellpadding="0" cellspacing="0" width="310" style="-webkit-text-size-adjust: 100%; border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 310px; margin: 0 auto;">
+
+<!--Logo-->
+<tr style="page-break-before: always">
+  <td align="center" id="firefox-logo" style="padding: 20px 0;">
+    {{^if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/4/11c1e411-7dfe-4e04-914c-0f098edac96c.png" height="88" width="85" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+
+    {{#if sync}}
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/4/9f34e2a3-7947-4b5b-9c73-98faf8f49df6.png" height="137" width="270" alt="" style="-ms-interpolation-mode: bicubic;" />
+    {{/if}}
+  </td>
+</tr>
+
+
+<!--Header Area-->
+<tr style="page-break-before: always">
+  <td valign="top">
+    <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">{{t "Is this you signing up?" }}</h1>
+    <p style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
+      <p style="font-family:sans-serif; font-size: 13px; line-height: 20px; font-weight: normal; margin: 0 0 24px 0px; text-align: center; color: #4a4a4f;">
+    {{#if primaryEmail }}{{ primaryEmail }}<br/>{{/if}}
+    {{#if device }}{{ device }}<br/>{{/if}}
+    {{#if location }}{{ location }}<br/>{{/if}}
+    {{#if ip }}{{t "IP address: %(ip)s" }}<br/>{{/if}}
+    {{#if timestamp }}{{ timestamp }}<br/>{{/if}}
+</p>
+
+  </td>
+</tr>
+<tr style="page-break-before: always">
+  <td valign="top">
+    <p style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
+      {{t "If yes, use this verification code:" }}
+    </p>
+    <p style="font-family: monospace !important; font-size: 32px; line-height: 26px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">
+      {{ code }}
+    </p>
+    <p style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
+      {{t "It expires in 20 minutes." }}
+    </p>
+  </td>
+</tr>
+<!--Button Area-->
+<tr style="page-break-before: always">
+  <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
+    <br/>
+    <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 0 0 12px 0; text-align: center; color: #737373; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit <a %(supportLinkAttributes)s>Mozilla Support</a>."}}}</p>
+  </td>
+</tr>
+
+
+<tr style="page-break-before: always">
+  <td valign="top">
+    <p style="font-family: sans-serif; font-weight: normal; margin: 0; text-align: center; color: #737373; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">Mozilla. 331 E Evelyn Ave, Mountain View, CA 94041
+    <br />
+    <a href="{{{privacyUrl}}}" style="color: #0a84ff; text-decoration: none; font-family: sans-serif; font-size: 11px; line-height: 18px;">{{t "Mozilla Privacy Policy" }}</a>
+    <br />
+    <a href="https://www.mozilla.org/about/legal/terms/services/" style="color: #0a84ff; text-decoration: none; font-family: sans-serif; font-size: 11px; line-height: 18px;">{{t "Firefox Cloud Terms of Service"}}</a></p>
+  </td>
+</tr>
+
+</table>
+
+</body>
+</html>

--- a/packages/fxa-auth-server/lib/senders/templates/verify_short_code.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/verify_short_code.txt
@@ -1,0 +1,15 @@
+{{t "Is this you signing up?" }}
+
+{{#if location}}{{ location }}{{/if}}
+{{#if ip}}{{t "IP address: %(ip)s" }}{{/if}}
+{{#if timestamp}}{{ timestamp }}{{/if}}
+
+{{t "If yes, use this verification code:" }}
+{{ code }}
+
+{{t "It expires in 20 minutes." }}
+{{t "This is an automated email; if you received it in error, no action is required."}} {{{t "For more information, please visit %(supportUrl)s"}}}
+
+Mozilla. 331 E Evelyn Ave, Mountain View, CA 94041
+{{t "Mozilla Privacy Policy" }} {{{privacyUrl}}}
+{{t "Firefox Cloud Terms of Service" }} https://www.mozilla.org/about/legal/terms/services/

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -160,6 +160,7 @@ module.exports = config => {
         device: options.device || undefined,
         metricsContext: options.metricsContext || undefined,
         style: options.style || undefined,
+        verificationMethod: options.verificationMethod || undefined,
       },
       {
         'accept-language': options.lang,
@@ -467,6 +468,36 @@ module.exports = config => {
       {
         'accept-language': options.lang,
       }
+    );
+  };
+
+  ClientApi.prototype.accountCreateWithShortCode = async function(
+    sessionTokenHex,
+    code,
+    options = {}
+  ) {
+    const token = await tokens.SessionToken.fromHex(sessionTokenHex);
+    return this.doRequest(
+      'POST',
+      `${this.baseURL}/session/verify_code`,
+      token,
+      {
+        code,
+        service: options.service,
+        newsletters: options.newsletters || undefined,
+      }
+    );
+  };
+
+  ClientApi.prototype.resendAccountCreateWithShortCode = async function(
+    sessionTokenHex
+  ) {
+    const token = await tokens.SessionToken.fromHex(sessionTokenHex);
+    return this.doRequest(
+      'POST',
+      `${this.baseURL}/session/resend_code`,
+      token,
+      {}
     );
   };
 

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -274,6 +274,22 @@ module.exports = config => {
     return this.api.recoveryEmailVerifyCode(this.uid, code, options);
   };
 
+  Client.prototype.verifyShortCodeEmail = async function(code, options = {}) {
+    return this.api.accountCreateWithShortCode(
+      this.sessionToken,
+      code,
+      options
+    );
+  };
+
+  Client.prototype.resendVerifyShortCodeEmail = async function(code, options) {
+    return this.api.resendAccountCreateWithShortCode(
+      this.sessionToken,
+      code,
+      options
+    );
+  };
+
   Client.prototype.verifyTokenCode = function(code, options) {
     return this.api.verifyTokenCode(this.sessionToken, code, options);
   };

--- a/packages/fxa-auth-server/test/lib/assert.js
+++ b/packages/fxa-auth-server/test/lib/assert.js
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const assert = { ...require('sinon').assert, ...require('chai').assert };
+
+async function assertFailure(asyncFn, assertFn) {
+  let err;
+  try {
+    await asyncFn;
+  } catch (e) {
+    err = e;
+  }
+  assertFn(err);
+}
+
+module.exports = {
+  assert,
+  assertFailure,
+};

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -761,6 +761,33 @@ const TESTS = new Map([
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+  ['verifyShortCodeEmail', new Map([
+    ['subject', { test: 'equal', expected: `Verification code: ${MESSAGE.code}` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verifyEmail') }],
+      ['X-Template-Name', { test: 'equal', expected: 'verifyShortCodeEmail' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.verifyShortCodeEmail }],
+      ['X-Verify-Short-Code', { test: 'equal', expected: MESSAGE.code }],
+    ])],
+    ['html', [
+      { test: 'include', expected: configHref('privacyUrl', 'welcome', 'privacy') },
+      { test: 'include', expected: configHref('supportUrl', 'welcome', 'support') },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: 'If yes, use this verification code:' },
+      { test: 'include', expected: MESSAGE.code },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Mozilla Privacy Policy ${configUrl('privacyUrl', 'welcome', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'welcome', 'support')}` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `If yes, use this verification code:\n${MESSAGE.code}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ]);
 
 // prettier-ignore

--- a/packages/fxa-auth-server/test/local/senders/templates.js
+++ b/packages/fxa-auth-server/test/local/senders/templates.js
@@ -44,7 +44,7 @@ describe('lib/senders/templates/index:', () => {
     it('result is correct', () => {
       assert.equal(typeof result, 'object');
       const keys = Object.keys(result);
-      assert.equal(keys.length, 29);
+      assert.equal(keys.length, 30);
       keys.forEach(key => {
         const fn = result[key];
         assert.equal(typeof fn, 'function');

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -141,6 +141,7 @@ const MAILER_METHOD_NAMES = [
   'sendRecoveryCode',
   'sendUnblockCode',
   'sendVerifyCode',
+  'sendVerifyShortCode',
   'sendVerifyLoginEmail',
   'sendVerifyLoginCodeEmail',
   'sendVerifySecondaryEmail',

--- a/packages/fxa-auth-server/test/remote/account_create_with_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_with_code_tests.js
@@ -1,0 +1,169 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert, assertFailure } = require('../lib/assert');
+const TestServer = require('../test_server');
+const Client = require('../client')();
+const config = require('../../config').getProperties();
+const otplib = require('otplib');
+
+describe('remote account create with sign-up code', function() {
+  this.timeout(15000);
+  const password = '4L6prUdlLNfxGIoj';
+  let server, client, email, emailStatus, emailData;
+
+  before(async () => {
+    server = await TestServer.start(config);
+    return server;
+  });
+
+  it('create and verify sync account', async () => {
+    email = server.uniqueEmail();
+
+    client = await Client.create(config.publicUrl, email, password, {
+      service: 'sync',
+      verificationMethod: 'email-otp',
+    });
+    assert.ok(client.authAt, 'authAt was set');
+
+    emailStatus = await client.emailStatus();
+    assert.equal(emailStatus.verified, false);
+
+    emailData = await server.mailbox.waitForEmail(email);
+    assert.equal(emailData.headers['x-template-name'], 'verifyShortCodeEmail');
+    assert.include(emailData.html, 'IP address');
+
+    await client.verifyShortCodeEmail(
+      emailData.headers['x-verify-short-code'],
+      {
+        service: 'sync',
+      }
+    );
+
+    emailData = await server.mailbox.waitForEmail(email);
+    assert.include(emailData.headers['x-link'], config.smtp.syncUrl);
+
+    emailStatus = await client.emailStatus();
+    assert.equal(emailStatus.verified, true);
+  });
+
+  it('create and verify account', async () => {
+    email = server.uniqueEmail();
+
+    client = await Client.create(config.publicUrl, email, password, {
+      verificationMethod: 'email-otp',
+    });
+    assert.ok(client.authAt, 'authAt was set');
+
+    emailStatus = await client.emailStatus();
+    assert.equal(emailStatus.verified, false);
+
+    emailData = await server.mailbox.waitForEmail(email);
+    assert.equal(emailData.headers['x-template-name'], 'verifyShortCodeEmail');
+    assert.include(emailData.html, 'IP address');
+
+    await client.verifyShortCodeEmail(emailData.headers['x-verify-short-code']);
+
+    emailStatus = await client.emailStatus();
+    assert.equal(emailStatus.verified, true);
+
+    // It's hard to test for "an email didn't arrive".
+    // Instead trigger sending of another email and test
+    // that there wasn't anything in the queue before it.
+    await client.forgotPassword();
+
+    const code = await server.mailbox.waitForCode(email);
+    assert.ok(code, 'the next email was reset-password, not post-verify');
+  });
+
+  it('throws for expired code', async () => {
+    // To generate an expired code, you have to retrieve the accounts `emailCode`
+    // and create the otp authenticator with the previous time window.
+    email = server.uniqueEmail();
+
+    client = await Client.create(config.publicUrl, email, password, {
+      verificationMethod: 'email-otp',
+    });
+    assert.ok(client.authAt, 'authAt was set');
+
+    emailData = await server.mailbox.waitForEmail(email);
+    assert.equal(emailData.headers['x-template-name'], 'verifyShortCodeEmail');
+
+    await client.requestVerifyEmail();
+    emailData = await server.mailbox.waitForEmail(email);
+    assert.equal(emailData.headers['x-template-name'], 'verifyEmail');
+
+    const secret = emailData.headers['x-verify-code'];
+    const futureAuthenticator = new otplib.authenticator.Authenticator();
+    futureAuthenticator.options = Object.assign(
+      otplib.authenticator.options,
+      config.otp,
+      { secret, epoch: Date.now() / 1000 - 600 }
+    );
+    const expiredCode = futureAuthenticator.generate();
+
+    await assertFailure(client.verifyShortCodeEmail(expiredCode), err => {
+      assert.equal(err.code, 400);
+      assert.equal(err.errno, 183, 'invalid or expired code errno');
+    });
+  });
+
+  it('throws for invalid code', async () => {
+    email = server.uniqueEmail();
+
+    client = await Client.create(config.publicUrl, email, password, {
+      verificationMethod: 'email-otp',
+    });
+    assert.ok(client.authAt, 'authAt was set');
+
+    emailData = await server.mailbox.waitForEmail(email);
+    assert.equal(emailData.headers['x-template-name'], 'verifyShortCodeEmail');
+    assert.include(emailData.html, 'IP address');
+
+    const invalidCode = emailData.headers['x-verify-short-code'] + 1;
+
+    await assertFailure(client.verifyShortCodeEmail(invalidCode), err => {
+      assert.equal(err.code, 400);
+      assert.equal(err.errno, 183, 'invalid or expired code errno');
+    });
+  });
+
+  it('create and resend authentication code', async () => {
+    email = server.uniqueEmail();
+
+    client = await Client.create(config.publicUrl, email, password, {
+      verificationMethod: 'email-otp',
+    });
+
+    emailData = await server.mailbox.waitForEmail(email);
+    const originalMessageId = emailData['messageId'];
+    const originalCode = emailData.headers['x-verify-short-code'];
+
+    assert.equal(emailData.headers['x-template-name'], 'verifyShortCodeEmail');
+    assert.include(emailData.html, 'IP address');
+
+    await client.resendVerifyShortCodeEmail();
+
+    emailData = await server.mailbox.waitForEmail(email);
+    assert.equal(emailData.headers['x-template-name'], 'verifyShortCodeEmail');
+    assert.include(emailData.html, 'IP address');
+
+    assert.notEqual(
+      originalMessageId,
+      emailData['messageId'],
+      'different email was sent'
+    );
+    assert.equal(
+      originalCode,
+      emailData.headers['x-verify-short-code'],
+      'codes match'
+    );
+  });
+
+  after(() => {
+    return TestServer.stop(server);
+  });
+});


### PR DESCRIPTION
Connects with #457 

- [x] Add routes (/session/verify_code, /session/resend_code)
- [x] Update route (/account/create
- [x] Add email templates
- [x] Add local tests
- [x] Add remote tests

I think this PR is ready for review. I've updated this based on the feature doc at https://docs.google.com/document/d/1i003YoL4cchn8fOpA9yb0ntnD-rHhq4zO-WMyX6Y_IE/edit#. A few notes

-  `/session/verify_code` not backwards compatible with email links (added too much complexity)
- When session become verified, they use the `email-2fa` level since that is what we currently use for signin codes
- Sign-up codes expired between 10-20minutes

Rendered email:
<img width="331" alt="Screen Shot 2019-08-14 at 2 45 42 PM" src="https://user-images.githubusercontent.com/1295288/63047670-e8ba1780-bea2-11e9-8b90-292b71188840.png">
