### PR TITLE
chore(payments): better separation for frontend and server testing configs

### DIFF
--- a/packages/fxa-payments-server/jest.config.js
+++ b/packages/fxa-payments-server/jest.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  roots: ['<rootDir>/src'],
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    '**/*.{js,jsx,ts,tsx}',
+    '!**/build/*',
+    '!**/*.stories.*',
+    '!**/types.tsx',
+    '!**/*.d.ts',
+    '!**/jest*js',
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 64,
+      functions: 53,
+      lines: 64,
+      statements: 64,
+    },
+  },
+};

--- a/packages/fxa-payments-server/package-lock.json
+++ b/packages/fxa-payments-server/package-lock.json
@@ -16250,14 +16250,13 @@
       }
     },
     "react": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
+      "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "prop-types": "^15.6.2"
       }
     },
     "react-app-polyfill": {
@@ -16481,14 +16480,25 @@
       }
     },
     "react-dom": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
+      "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "scheduler": "^0.15.0"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.15.0",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
+          "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-draggable": {

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -9,11 +9,11 @@
     "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "start": "node server/bin/fxa-payments-server.js",
     "start-dev": "concurrently -k \"PROXY_STATIC_RESOURCES_FROM='http://127.0.0.1:3032' node server/bin/fxa-payments-server.js\" \"react-scripts start\"",
-    "build-start-dev": "npm run build && npm run start-dev",
     "build": "react-scripts build",
     "eject": "react-scripts eject",
-    "test": "jest --coverage --verbose",
-    "test:watch": "jest --coverage --watchAll",
+    "test": "npm-run-all test:*",
+    "test:frontend": "react-scripts test --coverage --verbose",
+    "test:server": "jest --coverage --verbose --config server/jest.config.js",
     "format": "prettier '**' --write",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
@@ -107,8 +107,8 @@
     "node-sass": "^4.12.0",
     "nyc": "^14.1.0",
     "on-headers": "^1.0.2",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0",
     "react-redux": "^7.1.0-alpha.4",
     "react-router-dom": "^5.0.0",
     "react-scripts": "3.0.1",
@@ -127,27 +127,6 @@
     "npm": ">=6.4.1"
   },
   "readmeFilename": "README.md",
-  "jest": {
-    "projects": [
-      "src/jest.config.js",
-      "server/jest.config.js"
-    ],
-    "collectCoverageFrom": [
-      "**/*.{js,jsx,ts,tsx}",
-      "!**/*.stories.*",
-      "!**/types.tsx",
-      "!**/*.d.ts",
-      "!**/jest*js"
-    ],
-    "coverageThreshold": {
-      "global": {
-        "branches": 63,
-        "functions": 52,
-        "lines": 69,
-        "statements": 69
-      }
-    }
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/packages/fxa-payments-server/server/jest.config.js
+++ b/packages/fxa-payments-server/server/jest.config.js
@@ -1,7 +1,13 @@
-// TO DO: update this file once more server tests are in place
 module.exports = {
-  displayName: 'server',
-  // TO DO: ignore server coverage for now - remove this if / when we want
-  // server files included in coverage reports
   coveragePathIgnorePatterns: ['<rootDir>'],
+  collectCoverageFrom: ['**/*.js', '!**/jest*js'],
+  // TO DO: update this file once more server tests are in place
+  coverageThreshold: {
+    global: {
+      branches: 0,
+      functions: 0,
+      lines: 0,
+      statements: 0,
+    },
+  },
 };

--- a/packages/fxa-payments-server/server/lib/server.test.js
+++ b/packages/fxa-payments-server/server/lib/server.test.js
@@ -1,0 +1,3 @@
+it('works', () => {
+  expect(true).toEqual(true);
+});

--- a/packages/fxa-payments-server/src/jest-style-mock.js
+++ b/packages/fxa-payments-server/src/jest-style-mock.js
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/packages/fxa-payments-server/src/jest.config.js
+++ b/packages/fxa-payments-server/src/jest.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  displayName: 'frontend',
-  preset: 'ts-jest',
-  moduleNameMapper: {
-    '\\.(css|scss)$': '<rootDir>/jest-style-mock.js',
-  },
-};

--- a/packages/fxa-payments-server/src/routes/Product/PlanDetails/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PlanDetails/index.test.tsx
@@ -6,18 +6,16 @@ import { PlanDetails } from './index';
 afterEach(cleanup);
 
 it('renders default details for unknown product ID', async () => {
-  const { findByText, queryByTestId } = render(<Subject />);
-  await findByText('Loaded');
-  expect(queryByTestId('plan-default')).toBeInTheDocument();
+  const { findByTestId } = render(<Subject />);
+  await findByTestId('plan-default');
 });
 
 it('renders specific details for known product ID', async () => {
   const plan_id = 'plan_F4bof27uz71Vk7';
-  const { findByText, queryByTestId } = render(
+  const { findByTestId } = render(
     <Subject plan={{ ...MOCK_PLAN, plan_id }} />
   );
-  await findByText('Loaded');
-  expect(queryByTestId('plan-123donepro')).toBeInTheDocument();
+  await findByTestId('plan-123donepro');
 });
 
 const Loading = () => <div>Loading</div>;

--- a/packages/fxa-payments-server/tsconfig.json
+++ b/packages/fxa-payments-server/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -13,7 +17,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "preserve"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/servers.json
+++ b/servers.json
@@ -177,7 +177,7 @@
       "name": "payments server PORT 3031",
       "cwd": "packages/fxa-payments-server",
       "script": "npm",
-      "args": ["run", "build-start-dev"],
+      "args": ["run", "start-dev"],
       "max_restarts": "1",
       "min_uptime": "2m",
       "env": {


### PR DESCRIPTION
- upgrade to React 16.9.0, which should fix warnings in tests

- switch frontend back to react-scripts for create-react-app consistency

- separate jest config for server tests

- more robust async test for lazy-loaded PlanDetails subcomponent

- ignore build directory in test coverage

- skip production build before starting dev server - it was a workaround for an issue that PR #1838 fixed

issue #2102