### PR TITLE
fix(scripts): add missing mailer arg to verification reminder script

### DIFF
--- a/packages/fxa-auth-server/scripts/verification-reminders.js
+++ b/packages/fxa-auth-server/scripts/verification-reminders.js
@@ -40,19 +40,31 @@ run()
   });
 
 async function run() {
-  const [allReminders, db, templates, translator] = await Promise.all([
+  const [
+    allReminders,
+    db,
+    templates,
+    subscriptionTemplates,
+    translator,
+  ] = await Promise.all([
     verificationReminders.process(),
     require(`${LIB_DIR}/db`)(config, log, {}, {}).connect(
       config[config.db.backend]
     ),
     require(`${LIB_DIR}/senders/templates`).init(),
+    require(`${LIB_DIR}/senders/subscription-templates`)(log),
     require(`${LIB_DIR}/senders/translator`)(
       config.i18n.supportedLanguages,
       config.i18n.defaultLanguage
     ),
   ]);
 
-  const mailer = new Mailer(translator, templates, config.smtp);
+  const mailer = new Mailer(
+    translator,
+    templates,
+    subscriptionTemplates,
+    config.smtp
+  );
 
   const sent = {};
 


### PR DESCRIPTION
A `subscriptionTemplates` argument was added to the `Mailer` constructor in #1791. I forgot to update the verification reminders script when I added it. Side note, we should write some tests for the verification reminders script.

@jrgm r?