### PR TITLE
fix(fxa-content-server): fix #1907 - change server.csp log schema

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/post-csp.js
+++ b/packages/fxa-content-server/server/lib/routes/post-csp.js
@@ -9,7 +9,7 @@
 'use strict';
 const _ = require('lodash');
 const joi = require('joi');
-const logger = require('../logging/log')('');
+const logger = require('../logging/log')();
 const url = require('url');
 const validation = require('../validation');
 
@@ -80,7 +80,6 @@ module.exports = function(options = {}) {
         referrer: stripPIIFromUrl(report['referrer']),
         sample: report['script-sample'],
         source: stripPIIFromUrl(report['source-file']),
-        time: today.toISOString(),
         violated: report['violated-directive'],
       };
 


### PR DESCRIPTION
fix for #1907 

As discussed with @jbuck, `Fields.time` is removed with this PR because BigQuery expects an integer and cannot be changed, but if change this to an integer we'd just be getting duplicate data since we're already capturing `Timestamp`.