### PR TITLE
fix(css): fix #2125 - Remove horizontal scrollbars 

### DIFF
--- a/packages/fxa-content-server/app/styles/_layout.scss
+++ b/packages/fxa-content-server/app/styles/_layout.scss
@@ -49,7 +49,7 @@
     max-width: 640px;
     padding: 32px 0 0;
     transition: box-shadow 250ms cubic-bezier(0.07, 0.95, 0, 1);
-    width: 100vw;
+    width: 100%;
   }
 
   @include respond-to('small') {
@@ -58,7 +58,7 @@
     border-top: 1px solid $settings-header-border-bottom;
     box-shadow: none;
     padding: 30px 0 10px;
-    width: 100vw;
+    width: 100%;
   }
 
   &.animate-shadow {

--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -796,24 +796,24 @@ section.modal-panel {
 }
 
 .breadcrumbs {
+  padding-left: 100px;
+  margin-top: 0;
   width: 100%;
-  margin-top: 0px;
-  margin-left: 100px;
 
   li {
     list-style: none;
     float: left;
-    margin: 0px;
-    padding: 0px;
+    margin: 0;
+    padding: 0;
 
-    &:before {
+    &::before {
       content: "\003E";
-      padding: 0px 10px;
+      padding: 0 10px;
     }
 
-    &:first-child:before {
+    &:first-child::before {
       content: "";
-      padding: 0px;
+      padding: 0;
     }
   }
 }

--- a/packages/fxa-payments-server/src/components/AppLayout/index.scss
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.scss
@@ -31,8 +31,8 @@
 }
 
 .breadcrumbs {
-  margin-left: 100px;
   margin-top: 0;
+  padding-left: 100px;
   width: 100%;
 
   li {


### PR DESCRIPTION
fix for #2125 

I think what Ryan pointed out was actually fixed in #1969, but I did find at other breakpoints, `100vw` was still causing the scrollbar.

I also found that in the payments server, the breadcrumbs were causing a horizontal scrollbar due to use of `margin` instead of `padding` there. I also very minorly cleaned up some related CSS.