### PR TITLE
fix(tests): add missing coverage for the verification reminder script

### DIFF
--- a/packages/fxa-auth-server/test/scripts/verification-reminders.js
+++ b/packages/fxa-auth-server/test/scripts/verification-reminders.js
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const ROOT_DIR = '../..';
+
+const cp = require('child_process');
+const Promise = require(`${ROOT_DIR}/lib/promise`);
+const path = require('path');
+
+cp.execAsync = Promise.promisify(cp.exec);
+
+const cwd = path.resolve(__dirname, ROOT_DIR);
+
+describe('scripts/verification-reminders:', () => {
+  it('does not fail', () => {
+    return cp.execAsync('node scripts/verification-reminders', { cwd });
+  });
+});


### PR DESCRIPTION
Fixes #2184.

Not the most intricate test I've ever written, but it would have caught the problem yesterday. Just runs the script and makes sure it doesn't fail. Not perfect, but better than what we have now, which is nothing.

@mozilla/fxa-devs r?