### PR TITLE
fix(signin): Prefill email signing into Sync after OAuth

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/views/mixins/cached-credentials-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/cached-credentials-mixin.js
@@ -38,7 +38,7 @@ describe('views/mixins/cached-credentials-mixin', () => {
 
     formPrefill = new Model();
     model = new Model();
-    relier = new Relier();
+    relier = new Relier({ service: 'sync' });
     user = new User();
 
     view = new View({
@@ -111,6 +111,7 @@ describe('views/mixins/cached-credentials-mixin', () => {
       sinon.stub(view, 'allowSuggestedAccount').callsFake(() => true);
 
       assert.strictEqual(view.suggestedAccount(), account);
+      assert.isTrue(user.getChooserAccount.calledOnce);
     });
 
     it('returns the default account if user.chooserAccount is not allowed', () => {
@@ -119,6 +120,7 @@ describe('views/mixins/cached-credentials-mixin', () => {
 
       const suggestedAccount = view.suggestedAccount();
       assert.notStrictEqual(suggestedAccount, account);
+      assert.isTrue(user.getChooserAccount.calledOnce);
     });
   });
 

--- a/packages/fxa-content-server/app/tests/spec/views/oauth_index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/oauth_index.js
@@ -24,7 +24,9 @@ describe('views/oauth_index', () => {
     broker = new AuthBroker();
     formPrefill = new FormPrefill();
     notifier = new Notifier();
-    relier = new Relier();
+    relier = new Relier({
+      service: 'ea3ca969f8c6bb0d',
+    });
     user = new User();
     view = new OAuthIndexView({
       broker,
@@ -80,6 +82,7 @@ describe('views/oauth_index', () => {
 
         return view.render().then(() => {
           assert.isTrue(view.replaceCurrentPage.calledOnceWith('signin'));
+          assert.isTrue(user.getChooserAccount.calledOnce);
         });
       });
     });
@@ -124,6 +127,7 @@ describe('views/oauth_index', () => {
         return view.render().then(() => {
           assert.isTrue(view.logError.calledWith(err));
           assert.isTrue(view.replaceCurrentPage.calledOnceWith('signup'));
+          assert.isTrue(user.getChooserAccount.calledOnce);
         });
       });
     });

--- a/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js
+++ b/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js
@@ -100,9 +100,6 @@ registerSuite('Firefox desktop user info handshake', {
       .then(ensureUsers());
   },
 
-  afterEach: function() {
-    return this.remote.then(clearBrowserState());
-  },
   tests: {
     'Sync signup page - user signed into browser': function() {
       return (
@@ -278,12 +275,11 @@ registerSuite('Firefox desktop user info handshake', {
               },
             })
           )
-          // browsers version of the world is ignored for non-Sync signins if another
-          // user has already signed in.
+          // browser's view of the world takes precedence, it signed in last
           .then(
             testElementTextEquals(
               selectors.SIGNIN.EMAIL_NOT_EDITABLE,
-              otherEmail
+              browserSignedInEmail
             )
           )
           .then(click(selectors.SIGNIN.SUBMIT_USE_SIGNED_IN))
@@ -331,9 +327,7 @@ registerSuite('Firefox desktop user info handshake', {
             })
           )
 
-          // unfortunately, this is one hole in our implementation. localStorage
-          // is totally ignored for Sync.
-          .then(testElementValueEquals(selectors.SIGNIN.EMAIL, ''))
+          .then(testElementValueEquals(selectors.SIGNIN.EMAIL, otherEmail))
       );
     },
 

--- a/packages/fxa-content-server/tests/functional/oauth_handshake.js
+++ b/packages/fxa-content-server/tests/functional/oauth_handshake.js
@@ -26,8 +26,6 @@ const {
   createUser,
   fillOutSignIn,
   openFxaFromRp,
-  noSuchElement,
-  testElementExists,
   testElementTextEquals,
   thenify,
   visibleByQSA,
@@ -75,9 +73,6 @@ registerSuite('Firefox desktop user info handshake - OAuth flows', {
       .then(ensureUsers());
   },
 
-  afterEach: function() {
-    return this.remote.then(clearBrowserState());
-  },
   tests: {
     'OAuth signin page - user signed into browser, no user signed in locally': function() {
       return (
@@ -103,10 +98,14 @@ registerSuite('Firefox desktop user info handshake - OAuth flows', {
             )
           )
           // User can sign in with cached credentials, no password needed.
-          .then(noSuchElement(selectors.SIGNIN.PASSWORD))
           .then(click(selectors.SIGNIN_PASSWORD.SUBMIT_USE_SIGNED_IN))
 
-          .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
+          .then(
+            testElementTextEquals(
+              selectors['123DONE'].AUTHENTICATED,
+              browserSignedInEmail
+            )
+          )
       );
     },
 
@@ -153,19 +152,22 @@ registerSuite('Firefox desktop user info handshake - OAuth flows', {
               },
             })
           )
-          // browsers version of the world is ignored for non-Sync signins if another
-          // user has already signed in.
+          // browser's view of the world takes precedence, it signed in last.
           .then(
             testElementTextEquals(
               selectors.SIGNIN.EMAIL_NOT_EDITABLE,
-              otherEmail
+              browserSignedInEmail
             )
           )
           // User can sign in with cached credentials, no password needed.
-          .then(noSuchElement(selectors.SIGNIN.PASSWORD))
           .then(click(selectors.SIGNIN_PASSWORD.SUBMIT_USE_SIGNED_IN))
 
-          .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
+          .then(
+            testElementTextEquals(
+              selectors['123DONE'].AUTHENTICATED,
+              browserSignedInEmail
+            )
+          )
       );
     },
   },

--- a/packages/fxa-content-server/tests/functional/sign_in_cached.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_cached.js
@@ -95,7 +95,7 @@ registerSuite('cached signin', {
           .refresh()
           .then(testElementExists(selectors.SIGNIN.HEADER))
 
-          // email is not yet denormalized :(
+          // email is not yet normalized :(
           .then(
             testElementTextEquals(
               selectors.SIGNIN.EMAIL_NOT_EDITABLE,

--- a/packages/fxa-content-server/tests/functional/sign_in_token_code.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_token_code.js
@@ -54,6 +54,7 @@ registerSuite('signin token code', {
       .then(
         FunctionalHelpers.clearBrowserState({
           contentServer: true,
+          force: true,
         })
       )
       .then(createUser(email, PASSWORD, { preVerified: true }));


### PR DESCRIPTION
When signing into Sync, instead of using *only* the browser's
view of the world and using a memory store, merge the browser's
view of the world with the accounts stored in localStorage.

If there is an account in localStorage with the same uid,
then merge the accounts.

This PR slightly changes the behavior of which account is
chosen as the "cached account". An account that is signed
into Sync and has an active session always takes precendence
over an OAuth signin. This was to simplify and unify logic
over how to choose the account.

fixes #1949