### PR TITLE
fix(support form): allow mobile browsers with chosen-js

### DIFF
--- a/packages/fxa-content-server/npm-shrinkwrap.json
+++ b/packages/fxa-content-server/npm-shrinkwrap.json
@@ -2892,9 +2892,8 @@
             }
         },
         "chosen-js": {
-            "version": "1.8.7",
-            "resolved": "https://registry.npmjs.org/chosen-js/-/chosen-js-1.8.7.tgz",
-            "integrity": "sha512-eVdrZJ2U5ISdObkgsi0od5vIJdLwq1P1Xa/Vj/mgxkMZf14DlgobfB6nrlFi3kW4kkvKLsKk4NDqZj1MU1DCpw=="
+            "version": "git://github.com/chenba/chosen.git#d3a62f4fd5f4550f2af0b6ac8cd5cb62dd1edcfa",
+            "from": "git://github.com/chenba/chosen.git#d3a62f4"
         },
         "chownr": {
             "version": "1.1.2",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -49,7 +49,7 @@
         "body-parser": "1.18.2",
         "cache-loader": "^3.0.1",
         "celebrate": "7.0.3",
-        "chosen-js": "1.8.7",
+        "chosen-js": "git://github.com/chenba/chosen.git#d3a62f4",
         "connect-cachify": "0.0.17",
         "consolidate": "0.14.5",
         "convict": "1.5.0",

--- a/packages/fxa-content-server/webpack.config.js
+++ b/packages/fxa-content-server/webpack.config.js
@@ -62,7 +62,7 @@ const webpackConfig = {
       ),
       'chosen-js': path.resolve(
         __dirname,
-        'node_modules/chosen-js/chosen.jquery'
+        'node_modules/chosen-js/public/chosen.jquery'
       ),
       'cocktail-lib': path.resolve(
         __dirname,


### PR DESCRIPTION
Chosen, the library used for the support form drop down, does not
support mobile browsers.  I forked Chosen, removed the mobile useragent
detection, built the project (it's written in coffeescript), and
committed the dist files into a branch
(https://github.com/chenba/chosen/commit/d3a62f4fd5f4550f2af0b6ac8cd5cb62dd1edcfa).

The support form does not rely on any of Chosen's styles and does not
use many of its features, so this approach should not be an issue.

Part of #1832

@mozilla/fxa-devs r?