### PR TITLE
moved TOS below button on signin/up

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
@@ -37,12 +37,12 @@
       </div>
     </form>
 
-    <div class="links">
-      <a href="/reset_password" class="reset-password" data-flow-event="forgot-password">{{#t}}Forgot password?{{/t}}</a>
+    <div class="tos-pp faint">
+      {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
     </div>
 
-    <div class="tos-pp faint">
-      {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms" tabindex="-1">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy" tabindex="-1">Privacy Notice</a>.{{/unsafeTranslate}}
+    <div class="links">
+      <a href="/reset_password" class="reset-password" data-flow-event="forgot-password">{{#t}}Forgot password?{{/t}}</a>
     </div>
     {{/fatalError}}
   </section>

--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -25,10 +25,6 @@
         <input name="email" type="email" class="email tooltip-below" autofocus placeholder="{{#t}}Email{{/t}}"/>
       </div>
 
-      <div class="tos-pp faint">
-        {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms" tabindex="-1">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy" tabindex="-1">Privacy Notice</a>.{{/unsafeTranslate}}
-      </div>
-
       <div class="button-row">
         <button id="submit-btn" type="submit">{{#t}}Continue{{/t}}</button>
       </div>

--- a/packages/fxa-content-server/app/scripts/templates/sign_in.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in.mustache
@@ -75,13 +75,13 @@
         </div>
       </form>
 
+      <div class="tos-pp faint">
+        {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
+      </div>
+
       <div class="links">
           <a href="/signup" class="left sign-up" data-flow-event="create-account">{{#t}}Create an account{{/t}}</a>
           <a href="/reset_password" class="right reset-password" data-flow-event="forgot-password">{{#t}}Forgot password?{{/t}}</a>
-      </div>
-
-      <div class="tos-pp faint">
-        {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms" tabindex="-1">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy" tabindex="-1">Privacy Notice</a>.{{/unsafeTranslate}}
       </div>
       {{/suggestedAccount}}
 

--- a/packages/fxa-content-server/app/scripts/templates/sign_up.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up.mustache
@@ -58,12 +58,6 @@
 
       {{{ coppaHTML }}}
 
-      {{^isTrailhead}}
-        <div class="tos-pp faint">
-          {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms" tabindex="-1">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy" tabindex="-1">Privacy Notice</a>.{{/unsafeTranslate}}
-        </div>
-      {{/isTrailhead}}
-
       <section class="get-involved">
         {{#isTrailhead}}
           {{#isAnyNewsletterEnabled}}
@@ -80,22 +74,20 @@
         {{/newsletters}}
       </section>
 
-      {{#isTrailhead}}
-        <div class="tos-pp faint">
-          {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms" tabindex="-1">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy" tabindex="-1">Privacy Notice</a>.{{/unsafeTranslate}}
-        </div>
-      {{/isTrailhead}}
-
       <div class="button-row">
         <button id="submit-btn" type="submit">{{#t}}Create account{{/t}}</button>
       </div>
     </form>
 
-    <div class="links">
-      {{#isSignInEnabled}}
-        <a href="/signin" id="have-account" data-flow-event="have-account" class="sign-in">{{#t}}Have an account? Sign in{{/t}}</a>
-      {{/isSignInEnabled}}
+    <div class="tos-pp faint">
+      {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
     </div>
+
+      {{#isSignInEnabled}}
+      <div class="links">
+        <a href="/signin" id="have-account" data-flow-event="have-account" class="sign-in">{{#t}}Have an account? Sign in{{/t}}</a>
+      </div>
+      {{/isSignInEnabled}}
     {{/error}}
   </section>
 </div>

--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -45,12 +45,6 @@
 
       {{{ coppaHTML }}}
 
-      {{^isTrailhead}}
-        <div class="tos-pp faint">
-          {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms" tabindex="-1">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy" tabindex="-1">Privacy Notice</a>.{{/unsafeTranslate}}
-        </div>
-      {{/isTrailhead}}
-
       <section class="get-involved">
         {{#isTrailhead}}
           {{#isAnyNewsletterEnabled}}
@@ -67,14 +61,12 @@
         {{/newsletters}}
       </section>
 
-      {{#isTrailhead}}
-        <div class="tos-pp faint">
-          {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms" tabindex="-1">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy" tabindex="-1">Privacy Notice</a>.{{/unsafeTranslate}}
-        </div>
-      {{/isTrailhead}}
-
       <div class="button-row">
         <button id="submit-btn" type="submit">{{#t}}Create account{{/t}}</button>
+      </div>
+
+      <div class="tos-pp faint">
+          {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
       </div>
 
       {{^isTrailhead}}

--- a/packages/fxa-content-server/app/styles/_layout.scss
+++ b/packages/fxa-content-server/app/styles/_layout.scss
@@ -24,7 +24,6 @@
     border-radius: $big-border-radius;
     box-shadow: $card-box-high;
     margin: 0 auto;
-    min-height: 400px;
     padding: 50px 40px 40px 40px;
   }
 

--- a/packages/fxa-content-server/app/styles/modules/_button-row.scss
+++ b/packages/fxa-content-server/app/styles/modules/_button-row.scss
@@ -79,11 +79,7 @@ button {
 }
 
 .button-row {
-  margin: 0 0 24px;
-
-  .tos-pp + & {
-    margin: 24px 0;
-  }
+  margin: 0 0 20px;
 
   .button {
     text-decoration: none;

--- a/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
+++ b/packages/fxa-content-server/app/styles/modules/_custom-rows.scss
@@ -35,7 +35,7 @@
 .tos-pp {
   font-size: 12px;
 
-  .links + & {
+  & + .links {
     margin-top: 20px;
   }
 }

--- a/packages/fxa-content-server/app/tests/spec/views/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/index.js
@@ -127,8 +127,6 @@ describe('views/index', () => {
 
             assert.lengthOf(view.$('#fxa-enter-email-header'), 1);
             assert.lengthOf(view.$('input[type=email]'), 1);
-            assert.lengthOf(view.$('#fxa-tos'), 1);
-            assert.lengthOf(view.$('#fxa-pp'), 1);
             assert.include(view.$('.service').text(), 'Firefox Sync');
             assert.lengthOf(view.$(Selectors.FIREFOX_FAMILY_SERVICES), 0);
 
@@ -191,8 +189,6 @@ describe('views/index', () => {
 
             assert.lengthOf(view.$('#fxa-enter-email-header'), 1);
             assert.lengthOf(view.$('input[type=email]'), 1);
-            assert.lengthOf(view.$('#fxa-tos'), 1);
-            assert.lengthOf(view.$('#fxa-pp'), 1);
             assert.include(view.$('.service').text(), 'Firefox Sync');
 
             assert.isTrue(notifier.trigger.calledWith('email-first-flow'));

--- a/packages/fxa-content-server/app/tests/spec/views/sign_up.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_up.js
@@ -1033,8 +1033,8 @@ describe('views/sign_up', function() {
       // wait for tooltip
       return p.delay(50).then(() => {
         assert.equal($('.tooltip-suggest').text(), 'Did you mean gmail.com?✕');
-        // there are exactly 7 elements with tabindex in the page
-        assert.equal($('[tabindex]').length, 7);
+        // there are exactly 5 elements with tabindex in the page
+        assert.equal($('[tabindex]').length, 5);
         // the first element with tabindex is the span containing the website name
         assert.equal(
           $('.tooltip-suggest span:first').get(0),


### PR DESCRIPTION
fixes #2168

Removes TOS from email-first

<img width="573" alt="Screen Shot 2019-08-14 at 12 52 50 PM" src="https://user-images.githubusercontent.com/87619/63052074-56f6de00-be93-11e9-91bb-0a748b39fa3b.png">

Moves TOS under button

<img width="779" alt="Screen Shot 2019-08-14 at 12 58 16 PM" src="https://user-images.githubusercontent.com/87619/63052116-6f66f880-be93-11e9-85ed-50a9393b76ac.png">
<img width="532" alt="Screen Shot 2019-08-14 at 12 52 06 PM" src="https://user-images.githubusercontent.com/87619/63052132-755cd980-be93-11e9-824f-24e57f11023f.png">
<img width="537" alt="Screen Shot 2019-08-14 at 12 52 28 PM" src="https://user-images.githubusercontent.com/87619/63052140-7857ca00-be93-11e9-95ec-a343ad5b560c.png">
