### PR TITLE
chore(payments): 100% test coverage on product payment route

### DIFF
--- a/packages/fxa-payments-server/jest.config.js
+++ b/packages/fxa-payments-server/jest.config.js
@@ -3,20 +3,4 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
-  collectCoverageFrom: [
-    '**/*.{js,jsx,ts,tsx}',
-    '!**/build/*',
-    '!**/*.stories.*',
-    '!**/types.tsx',
-    '!**/*.d.ts',
-    '!**/jest*js',
-  ],
-  coverageThreshold: {
-    global: {
-      branches: 64,
-      functions: 53,
-      lines: 64,
-      statements: 64,
-    },
-  },
 };

--- a/packages/fxa-payments-server/package-lock.json
+++ b/packages/fxa-payments-server/package-lock.json
@@ -3366,9 +3366,9 @@
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "@types/react": {
-      "version": "16.8.24",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.24.tgz",
-      "integrity": "sha512-VpFHUoD37YNY2+lr/+c7qL/tZsIU/bKuskUF3tmGUArbxIcQdb5j3zvo4cuuzu2A6UaVmVn7sJ4PgWYNFEBGzg==",
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.2.tgz",
+      "integrity": "sha512-jYP2LWwlh+FTqGd9v7ynUKZzjj98T8x7Yclz479QdRhHfuW9yQ+0jjnD31eXSXutmBpppj5PYNLYLRfnZJvcfg==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -4173,7 +4173,8 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -5335,13 +5336,28 @@
       }
     },
     "browserslist": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.2.tgz",
-      "integrity": "sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==",
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+      "integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
       "requires": {
-        "caniuse-lite": "^1.0.30000974",
-        "electron-to-chromium": "^1.3.150",
-        "node-releases": "^1.1.23"
+        "caniuse-lite": "^1.0.30000984",
+        "electron-to-chromium": "^1.3.191",
+        "node-releases": "^1.1.25"
+      },
+      "dependencies": {
+        "electron-to-chromium": {
+          "version": "1.3.230",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.230.tgz",
+          "integrity": "sha512-r0RljY5DZi9RX4v8mjHxJkDWnQe+nsrkGlHtrDF2uvZcvAkw+iglvlQi1794gZhwRtJoDOomMJlDHL2LfXSCZA=="
+        },
+        "node-releases": {
+          "version": "1.1.27",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.27.tgz",
+          "integrity": "sha512-9iXUqHKSGo6ph/tdXVbHFbhRVQln4ZDTIBJCzsa90HimnBYc5jw8RWYt4wBYFHehGyC3koIz5O4mb2fHrbPOuA==",
+          "requires": {
+            "semver": "^5.3.0"
+          }
+        }
       }
     },
     "bs-logger": {
@@ -5543,9 +5559,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000974",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz",
-      "integrity": "sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww=="
+      "version": "1.0.30000989",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
+      "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -5574,6 +5590,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
@@ -5627,7 +5644,8 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chokidar": {
       "version": "2.1.6",
@@ -5683,11 +5701,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5704,7 +5724,8 @@
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
@@ -5833,6 +5854,7 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -7283,6 +7305,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
       }
@@ -9375,7 +9398,8 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.0",
@@ -11342,11 +11366,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -11363,7 +11389,8 @@
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
@@ -11492,6 +11519,7 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -13528,6 +13556,7 @@
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.6.tgz",
       "integrity": "sha512-b47OWj1qf/LqSQYnmokNWM8D88KvUl2y7jT0567NB3ZBAZFz2bWp2PC81Xn7u8F2/vJxzkzNZybnemeFa7AZ2w==",
+      "dev": true,
       "requires": {
         "chai": "^4.1.2",
         "debug": "^4.1.0",
@@ -13544,6 +13573,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -14515,7 +14545,8 @@
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.0.17",
@@ -15705,7 +15736,8 @@
     "propagate": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
-      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk="
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "property-information": {
       "version": "5.1.0",
@@ -16714,9 +16746,9 @@
       "integrity": "sha512-+CNMnI8QhgVMtAt54uQs3kUxC3Sybpa7Y63HR14uGLgI9/QR5ggHvpxwhGGe3wmx5V91YwqQIblN9k5lspAmGw=="
     },
     "redux": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
-      "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
+      "integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
       "requires": {
         "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
@@ -19253,7 +19285,8 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.3.1",

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -35,10 +35,6 @@
     "url": "https://github.com/mozilla/fxa/issues"
   },
   "homepage": "https://github.com/mozilla/fxa/tree/master/packages/fxa-payments-server#README.md",
-  "resolutions": {
-    "browserslist": "4.6.2",
-    "caniuse-lite": "1.0.30000974"
-  },
   "devDependencies": {
     "@babel/core": "^7.4.5",
     "@babel/register": "^7.4.4",
@@ -52,7 +48,7 @@
     "@types/jest": "^24.0.17",
     "@types/jsdom": "^12.2.4",
     "@types/node": "^12.7.1",
-    "@types/react": "^16.8.24",
+    "@types/react": "^16.9.1",
     "@types/react-dom": "^16.8.5",
     "@types/react-redux": "^7.1.1",
     "@types/react-router": "^5.0.3",
@@ -67,14 +63,15 @@
     "audit-filter": "^0.5.0",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.5",
-    "browserslist": "^4.6.2",
-    "caniuse-lite": "^1.0.30000974",
+    "browserslist": "^4.6.6",
+    "caniuse-lite": "^1.0.30000989",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-fxa": "^1.0.0",
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-sorting": "^0.4.1",
     "express-http-proxy": "^1.5.1",
+    "nock": "^10.0.6",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
     "redux-devtools-extension": "^2.13.8",
@@ -99,7 +96,6 @@
     "joi": "^14.3.1",
     "morgan": "^1.9.1",
     "mozlog": "^2.2.0",
-    "nock": "^10.0.6",
     "node-sass": "^4.12.0",
     "nyc": "^14.1.0",
     "on-headers": "^1.0.2",
@@ -110,7 +106,7 @@
     "react-scripts": "3.0.1",
     "react-stripe-elements": "^4.0.0",
     "react-test-renderer": "^16.9.0",
-    "redux": "^4.0.1",
+    "redux": "^4.0.4",
     "redux-actions": "^2.6.5",
     "redux-promise-middleware": "^6.1.0",
     "redux-thunk": "^2.3.0",
@@ -122,6 +118,26 @@
     "npm": ">=6.4.1"
   },
   "readmeFilename": "README.md",
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx,ts,tsx}",
+      "!**/node_modules/*",
+      "!**/test-utils.*",
+      "!**/build/*",
+      "!**/*.stories.*",
+      "!**/types.tsx",
+      "!**/*.d.ts",
+      "!**/jest*js"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 84,
+        "functions": 71,
+        "lines": 78,
+        "statements": 78
+      }
+    }
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Store } from 'redux';
-import { Provider } from 'react-redux';
+import { Provider as ReduxProvider } from 'react-redux';
 import { StripeProvider } from 'react-stripe-elements';
 import { BrowserRouter as Router, Route, Redirect } from 'react-router-dom';
 
 import { QueryParams } from './lib/types';
 import { Config } from './lib/config';
+import { Store } from './store/types';
 import { AppContext, AppContextType } from './lib/AppContext';
 
 import './App.scss';
@@ -48,7 +48,7 @@ export const App = ({
   };
   return (
     <StripeProvider apiKey={config.stripe.apiKey}>
-      <Provider store={store}>
+      <ReduxProvider store={store}>
         <AppContext.Provider value={appContextValue}>
           <Router>
             <React.Suspense fallback={<RouteFallback />}>
@@ -78,7 +78,7 @@ export const App = ({
             </React.Suspense>
           </Router>
         </AppContext.Provider>
-      </Provider>
+      </ReduxProvider>
     </StripeProvider>
   );
 };

--- a/packages/fxa-payments-server/src/components/DialogMessage.tsx
+++ b/packages/fxa-payments-server/src/components/DialogMessage.tsx
@@ -22,7 +22,7 @@ export const DialogMessage = ({
     <Portal id="dialogs">
       <div data-testid="dialog-message-container" className={classNames('blocker', 'current')}>
         <div data-testid="dialog-message-content" className={classNames('modal', className)} ref={dialogInsideRef}>
-          <button className="dismiss" onClick={onDismiss as () => void}>
+          <button data-testid="dialog-dismiss" className="dismiss" onClick={onDismiss as () => void}>
             &#x2715;
           </button>
           <div className="message">{children}</div>

--- a/packages/fxa-payments-server/src/components/fields.tsx
+++ b/packages/fxa-payments-server/src/components/fields.tsx
@@ -73,7 +73,7 @@ export const Field = ({
     () => validator.registerField({ name, initialValue, required, fieldType }),
     [name, required, fieldType]
   );
-  /* eslint-enable react-hooks/exhaustive-dep */
+  /* eslint-enable react-hooks/exhaustive-deps */
 
   return (
     <div className={className}>
@@ -107,6 +107,7 @@ export const Input = (props: InputProps) => {
     className,
     ...childProps
   } = props;
+
   const { validator } = useContext(FormContext) as FormContextValue;
 
   const onChange = useCallback(
@@ -126,7 +127,7 @@ export const Input = (props: InputProps) => {
         validator.updateField({ name, value, valid: true });
       }
     },
-    [name, validator]
+    [name, validator, onValidate, required]
   );
 
   const tooltipParentRef = useRef<HTMLInputElement>(null);
@@ -252,7 +253,7 @@ export const Checkbox = (props: CheckboxProps) => {
         validator.updateField({ name, value, valid: true });
       }
     },
-    [name, validator]
+    [name, validator, required]
   );
 
   return (

--- a/packages/fxa-payments-server/src/index.tsx
+++ b/packages/fxa-payments-server/src/index.tsx
@@ -26,9 +26,8 @@ async function init() {
   // We should have gotten an accessToken or else redirected, but guard here
   // anyway because App component requires a token.
   if (accessToken) {
-    [actions.fetchToken(accessToken), actions.fetchProfile(accessToken)].map(
-      store.dispatch
-    );
+    store.dispatch(actions.fetchToken(accessToken));
+    store.dispatch(actions.fetchProfile(accessToken));
 
     render(
       <App

--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -121,4 +121,4 @@ function getErrorMessage(type: string) {
 }
 
 // BASIC_ERROR and PAYMENT_ERROR_1 are exported for errors.test.tsx
-export { AuthServerErrno, getErrorMessage, BASIC_ERROR, PAYMENT_ERROR_1 };
+export { AuthServerErrno, getErrorMessage, BASIC_ERROR, PAYMENT_ERROR_1, PAYMENT_ERROR_2 };

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -1,0 +1,190 @@
+import React, { useContext, ReactNode } from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { AppContext, AppContextType } from '../../src/lib/AppContext';
+import { config, updateConfig } from '../../src/lib/config';
+import ScreenInfo from '../../src/lib/screen-info';
+import { ReactStripeElements } from 'react-stripe-elements';
+
+import { State } from '../../src/store/types';
+import { createAppStore } from '../../src/store';
+
+declare global {
+  namespace NodeJS {
+    interface Global {
+      fetch: Function;
+    }
+  }
+}
+
+export const wait = (delay: number) =>
+  new Promise(
+    resolve => setTimeout(resolve, delay)
+  );
+
+export const mockConfig = {
+  productRedirectURLs: {
+    product_8675309: 'https://example.com/product',
+  },
+  servers: {
+    content: {
+      url: 'https://content.example',
+    },
+    auth: {
+      url: 'https://auth.example',
+    },
+    oauth: {
+      url: 'https://oauth.example',
+    },
+    profile: {
+      url: 'https://profile.example',
+    },
+  },
+};
+
+export const mockServerUrl = (name: 'auth' | 'oauth' | 'profile' | 'content') =>
+  config.servers[name].url;
+
+export const setupMockConfig = (config?: typeof mockConfig) => {
+  updateConfig(config || mockConfig);
+};
+
+// Minimal mock for react-stripe-elements that lets us trigger onChange
+// handlers with testing data
+const MockStripeElement = ({ testid }: { testid: string }) =>
+  class extends React.Component {
+    _ref: null;
+    setRef: (el: any) => void;
+
+    constructor(props: ReactStripeElements.ElementProps) {
+      super(props);
+
+      // Stash this element's onChange handler in module-global registry.
+      const { onChange } = props;
+      mockStripeElementOnChangeFns[testid] = onChange as onChangeFunctionType;
+
+      // Real react-stripe-elements stash a ref to their container in
+      // this._ref, which we use for tooltip positioning
+      this._ref = null;
+      this.setRef = el => (this._ref = el);
+    }
+
+    render() {
+      return (
+        <div ref={this.setRef} data-testid={testid}>
+          {testid}
+        </div>
+      );
+    }
+  };
+
+// onChange handler registry - indexed by per-component testid, of which
+// there should only be one instance per PaymentForm
+type onChangeFunctionType = (
+  value: stripe.elements.ElementChangeResponse
+) => void;
+
+export const mockStripeElementOnChangeFns: {
+  [name: string]: onChangeFunctionType;
+} = {};
+
+export type MockStripeType = {
+  createToken(
+    options?: stripe.TokenOptions
+  ): Promise<ReactStripeElements.PatchedTokenResponse>;
+};
+
+export type MockStripeContextType = {
+  mockStripe?: MockStripeType;
+};
+
+const MockStripeContext = React.createContext<MockStripeContextType>({});
+
+function injectStripe<P extends Object>(
+  WrappedComponent: React.ComponentType<
+    P & ReactStripeElements.InjectedStripeProps
+  >
+) {
+  return (props: P) => {
+    const { mockStripe } = useContext(MockStripeContext);
+    return <WrappedComponent {...{ ...props, stripe: mockStripe }} />;
+  };
+}
+
+// Mock out the Stripe elements we use in PaymentForm
+jest.setMock(
+  'react-stripe-elements',
+  Object.assign(require.requireActual('react-stripe-elements'), {
+    injectStripe,
+    Elements: ({ children }: { children: ReactNode }) => children,
+    CardNumberElement: MockStripeElement({ testid: 'cardNumberElement' }),
+    CardExpiryElement: MockStripeElement({ testid: 'cardExpiryElement' }),
+    CardCVCElement: MockStripeElement({ testid: 'cardCVCElement' }),
+  })
+);
+
+export const elementChangeResponse = ({
+  complete = true,
+  value,
+  errorMessage,
+}: {
+  complete?: boolean;
+  value?: any;
+  errorMessage?: string;
+}): stripe.elements.ElementChangeResponse => ({
+  elementType: 'test',
+  brand: 'test',
+  value: 'boof',
+  complete,
+  empty: !!value,
+  error:
+    (!!errorMessage && {
+      type: 'card_error',
+      charge: 'test',
+      message: errorMessage,
+    }) ||
+    undefined,
+});
+
+export const defaultAppContextValue = (): AppContextType => ({
+  accessToken: 'at_12345',
+  config,
+  queryParams: {},
+  navigateToUrl: jest.fn(),
+  getScreenInfo: () => new ScreenInfo(window),
+  locationReload: jest.fn(),
+});
+
+type MockAppProps = {
+  children: ReactNode;
+  appContextValue?: AppContextType;
+  initialState?: State;
+  storeEnhancers?: Array<any>;
+  mockStripe?: MockStripeType;
+};
+
+export const MockApp = ({
+  children,
+  initialState,
+  storeEnhancers,
+  appContextValue,
+  mockStripe,
+}: MockAppProps) => {
+  const store = createAppStore(initialState, storeEnhancers);
+  return (
+    <ReduxProvider store={store}>
+      <MockStripeContext.Provider value={{ mockStripe }}>
+        <AppContext.Provider
+          value={appContextValue || defaultAppContextValue()}
+        >
+          <React.Suspense
+            fallback={<div data-testid="is-loading">Loading</div>}
+          >
+            {children}
+          </React.Suspense>
+        </AppContext.Provider>
+      </MockStripeContext.Provider>
+    </ReduxProvider>
+  );
+};
+
+export default MockApp;

--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -1,0 +1,514 @@
+import React from 'react';
+import { render, cleanup, act, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import nock from 'nock';
+
+import { PAYMENT_ERROR_2 } from '../../lib/errors';
+import {
+  defaultAppContextValue,
+  MockApp,
+  MockStripeType,
+  setupMockConfig,
+  mockConfig,
+  mockServerUrl,
+  mockStripeElementOnChangeFns,
+  elementChangeResponse,
+} from '../../lib/test-utils';
+
+import { SignInLayout } from '../../components/AppLayout';
+import Product from './index';
+
+describe('routes/Product', () => {
+  let authServer = '';
+  let profileServer = '';
+
+  beforeEach(() => {
+    setupMockConfig({
+      ...mockConfig,
+      productRedirectURLs: PRODUCT_REDIRECT_URLS,
+    });
+    authServer = mockServerUrl('auth');
+    mockOptionsResponses(authServer);
+    profileServer = mockServerUrl('profile');
+    mockOptionsResponses(profileServer);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    return cleanup();
+  });
+
+  const Subject = ({
+    productId = PRODUCT_ID,
+    planId,
+    accountActivated,
+    navigateToUrl = jest.fn(),
+    createToken = jest.fn().mockResolvedValue(VALID_CREATE_TOKEN_RESPONSE),
+  }: {
+    productId?: string;
+    planId?: string;
+    navigateToUrl?: (url: string) => void;
+    accountActivated?: string;
+    createToken?: jest.Mock<any, any>;
+  }) => {
+    const props = {
+      match: {
+        params: {
+          productId,
+        },
+      },
+    };
+    const mockStripe = {
+      createToken,
+    };
+    const appContextValue = {
+      ...defaultAppContextValue(),
+      navigateToUrl: navigateToUrl || jest.fn(),
+      queryParams: {
+        plan: planId,
+        activated: accountActivated,
+      },
+    };
+    return (
+      <MockApp {...{ mockStripe, appContextValue }}>
+        <SignInLayout>
+          <Product {...props} />
+        </SignInLayout>
+      </MockApp>
+    );
+  };
+
+  const initApiMocks = (displayName?: string) => [
+    nock(profileServer)
+      .get('/v1/profile')
+      .reply(200, { ...MOCK_PROFILE, displayName }),
+    nock(authServer)
+      .get('/v1/oauth/subscriptions/plans')
+      .reply(200, MOCK_PLANS),
+    nock(authServer)
+      .get('/v1/oauth/subscriptions/active')
+      .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS),
+    nock(authServer)
+      .get('/v1/oauth/subscriptions/customer')
+      .reply(200, MOCK_CUSTOMER),
+  ];
+
+  const withExistingAccount = (useDisplayName?: boolean) => async () => {
+    const displayName = useDisplayName ? 'Foo Barson' : undefined;
+    const apiMocks = initApiMocks(displayName);
+    const { findByText, queryByText, queryByTestId } = render(<Subject />);
+    await findByText("Let's set up your subscription");
+    expect(queryByText(`${PLAN_NAME} for $5.00 per month`)).toBeInTheDocument();
+    expect(queryByTestId('account-activated')).not.toBeInTheDocument();
+    expect(queryByTestId('profile-email')).toBeInTheDocument();
+    if (displayName) {
+      expect(queryByTestId('profile-display-name')).toBeInTheDocument();
+    }
+    expectNockScopesDone(apiMocks);
+  };
+
+  it('renders with valid product ID', withExistingAccount(false));
+
+  it('renders with product ID and display name', withExistingAccount(true));
+
+  const withActivationBanner = (useDisplayName?: boolean) => async () => {
+    const displayName = useDisplayName ? 'Foo Barson' : undefined;
+    const apiMocks = initApiMocks(displayName);
+    const { findByText, queryByText, queryByTestId } = render(
+      <Subject planId={PLAN_ID} accountActivated="true" />
+    );
+    await findByText("Let's set up your subscription");
+    expect(queryByText(`${PLAN_NAME} for $5.00 per month`)).toBeInTheDocument();
+    expect(queryByTestId('account-activated')).toBeInTheDocument();
+    if (displayName) {
+      expect(queryByTestId('activated-display-name')).toBeInTheDocument();
+      expect(queryByTestId('activated-email')).not.toBeInTheDocument();
+    } else {
+      expect(queryByTestId('activated-display-name')).not.toBeInTheDocument();
+      expect(queryByTestId('activated-email')).toBeInTheDocument();
+    }
+    expectNockScopesDone(apiMocks);
+  };
+
+  it(
+    'renders with ?plan={PLAN_ID}&accountActivated given in query string',
+    withActivationBanner(false)
+  );
+  it(
+    'renders with display name and ?plan={PLAN_ID}&accountActivated given in query string',
+    withActivationBanner(true)
+  );
+
+  it('displays an error with invalid product ID', async () => {
+    const apiMocks = initApiMocks();
+    const { findByTestId } = render(<Subject productId="bad_product" />);
+    await findByTestId('no-such-plan-error');
+    expectNockScopesDone(apiMocks);
+  });
+
+  it('displays an error on failure to load profile', async () => {
+    const apiMocks = [
+      nock(profileServer)
+        .get('/v1/profile')
+        .reply(400, MOCK_PROFILE),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/plans')
+        .reply(200, MOCK_PLANS),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/active')
+        .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/customer')
+        .reply(200, MOCK_CUSTOMER),
+    ];
+    const { findByTestId } = render(<Subject />);
+    await findByTestId('error-loading-profile');
+  });
+
+  it('displays an error on failure to load plans', async () => {
+    const apiMocks = [
+      nock(profileServer)
+        .get('/v1/profile')
+        .reply(200, MOCK_PROFILE),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/plans')
+        .reply(400, MOCK_PLANS),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/active')
+        .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/customer')
+        .reply(200, MOCK_CUSTOMER),
+    ];
+    const { findByTestId } = render(<Subject />);
+    await findByTestId('error-loading-plans');
+  });
+
+  it('displays an error on failure to load customer', async () => {
+    const apiMocks = [
+      nock(profileServer)
+        .get('/v1/profile')
+        .reply(200, MOCK_PROFILE),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/plans')
+        .reply(200, MOCK_PLANS),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/active')
+        .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/customer')
+        .reply(400, MOCK_CUSTOMER),
+    ];
+    const { findByTestId } = render(<Subject />);
+    await findByTestId('error-loading-customer');
+  });
+
+  async function commonSubmitSetup(createToken: jest.Mock<any, any>) {
+    const apiMocks = [
+      ...initApiMocks(),
+      nock(authServer)
+        .post('/v1/oauth/subscriptions/active')
+        .reply(200, {}),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/active')
+        .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/customer')
+        .reply(200, MOCK_CUSTOMER_AFTER_SUBSCRIPTION),
+    ];
+
+    const navigateToUrl = jest.fn();
+    const renderResult = render(
+      <Subject {...{ navigateToUrl, createToken }} />
+    );
+    const { getByTestId, findByText } = renderResult;
+
+    await findByText("Let's set up your subscription");
+
+    act(() => {
+      for (const testid of STRIPE_FIELDS) {
+        mockStripeElementOnChangeFns[testid](
+          elementChangeResponse({ complete: true, value: 'test' })
+        );
+      }
+    });
+    fireEvent.change(getByTestId('name'), { target: { value: 'Foo Barson' } });
+    fireEvent.change(getByTestId('zip'), { target: { value: '90210' } });
+    fireEvent.click(getByTestId('confirm'));
+
+    return { ...renderResult, navigateToUrl, apiMocks };
+  }
+
+  it('handles a successful payment submission as expected', async () => {
+    const createToken = jest
+      .fn()
+      .mockResolvedValue(VALID_CREATE_TOKEN_RESPONSE);
+    const {
+      getByTestId,
+      findByText,
+      queryByText,
+      navigateToUrl,
+      apiMocks,
+    } = await commonSubmitSetup(createToken);
+
+    fireEvent.click(getByTestId('submit'));
+
+    await findByText('Your subscription is ready');
+    expect(createToken).toBeCalled();
+    expect(queryByText('Plan 12345')).toBeInTheDocument();
+    expect(
+      queryByText("Click here if you're not automatically redirected")
+    ).toBeInTheDocument();
+    expect(navigateToUrl).toBeCalledWith('https://example.com/product');
+    expectNockScopesDone(apiMocks);
+  });
+
+  it('redirects to product page if user is already subscribed', async () => {
+    const apiMocks = [
+      nock(profileServer)
+        .get('/v1/profile')
+        .reply(200, MOCK_PROFILE),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/plans')
+        .reply(200, MOCK_PLANS),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/active')
+        .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/customer')
+        .reply(200, MOCK_CUSTOMER_AFTER_SUBSCRIPTION),
+    ];
+
+    const navigateToUrl = jest.fn();
+    const createToken = jest
+      .fn()
+      .mockResolvedValue(VALID_CREATE_TOKEN_RESPONSE);
+
+    const { findByText, queryByText } = render(
+      <Subject {...{ navigateToUrl, createToken }} />
+    );
+
+    await findByText('Your subscription is ready');
+    expect(createToken).not.toBeCalled();
+    expect(queryByText('Plan 12345')).toBeInTheDocument();
+    expect(
+      queryByText("Click here if you're not automatically redirected")
+    ).toBeInTheDocument();
+    expect(navigateToUrl).toBeCalledWith('https://example.com/product');
+    expectNockScopesDone(apiMocks);
+  });
+
+  it('displays an error if payment submission somehow silently fails', async () => {
+    const createToken = jest.fn().mockResolvedValue({});
+    const {
+      container,
+      getByTestId,
+      findByTestId,
+      queryByTestId,
+      debug,
+    } = await commonSubmitSetup(createToken);
+    fireEvent.click(getByTestId('submit'));
+    await findByTestId('error-payment-submission');
+    fireEvent.click(getByTestId('dialog-dismiss'));
+    expect(queryByTestId('error-payment-submission')).not.toBeInTheDocument();
+  });
+
+  it('displays an error on failure to submit payment', async () => {
+    const createToken = jest.fn().mockRejectedValue({
+      type: 'call_issuer',
+    });
+    const { getByTestId, findByTestId, queryByText } = await commonSubmitSetup(
+      createToken
+    );
+    fireEvent.click(getByTestId('submit'));
+    await findByTestId('error-payment-submission');
+    expect(queryByText(PAYMENT_ERROR_2)).toBeInTheDocument();
+  });
+
+  async function commonCreateSubscriptionFailSetup(
+    code: string,
+    message: string
+  ) {
+    const apiMocks = [
+      ...initApiMocks(),
+      nock(authServer)
+        .post('/v1/oauth/subscriptions/active')
+        .reply(400, {
+          code,
+          message,
+        }),
+    ];
+    const renderResult = render(<Subject />);
+    const { getByTestId, findByText } = renderResult;
+
+    await findByText("Let's set up your subscription");
+    act(() => {
+      for (const testid of STRIPE_FIELDS) {
+        mockStripeElementOnChangeFns[testid](
+          elementChangeResponse({ complete: true, value: 'test' })
+        );
+      }
+    });
+    fireEvent.change(getByTestId('name'), { target: { value: 'Foo Barson' } });
+    fireEvent.change(getByTestId('zip'), { target: { value: '90210' } });
+    fireEvent.click(getByTestId('confirm'));
+
+    return renderResult;
+  }
+
+  it('displays an error if card declined during subscription creation', async () => {
+    const message = 'This is a library card';
+    const {
+      getByTestId,
+      queryByText,
+      findByTestId,
+    } = await commonCreateSubscriptionFailSetup('card_declined', message);
+    fireEvent.click(getByTestId('submit'));
+
+    await findByTestId('error-card-declined');
+    expect(queryByText(message)).toBeInTheDocument();
+  });
+
+  it('displays an error if subscription creation fails for some other reason', async () => {
+    const message = 'We done goofed';
+    const {
+      getByTestId,
+      queryByText,
+      findByTestId,
+    } = await commonCreateSubscriptionFailSetup('api_error', message);
+    fireEvent.click(getByTestId('submit'));
+    await findByTestId('error-subscription-failed');
+    expect(queryByText(message)).toBeInTheDocument();
+  });
+});
+
+function expectNockScopesDone(scopes: nock.Scope[]) {
+  for (const scope of scopes) {
+    expect(scope.isDone()).toBeTruthy();
+  }
+}
+
+function mockOptionsResponses(baseUrl: string) {
+  return nock(baseUrl)
+    .options(/\/v1/)
+    .reply(200, '', CORS_OPTIONS_HEADERS)
+    .persist();
+}
+
+const STRIPE_FIELDS = [
+  'cardNumberElement',
+  'cardCVCElement',
+  'cardExpiryElement',
+];
+
+const VALID_CREATE_TOKEN_RESPONSE: stripe.TokenResponse = {
+  token: {
+    id: 'tok_8675309',
+    object: 'test',
+    client_ip: '123.123.123.123',
+    created: Date.now(),
+    livemode: false,
+    type: 'card',
+    used: false,
+  },
+};
+
+const CORS_OPTIONS_HEADERS = {
+  'access-control-allow-methods': 'GET,POST',
+  'access-control-allow-origin': 'http://localhost',
+  'access-control-allow-headers':
+    'Accept,Authorization,Content-Type,If-None-Match',
+};
+
+const PLAN_ID = 'plan_12345';
+
+const PLAN_NAME = 'Plan 12345';
+
+const PRODUCT_ID = 'product_8675309';
+
+const PRODUCT_REDIRECT_URLS = {
+  [PRODUCT_ID]: 'https://example.com/product',
+};
+
+const MOCK_PLANS = [
+  {
+    plan_id: PLAN_ID,
+    plan_name: PLAN_NAME,
+    product_id: PRODUCT_ID,
+    product_name: 'Product 67890',
+    interval: 'month',
+    amount: '500',
+    currency: 'usd',
+  },
+];
+
+const MOCK_PROFILE = {
+  email: 'foo@example.com',
+  locale: 'en-US,en;q=0.5',
+  amrValues: ['pwd', 'email'],
+  twoFactorAuthentication: false,
+  uid: 'a90fef48240b49b2b6a33d333aee9b13',
+  avatar: 'http://127.0.0.1:1112/a/00000000000000000000000000000000',
+  avatarDefault: true,
+};
+
+const MOCK_ACTIVE_SUBSCRIPTIONS = [
+  {
+    uid: 'a90fef48240b49b2b6a33d333aee9b13',
+    subscriptionId: 'sub0.28964929339372136',
+    productName: '123doneProProduct',
+    createdAt: 1565816388815,
+    cancelledAt: null,
+  },
+];
+
+const MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION = [
+  {
+    uid: 'a90fef48240b49b2b6a33d333aee9b13',
+    subscriptionId: 'sub0.28964929339372136',
+    productName: '123doneProProduct',
+    createdAt: 1565816388815,
+    cancelledAt: null,
+  },
+  {
+    uid: 'a90fef48240b49b2b6a33d333aee9b13',
+    subscriptionId: 'sub0.21234123424',
+    productName: 'prod_67890',
+    createdAt: 1565816388815,
+    cancelledAt: null,
+  },
+];
+
+const MOCK_CUSTOMER = {
+  payment_type: 'tok_1F7TltEOSeHhIAfQo9u6eqTc',
+  last4: '8675',
+  exp_month: 8,
+  exp_year: 2020,
+  subscriptions: [
+    {
+      subscription_id: 'sub0.28964929339372136',
+      plan_id: '123doneProMonthly',
+      plan_name: '123done Pro Monthly',
+      status: 'active',
+      cancel_at_period_end: false,
+      current_period_start: 1565816388.815,
+      current_period_end: 1568408388.815,
+    },
+  ],
+};
+
+const MOCK_CUSTOMER_AFTER_SUBSCRIPTION = {
+  ...MOCK_CUSTOMER,
+  subscriptions: [
+    ...MOCK_CUSTOMER.subscriptions,
+    {
+      subscription_id: 'sub0.21234123424',
+      plan_id: PLAN_ID,
+      plan_name: 'Plan 12345',
+      status: 'active',
+      cancel_at_period_end: false,
+      current_period_start: 1565816388.815,
+      current_period_end: 1568408388.815,
+    },
+  ],
+};

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback, useContext } from 'react';
 import { connect } from 'react-redux';
 import { AuthServerErrno, getErrorMessage } from '../../lib/errors';
-import { actions, selectors } from '../../store';
+import { actions, thunks, selectors } from '../../store';
 import { AppContext } from '../../lib/AppContext';
 import { LoadingOverlay } from '../../components/LoadingOverlay';
 import { State as ValidatorState } from '../../lib/validator';
@@ -74,9 +74,7 @@ export const Product = ({
 
   // Fetch plans on initial render, change in product ID, or auth change.
   useEffect(() => {
-    if (accessToken) {
-      fetchProductRouteResources(accessToken);
-    }
+    fetchProductRouteResources(accessToken);
   }, [fetchProductRouteResources, accessToken]);
 
   // Reset subscription creation status on initial render.
@@ -124,7 +122,7 @@ export const Product = ({
   if (profile.error !== null) {
     return (
       <DialogMessage className="dialog-error" onDismiss={locationReload}>
-        <h4>Problem loading profile</h4>
+        <h4 data-testid="error-loading-profile">Problem loading profile</h4>
         <p>{profile.error.message}</p>
       </DialogMessage>
     );
@@ -133,7 +131,7 @@ export const Product = ({
   if (plans.error !== null) {
     return (
       <DialogMessage className="dialog-error" onDismiss={locationReload}>
-        <h4>Problem loading plans</h4>
+        <h4 data-testid="error-loading-plans">Problem loading plans</h4>
         <p>{plans.error.message}</p>
       </DialogMessage>
     );
@@ -146,7 +144,7 @@ export const Product = ({
   ) {
     return (
       <DialogMessage className="dialog-error" onDismiss={locationReload}>
-        <h4>Problem loading customer information</h4>
+        <h4 data-testid="error-loading-customer">Problem loading customer information</h4>
         <p>{customer.error.message}</p>
       </DialogMessage>
     );
@@ -156,7 +154,7 @@ export const Product = ({
     return (
       <DialogMessage className="dialog-error" onDismiss={locationReload}>
         <h4>Plan not found</h4>
-        <p>No such plan for this product.</p>
+        <p data-testid="no-such-plan-error">No such plan for this product.</p>
       </DialogMessage>
     );
   }
@@ -198,7 +196,7 @@ export const Product = ({
             setCreateTokenError({ type: '', error: false });
           }}
         >
-          <h4>Payment submission failed</h4>
+          <h4 data-testid="error-payment-submission">Payment submission failed</h4>
           <p>{getErrorMessage(createTokenError.type)}</p>
         </DialogMessage>
       )}
@@ -246,7 +244,7 @@ const CreateSubscriptionErrorDialog = ({
   if (code === 'card_declined') {
     return (
       <DialogMessage className="dialog-error" onDismiss={onDismiss}>
-        <h4>Card declined</h4>
+        <h4 data-testid="error-card-declined">Card declined</h4>
         <p>{message}</p>
       </DialogMessage>
     );
@@ -256,7 +254,7 @@ const CreateSubscriptionErrorDialog = ({
   // https://github.com/mozilla/subhub/issues/98
   return (
     <DialogMessage className="dialog-error" onDismiss={onDismiss}>
-      <h4>Subscription failed</h4>
+      <h4 data-testid="error-subscription-failed">Subscription failed</h4>
       <p>{message}</p>
     </DialogMessage>
   );
@@ -271,8 +269,8 @@ const ProfileBanner = ({
 }: ProfileProps) => (
   <div className="profile-banner">
     <img className="avatar hoisted" src={avatar} alt={displayName || email} />
-    {displayName && <h2 className="displayName">{displayName}</h2>}
-    <h3 className="name email">{email}</h3>
+    {displayName && <h2 data-testid="profile-display-name" className="displayName">{displayName}</h2>}
+    <h3 data-testid="profile-email" className="name email">{email}</h3>
     {/* TODO: what does "switch account" do? need to re-login and redirect eventually back here?
       <a href="">Switch account</a>
     */}
@@ -282,16 +280,16 @@ const ProfileBanner = ({
 const AccountActivatedBanner = ({
   profile: { email, displayName },
 }: ProfileProps) => (
-  <div className="account-activated">
+  <div data-testid="account-activated" className="account-activated">
     <h2>
       Your account is activated,{' '}
       {displayName ? (
         <>
-          <span className="displayName">{displayName}</span>
+          <span data-testid="activated-display-name" className="displayName">{displayName}</span>
         </>
       ) : (
         <>
-          <span className="email">{email}</span>
+          <span data-testid="activated-email" className="email">{email}</span>
         </>
       )}
     </h2>
@@ -308,9 +306,9 @@ export default connect(
     plansByProductId: selectors.plansByProductId(state),
   }),
   {
-    createSubscription: actions.createSubscriptionAndRefresh,
     resetCreateSubscription: actions.resetCreateSubscription,
     resetCreateSubscriptionError: actions.resetCreateSubscription,
-    fetchProductRouteResources: actions.fetchProductRouteResources,
+    fetchProductRouteResources: thunks.fetchProductRouteResources,
+    createSubscription: thunks.createSubscriptionAndRefresh,
   }
 )(Product);

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import dayjs from 'dayjs';
 
 import { AuthServerErrno } from '../../lib/errors';
-import { actions, selectors } from '../../store';
+import { actions, thunks, selectors } from '../../store';
 import { AppContext } from '../../lib/AppContext';
 
 import {
@@ -352,12 +352,12 @@ export default connect(
     plansByProductId: selectors.plansByProductId(state),
   }),
   {
-    fetchSubscriptionsRouteResources: actions.fetchSubscriptionsRouteResources,
-    updatePayment: actions.updatePaymentAndRefresh,
+    fetchSubscriptionsRouteResources: thunks.fetchSubscriptionsRouteResources,
+    updatePayment: thunks.updatePaymentAndRefresh,
     resetUpdatePayment: actions.resetUpdatePayment,
-    cancelSubscription: actions.cancelSubscriptionAndRefresh,
+    cancelSubscription: thunks.cancelSubscriptionAndRefresh,
     resetCancelSubscription: actions.resetCancelSubscription,
-    reactivateSubscription: actions.reactivateSubscriptionAndRefresh,
+    reactivateSubscription: thunks.reactivateSubscriptionAndRefresh,
     resetReactivateSubscription: actions.resetReactivateSubscription,
   }
 )(Subscriptions);

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -1,3 +1,4 @@
+import { Store as ReduxStore } from 'redux';
 import { APIError } from './utils';
 
 export interface Profile {
@@ -135,5 +136,7 @@ export interface AsyncThunkCreator {
 }
 
 export interface ActionCreators {
-  [propName: string]: ActionCreator | AsyncThunkCreator;
+  [propName: string]: ActionCreator;
 }
+
+export type Store = ReduxStore<State, Action>;


### PR DESCRIPTION
- outside-in tests for product payment route component that exercise all
  related sub-components, Redux actions, and API requests

- upgrade React, Redux, browserslist, and caniuse-lite dependencies

- separated actions from thunks in Redux store, which seems to work
  better with typescript annotations that got more strict in the upgrade

- better error handling in Redux store & API requests

- refactor mocks for react-stripe-elements into shared test-utils

- move jest config to package.json, where it actually gets read

Issue #2102