### PR TITLE
chore(support): Document support for Firefox 60+

### DIFF
--- a/docs/supported-browsers.md
+++ b/docs/supported-browsers.md
@@ -1,13 +1,12 @@
 # Firefox Accounts Browser Support
 
-Last update April 8, 2019
+Last update Aug 15, 2019
 
 Firefox Accounts must run in the following environments:
 
-- Firefox Desktop ESR - 1 (Firefox 52)
-- Firefox for Android ESR - 1 (Firefox 52)
+- Firefox Desktop ESR - 1 (Firefox 60)
+- Firefox for Android ESR - 1 (Firefox 60)
 - Firefox for iOS 17
 - Latest versions of modern browsers (Chrome, Safari, Opera, Edge)
 - iOS 12+ (and iOS WebView for Firefox iOS)
 - Android 7.0 (and Android WebView for Lockbox)
-


### PR DESCRIPTION
Current ESR is based on 68.0. ESR - 1 is based on Firefox 60.

@mozilla/fxa-devs - r?