### PR TITLE
fix(support form): make dropdown widget screen reader accessible

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/support.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/support.mustache
@@ -40,7 +40,7 @@
             <form id="fxa-support" novalidate>
               <div class="support-field">
                 <div class="form-label">
-                  <label for="topic">{{#t}}What do you need help with?{{/t}}</label>
+                  <label for="topic" id="topic-label">{{#t}}What do you need help with?{{/t}}</label>
                 </div>
                 <div class="input-row">
                   <select id="topic" name="topic" data-placeholder="{{topicPlaceHolder}}">

--- a/packages/fxa-content-server/app/scripts/views/support.js
+++ b/packages/fxa-content-server/app/scripts/views/support.js
@@ -83,6 +83,9 @@ const SupportView = BaseView.extend({
     this.messageEl = this.$('#message');
     this.topicEl.chosen({ disable_search: true, width: '100%' });
 
+    // Have screen readers use the form label for the drop down
+    $('div.chosen-drop ul').attr('aria-labelledby', 'topic-label');
+
     return proto.afterVisible.call(this).then(this._showAvatar.bind(this));
   },
 

--- a/packages/fxa-content-server/npm-shrinkwrap.json
+++ b/packages/fxa-content-server/npm-shrinkwrap.json
@@ -2892,8 +2892,8 @@
             }
         },
         "chosen-js": {
-            "version": "git://github.com/chenba/chosen.git#d3a62f4fd5f4550f2af0b6ac8cd5cb62dd1edcfa",
-            "from": "git://github.com/chenba/chosen.git#d3a62f4"
+            "version": "git://github.com/chenba/chosen.git#4c8a15580b22f968a2d8acbacffabfb22988aa5d",
+            "from": "git://github.com/chenba/chosen.git#4c8a155"
         },
         "chownr": {
             "version": "1.1.2",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -49,7 +49,7 @@
         "body-parser": "1.18.2",
         "cache-loader": "^3.0.1",
         "celebrate": "7.0.3",
-        "chosen-js": "git://github.com/chenba/chosen.git#d3a62f4",
+        "chosen-js": "git://github.com/chenba/chosen.git#4c8a155",
         "connect-cachify": "0.0.17",
         "consolidate": "0.14.5",
         "convict": "1.5.0",


### PR DESCRIPTION
https://github.com/chenba/chosen/commit/4c8a155 applied most of
itayadler's patch from https://github.com/harvesthq/chosen/pull/2047
to add ARIA attributes to the dropdown widget elements.

Fixes #2200

@mozilla/fxa-devs r?