### PR TITLE
fix(tests): fix this.timeout call in selectEmailServices test

### DIFF
--- a/packages/fxa-auth-server/test/local/senders/select_email_services.js
+++ b/packages/fxa-auth-server/test/local/senders/select_email_services.js
@@ -887,7 +887,7 @@ describe('call selectEmailServices with mocked safe-regex, regex-only match and 
 });
 
 if (config.redis.email.enabled) {
-  describe('selectEmailServices with real redis:', () => {
+  describe('selectEmailServices with real redis:', function() {
     const emailAddress = 'foo@example.com';
 
     let emailService, selectEmailServices;


### PR DESCRIPTION
Fixing my own faux pas, it turns out that errors thrown in `describe` don't show up as test failures. `this.timeout` was throwing because I autopiloted a fat arrow in there. Fortunately I spotted the stack trace locally.

@mozilla/fxa-devs r?