### PR TITLE
fix(avatar): Remove the WebRTC polyfill.

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/settings/avatar_camera.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/avatar_camera.js
@@ -5,7 +5,6 @@
 import _ from 'underscore';
 import AuthErrors from '../../lib/auth-errors';
 import AvatarMixin from '../mixins/avatar-mixin';
-import canvasToBlob from 'canvasToBlob'; //eslint-disable-line no-unused-vars
 import Cocktail from 'cocktail';
 import Constants from '../../lib/constants';
 import DisableFormMixin from '../mixins/disable-form-mixin';
@@ -16,7 +15,6 @@ import ModalSettingsPanelMixin from '../mixins/modal-settings-panel-mixin';
 import ProfileImage from '../../models/profile-image';
 import ProgressIndicator from '../progress_indicator';
 import Template from 'templates/settings/avatar_camera.mustache';
-import WebRTC from 'webrtc';
 
 // a blank 1x1 png
 var pngSrc =
@@ -66,12 +64,11 @@ const View = FormView.extend({
       video: true,
     };
 
-    // navigator.mediaDevices is polyfilled by WebRTC for older browsers.
     return this.window.navigator.mediaDevices.getUserMedia(constraints).then(
       stream => {
         this.stream = stream;
-        WebRTC.attachMediaStream(this.video, stream);
-        this.video.play();
+        const video = this.video;
+        video.srcObject = stream;
       },
       () => {
         this._avatarProgressIndicator.done();
@@ -136,6 +133,8 @@ const View = FormView.extend({
 
   onLoadedMetaData() {
     if (!this.streaming) {
+      this.video.play();
+
       var vw = this.video.videoWidth;
       var vh = this.video.videoHeight;
 

--- a/packages/fxa-content-server/app/tests/mocks/window.js
+++ b/packages/fxa-content-server/app/tests/mocks/window.js
@@ -53,7 +53,6 @@ function WindowMock() {
   this.navigator = {
     userAgent: window.navigator.userAgent,
     mediaDevices: {
-      // simulate the API presented by the WebRTC polyfill
       getUserMedia(options) {
         return new Promise((resolve, reject) => {
           var nav = this;

--- a/packages/fxa-content-server/npm-shrinkwrap.json
+++ b/packages/fxa-content-server/npm-shrinkwrap.json
@@ -2390,11 +2390,6 @@
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
             "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
         },
-        "blueimp-canvas-to-blob": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/blueimp-canvas-to-blob/-/blueimp-canvas-to-blob-2.1.0.tgz",
-            "integrity": "sha1-8EqvOLFjcCmYW8ihqL53v7p7M9A="
-        },
         "bn.js": {
             "version": "4.11.8",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -13091,11 +13086,6 @@
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
                 }
             }
-        },
-        "webrtc-adapter-test": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/webrtc-adapter-test/-/webrtc-adapter-test-0.2.5.tgz",
-            "integrity": "sha1-2dqMWi8hOSi7Zt5Kps/cBJuxGGs="
         },
         "which": {
             "version": "1.3.1",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -45,7 +45,6 @@
         "backbone.cocktail": "git://github.com/onsi/cocktail.git#87971c88e2e4f904a0984b5f236ee5dbb21ddb4a",
         "base32-decode": "1.0.0",
         "base64url": "3.0.0",
-        "blueimp-canvas-to-blob": "2.1.0",
         "body-parser": "1.18.2",
         "cache-loader": "^3.0.1",
         "celebrate": "7.0.3",
@@ -128,8 +127,7 @@
         "uglifyjs-webpack-plugin": "1.2.7",
         "underscore": "1.8.3",
         "webpack": "4.16.1",
-        "webpack-cli": "3.1.0",
-        "webrtc-adapter-test": "0.2.5"
+        "webpack-cli": "3.1.0"
     },
     "devDependencies": {
         "@babel/cli": "7.4.4",

--- a/packages/fxa-content-server/webpack.config.js
+++ b/packages/fxa-content-server/webpack.config.js
@@ -17,7 +17,6 @@ const webpackConfig = {
     appDependencies: [
       'lib/jquery',
       'backbone',
-      'canvasToBlob',
       'chosen-js',
       'cocktail-lib',
       'duration',
@@ -31,7 +30,6 @@ const webpackConfig = {
       'ua-parser-js',
       'uuid',
       'vat',
-      'webrtc',
       'styles/main.scss',
     ],
     head: './head/boot.js',
@@ -46,7 +44,7 @@ const webpackConfig = {
   },
 
   resolve: {
-    extensions: ['.ts', '.js','.jsx'],
+    extensions: ['.ts', '.js', '.jsx'],
     modules: [
       path.resolve(__dirname, 'app/scripts'),
       path.resolve(__dirname, 'app/scripts/templates'),
@@ -56,10 +54,6 @@ const webpackConfig = {
       'node_modules',
     ],
     alias: {
-      canvasToBlob: path.resolve(
-        __dirname,
-        'node_modules/blueimp-canvas-to-blob/js/canvas-to-blob'
-      ),
       'chosen-js': path.resolve(
         __dirname,
         'node_modules/chosen-js/public/chosen.jquery'
@@ -110,10 +104,6 @@ const webpackConfig = {
       ),
       uuid: path.resolve(__dirname, 'node_modules/node-uuid/uuid'),
       vat: path.resolve(__dirname, 'node_modules/node-vat/vat'),
-      webrtc: path.resolve(
-        __dirname,
-        'node_modules/webrtc-adapter-test/adapter'
-      ),
     },
   },
 
@@ -175,17 +165,17 @@ const webpackConfig = {
             options: {
               cacheDirectory: true,
               presets: [
-                [
-                  '@babel/preset-react', {
-                  }
-                ],
-                '@babel/preset-env', 
-                '@babel/preset-typescript'
+                ['@babel/preset-react', {}],
+                '@babel/preset-env',
+                '@babel/preset-typescript',
               ],
-              plugins: ['@babel/syntax-dynamic-import', '@babel/plugin-proposal-class-properties']
-            }
-          }
-        ]
+              plugins: [
+                '@babel/syntax-dynamic-import',
+                '@babel/plugin-proposal-class-properties',
+              ],
+            },
+          },
+        ],
       },
       {
         test: /\.scss$/,


### PR DESCRIPTION
The WebRTC adapter does some tests that cause some of our co-workers some pain.
We added the WebRTC adapter to normalize WebRTC connections across various
browsers to enable setting a profile using the camera.

Time has moved on, our supported browser list has too, the browsers we
officially support should all have decent WebRTC support.

fixes #2213