### PR TITLE
chore(docs): add changelogs for subscription packages

### DIFF
--- a/packages/fxa-event-broker/CHANGELOG.md
+++ b/packages/fxa-event-broker/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change history
+
+## 1.143.4
+
+Prehistoric.

--- a/packages/fxa-geodb/CHANGELOG.md
+++ b/packages/fxa-geodb/CHANGELOG.md
@@ -1,30 +1,28 @@
-<a name="1.0.4"></a>
+# Change history
 
-# 1.0.4 (2018-11-02)
+## 1.143.4
+
+Prehistoric.
+
+## 1.0.4 (2018-11-02)
 
 ### Bug Fixes
 
 - **package:** update deps ([0b1959e](https://github.com/mozilla/fxa-geodb/commit/0b1959e))
 
-<a name="1.0.3"></a>
-
-# 1.0.3 (2018-09-27)
+## 1.0.3 (2018-09-27)
 
 ### Bug Fixes
 
 - **test,ci,deps,docs:** Attribution, tests, update deps.
 
-<a name="1.0.2"></a>
-
-# 1.0.2 (2018-05-18)
+## 1.0.2 (2018-05-18)
 
 ### Bug Fixes
 
 - **deps:** Update all the deps to remove security warnings.
 
-<a name="0.0.8"></a>
-
-# 0.0.8 (2017-02-23)
+## 0.0.8 (2017-02-23)
 
 ### Bug Fixes
 

--- a/packages/fxa-geodb/package-lock.json
+++ b/packages/fxa-geodb/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-geodb",
-  "version": "1.0.4",
+  "version": "1.143.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-geodb",
-  "version": "1.0.4",
+  "version": "1.143.4",
   "private": false,
   "description": "Firefox Accounts GeoDB Repo for Geolocation based services",
   "main": "lib/fxa-geodb.js",

--- a/packages/fxa-payments-server/CHANGELOG.md
+++ b/packages/fxa-payments-server/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change history
+
+## 1.143.4
+
+Prehistoric.

--- a/packages/fxa-shared/CHANGELOG.md
+++ b/packages/fxa-shared/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change history
+
+## 1.143.4
+
+Prehistoric.

--- a/packages/fxa-shared/package-lock.json
+++ b/packages/fxa-shared/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.28",
+  "version": "1.143.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.0.28",
+  "version": "1.143.4",
   "description": "Shared module for FxA repositories",
   "main": "index.js",
   "scripts": {

--- a/packages/fxa-support-panel/CHANGELOG.md
+++ b/packages/fxa-support-panel/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change history
+
+## 1.143.4
+
+Prehistoric.

--- a/release.sh
+++ b/release.sh
@@ -299,8 +299,10 @@ packages/fxa-customs-server
 packages/fxa-email-event-proxy
 packages/fxa-email-service
 packages/fxa-event-broker
+packages/fxa-geodb
 packages/fxa-payments-server
 packages/fxa-profile-server
+packages/fxa-shared
 packages/fxa-support-panel"
 
 for TARGET in $TARGETS; do


### PR DESCRIPTION
Fixes #1963.

Adds changelogs for the event broker, the payments server and the support panel. Also adds them for `fxa-shared` and `fxa-geodb`, although I was less certain whether that'd be useful. But it can't do any harm, and now they're no longer npm published I didn't see any reason to version them independently.

~~Additionally, `fxa-support-panel` had a different config to everything else and it was causing problems. Because `"parser": "typescript"` was explcitly specified in `.prettierrc`, it fell over on line 1, character 1 of the changelog. I've given it the same config as all the other packages, presumably that's fine.~~

@mozilla/fxa-devs r?