### PR TITLE
chore(package): give prettier the same config as other packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,10 @@
       "prettier --write",
       "git add"
     ],
+    "*.ts": [
+      "prettier --write",
+      "git add"
+    ],
     "*.css": [
       "prettier --write",
       "git add"

--- a/packages/fxa-event-broker/tslint.json
+++ b/packages/fxa-event-broker/tslint.json
@@ -1,12 +1,9 @@
 {
-    "extends": [
-        "tslint:recommended",
-        "tslint-config-prettier"
-    ],
-    "rulesDirectory": ["tslint-plugin-prettier"],
-    "rules": {
-        "interface-name": [true, "never-prefix"],
-        "interface-over-type-literal": false,
-        "prettier": [true, ".prettierrc"]
-    }
+  "extends": ["tslint:recommended", "tslint-config-prettier"],
+  "rulesDirectory": ["tslint-plugin-prettier"],
+  "rules": {
+    "interface-name": [true, "never-prefix"],
+    "interface-over-type-literal": false,
+    "prettier": [true, ".prettierrc"]
+  }
 }

--- a/packages/fxa-payments-server/tsconfig.json
+++ b/packages/fxa-payments-server/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -19,7 +15,5 @@
     "noEmit": true,
     "jsx": "preserve"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/packages/fxa-support-panel/.prettierrc
+++ b/packages/fxa-support-panel/.prettierrc
@@ -1,5 +1,4 @@
 {
-  "printWidth": 100,
   "singleQuote": true,
-  "parser": "typescript"
+  "trailingComma": "es5"
 }

--- a/packages/fxa-support-panel/config/index.ts
+++ b/packages/fxa-support-panel/config/index.ts
@@ -11,61 +11,61 @@ const conf = convict({
     default: 'oidc-claim-id-token-email',
     doc: 'Authentication header that should be logged for the user',
     env: 'AUTH_HEADER',
-    format: String
+    format: String,
   },
   authdbUrl: {
     default: 'http://localhost:8000',
     doc: 'fxa-auth-db-mysql url',
     env: 'AUTHDB_URL',
-    format: String
+    format: String,
   },
   env: {
     default: 'production',
     doc: 'The current node.js environment',
     env: 'NODE_ENV',
-    format: ['development', 'stage', 'production']
+    format: ['development', 'stage', 'production'],
   },
   listen: {
     host: {
       default: '127.0.0.1',
       doc: 'The ip address the server should bind',
       env: 'IP_ADDRESS',
-      format: 'ipaddress'
+      format: 'ipaddress',
     },
     port: {
       default: 7100,
       doc: 'The port the server should bind',
       env: 'PORT',
-      format: 'port'
+      format: 'port',
     },
     publicUrl: {
       default: 'http://127.0.0.1:3031',
       env: 'PUBLIC_URL',
-      format: 'url'
-    }
+      format: 'url',
+    },
   },
   logging: {
     app: { default: 'fxa-support-panel' },
     fmt: {
       default: 'heka',
       env: 'LOGGING_FORMAT',
-      format: ['heka', 'pretty']
+      format: ['heka', 'pretty'],
     },
     level: {
       default: 'info',
-      env: 'LOG_LEVEL'
+      env: 'LOG_LEVEL',
     },
     routes: {
       enabled: {
         default: true,
         doc: 'Enable route logging. Set to false to trimming CI logs.',
-        env: 'ENABLE_ROUTE_LOGGING'
+        env: 'ENABLE_ROUTE_LOGGING',
       },
       format: {
         default: 'default_fxa',
-        format: ['default_fxa', 'dev_fxa', 'default', 'dev', 'short', 'tiny']
-      }
-    }
+        format: ['default_fxa', 'dev_fxa', 'default', 'dev', 'short', 'tiny'],
+      },
+    },
   },
   security: {
     csp: {
@@ -73,10 +73,10 @@ const conf = convict({
         default: 'none',
         doc:
           'https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors',
-        env: 'CSP_FRAME_ANCESTORS'
-      }
-    }
-  }
+        env: 'CSP_FRAME_ANCESTORS',
+      },
+    },
+  },
 });
 
 // handle configuration files.  you can specify a CSV list of configuration

--- a/packages/fxa-support-panel/lib/server.ts
+++ b/packages/fxa-support-panel/lib/server.ts
@@ -20,7 +20,10 @@ export type ServerConfig = api.SupportConfig & {
   };
 };
 
-export async function init(serverConfig: ServerConfig, logger: Logger): Promise<hapi.Server> {
+export async function init(
+  serverConfig: ServerConfig,
+  logger: Logger
+): Promise<hapi.Server> {
   const server = new hapi.Server({
     debug: serverConfig.env === 'production' ? false : { request: ['error'] },
     host: serverConfig.listen.host,
@@ -30,19 +33,19 @@ export async function init(serverConfig: ServerConfig, logger: Logger): Promise<
         hsts: {
           includeSubDomains: true,
           maxAge: 31536000,
-          preload: false
+          preload: false,
         },
-        xss: true
-      }
-    }
+        xss: true,
+      },
+    },
   });
 
   await server.register([
     Scooter,
     {
       options: Config.get('security.csp'),
-      plugin: Blankie
-    }
+      plugin: Blankie,
+    },
   ]);
 
   api.init(logger, serverConfig, server);

--- a/packages/fxa-support-panel/test/lib/api.spec.ts
+++ b/packages/fxa-support-panel/test/lib/api.spec.ts
@@ -16,7 +16,7 @@ import {
   AccountResponse,
   DevicesResponse,
   SubscriptionResponse,
-  TotpTokenResponse
+  TotpTokenResponse,
 } from '../../lib/api';
 import * as supportServer from '../../lib/server';
 
@@ -42,27 +42,27 @@ function createDefaults(): MockCallsResponse {
         createdAt: now,
         email: 'test@example.com',
         emailVerified: true,
-        locale: 'en-us'
+        locale: 'en-us',
       },
-      status: 200
+      status: 200,
     },
     devices: {
       response: [],
-      status: 200
+      status: 200,
     },
     subscriptions: {
       response: [],
-      status: 200
+      status: 200,
     },
     totp: {
       response: {
         enabled: true,
         epoch: now,
         sharedSecret: '',
-        verified: true
+        verified: true,
       },
-      status: 200
-    }
+      status: 200,
+    },
   };
 }
 
@@ -95,8 +95,8 @@ describe('Support Controller', () => {
         env: 'development',
         listen: {
           host: 'localhost',
-          port: 8099
-        }
+          port: 8099,
+        },
       },
       logger
     );
@@ -111,7 +111,7 @@ describe('Support Controller', () => {
   it('has a heartbeat', async () => {
     const result = await server.inject({
       method: 'GET',
-      url: '/__lbheartbeat__'
+      url: '/__lbheartbeat__',
     });
     cassert.equal(result.statusCode, 200);
   });
@@ -124,10 +124,10 @@ describe('Support Controller', () => {
     const getWithUrl = (url: string): Promise<hapi.ServerInjectResponse> => {
       return server.inject({
         headers: {
-          testing: 'example@example.com'
+          testing: 'example@example.com',
         },
         method: 'GET',
-        url
+        url,
       });
     };
 
@@ -160,7 +160,9 @@ describe('Support Controller', () => {
     });
 
     it('rejects a uid that is too long', async () => {
-      const result = await getWithUrl('/?uid=4a0f70e0e32a435e8066d353e8577d22a');
+      const result = await getWithUrl(
+        '/?uid=4a0f70e0e32a435e8066d353e8577d22a'
+      );
       cassert.equal(result.statusCode, 400);
       assertValidateErrorMessage(result.payload);
     });
@@ -198,10 +200,10 @@ describe('Support Controller', () => {
     mockCalls(createDefaults());
     const result = await server.inject({
       headers: {
-        testing: 'example@example.com'
+        testing: 'example@example.com',
       },
       method: 'GET',
-      url: `/?uid=${uid}`
+      url: `/?uid=${uid}`,
     });
     cassert.equal(result.statusCode, 200);
     const calls = (logger.info as SinonSpy).getCalls();
@@ -211,8 +213,8 @@ describe('Support Controller', () => {
       {
         authUser: 'example@example.com',
         requestTicket: 'ticket-unknown',
-        uid: '4a0f70e0e32a435e8066d353e8577d2a'
-      }
+        uid: '4a0f70e0e32a435e8066d353e8577d2a',
+      },
     ]);
   });
 
@@ -222,7 +224,7 @@ describe('Support Controller', () => {
     mockCalls(defaults);
     let result = await server.inject({
       method: 'GET',
-      url: `/?uid=${uid}`
+      url: `/?uid=${uid}`,
     });
     cassert.equal(result.statusCode, 500);
 
@@ -232,7 +234,7 @@ describe('Support Controller', () => {
     mockCalls(defaults);
     result = await server.inject({
       method: 'GET',
-      url: `/?uid=${uid}`
+      url: `/?uid=${uid}`,
     });
     cassert.equal(result.statusCode, 500);
   });
@@ -243,10 +245,12 @@ describe('Support Controller', () => {
     mockCalls(defaults);
     const result = await server.inject({
       method: 'GET',
-      url: `/?uid=${uid}`
+      url: `/?uid=${uid}`,
     });
     cassert.equal(result.statusCode, 200);
-    const payloadMatch = result.payload.match(/2FA enabled\?<\/th>\s*<td>\s*no/g);
+    const payloadMatch = result.payload.match(
+      /2FA enabled\?<\/th>\s*<td>\s*no/g
+    );
     cassert.isTrue(payloadMatch && payloadMatch.length === 1);
   });
 
@@ -256,7 +260,7 @@ describe('Support Controller', () => {
     mockCalls(defaults);
     const result = await server.inject({
       method: 'GET',
-      url: `/?uid=${uid}`
+      url: `/?uid=${uid}`,
     });
     cassert.equal(result.statusCode, 500);
   });

--- a/packages/fxa-support-panel/tsconfig.json
+++ b/packages/fxa-support-panel/tsconfig.json
@@ -18,7 +18,5 @@
     "./test/**/*",
     "./types/**/*"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/packages/fxa-support-panel/tslint.json
+++ b/packages/fxa-support-panel/tslint.json
@@ -1,12 +1,9 @@
 {
-    "extends": [
-        "tslint:recommended",
-        "tslint-config-prettier"
-    ],
-    "rulesDirectory": ["tslint-plugin-prettier"],
-    "rules": {
-        "interface-name": [true, "never-prefix"],
-        "interface-over-type-literal": false,
-        "prettier": [true, ".prettierrc"]
-    }
+  "extends": ["tslint:recommended", "tslint-config-prettier"],
+  "rulesDirectory": ["tslint-plugin-prettier"],
+  "rules": {
+    "interface-name": [true, "never-prefix"],
+    "interface-over-type-literal": false,
+    "prettier": [true, ".prettierrc"]
+  }
 }


### PR DESCRIPTION
I noticed we weren't running the prettier hook against `.ts` files, so added that. I also took the opportunity to run a repo wide scan in case any of the typescript needed a big ol' reformat, but it only picked up changes to `.json` files.

Includes the same `fxa-support-panel` prettier config change I added in #2218 because I needed it to run the scan, but I'll `git rebase --skip` after whichever lands first.

@mozilla/fxa-devs r?
