### PR TITLE
fix(metrics): Emit an `fxa_login - complete` when signing in with cached credentials

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -67,6 +67,10 @@ const EVENTS = {
     group: GROUPS.settings,
     event: 'logout',
   },
+  'signin.success': {
+    group: GROUPS.login,
+    event: 'complete',
+  },
 };
 
 const VIEW_ENGAGE_SUBMIT_EVENT_GROUPS = {

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -384,7 +384,10 @@ const conf = (module.exports = convict({
     format: String,
   },
   oauth_client_id_map: {
-    default: {},
+    default: {
+      dcdb5ae7add825d2: '123done',
+      '325b4083e32fe8e7': '321done',
+    },
     doc:
       'Mappings from client id to service name: { "id1": "name-1", "id2": "name-2" }',
     env: 'OAUTH_CLIENT_IDS',

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -1562,5 +1562,58 @@ registerSuite('amplitude', {
       );
       assert.equal(logger.info.callCount, 0);
     },
+
+    'signin.success': () => {
+      amplitude(
+        {
+          time: 'foo',
+          type: 'signin.success',
+        },
+        {
+          connection: {},
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/65.0',
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: 'qux',
+          flowId: 'wibble',
+          lang: 'blee',
+          service: '1',
+          uid: 'soop',
+        }
+      );
+
+      assert.equal(process.stderr.write.callCount, 0);
+      assert.equal(logger.info.callCount, 1);
+      const args = logger.info.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], 'amplitudeEvent');
+      assert.deepEqual(args[1], {
+        app_version: APP_VERSION,
+        event_properties: {
+          oauth_client_id: '1',
+          service: 'pocket',
+        },
+        event_type: 'fxa_login - complete',
+        language: 'blee',
+        op: 'amplitudeEvent',
+        os_name: 'Mac OS X',
+        os_version: '10.11',
+        session_id: 'qux',
+        time: 'foo',
+        user_id: 'soop',
+        user_properties: {
+          flow_id: 'wibble',
+          ua_browser: 'Firefox',
+          ua_version: '65.0',
+          $append: {
+            fxa_services_used: 'pocket',
+          },
+        },
+      });
+    },
   },
 });


### PR DESCRIPTION
Emit the event whenever an `oauth.signin.signin.complete` or a `signin.signin.complete`
event is emit.

Looks like this:

> amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_login - complete","time":1565954783099,"user_id":"054d30e20521427c8dcf79378087153e","device_id":"88245ead2ab64fd7a84c5a22808c6c10","session_id":1565954773431,"app_version":"143","language":"es-ES","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"321done","oauth_client_id":"325b4083e32fe8e7"},"user_properties":{"flow_id":"489130346c1cb8776d61a239c384c251100a936155b7fda5c0408b87bf861814","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"321done"}}}

Note, I'm doing this from the content server rather than the OAuth server out of expedience and nothing else. @rfk's suggestion of emitting the event whenever a code is traded for a token is valid, but requires much more work.

This does not take care of the `password_required` event property. I'll open a subsequent PR for that, possibly after returning from PTO.

issue #2186