### PR TITLE
fix(payments server): stop embedding inline js in prod build

### DIFF
--- a/packages/fxa-payments-server/Dockerfile
+++ b/packages/fxa-payments-server/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /fxa-content-server
 RUN npm ci
 WORKDIR /app
 ENV PUBLIC_URL /
+ENV INLINE_RUNTIME_CHUNK false
 RUN npm run build
 
 FROM node:12-stretch-slim


### PR DESCRIPTION
Ref: https://create-react-app.dev/docs/advanced-configuration

Fixes 2242