### PR TITLE
fix(devices): fix null dereference in POST /account/device

### DIFF
--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -59,7 +59,7 @@ module.exports = (
 
   // Creates a "full" device response, provided a credentials object and an optional
   // updated DB device record.
-  function buildDeviceResponse(credentials, device = null) {
+  function buildDeviceResponse(credentials, device = {}) {
     // We must respond with the full device record,
     // including any default values for missing fields.
     return {
@@ -70,13 +70,13 @@ module.exports = (
       pushEndpointExpired: !!credentials.deviceCallbackIsExpired,
       ...device,
       // But these need to be non-falsey, using default fallbacks if necessary
-      id: (device && device.id) || credentials.deviceId,
+      id: device.id || credentials.deviceId,
       name:
-        (device && device.name) ||
+        device.name ||
         credentials.deviceName ||
         devices.synthesizeName(credentials),
       type:
-        (device && device.type) ||
+        device.type ||
         credentials.deviceType ||
         (credentials.client || device.refreshTokenId ? 'mobile' : 'desktop'),
       availableCommands:

--- a/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
@@ -199,6 +199,16 @@ describe('/account/device', () => {
     });
   });
 
+  // Regression test for https://github.com/mozilla/fxa/issues/2252
+  it('spurious update without device type', () => {
+    devicesData.spurious = true;
+    mockRequest.auth.credentials.deviceType = undefined;
+
+    return runTest(route, mockRequest, response => {
+      assert.equal(mockDevices.upsert.callCount, 0);
+    });
+  });
+
   it('device updates disabled', () => {
     config.deviceUpdatesEnabled = false;
 


### PR DESCRIPTION
Fixes #2252.

Right, what was I saying?

This fixes the Sentry error that came up yesterday, where `device` defaults to `null` in `buildDeviceResponse`. Defaulting it to an empty object instead fixes it, and I added a regression test too.

@mozilla/fxa-devs, this is the last remaining issue before we can tag train 144, so if someone is free to review this today that would be splendid!

(sorry about that last PR btw, I had two tabs open on the `compare` page and blindly submitted the wrong one)