### PR TITLE
refactor(db): rename productName to productId

### DIFF
--- a/packages/fxa-auth-db-mysql/db-server/index.js
+++ b/packages/fxa-auth-db-mysql/db-server/index.js
@@ -340,7 +340,7 @@ function createServer(db) {
       db.createAccountSubscription(
         req.params.id,
         req.params.subscriptionId,
-        req.body.productName,
+        req.body.productId,
         req.body.createdAt
       )
     )
@@ -364,7 +364,10 @@ function createServer(db) {
   api.post(
     '/account/:uid/subscriptions/:subscriptionId/reactivate',
     op(req =>
-      db.reactivateAccountSubscription(req.params.uid, req.params.subscriptionId)
+      db.reactivateAccountSubscription(
+        req.params.uid,
+        req.params.subscriptionId
+      )
     )
   );
   api.get(

--- a/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
@@ -4339,7 +4339,7 @@ module.exports = function(config, DB) {
           new Set([subscriptionIds[3], subscriptionIds[4], subscriptionIds[5]])
         );
         assert.deepEqual(
-          pickSet(result, 'productName'),
+          pickSet(result, 'productId'),
           new Set(['prod4', 'prod5', 'prod6'])
         );
       });
@@ -4373,7 +4373,7 @@ module.exports = function(config, DB) {
           new Set([subscriptionIds[6], subscriptionIds[8]])
         );
         assert.deepEqual(
-          pickSet(result, 'productName'),
+          pickSet(result, 'productId'),
           new Set(['prod4', 'prod6'])
         );
       });
@@ -4412,7 +4412,7 @@ module.exports = function(config, DB) {
           ])
         );
         assert.deepEqual(
-          pickSet(result, 'productName'),
+          pickSet(result, 'productId'),
           new Set(['prod4', 'prod5', 'prod6'])
         );
       });
@@ -4448,7 +4448,7 @@ module.exports = function(config, DB) {
           new Set([subscriptionIds[15], subscriptionIds[17]])
         );
         assert.deepEqual(
-          pickSet(result, 'productName'),
+          pickSet(result, 'productId'),
           new Set(['prod4', 'prod6'])
         );
       });
@@ -4633,7 +4633,7 @@ module.exports = function(config, DB) {
           account.uid,
           subscriptionIds[9]
         );
-        assert.equal(result.productName, 'prod7');
+        assert.equal(result.productId, 'prod7');
       });
 
       it('should fail to fetch a subscription that does not exist', async () => {

--- a/packages/fxa-auth-db-mysql/db-server/test/backend/remote.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/remote.js
@@ -2961,7 +2961,7 @@ module.exports = function(cfg, makeServer) {
       it('should create a new subscription', async () => {
         const result = await client.putThen(
           `/account/${user.accountId}/subscriptions/${subs[0]}`,
-          { productName: prods[0], createdAt: Date.now() }
+          { productId: prods[0], createdAt: Date.now() }
         );
         respOkEmpty(result);
       });
@@ -2969,18 +2969,18 @@ module.exports = function(cfg, makeServer) {
       it('should get one subscription', async () => {
         const result = await client.putThen(
           `/account/${user.accountId}/subscriptions/${subs[1]}`,
-          { productName: prods[2], createdAt: Date.now() }
+          { productId: prods[2], createdAt: Date.now() }
         );
         respOkEmpty(result);
 
         const {
-          obj: { subscriptionId, productName },
+          obj: { subscriptionId, productId },
         } = await client.getThen(
           `/account/${user.accountId}/subscriptions/${subs[1]}`
         );
 
         assert.equal(subscriptionId, subs[1]);
-        assert.equal(productName, prods[2]);
+        assert.equal(productId, prods[2]);
       });
 
       const pick = (list, name) => list.map(x => x[name]);
@@ -2988,15 +2988,15 @@ module.exports = function(cfg, makeServer) {
       it('should list subscriptions', async () => {
         await client.putThen(
           `/account/${user.accountId}/subscriptions/${subs[2]}`,
-          { productName: prods[3], createdAt: now - 30 }
+          { productId: prods[3], createdAt: now - 30 }
         );
         await client.putThen(
           `/account/${user.accountId}/subscriptions/${subs[3]}`,
-          { productName: prods[4], createdAt: now - 20 }
+          { productId: prods[4], createdAt: now - 20 }
         );
         await client.putThen(
           `/account/${user.accountId}/subscriptions/${subs[4]}`,
-          { productName: prods[5], createdAt: now - 10 }
+          { productId: prods[5], createdAt: now - 10 }
         );
 
         const { obj } = await client.getThen(
@@ -3009,7 +3009,7 @@ module.exports = function(cfg, makeServer) {
           subs[3],
           subs[4],
         ]);
-        assert.deepEqual(pick(obj, 'productName'), [
+        assert.deepEqual(pick(obj, 'productId'), [
           prods[3],
           prods[4],
           prods[5],
@@ -3020,15 +3020,15 @@ module.exports = function(cfg, makeServer) {
       it('should support deleting a subscription', async () => {
         await client.putThen(
           `/account/${user.accountId}/subscriptions/${subs[5]}`,
-          { productName: prods[6], createdAt: now - 30 }
+          { productId: prods[6], createdAt: now - 30 }
         );
         await client.putThen(
           `/account/${user.accountId}/subscriptions/${subs[6]}`,
-          { productName: prods[7], createdAt: now - 20 }
+          { productId: prods[7], createdAt: now - 20 }
         );
         await client.putThen(
           `/account/${user.accountId}/subscriptions/${subs[7]}`,
-          { productName: prods[8], createdAt: now - 10 }
+          { productId: prods[8], createdAt: now - 10 }
         );
         await client.delThen(
           `/account/${user.accountId}/subscriptions/${subs[6]}`
@@ -3040,13 +3040,13 @@ module.exports = function(cfg, makeServer) {
 
         assert.lengthOf(obj, 2);
         assert.deepEqual(pick(obj, 'subscriptionId'), [subs[5], subs[7]]);
-        assert.deepEqual(pick(obj, 'productName'), [prods[6], prods[8]]);
+        assert.deepEqual(pick(obj, 'productId'), [prods[6], prods[8]]);
       });
 
       it('should cancel and reactivate subscriptions', async () => {
         await client.putThen(
           `/account/${user.accountId}/subscriptions/${subs[8]}`,
-          { productName: prods[6], createdAt: now - 30 }
+          { productId: prods[6], createdAt: now - 30 }
         );
         const cancelledAt = Date.now();
         await client.postThen(

--- a/packages/fxa-auth-db-mysql/docs/API.md
+++ b/packages/fxa-auth-db-mysql/docs/API.md
@@ -2346,7 +2346,7 @@ curl \
  -X PUT \
  -H "Content-Type: application/json" \
  -d '{
-"productName" : "exampleProduct1",
+"productId" : "exampleProduct1",
 "createdAt" : 1424832691282
 }' \
  http://localhost:8000/account/6044486dd15b42e08b1fb9167415b9ac/subscriptions/sub8675309
@@ -2360,7 +2360,7 @@ curl \
   - `uid` : hex
   - `subscriptionId` : string255
 - Params:
-  - `productName`: Name of the subscribed product from the upstream payment system
+  - `productId`: Name of the subscribed product from the upstream payment system
   - `createdAt`: Date of subscription creation
 
 ### Response
@@ -2415,19 +2415,19 @@ Content-Length: 2
 {
 "uid": 6044486dd15b42e08b1fb9167415b9ac,
 "subscriptionId": "sub8675309",
-"productName": "exampleProduct1",
+"productId": "exampleProduct1",
 "createdAt": 1424832691282
 },
 {
 "uid": 6044486dd15b42e08b1fb9167415b9ac,
 "subscriptionId": "sub999",
-"productName": "exampleProduct2",
+"productId": "exampleProduct2",
 "createdAt": 1424832691282
 },
 {
 "uid": 6044486dd15b42e08b1fb9167415b9ac,
 "subscriptionId": "sub987",
-"productName": "exampleProduct3",
+"productId": "exampleProduct3",
 "createdAt": 1424832691282
 }
 ]
@@ -2438,7 +2438,7 @@ Content-Length: 2
   - Content-Type : `application/json`
   - Body : `[{}]`
     - `subscriptionId`: ID for the subscription from the upstream payment system
-    - `productName`: Name of the subscribed product from the upstream payment system
+    - `productId`: Name of the subscribed product from the upstream payment system
     - `createdAt`: Date of subscription creation
 - Status Code : `500 Internal Server Error`
   - Conditions: if something goes wrong on the server
@@ -2477,7 +2477,7 @@ Content-Length: 2
 {
 "uid": 6044486dd15b42e08b1fb9167415b9ac,
 "subscriptionId": "sub8675309",
-"productName": "exampleProduct1",
+"productId": "exampleProduct1",
 "createdAt": 1424832691282
 }
 
@@ -2487,7 +2487,7 @@ Content-Length: 2
   - Content-Type : `application/json`
   - Body : `{}`
     - `subscriptionId`: ID for the subscription from the upstream payment system
-    - `productName`: Name of the subscribed product from the upstream payment system
+    - `productId`: Name of the subscribed product from the upstream payment system
     - `createdAt`: Date of subscription creation
 - Status Code : `500 Internal Server Error`
   - Conditions: if something goes wrong on the server

--- a/packages/fxa-auth-db-mysql/docs/DB_API.md
+++ b/packages/fxa-auth-db-mysql/docs/DB_API.md
@@ -76,7 +76,7 @@ There are a number of methods that a DB storage backend should implement:
   - .deleteRecoveryKey(uid)
   - .recoveryKeyExists(uid)
 - Subscriptions
-  - .createAccountSubscription(uid, subscriptionId, productName, createdAt)
+  - .createAccountSubscription(uid, subscriptionId, productId, createdAt)
   - .fetchAccountSubscriptions(uid)
   - .getAccountSubscription(uid, subscriptionId)
   - .deleteAccountSubscription(uid, subscriptionId)
@@ -1039,7 +1039,7 @@ Returns:
 - Rejects with:
   - Any error from the underlying storage system (wrapped in `error.wrap()`)
 
-## .createAccountSubscription(uid, subscriptionId, productName, createdAt)
+## .createAccountSubscription(uid, subscriptionId, productId, createdAt)
 
 Create a product subscription for this user.
 
@@ -1049,7 +1049,7 @@ Parameters:
   The uid of the owning account
 - `subscriptionId` (String):
   The subscription ID from the upstream payment system
-- `productName` (String):
+- `productId` (String):
   The name of the product granted by the subscription
 - `createdAt` (number):
   Creation timestamp for the subscription, milliseconds since the epoch
@@ -1076,7 +1076,7 @@ Returns:
   - An array of objects:
     - `uid`
     - `subscriptionId`
-    - `productName`
+    - `productId`
     - `createdAt`
 - Rejects with:
   - Any error from the underlying storage system (wrapped in `error.wrap()`)
@@ -1098,7 +1098,7 @@ Returns:
   - An object `{}`
     - `uid`
     - `subscriptionId`
-    - `productName`
+    - `productId`
     - `createdAt`
 - Rejects with:
   - Any error from the underlying storage system (wrapped in `error.wrap()`)

--- a/packages/fxa-auth-db-mysql/lib/db/mem.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mem.js
@@ -1607,14 +1607,14 @@ module.exports = function(log, error) {
   Memory.prototype.createAccountSubscription = async function(
     uid,
     subscriptionId,
-    productName,
+    productId,
     createdAt
   ) {
     // Ensure user account exists
     uid = uid.toString('hex');
     await getAccountByUid(uid);
 
-    const key = [uid, subscriptionId, productName].join('|');
+    const key = [uid, subscriptionId, productId].join('|');
     if (accountSubscriptions[key]) {
       throw error.duplicate();
     }
@@ -1627,7 +1627,7 @@ module.exports = function(log, error) {
     accountSubscriptions[key] = {
       uid,
       subscriptionId,
-      productName,
+      productId,
       createdAt,
       cancelledAt: null,
     };

--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -1662,17 +1662,17 @@ module.exports = function(log, error) {
   };
 
   const CREATE_ACCOUNT_SUBSCRIPTION =
-    'CALL createAccountSubscription_1(?,?,?,?)';
+    'CALL createAccountSubscription_2(?,?,?,?)';
   MySql.prototype.createAccountSubscription = function(
     uid,
     subscriptionId,
-    productName,
+    productId,
     createdAt
   ) {
     return this.write(CREATE_ACCOUNT_SUBSCRIPTION, [
       uid,
       subscriptionId,
-      productName,
+      productId,
       createdAt,
     ]).then(
       result => ({}),
@@ -1685,7 +1685,7 @@ module.exports = function(log, error) {
     );
   };
 
-  const GET_ACCOUNT_SUBSCRIPTION = 'CALL getAccountSubscription_1(?,?)';
+  const GET_ACCOUNT_SUBSCRIPTION = 'CALL getAccountSubscription_2(?,?)';
   MySql.prototype.getAccountSubscription = function(uid, subscriptionId) {
     return this.readFirstResult(GET_ACCOUNT_SUBSCRIPTION, [
       uid,
@@ -1698,7 +1698,7 @@ module.exports = function(log, error) {
   // future, you must note this change in the deployment notes so the new
   // versioned name is granted the execute privilege, or
   // `fxa-support-panel` will break.
-  const FETCH_ACCOUNT_SUBSCRIPTIONS = 'CALL fetchAccountSubscriptions_2(?)';
+  const FETCH_ACCOUNT_SUBSCRIPTIONS = 'CALL fetchAccountSubscriptions_3(?)';
   MySql.prototype.fetchAccountSubscriptions = function(uid) {
     return this.readAllResults(FETCH_ACCOUNT_SUBSCRIPTIONS, [uid]);
   };

--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 102;
+module.exports.level = 103;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-102-103.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-102-103.sql
@@ -1,0 +1,74 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('102');
+
+-- Add column productId to the accountSubscriptions table.
+-- This is the first part of a two-step rename. A subsequent
+-- migration will set the value of productId to productName
+-- and then remove the productName column.
+ALTER TABLE accountSubscriptions
+ADD COLUMN productId VARCHAR(191),
+ADD UNIQUE INDEX UQ_accountSubscriptions_uid_productId_subscriptionId(uid, productId, subscriptionId),
+ALGORITHM = INPLACE, LOCK = NONE;
+
+CREATE PROCEDURE `createAccountSubscription_2` (
+  IN inUid BINARY(16),
+  IN inSubscriptionId VARCHAR(191),
+  IN inProductId VARCHAR(191),
+  IN inCreatedAt BIGINT SIGNED
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  SET @accountCount = 0;
+
+  -- Signal error if no user found
+  SELECT COUNT(*) INTO @accountCount FROM accounts WHERE uid = inUid;
+  IF @accountCount = 0 THEN
+    SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1643, MESSAGE_TEXT = 'Can not create subscription for unknown user.';
+  END IF;
+
+  INSERT INTO accountSubscriptions(
+    uid,
+    subscriptionId,
+    productId,
+    createdAt
+  )
+  VALUES (
+    inUid,
+    inSubscriptionId,
+    inProductId,
+    inCreatedAt
+  );
+
+  COMMIT;
+END;
+
+CREATE PROCEDURE `getAccountSubscription_2` (
+  IN uidArg BINARY(16),
+  IN subscriptionIdArg VARCHAR(191)
+)
+BEGIN
+  SELECT uid, subscriptionId, COALESCE(productId, productName) AS productId, createdAt, cancelledAt
+  FROM accountSubscriptions
+  WHERE uid = uidArg
+  AND subscriptionId = subscriptionIdArg;
+END;
+
+CREATE PROCEDURE `fetchAccountSubscriptions_3` (
+  IN uidArg BINARY(16)
+)
+BEGIN
+  SELECT uid, subscriptionId, COALESCE(productId, productName) AS productId, createdAt, cancelledAt
+  FROM accountSubscriptions
+  WHERE uid = uidArg
+  ORDER BY createdAt ASC;
+END;
+
+UPDATE dbMetadata SET value = '103' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-103-102.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-103-102.sql
@@ -1,0 +1,12 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE `fetchAccountSubscriptions_3`;
+-- DROP PROCEDURE `getAccountSubscription_2`;
+-- DROP PROCEDURE `createAccountSubscription_2`;
+
+-- ALTER TABLE `accountSubscriptions`
+-- DROP INDEX UQ_accountSubscriptions_uid_productId_subscriptionId,
+-- DROP COLUMN productId,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- UPDATE dbMetadata SET value = '102' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-server/docs/service_notifications.md
+++ b/packages/fxa-auth-server/docs/service_notifications.md
@@ -216,5 +216,5 @@ so other services probably shouldn't use this.
 - `uid`: User id.
 - `subscriptionId`: Subscription id.
 - `isActive`: Boolean indicating whether the subscription is active.
-- `productName`: Product name.
+- `productId`: Product id.
 - `productCapabilities`: Array of product capabilities.

--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -1523,12 +1523,12 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     'db.createAccountSubscription'
   );
   DB.prototype.createAccountSubscription = function(data) {
-    const { uid, subscriptionId, productName, createdAt } = data;
+    const { uid, subscriptionId, productId, createdAt } = data;
     log.trace('DB.createAccountSubscription', data);
     return this.pool.put(
       SAFE_URLS.createAccountSubscription,
       { uid, subscriptionId },
-      { productName, createdAt }
+      { productId, createdAt }
     );
   };
 
@@ -1583,10 +1583,10 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   );
   DB.prototype.reactivateAccountSubscription = function(uid, subscriptionId) {
     log.trace('DB.reactivateAccountSubscription', { uid, subscriptionId });
-    return this.pool.post(
-      SAFE_URLS.reactivateAccountSubscription,
-      { uid, subscriptionId },
-    );
+    return this.pool.post(SAFE_URLS.reactivateAccountSubscription, {
+      uid,
+      subscriptionId,
+    });
   };
 
   SAFE_URLS.fetchAccountSubscriptions = new SafeUrl(

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -133,10 +133,7 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
         if (!selectedPlan) {
           throw error.unknownSubscriptionPlan(planId);
         }
-        // TODO: The FxA DB has a column `productName` that we're using for
-        // product_id. We might want to rename that someday.
-        // https://github.com/mozilla/fxa/issues/1187
-        const productName = selectedPlan.product_id;
+        const productId = selectedPlan.product_id;
 
         const paymentResult = await subhub.createSubscription(
           uid,
@@ -156,7 +153,7 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
         await db.createAccountSubscription({
           uid,
           subscriptionId,
-          productName,
+          productId,
           createdAt: Date.now(),
         });
 

--- a/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
@@ -28,10 +28,7 @@ module.exports = {
       // All accounts get this product
       PRODUCT_REGISTERED,
       // Other products come from actual subscriptions
-      // TODO: The FxA DB has a column `productName` that we're using for
-      // product_id. We might want to rename that someday.
-      // https://github.com/mozilla/fxa/issues/1187
-      ...subscriptions.map(({ productName }) => productName),
+      ...subscriptions.map(({ productId }) => productId),
     ];
     // Accounts with at least one subscription get this product
     if (subscriptions.length > 0) {

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -292,10 +292,7 @@ module.exports.subscriptionsPaymentToken = isA.string().max(255);
 module.exports.activeSubscriptionValidator = isA.object({
   uid: isA.string().required(),
   subscriptionId: module.exports.subscriptionsSubscriptionId.required(),
-  // TODO: The FxA DB has a column `productName` that we're using for
-  // product ID. We might want to rename that someday.
-  // https://github.com/mozilla/fxa/issues/1187
-  productName: module.exports.subscriptionsProductId.required(),
+  productId: module.exports.subscriptionsProductId.required(),
   createdAt: isA.number().required(),
   cancelledAt: isA.alternatives(isA.number(), isA.any().allow(null)),
 });

--- a/packages/fxa-auth-server/lib/subhub/updates.js
+++ b/packages/fxa-auth-server/lib/subhub/updates.js
@@ -90,7 +90,7 @@ module.exports = function(log, config) {
               eventCreatedAt: message.eventCreatedAt,
               subscriptionId: message.subscriptionId,
               isActive: message.active,
-              productName: message.productName,
+              productId: message.productName,
               productCapabilities:
                 config.subscriptions.productCapabilities[message.productName] ||
                 [],

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -64,7 +64,7 @@ const ACTIVE_SUBSCRIPTIONS = [
   {
     uid: UID,
     subscriptionId: SUBSCRIPTION_ID_1,
-    productName: PLANS[0].product_id,
+    productId: PLANS[0].product_id,
     createdAt: NOW,
     cancelledAt: null,
   },
@@ -275,10 +275,7 @@ describe('subscriptions', () => {
       assert.deepEqual(createArgs, {
         uid: UID,
         subscriptionId: SUBSCRIPTION_ID_1,
-        // TODO: The FxA DB has a column `productName` that we're using for
-        // product_id. We might want to rename that someday.
-        // https://github.com/mozilla/fxa/issues/1187
-        productName: PLANS[0].product_id,
+        productId: PLANS[0].product_id,
         createdAt: createArgs.createdAt,
       });
       assert.deepEqual(res, { subscriptionId: SUBSCRIPTION_ID_1 });

--- a/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
@@ -20,13 +20,13 @@ const MOCK_SUBSCRIPTIONS = [
   {
     uid: UID,
     subscriptionId: 'sub1',
-    productName: 'p1',
+    productId: 'p1',
     createdAt: NOW,
   },
   {
     uid: UID,
     subscriptionId: 'sub2',
-    productName: 'p2',
+    productId: 'p2',
     createdAt: NOW,
   },
 ];

--- a/packages/fxa-auth-server/test/local/subhub/updates.js
+++ b/packages/fxa-auth-server/test/local/subhub/updates.js
@@ -100,7 +100,7 @@ describe('subhub updates', () => {
       uid: baseMessage.uid,
       subscriptionId: baseMessage.subscriptionId,
       isActive: true,
-      productName: baseMessage.productName,
+      productId: baseMessage.productName,
       productCapabilities: ['foo', 'bar'],
     });
 
@@ -139,7 +139,7 @@ describe('subhub updates', () => {
       uid: baseMessage.uid,
       subscriptionId: baseMessage.subscriptionId,
       isActive: false,
-      productName: baseMessage.productName,
+      productId: baseMessage.productName,
       productCapabilities: ['foo', 'bar'],
     });
   });
@@ -153,7 +153,7 @@ describe('subhub updates', () => {
       return {
         uid,
         subscriptionId,
-        productName: message.productName,
+        productId: message.productName,
         // It's a subscription FROM THE FUTURE!
         createdAt: message.eventCreatedAt + 1000,
       };
@@ -184,7 +184,7 @@ describe('subhub updates', () => {
       return {
         uid,
         subscriptionId,
-        productName: message.productName,
+        productId: message.productName,
         // It's a subscription FROM THE FUTURE!
         createdAt: message.eventCreatedAt + 1000,
       };

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -209,7 +209,7 @@ describe('remote subscriptions:', function() {
         assert.lengthOf(result, 1);
         assert.isAbove(result[0].createdAt, Date.now() - 1000);
         assert.isAtMost(result[0].createdAt, Date.now());
-        assert.equal(result[0].productName, PRODUCT_ID);
+        assert.equal(result[0].productId, PRODUCT_ID);
         assert.equal(result[0].uid, client.uid);
         assert.isNull(result[0].cancelledAt);
 
@@ -260,7 +260,7 @@ describe('remote subscriptions:', function() {
           assert.isAbove(result[0].createdAt, Date.now() - 1000);
           assert.isAtLeast(result[0].cancelledAt, result[0].createdAt);
           assert.isAtMost(result[0].cancelledAt, Date.now());
-          assert.equal(result[0].productName, PRODUCT_ID);
+          assert.equal(result[0].productId, PRODUCT_ID);
           assert.equal(result[0].uid, client.uid);
         });
 
@@ -303,7 +303,7 @@ describe('remote subscriptions:', function() {
             assert.lengthOf(result, 1);
             assert.isAbove(result[0].createdAt, Date.now() - 1000);
             assert.isNull(result[0].cancelledAt);
-            assert.equal(result[0].productName, PRODUCT_ID);
+            assert.equal(result[0].productId, PRODUCT_ID);
             assert.equal(result[0].uid, client.uid);
           });
         });

--- a/packages/fxa-event-broker/lib/serviceNotifications.ts
+++ b/packages/fxa-event-broker/lib/serviceNotifications.ts
@@ -55,7 +55,10 @@ const SUBSCRIPTION_UPDATE_SCHEMA = joi
       .array()
       .items(joi.string())
       .required(),
-    productName: joi.string().required(),
+    productId: joi.string().optional(),
+    // TODO: productName is the legacy name for productId, remove it
+    //       in due course then make productId required again.
+    productName: joi.string().optional(),
     subscriptionId: joi.string().required(),
     uid: joi.string().required()
   })

--- a/packages/fxa-event-broker/test/service-notifications/index.ts
+++ b/packages/fxa-event-broker/test/service-notifications/index.ts
@@ -22,7 +22,7 @@ FactoryBot.define(
     metricsContext: {},
     productCapabilities: (): string[] =>
       [...new Array(chance.integer({ max: 5, min: 1 }))].map(() => chance.word()),
-    productName: () => chance.word(),
+    productId: () => chance.word(),
     subscriptionId: () => chance.hash(),
     ts: () => new Date().getTime(),
     uid: () => chance.hash()

--- a/packages/fxa-event-broker/test/service-notifications/subscription-event.ts
+++ b/packages/fxa-event-broker/test/service-notifications/subscription-event.ts
@@ -12,7 +12,7 @@ export class SubscriptionEvent {
     public subscriptionId: string,
     public uid: string,
     public isActive: boolean,
-    public productName: string,
+    public productId: string,
     public productCapabilities: string[]
   ) {}
 }

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -272,7 +272,7 @@ export const MOCK_ACTIVE_SUBSCRIPTIONS = [
   {
     uid: 'a90fef48240b49b2b6a33d333aee9b13',
     subscriptionId: 'sub0.28964929339372136',
-    productName: '123doneProProduct',
+    productId: '123doneProProduct',
     createdAt: 1565816388815,
     cancelledAt: null,
   },
@@ -282,14 +282,14 @@ export const MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION = [
   {
     uid: 'a90fef48240b49b2b6a33d333aee9b13',
     subscriptionId: 'sub0.28964929339372136',
-    productName: '123doneProProduct',
+    productId: '123doneProProduct',
     createdAt: 1565816388815,
     cancelledAt: null,
   },
   {
     uid: 'a90fef48240b49b2b6a33d333aee9b13',
     subscriptionId: 'sub0.21234123424',
-    productName: 'prod_67890',
+    productId: 'prod_67890',
     createdAt: 1565816388815,
     cancelledAt: null,
   },

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -58,7 +58,7 @@ function init() {
             error: false,
             result: {
               subscriptionId: 'sub_5551212',
-              productName: 'product_123',
+              productId: 'product_123',
               createdAt: Date.now() - 86400000,
               cancelledAt: Date.now(),
             },
@@ -269,7 +269,7 @@ const subscribedProps: SubscriptionsProps = {
     result: [
       {
         subscriptionId: 'sub_5551212',
-        productName: 'product_123',
+        productId: 'product_123',
         createdAt: Date.now(),
         cancelledAt: null,
       },
@@ -291,7 +291,7 @@ const cancelledProps: SubscriptionsProps = {
     result: [
       {
         subscriptionId: 'sub_5551212',
-        productName: 'product_123',
+        productId: 'product_123',
         createdAt: Date.now() - 400000000,
         cancelledAt: Date.now() - 200000000,
       },

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
@@ -272,7 +272,7 @@ describe('routes/Subscriptions', () => {
         {
           uid: 'a90fef48240b49b2b6a33d333aee9b13',
           subscriptionId: 'sub0.28964929339372136',
-          productName: '123doneProProduct',
+          productId: '123doneProProduct',
           createdAt: 1565816388815,
           cancelledAt: 1566252991684,
         },
@@ -334,7 +334,7 @@ describe('routes/Subscriptions', () => {
           {
             uid: 'a90fef48240b49b2b6a33d333aee9b13',
             subscriptionId: 'sub0.28964929339372136',
-            productName: '123doneProProduct',
+            productId: '123doneProProduct',
             createdAt: 1565816388815,
             cancelledAt: 1566252991684,
           },
@@ -361,7 +361,7 @@ describe('routes/Subscriptions', () => {
         {
           uid: 'a90fef48240b49b2b6a33d333aee9b13',
           subscriptionId: 'sub0.28964929339372136',
-          productName: '123doneProProduct',
+          productId: '123doneProProduct',
           createdAt: 1565816388815,
           cancelledAt: null,
         },

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -35,9 +35,7 @@ export interface Plan {
 
 export interface Subscription {
   subscriptionId: string;
-  // TODO: Rename `productName` column to `productId`
-  // https://github.com/mozilla/fxa/issues/1187
-  productName: string;
+  productId: string;
   createdAt: number;
   cancelledAt: number | null;
 }

--- a/packages/fxa-support-panel/lib/api.ts
+++ b/packages/fxa-support-panel/lib/api.ts
@@ -55,7 +55,7 @@ export interface DevicesResponse extends Array<Device> {}
 interface Subscription {
   uid: string;
   subscriptionId: string;
-  productName: string;
+  productId: string;
   createdAt: number;
 }
 


### PR DESCRIPTION
Fixes #1187.

The `productName` thing has spread like wildfire. This PR includes changes to the auth db, auth server, event broker, payments server and support panel. It would have been a simpler change if we'd put a stop to it right away!

This is the first installment of a two-parter. We can't just run a migration that renames the column and adds new stored procedures, because deployed code running against the old procedures still expects to find the old column name. Instead we add a new column and new stored procedures in this migration, then in the next train we can remove the old junk in another migration. In the intervening period we read from both columns using `COALESCE`.

Because this PR creeps into some corners of the code I'm unfamiliar with, it might good if the responsible individuals for each particular area take a closer look at those bits. I'll give shoutouts in the inline comments. It's possible that I didn't need to change all of these places, but I was concerned about inconsistent nomenclature confusing us in the future.

Tests pass though so hopefully that's a good start (content server failures are unrelated).

@lmorchard, just fyi, this PR contains merge conflicts with your #2278, both the migration number and the versioning of the `createAccountSubscription` stored procedure.

@mozilla/fxa-devs r?