### PR TITLE
fix(build): run as app user when installing deps etc

### DIFF
--- a/packages/fxa-content-server/Dockerfile-build
+++ b/packages/fxa-content-server/Dockerfile-build
@@ -14,6 +14,9 @@ ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 
 RUN apk add --no-cache git
 
+RUN chown app:app /app
+USER app
+
 COPY fxa-content-server/npm-shrinkwrap.json npm-shrinkwrap.json
 COPY fxa-content-server/package.json package.json
 COPY fxa-content-server/scripts/download_l10n.sh scripts/download_l10n.sh
@@ -24,13 +27,20 @@ COPY fxa-content-server /app
 
 COPY ["fxa-geodb", "../fxa-geodb/"]
 WORKDIR /fxa-geodb
+USER root
+RUN chown -R app:app /fxa-geodb
+USER app
 RUN npm ci
 
 COPY ["fxa-shared", "../fxa-shared/"]
 WORKDIR /fxa-shared
+USER root
+RUN chown -R app:app /fxa-shared
+USER app
 RUN npm ci
 
 WORKDIR /app
-RUN npm run build-production --unsafe-perm
-
+USER root
+RUN chown -R app:app /app
 USER app
+RUN npm run build-production --unsafe-perm


### PR DESCRIPTION
Fixes the error that's failing the build for #2278 and #2284.

There's a bit of back-and-forth between `root` and `app` where I repeatedly invoke `chown` but it's the only combination I found that worked.

@mozilla/fxa-devs r?