### PR TITLE
refactor(api): prefer async/await in device/session routes

### DIFF
--- a/packages/fxa-auth-server/test/local/redis.js
+++ b/packages/fxa-auth-server/test/local/redis.js
@@ -32,7 +32,7 @@ describe('lib/redis:', () => {
     };
     fxaShared = sinon.spy(() => redis);
     wrapper = proxyquire(`${LIB_DIR}/redis`, {
-      '../../../fxa-shared/redis': fxaShared,
+      '../../fxa-shared/redis': fxaShared,
     })(config, log);
   });
 


### PR DESCRIPTION
Related to #2286. Contrary to the instructions there though, I've opened this directly against `master`.

Using one long-lived branch seems more prone to merge conflicts than independently merging short-lived branches as soon as they're ready. And there's nothing that precludes these asyc/await changes from landing bit-by-it.

Note this PR also contains a bonus fix where the path for `proxyquire` was wrong in the redis tests. Not sure where that came from or how long it's been broken, but I needed it to fix the build.

@mozilla/fxa-devs r?