### PR TITLE
fix(payments): update payment views for mobile

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/support.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/support.mustache
@@ -77,7 +77,7 @@
               </div>
               <div class="support-field">
                 <div class="form-label">
-                  <label for="message">{{#t}}Description of Issue{{/t}}</label>
+                  <label for="message">{{#t}}Description of issue{{/t}}</label>
                 </div>
                 <div class="input-row">
                   <textarea id="message" name="message" rows="5" cols="70"></textarea>

--- a/packages/fxa-content-server/app/styles/_layout.scss
+++ b/packages/fxa-content-server/app/styles/_layout.scss
@@ -56,7 +56,7 @@
     border-bottom: 1px solid $settings-header-border-bottom;
     border-top: 1px solid $settings-header-border-bottom;
     box-shadow: none;
-    padding: 30px 0 10px;
+    padding: 15px 0 10px;
     width: 100%;
   }
 

--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -70,7 +70,16 @@ body.settings #stage .settings {
   }
 
   @include respond-to('small') {
+    flex-direction: row;
     height: 64px;
+  }
+
+  #fxa-settings-header {
+    @include respond-to('small') {
+      flex: 1 1;
+      margin-bottom: 0;
+      width: inherit;
+    }
   }
 
   #fxa-manage-account {
@@ -249,6 +258,10 @@ body.settings #stage .settings {
     font-size: 20px;
     line-height: 24px;
     margin-bottom: 0;
+
+    @include respond-to('small') {
+      font-size: 14px;
+    }
   }
 
   .card-subheader {
@@ -809,6 +822,12 @@ section.modal-panel {
   margin-top: 0;
   width: 100%;
 
+  @include respond-to('small') {
+    margin-bottom: 0;
+    margin-left: 0;
+    padding: 0;
+  }
+
   li {
     list-style: none;
     float: left;
@@ -818,6 +837,10 @@ section.modal-panel {
     &::before {
       content: "\003E";
       padding: 0 10px;
+
+      @include respond-to('small') {
+        padding: 0 5px;
+      }
     }
 
     &:first-child::before {

--- a/packages/fxa-content-server/app/styles/modules/support.scss
+++ b/packages/fxa-content-server/app/styles/modules/support.scss
@@ -1,12 +1,6 @@
 .support {
   .settings-unit:first-child {
-    @include respond-to('small') {
-      display: none;
-    }
-
-    @include respond-to('big') {
-      display: block;
-    }
+    display: block;
 
     .settings-unit-stub {
       .settings-unit-title {
@@ -19,6 +13,10 @@
 .support-form {
   margin: 25px 32px;
 
+  @include respond-to('small') {
+    margin: 25px 16px;
+  }
+
   header {
     margin-bottom: 20px;
 
@@ -29,6 +27,10 @@
 
   .support-field {
     padding: 0 33px;
+
+    @include respond-to('small') {
+      padding: 0;
+    }
 
     &:nth-child(3) {
       margin-bottom: 30px;

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -24,6 +24,7 @@ type AppProps = {
   config: Config;
   store: Store;
   queryParams: QueryParams;
+  matchMedia: (query: string) => boolean;
   navigateToUrl: (url: string) => void;
   getScreenInfo: () => ScreenInfo;
   locationReload: () => void;
@@ -34,6 +35,7 @@ export const App = ({
   config,
   store,
   queryParams,
+  matchMedia,
   navigateToUrl,
   getScreenInfo,
   locationReload,
@@ -42,6 +44,7 @@ export const App = ({
     accessToken,
     config,
     queryParams,
+    matchMedia,
     navigateToUrl,
     getScreenInfo,
     locationReload,

--- a/packages/fxa-payments-server/src/components/AppLayout/index.scss
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.scss
@@ -37,6 +37,12 @@
   padding-left: 100px;
   width: 100%;
 
+  @include respond-to('small') {
+    margin-bottom: 0;
+    margin-left: 0;
+    padding: 0;
+  }
+
   li {
     float: left;
     list-style: none;
@@ -46,6 +52,10 @@
     &::before {
       content: '\003E';
       padding: 0 10px;
+
+      @include respond-to('small') {
+        padding: 0 5px;
+      }
     }
 
     &:first-child::before {
@@ -68,6 +78,7 @@ footer {
     align-self: flex-start;
     padding-left: 32px;
   }
+
   #legal-footer {
     align-self: flex-end;
   }

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.scss
@@ -21,3 +21,33 @@ form.payment {
     }
   }
 }
+
+@media (min-width: 320px) and (max-width: 480px) {
+  .StripeElement .InputContainer .InputElement::placeholder,
+  form.payment .input-row input::placeholder {
+    line-height: 37px !important;
+  }
+
+  .sign-in {
+    margin-top: 25px;
+  }
+
+  .product-payment {
+    h3.billing-title {
+      padding-top: 0;
+    }
+
+    .profile-banner h3.email {
+      margin-top: 15px;
+    }
+  }
+
+  #main-content.payments-card {
+    width: 100%;
+
+    .input-row input,
+    .input-row .StripeElement {
+      padding-left: 9px !important;
+    }
+  }
+}

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
@@ -9,7 +9,7 @@ import {
   elementChangeResponse,
 } from '../../lib/test-utils';
 
-import { PaymentForm, PaymentFormProps, PaymentFormStripeProps } from './index';
+import { PaymentForm, PaymentFormProps, PaymentFormStripeProps, checkMedia, SMALL_DEVICE_LINE_HEIGHT, DEFAULT_LINE_HEIGHT } from './index';
 
 const MOCK_PLAN = {
   plan_id: 'plan_123',
@@ -255,4 +255,12 @@ it('calls onPaymentError when payment processing fails', async () => {
   await waitForExpect(() =>
     expect(onPaymentError).toHaveBeenCalledWith('BAD THINGS')
   );
+});
+
+it('shows adjusts form styles on smaller devices', async () => {
+  const updatedElementStylesObjectSmallDev = checkMedia(true, {});
+  expect(updatedElementStylesObjectSmallDev.base.lineHeight).toEqual(SMALL_DEVICE_LINE_HEIGHT);
+
+  const updatedElementStylesObject = checkMedia(false, {});
+  expect(updatedElementStylesObject.base.lineHeight).toEqual(DEFAULT_LINE_HEIGHT);
 });

--- a/packages/fxa-payments-server/src/index.scss
+++ b/packages/fxa-payments-server/src/index.scss
@@ -120,6 +120,10 @@ h3.billing-title {
     display: flex;
     flex-direction: row;
 
+    @include respond-to('small') {
+      flex-wrap: wrap;
+    }
+
     .input-row {
       flex: 1 0;
       padding-right: 18px;
@@ -127,6 +131,12 @@ h3.billing-title {
 
       &.input-row--xl {
         flex: 2 0;
+
+        @include respond-to('small') {
+          flex: unset;
+          padding-right: 0;
+          width: 100%;
+        }
       }
     }
 

--- a/packages/fxa-payments-server/src/index.tsx
+++ b/packages/fxa-payments-server/src/index.tsx
@@ -36,6 +36,7 @@ async function init() {
           config,
           store,
           queryParams,
+          matchMedia,
           navigateToUrl,
           getScreenInfo,
           locationReload,
@@ -57,6 +58,10 @@ function getScreenInfo() {
 function locationReload() {
   // TODO: instrument with metrics & etc.
   window.location.reload();
+}
+
+function matchMedia(query: string) {
+  return window.matchMedia(query).matches;
 }
 
 function navigateToUrl(url: string) {

--- a/packages/fxa-payments-server/src/lib/AppContext.tsx
+++ b/packages/fxa-payments-server/src/lib/AppContext.tsx
@@ -7,6 +7,7 @@ export type AppContextType = {
   accessToken: string;
   config: Config;
   queryParams: QueryParams;
+  matchMedia: (query: string) => boolean;
   navigateToUrl: (url: string) => void;
   getScreenInfo: () => ScreenInfo;
   locationReload: (url: string) => void;
@@ -20,6 +21,7 @@ export const defaultAppContext = {
   config,
   getScreenInfo: () => new ScreenInfo(),
   locationReload: noopFunction,
+  matchMedia: () => false,
   navigateToUrl: noopFunction,
   queryParams: {},
 };

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -182,6 +182,7 @@ export const defaultAppContextValue = (): AppContextType => ({
   accessToken: 'at_12345',
   config,
   queryParams: {},
+  matchMedia: jest.fn().mockImplementation(query => false),
   navigateToUrl: jest.fn(),
   getScreenInfo: () => new ScreenInfo(window),
   locationReload: jest.fn(),

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -114,7 +114,7 @@ export const PaymentUpdateForm = ({
           </div>
           <div className="action">
             <button data-testid="reveal-payment-update-button" className="settings-button" onClick={onRevealUpdateClick}>
-              <span className="change-button">Change...</span>
+              <span className="change-button">Change</span>
             </button>
           </div>
         </div>

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -143,7 +143,7 @@ const CancelSubscriptionPanel = ({
               </div>
               <div className="action">
                 <button className="settings-button" onClick={revealCancel} data-testid="reveal-cancel-subscription-button">
-                  <span className="change-button">Cancel...</span>
+                  <span className="change-button">Cancel</span>
                 </button>
               </div>
             </div>
@@ -164,8 +164,8 @@ const CancelSubscriptionPanel = ({
                   defaultChecked={confirmationChecked}
                   onChange={onConfirmationChanged}
                 />
-                Cancel my access and my saved information within{' '}
-                {plan.plan_name} on {periodEndDate}
+                <span>Cancel my access and my saved information within{' '}
+                {plan.plan_name} on {periodEndDate}</span>
               </label>
             </p>
             <div className="button-row">

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
@@ -1,3 +1,5 @@
+@import '../../../../fxa-content-server/app/styles/breakpoints';
+
 .subscription-management {
   h2.settings-unit-title {
     font-size: 20px;
@@ -29,6 +31,10 @@
   .subscription {
     margin: 25px 32px;
 
+    @include respond-to('small') {
+      margin: 25px 16px;
+    }
+
     header {
       margin: 0 0 23px 0;
       padding: 0;
@@ -50,6 +56,17 @@
       font-weight: 500;
       margin: 13px 0;
       text-align: left;
+    }
+
+    @include respond-to('small') {
+      input {
+        width: 30px;
+      }
+
+      label {
+        display: flex;
+        flex-direction: row;
+      }
     }
   }
 
@@ -103,5 +120,40 @@
     .payment {
       padding: 10px 33px;
     }
+  }
+}
+
+@media (min-width: 320px) and (max-width: 480px) {
+  #fxa-settings-content .subscription-management,
+  #main-content.payments-card {
+    width: 100%;
+  }
+
+  #fxa-settings-header-wrapper {
+    flex-direction: row;
+  }
+
+  #fxa-settings-header {
+    flex: 1 1;
+    margin-bottom: 0;
+    width: inherit;
+  }
+
+  .breadcrumbs {
+    margin-bottom: 0;
+    margin-left: 0;
+  }
+
+  .subscription-management .payment-update .payment {
+    padding: 0;
+  }
+
+  .subscription-management .card-details {
+    flex-direction: column;
+  }
+
+  .input-row input,
+  .input-row .StripeElement {
+    padding-left: 9px !important;
   }
 }

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
@@ -56,11 +56,13 @@ describe('routes/Subscriptions', () => {
   const Subject = ({
     store,
     queryParams = {},
+    matchMedia = jest.fn(() =>false),
     navigateToUrl = jest.fn(),
     createToken = jest.fn().mockResolvedValue(VALID_CREATE_TOKEN_RESPONSE),
   }: {
     store?: Store;
     queryParams?: QueryParams;
+    matchMedia?: (query: string) => boolean;
     navigateToUrl?: (url: string) => void;
     createToken?: jest.Mock<any, any>;
   }) => {
@@ -70,6 +72,7 @@ describe('routes/Subscriptions', () => {
     };
     const appContextValue = {
       ...defaultAppContextValue(),
+      matchMedia: matchMedia || jest.fn(() => { return { matches: false } }),
       navigateToUrl: navigateToUrl || jest.fn(),
       queryParams,
     };
@@ -123,7 +126,8 @@ describe('routes/Subscriptions', () => {
   it('offers a button for support', async () => {
     initApiMocks();
     const navigateToUrl = jest.fn();
-    const { getByTestId, findByTestId, findByText } = render(<Subject navigateToUrl={navigateToUrl} />);
+    const matchMedia = jest.fn(() => { return { matches: false } });
+    const { getByTestId, findByTestId, findByText } = render(<Subject matchMedia={matchMedia} navigateToUrl={navigateToUrl} />);
     await findByTestId('subscription-management-loaded');
     fireEvent.click(getByTestId('contact-support-button'));
     await waitForExpect(() => expect(navigateToUrl).toBeCalled());


### PR DESCRIPTION
- fixes #1832

This is first pass at mobile screens in payment flow/support form. @janiceahn Feel free to ping me for changes if you don't wanna post them all here

![phase-1-mobile-subscription-cancel-expanded](https://user-images.githubusercontent.com/1844554/63742658-7c0e2800-c867-11e9-94c6-814639871831.png)
![phase-1-mobile-subscription-payment-update-form](https://user-images.githubusercontent.com/1844554/63742659-7c0e2800-c867-11e9-8e72-0230bcb003c1.png)
![phase-1-mobile-subscription-home](https://user-images.githubusercontent.com/1844554/63742660-7c0e2800-c867-11e9-97bc-b2ca486c33af.png)
![phase-1-mobile-screens](https://user-images.githubusercontent.com/1844554/63742662-7ca6be80-c867-11e9-990a-3fa22a4bdd5c.png)
![phase-1-mobile-support](https://user-images.githubusercontent.com/1844554/63742668-803a4580-c867-11e9-9b80-f4fca565ec09.png)


cc/ @janiceahn for UX review