### PR TITLE
[HOLD] fix(experiments): Add 'de-DE' to newsletter safelist

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/communication-prefs.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/communication-prefs.js
@@ -12,6 +12,7 @@ const BaseGroupingRule = require('./base');
 
 const AVAILABLE_LANGUAGES = [
   'de',
+  'de-de',
   'en',
   'en-[a-z]{2}',
   'es',

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/communication-prefs.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/communication-prefs.js
@@ -18,6 +18,7 @@ describe('lib/experiments/grouping-rules/communication-prefs', () => {
 
   [
     'de',
+    'de-DE',
     'en',
     'en-US',
     'en-GB',
@@ -37,7 +38,7 @@ describe('lib/experiments/grouping-rules/communication-prefs', () => {
     });
   });
 
-  ['de-DE', 'pt'].forEach(lang => {
+  ['de-AT', 'pt'].forEach(lang => {
     it(`choose returns false for ${lang}`, () => {
       assert.isFalse(experiment.choose({ lang }));
     });


### PR DESCRIPTION
Some German language users were unable to access the email settings page with the 'de-DE' language enabled as their primary language in about:preferences. Previously, 'de' was allowed, but 'de-DE' was explicitly disallowed.

Fixes #2217.

-----

Notes for reviewer: 

I'm not sure of the backstory here, but the test I modified indicates that, originally, `de` was allowed, while `de-DE` was explicitly not allowed (along with any other region-specific language subtags like `de-AT`).

I'm not sure what the wider consequences will be of widening the list of allowed languages to include `de-DE`. This might affect experiment targeting. Hopefully someone with experience using the FxA experiment framework can review.

Note also that users with French language subtags like `fr-FR` set as the first language in their about:preferences list of languages will not be able to manage their email preferences, since `fr` but not `fr-FR` is in the allowlist; this presumably holds true for other languages where we only specify the two-character base language in the `communication-prefs.js` file. TBH I wonder if this issue has come up before, but can't find anything in the bug list, or in that file's commit history. 🤷‍♂ 

-----

Here's the preferences screen in a few languages, showing this change actually fixes #2217. Note the presence or absence of the 'email newsletter' link at the bottom of the screen:

American English (en-US):

<img width="1052" alt="Screen Shot 2019-08-27 at 4 49 43 PM" src="https://user-images.githubusercontent.com/96396/63815889-106d9e80-c8eb-11e9-8809-00fd4f685583.png">

er, German German (de-DE):

<img width="1052" alt="Screen Shot 2019-08-27 at 4 49 55 PM" src="https://user-images.githubusercontent.com/96396/63815907-1d8a8d80-c8eb-11e9-8633-bd7f45433ecf.png">

Austrian German (de-AT):

<img width="1052" alt="Screen Shot 2019-08-27 at 4 50 45 PM" src="https://user-images.githubusercontent.com/96396/63815953-34c97b00-c8eb-11e9-9415-37ce6e9f7b8d.png">
