### PR TITLE
fix(metrics): Update `signin.success` metric to `oauth.force-auth.signin.success`

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
@@ -83,7 +83,7 @@ export default {
     // the email will be prefilled on the legacy signin page.
     // If the signin fails
     this.formPrefill.set(account.pick('email'));
-    return this.signIn(account, null).catch(err => {
+    const result = this.signIn(account, null).catch(err => {
       // Session was invalid. Set a SESSION EXPIRED error on the model
       // causing an error to be displayed when the view re-renders
       // due to the sessionToken update.
@@ -93,6 +93,12 @@ export default {
         throw err;
       }
     });
+
+    // When using a cached credential, the auth-server routes do not get hit,
+    // This event will cause the content-server to emit the complete event.
+    this.logEvent('cached.signin.success');
+
+    return result;
   },
 
   /**

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -67,7 +67,7 @@ const EVENTS = {
     group: GROUPS.settings,
     event: 'logout',
   },
-  'signin.success': {
+  'cached.signin.success': {
     group: GROUPS.login,
     event: 'complete',
   },

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -1586,11 +1586,11 @@ registerSuite('amplitude', {
       assert.equal(logger.info.callCount, 0);
     },
 
-    'signin.success': () => {
+    'oauth.force-auth.signin.success': () => {
       amplitude(
         {
           time: 'foo',
-          type: 'signin.success',
+          type: 'oauth.force-auth.signin.success',
         },
         {
           connection: {},


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/2343 (I think)

I couldn't actually reproduce the multiple complete events locally but looking at what was being sent when I forced auth on 123Done, it seems like `oauth.force-auth.signin.success` is the right event here?

<img width="315" alt="Screen Shot 2019-08-28 at 2 31 53 PM" src="https://user-images.githubusercontent.com/1295288/63883092-5dac4780-c9a1-11e9-91a7-2e9cef062795.png">

@philbooth @irrationalagent Thoughts?
