### PR TITLE
fix(metrics): Emit cached.signin.success metric when using cached creds

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
@@ -83,7 +83,7 @@ export default {
     // the email will be prefilled on the legacy signin page.
     // If the signin fails
     this.formPrefill.set(account.pick('email'));
-    return this.signIn(account, null).catch(err => {
+    const result = this.signIn(account, null).catch(err => {
       // Session was invalid. Set a SESSION EXPIRED error on the model
       // causing an error to be displayed when the view re-renders
       // due to the sessionToken update.
@@ -93,6 +93,12 @@ export default {
         throw err;
       }
     });
+
+    // When using a cached credential, the auth-server routes do not get hit,
+    // This event will cause the content-server to emit the complete event.
+    this.logEvent('cached.signin.success');
+
+    return result;
   },
 
   /**

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -67,7 +67,7 @@ const EVENTS = {
     group: GROUPS.settings,
     event: 'logout',
   },
-  'signin.success': {
+  'cached.signin.success': {
     group: GROUPS.login,
     event: 'complete',
   },

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -1586,11 +1586,11 @@ registerSuite('amplitude', {
       assert.equal(logger.info.callCount, 0);
     },
 
-    'signin.success': () => {
+    'cached.signin.success': () => {
       amplitude(
         {
           time: 'foo',
-          type: 'signin.success',
+          type: 'cached.signin.success',
         },
         {
           connection: {},

--- a/packages/fxa-email-service/Cargo.lock
+++ b/packages/fxa-email-service/Cargo.lock
@@ -1008,7 +1008,7 @@ name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -3114,7 +3114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum socket2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "4e626972d3593207547f14bf5fc9efa4d0e7283deb73fef1dff313dae9ab8878"
 "checksum socketlabs 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "df011948397510aca5788114c2af450dd826d27352217be05c0f1fbd731aa56f"
-"checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
+"checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"


### PR DESCRIPTION
Implements https://github.com/mozilla/fxa/issues/2343#issuecomment-525889096.

To test locally I did the following

### Sign in using force auth

1. Sign into Sync in browser
2. Sign into 123Done using `127.0.0.1:8080/?email=valid_user_email` (force auth)

Auth-server amplitude events
```
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_login - success","time":1567023797557,"user_id":"8edccb000bec419e9bd415d2bc75ad6a","device_id":"351fc197c9ca4c67988a0238de5dd955","session_id":1567023780110,"app_version":"144","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"6ba5dfc8aeaf1f723a77413064c7914467c5d41a82b9a9b456c7a7b8ba4646e6","ua_browser":"Firefox","ua_version":"69.0","$append":{"fxa_services_used":"undefined_oauth"},"sync_device_count":1,"sync_active_devices_day":1,"sync_active_devices_week":1,"sync_active_devices_month":1}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_login - complete","time":1567023797557,"user_id":"8edccb000bec419e9bd415d2bc75ad6a","device_id":"351fc197c9ca4c67988a0238de5dd955","session_id":1567023780110,"app_version":"144","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"undefined_oauth","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"6ba5dfc8aeaf1f723a77413064c7914467c5d41a82b9a9b456c7a7b8ba4646e6","ua_browser":"Firefox","ua_version":"69.0","$append":{"fxa_services_used":"undefined_oauth"},"sync_device_count":1,"sync_active_devices_day":1,"sync_active_devices_week":1,"sync_active_devices_month":1}}`
```

Content-server amplitude events
```
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_login - view","time":1567023780892,"user_id":"8edccb000bec419e9bd415d2bc75ad6a","device_id":"351fc197c9ca4c67988a0238de5dd955","session_id":1567023780110,"app_version":"144","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"6ba5dfc8aeaf1f723a77413064c7914467c5d41a82b9a9b456c7a7b8ba4646e6","ua_browser":"Firefox","ua_version":"69.0","$append":{"fxa_services_used":"123done"}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_login - engage","time":1567023782138,"user_id":"8edccb000bec419e9bd415d2bc75ad6a","device_id":"351fc197c9ca4c67988a0238de5dd955","session_id":1567023780110,"app_version":"144","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"6ba5dfc8aeaf1f723a77413064c7914467c5d41a82b9a9b456c7a7b8ba4646e6","ua_browser":"Firefox","ua_version":"69.0","$append":{"fxa_services_used":"123done"}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_login - submit","time":1567023797220,"user_id":"8edccb000bec419e9bd415d2bc75ad6a","device_id":"351fc197c9ca4c67988a0238de5dd955","session_id":1567023780110,"app_version":"144","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"6ba5dfc8aeaf1f723a77413064c7914467c5d41a82b9a9b456c7a7b8ba4646e6","ua_browser":"Firefox","ua_version":"69.0","$append":{"fxa_services_used":"123done"}}}
```

Result: Auth-server emits complete event

### Sign in using cached creds

1. Sign into Sync in browser
2. Sign into 123Done using `Choose my sign-in flow for me`

Auth-server amplitude events
```
None...
```

Content-server amplitude events
```
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_login - view","time":1567023988862,"user_id":"8edccb000bec419e9bd415d2bc75ad6a","device_id":"ea01c584e80b424a8d6b527039cdada5","session_id":1567023988391,"app_version":"144","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"9abff344b8ed0e7a632a2386db6fcd576afc27113002b4fcb2024fb36cc09dbf","ua_browser":"Firefox","ua_version":"69.0","$append":{"fxa_services_used":"123done"}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_login - submit","time":1567023989691,"user_id":"8edccb000bec419e9bd415d2bc75ad6a","device_id":"ea01c584e80b424a8d6b527039cdada5","session_id":1567023988391,"app_version":"144","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"9abff344b8ed0e7a632a2386db6fcd576afc27113002b4fcb2024fb36cc09dbf","ua_browser":"Firefox","ua_version":"69.0","$append":{"fxa_services_used":"123done"}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_login - complete","time":1567023989694,"user_id":"8edccb000bec419e9bd415d2bc75ad6a","device_id":"ea01c584e80b424a8d6b527039cdada5","session_id":1567023988391,"app_version":"144","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"9abff344b8ed0e7a632a2386db6fcd576afc27113002b4fcb2024fb36cc09dbf","ua_browser":"Firefox","ua_version":"69.0","$append":{"fxa_services_used":"123done"}}}
```

Result: Content-server emits completed event