### PR TITLE
fix(metrics): only emit cached.signin.success in the success case

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/cached-credentials-mixin.js
@@ -83,7 +83,11 @@ export default {
     // the email will be prefilled on the legacy signin page.
     // If the signin fails
     this.formPrefill.set(account.pick('email'));
-    const result = this.signIn(account, null).catch(err => {
+    return this.signIn(account, null, {
+      // When using a cached credential, the auth-server routes do not get hit,
+      // This event will cause the content-server to emit the complete event.
+      onSuccess: () => this.logEvent('cached.signin.success'),
+    }).catch(err => {
       // Session was invalid. Set a SESSION EXPIRED error on the model
       // causing an error to be displayed when the view re-renders
       // due to the sessionToken update.
@@ -93,12 +97,6 @@ export default {
         throw err;
       }
     });
-
-    // When using a cached credential, the auth-server routes do not get hit,
-    // This event will cause the content-server to emit the complete event.
-    this.logEvent('cached.signin.success');
-
-    return result;
   },
 
   /**

--- a/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
@@ -29,6 +29,8 @@ export default {
    *  user is signing in with a sessionToken.
    * @param {Object} [options]
    *   @param {String} [options.unblockCode] - unblock code
+   *   @param {Function} [options.onSuccess] - extra success handler to be invoked
+   *                                           before this.onSignInSuccess
    * @return {Object} promise
    */
   signIn(account, password, options = {}) {
@@ -100,6 +102,10 @@ export default {
             // with an updated account
             onSubmitComplete: this.onSignInSuccess.bind(this),
           });
+        }
+
+        if (typeof options.onSuccess === 'function') {
+          options.onSuccess();
         }
 
         return this.onSignInSuccess(account);

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/cached-credentials-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/cached-credentials-mixin.js
@@ -179,12 +179,25 @@ describe('views/mixins/cached-credentials-mixin', () => {
       });
     });
 
-    it('delegates to signIn, saves email to formPrefill', () => {
+    it('delegates to signIn, logs cached.signin.success event', () => {
       sinon.stub(view, 'signIn').callsFake(() => Promise.resolve());
+      sinon.stub(view, 'logEvent');
 
       return view.useLoggedInAccount(account).then(() => {
-        assert.isTrue(view.signIn.calledOnce);
-        assert.isTrue(view.signIn.calledWith(account));
+        assert.equal(view.signIn.callCount, 1);
+        const args = view.signIn.args[0];
+        assert.lengthOf(args, 3);
+        assert.equal(args[0], account);
+        assert.isNull(args[1]);
+        assert.isObject(args[2]);
+        const { onSuccess } = args[2];
+        assert.isFunction(onSuccess);
+        assert.lengthOf(onSuccess, 0);
+
+        assert.equal(view.logEvent.callCount, 0);
+        onSuccess();
+        assert.equal(view.logEvent.callCount, 1);
+        assert.deepEqual(view.logEvent.args[0], ['cached.signin.success']);
       });
     });
 

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/signin-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/signin-mixin.js
@@ -177,6 +177,20 @@ describe('views/mixins/signin-mixin', function() {
           assert.isFalse(broker.setBehavior.called);
         });
       });
+
+      describe('with `onSuccess` option', () => {
+        let onSuccess;
+
+        beforeEach(() => {
+          onSuccess = sinon.spy();
+          return view.signIn(account, 'password', { onSuccess });
+        });
+
+        it('called onSuccess', () => {
+          assert.equal(onSuccess.callCount, 1);
+          assert.lengthOf(onSuccess.args[0], 0);
+        });
+      });
     });
 
     describe('unverified account', function() {
@@ -363,6 +377,21 @@ describe('views/mixins/signin-mixin', function() {
           it('re-throws the error for display', () => {
             assert.strictEqual(thrownErr, err);
           });
+        });
+      });
+
+      describe('with `onSuccess` option', () => {
+        let onSuccess;
+
+        beforeEach(() => {
+          onSuccess = sinon.spy();
+          return view
+            .signIn(account, 'password', { onSuccess })
+            .catch(() => {});
+        });
+
+        it('did not call onSuccess', () => {
+          assert.equal(onSuccess.callCount, 0);
         });
       });
     });


### PR DESCRIPTION
Fixes #2358.

Although, advance warning, it's a bit of a hack as I'm off to [EOTR :notes::tent:](https://endoftheroadfestival.com/) in a bit. But I wanted to at least check my thinking / prove the concept before dashing off, so you're welcome to replace it with something more considered if you like.

The problem with the fix from #2354 was that it emits the success event in the failure case too. And of course, we can't just stick the event in a `.then` handler hanging off `this.signIn` because `onSignInSuccess` navigates back to the relier. So I hacked it to pass an optional extra success handler in to `this.signIn`, which it can invoke before `onSignInSuccess`. This removes the login complete event in the failure case but preserves it in the success case:

```
{"op":"amplitudeEvent","event_type":"fxa_login - view","time":1567062142275,"user_id":"931b8393a8ec4897829cd3333024a437","device_id":"edc09e189eef4ec39909645f91bca06c","session_id":1567062141937,"app_version":"144","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"27b913c76eb9cd5015b57117a51aa45fe3c0e57a222aad47bc47577e8b216115","ua_browser":"Firefox","ua_version":"68.0","$append":{"fxa_services_used":"123done"}}}
{"op":"amplitudeEvent","event_type":"fxa_login - submit","time":1567062144459,"user_id":"931b8393a8ec4897829cd3333024a437","device_id":"edc09e189eef4ec39909645f91bca06c","session_id":1567062141937,"app_version":"144","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"27b913c76eb9cd5015b57117a51aa45fe3c0e57a222aad47bc47577e8b216115","ua_browser":"Firefox","ua_version":"68.0","$append":{"fxa_services_used":"123done"}}}
{"op":"amplitudeEvent","event_type":"fxa_login - complete","time":1567062144487,"user_id":"931b8393a8ec4897829cd3333024a437","device_id":"edc09e189eef4ec39909645f91bca06c","session_id":1567062141937,"app_version":"144","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"27b913c76eb9cd5015b57117a51aa45fe3c0e57a222aad47bc47577e8b216115","ua_browser":"Firefox","ua_version":"68.0","$append":{"fxa_services_used":"123done"}}}
```

Opened against `train-144` for a point release.

@mozilla/fxa-devs r?