### PR TITLE
fix(client): Remove reference to `let` in js-client

### DIFF
--- a/packages/fxa-js-client/client/FxAccountClient.js
+++ b/packages/fxa-js-client/client/FxAccountClient.js
@@ -1726,7 +1726,7 @@ FxAccountClient.prototype.securityEvents = function(sessionToken) {
  * @return {Promise} A promise that will be fulfilled with JSON `xhr.responseText` of the request
  */
 FxAccountClient.prototype.deleteSecurityEvents = function(sessionToken) {
-  let request = this.request;
+  var request = this.request;
 
   return Promise.resolve()
     .then(function() {


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/2340

I suspect this is what is causing the sentry error. No harm in making this `var` and seeing if it fixes it.