### PR TITLE
chore(settings): change "last sync" to "last seen" in devices view

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/settings/clients.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/clients.js
@@ -44,21 +44,21 @@ const LAST_ACTIVITY_FORMATS = {
   /* eslint-disable sorting/sort-object-props */
   device: {
     withoutLocation: {
-      precise: t('Last sync %(translatedTimeAgo)s'),
-      approximate: t('Last sync over %(translatedTimeAgo)s'),
+      precise: t('Last seen %(translatedTimeAgo)s'),
+      approximate: t('Last seen over %(translatedTimeAgo)s'),
     },
     withCountry: {
-      precise: t('Last sync %(translatedTimeAgo)s in %(translatedCountry)s'),
+      precise: t('Last seen %(translatedTimeAgo)s in %(translatedCountry)s'),
       approximate: t(
-        'Last sync over %(translatedTimeAgo)s in %(translatedCountry)s'
+        'Last seen over %(translatedTimeAgo)s in %(translatedCountry)s'
       ),
     },
     withCityStateCountry: {
       precise: t(
-        'Last sync %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s'
+        'Last seen %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s'
       ),
       approximate: t(
-        'Last sync over %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s'
+        'Last seen over %(translatedTimeAgo)s near %(translatedCity)s, %(translatedState)s, %(translatedCountry)s'
       ),
     },
   },
@@ -150,7 +150,7 @@ const View = FormView.extend(
           }
         } else {
           if (item.clientType === Constants.CLIENT_TYPE_DEVICE) {
-            item.lastAccessTimeFormatted = t('Last sync time unknown');
+            item.lastAccessTimeFormatted = t('Last seen time unknown');
           } else {
             // unknown lastAccessTimeFormatted or not possible to format.
             item.lastAccessTimeFormatted = '';

--- a/packages/fxa-content-server/app/tests/spec/views/settings/clients.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/clients.js
@@ -518,7 +518,7 @@ describe('views/settings/clients', () => {
       return initView().then(() => {
         view.translator = {
           get: untranslatedText => {
-            if (untranslatedText === 'Last sync %(translatedTimeAgo)s') {
+            if (untranslatedText === 'Last seen %(translatedTimeAgo)s') {
               return 'Translated %(translatedTimeAgo)s';
             }
 
@@ -660,15 +660,15 @@ describe('views/settings/clients', () => {
 
         assert.equal(
           formatted[0].lastAccessTimeFormatted,
-          'Last sync 32 minutes ago near Bournemouth, EN, United Kingdom'
+          'Last seen 32 minutes ago near Bournemouth, EN, United Kingdom'
         );
         assert.equal(
           formatted[1].lastAccessTimeFormatted,
-          'Last sync over 1 hour ago in United Kingdom'
+          'Last seen over 1 hour ago in United Kingdom'
         );
         assert.equal(
           formatted[2].lastAccessTimeFormatted,
-          'Last sync 4 months ago in United Kingdom'
+          'Last seen 4 months ago in United Kingdom'
         );
         assert.equal(formatted[3].lastAccessTimeFormatted, '1 day ago');
         assert.equal(
@@ -768,12 +768,12 @@ describe('views/settings/clients', () => {
         assert.equal(formatted[5].title, 'device-1');
         assert.equal(
           formatted[5].lastAccessTimeFormatted,
-          'Last sync 30 minutes ago in Canada'
+          'Last seen 30 minutes ago in Canada'
         );
         assert.equal(formatted[6].title, 'device-2');
         assert.equal(
           formatted[6].lastAccessTimeFormatted,
-          'Last sync time unknown'
+          'Last seen time unknown'
         );
       });
     });


### PR DESCRIPTION
Fixes #2362.

Draft until train 145 is tagged because it missed the deadline for strings.
