### PR TITLE
fix(experiments): experiment bucketing should liberally match on region-free languages

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/communication-prefs.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/communication-prefs.js
@@ -10,22 +10,24 @@
 
 const BaseGroupingRule = require('./base');
 
-const AVAILABLE_LANGUAGES = [
-  'de',
-  'en',
-  'en-[a-z]{2}',
-  'es',
-  'es-[a-z]{2}',
-  'fr',
-  'hu',
-  'id',
-  'pl',
-  'pt-br',
-  'ru',
-  'zh-tw',
-];
+// If only the language, not the region, is specified, then all regions
+// will be considered a match. For instance, 'de' will match 'de', 'de-de',
+// 'de-at', etc. #2217
+const AVAILABLE_LANGUAGES = ['de', 'en', 'es', 'fr', 'hu', 'id', 'pl', 'ru'];
 
-const AVAILABLE_LANGUAGES_REGEX = arrayToRegex(AVAILABLE_LANGUAGES);
+// If the region is specified, other regions will not match. For instance,
+// 'pt-br' will not match 'pt' or 'pt-pt'. #2217
+const AVAILABLE_REGIONS = ['pt-br', 'zh-tw'];
+
+const AVAILABLE_LANGUAGES_REGEX = generateRegex(
+  AVAILABLE_LANGUAGES,
+  AVAILABLE_REGIONS
+);
+
+function generateRegex(langs, regions) {
+  const combined = langs.map(x => `${x}|${x}-[a-z]{2}`).concat(regions);
+  return arrayToRegex(combined);
+}
 
 function normalizeLanguage(lang) {
   return lang.toLowerCase().replace(/_/g, '-');

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/communication-prefs.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/communication-prefs.js
@@ -18,18 +18,25 @@ describe('lib/experiments/grouping-rules/communication-prefs', () => {
 
   [
     'de',
+    'de-AT',
+    'de-DE',
     'en',
+    'en-CA',
     'en-US',
     'en-GB',
     'es',
     'es-ES',
     'es-MX',
     'fr',
+    'fr-CA',
+    'fr-CH',
+    'fr-FR',
     'hu',
     'id',
     'pl',
-    'pt-br',
+    'pt-BR',
     'ru',
+    'ru-MO',
     'zh-TW',
   ].forEach(lang => {
     it(`choose returns true for ${lang}`, () => {
@@ -37,7 +44,7 @@ describe('lib/experiments/grouping-rules/communication-prefs', () => {
     });
   });
 
-  ['de-DE', 'pt'].forEach(lang => {
+  ['pt', 'pt-PT', 'zh'].forEach(lang => {
     it(`choose returns false for ${lang}`, () => {
       assert.isFalse(experiment.choose({ lang }));
     });


### PR DESCRIPTION
Some German language users were unable to access the email settings page
with the 'de-DE' language enabled. Previously, 'de' was allowed, but
'de-DE' was explicitly disallowed. This commit changes the matching
behavior to work as follows:

* Loosely match languages specified without a region: if 'de' is
given, then 'de', 'de-DE', and 'de-AT' will all match.

* Strictly match languages specified with a region: if 'zh-tw'
is given, then 'zh' and 'zh-cn' will not match.

Fixes #2217, see also #2332 for context.