### PR TITLE
refactor(codes): Update sign in codes to use otp based code

### DIFF
--- a/packages/fxa-auth-server/lib/routes/password.js
+++ b/packages/fxa-auth-server/lib/routes/password.js
@@ -28,7 +28,7 @@ module.exports = function(
   push,
   config
 ) {
-  const totpUtils = require('../../lib/routes/utils/totp')(log, config, db);
+  const otpUtils = require('../../lib/routes/utils/otp')(log, config, db);
 
   function failVerifyAttempt(passwordForgotToken) {
     return passwordForgotToken.failAttempt()
@@ -170,7 +170,7 @@ module.exports = function(
           .then(createResponse);
 
         function checkTotpToken() {
-          return totpUtils.hasTotpToken(passwordChangeToken).then(result => {
+          return otpUtils.hasTotpToken(passwordChangeToken).then(result => {
             hasTotp = result;
 
             // Currently, users that have a TOTP token must specify a sessionTokenId to complete the

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -13,7 +13,7 @@ const { promisify } = require('util');
 const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;
 
 module.exports = (log, db, mailer, customs, config) => {
-  const totpUtils = require('../../lib/routes/utils/totp')(log, config, db);
+  const otpUtils = require('../../lib/routes/utils/otp')(log, config, db);
 
   // Default options for TOTP
   otplib.authenticator.options = {
@@ -107,7 +107,7 @@ module.exports = (log, db, mailer, customs, config) => {
 
         // If a TOTP token is not verified, we should be able to safely delete regardless of session
         // verification state.
-        const hasEnabledToken = await totpUtils.hasTotpToken({ uid });
+        const hasEnabledToken = await otpUtils.hasTotpToken({ uid });
 
         // To help prevent users from getting locked out of their account, sessions created and verified
         // before TOTP was enabled, can remove TOTP. Any new sessions after TOTP is enabled, are only considered

--- a/packages/fxa-auth-server/lib/routes/utils/otp.js
+++ b/packages/fxa-auth-server/lib/routes/utils/otp.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const errors = require('../../error');
+const otplib = require('otplib');
 
 module.exports = (log, config, db) => {
   return {
@@ -30,6 +31,24 @@ module.exports = (log, config, db) => {
           throw err;
         }
       );
+    },
+
+    /**
+     * Helper function to simplify generating otp codes.
+     *
+     * @param secret
+     * @param otpOptions
+     * @returns number
+     */
+    generateOtpCode(secret, otpOptions) {
+      const authenticator = new otplib.authenticator.Authenticator();
+      authenticator.options = Object.assign(
+        {},
+        otplib.authenticator.options,
+        otpOptions,
+        { secret }
+      );
+      return authenticator.generate();
     },
   };
 };

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -780,7 +780,7 @@ module.exports = function(log, config, oauthdb) {
             message.timeZone,
             message.acceptLanguage
           ),
-          tokenCode: message.code,
+          code: message.code,
         },
       })
     );

--- a/packages/fxa-auth-server/lib/senders/partials/verify_login_code.html
+++ b/packages/fxa-auth-server/lib/senders/partials/verify_login_code.html
@@ -12,10 +12,13 @@
 <tr style="page-break-before: always">
   <td valign="top">
     <p style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
-    {{t "If yes, here is the authorization code you need:" }}
+    {{t "If yes, here is the verification code:" }}
     </p>
     <p style="font-family: monospace !important; font-size: 32px; line-height: 26px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">
-    {{ tokenCode }}
+    {{ code }}
+    </p>
+    <p style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
+      {{t "It expires in 5 minutes." }}
     </p>
   </td>
 </tr>

--- a/packages/fxa-auth-server/lib/senders/templates/verify_login_code.html
+++ b/packages/fxa-auth-server/lib/senders/templates/verify_login_code.html
@@ -40,10 +40,13 @@
 <tr style="page-break-before: always">
   <td valign="top">
     <p style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
-    {{t "If yes, here is the authorization code you need:" }}
+    {{t "If yes, here is the verification code:" }}
     </p>
     <p style="font-family: monospace !important; font-size: 32px; line-height: 26px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">
-    {{ tokenCode }}
+    {{ code }}
+    </p>
+    <p style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
+      {{t "It expires in 5 minutes." }}
     </p>
   </td>
 </tr>

--- a/packages/fxa-auth-server/lib/senders/templates/verify_login_code.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/verify_login_code.txt
@@ -5,7 +5,9 @@
 {{#if ip}}{{t "IP address: %(ip)s" }}{{/if}}
 {{#if timestamp}}{{ timestamp }}{{/if}}
 
-{{t "If yes, here is the authorization code you need:"}} {{ tokenCode }}
+{{t "If yes, here is the authorization code you need:"}} {{ code }}
+
+{{t "It expires in 5 minutes."}}
 
 {{t "If you suspect that someone is trying to gain access to your account, please change your password." }}
 {{{ passwordChangeLink }}}

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -960,6 +960,7 @@ describe('/account/create', () => {
 
           const authenticator = new otplib.authenticator.Authenticator();
           authenticator.options = Object.assign(
+            {},
             otplib.authenticator.options,
             config.otp,
             { secret: emailCode }

--- a/packages/fxa-auth-server/test/local/routes/session.js
+++ b/packages/fxa-auth-server/test/local/routes/session.js
@@ -83,9 +83,14 @@ function hexString(bytes) {
 
 function getExpectedOtpCode(options = {}, secret = 'abcdef') {
   const authenticator = new otplib.authenticator.Authenticator();
-  authenticator.options = Object.assign(otplib.authenticator.options, options, {
-    secret,
-  });
+  authenticator.options = Object.assign(
+    {},
+    otplib.authenticator.options,
+    options,
+    {
+      secret,
+    }
+  );
   return authenticator.generate();
 }
 

--- a/packages/fxa-auth-server/test/remote/account_create_with_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_with_code_tests.js
@@ -99,6 +99,7 @@ describe('remote account create with sign-up code', function() {
     const secret = emailData.headers['x-verify-code'];
     const futureAuthenticator = new otplib.authenticator.Authenticator();
     futureAuthenticator.options = Object.assign(
+      {},
       otplib.authenticator.options,
       config.otp,
       { secret, epoch: Date.now() / 1000 - 600 }

--- a/packages/fxa-auth-server/test/remote/token_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/token_code_tests.js
@@ -47,7 +47,7 @@ describe('remote tokenCodes', function() {
           'email-2fa',
           'sets correct verification method'
         );
-        return client.verifyTokenCode('011001');
+        return client.verifyShortCodeEmail('011001');
       })
       .then(
         () => {
@@ -56,7 +56,7 @@ describe('remote tokenCodes', function() {
         err => {
           assert.equal(
             err.errno,
-            error.ERRNO.INVALID_TOKEN_VERIFICATION_CODE,
+            error.ERRNO.INVALID_EXPIRED_OTP_CODE,
             'correct errno'
           );
           return client.emailStatus();
@@ -81,7 +81,7 @@ describe('remote tokenCodes', function() {
           'email-2fa',
           'sets correct verification method'
         );
-        return client.verifyTokenCode('Cool Runnings 4 u');
+        return client.verifyShortCodeEmail('Cool Runnings 4 u');
       })
       .then(
         () => {
@@ -131,7 +131,7 @@ describe('remote tokenCodes', function() {
         );
         code = emailData.headers['x-signin-verify-code'];
         assert.ok(code, 'code is sent');
-        return client.verifyTokenCode(code);
+        return client.verifyShortCodeEmail(code);
       })
       .then(res => {
         assert.ok(res, 'verified successful response');
@@ -161,7 +161,7 @@ describe('remote tokenCodes', function() {
         );
         code = emailData.headers['x-signin-verify-code'];
         assert.ok(code, 'code is sent');
-        return client.verifyTokenCode(code, { uid: client.uid });
+        return client.verifyShortCodeEmail(code, { uid: client.uid });
       })
       .then(res => {
         assert.ok(res, 'verified successful response');
@@ -241,7 +241,7 @@ describe('remote tokenCodes', function() {
         );
         code = emailData.headers['x-signin-verify-code'];
         assert.ok(code, 'code is sent');
-        return client.verifyTokenCode(code);
+        return client.verifyShortCodeEmail(code);
       })
       .then(res => {
         assert.ok(res, 'verified successful response');

--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -269,8 +269,8 @@ var ERRORS = {
     message: t('Update was rejected, please try again'),
   },
   INVALID_EXPIRED_SIGNUP_CODE: {
-    errno: 182,
-    message: t('Expired or invalid signup code'),
+    errno: 183,
+    message: t('Expired or invalid code'),
   },
   SERVER_BUSY: {
     errno: 201,

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
@@ -25,6 +25,7 @@
     </form>
 
     <div class="links">
+        <a id="resend" class="left delayed-fadein" href="#">{{#t}}Not in inbox or spam folder? Resend{{/t}}</a>
         <a href="{{{ escapedSupportLink }}}" id="support-link" class="delayed-fadein right" target="_blank">{{#t}}Why is this happening?{{/t}}</a>
     </div>
   </section>

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_token_code.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_token_code.js
@@ -138,7 +138,7 @@ describe('views/sign_in_token_code', () => {
     describe('success', () => {
       beforeEach(() => {
         sinon
-          .stub(account, 'verifyTokenCode')
+          .stub(account, 'verifySessionCode')
           .callsFake(() => Promise.resolve());
         sinon
           .stub(view, 'invokeBrokerMethod')
@@ -149,7 +149,7 @@ describe('views/sign_in_token_code', () => {
 
       it('calls correct broker methods', () => {
         assert.isTrue(
-          account.verifyTokenCode.calledWith(TOKEN_CODE),
+          account.verifySessionCode.calledWith(TOKEN_CODE),
           'verify with correct code'
         );
         assert.isTrue(
@@ -162,11 +162,11 @@ describe('views/sign_in_token_code', () => {
     });
 
     describe('errors', () => {
-      const error = AuthErrors.toError('INVALID_TOKEN_VERIFICATION_CODE');
+      const error = AuthErrors.toError('INVALID_EXPIRED_OTP_CODE');
 
       beforeEach(() => {
         sinon
-          .stub(account, 'verifyTokenCode')
+          .stub(account, 'verifySessionCode')
           .callsFake(() => Promise.reject(error));
         sinon.spy(view, 'showValidationError');
         view.$('input.token-code').val(TOKEN_CODE);
@@ -176,6 +176,21 @@ describe('views/sign_in_token_code', () => {
       it('rejects with the error for display', () => {
         const args = view.showValidationError.args[0];
         assert.equal(args[1], error);
+      });
+    });
+  });
+
+  describe('resend', () => {
+    describe('success', () => {
+      beforeEach(() => {
+        sinon
+          .stub(account, 'verifySessionResendCode')
+          .callsFake(() => Promise.resolve());
+        return view.resend();
+      });
+
+      it('calls correct methods', () => {
+        assert.equal(account.verifySessionResendCode.callCount, 1);
       });
     });
   });

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -868,7 +868,7 @@ const getUnblockInfo = thenify(function(user, index) {
  *
  * @param {string} user or email
  * @param {number} index
- * @returns {promise} that resolves with token code
+ * @returns {promise} that resolves with token code  cc0
  */
 const getTokenCode = thenify(function(user, index) {
   if (/@/.test(user)) {
@@ -876,7 +876,8 @@ const getTokenCode = thenify(function(user, index) {
   }
 
   return this.parent.then(getEmailHeaders(user, index)).then(headers => {
-    const code = headers['x-signin-verify-code'];
+    const code =
+      headers['x-signin-verify-code'] || headers['x-verify-short-code'];
     if (!code) {
       throw new Error(
         'Email does not contain token code: ' + headers['x-template-name']

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -294,7 +294,10 @@ module.exports = {
     ERROR: '.error',
     HEADER: '#fxa-signin-code-header',
     INPUT: '.token-code',
+    RESEND: '#resend',
+    SUCCESS: '.success',
     SUBMIT: 'button[type="submit"]',
+    TOOLTIP: '.tooltip',
   },
   SIGNIN_UNBLOCK: {
     EMAIL_FIELD: '.verification-email-message',

--- a/packages/fxa-content-server/tests/functional/sign_up_with_code.js
+++ b/packages/fxa-content-server/tests/functional/sign_up_with_code.js
@@ -145,7 +145,10 @@ registerSuite('signup with code', {
         })
         .then(click(selectors.SIGNIN_TOKEN_CODE.SUBMIT))
         .then(
-          testElementTextInclude('.tooltip', 'invalid or expired otp code')
+          testElementTextInclude(
+            selectors.SIGNIN_TOKEN_CODE.TOOLTIP,
+            'expired or invalid code'
+          )
         );
     },
   },


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/1650

This PR updates our original sign-in codes (token codes) feature to use the new OTP based codes that were implemented as part of boomerang.

Code sign-in screen:
<img width="545" alt="Screen Shot 2019-09-04 at 11 28 56 AM" src="https://user-images.githubusercontent.com/1295288/64269157-63f17500-cf07-11e9-9f84-9d3b2a1edf79.png">

Email:
<img width="345" alt="Screen Shot 2019-09-04 at 11 22 54 AM" src="https://user-images.githubusercontent.com/1295288/64269175-7075cd80-cf07-11e9-8732-aca02d704789.png">

@mozilla/fxa-devs r?

