### PR TITLE
fix(oauth): Make refresh_token grants default to using original scopes.

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/authorization.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/authorization.js
@@ -50,7 +50,7 @@ module.exports = {
         .uri({
           scheme: ALLOWED_SCHEMES,
         }),
-      scope: validators.scope,
+      scope: validators.scope.required(),
       response_type: Joi.string()
         .valid(RESPONSE_TYPE_CODE, RESPONSE_TYPE_TOKEN)
         .default(RESPONSE_TYPE_CODE),

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/key_data.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/key_data.js
@@ -27,7 +27,7 @@ module.exports = {
     payload: {
       client_id: validators.clientId,
       assertion: validators.assertion.required(),
-      scope: validators.scope,
+      scope: validators.scope.required(),
     },
   },
   response: {

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/token.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/token.js
@@ -105,10 +105,16 @@ const PAYLOAD_SCHEMA = Joi.object({
     .default(MAX_TTL_S)
     .optional(),
 
-  scope: validators.scope.when('grant_type', {
-    is: Joi.string().valid(GRANT_REFRESH_TOKEN, GRANT_FXA_ASSERTION),
-    otherwise: Joi.forbidden(),
-  }),
+  scope: Joi.alternatives()
+    .when('grant_type', {
+      is: GRANT_REFRESH_TOKEN,
+      then: validators.scope.optional(),
+    })
+    .when('grant_type', {
+      is: GRANT_FXA_ASSERTION,
+      then: validators.scope.required(),
+      otherwise: Joi.forbidden(),
+    }),
 
   access_type: Joi.string()
     .valid(ACCESS_TYPE_OFFLINE, ACCESS_TYPE_ONLINE)
@@ -366,18 +372,21 @@ async function validateRefreshTokenGrant(client, params) {
     });
     throw AppError.invalidToken();
   }
-  // Does it have all the requested scopes?
-  if (!tokObj.scope.contains(params.scope)) {
-    logger.debug('refresh_token.invalidScopes', {
-      allowed: tokObj.scope,
-      requested: params.scope,
-    });
-    throw AppError.invalidScopes(
-      params.scope.difference(tokObj.scope).getScopeValues()
-    );
+  // Scope should default to those previously requested,
+  // but can be further limited on request.
+  if (params.scope) {
+    // You can't request *extra* scopes using this grant though!
+    if (!tokObj.scope.contains(params.scope)) {
+      logger.debug('refresh_token.invalidScopes', {
+        allowed: tokObj.scope,
+        requested: params.scope,
+      });
+      throw AppError.invalidScopes(
+        params.scope.difference(tokObj.scope).getScopeValues()
+      );
+    }
+    tokObj.scope = params.scope;
   }
-  // Limit the new grant to just the requested scopes.
-  tokObj.scope = params.scope;
   // An additional sanity-check that we don't accidentally grant refresh tokens
   // from other refresh tokens.  There should be no way to trigger this in practice.
   if (tokObj.offline) {

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/validators.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/validators.js
@@ -48,9 +48,7 @@ exports.scope = Joi.extend({
       return this.createError('scope.base', { v: value }, state, options);
     }
   },
-})
-  .scope()
-  .default(ScopeSet.fromArray([]));
+}).scope();
 
 exports.redirectUri = Joi.string()
   .max(256)

--- a/packages/fxa-auth-server/fxa-oauth-server/test/routes/authorization.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/routes/authorization.js
@@ -68,11 +68,22 @@ describe('/authorization POST', function() {
       );
     });
 
+    it('fails with no scope', () => {
+      joiAssertFail(
+        {
+          client_id: CLIENT_ID,
+          assertion: BASE64URL_STRING,
+        },
+        'scope'
+      );
+    });
+
     it('fails with no state', () => {
       joiAssertFail(
         {
           client_id: CLIENT_ID,
           assertion: BASE64URL_STRING,
+          scope: 'bar',
         },
         'state'
       );
@@ -83,6 +94,7 @@ describe('/authorization POST', function() {
         {
           client_id: CLIENT_ID,
           assertion: BASE64URL_STRING,
+          scope: 'bar',
           state: 'foo',
         },
         validation
@@ -95,6 +107,7 @@ describe('/authorization POST', function() {
           {
             client_id: CLIENT_ID,
             assertion: BASE64URL_STRING,
+            scope: 'bar',
             state: 'foo',
             code_challenge: PKCE_CODE_CHALLENGE,
             code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
@@ -108,6 +121,7 @@ describe('/authorization POST', function() {
           {
             client_id: CLIENT_ID,
             assertion: BASE64URL_STRING,
+            scope: 'bar',
             state: 'foo',
             code_challenge: PKCE_CODE_CHALLENGE,
             code_challenge_method: 'bad_method',
@@ -122,6 +136,7 @@ describe('/authorization POST', function() {
           {
             client_id: CLIENT_ID,
             assertion: BASE64URL_STRING,
+            scope: 'bar',
             state: 'foo',
             code_challenge: 'foo',
             code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
@@ -136,6 +151,7 @@ describe('/authorization POST', function() {
           {
             client_id: CLIENT_ID,
             assertion: BASE64URL_STRING,
+            scope: 'bar',
             state: 'foo',
             code_challenge: PKCE_CODE_CHALLENGE,
             code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,
@@ -150,6 +166,7 @@ describe('/authorization POST', function() {
           {
             client_id: CLIENT_ID,
             assertion: BASE64URL_STRING,
+            scope: 'bar',
             state: 'foo',
             code_challenge: PKCE_CODE_CHALLENGE,
             code_challenge_method: PKCE_CODE_CHALLENGE_METHOD,

--- a/packages/fxa-auth-server/test/remote/oauth_tests.js
+++ b/packages/fxa-auth-server/test/remote/oauth_tests.js
@@ -58,6 +58,7 @@ describe('/oauth/ routes', function() {
   it('successfully grants an authorization code', async () => {
     const res = await client.createAuthorizationCode({
       client_id: PUBLIC_CLIENT_ID,
+      scope: 'abc',
       state: 'xyz',
       code_challenge: MOCK_CODE_CHALLENGE,
       code_challenge_method: 'S256',


### PR DESCRIPTION
Previously, clients that did not provide an explicit `scope` parameter with their refresh_token request would generate an access_token bearing the empty scope. This changes it to the behaviour required by RFC6749 of defaulting to the originally-requested scopes.

Fixes #2408 
fixes #1867