### PR TITLE
chore(codes): Enable signup code sync experiment and enable for proxy

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/signup-code.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/signup-code.js
@@ -33,13 +33,19 @@ const ROLLOUT_CLIENTS = {
     name: 'TestClient',
     rolloutRate: 0.0,
   },
+  a8c528140153d1c6: {
+    enableTestEmails: true,
+    groups: ['treatment'], // All proxy users get the signup code experience
+    name: 'fx-priv-network',
+    rolloutRate: 1.0,
+  },
 };
 
 module.exports = class SignupCodeGroupingRule extends BaseGroupingRule {
   constructor() {
     super();
     this.name = 'signupCode';
-    this.SYNC_ROLLOUT_RATE = 0.0;
+    this.SYNC_ROLLOUT_RATE = 0.4; // 40% of Sync users enrolled, 20% control and 20% treatment
     this.ROLLOUT_CLIENTS = ROLLOUT_CLIENTS;
   }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/2338

Enrolls 40% of sync users (20% control, 20% treatment), and enables for all secure proxy clients.

cc @irrationalagent 