### PR TITLE
fix(123done): use correct product ID from Stripe for 123done Pro staging

### DIFF
--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
       break;
     case '123done-stage.dev.lcip.org':
       paymentURL =
-        'https://accounts.stage.mozaws.net/subscriptions/products/prod_FUUNYnlDso7FeB';
+        'https://accounts.stage.mozaws.net/subscriptions/products/prod_FfiuDs9u11ESbD';
       break;
     default:
       paymentURL = '//127.0.0.1:3030/subscriptions/products/123doneProProduct';


### PR DESCRIPTION
Clicked on the button in 123done Pro staging to subscribe, ended up on the wrong payment page. I think we want `prod_FfiuDs9u11ESbD` here:

![Screenshot_2019-09-05 Product(1)](https://user-images.githubusercontent.com/21687/64379955-db490680-cfe4-11e9-9e20-c471e1d684ce.png)

Looks like `prod_FUUNYnlDso7FeB` is for "Firefox Fortress":

![Screenshot_2019-09-05 Product](https://user-images.githubusercontent.com/21687/64379906-beacce80-cfe4-11e9-84d2-50700a2d87ae.png)
