### PR TITLE
feat(support form): include product name in support ticket

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -1096,6 +1096,12 @@ const conf = convict({
       env: 'ZENDESK_SUBDOMAIN',
       format: String,
     },
+    productNameFieldId: {
+      doc: 'Zendesk support ticket custom field for the product name',
+      default: '360022027772',
+      env: 'ZENDESK_PRODUCT_NAME_FIELD_ID',
+      format: String,
+    },
   },
   otp: {
     step: {

--- a/packages/fxa-auth-server/lib/routes/support.js
+++ b/packages/fxa-auth-server/lib/routes/support.js
@@ -45,6 +45,7 @@ module.exports = (log, db, config, customs, zendeskClient) => {
         validate: {
           payload: isA.object().keys({
             plan: isA.string().required(),
+            productName: isA.string().required(),
             topic: isA.string().required(),
             subject: isA
               .string()
@@ -70,16 +71,20 @@ module.exports = (log, db, config, customs, zendeskClient) => {
           subject = subject.concat(': ', request.payload.subject);
         }
 
+        const zendeskReq = {
+          comment: { body: request.payload.message },
+          subject,
+          requester: {
+            email,
+            name: 'Anonymous User',
+          },
+        };
+        zendeskReq[config.zendesk.productNameFieldId] =
+          request.payload.productName;
+
         try {
           const { result: createRequest } = await zendeskClient.createRequest({
-            request: {
-              comment: { body: request.payload.message },
-              subject,
-              requester: {
-                email,
-                name: 'Anonymous User',
-              },
-            },
+            request: zendeskReq,
           });
 
           // Ensure that the user has the appropriate custom fields

--- a/packages/fxa-auth-server/test/local/routes/support.js
+++ b/packages/fxa-auth-server/test/local/routes/support.js
@@ -146,6 +146,7 @@ describe('support', () => {
       },
       zendesk: {
         subdomain: 'test',
+        productNameFieldId: '192837465',
       },
     };
 
@@ -171,6 +172,7 @@ describe('support', () => {
     method: 'POST',
     payload: {
       plan: '123done',
+      productName: 'FxA - 123done Pro',
       topic: 'Billing',
       subject: 'Change of address',
       message: 'How do I change it?',
@@ -210,6 +212,10 @@ describe('support', () => {
           `${requestOptions.payload.topic} for ${requestOptions.payload.plan}: ${requestOptions.payload.subject}`
         );
         assert.equal(zendeskReq.comment.body, requestOptions.payload.message);
+        assert.equal(
+          zendeskReq[config.zendesk.productNameFieldId],
+          'FxA - 123done Pro'
+        );
         assert.deepEqual(res, { success: true, ticket: 91 });
         nock.isDone();
         spy.restore();

--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -1308,6 +1308,15 @@ FxaClientWrapper.prototype = {
   getOAuthScopedKeyData: createClientDelegate('getOAuthScopedKeyData'),
 
   /**
+   * Get a list of subscription plans with an OAuth access token.
+   *
+   * @param {String} token An access token from the OAuth server.
+   * @returns {Promise} A promise that will be fulfilled with a list of
+   * subscription plans from SubHub.
+   */
+  getSubscriptionPlans: createClientDelegate('getSubscriptionPlans'),
+
+  /**
    * Get a list of active subscriptions with an OAuth access token.
    *
    * @param {String} token A token from the OAuth server.

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -1080,6 +1080,19 @@ const Account = Backbone.Model.extend(
     },
 
     /**
+     * Fetch the list of subscription plans on SubHub.
+     *
+     * @returns {Promise} - resolves with a list of subscription plans.
+     */
+    fetchSubscriptionPlans() {
+      return this._fetchShortLivedSubscriptionsOAuthToken().then(
+        accessToken => {
+          return this._fxaClient.getSubscriptionPlans(accessToken.get('token'));
+        }
+      );
+    },
+
+    /**
      * Check to see if the account has any subscriptions.
      *
      * @returns {Promise} resolves to an array of zero or more subscriptions.

--- a/packages/fxa-content-server/app/scripts/models/support-form.js
+++ b/packages/fxa-content-server/app/scripts/models/support-form.js
@@ -6,7 +6,12 @@ import Backbone from 'backbone';
 
 const SupportForm = Backbone.Model.extend({
   validate: function(attrs) {
-    if (attrs.message !== '' && attrs.plan !== '' && attrs.topic !== '') {
+    if (
+      attrs.message !== '' &&
+      attrs.plan !== '' &&
+      attrs.productName &&
+      attrs.topic !== ''
+    ) {
       return;
     }
 

--- a/packages/fxa-content-server/app/tests/spec/models/account.js
+++ b/packages/fxa-content-server/app/tests/spec/models/account.js
@@ -2958,6 +2958,24 @@ describe('models/account', function() {
     });
   });
 
+  describe('fetchSubscriptionPlans', () => {
+    it('delegates to the fxa-client', () => {
+      const token = 'tickettoride';
+      const plans = [{ product_id: 'foo', plan_id: 'bar' }];
+      sinon
+        .stub(account, 'createOAuthToken')
+        .resolves(new OAuthToken({ token }));
+      const plansStub = sinon
+        .stub(fxaClient, 'getSubscriptionPlans')
+        .resolves(plans);
+
+      return account.fetchSubscriptionPlans().then(resp => {
+        assert.isTrue(plansStub.calledWith(token));
+        assert.deepEqual(resp, plans);
+      });
+    });
+  });
+
   describe('fetchActiveSubscriptions', () => {
     it('delegates to the fxa-client', () => {
       const token = 'tickettoride';

--- a/packages/fxa-content-server/app/tests/spec/models/support-form.js
+++ b/packages/fxa-content-server/app/tests/spec/models/support-form.js
@@ -11,6 +11,7 @@ describe('models/support-form', function() {
   beforeEach(function() {
     supportForm = new SupportForm({
       plan: '123done',
+      productName: 'FxA - Best Product Ever',
       topic: '345finished',
       subject: '',
       message: '678completed',
@@ -19,6 +20,11 @@ describe('models/support-form', function() {
 
   it('requires a plan', function() {
     supportForm.set('plan', '');
+    assert.isFalse(supportForm.isValid());
+  });
+
+  it('requires a product name', function() {
+    supportForm.set('productName', '');
     assert.isFalse(supportForm.isValid());
   });
 

--- a/packages/fxa-content-server/app/tests/spec/views/support.js
+++ b/packages/fxa-content-server/app/tests/spec/views/support.js
@@ -28,6 +28,7 @@ describe('views/support', function() {
   const subscriptionsConfig = { managementClientId: 'OVER9000' };
   const supportTicket = {
     plan: '123done',
+    productName: 'FxA - 123Done Pro',
     topic: 'General inquiries',
     subject: '',
     message: 'inquiries from generals',
@@ -61,7 +62,15 @@ describe('views/support', function() {
     sinon.stub(account, 'fetchProfile').returns(Promise.resolve());
     sinon
       .stub(account, 'getSubscriptions')
-      .resolves([{ plan_name: '123done' }]);
+      .resolves([{ plan_id: '123done_9001', plan_name: '123done' }]);
+    sinon.stub(account, 'fetchSubscriptionPlans').resolves([
+      {
+        plan_id: '123done_9001',
+        plan_name: '123done',
+        product_id: '123done_xyz',
+        product_name: '123Done Pro',
+      },
+    ]);
     sinon.stub(user, 'getAccountByUid').returns(account);
     sinon.stub(user, 'setSignedInAccountByUid').returns(Promise.resolve());
     sinon.stub(user, 'getSignedInAccount').returns(account);
@@ -89,6 +98,43 @@ describe('views/support', function() {
           email
         );
       });
+  });
+
+  describe('product name', function() {
+    it('should be the prefixed product name of the selected plan', function() {
+      return view
+        .render()
+        .then(function() {
+          view.afterVisible();
+          $('#container').append(view.el);
+        })
+        .then(function() {
+          view
+            .$('#plan option:eq(1)')
+            .prop('selected', true)
+            .trigger('change');
+          assert.equal(
+            view.supportForm.get('productName'),
+            'FxA - 123Done Pro'
+          );
+        });
+    });
+
+    it('should be prefixed "Other" when "Other" is selected', function() {
+      return view
+        .render()
+        .then(function() {
+          view.afterVisible();
+          $('#container').append(view.el);
+        })
+        .then(function() {
+          view
+            .$('#plan option:eq(2)')
+            .prop('selected', true)
+            .trigger('change');
+          assert.equal(view.supportForm.get('productName'), 'FxA - Other');
+        });
+    });
   });
 
   describe('submit button', function() {

--- a/packages/fxa-content-server/app/tests/test_start.js
+++ b/packages/fxa-content-server/app/tests/test_start.js
@@ -119,6 +119,7 @@ require('./spec/models/reliers/relier');
 require('./spec/models/reliers/sync');
 require('./spec/models/resume-token');
 require('./spec/models/security-events');
+require('./spec/models/support-form');
 require('./spec/models/sync-engines');
 require('./spec/models/unique-user-id');
 require('./spec/models/user');

--- a/packages/fxa-content-server/npm-shrinkwrap.json
+++ b/packages/fxa-content-server/npm-shrinkwrap.json
@@ -5854,9 +5854,9 @@
             }
         },
         "fxa-js-client": {
-            "version": "1.0.19",
-            "resolved": "https://registry.npmjs.org/fxa-js-client/-/fxa-js-client-1.0.19.tgz",
-            "integrity": "sha512-ou2gXD1RrA2vawSALUyBaQ0IX+YaKj1lCr4DKssIXdxZWiNpNhQMwpqFiANrU496VlSfWptMe+UdYoKUTKpsNQ==",
+            "version": "1.0.21",
+            "resolved": "https://registry.npmjs.org/fxa-js-client/-/fxa-js-client-1.0.21.tgz",
+            "integrity": "sha512-xPyc1CtpvzC4WSC/ZeeuJ5tsjlJDt2SldNLCevpWpu58Btb4/3GD//7WYFL8HchazYvS5L97329gViYxb0ZsBA==",
             "requires": {
                 "es6-promise": "4.1.1",
                 "sjcl": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8e",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -63,7 +63,7 @@
         "file-loader": "1.1.11",
         "fxa-common-password-list": "^0.0.3",
         "fxa-crypto-relier": "2.3.0",
-        "fxa-js-client": "^1.0.19",
+        "fxa-js-client": "^1.0.21",
         "fxa-mustache-loader": "0.0.2",
         "fxa-pairing-channel": "1.0.1",
         "got": "6.7.1",


### PR DESCRIPTION
Fixes #2367

This PR replaces PR #2409 and move the product name look up to the client side as a side effect of needing the product id on the client side for metrics.

@mozilla/fxa-devs r?