### PR TITLE
feat(dataflow): handle new action messages from dataflow pipeline

### DIFF
--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -43,10 +43,24 @@ module.exports = function(fs, path, url, convict) {
     },
     limits: {
       blockIntervalSeconds: {
-        doc: 'Duration of a manual ban',
+        doc: 'Duration of a manual `block` ban',
         default: 60 * 60 * 24,
         format: 'nat',
         env: 'BLOCK_INTERVAL_SECONDS',
+      },
+      suspectInterval: {
+        doc:
+          'Duration of a `suspect` flag, instigated by the Dataflow pipeline',
+        default: '1 day',
+        env: 'SUSPECT_INTERVAL',
+        format: 'duration',
+      },
+      disableInterval: {
+        doc:
+          'Duration of a long-term `disable` flag, instigated by the Dataflow pipeline',
+        default: '1 year',
+        env: 'DISABLE_INTERVAL',
+        format: 'duration',
       },
       rateLimitIntervalSeconds: {
         doc: 'Duration of automatic throttling',
@@ -352,6 +366,13 @@ module.exports = function(fs, path, url, convict) {
         format: Boolean,
         default: false,
         env: 'DATAFLOW_ENABLED',
+      },
+      reportOnly: {
+        doc:
+          'Treat all suggested actions from the Dataflow pipeline as `report`',
+        default: true,
+        env: 'DATAFLOW_REPORT_ONLY',
+        format: Boolean,
       },
       gcpPubSub: {
         projectId: {

--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -374,6 +374,13 @@ module.exports = function(fs, path, url, convict) {
         env: 'DATAFLOW_REPORT_ONLY',
         format: Boolean,
       },
+      ignoreOlderThan: {
+        doc:
+          'Ignore messages older than this value. Or set to `0` to never ignore old messages',
+        default: '1 day',
+        env: 'DATAFLOW_IGNORE_OLDER_THAN',
+        format: 'duration',
+      },
       gcpPubSub: {
         projectId: {
           doc: 'GCP PubSub project ID',

--- a/packages/fxa-customs-server/lib/dataflow.js
+++ b/packages/fxa-customs-server/lib/dataflow.js
@@ -2,29 +2,31 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/**
- * Listens for events from the DataFlow fraud detection pipeline.
- *
- * Events currently are only logged to ensure the PubSub subscription
- * is connected and events are being received as expected.
- *
- * Next steps are:
- * 1. Log discrepancies between events DataFlow sends and whether we think
- *    think the same action should be taken, e.g., if DataFlow says an
- *    IP address should be blocked, then block it.
- * 2. Once the discrepancy volume is sufficiently low, start to
- *    act on DataFlow events.
- * 3. Once we build confidence in the DataFlow events, remove duplicate
- *    rules from the content server and rely upon DataFlow.
- */
+// Handle events from the DataFlow fraud detection pipeline.
 
-module.exports = function(config, log, fetchRecords) {
+'use strict';
+
+const { PubSub } = require('@google-cloud/pubsub');
+
+const VALID_ACTIONS = new Set(['report', 'suspect', 'block', 'disable']);
+const TYPES = new Map([['email', 'email'], ['sourceaddress', 'ip']]);
+
+/**
+ * Initialise the DataFlow handler.
+ *
+ * @param {Object} config
+ * @param {Object} log
+ * @param {Function} fetchRecords
+ * @param {Function} setRecords
+ */
+module.exports = (config, log, fetchRecords, setRecords) => {
   if (!config.dataflow.enabled) {
     // no-op if not enabled
     return;
   }
 
   const { projectId, subscriptionName } = config.dataflow.gcpPubSub;
+  const { reportOnly } = config.dataflow;
 
   if (!projectId) {
     throw new Error(
@@ -38,12 +40,10 @@ module.exports = function(config, log, fetchRecords) {
     );
   }
 
-  const { PubSub } = require('@google-cloud/pubsub');
   const pubsub = new PubSub({ projectId });
-  let messageCount = 0;
 
   const subscription = pubsub.subscription(subscriptionName);
-  subscription.on('message', messageHandler);
+  subscription.on('message', handleMessage);
   subscription.on('error', error => {
     log.error({
       op: 'dataflow.subscription.error',
@@ -51,190 +51,107 @@ module.exports = function(config, log, fetchRecords) {
     });
   });
 
-  const UNEXPECTED_BLOCK_CHECKS = {
-    rl_login_failure_sourceaddress_accountid: isIpEmailBlockUnexpected,
-    rl_sms_sourceaddress: isIpBlockUnexpected,
-    rl_sms_accountid: isEmailBlockUnexpected,
-    rl_email_recipient: isEmailBlockUnexpected,
-    rl_statuscheck: isIpBlockUnexpected,
-    // accountid in this instance is a uid and we don't have a UidIpBlock, trying for just a UID block
-    rl_verifycode_sourceaddress_accountid: isUidBlockUnexpected,
-  };
-
-  // Returned for testing
-  return {
-    checkForUnexpectedBlock,
-    messageHandler,
-    parseMessage,
-    processMessage,
-  };
-
   /**
-   * Ack, log, and process a message
+   * Handle a message.
    *
    * @param {Object} message
-   * @param {Function} [_processMessage=processMessage] message processing method
    */
-  function messageHandler(message, _processMessage = processMessage) {
-    message.ack();
-
-    log.info({
-      op: 'dataflow.message',
-      count: messageCount,
-      id: message.id,
-      // message.data is a Buffer, convert to a string
-      data: message.data.toString(),
-      attributes: message.attributes,
-    });
-
-    messageCount++;
-
-    _processMessage(message);
-  }
-
-  /**
-   * Parse a message and check the metadata for any unexpected rate limits
-   *
-   * @param {Object} message
-   * @param {Function} [_parseMessage=parseMessage]
-   * @param {Function} [_checkForUnexpectedBlock=checkForUnexpectedBlock]
-   */
-  function processMessage(
-    message,
-    _parseMessage = parseMessage,
-    _checkForUnexpectedBlock = checkForUnexpectedBlock
-  ) {
-    let block;
-
+  async function handleMessage(message) {
     try {
-      block = _parseMessage(message);
-    } catch (err) {
-      log.error({
-        op: 'dataflow.message.invalid',
-        reason: err.message,
-      });
-    }
+      const action = parseMessage(message);
+      const type = TYPES.get(action.indicator_type);
 
-    if (block) {
-      _checkForUnexpectedBlock(block);
+      if (reportOnly || action.suggested_action === 'report') {
+        log.warn({
+          op: 'dataflow.report',
+          [type]: action.indicator,
+          severity: action.severity,
+          confidence: action.confidence,
+          heuristic: action.heuristic,
+          heuristic_description: action.heuristic_description,
+          reason: action.reason,
+          suggested_action: action.suggested_action,
+        });
+      } else {
+        const records = await fetchRecords({
+          [type]: action.indicator,
+        });
+
+        records[type][action.suggested_action]();
+
+        await setRecords(records);
+      }
+
+      message.ack();
+
+      log.info({
+        op: 'dataflow.message.success',
+        id: message.id,
+        [type]: action.indicator,
+        suggested_action: action.suggested_action,
+        reportOnly,
+      });
+    } catch (error) {
+      log.error({
+        op: 'dataflow.message.error',
+        id: message.id,
+        data: message.data,
+        error: error.message,
+      });
+
+      message.nack();
     }
   }
 
   /**
-   * Parse a message that arrives from PubSub, returning
-   * the information about the DataFlow block.
+   * Parse a message.
    *
    * @param {Object} message
-   * @returns {Object}
+   * @returns {Action}
    */
   function parseMessage(message) {
-    if (!message) {
-      throw new Error('missing message');
-    }
-    if (!message.data) {
-      throw new Error('missing message data');
-    }
-    if (!Buffer.isBuffer(message.data)) {
-      throw new Error('message data is not a Buffer');
+    if (!message || !Buffer.isBuffer(message.data)) {
+      throw new TypeError('invalid message');
     }
 
-    // message.data is a Buffer
-    const body = message.data.toString();
-    const parsedBody = JSON.parse(body);
+    /*
+     * @typedef {Object} Action
+     * @property {String} timestamp             - ISO 8601 timestamp
+     * @property {String} id                    - String-serialised UUID
+     * @property {String} indicator_type        - `email` or `sourceaddress`
+     * @property {String} indicator             - An email or IP address
+     * @property {String} severity              - `info`, `warn` or `critical`
+     * @property {Number} confidence            - Confidence percentage
+     * @property {String} heuristic             - Originating heuristic
+     * @property {String} heuristic_description - Heuristic description
+     * @property {String} reason                - Reason
+     * @property {String} suggested_action      - `report`, `suspect`, `block` or `disable`
+     * @property {Object} details               - Custom data
+     */
+    const action = JSON.parse(message.data.toString());
 
-    if (!parsedBody.metadata) {
-      throw new Error('missing metadata');
-    }
+    assertAction(action);
 
-    if (!Array.isArray(parsedBody.metadata)) {
-      throw new Error('metadata is not an Array');
-    }
-
-    const block = {};
-
-    // See https://docs.google.com/document/d/1ESuraiNM5nPlicQ5zLFwOYZktTV-i8tqwbnwmxdJzyk
-    // for expected metadata fields
-    parsedBody.metadata.forEach(({ key, value }) => {
-      if (typeof key === 'undefined') {
-        throw new Error('missing metadata key');
-      }
-      if (typeof value === 'undefined') {
-        throw new Error(`missing metadata value: ${key}`);
-      }
-      block[key] = value;
-    });
-
-    return block;
+    return action;
   }
 
   /**
-   * Check for unexpected DataFlow blocks.
-   * Logs whenever an unexpected block is found.
+   * Throw if action fields contain unexpected values.
    *
-   * @param {Object} block
+   * @param {Action} action
    */
-  async function checkForUnexpectedBlock(block) {
-    const { customs_category: category } = block;
-
-    if (!category) {
-      log.error({
-        op: 'dataflow.customs_category.missing',
-      });
-      return;
+  function assertAction({ suggested_action, indicator_type, indicator }) {
+    if (!VALID_ACTIONS.has(suggested_action)) {
+      throw new TypeError(`invalid suggested_action: ${suggested_action}`);
     }
 
-    const isBlockUnexpected = UNEXPECTED_BLOCK_CHECKS[category];
-    if (!isBlockUnexpected) {
-      log.error({
-        op: 'dataflow.customs_category.unknown',
-        customs_category: category,
-      });
-      return;
+    if (!TYPES.has(indicator_type)) {
+      throw new TypeError(`invalid indicator_type: ${indicator_type}`);
     }
 
-    if (await isBlockUnexpected(block)) {
-      log.info(
-        Object.assign({}, block, {
-          op: 'dataflow.block.unexpected',
-        })
-      );
-    } else {
-      log.info(
-        Object.assign({}, block, {
-          op: 'dataflow.block.expected',
-        })
-      );
+    const type = typeof indicator;
+    if (type !== 'string' || indicator === '') {
+      throw new TypeError(`invalid indicator: ${type}`);
     }
-  }
-
-  async function isIpEmailBlockUnexpected(block) {
-    const { sourceaddress: ip, accountid: email } = block;
-
-    const { ipEmailRecord } = await fetchRecords({ ip, email });
-
-    return !(ipEmailRecord && ipEmailRecord.shouldBlock());
-  }
-
-  async function isIpBlockUnexpected(block) {
-    const { sourceaddress: ip } = block;
-
-    const { ipRecord } = await fetchRecords({ ip });
-
-    return !(ipRecord && ipRecord.shouldBlock());
-  }
-
-  async function isEmailBlockUnexpected(block) {
-    const { accountid: email } = block;
-    const { emailRecord } = await fetchRecords({ email });
-
-    return !(emailRecord && emailRecord.shouldBlock());
-  }
-
-  async function isUidBlockUnexpected(block) {
-    const { uid } = block;
-
-    const { uidRecord } = await fetchRecords({ uid });
-
-    return !(uidRecord && uidRecord.isRateLimited());
   }
 };

--- a/packages/fxa-customs-server/lib/email_record.js
+++ b/packages/fxa-customs-server/lib/email_record.js
@@ -18,7 +18,9 @@ module.exports = function(limits, now) {
   EmailRecord.parse = function(object) {
     var rec = new EmailRecord();
     object = object || {};
-    rec.bk = object.bk; // timestamp when the account was banned
+    rec.bk = object.bk; // timestamp when the account was blocked
+    rec.su = object.su; // timestamp when the account was suspected
+    rec.di = object.di; // timestamp when the account was disabled
     rec.rl = object.rl; // timestamp when the account was rate-limited
     rec.vc = object.vc || rec.vc; // timestamps when code verifications happened
     rec.xs = object.xs || rec.xs; // timestamps when emails were sent
@@ -144,7 +146,7 @@ module.exports = function(limits, now) {
   };
 
   EmailRecord.prototype.shouldBlock = function() {
-    return this.isRateLimited() || this.isBlocked();
+    return this.isRateLimited() || this.isBlocked() || this.isDisabled();
   };
 
   EmailRecord.prototype.isRateLimited = function() {
@@ -155,8 +157,24 @@ module.exports = function(limits, now) {
     return !!(this.bk && now() - this.bk < limits.blockIntervalMs);
   };
 
+  EmailRecord.prototype.isSuspected = function() {
+    return !!(this.su && now() - this.su < limits.suspectIntervalMs);
+  };
+
+  EmailRecord.prototype.isDisabled = function() {
+    return !!(this.di && now() - this.di < limits.disableIntervalMs);
+  };
+
   EmailRecord.prototype.block = function() {
     this.bk = now();
+  };
+
+  EmailRecord.prototype.suspect = function() {
+    this.su = now();
+  };
+
+  EmailRecord.prototype.disable = function() {
+    this.di = now();
   };
 
   EmailRecord.prototype.rateLimit = function() {

--- a/packages/fxa-customs-server/lib/settings/limits.js
+++ b/packages/fxa-customs-server/lib/settings/limits.js
@@ -17,6 +17,8 @@ module.exports = (config, Settings, log) => {
     setAll(settings) {
       this.blockIntervalSeconds = settings.blockIntervalSeconds;
       this.blockIntervalMs = settings.blockIntervalSeconds * 1000;
+      this.suspectIntervalMs = settings.suspectInterval;
+      this.disableIntervalMs = settings.disableInterval;
       this.rateLimitIntervalSeconds = settings.rateLimitIntervalSeconds;
       this.rateLimitIntervalMs = settings.rateLimitIntervalSeconds * 1000;
       this.maxEmails = settings.maxEmails;

--- a/packages/fxa-customs-server/test/local/dataflow_tests.js
+++ b/packages/fxa-customs-server/test/local/dataflow_tests.js
@@ -6,883 +6,664 @@ const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const { test: tapTest } = require('tap');
 
-let log;
-let config;
-let dataflow;
-let PubSub;
-let pubsub;
-let sandbox;
-let subscription;
-
-function reset() {
-  if (sandbox) {
-    sandbox.reset();
-  }
-
-  config = {
+tapTest('dataflow', async () => {
+  const sandbox = sinon.createSandbox();
+  const config = {
     dataflow: {
       enabled: true,
+      reportOnly: false,
       gcpPubSub: {
         projectId: 'foo',
         subscriptionName: 'bar',
       },
     },
   };
-}
-
-function test(testName, testFunction) {
-  // Convert each test to use an async function to
-  // lean on tap's promise handling instead of being
-  // forced to call `t.done` in each test.
-  return tapTest(testName, async () => {
-    reset();
-    return await testFunction();
-  });
-}
-
-test('dataflow', () => {
-  sandbox = sinon.createSandbox();
-
-  log = {
+  const log = {
     error: sandbox.spy(),
     info: sandbox.spy(),
+    warn: sandbox.spy(),
   };
-
-  subscription = {
+  const records = {
+    email: {
+      suspect: sandbox.spy(),
+      block: sandbox.spy(),
+      disable: sandbox.spy(),
+    },
+    ip: {
+      suspect: sandbox.spy(),
+      block: sandbox.spy(),
+      disable: sandbox.spy(),
+    },
+  };
+  const fetchRecords = sandbox.spy(async () => records);
+  const setRecords = sandbox.spy(async () => {});
+  const subscription = {
     on: sandbox.spy(),
   };
-
-  pubsub = {
+  const pubsub = {
     subscription: sandbox.spy(() => subscription),
   };
-
-  PubSub = {
-    PubSub: sandbox.spy(function(config) {
-      return pubsub;
-    }),
+  const PubSub = sandbox.spy(function() {
+    return pubsub;
+  });
+  const dataflow = proxyquire('../../lib/dataflow', {
+    '@google-cloud/pubsub': { PubSub },
+  });
+  const data = {
+    timestamp: new Date().toISOString(),
+    id: 'wibble',
+    indicator_type: 'email',
+    indicator: 'pb@example.com',
+    severity: 'warn',
+    confidence: 42,
+    heuristic: 'heurizzle',
+    heuristic_description: 'this is a heuristic',
+    reason: 'because',
+    suggested_action: 'report',
+    details: {
+      key: 'value',
+    },
   };
 
-  dataflow = proxyquire('../../lib/dataflow', {
-    '@google-cloud/pubsub': PubSub,
+  test('dataflow disabled', () => {
+    config.dataflow.enabled = false;
+
+    dataflow(config, log, fetchRecords, setRecords);
+
+    assert.equal(PubSub.callCount, 0);
   });
 
-  test('setup', () => {
-    test('DataFlow not enabled causes a no-op', () => {
-      config.dataflow.enabled = false;
+  test('missing gcp projectId', () => {
+    config.dataflow.enabled = true;
+    config.dataflow.gcpPubSub.projectId = null;
 
-      dataflow(config, log, async () => ({}));
-
-      assert.isFalse(PubSub.PubSub.called);
-    });
-
-    test('missing projectId', () => {
-      delete config.dataflow.gcpPubSub.projectId;
-
-      assert.throws(() => dataflow(config, log, async () => {}));
-    });
-
-    test('missing subscriptionName', () => {
-      delete config.dataflow.gcpPubSub.subscriptionName;
-
-      assert.throws(() => dataflow(config, log, async () => {}));
-    });
-
-    test('valid config', () => {
-      test('subscription is established to the expected Project ID/Subscription', () => {
-        dataflow(config, log, async () => ({}));
-
-        assert.isTrue(PubSub.PubSub.calledOnceWith({ projectId: 'foo' }));
-        assert.isTrue(pubsub.subscription.calledOnceWith('bar'));
-      });
-
-      test('subscription messages are listened for', () => {
-        dataflow(config, log, async () => ({}));
-
-        assert.isTrue(subscription.on.calledTwice);
-        assert.strictEqual(subscription.on.args[0][0], 'message');
-        assert.isFunction(subscription.on.args[0][1]);
-
-        assert.strictEqual(subscription.on.args[1][0], 'error');
-        assert.isFunction(subscription.on.args[1][1]);
-      });
-
-      test('subscription errors are logged', () => {
-        dataflow(config, log, async () => ({}));
-
-        const errorHandler = subscription.on.args[1][1];
-        errorHandler('this is an error');
-
-        assert.deepEqual(log.error.args[0][0], {
-          error: 'this is an error',
-          op: 'dataflow.subscription.error',
-        });
-      });
-    });
+    assert.throws(() => dataflow(config, log, fetchRecords, setRecords));
   });
 
-  test('messageHandler', () => {
-    test('messages are acked, logged, and processed', () => {
-      const { messageHandler } = dataflow(config, log, async () => ({}));
+  test('missing gcp subscriptionName', () => {
+    config.dataflow.gcpPubSub.projectId = 'foo';
+    config.dataflow.gcpPubSub.subscriptionName = null;
 
-      const messageData = JSON.stringify({
-        metadata: [{ key: 'customs_category', value: 'bar' }],
-      });
+    assert.throws(() => dataflow(config, log, fetchRecords, setRecords));
+  });
+
+  test('default config', () => {
+    config.dataflow.gcpPubSub.subscriptionName = 'bar';
+
+    dataflow(config, log, fetchRecords, setRecords);
+
+    assert.equal(PubSub.callCount, 1);
+    let args = PubSub.args[0];
+    assert.lengthOf(args, 1);
+    assert.deepEqual(args[0], { projectId: 'foo' });
+
+    assert.equal(pubsub.subscription.callCount, 1);
+    args = pubsub.subscription.args[0];
+    assert.lengthOf(args, 1);
+    assert.equal(args[0], 'bar');
+
+    assert.equal(subscription.on.callCount, 2);
+    args = subscription.on.args[0];
+    assert.lengthOf(args, 2);
+    assert.equal(args[0], 'message');
+    const messageHandler = args[1];
+    assert.isFunction(messageHandler);
+    assert.lengthOf(messageHandler, 1);
+
+    args = subscription.on.args[1];
+    assert.lengthOf(args, 2);
+    assert.equal(args[0], 'error');
+    const errorHandler = args[1];
+    assert.isFunction(errorHandler);
+    assert.lengthOf(errorHandler, 1);
+    assert.notEqual(errorHandler, messageHandler);
+
+    assert.equal(log.error.callCount, 0);
+    assert.equal(log.info.callCount, 0);
+    assert.equal(log.warn.callCount, 0);
+    assert.equal(fetchRecords.callCount, 0);
+    assert.equal(setRecords.callCount, 0);
+
+    test('invalid data', async () => {
       const message = {
-        ack: sinon.spy(),
-        id: 'message1',
-        data: Buffer.from(messageData),
-        attributes: {
-          quix: 'quux',
-        },
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: { ...data },
       };
+      await messageHandler(message);
 
-      let processSpy = sinon.spy();
-      messageHandler(message, processSpy);
+      assert.equal(log.error.callCount, 1);
+      args = log.error.args[0];
+      assert.lengthOf(args, 1);
+      assert.deepEqual(args[0], {
+        op: 'dataflow.message.error',
+        id: 'blee',
+        data,
+        error: 'invalid message',
+      });
 
-      assert.isTrue(message.ack.calledOnce);
+      assert.equal(message.nack.callCount, 1);
+      assert.lengthOf(message.nack.args[0], 0);
 
-      assert.isTrue(
-        log.info.calledOnceWith({
-          op: 'dataflow.message',
-          count: 0,
-          id: 'message1',
-          data: messageData,
-          attributes: {
-            quix: 'quux',
-          },
-        })
-      );
+      assert.equal(message.ack.callCount, 0);
+      assert.equal(log.info.callCount, 0);
+      assert.equal(log.warn.callCount, 0);
+      assert.equal(fetchRecords.callCount, 0);
+      assert.equal(setRecords.callCount, 0);
+    });
 
-      assert.isTrue(processSpy.calledOnceWith(message));
+    test('invalid suggested_action', async () => {
+      const message = {
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: Buffer.from(
+          JSON.stringify({
+            ...data,
+            suggested_action: 'ban',
+          })
+        ),
+      };
+      await messageHandler(message);
+
+      assert.equal(log.error.callCount, 1);
+      assert.deepEqual(log.error.args[0][0], {
+        op: 'dataflow.message.error',
+        id: 'blee',
+        data: message.data,
+        error: 'invalid suggested_action: ban',
+      });
+
+      assert.equal(message.nack.callCount, 1);
+
+      assert.equal(message.ack.callCount, 0);
+      assert.equal(log.info.callCount, 0);
+      assert.equal(log.warn.callCount, 0);
+      assert.equal(fetchRecords.callCount, 0);
+      assert.equal(setRecords.callCount, 0);
+    });
+
+    test('invalid indicator_type', async () => {
+      const message = {
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: Buffer.from(
+          JSON.stringify({
+            ...data,
+            indicator_type: 'ip',
+            indicator: '1.1.1.1',
+          })
+        ),
+      };
+      await messageHandler(message);
+
+      assert.equal(log.error.callCount, 1);
+      assert.equal(log.error.args[0][0].error, 'invalid indicator_type: ip');
+
+      assert.equal(message.nack.callCount, 1);
+
+      assert.equal(message.ack.callCount, 0);
+      assert.equal(log.info.callCount, 0);
+      assert.equal(log.warn.callCount, 0);
+      assert.equal(fetchRecords.callCount, 0);
+      assert.equal(setRecords.callCount, 0);
+    });
+
+    test('invalid indicator', async () => {
+      const message = {
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: Buffer.from(
+          JSON.stringify({
+            ...data,
+            indicator: {},
+          })
+        ),
+      };
+      await messageHandler(message);
+
+      assert.equal(log.error.callCount, 1);
+      assert.equal(log.error.args[0][0].error, 'invalid indicator: object');
+
+      assert.equal(message.nack.callCount, 1);
+
+      assert.equal(message.ack.callCount, 0);
+      assert.equal(log.info.callCount, 0);
+      assert.equal(log.warn.callCount, 0);
+      assert.equal(fetchRecords.callCount, 0);
+      assert.equal(setRecords.callCount, 0);
+    });
+
+    test('empty indicator', async () => {
+      const message = {
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: Buffer.from(
+          JSON.stringify({
+            ...data,
+            indicator: '',
+          })
+        ),
+      };
+      await messageHandler(message);
+
+      assert.equal(log.error.callCount, 1);
+      assert.equal(log.error.args[0][0].error, 'invalid indicator: string');
+
+      assert.equal(message.nack.callCount, 1);
+
+      assert.equal(message.ack.callCount, 0);
+      assert.equal(log.info.callCount, 0);
+      assert.equal(log.warn.callCount, 0);
+      assert.equal(fetchRecords.callCount, 0);
+      assert.equal(setRecords.callCount, 0);
+    });
+
+    test('report email', async () => {
+      const message = {
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: Buffer.from(JSON.stringify(data)),
+      };
+      await messageHandler(message);
+
+      assert.equal(log.warn.callCount, 1);
+      args = log.warn.args[0];
+      assert.lengthOf(args, 1);
+      assert.deepEqual(args[0], {
+        op: 'dataflow.report',
+        email: 'pb@example.com',
+        severity: 'warn',
+        confidence: 42,
+        heuristic: 'heurizzle',
+        heuristic_description: 'this is a heuristic',
+        reason: 'because',
+        suggested_action: 'report',
+      });
+
+      assert.equal(message.ack.callCount, 1);
+      assert.lengthOf(message.ack.args[0], 0);
+
+      assert.equal(log.info.callCount, 1);
+      args = log.info.args[0];
+      assert.lengthOf(args, 1);
+      assert.deepEqual(args[0], {
+        op: 'dataflow.message.success',
+        id: 'blee',
+        email: 'pb@example.com',
+        suggested_action: 'report',
+        reportOnly: false,
+      });
+
+      assert.equal(message.nack.callCount, 0);
+      assert.equal(log.error.callCount, 0);
+      assert.equal(fetchRecords.callCount, 0);
+      assert.equal(setRecords.callCount, 0);
+    });
+
+    test('report sourceaddress', async () => {
+      const message = {
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: Buffer.from(
+          JSON.stringify({
+            ...data,
+            indicator_type: 'sourceaddress',
+            indicator: '1.1.1.1',
+          })
+        ),
+      };
+      await messageHandler(message);
+
+      assert.equal(log.warn.callCount, 1);
+      args = log.warn.args[0];
+      assert.equal(args[0].ip, '1.1.1.1');
+      assert.isUndefined(args[0].email);
+
+      assert.equal(message.ack.callCount, 1);
+
+      assert.equal(log.info.callCount, 1);
+      args = log.info.args[0];
+      assert.equal(args[0].ip, '1.1.1.1');
+      assert.isUndefined(args[0].email);
+
+      assert.equal(message.nack.callCount, 0);
+      assert.equal(log.error.callCount, 0);
+      assert.equal(fetchRecords.callCount, 0);
+      assert.equal(setRecords.callCount, 0);
+    });
+
+    test('suspect email', async () => {
+      const message = {
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: Buffer.from(
+          JSON.stringify({
+            ...data,
+            suggested_action: 'suspect',
+          })
+        ),
+      };
+      await messageHandler(message);
+
+      assert.equal(fetchRecords.callCount, 1);
+      args = fetchRecords.args[0];
+      assert.lengthOf(args, 1);
+      assert.deepEqual(args[0], {
+        email: 'pb@example.com',
+      });
+
+      assert.equal(records.email.suspect.callCount, 1);
+      assert.lengthOf(records.email.suspect.args[0], 0);
+
+      assert.equal(setRecords.callCount, 1);
+      args = setRecords.args[0];
+      assert.lengthOf(args, 1);
+      assert.equal(args[0], records);
+      assert.isTrue(setRecords.calledAfter(records.email.suspect));
+
+      assert.equal(message.ack.callCount, 1);
+
+      assert.equal(log.info.callCount, 1);
+      assert.deepEqual(log.info.args[0][0], {
+        op: 'dataflow.message.success',
+        id: 'blee',
+        email: 'pb@example.com',
+        suggested_action: 'suspect',
+        reportOnly: false,
+      });
+
+      assert.equal(message.nack.callCount, 0);
+      assert.equal(log.warn.callCount, 0);
+      assert.equal(log.error.callCount, 0);
+      assert.equal(records.email.block.callCount, 0);
+      assert.equal(records.email.disable.callCount, 0);
+      assert.equal(records.ip.suspect.callCount, 0);
+      assert.equal(records.ip.block.callCount, 0);
+      assert.equal(records.ip.disable.callCount, 0);
+    });
+
+    test('suspect sourceaddress', async () => {
+      const message = {
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: Buffer.from(
+          JSON.stringify({
+            ...data,
+            suggested_action: 'suspect',
+            indicator_type: 'sourceaddress',
+            indicator: '1.1.1.1',
+          })
+        ),
+      };
+      await messageHandler(message);
+
+      assert.equal(fetchRecords.callCount, 1);
+      assert.deepEqual(fetchRecords.args[0][0], {
+        ip: '1.1.1.1',
+      });
+
+      assert.equal(records.ip.suspect.callCount, 1);
+      assert.lengthOf(records.ip.suspect.args[0], 0);
+
+      assert.equal(setRecords.callCount, 1);
+      assert.equal(setRecords.args[0][0], records);
+      assert.isTrue(setRecords.calledAfter(records.ip.suspect));
+
+      assert.equal(message.ack.callCount, 1);
+
+      assert.equal(log.info.callCount, 1);
+      assert.equal(log.info.args[0][0].ip, '1.1.1.1');
+
+      assert.equal(message.nack.callCount, 0);
+      assert.equal(log.warn.callCount, 0);
+      assert.equal(log.error.callCount, 0);
+      assert.equal(records.email.suspect.callCount, 0);
+      assert.equal(records.email.block.callCount, 0);
+      assert.equal(records.email.disable.callCount, 0);
+      assert.equal(records.ip.block.callCount, 0);
+      assert.equal(records.ip.disable.callCount, 0);
+    });
+
+    test('block', async () => {
+      const message = {
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: Buffer.from(
+          JSON.stringify({
+            ...data,
+            suggested_action: 'block',
+          })
+        ),
+      };
+      await messageHandler(message);
+
+      assert.equal(fetchRecords.callCount, 1);
+
+      assert.equal(records.email.block.callCount, 1);
+      assert.lengthOf(records.email.block.args[0], 0);
+
+      assert.equal(setRecords.callCount, 1);
+      assert.equal(setRecords.args[0][0], records);
+      assert.isTrue(setRecords.calledAfter(records.email.block));
+
+      assert.equal(message.ack.callCount, 1);
+
+      assert.equal(log.info.callCount, 1);
+
+      assert.equal(message.nack.callCount, 0);
+      assert.equal(log.warn.callCount, 0);
+      assert.equal(log.error.callCount, 0);
+      assert.equal(records.email.suspect.callCount, 0);
+      assert.equal(records.email.disable.callCount, 0);
+      assert.equal(records.ip.suspect.callCount, 0);
+      assert.equal(records.ip.block.callCount, 0);
+      assert.equal(records.ip.disable.callCount, 0);
+    });
+
+    test('disable', async () => {
+      const message = {
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: Buffer.from(
+          JSON.stringify({
+            ...data,
+            suggested_action: 'disable',
+          })
+        ),
+      };
+      await messageHandler(message);
+
+      assert.equal(fetchRecords.callCount, 1);
+
+      assert.equal(records.email.disable.callCount, 1);
+      assert.lengthOf(records.email.disable.args[0], 0);
+
+      assert.equal(setRecords.callCount, 1);
+      assert.equal(setRecords.args[0][0], records);
+      assert.isTrue(setRecords.calledAfter(records.email.disable));
+
+      assert.equal(message.ack.callCount, 1);
+
+      assert.equal(log.info.callCount, 1);
+
+      assert.equal(message.nack.callCount, 0);
+      assert.equal(log.warn.callCount, 0);
+      assert.equal(log.error.callCount, 0);
+      assert.equal(records.email.suspect.callCount, 0);
+      assert.equal(records.email.block.callCount, 0);
+      assert.equal(records.ip.suspect.callCount, 0);
+      assert.equal(records.ip.block.callCount, 0);
+      assert.equal(records.ip.disable.callCount, 0);
+    });
+
+    test('error handler', () => {
+      errorHandler(new TypeError('something failed'));
+
+      assert.equal(log.error.callCount, 1);
+      args = log.error.args[0];
+      assert.lengthOf(args, 1);
+      assert.deepEqual(args[0], {
+        op: 'dataflow.subscription.error',
+        error: 'TypeError: something failed',
+      });
+
+      assert.equal(log.info.callCount, 0);
+      assert.equal(log.warn.callCount, 0);
+      assert.equal(fetchRecords.callCount, 0);
+      assert.equal(setRecords.callCount, 0);
     });
   });
 
-  test('processMessage', () => {
-    test('parse error logs an error', () => {
-      const message = {};
-      const { processMessage } = dataflow(config, log, async () => ({}));
+  test('config.reportOnly', () => {
+    config.dataflow.reportOnly = true;
 
-      const checkMetadata = sinon.spy();
-      processMessage(message, () => {
-        throw new Error('uh oh');
+    dataflow(config, log, fetchRecords, setRecords);
+
+    assert.equal(PubSub.callCount, 1);
+    assert.equal(pubsub.subscription.callCount, 1);
+
+    assert.equal(subscription.on.callCount, 2);
+    args = subscription.on.args[0];
+    assert.equal(args[0], 'message');
+    const messageHandler = args[1];
+    assert.isFunction(messageHandler);
+
+    assert.equal(log.error.callCount, 0);
+    assert.equal(log.info.callCount, 0);
+    assert.equal(log.warn.callCount, 0);
+    assert.equal(fetchRecords.callCount, 0);
+    assert.equal(setRecords.callCount, 0);
+
+    test('report', async () => {
+      const message = {
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: Buffer.from(JSON.stringify(data)),
+      };
+      await messageHandler(message);
+
+      assert.equal(log.warn.callCount, 1);
+      assert.deepEqual(log.warn.args[0][0], {
+        op: 'dataflow.report',
+        email: 'pb@example.com',
+        severity: 'warn',
+        confidence: 42,
+        heuristic: 'heurizzle',
+        heuristic_description: 'this is a heuristic',
+        reason: 'because',
+        suggested_action: 'report',
       });
 
-      assert.strictEqual(log.error.callCount, 1);
-      assert.isTrue(
-        log.error.calledOnceWith({
-          op: 'dataflow.message.invalid',
-          reason: 'uh oh',
-        })
-      );
+      assert.equal(message.ack.callCount, 1);
 
-      assert.isFalse(checkMetadata.called);
+      assert.equal(log.info.callCount, 1);
+
+      assert.equal(message.nack.callCount, 0);
+      assert.equal(log.error.callCount, 0);
+      assert.equal(fetchRecords.callCount, 0);
+      assert.equal(setRecords.callCount, 0);
     });
 
-    test('properly formed message is checked for unexpected blocks', () => {
-      const message = {};
-      const { processMessage } = dataflow(config, log, async () => ({}));
+    test('suspect', async () => {
+      const message = {
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: Buffer.from(
+          JSON.stringify({
+            ...data,
+            suggested_action: 'suspect',
+          })
+        ),
+      };
+      await messageHandler(message);
 
-      const processBlockEvent = sinon.spy();
-      processMessage(message, () => {
-        throw new Error('uh oh');
-      });
+      assert.equal(log.warn.callCount, 1);
+      assert.deepEqual(log.warn.args[0][0].suggested_action, 'suspect');
 
-      assert.strictEqual(log.error.callCount, 1);
-      assert.isTrue(
-        log.error.calledOnceWith({
-          op: 'dataflow.message.invalid',
-          reason: 'uh oh',
-        })
-      );
+      assert.equal(message.ack.callCount, 1);
 
-      assert.isFalse(processBlockEvent.called);
-    });
-  });
+      assert.equal(log.info.callCount, 1);
 
-  test('parseMessage', () => {
-    const { parseMessage } = dataflow(config, log, async () => ({}));
-
-    test('no message throws an error', () => {
-      assert.throws(() => parseMessage(), 'missing message');
-    });
-
-    test('no data throws an error', () => {
-      assert.throws(() => parseMessage({}), 'missing message data');
-      assert.throws(() => parseMessage({ foo: 'bar' }), 'missing message data');
+      assert.equal(message.nack.callCount, 0);
+      assert.equal(log.error.callCount, 0);
+      assert.equal(fetchRecords.callCount, 0);
+      assert.equal(setRecords.callCount, 0);
     });
 
-    test('invalid data throws an error (must be a Buffer)', () => {
-      assert.throws(
-        () => parseMessage({ data: 1 }),
-        'message data is not a Buffer'
-      );
+    test('block', async () => {
+      const message = {
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: Buffer.from(
+          JSON.stringify({
+            ...data,
+            suggested_action: 'block',
+          })
+        ),
+      };
+      await messageHandler(message);
+
+      assert.equal(log.warn.callCount, 1);
+      assert.deepEqual(log.warn.args[0][0].suggested_action, 'block');
+
+      assert.equal(message.ack.callCount, 1);
+
+      assert.equal(log.info.callCount, 1);
+
+      assert.equal(message.nack.callCount, 0);
+      assert.equal(log.error.callCount, 0);
+      assert.equal(fetchRecords.callCount, 0);
+      assert.equal(setRecords.callCount, 0);
     });
 
-    test('invalid JSON throw an error', () => {
-      assert.throws(
-        () => parseMessage({ data: Buffer.from('{') }),
-        'Unexpected end of JSON input'
-      );
-    });
-
-    test('missing metadata throws an error', () => {
-      assert.throws(() =>
-        parseMessage({ data: Buffer.from(JSON.stringify({})) })
-      );
-    });
-
-    test('invalid metadata throws an error', () => {
-      assert.throws(() =>
-        parseMessage({ data: Buffer.from(JSON.stringify({ metadata: 1 })) })
-      );
-    });
-
-    test('missing entry key throws an error', () => {
-      assert.throws(
-        () =>
-          parseMessage({
-            data: Buffer.from(
-              JSON.stringify({
-                metadata: [{ value: 'bar' }],
-              })
-            ),
-          }),
-        'missing metadata key'
-      );
-    });
-
-    test('missing entry value throws an error', () => {
-      assert.throws(
-        () =>
-          parseMessage({
-            data: Buffer.from(
-              JSON.stringify({
-                metadata: [{ key: 'bar' }],
-              })
-            ),
-          }),
-        'missing metadata value'
-      );
-    });
-
-    test('valid message returns metadata array converted to an object', () => {
-      assert.deepEqual(
-        parseMessage({
-          data: Buffer.from(
-            JSON.stringify({
-              metadata: [
-                {
-                  key: 'foo',
-                  value: 'bar',
-                },
-                {
-                  key: 'biz',
-                  value: 'buz',
-                },
-              ],
-            })
-          ),
-        }),
-        {
-          biz: 'buz',
-          foo: 'bar',
-        }
-      );
-    });
-  });
-
-  test('checkForUnexpectedBlock', () => {
-    let fetchSpy;
-
-    const { checkForUnexpectedBlock } = dataflow(config, log, (...args) =>
-      fetchSpy(...args)
-    );
-
-    test('missing customs_category logs an error', () => {
-      fetchSpy = sinon.spy();
-
-      checkForUnexpectedBlock({
-        accountid: 'testuser@testusre.com',
-        sourceaddress: '127.0.0.1',
-      });
-
-      assert.isTrue(log.error.calledOnce);
-      assert.isTrue(
-        log.error.calledOnceWith({
-          op: 'dataflow.customs_category.missing',
-        })
-      );
-
-      assert.isFalse(fetchSpy.called);
-    });
-
-    test('unknown category logs an error', () => {
-      fetchSpy = sinon.spy();
-
-      checkForUnexpectedBlock({
-        customs_category: 'category',
-        accountid: 'testuser@testusre.com',
-        sourceaddress: '127.0.0.1',
-      });
-
-      assert.isTrue(log.error.calledOnce);
-      assert.isTrue(
-        log.error.calledOnceWith({
-          op: 'dataflow.customs_category.unknown',
-          customs_category: 'category',
-        })
-      );
-
-      assert.isFalse(fetchSpy.called);
-    });
-
-    test('rl_login_failure_sourceaddress_accountid', () => {
-      test('no ipEmailRecord logs an unexpected block', async () => {
-        fetchSpy = sinon.spy(() => ({}));
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_login_failure_sourceaddress_accountid',
-          accountid: 'foo',
-          sourceaddress: 'bar',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            email: 'foo',
-            ip: 'bar',
+    test('disable', async () => {
+      const message = {
+        ack: sandbox.spy(),
+        nack: sandbox.spy(),
+        id: 'blee',
+        data: Buffer.from(
+          JSON.stringify({
+            ...data,
+            suggested_action: 'disable',
           })
-        );
+        ),
+      };
+      await messageHandler(message);
 
-        assert.equal(log.info.callCount, 1);
-        assert.isTrue(
-          log.info.calledOnceWith({
-            accountid: 'foo',
-            customs_category: 'rl_login_failure_sourceaddress_accountid',
-            op: 'dataflow.block.unexpected',
-            sourceaddress: 'bar',
-          })
-        );
-      });
+      assert.equal(log.warn.callCount, 1);
+      assert.deepEqual(log.warn.args[0][0].suggested_action, 'disable');
 
-      test('ipEmailRecord is not blocked logs an unexpected block', async () => {
-        const records = {
-          ipEmailRecord: {
-            shouldBlock: sinon.spy(() => false),
-          },
-        };
+      assert.equal(message.ack.callCount, 1);
 
-        fetchSpy = sinon.spy(() => records);
+      assert.equal(log.info.callCount, 1);
 
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_login_failure_sourceaddress_accountid',
-          accountid: 'foo',
-          sourceaddress: 'bar',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            email: 'foo',
-            ip: 'bar',
-          })
-        );
-
-        assert.isTrue(records.ipEmailRecord.shouldBlock.calledOnce);
-
-        assert.equal(log.info.callCount, 1);
-        assert.isTrue(
-          log.info.calledOnceWith({
-            accountid: 'foo',
-            customs_category: 'rl_login_failure_sourceaddress_accountid',
-            op: 'dataflow.block.unexpected',
-            sourceaddress: 'bar',
-          })
-        );
-      });
-
-      test('ipEmailRecord is blocked logs an expected block', async () => {
-        const records = {
-          ipEmailRecord: {
-            shouldBlock: sinon.spy(() => true),
-          },
-        };
-
-        fetchSpy = sinon.spy(() => records);
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_login_failure_sourceaddress_accountid',
-          accountid: 'foo',
-          sourceaddress: 'bar',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            email: 'foo',
-            ip: 'bar',
-          })
-        );
-
-        assert.isTrue(records.ipEmailRecord.shouldBlock.calledOnce);
-
-        assert.isTrue(
-          log.info.calledOnceWith({
-            accountid: 'foo',
-            customs_category: 'rl_login_failure_sourceaddress_accountid',
-            op: 'dataflow.block.expected',
-            sourceaddress: 'bar',
-          })
-        );
-      });
-    });
-
-    test('rl_sms_sourceaddress', () => {
-      test('no ipRecord logs an unexpected block', async () => {
-        fetchSpy = sinon.spy(() => ({}));
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_sms_sourceaddress',
-          sourceaddress: 'bar',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            ip: 'bar',
-          })
-        );
-
-        assert.equal(log.info.callCount, 1);
-        assert.isTrue(
-          log.info.calledOnceWith({
-            customs_category: 'rl_sms_sourceaddress',
-            op: 'dataflow.block.unexpected',
-            sourceaddress: 'bar',
-          })
-        );
-      });
-
-      test('ipRecord is not blocked logs an unexpected block', async () => {
-        const records = {
-          ipRecord: {
-            shouldBlock: sinon.spy(() => false),
-          },
-        };
-
-        fetchSpy = sinon.spy(() => records);
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_sms_sourceaddress',
-          sourceaddress: 'bar',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            ip: 'bar',
-          })
-        );
-
-        assert.isTrue(records.ipRecord.shouldBlock.calledOnce);
-
-        assert.equal(log.info.callCount, 1);
-        assert.isTrue(
-          log.info.calledOnceWith({
-            customs_category: 'rl_sms_sourceaddress',
-            op: 'dataflow.block.unexpected',
-            sourceaddress: 'bar',
-          })
-        );
-      });
-
-      test('ipRecord is blocked logs an expected block', async () => {
-        const records = {
-          ipRecord: {
-            shouldBlock: sinon.spy(() => true),
-          },
-        };
-
-        fetchSpy = sinon.spy(() => records);
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_sms_sourceaddress',
-          sourceaddress: 'bar',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            ip: 'bar',
-          })
-        );
-
-        assert.isTrue(records.ipRecord.shouldBlock.calledOnce);
-
-        assert.isTrue(
-          log.info.calledOnceWith({
-            customs_category: 'rl_sms_sourceaddress',
-            op: 'dataflow.block.expected',
-            sourceaddress: 'bar',
-          })
-        );
-      });
-    });
-
-    test('rl_sms_accountid', () => {
-      test('no emailRecord logs an unexpected block', async () => {
-        fetchSpy = sinon.spy(() => ({}));
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_sms_accountid',
-          accountid: 'foo',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            email: 'foo',
-          })
-        );
-
-        assert.equal(log.info.callCount, 1);
-        assert.isTrue(
-          log.info.calledOnceWith({
-            accountid: 'foo',
-            customs_category: 'rl_sms_accountid',
-            op: 'dataflow.block.unexpected',
-          })
-        );
-      });
-
-      test('emailRecord is not blocked logs an unexpected block', async () => {
-        const records = {
-          emailRecord: {
-            shouldBlock: sinon.spy(() => false),
-          },
-        };
-
-        fetchSpy = sinon.spy(() => records);
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_sms_accountid',
-          accountid: 'foo',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            email: 'foo',
-          })
-        );
-
-        assert.isTrue(records.emailRecord.shouldBlock.calledOnce);
-
-        assert.equal(log.info.callCount, 1);
-        assert.isTrue(
-          log.info.calledOnceWith({
-            accountid: 'foo',
-            customs_category: 'rl_sms_accountid',
-            op: 'dataflow.block.unexpected',
-          })
-        );
-      });
-
-      test('emailRecord is blocked logs an expected block', async () => {
-        const records = {
-          emailRecord: {
-            shouldBlock: sinon.spy(() => true),
-          },
-        };
-
-        fetchSpy = sinon.spy(() => records);
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_sms_accountid',
-          accountid: 'foo',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            email: 'foo',
-          })
-        );
-
-        assert.isTrue(records.emailRecord.shouldBlock.calledOnce);
-
-        assert.isTrue(
-          log.info.calledOnceWith({
-            accountid: 'foo',
-            customs_category: 'rl_sms_accountid',
-            op: 'dataflow.block.expected',
-          })
-        );
-      });
-    });
-
-    test('rl_email_recipient', () => {
-      test('no emailRecord logs an unexpected block', async () => {
-        fetchSpy = sinon.spy(() => ({}));
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_email_recipient',
-          accountid: 'foo',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            email: 'foo',
-          })
-        );
-
-        assert.equal(log.info.callCount, 1);
-        assert.isTrue(
-          log.info.calledOnceWith({
-            accountid: 'foo',
-            customs_category: 'rl_email_recipient',
-            op: 'dataflow.block.unexpected',
-          })
-        );
-      });
-
-      test('emailRecord is not blocked logs an unexpected block', async () => {
-        const records = {
-          emailRecord: {
-            shouldBlock: sinon.spy(() => false),
-          },
-        };
-
-        fetchSpy = sinon.spy(() => records);
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_email_recipient',
-          accountid: 'foo',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            email: 'foo',
-          })
-        );
-
-        assert.isTrue(records.emailRecord.shouldBlock.calledOnce);
-
-        assert.equal(log.info.callCount, 1);
-        assert.isTrue(
-          log.info.calledOnceWith({
-            accountid: 'foo',
-            customs_category: 'rl_email_recipient',
-            op: 'dataflow.block.unexpected',
-          })
-        );
-      });
-
-      test('emailRecord is blocked logs an expected block', async () => {
-        const records = {
-          emailRecord: {
-            shouldBlock: sinon.spy(() => true),
-          },
-        };
-
-        fetchSpy = sinon.spy(() => records);
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_email_recipient',
-          accountid: 'foo',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            email: 'foo',
-          })
-        );
-
-        assert.isTrue(records.emailRecord.shouldBlock.calledOnce);
-
-        assert.isTrue(
-          log.info.calledOnceWith({
-            accountid: 'foo',
-            customs_category: 'rl_email_recipient',
-            op: 'dataflow.block.expected',
-          })
-        );
-      });
-    });
-
-    test('rl_statuscheck', () => {
-      test('no ipRecord logs an unexpected block', async () => {
-        fetchSpy = sinon.spy(() => ({}));
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_statuscheck',
-          sourceaddress: 'bar',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            ip: 'bar',
-          })
-        );
-
-        assert.equal(log.info.callCount, 1);
-        assert.isTrue(
-          log.info.calledOnceWith({
-            customs_category: 'rl_statuscheck',
-            op: 'dataflow.block.unexpected',
-            sourceaddress: 'bar',
-          })
-        );
-      });
-
-      test('ipRecord is not blocked logs an unexpected block', async () => {
-        const records = {
-          ipRecord: {
-            shouldBlock: sinon.spy(() => false),
-          },
-        };
-
-        fetchSpy = sinon.spy(() => records);
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_statuscheck',
-          sourceaddress: 'bar',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            ip: 'bar',
-          })
-        );
-
-        assert.isTrue(records.ipRecord.shouldBlock.calledOnce);
-
-        assert.equal(log.info.callCount, 1);
-        assert.isTrue(
-          log.info.calledOnceWith({
-            customs_category: 'rl_statuscheck',
-            op: 'dataflow.block.unexpected',
-            sourceaddress: 'bar',
-          })
-        );
-      });
-
-      test('ipRecord is blocked logs an expected block', async () => {
-        const records = {
-          ipRecord: {
-            shouldBlock: sinon.spy(() => true),
-          },
-        };
-
-        fetchSpy = sinon.spy(() => records);
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_statuscheck',
-          sourceaddress: 'bar',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            ip: 'bar',
-          })
-        );
-
-        assert.isTrue(records.ipRecord.shouldBlock.calledOnce);
-
-        assert.isTrue(
-          log.info.calledOnceWith({
-            customs_category: 'rl_statuscheck',
-            op: 'dataflow.block.expected',
-            sourceaddress: 'bar',
-          })
-        );
-      });
-    });
-
-    test('rl_verifycode_sourceaddress_accountid', () => {
-      test('no uidRecord logs an unexpected block', async () => {
-        fetchSpy = sinon.spy(() => ({}));
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_verifycode_sourceaddress_accountid',
-          sourceaddress: 'bar',
-          uid: 'buz',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            uid: 'buz',
-          })
-        );
-
-        assert.equal(log.info.callCount, 1);
-        assert.isTrue(
-          log.info.calledOnceWith({
-            customs_category: 'rl_verifycode_sourceaddress_accountid',
-            op: 'dataflow.block.unexpected',
-            sourceaddress: 'bar',
-            uid: 'buz',
-          })
-        );
-      });
-
-      test('uidRecord is not blocked logs an unexpected block', async () => {
-        const records = {
-          uidRecord: {
-            isRateLimited: sinon.spy(() => false),
-          },
-        };
-
-        fetchSpy = sinon.spy(() => records);
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_verifycode_sourceaddress_accountid',
-          sourceaddress: 'bar',
-          uid: 'buz',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            uid: 'buz',
-          })
-        );
-
-        assert.isTrue(records.uidRecord.isRateLimited.calledOnce);
-
-        assert.equal(log.info.callCount, 1);
-        assert.isTrue(
-          log.info.calledOnceWith({
-            customs_category: 'rl_verifycode_sourceaddress_accountid',
-            op: 'dataflow.block.unexpected',
-            sourceaddress: 'bar',
-            uid: 'buz',
-          })
-        );
-      });
-
-      test('uidRecord is blocked logs an expected block', async () => {
-        const records = {
-          uidRecord: {
-            isRateLimited: sinon.spy(() => true),
-          },
-        };
-
-        fetchSpy = sinon.spy(() => records);
-
-        await checkForUnexpectedBlock({
-          customs_category: 'rl_verifycode_sourceaddress_accountid',
-          sourceaddress: 'bar',
-          uid: 'buz',
-        });
-
-        assert.isTrue(
-          fetchSpy.calledOnceWith({
-            uid: 'buz',
-          })
-        );
-
-        assert.isTrue(records.uidRecord.isRateLimited.calledOnce);
-
-        assert.isTrue(
-          log.info.calledOnceWith({
-            customs_category: 'rl_verifycode_sourceaddress_accountid',
-            op: 'dataflow.block.expected',
-            sourceaddress: 'bar',
-            uid: 'buz',
-          })
-        );
-      });
+      assert.equal(message.nack.callCount, 0);
+      assert.equal(log.error.callCount, 0);
+      assert.equal(fetchRecords.callCount, 0);
+      assert.equal(setRecords.callCount, 0);
     });
   });
+
+  function test(name, callback) {
+    // Wrap tap so that sandbox is reset automatically and return
+    // a promise so we don't have to call t.end() like a chump.
+    tapTest(name, async () => {
+      sandbox.reset();
+      await callback();
+    });
+  }
 });

--- a/packages/fxa-customs-server/test/local/email_record_tests.js
+++ b/packages/fxa-customs-server/test/local/email_record_tests.js
@@ -11,7 +11,9 @@ function now() {
 function simpleEmailRecord() {
   var limits = {
     rateLimitIntervalMs: 500,
+    suspectIntervalMs: 700,
     blockIntervalMs: 800,
+    disableIntervalMs: 900,
     maxEmails: 2,
     maxUnblockAttempts: 2,
   };
@@ -22,7 +24,7 @@ test('shouldBlock works', function(t) {
   var er = simpleEmailRecord();
 
   t.equal(er.shouldBlock(), false, 'record has never been blocked');
-  er.rl = 499;
+  er.rl = 500;
   t.equal(
     er.shouldBlock(),
     false,
@@ -37,10 +39,50 @@ test('shouldBlock works', function(t) {
   delete er.rl;
   t.equal(er.shouldBlock(), false, 'record is no longer blocked');
 
-  er.bk = 199;
+  er.bk = 200;
   t.equal(er.shouldBlock(), false, 'blockedAt is older than block interval');
   er.bk = 201;
   t.equal(er.shouldBlock(), true, 'blockedAt is within the block interval');
+  delete er.bk;
+  t.equal(er.shouldBlock(), false);
+
+  er.di = 100;
+  t.equal(er.shouldBlock(), false);
+  er.di = 101;
+  t.equal(er.shouldBlock(), true);
+  delete er.di;
+  t.equal(er.shouldBlock(), false);
+
+  t.end();
+});
+
+test('suspect', t => {
+  const record = simpleEmailRecord();
+  t.equal(record.isSuspected(), false);
+
+  record.suspect();
+  t.equal(record.isSuspected(), true);
+
+  t.end();
+});
+
+test('block', t => {
+  const record = simpleEmailRecord();
+  t.equal(record.isBlocked(), false);
+
+  record.block();
+  t.equal(record.isBlocked(), true);
+
+  t.end();
+});
+
+test('disable', t => {
+  const record = simpleEmailRecord();
+  t.equal(record.isDisabled(), false);
+
+  record.disable();
+  t.equal(record.isDisabled(), true);
+
   t.end();
 });
 

--- a/packages/fxa-customs-server/test/local/ip_record_tests.js
+++ b/packages/fxa-customs-server/test/local/ip_record_tests.js
@@ -10,7 +10,9 @@ function now() {
 
 function simpleIpRecord() {
   var limits = {
+    suspectIntervalMs: 110000,
     blockIntervalMs: 120000,
+    disableIntervalMs: 130000,
     ipRateLimitIntervalMs: 1000,
     ipRateLimitBanDurationMs: 1000,
     maxBadLoginsPerIp: 3,
@@ -30,15 +32,45 @@ test('shouldBlock works', function(t) {
   t.equal(ir.shouldBlock(), true, 'record is still blocked');
   ir.bk = now() - 120 * 1000; // blockInterval
   t.equal(ir.shouldBlock(), false, 'record is no longer blocked');
+
+  ir.di = now() - 129999;
+  t.equal(ir.shouldBlock(), true);
+  ir.di = now() - 130000;
+  t.equal(ir.shouldBlock(), false);
+
   t.end();
 });
 
-test('block works', function(t) {
-  var ir = simpleIpRecord();
+test('suspect', t => {
+  const record = simpleIpRecord();
+  t.equal(record.isSuspected(), false);
 
-  t.equal(ir.shouldBlock(), false, 'record has never been blocked');
+  record.suspect();
+  t.equal(record.isSuspected(), true);
+
+  t.end();
+});
+
+test('block', t => {
+  const ir = simpleIpRecord();
+
+  t.equal(ir.shouldBlock(), false);
+  t.equal(ir.isBlocked(), false);
+
   ir.block();
-  t.equal(ir.shouldBlock(), true, 'record is blocked');
+  t.equal(ir.shouldBlock(), true);
+  t.equal(ir.isBlocked(), true);
+
+  t.end();
+});
+
+test('disable', t => {
+  const record = simpleIpRecord();
+  t.equal(record.isDisabled(), false);
+
+  record.disable();
+  t.equal(record.isDisabled(), true);
+
   t.end();
 });
 


### PR DESCRIPTION
Fixes #2116.

This is not a perfect implementation, but hopefully it's a reasonable first stab. It seeks to be a compromise between the vision set out in the [proposal](https://docs.google.com/document/d/12PhwR8k8cuesjhmgIjYrYTZwSAD-7M_oNecOZ5zuZSE) and the current reality of the customs server codebase. Essentially I've tried to implement everything in the least disruptive way possible, because I'm conscious that there's an overhaul planned at some point.

I'll add inline commentary to call out some of the more contentious details, but the headlines are:

* New properties for `suspect` and `disable` are added to the email and IP records.

* `disable` is stored in memcached like everything else, even though it's intended to be a long-term ban that's wholly unsuited to memcached's eviction policy. There's some discussion around this point in the proposal doc and a follow-up PR will be needed to implement the long-term resolution.

* Contrary to discussion in the proposal, `block` re-uses the existing limit from config instead of an independent one, just to keep the code a bit cleaner. It makes the email and IP records (and their callers) messier if we have two different types of blocks, with independent limits and methods for setting/checking.

* The existing dataflow module has pretty much been gutted because there's no relationship between the old message format and the new one. To that end, the diff is kind of unhelpful here and it might be easier to review the entire module instead of looking at the diff.

* A `reportOnly` property is added to config, initially defaulting to `true` so we can make sure we're comfortable with it in prod before flipping switches to make it actually do stuff.

Opened as a draft because I haven't done any end-to-end testing against real messages yet. And also because we don't want to land it until we're ready.

Still worth reviewing though, I think the code should be in a good state and there's unit test coverage in place.

@mozilla/fxa-devs r?

/cc @ameihm0912.