### PR TITLE
fix(css): Fix change avatar spinner not loading correctly

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/avatar_change.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/avatar_change.mustache
@@ -1,11 +1,8 @@
 <div id="avatar-change">
   <section class="modal-panel">
     <div class="main-avatar">
-      <div id="loading-avatar-spinner">
-        <img alt="" src="../../../images/spinnerlight.svg">
-      </div>
-      <p id="image-holder" class="avatar-wrapper">
-      </p>
+      <div id="loading-avatar-spinner"></div>
+      <p id="image-holder" class="avatar-wrapper"></p>
     </div>
 
     <div class="error"></div>

--- a/packages/fxa-content-server/app/styles/modules/_spinner.scss
+++ b/packages/fxa-content-server/app/styles/modules/_spinner.scss
@@ -11,8 +11,11 @@
   width: 36px;
 }
 
-#loading-avatar-spinner img {
+#loading-avatar-spinner {
   animation: 0.9s spin infinite linear;
+  background-image: url('/images/spinnerlight.svg');
+  background-repeat: no-repeat;
+  background-size: 100%;
   display: inline-block;
   height: $avatar-size;
   margin: 0 0 5px;


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/1107

Image was not loading in stage because the relative path was not pointing to correct location. Fixed by loading the image from css.