### PR TITLE
fix(experiment): Fix signup code experiment so it reports to amplitude

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -38,6 +38,7 @@ const EMAIL_TYPES = {
   recoveryEmail: 'reset_password',
   unblockCode: 'unblock',
   verifyEmail: 'registration',
+  verifyShortCodeEmail: 'registration',
   verifyLoginEmail: 'login',
   verifyLoginCodeEmail: 'login',
   verifyPrimaryEmail: 'verify',

--- a/packages/fxa-content-server/app/scripts/lib/experiment.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiment.js
@@ -23,6 +23,7 @@ const MANUAL_EXPERIMENTS = {
   emailFirst: BaseExperiment,
   // For now, the send SMS experiment only needs to log "enrolled", so
   // no special experiment is created.
+  signupCode: BaseExperiment,
   sendSms: BaseExperiment,
   tokenCode: BaseExperiment,
   totp: BaseExperiment,

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/README.md
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/README.md
@@ -11,6 +11,7 @@ and if so, which group.
 4. Fill in the `choose` function.
 5. Include the new grouping rule file in [index.js](https://github.com/mozilla/fxa-content-server/tree/master/app/scripts/experiments/grouping-rules/index.js).
 6. Access in views via `this.experiments.choose('name from 3')`
+7. Add to manual [experiment rules](https://github.com/mozilla/fxa-content-server/tree/master/app/scripts/lib/experiments.js) if needed.
 
 ## `choose` recipes
 
@@ -139,4 +140,14 @@ choose (subject = {}) {
 if (this.isInExperimentGroup('experiment-2', 'treatment')) {
     // do something awesome here.
 }
+```
+
+#### add as manual experiment
+
+```js
+const MANUAL_EXPERIMENTS = {
+    emailFirst: BaseExperiment,
+    // The next great experiment
+    sendSms: BaseExperiment,
+};
 ```


### PR DESCRIPTION
Fixes #2458 

After a little digging, I found that the experiment was not included in the manual experiments. Once it was added there the experiment data was logged. I also updated the experiment docs to mention this.

Targeting as a point release on train 145

<img width="914" alt="Screen Shot 2019-09-10 at 4 21 03 PM" src="https://user-images.githubusercontent.com/1295288/64647432-010c4c00-d3e7-11e9-8f13-66280f56e9a5.png">

