### PR TITLE
fix(payments): respond to /__version__

### DIFF
--- a/packages/fxa-payments-server/Dockerfile-test
+++ b/packages/fxa-payments-server/Dockerfile-test
@@ -1,18 +1,6 @@
-FROM node:12-stretch AS node-builder
-RUN groupadd --gid 10001 app  && \
-    useradd --uid 10001 --gid 10001 --home /app --create-home app
-USER app
-WORKDIR /app
-COPY package*.json ./
-RUN npm install
-
-FROM node:12-stretch-slim
-RUN groupadd --gid 10001 app  && \
-    useradd --uid 10001 --gid 10001 --home /app --create-home app
-USER app
-WORKDIR /app
-COPY --chown=app:app --from=node-builder /app .
-COPY --chown=app:app . .
+# the build image does a full `npm ci` and `npm run build`.
+# It is ready to test, but needs one evironment setting.
+FROM fxa-payments-server:build
 
 # Jest test runner needs this to disable interactive mode
 ENV CI=yes

--- a/packages/fxa-payments-server/package-lock.json
+++ b/packages/fxa-payments-server/package-lock.json
@@ -5701,6 +5701,12 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
+      "dev": true
+    },
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -8242,6 +8248,12 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
       "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
+      "dev": true
+    },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
       "dev": true
     },
     "forwarded": {
@@ -17621,6 +17633,34 @@
             "uniq": "^1.0.1"
           }
         }
+      }
+    },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      }
+    },
+    "supertest": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-4.0.2.tgz",
+      "integrity": "sha512-1BAbvrOZsGA3YTCWqbmh14L0YEq0EGICX/nBnfkfVJn7SrxQV1I3pMYjSzG9y/7ZU2V9dWqyqk2POwxlb09duQ==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^3.8.3"
       }
     },
     "supports-color": {

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -76,6 +76,7 @@
     "prettier": "^1.18.2",
     "redux-devtools-extension": "^2.13.8",
     "sass-lint": "^1.13.1",
+    "supertest": "4.0.2",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.1.0",
     "typescript": "^3.4.5",

--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -192,6 +192,10 @@ module.exports = () => {
     res.type('txt').send('Ok');
   });
 
+  app.get('/__version__', (req, res) => {
+    res.type('application/json').send(JSON.stringify(version));
+  });
+
   // it's a four-oh-four not found.
   app.use(require('./404'));
 
@@ -215,6 +219,7 @@ module.exports = () => {
 
   return {
     listen,
+    app, // for testing
   };
 
   function isCorsRequired() {

--- a/packages/fxa-payments-server/server/lib/server.test.js
+++ b/packages/fxa-payments-server/server/lib/server.test.js
@@ -1,3 +1,53 @@
-it('works', () => {
-  expect(true).toEqual(true);
+const request = require('supertest');
+const server = require('./server')();
+const app = server.app;
+const pkg = require('../../package.json');
+
+function expectValueNotToBeUnknown(value) {
+  expect(value).toBeTruthy();
+  expect(value).not.toBe('unknown');
+}
+
+describe('Test simple server routes', () => {
+  test('__version__ should have correct structure', done => {
+    request(app)
+      .get('/__version__')
+      .then(response => {
+        expect(response.statusCode).toStrictEqual(200);
+        expect(response.headers['content-type']).toStrictEqual(
+          'application/json; charset=utf-8'
+        );
+
+        const body = response.body;
+        expect(Object.keys(body).sort()).toStrictEqual([
+          'commit',
+          'source',
+          'version',
+        ]);
+
+        expectValueNotToBeUnknown(body.commit);
+        expectValueNotToBeUnknown(body.source);
+        expectValueNotToBeUnknown(body.version);
+
+        expect(body.version).toStrictEqual(pkg.version);
+        // check that the git hash just looks like a git SHA
+        expect(body.commit).toMatch(/^[0-9a-f]{40}$/);
+
+        done();
+      });
+  });
+
+  test('__lbheartbeat__ should return as expected', done => {
+    request(app)
+      .get('/__lbheartbeat__')
+      .then(response => {
+        expect(response.statusCode).toStrictEqual(200);
+        expect(response.headers['content-type']).toStrictEqual(
+          'text/plain; charset=utf-8'
+        );
+        expect(response.text).toStrictEqual('Ok');
+
+        done();
+      });
+  });
 });

--- a/packages/fxa-payments-server/server/lib/server.test.js
+++ b/packages/fxa-payments-server/server/lib/server.test.js
@@ -30,7 +30,7 @@ describe('Test simple server routes', () => {
         expectValueNotToBeUnknown(body.version);
 
         expect(body.version).toStrictEqual(pkg.version);
-        // check that the git hash just looks like a git SHA
+        // check that the commit value looks like a git SHA
         expect(body.commit).toMatch(/^[0-9a-f]{40}$/);
 
         done();


### PR DESCRIPTION
r? - @lmorchard

Adding standard `/__version__` route so it's easy to check the deployed version information.

I'm not sure about the change to `Dockerfile-test`, but it was repeating what had been done in the base :build image for the most part.

There is a benefit to docker image size of not installing `devDependencies` in the production image, and adding them into the `:test` image. But we can look at maybe doing that later.