### PR TITLE
fix(experiment): Fix signup code experiment and add test for grouping rules

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/signup-code.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/signup-code.js
@@ -6,7 +6,7 @@
 
 const BaseGroupingRule = require('./base');
 const Constants = require('../../../lib/constants');
-const GROUPS_DEFAULT = ['control, treatment'];
+const GROUPS_DEFAULT = ['control', 'treatment'];
 
 const ROLLOUT_CLIENTS = {
   '37fdfa37698f251a': {

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/signup-code.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/signup-code.js
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import Account from 'models/account';
+import Experiment from 'lib/experiments/grouping-rules/signup-code';
+import sinon from 'sinon';
+
+const ROLLOUT_CLIENTS = {
+  '3a1f53aabe17ba32': {
+    name: 'Firefox Add-ons',
+    rolloutRate: 0.0, // Rollout rate between 0..1
+  },
+  dcdb5ae7add825d2: {
+    name: '123Done',
+    rolloutRate: 1.0,
+  },
+  ecdb5ae7add825d4: {
+    enableTestEmails: true,
+    name: 'TestClient',
+    rolloutRate: 0.0,
+  },
+};
+
+describe('lib/experiments/grouping-rules/signup-code', () => {
+  describe('choose', () => {
+    let account;
+    let experiment;
+    let subject;
+
+    beforeEach(() => {
+      account = new Account();
+      experiment = new Experiment();
+      experiment.ROLLOUT_CLIENTS = ROLLOUT_CLIENTS;
+      subject = {
+        account,
+        experimentGroupingRules: {},
+        isSignupCodeSupported: true,
+        service: null,
+        uniqueUserId: 'user-id',
+      };
+    });
+
+    it('returns false experiment not enabled', () => {
+      subject = {
+        isSignupCodeSupported: false,
+      };
+      assert.equal(experiment.choose(subject), false);
+    });
+
+    describe('with oauth client', () => {
+      it('returns false if client not defined in config', () => {
+        subject.clientId = 'invalidClientId';
+        assert.equal(experiment.choose(subject), false);
+      });
+
+      it('returns false if client rollout is 0', () => {
+        subject.clientId = '3a1f53aabe17ba32';
+        assert.equal(experiment.choose(subject), false);
+      });
+
+      it('delegates to uniformChoice', () => {
+        subject.clientId = 'dcdb5ae7add825d2';
+        sinon.stub(experiment, 'uniformChoice').callsFake(() => 'control');
+        experiment.choose(subject);
+        assert.isTrue(experiment.uniformChoice.calledOnce);
+        assert.isTrue(
+          experiment.uniformChoice.calledWith(
+            ['control', 'treatment'],
+            'user-id'
+          )
+        );
+      });
+
+      it('delegates to uniformChoice when `enableTestEmails` is true and using test email', () => {
+        subject.clientId = 'ecdb5ae7add825d4';
+        subject.account.set('email', 'a@mozilla.org');
+        sinon.stub(experiment, 'uniformChoice').callsFake(() => 'control');
+        experiment.choose(subject);
+        assert.isTrue(experiment.uniformChoice.calledOnce);
+        assert.isTrue(
+          experiment.uniformChoice.calledWith(
+            ['control', 'treatment'],
+            'user-id'
+          )
+        );
+      });
+
+      it('featureFlags take precedence', () => {
+        subject.clientId = 'invalidClientId';
+        assert.equal(
+          experiment.choose(
+            Object.assign(
+              {
+                featureFlags: {
+                  signupCodeClients: {
+                    invalidClientId: {
+                      groups: ['control'],
+                      rolloutRate: 1,
+                    },
+                  },
+                },
+              },
+              subject
+            )
+          ),
+          ['control']
+        );
+      });
+    });
+
+    describe('with sync', () => {
+      beforeEach(() => {
+        subject.service = 'sync';
+      });
+
+      it('returns false if not Sync', () => {
+        subject.service = 'notSync';
+        assert.equal(experiment.choose(subject), false);
+      });
+
+      it('returns false if rollout is 0', () => {
+        assert.equal(experiment.choose(subject), false);
+      });
+
+      it('delegates to uniformChoice', () => {
+        experiment.SYNC_ROLLOUT_RATE = 1.0;
+        sinon.stub(experiment, 'uniformChoice').callsFake(() => 'control');
+        experiment.choose(subject);
+        assert.isTrue(experiment.uniformChoice.calledOnce, 'called once');
+        assert.isTrue(
+          experiment.uniformChoice.calledWith(
+            ['control', 'treatment'],
+            'user-id'
+          )
+        );
+      });
+
+      it('featureFlags take precedence', () => {
+        assert.isFalse(
+          experiment.choose(
+            Object.assign({
+              featureFlags: {
+                signupCodeClients: {
+                  sync: {
+                    groups: ['control', 'treatment'],
+                    rolloutRate: 0,
+                  },
+                },
+              },
+              subject,
+            })
+          )
+        );
+      });
+    });
+  });
+});

--- a/packages/fxa-content-server/app/tests/test_start.js
+++ b/packages/fxa-content-server/app/tests/test_start.js
@@ -47,6 +47,7 @@ require('./spec/lib/experiments/grouping-rules/index');
 require('./spec/lib/experiments/grouping-rules/is-sampled-user');
 require('./spec/lib/experiments/grouping-rules/send-sms-install-link');
 require('./spec/lib/experiments/grouping-rules/sentry');
+require('./spec/lib/experiments/grouping-rules/signup-code');
 require('./spec/lib/experiments/grouping-rules/token-code');
 require('./spec/lib/fxa-client');
 require('./spec/lib/image-loader');


### PR DESCRIPTION
Train 145.3 was released today and it *should* have started reporting metrics for boomerang...unfortunately it did not because of a typo in the group logic. Luckily this was caught by our experiment regex and it rejected the metrics POST.

![Screen Shot 2019-09-12 at 9 28 24 PM](https://user-images.githubusercontent.com/1295288/64832795-660f9f80-d5a9-11e9-80c1-ee2714833d3c.png)

I wondered why this wasn't caught earlier and it turns out because I didn't write a test for it! 🙇🏽‍♂️ This PR adds the test and the fix for train 145.