### PR TITLE
chore(log): Replace `fatal` error log with `warn`

### DIFF
--- a/packages/fxa-auth-server/lib/senders/oauth_client_info.js
+++ b/packages/fxa-auth-server/lib/senders/oauth_client_info.js
@@ -45,7 +45,7 @@ module.exports = (log, config, oauthdb) => {
     } catch (err) {
       // fallback to the Firefox client if request fails
       if (!err.statusCode) {
-        log.fatal('fetch.failed', { err: err });
+        log.fatal('fetch.failed', { err });
       } else {
         log.warn('fetch.failedForClient', { clientId });
       }

--- a/packages/fxa-auth-server/test/test_server.js
+++ b/packages/fxa-auth-server/test/test_server.js
@@ -32,6 +32,8 @@ function TestServer(config, printLogs, options = {}) {
     config.log.level = 'critical';
     config.log.stdout = new EventEmitter();
     config.log.stdout.write = function() {};
+    config.log.stderr = new EventEmitter();
+    config.log.stderr.write = function() {};
   }
   this.printLogs = printLogs;
   this.config = config;


### PR DESCRIPTION
Fixes #2489

I can't really think of a reason why this should be a fatal error log vs warn like the one below. When running tests, it will print out fatal error logs, ref https://github.com/mozilla/fxa/blob/b22d8cdeb47cf4dcd52aa90fc8e21f4eedd24725/packages/fxa-auth-server/test/test_server.js#L32