### PR TITLE
fix(payments-server): trap exceptions in App component to display an error dialog

### DIFF
--- a/packages/fxa-payments-server/src/App.test.tsx
+++ b/packages/fxa-payments-server/src/App.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { defaultAppContextValue } from './lib/test-utils';
+import { AppErrorBoundary, AppErrorDialog } from './App';
+import { AppContext } from './lib/AppContext';
+
+// TODO: backfill general App component tests
+// describe('App', () => {});
+
+describe('App/AppErrorBoundary', () => {
+  it('renders children that do not cause exceptions', () => {
+    const GoodComponent = () => <p data-testid="good-component">Hi</p>;
+    const { queryByTestId } = render(
+      <AppContext.Provider value={defaultAppContextValue()}>
+        <AppErrorBoundary>
+          <GoodComponent />
+        </AppErrorBoundary>
+      </AppContext.Provider>
+    );
+    expect(queryByTestId('error-loading-app')).not.toBeInTheDocument();
+  });
+
+  it('renders a general error dialog on exception in child component', () => {
+    const BadComponent = () => {
+      throw new Error('bad');
+    };
+    const { queryByTestId } = render(
+      <AppContext.Provider value={defaultAppContextValue()}>
+        <AppErrorBoundary>
+          <BadComponent />
+        </AppErrorBoundary>
+      </AppContext.Provider>
+    );
+    expect(queryByTestId('error-loading-app')).toBeInTheDocument();
+  });
+});
+
+describe('App/AppErrorDialog', () => {
+  it('renders a general error dialog', () => {
+    const { queryByTestId } = render(
+      <AppErrorDialog error={new Error('bad')} />
+    );
+    expect(queryByTestId('error-loading-app')).toBeInTheDocument();
+  });
+});

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -1,14 +1,17 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { StripeProvider } from 'react-stripe-elements';
 import { BrowserRouter as Router, Route, Redirect } from 'react-router-dom';
+import * as Sentry from '@sentry/browser';
 
 import { QueryParams } from './lib/types';
 import { Config } from './lib/config';
+import { getErrorMessage } from './lib/errors';
 import { Store } from './store/types';
 import { AppContext, AppContextType } from './lib/AppContext';
 
 import './App.scss';
+import DialogMessage from './components/DialogMessage';
 import { SignInLayout, SettingsLayout } from './components/AppLayout';
 import ScreenInfo from './lib/screen-info';
 import { LoadingOverlay } from './components/LoadingOverlay';
@@ -50,39 +53,77 @@ export const App = ({
     locationReload,
   };
   return (
-    <StripeProvider apiKey={config.stripe.apiKey}>
-      <ReduxProvider store={store}>
-        <AppContext.Provider value={appContextValue}>
-          <Router>
-            <React.Suspense fallback={<RouteFallback />}>
-              {/* Note: every Route below should also be listed in INDEX_ROUTES in server/lib/server.js */}
-              <Route
-                path="/"
-                exact
-                render={() => <Redirect to="/subscriptions" />}
-              />
-              <Route
-                path="/subscriptions"
-                exact
-                render={props => (
-                  <SettingsLayout>
-                    <Subscriptions {...props} />
-                  </SettingsLayout>
-                )}
-              />
-              <Route
-                path="/products/:productId"
-                render={props => (
-                  <SignInLayout>
-                    <Product {...props} />
-                  </SignInLayout>
-                )}
-              />
-            </React.Suspense>
-          </Router>
-        </AppContext.Provider>
-      </ReduxProvider>
-    </StripeProvider>
+    <AppContext.Provider value={appContextValue}>
+      <AppErrorBoundary>
+        <StripeProvider apiKey={config.stripe.apiKey}>
+          <ReduxProvider store={store}>
+            <Router>
+              <React.Suspense fallback={<RouteFallback />}>
+                {/* Note: every Route below should also be listed in INDEX_ROUTES in server/lib/server.js */}
+                <Route
+                  path="/"
+                  exact
+                  render={() => <Redirect to="/subscriptions" />}
+                />
+                <Route
+                  path="/subscriptions"
+                  exact
+                  render={props => (
+                    <SettingsLayout>
+                      <Subscriptions {...props} />
+                    </SettingsLayout>
+                  )}
+                />
+                <Route
+                  path="/products/:productId"
+                  render={props => (
+                    <SignInLayout>
+                      <Product {...props} />
+                    </SignInLayout>
+                  )}
+                />
+              </React.Suspense>
+            </Router>
+          </ReduxProvider>
+        </StripeProvider>
+      </AppErrorBoundary>
+    </AppContext.Provider>
+  );
+};
+
+export class AppErrorBoundary extends React.Component {
+  state: {
+    error: undefined | Error;
+  };
+  constructor(props: {}) {
+    super(props);
+    this.state = { error: undefined };
+  }
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+  componentDidCatch(error: Error, errorInfo: any) {
+    console.error('AppError', error);
+    Sentry.captureException(error);
+  }
+  render() {
+    const { error } = this.state;
+    return error ? <AppErrorDialog error={error} /> : this.props.children;
+  }
+}
+
+export const AppErrorDialog = ({ error: { message } }: { error: Error }) => {
+  const { locationReload } = useContext(AppContext);
+  // TODO: Not displaying the actual error message to the user, just logging it.
+  // Most of these errors will probably be failure to load Stripe widgets.
+  const displayMessage = getErrorMessage('api_connection_error');
+  return (
+    <SettingsLayout>
+      <DialogMessage className="dialog-error" onDismiss={locationReload}>
+        <h4 data-testid="error-loading-app">General application error</h4>
+        <p>{displayMessage}</p>
+      </DialogMessage>
+    </SettingsLayout>
   );
 };
 


### PR DESCRIPTION
While poking at failure modes for the app, I noticed that it just failed to render anything if the Stripe widget JS didn't load. So, this should at least render an error message dialog.

Not a great way to exercise this locally, other than going in and commenting out the JS include for Stripe:
```diff
diff --git a/packages/fxa-payments-server/public/index.html b/packages/fxa-payments-server/public/index.html
index f50fadec3..e617a5788 100644
--- a/packages/fxa-payments-server/public/index.html
+++ b/packages/fxa-payments-server/public/index.html
@@ -18,7 +18,7 @@
     <meta name="fxa-config" content="__SERVER_CONFIG__" />
     <meta name="fxa-feature-flags" content="__FEATURE_FLAGS__" />
 
-    <script src="https://js.stripe.com/v3/"></script>
+    <!--<script src="https://js.stripe.com/v3/"></script>-->
   </head>
 
   <body>
```