### PR TITLE
feat(auth-server): invalidate per-profile cache on subscription changes

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -76,6 +76,7 @@ function run(config) {
   let customs = null;
   let oauthdb = null;
   let subhub = null;
+  let profile = null;
 
   function logStatInfo() {
     log.stat(server.stat());
@@ -96,6 +97,7 @@ function run(config) {
         database = db;
         oauthdb = require('../lib/oauthdb')(log, config, statsd);
         subhub = require('../lib/subhub/client')(log, config, statsd);
+        profile = require('../lib/profile/client')(log, config, statsd);
 
         return require('../lib/senders')(
           log,
@@ -119,7 +121,8 @@ function run(config) {
             customs,
             zendeskClient,
             subhub,
-            statsd
+            statsd,
+            profile
           );
 
           statsInterval = setInterval(logStatInfo, 15000);

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -29,6 +29,10 @@
     "enabled": true,
     "sampleRate": 1
   },
+  "profileServer": {
+    "url": "http://127.0.0.1:1111",
+    "secretBearerToken": "8675309jenny"
+  },
   "pushbox": {
     "enabled": true,
     "url": "http://localhost:8002/",

--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -552,6 +552,21 @@ const conf = convict({
       default: '',
     },
   },
+  profileServer: {
+    url: {
+      doc: 'The url of the corresponding fxa-profile-server instance',
+      env: 'PROFILE_SERVER_URL',
+      format: 'url',
+      default: 'https://profile.accounts.firefox.com',
+    },
+    secretBearerToken: {
+      default: 'YOU MUST CHANGE ME',
+      doc:
+        'Secret for server-to-server bearer token auth for fxa-profile-server',
+      env: 'PROFILE_SERVER_AUTH_SECRET_BEARER_TOKEN',
+      format: 'String',
+    },
+  },
   useHttps: {
     doc: 'set to true to serve directly over https',
     env: 'USE_TLS',
@@ -1212,6 +1227,7 @@ if (conf.get('isProduction')) {
     'pushbox.key',
     'metrics.flow_id_key',
     'oauth.secretKey',
+    'profileServer.secretBearerToken',
   ];
   for (const key of SECRET_SETTINGS) {
     if (conf.get(key) === conf.default(key)) {

--- a/packages/fxa-auth-server/lib/profile/client.js
+++ b/packages/fxa-auth-server/lib/profile/client.js
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const isA = require('joi');
+const createBackendServiceAPI = require('../backendService');
+
+const PATH_PREFIX = '/v1';
+
+// Very generic validator, because there's not really a useful response
+// here other than that it didn't fail in error
+const DeleteCacheResponse = isA.any();
+
+module.exports = function(log, config, statsd) {
+  const ProfileAPI = createBackendServiceAPI(
+    log,
+    config,
+    'subhub',
+    {
+      deleteCache: {
+        path: `${PATH_PREFIX}/cache/:uid`,
+        method: 'DELETE',
+        validate: {
+          params: {
+            uid: isA.string().required(),
+          },
+          response: DeleteCacheResponse,
+        },
+      },
+    },
+    statsd
+  );
+
+  const api = new ProfileAPI(config.profileServer.url, {
+    headers: {
+      Authorization: `Bearer ${config.profileServer.secretBearerToken}`,
+    },
+    timeout: 15000,
+  });
+
+  return {
+    async deleteCache(uid) {
+      try {
+        return await api.deleteCache(uid);
+      } catch (err) {
+        log.error('profile.deleteCache.failed', { uid, err });
+        throw err;
+      }
+    },
+  };
+};

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -19,7 +19,8 @@ module.exports = function(
   customs,
   zendeskClient,
   subhub,
-  statsd
+  statsd,
+  profile
 ) {
   // Various extra helpers.
   const push = require('../push')(log, db, config);
@@ -150,7 +151,8 @@ module.exports = function(
     customs,
     push,
     oauthdb,
-    subhub
+    subhub,
+    profile
   );
   const support = require('./support')(log, db, config, customs, zendeskClient);
   const util = require('./util')(log, config, config.smtp.redirectDomain);

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -9,7 +9,7 @@ const isA = require('joi');
 const ScopeSet = require('../../../fxa-shared').oauth.scopes;
 const validators = require('./validators');
 
-module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
+module.exports = (log, db, config, customs, push, oauthdb, subhub, profile) => {
   // Skip routes if the subscriptions feature is not configured & enabled
   if (!config.subscriptions || !config.subscriptions.enabled) {
     return [];
@@ -163,6 +163,7 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
           uid,
           email,
         });
+        await profile.deleteCache(uid);
 
         log.info('subscriptions.createSubscription.success', {
           uid,
@@ -266,6 +267,7 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
           uid,
           email,
         });
+        await profile.deleteCache(uid);
 
         log.info('subscriptions.deleteSubscription.success', {
           uid,
@@ -314,6 +316,7 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub) => {
           uid,
           email,
         });
+        await profile.deleteCache(uid);
 
         log.info('subscriptions.reactivateSubscription.success', {
           uid,

--- a/packages/fxa-auth-server/test/local/config/index.js
+++ b/packages/fxa-auth-server/test/local/config/index.js
@@ -38,6 +38,10 @@ describe('Config', () => {
       mockEnv('PUSHBOX_KEY', 'production secret here');
       mockEnv('FLOW_ID_KEY', 'production secret here');
       mockEnv('OAUTH_SERVER_SECRET_KEY', 'production secret here');
+      mockEnv(
+        'PROFILE_SERVER_AUTH_SECRET_BEARER_TOKEN',
+        'production secret here'
+      );
       assert.doesNotThrow(() => {
         proxyquire(`${ROOT_DIR}/config`, {});
       });

--- a/packages/fxa-auth-server/test/local/profile/client.js
+++ b/packages/fxa-auth-server/test/local/profile/client.js
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const nock = require('nock');
+const { mockLog } = require('../../mocks');
+const proxyquire = require('proxyquire');
+
+// Common prefix for all API URL paths
+const PATH_PREFIX = '/v1';
+
+const profileModule = proxyquire('../../../lib/profile/client', {});
+
+const mockConfig = {
+  profileServer: {
+    url: 'https://foo.bar',
+    secretBearerToken: 'foo',
+  },
+};
+
+const mockServer = nock(mockConfig.profileServer.url, {
+  reqheaders: {
+    Authorization: `Bearer ${mockConfig.profileServer.secretBearerToken}`,
+  },
+}).defaultReplyHeaders({
+  'Content-Type': 'application/json',
+});
+
+describe('profile-server client', () => {
+  const makeSubject = (profileConfig = {}) => {
+    const log = mockLog();
+    const profile = profileModule(log, {
+      ...mockConfig,
+      profileServer: {
+        ...mockConfig.profileServer,
+        ...profileConfig,
+      },
+    });
+    return { log, profile };
+  };
+
+  afterEach(() => {
+    assert.ok(
+      nock.isDone(),
+      'there should be no pending request mocks at the end of a test'
+    );
+  });
+
+  describe('deleteCache', () => {
+    it('makes a DELETE request to the cache invalidation resource', async () => {
+      const uid = '8675309uid';
+      const expected = {};
+      mockServer.delete(`${PATH_PREFIX}/cache/${uid}`).reply(200, expected);
+      const { profile } = makeSubject();
+      const result = await profile.deleteCache(uid);
+      assert.deepEqual(result, expected);
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -19,6 +19,7 @@ let config,
   push,
   oauthdb,
   subhub,
+  profile,
   routes,
   route,
   request,
@@ -90,7 +91,8 @@ function runTest(routePath, requestOptions) {
     customs,
     push,
     oauthdb,
-    subhub
+    subhub,
+    profile
   );
   route = getRoute(routes, routePath, requestOptions.method || 'GET');
   request = mocks.mockRequest(requestOptions);
@@ -149,6 +151,10 @@ describe('subscriptions', () => {
       updateCustomer: sinon.spy(async (uid, token) => ({})),
     });
 
+    profile = mocks.mockProfile({
+      deleteCache: sinon.spy(async uid => ({})),
+    });
+
     requestOptions = {
       metricsContext: mocks.mockMetricsContext(),
       credentials: {
@@ -177,7 +183,8 @@ describe('subscriptions', () => {
         customs,
         push,
         oauthdb,
-        subhub
+        subhub,
+        profile
       );
       assert.deepEqual(routes, []);
     });
@@ -291,6 +298,7 @@ describe('subscriptions', () => {
         uid: UID,
         email: TEST_EMAIL,
       });
+      assert.equal(profile.deleteCache.args[0][0], UID);
     });
 
     it('should correctly handle payment backend failure on listing plans', async () => {
@@ -466,6 +474,7 @@ describe('subscriptions', () => {
         uid: UID,
         email: TEST_EMAIL,
       });
+      assert.equal(profile.deleteCache.args[0][0], UID);
     });
 
     it('should report error for unknown subscription', async () => {
@@ -565,6 +574,8 @@ describe('subscriptions', () => {
         uid: UID,
         email: TEST_EMAIL,
       });
+
+      assert.equal(profile.deleteCache.args[0][0], UID);
 
       assert.deepEqual(res, {});
     });

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -183,6 +183,8 @@ const SUBHUB_METHOD_NAMES = [
   'reactivateSubscription',
 ];
 
+const PROFILE_METHOD_NAMES = ['deleteCache'];
+
 module.exports = {
   MOCK_PUSH_KEY:
     'BDLugiRzQCANNj5KI1fAqui8ELrE7qboxzfa5K_R0wnUoJ89xY1D_SOXI_QJKNmellykaW_7U2BZ7hnrPW3A3LM',
@@ -199,6 +201,7 @@ module.exports = {
   mockPushbox,
   mockRequest,
   mockSubHub,
+  mockProfile,
   mockVerificationReminders,
 };
 
@@ -580,6 +583,16 @@ function mockSubHub(methods) {
     }
   });
   return subscriptionsBackend;
+}
+
+function mockProfile(methods) {
+  const profileBackend = Object.assign({}, methods);
+  PROFILE_METHOD_NAMES.forEach(name => {
+    if (!profileBackend[name]) {
+      profileBackend[name] = sinon.spy(() => P.resolve());
+    }
+  });
+  return profileBackend;
 }
 
 function mockDevices(data, errors) {

--- a/packages/fxa-auth-server/test/profile_helper.js
+++ b/packages/fxa-auth-server/test/profile_helper.js
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const config = require('../config').getProperties();
+const hapi = require('hapi');
+const url = require('url');
+const P = require('../lib/promise');
+
+module.exports = () => {
+  return new P((resolve, reject) => {
+    const api = new hapi.Server({
+      host: url.parse(config.profileServer.url).hostname,
+      port: parseInt(url.parse(config.profileServer.url).port),
+    });
+
+    api.route([
+      {
+        method: 'DELETE',
+        path: '/v1/cache/{uid}',
+        handler: async function(request, h) {
+          return h.response({}).code(200);
+        },
+      },
+    ]);
+
+    api.start().then(err => {
+      if (err) {
+        console.log(err); // eslint-disable-line no-console
+        return reject(err);
+      }
+      resolve({
+        close() {
+          return new P((resolve, reject) => {
+            api.stop().then(err => {
+              if (err) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            });
+          });
+        },
+      });
+    });
+  });
+};

--- a/packages/fxa-profile-server/config/development.json
+++ b/packages/fxa-profile-server/config/development.json
@@ -10,6 +10,7 @@
   },
   "customsUrl": "none",
   "serverCache": {
-    "useRedis": true
-  }
+    "useRedis": false
+  },
+  "secretBearerToken": "8675309jenny"
 }


### PR DESCRIPTION
fixes #2463

Just as a heads up: We might want to wait to merge this PR until we complete some config changes in all the environments.