### PR TITLE
fix(event-broker): response to /__version__ route

### DIFF
--- a/packages/fxa-event-broker/lib/api/proxy-controller.ts
+++ b/packages/fxa-event-broker/lib/api/proxy-controller.ts
@@ -11,6 +11,7 @@ import { JWT } from '../jwts';
 import { ClientWebhookService } from '../selfUpdatingService/clientWebhookService';
 import { DELETE_EVENT, SUBSCRIPTION_UPDATE_EVENT } from '../serviceNotifications';
 import { proxyPayload } from './proxy-validator';
+import { version } from './version';
 
 export default class ProxyController {
   constructor(
@@ -22,6 +23,14 @@ export default class ProxyController {
 
   public async heartbeat(request: hapi.Request, h: hapi.ResponseToolkit) {
     return h.response({}).code(200);
+  }
+
+  public async version(request: hapi.Request, h: hapi.ResponseToolkit) {
+    const body = JSON.stringify(version);
+    return h
+      .response(body)
+      .type('application/json')
+      .code(200);
   }
 
   public async proxyDelivery(request: hapi.Request, h: hapi.ResponseToolkit) {

--- a/packages/fxa-event-broker/lib/api/routes.ts
+++ b/packages/fxa-event-broker/lib/api/routes.ts
@@ -29,6 +29,11 @@ export default function(
       path: '/__lbheartbeat__'
     },
     {
+      handler: proxyController.version,
+      method: 'GET',
+      path: '/__version__'
+    },
+    {
       method: 'POST',
       options: {
         auth: 'pubsub',

--- a/packages/fxa-event-broker/lib/api/version.ts
+++ b/packages/fxa-event-broker/lib/api/version.ts
@@ -49,7 +49,13 @@ function getValue(name: string, command: string): string {
   return stdout && stdout.toString().trim();
 }
 
-function getVersionInfo(): object {
+interface Version {
+  commit: string;
+  source: string;
+  version: string;
+}
+
+function getVersionInfo(): Version {
   const commit = getValue('hash', 'git rev-parse HEAD');
   const source = getValue('source', 'git config --get remote.origin.url');
 
@@ -57,15 +63,11 @@ function getVersionInfo(): object {
     readJson(path.resolve(__dirname, '..', '..', 'package.json')) ||
     readJson(path.resolve(__dirname, '..', '..', '..', 'package.json'));
 
-  if (packageInfo) {
-    return {
-      commit,
-      source,
-      version: packageInfo.version
-    };
-  }
-
-  return {};
+  return {
+    commit,
+    source,
+    version: packageInfo && packageInfo.version
+  };
 }
 
 export const version = getVersionInfo();

--- a/packages/fxa-event-broker/lib/api/version.ts
+++ b/packages/fxa-event-broker/lib/api/version.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * Return version info based on package.json, the git sha, and source repo
+ *
+ * Try to statically determine commitHash and sourceRepo at startup.
+ *
+ * If commitHash cannot be found from `version.json` (i.e., this is not
+ * production or stage), then an attempt will be made to determine commitHash
+ * and sourceRepo dynamically from `git`. If it cannot be found with `git`,
+ * just show 'unknown' for commitHash and sourceRepo.
+ *
+ * This module may be called as ./dist/lib/version.js, or when testing,
+ * ./lib/version.ts so we need to look for `package.json` and `version.json`
+ * in two possible locations.
+ */
+
+import * as cp from 'child_process';
+import * as path from 'path';
+
+function readJson(filepath: string) {
+  try {
+    return require(filepath);
+  } catch (e) {
+    /* ignore */
+  }
+
+  return;
+}
+
+function getValue(name: string, command: string): string {
+  const value =
+    readJson(path.resolve(__dirname, '..', '..', 'version.json')) ||
+    readJson(path.resolve(__dirname, '..', '..', '..', 'version.json'));
+
+  if (value && value.version) {
+    return value.version[name];
+  }
+
+  let stdout = 'unknown';
+  try {
+    stdout = cp.execSync(command, { cwd: __dirname }).toString('utf8');
+  } catch (e) {
+    /* ignore */
+  }
+
+  return stdout && stdout.toString().trim();
+}
+
+function getVersionInfo(): object {
+  const commit = getValue('hash', 'git rev-parse HEAD');
+  const source = getValue('source', 'git config --get remote.origin.url');
+
+  const packageInfo =
+    readJson(path.resolve(__dirname, '..', '..', 'package.json')) ||
+    readJson(path.resolve(__dirname, '..', '..', '..', 'package.json'));
+
+  if (packageInfo) {
+    return {
+      commit,
+      source,
+      version: packageInfo.version
+    };
+  }
+
+  return {};
+}
+
+export const version = getVersionInfo();

--- a/packages/fxa-event-broker/test/lib/api/proxy-controller.spec.ts
+++ b/packages/fxa-event-broker/test/lib/api/proxy-controller.spec.ts
@@ -122,6 +122,20 @@ describe('Proxy Controller', () => {
     cassert.equal(result.statusCode, 200);
   });
 
+  it('has a version', async () => {
+    const result = await server.inject({
+      method: 'GET',
+      url: '/__version__'
+    });
+    cassert.equal(result.statusCode, 200);
+    cassert.equal(result.headers['content-type'], 'application/json; charset=utf-8');
+    cassert.deepEqual(Object.keys(JSON.parse(result.payload)).sort(), [
+      'commit',
+      'source',
+      'version'
+    ]);
+  });
+
   it('notifies successfully on subscription state change', async () => {
     mockWebhook();
     const message = createValidSubscriptionMessage();


### PR DESCRIPTION
Return version information on `/__version__`

Like `curl 'https://oauth.accounts.firefox.com/__version__'`:
```
{
  "version": "1.145.4",
  "commit": "04f47a3c381ca922dec07498e92c29bb5b5eba13",
  "source": "https://github.com/mozilla/fxa"
}
```