### PR TITLE
fix(payments): fix storybook rendering since adding matchMedia to app context

### DIFF
--- a/packages/fxa-payments-server/.storybook/components/MockApp.tsx
+++ b/packages/fxa-payments-server/.storybook/components/MockApp.tsx
@@ -36,6 +36,7 @@ export const defaultAppContextValue: AppContextType = {
   queryParams: {},
   navigateToUrl: action('navigateToUrl'),
   getScreenInfo: () => new ScreenInfo(window),
+  matchMedia: (query: string) => window.matchMedia(query).matches,
   locationReload: action('locationReload'),
 };
 


### PR DESCRIPTION
Looks like we added this to the AppContext, but forgot to add it here too