### PR TITLE
feat(oauth): Accept and validate client credentials when destroying a token.

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/client.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/client.js
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const crypto = require('crypto');
+const buf = require('buf').hex;
+const Joi = require('joi');
+
+const AppError = require('./error');
+const validators = require('./validators');
+const db = require('./db');
+const encrypt = require('./encrypt');
+const logger = require('./logging')('client');
+
+// Client credentials can be provided in either the Authorization header
+// or the request body, but not both.
+// These are some re-useable validators to assert that requirement.
+module.exports.clientAuthValidators = {
+  headers: Joi.object({
+    authorization: Joi.string()
+      .regex(validators.BASIC_AUTH_HEADER)
+      .optional(),
+  }).options({ allowUnknown: true }),
+
+  // The use of `$headers` here is Joi syntax for a "context reference"
+  // as described at https://hapi.dev/family/joi/?v=16.1.4#refkey-options.
+  // Hapi provides the headers as part of the context when validating request payload,
+  // as noted in https://github.com/hapijs/hapi/blob/master/API.md#-routeoptionsresponseschema.
+  clientId: validators.clientId.when('$headers.authorization', {
+    is: Joi.string().required(),
+    then: Joi.forbidden(),
+  }),
+
+  clientSecret: validators.clientSecret.when('$headers.authorization', {
+    is: Joi.string().required(),
+    then: Joi.forbidden(),
+  }),
+};
+
+/**
+ * Extract and normalize client credentials from a request.
+ * Clients may provide credentials in either the Authorization header
+ * or the request body, but not both.
+ *
+ * @param {Object} headers the headers from the request
+ * @param {Object} params the payload from the request
+ * @returns {Object} credentials
+ *   @param {String} client_id
+ *   @param {String} [client_secret]
+ */
+module.exports.getClientCredentials = function getClientCredentials(
+  headers,
+  params
+) {
+  const creds = {
+    client_id: params.client_id,
+    client_secret: params.client_secret,
+  };
+
+  // Clients are allowed to provide credentials in either
+  // the Authorization header or request body, but not both.
+  if (headers.authorization) {
+    const authzMatch = validators.BASIC_AUTH_HEADER.exec(headers.authorization);
+    const err = new AppError.invalidRequestParameter('authorization');
+    if (!authzMatch || creds.client_id || creds.client_secret) {
+      throw err;
+    }
+    const [clientId, clientSecret, ...rest] = Buffer.from(
+      authzMatch[1],
+      'base64'
+    )
+      .toString()
+      .split(':');
+    if (rest.length !== 0) {
+      throw err;
+    }
+    creds.client_id = Joi.attempt(clientId, validators.clientId, err);
+    creds.client_secret = Joi.attempt(
+      clientSecret,
+      validators.clientSecret,
+      err
+    );
+  }
+
+  return creds;
+};
+
+/**
+ * Authenticate a request made by an OAuth client, using credentials from
+ * either the Authorization header or request body parameters.
+ *
+ * @param {Object} headers the headers from the request
+ * @param {Object} params the payload from the request
+ * @returns {Promise} resolves with info about the client, or
+ *                    rejects if invalid credentials were provided
+ */
+module.exports.authenticateClient = async function authenticateClient(
+  headers,
+  params
+) {
+  const creds = exports.getClientCredentials(headers, params);
+
+  const client = await getClientById(creds.client_id);
+
+  // Public clients can't be authenticated in any useful way,
+  // and should never submit a client_secret.
+  if (client.publicClient) {
+    if (creds.client_secret) {
+      throw new AppError.invalidRequestParameter('client_secret');
+    }
+    return client;
+  }
+
+  // Check client_secret against both current and previous stored secrets,
+  // to allow for seamless rotation of the secret.
+  if (!creds.client_secret) {
+    throw new AppError.invalidRequestParameter('client_secret');
+  }
+  const submitted = encrypt.hash(buf(creds.client_secret));
+  const stored = client.hashedSecret;
+  if (crypto.timingSafeEqual(submitted, stored)) {
+    return client;
+  }
+  const storedPrevious = client.hashedSecretPrevious;
+  if (storedPrevious) {
+    if (crypto.timingSafeEqual(submitted, storedPrevious)) {
+      logger.info('client.matchSecretPrevious', { client: client.id });
+      return client;
+    }
+  }
+  logger.info('client.mismatchSecret', { client: client.id });
+  logger.verbose('client.mismatchSecret.details', {
+    submitted: submitted,
+    db: stored,
+    dbPrevious: storedPrevious,
+  });
+  throw AppError.incorrectSecret(client.id);
+};
+
+async function getClientById(clientId) {
+  const client = await db.getClient(buf(clientId));
+  if (!client) {
+    logger.debug('client.notFound', { id: clientId });
+    throw AppError.unknownClient(clientId);
+  }
+  return client;
+}

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/destroy.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/destroy.js
@@ -2,21 +2,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const crypto = require('crypto');
 const Joi = require('joi');
+const hex = require('buf').to.hex;
 
 const AppError = require('../error');
 const db = require('../db');
 const encrypt = require('../encrypt');
 const validators = require('../validators');
+const logger = require('../logging')('routes.destroy');
 const { getTokenId } = require('../token');
+const { authenticateClient, clientAuthValidators } = require('../client');
 
 /*jshint camelcase: false*/
 
 module.exports = {
   validate: {
+    headers: clientAuthValidators.headers,
     payload: Joi.object()
       .keys({
-        client_secret: Joi.string().allow(''),
+        client_id: clientAuthValidators.clientId.optional(),
+        // For historical reasons, we accept and ignore a client_secret if one
+        // is provided without a corresponding client_id.
+        // https://github.com/mozilla/fxa-oauth-server/pull/198
+        client_secret: clientAuthValidators.clientSecret.allow('').optional(),
         access_token: validators.accessToken,
         refresh_token: validators.token,
         refresh_token_id: validators.token,
@@ -28,6 +37,14 @@ module.exports = {
     var token;
     var getToken;
     var removeToken;
+
+    // If client credentials were provided, validate them.
+    // For legacy reasons it is possible to call this endpoint without credentials.
+    let client = null;
+    if (req.headers.authorization || req.payload.client_id) {
+      client = await authenticateClient(req.headers, req.payload);
+    }
+
     if (req.payload.access_token) {
       getToken = 'getAccessToken';
       removeToken = 'removeAccessToken';
@@ -42,15 +59,21 @@ module.exports = {
       }
     }
 
-    return db[getToken](token)
-      .then(function(tok) {
-        if (!tok) {
-          throw AppError.invalidToken();
-        }
-        return db[removeToken](token);
-      })
-      .then(function() {
-        return {};
+    const tokObj = await db[getToken](token);
+    if (!tokObj) {
+      throw AppError.invalidToken();
+    }
+    if (client && !crypto.timingSafeEqual(tokObj.clientId, client.id)) {
+      throw AppError.invalidToken();
+    } else if (!client && req.payload.hasOwnProperty('client_secret')) {
+      // Log a warning if legacy client_secret is provided, so we can
+      // measure whether it's safe to remove this behaviour.
+      logger.warn('destroy.unexpectedClientSecret', {
+        client_id: hex(tokObj.clientId),
       });
+    }
+
+    await db[removeToken](token);
+    return {};
   },
 };

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/validators.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/validators.js
@@ -10,6 +10,7 @@ const config = require('./config');
 
 exports.HEX_STRING = /^(?:[0-9a-f]{2})+$/;
 exports.B64URL_STRING = /^[A-Za-z0-9-_]+$/;
+exports.BASIC_AUTH_HEADER = /^Basic\s+([a-z0-9+\/]+)$/i;
 
 exports.clientId = Joi.string()
   .length(config.get('unique.id') * 2) // hex = bytes*2


### PR DESCRIPTION
The OAuth /destroy endpoint currently does not require clients to authenticate
themselves, assuming that anyone holding a token should have the power to
destroy it. By contrast, the standard OAuth token revocation endpoint (RFC7009)
mandates that  clients authenticate themselves in order to use it.

This change makes our current /destroy endpoint *optionally* authenticate clients.
You don't have to provide credentials in order to call it, but if you *do* then
those credentials will be checked.  That's sufficient to let us build a new
endpoint that wraps our existing one and complies with RFC7009.

Connects to #2540.