### PR TITLE
feat(keys): Explicitly track timestamp of last key rotation.

### DIFF
--- a/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
@@ -2410,6 +2410,29 @@ module.exports = function(config, DB) {
             );
           });
       });
+
+      it('should track keysChangedAt independently of verifierSetAt', async () => {
+        const account1 = await db.account(accountData.uid);
+        assert.equal(account1.verifierSetAt, account1.keysChangedAt);
+
+        accountData.verifierSetAt = now + 1;
+        accountData.keysHaveChanged = false;
+        await db.resetAccount(accountData.uid, accountData);
+        const account2 = await db.account(accountData.uid);
+        assert.notEqual(account1.verifierSetAt, account2.verifierSetAt);
+        assert.equal(account1.keysChangedAt, account2.keysChangedAt);
+
+        accountData.verifierSetAt = now + 2;
+        accountData.keysHaveChanged = true;
+        await db.resetAccount(accountData.uid, accountData);
+        const account3 = await db.account(accountData.uid);
+        assert.notEqual(account2.verifierSetAt, account3.verifierSetAt);
+        assert.notEqual(account2.keysChangedAt, account3.keysChangedAt);
+        assert.equal(account3.verifierSetAt, now + 2);
+        assert.equal(account3.keysChangedAt, now + 2);
+
+        delete accountData.keysHaveChanged;
+      });
     });
 
     describe('db.securityEvents', () => {

--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -841,9 +841,10 @@ module.exports = function(log, error) {
   //
   // Step   : 2
   // Update : accounts
-  // Set    : verifyHash = $2, authSalt = $3, wrapWrapKb = $4, verifierSetAt = $5, verifierVersion = $6
+  // Set    : verifyHash = $2, authSalt = $3, wrapWrapKb = $4, verifierSetAt = $5, verifierVersion = $6,
+  //          keysHaveChanged = $7
   // Where  : uid = $1
-  var RESET_ACCOUNT = 'CALL resetAccount_14(?, ?, ?, ?, ?, ?)';
+  var RESET_ACCOUNT = 'CALL resetAccount_15(?, ?, ?, ?, ?, ?, ?)';
 
   MySql.prototype.resetAccount = function(uid, data) {
     return this.write(RESET_ACCOUNT, [
@@ -853,6 +854,7 @@ module.exports = function(log, error) {
       data.wrapWrapKb,
       data.verifierSetAt,
       data.verifierVersion,
+      !!data.keysHaveChanged,
     ]);
   };
 

--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 105;
+module.exports.level = 106;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-104-105.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-104-105.sql
@@ -55,4 +55,5 @@ BEGIN
 
   COMMIT;
 END;
+
 UPDATE dbMetadata SET value = '105' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-105-106.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-105-106.sql
@@ -1,0 +1,49 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('105');
+
+CREATE PROCEDURE `resetAccount_15` (
+  IN `uidArg` BINARY(16),
+  IN `verifyHashArg` BINARY(32),
+  IN `authSaltArg` BINARY(32),
+  IN `wrapWrapKbArg` BINARY(32),
+  IN `verifierSetAtArg` BIGINT UNSIGNED,
+  IN `verifierVersionArg` TINYINT UNSIGNED,
+  IN `keysHaveChangedArg` BOOLEAN
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM sessionTokens WHERE uid = uidArg;
+  DELETE FROM keyFetchTokens WHERE uid = uidArg;
+  DELETE FROM accountResetTokens WHERE uid = uidArg;
+  DELETE FROM passwordChangeTokens WHERE uid = uidArg;
+  DELETE FROM passwordForgotTokens WHERE uid = uidArg;
+  DELETE FROM recoveryKeys WHERE uid = uidArg;
+  DELETE devices, deviceCommands FROM devices LEFT JOIN deviceCommands
+    ON (deviceCommands.uid = devices.uid AND deviceCommands.deviceId = devices.id)
+    WHERE devices.uid = uidArg;  DELETE FROM unverifiedTokens WHERE uid = uidArg;
+  UPDATE accounts
+  SET
+    verifyHash = verifyHashArg,
+    authSalt = authSaltArg,
+    wrapWrapKb = wrapWrapKbArg,
+    verifierVersion = verifierVersionArg,
+    profileChangedAt = verifierSetAtArg,
+    -- The `keysChangedAt` column was added in a migration, so its default value
+    -- is NULL meaning "we don't know".  Now that we do know whether or not the keys
+    -- are being changed, ensure it gets set to some concrete non-NULL value.
+    keysChangedAt = IF(keysHaveChangedArg, verifierSetAtArg,  COALESCE(keysChangedAt, verifierSetAt, createdAt)),
+    verifierSetAt = verifierSetAtArg
+  WHERE uid = uidArg;
+
+  COMMIT;
+END;
+
+UPDATE dbMetadata SET value = '106' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-106-105.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-106-105.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE `resetAccount_15`;
+
+-- UPDATE dbMetadata SET value = '105' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -1176,15 +1176,18 @@ module.exports = (
 
         async function resetAccountData() {
           const authSalt = await random.hex(32);
+          let keysHaveChanged;
           password = new Password(authPW, authSalt, config.verifierVersion);
           verifyHash = await password.verifyHash();
           if (recoveryKeyId) {
             // We have the previous kB, just re-wrap it with the new password.
             wrapWrapKb = await password.wrap(wrapKb);
+            keysHaveChanged = false;
           } else {
             // We need to regenerate kB and wrap it with the new password.
             wrapWrapKb = await random.hex(32);
             wrapKb = await password.unwrap(wrapWrapKb);
+            keysHaveChanged = true;
           }
           // db.resetAccount() deletes all the devices saved in the account,
           // so grab the list to notify before we call it.
@@ -1195,6 +1198,7 @@ module.exports = (
             verifyHash,
             wrapWrapKb,
             verifierVersion: password.version,
+            keysHaveChanged,
           });
           await db.resetAccountTokens(accountResetToken.uid);
           // Notify various interested parties about this password reset.

--- a/packages/fxa-auth-server/lib/routes/password.js
+++ b/packages/fxa-auth-server/lib/routes/password.js
@@ -242,6 +242,7 @@ module.exports = function(
                 authSalt: authSalt,
                 wrapWrapKb: wrapWrapKb,
                 verifierVersion: password.version,
+                keysHaveChanged: false,
               });
             })
             .then(result => {

--- a/packages/fxa-auth-server/test/remote/oauth_tests.js
+++ b/packages/fxa-auth-server/test/remote/oauth_tests.js
@@ -412,11 +412,7 @@ describe('/oauth/ routes', function() {
       scope: OAUTH_SCOPE_OLD_SYNC,
     }))[OAUTH_SCOPE_OLD_SYNC];
 
-    // Since we're not actually tracking a separate key-rotation timestamp yet,
-    // we report that the keys might have changed even on a password change.
-    // In future this will be:
-    //  assert.equal(keyData1.keyRotationTimestamp, keyData2.keyRotationTimestamp);
-    assert.ok(keyData1.keyRotationTimestamp < keyData2.keyRotationTimestamp);
+    assert.equal(keyData1.keyRotationTimestamp, keyData2.keyRotationTimestamp);
 
     await client.forgotPassword();
     const code = await server.mailbox.waitForCode(email);

--- a/packages/fxa-auth-server/test/remote/recovery_key_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_key_tests.js
@@ -185,12 +185,7 @@ describe('remote recovery keys', function() {
 
     assert.equal(cert1['fxa-uid'], cert2['fxa-uid']);
     assert.ok(cert1['fxa-generation'] < cert2['fxa-generation']);
-
-    // Since we're not actually tracking a separate key-rotation timestamp yet,
-    // we report that the keys might have changed even on a password change.
-    // In future this will be:
-    //    assert.equal(cert1['fxa-keysChangedAt'], cert2['fxa-keysChangedAt']);
-    assert.ok(cert1['fxa-keysChangedAt'] < cert2['fxa-keysChangedAt']);
+    assert.equal(cert1['fxa-keysChangedAt'], cert2['fxa-keysChangedAt']);
   });
 
   it('should delete recovery key', () => {


### PR DESCRIPTION
Up until now we have been using `verifierSetAt` for the timestamp component of OAuth scoped-key key ids. This works but means that we generate a new kid whenever the user changes their password, even if that did not involve resetting the master encryption key `kB`.

With this change, we track a separate timestamp that is only bumped when kB actually changes, which should produce more stable key ids while preserving the ability to quickly compare them to determine which is the most recent.

Fixes #490.

Key ideas:

* From previous PRs, the DB contains a `keysChangedAt` field on the `accounts` table, and we report this value out to consumers in OAuth key ids and in BrowserID assertions. Since nothing has been writing to that field yet, it has been defaulting to the value of `verifierSetAt`.
* `db.resetAccount` now takes a boolean `keysHaveChanged` argument to indicate whether or not the value of `kB` has changed; we can't tell this by inspecting the other arguments, because encryption.
* The value of `keysHaveChanged` causes the db to either bump the `keysChangedAt` timestamp, or set it explicitly to its previous value.
* Thus, it is now either the value that we were previously reporting before this change went live, or it is a more recent value corresponding to an actual key-change event.

Safe deployment of this change depends on prep work done in previous commits. We need to be sure that sync clients all see a consistent key-rotation timestamp regardless of whether they are using BrowserID or OAuth, regardless of whether they hit a server running the old code or the new code, and in the face of a rollback. This is assured as follows:

* As of #3060, both BrowserID and OAuth clients will report the value from the `keysChangedAt` column if it exists, or fallback to using `verifierSetAt` if it is NULL. So when the new code starts writing to that column, the old code will use it. If we rollback the old code will keep using values written into that column.
* As of #2571, users who reset their password on a server running the old code will have `keysChangedAt` reset to `NULL`. In this case both new and old codebases will fall back to using  `verifierSetAt` as described above.

I'm happy with the code here, but I'm leaving it as "draft" until:

* [x] We have deployed https://github.com/mozilla/fxa/pull/3060 to production.
* [x] We have [deployed an update to tokenserver](https://bugzilla.mozilla.org/show_bug.cgi?id=1589565) to stop it from assuming that OAuth key ids contain the generation number.
* [x] We have re-targetted this PR against `master` rather than against the branch for https://github.com/mozilla/fxa/pull/3060
