### PR TITLE
fix(db): Reset `keysChangedAt` to NULL if we don't know its correct value

### DIFF
--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -843,7 +843,7 @@ module.exports = function(log, error) {
   // Update : accounts
   // Set    : verifyHash = $2, authSalt = $3, wrapWrapKb = $4, verifierSetAt = $5, verifierVersion = $6
   // Where  : uid = $1
-  var RESET_ACCOUNT = 'CALL resetAccount_13(?, ?, ?, ?, ?, ?)';
+  var RESET_ACCOUNT = 'CALL resetAccount_14(?, ?, ?, ?, ?, ?)';
 
   MySql.prototype.resetAccount = function(uid, data) {
     return this.write(RESET_ACCOUNT, [

--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 104;
+module.exports.level = 105;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-104-105.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-104-105.sql
@@ -1,0 +1,58 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('104');
+
+CREATE PROCEDURE `resetAccount_14` (
+  IN `uidArg` BINARY(16),
+  IN `verifyHashArg` BINARY(32),
+  IN `authSaltArg` BINARY(32),
+  IN `wrapWrapKbArg` BINARY(32),
+  IN `verifierSetAtArg` BIGINT UNSIGNED,
+  IN `verifierVersionArg` TINYINT UNSIGNED
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM sessionTokens WHERE uid = uidArg;
+  DELETE FROM keyFetchTokens WHERE uid = uidArg;
+  DELETE FROM accountResetTokens WHERE uid = uidArg;
+  DELETE FROM passwordChangeTokens WHERE uid = uidArg;
+  DELETE FROM passwordForgotTokens WHERE uid = uidArg;
+  DELETE FROM recoveryKeys WHERE uid = uidArg;
+  DELETE devices, deviceCommands FROM devices LEFT JOIN deviceCommands
+    ON (deviceCommands.uid = devices.uid AND deviceCommands.deviceId = devices.id)
+    WHERE devices.uid = uidArg;  DELETE FROM unverifiedTokens WHERE uid = uidArg;
+  UPDATE accounts
+  SET
+    verifyHash = verifyHashArg,
+    authSalt = authSaltArg,
+    wrapWrapKb = wrapWrapKbArg,
+    verifierSetAt = verifierSetAtArg,
+    verifierVersion = verifierVersionArg,
+    profileChangedAt = verifierSetAtArg,
+    -- The auth-server doesn't yet tell us whether or not the user's keys have changed,
+    -- so if they do a password reset, explicitly set the `keysChangedAt` timestamp to NULL
+    -- for "we don't know". Without this logic we might get into a situation like:
+    --
+    --   1. Deploy a new auth-server version that starts writing to this column
+    --   2. Some users reset their password, populating their `keysChangedAt` timestamp
+    --   3. We have to roll back the new auth-server version for operational reasons
+    --   4. A user from (2) resets their password again, leaving `keysChangedAt` at the
+    --      non-NULL value given to it in (2).
+    --   5. As a result, we incorrectly report that their key-rotation timestamp hasn't
+    --      changed when in fact it has.
+    --
+    -- By resetting `keysChangedAt` to NULL if we don't know the proper value, we ensure it
+    -- falls back to the current behaviour of defaulting to `verifierSetAt`.
+    keysChangedAt = NULL
+  WHERE uid = uidArg;
+
+  COMMIT;
+END;
+UPDATE dbMetadata SET value = '105' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-105-104.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-105-104.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE `resetAccount_14`;
+
+-- UPDATE dbMetadata SET value = '104' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
I started working on #490 to track the timestamp at which the user's keys were last changed, and I realized that there could be a subtle issue if we deployed that change and then had to roll it back.  Details in comments in the code below, but I think if we get this small change deployed first, then rolling out the bigger change for #490 will be safer.