### PR TITLE
chore(metrics): de-categorise content server perf events

### DIFF
--- a/packages/fxa-content-server/server/lib/flow-event.js
+++ b/packages/fxa-content-server/server/lib/flow-event.js
@@ -71,8 +71,6 @@ const PERFORMANCE_TIMINGS = [
   },
 ];
 
-const AUTH_VIEWS = new Set(['enter-email', 'force-auth', 'signin', 'signup']);
-
 const metricsRequest = (req, metrics, requestReceivedTime) => {
   if (FLOW_METRICS_DISABLED || !isValidFlowData(metrics, requestReceivedTime)) {
     return;
@@ -82,9 +80,7 @@ const metricsRequest = (req, metrics, requestReceivedTime) => {
 
   let emitPerformanceEvents = false;
   const events = metrics.events || [];
-  const performanceCategory = AUTH_VIEWS.has(metrics.initialView)
-    ? 'auth'
-    : 'other';
+  const { initialView } = metrics;
   events.forEach(event => {
     if (event.type === FLOW_BEGIN_EVENT) {
       event.time = metrics.flowBeginTime;
@@ -102,7 +98,7 @@ const metricsRequest = (req, metrics, requestReceivedTime) => {
       if (event.type === 'loaded') {
         emitPerformanceEvents = true;
         event = Object.assign({}, event, {
-          type: `flow.performance.${performanceCategory}`,
+          type: `flow.performance.${initialView}`,
         });
       }
 
@@ -150,7 +146,7 @@ const metricsRequest = (req, metrics, requestReceivedTime) => {
           {
             flowTime: relativeTime,
             time: absoluteTime,
-            type: `flow.performance.${performanceCategory}.${item.event}`,
+            type: `flow.performance.${initialView}.${item.event}`,
           },
           metrics,
           req

--- a/packages/fxa-content-server/tests/server/flow-event.js
+++ b/packages/fxa-content-server/tests/server/flow-event.js
@@ -306,14 +306,14 @@ registerSuite('flow-event', {
 
         'first call to process.stderr.write was correct': () => {
           const arg = JSON.parse(process.stderr.write.args[0][0]);
-          assert.equal(arg.event, 'flow.performance.auth');
+          assert.equal(arg.event, 'flow.performance.signup');
           assert.equal(arg.time, new Date(mocks.time).toISOString());
           assert.equal(arg.flow_time, 2000);
         },
 
         'second call to process.stderr.write was correct': () => {
           const arg = JSON.parse(process.stderr.write.args[1][0]);
-          assert.equal(arg.event, 'flow.performance.auth.network');
+          assert.equal(arg.event, 'flow.performance.signup.network');
           assert.equal(
             arg.time,
             new Date(mocks.time - 2000 + 300).toISOString()
@@ -323,7 +323,7 @@ registerSuite('flow-event', {
 
         'third call to process.stderr.write was correct': () => {
           const arg = JSON.parse(process.stderr.write.args[2][0]);
-          assert.equal(arg.event, 'flow.performance.auth.server');
+          assert.equal(arg.event, 'flow.performance.signup.server');
           assert.equal(
             arg.time,
             new Date(mocks.time - 2000 + 100).toISOString()
@@ -333,7 +333,7 @@ registerSuite('flow-event', {
 
         'fourth call to process.stderr.write was correct': () => {
           const arg = JSON.parse(process.stderr.write.args[3][0]);
-          assert.equal(arg.event, 'flow.performance.auth.client');
+          assert.equal(arg.event, 'flow.performance.signup.client');
           assert.equal(
             arg.time,
             new Date(mocks.time - 2000 + 200).toISOString()
@@ -1040,17 +1040,17 @@ registerSuite('flow-event', {
 
         'first call to process.stderr.write was correct': () => {
           const arg = JSON.parse(process.stderr.write.args[0][0]);
-          assert.equal(arg.event, 'flow.performance.other.network');
+          assert.equal(arg.event, 'flow.performance.settings.network');
         },
 
         'second call to process.stderr.write was correct': () => {
           const arg = JSON.parse(process.stderr.write.args[1][0]);
-          assert.equal(arg.event, 'flow.performance.other.server');
+          assert.equal(arg.event, 'flow.performance.settings.server');
         },
 
         'third call to process.stderr.write was correct': () => {
           const arg = JSON.parse(process.stderr.write.args[2][0]);
-          assert.equal(arg.event, 'flow.performance.other.client');
+          assert.equal(arg.event, 'flow.performance.settings.client');
         },
       },
     },
@@ -1077,7 +1077,7 @@ registerSuite('flow-event', {
 
         'first call to process.stderr.write was correct': () => {
           const arg = JSON.parse(process.stderr.write.args[0][0]);
-          assert.equal(arg.event, 'flow.performance.other');
+          assert.equal(arg.event, 'flow.performance.reset-password');
         },
       },
     },
@@ -1098,7 +1098,7 @@ registerSuite('flow-event', {
         'process.stderr.write was called correctly': () => {
           assert.equal(process.stderr.write.callCount, 1);
           const arg = JSON.parse(process.stderr.write.args[0][0]);
-          assert.equal(arg.event, 'flow.performance.auth');
+          assert.equal(arg.event, 'flow.performance.signin');
         },
       },
     },
@@ -1119,7 +1119,7 @@ registerSuite('flow-event', {
         'process.stderr.write was called correctly': () => {
           assert.equal(process.stderr.write.callCount, 1);
           const arg = JSON.parse(process.stderr.write.args[0][0]);
-          assert.equal(arg.event, 'flow.performance.auth');
+          assert.equal(arg.event, 'flow.performance.enter-email');
         },
       },
     },
@@ -1140,7 +1140,7 @@ registerSuite('flow-event', {
         'process.stderr.write was called correctly': () => {
           assert.equal(process.stderr.write.callCount, 1);
           const arg = JSON.parse(process.stderr.write.args[0][0]);
-          assert.equal(arg.event, 'flow.performance.auth');
+          assert.equal(arg.event, 'flow.performance.force-auth');
         },
       },
     },


### PR DESCRIPTION
Related to https://github.com/mozilla/fxa/issues/662#issuecomment-533621163.

Historically we divided content server performance events into two categories, `auth` and `other`. That was useful for viewing agggregate performance at the start of our funnels, but got in the way of other analysis. This change ditches those categories and just uses the raw view names instead. If we need to categorise events, we can do that in bespoke queries in Redash.

Opened speculatively in response to the linked comment above. If we land it, we'll also need to update the queries for the [perf dashboard](https://sql.telemetry.mozilla.org/dashboard/fxa-performance).

@mozilla/fxa-devs r?