### PR TITLE
fix(oauth): /__lbheartbeat__ route; no connect to database

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/lbheartbeat.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/lbheartbeat.js
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = {
+  handler: async function lbheartbeat(req, h) {
+    return h.response({}).suffix('\n');
+  },
+};

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routing.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routing.js
@@ -28,7 +28,7 @@ exports.routes = [
   {
     method: 'GET',
     path: '/__lbheartbeat__',
-    config: require('./routes/heartbeat'),
+    config: require('./routes/lbheartbeat'),
   },
   {
     method: 'GET',


### PR DESCRIPTION
`/__lbheartbeat__` already existed, running the same `db.ping()` as `/__heartbeat__`. This just changes it to return `{}`; previous route test for `/__lbheartbeat__` kept as is.

r? @mozilla/fxa-devs 