### PR TITLE
fix(tests): Fix failing OAuth tests by making client_secret default to required.

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/redirect.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/redirect.js
@@ -13,7 +13,7 @@ module.exports = {
     // to prevent a malicious OAuth server from stealing
     // a user's Scoped Keys. See bz1456351
     if (req.query.keys_jwk) {
-      throw AppError.invalidRequestParameter('keys_jwk');
+      throw AppError.invalidRequestParameter({ keys: ['keys_jwk'] });
     }
 
     const redirect = url.parse(contentUrl, true);

--- a/packages/fxa-auth-server/fxa-oauth-server/test/api.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/api.js
@@ -157,6 +157,7 @@ function newToken(payload = {}, options = {}) {
 
 function assertInvalidRequestParam(result, param) {
   assert.equal(result.code, 400);
+  assert.equal(result.errno, 109);
   assert.equal(result.message, 'Invalid request parameter');
   assert.equal(result.validation.keys.length, 1);
   assert.equal(result.validation.keys[0], param);
@@ -263,9 +264,7 @@ describe('/v1', function() {
         return Server.api
           .get('/authorization?keys_jwk=xyz&client_id=123&state=321&scope=1')
           .then(function(res) {
-            assert.equal(res.statusCode, 400);
-            assert.equal(res.result.errno, 109);
-            assert.equal(res.result.validation, 'keys_jwk');
+            assertInvalidRequestParam(res.result, 'keys_jwk');
             assertSecurityHeaders(res);
           });
       });

--- a/packages/fxa-auth-server/lib/routes/oauth.js
+++ b/packages/fxa-auth-server/lib/routes/oauth.js
@@ -227,7 +227,7 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
           headers: clientAuthValidators.headers,
           payload: {
             client_id: clientAuthValidators.clientId,
-            client_secret: clientAuthValidators.clientSecret,
+            client_secret: clientAuthValidators.clientSecret.optional(),
             token: Joi.alternatives().try(
               validators.accessToken,
               validators.refreshToken


### PR DESCRIPTION
I'm not sure why but my latest merge to master caused some oauth tests to start failing. This fixes them be restoring the validator on `client_secret` to be required by default, and also tweaks some instances of `invalidRequestParameter` that the tests told me did not have the expected response format.