### PR TITLE
chore(ci): skip build & deploy of content-server docker image for PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,19 +149,28 @@ jobs:
       - deploy:
           command: ../../.circleci/test-content-server.sh pairing
 
-      - setup_remote_docker
+      - store_artifacts:
+          path: ~/.pm2/logs
+          destination: logs
 
+  build-and-deploy-content-server:
+    docker:
+      - image: circleci/node:10-stretch-browsers
+      - image: redis
+      - image: memcached
+      - image: pafortin/goaws
+
+    working_directory: ~/project/packages/fxa-content-server
+    steps:
+      - attach_workspace:
+          at: ~/
+      - setup_remote_docker
       - deploy:
           command: ../../_scripts/install_docker.sh
-
       - deploy:
           command: ../../.circleci/build.sh fxa-content-server
       - deploy:
           command: ../../.circleci/deploy.sh fxa-content-server
-
-      - store_artifacts:
-          path: ~/.pm2/logs
-          destination: logs
 
   fxa-shared:
     docker:
@@ -359,6 +368,17 @@ workflows:
       - test-content-server:
           requires:
             - install-content-server
+      - build-and-deploy-content-server:
+          requires:
+            - test-content-server
+          filters:
+            branches:
+              only:
+                - master
+                - /feature.*/
+                - /dockerpush.*/
+            tags:
+              only: /.*/
       - fxa-shared:
           requires:
             - install


### PR DESCRIPTION
TL;DR: This can possibly shave 10 whole minutes off CI times.

- split build & deploy out of test-content-server
- should still build & deploy for master branch and tagged releases

fixes #2526