### PR TITLE
chore(metrics): add sampling rate config for statsd

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -15,13 +15,17 @@ const StatsD = require('hot-shots');
 
 function run(config) {
   const log = require('../lib/log')(config.log);
-  const statsd = new StatsD({
-    ...config.statsd,
-    errorHandler: err => {
-      // eslint-disable-next-line no-use-before-define
-      log.error('statsd.error', err);
-    },
-  });
+
+  let statsd;
+  if (config.statsd.enabled) {
+    statsd = new StatsD({
+      ...config.statsd,
+      errorHandler: err => {
+        log.error('statsd.error', err);
+      },
+    });
+  }
+
   const getGeoData = require('../lib/geodb')(log);
   // Force the geo to load and run at startup, not waiting for it to run on
   // some route later.
@@ -164,6 +168,9 @@ function run(config) {
               customs.close();
               oauthdb.close();
               subhub.close();
+              if (statsd) {
+                statsd.close();
+              }
               try {
                 senders.email.stop();
               } catch (e) {

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -135,5 +135,9 @@
     "recoveryCodes": {
       "count": 3
     }
+  },
+  "statsd": {
+    "enabled": true,
+    "sampleRate": 1
   }
 }

--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -743,23 +743,35 @@ const conf = convict({
     },
   },
   statsd: {
+    enabled: {
+      doc: 'Enable StatsD',
+      format: Boolean,
+      default: false,
+      env: 'STATSD_ENABLE',
+    },
+    sampleRate: {
+      doc: 'Sampling rate for StatsD',
+      format: Number,
+      default: 0.1,
+      env: 'STATSD_SAMPLE_RATE',
+    },
     host: {
-      default: 'localhost',
       doc: 'StatsD host to report to',
-      env: 'DD_AGENT_HOST',
       format: String,
+      default: 'localhost',
+      env: 'DD_AGENT_HOST',
     },
     port: {
-      default: 8125,
       doc: 'Port number of StatsD server',
-      env: 'DD_DOGSTATSD_PORT',
       format: Number,
+      default: 8125,
+      env: 'DD_DOGSTATSD_PORT',
     },
     prefix: {
-      default: 'fxa-auth-server.',
       doc: 'StatsD metrics name prefix',
-      env: 'STATSD_PREFIX',
       format: String,
+      default: 'fxa-auth-server.',
+      env: 'STATSD_PREFIX',
     },
   },
   corsOrigin: {


### PR DESCRIPTION
In light of what Shane said (on Slack) about how statsd affected performance previously, default to off and a low sampling rate.

@mozilla/fxa-devs r?