### PR TITLE
chore(metrics): add config for statsd message buffer size

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -755,6 +755,12 @@ const conf = convict({
       default: 0.1,
       env: 'STATSD_SAMPLE_RATE',
     },
+    maxBufferSize: {
+      doc: 'StatsD message buffer size in number of characters',
+      format: Number,
+      default: 500,
+      env: 'STATSD_BUFFER_SIZE',
+    },
     host: {
       doc: 'StatsD host to report to',
       format: String,


### PR DESCRIPTION
Setting a message buffer should help reduce the amount UDP traffic from `hot-shots`.  Note that by default `hot-shots` still flushes the queue every second.

Part of #997

@mozilla/fxa-devs r?