### PR TITLE
chore(experiment): Enable sign-up codes 100% and sign-in codes 50%

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/signup-code.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/signup-code.js
@@ -6,7 +6,7 @@
 
 const BaseGroupingRule = require('./base');
 const Constants = require('../../../lib/constants');
-const GROUPS_DEFAULT = ['control', 'treatment'];
+const GROUPS_DEFAULT = ['treatment'];
 
 const ROLLOUT_CLIENTS = {
   '37fdfa37698f251a': {
@@ -45,7 +45,7 @@ module.exports = class SignupCodeGroupingRule extends BaseGroupingRule {
   constructor() {
     super();
     this.name = 'signupCode';
-    this.SYNC_ROLLOUT_RATE = 0.4; // 40% of Sync users enrolled, 20% control and 20% treatment
+    this.SYNC_ROLLOUT_RATE = 1.0;
     this.ROLLOUT_CLIENTS = ROLLOUT_CLIENTS;
   }
 

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/token-code.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/token-code.js
@@ -39,7 +39,7 @@ module.exports = class TokenCodeGroupingRule extends BaseGroupingRule {
   constructor() {
     super();
     this.name = 'tokenCode';
-    this.SYNC_ROLLOUT_RATE = 0.0;
+    this.SYNC_ROLLOUT_RATE = 1.0; // All sync users are enrolled, 50/50 control/treatment
     this.ROLLOUT_CLIENTS = ROLLOUT_CLIENTS;
   }
 
@@ -90,7 +90,10 @@ module.exports = class TokenCodeGroupingRule extends BaseGroupingRule {
       }
 
       if (this.bernoulliTrial(syncRolloutRate, subject.uniqueUserId)) {
-        return this.uniformChoice(GROUPS_DEFAULT, subject.uniqueUserId);
+        return this.uniformChoice(
+          ['treatment-code', 'treatment-link'],
+          subject.uniqueUserId
+        );
       }
     }
 

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/signup-code.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/signup-code.js
@@ -66,10 +66,7 @@ describe('lib/experiments/grouping-rules/signup-code', () => {
         experiment.choose(subject);
         assert.isTrue(experiment.uniformChoice.calledOnce);
         assert.isTrue(
-          experiment.uniformChoice.calledWith(
-            ['control', 'treatment'],
-            'user-id'
-          )
+          experiment.uniformChoice.calledWith(['treatment'], 'user-id')
         );
       });
 
@@ -80,10 +77,7 @@ describe('lib/experiments/grouping-rules/signup-code', () => {
         experiment.choose(subject);
         assert.isTrue(experiment.uniformChoice.calledOnce);
         assert.isTrue(
-          experiment.uniformChoice.calledWith(
-            ['control', 'treatment'],
-            'user-id'
-          )
+          experiment.uniformChoice.calledWith(['treatment'], 'user-id')
         );
       });
 
@@ -96,7 +90,7 @@ describe('lib/experiments/grouping-rules/signup-code', () => {
                 featureFlags: {
                   signupCodeClients: {
                     invalidClientId: {
-                      groups: ['control'],
+                      groups: ['treatment'],
                       rolloutRate: 1,
                     },
                   },
@@ -105,7 +99,7 @@ describe('lib/experiments/grouping-rules/signup-code', () => {
               subject
             )
           ),
-          ['control']
+          ['treatment']
         );
       });
     });
@@ -121,6 +115,7 @@ describe('lib/experiments/grouping-rules/signup-code', () => {
       });
 
       it('returns false if rollout is 0', () => {
+        experiment.SYNC_ROLLOUT_RATE = 0.0;
         assert.equal(experiment.choose(subject), false);
       });
 
@@ -130,10 +125,7 @@ describe('lib/experiments/grouping-rules/signup-code', () => {
         experiment.choose(subject);
         assert.isTrue(experiment.uniformChoice.calledOnce, 'called once');
         assert.isTrue(
-          experiment.uniformChoice.calledWith(
-            ['control', 'treatment'],
-            'user-id'
-          )
+          experiment.uniformChoice.calledWith(['treatment'], 'user-id')
         );
       });
 
@@ -144,7 +136,7 @@ describe('lib/experiments/grouping-rules/signup-code', () => {
               featureFlags: {
                 signupCodeClients: {
                   sync: {
-                    groups: ['control', 'treatment'],
+                    groups: ['treatment'],
                     rolloutRate: 0,
                   },
                 },

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/token-code.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/token-code.js
@@ -115,6 +115,7 @@ describe('lib/experiments/grouping-rules/token-code', () => {
       });
 
       it('returns false if rollout is 0', () => {
+        experiment.SYNC_ROLLOUT_RATE = 0.0;
         assert.equal(experiment.choose(subject), false);
       });
 
@@ -124,7 +125,10 @@ describe('lib/experiments/grouping-rules/token-code', () => {
         experiment.choose(subject);
         assert.isTrue(experiment.uniformChoice.calledOnce, 'called once');
         assert.isTrue(
-          experiment.uniformChoice.calledWith(['treatment-code'], 'user-id')
+          experiment.uniformChoice.calledWith(
+            ['treatment-code', 'treatment-link'],
+            'user-id'
+          )
         );
       });
 
@@ -136,7 +140,7 @@ describe('lib/experiments/grouping-rules/token-code', () => {
               featureFlags: {
                 tokenCodeClients: {
                   sync: {
-                    groups: ['treatment-code'],
+                    groups: ['treatment-code', 'treatment-link'],
                     rolloutRate: 0,
                   },
                 },


### PR DESCRIPTION
Update the experiment rollout for these sync users. @irrationalagent @davismtl @mozilla/fxa-devs  r?

Fixes https://github.com/mozilla/fxa/issues/2642