### PR TITLE
fix(content-server): fix #2399 - add autofocus to password field during sign up

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -21,7 +21,7 @@
       <a href="/" class="use-different">{{#t}}Change email{{/t}}</a>
 
       <div class="input-row password-row">
-        <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required data-form-prefill="password" data-synchronize-show="true" />
+        <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autofocus data-form-prefill="password" data-synchronize-show="true" />
         <div class="helper-balloon" tabindex="-1"></div>
       </div>
 


### PR DESCRIPTION
fix for #2399 

@dannycoates if possible I'd like to get the r+ from at least you because this seemed deceptively simple and you've modified this code a lot recently. (My screenshot differs from the video QA provided because of your PR here which removed the trailhead specific style: #2404)

This fix works for me in XCode:
<img width="427" alt="image" src="https://user-images.githubusercontent.com/13018240/65917161-5e6b3b80-e39c-11e9-9b41-e7b7e6243d89.png">
