### PR TITLE
fix(codes): Fix resend code for the sign-in code feature

### DIFF
--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -402,7 +402,7 @@ module.exports = function(
 
         const code = otpUtils.generateOtpCode(secret, otpOptions);
 
-        await mailer.sendVerifyShortCode([], account, {
+        const options = {
           code,
           acceptLanguage: account.locale,
           ip,
@@ -413,7 +413,19 @@ module.exports = function(
           uaOSVersion: sessionToken.uaOSVersion,
           uaDeviceType: sessionToken.uaDeviceType,
           uid: sessionToken.uid,
-        });
+        };
+
+        if (account.primaryEmail.isVerified) {
+          // Unverified emails mean that the user is attempting to resend the code from signup page,
+          // therefore they get sent a different email template with the code.
+          await mailer.sendVerifyLoginCodeEmail(
+            account.emails,
+            account,
+            options
+          );
+        } else {
+          await mailer.sendVerifyShortCode([], account, options);
+        }
 
         return {};
       },

--- a/packages/fxa-auth-server/test/local/routes/session.js
+++ b/packages/fxa-auth-server/test/local/routes/session.js
@@ -1218,7 +1218,7 @@ describe('/session/resend_code', () => {
     });
   });
 
-  it('should resend the verification code email', async () => {
+  it('should resend the verification code email with unverified account', async () => {
     const response = await runTest(route, request);
     assert.deepEqual(response, {});
     assert.calledOnce(db.account);
@@ -1226,6 +1226,31 @@ describe('/session/resend_code', () => {
 
     const expectedCode = getExpectedOtpCode({}, signupCodeAccount.emailCode);
     const args = mailer.sendVerifyShortCode.args[0];
+    assert.equal(args[2].code, expectedCode);
+  });
+
+  it('should resend the verification code email with verified account', async () => {
+    const verifiedAccount = {
+      uid: 'foo',
+      email: 'foo@example.org',
+      primaryEmail: {
+        isVerified: true,
+        isPrimary: true,
+        emailCode: 'abcdef',
+      },
+    };
+
+    db.account = sinon.spy(() => verifiedAccount);
+    const response = await runTest(route, request);
+    assert.deepEqual(response, {});
+    assert.calledOnce(db.account);
+    assert.calledOnce(mailer.sendVerifyLoginCodeEmail);
+
+    const expectedCode = getExpectedOtpCode(
+      {},
+      verifiedAccount.primaryEmail.emailCode
+    );
+    const args = mailer.sendVerifyLoginCodeEmail.args[0];
     assert.equal(args[2].code, expectedCode);
   });
 });

--- a/packages/fxa-auth-server/test/remote/token_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/token_code_tests.js
@@ -255,6 +255,37 @@ describe('remote tokenCodes', function() {
       });
   });
 
+  it('should resend authentication code', async () => {
+    await Client.login(config.publicUrl, email, password, {
+      verificationMethod: 'email-2fa',
+      keys: true,
+    });
+
+    let emailData = await server.mailbox.waitForEmail(email);
+    const originalMessageId = emailData['messageId'];
+    const originalCode = emailData.headers['x-verify-short-code'];
+
+    assert.equal(emailData.headers['x-template-name'], 'verifyLoginCodeEmail');
+    assert.include(emailData.html, 'IP address');
+
+    await client.resendVerifyShortCodeEmail();
+
+    emailData = await server.mailbox.waitForEmail(email);
+    assert.equal(emailData.headers['x-template-name'], 'verifyLoginCodeEmail');
+    assert.include(emailData.html, 'IP address');
+
+    assert.notEqual(
+      originalMessageId,
+      emailData['messageId'],
+      'different email was sent'
+    );
+    assert.equal(
+      originalCode,
+      emailData.headers['x-verify-short-code'],
+      'codes match'
+    );
+  });
+
   after(() => {
     return TestServer.stop(server);
   });

--- a/packages/fxa-payments-server/package-lock.json
+++ b/packages/fxa-payments-server/package-lock.json
@@ -8644,9 +8644,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.0.tgz",
+      "integrity": "sha512-7XlnO8yBXOdi7AzowjZssQr47Ctidqm7GbgARapOaqSN9HQhlClnOkR9HieGauIT3A8MBC6u9wPCXs97PCYpWg==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",

--- a/packages/fxa-support-panel/package-lock.json
+++ b/packages/fxa-support-panel/package-lock.json
@@ -1428,9 +1428,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.0.tgz",
+      "integrity": "sha512-7XlnO8yBXOdi7AzowjZssQr47Ctidqm7GbgARapOaqSN9HQhlClnOkR9HieGauIT3A8MBC6u9wPCXs97PCYpWg==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -34,7 +34,7 @@
     "blankie": "^4.1.1",
     "bluebird": "^3.5.5",
     "convict": "^5.0.0",
-    "handlebars": "^4.1.2",
+    "handlebars": "^4.3.0",
     "mozlog": "2.2.0",
     "raven": "2.6.4",
     "request": "^2.88.0",


### PR DESCRIPTION
I noticed this while creating the point release for the experiment for sign in codes. Previously, when the user attempted to resend the sign-in code, it would send the incorrect email template. However the code was correct and that was why the tests passed.

This fixes the issue and adds some more tests that would have correctly caught this. Targeting as a point release for train-146, since we are opening up the experiment for more users.