### PR TITLE
fix(tests): Fix broken sign up code test

### DIFF
--- a/packages/fxa-content-server/tests/functional/sign_in_token_code.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_token_code.js
@@ -133,7 +133,7 @@ registerSuite('signin token code', {
           .then(testElementExists(selectors.SIGNIN_TOKEN_CODE.HEADER))
           .then(getEmailHeaders(email, 1))
           .then(headers => {
-            assert.equal(headers['x-template-name'], 'verifyShortCodeEmail');
+            assert.equal(headers['x-template-name'], 'verifyShortCode');
           })
           .then(fillOutSignInTokenCode(email, 1))
 


### PR DESCRIPTION
Noticed this failed in https://app.circleci.com/jobs/github/mozilla/fxa/83486/parallel-runs/5?filterBy=FAILED. We landed changes recently that updates the email template names, they no longer the `Email` suffix.