### PR TITLE
fix(authorization): Fix timezone issues when trading a code for a token

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/config.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/config.js
@@ -239,6 +239,15 @@ const conf = convict({
       default: 10,
       env: 'MYSQL_CONNECTION_LIMIT',
     },
+    timezone: {
+      default: 'Z',
+      doc:
+        'The timezone configured on the MySQL server. This is used to type cast server date/time' +
+        'values to JavaScript `Date` object. Can be `local`, `Z`, or an offset in the form of or' +
+        'an offset in the form +HH:MM or -HH:MM.',
+      env: 'MYSQL_TIMEZONE',
+      format: String,
+    },
   },
   openid: {
     // See ../docs/signing-key-management.md to read more about what these different keys are for.


### PR DESCRIPTION
Times written to the OAuth database are in UTC time. Times read out
do not have timezone information and are assumed to be in local time.

In London for this time of the year, that means we are 1 hour ahead
of UTC, and all dates read from the DB are one hour in the past.

Specify a `timezone` when configuring the MySQL connection, default
to `UTC` which is the timezone of the MySQL database.

fixes #2626

@jrgm or @jbuck - will this cause any problems for the production servers? The MySQL docker containers seem to be running in UTC, but I don't want to make that assumption for prod.