### PR TITLE
fix(email): revert email subjects to sentence casing

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -425,7 +425,7 @@ module.exports = function(log, config, oauthdb) {
 
     let templateName = 'verify';
     const metricsTemplateName = templateName;
-    let subject = gettext('Verify Your Account');
+    let subject = gettext('Verify your account');
     let action = gettext('Activate now');
     const query = {
       uid: message.uid,
@@ -469,7 +469,7 @@ module.exports = function(log, config, oauthdb) {
     }
 
     if (message.style === 'trailhead') {
-      subject = gettext('Finish Creating Your Account');
+      subject = gettext('Finish creating your account');
       action = gettext('Confirm email');
       templateName = 'verifyTrailhead';
     }
@@ -518,7 +518,7 @@ module.exports = function(log, config, oauthdb) {
     );
 
     const headers = {
-      'X-Verify-Short-Code': message.code,
+      'X-Verify-Short-Code': code,
     };
 
     return this.send({
@@ -549,9 +549,9 @@ module.exports = function(log, config, oauthdb) {
     )}`;
     let subject;
     if (index < verificationReminders.keys.length - 1) {
-      subject = gettext('Reminder: Complete Registration');
+      subject = gettext('Reminder: Finish creating your account');
     } else {
-      subject = gettext('Final Reminder: Activate Your Account');
+      subject = gettext('Final reminder: Activate your account');
     }
 
     templateNameToCampaignMap[template] = `${key}-verification-reminder`;
@@ -606,7 +606,7 @@ module.exports = function(log, config, oauthdb) {
       email: message.email,
       uid: message.uid,
     };
-    const subject = gettext('Authorization Code for %(clientName)s');
+    const subject = gettext('Account authorization code');
 
     const links = this._generateLinks(null, message.email, query, templateName);
 
@@ -615,15 +615,12 @@ module.exports = function(log, config, oauthdb) {
       'X-Report-SignIn-Link': links.reportSignInLink,
     };
 
-    const clientName = safeUserAgent.name(message.uaBrowser);
-
     return this.send({
       ...message,
       headers,
       subject,
       template: templateName,
       templateValues: {
-        clientName,
         device: this._formatUserAgentInfo(message),
         email: message.email,
         ip: message.ip,
@@ -678,7 +675,9 @@ module.exports = function(log, config, oauthdb) {
 
     return oauthClientInfo.fetch(message.service).then(clientInfo => {
       const clientName = clientInfo.name;
-      const subject = translator.gettext('Confirm New Sign-in');
+      const subject = translator.gettext(
+        'Confirm new sign-in to %(clientName)s'
+      );
       const action = gettext('Confirm sign-in');
 
       return this.send({
@@ -721,7 +720,7 @@ module.exports = function(log, config, oauthdb) {
       code: message.code,
       uid: message.uid,
     };
-    const subject = gettext('Sign-in Code for %(serviceName)s');
+    const subject = gettext('Sign-in code for %(serviceName)s');
 
     if (message.service) {
       query.service = message.service;
@@ -786,7 +785,7 @@ module.exports = function(log, config, oauthdb) {
       type: 'primary',
       primary_email_verified: message.email,
     };
-    const subject = gettext('Verify Primary Email');
+    const subject = gettext('Confirm primary email');
     const action = gettext('Verify email');
 
     if (message.service) {
@@ -845,7 +844,7 @@ module.exports = function(log, config, oauthdb) {
     });
 
     const templateName = 'verifySecondary';
-    const subject = gettext('Verify Secondary Email');
+    const subject = gettext('Confirm secondary email');
     const action = gettext('Verify email');
     const query = {
       code: message.code,
@@ -926,7 +925,7 @@ module.exports = function(log, config, oauthdb) {
     if (message.emailToHashWith) {
       query.emailToHashWith = message.emailToHashWith;
     }
-    const subject = gettext('Reset Your Password');
+    const subject = gettext('Reset your password');
     const action = gettext('Create new password');
 
     const links = this._generateLinks(
@@ -968,7 +967,7 @@ module.exports = function(log, config, oauthdb) {
 
   Mailer.prototype.passwordChangedEmail = function(message) {
     const templateName = 'passwordChanged';
-    const subject = gettext('Password Changed');
+    const subject = gettext('Password updated');
 
     const links = this._generateLinks(
       this.initiatePasswordResetUrl,
@@ -1006,7 +1005,7 @@ module.exports = function(log, config, oauthdb) {
 
   Mailer.prototype.passwordResetEmail = function(message) {
     const templateName = 'passwordReset';
-    const subject = gettext('Password Updated');
+    const subject = gettext('Password updated');
     const links = this._generateLinks(
       this.initiatePasswordResetUrl,
       message.email,
@@ -1036,7 +1035,7 @@ module.exports = function(log, config, oauthdb) {
 
   Mailer.prototype.passwordResetRequiredEmail = function(message) {
     const templateName = 'passwordResetRequired';
-    const subject = gettext('Suspicious Activity: Password Reset Required');
+    const subject = gettext('Suspicious activity detected');
     const links = this._generateLinks(
       this.initiatePasswordResetUrl,
       message.email,
@@ -1077,7 +1076,7 @@ module.exports = function(log, config, oauthdb) {
 
     return oauthClientInfo.fetch(message.service).then(clientInfo => {
       const clientName = clientInfo.name;
-      const subject = translator.gettext('New Sign-in to %(clientName)s');
+      const subject = translator.gettext('New sign-in to %(clientName)s');
       const action = gettext('Manage account');
 
       return this.send({
@@ -1114,12 +1113,12 @@ module.exports = function(log, config, oauthdb) {
     });
 
     let templateName = 'postVerify';
-    let subject = gettext('Account Verified');
+    let subject = gettext('Account verified');
     const query = {};
 
     if (message.style === 'trailhead') {
       templateName = 'postVerifyTrailhead';
-      subject = gettext('Account Confirmed');
+      subject = gettext('Account confirmed');
       query.style = 'trailhead';
     }
 
@@ -1165,7 +1164,7 @@ module.exports = function(log, config, oauthdb) {
 
     const templateName = 'postVerifySecondary';
     const links = this._generateSettingLinks(message, templateName);
-    const subject = gettext('Secondary Email Added');
+    const subject = gettext('Secondary email added');
     const action = gettext('Manage account');
 
     const headers = {
@@ -1201,7 +1200,7 @@ module.exports = function(log, config, oauthdb) {
 
     const templateName = 'postChangePrimary';
     const links = this._generateSettingLinks(message, templateName);
-    const subject = gettext('New Primary Email');
+    const subject = gettext('Primary email updated');
     const action = gettext('Manage account');
 
     const headers = {
@@ -1237,7 +1236,7 @@ module.exports = function(log, config, oauthdb) {
 
     const templateName = 'postRemoveSecondary';
     const links = this._generateSettingLinks(message, templateName);
-    const subject = gettext('Secondary Email Removed');
+    const subject = gettext('Secondary email removed');
     const action = gettext('Manage account');
 
     const headers = {
@@ -1271,7 +1270,7 @@ module.exports = function(log, config, oauthdb) {
 
     const templateName = 'postAddTwoStepAuthentication';
     const links = this._generateSettingLinks(message, templateName);
-    const subject = gettext('Two-Step Authentication Enabled');
+    const subject = gettext('Two-step verification enabled');
     const action = gettext('Manage account');
 
     const headers = {
@@ -1314,7 +1313,7 @@ module.exports = function(log, config, oauthdb) {
 
     const templateName = 'postRemoveTwoStepAuthentication';
     const links = this._generateSettingLinks(message, templateName);
-    const subject = gettext('Two-Step Authentication Disabled');
+    const subject = gettext('Two-step verification is off');
     const action = gettext('Manage account');
 
     const headers = {
@@ -1357,7 +1356,7 @@ module.exports = function(log, config, oauthdb) {
 
     const templateName = 'postNewRecoveryCodes';
     const links = this._generateSettingLinks(message, templateName);
-    const subject = gettext('New Recovery Codes Generated');
+    const subject = gettext('New recovery codes generated');
     const action = gettext('Manage account');
 
     const headers = {
@@ -1400,7 +1399,7 @@ module.exports = function(log, config, oauthdb) {
 
     const templateName = 'postConsumeRecoveryCode';
     const links = this._generateSettingLinks(message, templateName);
-    const subject = gettext('Recovery Code Used');
+    const subject = gettext('Recovery code used');
     const action = gettext('Manage account');
 
     const headers = {
@@ -1453,9 +1452,9 @@ module.exports = function(log, config, oauthdb) {
 
     let subject;
     if (numberRemaining === 1) {
-      subject = gettext('1 Recovery Code Remaining');
+      subject = gettext('1 recovery code remaining');
     } else {
-      subject = gettext('%(numberRemaining)s Recovery Codes Remaining');
+      subject = gettext('%(numberRemaining)s recovery codes remaining');
     }
 
     const action = gettext('Generate codes');
@@ -1490,7 +1489,7 @@ module.exports = function(log, config, oauthdb) {
 
     const templateName = 'postAddAccountRecovery';
     const links = this._generateSettingLinks(message, templateName);
-    const subject = gettext('Account Recovery Key Generated');
+    const subject = gettext('Account recovery key generated');
     const action = gettext('Manage account');
 
     const headers = {
@@ -1536,7 +1535,7 @@ module.exports = function(log, config, oauthdb) {
 
     const templateName = 'postRemoveAccountRecovery';
     const links = this._generateSettingLinks(message, templateName);
-    const subject = gettext('Account Recovery Key Removed');
+    const subject = gettext('Account recovery key removed');
     const action = gettext('Manage account');
 
     const headers = {
@@ -1582,7 +1581,7 @@ module.exports = function(log, config, oauthdb) {
       message,
       templateName
     );
-    const subject = gettext('Password Updated Using Recovery Key');
+    const subject = gettext('Password updated using recovery key');
     const action = gettext('Create new recovery key');
 
     const headers = {

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -122,7 +122,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['lowRecoveryCodesEmail', new Map([
-    ['subject', { test: 'equal', expected: '2 Recovery Codes Remaining' }],
+    ['subject', { test: 'equal', expected: '2 recovery codes remaining' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountRecoveryCodesUrl', 'low-recovery-codes', 'recovery-codes', 'low_recovery_codes=true', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('lowRecoveryCodes') }],
@@ -143,7 +143,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['newDeviceLoginEmail', new Map([
-    ['subject', { test: 'equal', expected: 'New Sign-in to Mock Relier' }],
+    ['subject', { test: 'equal', expected: 'New sign-in to Mock Relier' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('initiatePasswordChangeUrl', 'new-device-signin', 'change-password', 'email') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('newDeviceLogin') }],
@@ -172,7 +172,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['passwordChangedEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Password Changed' }],
+    ['subject', { test: 'equal', expected: 'Password updated' }],
     ['headers', new Map([
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('passwordChanged') }],
       ['X-Template-Name', { test: 'equal', expected: 'passwordChanged' }],
@@ -198,7 +198,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['passwordResetAccountRecoveryEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Password Updated Using Recovery Key' }],
+    ['subject', { test: 'equal', expected: 'Password updated using recovery key' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('createAccountRecoveryUrl', 'password-reset-account-recovery-success', 'create-recovery-key', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('passwordResetAccountRecovery') }],
@@ -227,7 +227,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['passwordResetEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Password Updated' }],
+    ['subject', { test: 'equal', expected: 'Password updated' }],
     ['headers', new Map([
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('passwordReset') }],
       ['X-Template-Name', { test: 'equal', expected: 'passwordReset' }],
@@ -247,7 +247,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['passwordResetRequiredEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Suspicious Activity: Password Reset Required' }],
+    ['subject', { test: 'equal', expected: 'Suspicious activity detected' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('initiatePasswordResetUrl', 'password-reset-required', 'reset-password', 'email', 'reset_password_confirm=false', 'email_to_hash_with=') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('passwordResetRequired') }],
@@ -268,7 +268,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['postAddAccountRecoveryEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Account Recovery Key Generated' }],
+    ['subject', { test: 'equal', expected: 'Account recovery key generated' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-recovery-generated', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postAddAccountRecovery') }],
@@ -291,7 +291,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['postAddTwoStepAuthenticationEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Two-Step Authentication Enabled' }],
+    ['subject', { test: 'equal', expected: 'Two-step verification enabled' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-two-step-enabled', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postAddTwoStepAuthentication') }],
@@ -320,7 +320,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['postChangePrimaryEmail', new Map([
-    ['subject', { test: 'equal', expected: 'New Primary Email' }],
+    ['subject', { test: 'equal', expected: 'Primary email updated' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-email-changed', 'account-email-changed', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postChangePrimary') }],
@@ -343,7 +343,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['postConsumeRecoveryCodeEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Recovery Code Used' }],
+    ['subject', { test: 'equal', expected: 'Recovery code used' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-consume-recovery-code', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postConsumeRecoveryCode') }],
@@ -372,7 +372,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['postNewRecoveryCodesEmail', new Map([
-    ['subject', { test: 'equal', expected: 'New Recovery Codes Generated' }],
+    ['subject', { test: 'equal', expected: 'New recovery codes generated' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-replace-recovery-codes', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postNewRecoveryCodes') }],
@@ -401,7 +401,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['postRemoveAccountRecoveryEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Account Recovery Key Removed' }],
+    ['subject', { test: 'equal', expected: 'Account recovery key removed' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-recovery-removed', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postRemoveAccountRecovery') }],
@@ -430,7 +430,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['postRemoveSecondaryEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Secondary Email Removed' }],
+    ['subject', { test: 'equal', expected: 'Secondary email removed' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-email-removed', 'account-email-removed', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postRemoveSecondary') }],
@@ -451,7 +451,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['postRemoveTwoStepAuthenticationEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Two-Step Authentication Disabled' }],
+    ['subject', { test: 'equal', expected: 'Two-step verification is off' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-two-step-disabled', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postRemoveTwoStepAuthentication') }],
@@ -480,7 +480,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['postVerifyEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Account Verified' }],
+    ['subject', { test: 'equal', expected: 'Account verified' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('syncUrl', 'account-verified', 'connect-device') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postVerify') }],
@@ -504,7 +504,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['postVerifySecondaryEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Secondary Email Added' }],
+    ['subject', { test: 'equal', expected: 'Secondary email added' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-email-verified', 'manage-account', 'email', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postVerifySecondary') }],
@@ -527,7 +527,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['recoveryEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Reset Your Password' }],
+    ['subject', { test: 'equal', expected: 'Reset your password' }],
     ['headers', new Map([
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('recovery') }],
       ['X-Template-Name', { test: 'equal', expected: 'recovery' }],
@@ -551,7 +551,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['unblockCodeEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Authorization Code for Firefox' }],
+    ['subject', { test: 'equal', expected: 'Account authorization code' }],
     ['headers', new Map([
       ['X-Report-SignIn-Link', { test: 'equal', expected: configUrl('reportSignInUrl', 'new-unblock', 'report', 'uid', 'unblockCode') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('unblockCode') }],
@@ -579,7 +579,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['verificationReminderFirstEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Reminder: Complete Registration' }],
+    ['subject', { test: 'equal', expected: 'Reminder: Finish creating your account' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('verificationUrl', 'first-verification-reminder', 'confirm-email', 'code', 'reminder=first', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verificationReminderFirst') }],
@@ -601,7 +601,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['verificationReminderSecondEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Final Reminder: Activate Your Account' }],
+    ['subject', { test: 'equal', expected: 'Final reminder: Activate your account' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('verificationUrl', 'second-verification-reminder', 'confirm-email', 'code', 'reminder=second', 'uid') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verificationReminderSecond') }],
@@ -653,7 +653,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['verifyLoginCodeEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Sign-in Code for Mock Relier' }],
+    ['subject', { test: 'equal', expected: 'Sign-in code for Mock Relier' }],
     ['headers', new Map([
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verifyLoginCode') }],
       ['X-Signin-Verify-Code', { test: 'equal', expected: MESSAGE.code }],
@@ -676,7 +676,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['verifyLoginEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Confirm New Sign-in' }],
+    ['subject', { test: 'equal', expected: 'Confirm new sign-in to Mock Relier' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('verifyLoginUrl', 'new-signin', 'confirm-signin', 'code', 'uid', 'service') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verifyLogin') }],
@@ -703,7 +703,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['verifyPrimaryEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Verify Primary Email' }],
+    ['subject', { test: 'equal', expected: 'Confirm primary email' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('verifyPrimaryEmailUrl', 'welcome-primary', 'activate', 'code', 'uid', 'type=primary', 'primary_email_verified', 'service') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verifyPrimary') }],
@@ -733,7 +733,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['verifySecondaryEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Verify Secondary Email' }],
+    ['subject', { test: 'equal', expected: 'Confirm secondary email' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('verifySecondaryEmailUrl', 'welcome-secondary', 'activate', 'code', 'uid', 'type=secondary', 'secondary_email_verified', 'service') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verifySecondary') }],
@@ -796,7 +796,7 @@ const TESTS = new Map([
 // prettier-ignore
 const TRAILHEAD_TESTS = new Map([
   ['postVerifyEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Account Confirmed' }],
+    ['subject', { test: 'equal', expected: 'Account confirmed' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: `${config.smtp.syncUrl}?style=trailhead&utm_medium=email&utm_campaign=fx-account-verified&utm_content=fx-connect-device` }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postVerifyTrailhead') }],
@@ -813,7 +813,7 @@ const TRAILHEAD_TESTS = new Map([
     ]],
   ])],
   ['verifyEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Finish Creating Your Account' }],
+    ['subject', { test: 'equal', expected: 'Finish creating your account' }],
     ['headers', new Map([
       ['X-Link', { test: 'include', expected: '&style=trailhead&' }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verifyTrailhead') }],
@@ -1503,7 +1503,11 @@ describe('email translations', () => {
         'language header is correct'
       );
       // NOTE: translation might change, but we use the subject, we don't change that often.
-      assert.equal(emailConfig.subject, 'Завершите создание вашего Аккаунта');
+      // TODO: switch back to testing the subject when translations have caught up
+      assert.include(
+        emailConfig.text,
+        'Для получения большей информации, посетите'
+      );
     });
 
     return mailer.verifyEmail({

--- a/packages/fxa-auth-server/test/remote/account_signin_verification_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_signin_verification_tests.js
@@ -149,7 +149,7 @@ describe('remote account signin verification', function() {
       .then(emailData => {
         uid = emailData.headers['x-uid'];
         code = emailData.headers['x-verify-code'];
-        assert.equal(emailData.subject, 'Confirm New Sign-in');
+        assert.equal(emailData.subject, 'Confirm new sign-in to Firefox');
         assert.ok(uid, 'sent uid');
         assert.ok(code, 'sent verify code');
 
@@ -205,7 +205,7 @@ describe('remote account signin verification', function() {
       })
       .then(emailData => {
         // Ensure correct email sent
-        assert.equal(emailData.subject, 'Verify Your Account');
+        assert.equal(emailData.subject, 'Verify your account');
         emailCode = emailData.headers['x-verify-code'];
         assert.ok(emailCode, 'sent verify code');
         return client.verifyEmail(emailCode);
@@ -221,7 +221,7 @@ describe('remote account signin verification', function() {
         // Verify sign-confirm email
         uid = emailData.headers['x-uid'];
         tokenCode = emailData.headers['x-verify-code'];
-        assert.equal(emailData.subject, 'Confirm New Sign-in');
+        assert.equal(emailData.subject, 'Confirm new sign-in to Firefox');
         assert.ok(uid, 'sent uid');
         assert.ok(tokenCode, 'sent verify code');
         assert.notEqual(
@@ -279,7 +279,7 @@ describe('remote account signin verification', function() {
         assert.ok(query.code, 'code is in link');
         assert.equal(query.service, options.service, 'service is in link');
         assert.equal(query.resume, options.resume, 'resume is in link');
-        assert.equal(emailData.subject, 'Confirm New Sign-in');
+        assert.equal(emailData.subject, 'Confirm new sign-in to Firefox');
       });
   });
 
@@ -317,7 +317,7 @@ describe('remote account signin verification', function() {
         assert.ok(query.code, 'code is in link');
         assert.equal(query.service, options.service, 'service is in link');
         assert.equal(query.resume, options.resume, 'resume is in link');
-        assert.equal(emailData.subject, 'Confirm New Sign-in');
+        assert.equal(emailData.subject, 'Confirm new sign-in to Firefox');
       })
       .then(() => {
         // Attempt to login from new location
@@ -598,7 +598,7 @@ describe('remote account signin verification', function() {
         return server.mailbox.waitForEmail(email);
       })
       .then(emailData => {
-        assert.equal(emailData.subject, 'Verify Your Account');
+        assert.equal(emailData.subject, 'Verify your account');
         tokenCode = emailData.headers['x-verify-code'];
         assert.ok(tokenCode, 'sent verify code');
       })
@@ -667,7 +667,7 @@ describe('remote account signin verification', function() {
         return server.mailbox.waitForEmail(email);
       })
       .then(emailData => {
-        assert.equal(emailData.subject, 'Confirm New Sign-in');
+        assert.equal(emailData.subject, 'Confirm new sign-in to Firefox');
         tokenCode = emailData.headers['x-verify-code'];
         assert.ok(tokenCode, 'sent verify code');
       })

--- a/packages/fxa-auth-server/test/remote/oauth_tests.js
+++ b/packages/fxa-auth-server/test/remote/oauth_tests.js
@@ -136,7 +136,7 @@ describe('/oauth/ routes', function() {
     // got an email notification
     const emailData = await server.mailbox.waitForEmail(email);
     assert.equal(emailData.headers['x-template-name'], 'newDeviceLogin');
-    assert.equal(emailData.subject, `New Sign-in to ${OAUTH_CLIENT_NAME}`);
+    assert.equal(emailData.subject, `New sign-in to ${OAUTH_CLIENT_NAME}`);
     assert.equal(
       emailData.headers['x-service-id'],
       PUBLIC_CLIENT_ID,

--- a/packages/fxa-auth-server/test/remote/password_change_tests.js
+++ b/packages/fxa-auth-server/test/remote/password_change_tests.js
@@ -107,7 +107,7 @@ describe('remote password change', function() {
       })
       .then(emailData => {
         const subject = emailData.headers['subject'];
-        assert.equal(subject, 'Password Changed');
+        assert.equal(subject, 'Password updated');
         const link = emailData.headers['x-link'];
         const query = url.parse(link, true).query;
         assert.ok(query.email, 'email is in the link');
@@ -197,7 +197,7 @@ describe('remote password change', function() {
       })
       .then(emailData => {
         const subject = emailData.headers['subject'];
-        assert.equal(subject, 'Password Changed');
+        assert.equal(subject, 'Password updated');
         const link = emailData.headers['x-link'];
         const query = url.parse(link, true).query;
         assert.ok(query.email, 'email is in the link');
@@ -315,7 +315,7 @@ describe('remote password change', function() {
       })
       .then(emailData => {
         const subject = emailData.headers['subject'];
-        assert.equal(subject, 'Password Changed');
+        assert.equal(subject, 'Password updated');
         const link = emailData.headers['x-link'];
         const query = url.parse(link, true).query;
         assert.ok(query.email, 'email is in the link');


### PR DESCRIPTION
Fixes #1684.

I think there was some confusion about who was going to fix this that ended up with nobody doing it. So this updates all the subjects to match the final decisions from the Google Doc in the linked issue.

Note there are a couple of discrepancies because we still have code for non-trailhead emails in here. I'm going to remove that in a separate PR, just in case I'm wrong in thinking it can be removed now.

@mozilla/fxa-devs r?