### PR TITLE
chore(experiments): Actually enable sign-in codes for all reliers

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/base.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/base.js
@@ -593,7 +593,7 @@ const BaseAuthenticationBroker = Backbone.Model.extend({
     /**
      * Are token codes flow supported?
      */
-    tokenCode: false,
+    tokenCode: true,
   },
 
   /**

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-desktop-v3.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-desktop-v3.js
@@ -20,7 +20,7 @@ const FxDesktopV3AuthenticationBroker = FxDesktopV2AuthenticationBroker.extend({
   defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
     allowUidChange: true,
     emailFirst: true,
-    tokenCode: false,
+    tokenCode: true,
   }),
 
   type: 'fx-desktop-v3',

--- a/packages/fxa-content-server/app/scripts/models/reliers/sync.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/sync.js
@@ -35,7 +35,7 @@ export default Relier.extend({
   defaults: _.extend({}, Relier.prototype.defaults, {
     action: undefined,
     signinCode: undefined,
-    tokenCode: false,
+    tokenCode: true,
   }),
 
   initialize(attributes, options = {}) {


### PR DESCRIPTION
The experiment rollout rate was increased however we have some flags that explicitly disable signup codes for different reliers. This turns those knobs on.

This change should start adding metrics to https://analytics.amplitude.com/mozilla-corp/dashboard/r94v1so.