### PR TITLE
fix(ci): ensure test-content-server has fxa-email-service container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,12 @@ jobs:
       - image: memcached
       - image: pafortin/goaws
       - image: circleci/mysql:5.6
+      - image: mozilla/fxa-email-service
+        environment:
+          NODE_ENV: dev
+          FXA_EMAIL_ENV: dev
+          FXA_EMAIL_LOG_LEVEL: debug
+          RUST_BACKTRACE: 1
 
     working_directory: ~/project/packages/fxa-content-server
     steps:
@@ -160,6 +166,13 @@ jobs:
       - image: redis
       - image: memcached
       - image: pafortin/goaws
+      - image: circleci/mysql:5.6
+      - image: mozilla/fxa-email-service
+        environment:
+          NODE_ENV: dev
+          FXA_EMAIL_ENV: dev
+          FXA_EMAIL_LOG_LEVEL: debug
+          RUST_BACKTRACE: 1
 
     working_directory: ~/project/packages/fxa-content-server
     steps:


### PR DESCRIPTION
Noticed [test failures with servers not starting in pm2](https://circleci.com/gh/mozilla/fxa/85546) - looks like I was overzealous in moving Docker setup entirely into the new `build-and-deploy-content-server` job.