### PR TITLE
fix(codes): Use tooltip for sign-up code errors and error div for all others

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -270,7 +270,7 @@ var ERRORS = {
   },
   INVALID_EXPIRED_SIGNUP_CODE: {
     errno: 183,
-    message: t('Expired or invalid code'),
+    message: t('Invalid or expired verification code'),
   },
   SERVER_BUSY: {
     errno: 201,

--- a/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
+++ b/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import _ from 'underscore';
+import AuthErrors from '../lib/auth-errors';
 import Cocktail from 'cocktail';
 import FlowEventsMixin from './mixins/flow-events-mixin';
 import FormView from './form';
@@ -72,7 +73,14 @@ class ConfirmSignupCodeView extends FormView {
 
         return this.invokeBrokerMethod('afterSignUpConfirmationPoll', account);
       })
-      .catch(err => this.showValidationError(this.$(CODE_INPUT_SELECTOR), err));
+      .catch(err => {
+        if (AuthErrors.is(err, 'INVALID_EXPIRED_SIGNUP_CODE')) {
+          return this.showValidationError(this.$(CODE_INPUT_SELECTOR), err);
+        }
+        // Throw all other errors, these will be displayed in the .error div and not
+        // tooltip.
+        throw err;
+      });
   }
 }
 

--- a/packages/fxa-content-server/app/tests/spec/views/confirm_signup_code.js
+++ b/packages/fxa-content-server/app/tests/spec/views/confirm_signup_code.js
@@ -202,7 +202,7 @@ describe('views/confirm_signup_code', () => {
       });
     });
 
-    describe('errors', () => {
+    describe('invalid or expired code error', () => {
       const error = AuthErrors.toError('INVALID_EXPIRED_SIGNUP_CODE');
 
       beforeEach(() => {
@@ -217,6 +217,25 @@ describe('views/confirm_signup_code', () => {
       it('rejects with the error for display', () => {
         const args = view.showValidationError.args[0];
         assert.equal(args[1], error);
+      });
+    });
+
+    describe('unexpected error', () => {
+      const error = AuthErrors.toError('UNEXPECTED_ERROR');
+
+      beforeEach(() => {
+        sinon
+          .stub(account, 'verifySessionCode')
+          .callsFake(() => Promise.reject(error));
+        sinon.spy(view, 'showValidationError');
+      });
+
+      it('rejects with the error for display', () => {
+        view.$('input.token-code').val(CODE);
+        return view.validateAndSubmit().then(assert.fail, () => {
+          assert.ok(view.$('.error').text().length);
+          assert.equal(view.showValidationError.callCount, 0);
+        });
       });
     });
   });

--- a/packages/fxa-content-server/tests/functional/sign_up_with_code.js
+++ b/packages/fxa-content-server/tests/functional/sign_up_with_code.js
@@ -147,7 +147,7 @@ registerSuite('signup with code', {
         .then(
           testElementTextInclude(
             selectors.SIGNIN_TOKEN_CODE.TOOLTIP,
-            'expired or invalid code'
+            'invalid or expired verification code'
           )
         );
     },


### PR DESCRIPTION
This fixes the comment I made in https://github.com/mozilla/fxa/pull/2558#discussion_r326732664. This correctly transforms the error recieved by the auth-server to a content-server error and displays it as a tooltip. All other errors will be handled at a lower level (which displays error in the `.error` class).

Fixes https://github.com/mozilla/fxa/issues/2701