### PR TITLE
fix(bug): ensure the jwt audience is set to the oauth-server url

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/assertion.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/assertion.js
@@ -71,7 +71,7 @@ const validateClaims = P.promisify(CLAIMS_SCHEMA.validate, {
   context: CLAIMS_SCHEMA,
 });
 
-const AUDIENCE = config.get('publicUrl');
+const AUDIENCE = config.get('audience');
 const ALLOWED_ISSUER = config.get('browserid.issuer');
 
 const request = P.promisify(

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/config/index.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/config/index.js
@@ -35,6 +35,7 @@ if (process.mainModule.filename.includes('key_server')) {
   conf.validate({
     allowed: 'strict',
   });
+  conf.set('audience', conf.get('publicUrl'));
 }
 
 if (conf.get('openid.keyFile')) {

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/config/schema.json
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/config/schema.json
@@ -18,6 +18,12 @@
     "format": "Boolean",
     "default": false
   },
+  "audience": {
+    "doc": "audience for oauth JWTs",
+    "format": "url",
+    "default": "http://127.0.0.1:9010",
+    "env": "OAUTH_URL"
+  },
   "auth": {
     "poolee": {
       "timeout": {


### PR DESCRIPTION
The jwt audience should be the oauth-server. Since both auth-server and oauth-server set `publicUrl` differently we can't use it as the audience directly. This change picks the right one based on the context the config was loaded in.