### PR TITLE
fix(pw-strength): No more false positives on the password checker!

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/models/password_strength/password_strength_balloon.js
+++ b/packages/fxa-content-server/app/tests/spec/models/password_strength/password_strength_balloon.js
@@ -45,6 +45,13 @@ describe('models/password_strength/password_strength_balloon', () => {
       assert.isUndefined(err);
     });
 
+    it('does not error with `JUA7MYM8ni3cgU`', () => {
+      // JUA7MYM8ni3cgU was a false positive with the bloomfilter based
+      // dictionary.
+      const err = model.validate({ password: 'JUA7MYM8ni3cgU' });
+      assert.isUndefined(err);
+    });
+
     it('catches if no password entered but user has taken some action', () => {
       const err = model.validate({ hasUserTakenAction: true, password: '' });
       assert.isTrue(AuthErrors.is(err, 'PASSWORD_REQUIRED'));

--- a/packages/fxa-content-server/npm-shrinkwrap.json
+++ b/packages/fxa-content-server/npm-shrinkwrap.json
@@ -2380,11 +2380,6 @@
                 "inherits": "~2.0.0"
             }
         },
-        "bloomfilter": {
-            "version": "0.0.18",
-            "resolved": "https://registry.npmjs.org/bloomfilter/-/bloomfilter-0.0.18.tgz",
-            "integrity": "sha512-CbnyHE78gY1tpXS/Ap+B0RJxKdRWCDzjBnX97UJSG8rdLv1PK8GiTWc/CCQyWu6PWVD4lUceeFrqC6Mf3nMgOA=="
-        },
         "bluebird": {
             "version": "3.5.5",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
@@ -5793,11 +5788,11 @@
             "dev": true
         },
         "fxa-common-password-list": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/fxa-common-password-list/-/fxa-common-password-list-0.0.3.tgz",
-            "integrity": "sha512-lRQX4EfMuiNACW4/L6Yr7gsAB2E1kSZBiP5qDV/l+2RkFazpDdtqBEN5piQYyECr1qw18VLt/+M3agF3ZDFtLA==",
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/fxa-common-password-list/-/fxa-common-password-list-0.0.4.tgz",
+            "integrity": "sha512-hjLkf5dTkFvR69IZHr5hWn+oV7gPBdkJNu0jbSKk+Drn0J/IMu9Ha4Z0THrAj5ZuJLYfYeFmfPM0XxDEVgoLkA==",
             "requires": {
-                "bloomfilter": "0.0.18"
+                "incremental-encoder": "0.0.1"
             }
         },
         "fxa-crypto-relier": {
@@ -7058,6 +7053,11 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
             "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
+        },
+        "incremental-encoder": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/incremental-encoder/-/incremental-encoder-0.0.1.tgz",
+            "integrity": "sha512-rx1ygYJNABGCN6C2oC4DWLbY1QDGXldeU3GqSRdTfegTIVkZXYvtSOy4dTTMQ29w270eCTCzEzaMOr1E23jwvA=="
         },
         "indent-string": {
             "version": "2.1.0",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -61,7 +61,7 @@
         "express": "4.16.2",
         "extract-loader": "2.0.1",
         "file-loader": "1.1.11",
-        "fxa-common-password-list": "^0.0.3",
+        "fxa-common-password-list": "0.0.4",
         "fxa-crypto-relier": "2.3.0",
         "fxa-js-client": "^1.0.21",
         "fxa-mustache-loader": "0.0.2",


### PR DESCRIPTION
The bloomfilter datastructure is replaced with an incrementally encoded
list of words and is no longer prone to false positives.

fixes #1530

@mozilla/fxa-devs - r?