### PR TITLE
fix(test): Fix the declarative test that timed out.

### DIFF
--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -845,8 +845,8 @@ describe('lib/senders/email:', () => {
     assert.notEqual(mailer.mailer, mailer.emailService);
   });
 
-  it('declarative tests', async () => {
-    for (const [type, test] of TESTS) {
+  for (const [type, test] of TESTS) {
+    it(`declarative test for ${type}`, async () => {
       mailer.mailer.sendMail = stubSendMail(message => {
         COMMON_TESTS.forEach((assertions, property) => {
           applyAssertions(type, message, property, assertions);
@@ -858,8 +858,8 @@ describe('lib/senders/email:', () => {
       });
 
       await mailer[type](MESSAGE);
-    }
-  });
+    });
+  }
 
   it('formats user-agent strings sanely', () => {
     let result = mailer._formatUserAgentInfo({


### PR DESCRIPTION
The test has a limit of 5 seconds, and all of the emails were
being checked in a single test. This breaks apart the tests
so that each email is run in its own test, with its own
5 second timeout

fixes #2788

@mozilla/fxa-devs - r?