### PR TITLE
feat(auth-server): send subscription download email immediately on activation

### DIFF
--- a/packages/fxa-auth-server/bin/subhub_messaging.js
+++ b/packages/fxa-auth-server/bin/subhub_messaging.js
@@ -34,7 +34,7 @@ async function run() {
       [config.subhubServerMessaging.subhubUpdatesQueueUrl]
     );
 
-    const [db, translator] = await Promise.all([
+    const [db] = await Promise.all([
       require(`${LIB_DIR}/db`)(config, log, Token).connect(
         config[config.db.backend]
       ),
@@ -44,15 +44,7 @@ async function run() {
       ),
     ]);
 
-    const { email: mailer } = await require(`${LIB_DIR}/senders`)(
-      log,
-      config,
-      require(`${LIB_DIR}/error`),
-      translator,
-      require(`${LIB_DIR}/oauthdb`)(log, config)
-    );
-
-    subhubUpdates(subhubUpdatesQueue, db, mailer);
+    subhubUpdates(subhubUpdatesQueue, db);
   } catch (err) {
     log.error('bin.subhub.error', { err });
     process.exit(1);

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -150,7 +150,7 @@ module.exports = function(
     config,
     customs,
     push,
-    oauthdb,
+    mailer,
     subhub,
     profile
   );

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -9,7 +9,7 @@ const isA = require('joi');
 const ScopeSet = require('../../../fxa-shared').oauth.scopes;
 const validators = require('./validators');
 
-module.exports = (log, db, config, customs, push, oauthdb, subhub, profile) => {
+module.exports = (log, db, config, customs, push, mailer, subhub, profile) => {
   // Skip routes if the subscriptions feature is not configured & enabled
   if (!config.subscriptions || !config.subscriptions.enabled) {
     return [];
@@ -164,6 +164,12 @@ module.exports = (log, db, config, customs, push, oauthdb, subhub, profile) => {
           email,
         });
         await profile.deleteCache(uid);
+
+        const account = await db.account(uid);
+        await mailer.sendDownloadSubscriptionEmail(account.emails, account, {
+          acceptLanguage: account.locale,
+          productId,
+        });
 
         log.info('subscriptions.createSubscription.success', {
           uid,

--- a/packages/fxa-auth-server/lib/subhub/updates.js
+++ b/packages/fxa-auth-server/lib/subhub/updates.js
@@ -29,7 +29,7 @@ function validateMessage(message) {
 }
 
 module.exports = function(log, config) {
-  return function start(messageQueue, db, mailer) {
+  return function start(messageQueue, db) {
     async function handleSubHubUpdates(message) {
       const uid = message && message.uid;
 
@@ -63,11 +63,6 @@ module.exports = function(log, config) {
               createdAt: message.eventCreatedAt,
             });
           }
-          const account = await db.account(uid);
-          await mailer.sendDownloadSubscriptionEmail(account.emails, account, {
-            acceptLanguage: account.locale,
-            productId: message.productName,
-          });
         } else {
           if (existing && existing.createdAt >= message.eventCreatedAt) {
             suppressNotification = true;


### PR DESCRIPTION
- move sending of download email from async queue into API route
- clean up unused mailer references in subhub message processing.
- clean up unused oauthdb references in subscription API route

fixes #2797