### PR TITLE
fix(payments): add config to disable HSTS to avoid multiple headers in production

### DIFF
--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -45,6 +45,12 @@ const conf = convict({
     env: 'NODE_ENV',
     format: ['development', 'production', 'test'],
   },
+  hstsEnabled: {
+    default: true,
+    doc: 'Send a Strict-Transport-Security header',
+    env: 'HSTS_ENABLED',
+    format: Boolean,
+  },
   hstsMaxAge: {
     default: 31536000, // a year
     doc: 'Max age of the STS directive in seconds',

--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -68,6 +68,17 @@ module.exports = () => {
     app.use(sentry.Handlers.requestHandler());
   }
 
+  const hstsEnabled = config.get('hstsEnabled');
+  if (hstsEnabled) {
+    app.use(
+      helmet.hsts({
+        force: true,
+        includeSubDomains: true,
+        maxAge: config.get('hstsMaxAge'),
+      })
+    );
+  }
+
   app.use(
     // Side effect - Adds default_fxa and dev_fxa to express.logger formats
     require('./logging/route-logging')(),
@@ -77,12 +88,6 @@ module.exports = () => {
     }),
 
     helmet.xssFilter(),
-
-    helmet.hsts({
-      force: true,
-      includeSubDomains: true,
-      maxAge: config.get('hstsMaxAge'),
-    }),
 
     helmet.noSniff(),
 


### PR DESCRIPTION
Because in production, under kubernetes we run iprep-nginx in front of the nodejs app server, and it unilaterally adds its own HSTS headers, the resulting response has >1 `Strict-Transport-Security` headers (#2650). If this merges, I'll configure production to `HSTS_ENABLED=false`, with the net result that only one HSTS header will be sent (although without the includeSubmains assertion).