### PR TITLE
fix(codes): Remove extra spaces from email templates

### DIFF
--- a/packages/fxa-auth-server/lib/senders/templates/verifyLoginCode.html
+++ b/packages/fxa-auth-server/lib/senders/templates/verifyLoginCode.html
@@ -12,9 +12,7 @@
       {{t "If yes, here is the verification code:" }}
     </p>
 
-    <p style="font-family: monospace !important; font-size: 32px; line-height: 26px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">
-      {{ code }}
-    </p>
+    <p style="font-family: monospace !important; font-size: 32px; line-height: 26px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{code}}</p>
 
     <p style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
       {{t "It expires in 5 minutes." }}

--- a/packages/fxa-auth-server/lib/senders/templates/verifyShortCode.html
+++ b/packages/fxa-auth-server/lib/senders/templates/verifyShortCode.html
@@ -14,9 +14,7 @@
       {{t "If yes, use this verification code:" }}
     </p>
 
-    <p style="font-family: monospace !important; font-size: 32px; line-height: 26px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">
-      {{ code }}
-    </p>
+    <p style="font-family: monospace !important; font-size: 32px; line-height: 26px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{code}}</p>
 
     <p style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
       {{t "It expires in 5 minutes." }}


### PR DESCRIPTION
Fixes #2498

This is a simple fix to remove the extra spaces from our codes emails so users can copy and paste them easier.

I took a stab at fixing our front end validation to remove/support spaces in the input field but that quickly grew into a bigger refactor than I was expecting and should be done in it's own PR.