### PR TITLE
feat: update sentry & capture uncaught subhub msgs

### DIFF
--- a/packages/fxa-auth-server/bin/subhub_messaging.js
+++ b/packages/fxa-auth-server/bin/subhub_messaging.js
@@ -7,11 +7,7 @@
 
 const LIB_DIR = '../lib';
 
-// This MUST be the first require in the program.
-// Only `require()` the newrelic module if explicity enabled.
-// If required, modules will be instrumented.
-require(`${LIB_DIR}/newrelic`)();
-
+const sentry = require('@sentry/node');
 const config = require('../config').getProperties();
 const StatsD = require('hot-shots');
 const statsd = new StatsD(config.statsd);
@@ -24,6 +20,8 @@ const Promise = require(`${LIB_DIR}/promise`);
 const Token = require(`${LIB_DIR}/tokens`)(log, config);
 const SQSReceiver = require(`${LIB_DIR}/sqs`)(log, statsd);
 const subhubUpdates = require(`${LIB_DIR}/subhub/updates`)(log, config);
+
+sentry.init({ dsn: config.sentryDsn });
 
 run();
 

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/server/configureSentry.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/server/configureSentry.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const Raven = require('raven');
+const sentry = require('@sentry/node');
 
 function configureSentry(server, config) {
   const sentryDsn = config.sentryDsn;
   if (sentryDsn) {
-    Raven.config(sentryDsn, {});
+    sentry.init({ dsn: sentryDsn });
     server.events.on({ name: 'request', channels: 'error' }, function(req, ev) {
       const err = (ev && ev.error) || null;
       let exception = '';
@@ -19,10 +19,10 @@ function configureSentry(server, config) {
         }
       }
 
-      Raven.captureException(err, {
-        extra: {
-          exception: exception,
-        },
+      sentry.withScope(scope => {
+        scope.setExtra('exception', exception);
+        sentry.captureException(err);
+        scope.clear();
       });
     });
   }

--- a/packages/fxa-auth-server/package-lock.json
+++ b/packages/fxa-auth-server/package-lock.json
@@ -171,6 +171,67 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@sentry/core": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.6.2.tgz",
+      "integrity": "sha512-grbjvNmyxP5WSPR6UobN2q+Nss7Hvz+BClBT8QTr7VTEG5q89TwNddn6Ej3bGkaUVbct/GpVlI3XflWYDsnU6Q==",
+      "requires": {
+        "@sentry/hub": "5.6.1",
+        "@sentry/minimal": "5.6.1",
+        "@sentry/types": "5.6.1",
+        "@sentry/utils": "5.6.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.6.1.tgz",
+      "integrity": "sha512-m+OhkIV5yTAL3R1+XfCwzUQka0UF/xG4py8sEfPXyYIcoOJ2ZTX+1kQJLy8QQJ4RzOBwZA+DzRKP0cgzPJ3+oQ==",
+      "requires": {
+        "@sentry/types": "5.6.1",
+        "@sentry/utils": "5.6.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.6.1.tgz",
+      "integrity": "sha512-ercCKuBWHog6aS6SsJRuKhJwNdJ2oRQVWT2UAx1zqvsbHT9mSa8ZRjdPHYOtqY3DoXKk/pLUFW/fkmAnpdMqRw==",
+      "requires": {
+        "@sentry/hub": "5.6.1",
+        "@sentry/types": "5.6.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.6.2.tgz",
+      "integrity": "sha512-A9CELco6SjF4zt8iS1pO3KdUVI2WVhtTGhSH6X04OVf2en1fimPR+Vs8YVY/04udwd7o+3mI6byT+rS9+/Qzow==",
+      "requires": {
+        "@sentry/core": "5.6.2",
+        "@sentry/hub": "5.6.1",
+        "@sentry/types": "5.6.1",
+        "@sentry/utils": "5.6.1",
+        "cookie": "0.3.1",
+        "https-proxy-agent": "2.2.1",
+        "lru_map": "0.3.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.6.1.tgz",
+      "integrity": "sha512-Kub8TETefHpdhvtnDj3kKfhCj0u/xn3Zi2zIC7PB11NJHvvPXENx97tciz4roJGp7cLRCJsFqCg4tHXniqDSnQ=="
+    },
+    "@sentry/utils": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.6.1.tgz",
+      "integrity": "sha512-rfgha+UsHW816GqlSRPlniKqAZylOmQWML2JsujoUP03nPu80zdN43DK9Poy/d9OxBxv0gd5K2n+bFdM2kqLQQ==",
+      "requires": {
+        "@sentry/types": "5.6.1",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
@@ -238,6 +299,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
       "integrity": "sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y="
+    },
+    "agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
     },
     "ajv": {
       "version": "4.1.7",
@@ -1213,6 +1282,19 @@
         "es6-set": "~0.1.5",
         "es6-symbol": "~3.1.1",
         "event-emitter": "~0.3.5"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
       }
     },
     "es6-set": {
@@ -2517,6 +2599,30 @@
       "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz",
       "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8="
     },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "i18n-abide": {
       "version": "0.0.26",
       "resolved": "https://registry.npmjs.org/i18n-abide/-/i18n-abide-0.0.26.tgz",
@@ -3319,10 +3425,10 @@
         "yallist": "^2.1.2"
       }
     },
-    "lsmod": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz",
-      "integrity": "sha1-mgD3bco26yP6BTUK/htYXUKZ5ks="
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "mailcomposer": {
       "version": "4.0.1",
@@ -4854,30 +4960,6 @@
       "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ==",
       "dev": true
     },
-    "raven": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-2.2.1.tgz",
-      "integrity": "sha1-V8f75oqAFH7FJ97z18AVdc+Uj+M=",
-      "requires": {
-        "cookie": "0.3.1",
-        "lsmod": "1.0.0",
-        "stack-trace": "0.0.9",
-        "timed-out": "4.0.1",
-        "uuid": "3.0.0"
-      },
-      "dependencies": {
-        "stack-trace": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
-          "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
-        },
-        "uuid": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
-          "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
-        }
-      }
-    },
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -5708,11 +5790,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -5771,6 +5848,11 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "tslib": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -36,6 +36,7 @@
   "author": "Mozilla (https://mozilla.org/)",
   "readmeFilename": "README.md",
   "dependencies": {
+    "@sentry/node": "^5.6.2",
     "ajv": "4.1.7",
     "aws-sdk": "2.77.0",
     "base64url": "3.0.0",
@@ -79,7 +80,6 @@
     "poolee": "1.0.1",
     "punycode.js": "2.1.0",
     "qrcode": "1.2.0",
-    "raven": "2.2.1",
     "redis": "2.7.1",
     "request": "2.88.0",
     "safe-regex": "1.1.0",


### PR DESCRIPTION
Because:

* FxA Auth server used an old obsolete Raven client.
* SubHub SQS receiver didn't capture exceptions.

This commit:

* Add's Sentry error capturing to SubHub SQS
  receiver.
* Upgrades auth-server error reporting to use
  the current Sentry library.

Closes #2756