### PR TITLE
feat: add queue prefix config and fix login validation

### DIFF
--- a/packages/fxa-event-broker/bin/worker.ts
+++ b/packages/fxa-event-broker/bin/worker.ts
@@ -67,6 +67,7 @@ async function main() {
     capabilityService,
     webhookService,
     pubsub,
+    Config.get('topicPrefix'),
     serviceNotificationQueueUrl,
     new SQS({ region })
   );

--- a/packages/fxa-event-broker/bin/workerDev.ts
+++ b/packages/fxa-event-broker/bin/workerDev.ts
@@ -139,6 +139,7 @@ async function main() {
     capabilityService,
     webhookService,
     pubsub,
+    Config.get('topicPrefix'),
     Config.get('serviceNotificationQueueUrl'),
     new SQS()
   );

--- a/packages/fxa-event-broker/config/index.ts
+++ b/packages/fxa-event-broker/config/index.ts
@@ -181,6 +181,12 @@ const conf = convict({
       'The queue URL to use (should include https://sqs.<region>.amazonaws.com/<account-id>/<queue-name>)',
     env: 'SERVICE_NOTIFICATION_QUEUE_URL',
     format: String
+  },
+  topicPrefix: {
+    default: 'rpQueue-',
+    doc: 'GCP PubSub Queue prefix',
+    env: 'PUBSUB_QUEUE_PREFIX',
+    format: String
   }
 });
 

--- a/packages/fxa-event-broker/lib/db/firestore.ts
+++ b/packages/fxa-event-broker/lib/db/firestore.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { DocumentData, Firestore, Settings } from '@google-cloud/firestore';
+import { Firestore, Settings } from '@google-cloud/firestore';
 import { TypedCollectionReference, TypedDocumentReference } from 'typesafe-node-firestore';
 
 import { ClientWebhooks } from '../selfUpdatingService/clientWebhookService';

--- a/packages/fxa-event-broker/lib/notificationProcessor.ts
+++ b/packages/fxa-event-broker/lib/notificationProcessor.ts
@@ -31,7 +31,6 @@ function unhandledEventType(e: ServiceNotification) {
 
 class ServiceNotificationProcessor {
   public readonly app: Consumer;
-  private readonly topicPrefix = 'rpQueue-';
 
   constructor(
     private readonly logger: Logger,
@@ -40,6 +39,7 @@ class ServiceNotificationProcessor {
     private readonly capabilityService: ClientCapabilityService,
     private readonly webhookService: ClientWebhookService,
     private readonly pubsub: PubSub,
+    private readonly topicPrefix: string,
     queueUrl: string,
     sqs: SQS
   ) {

--- a/packages/fxa-event-broker/test/lib/notificationProcessor.spec.ts
+++ b/packages/fxa-event-broker/test/lib/notificationProcessor.spec.ts
@@ -95,6 +95,7 @@ describe('ServiceNotificationProcessor', () => {
       capabilityService,
       webhookService,
       pubsub,
+      'rpQueue-',
       'https://sqs.eu-west-1.amazonaws.com/account-id/queue-name',
       sqs
     );


### PR DESCRIPTION
Because:

* The queue prefix is not configurable and FxA reuses client ID's in
  the dev/stage environment.
* Login messages don't always include a service property.

This commit:

* Allows the queue prefix to be configured.
* Makes the service property optional for login messages.

Closes #2819