### PR TITLE
chore(npm): changed 'npm start' to run 'pm2 start mysql_servers.json'

### DIFF
--- a/mysql_servers.json
+++ b/mysql_servers.json
@@ -1,6 +1,67 @@
 {
   "apps": [
     {
+      "name": "MySQL server PORT 3306",
+      "script": "_scripts/mysql.sh",
+      "max_restarts": "1",
+      "min_uptime": "2m",
+      "kill_timeout": 20000
+    },
+    {
+      "name": "redis PORT 6379",
+      "script": "_scripts/redis.sh",
+      "env": {
+        "PORT": "6379"
+      },
+      "max_restarts": "1",
+      "min_uptime": "2m",
+      "kill_timeout": 20000
+    },
+    {
+      "name": "memcached PORT 11211",
+      "script": "_scripts/memcached.sh",
+      "max_restarts": "1",
+      "min_uptime": "2m",
+      "kill_timeout": 20000
+    },
+    {
+      "name": "Fake SQS/SNS PORT 4100",
+      "script": "_scripts/goaws.sh",
+      "max_restarts": "1",
+      "min_uptime": "2m",
+      "autorestart": false,
+      "kill_timeout": 20000
+    },
+    {
+      "name": "google-pubsub-emulator PORT 8005",
+      "script": "_scripts/pubsub.sh",
+      "max_restarts": "1",
+      "min_uptime": "2m",
+      "kill_timeout": 20000
+    },
+    {
+      "name": "google-firestore-emulator PORT 8006",
+      "script": "_scripts/firestore.sh",
+      "max_restarts": "1",
+      "min_uptime": "2m",
+      "kill_timeout": 20000
+    },
+    {
+      "name": "sync server PORT 5000",
+      "script": "_scripts/syncserver.sh",
+      "max_restarts": "1",
+      "min_uptime": "2m",
+      "autorestart": false,
+      "kill_timeout": 20000
+    },
+    {
+      "name": "email-service PORT 8001",
+      "script": "_scripts/fxa_email_service.sh",
+      "max_restarts": "1",
+      "min_uptime": "2m",
+      "kill_timeout": 20000
+    },
+    {
       "name": "auth-server local mail helper",
       "script": "test/mail_helper.js",
       "cwd": "packages/fxa-auth-server",
@@ -137,48 +198,6 @@
       "min_uptime": "2m"
     },
     {
-      "name": "sync server PORT 5000",
-      "script": "_scripts/syncserver.sh",
-      "max_restarts": "1",
-      "min_uptime": "2m",
-      "autorestart": false
-    },
-    {
-      "name": "redis PORT 6379",
-      "script": "_scripts/redis.sh",
-      "env": {
-        "PORT": "6379"
-      },
-      "max_restarts": "1",
-      "min_uptime": "2m"
-    },
-    {
-      "name": "memcached PORT 11211",
-      "script": "_scripts/memcached.sh",
-      "max_restarts": "1",
-      "min_uptime": "2m"
-    },
-    {
-      "name": "Fake SQS/SNS PORT 4100",
-      "script": "_scripts/goaws.sh",
-      "max_restarts": "1",
-      "min_uptime": "2m",
-      "autorestart": false
-    },
-    {
-      "name": "email-service PORT 8001",
-      "script": "_scripts/fxa_email_service.sh",
-      "max_restarts": "1",
-      "min_uptime": "2m"
-    },
-    {
-      "name": "pushbox PORT 8002",
-      "script": "_scripts/pushbox.sh",
-      "max_restarts": "1",
-      "min_uptime": "2m",
-      "args": "3306 root@mydb:3306"
-    },
-    {
       "name": "payments server PORT 3031",
       "cwd": "packages/fxa-payments-server",
       "script": "npm",
@@ -215,23 +234,12 @@
       "min_uptime": "2m"
     },
     {
-      "name": "google-pubsub-emulator PORT 8005",
-      "script": "_scripts/pubsub.sh",
+      "name": "pushbox PORT 8002",
+      "script": "_scripts/pushbox.sh",
       "max_restarts": "1",
-      "min_uptime": "2m"
-    },
-    {
-      "name": "google-firestore-emulator PORT 8006",
-      "script": "_scripts/firestore.sh",
-      "max_restarts": "1",
-      "min_uptime": "2m"
-    },
-
-    {
-      "name": "MySQL server PORT 3306",
-      "script": "_scripts/mysql.sh",
-      "max_restarts": "1",
-      "min_uptime": "2m"
+      "min_uptime": "2m",
+      "args": "3306 root@mydb:3306",
+      "kill_timeout": 20000
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "authors": "git shortlog -s | cut -c8- | sort -f > AUTHORS",
     "postinstall": "_scripts/postinstall.sh",
-    "update": "./pm2 kill && _scripts/update_all.sh",
-    "start": "fxa-dev-launcher",
+    "update": "pm2 kill && _scripts/update_all.sh",
+    "start": "pm2 start mysql_servers.json",
+    "start-firefox": "fxa-dev-launcher",
     "start-android": "node _scripts/start-android.js",
     "test": "lerna run test",
     "config-fxios": "node _scripts/config-fxios.js",


### PR DESCRIPTION
Moved `fxa-dev-launcher` to `npm run start-firefox` and made `npm start` run `pm2 start mysql_servers.json`

Using `npm start` again on an already running cluster will restart all the services.

Also extended the pm2 `kill_timeout` for docker processes to make restarts behave better.