### PR TITLE
feat(metrics): Propagate flow_* params from content to payments server

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/payment-server.js
+++ b/packages/fxa-content-server/app/scripts/lib/payment-server.js
@@ -4,12 +4,22 @@
 
 'use strict';
 
+import Url from './url';
+
 const PaymentServer = {
+  /**
+   * Navigate to the payments server after flushing metrics.
+   *
+   * @param {Object} view
+   * @param {Object} subscriptionsConfig
+   * @param {String} redirectPath
+   * @param {Object} [queryParams={}]
+   */
   navigateToPaymentServer(
     view,
     subscriptionsConfig,
     redirectPath,
-    queryParams
+    queryParams = {}
   ) {
     const {
       managementClientId,
@@ -17,15 +27,13 @@ const PaymentServer = {
       managementTokenTTL,
       managementUrl,
     } = subscriptionsConfig;
-    const queryString =
-      typeof queryParams === 'object' &&
-      Object.keys(queryParams)
-        .filter(k => queryParams[k] !== null && queryParams[k] !== '')
-        .map(
-          k => `${encodeURIComponent(k)}=${encodeURIComponent(queryParams[k])}`
-        )
-        .join('&');
-    const qs = queryString.length ? `?${queryString}` : '';
+
+    const {
+      deviceId,
+      flowBeginTime,
+      flowId,
+    } = view.metrics.getFlowEventMetadata();
+
     return view
       .getSignedInAccount()
       .createOAuthToken(managementClientId, {
@@ -33,9 +41,22 @@ const PaymentServer = {
         ttl: managementTokenTTL,
       })
       .then(accessToken => {
-        const url = `${managementUrl}/${redirectPath}${qs}#accessToken=${encodeURIComponent(
-          accessToken.get('token')
-        )}`;
+        const queryString = Url.objToSearchString({
+          // device_id, flow_begin_time, and flow_id need to be propagated to
+          // the payments server so that the user funnel can be traced from the RP,
+          // through the content server, and to the payments server, appearing as
+          // the same user throughout.
+          device_id: deviceId,
+          flow_begin_time: flowBeginTime,
+          flow_id: flowId,
+          ...queryParams,
+        });
+
+        const hashString = Url.objToHashString({
+          accessToken: accessToken.get('token'),
+        });
+
+        const url = `${managementUrl}/${redirectPath}${queryString}${hashString}`;
         view.navigateAway(url);
       });
   },

--- a/packages/fxa-content-server/app/scripts/lib/url.js
+++ b/packages/fxa-content-server/app/scripts/lib/url.js
@@ -114,7 +114,11 @@ export default {
     const params = [];
     for (const paramName in obj) {
       const paramValue = obj[paramName];
-      if (typeof paramValue !== 'undefined' && paramValue !== null) {
+      if (
+        typeof paramValue !== 'undefined' &&
+        paramValue !== null &&
+        paramValue !== ''
+      ) {
         params.push(paramName + '=' + encodeURIComponent(paramValue));
       }
     }

--- a/packages/fxa-content-server/app/scripts/views/mixins/flow-events-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/flow-events-mixin.js
@@ -9,7 +9,7 @@ import KEYS from '../../lib/key-codes';
 
 export default {
   afterRender() {
-    this.notifier.trigger('flow.initialize');
+    this.initializeFlowEvents();
   },
 
   events: {
@@ -20,6 +20,10 @@ export default {
     'keyup input': '_keyupFlowEventsInput',
     'keyup textarea': '_keyupFlowEventsInput',
     submit: '_submitFlowEventsForm',
+  },
+
+  initializeFlowEvents() {
+    this.notifier.trigger('flow.initialize');
   },
 
   _clickFlowEventsLink(event) {

--- a/packages/fxa-content-server/app/scripts/views/subscriptions_management_redirect.js
+++ b/packages/fxa-content-server/app/scripts/views/subscriptions_management_redirect.js
@@ -2,28 +2,36 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- import FormView from './form';
- import Template from 'templates/subscriptions_redirect.mustache';
- import PaymentServer from '../lib/payment-server';
+import Cocktail from '../lib/cocktail';
+import FlowEventsMixin from './mixins/flow-events-mixin';
+import FormView from './form';
+import Template from 'templates/subscriptions_redirect.mustache';
+import PaymentServer from '../lib/payment-server';
 
- class SubscriptionsManagementRedirectView extends FormView {
-   mustAuth = true;
-   template = Template;
+class SubscriptionsManagementRedirectView extends FormView {
+  mustAuth = true;
+  template = Template;
 
-   initialize(options) {
-     this._subscriptionsConfig = {};
-     if (options && options.config && options.config.subscriptions) {
-       this._subscriptionsConfig = options.config.subscriptions;
-     }
-   }
+  initialize(options) {
+    this._subscriptionsConfig = {};
+    if (options && options.config && options.config.subscriptions) {
+      this._subscriptionsConfig = options.config.subscriptions;
+    }
 
-   afterRender() {
-     return PaymentServer.navigateToPaymentServer(
-       this,
-       this._subscriptionsConfig,
-       'subscriptions'
-     );
-   }
- }
+    // Flow events need to be initialized before the navigation
+    // so the flow_id and flow_begin_time are propagated
+    this.initializeFlowEvents();
+  }
 
- export default SubscriptionsManagementRedirectView;
+  afterRender() {
+    return PaymentServer.navigateToPaymentServer(
+      this,
+      this._subscriptionsConfig,
+      'subscriptions'
+    );
+  }
+}
+
+Cocktail.mixin(SubscriptionsManagementRedirectView, FlowEventsMixin);
+
+export default SubscriptionsManagementRedirectView;

--- a/packages/fxa-content-server/app/scripts/views/subscriptions_product_redirect.js
+++ b/packages/fxa-content-server/app/scripts/views/subscriptions_product_redirect.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import Cocktail from '../lib/cocktail';
+import FlowEventsMixin from './mixins/flow-events-mixin';
 import FormView from './form';
 import Template from 'templates/subscriptions_redirect.mustache';
 import PaymentServer from '../lib/payment-server';
@@ -16,6 +18,10 @@ class SubscriptionsProductRedirectView extends FormView {
     if (options && options.config && options.config.subscriptions) {
       this._subscriptionsConfig = options.config.subscriptions;
     }
+
+    // Flow events need to be initialized before the navigation
+    // so the flow_id and flow_begin_time are propagated
+    this.initializeFlowEvents();
   }
 
   afterRender() {
@@ -29,5 +35,7 @@ class SubscriptionsProductRedirectView extends FormView {
     );
   }
 }
+
+Cocktail.mixin(SubscriptionsProductRedirectView, FlowEventsMixin);
 
 export default SubscriptionsProductRedirectView;

--- a/packages/fxa-content-server/app/scripts/views/support.js
+++ b/packages/fxa-content-server/app/scripts/views/support.js
@@ -249,6 +249,10 @@ const SupportView = BaseView.extend({
   },
 
   navigateToSubscriptionsManagement(queryParams = {}) {
+    // Flow events need to be initialized before the navigation
+    // so the flow_id and flow_begin_time are propagated
+    this.initializeFlowEvents();
+
     PaymentServer.navigateToPaymentServer(
       this,
       this._subscriptionsConfig,

--- a/packages/fxa-content-server/app/tests/spec/views/subscriptions_management_redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/views/subscriptions_management_redirect.js
@@ -2,78 +2,75 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- import $ from 'jquery';
- import Account from 'models/account';
- import { assert } from 'chai';
- import sinon from 'sinon';
- import User from 'models/user';
- import View from 'views/subscriptions_management_redirect';
- import Notifier from 'lib/channels/notifier';
- import WindowMock from '../../mocks/window';
- import PaymentServer from 'lib/payment-server';
+import $ from 'jquery';
+import Account from 'models/account';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import User from 'models/user';
+import View from 'views/subscriptions_management_redirect';
+import Notifier from 'lib/channels/notifier';
+import WindowMock from '../../mocks/window';
+import PaymentServer from 'lib/payment-server';
 
- describe('views/subscriptions_management_redirect', function() {
-   let account;
-   let user;
-   let view;
-   let windowMock;
-   let config;
-   let notifier;
+describe('views/subscriptions_management_redirect', function() {
+  let account;
+  let user;
+  let view;
+  let windowMock;
+  let config;
+  let notifier;
 
-   function render() {
-     return view.render().then(() => view.afterVisible());
-   }
+  function render() {
+    return view.render().then(() => view.afterVisible());
+  }
 
-   beforeEach(function() {
-     user = new User();
-     account = new Account();
-     notifier = new Notifier();
-     windowMock = new WindowMock();
+  beforeEach(function() {
+    user = new User();
+    account = new Account();
+    notifier = new Notifier();
+    windowMock = new WindowMock();
 
-     config = {
-       subscriptions: {
-         managementClientId: 'MOCK_CLIENT_ID',
-         managementScopes: 'MOCK_SCOPES',
-         managementTokenTTL: 900,
-         managementUrl: 'http://example.com',
-       },
-     };
+    config = {
+      subscriptions: {
+        managementClientId: 'MOCK_CLIENT_ID',
+        managementScopes: 'MOCK_SCOPES',
+        managementTokenTTL: 900,
+        managementUrl: 'http://example.com',
+      },
+    };
 
-     sinon.stub(user, 'sessionStatus').callsFake(() => Promise.resolve(account));
+    sinon.stub(user, 'sessionStatus').callsFake(() => Promise.resolve(account));
 
-     view = new View({
-       config,
-       currentPage: `subscriptions`,
-       notifier,
-       user,
-       window: windowMock,
-     });
+    view = new View({
+      config,
+      currentPage: `subscriptions`,
+      notifier,
+      user,
+      window: windowMock,
+    });
 
-     sinon.stub(view, 'getSignedInAccount').callsFake(() => account);
+    sinon.stub(view, 'getSignedInAccount').callsFake(() => account);
+    sinon.stub(view, 'initializeFlowEvents');
 
-     sinon
-       .stub(PaymentServer, 'navigateToPaymentServer')
-       .resolves(true);
+    sinon.stub(PaymentServer, 'navigateToPaymentServer').resolves(true);
 
-     return render();
-   });
+    return render();
+  });
 
-   afterEach(function() {
-     PaymentServer.navigateToPaymentServer.restore();
-     $(view.el).remove();
-     view.destroy();
-     view = null;
-   });
+  afterEach(function() {
+    PaymentServer.navigateToPaymentServer.restore();
+    $(view.el).remove();
+    view.destroy();
+    view = null;
+  });
 
-   describe('render', () => {
-     it('renders correctly', () => {
-       assert.lengthOf(view.$('.subscriptions-redirect'), 1);
-     });
-
-     it('calls PaymentServer.navigateToPaymentServer as expected', () => {
-       assert.deepEqual(PaymentServer.navigateToPaymentServer.args, [
-         [view, config.subscriptions, `subscriptions`],
-       ]);
-     });
-   });
- });
+  describe('render', () => {
+    it('renders correctly, initializes flow events, navigates to payments server', () => {
+      assert.lengthOf(view.$('.subscriptions-redirect'), 1);
+      assert.isTrue(view.initializeFlowEvents.calledOnce);
+      assert.deepEqual(PaymentServer.navigateToPaymentServer.args, [
+        [view, config.subscriptions, `subscriptions`],
+      ]);
+    });
+  });
+});

--- a/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
@@ -54,6 +54,7 @@ describe('views/subscriptions_product_redirect', function() {
     });
 
     sinon.stub(view, 'getSignedInAccount').callsFake(() => account);
+    sinon.stub(view, 'initializeFlowEvents');
 
     sinon
       .stub(PaymentServer, 'navigateToPaymentServer')
@@ -70,11 +71,9 @@ describe('views/subscriptions_product_redirect', function() {
   });
 
   describe('render', () => {
-    it('renders correctly', () => {
+    it('renders, initializes flow metrics, navigates to payments server', () => {
       assert.lengthOf(view.$('.subscriptions-redirect'), 1);
-    });
-
-    it('calls PaymentServer.navigateToPaymentServer as expected', () => {
+      assert.isTrue(view.initializeFlowEvents.calledOnce);
       assert.deepEqual(PaymentServer.navigateToPaymentServer.args, [
         [view, config.subscriptions, `products/${PRODUCT_ID}${SEARCH_QUERY}`],
       ]);

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -2383,6 +2383,12 @@ const subscribeToTestProduct = thenify(function() {
   const nextYear = (new Date().getFullYear() + 1).toString().substr(2);
   return this.parent
     .then(openPage(TEST_PRODUCT_URL, 'div.product-payment'))
+    .then(getQueryParamValue('device_id'))
+    .then(deviceId => assert.ok(deviceId))
+    .then(getQueryParamValue('flow_begin_time'))
+    .then(flowBeginTime => assert.ok(flowBeginTime))
+    .then(getQueryParamValue('flow_id'))
+    .then(flowId => assert.ok(flowId))
     .then(type('input[name=name]', 'Testo McTestson'))
     .switchToFrame(2)
     .then(type('input[name=cardnumber]', '4242 4242 4242 4242'))

--- a/packages/fxa-content-server/tests/functional/support.js
+++ b/packages/fxa-content-server/tests/functional/support.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
+const { assert } = require('chai');
 const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
@@ -19,6 +20,7 @@ const {
   click,
   createUser,
   fillOutSignIn,
+  getQueryParamValue,
   openPage,
   subscribeToTestProduct,
   testElementExists,
@@ -45,7 +47,13 @@ registerSuite('support form without active subscriptions', {
         .then(openPage(SIGNIN_URL, selectors.SIGNIN.HEADER))
         .then(fillOutSignIn(email, PASSWORD))
         .then(testElementExists(selectors.SETTINGS.HEADER))
-        .then(openPage(SUPPORT_URL, '.subscription-management'));
+        .then(openPage(SUPPORT_URL, '.subscription-management'))
+        .then(getQueryParamValue('device_id'))
+        .then(deviceId => assert.ok(deviceId))
+        .then(getQueryParamValue('flow_begin_time'))
+        .then(flowBeginTime => assert.ok(flowBeginTime))
+        .then(getQueryParamValue('flow_id'))
+        .then(flowId => assert.ok(flowId));
     },
   },
 });


### PR DESCRIPTION
This fetches the flow_begin_time and flow_id out of a view's metrics and propagates them whenever redirecting to the payments server as the flow_begin_time and flow_id query params.

There were some indentation fixes, so this might be easier to review with ?w=1

issue #2425
issue #2801

@6a68, @chenba - r?