### PR TITLE
refactor(code): Rename token code input to otp code input and cleanup logic

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -202,7 +202,7 @@ var ERRORS = {
     errno: 151,
     message: t('Failed to send email'),
   },
-  INVALID_TOKEN_VERIFICATION_CODE: {
+  INVALID_OTP_CODE: {
     errno: 152,
     message: t('Valid code required'),
   },
@@ -571,7 +571,7 @@ var ERRORS = {
     errno: 1059,
     message: t('Recovery key required'),
   },
-  TOKEN_VERIFICATION_CODE_REQUIRED: {
+  OTP_CODE_REQUIRED: {
     errno: 1060,
     message: t('Please enter verification code'),
   },

--- a/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
@@ -20,7 +20,8 @@
         <p class="verification-email-message">{{#unsafeTranslate}}Please enter the verification code that was sent to %(escapedEmail)s within 5 minutes.{{/unsafeTranslate}}</p>
         <form novalidate>
             <div class="input-row">
-                <input type="number" pattern="\d*" class="tooltip-below token-code" placeholder="{{#t}}Enter 6-digit code{{/t}}" required autofocus />
+                <!-- Using `type="text" inputmode="numeric"` shows the numericpad on mobile and strips out whitespace on desktop. -->
+                <input type="text" inputmode="numeric" pattern="\d[ ]*" class="tooltip-below otp-code" placeholder="{{#t}}Enter 6-digit code{{/t}}" required autofocus />
             </div>
             <div class="button-row">
                 <button id="submit-btn" type="submit">{{#t}}Verify{{/t}}</button>

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_recovery_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_recovery_code.mustache
@@ -18,7 +18,7 @@
     </p>
 
     <form novalidate>
-      <div class="input-row token-code-row">
+      <div class="input-row otp-code-row">
         <input type="text" class="tooltip-below recovery-code" placeholder="{{#t}}Enter 10-digit recovery code{{/t}}" required autofocus />
       </div>
 

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
@@ -14,8 +14,9 @@
     </p>
 
     <form novalidate>
-      <div class="input-row token-code-row">
-        <input type="number" pattern="\d*" class="tooltip-below token-code" placeholder="{{#t}}Enter 6-digit code{{/t}}" required autofocus />
+      <div class="input-row otp-code-row">
+          <!-- Using `type="text" inputmode="numeric"` shows the numericpad on mobile and strips out whitespace on desktop. -->
+          <input type="text" inputmode="numeric" pattern="\d[ ]*" class="tooltip-below otp-code" placeholder="{{#t}}Enter 6-digit code{{/t}}" required autofocus />
       </div>
 
       <div class="button-row">

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_totp_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_totp_code.mustache
@@ -18,7 +18,7 @@
     </p>
 
     <form novalidate>
-      <div class="input-row token-code-row">
+      <div class="input-row otp-code-row">
         <input type="number" pattern="\d*" class="tooltip-below totp-code" placeholder="{{#t}}Enter 6-digit code{{/t}}" required autofocus />
       </div>
 

--- a/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
+++ b/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
@@ -11,7 +11,7 @@ import ServiceMixin from './mixins/service-mixin';
 import Template from 'templates/confirm_signup_code.mustache';
 import ResendMixin from './mixins/resend-mixin';
 
-const CODE_INPUT_SELECTOR = 'input.token-code';
+const CODE_INPUT_SELECTOR = 'input.otp-code';
 
 const proto = FormView.prototype;
 
@@ -77,7 +77,11 @@ class ConfirmSignupCodeView extends FormView {
         return this.invokeBrokerMethod('afterSignUpConfirmationPoll', account);
       })
       .catch(err => {
-        if (AuthErrors.is(err, 'INVALID_EXPIRED_SIGNUP_CODE')) {
+        if (
+          AuthErrors.is(err, 'INVALID_EXPIRED_SIGNUP_CODE') ||
+          AuthErrors.is(err, 'OTP_CODE_REQUIRED') ||
+          AuthErrors.is(err, 'INVALID_OTP_CODE')
+        ) {
           return this.showValidationError(this.$(CODE_INPUT_SELECTOR), err);
         }
         // Throw all other errors, these will be displayed in the .error div and not

--- a/packages/fxa-content-server/app/scripts/views/elements/jquery-plugin.js
+++ b/packages/fxa-content-server/app/scripts/views/elements/jquery-plugin.js
@@ -21,7 +21,7 @@ import recoveryKeyInput from './recovery-key-input';
 import telInput from './tel-input';
 import textInput from './text-input';
 import totpCodeInput from './totp-code-input';
-import tokenCodeInput from './token-code-input';
+import tokenCodeInput from './otp-code-input';
 import unblockCodeInput from './unblock-code-input';
 
 const elementHelpers = [

--- a/packages/fxa-content-server/app/scripts/views/elements/otp-code-input.js
+++ b/packages/fxa-content-server/app/scripts/views/elements/otp-code-input.js
@@ -9,22 +9,22 @@ import Vat from '../../lib/vat';
 const element = Object.create(textInput);
 
 element.match = function($el) {
-  return $el.attr('type') === 'number' && $el.hasClass('token-code');
+  return $el.attr('type') === 'text' && $el.hasClass('otp-code');
 };
 
 element.val = function(val) {
   if (arguments.length === 1) {
-    return this.__val(val.replace(/[- ]/g, ''));
+    return this.__val(val.replace(/ /g, ''));
   }
 
-  return this.__val();
+  return this.__val().replace(/ /g, '');
 };
 
 element.validate = function() {
   const value = this.val();
 
   if (!value.length) {
-    throw AuthErrors.toError('TOKEN_VERIFICATION_CODE_REQUIRED');
+    throw AuthErrors.toError('OTP_CODE_REQUIRED');
   } else if (Vat.totpCode().validate(value).error) {
     throw AuthErrors.toError('INVALID_TOKEN_VERIFICATION_CODE');
   }

--- a/packages/fxa-content-server/app/scripts/views/sign_in_token_code.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_token_code.js
@@ -12,7 +12,7 @@ import FormView from './form';
 import Template from 'templates/sign_in_token_code.mustache';
 import ResendMixin from './mixins/resend-mixin';
 
-const CODE_INPUT_SELECTOR = 'input.token-code';
+const CODE_INPUT_SELECTOR = 'input.otp-code';
 
 const View = FormView.extend({
   className: 'sign-in-token-code',

--- a/packages/fxa-content-server/app/tests/spec/views/confirm_signup_code.js
+++ b/packages/fxa-content-server/app/tests/spec/views/confirm_signup_code.js
@@ -89,7 +89,7 @@ describe('views/confirm_signup_code', () => {
         1,
         'has header'
       );
-      assert.lengthOf(view.$('.token-code'), 1, 'has input');
+      assert.lengthOf(view.$('.otp-code'), 1, 'has input');
       assert.include(
         view.$('.verification-email-message').text(),
         'a@a.com',
@@ -151,7 +151,7 @@ describe('views/confirm_signup_code', () => {
 
     describe('with an empty code', () => {
       beforeEach(() => {
-        view.$('input.token-code').val('');
+        view.$('input.otp-code').val('');
         return view.validateAndSubmit().then(assert.fail, () => {});
       });
 
@@ -165,7 +165,7 @@ describe('views/confirm_signup_code', () => {
     validCodes.forEach(code => {
       describe(`with a valid code: '${code}'`, () => {
         beforeEach(() => {
-          view.$('input.token-code').val(code);
+          view.$('input.otp-code').val(code);
           return view.validateAndSubmit();
         });
 
@@ -185,7 +185,7 @@ describe('views/confirm_signup_code', () => {
         sinon
           .stub(view, 'invokeBrokerMethod')
           .callsFake(() => Promise.resolve());
-        view.$('input.token-code').val(CODE);
+        view.$('input.otp-code').val(CODE);
         return view.submit();
       });
 
@@ -211,7 +211,7 @@ describe('views/confirm_signup_code', () => {
           .stub(account, 'verifySessionCode')
           .callsFake(() => Promise.reject(error));
         sinon.spy(view, 'showValidationError');
-        view.$('input.token-code').val(CODE);
+        view.$('input.otp-code').val(CODE);
         return view.submit();
       });
 
@@ -232,7 +232,7 @@ describe('views/confirm_signup_code', () => {
       });
 
       it('rejects with the error for display', () => {
-        view.$('input.token-code').val(CODE);
+        view.$('input.otp-code').val(CODE);
         return view.validateAndSubmit().then(assert.fail, () => {
           assert.ok(view.$('.error').text().length);
           assert.equal(view.showValidationError.callCount, 0);

--- a/packages/fxa-content-server/app/tests/spec/views/elements/otp-code-input.js
+++ b/packages/fxa-content-server/app/tests/spec/views/elements/otp-code-input.js
@@ -5,19 +5,19 @@
 import $ from 'jquery';
 import { assert } from 'chai';
 import AuthErrors from 'lib/auth-errors';
-import TotpEl from 'views/elements/token-code-input';
+import TotpEl from 'views/elements/otp-code-input';
 
 const TEMPLATE =
-  '<input type="number" pattern="d*" class="token-code"></input>' +
-  '<input type="number" pattern="d*" class="not-code"></input>';
+  '<input type="text" pattern="d*" class="otp-code"></input>' +
+  '<input type="text" pattern="d*" class="not-code"></input>';
 
-describe('views/elements/token-code-input', function() {
+describe('views/elements/otp-code-input', function() {
   let $element;
   let $otherElement;
 
   before(() => {
     $('#container').html(TEMPLATE);
-    $element = $('.token-code');
+    $element = $('.otp-code');
     $otherElement = $('.not-code');
   });
 
@@ -26,7 +26,7 @@ describe('views/elements/token-code-input', function() {
   });
 
   describe('match', () => {
-    it('returns `true` for class `token-code`', () => {
+    it('returns `true` for class `otp-code`', () => {
       assert.isTrue(TotpEl.match($element));
     });
 
@@ -36,12 +36,9 @@ describe('views/elements/token-code-input', function() {
   });
 
   describe('val', () => {
-    it('strips, -, spaces', () => {
+    it('strips spaces', () => {
       $element.val('  000001');
       assert.equal($element.val(), '000001');
-
-      $element.val('000-002');
-      assert.equal($element.val(), '000002');
 
       $element.val('000 003');
       assert.equal($element.val(), '000003');
@@ -62,11 +59,11 @@ describe('views/elements/token-code-input', function() {
       assert.isTrue(AuthErrors.is(validate($el, text), expectedErrorType));
     }
 
-    it('if empty, throws a `TOKEN_VERIFICATION_CODE_REQUIRED`', () => {
-      testInvalidInput($element, '', 'TOKEN_VERIFICATION_CODE_REQUIRED');
+    it('if empty, throws a `OTP_CODE_REQUIRED`', () => {
+      testInvalidInput($element, '', 'OTP_CODE_REQUIRED');
     });
 
-    it('if invalid, throws a `INVALID_TOKEN_VERIFICATION_CODE`', () => {
+    it('if invalid, throws a `OTP_VERIFICATION_CODE`', () => {
       testInvalidInput(
         $element,
         '000000000',

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_token_code.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_token_code.js
@@ -104,7 +104,7 @@ describe('views/sign_in_token_code', () => {
 
     describe('with an empty code', () => {
       beforeEach(() => {
-        view.$('input.token-code').val('');
+        view.$('input.otp-code').val('');
         return view.validateAndSubmit().then(assert.fail, () => {});
       });
 
@@ -123,7 +123,7 @@ describe('views/sign_in_token_code', () => {
     validCodes.forEach(code => {
       describe(`with a valid code: '${code}'`, () => {
         beforeEach(() => {
-          view.$('input.token-code').val(code);
+          view.$('input.otp-code').val(code);
           return view.validateAndSubmit();
         });
 
@@ -143,7 +143,7 @@ describe('views/sign_in_token_code', () => {
         sinon
           .stub(view, 'invokeBrokerMethod')
           .callsFake(() => Promise.resolve());
-        view.$('input.token-code').val(TOKEN_CODE);
+        view.$('input.otp-code').val(TOKEN_CODE);
         return view.submit();
       });
 
@@ -169,7 +169,7 @@ describe('views/sign_in_token_code', () => {
           .stub(account, 'verifySessionCode')
           .callsFake(() => Promise.reject(error));
         sinon.spy(view, 'showValidationError');
-        view.$('input.token-code').val(TOKEN_CODE);
+        view.$('input.otp-code').val(TOKEN_CODE);
         return view.submit();
       });
 

--- a/packages/fxa-content-server/app/tests/test_start.js
+++ b/packages/fxa-content-server/app/tests/test_start.js
@@ -158,7 +158,7 @@ require('./spec/views/decorators/progress_indicator');
 require('./spec/views/elements/coppa-age-input');
 require('./spec/views/elements/tel-input');
 require('./spec/views/elements/totp-code-input');
-require('./spec/views/elements/token-code-input');
+require('./spec/views/elements/otp-code-input');
 require('./spec/views/elements/recovery-code-input');
 require('./spec/views/elements/recovery-key-input');
 require('./spec/views/force_auth');

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -107,7 +107,7 @@ module.exports = {
   CONFIRM_SIGNUP_CODE: {
     HEADER: '#fxa-confirm-signup-code-header',
     EMAIL_FIELD: '.verification-email-message',
-    INPUT: '.token-code',
+    INPUT: '.otp-code',
     LINK_BACK: '#back',
   },
   CONNECT_ANOTHER_DEVICE: {
@@ -300,7 +300,7 @@ module.exports = {
     EMAIL_FIELD: '.verification-email-message',
     ERROR: '.error',
     HEADER: '#fxa-signin-code-header',
-    INPUT: '.token-code',
+    INPUT: '.otp-code',
     RESEND: '#resend',
     SUCCESS: '.success',
     SUBMIT: 'button[type="submit"]',


### PR DESCRIPTION
The `token code` name will be going away in https://github.com/mozilla/fxa/issues/2427, lets cleanup relevant parts on the content-server.

As part of cleanup logic, this was tweaked to strip away spaces before validating the input. Keeping this as a draft until I can verify that the keypad is present when signing up in FxiOS.

Fixes https://github.com/mozilla/fxa/issues/2829