### PR TITLE
fix(css): Show firefox account title on all setting screen sizes

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -113,10 +113,6 @@ body.settings #stage .settings {
       height: 48px;
       line-height: 50px;
 
-      & .fxa-account-title {
-        display: none;
-      }
-
       html[dir='ltr'] & {
         padding-left: 36px;
       }


### PR DESCRIPTION
Fixes #2864 

@johngruen I'm not sure what the original intended header section should look like? Should it show the title like this?

<img width="450" alt="Screen Shot 2019-10-11 at 2 57 42 PM" src="https://user-images.githubusercontent.com/1295288/66677462-afe6b680-ec37-11e9-9633-a746206f1464.png">

If so r?