### PR TITLE
fix(css): Fix authorize sign-in screen size on mobile

### DIFF
--- a/packages/fxa-content-server/app/styles/_layout.scss
+++ b/packages/fxa-content-server/app/styles/_layout.scss
@@ -8,6 +8,10 @@
     @include respond-to('big') {
       width: 480px;
     }
+
+    @include respond-to('small') {
+      width: 300px;
+    }
   }
 
   &.panel {
@@ -29,9 +33,7 @@
 
   @include respond-to('small') {
     margin: 0 auto;
-    max-width: 640px;
     min-height: 300px !important;
-    min-width: 300px;
     padding: 76px 20px 20px 20px;
     position: relative;
     width: 94%;


### PR DESCRIPTION
Fixes #2859 

This sets an explicit 300px width for small screens. Small screens don't have the card panel that the big screens do so I think this should be ok to do. Also, big screen width is set to 480px so this only applies for the screen sizes in between.

![Oct-11-2019 15-54-50](https://user-images.githubusercontent.com/1295288/66681192-2e475680-ec40-11e9-8b97-adc48d54992a.gif)

