### PR TITLE
fix(codes): Enabled signup code experiment when going from signin to signup

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/signup-code.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/signup-code.js
@@ -10,31 +10,26 @@ const GROUPS_DEFAULT = ['treatment'];
 
 const ROLLOUT_CLIENTS = {
   '37fdfa37698f251a': {
-    enableTestEmails: false,
     groups: GROUPS_DEFAULT,
     name: 'Lockbox Extension',
     rolloutRate: 0.0,
   },
   '3c49430b43dfba77': {
-    enableTestEmails: false,
     groups: GROUPS_DEFAULT,
     name: 'Android Components Reference Browser',
     rolloutRate: 0.0,
   },
   '98adfa37698f255b': {
-    enableTestEmails: true,
     groups: GROUPS_DEFAULT,
     name: 'Lockbox Extension iOS',
     rolloutRate: 0.0,
   },
   ecdb5ae7add825d4: {
-    enableTestEmails: false,
     groups: GROUPS_DEFAULT,
     name: 'TestClient',
     rolloutRate: 0.0,
   },
   a8c528140153d1c6: {
-    enableTestEmails: true,
     groups: ['treatment'], // All proxy users get the signup code experience
     name: 'fx-priv-network',
     rolloutRate: 1.0,
@@ -54,8 +49,7 @@ module.exports = class SignupCodeGroupingRule extends BaseGroupingRule {
       !subject ||
       !subject.uniqueUserId ||
       !subject.experimentGroupingRules ||
-      !subject.isSignupCodeSupported ||
-      !subject.account
+      !subject.isSignupCodeSupported
     ) {
       return false;
     }
@@ -70,14 +64,6 @@ module.exports = class SignupCodeGroupingRule extends BaseGroupingRule {
 
       if (client) {
         const groups = client.groups || GROUPS_DEFAULT;
-
-        // Check if this client supports test emails
-        if (
-          client.enableTestEmails &&
-          this.isTestEmail(subject.account.get('email'))
-        ) {
-          return this.uniformChoice(groups, subject.uniqueUserId);
-        }
 
         if (this.bernoulliTrial(client.rolloutRate, subject.uniqueUserId)) {
           return this.uniformChoice(groups, subject.uniqueUserId);

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/signup-code.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/signup-code.js
@@ -70,17 +70,6 @@ describe('lib/experiments/grouping-rules/signup-code', () => {
         );
       });
 
-      it('delegates to uniformChoice when `enableTestEmails` is true and using test email', () => {
-        subject.clientId = 'ecdb5ae7add825d4';
-        subject.account.set('email', 'a@mozilla.org');
-        sinon.stub(experiment, 'uniformChoice').callsFake(() => 'control');
-        experiment.choose(subject);
-        assert.isTrue(experiment.uniformChoice.calledOnce);
-        assert.isTrue(
-          experiment.uniformChoice.calledWith(['treatment'], 'user-id')
-        );
-      });
-
       it('featureFlags take precedence', () => {
         subject.clientId = 'invalidClientId';
         assert.equal(


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/2847

The main issue found here is that the signup code experiment does not get created when you goto the `Sign In` page. When users sign-in with an unknown account, they are given an option to create the account.

We currently, don't populate an account object when going from Sign-in -> Sign-up, this removes the check and starts the experiment. I'm hesitant to make bigger changes since I know this code will be removed.

Targeted against Train-148