### PR TITLE
fix(email): correct product name and configurable download URL in subscription download email

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -16,7 +16,9 @@
     "host": "127.0.0.1",
     "port": 9999,
     "secure": false,
-    "redirectDomain": "127.0.0.1"
+    "redirectDomain": "127.0.0.1",
+    "subscriptionDownloadUrl": "https://fpn.firefox.com/vpn/download?source=email&env=dev",
+    "subscriptionTermsUrl": "https://nightly.dev.lcip.org/legal/subscription_terms"
   },
   "snsTopicArn": "arn:aws:sns:local-01:000000000000:local-topic1",
   "snsTopicEndpoint": "http://localhost:4100/",

--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -283,6 +283,18 @@ const conf = convict({
       default:
         'https://support.mozilla.org/kb/password-manager-remember-delete-change-and-import#w_viewing-and-deleting-passwords',
     },
+    subscriptionDownloadUrl: {
+      default: 'https://example.com/placeholder-product-link-changeme',
+      doc: 'Subscription download URL',
+      env: 'SUBSCRIPTION_DOWNLOAD_URL',
+      format: String,
+    },
+    subscriptionTermsUrl: {
+      default: 'https://accounts.firefox.com/legal/subscription_terms',
+      doc: 'Subscription terms and cancellation policy URL',
+      env: 'SUBSCRIPTION_TERMS_URL',
+      format: String,
+    },
     sesConfigurationSet: {
       doc:
         'AWS SES Configuration Set for SES Event Publishing. If defined, ' +
@@ -1206,10 +1218,8 @@ conf.set(
 );
 conf.set('smtp.verifyPrimaryEmailUrl', `${baseUri}/verify_primary_email`);
 conf.set('smtp.verifySecondaryEmailUrl', `${baseUri}/verify_secondary_email`);
-conf.set('smtp.subscriptionDownloadUrl', `${baseUri}/subscriptions/download`);
 conf.set('smtp.subscriptionSettingsUrl', `${baseUri}/subscriptions`);
 conf.set('smtp.subscriptionSupportUrl', `${baseUri}/support`);
-conf.set('smtp.subscriptionTermsUrl', `${baseUri}/legal/subscription_terms`);
 
 conf.set('isProduction', conf.get('env') === 'prod');
 


### PR DESCRIPTION
- partly reverts 330a4926dae26fbe0c845b40a36329290d334fbe
- change hard-coded "Secure Proxy" to "Firefox Private Network"
- bugfix for query param handling in GA UTM URL construction

fixes #2882