### PR TITLE
fix(content-server): plan query param fix for subscription product redirect

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/subscriptions_product_redirect.js
+++ b/packages/fxa-content-server/app/scripts/views/subscriptions_product_redirect.js
@@ -7,6 +7,7 @@ import FlowEventsMixin from './mixins/flow-events-mixin';
 import FormView from './form';
 import Template from 'templates/subscriptions_redirect.mustache';
 import PaymentServer from '../lib/payment-server';
+import Url from '../lib/url';
 
 class SubscriptionsProductRedirectView extends FormView {
   mustAuth = true;
@@ -25,13 +26,14 @@ class SubscriptionsProductRedirectView extends FormView {
   }
 
   afterRender() {
-    const searchQuery = this.window.location.search;
+    const queryParams = Url.searchParams(this.window.location.href);
     const productId = this._currentPage.split('/').pop();
-    const redirectPath = `products/${productId}${searchQuery}`;
+    const redirectPath = `products/${productId}`;
     return PaymentServer.navigateToPaymentServer(
       this,
       this._subscriptionsConfig,
-      redirectPath
+      redirectPath,
+      queryParams
     );
   }
 }

--- a/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
@@ -13,7 +13,7 @@ import WindowMock from '../../mocks/window';
 import PaymentServer from 'lib/payment-server';
 
 const PRODUCT_ID = 'pk_8675309';
-const SEARCH_QUERY = '?plan_id=plk_12345';
+const SEARCH_QUERY = '?plan=plk_12345';
 
 describe('views/subscriptions_product_redirect', function() {
   let account;
@@ -32,7 +32,7 @@ describe('views/subscriptions_product_redirect', function() {
     account = new Account();
     notifier = new Notifier();
     windowMock = new WindowMock();
-    windowMock.location.search = SEARCH_QUERY;
+    windowMock.location.href = `http://example.com/products${SEARCH_QUERY}`;
 
     config = {
       subscriptions: {
@@ -75,7 +75,12 @@ describe('views/subscriptions_product_redirect', function() {
       assert.lengthOf(view.$('.subscriptions-redirect'), 1);
       assert.isTrue(view.initializeFlowEvents.calledOnce);
       assert.deepEqual(PaymentServer.navigateToPaymentServer.args, [
-        [view, config.subscriptions, `products/${PRODUCT_ID}${SEARCH_QUERY}`],
+        [
+          view,
+          config.subscriptions,
+          `products/${PRODUCT_ID}`,
+          { plan: 'plk_12345' },
+        ],
       ]);
     });
   });


### PR DESCRIPTION
parse the query parameters into a object to pass into
PaymentServer.navigateToPaymentServer, rather than relying on string
concatenation.

fixes #2883