### PR TITLE
fix(account deletion): Allow account deletion for users with no subscription

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -1463,7 +1463,18 @@ module.exports = (
         const { uid } = emailRecord;
 
         if (config.subscriptions && config.subscriptions.enabled) {
-          await subhub.deleteCustomer(uid);
+          try {
+            await subhub.deleteCustomer(uid);
+          } catch (err) {
+            if (err.message === 'Customer not available') {
+              // if subhub didn't know about the customer, no problem.
+              // This should not stop the user from deleting their account.
+              // See https://github.com/mozilla/fxa/issues/2900
+              // https://github.com/mozilla/fxa/issues/2896
+            } else {
+              throw err;
+            }
+          }
         }
 
         // We fetch the devices to notify before deleteAccount()

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -2765,6 +2765,21 @@ describe('/account/destroy', () => {
     });
   });
 
+  it('should not fail if subhub.deleteCustomer fails with `Customer not available`', async () => {
+    mockSubhub.deleteCustomer = sinon.spy(async function() {
+      throw new Error('Customer not available');
+    });
+    let failed = false;
+    try {
+      await runTest(buildRoute(), mockRequest);
+    } catch (err) {
+      failed = true;
+    }
+    assert.isFalse(failed);
+
+    assert.isTrue(mockDB.deleteAccount.calledOnce);
+  });
+
   it('should fail if subhub.deleteCustomer fails', async () => {
     mockSubhub.deleteCustomer = sinon.spy(async function() {
       throw new Error('wibble');


### PR DESCRIPTION
I opened this against train-147 because users are currently unable to delete their accounts.

fixes #2896
fixes #2900

@mozilla/fxa-devs - r?