### PR TITLE
fix(errors): Scrub `x-forwarded-for` from response data on a 500 error.

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -1280,7 +1280,7 @@ function decorateErrorWithRequest(error, request) {
       path: request.path,
       query: request.query,
       payload: scrubPii(request.payload),
-      headers: request.headers,
+      headers: scrubHeaders(request.headers),
     };
   }
 }
@@ -1297,4 +1297,10 @@ function scrubPii(payload) {
 
     return scrubbed;
   }, {});
+}
+
+function scrubHeaders(headers) {
+  const scrubbed = { ...headers };
+  delete scrubbed['x-forwarded-for'];
+  return scrubbed;
 }

--- a/packages/fxa-auth-server/test/local/error.js
+++ b/packages/fxa-auth-server/test/local/error.js
@@ -137,6 +137,9 @@ describe('AppErrors', () => {
         service: 'sync',
       },
       headers: {
+        // x-forwarded-for is stripped out because it contains internal server IPs
+        // See https://github.com/mozilla/fxa-private/issues/66
+        'x-forwarded-for': '192.168.1.1 192.168.2.2',
         wibble: 'blee',
       },
     });


### PR DESCRIPTION
fixes mozilla/fxa-private#66

@mozilla/fxa-devs 