### PR TITLE
fix(modal): Make modal keyboard accessible

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/key-codes.js
+++ b/packages/fxa-content-server/app/scripts/lib/key-codes.js
@@ -17,4 +17,5 @@ export default {
   RIGHT_ARROW: 39,
   TAB: 9,
   UP_ARROW: 38,
+  IME: 229,
 };

--- a/packages/fxa-content-server/app/scripts/templates/settings/client_disconnect.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/client_disconnect.mustache
@@ -1,7 +1,7 @@
 <div id="client-disconnect">
   <section class="modal-panel">
     {{^hasDisconnected}}
-      <h2>{{#t}}Disconnect from Sync?{{/t}}</h2>
+      <h2>{{#t}}Disconnect from Sync{{/t}}</h2>
       <div class="error"></div>
 
       <p class="intro">
@@ -9,22 +9,24 @@
       </p>
 
       <form novalidate>
+        <div role="radiogroup" aria-labelledby="radio-header">
+          <h3 id="radio-header" class="radio-header">{{#t}}You are disconnecting %(deviceName)s from Sync because this device is:{{/t}}</h3>
           <p class="disconnect-reasons fxa-radio">
             <label>
               <input type="radio" name="disconnect-reasons" value="suspicious"/>
-              {{#t}}Suspicious device{{/t}}
+              {{#t}}Suspicious{{/t}}
             </label>
             <label>
               <input type="radio" name="disconnect-reasons" value="lost"/>
-              {{#t}}Lost or stolen device{{/t}}
+              {{#t}}Lost or stolen{{/t}}
             </label>
             <label>
               <input type="radio" name="disconnect-reasons" value="old"/>
-              {{#t}}Old or replaced device{{/t}}
+              {{#t}}Old or replaced{{/t}}
             </label>
             <label>
               <input type="radio" name="disconnect-reasons" value="duplicate"/>
-              {{#t}}Duplicate device{{/t}}
+              {{#t}}Duplicate{{/t}}
             </label>
             <label>
               <input type="radio" name="disconnect-reasons" value="no" checked="checked"/>

--- a/packages/fxa-content-server/app/scripts/views/mixins/modal-panel-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/modal-panel-mixin.js
@@ -10,13 +10,16 @@
  */
 
 import $ from 'jquery';
+import KeyCodes from '../../lib/key-codes';
 
 export default {
   isModal: true,
-
   notifications: {
     navigate: 'closePanel',
     'navigate-back': 'closePanel',
+  },
+  events: {
+    keydown: 'keyDownListener',
   },
 
   /**
@@ -33,8 +36,69 @@ export default {
 
     this.$el.on($.modal.AFTER_CLOSE, () => this.onAfterClose());
 
+    this._previousActiveElement = document.activeElement;
     this._boundBlockerClick = this.onBlockerClick.bind(this);
     $('.blocker').on('click', this._boundBlockerClick);
+
+    /**
+     * Trap keyboard focus when modal opens.
+     */
+    const modal = this.$el[0];
+    modal.setAttribute('tabindex', '1');
+    modal.focus();
+
+    const focusableElementsNodeList = modal.querySelectorAll(
+      'a[href], button, input[type="radio"]'
+    );
+    const focusableElements = Array.prototype.slice.call(
+      focusableElementsNodeList
+    );
+
+    this._keyDownListener = this.keyDownListener.bind(null, focusableElements);
+    modal.addEventListener('keydown', this._keyDownListener);
+  },
+
+  keyDownListener(focusableElements, event) {
+    function getNextSelectable(element = focusableElements[0]) {
+      const nextIndex = focusableElements.indexOf(element) + 1;
+      // return first element if the next element doesn't exist
+      return focusableElements[nextIndex]
+        ? focusableElements[nextIndex]
+        : focusableElements[0];
+    }
+
+    function getPreviousSelectable(
+      element = focusableElements[focusableElements.length - 1]
+    ) {
+      const previousIndex = focusableElements.indexOf(element) - 1;
+      // return last element if the previous element doesn't exist
+      return focusableElements[previousIndex]
+        ? focusableElements[previousIndex]
+        : focusableElements[focusableElements.length - 1];
+    }
+
+    //avoid IME composition keydown events
+    //ref: https://developer.mozilla.org/docs/Web/Events/keydown#Notes
+    if (event.isComposing || event.keyCode === KeyCodes.IME) {
+      return;
+    }
+    if (event.keyCode === KeyCodes.TAB) {
+      event.preventDefault();
+      if (event.shiftKey) {
+        getPreviousSelectable(document.activeElement).focus();
+      } else {
+        getNextSelectable(document.activeElement).focus();
+      }
+      // the form submits on 'enter' keypress by default, but if focus is on an
+      // unselected radio button, we want to select it instead
+    } else if (
+      event.keyCode === KeyCodes.ENTER &&
+      document.activeElement.getAttribute('type') === 'radio' &&
+      document.activeElement.checked === false
+    ) {
+      event.preventDefault();
+      document.activeElement.checked = true;
+    }
   },
 
   /**
@@ -69,6 +133,7 @@ export default {
     this.destroy(true);
     this.trigger('modal-cancel');
     $('.blocker').off('click', this._boundBlockerClick);
+    this._previousActiveElement.focus();
   },
 
   /**

--- a/packages/fxa-content-server/app/styles/_base.scss
+++ b/packages/fxa-content-server/app/styles/_base.scss
@@ -149,7 +149,7 @@ input[type='radio'] {
     font-size: $base-font + $media-adjustment;
   }
 
-  &:active {
+  &:active, &:focus {
     box-shadow: 0 0 0 2px $radio-box-shadow-color;
   }
 

--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -651,8 +651,11 @@ section.modal-panel {
 }
 
 #client-disconnect {
-  .intro {
-    margin-bottom: 30px;
+  .radio-header {
+    font-size: 14px;
+    font-weight: normal;
+    margin-bottom: 15px;
+    text-align: left;
   }
 }
 

--- a/packages/fxa-content-server/tests/functional/avatar.js
+++ b/packages/fxa-content-server/tests/functional/avatar.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
+const assert = intern.getPlugin('chai').assert;
 const path = require('path');
 const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
@@ -70,6 +71,18 @@ registerSuite('settings/avatar', {
           // success is going to the change avatar page
           .then(testElementExists(selectors.SETTINGS_AVATAR.CHANGE_HEADER))
       );
+    },
+
+    'keyboard focus changes to the modal': function() {
+      return this.remote
+        .then(openPage(AVATAR_CHANGE_URL_AUTOMATED, '#camera'))
+        .getActiveElement()
+        .then(function(element) {
+          element.getAttribute('class').then(function(className) {
+            // active element should be the modal, not the body
+            assert.isTrue(className.includes('modal'));
+          });
+        });
     },
 
     'go to settings with an email selected to see change link then click on avatar to change': function() {


### PR DESCRIPTION
Fixes #597, #636, #2869

@shane-tomlinson I'd like you to take a look at this when you can since you'd reviewed #724, I have a question around testing... Should this be taken out of unit tests and placed in avatar & client disconnection selenium tests? Or how would you test these changes?

Also, I created #2869 while working on these issues, but I'm actually having trouble getting into the modal with a screenreader cursor to benefit from the context created there with `aria-labelledby`, but I asked UX if they'd like me to leave that header in there anyway and they confirmed it should be left. I'll take a better look at this accessibility-wise when/after we do the settings redesign. Ideally, we use `aria-hidden` and other `aria` properties, but this issue fix is to make the modal _keyboard_ accessible and not necessarily screenreader accessible, which will be on my radar for settings redesign.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/13018240/66847541-28e85580-ef39-11e9-81a4-02bb34e6a7e3.png">
Text spacing was given the r+ from Julia and Janice. Screenshot shows what "focus" looks like when tabbing around (which is the same as hovering).