### PR TITLE
Make Firefox Desktop a public client in dev

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/config/dev.json
+++ b/packages/fxa-auth-server/fxa-oauth-server/config/dev.json
@@ -108,7 +108,8 @@
       "imageUri": "",
       "redirectUri": "urn:ietf:wg:oauth:2.0:oob",
       "trusted": true,
-      "canGrant": true
+      "canGrant": true,
+      "publicClient": true
     },
     {
       "name": "Fennec",


### PR DESCRIPTION
This is the same as https://bugzilla.mozilla.org/show_bug.cgi?id=1582837 but for dev.json, making sure we keep this in sync.