### PR TITLE
restore workdir in payments dockerfile build

### DIFF
--- a/packages/fxa-payments-server/Dockerfile
+++ b/packages/fxa-payments-server/Dockerfile
@@ -50,4 +50,5 @@ RUN chown -R app:app /fxa-shared
 USER app
 RUN npm ci
 
+WORKDIR /app
 CMD [ "/usr/local/bin/node", "server/bin/fxa-payments-server.js" ]

--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -11,12 +11,10 @@ const {
   mapFormFactor,
   mapLocation,
   mapOs,
-  mapUserAgentProperties,
   toSnakeCase,
 } = require('../../../fxa-shared/metrics/amplitude.js');
 const config = require('../config');
 const amplitude = config.get('amplitude');
-const joi = require('joi');
 const log = require('./logging/log')();
 const ua = require('../../../fxa-shared/metrics/user-agent');
 const { version: VERSION } = require('../../package.json');


### PR DESCRIPTION
Hey Jared,

The payments server was failing on start in kubernetes dev because it was looking for bin/fxa-payments-server.js relative to /fxa-shared and failing. (I suppose the startup command could use an  absolute path, but still seems better to just restore the WORKDIR).

But then a second issue on the build: lint was failing. So added the second commit. I dunno if that's the idiomatic way to ignore an unused variable from a destructure, so let me know if there's a better way.

r? @6a68 