### PR TITLE
fix(payments): Get post-metrics route working and add tests

### DIFF
--- a/packages/fxa-payments-server/package-lock.json
+++ b/packages/fxa-payments-server/package-lock.json
@@ -4672,6 +4672,15 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "celebrate": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/celebrate/-/celebrate-10.0.1.tgz",
+      "integrity": "sha512-Eke/caDOlcLjwk8WN4+bX9WyiiIgJ+zjbsh368FAtEj74bNC3Y+gVfFF8efmP9iYVnFSkLy31+6bKCQm/Zza+g==",
+      "requires": {
+        "@hapi/joi": "15.x.x",
+        "escape-html": "1.0.3"
+      }
+    },
     "chai": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -87,6 +87,7 @@
     "@sentry/node": "^5.6.1",
     "@types/nock": "^10.0.1",
     "@types/react-stripe-elements": "^1.3.1",
+    "celebrate": "^10.0.1",
     "classnames": "^2.2.6",
     "convict": "^5.1.0",
     "cors": "^2.8.5",

--- a/packages/fxa-payments-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-payments-server/server/lib/routes/post-metrics.js
@@ -37,7 +37,10 @@ const BODY_SCHEMA = {
 module.exports = {
   method: 'post',
   path: '/metrics',
-  handler: (req, res) => {
+  validate: {
+    body: BODY_SCHEMA,
+  },
+  preProcess: function(req, res, next) {
     // convert text/plain types to JSON for validation.
     if (/^text\/plain/.test(req.get('content-type'))) {
       try {
@@ -49,16 +52,11 @@ module.exports = {
       }
     }
 
-    // validate the request; if invalid, return 400.
-    joi.validate(req.body, BODY_SCHEMA).then(
-      () => {
-        const { data, events } = req.body;
-        events.forEach(event => amplitude(event, req, data));
-        res.status(200).end();
-      },
-      err => {
-        res.status(400).end();
-      }
-    );
+    next();
+  },
+  process(request, response) {
+    const { data, events } = request.body;
+    events.forEach(event => amplitude(event, request, data));
+    response.status(200).end();
   },
 };

--- a/packages/fxa-payments-server/server/lib/routes/post-metrics.test.js
+++ b/packages/fxa-payments-server/server/lib/routes/post-metrics.test.js
@@ -1,0 +1,56 @@
+const request = require('supertest');
+const server = require('../server')();
+const app = server.app;
+
+const validBody = {
+  data: {
+    deviceId: '016de98b32a54747b18ccbeaab2a6075',
+    flowBeginTime: '1571195527850',
+    flowId: '641530e2645e0e8d96ea7e409ebeebabfc3fb2fc9204fec999d9d8baa2ebb0da',
+    planId: '123doneProMonthly',
+    productId: '123doneProProduct',
+  },
+  events: [
+    {
+      offset: 100,
+      type: 'amplitude.subPaySetup.view',
+    },
+  ],
+};
+
+const invalidBody = {
+  data: {
+    deviceId: '016de98b32a54747b18ccbeaab2a6075',
+    flowBeginTime: '1571195527850',
+    flowId: '641530e2645e0e8d96ea7e409ebeebabfc3fb2fc9204fec999d9d8baa2ebb0da',
+    planId: '123doneProMonthly',
+    productId: '123doneProProduct',
+  },
+  // 'events' is required and is missing
+};
+
+describe('post-metrics route', () => {
+  test('POST valid input should return 200', done => {
+    request(app)
+      .post('/metrics')
+      .send(validBody)
+      .set('Accept', 'application/json')
+      .expect(200)
+      .end((err, res) => {
+        if (err) return done(err);
+        done();
+      });
+  });
+
+  test('POST invalid input should return 400', done => {
+    request(app)
+      .post('/metrics')
+      .send(invalidBody)
+      .set('Accept', 'application/json')
+      .expect(400)
+      .end((err, res) => {
+        if (err) return done(err);
+        done();
+      });
+  });
+});

--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -7,6 +7,12 @@
 module.exports = () => {
   const path = require('path');
   const fs = require('fs');
+  const {
+    celebrate,
+    isCelebrate: isValidationError,
+    errors: validationErrorHandlerFactory,
+  } = require('celebrate');
+  const cors = require('cors');
 
   // setup version first for the rest of the modules
   const logger = require('./logging/log')('server.main');
@@ -125,21 +131,58 @@ module.exports = () => {
       origin: config.get('listen.publicUrl'),
     };
 
-    app
-      .route(/\.(js|css|woff|woff2|eot|ttf)$/)
-      .get(require('cors')(corsOptions));
+    app.route(/\.(js|css|woff|woff2|eot|ttf)$/).get(cors(corsOptions));
   }
 
-  function injectHtmlConfig(html, config, featureFlags) {
-    const encodedConfig = encodeURIComponent(JSON.stringify(config));
-    let result = html.replace('__SERVER_CONFIG__', encodedConfig);
-    const encodedFeatureFlags = encodeURIComponent(
-      JSON.stringify(featureFlags)
-    );
-    result = result.replace('__FEATURE_FLAGS__', encodedFeatureFlags);
-    return result;
-  }
+  routes.forEach(route => {
+    if (!isValidRoute(route)) {
+      return logger.error('route definition invalid: ', route);
+    }
 
+    // Build a list of route handlers.
+    // `cors`, preProcess` and `validate` are optional.
+    const routeHandlers = [];
+
+    // Enable CORS using https://github.com/expressjs/cors
+    // If defined, `cors` can be truthy or an object.
+    // Objects are passed to the middleware directly.
+    // Other truthy values use the default configuration.
+    if (route.cors) {
+      const corsConfig =
+        typeof route.cors === 'object' ? route.cors : undefined;
+      // Enable the pre-flight OPTIONS request
+      app.options(route.path, cors(corsConfig));
+      routeHandlers.push(cors(corsConfig));
+    }
+
+    if (route.preProcess) {
+      routeHandlers.push(route.preProcess);
+    }
+
+    if (route.validate) {
+      routeHandlers.push(
+        celebrate(route.validate, {
+          // silently drop any unknown fields within objects on the ground.
+          stripUnknown: { arrays: false, objects: true },
+        })
+      );
+    }
+
+    routeHandlers.push(route.process);
+    app[route.method].apply(app, [route.path].concat(routeHandlers));
+  });
+
+  app.get('/__lbheartbeat__', (req, res) => {
+    res.type('txt').send('Ok');
+  });
+
+  app.get('/__version__', (req, res) => {
+    res.type('application/json').send(JSON.stringify(version));
+  });
+
+  // Note - the static route handlers must come last
+  // because the proxyUrl handler's app.use('/') captures
+  // all requests that match no others.
   const proxyUrl = config.get('proxyStaticResourcesFrom');
   if (proxyUrl) {
     logger.info('static.proxying', { url: proxyUrl });
@@ -191,9 +234,7 @@ module.exports = () => {
         res.send(renderedStaticHtml);
       });
     });
-    routes.forEach(route => {
-      app[route.method](route.path, route.handler);
-    });
+
     app.use(
       serveStatic(STATIC_DIRECTORY, {
         maxAge: config.get('staticResources.maxAge'),
@@ -201,19 +242,45 @@ module.exports = () => {
     );
   }
 
-  app.get('/__lbheartbeat__', (req, res) => {
-    res.type('txt').send('Ok');
-  });
-
-  app.get('/__version__', (req, res) => {
-    res.type('application/json').send(JSON.stringify(version));
-  });
-
   // it's a four-oh-four not found.
   app.use(require('./404'));
 
+  const validationErrorHandler = validationErrorHandlerFactory();
+  app.use((err, req, res, next) => {
+    if (err && isValidationError(err)) {
+      logger.error('validation.failed', {
+        err,
+        method: req.method,
+        path: req.url,
+      });
+      validationErrorHandler(err, req, res, next);
+    } else {
+      // not a validation error, send to the next error handler
+      next(err);
+    }
+  });
+
   if (sentryDsn) {
     app.use(sentry.Handlers.errorHandler());
+  }
+
+  return {
+    listen,
+    app, // for testing
+  };
+
+  function isCorsRequired() {
+    return config.get('staticResources.url') !== config.get('listen.publicUrl');
+  }
+
+  function injectHtmlConfig(html, config, featureFlags) {
+    const encodedConfig = encodeURIComponent(JSON.stringify(config));
+    let result = html.replace('__SERVER_CONFIG__', encodedConfig);
+    const encodedFeatureFlags = encodeURIComponent(
+      JSON.stringify(featureFlags)
+    );
+    result = result.replace('__FEATURE_FLAGS__', encodedFeatureFlags);
+    return result;
   }
 
   function listen() {
@@ -230,12 +297,19 @@ module.exports = () => {
     });
   }
 
-  return {
-    listen,
-    app, // for testing
-  };
-
-  function isCorsRequired() {
-    return config.get('staticResources.url') !== config.get('listen.publicUrl');
+  /**
+   * Each route has 3 attributes: `method`, `path` and `process`.
+   * `method` is one of `GET`, `POST`, etc.
+   * `path` is a string or regular expression that express uses to match a route.
+   * `process` is a function that is called with req and res to handle the route.
+   *
+   * Each route can have 2 additional attributes: `preProcess` and `validate`.
+   * `preProcess` is a function that is called with `req`, `res`, and `next`.
+   *   Use to do any pre-processing before validation, such as converting from text to JSON.
+   * `validate` is where to declare JOI validation. Follows
+   *   [celebrate](https://www.npmjs.com/package/celebrate) conventions.
+   */
+  function isValidRoute(route) {
+    return !!route.method && route.path && route.process;
   }
 };


### PR DESCRIPTION
I assumed the `validate` and `preProcess` route properties were supported on payments-server, as they are on content-server, but noticed `/metrics` was 404ing locally, which led me to this fix. I've inlined the validate and preprocess code inside the route handler.

For some reason, the " __version__ should have correct structure" route test is failing locally for me, but doesn't seem to fail on CI. ¯\_(ツ)_/¯