### PR TITLE
fix(styles): match subscription styles to fxa settings

### DIFF
--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -106,11 +106,11 @@ export const PaymentUpdateForm = ({
       {!updateRevealed ? (
         <div className="with-settings-button">
           <div className="card-details">
-            <div>
+            <div className="last-four">
               {/* TODO: Need to find a way to display a card icon here? */}
               Card ending {last4}
             </div>
-            <div>Expires {expirationDate}</div>
+            <div className="expiry">Expires {expirationDate}</div>
           </div>
           <div className="action">
             <button

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
@@ -2,13 +2,7 @@
 
 .subscription-management {
 
-  h2.settings-unit-title {
-    font-size: 20px;
-    font-weight: bold;
-  }
-
   button.settings-button {
-    font-size: 13px;
     font-weight: 600;
     padding: 0 16px;
   }
@@ -51,10 +45,14 @@
     border-top: 1px solid #e0e0e6;
     padding-top: 16px;
 
+    p {
+      color: #737373;
+      line-height: 1.5;
+    }
+
     h3 {
-      color: #000;
       font-size: 16px;
-      font-weight: 500;
+      font-weight: 400;
       margin: 13px 0;
       text-align: left;
     }
@@ -78,6 +76,13 @@
   .card-details {
     display: flex;
 
+    .last-four,
+    .expiry {
+      align-items: center;
+      display: flex;
+      font-weight: 700;
+    }
+
     > div {
       padding-right: 32px;
     }
@@ -88,7 +93,7 @@
     flex-direction: row;
 
     p {
-      margin: 0 0 1em 0;
+      margin: 0 1em 1em 0;
 
       &:last-child {
         margin: 0;
@@ -104,7 +109,6 @@
 
       button {
         display: block;
-        font-size: 13px;
         font-weight: 600;
         padding: 0 16px;
         width: 128px;
@@ -116,9 +120,7 @@
     padding-bottom: 18px;
 
     .billing-description {
-      color: #000;
-      font-size: 12px;
-      font-weight: 500;
+      color: #737373;
       line-height: 1.5;
     }
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -235,7 +235,7 @@ export const Subscriptions = ({
               </header>
               <button
                 data-testid="contact-support-button"
-                className="settings-button secondary-button settings-unit-toggle"
+                className="settings-button primary-button settings-unit-toggle"
                 onClick={onSupportClick}
               >
                 <span className="change-button">Contact Support</span>
@@ -359,12 +359,12 @@ const ProfileBanner = ({
   profile: { email, avatar, displayName },
 }: ProfileProps) => (
   <header id="fxa-settings-profile-header-wrapper">
-    <div className="avatar-wrapper avatar-settings-view">
+    <div className="avatar-wrapper avatar-settings-view nohover">
       <img src={avatar} alt={displayName || email} className="profile-image" />
     </div>
     <div id="fxa-settings-profile-header">
-      {displayName && <h1 className="card-header">{displayName}</h1>}
-      <h2 className="card-subheader">{email}</h2>
+      <h1 className="card-header">{displayName ? displayName : email}</h1>
+      {displayName && <h2 className="card-subheader">{email}</h2>}
     </div>
   </header>
 );


### PR DESCRIPTION
it's been bugging me that the subscription settings are slightly off from the FxA settings in a few ways...this patch fixes that:

* Makes settings paragraphs 1.5 line-height
* Makes settings paragraph color conform to fxa settings
* makes display name and email in header conform to display pattern on fxa settings
* makes button text conform to sizing on fxa settings
* better aligns CC information
* makes contact support a primary action
* removes `:hover` interaction from avatar

Before
![image](https://user-images.githubusercontent.com/3323249/66922283-0af91e80-f027-11e9-8984-ec37ca429cad.png)

After
![image](https://user-images.githubusercontent.com/3323249/66921893-5232df80-f026-11e9-9f09-8f24d387a83b.png)
