### PR TITLE
fix(emails): Send service when verifying account with code

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
+++ b/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
@@ -60,8 +60,11 @@ class ConfirmSignupCodeView extends FormView {
     const account = this.getAccount();
     const code = this.getElementValue(CODE_INPUT_SELECTOR);
     const newsletters = account.get('newsletters');
+    const options = {
+      service: this.relier.get('service') || null,
+    };
     return account
-      .verifySessionCode(code)
+      .verifySessionCode(code, options)
       .then(() => {
         this.logViewEvent('verification.success');
         this.notifier.trigger('verification.success');

--- a/packages/fxa-content-server/app/tests/spec/views/confirm_signup_code.js
+++ b/packages/fxa-content-server/app/tests/spec/views/confirm_signup_code.js
@@ -40,6 +40,7 @@ describe('views/confirm_signup_code', () => {
 
     relier = new Relier({
       window: windowMock,
+      service: 'sync',
     });
 
     broker = new BaseBroker({
@@ -190,7 +191,7 @@ describe('views/confirm_signup_code', () => {
 
       it('calls correct broker methods', () => {
         assert.isTrue(
-          account.verifySessionCode.calledWith(CODE),
+          account.verifySessionCode.calledWith(CODE, { service: 'sync' }),
           'verify with correct code'
         );
         assert.isTrue(


### PR DESCRIPTION
This fixes an issue where we don't send a post verification email after the user verifies their account using a code.

I targeted against train-148 since it is a regression, but it could go on 149.

cc @davismtl @ryanfeeley  @irrationalagent 