### PR TITLE
chore(codes): Enabled signup codes for all users

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/signup-code.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/signup-code.js
@@ -5,48 +5,11 @@
 'use strict';
 
 const BaseGroupingRule = require('./base');
-const Constants = require('../../../lib/constants');
-const GROUPS_DEFAULT = ['treatment'];
-
-const ROLLOUT_CLIENTS = {
-  '37fdfa37698f251a': {
-    groups: GROUPS_DEFAULT,
-    name: 'Lockbox Extension',
-    rolloutRate: 0.0,
-  },
-  '3c49430b43dfba77': {
-    groups: GROUPS_DEFAULT,
-    name: 'Android Components Reference Browser',
-    rolloutRate: 0.0,
-  },
-  '98adfa37698f255b': {
-    groups: GROUPS_DEFAULT,
-    name: 'Lockbox Extension iOS',
-    rolloutRate: 0.0,
-  },
-  e6eb0d1e856335fc: {
-    groups: ['treatment'], // All fpn users get the signup code experience
-    name: 'fpn-site',
-    rolloutRate: 1.0,
-  },
-  ecdb5ae7add825d4: {
-    groups: GROUPS_DEFAULT,
-    name: 'TestClient',
-    rolloutRate: 0.0,
-  },
-  a8c528140153d1c6: {
-    groups: ['treatment'], // All proxy users get the signup code experience
-    name: 'fx-priv-network',
-    rolloutRate: 1.0,
-  },
-};
 
 module.exports = class SignupCodeGroupingRule extends BaseGroupingRule {
   constructor() {
     super();
     this.name = 'signupCode';
-    this.SYNC_ROLLOUT_RATE = 1.0;
-    this.ROLLOUT_CLIENTS = ROLLOUT_CLIENTS;
   }
 
   choose(subject) {
@@ -59,38 +22,6 @@ module.exports = class SignupCodeGroupingRule extends BaseGroupingRule {
       return false;
     }
 
-    const { featureFlags } = subject;
-
-    if (subject.clientId) {
-      let client = this.ROLLOUT_CLIENTS[subject.clientId];
-      if (featureFlags && featureFlags.signupCodeClients) {
-        client = featureFlags.signupCodeClients[subject.clientId];
-      }
-
-      if (client) {
-        const groups = client.groups || GROUPS_DEFAULT;
-
-        if (this.bernoulliTrial(client.rolloutRate, subject.uniqueUserId)) {
-          return this.uniformChoice(groups, subject.uniqueUserId);
-        }
-      }
-
-      // If a clientId was specified but not defined in the rollout configuration, the default
-      // is to disable the experiment for them.
-      return false;
-    }
-
-    if (subject.service && subject.service === Constants.SYNC_SERVICE) {
-      let syncRolloutRate = this.SYNC_ROLLOUT_RATE;
-      if (featureFlags && featureFlags.signupCodeClients) {
-        syncRolloutRate = featureFlags.signupCodeClients.sync.rolloutRate;
-      }
-
-      if (this.bernoulliTrial(syncRolloutRate, subject.uniqueUserId)) {
-        return this.uniformChoice(GROUPS_DEFAULT, subject.uniqueUserId);
-      }
-    }
-
-    return false;
+    return 'treatment';
   }
 };


### PR DESCRIPTION
From meeting: We should enable signup codes for all reliers.

I chose to keep the experiment logic since that involved the least amount of test changes. Once skyline is over, we can clean this up further.

Targetted against train-148, but can be on another.

cc @davismtl @clouserw 