### PR TITLE
feat(metrics): Add amplitude user properties for security features

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/metrics.js
+++ b/packages/fxa-content-server/app/scripts/lib/metrics.js
@@ -65,6 +65,7 @@ const ALLOWED_FIELDS = [
   'timers',
   'uid',
   'uniqueUserId',
+  'userPreferences',
   'utm_campaign',
   'utm_content',
   'utm_medium',
@@ -165,6 +166,7 @@ function Metrics(options = {}) {
   this._syncEngines = options.syncEngines || [];
   this._uid = options.uid || NOT_REPORTED_VALUE;
   this._uniqueUserId = options.uniqueUserId || NOT_REPORTED_VALUE;
+  this._userPreferences = {};
   this._utmCampaign = options.utmCampaign || NOT_REPORTED_VALUE;
   this._utmContent = options.utmContent || NOT_REPORTED_VALUE;
   this._utmMedium = options.utmMedium || NOT_REPORTED_VALUE;
@@ -421,6 +423,7 @@ _.extend(Metrics.prototype, Backbone.Events, {
       syncEngines: this._syncEngines,
       uid: this._uid,
       uniqueUserId: this._uniqueUserId,
+      userPreferences: this._userPreferences,
       utm_campaign: this._utmCampaign, //eslint-disable-line camelcase
       utm_content: this._utmContent, //eslint-disable-line camelcase
       utm_medium: this._utmMedium, //eslint-disable-line camelcase
@@ -652,6 +655,17 @@ _.extend(Metrics.prototype, Backbone.Events, {
       choice: choice,
       group: group,
     };
+  },
+
+  /**
+   * Log when a user preference is updated. Example, two step authentication,
+   * adding recovery email or recovery key.
+   *
+   * @param {String} prefName - name of preference, typically view name
+   * @param {Boolean} value - value of preference
+   */
+  logUserPreferences(prefName, value) {
+    this._userPreferences[prefName] = !!value;
   },
 
   /**

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_recovery_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_recovery_code.mustache
@@ -28,9 +28,9 @@
 
     </form>
 
-    <div class="links centered">
-      <a id="use-backup-link" href="/signin_totp_code">{{#t}}Use security code{{/t}}</a>
-      <a class="different-account-link" href="/signin">{{#t}}Use a different account{{/t}}</a>
+    <div class="links">
+      <a id="use-backup-link" class="left" href="/signin_totp_code">{{#t}}Back{{/t}}</a>
+      <a id="locked-out-link" class="right" target="_blank" href="{{{ escapedLockedOutSupportLink }}}" >{{#t}}Are you locked out?{{/t}}</a>
     </div>
   </section>
 </div>

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_totp_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_totp_code.mustache
@@ -29,9 +29,9 @@
     </form>
 
     {{^hideTotpAlternatives}}
-    <div class="links centered">
-      <a id="use-recovery-code-link" href="/signin_recovery_code">{{#t}}Use recovery code{{/t}}</a>
-      <a class="different-account-link" href="/signin">{{#t}}Use a different account{{/t}}</a>
+    <div class="links">
+      <a class="different-account-link left" href="/signin">{{#t}}Use a different account{{/t}}</a>
+      <a id="use-recovery-code-link" class="right" href="/signin_recovery_code">{{#t}}Trouble entering code?{{/t}}</a>
     </div>
     {{/hideTotpAlternatives}}
 

--- a/packages/fxa-content-server/app/scripts/views/settings/account_recovery/account_recovery.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/account_recovery/account_recovery.js
@@ -47,10 +47,12 @@ const View = BaseView.extend({
 
   beforeRender() {
     const account = this.getSignedInAccount();
-    return this.setupSessionGateIfRequired().then(() => {
-      return account.checkRecoveryKeyExists().then(status => {
-        this.model.set('hasRecoveryKey', status.exists);
-      });
+    return this.setupSessionGateIfRequired().then(isEnabled => {
+      if (isEnabled) {
+        return account.checkRecoveryKeyExists().then(status => {
+          this.model.set('hasRecoveryKey', status.exists);
+        });
+      }
     });
   },
 
@@ -63,6 +65,8 @@ const View = BaseView.extend({
       hasRecoveryKey: !!hasRecoveryKey,
       isPanelOpen: this.isPanelOpen(),
     });
+
+    this.metrics.logUserPreferences(this.className, !!hasRecoveryKey);
   },
 
   refresh: showProgressIndicator(

--- a/packages/fxa-content-server/app/scripts/views/settings/emails.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/emails.js
@@ -61,6 +61,11 @@ var View = FormView.extend({
       lastCheckedTime: this.getLastCheckedTimeString(),
       newEmail: this.newEmail,
     });
+
+    this.metrics.logUserPreferences(
+      this.className,
+      this._hasSecondaryVerifiedEmail()
+    );
   },
 
   afterRender() {

--- a/packages/fxa-content-server/app/scripts/views/settings/two_step_authentication.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/two_step_authentication.js
@@ -99,6 +99,8 @@ const View = FormView.extend({
       isPanelOpen: this.isPanelOpen(),
       statusVisible: this._statusVisible,
     });
+
+    this.metrics.logUserPreferences(this.className, this._hasToken);
   },
 
   cancel() {

--- a/packages/fxa-content-server/app/scripts/views/sign_in_recovery_code.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_recovery_code.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import _ from 'underscore';
 import AuthErrors from 'lib/auth-errors';
 import Cocktail from 'cocktail';
 import FormView from './form';
@@ -10,6 +11,8 @@ import Template from 'templates/sign_in_recovery_code.mustache';
 
 const CODE_INPUT_SELECTOR = 'input.recovery-code';
 const MIN_REPLACE_RECOVERY_CODE = 2;
+const LOCKED_OUT_SUPPORT_URL =
+  'https://support.mozilla.org/kb/what-if-im-locked-out-two-step-authentication';
 
 const View = FormView.extend({
   className: 'sign-in-recovery-code',
@@ -21,6 +24,12 @@ const View = FormView.extend({
     if (!account || !account.get('sessionToken')) {
       this.navigate(this._getAuthPage());
     }
+  },
+
+  setInitialContext(context) {
+    context.set({
+      escapedLockedOutSupportLink: _.escape(LOCKED_OUT_SUPPORT_URL),
+    });
   },
 
   submit() {

--- a/packages/fxa-content-server/app/tests/spec/views/settings/emails.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/emails.js
@@ -65,6 +65,8 @@ describe('views/settings/emails', function() {
     sinon.stub(user, 'getSignedInAccount').callsFake(() => {
       return account;
     });
+
+    sinon.spy(metrics, 'logUserPreferences');
   });
 
   afterEach(() => {
@@ -114,6 +116,10 @@ describe('views/settings/emails', function() {
         assert.ok(view.$('.email-address .address').length, 1);
         assert.equal(view.$('.email-address .address').text(), email);
       });
+
+      it('does not log any enable/disable metrics', function() {
+        assert.isTrue(metrics.logUserPreferences.calledOnce);
+      });
     });
   });
 
@@ -156,6 +162,13 @@ describe('views/settings/emails', function() {
       it('has email input field', function() {
         assert.ok(view.$('input.new-email').length, 1);
         assert.ok(view.$('.email-add.primary-button').length, 1);
+      });
+
+      it('logs `emails` disabled metric', function() {
+        assert.isTrue(metrics.logUserPreferences.calledOnce);
+        assert.isTrue(
+          metrics.logUserPreferences.calledWith(view.className, false)
+        );
       });
     });
 
@@ -252,6 +265,13 @@ describe('views/settings/emails', function() {
       it('panel always open when unverified secondary email', () => {
         assert.equal(view.isPanelOpen(), true);
       });
+
+      it('logs `emails` disabled metric', function() {
+        assert.isTrue(metrics.logUserPreferences.calledOnce);
+        assert.isTrue(
+          metrics.logUserPreferences.calledWith(view.className, false)
+        );
+      });
     });
 
     describe('with verified secondary email', () => {
@@ -318,6 +338,13 @@ describe('views/settings/emails', function() {
 
       it('panel closed when verified secondary email', () => {
         assert.equal(view.isPanelOpen(), false);
+      });
+
+      it('logs `emails` enabled metric', () => {
+        assert.isTrue(metrics.logUserPreferences.calledOnce);
+        assert.isTrue(
+          metrics.logUserPreferences.calledWith(view.className, true)
+        );
       });
     });
 

--- a/packages/fxa-content-server/app/tests/spec/views/settings/two_step_authentication.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/two_step_authentication.js
@@ -102,6 +102,7 @@ describe('views/settings/two_step_authentication', () => {
   describe('should show token status', () => {
     beforeEach(() => {
       hasToken = true;
+      sinon.spy(metrics, 'logUserPreferences');
       return initView();
     });
 
@@ -109,11 +110,19 @@ describe('views/settings/two_step_authentication', () => {
       assert.equal(view.$('#totp-status .enabled').length, 1);
       assert.equal(view.$('#totp.hidden').length, 1);
     });
+
+    it('logs `two_step_authentication` enabled metric', () => {
+      assert.isTrue(metrics.logUserPreferences.calledOnce);
+      assert.isTrue(
+        metrics.logUserPreferences.calledWith(view.className, true)
+      );
+    });
   });
 
   describe('should create new token', () => {
     beforeEach(() => {
       hasToken = false;
+      sinon.spy(metrics, 'logUserPreferences');
       return initView().then(() => view.createToken());
     });
 
@@ -127,6 +136,13 @@ describe('views/settings/two_step_authentication', () => {
 
     it('should not show status section', () => {
       assert.equal(view.$('.totp-list.hidden').length, 1);
+    });
+
+    it('logs `two_step_authentication` disabled metric', () => {
+      assert.isTrue(metrics.logUserPreferences.calledOnce);
+      assert.isTrue(
+        metrics.logUserPreferences.calledWith(view.className, false)
+      );
     });
 
     describe('should show code and hide `show code link`', () => {
@@ -166,6 +182,7 @@ describe('views/settings/two_step_authentication', () => {
   describe('should validate token code', () => {
     beforeEach(() => {
       validCode = true;
+      sinon.spy(metrics, 'logUserPreferences');
       return initView().then(() => {
         sinon.spy(view, 'render');
         sinon.spy(view, 'displaySuccess');
@@ -176,6 +193,13 @@ describe('views/settings/two_step_authentication', () => {
     it('confirms code', () => {
       assert.equal(view.render.callCount, 1);
       assert.equal(view.displaySuccess.callCount, 1);
+    });
+
+    it('logs `two_step_authentication` enabled metric', () => {
+      assert.isTrue(metrics.logUserPreferences.calledOnce);
+      assert.isTrue(
+        metrics.logUserPreferences.calledWith(view.className, true)
+      );
     });
   });
 

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_recovery_code.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_recovery_code.js
@@ -20,6 +20,8 @@ import WindowMock from '../../mocks/window';
 const { createRandomHexString } = helpers;
 
 const RECOVERY_CODE = createRandomHexString(Constants.RECOVERY_CODE_LENGTH);
+const LOCKED_OUT_SUPPORT_URL =
+  'https://support.mozilla.org/kb/what-if-im-locked-out-two-step-authentication';
 
 describe('views/sign_in_recovery_code', () => {
   let account;
@@ -94,7 +96,10 @@ describe('views/sign_in_recovery_code', () => {
         view.$('#use-backup-link').attr('href'),
         '/signin_totp_code'
       );
-      assert.equal(view.$('.different-account-link').attr('href'), '/signin');
+      assert.equal(
+        view.$('#locked-out-link').attr('href'),
+        LOCKED_OUT_SUPPORT_URL
+      );
     });
 
     describe('without an account', () => {

--- a/packages/fxa-content-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-content-server/server/lib/routes/post-metrics.js
@@ -41,6 +41,7 @@ const {
   SYNC_ENGINES: SYNC_ENGINES_TYPE,
   TIME: TIME_TYPE,
   URL: URL_TYPE,
+  USER_PREFERENCES: USER_PREFERENCES,
   UTM: UTM_TYPE,
   UTM_CAMPAIGN: UTM_CAMPAIGN_TYPE,
 } = validation.TYPES;
@@ -152,6 +153,7 @@ const BODY_SCHEMA = {
   uniqueUserId: STRING_TYPE.regex(UNIQUE_USER_ID_PATTERN)
     .allow('none')
     .required(),
+  userPreferences: USER_PREFERENCES.optional(),
   utm_campaign: UTM_CAMPAIGN_TYPE.required(),
   utm_content: UTM_TYPE.required(),
   utm_medium: UTM_TYPE.required(),

--- a/packages/fxa-content-server/server/lib/validation.js
+++ b/packages/fxa-content-server/server/lib/validation.js
@@ -74,6 +74,11 @@ const TYPES = {
     .string()
     .max(2048)
     .uri({ scheme: ['http', 'https'] }), // 2048 is also arbitrary, the same limit we use on the front end.
+  USER_PREFERENCES: joi.object().keys({
+    'account-recovery': joi.boolean(),
+    emails: joi.boolean(),
+    'two-step-authentication': joi.boolean(),
+  }),
   UTM: joi
     .string()
     .max(128)

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -297,10 +297,16 @@ module.exports = {
     function mapAppendProperties(data) {
       const servicesUsed = mapServicesUsed(data);
       const experiments = mapExperiments(data);
+      const userPreferences = mapUserPreferences(data);
 
-      if (servicesUsed || experiments) {
+      if (servicesUsed || experiments || userPreferences) {
         return {
-          $append: Object.assign({}, servicesUsed, experiments),
+          $append: Object.assign(
+            {},
+            servicesUsed,
+            experiments,
+            userPreferences
+          ),
         };
       }
     }
@@ -341,6 +347,22 @@ function mapExperiments(data) {
       ),
     };
   }
+}
+
+function mapUserPreferences(data) {
+  const { userPreferences } = data;
+
+  // Don't send user preferences metric if there are none!
+  if (!userPreferences || Object.keys(userPreferences).length === 0) {
+    return;
+  }
+
+  const formattedUserPreferences = {};
+  for (const pref in userPreferences) {
+    formattedUserPreferences[toSnakeCase(pref)] = userPreferences[pref];
+  }
+
+  return formattedUserPreferences;
 }
 
 function toSnakeCase(string) {

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -171,6 +171,9 @@ describe('metrics/amplitude:', () => {
             syncEngines: ['wibble', 'blee'],
             templateVersion: 's',
             uid: 't',
+            userPreferences: {
+              'account-recovery': true,
+            },
             utm_campaign: 'u',
             utm_content: 'v',
             utm_medium: 'w',
@@ -206,6 +209,7 @@ describe('metrics/amplitude:', () => {
           user_id: 't',
           user_properties: {
             $append: {
+              account_recovery: true,
               experiments: ['g_h', 'i_i_j_j_j'],
               fxa_services_used: 'qux',
             },


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/2704
 
This PR adds user properties to our amplitude events on the content-server. The new user properties correspond to whether or not the user has enabled secondary email, recovery key and two step authentication.

```
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_pref - view","time":1571344015406,"user_id":"26d445cc0b50448db828e3180422e043","device_id":"eaea82064cc54ec3aee3985bcef58cbd","session_id":1571344014615,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{},"user_properties":{"flow_id":"e94d846b7ebdc5f07d23277cf8608d5b25f169e271abed962856b7180ebb4581","ua_browser":"Firefox","ua_version":"70.0","utm_campaign":"fx-welcome-secondary","utm_content":"fx-activate","utm_medium":"email","$append":{"two_step_authentication":false,"account_recovery":false,"emails":true}}}
```

Prefs
- two_step_authentication
  - True or false whether user has 2FA enabled
- account_recovery
  - True or false whether user has account recovery enabled
- emails
  - True or false whether user has secondary emails enabled


- [x] Add tests