### PR TITLE
feat(email-first): Email first by default brokers that have it enabled.

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/email-first.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/email-first.js
@@ -21,18 +21,14 @@ class EmailFirstGroupingRule extends BaseGroupingRule {
    * @returns {Any}
    */
   choose(subject) {
-    const GROUPS = ['control', 'treatment'];
-
     if (!this._isValidSubject(subject)) {
       return false;
     } else if (!subject.isEmailFirstSupported) {
       // isEmailFirstSupported is `true` for brokers that support the email-first flow.
       return false;
-    } else if (!this._isSampledUser(subject)) {
-      return false;
     }
 
-    return this.uniformChoice(GROUPS, subject.uniqueUserId);
+    return 'treatment';
   }
 
   /**
@@ -43,20 +39,7 @@ class EmailFirstGroupingRule extends BaseGroupingRule {
    * @private
    */
   _isValidSubject(subject) {
-    return subject && subject.uniqueUserId && subject.experimentGroupingRules;
-  }
-
-  /**
-   * Is the user sample the experiment?
-   *
-   * @param {Object} subject
-   * @returns {Boolean}
-   * @private
-   */
-  _isSampledUser(subject) {
-    // All users that make it to this point that also report metrics are
-    // sampled users.
-    return subject.experimentGroupingRules.choose('isSampledUser', subject);
+    return subject;
   }
 }
 

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/email-first.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/email-first.js
@@ -8,20 +8,10 @@ import sinon from 'sinon';
 
 describe('lib/experiments/grouping-rules/email-first', () => {
   let experiment;
-  let experimentGroupingRules;
   let sandbox;
 
   before(() => {
     experiment = new Experiment();
-
-    experimentGroupingRules = {
-      choose(experimentName) {
-        if (experimentName === 'isSampledUser') {
-          return true;
-        }
-        return false;
-      },
-    };
   });
 
   beforeEach(() => {
@@ -35,30 +25,23 @@ describe('lib/experiments/grouping-rules/email-first', () => {
   describe('choose', () => {
     it('returns `false` if prereqs not met', () => {
       assert.isFalse(experiment.choose());
-      assert.isFalse(experiment.choose({}));
-      assert.isFalse(experiment.choose({ uniqueUserId: 'user-id' }));
     });
 
     it('returns `false` if `isEmailFirstSupported=false`', () => {
       assert.isFalse(
         experiment.choose({
-          experimentGroupingRules,
           isEmailFirstSupported: false,
-          uniqueUserId: 'user-id',
         })
       );
     });
 
-    it('returns chooses some experiment ', () => {
-      sandbox.stub(experiment, 'bernoulliTrial').callsFake(() => true);
-
-      assert.ok(
+    it('returns `treatment` otherwise', () => {
+      assert.equal(
         experiment.choose({
           env: 'development',
-          experimentGroupingRules,
           isEmailFirstSupported: true,
-          uniqueUserId: 'user-id',
-        })
+        }),
+        'treatment'
       );
     });
   });


### PR DESCRIPTION
This leans on the experiment code to enable email first by default
for all brokers with support. This approach was taken because
the number of test updates that are needed is astronomical and
this is a step in the right direction without causing too much
churn.

A step towards #2827