### PR TITLE
feat(email-first): Disable legacy signin/signup flows in fx_desktop_v3

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -298,6 +298,12 @@ const Router = Backbone.Router.extend({
     this.notifier.on('navigate-back', this.onNavigateBack.bind(this));
     this.notifier.on('email-first-flow', () => this._onEmailFirstFlow());
 
+    // If legacy signin/signup flows are disabled, this is obviously
+    // an email-first flow!
+    if (this.broker.getCapability('disableLegacySigninSignup')) {
+      this._isEmailFirstFlow = true;
+    }
+
     this.storage = Storage.factory('sessionStorage', this.window);
   },
 

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-desktop-v3.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-desktop-v3.js
@@ -19,6 +19,7 @@ const proto = FxDesktopV2AuthenticationBroker.prototype;
 const FxDesktopV3AuthenticationBroker = FxDesktopV2AuthenticationBroker.extend({
   defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
     allowUidChange: true,
+    disableLegacySigninSignup: true,
     emailFirst: true,
     tokenCode: true,
   }),

--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -18,7 +18,9 @@
     <form novalidate>
       <p class="prefillEmail">{{ email }}</p>
       <input type="email" class="email hidden" value="{{ email }}" disabled />
+      {{#canChangeAccount}}
       <a href="/" class="use-different">{{#t}}Change email{{/t}}</a>
+      {{/canChangeAccount}}
 
       <div class="input-row password-row">
         <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autofocus data-form-prefill="password" data-synchronize-show="true" />

--- a/packages/fxa-content-server/app/scripts/views/force_auth.js
+++ b/packages/fxa-content-server/app/scripts/views/force_auth.js
@@ -139,6 +139,11 @@ var View = SignInView.extend({
 
     return this.navigate('signup', {
       error: AuthErrors.toError('DELETED_ACCOUNT'),
+      // account is for the email-first signup flow, without an account
+      // the signup page redirects to index
+      account,
+      // forceEmail is a hint to the signup page that the user should not
+      // be given the option to change their address.
       forceEmail: account.get('email'),
     });
   },

--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -60,7 +60,15 @@ class IndexView extends FormView {
       return this.chooseEmailActionPage();
     }
 
+    const isLegacySigninSignupDisabled = this.broker.getCapability(
+      'disableLegacySigninSignup'
+    );
     const action = this.relier.get('action');
+
+    if (isLegacySigninSignupDisabled && action !== 'force_auth') {
+      return this.chooseEmailActionPage();
+    }
+
     if (action && action !== 'email') {
       this.replaceCurrentPage(action);
     } else if (

--- a/packages/fxa-content-server/app/scripts/views/mixins/email-first-experiment-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/email-first-experiment-mixin.js
@@ -25,7 +25,11 @@ export default (options = {}) => {
     dependsOn: [ExperimentMixin],
 
     beforeRender() {
-      if (this.relier.get('action') === 'email' && options.treatmentPathname) {
+      if (
+        (this.relier.get('action') === 'email' ||
+          this.broker.getCapability('disableLegacySigninSignup')) &&
+        options.treatmentPathname
+      ) {
         this.replaceCurrentPage(options.treatmentPathname);
       } else if (this.isInEmailFirstExperiment()) {
         const experimentGroup = this.getEmailFirstExperimentGroup();

--- a/packages/fxa-content-server/app/scripts/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_up_password.js
@@ -18,6 +18,8 @@ import ServiceMixin from './mixins/service-mixin';
 import SignUpMixin from './mixins/signup-mixin';
 import Template from 'templates/sign_up_password.mustache';
 
+const t = msg => msg;
+
 const proto = FormView.prototype;
 const SignUpPasswordView = FormView.extend({
   template: Template,
@@ -46,10 +48,18 @@ const SignUpPasswordView = FormView.extend({
     if (!this.getAccount()) {
       this.navigate('/');
     }
+    const error = this.model.get('error');
+    if (error && AuthErrors.is(error, 'DELETED_ACCOUNT')) {
+      error.forceMessage = t('Account no longer exists. Recreate it?');
+    }
+    return proto.beforeRender.call(this);
   },
 
   setInitialContext(context) {
-    context.set(this.getAccount().pick('email'));
+    context.set({
+      canChangeAccount: !this.model.get('forceEmail'),
+      email: this.getAccount().get('email'),
+    });
   },
 
   isValidEnd() {

--- a/packages/fxa-content-server/app/tests/spec/lib/router.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/router.js
@@ -368,6 +368,7 @@ describe('lib/router', () => {
     it('is `true` if sessionStorage.canGoBack is set', () => {
       windowMock.sessionStorage.setItem('canGoBack', true);
       router = new Router({
+        broker,
         metrics: metrics,
         notifier: notifier,
         relier: relier,

--- a/packages/fxa-content-server/app/tests/spec/views/force_auth.js
+++ b/packages/fxa-content-server/app/tests/spec/views/force_auth.js
@@ -635,4 +635,6 @@ function testNavigatesToForceSignUp(view, email) {
   var navigateData = view.navigate.args[0][1];
   assert.isTrue(AuthErrors.is(navigateData.error, 'DELETED_ACCOUNT'));
   assert.equal(navigateData.forceEmail, email);
+  assert.ok(navigateData.account);
+  assert.equal(navigateData.account.get('email'), email);
 }

--- a/packages/fxa-content-server/app/tests/spec/views/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/index.js
@@ -129,6 +129,23 @@ describe('views/index', () => {
         });
       });
 
+      describe('broker disables legacy signin/signup', () => {
+        it('renders as expected, starts the flow metrics', () => {
+          broker.setCapability('disableLegacySigninSignup', true);
+
+          relier.set({
+            service: 'sync',
+            serviceName: 'Firefox Sync',
+          });
+
+          sinon
+            .stub(view, 'isInEmailFirstExperimentGroup')
+            .callsFake(() => false);
+
+          return renderTestEnterEmailDisplayed(view);
+        });
+      });
+
       describe('relier.action === email', () => {
         it('renders as expected, starts the flow metrics', () => {
           relier.set({
@@ -140,21 +157,8 @@ describe('views/index', () => {
           sinon
             .stub(view, 'isInEmailFirstExperimentGroup')
             .callsFake(() => false);
-          sinon.spy(view, 'logFlowEventOnce');
 
-          return view.render().then(() => {
-            assert.isFalse(view.replaceCurrentPage.called);
-
-            assert.lengthOf(view.$(Selectors.HEADER), 1);
-            assert.lengthOf(view.$(Selectors.EMAIL), 1);
-            assert.include(view.$(Selectors.SUB_HEADER).text(), 'Firefox Sync');
-            assert.lengthOf(view.$(Selectors.FIREFOX_FAMILY_SERVICES), 1);
-
-            assert.isTrue(notifier.trigger.calledWith('email-first-flow'));
-
-            assert.isTrue(view.logFlowEventOnce.calledOnce);
-            assert.isTrue(view.logFlowEventOnce.calledWith('begin'));
-          });
+          return renderTestEnterEmailDisplayed(view);
         });
 
         it('handles relier specified emails', () => {
@@ -191,29 +195,11 @@ describe('views/index', () => {
             serviceName: 'Firefox Sync',
           });
 
-          sinon.spy(view, 'logFlowEventOnce');
           sinon
             .stub(view, 'isInEmailFirstExperimentGroup')
             .callsFake(() => true);
 
-          return view.render().then(() => {
-            assert.isFalse(view.replaceCurrentPage.called);
-            assert.isFalse(view.replaceCurrentPage.called);
-
-            assert.isTrue(view.isInEmailFirstExperimentGroup.calledOnce);
-            assert.isTrue(
-              view.isInEmailFirstExperimentGroup.calledWith('treatment')
-            );
-
-            assert.lengthOf(view.$(Selectors.HEADER), 1);
-            assert.lengthOf(view.$(Selectors.EMAIL), 1);
-            assert.include(view.$(Selectors.SUB_HEADER).text(), 'Firefox Sync');
-
-            assert.isTrue(notifier.trigger.calledWith('email-first-flow'));
-
-            assert.isTrue(view.logFlowEventOnce.calledOnce);
-            assert.isTrue(view.logFlowEventOnce.calledWith('begin'));
-          });
+          return renderTestEnterEmailDisplayed(view);
         });
       });
 
@@ -369,4 +355,22 @@ describe('views/index', () => {
       });
     });
   });
+
+  function renderTestEnterEmailDisplayed(view) {
+    sinon.spy(view, 'logFlowEventOnce');
+
+    return view.render().then(() => {
+      assert.isFalse(view.replaceCurrentPage.called);
+
+      assert.lengthOf(view.$(Selectors.HEADER), 1);
+      assert.lengthOf(view.$(Selectors.EMAIL), 1);
+      assert.include(view.$(Selectors.SUB_HEADER).text(), 'Firefox Sync');
+      assert.lengthOf(view.$(Selectors.FIREFOX_FAMILY_SERVICES), 1);
+
+      assert.isTrue(notifier.trigger.calledWith('email-first-flow'));
+
+      assert.isTrue(view.logFlowEventOnce.calledOnce);
+      assert.isTrue(view.logFlowEventOnce.calledWith('begin'));
+    });
+  }
 });

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/email-first-experiment-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/email-first-experiment-mixin.js
@@ -102,10 +102,19 @@ describe('views/mixins/email-first-experiment-mixin', () => {
     beforeEach(() => {
       sandbox.spy(view, 'createExperiment');
       sandbox.spy(view, 'replaceCurrentPage');
+      broker.unsetCapability('disableLegacySigninSignup');
     });
 
     it('redirects to the treatment page if `action=email`', () => {
       relier.set('action', 'email');
+
+      view.beforeRender();
+
+      assert.isTrue(view.replaceCurrentPage.calledOnceWith('/'));
+    });
+
+    it('redirects to the treatment page if legacy signin/signup disabled for broker', () => {
+      broker.setCapability('disableLegacySigninSignup', true);
 
       view.beforeRender();
 

--- a/packages/fxa-content-server/app/tests/spec/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_up_password.js
@@ -101,23 +101,41 @@ describe('views/sign_up_password', () => {
   describe('render', () => {
     it('renders as expected, initializes flow events', () => {
       assert.include(view.$('.service').text(), 'Firefox Sync');
-      assert.lengthOf(view.$('input[type=email]'), 1);
-      assert.equal(view.$('input[type=email]').val(), EMAIL);
-      assert.lengthOf(view.$('#password'), 1);
-      assert.lengthOf(view.$('#vpassword'), 1);
-      assert.lengthOf(view.$('#age'), 1);
-      assert.lengthOf(view.$('#fxa-tos'), 1);
-      assert.lengthOf(view.$('#fxa-pp'), 1);
+      assert.lengthOf(view.$(Selectors.EMAIL), 1);
+      assert.equal(view.$(Selectors.EMAIL).val(), EMAIL);
+      assert.lengthOf(view.$(Selectors.PASSWORD), 1);
+      assert.lengthOf(view.$(Selectors.VPASSWORD), 1);
+      assert.lengthOf(view.$(Selectors.AGE), 1);
+      assert.lengthOf(view.$(Selectors.TOS), 1);
+      assert.lengthOf(view.$(Selectors.PRIVACY_POLICY), 1);
+      assert.lengthOf(view.$(Selectors.LINK_MISTYPED_EMAIL), 1);
       assert.lengthOf(view.$(Selectors.MARKETING_EMAIL_OPTIN), 3);
       assert.lengthOf(view.$(Selectors.FIREFOX_FAMILY_SERVICES), 1);
+      assert.lengthOf(view.$(Selectors.FIREFOX_FAMILY_SERVICES), 1);
+      assert.lengthOf(view.$(Selectors.MARKETING_EMAIL_OPTIN), 3);
       assert.isTrue(notifier.trigger.calledOnce);
       assert.isTrue(notifier.trigger.calledWith('flow.initialize'));
     });
 
-    it('renders the firefox-family services', () => {
+    it('does not display the link to change accounts if email forced', () => {
+      model.set('forceEmail', EMAIL);
+
       return view.render().then(() => {
-        assert.lengthOf(view.$(Selectors.FIREFOX_FAMILY_SERVICES), 1);
-        assert.lengthOf(view.$(Selectors.MARKETING_EMAIL_OPTIN), 3);
+        assert.lengthOf(view.$(Selectors.LINK_MISTYPED_EMAIL), 0);
+      });
+    });
+
+    it('handles the deleted account error', () => {
+      model.set('error', AuthErrors.toError('DELETED_ACCOUNT'));
+      return view.render().then(() => {
+        view.afterVisible();
+        assert.include(
+          view
+            .$(Selectors.ERROR)
+            .text()
+            .toLowerCase(),
+          'recreate'
+        );
       });
     });
   });
@@ -131,9 +149,9 @@ describe('views/sign_up_password', () => {
 
     describe('password and vpassword do not match', () => {
       it('displays an error', () => {
-        view.$('#password').val('password123123');
-        view.$('#vpassword').val('different_password');
-        view.$('#age').val('21');
+        view.$(Selectors.PASSWORD).val('password123123');
+        view.$(Selectors.VPASSWORD).val('different_password');
+        view.$(Selectors.AGE).val('21');
 
         return Promise.resolve(view.validateAndSubmit()).then(
           assert.fail,
@@ -151,9 +169,9 @@ describe('views/sign_up_password', () => {
 
     describe('user is too young', () => {
       it('delegates to `tooYoung`', () => {
-        view.$('#password').val('password123123');
-        view.$('#vpassword').val('password123123');
-        view.$('#age').val('11');
+        view.$(Selectors.PASSWORD).val('password123123');
+        view.$(Selectors.VPASSWORD).val('password123123');
+        view.$(Selectors.AGE).val('11');
 
         return Promise.resolve(view.validateAndSubmit()).then(() => {
           assert.isTrue(view.tooYoung.calledOnce);
@@ -165,9 +183,9 @@ describe('views/sign_up_password', () => {
 
     describe('user is old enough', () => {
       it('signs up the user', () => {
-        view.$('#password').val('password123123');
-        view.$('#vpassword').val('password123123');
-        view.$('#age').val('21');
+        view.$(Selectors.PASSWORD).val('password123123');
+        view.$(Selectors.VPASSWORD).val('password123123');
+        view.$(Selectors.AGE).val('21');
 
         sinon.stub(view, 'isAnyNewsletterVisible').callsFake(() => true);
         sinon.stub(view, '_hasOptedIntoNewsletter').callsFake(() => true);
@@ -187,9 +205,9 @@ describe('views/sign_up_password', () => {
 
     describe('marketing opt-in not visible', () => {
       it('does not set `hasOptedIntoNewsletter`', () => {
-        view.$('#password').val('password123123');
-        view.$('#vpassword').val('password123123');
-        view.$('#age').val('21');
+        view.$(Selectors.PASSWORD).val('password123123');
+        view.$(Selectors.VPASSWORD).val('password123123');
+        view.$(Selectors.AGE).val('21');
 
         sinon.stub(view, 'isAnyNewsletterVisible').callsFake(() => false);
 

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -75,11 +75,11 @@ module.exports = [
   'tests/functional/sync_v1.js',
   'tests/functional/sync_v2.js',
   'tests/functional/sync_v3_email_first.js',
+  'tests/functional/sync_v3_sign_in.js',
+  'tests/functional/sync_v3_sign_up.js',
   'tests/functional/sync_v3_force_auth.js',
   'tests/functional/sync_v3_reset_password.js',
   'tests/functional/sync_v3_settings.js',
-  'tests/functional/sync_v3_sign_in.js',
-  'tests/functional/sync_v3_sign_up.js',
   'tests/functional/tos.js',
 ];
 

--- a/packages/fxa-content-server/tests/functional/bounced_email.js
+++ b/packages/fxa-content-server/tests/functional/bounced_email.js
@@ -14,7 +14,7 @@ let deliveredEmail;
 const PASSWORD = 'password12345678';
 const ENTER_EMAIL_URL = `${
   intern._config.fxaContentRoot
-}?action=email&context=fx_desktop_v3&service=sync&automatedBrowser=true&forceAboutAccounts=true&forceUA=${encodeURIComponent(
+}?context=fx_desktop_v3&service=sync&automatedBrowser=true&forceAboutAccounts=true&forceUA=${encodeURIComponent(
   uaStrings.desktop_firefox_56
 )}`; //eslint-disable-line max-len
 

--- a/packages/fxa-content-server/tests/functional/complete_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/complete_sign_in.js
@@ -11,23 +11,24 @@ const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const config = intern._config;
 const PAGE_COMPLETE_SIGNIN_URL = config.fxaContentRoot + 'complete_signin';
-const PAGE_SIGNIN_URL =
-  config.fxaContentRoot + 'signin?context=fx_desktop_v3&service=sync';
+const ENTER_EMAIL_URL =
+  config.fxaContentRoot + '?context=fx_desktop_v3&service=sync';
 const PASSWORD = 'passwordzxcv';
 
 let code;
 let email;
 let uid;
 let user;
-
-const clearBrowserState = FunctionalHelpers.clearBrowserState;
-const createUser = FunctionalHelpers.createUser;
-const fillOutSignIn = FunctionalHelpers.fillOutSignIn;
-const getEmailHeaders = FunctionalHelpers.getEmailHeaders;
-const noSuchElement = FunctionalHelpers.noSuchElement;
-const openPage = FunctionalHelpers.openPage;
-const testElementExists = FunctionalHelpers.testElementExists;
-const testIsBrowserNotified = FunctionalHelpers.testIsBrowserNotified;
+const {
+  clearBrowserState,
+  createUser,
+  fillOutEmailFirstSignIn,
+  getEmailHeaders,
+  noSuchElement,
+  openPage,
+  testElementExists,
+  testIsBrowserNotified,
+} = FunctionalHelpers;
 
 const createRandomHexString = TestHelpers.createRandomHexString;
 
@@ -39,14 +40,14 @@ registerSuite('complete_sign_in', {
       .then(clearBrowserState())
       .then(createUser(email, PASSWORD, { preVerified: true }))
       .then(
-        openPage(PAGE_SIGNIN_URL, selectors.SIGNIN.HEADER, {
+        openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
           webChannelResponses: {
             'fxaccounts:can_link_account': { ok: true },
             'fxaccounts:fxa_status': { capabilities: null, signedInUser: null },
           },
         })
       )
-      .then(fillOutSignIn(email, PASSWORD))
+      .then(fillOutEmailFirstSignIn(email, PASSWORD))
       .then(testElementExists(selectors.CONFIRM_SIGNIN.HEADER))
       .then(testIsBrowserNotified('fxaccounts:can_link_account'))
       .then(testIsBrowserNotified('fxaccounts:login'))

--- a/packages/fxa-content-server/tests/functional/confirm.js
+++ b/packages/fxa-content-server/tests/functional/confirm.js
@@ -7,24 +7,29 @@
 const { registerSuite } = intern.getInterface('object');
 const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
-var config = intern._config;
-var CONFIRM_URL = config.fxaContentRoot + 'confirm';
-var SIGNUP_URL = config.fxaContentRoot + 'signup';
-var PASSWORD = '12345678';
+const selectors = require('./lib/selectors');
 
-var email;
+const config = intern._config;
+const CONFIRM_URL = config.fxaContentRoot + 'confirm';
+const SIGNUP_URL = config.fxaContentRoot + 'signup';
+const PASSWORD = 'password12345678';
 
-var clearBrowserState = FunctionalHelpers.clearBrowserState;
-var click = FunctionalHelpers.click;
-var closeCurrentWindow = FunctionalHelpers.closeCurrentWindow;
-var fillOutSignUp = FunctionalHelpers.fillOutSignUp;
-var noSuchElement = FunctionalHelpers.noSuchElement;
-var openPage = FunctionalHelpers.openPage;
-var respondToWebChannelMessage = FunctionalHelpers.respondToWebChannelMessage;
-var switchToWindow = FunctionalHelpers.switchToWindow;
-var testElementExists = FunctionalHelpers.testElementExists;
-var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
-var testSuccessWasShown = FunctionalHelpers.testSuccessWasShown;
+let email;
+
+const {
+  clearBrowserState,
+  click,
+  closeCurrentWindow,
+  fillOutSignUp,
+  fillOutEmailFirstSignUp,
+  noSuchElement,
+  openPage,
+  respondToWebChannelMessage,
+  switchToWindow,
+  testElementExists,
+  testElementTextInclude,
+  testSuccessWasShown,
+} = FunctionalHelpers;
 
 registerSuite('confirm', {
   beforeEach: function() {
@@ -32,6 +37,7 @@ registerSuite('confirm', {
     // clear localStorage to avoid polluting other tests.
     return this.remote.then(clearBrowserState());
   },
+
   tests: {
     'visit confirmation screen without initiating sign up, user is redirected to /signup': function() {
       return (
@@ -39,23 +45,28 @@ registerSuite('confirm', {
           // user is immediately redirected to /signup if they have no
           // sessionToken.
           // Success is showing the screen
-          .then(openPage(CONFIRM_URL, '#fxa-signup-header'))
+          .then(openPage(CONFIRM_URL, selectors.SIGNUP.HEADER))
       );
     },
 
     'sign up, wait for confirmation screen, click resend': function() {
-      var email = 'test_signin' + Math.random() + '@restmail.dev.lcip.org';
+      const email = 'test_signin' + Math.random() + '@restmail.dev.lcip.org';
 
       return (
         this.remote
-          .then(openPage(SIGNUP_URL, '#fxa-signup-header'))
+          .then(openPage(SIGNUP_URL, selectors.SIGNUP.HEADER))
           .then(fillOutSignUp(email, PASSWORD))
 
-          .then(testElementExists('#fxa-confirm-header'))
-          .then(testElementTextInclude('.verification-email-message', email))
-          .then(noSuchElement('#open-webmail'))
+          .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
+          .then(
+            testElementTextInclude(
+              selectors.CONFIRM_SIGNUP.EMAIL_MESSAGE,
+              email
+            )
+          )
+          .then(noSuchElement(selectors.CONFIRM_SIGNUP.LINK_OPEN_WEBMAIL))
 
-          .then(click('#resend'))
+          .then(click(selectors.CONFIRM_SIGNUP.LINK_RESEND))
 
           // the test below depends on the speed of the email resent XHR
           // we have to wait until the resent request completes and the
@@ -65,27 +76,26 @@ registerSuite('confirm', {
     },
 
     'sign up with a restmail address, get the open restmail button': function() {
-      var SIGNUP_URL =
-        intern._config.fxaContentRoot +
-        'signup?context=fx_desktop_v3&service=sync';
+      const ENTER_EMAIL_URL =
+        intern._config.fxaContentRoot + '?context=fx_desktop_v3&service=sync';
       this.timeout = 90000;
 
       return (
         this.remote
-          .then(openPage(SIGNUP_URL, '#fxa-signup-header'))
+          .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
           .then(
             respondToWebChannelMessage('fxaccounts:can_link_account', {
               ok: true,
             })
           )
 
-          .then(fillOutSignUp(email, PASSWORD))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
 
-          .then(testElementExists('#choose-what-to-sync'))
-          .then(click('button[type="submit"]'))
+          .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
+          .then(click(selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT))
 
-          .then(testElementExists('#fxa-confirm-header'))
-          .then(click('[data-webmail-type="restmail"]'))
+          .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
+          .then(click(selectors.CONFIRM_SIGNUP.LINK_OPEN_WEBMAIL))
 
           .then(switchToWindow(1))
 
@@ -102,7 +112,7 @@ registerSuite('confirm', {
 
           .then(closeCurrentWindow())
 
-          .then(testElementExists('#fxa-confirm-header'))
+          .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
       );
     },
   },

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -101,8 +101,11 @@ module.exports = {
     RESEND_SUCCESS: '.success',
   },
   CONFIRM_SIGNUP: {
+    EMAIL_MESSAGE: '.verification-email-message',
     HEADER: '#fxa-confirm-header',
     LINK_BACK: '#back',
+    LINK_OPEN_WEBMAIL: '#open-webmail',
+    LINK_RESEND: '#resend',
   },
   CONFIRM_SIGNUP_CODE: {
     HEADER: '#fxa-confirm-signup-code-header',
@@ -358,6 +361,7 @@ module.exports = {
   SIGNUP_PASSWORD: {
     AGE: '#age',
     EMAIL: 'input[type=email]',
+    ERROR: '.error',
     ERROR_PASSWORDS_DO_NOT_MATCH: '.error',
     FIREFOX_FAMILY_SERVICES: '.firefox-family-services',
     HEADER: '#fxa-signup-password-header',
@@ -365,9 +369,11 @@ module.exports = {
     MARKETING_EMAIL_OPTIN: 'input.marketing-email-optin',
     PASSWORD: '#password',
     PASSWORD_BALLOON,
+    PRIVACY_POLICY: '#fxa-pp',
     SHOW_PASSWORD: '#password ~ .show-password-label',
     SHOW_VPASSWORD: '#vpassword ~ .show-password-label',
     SUBMIT: 'button[type="submit"]',
+    TOS: '#fxa-tos',
     VPASSWORD: '#vpassword',
   },
   SMS_LEARN_MORE: {
@@ -412,6 +418,7 @@ module.exports = {
     SHOW_CODE_LINK: '.show-code-link',
     STATUS_DISABLED: '.two-step-authentication .disabled',
     STATUS_ENABLED: '.two-step-authentication .enabled',
+    TOOLTIP: '.totp-code + .tooltip',
     UNLOCK_BUTTON: '.two-step-authentication .unlock-button',
     UNLOCK_REFRESH_BUTTON:
       '.two-step-authentication .refresh-verification-state',

--- a/packages/fxa-content-server/tests/functional/oauth_sync_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sync_sign_in.js
@@ -10,8 +10,6 @@ const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const config = intern._config;
 
-const SYNC_LEGACY_SIGNIN_URL =
-  config.fxaContentRoot + 'signin?context=fx_desktop_v3&service=sync';
 const SYNC_EMAIL_FIRST_URL =
   config.fxaContentRoot + '?context=fx_desktop_v3&service=sync&action=email';
 
@@ -24,7 +22,6 @@ const {
   closeCurrentWindow,
   createUser,
   fillOutEmailFirstSignIn,
-  fillOutSignIn,
   fillOutSignUp,
   openFxaFromRp,
   openPage,
@@ -58,7 +55,7 @@ registerSuite('signin with OAuth after Sync', {
         this.remote
           .then(createUser(email, PASSWORD, { preVerified: true }))
           .then(
-            openPage(SYNC_LEGACY_SIGNIN_URL, selectors.SIGNIN.HEADER, {
+            openPage(SYNC_EMAIL_FIRST_URL, selectors.ENTER_EMAIL.HEADER, {
               webChannelResponses: {
                 'fxaccounts:can_link_account': { ok: true },
                 'fxaccounts:fxa_status': {
@@ -69,7 +66,7 @@ registerSuite('signin with OAuth after Sync', {
             })
           )
 
-          .then(fillOutSignIn(email, PASSWORD))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
           .then(testElementExists(selectors.CONFIRM_SIGNIN.HEADER))
           .then(testIsBrowserNotified('fxaccounts:login'))
 
@@ -135,33 +132,6 @@ registerSuite('signin to Sync after OAuth', {
   },
 
   tests: {
-    'legacy Sync signin': function() {
-      return this.remote
-        .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(
-          openFxaFromRp('email-first', { header: selectors.ENTER_EMAIL.HEADER })
-        )
-        .then(fillOutEmailFirstSignIn(email, PASSWORD))
-        .then(testElementTextEquals(selectors['123DONE'].AUTHENTICATED, email))
-
-        .then(
-          openPage(SYNC_LEGACY_SIGNIN_URL, selectors.SIGNIN.HEADER, {
-            webChannelResponses: {
-              'fxaccounts:can_link_account': { ok: true },
-              'fxaccounts:fxa_status': {
-                capabilities: null,
-                signedInUser: null,
-              },
-            },
-          })
-        )
-        .then(testElementTextEquals(selectors.SIGNIN.EMAIL_NOT_EDITABLE, email))
-        .then(type(selectors.SIGNIN.PASSWORD, PASSWORD))
-        .then(click(selectors.SIGNIN.SUBMIT))
-
-        .then(testElementExists(selectors.CONFIRM_SIGNIN.HEADER));
-    },
-
     'email-first Sync signin': function() {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))

--- a/packages/fxa-content-server/tests/functional/settings_secondary_emails.js
+++ b/packages/fxa-content-server/tests/functional/settings_secondary_emails.js
@@ -25,6 +25,7 @@ const {
   closeCurrentWindow,
   createUser,
   fillOutResetPassword,
+  fillOutEmailFirstSignIn,
   fillOutSignIn,
   fillOutSignUp,
   getUnblockInfo,
@@ -51,9 +52,6 @@ registerSuite('settings secondary emails', {
     return this.remote.then(clearBrowserState({ force: true }));
   },
 
-  afterEach: function() {
-    return this.remote.then(clearBrowserState());
-  },
   tests: {
     'gated in unverified session open verification same tab': function() {
       return (
@@ -297,7 +295,7 @@ registerSuite('settings secondary emails', {
     },
 
     'signin confirmation is sent to secondary emails': function() {
-      const PAGE_SIGNIN_DESKTOP = `${SIGNIN_URL}?context=fx_desktop_v3&service=sync&forceAboutAccounts=true`;
+      const EMAIL_FIRST_URL = `${SIGNIN_URL}?context=fx_desktop_v3&service=sync&forceAboutAccounts=true`;
       const SETTINGS_URL = `${config.fxaContentRoot}settings?context=fx_desktop_v3&service=sync&forceAboutAccounts=true`;
 
       email = TestHelpers.createEmail('sync{id}');
@@ -311,13 +309,13 @@ registerSuite('settings secondary emails', {
               secondaryEmail
             );
           })
-          .then(openPage(PAGE_SIGNIN_DESKTOP, selectors.SIGNIN.HEADER))
+          .then(openPage(EMAIL_FIRST_URL, selectors.ENTER_EMAIL.HEADER))
           .then(
             respondToWebChannelMessage('fxaccounts:can_link_account', {
               ok: true,
             })
           )
-          .then(fillOutSignIn(email, PASSWORD))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
 
           .then(testElementExists(selectors.CONFIRM_SIGNIN.HEADER))
           .then(openVerificationLinkInDifferentBrowser(email))
@@ -348,13 +346,13 @@ registerSuite('settings secondary emails', {
           // force: true goes to the /clear page.
           .then(clearBrowserState({ force: true }))
 
-          .then(openPage(PAGE_SIGNIN_DESKTOP, selectors.SIGNIN.HEADER))
+          .then(openPage(EMAIL_FIRST_URL, selectors.ENTER_EMAIL.HEADER))
           .then(
             respondToWebChannelMessage('fxaccounts:can_link_account', {
               ok: true,
             })
           )
-          .then(fillOutSignIn(email, PASSWORD))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
           .then(testElementExists(selectors.CONFIRM_SIGNIN.HEADER))
 
           .then(openVerificationLinkInNewTab(secondaryEmail, 1))

--- a/packages/fxa-content-server/tests/functional/sign_in_cached.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_cached.js
@@ -13,17 +13,13 @@ const selectors = require('./lib/selectors');
 
 const config = intern._config;
 
+const PAGE_SIGNIN = config.fxaContentRoot + 'signin';
+const PAGE_SIGNUP = config.fxaContentRoot + 'signup';
 // The automatedBrowser query param tells signin/up to stub parts of the flow
 // that require a functioning desktop channel
-const PAGE_SIGNIN = config.fxaContentRoot + 'signin';
-const PAGE_SIGNIN_SYNC_DESKTOP =
-  PAGE_SIGNIN +
-  '?context=' +
-  FX_DESKTOP_V3_CONTEXT +
-  '&service=sync&forceAboutAccounts=true';
-const PAGE_SIGNUP = config.fxaContentRoot + 'signup';
+const PAGE_ENTER_EMAIL_SYNC_DESKTOP = `${config.fxaContentRoot}?context=${FX_DESKTOP_V3_CONTEXT}&service=sync&forceAboutAccounts=true`;
 
-const PASSWORD = 'password';
+const PASSWORD = 'password12345678';
 let email;
 let email2;
 
@@ -34,6 +30,7 @@ const {
   createUser,
   denormalizeStoredEmail,
   destroySessionForEmail,
+  fillOutEmailFirstSignIn,
   fillOutSignIn,
   fillOutSignUp,
   getStoredAccountByEmail,
@@ -211,13 +208,18 @@ registerSuite('cached signin', {
     'sign in on desktop then specify a different email on query parameter continues to cache desktop signin': function() {
       return (
         this.remote
-          .then(openPage(PAGE_SIGNIN_SYNC_DESKTOP, selectors.SIGNIN.HEADER))
+          .then(
+            openPage(
+              PAGE_ENTER_EMAIL_SYNC_DESKTOP,
+              selectors.ENTER_EMAIL.HEADER
+            )
+          )
           .then(
             respondToWebChannelMessage('fxaccounts:can_link_account', {
               ok: true,
             })
           )
-          .then(fillOutSignIn(email, PASSWORD))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
           .then(testElementExists(selectors.CONFIRM_SIGNIN.HEADER))
           .then(testIsBrowserNotified('fxaccounts:login'))
 
@@ -247,13 +249,18 @@ registerSuite('cached signin', {
     'sign in with desktop context then no context, desktop credentials should persist': function() {
       return (
         this.remote
-          .then(openPage(PAGE_SIGNIN_SYNC_DESKTOP, selectors.SIGNIN.HEADER))
+          .then(
+            openPage(
+              PAGE_ENTER_EMAIL_SYNC_DESKTOP,
+              selectors.ENTER_EMAIL.HEADER
+            )
+          )
           .then(
             respondToWebChannelMessage('fxaccounts:can_link_account', {
               ok: true,
             })
           )
-          .then(fillOutSignIn(email, PASSWORD))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
           .then(testElementExists(selectors.CONFIRM_SIGNIN.HEADER))
           .then(testIsBrowserNotified('fxaccounts:login'))
 
@@ -329,14 +336,19 @@ registerSuite('cached signin', {
           accountData1 = accountData;
         })
 
-        .then(openPage(PAGE_SIGNIN_SYNC_DESKTOP, selectors.SIGNIN.HEADER))
+        .then(
+          openPage(
+            PAGE_ENTER_EMAIL_SYNC_DESKTOP,
+            selectors.SIGNIN_PASSWORD.HEADER
+          )
+        )
         .then(
           respondToWebChannelMessage('fxaccounts:can_link_account', {
             ok: true,
           })
         )
-        .then(type(selectors.SIGNIN.PASSWORD, PASSWORD))
-        .then(click(selectors.SIGNIN.SUBMIT))
+        .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
+        .then(click(selectors.SIGNIN_PASSWORD.SUBMIT))
 
         .then(testIsBrowserNotified('fxaccounts:login'))
         .then(getStoredAccountByEmail(email))

--- a/packages/fxa-content-server/tests/functional/sign_in_recovery_code.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_recovery_code.js
@@ -11,10 +11,10 @@ const selectors = require('./lib/selectors');
 
 const config = intern._config;
 
-const SIGNUP_URL = `${config.fxaContentRoot}signup`;
+const ENTER_EMAIL_URL = `${config.fxaContentRoot}?action=email`;
 const SETTINGS_URL = `${config.fxaContentRoot}settings`;
 const PASSWORD = 'passwordzxcv';
-const SYNC_SIGNIN_URL = `${config.fxaContentRoot}signin?context=fx_desktop_v3&service=sync`;
+const SYNC_ENTER_EMAIL_URL = `${config.fxaContentRoot}?context=fx_desktop_v3&service=sync`;
 
 let email;
 let recoveryCode, recoveryCode2;
@@ -23,8 +23,8 @@ let secret;
 const {
   clearBrowserState,
   click,
-  fillOutSignUp,
-  fillOutSignIn,
+  fillOutEmailFirstSignIn,
+  fillOutEmailFirstSignUp,
   generateTotpCode,
   noSuchBrowserNotification,
   openPage,
@@ -43,8 +43,8 @@ registerSuite('recovery code', {
     return (
       this.remote
         .then(clearBrowserState({ force: true }))
-        .then(openPage(SIGNUP_URL, selectors.SIGNUP.HEADER))
-        .then(fillOutSignUp(email, PASSWORD))
+        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(fillOutEmailFirstSignUp(email, PASSWORD))
         .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
         .then(openVerificationLinkInSameTab(email, 0))
         .then(testElementExists(selectors.SETTINGS.HEADER))
@@ -100,7 +100,7 @@ registerSuite('recovery code', {
           .then(click(selectors.SIGNIN_RECOVERY_CODE.DONE_BUTTON))
           .then(click(selectors.SETTINGS.SIGNOUT))
           .then(
-            openPage(SYNC_SIGNIN_URL, selectors.SIGNIN.HEADER, {
+            openPage(SYNC_ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {},
               webChannelResponses: {
                 'fxaccounts:can_link_account': { ok: true },
@@ -112,7 +112,7 @@ registerSuite('recovery code', {
             })
           )
 
-          .then(fillOutSignIn(email, PASSWORD))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
           .then(testElementExists(selectors.TOTP_SIGNIN.HEADER))
           .then(click(selectors.SIGNIN_RECOVERY_CODE.LINK))
 
@@ -136,7 +136,7 @@ registerSuite('recovery code', {
           .then(click(selectors.SIGNIN_RECOVERY_CODE.DONE_BUTTON))
           .then(click(selectors.SETTINGS.SIGNOUT))
           .then(
-            openPage(SYNC_SIGNIN_URL, selectors.SIGNIN.HEADER, {
+            openPage(SYNC_ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {},
               webChannelResponses: {
                 'fxaccounts:can_link_account': { ok: true },
@@ -148,7 +148,7 @@ registerSuite('recovery code', {
             })
           )
 
-          .then(fillOutSignIn(email, PASSWORD))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
           .then(testElementExists(selectors.TOTP_SIGNIN.HEADER))
           .then(click(selectors.SIGNIN_RECOVERY_CODE.LINK))
 
@@ -162,7 +162,7 @@ registerSuite('recovery code', {
           .then(clearBrowserState({ force: true }))
 
           .then(
-            openPage(SYNC_SIGNIN_URL, selectors.SIGNIN.HEADER, {
+            openPage(SYNC_ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {},
               webChannelResponses: {
                 'fxaccounts:can_link_account': { ok: true },
@@ -174,7 +174,7 @@ registerSuite('recovery code', {
             })
           )
 
-          .then(fillOutSignIn(email, PASSWORD))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
           .then(testElementExists(selectors.TOTP_SIGNIN.HEADER))
           .then(click(selectors.SIGNIN_RECOVERY_CODE.LINK))
 

--- a/packages/fxa-content-server/tests/functional/sync_v3_force_auth.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_force_auth.js
@@ -11,7 +11,7 @@ const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
 
 let email;
-const PASSWORD = '12345678';
+const PASSWORD = 'password12345678';
 
 const {
   clearBrowserState,
@@ -20,9 +20,10 @@ const {
   createUser,
   fillOutForceAuth,
   fillOutSignInUnblock,
-  fillOutSignUp,
+  fillOutEmailFirstSignUp,
   noPageTransition,
   noSuchBrowserNotification,
+  noSuchElement,
   openForceAuth,
   openVerificationLinkInDifferentBrowser,
   openVerificationLinkInNewTab,
@@ -162,7 +163,7 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
               // user should be automatically redirected to the
               // signup page where they can signup with the
               // specified email
-              header: selectors.SIGNUP.HEADER,
+              header: selectors.SIGNUP_PASSWORD.HEADER,
               query: {
                 context: 'fx_desktop_v3',
                 email: email,
@@ -176,12 +177,15 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
               ok: true,
             })
           )
-          .then(visibleByQSA(selectors.SIGNUP.ERROR))
-          .then(testElementTextInclude(selectors.SIGNUP.ERROR, 'recreate'))
+          .then(visibleByQSA(selectors.SIGNUP_PASSWORD.ERROR))
+          .then(
+            testElementTextInclude(selectors.SIGNUP_PASSWORD.ERROR, 'recreate')
+          )
           // ensure the email is filled in, and not editible.
-          .then(testElementValueEquals(selectors.SIGNUP.EMAIL, email))
-          .then(testElementDisabled(selectors.SIGNUP.EMAIL))
-          .then(fillOutSignUp(email, PASSWORD, { enterEmail: false }))
+          .then(testElementValueEquals(selectors.SIGNUP_PASSWORD.EMAIL, email))
+          .then(testElementDisabled(selectors.SIGNUP_PASSWORD.EMAIL))
+          .then(noSuchElement(selectors.SIGNUP_PASSWORD.LINK_MISTYPED_EMAIL))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD, { enterEmail: false }))
 
           .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
           .then(click(selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT))
@@ -205,7 +209,7 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
               // user should be automatically redirected to the
               // signup page where they can signup with the
               // specified email
-              header: selectors.SIGNUP.HEADER,
+              header: selectors.SIGNUP_PASSWORD.HEADER,
               query: {
                 context: 'fx_desktop_v3',
                 email: unregisteredEmail,
@@ -215,13 +219,19 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
               },
             }).call(this);
           })
-          .then(visibleByQSA(selectors.SIGNUP.ERROR))
-          .then(testElementTextInclude(selectors.SIGNUP.ERROR, 'recreate'))
+          .then(visibleByQSA(selectors.SIGNUP_PASSWORD.ERROR))
+          .then(
+            testElementTextInclude(selectors.SIGNUP_PASSWORD.ERROR, 'recreate')
+          )
           // ensure the email is filled in, and not editible.
           .then(
-            testElementValueEquals(selectors.SIGNUP.EMAIL, unregisteredEmail)
+            testElementValueEquals(
+              selectors.SIGNUP_PASSWORD.EMAIL,
+              unregisteredEmail
+            )
           )
-          .then(testElementDisabled(selectors.SIGNUP.EMAIL))
+          .then(testElementDisabled(selectors.SIGNUP_PASSWORD.EMAIL))
+          .then(noSuchElement(selectors.SIGNUP_PASSWORD.LINK_MISTYPED_EMAIL))
       );
     },
 
@@ -233,7 +243,7 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
               // user should be automatically redirected to the
               // signup page where they can signup with the
               // specified email
-              header: selectors.SIGNUP.HEADER,
+              header: selectors.SIGNUP_PASSWORD.HEADER,
               query: {
                 context: 'fx_desktop_v3',
                 email: email,
@@ -243,11 +253,14 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
               },
             })
           )
-          .then(visibleByQSA(selectors.SIGNUP.ERROR))
-          .then(testElementTextInclude(selectors.SIGNUP.ERROR, 'recreate'))
+          .then(visibleByQSA(selectors.SIGNUP_PASSWORD.ERROR))
+          .then(
+            testElementTextInclude(selectors.SIGNUP_PASSWORD.ERROR, 'recreate')
+          )
           // ensure the email is filled in, and not editible.
-          .then(testElementValueEquals(selectors.SIGNUP.EMAIL, email))
-          .then(testElementDisabled(selectors.SIGNUP.EMAIL))
+          .then(testElementValueEquals(selectors.SIGNUP_PASSWORD.EMAIL, email))
+          .then(testElementDisabled(selectors.SIGNUP_PASSWORD.EMAIL))
+          .then(noSuchElement(selectors.SIGNUP_PASSWORD.LINK_MISTYPED_EMAIL))
       );
     },
 

--- a/packages/fxa-content-server/tests/functional/sync_v3_settings.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_settings.js
@@ -7,13 +7,15 @@
 const { registerSuite } = intern.getInterface('object');
 const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
+const selectors = require('./lib/selectors');
+
 const {
   click,
   clearBrowserState,
   createUser,
   fillOutChangePassword,
   fillOutDeleteAccount,
-  fillOutSignIn,
+  fillOutEmailFirstSignIn,
   noSuchBrowserNotification,
   noSuchElement,
   openPage,
@@ -25,9 +27,9 @@ const {
 } = FunctionalHelpers;
 
 const config = intern._config;
-const SIGNIN_URL =
+const ENTER_EMAIL_URL =
   config.fxaContentRoot +
-  'signin?context=fx_desktop_v3&service=sync&forceAboutAccounts=true';
+  '?context=fx_desktop_v3&service=sync&forceAboutAccounts=true';
 const SETTINGS_URL =
   config.fxaContentRoot +
   'settings?context=fx_desktop_v3&service=sync&forceAboutAccounts=true';
@@ -45,15 +47,15 @@ registerSuite('Firefox Desktop Sync v3 settings', {
       this.remote
         .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
-        .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
+        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
         .then(
           respondToWebChannelMessage('fxaccounts:can_link_account', {
             ok: true,
           })
         )
-        .then(fillOutSignIn(email, FIRST_PASSWORD))
+        .then(fillOutEmailFirstSignIn(email, FIRST_PASSWORD))
 
-        .then(testElementExists('#fxa-confirm-signin-header'))
+        .then(testElementExists(selectors.CONFIRM_SIGNIN.HEADER))
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(testIsBrowserNotified('fxaccounts:login'))
         .then(openVerificationLinkInDifferentBrowser(email))
@@ -72,23 +74,23 @@ registerSuite('Firefox Desktop Sync v3 settings', {
           )
         )
 
-        .then(openPage(SETTINGS_URL, '#fxa-settings-header'))
+        .then(openPage(SETTINGS_URL, selectors.SETTINGS.HEADER))
     );
   },
   tests: {
     'sign in, change the password': function() {
       return this.remote
-        .then(click('#change-password .settings-unit-toggle'))
-        .then(visibleByQSA('#change-password .settings-unit-details'))
+        .then(click(selectors.CHANGE_PASSWORD.MENU_BUTTON))
+        .then(visibleByQSA(selectors.CHANGE_PASSWORD.DETAILS))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
     },
 
     'sign in, change the password by browsing directly to settings': function() {
       return this.remote
-        .then(openPage(SETTINGS_NOCONTEXT_URL, '#fxa-settings-header'))
-        .then(click('#change-password .settings-unit-toggle'))
-        .then(visibleByQSA('#change-password .settings-unit-details'))
+        .then(openPage(SETTINGS_NOCONTEXT_URL, selectors.SETTINGS.HEADER))
+        .then(click(selectors.CHANGE_PASSWORD.MENU_BUTTON))
+        .then(visibleByQSA(selectors.CHANGE_PASSWORD.DETAILS))
         .then(noSuchBrowserNotification('fxaccounts:change_password'))
 
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
@@ -96,20 +98,20 @@ registerSuite('Firefox Desktop Sync v3 settings', {
 
     'sign in, delete the account': function() {
       return this.remote
-        .then(click('#delete-account .settings-unit-toggle'))
-        .then(visibleByQSA('#delete-account .settings-unit-details'))
+        .then(click(selectors.SETTINGS_DELETE_ACCOUNT.MENU_BUTTON))
+        .then(visibleByQSA(selectors.SETTINGS_DELETE_ACCOUNT.DETAILS))
 
         .then(fillOutDeleteAccount(FIRST_PASSWORD))
         .then(testIsBrowserNotified('fxaccounts:delete'))
 
-        .then(testElementExists('#fxa-signup-header'));
+        .then(testElementExists(selectors.ENTER_EMAIL.HEADER));
     },
 
     'sign in, no way to sign out': function() {
       return (
         this.remote
           // make sure the sign out element doesn't exist
-          .then(noSuchElement('#signout'))
+          .then(noSuchElement(selectors.SETTINGS.SIGNOUT))
       );
     },
   },

--- a/packages/fxa-content-server/tests/functional/sync_v3_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_sign_in.js
@@ -11,8 +11,8 @@ const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
 
 const config = intern._config;
-const PAGE_URL = `${config.fxaContentRoot}signin?context=fx_desktop_v3&service=sync&forceAboutAccounts=true&automatedBrowser=true`;
-const TOKEN_CODE_PAGE_URL = `${config.fxaContentRoot}signin?context=fx_desktop_v3&service=sync`;
+const ENTER_EMAIL_URL = `${config.fxaContentRoot}?context=fx_desktop_v3&service=sync&forceAboutAccounts=true&automatedBrowser=true`;
+const TOKEN_CODE_PAGE_URL = `${config.fxaContentRoot}?context=fx_desktop_v3&service=sync&automatedBrowser=true`;
 
 let email;
 const PASSWORD = '12345678';
@@ -22,7 +22,7 @@ const {
   click,
   closeCurrentWindow,
   createUser,
-  fillOutSignIn,
+  fillOutEmailFirstSignIn,
   fillOutSignInTokenCode,
   fillOutSignInUnblock,
   noEmailExpected,
@@ -55,7 +55,7 @@ const setupTest = thenify(function(options = {}) {
       createUser(signUpEmail, PASSWORD, { preVerified: options.preVerified })
     )
     .then(
-      openPage(PAGE_URL, selectors.SIGNIN.HEADER, {
+      openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
         query: options.query,
         webChannelResponses: {
           'fxaccounts:can_link_account': { ok: true },
@@ -63,7 +63,7 @@ const setupTest = thenify(function(options = {}) {
         },
       })
     )
-    .then(fillOutSignIn(signInEmail, PASSWORD))
+    .then(fillOutEmailFirstSignIn(signInEmail, PASSWORD))
     .then(testElementExists(successSelector))
     .then(testIsBrowserNotified('fxaccounts:can_link_account'))
     .then(() => {
@@ -89,7 +89,7 @@ registerSuite('Firefox Desktop Sync v3 signin', {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(
-          openPage(PAGE_URL, selectors.SIGNIN.HEADER, {
+          openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
             query,
             webChannelResponses: {
               'fxaccounts:can_link_account': { ok: true },
@@ -100,7 +100,7 @@ registerSuite('Firefox Desktop Sync v3 signin', {
             },
           })
         )
-        .then(fillOutSignIn(email, PASSWORD))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
 
         .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER));
     },
@@ -149,8 +149,8 @@ registerSuite('Firefox Desktop Sync v3 signin', {
         this.remote
           .then(setupTest({ preVerified: true }))
 
-          .then(click('#resend'))
-          .then(visibleByQSA('.success'))
+          .then(click(selectors.CONFIRM_SIGNIN.LINK_RESEND))
+          .then(visibleByQSA(selectors.CONFIRM_SIGNIN.RESEND_SUCCESS))
 
           // email 0 is the original signin email, open the resent email instead
           .then(openVerificationLinkInNewTab(email, 1))
@@ -282,7 +282,7 @@ registerSuite('Firefox Desktop Sync v3 signin - token code', {
       return (
         this.remote
           .then(
-            openPage(TOKEN_CODE_PAGE_URL, selectors.SIGNIN.HEADER, {
+            openPage(TOKEN_CODE_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
               query,
               webChannelResponses: {
                 'fxaccounts:can_link_account': { ok: true },
@@ -294,7 +294,7 @@ registerSuite('Firefox Desktop Sync v3 signin - token code', {
             })
           )
 
-          .then(fillOutSignIn(email, PASSWORD))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
 
           // about:accounts will take over post-verification, no transition
           .then(testIsBrowserNotified('fxaccounts:login'))
@@ -309,7 +309,7 @@ registerSuite('Firefox Desktop Sync v3 signin - token code', {
       return (
         this.remote
           .then(
-            openPage(TOKEN_CODE_PAGE_URL, selectors.SIGNIN.HEADER, {
+            openPage(TOKEN_CODE_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
               query,
               webChannelResponses: {
                 'fxaccounts:can_link_account': { ok: true },
@@ -317,7 +317,7 @@ registerSuite('Firefox Desktop Sync v3 signin - token code', {
               },
             })
           )
-          .then(fillOutSignIn(email, PASSWORD))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
 
           // Correctly submits the token code
           .then(testElementExists(selectors.SIGNIN_TOKEN_CODE.HEADER))
@@ -336,7 +336,7 @@ registerSuite('Firefox Desktop Sync v3 signin - token code', {
       return (
         this.remote
           .then(
-            openPage(TOKEN_CODE_PAGE_URL, selectors.SIGNIN.HEADER, {
+            openPage(TOKEN_CODE_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
               query,
               webChannelResponses: {
                 'fxaccounts:can_link_account': { ok: true },
@@ -344,7 +344,7 @@ registerSuite('Firefox Desktop Sync v3 signin - token code', {
               },
             })
           )
-          .then(fillOutSignIn(email, PASSWORD))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
 
           // Displays invalid code errors
           .then(testElementExists(selectors.SIGNIN_TOKEN_CODE.HEADER))
@@ -360,7 +360,7 @@ registerSuite('Firefox Desktop Sync v3 signin - token code', {
       };
       return this.remote
         .then(
-          openPage(TOKEN_CODE_PAGE_URL, selectors.SIGNIN.HEADER, {
+          openPage(TOKEN_CODE_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
             query,
             webChannelResponses: {
               'fxaccounts:can_link_account': { ok: true },
@@ -368,7 +368,7 @@ registerSuite('Firefox Desktop Sync v3 signin - token code', {
             },
           })
         )
-        .then(fillOutSignIn(email, PASSWORD))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
 
         .then(testElementExists(selectors.CONFIRM_SIGNIN.HEADER))
         .then(openVerificationLinkInNewTab(email, 0))

--- a/packages/fxa-content-server/tests/functional/sync_v3_sign_up.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_sign_up.js
@@ -11,16 +11,16 @@ const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
 
 const config = intern._config;
-const SIGNUP_PAGE_URL = `${config.fxaContentRoot}signup?context=fx_desktop_v3&service=sync&forceAboutAccounts=true&automatedBrowser=true`;
+const ENTER_EMAIL_URL = `${config.fxaContentRoot}?context=fx_desktop_v3&service=sync&forceAboutAccounts=true&automatedBrowser=true`;
 
 let email;
-const PASSWORD = '12345678';
+const PASSWORD = 'password12345678';
 
 const {
   clearBrowserState,
   click,
   closeCurrentWindow,
-  fillOutSignUp,
+  fillOutEmailFirstSignUp,
   fillOutSignUpCode,
   getVerificationLink,
   getWebChannelMessageData,
@@ -52,7 +52,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
       return (
         this.remote
           .then(
-            openPage(SIGNUP_PAGE_URL, selectors.SIGNUP.HEADER, {
+            openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {
                 forceUA: uaStrings['desktop_firefox_57'],
               },
@@ -62,9 +62,9 @@ registerSuite('Firefox Desktop Sync v3 signup', {
               },
             })
           )
-          .then(visibleByQSA(selectors.SIGNUP.SUB_HEADER))
+          .then(visibleByQSA(selectors.ENTER_EMAIL.SUB_HEADER))
 
-          .then(fillOutSignUp(email, PASSWORD))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
 
           .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
           .then(testIsBrowserNotified('fxaccounts:can_link_account'))
@@ -86,7 +86,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
       return (
         this.remote
           .then(
-            openPage(SIGNUP_PAGE_URL, selectors.SIGNUP.HEADER, {
+            openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {
                 forceUA: uaStrings['desktop_firefox_58'],
               },
@@ -99,9 +99,9 @@ registerSuite('Firefox Desktop Sync v3 signup', {
               },
             })
           )
-          .then(visibleByQSA(selectors.SIGNUP.SUB_HEADER))
+          .then(visibleByQSA(selectors.ENTER_EMAIL.SUB_HEADER))
 
-          .then(fillOutSignUp(email, PASSWORD))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
 
           .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
           .then(testIsBrowserNotified('fxaccounts:can_link_account'))
@@ -126,7 +126,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
       return (
         this.remote
           .then(
-            openPage(SIGNUP_PAGE_URL, selectors.SIGNUP.HEADER, {
+            openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {
                 forceUA: uaStrings['desktop_firefox_55'],
               },
@@ -140,8 +140,8 @@ registerSuite('Firefox Desktop Sync v3 signup', {
               },
             })
           )
-          .then(noSuchElement(selectors.SIGNUP.LINK_SUGGEST_SYNC))
-          .then(fillOutSignUp(email, PASSWORD))
+          .then(noSuchElement(selectors.ENTER_EMAIL.LINK_SUGGEST_SYNC))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
 
           // user should be transitioned to /choose_what_to_sync
           .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
@@ -185,7 +185,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
       return (
         this.remote
           .then(
-            openPage(SIGNUP_PAGE_URL, selectors.SIGNUP.HEADER, {
+            openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {
                 forceUA: uaStrings['desktop_firefox_55'],
               },
@@ -200,8 +200,8 @@ registerSuite('Firefox Desktop Sync v3 signup', {
             })
           )
           .then(storeWebChannelMessageData('fxaccounts:login'))
-          .then(noSuchElement(selectors.SIGNUP.LINK_SUGGEST_SYNC))
-          .then(fillOutSignUp(email, PASSWORD))
+          .then(noSuchElement(selectors.ENTER_EMAIL.LINK_SUGGEST_SYNC))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
 
           // user should be transitioned to /choose_what_to_sync
           .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
@@ -257,7 +257,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
       return (
         this.remote
           .then(
-            openPage(SIGNUP_PAGE_URL, selectors.SIGNUP.HEADER, {
+            openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {
                 forceUA: uaStrings['desktop_firefox_56'],
               },
@@ -271,7 +271,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
               },
             })
           )
-          .then(fillOutSignUp(email, PASSWORD))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
 
           // user should be transitioned to /choose_what_to_sync
           .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
@@ -286,7 +286,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
       return (
         this.remote
           .then(
-            openPage(SIGNUP_PAGE_URL, selectors.SIGNUP.HEADER, {
+            openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {
                 forceUA: uaStrings['desktop_firefox_56'],
               },
@@ -303,7 +303,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
               },
             })
           )
-          .then(fillOutSignUp(email, PASSWORD))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
 
           // user should be transitioned to /choose_what_to_sync
           .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
@@ -318,7 +318,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
       return (
         this.remote
           .then(
-            openPage(SIGNUP_PAGE_URL, selectors.SIGNUP.HEADER, {
+            openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {
                 forceUA: uaStrings['desktop_firefox_56'],
               },
@@ -335,7 +335,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
               },
             })
           )
-          .then(fillOutSignUp(email, PASSWORD))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
 
           // user should be transitioned to /choose_what_to_sync
           .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
@@ -352,7 +352,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
       return (
         this.remote
           .then(
-            openPage(SIGNUP_PAGE_URL, selectors.SIGNUP.HEADER, {
+            openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {
                 forceUA: uaStrings['desktop_firefox_57'],
               },
@@ -365,7 +365,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
               },
             })
           )
-          .then(fillOutSignUp(email, PASSWORD))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
           .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
           .then(click(selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT))
 
@@ -383,7 +383,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
       return (
         this.remote
           .then(
-            openPage(SIGNUP_PAGE_URL, selectors.SIGNUP.HEADER, {
+            openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {
                 forceUA: uaStrings['desktop_firefox_58'],
               },
@@ -396,7 +396,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
               },
             })
           )
-          .then(fillOutSignUp(email, PASSWORD))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
           .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
           .then(click(selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT))
           .then(testIsBrowserNotified('fxaccounts:login'))
@@ -427,7 +427,7 @@ registerSuite('Firefox Desktop Sync v3 signup with code', {
       return (
         this.remote
           .then(
-            openPage(SIGNUP_PAGE_URL, selectors.SIGNUP.HEADER, {
+            openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {
                 forceExperiment: 'signupCode',
                 forceExperimentGroup: 'control',
@@ -442,7 +442,7 @@ registerSuite('Firefox Desktop Sync v3 signup with code', {
               },
             })
           )
-          .then(fillOutSignUp(email, PASSWORD))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
           .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
           .then(click(selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT))
           .then(testIsBrowserNotified('fxaccounts:login'))
@@ -460,7 +460,7 @@ registerSuite('Firefox Desktop Sync v3 signup with code', {
       return (
         this.remote
           .then(
-            openPage(SIGNUP_PAGE_URL, selectors.SIGNUP.HEADER, {
+            openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {
                 forceExperiment: 'signupCode',
                 forceExperimentGroup: 'treatment',
@@ -475,7 +475,7 @@ registerSuite('Firefox Desktop Sync v3 signup with code', {
               },
             })
           )
-          .then(fillOutSignUp(email, PASSWORD))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
           .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
           .then(click(selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT))
 


### PR DESCRIPTION
Add a new broker capability: 'emailFirstForced', if set to `true`, then legacy signin/signup
pages are disabled for that broker. Used in fx_desktop_v3, and loads of tests updated.

Partial extraction from #2827
fixes #595

@mozilla/fxa-devs - r?