### PR TITLE
fix(styles): clean up payment page UI a bit

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -52,9 +52,16 @@ type StripeElementStyles = {
   lineHeight: string;
 };
 
+type StripeElementDirectStyles = {
+  color: string;
+};
+
 export function checkMedia(
   matched: boolean,
-  stripeElementStyles: { base: StripeElementStyles }
+  stripeElementStyles: {
+    base: StripeElementStyles;
+    invalid: StripeElementDirectStyles;
+  }
 ) {
   let lh = matched ? SMALL_DEVICE_LINE_HEIGHT : DEFAULT_LINE_HEIGHT;
   return Object.assign(stripeElementStyles, { base: { lineHeight: lh } });
@@ -282,7 +289,8 @@ export const PaymentForm = ({
       <div className="legal-blurb">
         <p>Mozilla uses Stripe for secure payment processing.</p>
         <p>
-          View the <a href="https://stripe.com/privacy">Stripe privacy policy</a>.
+          View the{' '}
+          <a href="https://stripe.com/privacy">Stripe privacy policy</a>.
         </p>
       </div>
     </Form>

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -40,6 +40,9 @@ let stripeElementStyles = {
     fontWeight: '500',
     lineHeight: '48px',
   },
+  invalid: {
+    color: '#0c0c0d',
+  },
 };
 
 type StripeElementStyles = {

--- a/packages/fxa-payments-server/src/components/fields.tsx
+++ b/packages/fxa-payments-server/src/components/fields.tsx
@@ -79,12 +79,12 @@ export const Field = ({
     <div className={className}>
       <label>
         {label && <span className="label-text">{label}</span>}
-        {children}
         {tooltip && tooltipParentRef && validator.getError(name) && (
           <Tooltip parentRef={tooltipParentRef}>
             {validator.getError(name)}
           </Tooltip>
         )}
+        {children}
       </label>
     </div>
   );

--- a/packages/fxa-payments-server/src/index.scss
+++ b/packages/fxa-payments-server/src/index.scss
@@ -83,12 +83,16 @@ h3.billing-title {
       }
     }
 
-    .StripeElement--focus {
+
+    .StripeElement--focus,
+    .StripeElement--focus:hover {
       border-color: $input-border-color-focus;
       box-shadow: 0 0 0 3px rgba($blue-50, 0.3);
     }
 
-    .StripeElement--invalid {
+    .tooltip + .StripeElement--empty,
+    .StripeElement--invalid,
+    .StripeElement--invalid:hover {
       border-color: $error-background-color;
 
       &.StripeElement--focus {


### PR DESCRIPTION
Fixes #3013

Hey Les and Dave, wanted to get your eyes on this PR since it removes some of the form validation on the payments page. Namely, it gets rid of onChange validation on inputs that seemed to make error tool tips a bit over eager. It also gets rid of empty field validation since you can't submit the form without completing fields and the tool-tips seemed really loud to me in the case of empty fields.