### PR TITLE
fix(autofocus): Autofocus the sign-up page password input field

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -21,7 +21,7 @@
       <a href="/" class="use-different">{{#t}}Change email{{/t}}</a>
 
       <div class="input-row password-row">
-        <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required data-form-prefill="password" data-synchronize-show="true" />
+        <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autofocus data-form-prefill="password" data-synchronize-show="true" />
         <div class="helper-balloon" tabindex="-1"></div>
       </div>
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/2705 and taken from https://github.com/mozilla/fxa/pull/2663 (Thanks @LZoog!)

Seems like worthwhile fix to get on train-148 since it is dropping registration rates.