### PR TITLE
feat(payments): rework form validation to handle focus & blur independently

### DIFF
--- a/packages/fxa-payments-server/.nsprc
+++ b/packages/fxa-payments-server/.nsprc
@@ -1,3 +1,5 @@
 {
-  "exceptions": []
+  "exceptions": [
+    "https://npmjs.com/advisories/1184"
+  ]
 }

--- a/packages/fxa-payments-server/src/App.test.tsx
+++ b/packages/fxa-payments-server/src/App.test.tsx
@@ -10,6 +10,17 @@ import { AppContext } from './lib/AppContext';
 // describe('App', () => {});
 
 describe('App/AppErrorBoundary', () => {
+  beforeEach(() => {
+    // HACK: Swallow the exception thrown by BadComponent - it bubbles up
+    // unnecesarily to jest and makes noise.
+    jest.spyOn(console, 'error');
+    global.console.error.mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    global.console.error.mockRestore();
+  });
+
   it('renders children that do not cause exceptions', () => {
     const GoodComponent = () => <p data-testid="good-component">Hi</p>;
     const { queryByTestId } = render(

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
@@ -6,6 +6,7 @@ import { Omit } from '../../lib/types';
 
 import {
   mockStripeElementOnChangeFns,
+  mockStripeElementOnBlurFns,
   elementChangeResponse,
 } from '../../lib/test-utils';
 
@@ -103,7 +104,10 @@ it('renders error tooltips for invalid stripe elements', () => {
   act(() => {
     for (const [testid, errorMessage] of Object.entries(mockErrors)) {
       mockStripeElementOnChangeFns[testid](
-        elementChangeResponse({ errorMessage })
+        elementChangeResponse({ errorMessage, value: 'foo' })
+      );
+      mockStripeElementOnBlurFns[testid](
+        elementChangeResponse({ errorMessage, value: 'foo' })
       );
     }
   });
@@ -111,7 +115,7 @@ it('renders error tooltips for invalid stripe elements', () => {
   for (const [testid, expectedMessage] of Object.entries(mockErrors)) {
     const el = getByTestId(testid);
     const tooltipEl = (el.parentNode as ParentNode).querySelector('.tooltip');
-    expect(tooltipEl).toBeDefined();
+    expect(tooltipEl).not.toBeNull();
     expect((tooltipEl as Node).textContent).toEqual(expectedMessage);
   }
 });

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -155,12 +155,16 @@ export const PaymentForm = ({
         required
         autoFocus
         spellCheck={false}
-        onValidate={value => {
-          let error = null;
+        onValidate={(value, focused) => {
+          let valid = true;
           if (value !== null && !value) {
-            error = 'Please enter your name';
+            valid = false;
           }
-          return { value, error };
+          return {
+            value,
+            valid,
+            error: !valid && !focused ? 'Please enter your name' : null,
+          };
         }}
       />
 
@@ -199,15 +203,22 @@ export const PaymentForm = ({
           required
           data-testid="zip"
           placeholder="12345"
-          onValidate={value => {
+          onValidate={(value, focused) => {
+            let valid = true;
             let error = null;
             value = ('' + value).substr(0, 5);
             if (!value) {
+              valid = false;
               error = 'Zip code is required';
             } else if (value.length !== 5) {
+              valid = false;
               error = 'Zip code is too short';
             }
-            return { value, error };
+            return {
+              value,
+              valid,
+              error: !focused ? error : null,
+            };
           }}
         />
       </FieldGroup>

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -92,8 +92,9 @@ const MockStripeElement = ({ testid }: { testid: string }) =>
       super(props);
 
       // Stash this element's onChange handler in module-global registry.
-      const { onChange } = props;
+      const { onChange, onBlur } = props;
       mockStripeElementOnChangeFns[testid] = onChange as onChangeFunctionType;
+      mockStripeElementOnBlurFns[testid] = onBlur as onBlurFunctionType;
 
       // Real react-stripe-elements stash a ref to their container in
       // this._ref, which we use for tooltip positioning
@@ -118,6 +119,14 @@ type onChangeFunctionType = (
 
 export const mockStripeElementOnChangeFns: {
   [name: string]: onChangeFunctionType;
+} = {};
+
+type onBlurFunctionType = (
+  value: stripe.elements.ElementChangeResponse
+) => void;
+
+export const mockStripeElementOnBlurFns: {
+  [name: string]: onBlurFunctionType;
 } = {};
 
 export type MockStripeType = {
@@ -168,7 +177,7 @@ export const elementChangeResponse = ({
   brand: 'test',
   value: 'boof',
   complete,
-  empty: !!value,
+  empty: !value,
   error:
     (!!errorMessage && {
       type: 'card_error',

--- a/packages/fxa-payments-server/src/lib/validator.ts
+++ b/packages/fxa-payments-server/src/lib/validator.ts
@@ -75,12 +75,9 @@ export class Validator {
   }: {
     name: string;
     value: any;
-    valid?: boolean;
+    valid?: boolean | null | undefined;
     error?: any;
   }) {
-    if (typeof valid === 'undefined') {
-      valid = !!error;
-    }
     return this.dispatch({ type: 'updateField', name, value, valid, error });
   }
 
@@ -132,7 +129,7 @@ type FieldState = {
   fieldType: FieldType;
   value: any;
   required: boolean;
-  valid: boolean | null;
+  valid: boolean | undefined | null;
   error: string | null;
 };
 
@@ -153,7 +150,7 @@ export type Action =
       type: 'updateField';
       name: string;
       value: any;
-      valid: boolean;
+      valid: boolean | null | undefined;
       error: any;
     }
   | { type: 'setGlobalError'; error: any }

--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -62,7 +62,7 @@ describe('routes/Product', () => {
   }: {
     productId?: string;
     planId?: string;
-    matchMedia: (query: string) => boolean;
+    matchMedia?: (query: string) => boolean;
     navigateToUrl?: (url: string) => void;
     accountActivated?: string;
     createToken?: jest.Mock<any, any>;


### PR DESCRIPTION
- rework onValidate handlers in form fields - they work on both focused
  and blurred states, can supply valid state and error message separately

- remove most validation logic out of field components and into default
  validation handler functions

- test updates to handle new arrangement

- misc small bug and lint fixes

- squelch expected exceptions during AppErrorBoundary test

- add exception for NPM security advisory for https://npmjs.com/advisories/1184

fixes #2994