### PR TITLE
refactor(content-server): use spead syntax in createAuthBroker

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync-channel.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync-channel.js
@@ -21,27 +21,23 @@ describe('models/auth_brokers/fx-sync-channel', () => {
   let windowMock;
 
   function createAuthBroker(options = {}) {
-    broker = new FxSyncChannelAuthenticationBroker(
-      _.extend(
-        {
-          channel: channelMock,
-          commands: {
-            CAN_LINK_ACCOUNT: 'can_link_account',
-            CHANGE_PASSWORD: 'change_password',
-            DELETE_ACCOUNT: 'delete_account',
-            LOADED: 'loaded',
-            LOGIN: 'login',
-            /*
+    broker = new FxSyncChannelAuthenticationBroker({
+      channel: channelMock,
+      commands: {
+        CAN_LINK_ACCOUNT: 'can_link_account',
+        CHANGE_PASSWORD: 'change_password',
+        DELETE_ACCOUNT: 'delete_account',
+        LOADED: 'loaded',
+        LOGIN: 'login',
+        /*
         SYNC_PREFERENCES: 'sync_preferences' // Removed in issue #4250
         */
-            VERIFIED: 'verified',
-          },
-          window: windowMock,
-          relier,
-        },
-        options
-      )
-    );
+        VERIFIED: 'verified',
+      },
+      window: windowMock,
+      relier,
+      ...options,
+    });
   }
 
   beforeEach(() => {

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync-web-channel.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync-web-channel.js
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import _ from 'underscore';
 import { assert } from 'chai';
 import FxSyncWebChannelAuthenticationBroker from 'models/auth_brokers/fx-sync-web-channel';
 import NullChannel from 'lib/channels/null';
@@ -18,15 +17,11 @@ describe('models/auth_brokers/fx-sync-web-channel', () => {
   let windowMock;
 
   function createAuthBroker(options = {}) {
-    broker = new FxSyncWebChannelAuthenticationBroker(
-      _.extend(
-        {
-          channel: channelMock,
-          window: windowMock,
-        },
-        options
-      )
-    );
+    broker = new FxSyncWebChannelAuthenticationBroker({
+      channel: channelMock,
+      window: windowMock,
+      ...options,
+    });
   }
 
   beforeEach(() => {

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
@@ -11,7 +11,6 @@ import Session from 'lib/session';
 import sinon from 'sinon';
 import User from 'models/user';
 import WindowMock from '../../../mocks/window';
-import _ from 'underscore';
 
 const HEX_CHARSET = '0123456789abcdef';
 function generateOAuthCode() {
@@ -39,18 +38,14 @@ describe('models/auth_brokers/oauth-webchannel-v1', () => {
   let windowMock;
 
   function createAuthBroker(options = {}) {
-    broker = new OAuthWebChannelBroker(
-      _.extend(
-        {
-          notificationChannel: channelMock,
-          metrics: metrics,
-          relier: relier,
-          session: Session,
-          window: windowMock,
-        },
-        options
-      )
-    );
+    broker = new OAuthWebChannelBroker({
+      notificationChannel: channelMock,
+      metrics: metrics,
+      relier: relier,
+      session: Session,
+      window: windowMock,
+      ...options,
+    });
     sinon.spy(broker, 'send');
     broker.DELAY_BROKER_RESPONSE_MS = 0;
   }


### PR DESCRIPTION
Fixes #2407 