### PR TITLE
feat: use email instead of 'Anonymous' for support

### DIFF
--- a/packages/fxa-auth-server/lib/routes/support.js
+++ b/packages/fxa-auth-server/lib/routes/support.js
@@ -76,7 +76,7 @@ module.exports = (log, db, config, customs, zendeskClient) => {
           subject,
           requester: {
             email,
-            name: 'Anonymous User',
+            name: email,
           },
         };
         zendeskReq[config.zendesk.productNameFieldId] =

--- a/packages/fxa-auth-server/test/local/routes/support.js
+++ b/packages/fxa-auth-server/test/local/routes/support.js
@@ -69,7 +69,7 @@ const MOCK_CREATE_REPLY = {
 const MOCK_NEW_SHOW_REPLY = {
   id: 384164869571,
   url: `https://${SUBDOMAIN}.zendesk.com/api/v2/users/${REQUESTER_ID}.json`,
-  name: 'Anonymous User',
+  name: TEST_EMAIL,
   email: TEST_EMAIL,
   created_at: '2019-07-01T17:27:01Z',
   updated_at: '2019-07-01T17:27:02Z',


### PR DESCRIPTION
Because:

* FxA does not store the users actual user name, it is only
  submitted to Stripe for storage.
* The 'name' in FxA is user configured and many users have not
  entered a name.
* Sending emails to the user calling them 'Anonymous User' is not a
  great experience.
* Displaying a long list of 'Anonymous User' in the Zendesk UX is
  not helpful for skimming.

This commit:

* Uses the email address for the display name.

Closes #2912