### PR TITLE
fix(ios): Do not autofocus elements on iOS

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/base.js
+++ b/packages/fxa-content-server/app/scripts/views/base.js
@@ -292,6 +292,18 @@ var BaseView = Backbone.View.extend({
             this._isErrorVisible = this.$('.error').hasClass('visible');
             this._isSuccessVisible = this.$('.success').hasClass('visible');
 
+            // make a huge assumption and say if the device has touch, it's a mobile
+            // device and autofocus should not be applied. autofocus causes
+            // the virtual keyboard to be displayed, which hides part of
+            // the screen. The touch class is added in startup-styles.js.
+            // iOS autofocuses elements that are dynamically insert into the DOM
+            // without us needing to programmatically focus it in `focusAutofocusElement`.
+            // Remove the autofocus attribute from any elements so they
+            // are not focused on mobile, see #3040
+            if ($('html').hasClass('touch')) {
+              this.$('[autofocus]').removeAttr('autofocus');
+            }
+
             return this.afterRender();
           });
       })
@@ -951,12 +963,12 @@ var BaseView = Backbone.View.extend({
    * be displayed, which hides part of the screen.
    */
   focusAutofocusElement() {
-    // make a huge assumption and say if the device does not have touch,
-    // it's a desktop device and autofocus can be applied without
-    // hiding part of the view. The no-touch class is added by
-    // startup-styles
+    // make a huge assumption and say if the device has touch, it's a mobile
+    // device and autofocus should not be applied. autofocus causes
+    // the virtual keyboard to be displayed, which hides part of
+    // the screen. The touch class is added in startup-styles.js
     const $autofocusEl = this.$('[autofocus]');
-    if (!$('html').hasClass('no-touch') || !$autofocusEl.length) {
+    if ($('html').hasClass('touch') || !$autofocusEl.length) {
       return;
     }
 

--- a/packages/fxa-content-server/app/tests/spec/views/base.js
+++ b/packages/fxa-content-server/app/tests/spec/views/base.js
@@ -399,6 +399,18 @@ describe('views/base', function() {
         assert.isTrue(view.isSuccessVisible());
       });
     });
+
+    it('removes `autofocus` attributes on mobile', () => {
+      $('html').addClass('touch');
+      return view
+        .render()
+        .then(() => {
+          assert.lengthOf(view.$('[autofocus]'), 0);
+        })
+        .finally(() => {
+          $('html').removeClass('touch');
+        });
+    });
   });
 
   describe('rerender', () => {
@@ -420,7 +432,9 @@ describe('views/base', function() {
 
   describe('afterVisible', function() {
     afterEach(function() {
-      $('html').removeClass('no-touch');
+      $('html')
+        .removeClass('no-touch')
+        .removeClass('touch');
     });
 
     it('shows success messages', function() {
@@ -448,7 +462,11 @@ describe('views/base', function() {
       }, done);
     });
 
-    it('does not focus descendent element containing `autofocus` if html does not have `no-touch` class', function(done) {
+    it('does not focus descendent element containing `autofocus` if html has `touch` class', function(done) {
+      $('html')
+        .removeClass('no-touch')
+        .addClass('touch');
+
       requiresFocus(function() {
         var handlerCalled = false;
         $('#focusMe').on('focus', function() {


### PR DESCRIPTION
iOS autofocuses elements with the [autofocus] attribute
itself, without relying on our `focusAutofocusElement` method.

In `afterRender`, if it's a mobile device, remove
the `autofocus` attribute before writing to the DOM
to prevent iOS from autofocusing elements.

fixes #3040

@vbudhram or @LZoog - r?