### PR TITLE
fix(links): stop converting links to text on Firefox iOS

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/base.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/base.js
@@ -550,10 +550,6 @@ const BaseAuthenticationBroker = Backbone.Model.extend({
      */
     browserTransitionsAfterEmailVerification: true,
     /**
-     * Should external links be converted to text?
-     */
-    convertExternalLinksToText: false,
-    /**
      * Should the legacy signin/signup pages be disabled?
      */
     disableLegacySigninSignup: false,

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -45,7 +45,6 @@ export default FxSyncChannelAuthenticationBroker.extend({
   }),
 
   defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
-    convertExternalLinksToText: true,
     disableLegacySigninSignup: true,
     emailFirst: true,
   }),

--- a/packages/fxa-content-server/app/scripts/templates/test_template.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/test_template.mustache
@@ -68,6 +68,5 @@
 
   <a id="external-link" href="http://external.com">External link</a>
   <a id="internal-link" href="/signin">Internal link</a>
-  <a id="data-visible-url-not-added" href="https://mozilla.org">https://mozilla.org</a>
   <a id="open-webmail" data-webmail-type="{{webmailType}}" href="{{{ escapedWebmailLink }}}">{{webmailButtonText}}</a>
 </div>

--- a/packages/fxa-content-server/app/scripts/views/mixins/external-links-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/external-links-mixin.js
@@ -5,29 +5,11 @@
 /**
  * A View Mixin to:
  *
- * 1) convert external links to visible text for
- *  environments that cannot open external links.
- * 2) When external links are clicked, flush metrics
+ * 1) When external links are clicked, flush metrics
  *  then redirect.
  */
 
 import $ from 'jquery';
-
-function shouldConvertExternalLinksToText(broker) {
-  // not all views have a broker, e.g., the CoppaAgeInput
-  // has no need for a broker.
-  return broker && broker.hasCapability('convertExternalLinksToText');
-}
-
-function convertToVisibleLink(el) {
-  const $el = $(el);
-  const href = $el.attr('href');
-  const text = $el.text();
-
-  if (href && href !== text) {
-    $el.addClass('visible-url').attr('data-visible-url', $el.attr('href'));
-  }
-}
 
 export default {
   afterRender() {
@@ -45,10 +27,6 @@ export default {
         $(el).attr('target', '_blank');
       }
     });
-
-    if (shouldConvertExternalLinksToText(this.broker)) {
-      $externalLinks.each((index, el) => convertToVisibleLink(el));
-    }
   },
 
   events: {

--- a/packages/fxa-content-server/app/scripts/views/settings/clients.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/clients.js
@@ -221,11 +221,6 @@ const View = FormView.extend(
      * @private
      */
     _showMobileApps(clients) {
-      if (this.broker.hasCapability('convertExternalLinksToText')) {
-        // if we cannot show links exit out early
-        return false;
-      }
-
       // we would show mobile apps if there are no mobile or tablet clients
       return !_.some(clients, function(client) {
         return client.deviceType === 'mobile' || client.deviceType === 'tablet';

--- a/packages/fxa-content-server/app/styles/_base.scss
+++ b/packages/fxa-content-server/app/styles/_base.scss
@@ -189,33 +189,6 @@ section p {
   display: block;
 }
 
-// Links cannot be opened from the TOS/PP text when signing
-// in to Sync on Fx for iOS. When signing in elsewhere, links
-// replace the app. Yuck. Show the links href next to the link text.
-// The href is fetched from the data-visible-url attribute instead of
-// the href attribute because some links are the same as their
-// text. In those cases, there is no point showing both.
-//
-// hrefs are only visible from the app, when the TOS/PP agreements
-// are opened directly, the links display/act normally.
-a[href^='http'].visible-url {
-  // using text-decoration: underline underlines the ::after
-  // section as well, with no way to remove it.
-  // So, add a border to the entire element, then hide
-  // the border in the ::after using a border that is the same
-  // color as the background.
-  color: $text-color;
-  cursor: default;
-  pointer-events: none;
-  text-decoration: none;
-}
-
-a[data-visible-url^='http']::after {
-  border-bottom: 1px solid $content-background-color;
-  content: ' (' attr(href) ') ';
-  word-break: break-all;
-}
-
 // Add the clearfix class to an element that contains
 // floated elements to give the element the height
 // of the tallest floated element. This fixes layout

--- a/packages/fxa-content-server/app/tests/spec/views/cannot_create_account.js
+++ b/packages/fxa-content-server/app/tests/spec/views/cannot_create_account.js
@@ -51,18 +51,4 @@ describe('views/cannot_create_account', function() {
       assert.equal(view.$('.ftc').attr('target'), null);
     });
   });
-
-  it('has a working `Learn More` link with the default broker', function() {
-    return view.render().then(function() {
-      assert.lengthOf(view.$('.show-visible-url'), 0);
-    });
-  });
-
-  it('has a `Learn More` link converted to text with `convertExternalLinksToText` capability', function() {
-    broker.setCapability('convertExternalLinksToText', true);
-
-    return view.render().then(function() {
-      assert.lengthOf(view.$('.visible-url'), 1);
-    });
-  });
 });

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/external-links-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/external-links-mixin.js
@@ -43,47 +43,6 @@ describe('views/mixins/external-links-mixin', function() {
   });
 
   describe('link conversion', () => {
-    describe('broker does not support convertExternalLinksToText', function() {
-      beforeEach(function() {
-        return view.render();
-      });
-
-      it('does not convert any links', function() {
-        assert.isFalse(view.$('#external-link').hasClass('visible-url'));
-        assert.isFalse(view.$('#internal-link').hasClass('visible-url'));
-      });
-    });
-
-    describe('broker supports convertExternalLinksToText', function() {
-      beforeEach(function() {
-        broker.setCapability('convertExternalLinksToText', true);
-        return view.render();
-      });
-
-      it('converts external links, adding rel to links', function() {
-        var $externalLink = view.$('#external-link');
-        assert.isTrue($externalLink.hasClass('visible-url'));
-        assert.equal(
-          $externalLink.attr('data-visible-url'),
-          $externalLink.attr('href')
-        );
-        assert.equal($externalLink.attr('rel'), 'noopener noreferrer');
-      });
-
-      it('does not convert internal links, does not add rel', function() {
-        var $internalLink = view.$('#internal-link');
-        assert.isFalse($internalLink.hasClass('visible-url'));
-        assert.notEqual($internalLink.attr('rel'), 'noopener noreferrer');
-      });
-
-      it('does not convert if text and the href are the same', () => {
-        assert.equal(
-          typeof view.$('#data-visible-url-not-added').attr('data-visible-url'),
-          'undefined'
-        );
-      });
-    });
-
     it('uses opens external links in new tabs with about:accounts', () => {
       sinon.stub(broker.environment, 'isAboutAccounts').callsFake(function() {
         return true;

--- a/packages/fxa-content-server/app/tests/spec/views/pp.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pp.js
@@ -9,10 +9,7 @@ import WindowMock from '../../mocks/window';
 
 var assert = chai.assert;
 
-var TEMPLATE_TEXT =
-  '<span id="fxa-pp-header"></span>' +
-  '<a id="data-visible-url-added" href="https://accounts.firefox.com">Firefox Accounts</a>' +
-  '<a id="data-visible-url-not-added" href="https://mozilla.org">https://mozilla.org</a>';
+var TEMPLATE_TEXT = '<span id="fxa-pp-header"></span>';
 
 describe('views/pp', function() {
   var view;
@@ -85,24 +82,6 @@ describe('views/pp', function() {
     return view.render().then(function() {
       assert.isTrue(xhrMock.ajax.called);
       assert.isTrue(view.isErrorVisible());
-    });
-  });
-
-  it('adds a `data-visible-url` to an anchor if the href and the text differ', function() {
-    return view.render().then(function() {
-      assert.equal(
-        view.$('#data-visible-url-added').data('visible-url'),
-        'https://accounts.firefox.com'
-      );
-    });
-  });
-
-  it('does not add a `data-visible-url` to an anchor if the href is the same as the text', function() {
-    return view.render().then(function() {
-      assert.equal(
-        typeof view.$('#data-visible-url-not-added').data('visible-url'),
-        'undefined'
-      );
     });
   });
 });

--- a/packages/fxa-content-server/app/tests/spec/views/tos.js
+++ b/packages/fxa-content-server/app/tests/spec/views/tos.js
@@ -9,10 +9,7 @@ import WindowMock from '../../mocks/window';
 
 var assert = chai.assert;
 
-var TEMPLATE_TEXT =
-  '<span id="fxa-tos-header"></span>' +
-  '<a id="data-visible-url-added" href="https://accounts.firefox.com">Firefox Accounts</a>' +
-  '<a id="data-visible-url-not-added" href="https://mozilla.org">https://mozilla.org</a>';
+var TEMPLATE_TEXT = '<span id="fxa-tos-header"></span>';
 
 describe('views/tos', function() {
   var view;
@@ -88,24 +85,6 @@ describe('views/tos', function() {
     return view.render().then(function() {
       assert.isTrue(xhrMock.ajax.called);
       assert.isTrue(view.isErrorVisible());
-    });
-  });
-
-  it('adds a `data-visible-url` to an anchor if the href and the text differ', function() {
-    return view.render().then(function() {
-      assert.equal(
-        view.$('#data-visible-url-added').attr('data-visible-url'),
-        'https://accounts.firefox.com'
-      );
-    });
-  });
-
-  it('does not add a `data-visible-url` to an anchor if the href is the same as the text', function() {
-    return view.render().then(function() {
-      assert.equal(
-        typeof view.$('#data-visible-url-not-added').attr('data-visible-url'),
-        'undefined'
-      );
     });
   });
 });


### PR DESCRIPTION
Fixes #3047