### PR TITLE
fix(payments): Append time property to amplitude events

### DIFF
--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -11,6 +11,7 @@ const {
   mapFormFactor,
   mapLocation,
   mapOs,
+  mapTime,
   toSnakeCase,
 } = require('../../../fxa-shared/metrics/amplitude.js');
 const config = require('../config');
@@ -32,10 +33,12 @@ const FUZZY_EVENTS = new Map([
 
 const transform = initialize({}, {}, FUZZY_EVENTS);
 
-module.exports = (event, request, data) => {
+module.exports = (event, request, data, requestReceivedTime) => {
   if (!amplitude.enabled || !event || !request || !data) {
     return;
   }
+
+  requestReceivedTime = requestReceivedTime || Date.now();
 
   const userAgent = ua.parse(request.headers['user-agent']);
 
@@ -45,6 +48,7 @@ module.exports = (event, request, data) => {
     ...mapOs(userAgent),
     ...mapFormFactor(userAgent),
     ...mapLocation(data.location),
+    ...mapTime(data, requestReceivedTime),
     ...data,
   });
 

--- a/packages/fxa-payments-server/server/lib/amplitude.test.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.test.js
@@ -1,0 +1,108 @@
+const amplitude = require('./amplitude');
+const log = require('./logging/log')();
+jest.spyOn(log, 'info').mockImplementation(() => {});
+
+jest.mock('../config', () => ({
+  ...jest.requireActual('../config'),
+  get: key => {
+    switch (key) {
+      case 'amplitude':
+        return { enabled: true };
+    }
+  },
+}));
+
+const mocks = {
+  event: {
+    offset: 150,
+    type: 'amplitude.subPaySetup.view',
+  },
+  invalidEventType: {
+    offset: 150,
+    type: 'foo.bar.baz',
+  },
+  data: {
+    deviceId: '0123456789abcdef0123456789abcdef',
+    flowBeginTime: 1570000000000,
+    flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    flushTime: 9002,
+    perfStartTime: 9001,
+    requestReceivedTime: 11000,
+    view: 'product',
+  },
+  request: {
+    headers: {
+      'user-agent':
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:72.0) Gecko/20100101 Firefox/72.0',
+    },
+  },
+  requestReceivedTime: 1570000001000,
+};
+
+const expectedOutput = {
+  app_version: '148.8',
+  device_id: '0123456789abcdef0123456789abcdef',
+  event_properties: {},
+  event_type: 'fxa_pay_setup - view',
+  op: 'amplitudeEvent',
+  os_name: 'Mac OS X',
+  os_version: '10.14',
+  session_id: 1570000000000,
+  user_properties: {
+    flow_id: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+    ua_browser: 'Firefox',
+    ua_version: '72.0',
+  },
+};
+
+describe('lib/amplitude', () => {
+  beforeEach(() => {
+    log.info.mockClear();
+  });
+  it('logs a correctly formatted message', done => {
+    amplitude(
+      mocks.event,
+      mocks.request,
+      mocks.data,
+      mocks.requestReceivedTime
+    );
+    expect(log.info).toHaveBeenCalled();
+    expect(log.info.mock.calls[0][0]).toMatch('amplitudeEvent');
+    expect(log.info.mock.calls[0][1]).toMatchObject(expectedOutput);
+    done();
+  });
+
+  describe('validates inputs', () => {
+    it('returns if `event` is missing', () => {
+      amplitude(
+        undefined,
+        mocks.request,
+        mocks.data,
+        mocks.requestReceivedTime
+      );
+      expect(log.info).not.toHaveBeenCalled();
+    });
+    it('returns if `request` is missing', () => {
+      amplitude(mocks.event, undefined, mocks.data, mocks.requestReceivedTime);
+      expect(log.info).not.toHaveBeenCalled();
+    });
+    it('returns if `data` is missing', () => {
+      amplitude(
+        mocks.event,
+        mocks.request,
+        undefined,
+        mocks.requestReceivedTime
+      );
+      expect(log.info).not.toHaveBeenCalled();
+    });
+    it('returns if the message format does not match `amplitude.str.str`', () => {
+      amplitude(
+        mocks.invalidEventType,
+        mocks.request,
+        mocks.data,
+        mocks.requestReceivedTime
+      );
+      expect(log.info).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/fxa-payments-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-payments-server/server/lib/routes/post-metrics.js
@@ -64,7 +64,7 @@ module.exports = {
         // performance event.
         logPerformanceEvent(event, request, { ...data, requestReceivedTime });
       } else {
-        amplitude(event, request, data);
+        amplitude(event, request, data, requestReceivedTime);
       }
     });
     response.status(200).end();

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -108,6 +108,7 @@ module.exports = {
   mapFormFactor,
   mapLocation,
   mapOs,
+  mapTime,
   mapUserAgentProperties,
   toSnakeCase,
 
@@ -441,4 +442,19 @@ function mapLocation(location) {
       region: location.state,
     };
   }
+}
+
+function estimateTime(times) {
+  const skew = times.received - times.sent;
+  return times.start + times.offset + skew;
+}
+
+function mapTime(data, receivedTime) {
+  const time = estimateTime({
+    offset: data.offset,
+    received: receivedTime,
+    start: data.startTime,
+    sent: data.flushTime,
+  });
+  return { time };
 }


### PR DESCRIPTION
Fixes #3050.

@jbuck discovered this morning that the `time` property was missing from the payments server events, which is required. This PR pulls over the bit of code from the content server's ([stderr-metrics-collector](https://github.com/mozilla/fxa/blob/8701348cdd79dbdc9879b2b4a55a23a135a32bc1/packages/fxa-content-server/server/lib/metrics-collector-stderr.js#L16-L21)) that appends the missing property to the event object.

I'm working on tests in another PR, and trying to figure  out if  we should just reuse the stderr-metrics-collector for both payments and content server, but wanted to get this out quickly and with a minimal patch, in case we want to add it to a point release this week.