### PR TITLE
feat(keys): Report keysChangedAt in assertions and key ids.

### DIFF
--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -3266,12 +3266,39 @@ The signed certificate includes these additional claims:
   A number that increases
   each time the user's password is changed.
 
+- `fxa-keysChangedAt`:
+  A timestamp that increases
+  each time the user's encryption key is changed.
+
+- `fxa-profileChangedAt`:
+  A timestamp that increases
+  each time the user's core profile data is changed.
+
 - `fxa-lastAuthAt`:
   Authentication time for this session,
   in seconds since epoch.
 
 - `fxa-verifiedEmail`:
   The user's verified recovery email address.
+
+- `fxa-tokenVerified`:
+  A boolean indicating whether the user's login was
+  verified using an email confirmation or 2FA in
+  addition to their password.
+
+- `fxa-amr`:
+  A list of strings giving the ways in which the
+  user was authenticated. Possible values include:
+
+  - `pwd`: the user provided the account password
+  - `email`: the user completed an email confirmation loop
+  - `otp`: the user completed a 2FA challenge
+
+- `fxa-aal`:
+  An integer giving the "authenticator assurance level" at which
+  the user was authenticated - that is, the number of independent
+  auth factors that they provided during login.
+
   <!--end-route-post-certificatesign-->
 
 ##### Query parameters

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/assertion.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/assertion.js
@@ -32,6 +32,9 @@ const logger = require('./logging')('assertion');
 const { verifyJWT } = require('../../lib/serverJWT');
 
 const HEX_STRING = /^[0-9a-f]+$/;
+
+// FxA sends several custom claims, ref
+// https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/docs/api.md#post-certificatesign
 const CLAIMS_SCHEMA = Joi.object({
   uid: Joi.string()
     .length(32)
@@ -63,6 +66,10 @@ const CLAIMS_SCHEMA = Joi.object({
     .max(3)
     .optional(),
   'fxa-profileChangedAt': Joi.number()
+    .integer()
+    .min(0)
+    .optional(),
+  'fxa-keysChangedAt': Joi.number()
     .integer()
     .min(0)
     .optional(),

--- a/packages/fxa-auth-server/fxa-oauth-server/lib/routes/key_data.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/routes/key_data.js
@@ -71,10 +71,12 @@ module.exports = {
     }
 
     const iat = claims.iat || claims['fxa-lastAuthAt'];
+    const keysChangedAt =
+      claims['fxa-keysChangedAt'] || claims['fxa-generation'];
     const response = {};
     for (const keyScope of keyBearingScopes) {
       const keyRotationTimestamp = Math.max(
-        claims['fxa-generation'],
+        keysChangedAt,
         keyScope.keyRotationTimestamp
       );
       // If the assertion certificate was issued prior to a key-rotation event,

--- a/packages/fxa-auth-server/lib/oauthdb/utils.js
+++ b/packages/fxa-auth-server/lib/oauthdb/utils.js
@@ -98,6 +98,7 @@ module.exports = {
       'fxa-amr': Array.from(credentials.authenticationMethods),
       'fxa-aal': credentials.authenticatorAssuranceLevel,
       'fxa-profileChangedAt': credentials.profileChangedAt,
+      'fxa-keysChangedAt': credentials.keysChangedAt,
     };
     return signJWT(
       claims,

--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -1173,70 +1173,43 @@ module.exports = (
             });
         }
 
-        function resetAccountData() {
-          let authSalt;
-          return random
-            .hex(32)
-            .then(hex => {
-              authSalt = hex;
-              password = new Password(authPW, authSalt, config.verifierVersion);
-              return password.verifyHash();
-            })
-            .then(verifyHashData => {
-              verifyHash = verifyHashData;
-
-              return setupKb();
-            })
-            .then(() => {
-              return db.resetAccount(accountResetToken, {
-                authSalt,
-                verifyHash,
-                wrapWrapKb,
-                verifierVersion: password.version,
-              });
-            })
-            .then(() => {
-              // Delete all passwordChangeTokens, passwordForgotTokens and
-              // accountResetTokens associated with this uid
-              return db.resetAccountTokens(accountResetToken.uid);
-            })
-            .then(() => {
-              // Notify the devices that the account has changed.
-              request.app.devices.then(devices =>
-                push.notifyPasswordReset(accountResetToken.uid, devices)
-              );
-
-              return db
-                .account(accountResetToken.uid)
-                .then(accountData => (account = accountData));
-            })
-            .then(() => {
-              return P.all([
-                request.emitMetricsEvent('account.reset', {
-                  uid: account.uid,
-                }),
-                log.notifyAttachedServices('reset', request, {
-                  uid: account.uid,
-                  generation: account.verifierSetAt,
-                }),
-                customs.reset(account.email),
-              ]);
-            });
-        }
-
-        function setupKb() {
+        async function resetAccountData() {
+          const authSalt = await random.hex(32);
+          password = new Password(authPW, authSalt, config.verifierVersion);
+          verifyHash = await password.verifyHash();
           if (recoveryKeyId) {
             // We have the previous kB, just re-wrap it with the new password.
-            return password.wrap(wrapKb).then(result => (wrapWrapKb = result));
+            wrapWrapKb = await password.wrap(wrapKb);
           } else {
             // We need to regenerate kB and wrap it with the new password.
-            return random.hex(32).then(result => {
-              wrapWrapKb = result;
-              return password
-                .unwrap(wrapWrapKb)
-                .then(result => (wrapKb = result));
-            });
+            wrapWrapKb = await random.hex(32);
+            wrapKb = await password.unwrap(wrapWrapKb);
           }
+          // db.resetAccount() deletes all the devices saved in the account,
+          // so grab the list to notify before we call it.
+          const devicesToNotify = await request.app.devices;
+          // Reset the account, and delete any other outstanding account-related tokens.
+          await db.resetAccount(accountResetToken, {
+            authSalt,
+            verifyHash,
+            wrapWrapKb,
+            verifierVersion: password.version,
+          });
+          await db.resetAccountTokens(accountResetToken.uid);
+          // Notify various interested parties about this password reset.
+          // These can all safely happen in parallel.
+          account = await db.account(accountResetToken.uid);
+          await P.all([
+            push.notifyPasswordReset(account.uid, devicesToNotify),
+            request.emitMetricsEvent('account.reset', {
+              uid: account.uid,
+            }),
+            log.notifyAttachedServices('reset', request, {
+              uid: account.uid,
+              generation: account.verifierSetAt,
+            }),
+            customs.reset(account.email),
+          ]);
         }
 
         function recoveryKeyDeleteAndEmailNotification() {

--- a/packages/fxa-auth-server/lib/routes/sign.js
+++ b/packages/fxa-auth-server/lib/routes/sign.js
@@ -178,6 +178,7 @@ module.exports = (log, signer, db, domain, devices) => {
           authenticationMethods: Array.from(sessionToken.authenticationMethods),
           authenticatorAssuranceLevel: sessionToken.authenticatorAssuranceLevel,
           profileChangedAt: sessionToken.profileChangedAt,
+          keysChangedAt: sessionToken.keysChangedAt,
         });
         request.emitMetricsEvent('account.signed', {
           uid: uid,

--- a/packages/fxa-auth-server/lib/signer.js
+++ b/packages/fxa-auth-server/lib/signer.js
@@ -28,6 +28,7 @@ module.exports = function(secretKeyFile, domain) {
           'fxa-amr': data.authenticationMethods,
           'fxa-aal': data.authenticatorAssuranceLevel,
           'fxa-profileChangedAt': data.profileChangedAt,
+          'fxa-keysChangedAt': data.keysChangedAt,
         })
         .then(cert => {
           return { cert: cert };

--- a/packages/fxa-auth-server/lib/tokens/session_token.js
+++ b/packages/fxa-auth-server/lib/tokens/session_token.js
@@ -35,6 +35,7 @@ module.exports = (log, Token, config) => {
       this.emailVerified = !!details.emailVerified;
       this.verifierSetAt = details.verifierSetAt;
       this.profileChangedAt = details.profileChangedAt;
+      this.keysChangedAt = details.keysChangedAt;
       this.authAt = details.authAt || 0;
       this.locale = details.locale || null;
       this.mustVerify = !!details.mustVerify || false;

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -1123,6 +1123,20 @@ module.exports = config => {
     );
   };
 
+  ClientApi.prototype.getScopedKeyData = function(
+    sessionTokenHex,
+    oauthParams
+  ) {
+    return tokens.SessionToken.fromHex(sessionTokenHex).then(token => {
+      return this.doRequest(
+        'POST',
+        `${this.baseURL}/account/scoped-key-data`,
+        token,
+        oauthParams
+      );
+    });
+  };
+
   ClientApi.prototype.getSubscriptionClients = function(secret) {
     return this.doRequestWithSecret(
       'GET',

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -795,6 +795,10 @@ module.exports = config => {
     return this.api.revokeOAuthToken(oauthParams);
   };
 
+  Client.prototype.getScopedKeyData = function(oauthParams) {
+    return this.api.getScopedKeyData(this.sessionToken, oauthParams);
+  };
+
   Client.prototype.getSubscriptionClients = function(secret) {
     return this.api.getSubscriptionClients(secret);
   };

--- a/packages/fxa-auth-server/test/local/routes/session.js
+++ b/packages/fxa-auth-server/test/local/routes/session.js
@@ -853,7 +853,7 @@ describe('/session/duplicate', () => {
       const sessionTokenOptions = db.createSessionToken.args[0][0];
       assert.equal(
         Object.keys(sessionTokenOptions).length,
-        36,
+        37,
         'was called with correct number of options'
       );
       assert.equal(
@@ -989,7 +989,7 @@ describe('/session/duplicate', () => {
       const sessionTokenOptions = db.createSessionToken.args[0][0];
       assert.equal(
         Object.keys(sessionTokenOptions).length,
-        36,
+        37,
         'was called with correct number of options'
       );
       assert.equal(

--- a/packages/fxa-auth-server/test/remote/account_signin_verification_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_signin_verification_tests.js
@@ -497,6 +497,14 @@ describe('remote account signin verification', function() {
             1000 * 60 * 60,
           'lastAuthAt is plausible'
         );
+        assert.ok(
+          payload['fxa-profileChangedAt'] > 0,
+          'cert has non-zero profileChangedAt'
+        );
+        assert.ok(
+          payload['fxa-keysChangedAt'] > 0,
+          'cert has non-zero keysChangedAt'
+        );
         assert.equal(
           payload['fxa-verifiedEmail'],
           email,
@@ -556,6 +564,14 @@ describe('remote account signin verification', function() {
           new Date() - new Date(payload['fxa-lastAuthAt'] * 1000) <
             1000 * 60 * 60,
           'lastAuthAt is plausible'
+        );
+        assert.ok(
+          payload['fxa-profileChangedAt'] > 0,
+          'cert has non-zero profileChangedAt'
+        );
+        assert.ok(
+          payload['fxa-keysChangedAt'] > 0,
+          'cert has non-zero keysChangedAt'
         );
         assert.equal(
           payload['fxa-verifiedEmail'],


### PR DESCRIPTION
This PR extracts part of https://github.com/mozilla/fxa/pull/2570 into a standalone commit that we can safely merge and deploy without waiting for any tokenserver changes.

Connects to #490.

#### Background

The "durable sync" project wants to bucket storage of server-side sync data based on the id of the key used to encrypt it, including a timestamp component so that it can easily determine which data
is newest. Our OAuth scoped key ids include a leading timestamp designed for just this purpose.

Up until now we have been using `verifierSetAt` for that timestamp. This works but means that we generate a new kid whenever the user changes their password, even if that did not involve resetting the master encryption key `kB`. This means that durable sync will give users a new storage bucket, in  response to a password change, discarding the user's previous sync data even though their key had
not changed.

Instead, we need to explicitly track the timestamp at which key material actually changed, and report that in both OAuth key ids and in BrowserID assertions so that all Sync clients see a consistent
timestamp.  We already have a `keysChangedAt` database column from a previous migration, but haven't been making any use of it, and it currently defaults to the value of `verifierSetAt`.

#### This Change

With this commit, we start using `keysChangedAt` for the timestamp component of OAuth scoped key ids, and start reporting it in BrowserID assertions. For now the reported value will always be
the same as `verifierSetAt`, which will let us get the new logic into production without changing what timestamps are observed by the sync service.

A follow-up commit will be required to actually start tracking `keysChangedAt` separately from `verifierSetAt`. I'd like to get this smaller change into production first, to help ensure a smooth deployment. That follow-up commit commit also has to wait on a Tokenserver deployment, and will be the remainder of https://github.com/mozilla/fxa/pull/2570.
