### PR TITLE
fix(oauth): Revoke access tokens when revoking a refresh token

### DIFF
--- a/packages/123done/oauth.js
+++ b/packages/123done/oauth.js
@@ -48,6 +48,7 @@ function verifyIdToken(oauthConfig, token) {
 
 function setupOAuthFlow(req, action, options = {}, cb) {
   var params = {
+    access_type: 'offline',
     client_id: config.client_id,
     pkce_client_id: config.pkce_client_id,
     redirect_uri: config.redirect_uri,

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -231,7 +231,9 @@ module.exports = {
   },
   SETTINGS_CLIENTS: {
     BUTTON_REFRESH: '.clients-refresh',
+    BUTTON_REFRESH_LOADING: '.clients-refresh .spinner',
     CLIENT_LIST: '.client-list',
+    OAUTH_CLIENT: 'li.client-oAuthApp',
     REFRESHING: '.clients-refresh.disabled',
   },
   SETTINGS_COMMUNICATION: {

--- a/packages/fxa-content-server/tests/functional/oauth_settings_clients.js
+++ b/packages/fxa-content-server/tests/functional/oauth_settings_clients.js
@@ -20,6 +20,7 @@ const {
   click,
   closeCurrentWindow,
   fillOutSignUp,
+  noSuchElement,
   openFxaFromRp,
   openPage,
   openTab,
@@ -93,7 +94,18 @@ registerSuite('oauth settings clients', {
           .then(
             click('li.client-oAuthApp[data-name^="321"] .client-disconnect')
           )
-          .then(pollUntilGoneByQSA('li.client-oAuthApp'))
+          .then(pollUntilGoneByQSA(selectors.SETTINGS_CLIENTS.OAUTH_CLIENT))
+
+          // the deleted clients should not show up again, this ensures
+          // that access tokens are deleted along with the refresh tokens.
+          .then(click(selectors.SETTINGS_CLIENTS.BUTTON_REFRESH))
+          .then(
+            pollUntilGoneByQSA(
+              selectors.SETTINGS_CLIENTS.BUTTON_REFRESH_LOADING
+            )
+          )
+
+          .then(noSuchElement(selectors.SETTINGS_CLIENTS.OAUTH_CLIENT))
       );
     },
   },


### PR DESCRIPTION
All access tokens for a client_id, uid pair are revoked whenever
revoking a refresh token to avoid phantom entries in the
user's devices & apps list.

Before this PR, the problem was revoking a refresh token would
only revoke the refresh token and none of the access tokens created
from it. This led to a user revoking a refresh token, but then
the access tokens created from it showing up in the user's devices
& apps list, and needing to revoke those separately.

Because we don't associate access tokens and refresh tokens, we can't
delete just the access token associated with the refresh token. Instead,
this PR uses a blunt instrument and revokes *all* the access tokens
for the user/client_id. If the user has multiple active refresh tokens,
then the clients will use those refresh tokens to get new access
tokens for the ones that were revoked prematurely.

fixes #1249
fixes #3017 

@vladikoff, @vbudhram, @rfk - r?