### PR TITLE
fix(copy) Update payments resub confirm modal copy

### DIFF
--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -306,8 +306,10 @@ const ReactivateSubscriptionPanel = ({
           <h4>Want to keep using {plan.product_name}?</h4>
           {/* TO DO: display card type, IE 'to the Visa card ending...' */}
           <p>
-            You will lose access to {plan.product_name} on{' '}
-            <strong>{periodEndDate}</strong>.
+            Your access to {plan.product_name} will continue, and your billing
+            cycle and payment will stay the same. Your next charge will be $
+            {formatCurrencyInCents(plan.amount)} to the card ending in {last4}{' '}
+            on {periodEndDate}.
           </p>
           <div className="action">
             <button


### PR DESCRIPTION
Fixes #3064

Looks like this was accidentally reverted in: https://github.com/mozilla/fxa/commit/d77edd5c387e180c5026962a89e2e11acf205574#diff-26536462dde17ca7b7be2abc70150046R306

Now referencing `product_name` instead of `plan_name`.