### PR TITLE
fix(metrics): Add amplitude screen metrics for signup code

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -78,6 +78,20 @@ const EVENTS = {
     group: GROUPS.login,
     event: 'complete',
   },
+
+  // Signup code based metrics
+  'screen.confirm-signup-code': {
+    group: GROUPS.registration,
+    event: 'signup_code_view',
+  },
+  'flow.confirm-signup-code.engage': {
+    group: GROUPS.registration,
+    event: 'signup_code_engage',
+  },
+  'flow.confirm-signup-code.submit': {
+    group: GROUPS.registration,
+    event: 'signup_code_submit',
+  },
 };
 
 const VIEW_ENGAGE_SUBMIT_EVENT_GROUPS = {

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -1801,5 +1801,86 @@ registerSuite('amplitude', {
         },
       });
     },
+
+    'screen.confirm-signup-code': () => {
+      amplitude(
+        {
+          time: 'a',
+          type: 'screen.confirm-signup-code',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: 'b',
+          flowId: 'c',
+          uid: 'd',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_reg - signup_code_view'
+      );
+      assert.isUndefined(logger.info.args[0][1].user_properties.sync_engines);
+    },
+
+    'flow.confirm-signup-code.engage': () => {
+      amplitude(
+        {
+          time: 'a',
+          type: 'flow.confirm-signup-code.engage',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: 'b',
+          flowId: 'c',
+          uid: 'd',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_reg - signup_code_engage'
+      );
+      assert.isUndefined(logger.info.args[0][1].user_properties.sync_engines);
+    },
+
+    'flow.confirm-signup-code.submit': () => {
+      amplitude(
+        {
+          time: 'a',
+          type: 'flow.confirm-signup-code.submit',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: 'b',
+          flowId: 'c',
+          uid: 'd',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      assert.equal(
+        logger.info.args[0][1].event_type,
+        'fxa_reg - signup_code_submit'
+      );
+      assert.isUndefined(logger.info.args[0][1].user_properties.sync_engines);
+    },
   },
 });


### PR DESCRIPTION
Fixes #3073 

Going through the signup flow and grepping content-server logs:

```
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_email_first - view","time":1571768122592,"device_id":"62b46fd8d375478e839764fb8bc8bcc0","session_id":1571768121760,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b7a0a173cdf78bc871a45eb73da92852dda94c636d2d282e188371c2bc2fa042","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["email_first_treatment","signup_code_treatment"]}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_email_first - engage","time":1571768132157,"device_id":"62b46fd8d375478e839764fb8bc8bcc0","session_id":1571768121760,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b7a0a173cdf78bc871a45eb73da92852dda94c636d2d282e188371c2bc2fa042","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["email_first_treatment","signup_code_treatment"]}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_email_first - submit","time":1571768134428,"device_id":"62b46fd8d375478e839764fb8bc8bcc0","session_id":1571768121760,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b7a0a173cdf78bc871a45eb73da92852dda94c636d2d282e188371c2bc2fa042","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["email_first_treatment","signup_code_treatment"]}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - view","time":1571768134557,"device_id":"62b46fd8d375478e839764fb8bc8bcc0","session_id":1571768121760,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b7a0a173cdf78bc871a45eb73da92852dda94c636d2d282e188371c2bc2fa042","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["email_first_treatment","signup_code_treatment"]}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - engage","time":1571768141002,"device_id":"62b46fd8d375478e839764fb8bc8bcc0","session_id":1571768121760,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b7a0a173cdf78bc871a45eb73da92852dda94c636d2d282e188371c2bc2fa042","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["email_first_treatment","signup_code_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - submit","time":1571768145314,"device_id":"62b46fd8d375478e839764fb8bc8bcc0","session_id":1571768121760,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b7a0a173cdf78bc871a45eb73da92852dda94c636d2d282e188371c2bc2fa042","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["email_first_treatment","signup_code_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - cwts_view","time":1571768145914,"device_id":"62b46fd8d375478e839764fb8bc8bcc0","session_id":1571768121760,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b7a0a173cdf78bc871a45eb73da92852dda94c636d2d282e188371c2bc2fa042","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["email_first_treatment","signup_code_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - cwts_submit","time":1571768147381,"device_id":"62b46fd8d375478e839764fb8bc8bcc0","session_id":1571768121760,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b7a0a173cdf78bc871a45eb73da92852dda94c636d2d282e188371c2bc2fa042","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["email_first_treatment","signup_code_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - signup_code_view","time":1571768147388,"device_id":"62b46fd8d375478e839764fb8bc8bcc0","session_id":1571768121760,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b7a0a173cdf78bc871a45eb73da92852dda94c636d2d282e188371c2bc2fa042","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["email_first_treatment","signup_code_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - signup_code_engage","time":1571768155257,"device_id":"62b46fd8d375478e839764fb8bc8bcc0","session_id":1571768121760,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b7a0a173cdf78bc871a45eb73da92852dda94c636d2d282e188371c2bc2fa042","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["email_first_treatment","signup_code_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - signup_code_submit","time":1571768156574,"device_id":"62b46fd8d375478e839764fb8bc8bcc0","session_id":1571768121760,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b7a0a173cdf78bc871a45eb73da92852dda94c636d2d282e188371c2bc2fa042","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["email_first_treatment","signup_code_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
```