### PR TITLE
fix(metrics): Update app_version to send complete train version number

### DIFF
--- a/packages/fxa-auth-server/test/local/metrics/amplitude.js
+++ b/packages/fxa-auth-server/test/local/metrics/amplitude.js
@@ -180,7 +180,7 @@ describe('metrics/amplitude', () => {
           },
         });
         assert.ok(args[0].time > Date.now() - 1000);
-        assert.ok(/^[1-9][0-9]+$/.test(args[0].app_version));
+        assert.ok(/^([0-9]+)\.([0-9])$/.test(args[0].app_version));
       });
     });
 

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -30,7 +30,7 @@ const amplitude = proxyquire(path.resolve('server/lib/amplitude'), {
   },
   './logging/log': () => logger,
 });
-const APP_VERSION = /^[0-9]+\.([0-9]+)\./.exec(pkg.version)[1];
+const APP_VERSION = /([0-9]+)\.([0-9])$/.exec(pkg.version)[0];
 
 registerSuite('amplitude', {
   beforeEach: function() {
@@ -47,7 +47,7 @@ registerSuite('amplitude', {
     /*eslint-disable sorting/sort-object-props */
     'app version seems sane': () => {
       assert.typeOf(APP_VERSION, 'string');
-      assert.match(APP_VERSION, /^[0-9]+$/);
+      assert.match(APP_VERSION, /([0-9]+)\.([0-9])$/);
     },
 
     'interface is correct': () => {

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -199,7 +199,7 @@ module.exports = {
 
         let version;
         try {
-          version = /^[0-9]+\.([0-9]+)\./.exec(data.version)[1];
+          version = /([0-9]+)\.([0-9])$/.exec(data.version)[0];
         } catch (err) {}
 
         return pruneUnsetValues({

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -9,6 +9,7 @@ const { assert } = require('chai');
 const DAY = 1000 * 60 * 60 * 24;
 const WEEK = DAY * 7;
 const FOUR_WEEKS = WEEK * 4;
+const APP_VERSION = /^([0-9]+)\.([0-9])$/; // Matches `XXX.X` version number
 
 describe('metrics/amplitude:', () => {
   let amplitude;
@@ -184,6 +185,9 @@ describe('metrics/amplitude:', () => {
         // HACK: app_version is set if the tests are run in the monorepo but not if
         //       they're run inside a container, due to the resolution or otherwise
         //       of `require('../../../package.json')` in metrics/amplitude.js
+        if (result.app_version) {
+          assert.equal(APP_VERSION.test(result.app_version), true);
+        }
         delete result.app_version;
         assert.deepEqual(result, {
           country: 'c',
@@ -253,6 +257,9 @@ describe('metrics/amplitude:', () => {
         // HACK: app_version is set if the tests are run in the monorepo but not if
         //       they're run inside a container, due to the resolution or otherwise
         //       of `require('../../../package.json')` in metrics/amplitude.js
+        if (result.app_version) {
+          assert.equal(APP_VERSION.test(result.app_version), true);
+        }
         delete result.app_version;
         assert.deepEqual(result, {
           device_id: 'a',


### PR DESCRIPTION
Fixes #3028 

~Marking as draft since I fully expect some test bustage.~

Example amplitude log
```
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_email_first - engage","time":1571938016089,"device_id":"0222132c0469472496d5592b80a230f1","session_id":1571938014298,"app_version":"148.8","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"3d567c9a9d914d935ef2babbffccb91735be2a2c065cdb28084e72f28745c41d","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["email_first_treatment"]}}}
```