### PR TITLE
feat(delete_account): fix #2856, add manage subscriptions link to delete account when user has subscriptions

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/delete_account.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/delete_account.mustache
@@ -12,41 +12,46 @@
 
   <div class="settings-unit-details">
     <div class="error"></div>
+    {{#subscriptions}}
+      <p class="subscription-link">
+        {{#unsafeTranslate}}Looking to cancel a paid subscription? Go to <a href="/subscriptions">Manage Subscriptions</a>.{{/unsafeTranslate}}
+      </p>
+    {{/subscriptions}}
 
-    <form novalidate>
-      <div class="delete-account-product-container {{#hideProductContainer}}hide{{/hideProductContainer}}">
-        <p>{{#t}}You've connected your Firefox account to Mozilla products that keep you secure and productive on the web:{{/t}}</p>
+    <div class="delete-account-product-container {{#hideProductContainer}}hide{{/hideProductContainer}}">
+      <p>{{#t}}You've connected your Firefox account to Mozilla products that keep you secure and productive on the web:{{/t}}</p>
 
-        <ul class="delete-account-product-list {{#hasTwoColumnProductList}}two-col{{/hasTwoColumnProductList}}">
-          {{#subscriptions}}
-            {{#plan_name}}
-              <li class="delete-account-product-subscription" title="{{plan_name}}">
-                {{plan_name}}
-              </li>
-            {{/plan_name}}
-          {{/subscriptions}}
+      <ul class="delete-account-product-list {{#hasTwoColumnProductList}}two-col{{/hasTwoColumnProductList}}">
+        {{#subscriptions}}
+          {{#plan_name}}
+            <li class="delete-account-product-subscription" title="{{plan_name}}">
+              {{plan_name}}
+            </li>
+          {{/plan_name}}
+        {{/subscriptions}}
 
-          {{#uniqueBrowserNames}}
+        {{#uniqueBrowserNames}}
+          {{#name}}
+            <li class="delete-account-product-browser" title="{{name}}">
+              {{name}}
+            </li>
+          {{/name}}
+        {{/uniqueBrowserNames}}
+
+        {{#clients}}
+          {{#isOAuthApp}}
             {{#name}}
-              <li class="delete-account-product-browser" title="{{name}}">
+              <li class="delete-account-product-client" title="{{name}}">
                 {{name}}
               </li>
             {{/name}}
-          {{/uniqueBrowserNames}}
+          {{/isOAuthApp}}
 
-          {{#clients}}
-            {{#isOAuthApp}}
-              {{#name}}
-                <li class="delete-account-product-client" title="{{name}}">
-                  {{name}}
-                </li>
-              {{/name}}
-            {{/isOAuthApp}}
+        {{/clients}}
+      </ul>
+    </div>
 
-          {{/clients}}
-        </ul>
-      </div>
-
+    <form novalidate>
       <p>{{#t}}Please acknowledge that by deleting your account:{{/t}}</p>
 
       <ul class="delete-account-checkbox-list">

--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -400,6 +400,14 @@ section.modal-panel {
 }
 
 .delete-account {
+  p {
+    margin-bottom: 12px;
+  }
+
+  .subscription-link {
+    margin: 0 0 24px;
+  }
+
   &-product-container {
     &.hide { // 0 products or error during fetch for subscriptions and/or clients
       display: none;

--- a/packages/fxa-content-server/app/tests/spec/views/settings/delete_account.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/delete_account.js
@@ -298,6 +298,30 @@ describe('views/settings/delete_account', function() {
       });
     });
 
+    describe('link to subscriptions', () => {
+      it('renders if user has at least one subscription', () => {
+        return view
+          .render()
+          .then(() => view.openPanel())
+          .then(() => {
+            assert.lengthOf(view.$('.delete-account-product-subscription'), 1);
+            assert.lengthOf(view.$('.subscription-link'), 1);
+          });
+      });
+
+      it('does not render if user does not have any subscriptions', () => {
+        activeSubscriptions = [];
+
+        return view
+          .render()
+          .then(() => view.openPanel())
+          .then(() => {
+            assert.lengthOf(view.$('.delete-account-product-subscription'), 0);
+            assert.lengthOf(view.$('.subscription-link'), 0);
+          });
+      });
+    });
+
     describe('openPanel', () => {
       beforeEach(() => {
         sinon.spy($.prototype, 'trigger');


### PR DESCRIPTION
fixes #2856 

Also
- slightly adjusts some padding in `delete_account`, approved by Janice via screenshot.
- moves elements out of `form` that probably don't need to be in there


<img width="600" alt="image" src="https://user-images.githubusercontent.com/13018240/67325964-8d785700-f4db-11e9-9e26-4a233e5363e0.png">
