### PR TITLE
fix(test): Do not run mocha tests on teamcity.

### DIFF
--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -38,7 +38,6 @@ module.exports = [
   'tests/functional/fx_ios_v1_sign_up.js',
   'tests/functional/legal.js',
   'tests/functional/mailcheck.js',
-  'tests/functional/mocha.js',
   'tests/functional/oauth_choose_redirect.js',
   'tests/functional/oauth_email_first.js',
   'tests/functional/oauth_force_auth.js',
@@ -83,3 +82,11 @@ module.exports = [
   'tests/functional/sync_v3_sign_up.js',
   'tests/functional/tos.js',
 ];
+
+// Mocha tests are only exposed during local dev, not on prod-like
+// instances such as latest, stable, stage, and prod. To avoid
+// Teamcity failing trying to run mocha tests, expose an environment
+// variable it can use to skip the mocha tests.
+if (!process.env.SKIP_MOCHA) {
+  module.exports.unshift('tests/functional/mocha.js');
+}


### PR DESCRIPTION
Teamcity cannot run mocha tests against latest, stage, stable, etc
because only dev instances expose the /tests/index.html endpoint.

Only run the mocha tests as part of the functional
suite if the SKIP_MOCHA environment variable is not set

Teamcity has this environment variable set (I did it in anticipation of this PR)
and will not run the mocha tests.

fixes #3101

@mozilla/fxa-devs - r?