### PR TITLE
fix(test): Fix the broken delete_account test

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -240,6 +240,7 @@ module.exports = {
     BUTTON_MANAGE: '.open-email-preferences',
   },
   SETTINGS_DELETE_ACCOUNT: {
+    CANCEL: '#delete-account .cancel',
     DETAILS: '#delete-account .settings-unit-details',
     MENU_BUTTON: '#delete-account .settings-unit-toggle',
     CHECKBOXES: '#delete-account .delete-account-checkbox',


### PR DESCRIPTION
After clicking the "cancel" button we were checking for the existence
of the '#settings' element, which could have gone stale due to a re-render.

Instead, ensure the delete panel details become hidden.

fixes #3101