### PR TITLE
fix(test): Fix the OAuth TOTP required tests

### DIFF
--- a/packages/fxa-content-server/tests/functional/oauth_require_totp.js
+++ b/packages/fxa-content-server/tests/functional/oauth_require_totp.js
@@ -12,19 +12,20 @@ const config = intern._config;
 const OAUTH_APP = config.fxaOAuthApp;
 const selectors = require('./lib/selectors');
 
-const SIGNIN_URL = `${config.fxaContentRoot}signin`;
+const ENTER_EMAIL_URL = `${config.fxaContentRoot}?action=email`;
 
 const PASSWORD = 'passwordzxcv';
 
 let email;
-let secret;
 
 const {
   clearBrowserState,
   click,
   closeCurrentWindow,
   confirmTotpCode,
-  fillOutSignIn,
+  createUser,
+  fillOutEmailFirstSignIn,
+  fillOutEmailFirstSignUp,
   generateTotpCode,
   openFxaFromRp,
   openPage,
@@ -32,10 +33,10 @@ const {
   switchToWindow,
   testElementExists,
   testElementTextInclude,
-  testElementValueEquals,
   testErrorTextInclude,
   thenify,
   type,
+  visibleByQSA,
 } = FunctionalHelpers;
 
 const testAtOAuthApp = thenify(function() {
@@ -53,131 +54,93 @@ registerSuite('oauth require totp', {
   beforeEach: function() {
     email = createEmail();
 
-    return this.remote
-      .then(
-        clearBrowserState({
-          '123done': true,
-          contentServer: true,
-          force: true,
-        })
-      )
-      .then(
-        openFxaFromRp('two-step-authentication', {
-          header: selectors.ENTER_EMAIL.HEADER,
-        })
-      )
-
-      .then(type(selectors.ENTER_EMAIL.EMAIL, email))
-      .then(
-        click(selectors.ENTER_EMAIL.SUBMIT, selectors.SIGNUP_PASSWORD.HEADER)
-      )
-
-      .then(testElementValueEquals(selectors.SIGNUP_PASSWORD.EMAIL, email))
-      .then(type(selectors.SIGNUP_PASSWORD.PASSWORD, PASSWORD))
-      .then(testElementExists(selectors.SIGNUP_PASSWORD.SHOW_PASSWORD))
-
-      .then(type(selectors.SIGNUP_PASSWORD.VPASSWORD, PASSWORD))
-      .then(testElementExists(selectors.SIGNUP_PASSWORD.SHOW_VPASSWORD))
-
-      .then(type(selectors.SIGNUP_PASSWORD.AGE, 21))
-      .then(
-        click(selectors.SIGNUP_PASSWORD.SUBMIT, selectors.CONFIRM_SIGNUP.HEADER)
-      )
-
-      .then(openVerificationLinkInNewTab(email, 0))
-      .then(switchToWindow(1))
-      .then(testElementExists(selectors.SIGNUP_COMPLETE.HEADER))
-      .then(closeCurrentWindow())
-
-      .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER))
-      .then(
-        clearBrowserState({
-          '123done': true,
-          contentServer: true,
-          force: true,
-        })
-      );
+    return this.remote.then(
+      clearBrowserState({
+        '123done': true,
+        contentServer: true,
+        force: true,
+      })
+    );
   },
 
   tests: {
-    'fails for account without TOTP': function() {
+    signup: function() {
       return this.remote
         .then(
           openFxaFromRp('two-step-authentication', {
             header: selectors.ENTER_EMAIL.HEADER,
           })
         )
-        .then(type(selectors.ENTER_EMAIL.EMAIL, email))
+
+        .then(fillOutEmailFirstSignUp(email, PASSWORD))
+        .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
+
+        .then(openVerificationLinkInNewTab(email, 0))
+        .then(switchToWindow(1))
+        .then(testElementExists(selectors.SIGNUP_COMPLETE.HEADER))
+        .then(closeCurrentWindow())
+
+        .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER));
+    },
+
+    'fails for account without TOTP': function() {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(
-          click(selectors.ENTER_EMAIL.SUBMIT, selectors.SIGNIN_PASSWORD.HEADER)
+          openFxaFromRp('two-step-authentication', {
+            header: selectors.ENTER_EMAIL.HEADER,
+          })
         )
-        .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
-        .then(
-          click(
-            selectors.SIGNIN_PASSWORD.SUBMIT,
-            selectors.SIGNIN_PASSWORD.HEADER
-          )
-        )
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
         .then(testErrorTextInclude('requires two step authentication enabled'))
         .then(testErrorTextInclude('More information'));
     },
 
     'succeed for account with TOTP': function() {
+      this.timeout = 60 * 1000;
+      let secret;
+
       return (
         this.remote
-          .then(openPage(SIGNIN_URL, selectors.SIGNIN.HEADER))
-          .then(fillOutSignIn(email, PASSWORD))
+          .then(createUser(email, PASSWORD, { preVerified: true }))
+          .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
           .then(testElementExists(selectors.SETTINGS.HEADER))
 
           .then(click(selectors.TOTP.MENU_BUTTON))
 
           .then(click(selectors.TOTP.SHOW_CODE_LINK))
-          .then(testElementExists(selectors.TOTP.MANUAL_CODE))
+          .then(visibleByQSA(selectors.TOTP.MANUAL_CODE))
 
           // Store the secret key to recalculate the code later
           .findByCssSelector(selectors.TOTP.MANUAL_CODE)
           .getVisibleText()
           .then(secretKey => {
             secret = secretKey;
-            return (
-              this.remote
-                .then(confirmTotpCode(secret))
-                .then(
-                  clearBrowserState({
-                    '123done': true,
-                    contentServer: true,
-                  })
-                )
-                .then(
-                  openFxaFromRp('two-step-authentication', {
-                    header: selectors.ENTER_EMAIL.HEADER,
-                  })
-                )
-                .then(type(selectors.ENTER_EMAIL.EMAIL, email))
-                .then(
-                  click(
-                    selectors.ENTER_EMAIL.SUBMIT,
-                    selectors.SIGNIN_PASSWORD.HEADER
-                  )
-                )
-                .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
-                .then(
-                  click(
-                    selectors.SIGNIN_PASSWORD.SUBMIT,
-                    selectors.TOTP_SIGNIN.HEADER
-                  )
-                )
-
-                // Correctly submits the totp code and navigates to oauth page
-                .then(
-                  type(selectors.TOTP_SIGNIN.INPUT, generateTotpCode(secret))
-                )
-                .then(click(selectors.TOTP_SIGNIN.SUBMIT))
-
-                .then(testAtOAuthApp())
-            );
           })
           .end()
+
+          .then(() => {
+            return this.remote.then(confirmTotpCode(secret));
+          })
+          .then(clearBrowserState({ force: true }))
+          .then(
+            openFxaFromRp('two-step-authentication', {
+              header: selectors.ENTER_EMAIL.HEADER,
+            })
+          )
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
+          .then(testElementExists(selectors.TOTP_SIGNIN.HEADER))
+
+          // Correctly submits the totp code and navigates to oauth page
+          .then(() => {
+            return this.remote.then(
+              type(selectors.TOTP_SIGNIN.INPUT, generateTotpCode(secret))
+            );
+          })
+          .then(click(selectors.TOTP_SIGNIN.SUBMIT))
+
+          .then(testAtOAuthApp())
       );
     },
   },


### PR DESCRIPTION
The beforeEach seemed to do too much to me, like it was testing
the signup flow, and that slowed the actual tests down because
too much was happening. So, I created a separate signup test
that tests that flow.

I could not solidly pinpoint a reason why the tests sometimes
failed and sometimes didn't, but my guess is because generateTotpCode
was called before TOTP was even confirmed. Because remote tests
can take a significant amount of time (and in fact I saw this test
time out several times while running against latest), the TOTP
code may have been expired by time it was entered into the form.

The major change here is to generate the TOTP code when the form
should be filled out, not before.

Other changes are to make heavier use of helpers to reduce
boilerplate signin/signup code.

fixes #3121