### PR TITLE
chore(deps): Update the intern.js to 4.5.0

### DIFF
--- a/packages/fxa-content-server/package-lock.json
+++ b/packages/fxa-content-server/package-lock.json
@@ -1111,12 +1111,12 @@
             }
         },
         "@theintern/common": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/@theintern/common/-/common-0.1.4.tgz",
-            "integrity": "sha512-gkoL0S3nQJToKTcfTOHoxqBVChhCmQ3bgXS9a5iV32VSTmq7jK3FHSol7vJNRatbdL8/YvzQEXbbc+q8B62dLA==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@theintern/common/-/common-0.2.3.tgz",
+            "integrity": "sha512-91kL3C6USiNfumAm5m07HjGdc40IJaNzEczhcdW5T8fjsHVNg8ttVSXCzy5C9BM57WLevVjR5eHUNjEl4foGMQ==",
             "dev": true,
             "requires": {
-                "axios": "~0.18.0",
+                "axios": "~0.19.0",
                 "tslib": "~1.9.3"
             },
             "dependencies": {
@@ -1129,24 +1129,17 @@
             }
         },
         "@theintern/digdug": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.2.4.tgz",
-            "integrity": "sha512-hVsQ9YFFW8F675ITnNsCfrIMTOYf4JdhceHKx8O40r4xZImXPBnTGYHGh6djBV68ULxxv1dWyCI+1xa/dTjWdg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.3.0.tgz",
+            "integrity": "sha512-/pV38wCLadOUx5mtQ60ePiZ+vclFzburg0P8XMNFY0wuRwuhbHZ3jsVVWfHqeUIvGxrtI325MIkZ4xfMefWWeQ==",
             "dev": true,
             "requires": {
-                "@theintern/common": "~0.1.3",
+                "@theintern/common": "~0.2.3",
                 "command-exists": "~1.2.6",
                 "decompress": "~4.2.0",
-                "semver": "~5.5.0",
                 "tslib": "~1.9.3"
             },
             "dependencies": {
-                "semver": {
-                    "version": "5.5.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-                    "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
-                    "dev": true
-                },
                 "tslib": {
                     "version": "1.9.3",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
@@ -1156,13 +1149,13 @@
             }
         },
         "@theintern/leadfoot": {
-            "version": "2.2.12",
-            "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.2.12.tgz",
-            "integrity": "sha512-S6GvDXEVVOUG0YduPcfYF5FKWWvMM9CDNKGPU6uUc/hUHEWLVNO4c8K5KLsi1x91fSUvFGcdl8gnUhWcs51x0w==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.3.0.tgz",
+            "integrity": "sha512-OANCuu0dG2UJcxOgCcsO28iKXacXt1GAZ1tFAsHG83y5YkJ/N/lODepsQOVl6wpFRuF+5tyTdhhQ8/ZIFmfs0A==",
             "dev": true,
             "requires": {
-                "@theintern/common": "~0.1.3",
-                "jszip": "~3.1.5",
+                "@theintern/common": "~0.2.3",
+                "jszip": "~3.2.1",
                 "tslib": "~1.9.3"
             },
             "dependencies": {
@@ -1197,9 +1190,9 @@
             "dev": true
         },
         "@types/body-parser": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
-            "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
+            "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
             "dev": true,
             "requires": {
                 "@types/connect": "*",
@@ -1237,9 +1230,9 @@
             "dev": true
         },
         "@types/express": {
-            "version": "4.16.1",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
-            "integrity": "sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==",
+            "version": "4.17.1",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
+            "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
             "dev": true,
             "requires": {
                 "@types/body-parser": "*",
@@ -1248,9 +1241,9 @@
             }
         },
         "@types/express-serve-static-core": {
-            "version": "4.16.7",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
-            "integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
+            "version": "4.16.10",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.10.tgz",
+            "integrity": "sha512-gM6evDj0OvTILTRKilh9T5dTaGpv1oYiFcJAfgSejuMJgGJUsD9hKEU2lB4aiTNy4WwChxRnjfYFuBQsULzsJw==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -1264,9 +1257,9 @@
             "dev": true
         },
         "@types/istanbul-lib-instrument": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.2.tgz",
-            "integrity": "sha512-SWIpdKneXqThfrKIokt9dXSPeslS2NWcxhtr+/a2+N81aLyOMAsVTMmwaKuCoEahcI0FfhY3/79AR6Vilk9i8A==",
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.3.tgz",
+            "integrity": "sha512-bnWCOhyg4h/wAb0D2pwcD2e6JtK4Oh/7+gOgAS6bYi2hDn9jb7X08Afe2CbtzZQN6U0AnMpA91IPgw10HGgTpw==",
             "dev": true,
             "requires": {
                 "@types/babel-types": "*",
@@ -1292,9 +1285,9 @@
             }
         },
         "@types/istanbul-lib-source-maps": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
-            "integrity": "sha512-K0IvmTFbI2GjLG0O4AOLPV2hFItE5Bg/TY41IBZIThhLhYthJc3VjpZpM8/sIaIVtnQcX8b2k3muPDvsvhk+Fg==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
+            "integrity": "sha512-41eeNQ3Du3++LV0Hdz7m0UbeYMnShlJ7CkUOVy3tBeFwc0BE7chBs2Vqdx7xOzXBo2iRQfyiWBmqIZTbau3q+A==",
             "dev": true,
             "requires": {
                 "@types/istanbul-lib-coverage": "*",
@@ -1335,9 +1328,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "12.7.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
-            "integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==",
+            "version": "12.11.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.5.tgz",
+            "integrity": "sha512-LC8ALj/24PhByn39nr5jnTvpE7MujK8y7LQmV74kHYF5iQ0odCPkMH4IZNZw+cobKfSXqaC8GgegcbIsQpffdA==",
             "dev": true
         },
         "@types/range-parser": {
@@ -1347,9 +1340,9 @@
             "dev": true
         },
         "@types/serve-static": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
-            "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
+            "version": "1.13.3",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
+            "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
             "dev": true,
             "requires": {
                 "@types/express-serve-static-core": "*",
@@ -1736,12 +1729,12 @@
             }
         },
         "append-transform": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-            "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+            "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
             "dev": true,
             "requires": {
-                "default-require-extensions": "^1.0.0"
+                "default-require-extensions": "^2.0.0"
             }
         },
         "aproba": {
@@ -1863,12 +1856,6 @@
             "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
             "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
         },
-        "array-filter": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-            "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-            "dev": true
-        },
         "array-find-index": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -1883,18 +1870,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
             "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
-            "dev": true
-        },
-        "array-map": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-            "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-            "dev": true
-        },
-        "array-reduce": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-            "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
             "dev": true
         },
         "array-union": {
@@ -2083,9 +2058,9 @@
             "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
         },
         "axios": {
-            "version": "0.18.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-            "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+            "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
             "dev": true,
             "requires": {
                 "follow-redirects": "1.5.10",
@@ -2093,9 +2068,9 @@
             },
             "dependencies": {
                 "is-buffer": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-                    "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+                    "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
                     "dev": true
                 }
             }
@@ -3269,6 +3244,12 @@
                 }
             }
         },
+        "concurrent": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/concurrent/-/concurrent-0.3.2.tgz",
+            "integrity": "sha1-DqoAEaFXmMVjURKPIiR/biMX9Q4=",
+            "dev": true
+        },
         "connect-cachify": {
             "version": "0.0.17",
             "resolved": "https://registry.npmjs.org/connect-cachify/-/connect-cachify-0.0.17.tgz",
@@ -3933,12 +3914,20 @@
             "dev": true
         },
         "default-require-extensions": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-            "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+            "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
             "dev": true,
             "requires": {
-                "strip-bom": "^2.0.0"
+                "strip-bom": "^3.0.0"
+            },
+            "dependencies": {
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                }
             }
         },
         "define-properties": {
@@ -7308,106 +7297,103 @@
             }
         },
         "intern": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/intern/-/intern-4.4.3.tgz",
-            "integrity": "sha512-amrOqBKIJwlXestVRo42zk3Du54vjQtXEjPDt2PjhVIhin97/izFlAIpsyti8fENuHLa9UMkaReb7nHl6zP0Vg==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/intern/-/intern-4.5.0.tgz",
+            "integrity": "sha512-5qxu/ck4rdEW1rctVrLLJMwKt8PgDhzgVmuvYqH70evIwW4eK+6rvGpFmU0iuQMYvxiCEbt3uaahtKYRpQjgcg==",
             "dev": true,
             "requires": {
-                "@theintern/common": "~0.1.3",
-                "@theintern/digdug": "~2.2.3",
-                "@theintern/leadfoot": "~2.2.10",
+                "@theintern/common": "~0.2.3",
+                "@theintern/digdug": "~2.3.0",
+                "@theintern/leadfoot": "~2.3.0",
                 "@types/benchmark": "1.0.31",
                 "@types/chai": "4.1.7",
                 "@types/charm": "1.0.1",
-                "@types/express": "4.16.1",
-                "@types/istanbul-lib-coverage": "1.1.0",
-                "@types/istanbul-lib-instrument": "1.7.2",
-                "@types/istanbul-lib-report": "1.1.0",
-                "@types/istanbul-lib-source-maps": "1.2.1",
-                "@types/istanbul-reports": "1.1.0",
+                "@types/express": "~4.17.0",
+                "@types/istanbul-lib-coverage": "~2.0.1",
+                "@types/istanbul-lib-instrument": "~1.7.3",
+                "@types/istanbul-lib-report": "~1.1.1",
+                "@types/istanbul-lib-source-maps": "~1.2.2",
+                "@types/istanbul-reports": "~1.1.1",
                 "@types/ws": "6.0.1",
                 "benchmark": "~2.1.4",
-                "body-parser": "~1.18.3",
-                "chai": "~4.1.2",
+                "body-parser": "~1.19.0",
+                "chai": "~4.2.0",
                 "charm": "~1.0.2",
-                "diff": "~3.5.0",
-                "express": "~4.16.3",
-                "glob": "~7.1.1",
-                "http-errors": "~1.6.3",
-                "istanbul-lib-coverage": "~1.2.1",
-                "istanbul-lib-hook": "~1.2.2",
-                "istanbul-lib-instrument": "~1.10.2",
-                "istanbul-lib-report": "~1.1.5",
-                "istanbul-lib-source-maps": "~1.2.6",
-                "istanbul-reports": "~1.5.1",
+                "concurrent": "~0.3.2",
+                "diff": "~4.0.1",
+                "express": "~4.17.1",
+                "glob": "~7.1.4",
+                "http-errors": "~1.7.2",
+                "istanbul-lib-coverage": "~2.0.5",
+                "istanbul-lib-hook": "~2.0.7",
+                "istanbul-lib-instrument": "~3.3.0",
+                "istanbul-lib-report": "~2.0.8",
+                "istanbul-lib-source-maps": "~3.0.6",
+                "istanbul-reports": "~2.2.6",
                 "lodash": "~4.17.11",
-                "mime-types": "~2.1.19",
+                "mime-types": "~2.1.24",
                 "minimatch": "~3.0.4",
                 "platform": "~1.3.5",
-                "resolve": "~1.7.1",
+                "resolve": "~1.11.1",
                 "shell-quote": "~1.6.1",
                 "source-map": "~0.6.1",
-                "statuses": "~1.5.0",
                 "tslib": "~1.9.3",
-                "ws": "~5.1.1"
+                "ws": "~7.0.0"
             },
             "dependencies": {
-                "@types/istanbul-lib-coverage": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
-                    "integrity": "sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==",
-                    "dev": true
-                },
-                "@types/istanbul-lib-report": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.0.tgz",
-                    "integrity": "sha512-nW5QuzmMhr7fHPijtaGOemFFI8Ctrxb/dIXgouSlKmWT16RxWlGLEX/nGghIBOReKe9hPFZXoNh338nFQk2xcA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "*"
-                    }
-                },
-                "@types/istanbul-reports": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.0.tgz",
-                    "integrity": "sha512-wrJUtE1+HuaRz0Le7fc5l1nMTermRh6wlEvOdQPilseNScyYgQK8MdgDP2cf/X8+6e1dtsX/zP4W4kH/jyHvFw==",
-                    "dev": true,
-                    "requires": {
-                        "@types/istanbul-lib-coverage": "*",
-                        "@types/istanbul-lib-report": "*"
-                    }
-                },
                 "body-parser": {
-                    "version": "1.18.3",
-                    "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-                    "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+                    "version": "1.19.0",
+                    "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+                    "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
                     "dev": true,
                     "requires": {
-                        "bytes": "3.0.0",
+                        "bytes": "3.1.0",
                         "content-type": "~1.0.4",
                         "debug": "2.6.9",
                         "depd": "~1.1.2",
-                        "http-errors": "~1.6.3",
-                        "iconv-lite": "0.4.23",
+                        "http-errors": "1.7.2",
+                        "iconv-lite": "0.4.24",
                         "on-finished": "~2.3.0",
-                        "qs": "6.5.2",
-                        "raw-body": "2.3.3",
-                        "type-is": "~1.6.16"
+                        "qs": "6.7.0",
+                        "raw-body": "2.4.0",
+                        "type-is": "~1.6.17"
+                    },
+                    "dependencies": {
+                        "http-errors": {
+                            "version": "1.7.2",
+                            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+                            "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+                            "dev": true,
+                            "requires": {
+                                "depd": "~1.1.2",
+                                "inherits": "2.0.3",
+                                "setprototypeof": "1.1.1",
+                                "statuses": ">= 1.5.0 < 2",
+                                "toidentifier": "1.0.0"
+                            }
+                        }
                     }
                 },
-                "chai": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-                    "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+                "bytes": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+                    "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+                    "dev": true
+                },
+                "content-disposition": {
+                    "version": "0.5.3",
+                    "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+                    "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
                     "dev": true,
                     "requires": {
-                        "assertion-error": "^1.0.1",
-                        "check-error": "^1.0.1",
-                        "deep-eql": "^3.0.0",
-                        "get-func-name": "^2.0.0",
-                        "pathval": "^1.0.0",
-                        "type-detect": "^4.0.0"
+                        "safe-buffer": "5.1.2"
                     }
+                },
+                "cookie": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+                    "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+                    "dev": true
                 },
                 "debug": {
                     "version": "2.6.9",
@@ -7419,84 +7405,68 @@
                     }
                 },
                 "diff": {
-                    "version": "3.5.0",
-                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-                    "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+                    "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
                     "dev": true
                 },
                 "express": {
-                    "version": "4.16.4",
-                    "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-                    "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+                    "version": "4.17.1",
+                    "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+                    "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
                     "dev": true,
                     "requires": {
-                        "accepts": "~1.3.5",
+                        "accepts": "~1.3.7",
                         "array-flatten": "1.1.1",
-                        "body-parser": "1.18.3",
-                        "content-disposition": "0.5.2",
+                        "body-parser": "1.19.0",
+                        "content-disposition": "0.5.3",
                         "content-type": "~1.0.4",
-                        "cookie": "0.3.1",
+                        "cookie": "0.4.0",
                         "cookie-signature": "1.0.6",
                         "debug": "2.6.9",
                         "depd": "~1.1.2",
                         "encodeurl": "~1.0.2",
                         "escape-html": "~1.0.3",
                         "etag": "~1.8.1",
-                        "finalhandler": "1.1.1",
+                        "finalhandler": "~1.1.2",
                         "fresh": "0.5.2",
                         "merge-descriptors": "1.0.1",
                         "methods": "~1.1.2",
                         "on-finished": "~2.3.0",
-                        "parseurl": "~1.3.2",
+                        "parseurl": "~1.3.3",
                         "path-to-regexp": "0.1.7",
-                        "proxy-addr": "~2.0.4",
-                        "qs": "6.5.2",
-                        "range-parser": "~1.2.0",
+                        "proxy-addr": "~2.0.5",
+                        "qs": "6.7.0",
+                        "range-parser": "~1.2.1",
                         "safe-buffer": "5.1.2",
-                        "send": "0.16.2",
-                        "serve-static": "1.13.2",
-                        "setprototypeof": "1.1.0",
-                        "statuses": "~1.4.0",
-                        "type-is": "~1.6.16",
+                        "send": "0.17.1",
+                        "serve-static": "1.14.1",
+                        "setprototypeof": "1.1.1",
+                        "statuses": "~1.5.0",
+                        "type-is": "~1.6.18",
                         "utils-merge": "1.0.1",
                         "vary": "~1.1.2"
-                    },
-                    "dependencies": {
-                        "statuses": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-                            "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-                            "dev": true
-                        }
                     }
                 },
                 "finalhandler": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-                    "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+                    "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
                     "dev": true,
                     "requires": {
                         "debug": "2.6.9",
                         "encodeurl": "~1.0.2",
                         "escape-html": "~1.0.3",
                         "on-finished": "~2.3.0",
-                        "parseurl": "~1.3.2",
-                        "statuses": "~1.4.0",
+                        "parseurl": "~1.3.3",
+                        "statuses": "~1.5.0",
                         "unpipe": "~1.0.0"
-                    },
-                    "dependencies": {
-                        "statuses": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-                            "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-                            "dev": true
-                        }
                     }
                 },
                 "glob": {
-                    "version": "7.1.4",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-                    "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+                    "version": "7.1.5",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
+                    "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -7507,14 +7477,47 @@
                         "path-is-absolute": "^1.0.0"
                     }
                 },
+                "http-errors": {
+                    "version": "1.7.3",
+                    "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+                    "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
+                    "dev": true,
+                    "requires": {
+                        "depd": "~1.1.2",
+                        "inherits": "2.0.4",
+                        "setprototypeof": "1.1.1",
+                        "statuses": ">= 1.5.0 < 2",
+                        "toidentifier": "1.0.0"
+                    },
+                    "dependencies": {
+                        "inherits": {
+                            "version": "2.0.4",
+                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+                            "dev": true
+                        }
+                    }
+                },
                 "iconv-lite": {
-                    "version": "0.4.23",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-                    "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+                    "version": "0.4.24",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                     "dev": true,
                     "requires": {
                         "safer-buffer": ">= 2.1.2 < 3"
                     }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                },
+                "mime": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+                    "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+                    "dev": true
                 },
                 "ms": {
                     "version": "2.0.0",
@@ -7522,43 +7525,52 @@
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                     "dev": true
                 },
-                "platform": {
-                    "version": "1.3.5",
-                    "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
-                    "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
-                    "dev": true
-                },
                 "qs": {
-                    "version": "6.5.2",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+                    "version": "6.7.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+                    "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
                     "dev": true
                 },
                 "raw-body": {
-                    "version": "2.3.3",
-                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-                    "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+                    "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
                     "dev": true,
                     "requires": {
-                        "bytes": "3.0.0",
-                        "http-errors": "1.6.3",
-                        "iconv-lite": "0.4.23",
+                        "bytes": "3.1.0",
+                        "http-errors": "1.7.2",
+                        "iconv-lite": "0.4.24",
                         "unpipe": "1.0.0"
+                    },
+                    "dependencies": {
+                        "http-errors": {
+                            "version": "1.7.2",
+                            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+                            "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+                            "dev": true,
+                            "requires": {
+                                "depd": "~1.1.2",
+                                "inherits": "2.0.3",
+                                "setprototypeof": "1.1.1",
+                                "statuses": ">= 1.5.0 < 2",
+                                "toidentifier": "1.0.0"
+                            }
+                        }
                     }
                 },
                 "resolve": {
-                    "version": "1.7.1",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-                    "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+                    "version": "1.11.1",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+                    "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
                     "dev": true,
                     "requires": {
-                        "path-parse": "^1.0.5"
+                        "path-parse": "^1.0.6"
                     }
                 },
                 "send": {
-                    "version": "0.16.2",
-                    "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-                    "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+                    "version": "0.17.1",
+                    "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+                    "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
                     "dev": true,
                     "requires": {
                         "debug": "2.6.9",
@@ -7568,33 +7580,39 @@
                         "escape-html": "~1.0.3",
                         "etag": "~1.8.1",
                         "fresh": "0.5.2",
-                        "http-errors": "~1.6.2",
-                        "mime": "1.4.1",
-                        "ms": "2.0.0",
+                        "http-errors": "~1.7.2",
+                        "mime": "1.6.0",
+                        "ms": "2.1.1",
                         "on-finished": "~2.3.0",
-                        "range-parser": "~1.2.0",
-                        "statuses": "~1.4.0"
+                        "range-parser": "~1.2.1",
+                        "statuses": "~1.5.0"
                     },
                     "dependencies": {
-                        "statuses": {
-                            "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-                            "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+                        "ms": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                            "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                             "dev": true
                         }
                     }
                 },
                 "serve-static": {
-                    "version": "1.13.2",
-                    "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-                    "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+                    "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
                     "dev": true,
                     "requires": {
                         "encodeurl": "~1.0.2",
                         "escape-html": "~1.0.3",
-                        "parseurl": "~1.3.2",
-                        "send": "0.16.2"
+                        "parseurl": "~1.3.3",
+                        "send": "0.17.1"
                     }
+                },
+                "setprototypeof": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+                    "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+                    "dev": true
                 },
                 "source-map": {
                     "version": "0.6.1",
@@ -7906,101 +7924,93 @@
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "istanbul-lib-coverage": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
-            "integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+            "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
             "dev": true
         },
         "istanbul-lib-hook": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
-            "integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz",
+            "integrity": "sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==",
             "dev": true,
             "requires": {
-                "append-transform": "^0.4.0"
+                "append-transform": "^1.0.0"
             }
         },
         "istanbul-lib-instrument": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
-            "integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+            "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
             "dev": true,
             "requires": {
-                "babel-generator": "^6.18.0",
-                "babel-template": "^6.16.0",
-                "babel-traverse": "^6.18.0",
-                "babel-types": "^6.18.0",
-                "babylon": "^6.18.0",
-                "istanbul-lib-coverage": "^1.2.1",
-                "semver": "^5.3.0"
+                "@babel/generator": "^7.4.0",
+                "@babel/parser": "^7.4.3",
+                "@babel/template": "^7.4.0",
+                "@babel/traverse": "^7.4.3",
+                "@babel/types": "^7.4.0",
+                "istanbul-lib-coverage": "^2.0.5",
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
             }
         },
         "istanbul-lib-report": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
-            "integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
+            "version": "2.0.8",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+            "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
             "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "^1.2.1",
-                "mkdirp": "^0.5.1",
-                "path-parse": "^1.0.5",
-                "supports-color": "^3.1.2"
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "supports-color": "^6.1.0"
             },
             "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
                 "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^1.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
         },
         "istanbul-lib-source-maps": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
-            "integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+            "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
             "dev": true,
             "requires": {
-                "debug": "^3.1.0",
-                "istanbul-lib-coverage": "^1.2.1",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.6.1",
-                "source-map": "^0.5.3"
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "rimraf": "^2.6.3",
+                "source-map": "^0.6.1"
             },
             "dependencies": {
-                "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
                 "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
                 }
             }
         },
         "istanbul-reports": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
-            "integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
+            "version": "2.2.6",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+            "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
             "dev": true,
             "requires": {
-                "handlebars": "^4.0.3"
+                "handlebars": "^4.1.2"
             }
         },
         "jetpack-id": {
@@ -8223,56 +8233,15 @@
             }
         },
         "jszip": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
-            "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.2.2.tgz",
+            "integrity": "sha512-NmKajvAFQpbg3taXQXr/ccS2wcucR1AZ+NtyWp2Nq7HHVsXhcJFR8p0Baf32C2yVvBylFWVeKf+WI2AnvlPhpA==",
             "dev": true,
             "requires": {
-                "core-js": "~2.3.0",
-                "es6-promise": "~3.0.2",
-                "lie": "~3.1.0",
+                "lie": "~3.3.0",
                 "pako": "~1.0.2",
-                "readable-stream": "~2.0.6"
-            },
-            "dependencies": {
-                "core-js": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
-                    "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
-                    "dev": true
-                },
-                "es6-promise": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-                    "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
-                    "dev": true
-                },
-                "process-nextick-args": {
-                    "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "2.0.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~1.0.6",
-                        "string_decoder": "~0.10.x",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                }
+                "readable-stream": "~2.3.6",
+                "set-immediate-shim": "~1.0.1"
             }
         },
         "just-extend": {
@@ -8324,9 +8293,9 @@
             }
         },
         "lie": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-            "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
             "dev": true,
             "requires": {
                 "immediate": "~3.0.5"
@@ -9856,9 +9825,9 @@
             }
         },
         "platform": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz",
-            "integrity": "sha1-bw+xftqqSPIUQrOpdcBjEw8cPr0=",
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+            "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
             "dev": true
         },
         "plist": {
@@ -11579,6 +11548,12 @@
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
+        "set-immediate-shim": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+            "dev": true
+        },
         "set-value": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -11650,16 +11625,10 @@
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "shell-quote": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
-            "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-            "dev": true,
-            "requires": {
-                "array-filter": "~0.0.0",
-                "array-map": "~0.0.0",
-                "array-reduce": "~0.0.0",
-                "jsonify": "~0.0.0"
-            }
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.3.tgz",
+            "integrity": "sha512-KvITSOPOP542Mv4lS5Cx6/qgya20Hyk+JJUdfRfikzyV6iKPszdz5TrssURXRghmi6Z9y9gATRvxJ69zD7wydQ==",
+            "dev": true
         },
         "shelljs": {
             "version": "0.6.1",
@@ -12365,6 +12334,12 @@
                 "repeat-string": "^1.6.1"
             }
         },
+        "toidentifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+            "dev": true
+        },
         "token-stream": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
@@ -12631,9 +12606,9 @@
             },
             "dependencies": {
                 "buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-                    "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+                    "version": "5.4.3",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+                    "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
                     "dev": true,
                     "requires": {
                         "base64-js": "^1.0.2",
@@ -13218,12 +13193,12 @@
             }
         },
         "ws": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
-            "integrity": "sha512-bOusvpCb09TOBLbpMKszd45WKC2KPtxiyiHanv+H2DE3Az+1db5a/L7sVJZVDPUC1Br8f0SKRr1KjLpD1U/IAw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.1.tgz",
+            "integrity": "sha512-ILHfMbuqLJvnSgYXLgy4kMntroJpe8hT41dOVWM8bxRuw6TK4mgMp9VJUNsZTEc5Bh+Mbs0DJT4M0N+wBG9l9A==",
             "dev": true,
             "requires": {
-                "async-limiter": "~1.0.0"
+                "async-limiter": "^1.0.0"
             }
         },
         "x-xss-protection": {

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -148,7 +148,7 @@
         "grunt-todo": "0.5.0",
         "htmlparser2": "3.9.0",
         "install": "0.12.1",
-        "intern": "^4.4.3",
+        "intern": "^4.5.0",
         "jsqr": "1.2.0",
         "otplib": "7.1.0",
         "prettier": "^1.18.2",

--- a/packages/fxa-content-server/tests/intern.js
+++ b/packages/fxa-content-server/tests/intern.js
@@ -72,7 +72,12 @@ const config = {
   serverUrl: 'http://127.0.0.1:9090',
   socketPort: 9077,
   tunnelOptions: {
-    drivers: ['firefox'],
+    drivers: [
+      {
+        name: 'firefox',
+        version: '0.26.0',
+      },
+    ],
   },
 
   testProductId,


### PR DESCRIPTION
Updates the intern to 4.5.0, and geckodriver to 0.26.0, both
of which are the latest.

The Geckodriver 0.26.0 CHANGELOG has this:

> Connection attempts to Firefox made more reliable
>
> geckodriver now waits for the Marionette handshake before assuming
the session has been established. This should improve reliability
in creating new WebDriver sessions.

Hopefully that helps to fix the NoSuchDriver failures we've been seeing.

issue #2877
issue #3123