### PR TITLE
fix(metrics): Add connect another device screen metrics

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -92,6 +92,11 @@ const EVENTS = {
     group: GROUPS.registration,
     event: 'signup_code_submit',
   },
+
+  'screen.connect-another-device': {
+    group: GROUPS.connectDevice,
+    event: 'view',
+  },
 };
 
 const VIEW_ENGAGE_SUBMIT_EVENT_GROUPS = {

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -1882,5 +1882,29 @@ registerSuite('amplitude', {
       );
       assert.isUndefined(logger.info.args[0][1].user_properties.sync_engines);
     },
+
+    'screen.connect-another-device': () => {
+      amplitude(
+        {
+          time: 'a',
+          type: 'screen.connect-another-device',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: 'b',
+          flowId: 'c',
+          uid: 'd',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_connect_device - view');
+    },
   },
 });


### PR DESCRIPTION
Partly fixes #3059 

When a user creates an account via a link, we emitted the `fxa_connect_device - view` when they open the link. When using a code, this didn't get emitted. This updates the metrics lib to explicitly emit this event regardless of how the user account was created.

Updated logs:
```
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_email_first - submit","time":1571945090659,"device_id":"dbe8e7f0a1bf42c29e245004ec21dc16","session_id":1571945073224,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"70c4595a49f81727657c373cda48d89f5721ee895fd9bfe80bbed7dd1351a6fd","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["signup_code_treatment","email_first_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - view","time":1571945090742,"device_id":"dbe8e7f0a1bf42c29e245004ec21dc16","session_id":1571945073224,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"70c4595a49f81727657c373cda48d89f5721ee895fd9bfe80bbed7dd1351a6fd","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["signup_code_treatment","email_first_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - engage","time":1571945091901,"device_id":"dbe8e7f0a1bf42c29e245004ec21dc16","session_id":1571945073224,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"70c4595a49f81727657c373cda48d89f5721ee895fd9bfe80bbed7dd1351a6fd","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["signup_code_treatment","email_first_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - submit","time":1571945100942,"device_id":"dbe8e7f0a1bf42c29e245004ec21dc16","session_id":1571945073224,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"70c4595a49f81727657c373cda48d89f5721ee895fd9bfe80bbed7dd1351a6fd","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["signup_code_treatment","email_first_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - cwts_view","time":1571945101654,"device_id":"dbe8e7f0a1bf42c29e245004ec21dc16","session_id":1571945073224,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"70c4595a49f81727657c373cda48d89f5721ee895fd9bfe80bbed7dd1351a6fd","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["signup_code_treatment","email_first_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - cwts_submit","time":1571945102889,"device_id":"dbe8e7f0a1bf42c29e245004ec21dc16","session_id":1571945073224,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"70c4595a49f81727657c373cda48d89f5721ee895fd9bfe80bbed7dd1351a6fd","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["signup_code_treatment","email_first_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - signup_code_view","time":1571945102904,"device_id":"dbe8e7f0a1bf42c29e245004ec21dc16","session_id":1571945073224,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"70c4595a49f81727657c373cda48d89f5721ee895fd9bfe80bbed7dd1351a6fd","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["signup_code_treatment","email_first_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - signup_code_engage","time":1571945110498,"device_id":"dbe8e7f0a1bf42c29e245004ec21dc16","session_id":1571945073224,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"70c4595a49f81727657c373cda48d89f5721ee895fd9bfe80bbed7dd1351a6fd","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["signup_code_treatment","email_first_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_reg - signup_code_submit","time":1571945110890,"device_id":"dbe8e7f0a1bf42c29e245004ec21dc16","session_id":1571945073224,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"70c4595a49f81727657c373cda48d89f5721ee895fd9bfe80bbed7dd1351a6fd","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync","experiments":["signup_code_treatment","email_first_treatment","token_code_treatment_code"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_connect_device - view","time":1571945140520,"device_id":"de093747a0ae49559120d0d7f8724de3","session_id":1571945139903,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync","connect_device_flow":"sms"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"d9b4a6e0f6d18c87a44ab987a7247ed2f4cddf5793ed40147fdb38aa6cd4de91","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync"}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_connect_device - engage","time":1571945142507,"device_id":"de093747a0ae49559120d0d7f8724de3","session_id":1571945139903,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync","connect_device_flow":"sms"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"d9b4a6e0f6d18c87a44ab987a7247ed2f4cddf5793ed40147fdb38aa6cd4de91","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync"}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_connect_device - submit","time":1571945147386,"device_id":"de093747a0ae49559120d0d7f8724de3","session_id":1571945139903,"app_version":"148","language":"en","os_name":"Mac OS X","os_version":"10.14","event_properties":{"service":"sync","connect_device_flow":"sms"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"d9b4a6e0f6d18c87a44ab987a7247ed2f4cddf5793ed40147fdb38aa6cd4de91","ua_browser":"Firefox","ua_version":"70.0","$append":{"fxa_services_used":"sync"}}}
```

It would be nice to get this on train-148, but targeted against master for the time being.

cc @davismtl @irrationalagent 