### PR TITLE
feat(auth-server): capture req data to Sentry

### DIFF
--- a/packages/fxa-auth-server/bin/profile_server_messaging.js
+++ b/packages/fxa-auth-server/bin/profile_server_messaging.js
@@ -4,11 +4,6 @@
 
 'use strict';
 
-// This MUST be the first require in the program.
-// Only `require()` the newrelic module if explicity enabled.
-// If required, modules will be instrumented.
-require('../lib/newrelic')();
-
 const config = require('../config').getProperties();
 const StatsD = require('hot-shots');
 const statsd = new StatsD(config.statsd);

--- a/packages/fxa-auth-server/lib/backendService.js
+++ b/packages/fxa-auth-server/lib/backendService.js
@@ -182,7 +182,10 @@ module.exports = function createBackendServiceAPI(
           throw err;
         } else {
           log.error(`${fullMethodName}.1`, { params, query, payload, err });
-          throw error.backendServiceFailure(serviceName, methodName);
+          throw error.backendServiceFailure(serviceName, methodName, {
+            method,
+            path,
+          });
         }
       }
     }

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -1209,7 +1209,22 @@ AppError.invalidOrExpiredOtpCode = () => {
   });
 };
 
-AppError.backendServiceFailure = (service, operation) => {
+AppError.backendServiceFailure = (service, operation, extra) => {
+  if (extra) {
+    return new AppError(
+      {
+        code: 500,
+        error: 'Internal Server Error',
+        errno: ERRNO.BACKEND_SERVICE_FAILURE,
+        message: 'A backend service request failed.',
+      },
+      {
+        service,
+        operation,
+        ...extra,
+      }
+    );
+  }
   return new AppError(
     {
       code: 500,

--- a/packages/fxa-auth-server/lib/sentry.js
+++ b/packages/fxa-auth-server/lib/sentry.js
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const Hoek = require('@hapi/hoek');
+const Sentry = require('@sentry/node');
+
+const getVersion = require('./version').getVersion;
+
+// Matches uid, session, oauth and other common tokens which we would
+// prefer not to include in Sentry reports.
+const TOKENREGEX = /[a-fA-F0-9]{32,}/gi;
+const FILTERED = '[Filtered]';
+const URIENCODEDFILTERED = encodeURIComponent(FILTERED);
+
+/**
+ * Filters all of an objects string properties to remove tokens.
+ *
+ * @param {Object} obj Object to filter values on
+ */
+function filterObject(obj) {
+  if (typeof obj === 'object') {
+    for (const [key, value] of Object.entries(obj)) {
+      if (typeof value === 'string') {
+        obj[key] = value.replace(TOKENREGEX, FILTERED);
+      }
+    }
+  }
+  return obj;
+}
+
+/**
+ * Filter a sentry event for PII in addition to the default filters.
+ *
+ * Current replacements:
+ *   - A 32-char hex string that typically is a FxA user-id.
+ *
+ * Data Removed:
+ *   - Request body.
+ *
+ * @param {Sentry.Event} event
+ */
+function filterSentryEvent(event, hint) {
+  if (event.breadcrumbs) {
+    for (const bc of event.breadcrumbs) {
+      if (bc.message) {
+        bc.message = bc.message.replace(TOKENREGEX, FILTERED);
+      }
+      if (bc.data) {
+        bc.data = filterObject(bc.data);
+      }
+    }
+  }
+  if (event.request) {
+    if (event.request.url) {
+      event.request.url = event.request.url.replace(TOKENREGEX, FILTERED);
+    }
+    if (event.request.query_string) {
+      event.request.query_string = event.request.query_string.replace(
+        TOKENREGEX,
+        URIENCODEDFILTERED
+      );
+    }
+    if (event.request.headers) {
+      event.request.headers = filterObject(event.request.headers);
+    }
+    if (event.request.data) {
+      // Remove request data entirely
+      delete event.request.data;
+    }
+  }
+  if (event.tags && event.tags.url) {
+    event.tags.url = event.request.url.replace(TOKENREGEX, FILTERED);
+  }
+  return event;
+}
+
+async function configureSentry(server, config) {
+  const sentryDsn = config.sentryDsn;
+  const versionData = await getVersion();
+  if (sentryDsn) {
+    Sentry.init({
+      dsn: sentryDsn,
+      release: versionData.version,
+      beforeSend(event, hint) {
+        return filterSentryEvent(event, hint);
+      },
+    });
+    Sentry.configureScope(scope => {
+      scope.setTag('process', 'key_server');
+    });
+
+    // Attach a new Sentry scope to the request for breadcrumbs/tags/extras
+    server.ext({
+      type: 'onRequest',
+      method(request, h) {
+        request.sentryScope = new Sentry.Scope();
+        return h.continue;
+      },
+    });
+
+    // Sentry handler for hapi errors
+    server.events.on(
+      { name: 'request', channels: 'error' },
+      (request, event) => {
+        const err = (event && event.error) || null;
+        let exception = '';
+        if (err && err.stack) {
+          try {
+            exception = err.stack.split('\n')[0];
+          } catch (e) {
+            // ignore bad stack frames
+          }
+        }
+
+        Sentry.withScope(scope => {
+          scope.addEventProcessor(_sentryEvent => {
+            const sentryEvent = Sentry.Handlers.parseRequest(
+              _sentryEvent,
+              request.raw.req
+            );
+            sentryEvent.level = 'error';
+            return sentryEvent;
+          });
+          scope.setExtra('exception', exception);
+
+          // Merge the request scope into the temp scope
+          Hoek.merge(scope, request.sentryScope);
+          Sentry.captureException(err);
+        });
+      }
+    );
+  }
+}
+
+module.exports = { configureSentry };

--- a/packages/fxa-auth-server/lib/version.js
+++ b/packages/fxa-auth-server/lib/version.js
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const path = require('path');
+const cp = require('child_process');
+const promisify = require('util').promisify;
+
+const version = require('../package.json').version;
+let commitHash;
+let sourceRepo;
+
+const UNKNOWN = 'unknown';
+
+const processExec = promisify(cp.exec);
+
+// Production and stage provide './config/version.json'. Try to load this at
+// startup; punt on failure. For dev environments, we'll get this from `git`
+// for dev environments.
+try {
+  const versionJson = path.join(__dirname, '..', 'config', 'version.json');
+  const info = require(versionJson);
+  commitHash = info.version.hash;
+  sourceRepo = info.version.source;
+} catch (e) {
+  /* ignore */
+}
+
+async function getVersion() {
+  // If we already have the commitHash, return it
+  if (commitHash) {
+    return { version, commit: commitHash, source: sourceRepo };
+  }
+
+  // ignore errors and default to 'unknown' if not found
+  const gitDir = path.resolve(__dirname, '..', '..', '..', '.git');
+
+  const { stdout: stdout1, stderr: stderr1 } = await processExec(
+    'git rev-parse HEAD',
+    {
+      cwd: gitDir,
+    }
+  );
+  if (stderr1) {
+    throw new Error(stderr1);
+  }
+  const configPath = path.join(gitDir, 'config');
+  const cmd = 'git config --get remote.origin.url';
+
+  const { stdout: stdout2, stderr: stderr2 } = await processExec(cmd, {
+    env: { GIT_CONFIG: configPath, PATH: process.env.PATH },
+  });
+  if (stderr2) {
+    throw new Error(stderr2);
+  }
+  commitHash = (stdout1 && stdout1.trim()) || UNKNOWN;
+  sourceRepo = (stdout2 && stdout2.trim()) || UNKNOWN;
+  return { version, commit: commitHash, source: sourceRepo };
+}
+
+module.exports = { getVersion };

--- a/packages/fxa-auth-server/package-lock.json
+++ b/packages/fxa-auth-server/package-lock.json
@@ -171,6 +171,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@hapi/hoek": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.3.2.tgz",
+      "integrity": "sha512-NP5SG4bzix+EtSMtcudp8TvI0lB46mXNo8uFpTDw6tqxGx4z5yx+giIunEFA0Z7oUO4DuWrOJV9xqR2tJVEdyA=="
+    },
     "@sentry/core": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.7.1.tgz",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -36,6 +36,7 @@
   "author": "Mozilla (https://mozilla.org/)",
   "readmeFilename": "README.md",
   "dependencies": {
+    "@hapi/hoek": "^8.3.2",
     "@sentry/node": "^5.7.1",
     "ajv": "4.1.7",
     "aws-sdk": "2.77.0",


### PR DESCRIPTION
Because:

* Default Sentry did not annotate stack traces with useful data
  such as the release information, request that was in flight when the
  traceback occurred, etc.
* Had no way to leave Sentry breadcrumbs for the current request
  scope.
* Nested the getVersion within a function making it inaccessible to
  other callers.

This commit:

* Add's Hapi request data to the Sentry report.
* Add's a Sentry.Scope object to the Hapi request object for use by
  other code to add bread-crumbs, tags, etc.
* Refactors the getVersion to its own function so that other calling
  code (such as Sentry.init) can report the release data.

Closes #3110