### PR TITLE
fix(logging): Log excluded amplitude events under a different name.

### DIFF
--- a/packages/fxa-auth-server/fxa-oauth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/lib/metrics/amplitude.js
@@ -30,10 +30,8 @@ const EVENTS = {
 
 const FUZZY_EVENTS = new Map([]);
 
-function sane(event) {
-  if (!event) {
-    return false;
-  }
+function shouldExclude(event) {
+  // Exclude certain high-volume clients from logging events into amplitude.
   const props = event.event_properties;
   const excluded =
     (props.service === 'fennec-stage' &&
@@ -42,7 +40,7 @@ function sane(event) {
       props.oauth_client_id === '5882386c6d801776') ||
     (props.service === 'firefox-ios' &&
       props.oauth_client_id === '1b1a3e44c54fbb58');
-  return !excluded;
+  return excluded;
 }
 
 module.exports = (log, config) => {
@@ -79,8 +77,12 @@ module.exports = (log, config) => {
       eventData
     );
 
-    if (sane(amplitudeEvent)) {
-      log.info('amplitudeEvent', amplitudeEvent);
+    if (amplitudeEvent) {
+      if (shouldExclude(amplitudeEvent)) {
+        log.info('excludedAmplitudeEvent', amplitudeEvent);
+      } else {
+        log.info('amplitudeEvent', amplitudeEvent);
+      }
     }
   };
 };

--- a/packages/fxa-auth-server/fxa-oauth-server/test/metrics/amplitude.js
+++ b/packages/fxa-auth-server/fxa-oauth-server/test/metrics/amplitude.js
@@ -160,13 +160,16 @@ describe('metrics/amplitude', () => {
     });
 
     describe('service filter', () => {
-      it('does not log a blocked service', () => {
+      it('excludes events from a blocked service', () => {
         amplitude('token.created', {
           service: '3332a18d142636cb',
           uid: 'blee',
         });
 
-        assert.strictEqual(log.info.callCount, 0);
+        assert.strictEqual(log.info.callCount, 1);
+
+        const args = log.info.args[0];
+        assert.strictEqual(args[0], 'excludedAmplitudeEvent');
       });
     });
   });


### PR DESCRIPTION
#2996 had the desired effect of avoiding sending an overwhelming deluge of oauth activity event into amplitude, but it had the side-effect of making those events unavailable for analysis in other tools such as BigQuery. In particular, they're no longer available for [export to CDP](https://bugzilla.mozilla.org/show_bug.cgi?id=1573359).

Would it be OK if we continue to log them, but under a different name so that they don't get sent off to amplitude?

Fixes #3160.

---

Trying out @bbangert's suggested format for commit messages:

Because:

* It's useful to analyse oauth activity events in BigQuery even
  if they're not available in amplitude.
* We need to provide an accurate summary of what services a user
  has been active on for export the Customer Data Platform.
* But we don't want to overwhelm amplitude with oauth activity events.

This patch:

* Restores logging of oauth activity events for all clients, even
  the really heavy ones like Firefox Desktop.
* But writes them out under a different event name, so they show up
  in raw log analysis but don't get exported to amplitude.