### PR TITLE
chore(payments): fix #2812 - Add generic error message for 'card_error' types from Stripe

### DIFF
--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -35,6 +35,8 @@ let errorMessageIndex: { [key: string]: string } = {
   duplicate_transaction:
     'Hmm. Looks like an identical transaction was just sent. Check your payment history.',
   coupon_expired: 'It looks like that promo code has expired.',
+  card_error:
+    'Your transaction could not be processed. Please verify your credit card information and try again.',
   // todo: handle "parameters_exclusive": "Your already subscribed to _product_"
 };
 


### PR DESCRIPTION
fix for #2812 

None of the [test cards](https://stripe.com/docs/testing#cards) I tried using would actually decline for me in dev.

We're currently checking for only `.type` on `createToken` errors. We may want to take into account the error `code`s if we want to be more specific with messaging, but this message provided by @johngruen seems generic enough for `card_error`s and prevents our `BASIC_ERROR` message from showing instead.