### PR TITLE
feat(auth-server): add typescript checking capability

### DIFF
--- a/packages/fxa-auth-server/lib/sentry.js
+++ b/packages/fxa-auth-server/lib/sentry.js
@@ -121,7 +121,7 @@ async function configureSentry(server, config) {
               _sentryEvent,
               request.raw.req
             );
-            sentryEvent.level = 'error';
+            sentryEvent.level = Sentry.Severity.Error;
             return sentryEvent;
           });
           scope.setExtra('exception', exception);

--- a/packages/fxa-auth-server/package-lock.json
+++ b/packages/fxa-auth-server/package-lock.json
@@ -281,6 +281,167 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/boom": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@types/boom/-/boom-7.3.0.tgz",
+      "integrity": "sha512-PH7bfkt1nu4pnlxz+Ws+wwJJF1HE12W3ia+Iace2JT7q56DLH3hbyjOJyNHJYRxk3PkKaC36fHfHKyeG1rMgCA==",
+      "dev": true
+    },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
+    },
+    "@types/catbox": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@types/catbox/-/catbox-10.0.6.tgz",
+      "integrity": "sha512-qS0VHlL6eBUUoUeBnI/ASCffoniS62zdV6IUtLSIjGKmRhZNawotaOMsTYivZOTZVktfe9koAJkD9XFac7tEEg==",
+      "dev": true
+    },
+    "@types/chai": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.4.tgz",
+      "integrity": "sha512-7qvf9F9tMTzo0akeswHPGqgUx/gIaJqrOEET/FCD8CFRkSUHlygQiM5yB6OvjrtdxBVLSyw7COJubsFYs0683g==",
+      "dev": true
+    },
+    "@types/convict": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@types/convict/-/convict-4.2.1.tgz",
+      "integrity": "sha512-2cd51m3i0yeY1i3dKxcqJKeS5Q4jZnjP37OseoNeIX1OM0AhmGPuuYmwJ9OqtsU35YrREQxdb2VeX5sM3cwGMQ==",
+      "dev": true
+    },
+    "@types/hapi": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/@types/hapi/-/hapi-18.0.2.tgz",
+      "integrity": "sha512-I3THPpOY0G0bXNLzyaqUzMIbqPrci21C1Vqlnek348SJq2Gp7TLSnQbwOb+v/xunxCTzY3o2fV3h7uffL3Ln0w==",
+      "dev": true,
+      "requires": {
+        "@types/boom": "*",
+        "@types/catbox": "*",
+        "@types/iron": "*",
+        "@types/joi": "*",
+        "@types/mimos": "*",
+        "@types/node": "*",
+        "@types/podium": "*",
+        "@types/shot": "*"
+      }
+    },
+    "@types/iron": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/iron/-/iron-5.0.1.tgz",
+      "integrity": "sha512-Ng5BkVGPt7Tw9k1OJ6qYwuD9+dmnWgActmsnnrdvs4075N8V2go1f6Pz8omG3q5rbHjXN6yzzZDYo3JOgAE/Ug==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/joi": {
+      "version": "14.3.3",
+      "resolved": "https://registry.npmjs.org/@types/joi/-/joi-14.3.3.tgz",
+      "integrity": "sha512-6gAT/UkIzYb7zZulAbcof3lFxpiD5EI6xBeTvkL1wYN12pnFQ+y/+xl9BvnVgxkmaIDN89xWhGZLD9CvuOtZ9g==",
+      "dev": true
+    },
+    "@types/jsonwebtoken": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.3.5.tgz",
+      "integrity": "sha512-VGM1gb+LwsQ5EPevvbvdnKncajBdYqNcrvixBif1BsiDQiSF1q+j4bBTvKC6Bt9n2kqNSx+yNTY2TVJ360E7EQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/jws": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/jws/-/jws-3.2.0.tgz",
+      "integrity": "sha512-2s6isKtNTfbfeP/VtvdB9JXE1LkFXndO2AjQ2f+nvTqwL8bxK1s9qxmymwklCpNthJG16dwvpsBjKE14Yc/pbA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/mime-db": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.27.0.tgz",
+      "integrity": "sha1-m8AUof0f30dknBpUxt15ZrgoR5I=",
+      "dev": true
+    },
+    "@types/mimos": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mimos/-/mimos-3.0.1.tgz",
+      "integrity": "sha512-MATIRH4VMIJki8lcYUZdNQEHuAG7iQ1FWwoLgxV+4fUOly2xZYdhHtGgvQyWiTeJqq2tZbE0nOOgZD6pR0FpNQ==",
+      "dev": true,
+      "requires": {
+        "@types/mime-db": "*"
+      }
+    },
+    "@types/mocha": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+      "dev": true
+    },
+    "@types/nock": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@types/nock/-/nock-11.1.0.tgz",
+      "integrity": "sha512-jI/ewavBQ7X5178262JQR0ewicPAcJhXS/iFaNJl0VHLfyosZ/kwSrsa6VNQNSO8i9d8SqdRgOtZSOKJ/+iNMw==",
+      "dev": true,
+      "requires": {
+        "nock": "*"
+      }
+    },
+    "@types/node": {
+      "version": "12.11.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.7.tgz",
+      "integrity": "sha512-JNbGaHFCLwgHn/iCckiGSOZ1XYHsKFwREtzPwSGCVld1SGhOlmZw2D4ZI94HQCrBHbADzW9m4LER/8olJTRGHA==",
+      "dev": true
+    },
+    "@types/podium": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/podium/-/podium-1.0.0.tgz",
+      "integrity": "sha1-v6ohUb4rHWEJzGn3+qnawsujuyA=",
+      "dev": true
+    },
+    "@types/request": {
+      "version": "2.48.3",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.3.tgz",
+      "integrity": "sha512-3Wo2jNYwqgXcIz/rrq18AdOZUQB8cQ34CXZo+LUwPJNpvRAL86+Kc2wwI8mqpz9Cr1V+enIox5v+WZhy/p3h8w==",
+      "dev": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@types/shot": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/shot/-/shot-4.0.0.tgz",
+      "integrity": "sha512-Xv+n8yfccuicMlwBY58K5PVVNtXRm7uDzcwwmCarBxMP+XxGfnh1BI06YiVAsPbTAzcnYsrzpoS5QHeyV7LS8A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -5897,6 +6058,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
       "dev": true
     },
     "uap-core": {

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -92,6 +92,16 @@
     "web-push": "3.3.0"
   },
   "devDependencies": {
+    "@types/chai": "^4.2.4",
+    "@types/convict": "^4.2.1",
+    "@types/hapi": "^18.0.2",
+    "@types/joi": "^14.3.3",
+    "@types/jsonwebtoken": "^8.3.5",
+    "@types/jws": "^3.2.0",
+    "@types/mocha": "^5.2.7",
+    "@types/nock": "^11.1.0",
+    "@types/node": "^12.11.7",
+    "@types/request": "^2.48.3",
     "acorn": "^5.7.3",
     "audit-filter": "^0.5.0",
     "chai": "4.1.2",
@@ -122,6 +132,7 @@
     "simplesmtp": "0.3.35",
     "sinon": "7.0.0",
     "sjcl": "1.0.6",
+    "typescript": "^3.6.4",
     "ws": "5.2.2"
   }
 }

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -253,7 +253,7 @@ module.exports = config => {
             c.authAt = data.authAt;
             c.verified = data.verified;
             c.verificationReason = data.verificationReason;
-            c.verificationMetho = data.verificationMethod;
+            c.verificationMethod = data.verificationMethod;
           });
         }
       })

--- a/packages/fxa-auth-server/tsconfig.json
+++ b/packages/fxa-auth-server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "target": "esnext",
+    "module": "commonjs",
+    "resolveJsonModule": true,
+    "strict": false
+    // Turn these on to find a few dozen functions that don't return a value
+    // "noImplicitReturns": true,
+    // "noFallthroughCasesInSwitch": true
+  },
+  "exclude": ["test/**", "fxa-oauth-server/test/**"]
+}


### PR DESCRIPTION
Because:

* Javascript is prone to a variety of type errors.

This commit:

* Allows TypeScript checking of Javascript.