### PR TITLE
fix(tests): mock version value for Amplitude test

### DIFF
--- a/packages/fxa-payments-server/server/lib/amplitude.test.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.test.js
@@ -22,6 +22,7 @@ const mocks = {
     type: 'foo.bar.baz',
   },
   data: {
+    version: '148.8',
     deviceId: '0123456789abcdef0123456789abcdef',
     flowBeginTime: 1570000000000,
     flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',


### PR DESCRIPTION
Fix a server test for Amplitude on payments where the version value is
not mocked.

Fixes #3149

@mozilla/fxa-devs r?