### PR TITLE
fix(browserid): Let clients specify service=${client_id} in /certificate/sign

### DIFF
--- a/packages/fxa-auth-server/lib/routes/sign.js
+++ b/packages/fxa-auth-server/lib/routes/sign.js
@@ -22,7 +22,7 @@ module.exports = (log, signer, db, domain, devices) => {
         },
         validate: {
           query: {
-            service: validators.service.valid('sync').optional(),
+            service: validators.service.optional(),
           },
           payload: {
             publicKey: isA
@@ -54,8 +54,9 @@ module.exports = (log, signer, db, domain, devices) => {
         const sessionToken = request.auth.credentials;
         const publicKey = request.payload.publicKey;
         const duration = request.payload.duration;
-        // This is a legacy endpoint that's only used by clients connected to sync,
-        // so always set `service=sync` for metrics logging purposes.
+        // This is a legacy endpoint that's typically only used by
+        // clients connected to sync, so assume `service=sync` for
+        // metrics logging purposes unless we're told otherwise.
         if (!request.query.service) {
           request.query.service = 'sync';
         }
@@ -96,7 +97,7 @@ module.exports = (log, signer, db, domain, devices) => {
         if (sessionToken.deviceId) {
           deviceId = sessionToken.deviceId;
         } else {
-          // Synthesize a device record for Sync sessions that don't already have one.
+          // Synthesize a device record for browser sessions that don't already have one.
           // Include the UA info so that we can synthesize a device name
           // for any push notifications.
           const deviceInfo = {

--- a/packages/fxa-auth-server/test/local/routes/sign.js
+++ b/packages/fxa-auth-server/test/local/routes/sign.js
@@ -220,6 +220,34 @@ describe('/certificate/sign', () => {
           1,
           'log.activityEvent was called once'
         );
+        const args = mockLog.activityEvent.args[0];
+        assert.equal(args[0].service, 'sync', 'service=sync was logged');
+      }
+    );
+  });
+
+  it('with service=foo', () => {
+    mockRequest.query.service = 'foo';
+
+    return runTest(
+      {
+        devices: mockDevices,
+        log: mockLog,
+      },
+      mockRequest,
+      () => {
+        assert.equal(
+          mockDevices.upsert.callCount,
+          1,
+          'devices.upsert was called'
+        );
+        assert.equal(
+          mockLog.activityEvent.callCount,
+          1,
+          'log.activityEvent was called once'
+        );
+        const args = mockLog.activityEvent.args[0];
+        assert.equal(args[0].service, 'foo', 'service=foo was logged');
       }
     );
   });


### PR DESCRIPTION
Due to some issues with processing the high volume of OAuth token-creation
events, we may need to have desktop Firefox use BrowserID assertions to
create its OAuth tokens, meaning it may want to call /certificate/sign even
if the `sync` service is not enabled.

This commit allows values other than `sync` in the `service` query param
for /certificate/sign, so that we won't get bogus metrics from browsers
that are calling this endpoint but are not connected to sync. For more
context see https://bugzilla.mozilla.org/show_bug.cgi?id=1591312.