### PR TITLE
fix(customs): Fix ip_blocklist .netstat file parse error.

### DIFF
--- a/packages/fxa-customs-server/package-lock.json
+++ b/packages/fxa-customs-server/package-lock.json
@@ -1210,11 +1210,6 @@
       "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-1.1.2.tgz",
       "integrity": "sha1-7GsA7a7W5ZrZwgWC9MNk4osUYkA="
     },
-    "csv-parse": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.4.6.tgz",
-      "integrity": "sha512-VisC5TBBhOF+70zjrF9FOiqI2LZOhXK/vAWlOrqyqz3lLa+P8jzJ7L/sg90MHmkSY/brAXWwrmGSZR0tM5yi4g=="
-    },
     "csv-stringify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-1.1.2.tgz",

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -25,7 +25,6 @@
     "bluebird": "3.3.4",
     "bunyan": "1.8.0",
     "convict": "4.0.2",
-    "csv-parse": "4.4.6",
     "deep-equal": "1.0.1",
     "ip": "1.1.3",
     "ip-reputation-js-client": "4.1.0",


### PR DESCRIPTION
We updated csv-parse from 1.0.4 to 4.4.6, and the major
version change included changes to how csv-parse treats
lines that start with a `#`, no longer are they considered
comments by default.

Instead of using csv-parse, this ditches the library
all together because we only used the first column of
each row anyways. Instead of relying on csv-parse,
just trim the line, then filter out empty or comment
lines.

fixes #3158

Note, locally, I still have a ton of remote test failures, just not in the local/ip_blocklist_tests.js module.

I imagine we'll have to uplift this to 149. Or I can target 149 and then merge to master.

@jrgm, @mozilla/fxa-devs - r?

