### PR TITLE
fix(emails): Add new email templates for adding secondary email, recovery key

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -1560,6 +1560,22 @@ const conf = convict({
       env: 'OTP_SIGNUP_DIGIT',
     },
   },
+  experiments: {
+    postVerifyEmails: {
+      enabled: {
+        doc: 'Feature flag for whether post verify experiments are active',
+        default: false,
+        env: 'EXPERIMENT_POST_VERIFY_EMAIL_ENABLED',
+        format: Boolean,
+      },
+      rolloutRate: {
+        doc: 'Rollout rate for post verify email experiment',
+        default: 0,
+        env: 'EXPERIMENT_POST_VERIFY_EMAIL_ROLLOUT_RATE',
+        format: Number,
+      },
+    },
+  },
 });
 
 // handle configuration files.  you can specify a CSV list of configuration
@@ -1603,6 +1619,12 @@ conf.set('smtp.verifyPrimaryEmailUrl', `${baseUri}/verify_primary_email`);
 conf.set('smtp.verifySecondaryEmailUrl', `${baseUri}/verify_secondary_email`);
 conf.set('smtp.subscriptionSettingsUrl', `${baseUri}/subscriptions`);
 conf.set('smtp.subscriptionSupportUrl', `${baseUri}/support`);
+
+conf.set('smtp.settingsEmailsUrl', `${baseUri}/settings/emails/`);
+conf.set(
+  'smtp.settingsRecoveryKeyUrl',
+  `${baseUri}/settings/account_recovery/`
+);
 
 conf.set('isProduction', conf.get('env') === 'prod');
 

--- a/packages/fxa-auth-server/lib/experiments/post-verify-emails.js
+++ b/packages/fxa-auth-server/lib/experiments/post-verify-emails.js
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const BaseGroupingRule = require('../../../fxa-shared').experiments
+  .BaseGroupingRule;
+
+const GROUPS_DEFAULT = [
+  'control',
+  'treatment-secondary',
+  'treatment-recovery',
+  'treatment-both',
+];
+
+class PostVerifyEmailGroupingRule extends BaseGroupingRule {
+  constructor(config) {
+    super();
+    this.enabled = config.enabled;
+    this.rolloutRate = config.rolloutRate;
+    this.name = 'postVerifyEmails';
+    this.groups = GROUPS_DEFAULT;
+  }
+
+  /**
+   * Get the experiment group that the user belongs too.
+   *
+   * @param {Object} subject
+   *  @param {String} uid
+   * @returns {String | Boolean}
+   */
+  choose(subject) {
+    if (!subject.uid) {
+      throw new Error('subject missing uid');
+    }
+    if (this.enabled && this.bernoulliTrial(this.rolloutRate, subject.uid)) {
+      return this.uniformChoice(this.groups, subject.uid);
+    }
+    return false;
+  }
+}
+
+module.exports = PostVerifyEmailGroupingRule;

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -11,6 +11,7 @@ const P = require('bluebird');
 const safeUserAgent = require('../userAgent/safe');
 const url = require('url');
 const { URL } = url;
+const PostVerifyEmailGroupingRule = require('../experiments/post-verify-emails');
 
 const TEMPLATE_VERSIONS = require('./templates/_versions.json');
 
@@ -27,6 +28,9 @@ module.exports = function(log, config, oauthdb) {
     log,
     config
   );
+  const postVerifyEmailsExperiment = new PostVerifyEmailGroupingRule(
+    config.experiments.postVerifyEmails
+  );
 
   // Email template to UTM campaign map, each of these should be unique and
   // map to exactly one email template.
@@ -40,6 +44,9 @@ module.exports = function(log, config, oauthdb) {
     passwordResetAccountRecovery: 'password-reset-account-recovery-success',
     postRemoveSecondary: 'account-email-removed',
     postVerify: 'account-verified',
+    postVerifyAddBoth: 'account-verified',
+    postVerifyAddRecoveryKey: 'account-verified',
+    postVerifyAddSecondary: 'account-verified',
     postChangePrimary: 'account-email-changed',
     postVerifySecondary: 'account-email-verified',
     postAddTwoStepAuthentication: 'account-two-step-enabled',
@@ -70,6 +77,9 @@ module.exports = function(log, config, oauthdb) {
     passwordResetRequired: 'password-reset',
     postRemoveSecondary: 'account-email-removed',
     postVerify: 'connect-device',
+    postVerifyAddBoth: 'manage-account',
+    postVerifyAddRecoveryKey: 'add-recovery-key',
+    postVerifyAddSecondary: 'add-secondary-email',
     postChangePrimary: 'account-email-changed',
     postVerifySecondary: 'manage-account',
     postAddTwoStepAuthentication: 'manage-account',
@@ -177,6 +187,8 @@ module.exports = function(log, config, oauthdb) {
     this.verifyLoginUrl = mailerConfig.verifyLoginUrl;
     this.verifySecondaryEmailUrl = mailerConfig.verifySecondaryEmailUrl;
     this.verifyPrimaryEmailUrl = mailerConfig.verifyPrimaryEmailUrl;
+    this.settingsEmailsUrl = mailerConfig.settingsEmailsUrl;
+    this.settingsRecoveryKeyUrl = mailerConfig.settingsRecoveryKeyUrl;
   }
 
   Mailer.prototype.stop = function() {
@@ -1090,6 +1102,23 @@ module.exports = function(log, config, oauthdb) {
   };
 
   Mailer.prototype.postVerifyEmail = function(message) {
+    // If post verify email experiment is active, send the corresponding emails
+    if (postVerifyEmailsExperiment.enabled) {
+      const choice = postVerifyEmailsExperiment.choose({ uid: message.uid });
+      switch (choice) {
+        case 'treatment-secondary':
+          return this.postVerifyAddSecondaryEmail(message);
+        case 'treatment-recovery':
+          return this.postVerifyAddRecoveryKeyEmail(message);
+        case 'treatment-both':
+          return this.postVerifyAddBothEmail(message);
+        case 'control':
+          // The control for the experiment is the default `Connect another device` email
+          break;
+        default:
+      }
+    }
+
     log.trace('mailer.postVerifyEmail', {
       email: message.email,
       uid: message.uid,
@@ -1154,6 +1183,125 @@ module.exports = function(log, config, oauthdb) {
       subject,
       template: templateName,
       templateValues: {
+        action,
+        androidLink: links.androidLink,
+        iosLink: links.iosLink,
+        link: links.link,
+        passwordChangeLink: links.passwordChangeLink,
+        passwordChangeLinkAttributes: links.passwordChangeLinkAttributes,
+        privacyUrl: links.privacyUrl,
+        secondaryEmail: message.secondaryEmail,
+        subject,
+        supportLinkAttributes: links.supportLinkAttributes,
+        supportUrl: links.supportUrl,
+      },
+    });
+  };
+
+  Mailer.prototype.postVerifyAddBothEmail = function(message) {
+    log.trace('mailer.postVerifyAddBothEmail', {
+      email: message.email,
+      uid: message.uid,
+    });
+
+    const templateName = 'postVerifyAddBoth';
+    const links = this._generateSettingLinks(message, templateName);
+    const subject = gettext('Set up account recovery');
+    const action = gettext('Open account settings');
+
+    const headers = {
+      'X-Link': links.link,
+    };
+
+    return this.send({
+      ...message,
+      headers,
+      subject,
+      template: templateName,
+      templateValues: {
+        email: message.email,
+        action,
+        androidLink: links.androidLink,
+        iosLink: links.iosLink,
+        link: links.link,
+        passwordChangeLink: links.passwordChangeLink,
+        passwordChangeLinkAttributes: links.passwordChangeLinkAttributes,
+        privacyUrl: links.privacyUrl,
+        secondaryEmail: message.secondaryEmail,
+        subject,
+        supportLinkAttributes: links.supportLinkAttributes,
+        supportUrl: links.supportUrl,
+      },
+    });
+  };
+
+  Mailer.prototype.postVerifyAddSecondaryEmail = function(message) {
+    log.trace('mailer.postVerifyAddSecondaryEmail', {
+      email: message.email,
+      uid: message.uid,
+    });
+
+    const templateName = 'postVerifyAddSecondary';
+    const links = this._generateSettingLinks(
+      message,
+      templateName,
+      this.settingsEmailsUrl
+    );
+    const subject = gettext('Set up recovery email');
+    const action = gettext('Add a secondary email');
+
+    const headers = {
+      'X-Link': links.link,
+    };
+
+    return this.send({
+      ...message,
+      headers,
+      subject,
+      template: templateName,
+      templateValues: {
+        email: message.email,
+        action,
+        androidLink: links.androidLink,
+        iosLink: links.iosLink,
+        link: links.link,
+        passwordChangeLink: links.passwordChangeLink,
+        passwordChangeLinkAttributes: links.passwordChangeLinkAttributes,
+        privacyUrl: links.privacyUrl,
+        secondaryEmail: message.secondaryEmail,
+        subject,
+        supportLinkAttributes: links.supportLinkAttributes,
+        supportUrl: links.supportUrl,
+      },
+    });
+  };
+
+  Mailer.prototype.postVerifyAddRecoveryKeyEmail = function(message) {
+    log.trace('mailer.postVerifyAddRecoveryKeyEmail', {
+      email: message.email,
+      uid: message.uid,
+    });
+
+    const templateName = 'postVerifyAddRecoveryKey';
+    const links = this._generateSettingLinks(
+      message,
+      templateName,
+      this.settingsRecoveryKeyUrl
+    );
+    const subject = gettext('Get a recovery key');
+    const action = gettext('Get a recovery key');
+
+    const headers = {
+      'X-Link': links.link,
+    };
+
+    return this.send({
+      ...message,
+      headers,
+      subject,
+      template: templateName,
+      templateValues: {
+        email: message.email,
         action,
         androidLink: links.androidLink,
         iosLink: links.iosLink,
@@ -1794,7 +1942,11 @@ module.exports = function(log, config, oauthdb) {
     return links;
   };
 
-  Mailer.prototype._generateSettingLinks = function(message, templateName) {
+  Mailer.prototype._generateSettingLinks = function(
+    message,
+    templateName,
+    link = this.accountSettingsUrl
+  ) {
     // Generate all possible links where the primary link is `accountSettingsUrl`.
     const query = {};
     if (message.email) {
@@ -1804,12 +1956,7 @@ module.exports = function(log, config, oauthdb) {
       query.uid = message.uid;
     }
 
-    return this._generateLinks(
-      this.accountSettingsUrl,
-      message.email,
-      query,
-      templateName
-    );
+    return this._generateLinks(link, message.email, query, templateName);
   };
 
   Mailer.prototype._generateLowRecoveryCodesLinks = function(

--- a/packages/fxa-auth-server/lib/senders/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/templates/_versions.json
@@ -26,5 +26,8 @@
   "postNewRecoveryCodes": 4,
   "passwordResetAccountRecovery": 5,
   "postAddAccountRecovery": 5,
-  "postRemoveAccountRecovery": 5
+  "postRemoveAccountRecovery": 5,
+  "postVerifyAddBoth": 1,
+  "postVerifyAddRecoveryKey": 1,
+  "postVerifyAddSecondary": 1
 }

--- a/packages/fxa-auth-server/lib/senders/templates/postVerifyAddBoth.html
+++ b/packages/fxa-auth-server/lib/senders/templates/postVerifyAddBoth.html
@@ -1,0 +1,19 @@
+<tr style="page-break-before: always">
+  <td valign="top">
+    <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">{{t "Avoid account lockout" }}</h1>
+
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{t "Two simple steps help you get back into your account and protect your data if you need to reset your password." }}</p>
+
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
+      <b>{{t "Set up a secondary email: " }}</b>{{t "Helps you get back in if you lose access to your email." }}
+    </p>
+
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
+      <b>{{t " Create a recovery key: " }}</b>{{t "Firefox protects your data by erasing your synced data if you reset your password. A recovery key restores it." }}
+    </p>
+  </td>
+</tr>
+
+{{> button}}
+
+{{> automatedEmailNoAction}}

--- a/packages/fxa-auth-server/lib/senders/templates/postVerifyAddBoth.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/postVerifyAddBoth.txt
@@ -1,0 +1,15 @@
+{{t "Avoid account lockout" }}
+
+{{t "Two simple steps help you get back into your account and protect your data if you need to reset your password." }}
+
+{{t "Set up a secondary email:" }}
+
+{{t "Helps you get back in if you lose access to your email." }}
+
+{{t "Create a recovery key:" }}
+
+{{t "Firefox protects your data by erasing your synced data if you reset your password. A recovery key restores it." }}
+
+{{{ link }}}
+
+{{> automatedEmailNoAction}}

--- a/packages/fxa-auth-server/lib/senders/templates/postVerifyAddRecoveryKey.html
+++ b/packages/fxa-auth-server/lib/senders/templates/postVerifyAddRecoveryKey.html
@@ -1,0 +1,13 @@
+<tr style="page-break-before: always">
+  <td valign="top">
+    <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">{{t "Protect your data with a recovery key" }}</h1>
+
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{t "Restore your synced data and pick up right where you left off with a unique recovery key." }}</p>
+
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{t "Otherwise, Firefox protects your data by erasing it when your password is reset." }}</p>
+  </td>
+</tr>
+
+{{> button}}
+
+{{> automatedEmailNoAction}}

--- a/packages/fxa-auth-server/lib/senders/templates/postVerifyAddRecoveryKey.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/postVerifyAddRecoveryKey.txt
@@ -1,0 +1,10 @@
+{{t "Protect your data with a recovery key" }}
+
+{{t "Restore your synced data and pick up right where you left off with a unique recovery key." }}
+
+{{t "Otherwise, Firefox protects your data by erasing it when your password is reset." }}
+
+{{{ link }}}
+
+{{> automatedEmailNoAction}}
+

--- a/packages/fxa-auth-server/lib/senders/templates/postVerifyAddSecondary.html
+++ b/packages/fxa-auth-server/lib/senders/templates/postVerifyAddSecondary.html
@@ -1,0 +1,12 @@
+<tr style="page-break-before: always">
+  <td valign="top">
+    <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">{{t "Protect yourself from being locked out" }}</h1>
+
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{t "Adding a secondary email helps get back into your account if you’re locked out and can’t access your email." }}</p>
+
+  </td>
+</tr>
+
+{{> button}}
+
+{{> automatedEmailNoAction}}

--- a/packages/fxa-auth-server/lib/senders/templates/postVerifyAddSecondary.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/postVerifyAddSecondary.txt
@@ -1,0 +1,7 @@
+{{t "Protect yourself from being locked out" }}
+
+{{t "Adding a secondary email helps get back into your account if you’re locked out and can’t access your email." }}
+
+{{{ link }}}
+
+{{> automatedEmailNoAction}}

--- a/packages/fxa-auth-server/test/local/experiments/post-verify-emails
+++ b/packages/fxa-auth-server/test/local/experiments/post-verify-emails
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { assert } = require('chai');
+import PostVerifyEmailGroupingRule from '../../experiments/post-verify-emails';
+
+const GROUPS_DEFAULT = [
+  'control',
+  'treatment-secondary',
+  'treatment-recovery',
+  'treatment-both',
+];
+
+describe('experiments/post-verify-emails', () => {
+  let experiment;
+  const subject = {
+    uid: 'uid',
+  };
+
+  describe('choose', () => {
+    it('throws when no uid', () => {
+      experiment = new PostVerifyEmailGroupingRule({
+        enabled: true,
+        rolloutRate: 1,
+      });
+      assert.throws(function() {
+        experiment.choose({});
+      }, 'subject missing uid');
+    });
+
+    it('returns false when disabled', () => {
+      experiment = new PostVerifyEmailGroupingRule({
+        enabled: false,
+        rolloutRate: 1,
+      });
+      assert.equal(experiment.choose(subject), false);
+    });
+
+    it('returns false when rollout is 0', () => {
+      experiment = new PostVerifyEmailGroupingRule({
+        enabled: true,
+        rolloutRate: 0,
+      });
+      assert.equal(experiment.choose(subject), false);
+    });
+
+    it('returns experiment group', () => {
+      experiment = new PostVerifyEmailGroupingRule({
+        enabled: true,
+        rolloutRate: 1,
+      });
+      assert.include(GROUPS_DEFAULT, experiment.choose(subject));
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -797,6 +797,87 @@ const TESTS = new Map([
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+  ['postVerifyAddSecondaryEmail', new Map([
+    ['subject', { test: 'equal', expected: 'Set up recovery email' }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postVerifyAddSecondary') }],
+      ['X-Template-Name', { test: 'equal', expected: 'postVerifyAddSecondary' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postVerifyAddSecondary }],
+      ['X-Link', { test: 'equal', expected:  configUrl('settingsEmailsUrl', 'account-verified', 'add-secondary-email', 'email', 'uid')}],
+    ])],
+    ['html', [
+      { test: 'include', expected: configHref('privacyUrl', 'account-verified', 'privacy') },
+      { test: 'include', expected: configHref('supportUrl', 'account-verified', 'support') },
+      { test: 'include', expected: 'Protect yourself from being locked out' },
+      { test: 'include', expected: 'Adding a secondary email helps get back into your account if you’re locked out and can’t access your email.' },
+      { test: 'include', expected: configHref('settingsEmailsUrl', 'account-verified', 'add-secondary-email', 'email', 'uid') },
+      { test: 'include', expected: 'Add a secondary email' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-verified', 'privacy')}` },
+      { test: 'include', expected: 'Protect yourself from being locked out' },
+      { test: 'include', expected: 'Adding a secondary email helps get back into your account if you’re locked out and can’t access your email.' },
+      { test: 'include', expected: configUrl('settingsEmailsUrl', 'account-verified', 'add-secondary-email', 'email', 'uid') },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
+  ['postVerifyAddRecoveryKeyEmail', new Map([
+    ['subject', { test: 'equal', expected: 'Get a recovery key' }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postVerifyAddRecoveryKey') }],
+      ['X-Template-Name', { test: 'equal', expected: 'postVerifyAddRecoveryKey' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postVerifyAddRecoveryKey }],
+      ['X-Link', { test: 'equal', expected:  configUrl('settingsRecoveryKeyUrl', 'account-verified', 'add-recovery-key', 'email', 'uid')}],
+    ])],
+    ['html', [
+      { test: 'include', expected: configHref('privacyUrl', 'account-verified', 'privacy') },
+      { test: 'include', expected: configHref('supportUrl', 'account-verified', 'support') },
+      { test: 'include', expected: 'Protect your data with a recovery key' },
+      { test: 'include', expected: 'Restore your synced data and pick up right where you left off with a unique recovery key.' },
+      { test: 'include', expected: 'Otherwise, Firefox protects your data by erasing it when your password is reset.' },
+      { test: 'include', expected: configHref('settingsRecoveryKeyUrl', 'account-verified', 'add-recovery-key', 'email', 'uid') },
+      { test: 'include', expected: 'Get a recovery key' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-verified', 'privacy')}` },
+      { test: 'include', expected: 'Protect your data with a recovery key' },
+      { test: 'include', expected: 'Restore your synced data and pick up right where you left off with a unique recovery key.' },
+      { test: 'include', expected: 'Otherwise, Firefox protects your data by erasing it when your password is reset.' },
+      { test: 'include', expected: configUrl('settingsRecoveryKeyUrl', 'account-verified', 'add-recovery-key', 'email', 'uid') },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
+  ['postVerifyAddBothEmail', new Map([
+    ['subject', { test: 'equal', expected: 'Set up account recovery' }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postVerifyAddBoth') }],
+      ['X-Template-Name', { test: 'equal', expected: 'postVerifyAddBoth' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postVerifyAddBoth }],
+      ['X-Link', { test: 'equal', expected:  configUrl('accountSettingsUrl', 'account-verified', 'manage-account', 'email', 'uid')}],
+    ])],
+    ['html', [
+      { test: 'include', expected: configHref('privacyUrl', 'account-verified', 'privacy') },
+      { test: 'include', expected: configHref('supportUrl', 'account-verified', 'support') },
+      { test: 'include', expected: 'Avoid account lockout' },
+      { test: 'include', expected: 'Two simple steps help you get back into your account and protect your data if you need to reset your password.' },
+      { test: 'include', expected: 'Helps you get back in if you lose access to your email.' },
+      { test: 'include', expected: 'Firefox protects your data by erasing your synced data if you reset your password. A recovery key restores it.' },
+      { test: 'include', expected: configHref('accountSettingsUrl', 'account-verified', 'manage-account', 'email', 'uid') },
+      { test: 'include', expected: 'Open account settings' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-verified', 'privacy')}` },
+      { test: 'include', expected: 'Avoid account lockout' },
+      { test: 'include', expected: 'Two simple steps help you get back into your account and protect your data if you need to reset your password.' },
+      { test: 'include', expected: 'Helps you get back in if you lose access to your email.' },
+      { test: 'include', expected: 'Firefox protects your data by erasing your synced data if you reset your password. A recovery key restores it.' },
+      { test: 'include', expected: configUrl('accountSettingsUrl', 'account-verified', 'manage-account', 'email', 'uid') },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ]);
 
 describe('lib/senders/email:', () => {
@@ -1403,6 +1484,7 @@ describe('email translations', () => {
   let mockLog, mailer;
   const message = {
     email: 'a@b.com',
+    uid: '123',
   };
 
   async function setupMailerWithTranslations(locale) {
@@ -1522,7 +1604,11 @@ function applyAssertions(type, target, property, assertions) {
     assertions = [assertions];
   }
 
-  assertions.forEach(({ test, expected }) => {
-    assert[test](target, expected, `${type}: ${property}`);
+  describe(`${type} - ${property}`, () => {
+    assertions.forEach(({ test, expected }) => {
+      it(`${test} - ${expected}`, () => {
+        assert[test](target, expected, `${type}: ${property}`);
+      });
+    });
   });
 }

--- a/packages/fxa-shared/index.ts
+++ b/packages/fxa-shared/index.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 import * as popularDomains from './email/popularDomains.json';
+import BaseGroupingRule from './experiments/base';
 import { localizeTimestamp } from './l10n/localizeTimestamp';
 import * as supportedLanguages from './l10n/supportedLanguages.json';
 import * as amplitude from './metrics/amplitude';
@@ -12,6 +13,9 @@ import * as redis from './redis';
 module.exports = {
   email: {
     popularDomains,
+  },
+  experiments: {
+    BaseGroupingRule,
   },
   l10n: {
     localizeTimestamp,


### PR DESCRIPTION
Connect with https://github.com/mozilla/fxa/issues/2595

This adds the new email templates needed for phase 1 of the feature. It also adds the support to feature flag our emails. By default it is disabled and rollout is set to 0.

Adds new email templates:
<img width="345" alt="Screen Shot 2019-11-21 at 2 41 22 PM" src="https://user-images.githubusercontent.com/1295288/69371013-04d11000-0c6d-11ea-9b99-b9ad0646ecc1.png">
<img width="371" alt="Screen Shot 2019-11-21 at 2 40 04 PM" src="https://user-images.githubusercontent.com/1295288/69370923-deab7000-0c6c-11ea-8ab7-6dd745376861.png">
<img width="350" alt="Screen Shot 2019-11-21 at 2 39 50 PM" src="https://user-images.githubusercontent.com/1295288/69370924-deab7000-0c6c-11ea-991c-0ca6cd58d61d.png">

- [x] Add all the tests
- [x] Add feature flagging