### PR TITLE
fix(docker): fixed content-server docker build

### DIFF
--- a/packages/fxa-content-server/Dockerfile-build
+++ b/packages/fxa-content-server/Dockerfile-build
@@ -13,14 +13,9 @@ ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 RUN apk add --no-cache git
 
 USER app
-
-COPY --chown=app:app fxa-content-server/package-lock.json package-lock.json
-COPY --chown=app:app fxa-content-server/package.json package.json
-COPY --chown=app:app fxa-content-server/scripts/download_l10n.sh scripts/download_l10n.sh
-
-RUN npm install && rm -rf ~/.cache ~/.npm /tmp/*
-
 COPY --chown=app:app fxa-content-server /app
+RUN npm ci && rm -rf ~/.cache ~/.npm /tmp/*
+
 
 COPY --chown=app:app ["fxa-geodb", "../fxa-geodb/"]
 WORKDIR /fxa-geodb


### PR DESCRIPTION
I broke the content-server docker build in #3156 so here's the fix.

To verify run:

`docker build -t fxa-content-server:build -f ./fxa-content-server/Dockerfile-build .`

from the `fxa/packages` directory