### PR TITLE
feat(auth-server): add proper support backend err

### DIFF
--- a/packages/fxa-auth-server/lib/sentry.js
+++ b/packages/fxa-auth-server/lib/sentry.js
@@ -6,6 +6,7 @@
 
 const Hoek = require('@hapi/hoek');
 const Sentry = require('@sentry/node');
+const verror = require('verror');
 
 const getVersion = require('./version').getVersion;
 
@@ -113,6 +114,11 @@ async function configureSentry(server, config) {
           } catch (e) {
             // ignore bad stack frames
           }
+        }
+
+        // If it's a verror replace the stack with the full stack
+        if (err instanceof verror) {
+          err.stack = verror.fullStack(err);
         }
 
         Sentry.withScope(scope => {

--- a/packages/fxa-auth-server/package-lock.json
+++ b/packages/fxa-auth-server/package-lock.json
@@ -442,6 +442,12 @@
       "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
       "dev": true
     },
+    "@types/verror": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.3.tgz",
+      "integrity": "sha512-7Jz0MPsW2pWg5dJfEp9nJYI0RDCYfgjg2wIo5HfQ8vOJvUq0/BxT7Mv2wNQvkKBmV9uT++6KF3reMnLmh/0HrA==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -88,6 +88,7 @@
     "through": "2.3.8",
     "urijs": "1.19.1",
     "uuid": "1.4.1",
+    "verror": "^1.10.0",
     "web-push": "3.3.0"
   },
   "devDependencies": {
@@ -101,6 +102,7 @@
     "@types/nock": "^11.1.0",
     "@types/node": "^12.11.7",
     "@types/request": "^2.48.3",
+    "@types/verror": "^1.10.3",
     "acorn": "^5.7.3",
     "audit-filter": "^0.5.0",
     "chai": "4.1.2",

--- a/packages/fxa-auth-server/test/local/error.js
+++ b/packages/fxa-auth-server/test/local/error.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const { assert } = require('chai');
+const verror = require('verror');
 const messages = require('joi/lib/language');
 const AppError = require('../../lib/error');
 const P = require('../../lib/promise');
@@ -17,7 +18,7 @@ describe('AppErrors', () => {
 
   it('exported functions exist', () => {
     assert.equal(typeof AppError, 'function');
-    assert.equal(AppError.length, 3);
+    assert.equal(AppError.length, 4);
     assert.equal(typeof AppError.translate, 'function');
     assert.lengthOf(AppError.translate, 2);
     assert.equal(typeof AppError.invalidRequestParameter, 'function');
@@ -76,6 +77,18 @@ describe('AppErrors', () => {
     assert.equal(result.output.payload.error, 'Internal Server Error');
     assert.equal(result.output.payload.errno, result.errno);
     assert.equal(result.output.payload.message, result.message);
+  });
+
+  it('backend error includes a cause error when supplied', () => {
+    const originalError = new Error('Service timed out.');
+    const err = AppError.backendServiceFailure(
+      'test',
+      'checking',
+      {},
+      originalError
+    );
+    const fullError = verror.fullStack(err);
+    assert.include(fullError, 'caused by: Error: Service timed out.');
   });
 
   it('tooManyRequests', () => {


### PR DESCRIPTION
Because:

* The Support API call ate the error and only returned the message from
  it in the response payload but didn't Sentry report it.
* AppError used to handle control flow in our system does not handle
  error chaining to retain the original stack trace.
* Sentry errors don't know about verror.

This commit:

* Adds the verror package for error chaining and stack preservation.
* Updates AppError and backendServiceFailure to optionally allow the
  original error to be chained.
* Switches AppError to inherit from verror.WError, intended for error
  wrapping where the output error is not supposed to be seen by
  end-users. As is the case with AppError.
* Checks for a verror object when reporting with Sentry to use the
  full error stack.

Issue #3090, #3138