### PR TITLE
feat(auth-server): retain backendService errors

### DIFF
--- a/packages/fxa-auth-server/lib/backendService.js
+++ b/packages/fxa-auth-server/lib/backendService.js
@@ -147,7 +147,11 @@ module.exports = function createBackendServiceAPI(
             value,
           });
           reject(
-            error.internalValidationError(fullMethodName, { location, value })
+            error.internalValidationError(
+              fullMethodName,
+              { location, value },
+              err
+            )
           );
         });
       });
@@ -182,10 +186,15 @@ module.exports = function createBackendServiceAPI(
           throw err;
         } else {
           log.error(`${fullMethodName}.1`, { params, query, payload, err });
-          throw error.backendServiceFailure(serviceName, methodName, {
-            method,
-            path,
-          });
+          throw error.backendServiceFailure(
+            serviceName,
+            methodName,
+            {
+              method,
+              path,
+            },
+            err
+          );
         }
       }
     }

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -1246,7 +1246,9 @@ AppError.backendServiceFailure = (service, operation, extra, error) => {
     {
       service,
       operation,
-    }
+    },
+    {},
+    error
   );
 };
 
@@ -1271,7 +1273,7 @@ AppError.disabledClientId = (clientId, retryAfter) => {
   );
 };
 
-AppError.internalValidationError = (op, data) => {
+AppError.internalValidationError = (op, data, error) => {
   return new AppError(
     {
       code: 500,
@@ -1282,7 +1284,9 @@ AppError.internalValidationError = (op, data) => {
     {
       op,
       data,
-    }
+    },
+    {},
+    error
   );
 };
 
@@ -1291,9 +1295,6 @@ AppError.unexpectedError = request => {
   decorateErrorWithRequest(error, request);
   return error;
 };
-
-module.exports = AppError;
-module.exports.ERRNO = ERRNO;
 
 function decorateErrorWithRequest(error, request) {
   if (request) {
@@ -1330,3 +1331,6 @@ function scrubHeaders(headers) {
   delete scrubbed['x-forwarded-for'];
   return scrubbed;
 }
+
+module.exports = AppError;
+module.exports.ERRNO = ERRNO;


### PR DESCRIPTION
Because:

* backendService.js dropped the original error when throwing an
  AppError.

This commit:

* Retains the original error when throwing backend service or
  validation errors in backendService.js.

Closes #3138