### PR TITLE
fix(events): set default `metrics.prefix` to have trailing `.`

### DIFF
--- a/packages/fxa-event-broker/config/index.ts
+++ b/packages/fxa-event-broker/config/index.ts
@@ -116,7 +116,7 @@ const conf = convict({
       format: Number
     },
     prefix: {
-      default: 'fxa-event-broker',
+      default: 'fxa-event-broker.',
       doc: 'Metric prefix for statsD',
       env: 'METRIC_PREFIX',
       format: String


### PR DESCRIPTION
fixes #3198 - r? @bbangert 