### PR TITLE
fix(payments): correctly calculate and append time to amplitude events

### DIFF
--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -48,7 +48,7 @@ module.exports = (event, request, data, requestReceivedTime) => {
     ...mapOs(userAgent),
     ...mapFormFactor(userAgent),
     ...mapLocation(data.location),
-    ...mapTime(data, requestReceivedTime),
+    ...mapTime(data, event.offset, requestReceivedTime),
     ...data,
   });
 

--- a/packages/fxa-payments-server/server/lib/amplitude.test.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.test.js
@@ -12,49 +12,7 @@ jest.mock('../config', () => ({
   },
 }));
 
-const mocks = {
-  event: {
-    offset: 150,
-    type: 'amplitude.subPaySetup.view',
-  },
-  invalidEventType: {
-    offset: 150,
-    type: 'foo.bar.baz',
-  },
-  data: {
-    version: '148.8',
-    deviceId: '0123456789abcdef0123456789abcdef',
-    flowBeginTime: 1570000000000,
-    flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-    flushTime: 9002,
-    perfStartTime: 9001,
-    requestReceivedTime: 11000,
-    view: 'product',
-  },
-  request: {
-    headers: {
-      'user-agent':
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:72.0) Gecko/20100101 Firefox/72.0',
-    },
-  },
-  requestReceivedTime: 1570000001000,
-};
-
-const expectedOutput = {
-  app_version: '148.8',
-  device_id: '0123456789abcdef0123456789abcdef',
-  event_properties: {},
-  event_type: 'fxa_pay_setup - view',
-  op: 'amplitudeEvent',
-  os_name: 'Mac OS X',
-  os_version: '10.14',
-  session_id: 1570000000000,
-  user_properties: {
-    flow_id: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
-    ua_browser: 'Firefox',
-    ua_version: '72.0',
-  },
-};
+const mocks = require('./test-mocks').amplitude;
 
 describe('lib/amplitude', () => {
   beforeEach(() => {
@@ -69,7 +27,7 @@ describe('lib/amplitude', () => {
     );
     expect(log.info).toHaveBeenCalled();
     expect(log.info.mock.calls[0][0]).toMatch('amplitudeEvent');
-    expect(log.info.mock.calls[0][1]).toMatchObject(expectedOutput);
+    expect(log.info.mock.calls[0][1]).toMatchObject(mocks.expectedOutput);
     done();
   });
 
@@ -97,8 +55,11 @@ describe('lib/amplitude', () => {
       expect(log.info).not.toHaveBeenCalled();
     });
     it('returns if the message format does not match `amplitude.str.str`', () => {
+      const invalidEvent = Object.assign({}, mocks.event);
+      // This is an invalid type because it doesn't start with 'amplitude'.
+      invalidEvent.type = 'foo.bar.baz';
       amplitude(
-        mocks.invalidEventType,
+        invalidEvent,
         mocks.request,
         mocks.data,
         mocks.requestReceivedTime

--- a/packages/fxa-payments-server/server/lib/routes/post-metrics.test.js
+++ b/packages/fxa-payments-server/server/lib/routes/post-metrics.test.js
@@ -3,34 +3,13 @@ const server = require('../server')();
 const app = server.app;
 jest.mock('../flow-performance', () => () => {});
 
-const validBody = {
-  data: {
-    deviceId: '016de98b32a54747b18ccbeaab2a6075',
-    flowBeginTime: '1571195527850',
-    flowId: '641530e2645e0e8d96ea7e409ebeebabfc3fb2fc9204fec999d9d8baa2ebb0da',
-    planId: '123doneProMonthly',
-    productId: '123doneProProduct',
-  },
-  events: [
-    {
-      offset: 100,
-      type: 'amplitude.subPaySetup.view',
-    },
-  ],
-};
-
-const invalidBody = {
-  data: {
-    deviceId: '016de98b32a54747b18ccbeaab2a6075',
-    flowBeginTime: '1571195527850',
-    flowId: '641530e2645e0e8d96ea7e409ebeebabfc3fb2fc9204fec999d9d8baa2ebb0da',
-    planId: '123doneProMonthly',
-    productId: '123doneProProduct',
-  },
-  // 'events' is required and is missing
-};
+const mocks = require('../test-mocks').amplitude;
 
 describe('post-metrics route', () => {
+  const validBody = {
+    data: mocks.data,
+    events: [mocks.event],
+  };
   test('POST valid input should return 200', done => {
     request(app)
       .post('/metrics')
@@ -44,6 +23,8 @@ describe('post-metrics route', () => {
   });
 
   test('POST invalid input should return 400', done => {
+    const invalidBody = Object.assign({}, validBody);
+    delete invalidBody.events;
     request(app)
       .post('/metrics')
       .send(invalidBody)

--- a/packages/fxa-payments-server/server/lib/test-mocks.js
+++ b/packages/fxa-payments-server/server/lib/test-mocks.js
@@ -1,0 +1,58 @@
+const baseTime = 1570000000000;
+const relativeBaseTime = 9000;
+const offset = 150;
+
+module.exports = {
+  // Mocks shared between lib/amplitude.test.js and
+  // lib/routes/post-metrics.test.js.
+  amplitude: {
+    baseTime,
+    relativeBaseTime,
+    requestReceivedTime: baseTime + 1000,
+    event: {
+      offset,
+      type: 'amplitude.subPaySetup.view',
+    },
+    data: {
+      deviceId: '0123456789abcdef0123456789abcdef',
+      flowBeginTime: baseTime + offset,
+      flowId:
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      flushTime: relativeBaseTime + 2,
+      perfStartTime: relativeBaseTime + 1,
+      planId: '123doneProMonthly',
+      productId: '123doneProProduct',
+      startTime: baseTime,
+      version: '148.8',
+      view: 'product',
+    },
+    request: {
+      headers: {
+        'user-agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:72.0) Gecko/20100101 Firefox/72.0',
+      },
+    },
+    expectedOutput: {
+      app_version: '148.8',
+      device_id: '0123456789abcdef0123456789abcdef',
+      event_properties: {
+        plan_id: '123doneProMonthly',
+        product_id: '123doneProProduct',
+      },
+      event_type: 'fxa_pay_setup - view',
+      op: 'amplitudeEvent',
+      os_name: 'Mac OS X',
+      os_version: '10.14',
+      session_id: baseTime + offset,
+      // time = data.perfStartTime + event.offset + requestReceivedTime - data.flushTime
+      //      = 9001 + 150 + (baseTime + 1000) - 9002 = baseTime + 1149 = 1570000001149
+      time: 1570000001149,
+      user_properties: {
+        flow_id:
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        ua_browser: 'Firefox',
+        ua_version: '72.0',
+      },
+    },
+  },
+};

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -206,7 +206,7 @@ module.exports = {
         return pruneUnsetValues({
           op: 'amplitudeEvent',
           event_type: `${eventGroup} - ${eventType}`,
-          time: event.time,
+          time: data.time,
           user_id: data.uid,
           device_id: data.deviceId,
           session_id: data.flowBeginTime,
@@ -471,11 +471,11 @@ function estimateTime(times) {
   return times.start + times.offset + skew;
 }
 
-function mapTime(data, receivedTime) {
+function mapTime(data, offset, receivedTime) {
   const time = estimateTime({
-    offset: data.offset,
+    offset: offset,
     received: receivedTime,
-    start: data.startTime,
+    start: data.perfStartTime,
     sent: data.flushTime,
   });
   return { time };

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -43,6 +43,16 @@ describe('metrics/amplitude:', () => {
     assert.lengthOf(amplitude.initialize, 3);
   });
 
+  describe('transforms:', () => {
+    it('mapTime calculates event.time', () => {
+      const data = { perfStartTime: 1000, flushTime: 2000 };
+      const receivedTime = 10000;
+      const offset = 100;
+      const result = amplitude.mapTime(data, offset, receivedTime);
+      assert.equal(result.time, 9100);
+    });
+  });
+
   describe('initialize:', () => {
     let transform;
 


### PR DESCRIPTION
The bug was looking for event.time, not data.time, in pruneUnsetValues,
but I added and cleaned up some tests and mocks along the way, which
seems worth keeping.

Fixes #3050.

(Looks like I broke something in fxa-content-server with the fix to fxa-payment-server, I'll look at that in a bit)