### PR TITLE
fix(payments): correctly append event time to amplitude events

### DIFF
--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -11,7 +11,6 @@ const {
   mapFormFactor,
   mapLocation,
   mapOs,
-  mapTime,
   toSnakeCase,
 } = require('../../../fxa-shared/metrics/amplitude.js');
 const config = require('../config');
@@ -48,7 +47,6 @@ module.exports = (event, request, data, requestReceivedTime) => {
     ...mapOs(userAgent),
     ...mapFormFactor(userAgent),
     ...mapLocation(data.location),
-    ...mapTime(data, requestReceivedTime),
     ...data,
   });
 

--- a/packages/fxa-payments-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-payments-server/server/lib/routes/post-metrics.js
@@ -64,6 +64,11 @@ module.exports = {
         // performance event.
         logPerformanceEvent(event, request, { ...data, requestReceivedTime });
       } else {
+        event.time =
+          data.perfStartTime +
+          event.offset +
+          requestReceivedTime -
+          data.flushTime;
         amplitude(event, request, data, requestReceivedTime);
       }
     });

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -108,7 +108,6 @@ module.exports = {
   mapFormFactor,
   mapLocation,
   mapOs,
-  mapTime,
   mapUserAgentProperties,
   toSnakeCase,
 
@@ -464,19 +463,4 @@ function mapLocation(location) {
       region: location.state,
     };
   }
-}
-
-function estimateTime(times) {
-  const skew = times.received - times.sent;
-  return times.start + times.offset + skew;
-}
-
-function mapTime(data, receivedTime) {
-  const time = estimateTime({
-    offset: data.offset,
-    received: receivedTime,
-    start: data.startTime,
-    sent: data.flushTime,
-  });
-  return { time };
 }


### PR DESCRIPTION
Deferring any attempt at refactoring until the payments metrics are
actually working.

Fixes #3050.