### PR TITLE
feat(build): add build requirements for fxa-amplitude-send to fxa-circleci

### DIFF
--- a/packages/fxa-circleci/Dockerfile
+++ b/packages/fxa-circleci/Dockerfile
@@ -2,12 +2,19 @@ FROM circleci/node:10-stretch-browsers
 
 USER root
 RUN apt-get update && apt-get install -y \
+    bison \
     build-essential \
     cmake \
+    flex \
     graphicsmagick \
+    libboost-dev \
+    libboost-filesystem-dev \
+    libboost-regex-dev \
+    libboost-system-dev \
     python-setuptools \
     python-dev \
     && rm -rf /var/lib/apt/lists/*
+RUN npm install -g npm
 RUN easy_install pip
 RUN pip install mozdownload mozinstall
 RUN mozdownload --version 68.0 --destination firefox.tar.bz2


### PR DESCRIPTION
there's more than `cmake`. this time i actually ensured it will build in a container