### PR TITLE
fix(client): show password permanently on toggle

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/test_template.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/test_template.mustache
@@ -39,14 +39,16 @@
     </div>
     <div class="input-row password-row">
       <input type="password" class="password" id="password" pattern=".{8,}" data-synchronize-show="true" required />
-      <input type="password" id="old_password" placeholder="Old password" required pattern=".{8,}" />
-      <input type="password" id="new_password" placeholder="New password" required pattern=".{8,}" />
-      <div class="input-help input-help-focused input-help-signup">Must be at least 8 characters</div>
-      <div class="input-help input-help-forgot-pw links"><a href="/" class="reset-password">Forgot password?</a></div>
     </div>
     <div class="input-row password-row">
       <input type="password" class="password check-password tooltip-below" id="vpassword" pattern=".{8,}" required />
       <div class="input-help input-help-focused input-help-complete-password">Must be at least 8 characters</div>
+    </div>
+    <div class="input-row password-row">
+      <input type="password" id="old_password" placeholder="Old password" required pattern=".{8,}" />
+      <input type="password" id="new_password" placeholder="New password" required pattern=".{8,}" />
+      <div class="input-help input-help-focused input-help-signup">Must be at least 8 characters</div>
+      <div class="input-help input-help-forgot-pw links"><a href="/" class="reset-password">Forgot password?</a></div>
     </div>
     <div class="input-row password-row">
       <label class="fxa-checkbox"><input type="checkbox" /></label>

--- a/packages/fxa-content-server/app/scripts/views/mixins/password-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/password-mixin.js
@@ -4,7 +4,6 @@
 
 // helper functions for views with passwords. Meant to be mixed into views.
 
-import $ from 'jquery';
 import KeyCodes from '../../lib/key-codes';
 import AuthErrors from '../../lib/auth-errors';
 import showPasswordTemplate from 'templates/partial/show-password.mustache';
@@ -91,32 +90,22 @@ export default {
   onShowPasswordTV(event) {
     if (event.which === KeyCodes.ENTER) {
       const $passwordEl = this.getAffectedPasswordInputs(this.$(event.target));
-      this.showPassword($passwordEl);
-      const hideVisiblePasswords = () => {
-        $(this.window).off('keyup', hideVisiblePasswords);
-        this.hideVisiblePasswords();
-      };
-      $(this.window).one('keyup', hideVisiblePasswords);
+      this.togglePasswordVisibility($passwordEl);
     }
   },
 
   onShowPasswordMouseDown(event) {
     const $buttonEl = this.$(event.target).siblings('.show-password');
     const $passwordEl = this.getAffectedPasswordInputs($buttonEl);
+    this.togglePasswordVisibility($passwordEl);
+  },
 
-    this.showPassword($passwordEl);
-
-    // hide the password field as soon as the user
-    // lets up on the mouse or their finger.
-    const hideVisiblePasswords = () => {
-      $(this.window).off('mouseup', hideVisiblePasswords);
-      $(this.window).off('touchend', hideVisiblePasswords);
-
-      this.hideVisiblePasswords();
-    };
-
-    $(this.window).one('mouseup', hideVisiblePasswords);
-    $(this.window).one('touchend', hideVisiblePasswords);
+  togglePasswordVisibility($el) {
+    if ($el.attr('type') === 'text') {
+      this.hidePassword($el);
+    } else {
+      this.showPassword($el);
+    }
   },
 
   getAffectedPasswordInputs(button) {

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/password-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/password-mixin.js
@@ -120,7 +120,9 @@ describe('views/mixins/password-mixin', function() {
         assert.equal(view.$('#password').attr('type'), 'text');
 
         $(windowMock).trigger('mouseup');
+        assert.equal(view.$('#password').attr('type'), 'text');
 
+        view.$('#password ~ .show-password-label').trigger('mousedown');
         assert.equal(view.$('#password').attr('type'), 'password');
       });
 
@@ -129,21 +131,24 @@ describe('views/mixins/password-mixin', function() {
         assert.equal(view.$('#password').attr('type'), 'text');
 
         $(windowMock).trigger('touchend');
+        assert.equal(view.$('#password').attr('type'), 'text');
 
+        view.$('.show-password-label').trigger('touchstart');
         assert.equal(view.$('#password').attr('type'), 'password');
       });
 
       it('logs whether the password is shown or hidden', function() {
-        view.$('.show-password-label').trigger('mousedown');
+        view.$('#password ~ .show-password-label').trigger('mousedown');
         assert.isTrue(
           TestHelpers.isEventLogged(metrics, 'password-view.password.visible')
         );
+
         // the password has not been hidden yet.
         assert.isFalse(
           TestHelpers.isEventLogged(metrics, 'password-view.password.hidden')
         );
 
-        $(windowMock).trigger('mouseup');
+        view.$('#password ~ .show-password-label').trigger('mousedown');
         assert.isTrue(
           TestHelpers.isEventLogged(metrics, 'password-view.password.hidden')
         );

--- a/packages/fxa-content-server/tests/functional/password_visibility.js
+++ b/packages/fxa-content-server/tests/functional/password_visibility.js
@@ -12,7 +12,6 @@ const SIGNIN_URL = config.fxaContentRoot + 'signin';
 const {
   clearBrowserState,
   mousedown,
-  mouseup,
   noSuchAttribute,
   openPage,
   testAttributeEquals,
@@ -26,7 +25,7 @@ registerSuite('password visibility', {
     return this.remote.then(clearBrowserState());
   },
   tests: {
-    'show password ended with mouseup': function() {
+    'show password ended with second mousedown': function() {
       return (
         this.remote
           .then(openPage(SIGNIN_URL, '#fxa-signin-header'))
@@ -41,7 +40,7 @@ registerSuite('password visibility', {
           .then(testAttributeEquals('#password', 'autocomplete', 'off'))
 
           // turn text field back into a password field
-          .then(mouseup('.show-password-label'))
+          .then(mousedown('.show-password-label'))
 
           .then(testAttributeEquals('#password', 'type', 'password'))
           .then(noSuchAttribute('#password', 'autocomplete'))


### PR DESCRIPTION
This patch reverts the change where users are required to hold the show
password label in order to view the password.

Fixes #1395

Ref: https://github.com/mozilla/fxa-content-server/issues/3799, https://github.com/mozilla/fxa-content-server/pull/3978