### PR TITLE
fix(copy): Made resend copy more inclusive

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
@@ -27,7 +27,7 @@
                 <button id="submit-btn" type="submit">{{#t}}Verify{{/t}}</button>
             </div>
             <div class="links">
-                <a id="resend" class="left delayed-fadein" href="#">{{#t}}Not in inbox or spam folder? Resend{{/t}}</a>
+                <a id="resend" class="left delayed-fadein" href="#">{{#t}}Need another code? Resend{{/t}}</a>
             </div>
         </form>
     </section>


### PR DESCRIPTION
Sometimes codes expire, so the copy is now more generic, not mentioning spam