### PR TITLE
fix(pw-strength): Update the text of the vpassword bubble, add icon

### DIFF
--- a/packages/fxa-content-server/app/images/icon-key-grey-50.svg
+++ b/packages/fxa-content-server/app/images/icon-key-grey-50.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="#737373" d="M12 4a4 4 0 00-3.86 3H1a1 1 0 000 2v1a1 1 0 002 0V9h1v1a1 1 0 002 0V9h2.14A4 4 0 1012 4zm0 6a2 2 0 112-2 2 2 0 01-2 2z"/></svg>

--- a/packages/fxa-content-server/app/scripts/templates/sign_up.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up.mustache
@@ -41,7 +41,7 @@
       <div class="input-row password-row">
         <input id="vpassword" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Repeat password{{/t}}" pattern=".{8,}" required data-synchronize-show="true" />
         <div class="input-help input-help-focused input-help-signup input-help-balloon">
-          {{#t}}Don’t lose this password. If you need to reset it, you may lose Sync data.{{/t}}
+          {{#unsafeTranslate}}You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks.{{/unsafeTranslate}}
         </div>
       </div>
 

--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -31,7 +31,7 @@
         <input id="vpassword" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Repeat password{{/t}}" pattern=".{8,}" required data-synchronize-show="true" />
 
         <div class="input-help input-help-focused input-help-signup input-help-balloon">
-          {{#t}}Don’t lose this password. If you need to reset it, you may lose Sync data.{{/t}}
+          {{#unsafeTranslate}}You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks.{{/unsafeTranslate}}
         </div>
       </div>
 

--- a/packages/fxa-content-server/app/styles/modules/_password-row.scss
+++ b/packages/fxa-content-server/app/styles/modules/_password-row.scss
@@ -169,7 +169,24 @@
   }
 
   .input-help-signup {
+    background-image: image-url('icon-key-grey-50.svg');
+    background-repeat: no-repeat;
+    background-size: 16px 16px;
     text-align: center;
+
+    br {
+      margin-bottom: 20px;
+    }
+
+    html[dir='ltr'] & {
+      background-position: 12px 16px;
+      padding-left: 35px;
+    }
+
+    html[dir='rtl'] & {
+      background-position: calc(100% - 12px) 16px;
+      padding-right: 35px;
+    }
   }
 
   .show-password {
@@ -227,7 +244,7 @@
   }
 
   .input-help-balloon {
-    background: $color-white;
+    background-color: $color-white;
     border: 1px solid $marketing-border-color;
     border-radius: $small-border-radius;
     box-shadow: 0 2px 8px rgba($grey-90, 0.1);


### PR DESCRIPTION
The design didn't quite match the spec, this update changes
the text and adds a key icon to match the spec.

fixes #3192

## LTR

<img width="290" alt="Screenshot 2019-11-04 at 21 46 23" src="https://user-images.githubusercontent.com/848085/68161044-ed93e200-ff4c-11e9-8c5e-120dc92dbf54.png">



## RTL

<img width="363" alt="Screenshot 2019-11-04 at 21 46 08" src="https://user-images.githubusercontent.com/848085/68161019-dead2f80-ff4c-11e9-9c1a-c5dc90a964fb.png">


@ryanfeeley and @mozilla/fxa-devs - r?