### PR TITLE
fix(one-ups): Update the text of the one-ups

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/firefox-family-services.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/firefox-family-services.mustache
@@ -1,13 +1,13 @@
 <aside class="firefox-family-services">
-  <h2>{{#t}}Get more from these features:{{/t}}</h2>
+  <h2>{{#t}}Sign up to get more features:{{/t}}</h2>
   <ul>
     <li class="firefox-service">
       <span class="logo logo-firefox-browser">{{#t}}Firefox browser{{/t}}</span>
-      {{#t}}Travel the internet with protection, on every device.{{/t}}
+      {{#t}}Sync your bookmarks, passwords, and more on every device.{{/t}}
     </li>
     <li class="firefox-service service-lockwise">
       <span class="logo logo-lockwise">{{#t}}Firefox Lockwise{{/t}}</span>
-      {{#t}}Keep your passwords protected and portable.{{/t}}
+      {{#unsafeTranslate}}Securely access passwords saved in Firefox anywhere &mdash; even outside of the browser.{{/unsafeTranslate}}
     </li>
     <li class="firefox-service">
       <span class="logo logo-monitor">{{#t}}Firefox Monitor{{/t}}</span>
@@ -15,7 +15,7 @@
     </li>
     <li class="firefox-service">
       <span class="logo logo-send">{{#t}}Firefox Send{{/t}}</span>
-      {{#t}}Share large files without prying eyes.{{/t}}
+      {{#t}}Send larger files securely and privately.{{/t}}
     </li>
   </ul>
 </aside>


### PR DESCRIPTION
Text updated for clarity and to be more general.

<img width="495" alt="Screenshot 2019-11-04 at 21 57 20" src="https://user-images.githubusercontent.com/848085/68161624-23859600-ff4e-11e9-98d3-63334e1036ec.png">

fixes #3054

@mozilla/fxa-devs - r?