### PR TITLE
fix(security): filter handlebars security advisory for now

### DIFF
--- a/packages/fxa-payments-server/.nsprc
+++ b/packages/fxa-payments-server/.nsprc
@@ -1,5 +1,6 @@
 {
   "exceptions": [
-    "https://npmjs.com/advisories/1184"
+    "https://npmjs.com/advisories/1184",
+    "https://npmjs.com/advisories/1300"
   ]
 }


### PR DESCRIPTION
issue #3238

Not sure how we want to handle this kind of thing. It's a security advisory, but I think our usage of the code doesn't expose us to the issue? But we should eventually upgrade our dependency once the updates have filtered up?