### PR TITLE
feat(auth-server): add zendesk API retries

### DIFF
--- a/packages/fxa-auth-server/package-lock.json
+++ b/packages/fxa-auth-server/package-lock.json
@@ -427,6 +427,11 @@
         }
       }
     },
+    "@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+    },
     "@types/shot": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/shot/-/shot-4.0.0.tgz",
@@ -4661,6 +4666,22 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
         "p-limit": "^1.1.0"
+      }
+    },
+    "p-retry": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
+      "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+      "requires": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.12.0"
+      },
+      "dependencies": {
+        "retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+        }
       }
     },
     "p-try": {

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -75,6 +75,7 @@
     "node-zendesk": "^1.4.0",
     "nodemailer": "2.7.2",
     "otplib": "8.0.1",
+    "p-retry": "^4.2.0",
     "pem-jwk": "^2.0.0",
     "po2json": "0.4.5",
     "poolee": "1.0.1",


### PR DESCRIPTION
Because:

* Zendesk calls could have intermittent network failures.
* Failing to update a created Zendesk user to include the FxA uid
  makes it harder to link to the FxA user.

This commit:

* Retries Zendesk calls to reduce errors from network errors.

Issue #3090