### PR TITLE
fix(ui): extend alert bar auto-dismiss delay and restore close icon

### DIFF
--- a/packages/fxa-payments-server/src/components/AlertBar.scss
+++ b/packages/fxa-payments-server/src/components/AlertBar.scss
@@ -10,6 +10,10 @@
 #top-bar .alertSuccess {
   background: #1d1133;
   color: #fff;
+
+  svg.close g path {
+    fill: #fff;
+  }
 }
 
 .alert span.checked::before {
@@ -28,4 +32,13 @@
   margin: 0 auto;
   position: relative;
   width: 80%;
+}
+
+.close {
+  cursor: pointer;
+  display: inline-block;
+  height: 16px;
+  position: absolute;
+  right: 20px;
+  width: 16px;
 }

--- a/packages/fxa-payments-server/src/components/DialogMessage.tsx
+++ b/packages/fxa-payments-server/src/components/DialogMessage.tsx
@@ -33,6 +33,7 @@ export const DialogMessage = ({
           <button
             data-testid="dialog-dismiss"
             className="dismiss"
+            aria-label="Close modal"
             onClick={onDismiss as () => void}
           >
             <CloseIcon />

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
@@ -580,6 +580,9 @@ describe('routes/Subscriptions', () => {
 
     await findByTestId('success-billing-update');
 
+    // click outside the payment success dialog to trigger dismiss
+    fireEvent.click(getByTestId('clear-success-alert'));
+
     waitForExpect(() =>
       expect(getByTestId('success-billing-update')).not.toBeInTheDocument()
     );

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -66,6 +66,7 @@ import DialogMessage from '../../components/DialogMessage';
 
 import SubscriptionItem from './SubscriptionItem';
 import { LoadingOverlay } from '../../components/LoadingOverlay';
+import CloseIcon from '../../components/CloseIcon';
 
 export type SubscriptionsProps = {
   profile: ProfileFetchState;
@@ -239,10 +240,19 @@ export const Subscriptions = ({
         />
       )}
 
-      {updatePaymentStatus.result && (
+      {updatePaymentStatus.result && showPaymentSuccessAlert && (
         <AlertBar className="alert alertSuccess alertCenter">
           <span data-testid="success-billing-update" className="checked">
             Your billing information has been updated successfully
+          </span>
+
+          <span
+            data-testid="clear-success-alert"
+            className="close"
+            aria-label="Close modal"
+            onClick={clearSuccessAlert}
+          >
+            <CloseIcon className="close" />
           </span>
         </AlertBar>
       )}

--- a/packages/fxa-payments-server/src/store/thunks.ts
+++ b/packages/fxa-payments-server/src/store/thunks.ts
@@ -11,7 +11,10 @@ import {
 } from './actions';
 import { Plan } from './types';
 
-const RESET_PAYMENT_DELAY = 2000;
+// This is the length fo time that alert bar is displayed before
+// auto-dismissing, in milliseconds. It should be long enough for the user to
+// read the message.
+const RESET_PAYMENT_DELAY = 5000;
 
 // TODO: Find another way to handle these errors? Rejected promises result
 // in Redux actions dispatched *and* exceptions thrown. We handle the


### PR DESCRIPTION
This patch extends the auto-dismissal delay of payments server's alert
bar by a few seconds.  It also restores the close icon that was
incorrectly removed in #3193.

Fixes #3187

@mozilla/fxa-devs r?