### PR TITLE
fix(payments): include time fields in amplitude events

### DIFF
--- a/packages/fxa-payments-server/src/lib/flow-event.test.ts
+++ b/packages/fxa-payments-server/src/lib/flow-event.test.ts
@@ -4,28 +4,32 @@ import SpeedTrap from 'speed-trap';
 const eventGroup = 'testo';
 const eventType = 'quuz';
 
+const mockNow = 1002003004005;
+const dateNow = jest.spyOn(Date, 'now').mockImplementation(() => mockNow);
+const perfStartTime = mockNow - 100; // started in the past, before "now"
+
 beforeEach(() => {
   // `sendBeacon` is undefined in this context
   window.navigator.sendBeacon = jest.fn();
 });
 
 it('does not send metrics when uninitialized', () => {
-  FlowEvent.logAmplitudeEvent(eventGroup, eventType, {});
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, perfStartTime, {});
   expect(window.navigator.sendBeacon).not.toHaveBeenCalled();
 });
 
 it('remains uninitialized when any flow param is empty', () => {
   FlowEvent.init({});
-  FlowEvent.logAmplitudeEvent(eventGroup, eventType, {});
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, perfStartTime, {});
 
   FlowEvent.init({ device_id: 'moz9000', flow_begin_time: 9001 });
-  FlowEvent.logAmplitudeEvent(eventGroup, eventType, {});
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, perfStartTime, {});
 
   FlowEvent.init({ device_id: 'moz9000', flow_id: 'ipsoandfacto' });
-  FlowEvent.logAmplitudeEvent(eventGroup, eventType, {});
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, perfStartTime, {});
 
   FlowEvent.init({ flow_begin_time: 9001, flow_id: 'ipsoandfacto' });
-  FlowEvent.logAmplitudeEvent(eventGroup, eventType, {});
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, perfStartTime, {});
 
   expect(window.navigator.sendBeacon).not.toHaveBeenCalled();
 });
@@ -36,13 +40,15 @@ it('initializes when given all flow params', () => {
     flow_begin_time: 9001,
     flow_id: 'ipsoandfacto',
   });
-  FlowEvent.logAmplitudeEvent(eventGroup, eventType, {});
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, mockNow - 9001, {});
 
   expect(window.navigator.sendBeacon).toHaveBeenCalled();
 });
 
 it('sends the correct Amplitude metric payload', () => {
-  FlowEvent.logAmplitudeEvent(eventGroup, eventType, { quuz: 'quux' });
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, perfStartTime, {
+    quuz: 'quux',
+  });
   const [metricsPath, payload] = (window.navigator
     .sendBeacon as jest.Mock).mock.calls[0];
   expect(metricsPath).toEqual(`/metrics`);

--- a/packages/fxa-payments-server/src/lib/flow-event.ts
+++ b/packages/fxa-payments-server/src/lib/flow-event.ts
@@ -43,6 +43,7 @@ export function init(eventData: FlowEventParams) {
 export function logAmplitudeEvent(
   groupName: string,
   eventName: string,
+  perfStartTime: number,
   eventProperties: object
 ) {
   if (!shouldSend()) {
@@ -50,14 +51,18 @@ export function logAmplitudeEvent(
   }
 
   try {
+    const now = Date.now();
     const eventData = {
       events: [
         {
-          offset: Date.now() - optEventData.flowBeginTime || 0,
+          offset: now - optEventData.flowBeginTime || 0,
           type: `amplitude.${groupName}.${eventName}`,
         },
       ],
       data: {
+        perfStartTime, // start time from the server
+        startTime: SpeedTrap.baseTime,
+        flushTime: now,
         ...optEventData,
         ...eventProperties,
       },

--- a/packages/fxa-payments-server/src/store/amplitude-middleware.test.ts
+++ b/packages/fxa-payments-server/src/store/amplitude-middleware.test.ts
@@ -2,11 +2,15 @@ import { Middleware, MiddlewareAPI, Dispatch, AnyAction } from 'redux';
 import { AmplitudeMiddleware } from './amplitude-middleware';
 import FlowEvent from '../lib/flow-event';
 jest.mock('../lib/flow-event');
+jest.mock('../lib/config', () => ({
+  config: { perfStartTime: 9999 },
+}));
 
 let next: Dispatch<AnyAction>;
 let dispatch: Dispatch<AnyAction>;
 let getState: any;
 let invoke: Function;
+let perfStartTime: number;
 
 const create = (
   middleware: Middleware,
@@ -22,6 +26,7 @@ beforeEach(() => {
   dispatch = jest.fn();
   getState = jest.fn();
   invoke = create(AmplitudeMiddleware, { dispatch, getState }, next);
+  perfStartTime = 9999;
 });
 
 it('should dispatch the next action', () => {
@@ -57,7 +62,11 @@ it('should call logAmplitudeEvent with the correct event group and type names', 
     invoke({ type: actionType });
 
     for (const args of expectedArgs as string[][]) {
-      expect(FlowEvent.logAmplitudeEvent).toBeCalledWith(...args, {});
+      expect(FlowEvent.logAmplitudeEvent).toBeCalledWith(
+        ...args,
+        perfStartTime,
+        {}
+      );
     }
 
     (<jest.Mock>FlowEvent.logAmplitudeEvent).mockClear();

--- a/packages/fxa-payments-server/src/store/amplitude-middleware.ts
+++ b/packages/fxa-payments-server/src/store/amplitude-middleware.ts
@@ -1,6 +1,7 @@
 import { AnyAction, Dispatch, Middleware, MiddlewareAPI } from 'redux';
 import { logAmplitudeEvent } from '../lib/flow-event';
 import * as Sentry from '@sentry/browser';
+import { config } from '../lib/config';
 
 const eventGroupNames = {
   createSubscription: 'subPaySetup',
@@ -41,6 +42,7 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.manageSubscriptions,
           eventTypeNames.view,
+          config.perfStartTime,
           {}
         );
         break;
@@ -48,6 +50,7 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.manageSubscriptions,
           eventTypeNames.engage,
+          config.perfStartTime,
           {}
         );
         break;
@@ -56,6 +59,7 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.createSubscription,
           eventTypeNames.view,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         break;
@@ -63,6 +67,7 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.createSubscription,
           eventTypeNames.engage,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         break;
@@ -70,6 +75,7 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.createSubscription,
           eventTypeNames.submit,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         break;
@@ -77,11 +83,13 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.createSubscription,
           eventTypeNames.success,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         logAmplitudeEvent(
           eventGroupNames.createSubscription,
           eventTypeNames.complete,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         break;
@@ -89,6 +97,7 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.createSubscription,
           eventTypeNames.fail,
+          config.perfStartTime,
           {
             ...getPlanPropsFromAction(action),
             ...getFailureReasonFromAction(action),
@@ -100,6 +109,7 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.updatePayment,
           eventTypeNames.view,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         break;
@@ -107,6 +117,7 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.updatePayment,
           eventTypeNames.engage,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         break;
@@ -114,6 +125,7 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.updatePayment,
           eventTypeNames.submit,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         break;
@@ -121,25 +133,33 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.updatePayment,
           eventTypeNames.success,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         logAmplitudeEvent(
           eventGroupNames.updatePayment,
           eventTypeNames.complete,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         break;
       case 'updatePayment_REJECTED':
-        logAmplitudeEvent(eventGroupNames.updatePayment, eventTypeNames.fail, {
-          ...getPlanPropsFromAction(action),
-          ...getFailureReasonFromAction(action),
-        });
+        logAmplitudeEvent(
+          eventGroupNames.updatePayment,
+          eventTypeNames.fail,
+          config.perfStartTime,
+          {
+            ...getPlanPropsFromAction(action),
+            ...getFailureReasonFromAction(action),
+          }
+        );
         break;
 
       case 'cancelSubscriptionMounted':
         logAmplitudeEvent(
           eventGroupNames.cancelSubscription,
           eventTypeNames.view,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         break;
@@ -147,6 +167,7 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.cancelSubscription,
           eventTypeNames.engage,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         break;
@@ -154,6 +175,7 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.cancelSubscription,
           eventTypeNames.submit,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         break;
@@ -161,11 +183,13 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.cancelSubscription,
           eventTypeNames.success,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         logAmplitudeEvent(
           eventGroupNames.cancelSubscription,
           eventTypeNames.complete,
+          config.perfStartTime,
           getPlanPropsFromAction(action)
         );
         break;
@@ -173,6 +197,7 @@ export const AmplitudeMiddleware: Middleware = (
         logAmplitudeEvent(
           eventGroupNames.cancelSubscription,
           eventTypeNames.fail,
+          config.perfStartTime,
           {
             ...getPlanPropsFromAction(action),
             ...getFailureReasonFromAction(action),


### PR DESCRIPTION
Note: opening as a draft because this still needs tests, but I want to make sure the overall approach seems correct.

Commit message continues:
-----

Specifically, include the `perfStartTime`, `startTime`, and `flushTime`
in each amplitude event emitted by the front-end.

More details:

The content-server amplitude events are also flow events, meaning
the `perfStartTime` and other times needed to reconstruct the event time
on the server are already available on the event object. The arithmetic
used to calculate `event.time` was copied over to the payments server
post-metrics route handler code without verifying that the needed data
was available on the amplitude events emitted by the front-end.

Unlike content server, the payments server amplitude events are
generated by a redux middleware that observes certain actions dispatched
while the user interacts with the payments pages, which is separate from
how payments flow events are generated and processed. This means that the
necessary time values need to be explicitly added to each amplitude event
before the event is sent down to the server.

I verified this patch fixed the issue by attaching the node debugger to
a local payments server process, but you could also look in the payments
server logs for an amplitude event logged with a `time` property. One
such event (the engage event) is emitted as soon as a character is typed
into the subscription form.

Hopefully, this really fixes #3050.