### PR TITLE
chore(style): Add additional padding between FF logo and content

### DIFF
--- a/packages/fxa-content-server/app/styles/_layout.scss
+++ b/packages/fxa-content-server/app/styles/_layout.scss
@@ -28,13 +28,13 @@
     border-radius: $big-border-radius;
     box-shadow: $card-box-high;
     margin: 0 auto;
-    padding: 50px 40px 40px 40px;
+    padding: 70px 40px 40px 40px;
   }
 
   @include respond-to('small') {
     margin: 0 auto;
     min-height: 300px !important;
-    padding: 76px 20px 20px 20px;
+    padding: 82px 20px 20px 20px;
     position: relative;
     width: 94%;
   }


### PR DESCRIPTION
Fix for #1218 

Desktop:
<img width="595" alt="image" src="https://user-images.githubusercontent.com/13018240/68403894-5644af80-0143-11ea-83ba-79a9acb99e27.png">

Mobile:
<img width="430" alt="image" src="https://user-images.githubusercontent.com/13018240/68403874-4cbb4780-0143-11ea-83d8-daff4faf539b.png">
