### PR TITLE
feat(email-first): Add tab synchronization in email first flow

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -20,6 +20,7 @@ import FormPrefillMixin from './mixins/form-prefill-mixin';
 import FormView from './form';
 import mailcheck from '../lib/mailcheck';
 import ServiceMixin from './mixins/service-mixin';
+import SignedInNotificationMixin from './mixins/signed-in-notification-mixin';
 import SyncSuggestionMixin from './mixins/sync-suggestion-mixin';
 import Template from 'templates/index.mustache';
 
@@ -228,6 +229,7 @@ Cocktail.mixin(
   FlowBeginMixin,
   FormPrefillMixin,
   ServiceMixin,
+  SignedInNotificationMixin,
   SyncSuggestionMixin({
     entrypoint: 'fxa:enter_email',
     flowEvent: 'link.signin',

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -13,6 +13,7 @@ import FormView from './form';
 import PasswordMixin from './mixins/password-mixin';
 import preventDefaultThen from './decorators/prevent_default_then';
 import ServiceMixin from './mixins/service-mixin';
+import SignedInNotificationMixin from './mixins/signed-in-notification-mixin';
 import SignInMixin from './mixins/signin-mixin';
 import Template from 'templates/sign_in_password.mustache';
 import UserCardMixin from './mixins/user-card-mixin';
@@ -88,6 +89,7 @@ Cocktail.mixin(
   PasswordMixin,
   ServiceMixin,
   SignInMixin,
+  SignedInNotificationMixin,
   UserCardMixin
 );
 

--- a/packages/fxa-content-server/app/scripts/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_up_password.js
@@ -15,6 +15,7 @@ import PasswordMixin from './mixins/password-mixin';
 import PasswordStrengthMixin from './mixins/password-strength-mixin';
 import preventDefaultThen from './decorators/prevent_default_then';
 import ServiceMixin from './mixins/service-mixin';
+import SignedInNotificationMixin from './mixins/signed-in-notification-mixin';
 import SignUpMixin from './mixins/signup-mixin';
 import Template from 'templates/sign_up_password.mustache';
 
@@ -120,6 +121,7 @@ Cocktail.mixin(
     passwordEl: '#password',
   }),
   ServiceMixin,
+  SignedInNotificationMixin,
   SignUpMixin
 );
 


### PR DESCRIPTION
There was no tab synchronization on the /, /signin, and /signup
pages in the email-first flow.

This adds synchronization, if the user is on any of /, /signin,
/signup then signs in using another tab, redirect the user to /settings.

fixes #3269