### PR TITLE
fix(email-first): Redirect to correct settings page after authentication

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -354,6 +354,14 @@ const Router = Backbone.Router.extend({
       options.trigger = true;
     }
 
+    // If the URL to navigate to has the origin as a prefix,
+    // remove the origin and just use from the path on. This
+    // prevents a situation where for url=http://accounts.firefox.com/settings,
+    // backbone sending the user to http://accounts.firefox.com/http://accounts.firefox.com/settings
+    if (url.indexOf(this.window.location.origin) === 0) {
+      url = url.replace(this.window.location.origin, '');
+    }
+
     const shouldClearQueryParams = !!options.clearQueryParams;
     const hasQueryParams = /\?/.test(url);
 

--- a/packages/fxa-content-server/app/scripts/views/base.js
+++ b/packages/fxa-content-server/app/scripts/views/base.js
@@ -394,9 +394,7 @@ var BaseView = Backbone.View.extend({
             // The redirectTo in .navigate() is lost if there's later navigations, so by saving it here
             // we can get it later (e.g., in case of a signUp):
             this.relier.set('redirectTo', this.window.location.href);
-            this.navigate(this._reAuthPage(), {
-              redirectTo: this.currentPage,
-            });
+            this.navigate(this._reAuthPage());
             return false;
           }
 
@@ -415,7 +413,12 @@ var BaseView = Backbone.View.extend({
     if (this.relier && this.relier.get('email')) {
       return 'force_auth';
     }
-    return 'signin';
+    // Until email-first is fully the default, this is
+    // needed to ensure the `/` uses the email-first flow
+    // and not redirect unauthenticated users directly
+    // to /signup.
+    this.relier.set('action', 'email');
+    return '/';
   },
 
   displayStatusMessages() {

--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -217,7 +217,9 @@ class IndexView extends FormView {
           // ensure it's email is set.
           account.set('email', email);
         }
-        this.navigate(nextEndpoint, { account });
+        this.navigate(nextEndpoint, {
+          account,
+        });
       });
   }
 }

--- a/packages/fxa-content-server/app/scripts/views/mixins/signed-in-notification-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signed-in-notification-mixin.js
@@ -14,7 +14,7 @@ var Mixin = {
   _navigateToSignedInView(event) {
     if (this.broker.hasCapability('handleSignedInNotification')) {
       this.user.setSignedInAccountByUid(event.uid);
-      this.navigate(this.model.get('redirectTo') || 'settings');
+      this.navigate(this.relier.get('redirectTo') || 'settings');
     }
 
     return Promise.resolve();

--- a/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
@@ -249,11 +249,11 @@ export default {
     const brokerMethod = this.afterSignInBrokerMethod || 'afterSignIn';
     const navigateData = this.afterSignInNavigateData || {};
 
-    if (this.model.get('redirectTo')) {
+    if (this.relier.get('redirectTo')) {
       // If `redirectTo` is specified, override the default behavior and
       // redirect to the requested page.
-      const behavior = new NavigateBehavior(this.model.get('redirectTo'));
-      this.model.unset('redirectTo');
+      const behavior = new NavigateBehavior(this.relier.get('redirectTo'));
+      this.relier.unset('redirectTo');
       this.broker.setBehavior(brokerMethod, behavior, navigateData);
     }
 

--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -38,7 +38,8 @@ const SignInPasswordView = FormView.extend({
   },
 
   beforeRender() {
-    if (!this.getAccount()) {
+    const account = this.getAccount();
+    if (!account || !account.get('email')) {
       this.navigate('/');
     }
   },

--- a/packages/fxa-content-server/app/scripts/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_up_password.js
@@ -47,7 +47,8 @@ const SignUpPasswordView = FormView.extend({
   },
 
   beforeRender() {
-    if (!this.getAccount()) {
+    const account = this.getAccount();
+    if (!account || !account.get('email')) {
       this.navigate('/');
     }
     const error = this.model.get('error');

--- a/packages/fxa-content-server/app/tests/spec/lib/router.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/router.js
@@ -79,6 +79,14 @@ describe('lib/router', () => {
       assert.equal(navigateUrl, '/oauth/signin');
       assert.deepEqual(navigateOptions, { trigger: true });
     });
+
+    it('strips the origin from the url', () => {
+      windowMock.location.origin = 'http://accounts.firefox.com';
+      router.navigate('http://accounts.firefox.com/signin');
+
+      assert.equal(navigateUrl, '/signin');
+      assert.deepEqual(navigateOptions, { trigger: true });
+    });
   });
 
   describe('`navigate` notifier message', () => {

--- a/packages/fxa-content-server/app/tests/spec/views/base.js
+++ b/packages/fxa-content-server/app/tests/spec/views/base.js
@@ -249,7 +249,7 @@ describe('views/base', function() {
       });
     });
 
-    it('redirects to `/signin` if the user is not authenticated', function() {
+    it('redirects to `/` if the user is not authenticated', function() {
       sinon
         .stub(user, 'sessionStatus')
         .callsFake(() => Promise.reject(AuthErrors.toError('INVALID_TOKEN')));
@@ -258,7 +258,7 @@ describe('views/base', function() {
       view.mustAuth = true;
       return view.render().then(function(result) {
         assert.isFalse(result);
-        assert.isTrue(view.navigate.calledWith('signin'));
+        assert.isTrue(view.navigate.calledWith('/'));
         assert.isTrue(
           TestHelpers.isErrorLogged(
             metrics,

--- a/packages/fxa-content-server/app/tests/spec/views/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/index.js
@@ -346,7 +346,11 @@ describe('views/index', () => {
           const brokerAccount = broker.beforeSignIn.args[0][0];
           assert.equal(brokerAccount.get('email'), EMAIL);
 
-          assert.isTrue(view.navigate.calledOnceWith('signin'));
+          assert.isTrue(
+            view.navigate.calledOnceWith('signin', {
+              account: storedAccount,
+            })
+          );
           const { account } = view.navigate.args[0][1];
           assert.strictEqual(account, storedAccount);
           // Ensure the email is added to the stored account.
@@ -361,8 +365,7 @@ describe('views/index', () => {
           .stub(user, 'checkAccountEmailExists')
           .callsFake(() => Promise.resolve(false));
         return view.checkEmail(EMAIL).then(() => {
-          assert.isTrue(view.navigate.calledOnce);
-          assert.isTrue(view.navigate.calledWith('signup'));
+          assert.isTrue(view.navigate.calledOnceWith('signup'));
           const { account } = view.navigate.args[0][1];
           assert.equal(account.get('email'), EMAIL);
 

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/signed-in-notification-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/signed-in-notification-mixin.js
@@ -21,17 +21,17 @@ describe('views/mixins/signed-in-notification-mixin', () => {
   });
 
   describe('new View', () => {
-    let model;
     let notifier;
+    let relier;
     let view;
 
     before(() => {
-      model = new Backbone.Model();
       notifier = new Notifier();
       notifier.on = sinon.spy();
+      relier = new Backbone.Model();
       view = new View({
-        model: model,
-        notifier: notifier,
+        notifier,
+        relier,
       });
     });
 
@@ -142,7 +142,7 @@ describe('views/mixins/signed-in-notification-mixin', () => {
         view.navigate = sinon.spy();
       });
 
-      describe('without model.redirectTo', () => {
+      describe('without relier.redirectTo', () => {
         beforeEach(() => {
           return notifier.on.args[0][1]({
             uid: 'uid',
@@ -164,9 +164,9 @@ describe('views/mixins/signed-in-notification-mixin', () => {
         });
       });
 
-      describe('with model.redirectTo', () => {
+      describe('with relier.redirectTo', () => {
         beforeEach(() => {
-          model.set('redirectTo', 'foo');
+          relier.set('redirectTo', 'foo');
           return notifier.on.args[0][1]({
             uid: 'uid',
           });

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/signin-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/signin-mixin.js
@@ -165,7 +165,7 @@ describe('views/mixins/signin-mixin', function() {
     describe('verified account', function() {
       describe('with `redirectTo` specified', function() {
         beforeEach(function() {
-          model.set('redirectTo', 'settings/avatar');
+          relier.set('redirectTo', 'settings/avatar');
           sinon.spy(broker, 'setBehavior');
 
           return view.signIn(account, 'password');

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
@@ -68,11 +68,9 @@ describe('views/sign_in_password', () => {
 
     it('redirects to `/` if no account', () => {
       sinon.stub(view, 'getAccount').callsFake(() => null);
-
       view.beforeRender();
 
-      assert.isTrue(view.navigate.calledOnce);
-      assert.isTrue(view.navigate.calledWith('/'));
+      assert.isTrue(view.navigate.calledOnceWith('/'));
     });
 
     it('does nothing if an account passed in', () => {

--- a/packages/fxa-content-server/app/tests/spec/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_up_password.js
@@ -85,8 +85,7 @@ describe('views/sign_up_password', () => {
 
       view.beforeRender();
 
-      assert.isTrue(view.navigate.calledOnce);
-      assert.isTrue(view.navigate.calledWith('/'));
+      assert.isTrue(view.navigate.calledOnceWith('/'));
     });
 
     it('does nothing if an account passed in', () => {
@@ -110,7 +109,6 @@ describe('views/sign_up_password', () => {
       assert.lengthOf(view.$(Selectors.PRIVACY_POLICY), 1);
       assert.lengthOf(view.$(Selectors.LINK_USE_DIFFERENT), 1);
       assert.lengthOf(view.$(Selectors.MARKETING_EMAIL_OPTIN), 3);
-      assert.lengthOf(view.$(Selectors.FIREFOX_FAMILY_SERVICES), 1);
       assert.lengthOf(view.$(Selectors.FIREFOX_FAMILY_SERVICES), 1);
       assert.lengthOf(view.$(Selectors.MARKETING_EMAIL_OPTIN), 3);
       assert.isTrue(notifier.trigger.calledOnce);

--- a/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js
+++ b/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js
@@ -423,7 +423,7 @@ registerSuite('Firefox desktop user info handshake', {
 
     'Sync settings page - no user signed into browser': function() {
       return this.remote.then(
-        openPage(SYNC_SETTINGS_PAGE_URL, selectors.SIGNIN.HEADER, {
+        openPage(SYNC_SETTINGS_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
           webChannelResponses: {
             'fxaccounts:fxa_status': {
               signedInUser: null,
@@ -435,7 +435,7 @@ registerSuite('Firefox desktop user info handshake', {
 
     'Non-Sync settings page - no user signed into browser, no user signed in locally': function() {
       return this.remote.then(
-        openPage(SETTINGS_PAGE_URL, selectors.SIGNIN.HEADER, {
+        openPage(SETTINGS_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
           webChannelResponses: {
             'fxaccounts:fxa_status': {
               signedInUser: null,

--- a/packages/fxa-content-server/tests/functional/sign_in.js
+++ b/packages/fxa-content-server/tests/functional/sign_in.js
@@ -12,7 +12,6 @@ const selectors = require('./lib/selectors');
 var config = intern._config;
 var PAGE_URL = config.fxaContentRoot + 'signin';
 const ENTER_EMAIL_URL = `${config.fxaContentRoot}?action=email`;
-var AVATAR_URL = config.fxaContentRoot + 'settings/avatar/change';
 var PASSWORD = 'passwordcxzv';
 var email;
 
@@ -62,14 +61,6 @@ registerSuite('signin', {
         .then(openPage(PAGE_URL, '#fxa-signin-header'))
         .then(fillOutSignIn(email, PASSWORD))
         .then(testElementTextInclude('.verification-email-message', email));
-    },
-
-    'redirect to requested page after signin verified with correct password': function() {
-      return this.remote
-        .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(openPage(AVATAR_URL, '#fxa-signin-header'))
-        .then(fillOutSignIn(email, PASSWORD))
-        .then(testElementExists('#avatar-change'));
     },
 
     'signin verified with correct password': function() {

--- a/packages/fxa-content-server/tests/functional/sign_up.js
+++ b/packages/fxa-content-server/tests/functional/sign_up.js
@@ -15,13 +15,14 @@ var ENTER_EMAIL_URL = `${config.fxaContentRoot}?action=email`;
 var SIGNUP_URL = config.fxaContentRoot + 'signup';
 
 var email;
-var PASSWORD = '12345678';
+var PASSWORD = 'password12345678';
 
 const {
   click,
   clearBrowserState,
   closeCurrentWindow,
   createUser,
+  fillOutEmailFirstSignUp,
   fillOutSignIn,
   fillOutSignInUnblock,
   fillOutSignUp,
@@ -493,8 +494,8 @@ registerSuite('signup', {
       const productUrlPath = new URL(PRODUCT_URL).pathname;
       return (
         this.remote
-          .then(openPage(PRODUCT_URL, selectors.SIGNIN.HEADER))
-          .then(fillOutSignUp(email, PASSWORD))
+          .then(openPage(PRODUCT_URL, selectors.ENTER_EMAIL.HEADER))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
           .then(testAtConfirmScreen(email))
           // Note the way getVerificationLink works, it doesn't get the link from the email but instead only gets the
           // verification code. We have to ask it to add redirectTo=... to recreate the entire URL

--- a/packages/fxa-content-server/tests/functional/support.js
+++ b/packages/fxa-content-server/tests/functional/support.js
@@ -11,7 +11,7 @@ const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
 const config = intern._config;
-const SIGNIN_URL = config.fxaContentRoot + 'signin';
+const ENTER_EMAIL_URL = config.fxaContentRoot + '?action=email';
 const SUPPORT_URL = config.fxaContentRoot + 'support';
 const PASSWORD = 'amazingpassword';
 
@@ -19,7 +19,7 @@ const {
   clearBrowserState,
   click,
   createUser,
-  fillOutSignIn,
+  fillOutEmailFirstSignIn,
   getQueryParamValue,
   openPage,
   subscribeToTestProduct,
@@ -29,10 +29,10 @@ const {
 
 registerSuite('support form without valid session', {
   tests: {
-    'go to support form, redirects to signin': function() {
+    'go to support form, redirects to index': function() {
       return this.remote
         .then(clearBrowserState({ force: true }))
-        .then(openPage(SUPPORT_URL, selectors.SIGNIN.HEADER));
+        .then(openPage(SUPPORT_URL, selectors.ENTER_EMAIL.HEADER));
     },
   },
 });
@@ -44,8 +44,8 @@ registerSuite('support form without active subscriptions', {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
-        .then(openPage(SIGNIN_URL, selectors.SIGNIN.HEADER))
-        .then(fillOutSignIn(email, PASSWORD))
+        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
         .then(testElementExists(selectors.SETTINGS.HEADER))
         .then(openPage(SUPPORT_URL, '.subscription-management'))
         .then(getQueryParamValue('device_id'))
@@ -66,8 +66,8 @@ registerSuite('support form with an active subscription', {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
-        .then(openPage(SIGNIN_URL, selectors.SIGNIN.HEADER))
-        .then(fillOutSignIn(email, PASSWORD))
+        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
         .then(testElementExists(selectors.SETTINGS.HEADER))
         .then(subscribeToTestProduct())
         .then(openPage(SUPPORT_URL, 'div.support'))
@@ -95,8 +95,8 @@ registerSuite('support form with an active subscription', {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
-        .then(openPage(SIGNIN_URL, selectors.SIGNIN.HEADER))
-        .then(fillOutSignIn(email, PASSWORD))
+        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
         .then(testElementExists(selectors.SETTINGS.HEADER))
         .then(subscribeToTestProduct())
         .then(openPage(SUPPORT_URL, 'div.support'))


### PR DESCRIPTION
If a user tried to go to, e.g., /settings/avatar/change
without having a session, they were asked to sign in.
After sign-in, they were redirected back to /settings
rather than /settings/avatar/change because redirectTo
was not correctly propagated. Instead of propagating
the value in the view->view model, rely on the value
stored in the relier.

This also changes the default behavior of an unauthenticdated
user - instead of sending the user to `/signin`,
send the user to `/`

builds on #3281 

fixes #3270