### PR TITLE
chore(security): remove exception for NPM advisory 1184

### DIFF
--- a/packages/fxa-payments-server/.nsprc
+++ b/packages/fxa-payments-server/.nsprc
@@ -1,6 +1,5 @@
 {
   "exceptions": [
-    "https://npmjs.com/advisories/1184",
     "https://npmjs.com/advisories/1300"
   ]
 }


### PR DESCRIPTION
Follow up to remove the exception, which was patched in f4d7e985547ec7a9fc05c4e9f75758c793382f0f