### PR TITLE
fix(scripts): set REVERT_SUMMARY for changelogs correctly

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -196,7 +196,7 @@ bump() {
         REFACTOR_SUMMARY="$REFACTOR_SUMMARY\n* $AREA$MESSAGE ($HASH)"
         ;;
       "revert")
-        if [ "$REFACTOR_SUMMARY" = "" ]; then
+        if [ "$REVERT_SUMMARY" = "" ]; then
           REVERT_SUMMARY="### Reverted changes\n"
         fi
         REVERT_SUMMARY="$REVERT_SUMMARY\n* $AREA$MESSAGE ($HASH)"
@@ -262,6 +262,7 @@ $1"
   FIX_SUMMARY=""
   PERF_SUMMARY=""
   REFACTOR_SUMMARY=""
+  REVERT_SUMMARY=""
   OTHER_SUMMARY=""
 
   # 8.4. If package.json exists, uppdate the version string in package.json.


### PR DESCRIPTION
Hey old gang! I was writing a release script in my new place and happened to, er, "refer" to this one, when I noticed some copy pasta meant the changelog summaries were broken for `revert` commit messages. So this fixes it. Hope you guys are well!

r?