### PR TITLE
chore(payments): small cleanup & refactoring in PaymentForm component

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentForm/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.scss
@@ -34,7 +34,7 @@ form.payment {
       }
 
       &:-moz-ui-invalid {
-        box-shadow:none;
+        box-shadow: none;
       }
     }
 

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
@@ -14,7 +14,7 @@ import {
   PaymentForm,
   PaymentFormProps,
   PaymentFormStripeProps,
-  checkMedia,
+  mkStripeElementStyles,
   SMALL_DEVICE_LINE_HEIGHT,
   DEFAULT_LINE_HEIGHT,
 } from './index';
@@ -295,12 +295,12 @@ it('calls onPaymentError when payment processing fails', async () => {
 });
 
 it('shows adjusts form styles on smaller devices', async () => {
-  const updatedElementStylesObjectSmallDev = checkMedia(true, {});
+  const updatedElementStylesObjectSmallDev = mkStripeElementStyles(true);
   expect(updatedElementStylesObjectSmallDev.base.lineHeight).toEqual(
     SMALL_DEVICE_LINE_HEIGHT
   );
 
-  const updatedElementStylesObject = checkMedia(false, {});
+  const updatedElementStylesObject = mkStripeElementStyles(false);
   expect(updatedElementStylesObject.base.lineHeight).toEqual(
     DEFAULT_LINE_HEIGHT
   );

--- a/packages/fxa-payments-server/src/lib/hooks.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.tsx
@@ -1,5 +1,16 @@
 import { useCallback, useState, useEffect, useRef, ChangeEvent } from 'react';
 
+export function useCallbackOnce(cb: Function, deps: any[]) {
+  const called = useRef(false);
+  return useCallback(() => {
+    if (!called.current) {
+      cb();
+      called.current = true;
+    }
+  }, // eslint-disable-next-line react-hooks/exhaustive-deps
+  [called, cb, ...deps]);
+}
+
 type useBooleanStateResult = [boolean, () => void, () => void];
 export function useBooleanState(
   defaultState: boolean = false


### PR DESCRIPTION
- moved validation functions out of in-line definitions in form JSX
- simplified style definitions for stripe elements
- extracted single-use callback state tracking into reusable hook