### PR TITLE
feat(event-broker): nest structures for debug log

### DIFF
--- a/packages/fxa-event-broker/lib/api/proxy-controller.ts
+++ b/packages/fxa-event-broker/lib/api/proxy-controller.ts
@@ -49,7 +49,7 @@ export default class ProxyController {
       // The message is a unicode string encoded in base64.
       const rawMessage = Buffer.from(payload.message.data, 'base64').toString('utf-8');
       message = JSON.parse(rawMessage);
-      this.logger.debug('proxyDelivery', message);
+      this.logger.debug('proxyDelivery', { message });
     } catch (err) {
       this.logger.error('proxyDelivery', { message: 'Failure to load message payload', err });
       return h.response('Invalid message').code(400);

--- a/packages/fxa-event-broker/lib/selfUpdatingService/clientWebhookService.ts
+++ b/packages/fxa-event-broker/lib/selfUpdatingService/clientWebhookService.ts
@@ -30,7 +30,7 @@ class ClientWebhookService extends SelfUpdatingService<ClientWebhooks> {
 
   protected async updateFunction(): Promise<Result<ClientWebhooks>> {
     const data = await this.db.fetchClientIdWebhooks();
-    this.logger.debug('fetchClientIdWebhooks', data);
+    this.logger.debug('fetchClientIdWebhooks', { data });
     return data;
   }
 }


### PR DESCRIPTION
Because:

* It's hard to make sense of the logging when the object has all its
  keys dumped in the logging message fields.

This commit:

* Ensures objects are dumped as a nested structure so its less
  confusing to read from BigQuery.

Closes #3125