### PR TITLE
chore(payments): fix some matchMedia type mismatches

### DIFF
--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -85,11 +85,7 @@ describe('routes/Product', () => {
     };
     const appContextValue = {
       ...defaultAppContextValue(),
-      matchMedia:
-        matchMedia ||
-        jest.fn(() => {
-          return { matches: false };
-        }),
+      matchMedia,
       navigateToUrl: navigateToUrl || jest.fn(),
       queryParams: {
         plan: planId,
@@ -254,9 +250,7 @@ describe('routes/Product', () => {
     ];
 
     const navigateToUrl = jest.fn();
-    const matchMedia = jest.fn(() => {
-      return { matches: false };
-    });
+    const matchMedia = jest.fn(() => false);
     const renderResult = render(
       <Subject {...{ matchMedia, navigateToUrl, createToken }} />
     );
@@ -323,9 +317,7 @@ describe('routes/Product', () => {
     ];
 
     const navigateToUrl = jest.fn();
-    const matchMedia = jest.fn(() => {
-      return { matches: false };
-    });
+    const matchMedia = jest.fn(() => false);
     const createToken = jest
       .fn()
       .mockResolvedValue(VALID_CREATE_TOKEN_RESPONSE);

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
@@ -89,11 +89,7 @@ describe('routes/Subscriptions', () => {
     };
     const appContextValue = {
       ...defaultAppContextValue(),
-      matchMedia:
-        matchMedia ||
-        jest.fn(() => {
-          return { matches: false };
-        }),
+      matchMedia,
       navigateToUrl: navigateToUrl || jest.fn(),
       queryParams: {
         deviceId: 'quux',
@@ -157,11 +153,8 @@ describe('routes/Subscriptions', () => {
   it('offers a button for support', async () => {
     initApiMocks();
     const navigateToUrl = jest.fn();
-    const matchMedia = jest.fn(() => {
-      return { matches: false };
-    });
-    const { getByTestId, findByTestId, findByText } = render(
-      <Subject matchMedia={matchMedia} navigateToUrl={navigateToUrl} />
+    const { getByTestId, findByTestId } = render(
+      <Subject navigateToUrl={navigateToUrl} />
     );
     await findByTestId('subscription-management-loaded');
     fireEvent.click(getByTestId('contact-support-button'));


### PR DESCRIPTION
Noticed that we were using mocks for `matchMedia` that didn't match [how it's defined in `index.tsx`](https://github.com/mozilla/fxa/blob/master/packages/fxa-payments-server/src/index.tsx#L71) - I think this cleans those up. In the future, `tslint` might catch this sort of thing, but it wasn't failing any tests