### PR TITLE
feat(auth-server): accept product & plan metadata from subhub

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -56,6 +56,9 @@
           "plan_name": "123done Pro Monthly",
           "product_id": "123doneProProduct",
           "product_name": "123done Pro",
+          "product_metadata": {
+            "upgradeCTA": "Interested in an upgrade? <a href=\"https://getfirefox.com\">Get Firefox!</a>"
+          },
           "interval": "month",
           "amount": 50,
           "currency": "usd"

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -319,11 +319,29 @@ module.exports.subscriptionsSubscriptionListValidator = isA.object({
     .items(module.exports.subscriptionsSubscriptionValidator),
 });
 
+// https://mana.mozilla.org/wiki/pages/viewpage.action?spaceKey=COPS&title=SP+Tiered+Product+Support#SPTieredProductSupport-MetadataAgreements
+// Trying to be a bit flexible in validation here:
+// - subhub may not yet be including product / plan metadata in responses
+// - metadata can contain arbitrary keys that we don't expect (e.g. used by other systems)
+// - but we can make a good effort at validating what we expect to see when we see it
+module.exports.subscriptionPlanMetadataValidator = isA.object().unknown(true);
+module.exports.subscriptionProductMetadataValidator = isA
+  .object({
+    productSet: isA.string().optional(),
+    productOrder: isA.number().optional(),
+    iconURL: isA.string().optional(),
+    upgradeCTA: isA.string().optional(),
+    downloadURL: isA.string().optional(),
+  })
+  .unknown(true);
+
 module.exports.subscriptionsPlanValidator = isA.object({
   plan_id: module.exports.subscriptionsPlanId.required(),
   plan_name: isA.string().required(),
+  plan_metadata: module.exports.subscriptionPlanMetadataValidator.optional(),
   product_id: module.exports.subscriptionsProductId.required(),
   product_name: isA.string().required(),
+  product_metadata: module.exports.subscriptionProductMetadataValidator.optional(),
   interval: isA.string().required(),
   amount: isA.number().required(),
   currency: isA.string().required(),

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -200,6 +200,33 @@ describe('subscriptions', () => {
         assert.equal(err.errno, error.ERRNO.BACKEND_SERVICE_FAILURE);
       }
     });
+
+    it('should filter out capabilities from plan or product metadata', async () => {
+      subhub.listPlans = sinon.spy(async () =>
+        PLANS.map(plan => ({
+          ...plan,
+          product_metadata: {
+            'capabilities:abcdef': '123done,321done',
+            'capabilities:fdecba': '123456,654321',
+          },
+          plan_metadata: {
+            'capabilities:123456': '123done,321done',
+            'capabilities:8675309': '123456,654321',
+          },
+        }))
+      );
+
+      const res = await runTest('/oauth/subscriptions/plans', requestOptions);
+      assert.equal(subhub.listPlans.callCount, 1);
+      assert.deepEqual(
+        res,
+        PLANS.map(plan => ({
+          ...plan,
+          product_metadata: {},
+          plan_metadata: {},
+        }))
+      );
+    });
   });
 
   describe('GET /oauth/subscriptions/active', () => {

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -357,4 +357,96 @@ describe('lib/routes/validators:', () => {
       assert.equal(res.value, 'https://mozilla.com%2Eevil.com');
     });
   });
+
+  describe('subscriptionPlanMetadataValidator', () => {
+    const { subscriptionPlanMetadataValidator: subject } = validators;
+
+    it('accepts an empty object', () => {
+      const res = subject.validate({});
+      assert.ok(!res.error);
+    });
+
+    it('does not accept a non-object', () => {
+      const res = subject.validate(123);
+      assert.ok(res.error);
+    });
+  });
+
+  describe('subscriptionProductMetadataValidator', () => {
+    const { subscriptionProductMetadataValidator: subject } = validators;
+
+    it('accepts an empty object', () => {
+      const res = subject.validate({});
+      assert.ok(!res.error);
+    });
+
+    it('rejects a non-object', () => {
+      const res = subject.validate(123);
+      assert.ok(res.error);
+    });
+
+    it('accepts unexpected keys', () => {
+      const res = subject.validate({
+        'capabilities:8675309': '123done,321done',
+        newThing: 'this is unexpected',
+      });
+      assert.ok(!res.error);
+    });
+
+    it('rejects expected keys with invalid values', () => {
+      const res = subject.validate({
+        iconURL: true,
+      });
+      assert.ok(res.error);
+    });
+  });
+
+  describe('subscriptionsPlanValidator', () => {
+    const { subscriptionsPlanValidator: subject } = validators;
+
+    const basePlan = {
+      plan_id: 'plan_8675309',
+      plan_name: 'example plan',
+      product_id: 'prod_8675309',
+      product_name: 'example product',
+      interval: 'month',
+      amount: '867',
+      currency: 'usd',
+    };
+
+    it('accepts missing plan and product metadata', () => {
+      const plan = { ...basePlan };
+      const res = subject.validate(plan);
+      assert.ok(!res.error);
+    });
+
+    it('accepts valid plan and product metadata', () => {
+      const plan = {
+        ...basePlan,
+        plan_metadata: {},
+        product_metadata: {
+          productSet: '123done',
+          productOrder: 0,
+          iconURL: 'http://example.org',
+          downloadURL: 'http://example.org',
+          upgradeCTA: 'hello <a href="http://example.org">world</a>',
+          newThing: 'this is unexpected',
+          'capabilities:8675309': '123done,321done',
+        },
+      };
+      const res = subject.validate(plan);
+      assert.ok(!res.error);
+    });
+
+    it('rejects invalid product metadata', () => {
+      const plan = {
+        ...basePlan,
+        product_metadata: {
+          iconURL: true,
+        },
+      };
+      const res = subject.validate(plan);
+      assert.ok(res.error);
+    });
+  });
 });


### PR DESCRIPTION
This supplies the metadata that's used in #3317 to display an upgrade call-to-action. But, this and #3317 can land in any order.

issue #3242
issue #3273