### PR TITLE
feat(payments): support display of upgradeCTA in Product / Plan metadata

### DIFF
--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -10,6 +10,7 @@ import {
   CustomerSubscription,
   Plan,
 } from '../../store/types';
+import { metadataFromPlan } from '../../store/utils';
 import PaymentForm from '../../components/PaymentForm';
 import ErrorMessage from '../../components/ErrorMessage';
 
@@ -82,6 +83,8 @@ export const PaymentUpdateForm = ({
 
   const inProgress = updatePaymentStatus.loading;
 
+  const { upgradeCTA } = metadataFromPlan(plan);
+
   const { last4, exp_month, exp_year } = customer.result as Customer;
 
   // TODO: date formats will need i18n someday
@@ -104,6 +107,13 @@ export const PaymentUpdateForm = ({
         You are billed ${formatCurrencyInCents(plan.amount)} per {plan.interval}{' '}
         for {plan.product_name}. Your next payment occurs on {periodEndDate}.
       </p>
+      {upgradeCTA && (
+        <p
+          className="upgrade-cta"
+          data-testid="upgrade-cta"
+          dangerouslySetInnerHTML={{ __html: upgradeCTA }}
+        />
+      )}
       {!updateRevealed ? (
         <div className="with-settings-button">
           <div className="card-details">

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
@@ -119,6 +119,7 @@
   .payment-update {
     padding-bottom: 18px;
 
+    .upgrade-cta,
     .billing-description {
       color: #737373;
       line-height: 1.5;

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -33,6 +33,29 @@ function init() {
         }}
       />
     ))
+    .add('subscribed with upgrade offer', () => (
+      <SubscriptionsRoute
+        routeProps={{
+          ...subscribedProps,
+          plans: {
+            error: null,
+            loading: false,
+            result: [
+              {
+                ...PLANS[0],
+                product_name: 'Upgradable Product',
+                product_metadata: {
+                  upgradeCTA: `
+                    Interested in better features?
+                    Upgrade to <a href="http://mozilla.org">the Upgrade Product</a>!
+                  `,
+                },
+              },
+            ],
+          },
+        }}
+      />
+    ))
     .add('updated payment', () => (
       <SubscriptionsRoute
         routeProps={{

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -26,11 +26,28 @@ export interface Token {
 export interface Plan {
   plan_id: string;
   plan_name: string;
+  plan_metadata?: PlanMetadata;
   product_id: string;
   product_name: string;
+  product_metadata?: ProductMetadata;
   currency: string;
   amount: number;
   interval: string;
+}
+
+// https://mana.mozilla.org/wiki/pages/viewpage.action?spaceKey=COPS&title=SP+Tiered+Product+Support#SPTieredProductSupport-MetadataAgreements
+export interface PlanMetadata {
+  // note: empty for now, but may be expanded in the future
+}
+
+// https://mana.mozilla.org/wiki/pages/viewpage.action?spaceKey=COPS&title=SP+Tiered+Product+Support#SPTieredProductSupport-MetadataAgreements
+export interface ProductMetadata {
+  productSet?: string | null;
+  productOrder?: number | null;
+  iconURL?: string | null;
+  upgradeCTA?: string | null;
+  downloadURL?: string | null;
+  // capabilities:{clientID}: string // filtered out or ignored for now
 }
 
 export interface Subscription {

--- a/packages/fxa-payments-server/src/store/utils.tsx
+++ b/packages/fxa-payments-server/src/store/utils.tsx
@@ -1,5 +1,5 @@
 import { ActionType as PromiseActionType } from 'redux-promise-middleware';
-import { Action, FetchState } from './types';
+import { Action, FetchState, Plan } from './types';
 
 type MappedObject = { [propName: string]: any };
 export const mapToObject = (
@@ -41,4 +41,16 @@ export const fetchReducer = (name: string): FetchReducer => ({
     ...state,
     [name]: { error: payload, loading: false, result: null },
   }),
+});
+
+// Support some default null values for product / plan metadata and
+// allow plan metadata to override product metadata
+export const metadataFromPlan = (plan: Plan) => ({
+  productSet: null,
+  productOrder: null,
+  iconURL: null,
+  upgradeCTA: null,
+  downloadURL: null,
+  ...plan.product_metadata,
+  ...plan.plan_metadata,
 });


### PR DESCRIPTION
issue #3242

This is *slightly* dependent on #3316 - that's the server-side part of this that accepts the Product / Plan metadata from subhub. But, this and #3316 can land in any order.

However, you *should* be able to see how it renders with [the new storybook story I added](http://127.0.0.1:6006/?path=/story/routes-subscriptions--subscribed-with-upgrade-offer)

<img width="333" alt="Capture" src="https://user-images.githubusercontent.com/21687/68631062-29bfc900-049e-11ea-9ef4-101abc464477.PNG">
.