### PR TITLE
fix(email): Ensure the action buttons are translated

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -282,14 +282,19 @@ module.exports = function(log, config, oauthdb) {
   Mailer.prototype.localize = function(message) {
     const translator = this.translator(message.acceptLanguage);
 
+    const templateValues = {
+      ...message.templateValues,
+      action:
+        message.templateValues.action &&
+        translator.gettext(message.templateValues.action),
+      language: translator.language,
+      translator,
+    };
+
     const localized = this.templates.render(
       message.template,
       message.layout || 'fxa',
-      {
-        ...message.templateValues,
-        language: translator.language,
-        translator,
-      }
+      templateValues
     );
 
     return {
@@ -297,7 +302,7 @@ module.exports = function(log, config, oauthdb) {
       language: translator.language,
       subject: translator.format(
         translator.gettext(message.subject),
-        message.templateValues,
+        templateValues,
         true
       ),
       text: localized.text,

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -1423,9 +1423,11 @@ describe('email translations', () => {
       // NOTE: translation might change, but we use the subject, we don't change that often.
       // TODO: switch back to testing the subject when translations have caught up
       assert.include(emailConfig.text, 'سياسة موزيلا للخصوصيّة');
+      // Ensure the "Connect another device" action button is translated
+      assert.include(emailConfig.html, 'صِلْ جهاز آخر');
     });
 
-    return mailer.verifyEmail(message);
+    return mailer.postVerifyEmail(message);
   });
 
   it('russian emails are translated', async () => {
@@ -1436,15 +1438,12 @@ describe('email translations', () => {
         'ru',
         'language header is correct'
       );
-      // NOTE: translation might change, but we use the subject, we don't change that often.
-      // TODO: switch back to testing the subject when translations have caught up
-      assert.include(
-        emailConfig.text,
-        'Для получения большей информации, посетите'
-      );
+      assert.include(emailConfig.subject, 'Аккаунт подтверждён');
+      // Ensure the "Connect another device" action button is translated
+      assert.include(emailConfig.html, 'Подсоединить другое устройство');
     });
 
-    return mailer.verifyEmail(message);
+    return mailer.postVerifyEmail(message);
   });
 });
 


### PR DESCRIPTION
The action button text was not being translated. The
action button text was wrapped in `gettext`, but `gettext`
on its own is only for string extraction. To translate,
the text needs to be run through `translator.gettext`
rather than just gettext.

I opted to do this in the `localize` method so
that translation could be centralized.

fixes #3258

@mozilla/fxa-devs - r? Should we try to get this onto train-150?