### PR TITLE
fix(style): Update payments product avatar/logo style to prevent overlap

### DIFF
--- a/packages/fxa-content-server/app/styles/_layout.scss
+++ b/packages/fxa-content-server/app/styles/_layout.scss
@@ -28,13 +28,13 @@
     border-radius: $big-border-radius;
     box-shadow: $card-box-high;
     margin: 0 auto;
-    padding: 70px 40px 40px 40px;
+    padding: $main-content-padding-top-desktop 40px 40px;
   }
 
   @include respond-to('small') {
     margin: 0 auto;
     min-height: 300px !important;
-    padding: 82px 20px 20px 20px;
+    padding: $main-content-padding-top 20px 20px;
     position: relative;
     width: 94%;
   }

--- a/packages/fxa-content-server/app/styles/_variables.scss
+++ b/packages/fxa-content-server/app/styles/_variables.scss
@@ -197,6 +197,10 @@ $long-transition: $short-transition * 7;
 //Settings UI Height Hack
 $settings-ui-height: 630px;
 
+//Main Content Padding Top
+$main-content-padding-top: 82px;
+$main-content-padding-top-desktop: 70px;
+
 //Avatar Variables
 $avatar-size: 240px;
 $avatar-spinner-color: $color-grey-spinner;

--- a/packages/fxa-payments-server/src/components/AppLayout/index.scss
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.scss
@@ -7,6 +7,10 @@
   background-image: url('./images/firefox-logo.svg');
 }
 
+#main-content.payments-card::before {
+  background-image: none;
+}
+
 #fxa-settings-header-wrapper {
   flex-direction: column;
 

--- a/packages/fxa-payments-server/src/routes/Product/index.scss
+++ b/packages/fxa-payments-server/src/routes/Product/index.scss
@@ -1,4 +1,5 @@
 @import '../../../../fxa-content-server/app/styles/breakpoints';
+@import '../../../../fxa-content-server/app/styles/variables';
 
 .product-payment {
   .account-activated {
@@ -33,21 +34,18 @@
     }
 
     img.avatar.hoisted {
-      // HACK: Move the avatar up to cover the fx logo. This is so absolutely dirty.
-      margin-top: -92px;
-      z-index: 999;
+      // TO DO: clean this up, see issue #3336
+      margin-top: -$main-content-padding-top-desktop - 42px; // half of avatar height
 
       @include respond-to('small') {
         border-radius: 30px;
         height: 60px;
-        margin-bottom: 32px;
+        margin: -$main-content-padding-top - 30px 0 32px;
         position: relative;
         top: 24px;
         width: 60px;
       }
     }
-
-
 
     h2.displayName {
       font-weight: 500;


### PR DESCRIPTION
fixes #3325 

Not a perfect solution, but a little less hacky since we're no longer overlapping the image. We can make these consistent with the settings redesign next quarter. If we need to update this padding again, the avatar in payments will still look good since it's now a variable.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/13018240/68702840-1a4c8880-054f-11ea-982d-eb301f2ff6f3.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/13018240/68702900-351efd00-054f-11ea-8a75-22a5f376ba94.png">


