### PR TITLE
fix(style): Update 'Resubscribe' button styles to have more flexibility with text

### DIFF
--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -323,7 +323,7 @@ const ReactivateSubscriptionPanel = ({
       )}
       <div className="subscription-cancelled">
         <div className="with-settings-button">
-          <div>
+          <div className="subscription-cancelled-details">
             <p>You cancelled your subscription on {cancelledAtDate}.</p>
             <p>
               You will lose access to {plan.product_name} on{' '}

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
@@ -111,8 +111,11 @@
         display: block;
         font-weight: 600;
         padding: 0 16px;
-        width: 128px;
       }
+    }
+
+    .subscription-cancelled-details {
+      flex: 4;
     }
   }
 


### PR DESCRIPTION
fix for #3302 

I checked this in FF desktop & mobile, Chrome desktop & mobile, Safari desktop & mobile, and iOS FF and I could not reproduce the issue. @johngruen suggested I add some space before "Resubscribe" to replicate the issue so I just made the button a little more flexible while visually looking the same.

Instead of increasing the width, I added `flex: 4` on the div beside the button, which has `flex: 1`.

Before:
![image](https://user-images.githubusercontent.com/13018240/68712551-994abc80-0561-11ea-8bf6-7d40ad032100.png)

To demonstrate what this looked like with extra text (or space) before "Resubscribe":
![image](https://user-images.githubusercontent.com/13018240/68712626-b67f8b00-0561-11ea-8933-f2fbb9479a5e.png)

And now, with the current change:
![image](https://user-images.githubusercontent.com/13018240/68713019-884e7b00-0562-11ea-9b6f-9fa7f12b1941.png)

It will expand if there's ever any weirdness:
![image](https://user-images.githubusercontent.com/13018240/68713076-a87e3a00-0562-11ea-9dd6-4a1abff9c7e8.png)