### PR TITLE
fix(event): copy over version.json to /app/version.json

### DIFF
--- a/packages/fxa-event-broker/Dockerfile
+++ b/packages/fxa-event-broker/Dockerfile
@@ -12,5 +12,6 @@ WORKDIR /app
 USER node
 COPY --from=builder --chown=node /app/dist ./dist/
 COPY --from=builder --chown=node /app/node_modules ./node_modules/
+COPY --from=builder --chown=node /app/version.json /app/version.json
 COPY --chown=node config/*.json ./config/
 COPY --chown=node package* ./


### PR DESCRIPTION
fixes https://github.com/mozilla/fxa/issues/3346

Even if I workaround with the build pipeline, the `/__version__` route returns `{ commit: unknown, source: unknown, version: 1.150.2 }`. This should fix that.

r? - @bbangert 