### PR TITLE
fix(tests): update a support form functional test

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -257,6 +257,7 @@ module.exports = {
     PROFILE_HEADER: '#fxa-settings-profile-header .card-header',
     PROFILE_SUB_HEADER: '#fxa-settings-profile-header .card-subheader',
     SIGNOUT: '#signout',
+    SUB_PANELS: '#sub-panels',
     SUCCESS: '.settings-success',
   },
   SETTINGS_AVATAR: {

--- a/packages/fxa-content-server/tests/functional/support.js
+++ b/packages/fxa-content-server/tests/functional/support.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const { assert } = require('chai');
 const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
@@ -20,9 +19,9 @@ const {
   click,
   createUser,
   fillOutEmailFirstSignIn,
-  getQueryParamValue,
   openPage,
   subscribeToTestProduct,
+  testUrlPathnameEquals,
   testElementExists,
   type,
 } = FunctionalHelpers;
@@ -47,14 +46,8 @@ registerSuite('support form without active subscriptions', {
         .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
         .then(fillOutEmailFirstSignIn(email, PASSWORD))
         .then(testElementExists(selectors.SETTINGS.HEADER))
-        .then(openPage(SUPPORT_URL, '.subscription-management'))
-        .then(getQueryParamValue('device_id'))
-        .then(deviceId => assert.ok(deviceId))
-        .then(getQueryParamValue('flow_begin_time'))
-        .then(flowBeginTime => assert.ok(flowBeginTime))
-        .then(getQueryParamValue('flow_id'))
-        .then(flowId => assert.ok(flowId))
-        .then(testElementExists(selectors.SETTINGS.HEADER));
+        .then(openPage(SUPPORT_URL, selectors.SETTINGS.SUB_PANELS))
+        .then(testUrlPathnameEquals('/settings'));
     },
   },
 });


### PR DESCRIPTION
PR #2824 updated payments server to redirect back to settings if a user
does not have any subscriptions.  Subsequently the relevant functional
test was updated in PR #3147.  However, there was a timing issue in the
test.  Since the payments server will redirect at some point during its
rendering process, there may not be enough time to do the assertions in
the test.

This patch updates the test to not perform any assertions on the
subscriptions management page.

Part of #3364

@mozilla/fxa-devs r?