### PR TITLE
chore(payments-server): set payments-server to listen on 0.0.0.0

### DIFF
--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -110,7 +110,7 @@ const conf = convict({
   },
   listen: {
     host: {
-      default: '127.0.0.1',
+      default: '0.0.0.0',
       doc: 'The ip address the server should bind',
       env: 'IP_ADDRESS',
       format: 'ipaddress',


### PR DESCRIPTION
This patch updates payments server to listen on 0.0.0.0 (all
interfaces).  This would allow connections from external machines.

Note that 0.0.0.0 is the default on node and express.  It also what
content server uses.