### PR TITLE
feat(cors): Ignore `Origin` header if all origins are allowed.

### DIFF
--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -117,7 +117,9 @@ async function create(log, error, config, routes, db, oauthdb, translator) {
     routes: {
       cors: {
         additionalExposedHeaders: ['Timestamp', 'Accept-Language'],
-        origin: config.corsOrigin,
+        // If we're accepting CORS from any origin then use Hapi's "ignore" mode,
+        // which is more forgiving of missing Origin header.
+        origin: config.corsOrigin[0] === '*' ? 'ignore' : config.corsOrigin,
       },
       security: {
         hsts: {


### PR DESCRIPTION
Because:

* Upcoming changes to Firefox may result in webextensions sending
  CORS pre-flight requests that do not have an `Origin` header.

This commit:

* Uses Hapi's special 'ignore' setting when our config says to allow
  any origin, which is more forgiving of missing `Origin` headers
  than the default configuration.

Connects to #2411