### PR TITLE
feat(metrics): add a flow.doNotSync flow event when users decline to sync

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/do-not-sync-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/do-not-sync-mixin.js
@@ -8,9 +8,10 @@
  * @mixin DoNotSync mixin
  */
 import SigninMixin from './signin-mixin';
+import FlowEventsMixin from './flow-events-mixin';
 
 export default {
-  dependsOn: [SigninMixin],
+  dependsOn: [SigninMixin, FlowEventsMixin],
 
   events: {
     'click #do-not-sync-device': 'doNotSync',
@@ -18,6 +19,7 @@ export default {
 
   doNotSync() {
     this.relier.set('doNotSync', true);
+    this.logFlowEvent('cwts_do_not_sync', this.viewName);
     return Promise.resolve().then(() => {
       const account = this.getAccount();
       return this.onSubmitComplete(account);

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/do-not-sync-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/do-not-sync-mixin.js
@@ -7,6 +7,7 @@ import DoNotSyncMixin from 'views/mixins/do-not-sync-mixin';
 import BaseView from 'views/base';
 import Relier from 'models/reliers/base';
 import Broker from 'models/auth_brokers/base';
+import Notifier from 'lib/channels/notifier';
 import Cocktail from 'cocktail';
 import sinon from 'sinon';
 
@@ -27,15 +28,20 @@ describe('views/mixins/do-not-sync-mixin', function() {
   let broker;
   let view;
   let relier;
+  let notifier;
 
   beforeEach(function() {
     relier = new Relier();
     broker = new Broker();
+    notifier = new Notifier();
     view = new View({
       relier,
       broker,
+      notifier,
       onSubmitComplete: sinon.spy(),
     });
+    view.viewName = 'test';
+    sinon.stub(view, 'logFlowEvent').callsFake(() => {});
 
     return view.render();
   });
@@ -45,6 +51,8 @@ describe('views/mixins/do-not-sync-mixin', function() {
       return view.doNotSync().then(() => {
         assert.isTrue(view.onSubmitComplete.calledOnce);
         assert.isTrue(relier.get('doNotSync'));
+        assert.isTrue(view.logFlowEvent.calledOnce);
+        assert.isTrue(view.logFlowEvent.calledWith('cwts_do_not_sync', 'test'));
       });
     });
   });

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -54,6 +54,14 @@ const EVENTS = {
     group: GROUPS.registration,
     event: 'cwts_submit',
   },
+  'flow.choose-what-to-sync.cwts_do_not_sync': {
+    group: GROUPS.registration,
+    event: 'cwts_do_not_sync',
+  },
+  'flow.would-you-like-to-sync.cwts_do_not_sync': {
+    group: GROUPS.login,
+    event: 'cwts_do_not_sync',
+  },
   'flow.update-firefox.engage': {
     group: GROUPS.notify,
     event: 'update_firefox_engage',


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/2088
Fixes https://github.com/mozilla/fxa/issues/3344

@shane-tomlinson @vbudhram r?

cc @davismtl 

Logs: 

```
11|content-server PORT 3030  | {"event":"flow.doNotSync","flow_id":"b7a7f3572c1cdf951a0465c37ad8c926127e04fec0c6a1fe9fd5ffff0e8b9812","flow_time":7964,"hostname":"Vlads-MacBook-Pro.local","locale":"en","op":"flowEvent","pid":20622,"time":"2019-11-18T16:20:35.667Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:72.0) Gecko/20100101 Firefox/72.0","v":1,"context":"fx_desktop_v3","entrypoint":"fxa_discoverability_native"}
 ```