### PR TITLE
fix(metrics): Use the correct uid validator in get-metrics-flow

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/get-metrics-flow.js
+++ b/packages/fxa-content-server/server/lib/routes/get-metrics-flow.js
@@ -27,10 +27,10 @@ const {
   FORM_TYPE: FORM_TYPE_PATTERN,
   PRODUCT_ID: PRODUCT_ID_PATTERN,
   SERVICE: SERVICE_PATTERN,
-  UNIQUE_USER_ID: UID_PATTERN,
 } = validation.PATTERNS;
 
 const {
+  HEX32: FXA_UID_TYPE,
   STRING: STRING_TYPE,
   UTM: UTM_TYPE,
   UTM_CAMPAIGN: UTM_CAMPAIGN_TYPE,
@@ -74,7 +74,7 @@ module.exports = function(config) {
     utm_term: UTM_TYPE.optional(),
     // event_type and uid are only passed by the RP engagement ping (#2743).
     event_type: STRING_TYPE.regex(EVENT_TYPE_PATTERN).optional(),
-    uid: STRING_TYPE.regex(UID_PATTERN).optional(),
+    uid: FXA_UID_TYPE.optional(),
   };
 
   const FORM_TYPES = {

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -1925,7 +1925,7 @@ registerSuite('amplitude', {
           flowBeginTime: 'b',
           flowId: 'c',
           service: '2',
-          uid: 'surprisingly-a-valid-fx-accounts-uid',
+          uid: 'ca11ab1efo1dab1e5a1eab1e5ca1ab1e',
         }
       );
 
@@ -1935,7 +1935,7 @@ registerSuite('amplitude', {
       assert.equal(arg.event_properties.oauth_client_id, '2');
       assert.equal(arg.event_properties.service, 'fx-monitor');
       assert.equal(arg.time, 'a');
-      assert.equal(arg.user_id, 'surprisingly-a-valid-fx-accounts-uid');
+      assert.equal(arg.user_id, 'ca11ab1efo1dab1e5a1eab1e5ca1ab1e');
     },
   },
 });

--- a/packages/fxa-content-server/tests/server/routes/get-metrics-flow.js
+++ b/packages/fxa-content-server/tests/server/routes/get-metrics-flow.js
@@ -113,7 +113,7 @@ registerSuite('routes/get-metrics-flow', {
           event_type: 'foo.bar',
           form_type: 'other',
           service: 'sync',
-          uid: 'exactly--thirty--six--characters--12',
+          uid: 'ca11ab1efo1dab1e5a1eab1e5ca1ab1e',
           utm_campaign: 'foo',
           utm_content: 'bar',
           utm_medium: 'biz',
@@ -137,7 +137,7 @@ registerSuite('routes/get-metrics-flow', {
       assert.equal(args[2].event_type, 'foo.bar');
       assert.equal(args[2].location.country, 'United States');
       assert.equal(args[2].location.state, 'California');
-      assert.equal(args[2].uid, 'exactly--thirty--six--characters--12');
+      assert.equal(args[2].uid, 'ca11ab1efo1dab1e5a1eab1e5ca1ab1e');
       assert.ok(args[2].flowId);
       assert.ok(args[2].deviceId);
       assert.notEqual(args[2].deviceId, args[2].flowId);
@@ -273,7 +273,7 @@ registerSuite('routes/get-metrics-flow', {
 
     'invalid uid query parameter': function() {
       const query = {
-        uid: 'too-short,illegalcharz,& whitespace',
+        uid: 'not-hex-string-not-35-charz',
       };
 
       const validation = joi.object(instance.validate.query);
@@ -281,7 +281,7 @@ registerSuite('routes/get-metrics-flow', {
       assert.ok(result.error);
       const error = result.error.details[0];
       assert.equal(error.path, 'uid');
-      assert.equal(error.context.value, 'too-short,illegalcharz,& whitespace');
+      assert.equal(error.context.value, 'not-hex-string-not-35-charz');
     },
 
     'invalid event_type query parameter': function() {
@@ -426,7 +426,7 @@ registerSuite('routes/get-metrics-flow', {
         query: {
           event_type: 'engage',
           service: '0123456789abcdef',
-          uid: 'surprisingly-a-valid-fx-accounts-uid',
+          uid: 'ca11ab1efo1dab1e5a1eab1e5ca1ab1e',
         },
       };
       instance.process(request, response);
@@ -440,7 +440,7 @@ registerSuite('routes/get-metrics-flow', {
       assert.ok(args[0].time);
       assert.equal(args[2].service, '0123456789abcdef');
       assert.equal(args[0].type, 'flow.rp.engage');
-      assert.equal(args[2].uid, 'surprisingly-a-valid-fx-accounts-uid');
+      assert.equal(args[2].uid, 'ca11ab1efo1dab1e5a1eab1e5ca1ab1e');
       assert.ok(args[2].flowId);
     },
 
@@ -450,7 +450,7 @@ registerSuite('routes/get-metrics-flow', {
         query: {
           event_type: 'engage',
           service: '1234123412341234', // syntactically valid but not a registered oauth client
-          uid: 'surprisingly-a-valid-fx-accounts-uid',
+          uid: 'ca11ab1efo1dab1e5a1eab1e5ca1ab1e',
         },
       };
       instance.process(request, response);


### PR DESCRIPTION
The first implementation used the wrong validator: unique user ID
instead of user ID. 

Fixes #2743.

### Testing this patch

This patch should allow any registered RP to submit an "engage" event including a valid uid and a registered oauth client ID as 'service' param. The 'Origin' header needs to be set to one of the registered RP domains, too. This should work locally:

`]$ curl -H "Origin: http://127.0.0.1:8001" "http://127.0.0.1:3030/metrics-flow?event_type=engage&service=dcdb5ae7add825d2&uid=b01dfacec01dfacebeeffacebeef1ace"`

You should see the following 2 log lines in the content-server logs after submitting this curl ping:

```
fxa-content-server.INFO: amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_rp - engage","time":1574101610963,"user_id":"b01dfacec01dfacebeeffacebeef1ace","device_id":"cd4241c0c44e4feba49191c252883f0f","app_version":"150.1","event_properties":{"service":"123done","oauth_client_id":"dcdb5ae7add825d2"},"user_properties":{"flow_id":"fc24eb26e2e44b779a8486388c5d1800a8704cd2e3dbf8583abd259eee7f315c","ua_browser":"curl","ua_version":"7.54.0","$append":{"fxa_services_used":"123done"}}}
fxa-content-server.server.requests.INFO: route GET /metrics-flow?event_type=engage&service=dcdb5ae7add825d2&uid=b01dfacec01dfacebeeffacebeef1ace 1.252 200
```
