### PR TITLE
fix(fxa-dev): add basePath to oauth routes on auth-server

### DIFF
--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -193,6 +193,9 @@ module.exports = function(
   defaults.forEach(r => {
     r.path = basePath + r.path;
   });
+  oauthServer.routes.forEach(r => {
+    r.path = basePath + r.path;
+  });
   const allRoutes = defaults.concat(idp, v1Routes, oauthServer.routes);
 
   allRoutes.forEach(r => {


### PR DESCRIPTION
fxa-dev runs the auth-server under /auth. fxa-dev now uses nginx to
rewrite oauth urls to point to /auth instead of the old oauth-server
so now they also need use the basePath.

This should fix https://github.com/mozilla/fxa-dev/issues/500