### PR TITLE
chore(deps): Remove stale nsp exceptions from .nsprc files

### DIFF
--- a/packages/fxa-auth-db-mysql/.nsprc
+++ b/packages/fxa-auth-db-mysql/.nsprc
@@ -1,16 +1,4 @@
 {
-  "comment_755": "755 is prototype pollution in handlebars, used by nyc.",
-  "comment_1065": "1065 is prototype pollution in lodash, used by nyc.",
-  "comment_1164": "1164 is prototype pollution in handlebars, used by nyc.",
-  "comment_1171": "1171 is RegExp denial of service in csv-parse, used by restify.",
-  "comment_1300": "1300 is denial of service vulnerability in handlebars, used by nyc.",
-  "comment_1316": "1316 is arbitrary code execution in handlebars, used by nyc.",
   "exceptions": [
-    "https://npmjs.com/advisories/755",
-    "https://npmjs.com/advisories/1065",
-    "https://npmjs.com/advisories/1164",
-    "https://npmjs.com/advisories/1171",
-    "https://npmjs.com/advisories/1300",
-    "https://npmjs.com/advisories/1316"
   ]
 }

--- a/packages/fxa-auth-server/.nsprc
+++ b/packages/fxa-auth-server/.nsprc
@@ -1,9 +1,7 @@
 {
+  "comment_766": "766 is sandbox breakout in sandbox.",
   "comment_1168": "Exception added for 'subtext' vulnerability in hapi 17, fixed in hapi 18 branch. See https://github.com/mozilla/fxa/issues/2601",
   "exceptions": [
-    "https://npmjs.com/advisories/39",
-    "https://npmjs.com/advisories/48",
-    "https://npmjs.com/advisories/658",
     "https://npmjs.com/advisories/766",
     "https://npmjs.com/advisories/1168"
   ]

--- a/packages/fxa-customs-server/.nsprc
+++ b/packages/fxa-customs-server/.nsprc
@@ -1,8 +1,6 @@
 {
   "comment_1171": "Exception added for csv-parse and restify, see issue #2600",
   "exceptions": [
-    "https://npmjs.com/advisories/813",
-    "https://npmjs.com/advisories/1065",
     "https://npmjs.com/advisories/1171"
    ]
 }

--- a/packages/fxa-geodb/.nsprc
+++ b/packages/fxa-geodb/.nsprc
@@ -1,8 +1,4 @@
 {
-  "comment_1300": "1300 is denial of service vulnerability in handlebars, used by nyc.",
-  "comment_1316": "1316 is arbitrary code execution in handlebars, used by nyc.",
   "exceptions": [
-    "https://npmjs.com/advisories/1300",
-    "https://npmjs.com/advisories/1316"
   ]
 }

--- a/packages/fxa-geodb/package-lock.json
+++ b/packages/fxa-geodb/package-lock.json
@@ -509,10 +509,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true,
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "optional": true
     },
     "commondir": {
@@ -1154,10 +1153,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
-      "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
-      "dev": true,
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -1900,8 +1898,7 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-      "dev": true
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
     },
     "nested-error-stacks": {
       "version": "2.1.0",
@@ -2213,18 +2210,9 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        }
       }
     },
     "optionator": {
@@ -2643,8 +2631,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "spawn-wrap": {
       "version": "1.4.3",
@@ -3075,13 +3062,12 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-      "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
-      "dev": true,
+      "version": "3.6.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
+      "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       }
     },
@@ -3149,6 +3135,11 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrap-ansi": {
       "version": "5.1.0",

--- a/packages/fxa-support-panel/.nsprc
+++ b/packages/fxa-support-panel/.nsprc
@@ -1,3 +1,3 @@
 {
-  "exceptions": ["https://npmjs.com/advisories/1316"]
+  "exceptions": []
 }


### PR DESCRIPTION
Just a quick bit of cleanup; many of the .nsprc exceptions have been fixed by updating dependencies. The fxa-geodb fix involved transitive dependencies, which is why its `package-lock.json` is included.

Testing this PR: `npm run lint:deps` from top-level in the FxA repo should complete without errors.