### PR TITLE
fix(input): Don't focus vpassword element when invalid

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/form.js
+++ b/packages/fxa-content-server/app/scripts/views/form.js
@@ -373,36 +373,40 @@ var FormView = BaseView.extend({
    *
    * @param {String} el
    * @param {Error} err
+   * @param {Boolean} shouldFocusEl
    * @returns {String}
    */
-  showValidationError(el, err) {
+  showValidationError(el, err, shouldFocusEl = true) {
     this.logError(err);
 
     const $invalidEl = this.$(el);
     const message = AuthErrors.toMessage(err);
 
-    const markElementInvalidAndFocus = describedById => {
+    const markElementInvalidAndMaybeFocus = describedById => {
       this.markElementInvalid($invalidEl, describedById);
-      // wait to focus otherwise
-      // on screen keyboard may cover message
-      setTimeout(
-        () => {
-          try {
-            $invalidEl.get(0).focus();
-          } catch (e) {
-            // IE can blow up if the element is not visible.
-          }
-        },
-        // Create account page needs a bit more time than next tick
-        // for some unknown reason. Maybe investigate later...
-        200
-      );
       // used for testing
       this.trigger('validation_error', el, message);
+
+      if (shouldFocusEl) {
+        // wait to focus otherwise
+        // on screen keyboard may cover message
+        setTimeout(
+          () => {
+            try {
+              $invalidEl.get(0).focus();
+            } catch (e) {
+              // IE can blow up if the element is not visible.
+            }
+          },
+          // Create account page needs a bit more time than next tick
+          // for some unknown reason. Maybe investigate later...
+          200
+        );
+      }
     };
 
     if (err.describedById) {
-      markElementInvalidAndFocus(err.describedById);
+      markElementInvalidAndMaybeFocus(err.describedById);
     } else {
       // tooltipId is used to bind the invalid element
       // with the tooltip using `aria-described-by`
@@ -421,7 +425,7 @@ var FormView = BaseView.extend({
           this.trigger('validation_error_removed', el);
         })
         .render()
-        .then(() => markElementInvalidAndFocus(tooltipId));
+        .then(() => markElementInvalidAndMaybeFocus(tooltipId));
 
       this.trackChildView(tooltip);
     }

--- a/packages/fxa-content-server/app/scripts/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_up_password.js
@@ -90,7 +90,8 @@ const SignUpPasswordView = FormView.extend({
     if (!this._doPasswordsMatch()) {
       this.showValidationError(
         this.$(VPASSWORD_INPUT_SELECTOR),
-        AuthErrors.toError('PASSWORDS_DO_NOT_MATCH')
+        AuthErrors.toError('PASSWORDS_DO_NOT_MATCH'),
+        false
       );
     }
   },

--- a/packages/fxa-content-server/app/tests/spec/views/form.js
+++ b/packages/fxa-content-server/app/tests/spec/views/form.js
@@ -354,7 +354,7 @@ describe('views/form', function() {
       view.showValidationError('#focusMe', 'this is an error');
     });
 
-    it('focuses the invalid element', function(done) {
+    it('focuses the invalid element by default', function(done) {
       $('#container').html(view.el);
 
       // wekbit fails unless focusing another element first.
@@ -366,6 +366,16 @@ describe('views/form', function() {
         });
         view.showValidationError('#focusMe', 'this is an error');
       }, done);
+    });
+
+    it('does not focus the invalid element', () => {
+      $('#container').html(view.el);
+
+      // Focus another element
+      view.$('#otherElement').focus();
+
+      view.showValidationError('#focusMe', 'this is an error', false);
+      assert.isFalse(view.$('#focusMe').is(':focus'));
     });
 
     it('logs the error', function(done) {

--- a/packages/fxa-content-server/app/tests/spec/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_up_password.js
@@ -241,6 +241,10 @@ describe('views/sign_up_password', () => {
               AuthErrors.toError('PASSWORDS_DO_NOT_MATCH')
             )
           );
+          assert.isFalse(
+            view.showValidationError.args[0][2],
+            'false to not focus element'
+          );
         });
       });
     });

--- a/packages/fxa-content-server/tests/functional/sign_up.js
+++ b/packages/fxa-content-server/tests/functional/sign_up.js
@@ -428,6 +428,8 @@ registerSuite('signup', {
               'Passwords do not match'
             )
           )
+          // user can enter to next input despite tooltip error
+          .then(type(selectors.SIGNUP_PASSWORD.AGE, '42'))
       );
     },
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/631

No longer focus the vpassword element when passwords do not match. I opted to extend the `showValidationError` function to accept a param to focus the element. This seemed like the most clean and straightforward way to get this functionality.