### PR TITLE
fix(circleci): use default size resources for content-server tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,6 @@ jobs:
       - run: ../../.circleci/deploy.sh << parameters.module >>
 
   fxa-content-server:
-    resource_class: xlarge
     parallelism: 6
     docker:
       - image: mozilla/fxa-circleci


### PR DESCRIPTION
testing out the run time...