### PR TITLE
feat(audit): run npm audit on push instead of in ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "authors": "git shortlog -s | cut -c8- | sort -f > AUTHORS",
     "postinstall": "_scripts/install_all.sh",
     "npm-ci-all": "lerna exec --parallel -- npm ci",
-    "lint:deps": "lerna exec --parallel -- npm run lint:deps",
+    "audit": "lerna run audit --parallel",
     "start": "pm2 start mysql_servers.json && echo \"Use 'npm stop' to stop all the servers\"",
     "stop": "pm2 kill",
     "start-firefox": "./packages/fxa-dev-launcher/bin/fxa-dev-launcher",
@@ -69,7 +69,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged",
+      "pre-push": "npm run audit"
     }
   },
   "lint-staged": {

--- a/packages/123done/package.json
+++ b/packages/123done/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "lint": "npm-run-all --parallel lint:*",
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint:eslint": "eslint .",
     "postinstall": "bower install --config.interactive=false -s",
     "start": "node server.js",

--- a/packages/browserid-verifier/package.json
+++ b/packages/browserid-verifier/package.json
@@ -42,7 +42,7 @@
   },
   "scripts": {
     "lint": "npm-run-all --parallel lint:*",
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint:eslint": "eslint .",
     "pretest": "npm run lint",
     "test": "mocha --exit -t 5000 -R spec tests/*.js",

--- a/packages/fortress/package.json
+++ b/packages/fortress/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "lint": "npm-run-all --parallel lint:*",
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint:eslint": "eslint .",
     "postinstall": "bower install --config.interactive=false -s",
     "start": "node server.js",

--- a/packages/fxa-amplitude-send/package.json
+++ b/packages/fxa-amplitude-send/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build-node-docker-image": "docker build -f Dockerfile-nodejs -t mozilla/fxa-amplitude-send:`git describe`-node .",
     "lint": "eslint *.js bin/*.js",
-    "lint:deps": "echo 'dependency checking not yet enabled for fxa-amplitude-send'"
+    "audit": "echo 'dependency checking not yet enabled for fxa-amplitude-send'"
   },
   "repository": {
     "type": "git",

--- a/packages/fxa-auth-db-mysql/package.json
+++ b/packages/fxa-auth-db-mysql/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "outdated": "npm outdated --depth 0 || exit 0",
     "lint": "npm-run-all --parallel lint:*",
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint:eslint": "eslint .",
     "start": "node ./bin/db_patcher.js >/dev/null && node ./bin/server.js",
     "start-mem": "node ./bin/mem",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "bump-template-versions": "node scripts/template-version-bump",
     "lint": "npm-run-all --parallel lint:*",
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint:eslint": "eslint .",
     "postinstall": "scripts/download_l10n.sh",
     "start": "npm run gen-keys && node ./bin/key_server.js",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -6,7 +6,7 @@
         "build-production": "NODE_ENV=production grunt build",
         "postinstall": "cp server/config/local.json-dist server/config/local.json && scripts/download_l10n.sh",
         "lint": "npm-run-all --parallel lint:*",
-        "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+        "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
         "lint:eslint": "eslint app server tests --cache",
         "start": "node scripts/check-local-config && grunt server",
         "start-dev-debug": "node scripts/check-local-config && node --inspect server/bin/fxa-content-server.js",

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -15,7 +15,7 @@
     "outdated": "npm outdated --depth 0 || exit 0",
     "start": "node bin/customs_server.js",
     "lint": "npm-run-all --parallel lint:*",
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint:eslint": "eslint .",
     "test": "scripts/test-local.sh",
     "format": "prettier '**' --write"

--- a/packages/fxa-dev-launcher/package.json
+++ b/packages/fxa-dev-launcher/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "start": "bin/fxa-dev-launcher"
   },
   "bin": {

--- a/packages/fxa-email-event-proxy/package.json
+++ b/packages/fxa-email-event-proxy/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "npm-run-all --parallel lint:*",
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint:eslint": "eslint .",
     "test": "mocha --ui tdd --recursive tests/",
     "build": "zip --recurse-paths -y fxa-email-event-proxy *.js *.json node_modules",

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "./node_modules/typescript/bin/tsc",
     "lint": "npm-run-all --parallel lint:*",
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint:tslint": "./node_modules/tslint/bin/tslint -p .",
     "watch": "tsc -w",
     "test": "FIRESTORE_EMULATOR_HOST=localhost:8006 FIRESTORE_PROJECT_ID=fx-event-broker ./node_modules/mocha/bin/mocha -r ts-node/register test/**/*.spec.ts test/**/**/*.spec.ts",

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "cover": "nyc _mocha",
     "lint": "npm-run-all --parallel lint:*",
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint:eslint": "eslint .",
     "postinstall": "node scripts/start-db-download.js",
     "test": "mocha",

--- a/packages/fxa-js-client/package.json
+++ b/packages/fxa-js-client/package.json
@@ -8,7 +8,7 @@
     "start": "grunt",
     "postinstall": "grunt sjcl",
     "lint": "npm-run-all --parallel lint:*",
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint:eslint": "eslint .",
     "test": "npm run lint && mocha tests/lib --reporter dot --timeout 5000",
     "test-local": "AUTH_SERVER_URL=http://127.0.0.1:9000 npm test",

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -6,7 +6,7 @@
     "lint": "npm-run-all --parallel lint:*",
     "lint:eslint": "eslint .",
     "lint:sass": "sass-lint -v",
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "start": "node server/bin/fxa-payments-server.js",
     "start-dev": "npm-run-all --parallel server:proxy server:react-scripts",
     "start-dev-debug": "npm-run-all --parallel server:proxy-debug server:react-scripts",

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "npm-run-all --parallel lint:*",
     "lint:eslint": "eslint .",
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "outdated": "npm outdated --depth 0 || exit 0",
     "preinstall": "./scripts/check_gm.sh && mkdir -p var/public/",
     "start": "scripts/run_dev.js",

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "test": "mocha -r ts-node/register --recursive test",
     "lint": "npm-run-all --parallel lint:*",
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint:eslint": "eslint .",
     "lint:tslint": "tslint -p .",
     "format": "prettier '**' --write"

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -9,7 +9,7 @@
     "build": "./node_modules/typescript/bin/tsc",
     "lint": "npm-run-all --parallel lint:*",
     "lint:tslint": "./node_modules/tslint/bin/tslint -p .",
-    "lint:deps": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
+    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "test": "./node_modules/mocha/bin/mocha -r ts-node/register test/**/*.spec.ts test/**/**/*.spec.ts",
     "shrink": "npmshrink && npm run postinstall",
     "watch": "tsc -w",


### PR DESCRIPTION
It's pretty disheartening when your PR fails in ci because of an
npm advisory unrelated to your changes. We still need to be aware
of them but have the ability to more easily keep doing other work.

Running the audit on git push allows us all to see advisories
quickly, but allows us to override and push with `--no-verify` so
work can continue and the advisory addressed on its own.