### PR TITLE
fix(sync): clean up and fix sync preference options for Firefox 71

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-sync-channel.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-sync-channel.js
@@ -293,13 +293,19 @@ const FxSyncChannelAuthenticationBroker = FxSyncAuthenticationBroker.extend(
      */
     _formatForMultiServiceBrowser(loginData) {
       loginData.services = {};
-      if (!this.relier.get('doNotSync') && loginData.offeredSyncEngines) {
-        // make sure to NOT send an empty 'sync' object,
-        // this can happen in the `force_auth` flow.
-        loginData.services.sync = {
-          offeredEngines: loginData.offeredSyncEngines,
-          declinedEngines: loginData.declinedSyncEngines,
-        };
+
+      const syncPreference = this.relier.get('syncPreference');
+
+      if (syncPreference) {
+        // sending an empty sync object turns on sync in the browser
+        loginData.services.sync = {};
+
+        if (loginData.offeredSyncEngines) {
+          loginData.services.sync = {
+            offeredEngines: loginData.offeredSyncEngines,
+            declinedEngines: loginData.declinedSyncEngines,
+          };
+        }
       } else if (this.relier.get('service') === 'sync') {
         // if service is already forced to be Sync, then for sign-in
         // attempts we tell Desktop to just enable sync

--- a/packages/fxa-content-server/app/scripts/models/reliers/browser.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/browser.js
@@ -35,7 +35,13 @@ export default Relier.extend({
   defaults: _.extend({}, Relier.prototype.defaults, {
     action: undefined,
     name: 'browser',
-    doNotSync: false,
+    /*
+    syncPreference specifies the user's choice for the following:
+      undefined - unset, happens during force_auth, sync setting in Firefox should not change
+      true - user wants to turn on sync
+      false - user doesn't want sync
+     */
+    syncPreference: undefined,
     multiService: false,
     signinCode: undefined,
     tokenCode: true,

--- a/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
+++ b/packages/fxa-content-server/app/scripts/views/choose_what_to_sync.js
@@ -101,7 +101,8 @@ const View = FormView.extend(
         const offeredSyncEngines = this._getOfferedEngineIds();
 
         this._trackDeclinedEngineIds(declinedSyncEngines);
-
+        // user made a choice to enable Sync by submitting the form
+        this.relier.set('syncPreference', true);
         account.set({
           declinedSyncEngines,
           offeredSyncEngines,

--- a/packages/fxa-content-server/app/scripts/views/mixins/do-not-sync-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/do-not-sync-mixin.js
@@ -18,7 +18,7 @@ export default {
   },
 
   doNotSync() {
-    this.relier.set('doNotSync', true);
+    this.relier.set('syncPreference', false);
     this.logFlowEvent('cwts_do_not_sync', this.viewName);
     return Promise.resolve().then(() => {
       const account = this.getAccount();

--- a/packages/fxa-content-server/app/scripts/views/would_you_like_to_sync.js
+++ b/packages/fxa-content-server/app/scripts/views/would_you_like_to_sync.js
@@ -42,6 +42,8 @@ const View = FormView.extend(
       return Promise.resolve().then(() => {
         const account = this.getAccount();
         if (this.skipCWTS) {
+          // set that user made a choice to enable Sync
+          this.relier.set('syncPreference', true);
           // don't ask to specify data choices via CWTS
           // see https://github.com/mozilla/fxa/issues/3083 for details
           return this.onSubmitComplete(account);

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync-channel.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync-channel.js
@@ -459,6 +459,7 @@ describe('models/auth_brokers/fx-sync-channel', () => {
 
     it('formats the login data for multi-service', () => {
       broker.relier.set('multiService', true);
+      broker.relier.set('syncPreference', true);
       const loginData = broker._getLoginData(account);
 
       assert.deepEqual(loginData, {
@@ -502,7 +503,7 @@ describe('models/auth_brokers/fx-sync-channel', () => {
 
     it('formats the login data for multi-service that did not opt-in to sync', () => {
       broker.relier.set('multiService', true);
-      broker.relier.set('doNotSync', true);
+      broker.relier.set('syncPreference', false);
       const loginData = broker._getLoginData(account);
 
       assert.deepEqual(loginData, {

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/do-not-sync-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/do-not-sync-mixin.js
@@ -50,7 +50,7 @@ describe('views/mixins/do-not-sync-mixin', function() {
     it('triggers onSubmitComplete', () => {
       return view.doNotSync().then(() => {
         assert.isTrue(view.onSubmitComplete.calledOnce);
-        assert.isTrue(relier.get('doNotSync'));
+        assert.isFalse(relier.get('syncPreference'));
         assert.isTrue(view.logFlowEvent.calledOnce);
         assert.isTrue(view.logFlowEvent.calledWith('cwts_do_not_sync', 'test'));
       });


### PR DESCRIPTION
Filed against train-150. This simplifies the whole logic for sync choices, we relied on 'loginData.offeredSyncEngines' and that is faulty. This is needed ASAP for Firefox 71 beta testing.

Sorry!

Fixes https://github.com/mozilla/application-services/issues/2239
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1597961