### PR TITLE
feat(payments): use Stripe metadata in download email as source for product name, icon, download URL

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -17,7 +17,6 @@
     "port": 9999,
     "secure": false,
     "redirectDomain": "127.0.0.1",
-    "subscriptionDownloadUrl": "https://fpn.firefox.com/vpn/download?source=email&env=dev",
     "subscriptionTermsUrl": "https://www.mozilla.org/about/legal/terms/firefox-private-network/"
   },
   "snsTopicArn": "arn:aws:sns:local-01:000000000000:local-topic1",
@@ -57,7 +56,10 @@
           "product_id": "123doneProProduct",
           "product_name": "123done Pro",
           "product_metadata": {
-            "upgradeCTA": "Interested in an upgrade? <a href=\"https://getfirefox.com\">Get Firefox!</a>"
+            "upgradeCTA": "Interested in an upgrade? <a href=\"https://getfirefox.com\">Get Firefox!</a>",
+            "webIconURL": "http://placekitten.com/512/512?image=6",
+            "emailIconURL": "http://placekitten.com/512/512?image=0",
+            "downloadURL": "http://getfirefox.com",
           },
           "interval": "month",
           "amount": 50,
@@ -68,6 +70,11 @@
           "plan_name": "321done Pro Monthly",
           "product_id": "321doneProProduct",
           "product_name": "321done Pro",
+          "product_metadata": {
+            "webIconURL": "http://placekitten.com/512/512?image=7",
+            "emailIconURL": "http://placekitten.com/512/512?image=1",
+            "downloadURL": "http://getfirefox.com",
+          },
           "interval": "month",
           "amount": 50,
           "currency": "usd"
@@ -77,6 +84,11 @@
           "plan_name": "123done Pro and 321done Pro Monthly",
           "product_id": "allDoneProProduct",
           "product_name": "123done Pro and 321done Pro",
+          "product_metadata": {
+            "webIconURL": "http://placekitten.com/512/512?image=8",
+            "emailIconURL": "http://placekitten.com/512/512?image=2",
+            "downloadURL": "http://getfirefox.com",
+          },
           "interval": "month",
           "amount": 50,
           "currency": "usd"
@@ -86,6 +98,11 @@
           "plan_name": "Fortress Pro Monthly",
           "product_id": "fortressProProduct",
           "product_name": "Fortress Pro",
+          "product_metadata": {
+            "webIconURL": "http://placekitten.com/512/512?image=9",
+            "emailIconURL": "http://placekitten.com/512/512?image=3",
+            "downloadURL": "http://getfirefox.com",
+          },
           "interval": "month",
           "amount": 50,
           "currency": "usd"
@@ -95,6 +112,11 @@
           "plan_name": "321done Pro Weekly",
           "product_id": "321doneProProduct",
           "product_name": "321done Pro",
+          "product_metadata": {
+            "webIconURL": "http://placekitten.com/512/512?image=10",
+            "emailIconURL": "http://placekitten.com/512/512?image=4",
+            "downloadURL": "http://getfirefox.com",
+          },
           "interval": "week",
           "amount": 5,
           "currency": "usd"
@@ -104,6 +126,11 @@
           "plan_name": "123done Pro and 321done Pro Weekly",
           "product_id": "allDoneProProduct",
           "product_name": "123done Pro and 321done Pro",
+          "product_metadata": {
+            "webIconURL": "http://placekitten.com/512/512?image=11",
+            "emailIconURL": "http://placekitten.com/512/512?image=5",
+            "downloadURL": "http://getfirefox.com",
+          },
           "interval": "week",
           "amount": 5,
           "currency": "usd"

--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -283,12 +283,6 @@ const conf = convict({
       default:
         'https://support.mozilla.org/kb/password-manager-remember-delete-change-and-import#w_viewing-and-deleting-passwords',
     },
-    subscriptionDownloadUrl: {
-      default: 'https://example.com/placeholder-product-link-changeme',
-      doc: 'Subscription download URL',
-      env: 'SUBSCRIPTION_DOWNLOAD_URL',
-      format: String,
-    },
     subscriptionTermsUrl: {
       default:
         'https://www.mozilla.org/about/legal/terms/firefox-private-network/',

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -9,6 +9,7 @@ const isA = require('joi');
 const ScopeSet = require('../../../fxa-shared').oauth.scopes;
 const validators = require('./validators');
 const StripeHelper = require('../payments/stripe');
+const { metadataFromPlan } = require ('./utils/subscriptions');
 
 const createRoutes = (
   log,
@@ -175,6 +176,7 @@ const createRoutes = (
           throw error.unknownSubscriptionPlan(planId);
         }
         const productId = selectedPlan.product_id;
+        const planMetadata = metadataFromPlan(selectedPlan);
 
         const paymentResult = await subhub.createSubscription(
           uid,
@@ -210,6 +212,10 @@ const createRoutes = (
         await mailer.sendDownloadSubscriptionEmail(account.emails, account, {
           acceptLanguage: account.locale,
           productId,
+          planId,
+          productName: selectedPlan.product_name,
+          planEmailIconURL: planMetadata.emailIconURL,
+          planDownloadURL: planMetadata.downloadURL,
         });
 
         log.info('subscriptions.createSubscription.success', {

--- a/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
@@ -11,6 +11,19 @@ module.exports = {
   PRODUCT_SUBSCRIBED,
   PRODUCT_REGISTERED,
 
+  // Support some default null values for product / plan metadata and
+  // allow plan metadata to override product metadata
+  metadataFromPlan: plan => ({
+    productSet: null,
+    productOrder: null,
+    emailIconURL: null,
+    webIconURL: null,
+    upgradeCTA: null,
+    downloadURL: null,
+    ...plan.product_metadata,
+    ...plan.plan_metadata,
+  }),
+
   determineClientVisibleSubscriptionCapabilities: async function(
     config,
     auth,

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -165,7 +165,6 @@ module.exports = function(log, config, oauthdb) {
     );
     this.sender = mailerConfig.sender;
     this.sesConfigurationSet = mailerConfig.sesConfigurationSet;
-    this.subscriptionDownloadUrl = mailerConfig.subscriptionDownloadUrl;
     this.subscriptionSettingsUrl = mailerConfig.subscriptionSettingsUrl;
     this.subscriptionSupportUrl = mailerConfig.subscriptionSupportUrl;
     this.subscriptionTermsUrl = mailerConfig.subscriptionTermsUrl;
@@ -1594,14 +1593,22 @@ module.exports = function(log, config, oauthdb) {
   };
 
   Mailer.prototype.downloadSubscriptionEmail = async function(message) {
-    const { email, productId, uid } = message;
+    const {
+      email,
+      productId,
+      planId,
+      productName,
+      planEmailIconURL,
+      planDownloadURL,
+      uid,
+    } = message;
 
     log.trace('mailer.downloadSubscription', { email, productId, uid });
 
-    const query = { product_id: productId, uid };
+    const query = { plan_id: planId, product_id: productId, uid };
     const template = 'downloadSubscription';
     const links = this._generateLinks(
-      this.subscriptionDownloadUrl,
+      planDownloadURL,
       email,
       query,
       template
@@ -1609,13 +1616,10 @@ module.exports = function(log, config, oauthdb) {
     const headers = {
       'X-Link': links.link,
     };
-    // TODO: product, subject, action and icon must vary per subscription for phase 2 - https://github.com/mozilla/fxa/issues/2026
+
     // TODO: re-enable translations when subscriptions are more widely available
-    const product = 'Firefox Private Network';
-    const subject = `Welcome to ${product}!`;
-    const action = `Download ${product}`;
-    // TODO: we're waiting on a production-ready icon - https://github.com/mozilla/fxa/issues/2027
-    //const icon = 'https://image.e.mozilla.org/lib/fe9915707361037e75/m/4/todo.png';
+    const subject = `Welcome to ${productName}!`;
+    const action = `Download ${productName}`;
 
     return this.send({
       ...message,
@@ -1627,8 +1631,8 @@ module.exports = function(log, config, oauthdb) {
         ...links,
         action,
         email,
-        //icon,
-        product,
+        icon: planEmailIconURL,
+        product: productName,
         subject,
       },
     });

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -22,7 +22,8 @@
     "test-scripts": "NODE_ENV=dev mocha test/scripts --exit",
     "test-remote": "MAILER_HOST=restmail.net MAILER_PORT=80 CORS_ORIGIN=http://baz mocha --timeout=300000 test/remote",
     "format": "prettier '**' --write",
-    "gen-keys": "./scripts/gen_keys.js; ./scripts/oauth_gen_keys.js; ./scripts/gen_vapid_keys.js"
+    "gen-keys": "./scripts/gen_keys.js; ./scripts/oauth_gen_keys.js; ./scripts/gen_vapid_keys.js",
+    "write-emails": "node ./scripts/write-emails-to-disk.js"
   },
   "repository": {
     "type": "git",

--- a/packages/fxa-auth-server/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/scripts/write-emails-to-disk.js
@@ -94,6 +94,10 @@ function sendMail(mailer, messageToSend) {
     locations: [],
     numberRemaining: 2,
     productId: '0123456789abcdef',
+    planId: 'plan-example',
+    productName: 'Firefox Fortress',
+    planEmailIconURL: 'http://placekitten.com/512/512',
+    planDownloadURL: 'http://getfirefox.com/',
     redirectTo: 'https://redirect.com/',
     resume:
       'eyJjYW1wYWlnbiI6bnVsbCwiZW50cnlwb2ludCI6bnVsbCwiZmxvd0lkIjoiM2Q1ODZiNzY4Mzc2NGJhOWFiNzhkMzMxMTdjZDU4Y2RmYjk3Mzk5MWU5NTk0NjgxODBlMDUyMmY2MThhNmEyMSIsInJlc2V0UGFzc3dvcmRDb25maXJtIjp0cnVlLCJ1bmlxdWVVc2VySWQiOiI1ODNkOGFlYS00NzU3LTRiZTQtYWJlNC0wZWQ2NWZhY2Y2YWQiLCJ1dG1DYW1wYWlnbiI6bnVsbCwidXRtQ29udGVudCI6bnVsbCwidXRtTWVkaXVtIjpudWxsLCJ1dG1Tb3VyY2UiOm51bGwsInV0bVRlcm0iOm51bGx9',

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -50,6 +50,10 @@ const PLANS = [
     interval: 'week',
     amount: '123',
     currency: 'usd',
+    product_metadata: {
+      emailIconURL: 'http://example.com/image.jpg',
+      downloadURL: 'http://getfirefox.com'
+    }
   },
   {
     plan_id: 'firefox_pro_basic_999',
@@ -341,7 +345,11 @@ describe('subscriptions', () => {
       assert.equal(args[1].uid, UID);
       assert.deepEqual(args[2], {
         acceptLanguage: ACCOUNT_LOCALE,
+        planDownloadURL: PLANS[0].product_metadata.downloadURL,
+        planEmailIconURL: PLANS[0].product_metadata.emailIconURL,
+        planId: PLANS[0].plan_id,
         productId: PLANS[0].product_id,
+        productName: PLANS[0].product_name,
       });
     });
 

--- a/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
@@ -12,6 +12,7 @@ const {
   PRODUCT_SUBSCRIBED,
   PRODUCT_REGISTERED,
   determineClientVisibleSubscriptionCapabilities,
+  metadataFromPlan,
 } = require('../../../../lib/routes/utils/subscriptions');
 
 const UID = 'uid8675309';
@@ -132,6 +133,71 @@ describe('routes/utils/subscriptions', () => {
         client
       );
       assert.deepEqual(result, ['capRegistered']);
+    });
+  });
+
+  describe('metadataFromPlan', () => {
+    const NULL_METADATA = {
+      productSet: null,
+      productOrder: null,
+      emailIconURL: null,
+      webIconURL: null,
+      upgradeCTA: null,
+      downloadURL: null,
+    };
+
+    const PLAN = {
+      plan_id: 'plan_8675309',
+      plan_name: 'Example plan',
+      product_id: 'prod_8675309',
+      product_name: 'Example product',
+      currency: 'usd',
+      amount: 599,
+      interval: 'monthly',
+    };
+
+    it('produces default null values', () => {
+      assert.deepEqual(metadataFromPlan(PLAN), NULL_METADATA);
+    });
+
+    it('extracts product metadata', () => {
+      const product_metadata = {
+        productSet: 'foo',
+        productOrder: 1,
+      };
+      assert.deepEqual(metadataFromPlan({ ...PLAN, product_metadata }), {
+        ...NULL_METADATA,
+        ...product_metadata,
+      });
+    });
+
+    it('extracts plan metadata', () => {
+      const plan_metadata = {
+        productSet: 'foo',
+        productOrder: 1,
+      };
+      assert.deepEqual(metadataFromPlan({ ...PLAN, plan_metadata }), {
+        ...NULL_METADATA,
+        ...plan_metadata,
+      });
+    });
+
+    it('overrides product metadata with plan metadata', () => {
+      const product_metadata = {
+        productSet: 'foo',
+        productOrder: 1,
+      };
+      const plan_metadata = {
+        productSet: 'bar',
+      };
+      assert.deepEqual(
+        metadataFromPlan({ ...PLAN, plan_metadata, product_metadata }),
+        {
+          ...NULL_METADATA,
+          productOrder: 1,
+          productSet: 'bar',
+        }
+      );
     });
   });
 });

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -20,8 +20,6 @@ if (!config.smtp.prependVerificationSubdomain.enabled) {
 if (!config.smtp.sesConfigurationSet) {
   config.smtp.sesConfigurationSet = 'ses-config';
 }
-config.smtp.subscriptionDownloadUrl =
-  'http://example.com/download?foo=bar&baz=quux';
 config.smtp.subscriptionTermsUrl = 'http://example.com/terms';
 
 const TEMPLATE_VERSIONS = require(`${ROOT_DIR}/lib/senders/templates/_versions.json`);
@@ -43,6 +41,10 @@ const MESSAGE = {
   numberRemaining: 2,
   primaryEmail: 'c@d.com',
   productId: 'wibble',
+  planId: 'plan-example',
+  productName: 'example product',
+  planEmailIconURL: 'http://example.com/icon.jpg',
+  planDownloadURL: 'http://getfirefox.com/',
   service: 'sync',
   timeZone: 'America/Los_Angeles',
   tokenCode: 'abc123',
@@ -61,6 +63,7 @@ const MESSAGE_PARAMS = new Map([
   ['email', 'email'],
   ['primary_email_verified', 'email'],
   ['product_id', 'productId'],
+  ['plan_id', 'planId'],
   ['secondary_email_verified', 'email'],
   ['service', 'service'],
   ['uid', 'uid'],
@@ -94,13 +97,10 @@ const COMMON_TESTS = new Map([
   ],
 ]);
 
-// TODO: subscription product, subject, action and icon must vary per subscription for phase 2 - https://github.com/mozilla/fxa/issues/2026
-const subscriptionProductEmail = 'Firefox Private Network';
-
 // prettier-ignore
 const TESTS = new Map([
   ['downloadSubscriptionEmail', new Map([
-    ['subject', { test: 'equal', expected: `Welcome to ${subscriptionProductEmail}!` }],
+    ['subject', { test: 'equal', expected: `Welcome to ${MESSAGE.productName}!` }],
     ['headers', new Map([
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('downloadSubscription') }],
       ['X-Template-Name', { test: 'equal', expected: 'downloadSubscription' }],
@@ -108,23 +108,23 @@ const TESTS = new Map([
     ])],
     ['html', [
       { test: 'include', expected: configHref('privacyUrl', 'new-subscription', 'privacy') },
-      { test: 'include', expected: configHref('subscriptionDownloadUrl', 'new-subscription', 'download-subscription', 'product_id', 'uid') },
-      { test: 'include', expected: configHref('subscriptionSettingsUrl', 'new-subscription', 'cancel-subscription', 'product_id', 'uid') },
+      { test: 'include', expected: MESSAGE.planDownloadURL },
+      { test: 'include', expected: configHref('subscriptionSettingsUrl', 'new-subscription', 'cancel-subscription', 'plan_id', 'product_id', 'uid') },
       { test: 'include', expected: configHref('subscriptionTermsUrl', 'new-subscription', 'subscription-terms') },
       { test: 'include', expected: configHref('subscriptionSupportUrl', 'new-subscription', 'subscription-support') },
-      { test: 'include', expected: `Welcome to ${subscriptionProductEmail}!` },
-      { test: 'include', expected: `If you haven&#x27;t already downloaded ${subscriptionProductEmail}, let&#x27;s get started using all the features included in your subscription.` },
-      { test: 'include', expected: `>Download ${subscriptionProductEmail}</a>` },
+      { test: 'include', expected: `Welcome to ${MESSAGE.productName}!` },
+      { test: 'include', expected: `If you haven&#x27;t already downloaded ${MESSAGE.productName}, let&#x27;s get started using all the features included in your subscription.` },
+      { test: 'include', expected: `>Download ${MESSAGE.productName}</a>` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
       { test: 'include', expected: `Privacy notice:\n${configUrl('privacyUrl', 'new-subscription', 'privacy')}` },
-      { test: 'include', expected: configUrl('subscriptionDownloadUrl', 'new-subscription', 'download-subscription', 'product_id', 'uid') },
-      { test: 'include', expected: configUrl('subscriptionSettingsUrl', 'new-subscription', 'cancel-subscription', 'product_id', 'uid') },
+      { test: 'include', expected: MESSAGE.planDownloadURL },
+      { test: 'include', expected: configUrl('subscriptionSettingsUrl', 'new-subscription', 'cancel-subscription', 'plan_id', 'product_id', 'uid') },
       { test: 'include', expected: configUrl('subscriptionTermsUrl', 'new-subscription', 'subscription-terms') },
       { test: 'include', expected: configUrl('subscriptionSupportUrl', 'new-subscription', 'subscription-support') },
-      { test: 'include', expected: `Welcome to ${subscriptionProductEmail}!` },
-      { test: 'include', expected: `If you haven't already downloaded ${subscriptionProductEmail}, let's get started using all the features included in your subscription:` },
+      { test: 'include', expected: `Welcome to ${MESSAGE.productName}!` },
+      { test: 'include', expected: `If you haven't already downloaded ${MESSAGE.productName}, let's get started using all the features included in your subscription:` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],

--- a/packages/fxa-payments-server/src/store/utils.tsx
+++ b/packages/fxa-payments-server/src/store/utils.tsx
@@ -2,6 +2,7 @@ import { Plan, ProductMetadata } from './types';
 
 // Support some default null values for product / plan metadata and
 // allow plan metadata to override product metadata
+// TODO: move to fxa-shared?
 export const metadataFromPlan = (plan: Plan): ProductMetadata => ({
   productSet: null,
   productOrder: null,


### PR DESCRIPTION
- remove subscriptionDownloadUrl config setting, since per-plan Stripe
  metadata should be the source for this URL now

- also add `write-emails` npm script shortcut to write-emails-to-disk

fixes #2026
