### PR TITLE
feat(signup): fix #3197 - Autocomplete common email domains during signup for better UX

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/user-agent.js
+++ b/packages/fxa-content-server/app/scripts/lib/user-agent.js
@@ -46,12 +46,21 @@ const UserAgent = function(userAgent) {
     },
 
     /**
+     * Check if the browser is Chrome
+     *
+     * @returns {Boolean}
+     */
+    isChrome() {
+      return this.browser.name === 'Chrome';
+    },
+
+    /**
      * Check if the browser is Chrome for Android
      *
      * @returns {Boolean}
      */
     isChromeAndroid() {
-      return this.browser.name === 'Chrome' && this.os.name === 'Android';
+      return this.isChrome() && this.isAndroid();
     },
 
     /**

--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -18,7 +18,7 @@
 
     <form novalidate>
       <div class="input-row">
-        <input name="email" type="email" class="email tooltip-below" autofocus placeholder="{{#t}}Email{{/t}}"/>
+        {{{ unsafeEmailAutocompleteDomainsHTML }}}
       </div>
 
       <div class="button-row">

--- a/packages/fxa-content-server/app/scripts/templates/partial/email-autocomplete-domains.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/email-autocomplete-domains.mustache
@@ -1,0 +1,7 @@
+<input name="email" type="email" class="email tooltip-below" autofocus placeholder="{{#t}}Email{{/t}}"/>
+<datalist id="autocomplete-domain">
+    {{#options}}
+        <option />
+    {{/options}}
+</datalist>
+<div id="focus-hack" tabindex="-1" aria-hidden="true"></div>

--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -21,6 +21,7 @@ import mailcheck from '../lib/mailcheck';
 import ServiceMixin from './mixins/service-mixin';
 import SignedInNotificationMixin from './mixins/signed-in-notification-mixin';
 import SyncSuggestionMixin from './mixins/sync-suggestion-mixin';
+import EmailAutocompleteDomainsMixin from './mixins/email-autocomplete-domains-mixin';
 import Template from 'templates/index.mustache';
 
 const EMAIL_SELECTOR = 'input[type=email]';
@@ -222,6 +223,7 @@ Cocktail.mixin(
   IndexView,
   CachedCredentialsMixin,
   CoppaMixin({}),
+  EmailAutocompleteDomainsMixin,
   TokenCodeExperimentMixin,
   FlowBeginMixin,
   FormPrefillMixin,

--- a/packages/fxa-content-server/app/scripts/views/mixins/email-autocomplete-domains-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/email-autocomplete-domains-mixin.js
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A mixin to autocomplete common domains from `datalist option` `value`s.
+ */
+import Template from 'templates/partial/email-autocomplete-domains.mustache';
+import UserAgentMixin from '../../lib/user-agent-mixin';
+
+export const EMAIL_SELECTOR = 'input[type=email]';
+export const DATALIST_OPTIONS_SELECTOR = '#autocomplete-domain option';
+export const FOCUS_HACK_SELECTOR = '#focus-hack';
+
+export const DOMAINS = [
+  'gmail.com',
+  'outlook.com',
+  'hotmail.com',
+  'yahoo.com',
+  'qq.com',
+  'web.de',
+  'aol.com',
+  'mail.ru',
+  'icloud.com',
+  'gmx.de',
+  't-online.de',
+  'orange.fr',
+  'yandex.ru',
+  'yahoo.fr',
+  'live.com',
+  '163.com',
+  'msn.com',
+  'comcast.net',
+  'hotmail.co.uk',
+  'hotmail.fr',
+];
+
+export default {
+  events: {
+    [`keyup ${EMAIL_SELECTOR}`]: '_toggleDomainAutocomplete',
+  },
+  dependsOn: [UserAgentMixin],
+
+  setInitialContext(context) {
+    const unsafeEmailAutocompleteDomainsHTML = this.renderTemplate(Template, {
+      options: DOMAINS,
+    });
+    context.set({
+      unsafeEmailAutocompleteDomainsHTML,
+    });
+  },
+
+  afterRender() {
+    this.isAndroid = this.getUserAgent().isAndroid();
+    this.isChrome = this.getUserAgent().isChrome();
+    this.isEdge = this.getUserAgent().isEdge();
+    this.input = this.$(EMAIL_SELECTOR);
+    this.datalistOptions = this.$(DATALIST_OPTIONS_SELECTOR);
+    this.focusHack = this.$(FOCUS_HACK_SELECTOR);
+    this.previousUsername = null;
+  },
+
+  /**
+   * A catch-most-browsers hack when datalist options are modified.
+   * Chrome otherwise shows all options when '@' is typed,
+   * Safari immediately goes to the dropdown preventing users
+   * from typing further, and FF will not update the dropdown on `keyup`
+   * and has a known bug with dynamic datalists
+   * https://bugzilla.mozilla.org/show_bug.cgi?id=1474137
+   */
+  _focusHack() {
+    this.focusHack.focus();
+    this.input.focus();
+  },
+
+  _toggleDomainAutocomplete() {
+    const inputValue = this.input.val();
+    const [username] = inputValue.split('@');
+
+    if (
+      inputValue.length >= 2 &&
+      inputValue.includes('@') &&
+      (username !== this.previousUsername || !this.input.attr('list'))
+    ) {
+      // Chrome, Android browsers,a nd Edge show all options when '@' is typed.
+      // Non-Android Chrome is covered in `_focusHack` but if the device is
+      // Android we must wait until there is one additional character.
+      if ((!this.isAndroid && !this.isEdge) || !inputValue.endsWith('@')) {
+        // Trigger _before_ datalist option mods here because Chrome
+        // looks janky if text entered pulls up the autocomplete list, but
+        // NOT in Chrome Android because it _causes_ jankiness
+        if (!this.isAndroid && this.isChrome) {
+          this._focusHack();
+        }
+        // Dynamically add/remove `list` attr because it makes conditionals
+        // easier and Chrome otherwise shows all options on focus
+        this.input.attr('list', 'autocomplete-domain');
+        this.datalistOptions.each((index, option) => {
+          option.setAttribute('value', `${username}@${DOMAINS[index]}`);
+        });
+
+        // Causes jankiness in Chrome Android, needed in other cases
+        if (!this.isAndroid || (this.isAndroid && !this.isChrome)) {
+          this._focusHack();
+        }
+      }
+    } else if (!inputValue.includes('@') && this.input.attr('list')) {
+      this.input.removeAttr('list');
+      this.datalistOptions.each((_, option) => {
+        option.removeAttribute('value');
+      });
+      this._focusHack();
+    }
+
+    this.previousUsername = username;
+  },
+};

--- a/packages/fxa-content-server/app/styles/modules/_input-row.scss
+++ b/packages/fxa-content-server/app/styles/modules/_input-row.scss
@@ -9,6 +9,7 @@
 
   input {
     transition: border-color $short-transition, box-shadow $short-transition;
+    padding: 0 $input-left-right-padding;
 
     &::placeholder {
       color: $input-placeholder-color !important;
@@ -45,12 +46,12 @@
     }
 
     html[dir='ltr'] & {
-      padding: 0 0 0 $input-left-right-padding;
+      padding: 0 11px 0 $input-left-right-padding;
     }
 
     html[dir='rtl'] & {
       direction: ltr;
-      padding: 0 $input-left-right-padding 0 0;
+      padding: 0 $input-left-right-padding 0 11px;
       text-align: right;
     }
 

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/email-autocomplete-domains-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/email-autocomplete-domains-mixin.js
@@ -1,0 +1,138 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import sinon from 'sinon';
+import FormView from 'views/form';
+import Cocktail from 'cocktail';
+import EmailAutocompleteDomainsMixin, {
+  DOMAINS,
+  EMAIL_SELECTOR,
+  DATALIST_OPTIONS_SELECTOR,
+  FOCUS_HACK_SELECTOR,
+} from 'views/mixins/email-autocomplete-domains-mixin';
+
+describe('views/mixins/email-autocomplete-domains-mixin', () => {
+  let view;
+
+  const EmailDatalistView = FormView.extend({
+    template: context => context.unsafeEmailAutocompleteDomainsHTML,
+  });
+
+  Cocktail.mixin(EmailDatalistView, EmailAutocompleteDomainsMixin);
+
+  beforeEach(() => {
+    view = new EmailDatalistView();
+    sinon.stub(view, 'getUserAgent').callsFake(() => ({
+      isAndroid: () => false,
+      isChrome: () => false,
+      isEdge: () => false,
+    }));
+    return view.render();
+  });
+
+  afterEach(() => {
+    view.remove();
+    view.destroy();
+    view = null;
+  });
+
+  describe('renders correctly', () => {
+    it('contains `option` elements the same length as the domains array', () => {
+      assert.lengthOf(view.$(DATALIST_OPTIONS_SELECTOR), DOMAINS.length);
+    });
+    it('contains #focus-hack element for cross-browser compatibility', () => {
+      assert.lengthOf(view.$(FOCUS_HACK_SELECTOR), 1);
+    });
+  });
+
+  describe('_toggleDomainAutocomplete', () => {
+    it('renders datalist with options from domains list on keyup when "@" is present', () => {
+      view
+        .$(EMAIL_SELECTOR)
+        .val('foo@')
+        .trigger('keyup');
+      assert.isTrue(
+        view.$(EMAIL_SELECTOR).attr('list') === 'autocomplete-domain'
+      );
+      assert.isTrue(
+        view.$(DATALIST_OPTIONS_SELECTOR)[0].getAttribute('value') ===
+          `foo@${DOMAINS[0]}`
+      );
+      assert.isTrue(
+        view
+          .$(DATALIST_OPTIONS_SELECTOR)
+          [DOMAINS.length - 1].getAttribute('value') ===
+          `foo@${DOMAINS[DOMAINS.length - 1]}`
+      );
+    });
+
+    it('does nothing if conditions are not met,', () => {
+      // input is too short
+      view
+        .$(EMAIL_SELECTOR)
+        .val('a')
+        .trigger('keyup');
+      assert.isTrue(view.$(EMAIL_SELECTOR).attr('list') === undefined);
+
+      // "@" is not present
+      view
+        .$(EMAIL_SELECTOR)
+        .val('foo')
+        .trigger('keyup');
+      assert.isTrue(view.$(EMAIL_SELECTOR).attr('list') === undefined);
+
+      // username doesn't change but user keeps typing
+      view
+        .$(EMAIL_SELECTOR)
+        .val('foo@')
+        .trigger('keyup');
+      view
+        .$(EMAIL_SELECTOR)
+        .val('foo@gmail')
+        .trigger('keyup');
+      assert.isTrue(
+        view.$(DATALIST_OPTIONS_SELECTOR)[0].getAttribute('value') ===
+          `foo@${DOMAINS[0]}`
+      );
+    });
+
+    it('updates options on username change when "@" sign is present', () => {
+      view
+        .$(EMAIL_SELECTOR)
+        .val('foo')
+        .trigger('keyup');
+      assert.isTrue(
+        view.$(DATALIST_OPTIONS_SELECTOR)[0].getAttribute('value') === null
+      );
+      view
+        .$(EMAIL_SELECTOR)
+        .val('foo@')
+        .trigger('keyup');
+      view
+        .$(EMAIL_SELECTOR)
+        .val('fo@')
+        .trigger('keyup');
+      assert.isTrue(
+        view.$(DATALIST_OPTIONS_SELECTOR)[0].getAttribute('value') ===
+          `fo@${DOMAINS[0]}`
+      );
+    });
+
+    it('clears options when "@" is present and then removed', () => {
+      view
+        .$(EMAIL_SELECTOR)
+        .val('foo@')
+        .trigger('keyup');
+      view
+        .$(EMAIL_SELECTOR)
+        .val('foo')
+        .trigger('keyup');
+      assert.isTrue(view.$(EMAIL_SELECTOR).attr('list') === undefined);
+      assert.isTrue(
+        view.$(DATALIST_OPTIONS_SELECTOR)[0].getAttribute('value') === null
+      );
+    });
+  });
+});

--- a/packages/fxa-content-server/app/tests/test_start.js
+++ b/packages/fxa-content-server/app/tests/test_start.js
@@ -177,6 +177,7 @@ require('./spec/views/mixins/disable-form-mixin');
 require('./spec/views/mixins/do-not-sync-mixin');
 require('./spec/views/mixins/pairing-graphics-mixin');
 require('./spec/views/mixins/email-opt-in-mixin');
+require('./spec/views/mixins/email-autocomplete-domains-mixin');
 require('./spec/views/mixins/experiment-mixin');
 require('./spec/views/mixins/external-links-mixin');
 require('./spec/views/mixins/flow-begin-mixin');

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -179,8 +179,8 @@ module.exports = {
     SUB_HEADER: '#fxa-enter-email-header .service',
     SUBMIT: 'button[type="submit"]',
     SUGGEST_EMAIL_DOMAIN_CORRECTION: '.tooltip-suggest',
-    TOOLTIP: 'input[type=email] + .tooltip',
-    TOOLTIP_BOUNCED_EMAIL: 'input[type=email] + .tooltip',
+    TOOLTIP: 'input[type=email] ~ .tooltip',
+    TOOLTIP_BOUNCED_EMAIL: 'input[type=email] ~ .tooltip',
   },
   FORCE_AUTH: {
     EMAIL: 'input[type=email]',


### PR DESCRIPTION
fix for #3197

Edit: expected functionality below is still applicable, but see [this comment](https://github.com/mozilla/fxa/pull/3436#issuecomment-557394065) for an update on tested devices/caveats.

---
Tested on Firefox, Chrome, Safari, iOS Firefox & Safari. `datalist` works on Edge according to CanIUse but it'd be nice if someone could see if anything is actually broken there.

Expected functionality:
- autocomplete works, in that if the browser has an e-mail used to sign up in other forms, those suggestions still show.
- when a user types '@' and one character after, domain drop-down autocompletion kicks in. This will use native styles per browser.
<img width="300" alt="image" src="https://user-images.githubusercontent.com/13018240/69281471-ec4df080-0bad-11ea-9d8d-35827650a74e.png">

- if the user backspaces this letter and the ending character is "@", all of the choices show in the drop-down. This functionality actually made browser cross-compatibility easier since I was able to do everything inside a `keyup` event.
- if the user backspaces the "@", the drop-down disappears
- if the user changes the text before the "@", the drop-down shows on one more character or press of the "down" arrow
- autocomplete and `datalist` play nicely and show both options with a horizontal rule between them
- when the native keyboard is used in iOS, the options will show in the keyboard and a down caret will show, giving users the option to scroll through the list if they choose to
<img width="300" alt="image" src="https://user-images.githubusercontent.com/13018240/69281850-a6455c80-0bae-11ea-87db-c00a9daded07.png">

**one caveat:**: If the user types enough in iOS for the suggestions to kick in, and they choose one, the caret disappears. However, if the user has the suggestions show and then they backspace to before the "@" sign (so if they go from "hello@g" to "hello"), the caret still shows and nothing happens when you click on it. I have tried removing this and haven't found the work around yet. I even tried a bunch of things with CSS, but it doesn't appear to be style-able in iOS.

@6a68 I looked into your suggestion around duplicate emails from what the browser natively suggests with `autocomplete` and from what I've found, that native dropdown is not in the DOM and we can't easily grab values from it. :/