### PR TITLE
fix(style): fix #3404 - Payments 'Cancel' and 'Change' buttons too wide

### DIFF
--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
@@ -75,6 +75,7 @@
 
   .card-details {
     display: flex;
+    flex: 4;
 
     .last-four,
     .expiry {
@@ -103,7 +104,7 @@
     .action {
       align-self: flex-end;
       display: flex;
-      flex: 1;
+      flex: 0 1 128px;
       flex-direction: row;
       justify-content: flex-end;
 


### PR DESCRIPTION
fix for #3404 

Checked with UX and they'd prefer the buttons to stay at `128px` to match the FxA main settings page (for now) so I gave the button container a `flex-basis` of 128px:

<img width="500" alt="image" src="https://user-images.githubusercontent.com/13018240/69286522-1d7fee00-0bb9-11ea-8eef-7ee2b3af815f.png">

This also protects us against issues like #3302, if this copy changes then the size will adjust:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/13018240/69286631-59b34e80-0bb9-11ea-8e0e-d820f8b7b06b.png">

"Resubscribe" looks good with this change too and hasn't regressed:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/13018240/69286654-69329780-0bb9-11ea-8a0c-2848a1b13319.png">

