### PR TITLE
fix(payments): only hide firefox logo when displaying profile avatar

### DIFF
--- a/packages/fxa-payments-server/src/components/AppLayout/index.scss
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.scss
@@ -3,12 +3,8 @@
 // HACK: create-react-app forbids using images outside the root level of the
 // project, so let's use local copies from fxa-content-server for now
 
-#main-content::before {
+#main-content:not(.hide-logo)::before {
   background-image: url('./images/firefox-logo.svg');
-}
-
-#main-content.payments-card::before {
-  background-image: none;
 }
 
 #fxa-settings-header-wrapper {

--- a/packages/fxa-payments-server/src/components/AppLayout/index.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.tsx
@@ -1,5 +1,6 @@
-import React, { ReactNode, useEffect, useContext } from 'react';
+import React, { ReactNode, useEffect, useContext, useState } from 'react';
 import { AppContext } from '../../lib/AppContext';
+import classNames from 'classnames';
 
 import './index.scss';
 
@@ -10,54 +11,75 @@ export type AppLayoutProps = {
 export const AppLayout = ({ children }: AppLayoutProps) => {
   const { config } = useContext(AppContext);
 
-  return <>
-    <div id="stage" data-testid="stage" className="fade-in-forward" style={{ opacity: 1 }}>
-      {children}
-    </div>
-    <footer data-testid="footer">
-      <div id="about-moz-footer" data-testid="about-moz-footer">
-        <a
-          id="about-mozilla"
-          rel="author noopener noreferrer"
-          target="_blank"
-          href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"
-        >
-          &nbsp;
-        </a>
+  return (
+    <>
+      <div
+        id="stage"
+        data-testid="stage"
+        className="fade-in-forward"
+        style={{ opacity: 1 }}
+      >
+        {children}
       </div>
-      <div id="legal-footer" data-testid="legal-footer">
-        <a className="terms"
-          rel="noopener noreferrer"
-          target="_blank"
-          href={config.legalDocLinks.termsOfService}>
-          Terms of Service
-        </a>
-        <a className="privacy"
-          rel="noopener noreferrer"
-          target="_blank"
-          href={config.legalDocLinks.privacyNotice}>
-          Privacy Notice
-        </a>
-      </div>
-    </footer>
-  </>;
+      <footer data-testid="footer">
+        <div id="about-moz-footer" data-testid="about-moz-footer">
+          <a
+            id="about-mozilla"
+            rel="author noopener noreferrer"
+            target="_blank"
+            href="https://www.mozilla.org/about/?utm_source=firefox-accounts&amp;utm_medium=Referral"
+          >
+            &nbsp;
+          </a>
+        </div>
+        <div id="legal-footer" data-testid="legal-footer">
+          <a
+            className="terms"
+            rel="noopener noreferrer"
+            target="_blank"
+            href={config.legalDocLinks.termsOfService}
+          >
+            Terms of Service
+          </a>
+          <a
+            className="privacy"
+            rel="noopener noreferrer"
+            target="_blank"
+            href={config.legalDocLinks.privacyNotice}
+          >
+            Privacy Notice
+          </a>
+        </div>
+      </footer>
+    </>
+  );
 };
 
 export type SignInLayout = {
   children: ReactNode;
 };
 
-export const SignInLayout = ({ children }: SignInLayout) => (
-  <>
+export const SignInLayoutContext = React.createContext({
+  setHideLogo: (hideLogo: boolean) => {},
+});
+
+export const SignInLayout = ({ children }: SignInLayout) => {
+  const [hideLogo, setHideLogo] = useState(false);
+  const mainContentClassNames = classNames('card', 'payments-card', {
+    'hide-logo': hideLogo,
+  });
+  return (
     <AppLayout>
-      <div className="sign-in">
-        <div id="main-content" className="card payments-card">
-          {children}
+      <SignInLayoutContext.Provider value={{ setHideLogo }}>
+        <div className="sign-in">
+          <div id="main-content" className={mainContentClassNames}>
+            {children}
+          </div>
         </div>
-      </div>
+      </SignInLayoutContext.Provider>
     </AppLayout>
-  </>
-);
+  );
+};
 
 export type SettingsLayout = {
   children: ReactNode;

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useContext } from 'react';
 import { Plan, Profile } from '../../../store/types';
 
 import { State as ValidatorState } from '../../../lib/validator';
 
 import { getErrorMessage } from '../../../lib/errors';
 
+import { SignInLayoutContext } from '../../../components/AppLayout';
 import PaymentForm from '../../../components/PaymentForm';
 import DialogMessage from '../../../components/DialogMessage';
 import ErrorMessage from '../../../components/ErrorMessage';
@@ -37,6 +38,12 @@ export const SubscriptionCreate = ({
   createSubscriptionMounted,
   createSubscriptionEngaged,
 }: SubscriptionCreateProps) => {
+  // Hide the Firefox logo in layout if we want to display the avatar
+  const { setHideLogo } = useContext(SignInLayoutContext);
+  useEffect(() => {
+    setHideLogo(!accountActivated);
+  }, [setHideLogo, accountActivated]);
+
   // Reset subscription creation status on initial render.
   useEffect(() => {
     resetCreateSubscription();

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionRedirect/index.scss
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionRedirect/index.scss
@@ -1,5 +1,6 @@
 .product-payment {
   .subscription-ready {
+
     h2 {
       color: #20123b;
       font-size: 24px;


### PR DESCRIPTION
While working on #3244, I noticed that the Firefox logo was missing from a few views on the product route on payments-server.

http://mozilla.github.io/fxa/fxa-payments-server/?path=/story/routes-product--success

Before:
<img width="342" alt="Capture" src="https://user-images.githubusercontent.com/21687/69353878-0df1bb00-0c34-11ea-8d8d-fe0a20035eb9.PNG">

After:
<img width="339" alt="Capture2" src="https://user-images.githubusercontent.com/21687/69353881-10ecab80-0c34-11ea-8f97-177e8316a57c.PNG">
