### PR TITLE
fix(event-broker): allow userAgent to be empty

### DIFF
--- a/packages/fxa-auth-server/docs/service_notifications.md
+++ b/packages/fxa-auth-server/docs/service_notifications.md
@@ -83,7 +83,7 @@ Message Properties:
 - `uid`: The userid of the account being that was used to log in.
 - `email`: The primary email address of the account.
 - `deviceCount`: The number of active sessions on the user's account.
-- `userAgent`: The user-agent header sent by the user on their login request.
+- `userAgent`: Optional,the user-agent header sent by the user on their login request.
 
 This event is currently consumed by the email marketing team
 in order to manage sync-setup-related email campaigns.

--- a/packages/fxa-event-broker/lib/serviceNotifications.ts
+++ b/packages/fxa-event-broker/lib/serviceNotifications.ts
@@ -37,7 +37,7 @@ const LOGIN_SCHEMA = joi
     timestamp: joi.number().optional(),
     ts: joi.number().required(),
     uid: joi.string().required(),
-    userAgent: joi.string().required()
+    userAgent: joi.string().optional()
   })
   .unknown(true)
   .required();


### PR DESCRIPTION
Because:

* The docs don't match actual login messages we emit.
* Event-broker required a userAgent string in the login message.

This commit:

* Updates the docs to reflect the optional nature of the userAgent.
* Changes the event-broker login messge schema to make the userAgent
  optional.

Closes #3421