### PR TITLE
feat(payments): use Stripe metadata for product details in UI

### DIFF
--- a/packages/fxa-payments-server/server/config/development.json
+++ b/packages/fxa-payments-server/server/config/development.json
@@ -1,0 +1,5 @@
+{
+  "csp": {
+    "extraImgSrc": [ "https://placekitten.com" ]
+  }
+}

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -52,6 +52,11 @@ const conf = convict({
       doc: 'Location of "report-uri" for report-only CSP rules',
       env: 'CSP_REPORT_ONLY_URI',
     },
+    extraImgSrc: {
+      default: [],
+      doc: 'Additional hosts to allow as image sources',
+      env: 'CSP_EXTRA_IMG_SRC',
+    },
   },
   env: {
     default: 'production',

--- a/packages/fxa-payments-server/server/lib/csp/blocking.js
+++ b/packages/fxa-payments-server/server/lib/csp/blocking.js
@@ -33,6 +33,8 @@ module.exports = function(config) {
   const STRIPE_HOOKS_URL = getOrigin(config.get('stripe.hooksUrl'));
   const STRIPE_SCRIPT_URL = getOrigin(config.get('stripe.scriptUrl'));
 
+  const EXTRA_IMG_SRC = config.get('csp.extraImgSrc');
+
   //
   // Double quoted values
   //
@@ -70,6 +72,7 @@ module.exports = function(config) {
         // their profile image.
         GRAVATAR,
         PROFILE_IMAGES_SERVER,
+        ...EXTRA_IMG_SRC,
       ]),
       mediaSrc: [NONE],
       objectSrc: [NONE],

--- a/packages/fxa-payments-server/src/components/DialogMessage.tsx
+++ b/packages/fxa-payments-server/src/components/DialogMessage.tsx
@@ -11,18 +11,20 @@ type DialogMessageProps = {
   className?: string;
   onDismiss: Function;
   children: ReactNode;
+  "data-testid"?: string;
 };
 
 export const DialogMessage = ({
   className = '',
   onDismiss,
   children,
+  'data-testid': testid = 'dialog-message-container',
 }: DialogMessageProps) => {
   const dialogInsideRef = useClickOutsideEffect<HTMLDivElement>(onDismiss);
   return (
     <Portal id="dialogs">
       <div
-        data-testid="dialog-message-container"
+        data-testid={testid}
         className={classNames('blocker', 'current')}
       >
         <div

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -156,7 +156,7 @@ export function apiCancelSubscription(subscriptionId: string) {
   );
 }
 
-export function apiReactivateSubscription(subscriptionId: string) {
+export function apiReactivateSubscription(subscriptionId: string): Promise<{}> {
   return apiFetch(
     'POST',
     `${config.servers.auth.url}/v1/oauth/subscriptions/reactivate`,

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -274,6 +274,7 @@ export const MOCK_PLANS: Plan[] = [
     currency: 'usd',
     product_metadata: {
       productSet: 'example_upgrade',
+      webIconURL: 'http://example.com/product.jpg',
     },
   },
   {
@@ -284,6 +285,10 @@ export const MOCK_PLANS: Plan[] = [
     interval: 'month',
     amount: 2500,
     currency: 'usd',
+    product_metadata: {
+      productSet: '123done',
+      webIconURL: 'http://example.com/123donepro.jpg',
+    },
   },
   {
     plan_id: 'plan_upgrade',

--- a/packages/fxa-payments-server/src/lib/types.tsx
+++ b/packages/fxa-payments-server/src/lib/types.tsx
@@ -18,3 +18,5 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type FunctionWithIgnoredReturn<T extends (...args: any) => any> = (
   ...args: Parameters<T>
 ) => unknown;
+
+export type PromiseResolved<T> = T extends Promise<infer U> ? U : T;

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionRedirect/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionRedirect/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useContext } from 'react';
 import { Plan } from '../../../store/types';
 import { AppContext } from '../../../lib/AppContext';
 
+import { metadataFromPlan } from '../../../store/utils';
 import fpnImage from '../../../images/fpn';
 import './index.scss';
 
@@ -11,16 +12,16 @@ export type SubscriptionRedirectProps = {
   plan: Plan;
 };
 
-export const SubscriptionRedirect = ({
-  plan: { product_id, product_name },
-}: SubscriptionRedirectProps) => {
+export const SubscriptionRedirect = ({ plan }: SubscriptionRedirectProps) => {
+  const { product_id, product_name } = plan;
+  const { webIconURL, downloadURL } = metadataFromPlan(plan);
   const {
     config: { productRedirectURLs },
     navigateToUrl,
   } = useContext(AppContext);
 
   const redirectUrl =
-    productRedirectURLs[product_id] || defaultProductRedirectURL;
+    downloadURL || productRedirectURLs[product_id] || defaultProductRedirectURL;
 
   useEffect(() => {
     navigateToUrl(redirectUrl);
@@ -30,7 +31,12 @@ export const SubscriptionRedirect = ({
     <div className="product-payment" data-testid="subscription-redirect">
       <div className="subscription-ready">
         <h2>Your subscription is ready</h2>
-        <img alt="Firefox Private Network" src={fpnImage} />
+        <img
+          alt={product_name}
+          src={webIconURL || fpnImage}
+          width="96"
+          height="96"
+        />
         <p>
           Hang on for a moment while we send you to the{' '}
           <span className="plan-name">{product_name}</span> download page.

--- a/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
@@ -10,7 +10,7 @@ import { APIError } from '../../lib/apiClient';
 import { SignInLayout } from '../../components/AppLayout';
 import { State as ValidatorState } from '../../lib/validator';
 import { Product, ProductProps } from './index';
-import { Customer } from '../../store/types';
+import { Customer, Plan, Profile } from '../../store/types';
 
 function init() {
   storiesOf('routes/Product', module)
@@ -199,7 +199,7 @@ const ProductRoute = ({
 
 const PRODUCT_ID = 'product_8675309';
 
-const PROFILE = {
+const PROFILE: Profile = {
   amrValues: [],
   avatar: 'http://placekitten.com/256/256',
   avatarDefault: false,
@@ -210,7 +210,7 @@ const PROFILE = {
   uid: '8675309asdf',
 };
 
-const PLANS = [
+const PLANS: Plan[] = [
   {
     plan_id: 'plan_123',
     plan_name: 'Example Plan',
@@ -219,6 +219,9 @@ const PLANS = [
     currency: 'USD',
     amount: 1050,
     interval: 'month',
+    product_metadata: {
+      webIconURL: 'http://placekitten.com/512/512',
+    },
   },
 ];
 

--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { render, cleanup, act, fireEvent } from '@testing-library/react';
+import {
+  render,
+  cleanup,
+  act,
+  fireEvent,
+  RenderResult,
+} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import nock from 'nock';
 import waitForExpect from 'wait-for-expect';
@@ -35,6 +41,7 @@ jest.mock('../../lib/flow-event');
 import { SignInLayout } from '../../components/AppLayout';
 import Product from './index';
 import { SMALL_DEVICE_RULE } from '../../components/PaymentForm';
+import { ProductMetadata } from '../../store/types';
 
 describe('routes/Product', () => {
   let authServer = '';
@@ -289,11 +296,22 @@ describe('routes/Product', () => {
     return { ...renderResult, matchMedia, navigateToUrl, apiMocks };
   }
 
+  const expectProductImage = ({
+    getByAltText,
+  }: {
+    getByAltText: RenderResult['getByAltText'];
+  }) => {
+    const productMetadata = MOCK_PLANS[0].product_metadata as ProductMetadata;
+    const productImg = getByAltText(PRODUCT_NAME);
+    expect(productImg.getAttribute('src')).toEqual(productMetadata.webIconURL);
+  };
+
   it('handles a successful payment submission as expected', async () => {
     const createToken = jest
       .fn()
       .mockResolvedValue(VALID_CREATE_TOKEN_RESPONSE);
     const {
+      getByAltText,
       getByTestId,
       findByText,
       queryByText,
@@ -305,6 +323,7 @@ describe('routes/Product', () => {
     fireEvent.click(getByTestId('submit'));
 
     await findByText('Your subscription is ready');
+    expectProductImage({ getByAltText });
     expect(matchMedia).toBeCalledWith(SMALL_DEVICE_RULE);
     expect(createToken).toBeCalled();
     expect(queryByText('Firefox Tanooki Suit')).toBeInTheDocument();
@@ -324,11 +343,12 @@ describe('routes/Product', () => {
       .fn()
       .mockResolvedValue(VALID_CREATE_TOKEN_RESPONSE);
 
-    const { findByText, queryByText } = render(
+    const { findByText, queryByText, getByAltText } = render(
       <Subject {...{ matchMedia, navigateToUrl, createToken }} />
     );
 
     await findByText('Your subscription is ready');
+    expectProductImage({ getByAltText });
     expect(createToken).not.toBeCalled();
     expect(queryByText('Firefox Tanooki Suit')).toBeInTheDocument();
     expect(

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -11,7 +11,7 @@ import ErrorMessage from '../../components/ErrorMessage';
 import { SubscriptionsProps } from './index';
 
 type PaymentUpdateFormProps = {
-  customer: SelectorReturns['customer'];
+  customer: Customer;
   customerSubscription: CustomerSubscription;
   plan: Plan;
   resetUpdatePayment: SubscriptionsProps['resetUpdatePayment'];
@@ -73,7 +73,7 @@ export const PaymentUpdateForm = ({
 
   const { upgradeCTA } = metadataFromPlan(plan);
 
-  const { last4, exp_month, exp_year } = customer.result as Customer;
+  const { last4, exp_month, exp_year } = customer;
 
   // TODO: date formats will need i18n someday
   const periodEndDate = dayjs

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { formatCurrencyInCents } from '../../../lib/formats';
+import DialogMessage from '../../../components/DialogMessage';
+import fpnImage from '../../../images/fpn';
+import { Plan, Customer } from '../../../store/types';
+import { metadataFromPlan } from '../../../store/utils';
+
+export default ({
+  onDismiss,
+  onConfirm,
+  plan,
+  customer,
+  periodEndDate,
+}: {
+  onDismiss: Function;
+  onConfirm: () => void;
+  plan: Plan;
+  customer: Customer;
+  periodEndDate: string;
+}) => {
+  const { webIconURL } = metadataFromPlan(plan);
+  const { last4 } = customer;
+
+  return (
+    <DialogMessage onDismiss={onDismiss}>
+      <img
+        className="fpn-reactivate-subscription"
+        alt={plan.product_name}
+        src={webIconURL || fpnImage}
+        height="48"
+        width="48"
+      />
+      <h4>Want to keep using {plan.product_name}?</h4>
+      {/* TO DO: display card type, IE 'to the Visa card ending...' */}
+      <p>
+        Your access to {plan.product_name} will continue, and your billing cycle
+        and payment will stay the same. Your next charge will be $
+        {formatCurrencyInCents(plan.amount)} to the card ending in {last4} on{' '}
+        {periodEndDate}.
+      </p>
+      <div className="action">
+        <button
+          className="settings-button"
+          onClick={onConfirm}
+          data-testid="reactivate-subscription-confirm-button"
+        >
+          <span className="change-button">Resubscribe</span>
+        </button>
+      </div>
+    </DialogMessage>
+  );
+};

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ManagementPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ManagementPanel.tsx
@@ -1,0 +1,84 @@
+import React, { useCallback } from 'react';
+import {
+  Plan,
+  CustomerSubscription,
+  Subscription,
+  Customer,
+} from '../../../store/types';
+import { useBooleanState } from '../../../lib/hooks';
+import { formatPeriodEndDate } from '../../../lib/formats';
+import { ActionFunctions } from '../../../store/actions';
+import ReactivationConfirmationDialog from './ConfirmationDialog';
+
+export default ({
+  plan,
+  customerSubscription,
+  subscription,
+  customer,
+  reactivateSubscription,
+}: {
+  plan: Plan;
+  customerSubscription: CustomerSubscription;
+  subscription: Subscription;
+  customer: Customer;
+  reactivateSubscription: ActionFunctions['reactivateSubscription'];
+}) => {
+  const { subscription_id } = customerSubscription;
+  const [
+    reactivateConfirmationRevealed,
+    revealReactivateConfirmation,
+    hideReactivateConfirmation,
+  ] = useBooleanState();
+
+  const onReactivateClick = useCallback(() => {
+    reactivateSubscription(subscription_id, plan);
+    hideReactivateConfirmation();
+  }, [
+    reactivateSubscription,
+    plan,
+    subscription_id,
+    hideReactivateConfirmation,
+  ]);
+
+  // TODO: date formats will need i18n someday
+  const cancelledAtDate = formatPeriodEndDate(
+    (subscription.cancelledAt as number) / 1000
+  );
+
+  // TODO: date formats will need i18n someday
+  const periodEndDate = formatPeriodEndDate(
+    customerSubscription.current_period_end
+  );
+
+  return (
+    <>
+      {reactivateConfirmationRevealed && (
+        <ReactivationConfirmationDialog
+          {...{ plan, customer, periodEndDate }}
+          onDismiss={hideReactivateConfirmation}
+          onConfirm={onReactivateClick}
+        />
+      )}
+      <div className="subscription-cancelled">
+        <div className="with-settings-button">
+          <div className="subscription-cancelled-details">
+            <p>You cancelled your subscription on {cancelledAtDate}.</p>
+            <p>
+              You will lose access to {plan.product_name} on{' '}
+              <strong>{periodEndDate}</strong>.
+            </p>
+          </div>
+          <div className="action">
+            <button
+              className="settings-button"
+              onClick={revealReactivateConfirmation}
+              data-testid="reactivate-subscription-button"
+            >
+              <span className="change-button">Resubscribe</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/SuccessDialog.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/SuccessDialog.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Plan } from '../../../store/types';
+import { metadataFromPlan } from '../../../store/utils';
+import DialogMessage from '../../../components/DialogMessage';
+import fpnImage from '../../../images/fpn';
+
+export default ({ plan, onDismiss }: { plan: Plan; onDismiss: () => void }) => {
+  const { product_name: productName } = plan;
+  const { webIconURL } = metadataFromPlan(plan);
+  return (
+    <DialogMessage onDismiss={onDismiss} data-testid="reactivate-subscription-success-dialog">
+      <img
+        alt={productName}
+        src={webIconURL || fpnImage}
+        width="96"
+        height="96"
+      />
+      <p
+        data-testid="reactivate-subscription-success"
+        className="reactivate-subscription-success"
+      >
+        Thanks! You're all set.
+      </p>
+      <button
+        className="settings-button"
+        onClick={onDismiss}
+        data-testid="reactivate-subscription-success-button"
+      >
+        Close
+      </button>
+    </DialogMessage>
+  );
+};

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -1,12 +1,11 @@
 import React, { useCallback, useContext, useEffect, useRef } from 'react';
-import { formatCurrencyInCents, formatPeriodEndDate } from '../../lib/formats';
+import { formatPeriodEndDate } from '../../lib/formats';
 import { useBooleanState, useCheckboxState } from '../../lib/hooks';
-import { State } from '../../store/state';
 import {
-  Customer,
   CustomerSubscription,
   Subscription,
   Plan,
+  Customer,
 } from '../../store/types';
 import { SelectorReturns } from '../../store/selectors';
 import { SubscriptionsProps } from './index';
@@ -14,7 +13,8 @@ import { SubscriptionsProps } from './index';
 import PaymentUpdateForm from './PaymentUpdateForm';
 import DialogMessage from '../../components/DialogMessage';
 import AppContext from '../../lib/AppContext';
-import fpnImage from '../../images/fpn';
+
+import ReactivateSubscriptionPanel from './Reactivate/ManagementPanel';
 
 type SubscriptionItemProps = {
   customerSubscription: CustomerSubscription;
@@ -22,7 +22,7 @@ type SubscriptionItemProps = {
   plan: Plan | null;
   cancelSubscription: SubscriptionsProps['cancelSubscription'];
   reactivateSubscription: SubscriptionsProps['reactivateSubscription'];
-  customer: SelectorReturns['customer'];
+  customer: Customer;
   updatePaymentStatus: SelectorReturns['updatePaymentStatus'];
   resetUpdatePayment: SubscriptionsProps['resetUpdatePayment'];
   updatePayment: SubscriptionsProps['updatePayment'];
@@ -132,7 +132,7 @@ type CancelSubscriptionPanelProps = {
   customerSubscription: CustomerSubscription;
   cancelSubscriptionMounted: SubscriptionsProps['cancelSubscriptionMounted'];
   cancelSubscriptionEngaged: SubscriptionsProps['cancelSubscriptionEngaged'];
-  cancelSubscriptionStatus: State['cancelSubscription'];
+  cancelSubscriptionStatus: SelectorReturns['cancelSubscriptionStatus'];
 };
 
 const CancelSubscriptionPanel = ({
@@ -249,96 +249,6 @@ const CancelSubscriptionPanel = ({
             </div>
           </>
         )}
-      </div>
-    </>
-  );
-};
-
-type ReactivateSubscriptionPanelProps = {
-  plan: Plan;
-  customerSubscription: CustomerSubscription;
-  subscription: Subscription;
-  reactivateSubscription: SubscriptionsProps['reactivateSubscription'];
-  customer: State['customer'];
-};
-const ReactivateSubscriptionPanel = ({
-  plan,
-  customerSubscription,
-  subscription,
-  reactivateSubscription,
-  customer,
-}: ReactivateSubscriptionPanelProps) => {
-  const { subscription_id } = customerSubscription;
-  const [
-    reactivateConfirmationRevealed,
-    revealReactivateConfirmation,
-    hideReactivateConfirmation,
-  ] = useBooleanState();
-
-  const onReactivateClick = useCallback(() => {
-    reactivateSubscription(subscription_id);
-    hideReactivateConfirmation();
-  }, [reactivateSubscription, subscription_id, hideReactivateConfirmation]);
-
-  const { last4 } = customer.result as Customer;
-
-  // TODO: date formats will need i18n someday
-  const cancelledAtDate = formatPeriodEndDate(
-    (subscription.cancelledAt as number) / 1000
-  );
-
-  // TODO: date formats will need i18n someday
-  const periodEndDate = formatPeriodEndDate(
-    customerSubscription.current_period_end
-  );
-
-  return (
-    <>
-      {reactivateConfirmationRevealed && (
-        <DialogMessage onDismiss={hideReactivateConfirmation}>
-          <img
-            className="fpn-reactivate-subscription"
-            alt="Firefox Private Network"
-            src={fpnImage}
-          />
-          <h4>Want to keep using {plan.product_name}?</h4>
-          {/* TO DO: display card type, IE 'to the Visa card ending...' */}
-          <p>
-            Your access to {plan.product_name} will continue, and your billing
-            cycle and payment will stay the same. Your next charge will be $
-            {formatCurrencyInCents(plan.amount)} to the card ending in {last4}{' '}
-            on {periodEndDate}.
-          </p>
-          <div className="action">
-            <button
-              className="settings-button"
-              onClick={onReactivateClick}
-              data-testid="reactivate-subscription-confirm-button"
-            >
-              <span className="change-button">Resubscribe</span>
-            </button>
-          </div>
-        </DialogMessage>
-      )}
-      <div className="subscription-cancelled">
-        <div className="with-settings-button">
-          <div className="subscription-cancelled-details">
-            <p>You cancelled your subscription on {cancelledAtDate}.</p>
-            <p>
-              You will lose access to {plan.product_name} on{' '}
-              <strong>{periodEndDate}</strong>.
-            </p>
-          </div>
-          <div className="action">
-            <button
-              className="settings-button"
-              onClick={revealReactivateConfirmation}
-              data-testid="reactivate-subscription-button"
-            >
-              <span className="change-button">Resubscribe</span>
-            </button>
-          </div>
-        </div>
       </div>
     </>
   );

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -93,10 +93,7 @@ function init() {
       <SubscriptionsRoute
         routeProps={{
           ...cancelledProps,
-          reactivateSubscription: linkTo(
-            'routes/Subscriptions',
-            'reactivation confirmation'
-          ),
+          reactivateSubscription: linkToReactivationConfirmation,
         }}
       />
     ))
@@ -109,9 +106,7 @@ function init() {
             error: null,
             result: {
               subscriptionId: 'sub_5551212',
-              productId: 'product_123',
-              createdAt: Date.now() - 86400000,
-              cancelledAt: Date.now(),
+              plan: PLANS[0],
             },
           },
           resetReactivateSubscription: linkTo(
@@ -180,6 +175,9 @@ function init() {
     ));
 }
 
+const linkToReactivationConfirmation = () =>
+  linkTo('routes/Subscriptions', 'reactivation confirmation');
+
 const errorFetchState = (): FetchState<any> => ({
   loading: false,
   result: null,
@@ -235,6 +233,9 @@ const PLANS = [
     currency: 'USD',
     amount: 1099,
     interval: 'month',
+    product_metadata: {
+      webIconURL: 'http://placekitten.com/512/512',
+    },
   },
 ];
 

--- a/packages/fxa-payments-server/src/store/actions/api.ts
+++ b/packages/fxa-payments-server/src/store/actions/api.ts
@@ -51,10 +51,18 @@ export default {
         return { ...result, subscriptionId };
       },
     } as const),
-  reactivateSubscription: (subscriptionId: string) =>
+  reactivateSubscription: (subscriptionId: string, plan: Plan) =>
     ({
       type: 'reactivateSubscription',
-      payload: apiReactivateSubscription(subscriptionId),
+      meta: { plan },
+      payload: async () => {
+        // Ignore the API result, because it's just `{}` on success.
+        await apiReactivateSubscription(subscriptionId);
+        return {
+          subscriptionId,
+          plan,
+        };
+      },
     } as const),
   updatePayment: (paymentToken: string, plan: Plan) =>
     ({

--- a/packages/fxa-payments-server/src/store/actions/index.ts
+++ b/packages/fxa-payments-server/src/store/actions/index.ts
@@ -1,7 +1,7 @@
 import apiActions from './api';
 import metricsActions from './metrics';
 import resetActions from './reset';
-import { FunctionWithIgnoredReturn } from '../../lib/types';
+import { FunctionWithIgnoredReturn, PromiseResolved } from '../../lib/types';
 
 // https://gist.github.com/schettino/c8bf5062ef99993ce32514807ffae849#gistcomment-2906407
 export type ActionType<
@@ -28,5 +28,24 @@ export type ActionsParameters = Parameters<ActionsCollection[ActionsKey]>;
 export type ActionFunctions = {
   [key in ActionsKey]: FunctionWithIgnoredReturn<ActionsCollection[key]>;
 };
+
+type PromisePayloadSequenceCreator = (
+  ...a: any
+) => { payload: () => Promise<any> };
+type PromisePayloadActionCreator = (...a: any) => { payload: Promise<any> };
+type PayloadActionCreator = (...a: any) => { payload: any };
+
+export type ActionPayload<
+  A extends
+    | PromisePayloadSequenceCreator
+    | PromisePayloadActionCreator
+    | PayloadActionCreator
+> = A extends PromisePayloadSequenceCreator
+  ? PromiseResolved<ReturnType<ReturnType<A>['payload']>>
+  : A extends PromisePayloadActionCreator
+  ? PromiseResolved<ReturnType<A>['payload']>
+  : A extends PayloadActionCreator
+  ? ReturnType<A>['payload']
+  : unknown;
 
 export default actions;

--- a/packages/fxa-payments-server/src/store/sequences.ts
+++ b/packages/fxa-payments-server/src/store/sequences.ts
@@ -97,10 +97,11 @@ export const cancelSubscriptionAndRefresh = (
 };
 
 export const reactivateSubscriptionAndRefresh = (
-  subscriptionId: string
+  subscriptionId: string,
+  plan: Plan
 ) => async (dispatch: Function, getState: Function) => {
   try {
-    await dispatch(reactivateSubscription(subscriptionId));
+    await dispatch(reactivateSubscription(subscriptionId, plan));
     await dispatch(fetchCustomerAndSubscriptions());
   } catch (err) {
     handleThunkError(err);

--- a/packages/fxa-payments-server/src/store/state.ts
+++ b/packages/fxa-payments-server/src/store/state.ts
@@ -12,6 +12,8 @@ import {
   UpdateSubscriptionPlanResult,
 } from './types';
 
+import { actions, ActionPayload } from './actions';
+
 export const defaultState = {
   customer: uninitializedFetch<Customer, APIError>(),
   plans: uninitializedFetch<Array<Plan>, APIError>(),
@@ -19,7 +21,10 @@ export const defaultState = {
   subscriptions: uninitializedFetch<Array<Subscription>>(),
   token: uninitializedFetch<Token>(),
   cancelSubscription: uninitializedFetch<Subscription>(),
-  reactivateSubscription: uninitializedFetch<any>(),
+  reactivateSubscription: uninitializedFetch<
+    ActionPayload<typeof actions['reactivateSubscription']>,
+    APIError
+  >(),
   createSubscription: uninitializedFetch<
     CreateSubscriptionResult,
     CreateSubscriptionError


### PR DESCRIPTION
- use downloadURL as product redirect URL on payment

- use webIconURL as product icon in reactivation & cancellation views

- also refactor subscription reactivation view into subcomponents

- start of better type coverage of results from apiClient

fixes #3244