### PR TITLE
fix(auth-server): tweaks to get subscription upgrade working with latest subhub

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -351,12 +351,12 @@ const createRoutes = (
         }
 
         // This call needs to succeed for us to consider this a success.
-        await db.createAccountSubscription(
+        await db.createAccountSubscription({
           uid,
           subscriptionId,
-          newProductId,
-          Date.now()
-        );
+          productId: newProductId,
+          createdAt: Date.now(),
+        });
 
         const devices = await request.app.devices;
         await push.notifyProfileUpdated(uid, devices);

--- a/packages/fxa-auth-server/lib/subhub/client.js
+++ b/packages/fxa-auth-server/lib/subhub/client.js
@@ -196,7 +196,7 @@ const client = function(log, config, statsd) {
             plan_id: isA.string().required(),
           },
           response: isA.alternatives(
-            validators.subscriptionsSubscriptionListValidator,
+            validators.subscriptionsSubscriptionValidator,
             ErrorValidator
           ),
         },

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -495,6 +495,17 @@ describe('subscriptions', () => {
       assert.deepEqual(subhub.updateSubscription.args, [
         [UID, SUBSCRIPTION_ID_1, PLAN_ID_1],
       ]);
+      assert.deepEqual(db.deleteAccountSubscription.args[0], [
+        UID,
+        SUBSCRIPTION_ID_1,
+      ]);
+      const createArgs = db.createAccountSubscription.args[0][0];
+      assert.deepEqual(createArgs, {
+        uid: UID,
+        subscriptionId: SUBSCRIPTION_ID_1,
+        productId: PLANS[2].product_id,
+        createdAt: createArgs.createdAt,
+      });
     });
 
     it('should correctly handle an error from subhub', async () => {


### PR DESCRIPTION
With these changes, I was able to get an end-to-end subscription upgrade working with payments-server + auth-server + subhub locally running and pointed at my personal Stripe account