### PR TITLE
OAuth CORS

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/routes/index.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/index.js
@@ -113,6 +113,7 @@ exports.clients = [
 ];
 
 routes.forEach(function(route) {
+  route.config.cors = { origin: 'ignore' };
   var method = route.method.toUpperCase();
   if (method !== 'GET' && method !== 'HEAD') {
     if (!route.config.payload) {


### PR DESCRIPTION
oauth-server used to use '\*' in prod while auth-server
is limited to a couple important domains. In the
oauth->auth merge this fact got overlooked, breaking oauth
for some reliers, like Send when we flipped DNS.
With #2411 we want to expand '*' to 'ignore' anyway.