### PR TITLE
fix(totp): Set TOTP options when instantiated instead of in route

### DIFF
--- a/packages/fxa-auth-server/package-lock.json
+++ b/packages/fxa-auth-server/package-lock.json
@@ -5344,9 +5344,9 @@
       "dev": true
     },
     "otplib": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/otplib/-/otplib-8.0.1.tgz",
-      "integrity": "sha512-dtW+K211t2MR/8zNoLP0/l46vdhJ+Y7bv4qOaPEktXVjYCxTU6P4Y0/g8DZ49A20ILMHHORP6SzM+7a8wj+sYQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-11.0.1.tgz",
+      "integrity": "sha512-oi57teljNyWTC/JqJztHOtSGeFNDiDh5C1myd+faocUtFAX27Sm1mbx69kpEJ8/JqrblI3kAm4Pqd6tZJoOIBQ==",
       "requires": {
         "thirty-two": "1.0.2"
       }

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -76,7 +76,7 @@
     "node-uap": "git+https://github.com/vladikoff/node-uap.git#9cdd16247",
     "node-zendesk": "^1.4.0",
     "nodemailer": "2.7.2",
-    "otplib": "8.0.1",
+    "otplib": "11.0.1",
     "p-retry": "^4.2.0",
     "pem-jwk": "^2.0.0",
     "po2json": "0.4.5",

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -122,7 +122,7 @@ module.exports = config => {
       mailbox,
       options
     ).then(client => {
-      client.totpAuthenticator = new otplib.Authenticator();
+      client.totpAuthenticator = new otplib.authenticator.Authenticator();
       return client
         .createTotpToken()
         .then(result => {

--- a/packages/fxa-auth-server/test/remote/totp_tests.js
+++ b/packages/fxa-auth-server/test/remote/totp_tests.js
@@ -479,7 +479,7 @@ describe('remote totp', function() {
     });
 
     it('should verify totp code from previous code window', () => {
-      const futureAuthenticator = new otplib.Authenticator();
+      const futureAuthenticator = new otplib.authenticator.Authenticator();
       futureAuthenticator.options = Object.assign({}, authenticator.options, {
         epoch: Date.now() / 1000 - 30,
       });
@@ -496,7 +496,7 @@ describe('remote totp', function() {
     });
 
     it('should not verify totp code from future code window', () => {
-      const futureAuthenticator = new otplib.Authenticator();
+      const futureAuthenticator = new otplib.authenticator.Authenticator();
       futureAuthenticator.options = Object.assign({}, authenticator.options, {
         epoch: Date.now() / 1000 + 3000,
       });


### PR DESCRIPTION
This hopefully fixes #3277. 

I believe there was a race condition between the two TOTP configurations used. The one used for signup/signin is configured for 10mins with 2 time windows and the 2FA version is configured for 30 seconds and 2 time windows.

I suspect that when the respective routes get created it might pull from the global configuration. At the very least this change does not break anything. I also updated the otplib to version 11.