### PR TITLE
fix(auth-server): move stripe dep out of devDependencies

### DIFF
--- a/packages/fxa-auth-server/package-lock.json
+++ b/packages/fxa-auth-server/package-lock.json
@@ -6602,10 +6602,9 @@
       "dev": true
     },
     "stripe": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-7.13.0.tgz",
-      "integrity": "sha512-txnnBWAcwIsQ4/P3gYp74C0O9hONDVjKBlPTSG4GheDTZ0V5rkpoFYbuv4g8LvmrPMCZmz3chZ/nunnrTli4Iw==",
-      "dev": true,
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-7.13.1.tgz",
+      "integrity": "sha512-aF9F/M10MulZumSrwoDULBOZKqNUvyYA22Bg6u98VJEH/2Dck60W1FcT793WhsHHa/+z6TPR/8Ev7GNq1+SYOQ==",
       "requires": {
         "qs": "^6.6.0"
       },
@@ -6613,8 +6612,7 @@
         "qs": {
           "version": "6.9.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-          "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==",
-          "dev": true
+          "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
         }
       }
     },

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -88,6 +88,7 @@
     "safe-regex": "1.1.0",
     "safe-url-assembler": "1.3.5",
     "sandbox": "0.8.6",
+    "stripe": "^7.13.1",
     "through": "2.3.8",
     "urijs": "1.19.1",
     "uuid": "1.4.1",
@@ -138,7 +139,6 @@
     "simplesmtp": "0.3.35",
     "sinon": "7.0.0",
     "sjcl": "1.0.6",
-    "stripe": "^7.13.0",
     "typescript": "^3.6.4",
     "ws": "5.2.2"
   }


### PR DESCRIPTION
Because:

* We require an import of stripe to start.

This commit:

* Requires stripe as a dependency, rather than devDependency.

Closes #3461