### PR TITLE
feat(event-broker): live firestore data updates

### DIFF
--- a/packages/fxa-event-broker/lib/selfUpdatingService/clientWebhookService.ts
+++ b/packages/fxa-event-broker/lib/selfUpdatingService/clientWebhookService.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Logger } from 'mozlog';
 
+import { FirestoreDatastore } from '../db/firestore';
 import { Datastore } from '../db/index';
 import { Result } from '../result';
 import { SelfUpdatingService } from './index';
@@ -18,14 +19,47 @@ interface ClientWebhooks {
  * Service that provides a list of Relying Party Client webhook URLs.
  *
  * This service refreshes its list at the designated interval from the
- * firestore database.
+ * database.
+ *
+ * If Firestore is used, then the collection will update automatically
+ * when the snapshot is emitted rather than at the interval.
+ *
  */
 class ClientWebhookService extends SelfUpdatingService<ClientWebhooks> {
   private readonly db: Datastore;
+  private cancel: (() => void) | undefined;
 
   constructor(logger: Logger, refreshInterval: number, db: Datastore) {
     super(logger, refreshInterval * 1000, {});
     this.db = db;
+    this.cancel = undefined;
+  }
+
+  public async start() {
+    if (this.db instanceof FirestoreDatastore) {
+      this.cancel = this.db.listenForClientIdWebhooks(
+        (changed, removed) => {
+          Object.assign(this.data, changed);
+          for (const key of Object.keys(removed)) {
+            delete this.data[key];
+          }
+        },
+        err => {
+          this.logger.error('updateServer', { err });
+          process.exit(1);
+        }
+      );
+    } else {
+      await super.start();
+    }
+  }
+
+  public async stop() {
+    if (this.cancel) {
+      this.cancel();
+    } else {
+      await super.stop();
+    }
   }
 
   protected async updateFunction(): Promise<Result<ClientWebhooks>> {

--- a/packages/fxa-event-broker/lib/selfUpdatingService/index.ts
+++ b/packages/fxa-event-broker/lib/selfUpdatingService/index.ts
@@ -8,7 +8,7 @@ import { isError, Result } from '../result';
 
 abstract class SelfUpdatingService<T> {
   protected logger: Logger;
-  private data: T;
+  protected data: T;
   private timer: NodeJS.Timeout | null;
   private readonly refreshInterval: number;
   private failOnStart: boolean;

--- a/packages/fxa-event-broker/package-lock.json
+++ b/packages/fxa-event-broker/package-lock.json
@@ -5689,7 +5689,8 @@
     "typesafe-node-firestore": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/typesafe-node-firestore/-/typesafe-node-firestore-1.1.0.tgz",
-      "integrity": "sha512-fBGcHN9Jdcr7PSU9tdDRTfEuHLgv0QyNil13ErwJDup7AdaCqyWnQx+Y044aBBwN/j7bY5BZ4+xvEMv4+kWahA=="
+      "integrity": "sha512-fBGcHN9Jdcr7PSU9tdDRTfEuHLgv0QyNil13ErwJDup7AdaCqyWnQx+Y044aBBwN/j7bY5BZ4+xvEMv4+kWahA==",
+      "dev": true
     },
     "typescript": {
       "version": "3.7.2",

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -42,8 +42,7 @@
     "request": "^2.88.0",
     "request-promise-native": "^1.0.8",
     "sqs-consumer": "^5.4.0",
-    "typesafe-joi": "^2.0.6",
-    "typesafe-node-firestore": "^1.1.0"
+    "typesafe-joi": "^2.0.6"
   },
   "devDependencies": {
     "@types/chai": "^4.2.4",
@@ -71,6 +70,7 @@
     "tslint": "5.20.1",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1",
+    "typesafe-node-firestore": "^1.1.0",
     "typescript": "^3.7.2",
     "uuid": "^3.3.3"
   }


### PR DESCRIPTION
Because:

* Firestore supports document/query listeners for db-driven
  notification of listeners.
* Using listeners avoids unnecessary polling.

This commit:

* Uses Firestore listeners for push-based data updates.

Closes #3415