### PR TITLE
chore(test): Avoid timing issues in sign_in_totp tests

### DIFF
--- a/packages/fxa-content-server/tests/functional/sign_in_totp.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_totp.js
@@ -7,7 +7,6 @@
 const { registerSuite } = intern.getInterface('object');
 const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
-const FxDesktopHelpers = require('./lib/fx-desktop');
 const selectors = require('./lib/selectors');
 
 const config = intern._config;
@@ -46,8 +45,6 @@ const {
   type,
   visibleByQSA,
 } = FunctionalHelpers;
-
-const { listenForFxaCommands } = FxDesktopHelpers;
 
 registerSuite('TOTP', {
   beforeEach: function() {
@@ -192,8 +189,8 @@ registerSuite('TOTP', {
         .then(click(selectors.SETTINGS.SIGNOUT, selectors.ENTER_EMAIL.HEADER))
 
         .then(openPage(RESET_PASSWORD_URL, selectors.RESET_PASSWORD.HEADER))
-        .execute(listenForFxaCommands)
         .then(fillOutResetPassword(email))
+        .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
 
         .then(openVerificationLinkInSameTab(email, 2))
         .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
@@ -214,8 +211,8 @@ registerSuite('TOTP', {
         .then(click(selectors.SETTINGS.SIGNOUT, selectors.ENTER_EMAIL.HEADER))
 
         .then(openPage(RESET_PASSWORD_URL, selectors.RESET_PASSWORD.HEADER))
-        .execute(listenForFxaCommands)
         .then(fillOutResetPassword(email))
+        .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
 
         .then(openVerificationLinkInNewTab(email, 2))
         .then(switchToWindow(1))
@@ -238,8 +235,8 @@ registerSuite('TOTP', {
           .then(click(selectors.SETTINGS.SIGNOUT, selectors.ENTER_EMAIL.HEADER))
 
           .then(openPage(RESET_PASSWORD_URL, selectors.RESET_PASSWORD.HEADER))
-          .execute(listenForFxaCommands)
           .then(fillOutResetPassword(email))
+          .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
 
           // clear all browser state, simulate opening in a new browser
           .then(clearBrowserState({ force: true }))


### PR DESCRIPTION
The reset password tests did not wait for the CONFIRM_RESET_PASSWORD.HEADER element
before opening the links from the emails. I haven't seen this be a problem
in practice, but am opening the PR as a belts and suspenders move.

Also removes the listenForFxCommands, it's not necessary for the tests
to pass since it is only used for fx_desktop_v1 and fx_ios_v1.

@mozilla/fxa-devs - r?