### PR TITLE
fix(totp): Use the totp options instead of global options

### DIFF
--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -246,10 +246,18 @@ module.exports = (log, db, mailer, customs, config) => {
         const sharedSecret = token.sharedSecret;
         const tokenVerified = token.verified;
 
+        // Default options for TOTP
+        const otpOptions = {
+          encoding: 'hex',
+          step: config.step,
+          window: config.window,
+        };
+
         const authenticator = new otplib.authenticator.Authenticator();
         authenticator.options = Object.assign(
           {},
           otplib.authenticator.options,
+          otpOptions,
           { secret: sharedSecret }
         );
         const isValidCode = authenticator.check(code, sharedSecret);

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -458,7 +458,7 @@ function setup(results, errors, routePath, requestOptions) {
 }
 
 function makeRoutes(options = {}) {
-  const config = { step: 30 };
+  const config = { step: 30, window: 1 };
   const { log, db, customs, mailer } = options;
   return require('../../../lib/routes/totp')(log, db, mailer, customs, config);
 }


### PR DESCRIPTION
Not linked to an issue, but we have had rising rates of TOTP tests failures. This fixes it...hopefully.

cc @shane-tomlinson 