### PR TITLE
fix(totp): Use a shared helper to check otp codes

### DIFF
--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -361,9 +361,9 @@ module.exports = function(
         const account = await db.account(sessionToken.uid);
         const secret = account.primaryEmail.emailCode;
 
-        const expectedCode = otpUtils.generateOtpCode(secret, otpOptions);
+        const isValidCode = otpUtils.verifyOtpCode(code, secret, otpOptions);
 
-        if (expectedCode !== code) {
+        if (!isValidCode) {
           throw error.invalidOrExpiredOtpCode();
         }
 

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -253,14 +253,11 @@ module.exports = (log, db, mailer, customs, config) => {
           window: config.window,
         };
 
-        const authenticator = new otplib.authenticator.Authenticator();
-        authenticator.options = Object.assign(
-          {},
-          otplib.authenticator.options,
-          otpOptions,
-          { secret: sharedSecret }
+        const isValidCode = otpUtils.verifyOtpCode(
+          code,
+          sharedSecret,
+          otpOptions
         );
-        const isValidCode = authenticator.check(code, sharedSecret);
 
         // Once a valid TOTP code has been detected, the token becomes verified
         // and enabled for the user.

--- a/packages/fxa-auth-server/lib/routes/utils/otp.js
+++ b/packages/fxa-auth-server/lib/routes/utils/otp.js
@@ -50,5 +50,24 @@ module.exports = (log, config, db) => {
       );
       return authenticator.generate();
     },
+
+    /**
+     * Helper function to simplify verifying otp codes.
+     *
+     * @param code
+     * @param secret
+     * @param otpOptions
+     * @returns number
+     */
+    verifyOtpCode(code, secret, otpOptions) {
+      const authenticator = new otplib.authenticator.Authenticator();
+      authenticator.options = Object.assign(
+        {},
+        otplib.authenticator.options,
+        otpOptions,
+        { secret }
+      );
+      return authenticator.check(code, secret);
+    },
   };
 };


### PR DESCRIPTION
I think I *finally* got the right fix for https://github.com/mozilla/fxa/issues/3277.

In the `/session/verify_code` route, I was using checking otp codes by generating the expected code. This fails sometimes because codes can be valid for multiple time windows and we only get that check when using the `.check` function on the otplib. 

I've extracted this into a shared helper function it make things a little cleaner.

I'm targeting train-151 because I feel confident this is the right fix.