### PR TITLE
fix(metrics): Flush metrics more often to capture more events on iOS

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/views/base.js
+++ b/packages/fxa-content-server/app/tests/spec/views/base.js
@@ -83,6 +83,9 @@ describe('views/base', function() {
         captureException() {},
       },
     });
+    // prevents metrics from being flushed
+    // so we can check if they were emit
+    sinon.stub(metrics, 'flush');
     relier = new Relier();
     user = new User();
     windowMock = new WindowMock();

--- a/packages/fxa-content-server/app/tests/spec/views/complete_reset_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/complete_reset_password.js
@@ -68,6 +68,10 @@ describe('views/complete_reset_password', () => {
     notifier = new Notifier();
     sentryMetrics = new SentryMetrics();
     metrics = new Metrics({ notifier, sentryMetrics });
+    // prevents metrics from being flushed
+    // so we can check if they were emit
+    sinon.stub(metrics, 'flush');
+
     relier = new Relier();
     user = new User({
       fxaClient: fxaClient,

--- a/packages/fxa-content-server/app/tests/spec/views/confirm.js
+++ b/packages/fxa-content-server/app/tests/spec/views/confirm.js
@@ -44,6 +44,10 @@ describe('views/confirm', function() {
     model = new Backbone.Model();
     notifier = new Notifier();
     metrics = new Metrics({ notifier });
+    // prevents metrics from being flushed
+    // so we can check if they were emit
+    sinon.stub(metrics, 'flush');
+
     user = new User();
     windowMock = new WindowMock();
 

--- a/packages/fxa-content-server/app/tests/spec/views/confirm_reset_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/confirm_reset_password.js
@@ -43,6 +43,10 @@ describe('views/confirm_reset_password', function() {
     model = new Backbone.Model();
     notifier = new Notifier();
     metrics = new Metrics({ notifier });
+    // prevents metrics from being flushed
+    // so we can check if they were emit
+    sinon.stub(metrics, 'flush');
+
     relier = new Relier();
     windowMock = new WindowMock();
 

--- a/packages/fxa-content-server/app/tests/spec/views/force_auth.js
+++ b/packages/fxa-content-server/app/tests/spec/views/force_auth.js
@@ -50,6 +50,10 @@ describe('/views/force_auth', function() {
         captureException() {},
       },
     });
+    // prevents metrics from being flushed
+    // so we can check if they were emit
+    sinon.stub(metrics, 'flush');
+
     translator = new Translator({ forceEnglish: true });
     relier = new Relier({ service: 'sync' });
     user = new User({

--- a/packages/fxa-content-server/app/tests/spec/views/settings.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings.js
@@ -96,6 +96,10 @@ describe('views/settings', function() {
     notifier = new Notifier();
     marketingEmailEnabled = true;
     metrics = new Metrics({ notifier });
+    // prevents metrics from being flushed
+    // so we can check if they were emit
+    sinon.stub(metrics, 'flush');
+
     profileClient = new ProfileClient();
     subscriptionsManagementEnabled = false;
     subscriptionsManagementLanguages = ['en'];

--- a/packages/fxa-content-server/app/tests/spec/views/settings/change_password.jsx
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/change_password.jsx
@@ -39,6 +39,10 @@ describe('views/settings/change_password', function() {
   beforeEach(function () {
     notifier = new Notifier();
     metrics = new Metrics({ notifier });
+    // prevents metrics from being flushed
+    // so we can check if they were emit
+    sinon.stub(metrics, 'flush');
+
     relier = new Relier();
 
     broker = new Broker({
@@ -91,7 +95,7 @@ describe('views/settings/change_password', function() {
       });
 
       render(
-        <ChangePasswordForm account={account} 
+        <ChangePasswordForm account={account}
         submit={(oldPassword, newPassword)=>view.submit(oldPassword, newPassword)}
         showValidationError={(id,err)=>view.showValidationError(this.$(id),err)}
         />

--- a/packages/fxa-content-server/app/tests/spec/views/settings/display_name.jsx
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/display_name.jsx
@@ -16,10 +16,7 @@ import {
   DisplayNameFormComponent,
   DisplayNameComponent,
 } from 'views/settings/display_name';
-import {
-  render,
-  cleanup,
-} from '@testing-library/react';
+import { render, cleanup } from '@testing-library/react';
 
 describe('views/settings/display_name', function() {
   afterEach(() => {
@@ -33,9 +30,7 @@ describe('views/settings/display_name', function() {
 
     it('renders the button correctly without displayName set', () => {
       renderButtonComponent('');
-      const settingsButtons = document.querySelectorAll(
-        '.settings-button'
-      );
+      const settingsButtons = document.querySelectorAll('.settings-button');
       assert.lengthOf(settingsButtons, 1);
       assert.include(settingsButtons[0].innerText, 'Add');
     });
@@ -43,9 +38,7 @@ describe('views/settings/display_name', function() {
     it('renders the button correctly with a displayName set', () => {
       renderButtonComponent('joe');
 
-      const settingsButtons = document.querySelectorAll(
-        '.settings-button'
-      );
+      const settingsButtons = document.querySelectorAll('.settings-button');
       assert.lengthOf(settingsButtons, 1);
       assert.include(settingsButtons[0].innerText, 'Change');
     });
@@ -59,9 +52,7 @@ describe('views/settings/display_name', function() {
     it('renders correctly', () => {
       renderDisplayNameComponent();
 
-      const headerEls = document.querySelectorAll(
-        '.settings-unit-summary'
-      );
+      const headerEls = document.querySelectorAll('.settings-unit-summary');
       assert.lengthOf(headerEls, 1);
       assert.include(headerEls[0].innerText, 'Display name');
     });
@@ -83,10 +74,7 @@ describe('views/settings/display_name', function() {
     });
     function renderDisplayNameFormComponent(displayName = '') {
       render(
-        <DisplayNameFormComponent
-          displayName={displayName}
-          account={account}
-        />
+        <DisplayNameFormComponent displayName={displayName} account={account} />
       );
     }
 
@@ -124,6 +112,10 @@ describe('views/settings/display_name', function() {
       relier = new Relier();
       notifier = new Notifier();
       metrics = new Metrics({ notifier });
+      // prevents metrics from being flushed
+      // so we can check if they were emit
+      sinon.stub(metrics, 'flush');
+
       account = user.initAccount({
         email: email,
         sessionToken: 'fake session token',
@@ -188,16 +180,10 @@ describe('views/settings/display_name', function() {
         })
         .then(() => {
           const expectedName = name.trim();
-          assert.isTrue(
-            account.postDisplayName.calledWith(expectedName)
-          );
-          assert.isTrue(
-            view.updateDisplayName.calledWith(expectedName)
-          );
+          assert.isTrue(account.postDisplayName.calledWith(expectedName));
+          assert.isTrue(view.updateDisplayName.calledWith(expectedName));
           assert.isTrue(view.displaySuccess.called);
-          assert.isTrue(
-            TestHelpers.isEventLogged(metrics, '.success')
-          );
+          assert.isTrue(TestHelpers.isEventLogged(metrics, '.success'));
           assert.isTrue(view.navigate.calledWith('settings'));
 
           assert.equal(view.logFlowEvent.callCount, 1);

--- a/packages/fxa-content-server/app/tests/spec/views/support.js
+++ b/packages/fxa-content-server/app/tests/spec/views/support.js
@@ -62,6 +62,10 @@ describe('views/support', function() {
         captureException() {},
       },
     });
+    // prevents metrics from being flushed
+    // so we can check if they were emit
+    sinon.stub(metrics, 'flush');
+
     sinon.spy(notifier, 'trigger');
     profileClient = new ProfileClient();
     relier = new Relier();

--- a/packages/fxa-content-server/package-lock.json
+++ b/packages/fxa-content-server/package-lock.json
@@ -7028,7 +7028,7 @@
             "integrity": "sha512-xPyc1CtpvzC4WSC/ZeeuJ5tsjlJDt2SldNLCevpWpu58Btb4/3GD//7WYFL8HchazYvS5L97329gViYxb0ZsBA==",
             "requires": {
                 "es6-promise": "4.1.1",
-                "sjcl": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8ef32329bc8d7bc28a438372b5acb46616b",
+                "sjcl": "git://github.com/bitwiseshiftleft/sjcl.git#a03ea8e",
                 "xhr2": "0.0.7"
             },
             "dependencies": {
@@ -13088,9 +13088,9 @@
             "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
         },
         "speed-trap": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/speed-trap/-/speed-trap-0.0.8.tgz",
-            "integrity": "sha512-ecDBY13wab2CTYHZ1YvHlc3jmM9LO74LEcPrccJ/wRx9eMDgOyAvcP37QECiezfUfvqIiO84/O1KcpBXGSCNLA=="
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/speed-trap/-/speed-trap-0.0.10.tgz",
+            "integrity": "sha512-++S6f6iIV6AIJQjijFUxyzWQXSYYiSyUduGrionHfUeNn8umchSp3CeMlfvn1yjiCOwBGHYLAdCxkN4QBsjUSw=="
         },
         "split-string": {
             "version": "3.1.0",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -116,7 +116,7 @@
         "serve-static": "1.13.1",
         "source-map": "^0.7.3",
         "source-map-loader": "^0.2.4",
-        "speed-trap": "0.0.8",
+        "speed-trap": "0.0.10",
         "thread-loader": "^2.1.2",
         "time-grunt": "1.4.0",
         "typescript": "^3.5.1",


### PR DESCRIPTION
Alex noticed that lots of frontend events are not reported, especially
on iOS. My theory is that the WebView that FxA is opened in is closed
as soon as the user verifies their account, before metrics can be
submit.

This PR flushes metrics more often, any time any of these events happen:

* flow.*
* screen.*
* *.success
* *.complete

It also sets the default inactivity timeout to 10 seconds instead of
2 minutes.

fixes #3213