### PR TITLE
fix(payments): hide message when cancellation date is unavailable

### DIFF
--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ManagementPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ManagementPanel.tsx
@@ -41,9 +41,9 @@ export default ({
   ]);
 
   // TODO: date formats will need i18n someday
-  const cancelledAtDate = formatPeriodEndDate(
-    (subscription.cancelledAt as number) / 1000
-  );
+  const cancelledAtDate = subscription.cancelledAt
+    ? formatPeriodEndDate((subscription.cancelledAt as number) / 1000)
+    : null;
 
   // TODO: date formats will need i18n someday
   const periodEndDate = formatPeriodEndDate(
@@ -62,7 +62,11 @@ export default ({
       <div className="subscription-cancelled">
         <div className="with-settings-button">
           <div className="subscription-cancelled-details">
-            <p>You cancelled your subscription on {cancelledAtDate}.</p>
+            {cancelledAtDate && (
+              <p data-testid="subscription-cancelled-date">
+                You cancelled your subscription on {cancelledAtDate}.
+              </p>
+            )}
             <p>
               You will lose access to {plan.product_name} on{' '}
               <strong>{periodEndDate}</strong>.


### PR DESCRIPTION
issue #3400

For context: The problem is that we only record a `cancelledAt` date in the FxA database when a user cancels the subscription from the payments-server UI.

If the subscription is cancelled from Stripe admin (e.g. by a support representative), then we currently have no `cancelledAt` date to display.

So, in the latter case, let's hide the whole message for now.