### PR TITLE
fix(totp): Increase otp code test window

### DIFF
--- a/packages/fxa-auth-server/lib/routes/utils/otp.js
+++ b/packages/fxa-auth-server/lib/routes/utils/otp.js
@@ -48,7 +48,7 @@ module.exports = (log, config, db) => {
         otpOptions,
         { secret }
       );
-      return authenticator.generate();
+      return authenticator.generate(secret);
     },
 
     /**

--- a/packages/fxa-auth-server/test/remote/account_create_with_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_with_code_tests.js
@@ -185,10 +185,10 @@ describe('remote account create with sign-up code', function() {
       {},
       otplib.authenticator.options,
       config.otp,
-      { secret, epoch: Date.now() / 1000 - 60 * 15 } // Code 15mins old
+      { secret, epoch: Date.now() / 1000 - 60 * 11 } // Code 11mins old
     );
 
-    const previousWindowCode = futureAuthenticator.generate();
+    const previousWindowCode = futureAuthenticator.generate(secret);
 
     const response = await client.verifyShortCodeEmail(previousWindowCode);
 
@@ -215,10 +215,10 @@ describe('remote account create with sign-up code', function() {
       {},
       otplib.authenticator.options,
       config.otp,
-      { secret, epoch: Date.now() / 1000 + 60 * 15 } // Code 15mins in future
+      { secret, epoch: Date.now() / 1000 + 60 * 30 } // Code 30mins in future
     );
 
-    const futureWindowCode = futureAuthenticator.generate();
+    const futureWindowCode = futureAuthenticator.generate(secret);
 
     await assert.failsAsync(client.verifyShortCodeEmail(futureWindowCode), {
       code: 400,


### PR DESCRIPTION
I suspect that https://github.com/mozilla/fxa/pull/3492 introduced a flakey test with sign-up verification. This expands the testing window and passes the secret into the generator function.

Targeted against train-151 since original patch landed there.