### PR TITLE
chore(tests): de-duplicate some sign in/up functional tests

### DIFF
--- a/packages/fxa-content-server/tests/functional/oauth_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sign_in.js
@@ -207,6 +207,12 @@ registerSuite('oauth signin', {
           .then(fillOutEmailFirstSignIn(email, PASSWORD))
 
           .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
+          .then(
+            testElementTextInclude(
+              selectors.CONFIRM_SIGNUP.EMAIL_MESSAGE,
+              email
+            )
+          )
 
           // get the second email, the first was sent on client.signUp w/
           // preVerified: false above. The second email has the `service` and

--- a/packages/fxa-content-server/tests/functional/sign_in.js
+++ b/packages/fxa-content-server/tests/functional/sign_in.js
@@ -27,10 +27,8 @@ const {
   openVerificationLinkInSameTab,
   switchToWindow,
   testAttributeMatches,
-  testErrorTextInclude,
   testElementExists,
   testElementTextInclude,
-  testElementValueEquals,
   type,
   visibleByQSA,
 } = FunctionalHelpers;
@@ -43,33 +41,6 @@ registerSuite('signin', {
   },
 
   tests: {
-    'with an invalid email': function() {
-      return this.remote
-        .then(
-          openPage(ENTER_EMAIL_URL + '?email=invalid', selectors['400'].HEADER)
-        )
-        .then(testErrorTextInclude('invalid'))
-        .then(testErrorTextInclude('email'));
-    },
-
-    'signin unverified': function() {
-      return this.remote
-        .then(createUser(email, PASSWORD, { preVerified: false }))
-        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-        .then(fillOutEmailFirstSignIn(email, PASSWORD))
-        .then(
-          testElementTextInclude(selectors.CONFIRM_SIGNUP.EMAIL_MESSAGE, email)
-        );
-    },
-
-    'signin verified with correct password': function() {
-      return this.remote
-        .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-        .then(fillOutEmailFirstSignIn(email, PASSWORD))
-        .then(testElementExists(selectors.SETTINGS.HEADER));
-    },
-
     'signin verified with incorrect password, click `forgot password?`': function() {
       return (
         this.remote
@@ -115,31 +86,6 @@ registerSuite('signin', {
               'password'
             )
           )
-      );
-    },
-
-    'form prefill information is cleared after signin->sign out': function() {
-      return (
-        this.remote
-          .then(createUser(email, PASSWORD, { preVerified: true }))
-          .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-          .then(fillOutEmailFirstSignIn(email, PASSWORD))
-
-          // success is seeing the sign-in-complete screen.
-          .then(testElementExists(selectors.SETTINGS.HEADER))
-          .then(click(selectors.SETTINGS.SIGNOUT, selectors.ENTER_EMAIL.HEADER))
-
-          // check the email and password were cleared
-          .then(testElementValueEquals(selectors.ENTER_EMAIL.EMAIL, ''))
-          .then(type(selectors.ENTER_EMAIL.EMAIL, email))
-          .then(
-            click(
-              selectors.ENTER_EMAIL.SUBMIT,
-              selectors.SIGNIN_PASSWORD.HEADER
-            )
-          )
-
-          .then(testElementValueEquals(selectors.SIGNIN_PASSWORD.PASSWORD, ''))
       );
     },
 

--- a/packages/fxa-content-server/tests/functional/sign_up.js
+++ b/packages/fxa-content-server/tests/functional/sign_up.js
@@ -104,52 +104,6 @@ registerSuite('signup', {
         .then(testAtConfirmScreen(email));
     },
 
-    'signup, verify same browser': function() {
-      return this.remote
-        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-        .then(visibleByQSA(selectors.ENTER_EMAIL.LINK_SUGGEST_SYNC))
-        .then(fillOutEmailFirstSignUp(email, PASSWORD))
-        .then(testAtConfirmScreen(email))
-        .then(openVerificationLinkInNewTab(email, 0))
-
-        .then(switchToWindow(1))
-        .then(testElementExists(selectors.SETTINGS.HEADER))
-        .then(testSuccessWasShown())
-        .then(closeCurrentWindow())
-
-        .then(testElementExists(selectors.SETTINGS.HEADER))
-        .then(testSuccessWasShown());
-    },
-
-    'signup, verify same browser with original tab closed, sign out': function() {
-      return (
-        this.remote
-          .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-          .then(fillOutEmailFirstSignUp(email, PASSWORD))
-          .then(testAtConfirmScreen(email))
-
-          .then(FunctionalHelpers.openExternalSite())
-          .then(openVerificationLinkInNewTab(email, 0))
-
-          .then(switchToWindow(1))
-          .then(testElementExists(selectors.SETTINGS.HEADER))
-
-          .then(testSuccessWasShown())
-
-          // Ref https://github.com/mozilla/fxa-content-server/issues/3187
-          // Ensure the signin screen shows if the user signs out after
-          // verification.
-          .then(click(selectors.SETTINGS.SIGNOUT))
-
-          .then(testElementExists(selectors.ENTER_EMAIL.HEADER))
-          // `visibleByQSA` is used to ensure visibility. With the bug in #3187
-          // referenced above, the signin screen is drawn, but invisible
-          .then(visibleByQSA(selectors.ENTER_EMAIL.HEADER))
-
-          .then(closeCurrentWindow())
-      );
-    },
-
     'signup, verify and sign out of two accounts, all in the same tab, then sign in to the first account': function() {
       // https://github.com/mozilla/fxa-content-server/issues/2209
       var secondEmail = createEmail();
@@ -178,51 +132,6 @@ registerSuite('signup', {
         .then(testElementExists(selectors.ENTER_EMAIL.HEADER))
         .then(fillOutEmailFirstSignIn(email, PASSWORD))
         .then(testElementExists(selectors.SETTINGS.HEADER));
-    },
-
-    'signup, verify same browser by replacing the original tab': function() {
-      return this.remote
-        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-        .then(fillOutEmailFirstSignUp(email, PASSWORD))
-        .then(testAtConfirmScreen(email))
-        .then(openVerificationLinkInSameTab(email, 0))
-
-        .then(testElementExists(selectors.SETTINGS.HEADER))
-        .then(testSuccessWasShown());
-    },
-
-    "signup, verify different browser - from original tab's P.O.V.": function() {
-      return (
-        this.remote
-          .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-          .then(fillOutEmailFirstSignUp(email, PASSWORD))
-          .then(testAtConfirmScreen(email))
-
-          .then(openVerificationLinkInDifferentBrowser(email))
-
-          // The original tab should transition to the settings page w/ success
-          // message.
-          .then(testElementExists(selectors.SETTINGS.HEADER))
-          .then(testSuccessWasShown())
-      );
-    },
-
-    "signup, verify different browser - from new browser's P.O.V.": function() {
-      return (
-        this.remote
-          .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-          .then(fillOutEmailFirstSignUp(email, PASSWORD))
-          .then(testAtConfirmScreen(email))
-
-          // clear local/sessionStorage to synthesize continuing in
-          // a separate browser.
-          .then(clearBrowserState())
-          .then(openVerificationLinkInSameTab(email, 0))
-
-          // user cannot be signed in and redirected to the settings page
-          // automatically, just show the signup complete screen.
-          .then(testElementExists(selectors.SIGNUP_COMPLETE.HEADER))
-      );
     },
 
     'signup with email with leading whitespace on the email': function() {


### PR DESCRIPTION
These tests are considered duplicates because:
 - Some are just plain duplicates
 - Some are sub-tests of other tests
 - Some test the same functionalities but with different starting points
   (content server vs. oauth relying party)

Fixes #1542

@mozilla/fxa-devs r?