### PR TITLE
fix(cwts): Ensure CWTS tests in sync optional flow test reality.

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/do-not-sync-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/do-not-sync-mixin.js
@@ -7,14 +7,14 @@
  *
  * @mixin DoNotSync mixin
  */
-import SigninMixin from './signin-mixin';
 import FlowEventsMixin from './flow-events-mixin';
+import preventDefaultThen from '../decorators/prevent_default_then';
 
 export default {
-  dependsOn: [SigninMixin, FlowEventsMixin],
+  dependsOn: [FlowEventsMixin],
 
   events: {
-    'click #do-not-sync-device': 'doNotSync',
+    'click #do-not-sync-device': preventDefaultThen('doNotSync'),
   },
 
   doNotSync() {

--- a/packages/fxa-content-server/tests/functional/fx_browser_relier.js
+++ b/packages/fxa-content-server/tests/functional/fx_browser_relier.js
@@ -30,9 +30,11 @@ const {
   createUser,
   type,
   closeCurrentWindow,
+  fillOutEmailFirstSignUp,
   openPage,
   openVerificationLinkInNewTab,
   switchToWindow,
+  testElementExists,
   testIsBrowserNotified,
 } = FunctionalHelpers;
 
@@ -52,7 +54,7 @@ registerSuite('Firefox Desktop non-sync', {
           .then(
             openPage(EMAIL_FIRST_URL, selectors.ENTER_EMAIL.SUB_HEADER, {
               query: {
-                forceUA: uaStrings['desktop_firefox_57'],
+                forceUA: uaStrings['desktop_firefox_71'],
               },
               webChannelResponses: {
                 'fxaccounts:can_link_account': { ok: true },
@@ -64,25 +66,20 @@ registerSuite('Firefox Desktop non-sync', {
               },
             })
           )
-          .then(type(selectors.ENTER_EMAIL.EMAIL, email))
-          .then(click(selectors.ENTER_EMAIL.SUBMIT))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
+          .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
           .then(testIsBrowserNotified('fxaccounts:can_link_account'))
-
-          .then(type(selectors.SIGNUP_PASSWORD.PASSWORD, PASSWORD))
-          .then(type(selectors.SIGNUP_PASSWORD.VPASSWORD, PASSWORD))
-          .then(type(selectors.SIGNUP_PASSWORD.AGE, 21))
-          .then(
-            click(
-              selectors.SIGNUP_PASSWORD.SUBMIT,
-              selectors.CHOOSE_WHAT_TO_SYNC.HEADER
-            )
-          )
           // verify the account
           .then(openVerificationLinkInNewTab(email, 0))
           .then(switchToWindow(1))
           // switch back to the original window, choose to "do not sync".
           .then(closeCurrentWindow())
-          .then(click(selectors.CHOOSE_WHAT_TO_SYNC.DO_NOT_SYNC))
+          .then(
+            click(
+              selectors.CHOOSE_WHAT_TO_SYNC.DO_NOT_SYNC,
+              selectors.CONNECT_ANOTHER_DEVICE.HEADER
+            )
+          )
           .then(testIsBrowserNotified('fxaccounts:login'))
       );
     },
@@ -92,7 +89,7 @@ registerSuite('Firefox Desktop non-sync', {
           .then(
             openPage(EMAIL_FIRST_URL, selectors.ENTER_EMAIL.SUB_HEADER, {
               query: {
-                forceUA: uaStrings['desktop_firefox_57'],
+                forceUA: uaStrings['desktop_firefox_71'],
               },
               webChannelResponses: {
                 'fxaccounts:can_link_account': { ok: true },
@@ -104,25 +101,20 @@ registerSuite('Firefox Desktop non-sync', {
               },
             })
           )
-          .then(type(selectors.ENTER_EMAIL.EMAIL, email))
-          .then(click(selectors.ENTER_EMAIL.SUBMIT))
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
+          .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
           .then(testIsBrowserNotified('fxaccounts:can_link_account'))
-
-          .then(type(selectors.SIGNUP_PASSWORD.PASSWORD, PASSWORD))
-          .then(type(selectors.SIGNUP_PASSWORD.VPASSWORD, PASSWORD))
-          .then(type(selectors.SIGNUP_PASSWORD.AGE, 21))
-          .then(
-            click(
-              selectors.SIGNUP_PASSWORD.SUBMIT,
-              selectors.CHOOSE_WHAT_TO_SYNC.HEADER
-            )
-          )
           // verify the account
           .then(openVerificationLinkInNewTab(email, 0))
           .then(switchToWindow(1))
           // switch back to the original window, choose to "do not sync".
           .then(closeCurrentWindow())
-          .then(click(selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT))
+          .then(
+            click(
+              selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT,
+              selectors.CONNECT_ANOTHER_DEVICE.HEADER
+            )
+          )
           .then(testIsBrowserNotified('fxaccounts:login'))
       );
     },
@@ -132,7 +124,7 @@ registerSuite('Firefox Desktop non-sync', {
         .then(
           openPage(EMAIL_FIRST_URL, selectors.ENTER_EMAIL.SUB_HEADER, {
             query: {
-              forceUA: uaStrings['desktop_firefox_57'],
+              forceUA: uaStrings['desktop_firefox_71'],
             },
             webChannelResponses: {
               'fxaccounts:can_link_account': { ok: true },
@@ -157,7 +149,12 @@ registerSuite('Firefox Desktop non-sync', {
             selectors.WOULD_YOU_LIKE_SYNC.HEADER
           )
         )
-        .then(click(selectors.WOULD_YOU_LIKE_SYNC.DO_NOT_SYNC))
+        .then(
+          click(
+            selectors.WOULD_YOU_LIKE_SYNC.DO_NOT_SYNC,
+            selectors.CONNECT_ANOTHER_DEVICE.HEADER
+          )
+        )
         .then(testIsBrowserNotified('fxaccounts:login'));
     },
     'signin with no service - sync': function() {
@@ -166,7 +163,7 @@ registerSuite('Firefox Desktop non-sync', {
         .then(
           openPage(EMAIL_FIRST_URL, selectors.ENTER_EMAIL.SUB_HEADER, {
             query: {
-              forceUA: uaStrings['desktop_firefox_57'],
+              forceUA: uaStrings['desktop_firefox_71'],
             },
             webChannelResponses: {
               'fxaccounts:can_link_account': { ok: true },
@@ -191,7 +188,12 @@ registerSuite('Firefox Desktop non-sync', {
             selectors.WOULD_YOU_LIKE_SYNC.HEADER
           )
         )
-        .then(click(selectors.WOULD_YOU_LIKE_SYNC.SUBMIT))
+        .then(
+          click(
+            selectors.WOULD_YOU_LIKE_SYNC.SUBMIT,
+            selectors.CONNECT_ANOTHER_DEVICE.HEADER
+          )
+        )
         .then(testIsBrowserNotified('fxaccounts:login'));
     },
   },

--- a/packages/fxa-content-server/tests/functional/lib/ua-strings.js
+++ b/packages/fxa-content-server/tests/functional/lib/ua-strings.js
@@ -20,6 +20,8 @@ module.exports = {
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:57.0) Gecko/20100101 Firefox/57.0',
   desktop_firefox_58:
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:58.0) Gecko/20100101 Firefox/58.0',
+  desktop_firefox_71:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:71.0) Gecko/20100101 Firefox/71.0',
   ios_firefox:
     'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4',
   ios_firefox_11_0:


### PR DESCRIPTION
The tests were using Firefox 57 even though functionality
is only available starting with Firefox 71, and did not test
which screen the user should be at on the end of the flow.

Use Firefox 71 as the user agent string, check the final
screen.

@mozilla/fxa-devs - r?