### PR TITLE
feat(service-mixin): fix #2054 - Display 'Account Settings' if `serviceName` is not provided by relier

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/account_recovery_confirm_key.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/account_recovery_confirm_key.mustache
@@ -21,12 +21,15 @@
     {{^isLinkExpired}}
         <header>
             <h1 id="fxa-recovery-key-confirm">
+                {{#t}}Reset password with recovery key{{/t}}
+                <!-- L10N: For languages structured like English, this phrase can read "to continue to %(serviceName)s" -->
                 {{#serviceName}}
-                    <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-                    {{#t}}Reset password with recovery key{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+                    <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
                 {{/serviceName}}
                 {{^serviceName}}
-                    {{#t}}Reset password with recovery key{{/t}}
+                    {{#noRelierServiceDefault}}
+                        <span class="service">{{#t}}Continue to %(noRelierServiceDefault)s{{/t}}</span>
+                    {{/noRelierServiceDefault}}
                 {{/serviceName}}
             </h1>
         </header>

--- a/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
@@ -1,12 +1,15 @@
 <div id="main-content" class="card confirm-signup">
     <header>
         <h1 id="fxa-confirm-signup-code-header">
+            {{#t}}Enter verification code{{/t}}
+            <!-- L10N: For languages structured like English, this phrase can read "to continue to %(serviceName)s" -->
             {{#serviceName}}
-                <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-                {{#t}}Enter verification code{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+                <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
             {{/serviceName}}
             {{^serviceName}}
-                {{#t}}Enter verification code{{/t}}
+                {{#noRelierServiceDefault}}
+                    <span class="service">{{#t}}Continue to %(noRelierServiceDefault)s{{/t}}</span>
+                {{/noRelierServiceDefault}}
             {{/serviceName}}
         </h1>
     </header>

--- a/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/force_auth.mustache
@@ -6,7 +6,12 @@
         {{#t}}Sign in{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
       {{/serviceName}}
       {{^serviceName}}
-        {{#t}}Sign in to continue{{/t}}
+        {{#noRelierServiceDefault}}
+          {{#t}}Sign in{{/t}} <span class="service">{{#t}}Continue to %(noRelierServiceDefault)s{{/t}}</span>
+        {{/noRelierServiceDefault}}
+        {{^noRelierServiceDefault}}
+          {{#t}}Sign in to continue{{/t}}
+        {{/noRelierServiceDefault}}
       {{/serviceName}}
     </h1>
   </header>

--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -1,12 +1,15 @@
 <div id="main-content" class="card">
   <header>
     <h1 id="fxa-enter-email-header">
+      {{#t}}Enter your email{{/t}}
+      <!-- L10N: For languages structured like English, this phrase can read "to continue to %(serviceName)s" -->
       {{#serviceName}}
-        <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-        {{#t}}Enter your email{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+        <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
       {{/serviceName}}
       {{^serviceName}}
-        {{#t}}Enter your email{{/t}}
+        {{#noRelierServiceDefault}}
+          <span class="service">{{#t}}Continue to %(noRelierServiceDefault)s{{/t}}
+        {{/noRelierServiceDefault}}
       {{/serviceName}}
     </h1>
   </header>

--- a/packages/fxa-content-server/app/scripts/templates/ready.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/ready.mustache
@@ -30,7 +30,9 @@
           {{/emailVerified}}
 
           {{^emailVerified}}
-              <p class="account-ready-generic">{{#t}}Your account is ready!{{/t}}</p>
+            {{#noRelierServiceDefault}}
+              <p class="account-ready-generic">{{#t}}You are now ready to use %(noRelierServiceDefault)s{{/t}}</p>
+            {{/noRelierServiceDefault}}
           {{/emailVerified}}
       {{/serviceName}}
     {{/isSync}}

--- a/packages/fxa-content-server/app/scripts/templates/reset_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/reset_password.mustache
@@ -1,12 +1,15 @@
 <div id="main-content" class="card">
   <header>
     <h1 id="fxa-reset-password-header">
+      {{#t}}Reset password{{/t}}
+        <!-- L10N: For languages structured like English, this phrase can read "to continue to %(serviceName)s" -->
       {{#serviceName}}
-        <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-        {{#t}}Reset password{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+        <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
       {{/serviceName}}
       {{^serviceName}}
-        {{#t}}Reset password{{/t}}
+        {{#noRelierServiceDefault}}
+          <span class="service">{{#t}}Continue to %(noRelierServiceDefault)s{{/t}}</span>
+        {{/noRelierServiceDefault}}
       {{/serviceName}}
     </h1>
   </header>

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -1,12 +1,15 @@
 <div id="main-content" class="card">
   <header>
     <h1 id="fxa-signin-password-header">
+      {{#t}}Sign in{{/t}}
+        <!-- L10N: For languages structured like English, this phrase can read "to continue to %(serviceName)s" -->
       {{#serviceName}}
-        <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-        {{#t}}Sign in{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+        <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
       {{/serviceName}}
       {{^serviceName}}
-        {{#t}}Sign in{{/t}}
+        {{#noRelierServiceDefault}}
+          <span class="service">{{#t}}Continue to %(noRelierServiceDefault)s{{/t}}</span>
+        {{/noRelierServiceDefault}}
       {{/serviceName}}
     </h1>
   </header>

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_recovery_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_recovery_code.mustache
@@ -4,6 +4,11 @@
         {{#serviceName}}
             <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
         {{/serviceName}}
+        {{^serviceName}}
+          {{#noRelierServiceDefault}}
+            <span class="service">{{#t}}Continue to %(noRelierServiceDefault)s{{/t}}
+          {{/noRelierServiceDefault}}
+        {{/serviceName}}
     </h1>
   </header>
 

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_totp_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_totp_code.mustache
@@ -1,9 +1,14 @@
 <div id="main-content" class="card">
   <header>
     <h1 id="fxa-totp-code-header">{{#t}}Enter security code{{/t}}
-        {{#serviceName}}
-            <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
-        {{/serviceName}}
+      {{#serviceName}}
+          <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+      {{/serviceName}}
+      {{^serviceName}}
+        {{#noRelierServiceDefault}}
+          <span class="service">{{#t}}Continue to %(noRelierServiceDefault)s{{/t}}
+        {{/noRelierServiceDefault}}
+      {{/serviceName}}
     </h1>
   </header>
 

--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -1,12 +1,15 @@
 <div id="main-content" class="card signup-password">
   <header>
       <h1 id="fxa-signup-password-header">
-      {{#serviceName}}
+      {{#t}}Create a Firefox Account{{/t}}
         <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-        {{#t}}Create a Firefox Account{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+      {{#serviceName}}
+        <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
       {{/serviceName}}
       {{^serviceName}}
-        {{#t}}Create a Firefox Account{{/t}}
+        {{#noRelierServiceDefault}}
+          <span class="service">{{#t}}Continue to %(noRelierServiceDefault)s{{/t}}
+        {{/noRelierServiceDefault}}
       {{/serviceName}}
       </h1>
   </header>

--- a/packages/fxa-content-server/app/scripts/views/mixins/service-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/service-mixin.js
@@ -14,7 +14,10 @@ export default {
   },
 
   setInitialContext(context) {
-    context.set(this.relier.pick('service', 'serviceName'));
+    context.set({
+      ...this.relier.pick('service', 'serviceName'),
+      noRelierServiceDefault: 'Account Settings',
+    });
   },
 
   transformLinks() {

--- a/packages/fxa-content-server/app/tests/spec/views/force_auth.js
+++ b/packages/fxa-content-server/app/tests/spec/views/force_auth.js
@@ -171,7 +171,10 @@ describe('/views/force_auth', function() {
 
       it('renders as expected', () => {
         assert.isFalse(view.navigate.called);
-        assert.lengthOf(view.$(Selectors.SUB_HEADER), 0);
+        assert.equal(
+          view.$(Selectors.SUB_HEADER).text(),
+          'Continue to Account Settings'
+        );
         assert.equal(view.$(Selectors.EMAIL).val(), email);
         assert.equal(view.$(Selectors.EMAIL_NOT_EDITABLE).text(), email);
         assert.lengthOf(view.$('.error.visible'), 0);

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/service-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/service-mixin.js
@@ -63,6 +63,12 @@ describe('views/mixins/service-mixin', () => {
       assert.equal(context.get('service'), 'sync');
       assert.equal(context.get('serviceName'), 'Firefox Sync');
     });
+
+    it('sets `noRelierServiceDefault`', () => {
+      const context = new Backbone.Model({});
+      view.setInitialContext(context);
+      assert.equal(context.get('noRelierServiceDefault'), 'Account Settings');
+    });
   });
 
   describe('render', () => {

--- a/packages/fxa-content-server/app/tests/spec/views/ready.js
+++ b/packages/fxa-content-server/app/tests/spec/views/ready.js
@@ -109,14 +109,20 @@ describe('views/ready', function() {
     });
 
     // regression test for #1216
-    it('does not show service name if service is defined but serviceName is not', function() {
+    it('shows `noRelierServiceDefault` text if service is defined but serviceName is not', function() {
       createView(VerificationReasons.SIGN_UP);
       sinon.stub(view, 'setInitialContext').callsFake(context => {
-        context.set('service', 'sync');
+        context.set({
+          service: 'sync',
+          noRelierServiceDefault: 'Another Service',
+        });
       });
 
       return view.render().then(function() {
-        assert.ok(view.$('.account-ready-generic').length);
+        assert.equal(
+          view.$('.account-ready-generic').text(),
+          'You are now ready to use Another Service'
+        );
       });
     });
 


### PR DESCRIPTION
fix for #2054 

Creating a new context key (`noRelierServiceDefault`) and checking for it when `serviceName` is not given in the template seemed like the safest approach for this (since "Account Settings" isn't really a _service_, it felt messy to mutate the context if `serviceName` didn't exist to set it as such). It displays the RP `serviceName` over “Account Settings” when one is provided. Let me know if you guys have a better name.

Some screenshots can be seen in the issue.

Since we aren’t checking for `{{#serviceName}}` in `permissions.mustache`, I didn’t update it, as it doesn’t seem this would be shown unless an actual RP is requesting permissions.

~@ryanfeeley one last question for you. In `ready.mustache`, or when the account is verified/ready, do we want the text to read “Your account is ready!” (current) if they were logging into settings, or “You are now ready to use Account Settings”? That one seemed questionable to me, but it could be argued if they've seen "Account Settings" through the flow that it'd be consistent to see it there too.~
Edit: Ryan and I pinged on Slack and he gave the thumbs up for `ready.js`.