### PR TITLE
fix(tests): verify subscriptions in a non-product specific fashion

### DIFF
--- a/packages/fxa-content-server/tests/intern.js
+++ b/packages/fxa-content-server/tests/intern.js
@@ -40,7 +40,7 @@ const asyncTimeout = parseInt(args.asyncTimeout || 5000, 10);
 // args.bailAfterFirstFailure comes in as a string.
 const bailAfterFirstFailure = args.bailAfterFirstFailure === 'true';
 
-const testProductId = '123doneProProduct';
+const testProductId = args.testProductId || '123doneProProduct';
 
 // Intern specific options are here: https://theintern.io/docs.html#Intern/4/docs/docs%2Fconfiguration.md/properties
 const config = {


### PR DESCRIPTION
This patch removes the 123Done Pro specific verification in functional
tests that require successful subscriptions.

It also allows an optional product id to be passed in for the subscribed
product in the tests.

Fixes #3502 