### PR TITLE
feat(signin-code): Add bounce handling to /signin_token_code

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -235,7 +235,9 @@ const Router = Backbone.Router.extend({
     }),
     'signin_recovery_code(/)': createViewHandler(SignInRecoveryCodeView),
     'signin_reported(/)': createViewHandler(SignInReportedView),
-    'signin_token_code(/)': createViewHandler(SignInTokenCodeView),
+    'signin_token_code(/)': createViewHandler(SignInTokenCodeView, {
+      type: VerificationReasons.SIGN_IN,
+    }),
     'signin_totp_code(/)': createViewHandler(SignInTotpCodeView),
     'signin_unblock(/)': createViewHandler(SignInUnblockView),
     'signin_verified(/)': createViewHandler(ReadyView, {

--- a/packages/fxa-content-server/app/scripts/views/mixins/session-verification-poll-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/session-verification-poll-mixin.js
@@ -80,7 +80,10 @@ export default {
   _handleSessionVerificationPollErrors(account, err) {
     // The user's email may have bounced because it was invalid.
     // Redirect them to the sign up page with an error notice.
-    if (AuthErrors.is(err, 'SIGNUP_EMAIL_BOUNCE')) {
+    if (
+      AuthErrors.is(err, 'SIGNUP_EMAIL_BOUNCE') ||
+      AuthErrors.is(err, 'INVALID_TOKEN')
+    ) {
       account.set('hasBounced', true);
       if (this.isSignUp()) {
         this.navigate('/', {

--- a/packages/fxa-content-server/app/scripts/views/sign_in_token_code.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_token_code.js
@@ -11,6 +11,7 @@ import Constants from '../lib/constants';
 import FormView from './form';
 import Template from 'templates/sign_in_token_code.mustache';
 import ResendMixin from './mixins/resend-mixin';
+import SessionVerificationPollMixin from './mixins/session-verification-poll-mixin';
 
 const CODE_INPUT_SELECTOR = 'input.otp-code';
 
@@ -27,6 +28,17 @@ const View = FormView.extend({
     if (!this.model.get('account')) {
       this.navigate(this._getAuthPage());
     }
+  },
+
+  afterVisible() {
+    // waitForSessionVerification handles bounced emails and will redirect
+    // the user to the appropriate screen depending on whether the account
+    // is deleted. If the account no longer exists, redirects the user to
+    // sign up, if the account exists, then notifies them their account
+    // has been blocked.
+    this.waitForSessionVerification(this.getAccount(), () => {
+      // don't do anything on verification, that's taken care of in the submit handler.
+    });
   },
 
   setInitialContext(context) {
@@ -82,6 +94,6 @@ const View = FormView.extend({
   },
 });
 
-Cocktail.mixin(View, ResendMixin());
+Cocktail.mixin(View, ResendMixin(), SessionVerificationPollMixin);
 
 export default View;

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/session-verification-poll-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/session-verification-poll-mixin.js
@@ -78,7 +78,7 @@ describe('views/mixins/session-verification-poll-mixin', () => {
   });
 
   describe('_handleSessionVerificationPollErrors', () => {
-    it('displays an error message allowing the user to re-signup if their email bounces on signup', () => {
+    it('navigates to / if SIGNUP_EMAIL_BOUNCE occurs on signup', () => {
       sinon.stub(view, 'isSignUp').callsFake(() => true);
       sinon.spy(view, 'navigate');
       view._handleSessionVerificationPollErrors(
@@ -91,12 +91,36 @@ describe('views/mixins/session-verification-poll-mixin', () => {
       assert.isTrue(account.get('hasBounced'));
     });
 
-    it('navigates to the signin-bounced screen if their email bounces on signin', () => {
+    it('navigates to /signin_bounced if SIGNUP_EMAIL_BOUNCE occurs on signin', () => {
       sinon.stub(view, 'isSignUp').callsFake(() => false);
       sinon.spy(view, 'navigate');
       view._handleSessionVerificationPollErrors(
         account,
         AuthErrors.toError('SIGNUP_EMAIL_BOUNCE')
+      );
+
+      assert.isTrue(
+        view.navigate.calledWith('signin_bounced', { email: 'a@a.com' })
+      );
+    });
+
+    it('navigates to / if INVALID_TOKEN occurs on signup', () => {
+      sinon.stub(view, 'isSignUp').callsFake(() => true);
+      sinon.spy(view, 'navigate');
+      view._handleSessionVerificationPollErrors(
+        account,
+        AuthErrors.toError('INVALID_TOKEN')
+      );
+
+      assert.isTrue(view.navigate.calledWith('/', { account }));
+    });
+
+    it('navigates to /signin_bounced if INVALID_TOKEN occurs on signin', () => {
+      sinon.stub(view, 'isSignUp').callsFake(() => false);
+      sinon.spy(view, 'navigate');
+      view._handleSessionVerificationPollErrors(
+        account,
+        AuthErrors.toError('INVALID_TOKEN')
       );
 
       assert.isTrue(

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_token_code.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_token_code.js
@@ -96,6 +96,19 @@ describe('views/sign_in_token_code', () => {
     });
   });
 
+  describe('afterVisible', () => {
+    it('starts polling in case the email bounces', () => {
+      const account = { uid: 'uid' };
+
+      sinon.stub(view, 'waitForSessionVerification');
+      sinon.stub(view, 'getAccount').returns(account);
+
+      view.afterVisible();
+
+      assert.isTrue(view.waitForSessionVerification.calledOnceWith(account));
+    });
+  });
+
   describe('validateAndSubmit', () => {
     beforeEach(() => {
       sinon.stub(view, 'submit').callsFake(() => Promise.resolve());

--- a/packages/fxa-content-server/tests/functional/sign_in_token_code.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_token_code.js
@@ -17,8 +17,10 @@ const {
   click,
   closeCurrentWindow,
   createUser,
+  destroySessionForEmail,
   fillOutEmailFirstSignIn,
   fillOutSignInTokenCode,
+  getStoredAccountByEmail,
   noSuchElement,
   openFxaFromRp,
   openVerificationLinkInNewTab,
@@ -101,6 +103,22 @@ registerSuite('signin token code', {
             )
           )
       );
+    },
+
+    'verified - treatment-code - bounce': function() {
+      experimentParams.query.forceExperiment = 'tokenCode';
+      experimentParams.query.forceExperimentGroup = 'treatment-code';
+
+      return this.remote
+        .then(openFxaFromRp('enter-email', experimentParams))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+        .then(testElementExists(selectors.SIGNIN_TOKEN_CODE.HEADER))
+        .then(getStoredAccountByEmail(email))
+        .then(destroySessionForEmail(email))
+        .then(testElementExists(selectors.SIGNIN_BOUNCED.HEADER))
+        .then(testElementExists(selectors.SIGNIN_BOUNCED.CREATE_ACCOUNT))
+        .then(testElementExists(selectors.SIGNIN_BOUNCED.BACK))
+        .then(testElementExists(selectors.SIGNIN_BOUNCED.SUPPORT));
     },
 
     'verified - treatment-code - valid code': function() {


### PR DESCRIPTION
If an email bounces when sending a token code, we never knew and
the user was not informed. This sends the user to /signin_bounced.

fixes #3528

@vbudhram - r?

I wasn't sure if there needed to be any additional logic on the back-end.
