### PR TITLE
fix(test): 'signin in Chrome for Android' goes back to RP at the end of the test

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -182,6 +182,9 @@ module.exports = {
     TOOLTIP: 'input[type=email] ~ .tooltip',
     TOOLTIP_BOUNCED_EMAIL: 'input[type=email] ~ .tooltip',
   },
+  FIREFOX_NOTES: {
+    HEADER: '#notes-by-firefox',
+  },
   FORCE_AUTH: {
     EMAIL: 'input[type=email]',
     EMAIL_NOT_EDITABLE: '.prefillEmail',

--- a/packages/fxa-content-server/tests/functional/oauth_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sign_in.js
@@ -21,6 +21,8 @@ otplib.authenticator.options = { encoding: 'hex' };
 const SETTINGS_URL = `${config.fxaContentRoot}settings`;
 
 const PASSWORD = 'passwordzxcv';
+const CODE_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+const CODE_CHALLENGE_METHOD = 'S256';
 
 let email;
 let secret;
@@ -517,6 +519,8 @@ registerSuite('oauth signin', {
             openFxaFromRp('enter-email', {
               query: {
                 client_id: '7f368c6886429f19', // eslint-disable-line camelcase
+                code_challenge: CODE_CHALLENGE,
+                code_challenge_method: CODE_CHALLENGE_METHOD,
                 forceUA:
                   'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Mobile Safari/537.36',
                 // eslint-disable-next-line camelcase
@@ -558,6 +562,7 @@ registerSuite('oauth signin', {
 
           .then(testElementExists(selectors.SIGNIN_COMPLETE.HEADER))
           .then(click(selectors.SIGNIN_COMPLETE.CONTINUE_BUTTON))
+          .then(testElementExists(selectors.FIREFOX_NOTES.HEADER))
       );
     },
   },


### PR DESCRIPTION


The 'signin in Chrome for Android, verify same browser' test did not check
to ensure clicking "Continue" sent the user back to the RP. In fact, when
clicking the button an error was displayed because code_challenge and
code_challenge_method were not passed in.

This passees in code_challenge and code_challenge_method and ensures
the user is sent back to the expected RP.

fixes #3530

@vladikoff - r?