### PR TITLE
refactor(test): Simplify test setup when WebChannel responses are expected

### DIFF
--- a/packages/fxa-content-server/tests/functional/bounced_email.js
+++ b/packages/fxa-content-server/tests/functional/bounced_email.js
@@ -14,7 +14,7 @@ let deliveredEmail;
 const PASSWORD = 'password12345678';
 const ENTER_EMAIL_URL = `${
   intern._config.fxaContentRoot
-}?context=fx_desktop_v3&service=sync&automatedBrowser=true&forceAboutAccounts=true&forceUA=${encodeURIComponent(
+}?context=fx_desktop_v3&service=sync&forceAboutAccounts=true&forceUA=${encodeURIComponent(
   uaStrings.desktop_firefox_56
 )}`; //eslint-disable-line max-len
 

--- a/packages/fxa-content-server/tests/functional/connect_another_device.js
+++ b/packages/fxa-content-server/tests/functional/connect_another_device.js
@@ -24,7 +24,7 @@ const ADJUST_LINK_IOS =
 
 const CONNECT_ANOTHER_DEVICE_URL = `${config.fxaContentRoot}connect_another_device`;
 const CONNECT_ANOTHER_DEVICE_SMS_ENABLED_URL = `${config.fxaContentRoot}connect_another_device?forceExperiment=sendSms&forceExperimentGroup=signinCodes`;
-const ENTER_EMAIL_URL = `${config.fxaContentRoot}?context=fx_desktop_v3&service=sync&action=email&automatedBrowser=true`;
+const ENTER_EMAIL_URL = `${config.fxaContentRoot}?context=fx_desktop_v3&service=sync&action=email`;
 
 const CHANNEL_COMMAND_CAN_LINK_ACCOUNT = 'fxaccounts:can_link_account';
 

--- a/packages/fxa-content-server/tests/functional/email_domain_mx_validation.js
+++ b/packages/fxa-content-server/tests/functional/email_domain_mx_validation.js
@@ -10,10 +10,10 @@ const selectors = require('./lib/selectors');
 
 const EMAIL_FORM_TREATMENT_URL =
   intern._config.fxaContentRoot +
-  '?automatedBrowser=true&action=email&forceExperiment=emailMxValidation&forceExperimentGroup=treatment';
+  '?action=email&forceExperiment=emailMxValidation&forceExperimentGroup=treatment';
 const EMAIL_FORM_CONTROL_URL =
   intern._config.fxaContentRoot +
-  '?automatedBrowser=true&action=email&forceExperiment=emailMxValidation&forceExperimentGroup=control';
+  '?action=email&forceExperiment=emailMxValidation&forceExperimentGroup=control';
 
 const INVALID_EMAIL = 'nofxauser@asdfafexample.xyz.gd';
 

--- a/packages/fxa-content-server/tests/functional/fx_browser_relier.js
+++ b/packages/fxa-content-server/tests/functional/fx_browser_relier.js
@@ -12,8 +12,7 @@ const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
 
 const config = intern._config;
-const URL_PARAMS =
-  'context=fx_desktop_v3&forceAboutAccounts=true&automatedBrowser=true&action=email';
+const URL_PARAMS = 'context=fx_desktop_v3&forceAboutAccounts=true&action=email';
 const EMAIL_FIRST_URL = `${config.fxaContentRoot}?${URL_PARAMS}`;
 const FIREFOX_CLIENT_ID = '5882386c6d801776';
 const CAPABILITIES = {

--- a/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js
+++ b/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js
@@ -16,22 +16,22 @@ const userAgent = uaStrings['desktop_firefox_55'];
 
 const FORCE_AUTH_PAGE_URL = `${
   config.fxaContentRoot
-}force_auth?automatedBrowser=true&forceUA=${encodeURIComponent(userAgent)}`;
+}force_auth?forceUA=${encodeURIComponent(userAgent)}`;
 const SYNC_FORCE_AUTH_PAGE_URL = `${FORCE_AUTH_PAGE_URL}&service=sync`;
 
 const ENTER_EMAIL_PAGE_URL = `${
   config.fxaContentRoot
-}?automatedBrowser=true&forceUA=${encodeURIComponent(userAgent)}`;
+}?forceUA=${encodeURIComponent(userAgent)}`;
 const SYNC_ENTER_EMAIL_PAGE_URL = `${ENTER_EMAIL_PAGE_URL}&service=sync`;
 
 const SETTINGS_PAGE_URL = `${
   config.fxaContentRoot
-}settings?automatedBrowser=true&forceUA=${encodeURIComponent(userAgent)}`;
+}settings?forceUA=${encodeURIComponent(userAgent)}`;
 const SYNC_SETTINGS_PAGE_URL = `${SETTINGS_PAGE_URL}&service=sync`;
 
 const SYNC_SMS_PAGE_URL = `${
   config.fxaContentRoot
-}sms?automatedBrowser=true&service=sync&forceExperiment=sendSms&forceExperimentGroup=signinCodes&forceUA=${encodeURIComponent(
+}sms?service=sync&forceExperiment=sendSms&forceExperimentGroup=signinCodes&forceUA=${encodeURIComponent(
   userAgent
 )}`; //eslint-disable-line max-len
 

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -1360,8 +1360,15 @@ const openSignUpInNewTab = thenify(function() {
  *  @param {Object} [options.query] - extra query parameters to add
  * @returns {Promise} - resolves when complete
  */
-const openPage = thenify(function(url, readySelector, options) {
-  options = options || {};
+const openPage = thenify(function(url, readySelector, options = {}) {
+  if (options.webChannelResponses) {
+    options.query = options.query || {};
+    // If there are webChannelResponses, the automatedBrowser
+    // query param introduces a short delay so that the web
+    // channel response listeners can be hooked up before FxA
+    // sends the fxaccounts:fxa_status message.
+    options.query.automatedBrowser = true;
+  }
 
   url = addQueryParamsToLink(url, options.query);
 

--- a/packages/fxa-content-server/tests/functional/mailcheck.js
+++ b/packages/fxa-content-server/tests/functional/mailcheck.js
@@ -7,7 +7,7 @@
 const { registerSuite } = intern.getInterface('object');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
-var ENTER_EMAIL_URL = intern._config.fxaContentRoot + '?automatedBrowser=true';
+var ENTER_EMAIL_URL = intern._config.fxaContentRoot;
 
 const {
   clearBrowserState,

--- a/packages/fxa-content-server/tests/functional/oauth_handshake.js
+++ b/packages/fxa-content-server/tests/functional/oauth_handshake.js
@@ -81,7 +81,6 @@ registerSuite('Firefox desktop user info handshake - OAuth flows', {
             openFxaFromRp('enter-email', {
               header: selectors.SIGNIN_PASSWORD.HEADER,
               query: {
-                automatedBrowser: true,
                 forceUA: userAgent,
               },
               webChannelResponses: {
@@ -117,7 +116,6 @@ registerSuite('Firefox desktop user info handshake - OAuth flows', {
             openFxaFromRp('enter-email', {
               header: selectors.ENTER_EMAIL.HEADER,
               query: {
-                automatedBrowser: true,
                 forceUA: userAgent,
               },
               webChannelResponses: {
@@ -142,7 +140,6 @@ registerSuite('Firefox desktop user info handshake - OAuth flows', {
             openFxaFromRp('enter-email', {
               header: selectors.SIGNIN_PASSWORD.HEADER,
               query: {
-                automatedBrowser: true,
                 forceUA: userAgent,
               },
               webChannelResponses: {

--- a/packages/fxa-content-server/tests/functional/oauth_webchannel.js
+++ b/packages/fxa-content-server/tests/functional/oauth_webchannel.js
@@ -100,7 +100,7 @@ registerSuite('oauth webchannel', {
         .then(testIsBrowserNotified('fxaccounts:oauth_login'));
     },
     settings: function() {
-      const SETTINGS_PAGE_URL = `${config.fxaContentRoot}settings?automatedBrowser=true&context=oauth_webchannel_v1`;
+      const SETTINGS_PAGE_URL = `${config.fxaContentRoot}settings?context=oauth_webchannel_v1`;
 
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))

--- a/packages/fxa-content-server/tests/functional/recovery_key.js
+++ b/packages/fxa-content-server/tests/functional/recovery_key.js
@@ -15,7 +15,7 @@ const ENTER_EMAIL_URL = config.fxaContentRoot;
 const SETTINGS_URL = `${config.fxaContentRoot}settings`;
 const RESET_PASSWORD_URL =
   config.fxaContentRoot +
-  'reset_password?context=fx_desktop_v3&service=sync&automatedBrowser=true&forceAboutAccounts=true';
+  'reset_password?context=fx_desktop_v3&service=sync&forceAboutAccounts=true';
 const PASSWORD = 'passwordzxcv';
 const NEW_PASSWORD = '()()():|';
 let email, recoveryKey;

--- a/packages/fxa-content-server/tests/functional/sign_in_cached.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_cached.js
@@ -15,8 +15,6 @@ const userAgent = require('./lib/ua-strings');
 const config = intern._config;
 
 const ENTER_EMAIL_URL = config.fxaContentRoot;
-// The automatedBrowser query param tells signin/up to stub parts of the flow
-// that require a functioning desktop channel
 const PAGE_ENTER_EMAIL_SYNC_DESKTOP = `${config.fxaContentRoot}?context=${FX_DESKTOP_V3_CONTEXT}&service=sync`;
 
 const PASSWORD = 'password12345678';
@@ -360,7 +358,6 @@ registerSuite('cached signin', {
             selectors.SIGNIN_PASSWORD.HEADER,
             {
               query: {
-                automatedBrowser: true,
                 forceUA: userAgent['desktop_firefox_71'],
               },
               webChannelResponses: {

--- a/packages/fxa-content-server/tests/functional/sync_v3_email_first.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_email_first.js
@@ -12,7 +12,7 @@ const selectors = require('./lib/selectors');
 const config = intern._config;
 
 const QUERY_PARAMS =
-  '?context=fx_desktop_v3&service=sync&forceAboutAccounts=true&automatedBrowser=true&action=email';
+  '?context=fx_desktop_v3&service=sync&forceAboutAccounts=true&action=email';
 const INDEX_PAGE_URL = `${config.fxaContentRoot}${QUERY_PARAMS}`;
 const SIGNUP_PAGE_URL = `${config.fxaContentRoot}signup${QUERY_PARAMS}`;
 const SIGNIN_PAGE_URL = `${config.fxaContentRoot}signin${QUERY_PARAMS}`;

--- a/packages/fxa-content-server/tests/functional/sync_v3_force_auth.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_force_auth.js
@@ -47,7 +47,6 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
         .then(function(accountInfo) {
           return openForceAuth({
             query: {
-              automatedBrowser: true,
               context: 'fx_desktop_v3',
               email,
               forceUA: uaStrings['desktop_firefox_71'],
@@ -80,7 +79,6 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
         .then(function(accountInfo) {
           return openForceAuth({
             query: {
-              automatedBrowser: true,
               context: 'fx_desktop_v3',
               email: email,
               forceUA: uaStrings['desktop_firefox_71'],
@@ -115,7 +113,6 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
         .then(
           openForceAuth({
             query: {
-              automatedBrowser: true,
               context: 'fx_desktop_v3',
               email: email,
               forceUA: uaStrings['desktop_firefox_71'],
@@ -154,7 +151,6 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
               // specified email
               header: selectors.SIGNUP_PASSWORD.HEADER,
               query: {
-                automatedBrowser: true,
                 context: 'fx_desktop_v3',
                 email: email,
                 forceUA: uaStrings['desktop_firefox_71'],
@@ -205,7 +201,6 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
               // specified email
               header: selectors.SIGNUP_PASSWORD.HEADER,
               query: {
-                automatedBrowser: true,
                 context: 'fx_desktop_v3',
                 email: unregisteredEmail,
                 forceAboutAccounts: 'true',
@@ -249,7 +244,6 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
               // specified email
               header: selectors.SIGNUP_PASSWORD.HEADER,
               query: {
-                automatedBrowser: true,
                 context: 'fx_desktop_v3',
                 email: email,
                 forceAboutAccounts: 'true',
@@ -287,7 +281,6 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
           .then(
             openForceAuth({
               query: {
-                automatedBrowser: true,
                 context: 'fx_desktop_v3',
                 email: email,
                 forceAboutAccounts: 'true',

--- a/packages/fxa-content-server/tests/functional/sync_v3_reset_password.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_reset_password.js
@@ -13,7 +13,7 @@ const uaStrings = require('./lib/ua-strings');
 const config = intern._config;
 
 const PASSWORD = 'passwordzxcv';
-const RESET_PASSWORD_URL = `${config.fxaContentRoot}reset_password?context=fx_desktop_v3&service=sync&automatedBrowser=true&forceAboutAccounts=true`;
+const RESET_PASSWORD_URL = `${config.fxaContentRoot}reset_password?context=fx_desktop_v3&service=sync&forceAboutAccounts=true`;
 
 let email;
 

--- a/packages/fxa-content-server/tests/functional/sync_v3_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_sign_in.js
@@ -11,7 +11,7 @@ const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
 
 const config = intern._config;
-const ENTER_EMAIL_URL = `${config.fxaContentRoot}?context=fx_desktop_v3&service=sync&automatedBrowser=true`;
+const ENTER_EMAIL_URL = `${config.fxaContentRoot}?context=fx_desktop_v3&service=sync`;
 
 let email;
 const PASSWORD = '12345678';

--- a/packages/fxa-content-server/tests/functional/sync_v3_sign_up.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_sign_up.js
@@ -12,7 +12,7 @@ const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
 
 const config = intern._config;
-const ENTER_EMAIL_URL = `${config.fxaContentRoot}?context=fx_desktop_v3&service=sync&forceAboutAccounts=true&automatedBrowser=true`;
+const ENTER_EMAIL_URL = `${config.fxaContentRoot}?context=fx_desktop_v3&service=sync&forceAboutAccounts=true`;
 
 let email;
 const PASSWORD = 'password12345678';
@@ -177,8 +177,6 @@ registerSuite('Firefox Desktop Sync v3 signup', {
           // the login message is only sent after the sync preferences screen
           // has been cleared.
           .then(testIsBrowserNotified('fxaccounts:login'))
-          // verify the user
-          .then(getWebChannelMessageData('fxaccounts:login'))
           .then(fillOutSignUpCode(email, 0))
           .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
       );


### PR DESCRIPTION
The `automatedBrowser` query param is needed whenever opening a page that
hooks up WebChannel listeners. The query param causes FxA to introduce a slight
delay before firing the fxaccounts:fxa_status WebChannel message, the delay allows
the tests to hook up listeners that intercept and respond to the message. Without
the delay, the fxaccounts:fxa_status message fires too early and no response
occurs, causing the tests to stall.

Up to this point, developers had to remember to add the `automatedBrowser`
query parameter. This ensures it's added automatically if `openPage` is
called with `webChannelResponses`, relieving the dev from remembering
the need to do this.

Not attached to an issue.