### PR TITLE
feat(content-server): Append '(Web Session)' to clients without a deviceId

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/settings/clients.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/clients.js
@@ -124,20 +124,19 @@ const View = FormView.extend(
       return _.map(items, item => {
         item.title = item.name;
 
-        if (item.scope) {
-          item.title += ' - ' + item.scope;
-        }
-
         if (item.lastAccessTimeFormatted) {
           if (item.clientType === Constants.CLIENT_TYPE_WEB_SESSION) {
             if (item.userAgent) {
-              item.title = this.translate(t('Web Session, %(userAgent)s'), {
+              item.title = this.translate(t('%(userAgent)s (Web Session)'), {
                 userAgent: item.userAgent,
               });
             } else {
               item.title = t('Web Session');
             }
             this._setLastAccessTimeFormatted(item, LAST_ACTIVITY_FORMATS.web);
+          } else if (item.deviceId === null) {
+            item.name = `${item.name} (Web Session)`;
+            item.title = item.name;
           } else if (item.clientType === Constants.CLIENT_TYPE_DEVICE) {
             this._setLastAccessTimeFormatted(
               item,
@@ -153,6 +152,10 @@ const View = FormView.extend(
             // unknown lastAccessTimeFormatted or not possible to format.
             item.lastAccessTimeFormatted = '';
           }
+        }
+
+        if (item.scope) {
+          item.title = `${item.title} - ${item.scope}`;
         }
 
         return item;

--- a/packages/fxa-content-server/app/tests/spec/views/settings/clients.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/clients.js
@@ -754,6 +754,15 @@ describe('views/settings/clients', () => {
             isDevice: true,
             name: 'device-2',
           },
+          {
+            clientType: 'device',
+            deviceId: null,
+            deviceType: 'mobile',
+            isCurrentSession: false,
+            isDevice: true,
+            name: 'device-3',
+            lastAccessTimeFormatted: '20 minutes ago',
+          },
         ]);
 
         assert.equal(formatted[0].title, '123Done - profile');
@@ -763,7 +772,7 @@ describe('views/settings/clients', () => {
         );
         assert.equal(formatted[1].title, 'Pocket - profile,profile:write');
         assert.equal(formatted[2].title, 'Add-ons');
-        assert.equal(formatted[3].title, 'Web Session, Firefox 40');
+        assert.equal(formatted[3].title, 'Firefox 40 (Web Session)');
         assert.equal(formatted[4].title, 'Web Session');
         assert.equal(formatted[5].title, 'device-1');
         assert.equal(
@@ -775,6 +784,7 @@ describe('views/settings/clients', () => {
           formatted[6].lastAccessTimeFormatted,
           'Last seen time unknown'
         );
+        assert.equal(formatted[7].title, 'device-3 (Web Session)');
       });
     });
   });


### PR DESCRIPTION
fixes #2505 

I'm not completely certain this is the proper solution for this issue. @ryanfeeley this changes "Web Session, [browser name]" references to "[browser name] (Web Session)" and then adds (Web Session) to devices that do _not_ have a `deviceId`.

From @vladikoff's test data provided in the issue (plus one browser session I added) here's an example of how some names render:

```
Firefox 70 (Web Session)
Firefox on Fox’s iPad
vladikoff4’s Nightly on Vlads-MBP
vladikoff’s Nightly on v
Firefox Lockwise
Firefox Send (Web Session)
Firefox Private Network (Web Session)
Firefox Sync (Web Session)
Firefox Monitor (Web Session)
Pocket (Web Session)
```

Is there a way to test Notes, Add-Ons, etc. locally, as Ryan provided in the issue? Lockwise seems like an odd one to me, since we capture the `deviceId` but don't display it with `name`.

I'm going to open this as a PR and not a draft since this may be all we need, but feedback is welcome.