### PR TITLE
fix(tooltip): Update/remove inline password tooltip when password changes

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_up_password.js
@@ -36,7 +36,6 @@ const SignUpPasswordView = FormView.extend({
 
   events: assign({}, FormView.prototype.events, {
     'click .use-different': preventDefaultThen('useDifferentAccount'),
-    'keyup #vpassword': '_onConfirmPasswordKeyUp',
   }),
 
   useDifferentAccount() {
@@ -86,6 +85,12 @@ const SignUpPasswordView = FormView.extend({
     return proto.isValidEnd.call(this);
   },
 
+  onFormChange() {
+    this.checkPasswordsMatchDebounce();
+
+    return proto.onFormChange.call(this);
+  },
+
   showValidationErrorsEnd() {
     if (!this._doPasswordsMatch()) {
       this.showValidationError(
@@ -93,6 +98,9 @@ const SignUpPasswordView = FormView.extend({
         AuthErrors.toError('PASSWORDS_DO_NOT_MATCH'),
         false
       );
+    } else {
+      // Called to clear validation tooltips.
+      this.$(VPASSWORD_INPUT_SELECTOR).change();
     }
   },
 
@@ -123,10 +131,6 @@ const SignUpPasswordView = FormView.extend({
 
   _doPasswordsMatch() {
     return this._getPassword() === this._getVPassword();
-  },
-
-  _onConfirmPasswordKeyUp() {
-    this.checkPasswordsMatchDebounce();
   },
 
   _checkPasswordsMatch() {

--- a/packages/fxa-content-server/tests/functional/sign_up.js
+++ b/packages/fxa-content-server/tests/functional/sign_up.js
@@ -27,6 +27,7 @@ const {
   noSuchElement,
   openPage,
   openSignUpInNewTab,
+  pollUntilHiddenByQSA,
   switchToWindow,
   testElementExists,
   testElementTextEquals,
@@ -303,6 +304,19 @@ registerSuite('signup here', {
               'Passwords do not match'
             )
           )
+          // Tooltip should disappear
+          .then(type(selectors.SIGNUP_PASSWORD.VPASSWORD, PASSWORD))
+          .then(pollUntilHiddenByQSA(selectors.SIGNUP_PASSWORD.TOOLTIP))
+
+          // Tooltip should reappear
+          .then(type(selectors.SIGNUP_PASSWORD.VPASSWORD, DROWSSAP))
+          .then(
+            testElementTextEquals(
+              selectors.SIGNUP_PASSWORD.TOOLTIP,
+              'Passwords do not match'
+            )
+          )
+
           // user can enter to next input despite tooltip error
           .then(type(selectors.SIGNUP_PASSWORD.AGE, '42'))
       );


### PR DESCRIPTION
Fixes #3504 
Fixes #3489
Fixes #3486

This PR updates the inline password validation rules to fix the above issues.

@LZoog you mentioned working on #3489 but I think I found an easy fix while working those other issues. I can flag you for review after adding tests here.