### PR TITLE
fix(icons): Shuffle `.client` CSS selectors to properly display Lockwise and FF Preview icons

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -545,52 +545,44 @@ section.modal-panel {
   &[data-os='Linux'] {
     background-image: url('/images/icon-device-laptop-linux.svg');
   }
-}
 
-.client.mobile {
-  background-image: url('/images/icon-device-phone.svg');
+  &.mobile {
+    background-image: url('/images/icon-device-phone.svg');
 
-  &[data-os='iOS'] {
-    background-image: url('/images/icon-device-phone-iphone.svg');
+    &[data-os='iOS'] {
+      background-image: url('/images/icon-device-phone-iphone.svg');
+    }
+
+    &[data-os='Android'],
+    // Preview is only offered on Android
+    &[data-name^='Firefox Preview'] {
+      background-image: url('/images/icon-device-phone-android.svg');
+    }
+
+    &[data-os='Windows'] {
+      background-image: url('/images/icon-device-phone-windows.svg');
+    }
   }
 
-  &[data-os='Android'] {
-    background-image: url('/images/icon-device-phone-android.svg');
+  &.tablet {
+    background-image: url('/images/icon-device-tablet.svg');
+
+    &[data-os='iOS'] {
+      background-image: url('/images/icon-device-tablet-ipad.svg');
+    }
+
+    &[data-os='Android'] {
+      background-image: url('/images/icon-device-tablet-android.svg');
+    }
   }
 
-  &[data-os='Windows'] {
-    background-image: url('/images/icon-device-phone-windows.svg');
-  }
-}
-
-.client.tablet {
-  background-image: url('/images/icon-device-tablet.svg');
-
-  &[data-os='iOS'] {
-    background-image: url('/images/icon-device-tablet-ipad.svg');
+  &.vr {
+    background-image: url('/images/icon-device-vr.svg');
   }
 
-  &[data-os='Android'] {
-    background-image: url('/images/icon-device-tablet-android.svg');
+  &.tv {
+    background-image: url('/images/icon-device-tv.svg');
   }
-}
-
-.client.vr {
-  background-image: url('/images/icon-device-vr.svg');
-}
-
-.client.tv {
-  background-image: url('/images/icon-device-tv.svg');
-}
-
-.client-device {
-  &.client-current {
-    background-position: left 5px;
-  }
-}
-
-.client-oAuthApp {
-  background-image: url('/images/icon-client-default.svg');
 
   &[data-name='Add-ons'],
   &[data-name='Firefox Add-ons'] {
@@ -602,6 +594,7 @@ section.modal-panel {
     background-image: url('/images/icon-service-lockbox.svg');
   }
 
+  // this selector must come after .mobile to take precedence
   &[data-name^='Firefox Lockwise'] {
     background-image: url('/images/icon-service-lockwise.svg');
   }
@@ -633,6 +626,10 @@ section.modal-panel {
   &[data-name='Screenshots'] {
     background-image: url('/images/icon-service-screenshots.svg');
   }
+}
+
+.client-oAuthApp {
+  background-image: url('/images/icon-client-default.svg');
 
   &[data-name='Fenix'],
   &[data-name='Android Components Reference Browser'],
@@ -648,6 +645,12 @@ section.modal-panel {
 
 .client-webSession {
   background-image: url('/images/icon-web-session.svg');
+}
+
+.client-device {
+  &.client-current {
+    background-position: left 5px;
+  }
 }
 
 #client-disconnect {


### PR DESCRIPTION
fixes #1782, #2506, #2353

- Convert `.client.other-class` to `.client { &.other-class` for better CSS hierarchy visibility
-  Add `&[data-name^='Firefox Preview']` along with `&[data-os='Android']` - we do not appear to capture the `os` with Preview registrants, but as we only offer this for Android, it seems acceptable to place where it is now
- Now that `&[data-name^='Firefox Lockwise']` has equal weight as `.mobile[data-ios='iOS']`, we let our CSS cascade to takes precedence on which icon should be displayed (this is not ideal since it depends on CSS order, hence the comment, but was the cleanest/easiest way to fix the problem)

@rfk I don't want to lose [your comment here](https://github.com/mozilla/fxa/issues/1782#issuecomment-511614223). When this PR is merged I'll create a new issue with a `needs:discussion` label, since this could be addressed with a fairly simple CSS change that should probably be a separate issue.

Before (ignore the incorrect iPad icon, that's a separate issue):
<img width="500" alt="image" src="https://user-images.githubusercontent.com/13018240/70003659-7476b300-1529-11ea-9dca-438f071b502a.png">

After:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/13018240/70003730-a6881500-1529-11ea-927c-f60c0bc89da4.png">
