### PR TITLE
feat(emails): Add server side support to verify secondary email by code

### DIFF
--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -55,6 +55,8 @@ see [`mozilla/fxa-js-client`](https://github.com/mozilla/fxa-js-client).
     - [POST /recovery_email (:lock: sessionToken)](#post-recovery_email)
     - [POST /recovery_email/destroy (:lock: sessionToken)](#post-recovery_emaildestroy)
     - [POST /recovery_email/set_primary (:lock: sessionToken)](#post-recovery_emailset_primary)
+    - [POST /recovery_email/secondary/verify_code (:lock: sessionToken)](#post-recovery_emailseconaryverify_code)
+    - [POST /recovery_email/secondary/resend_code (:lock: sessionToken)](#post-recovery_emailseconaryresend_code)
   - [Oauth](#oauth)
     - [GET /oauth/client/{client_id}](#get-oauthclientclient_id)
     - [POST /account/scoped-key-data (:lock: sessionToken)](#post-accountscoped-key-data)
@@ -2195,6 +2197,78 @@ by the following errors
 
 - `code: 400, errno: 148`:
   Can not change primary email to an email that does not belong to this account
+
+#### POST /recovery_email/secondary/verify_code
+
+:lock: HAWK-authenticated with session token
+
+<!--begin-route-post-recovery_emailsecondaryverify_code-->
+
+This endpoint verifies a secondary email using a time based (otp) code.
+
+<!--end-route-post-recovery_emailsecondaryverify_code-->
+
+##### Request body
+
+- `email`: _validators.email.required_
+
+  <!--begin-request-body-post-recovery_emailsecondaryverify_code-->
+
+  The secondary email address to verify.
+
+  <!--end-request-body-post-recovery_emailsecondaryverify_code-->
+
+- `code`: _validators.code.required_
+
+  <!--begin-request-body-post-recovery_emailsecondaryverify_code-->
+
+  Time based code to verify secondary email.
+
+  <!--end-request-body-post-recovery_emailsecondaryverify_code-->
+
+##### Error responses
+
+Failing requests may be caused
+by the following errors
+(this is not an exhaustive list):
+
+- `code: 400, errno: 138`:
+  Unverified session
+
+- `code: 400, errno: 105`:
+  Invalid verification code
+
+#### POST /recovery_email/secondary/resend_code
+
+:lock: HAWK-authenticated with session token
+
+<!--begin-route-post-recovery_emailsecondaryresend_code-->
+
+This endpoint resend the otp verification to verify the secondary email.
+
+<!--end-route-post-recovery_emailsecondaryresend_code-->
+
+##### Request body
+
+- `email`: _validators.email.required_
+
+  <!--begin-request-body-post-recovery_emailsecondaryresend_code-->
+
+  The secondary email address to verify.
+
+  <!--end-request-body-post-recovery_emailsecondaryresend_code-->
+
+##### Error responses
+
+Failing requests may be caused
+by the following errors
+(this is not an exhaustive list):
+
+- `code: 400, errno: 138`:
+  Unverified session
+
+- `code: 400, errno: 150`:
+  Can not resend code for email that does not belong to the account
 
 ### Oauth
 

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -63,6 +63,7 @@ module.exports = function(log, config, oauthdb) {
     verifyLoginCode: 'new-signin-verify-code',
     verifyPrimary: 'welcome-primary',
     verifySecondary: 'welcome-secondary',
+    verifySecondaryCode: 'welcome-secondary',
   };
 
   // Email template to UTM content, this is typically the main call out link/button
@@ -96,6 +97,7 @@ module.exports = function(log, config, oauthdb) {
     verifyLoginCode: 'new-signin-verify-code',
     verifyPrimary: 'activate',
     verifySecondary: 'activate',
+    verifySecondaryCode: 'activate',
   };
 
   function extend(target, source) {
@@ -888,6 +890,54 @@ module.exports = function(log, config, oauthdb) {
         privacyUrl: links.privacyUrl,
         reportSignInLink: links.reportSignInLink,
         reportSignInLinkAttributes: links.reportSignInLinkAttributes,
+        subject,
+        supportLinkAttributes: links.supportLinkAttributes,
+        supportUrl: links.supportUrl,
+        timestamp: this._constructLocalTimeString(
+          message.timeZone,
+          message.acceptLanguage
+        ),
+      },
+    });
+  };
+
+  Mailer.prototype.verifySecondaryCodeEmail = function(message) {
+    log.trace('mailer.verifySecondaryCodeEmail', {
+      email: message.email,
+      uid: message.uid,
+    });
+
+    const templateName = 'verifySecondaryCode';
+    const subject = gettext('Confirm secondary email');
+    const action = gettext('Verify email');
+
+    const links = this._generateLinks(
+      undefined,
+      message.email,
+      {},
+      templateName
+    );
+
+    const headers = {
+      'X-Verify-Code': message.code,
+    };
+
+    return this.send({
+      ...message,
+      headers,
+      subject,
+      template: templateName,
+      templateValues: {
+        action,
+        code: message.code,
+        device: this._formatUserAgentInfo(message),
+        email: message.email,
+        ip: message.ip,
+        location: this._constructLocationString(message),
+        passwordChangeLink: links.passwordChangeLink,
+        passwordChangeLinkAttributes: links.passwordChangeLinkAttributes,
+        primaryEmail: message.primaryEmail,
+        privacyUrl: links.privacyUrl,
         subject,
         supportLinkAttributes: links.supportLinkAttributes,
         supportUrl: links.supportUrl,

--- a/packages/fxa-auth-server/lib/senders/index.js
+++ b/packages/fxa-auth-server/lib/senders/index.js
@@ -95,6 +95,16 @@ module.exports = async (
     });
   };
 
+  senders.email.sendVerifySecondaryCodeEmail = (emails, account, options) => {
+    return mailer.verifySecondaryCodeEmail({
+      ...options,
+      acceptLanguage: options.acceptLanguage || defaultLanguage,
+      email: emails[0].email,
+      primaryEmail: account.email,
+      uid: account.uid,
+    });
+  };
+
   senders.email.sendPostVerifySecondaryEmail = (emails, account, options) => {
     return mailer.postVerifySecondaryEmail({
       ...options,

--- a/packages/fxa-auth-server/lib/senders/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/templates/_versions.json
@@ -20,6 +20,7 @@
   "verifyLoginCode": 5,
   "verifyShortCode": 2,
   "verifySecondary": 4,
+  "verifySecondaryCode": 1,
   "postAddTwoStepAuthentication": 7,
   "postRemoveTwoStepAuthentication": 7,
   "postConsumeRecoveryCode": 4,

--- a/packages/fxa-auth-server/lib/senders/templates/verifySecondaryCode.html
+++ b/packages/fxa-auth-server/lib/senders/templates/verifySecondaryCode.html
@@ -1,0 +1,23 @@
+<tr style="page-break-before: always">
+  <td valign="top">
+    <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">{{t "Verify secondary email"}}</h1>
+
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{t "A request to use %(email)s as a secondary email address has been made from the following Firefox Account:"}}</p>
+
+    {{> location}}
+  </td>
+</tr>
+
+<tr style="page-break-before: always">
+  <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
+    <p style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">
+      {{t "Use this verification code:" }}
+    </p>
+
+    <p style="font-family: monospace !important; font-size: 32px; line-height: 26px; font-weight: normal; margin: 0 0 24px 0; text-align: center;">{{code}}</p>
+
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 24px 0 0 0; text-align: center;">{{t "It expires in 5 minutes. Once verified, this address will begin receiving security notifications and confirmations."}}
+  </td>
+</tr>
+
+{{> automatedEmailNoAction}}

--- a/packages/fxa-auth-server/lib/senders/templates/verifySecondaryCode.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/verifySecondaryCode.txt
@@ -1,0 +1,15 @@
+{{t "Verify secondary email"}}
+
+{{t "A request to use %(email)s as a secondary email address has been made from the following Firefox Account:"}}
+
+{{> location}}
+
+{{t "Use this verification code:"}}
+
+{{{code}}}
+
+{{t "It expires in 5 minutes. Once verified, this address will begin receiving security notifications and confirmations."}}
+
+{{> automatedEmailNoAction}}
+
+{{> support}}

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -471,6 +471,40 @@ module.exports = config => {
     );
   };
 
+  ClientApi.prototype.recoveryEmailSecondaryVerifyCode = async function(
+    sessionTokenHex,
+    code,
+    email
+  ) {
+    const token = await tokens.SessionToken.fromHex(sessionTokenHex);
+    return this.doRequest(
+      'POST',
+      `${this.baseURL}/recovery_email/secondary/verify_code`,
+      token,
+      {
+        code,
+        email,
+      },
+      {}
+    );
+  };
+
+  ClientApi.prototype.recoveryEmailSecondaryResendCode = async function(
+    sessionTokenHex,
+    email
+  ) {
+    const token = await tokens.SessionToken.fromHex(sessionTokenHex);
+    return this.doRequest(
+      'POST',
+      `${this.baseURL}/recovery_email/secondary/resend_code`,
+      token,
+      {
+        email,
+      },
+      {}
+    );
+  };
+
   ClientApi.prototype.accountCreateWithShortCode = async function(
     sessionTokenHex,
     code,
@@ -875,13 +909,18 @@ module.exports = config => {
     });
   };
 
-  ClientApi.prototype.createEmail = function(sessionTokenHex, email) {
+  ClientApi.prototype.createEmail = function(
+    sessionTokenHex,
+    email,
+    options = {}
+  ) {
     const o = sessionTokenHex
       ? tokens.SessionToken.fromHex(sessionTokenHex)
       : P.resolve(null);
     return o.then(token => {
       return this.doRequest('POST', `${this.baseURL}/recovery_email`, token, {
         email: email,
+        verificationMethod: options.verificationMethod,
       });
     });
   };

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -290,6 +290,18 @@ module.exports = config => {
     );
   };
 
+  Client.prototype.verifySecondaryEmailWithCode = async function(code, email) {
+    return this.api.recoveryEmailSecondaryVerifyCode(
+      this.sessionToken,
+      code,
+      email
+    );
+  };
+
+  Client.prototype.resendVerifySecondaryEmailWithCode = async function(email) {
+    return this.api.recoveryEmailSecondaryResendCode(this.sessionToken, email);
+  };
+
   Client.prototype.verifyTokenCode = function(code, options) {
     return this.api.verifyTokenCode(this.sessionToken, code, options);
   };
@@ -607,8 +619,10 @@ module.exports = config => {
     return this.api.accountEmails(this.sessionToken);
   };
 
-  Client.prototype.createEmail = function(email) {
-    return this.api.createEmail(this.sessionToken, email);
+  Client.prototype.createEmail = function(email, verificationMethod) {
+    return this.api.createEmail(this.sessionToken, email, {
+      verificationMethod,
+    });
   };
 
   Client.prototype.deleteEmail = function(email) {

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -99,6 +99,40 @@ const COMMON_TESTS = new Map([
 
 // prettier-ignore
 const TESTS = new Map([
+  ['verifySecondaryCodeEmail', new Map([
+    ['subject', { test: 'equal', expected: 'Confirm secondary email' }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verifySecondaryCode') }],
+      ['X-Template-Name', { test: 'equal', expected: 'verifySecondaryCode' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.verifySecondaryCode }],
+    ])],
+    ['html', [
+      { test: 'include', expected: configHref('privacyUrl', 'welcome-secondary', 'privacy') },
+      { test: 'include', expected: configHref('supportUrl', 'welcome-secondary', 'support') },
+      { test: 'include', expected: 'Verify secondary email' },
+      { test: 'include', expected: `A request to use ${MESSAGE.email} as a secondary email address has been made from the following Firefox Account:` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: 'Use this verification code:' },
+      { test: 'include', expected: `${MESSAGE.code}` },
+      { test: 'include', expected: 'It expires in 5 minutes. Once verified, this address will begin receiving security notifications and confirmations.' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: configUrl('privacyUrl', 'welcome-secondary', 'privacy') },
+      { test: 'include', expected: configUrl('supportUrl', 'welcome-secondary', 'support') },
+      { test: 'include', expected: 'Verify secondary email' },
+      { test: 'include', expected: `A request to use ${MESSAGE.email} as a secondary email address has been made from the following Firefox Account:` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: 'Use this verification code:' },
+      { test: 'include', expected: `${MESSAGE.code}` },
+      { test: 'include', expected: 'It expires in 5 minutes. Once verified, this address will begin receiving security notifications and confirmations.' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
   ['downloadSubscriptionEmail', new Map([
     ['subject', { test: 'equal', expected: `Welcome to ${MESSAGE.productName}!` }],
     ['headers', new Map([

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -147,6 +147,7 @@ const MAILER_METHOD_NAMES = [
   'sendVerifyLoginEmail',
   'sendVerifyLoginCodeEmail',
   'sendVerifySecondaryEmail',
+  'sendVerifySecondaryCodeEmail',
 ];
 
 const METRICS_CONTEXT_METHOD_NAMES = [
@@ -643,17 +644,19 @@ function mockMetricsContext(methods) {
               this.headers && this.headers.dnt === '1'
                 ? {}
                 : {
-                  entrypoint: this.payload.metricsContext.entrypoint,
-                  entrypoint_experiment: this.payload.metricsContext.entrypointExperiment,
-                  entrypoint_variation: this.payload.metricsContext.entrypointVariation,
-                  utm_campaign: this.payload.metricsContext.utmCampaign,
-                  utm_content: this.payload.metricsContext.utmContent,
-                  utm_medium: this.payload.metricsContext.utmMedium,
-                  utm_source: this.payload.metricsContext.utmSource,
-                  utm_term: this.payload.metricsContext.utmTerm,
-                  product_id: this.payload.metricsContext.productId,
-                  plan_id: this.payload.metricsContext.planId,
-                }
+                    entrypoint: this.payload.metricsContext.entrypoint,
+                    entrypoint_experiment: this.payload.metricsContext
+                      .entrypointExperiment,
+                    entrypoint_variation: this.payload.metricsContext
+                      .entrypointVariation,
+                    utm_campaign: this.payload.metricsContext.utmCampaign,
+                    utm_content: this.payload.metricsContext.utmContent,
+                    utm_medium: this.payload.metricsContext.utmMedium,
+                    utm_source: this.payload.metricsContext.utmSource,
+                    utm_term: this.payload.metricsContext.utmTerm,
+                    product_id: this.payload.metricsContext.productId,
+                    plan_id: this.payload.metricsContext.planId,
+                  }
             );
           }
 

--- a/packages/fxa-content-server/app/scripts/lib/verification-methods.ts
+++ b/packages/fxa-content-server/app/scripts/lib/verification-methods.ts
@@ -9,10 +9,10 @@
  */
 
 enum VerificationMethods {
-    EMAIL = 'email',
-    EMAIL_2FA = 'email-2fa',
-    EMAIL_CAPTCHA = 'email-captcha',
-    TOTP_2FA = 'totp-2fa',
+  EMAIL = 'email',
+  EMAIL_2FA = 'email-2fa',
+  EMAIL_CAPTCHA = 'email-captcha',
+  TOTP_2FA = 'totp-2fa',
 }
 
 export default VerificationMethods;

--- a/packages/fxa-customs-server/lib/actions.js
+++ b/packages/fxa-customs-server/lib/actions.js
@@ -42,6 +42,7 @@ const EMAIL_SENDING_ACTION = {
   accountCreate: true,
   createEmail: true,
   recoveryEmailResendCode: true,
+  recoveryEmailSecondaryResendCode: true,
   passwordForgotSendCode: true,
   passwordForgotResendCode: true,
   sendUnblockCode: true,


### PR DESCRIPTION
Connects https://github.com/mozilla/fxa/issues/3531

This is needed as part of https://github.com/mozilla/fxa/issues/2653. To keeps things manageable, I will split this into adding server-side support and UX screens in another PR.

This PR adds the new email templates and routes to enabled this feature. Some key design decisions:

* Verify secondary email by code is now in its own route `recovery_email/secondary/verify_code`, instead of overloading the `recovery_email/verify_code`. The later route does way to many things and it makes sense to extract this out.
* Resend secondary email by code is in its own route as well for same reasons above.
* The create secondary email route `POST /recovery_email`, now accepts an optional param, `verificationMethod`, if content-server specifies `email-otp` then an otp code is generated using the `emailCode` as the otp secret. This follows the same pattern used in sign-in and sign-up codes.
