### PR TITLE
refactor(test): Hook up default WebChannel responses if none specified

### DIFF
--- a/packages/fxa-content-server/tests/functional/bounced_email.js
+++ b/packages/fxa-content-server/tests/functional/bounced_email.js
@@ -48,17 +48,7 @@ registerSuite('signup with an email that bounces', {
         // ensure a fresh signup page is loaded. If this suite is
         // run after a Sync suite, these tests try to use a Sync broker
         // which results in a channel timeout.
-        .then(
-          openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
-            webChannelResponses: {
-              'fxaccounts:can_link_account': { ok: true },
-              'fxaccounts:fxa_status': {
-                capabilities: null,
-                signedInUser: null,
-              },
-            },
-          })
-        )
+        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
     );
   },
 
@@ -121,14 +111,7 @@ const setUpBouncedSignIn = thenify(function(email) {
   return this.parent
     .then(clearBrowserState({ force: true }))
     .then(createUser(email, PASSWORD, { preVerified: true }))
-    .then(
-      openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
-        webChannelResponses: {
-          'fxaccounts:can_link_account': { ok: true },
-          'fxaccounts:fxa_status': { capabilities: null, signedInUser: null },
-        },
-      })
-    )
+    .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
     .then(fillOutEmailFirstSignIn(email, PASSWORD))
     .then(testElementExists(selectors.SIGNIN_TOKEN_CODE.HEADER))
     .then(testIsBrowserNotified('fxaccounts:can_link_account'))

--- a/packages/fxa-content-server/tests/functional/connect_another_device.js
+++ b/packages/fxa-content-server/tests/functional/connect_another_device.js
@@ -25,8 +25,6 @@ const CONNECT_ANOTHER_DEVICE_URL = `${config.fxaContentRoot}connect_another_devi
 const CONNECT_ANOTHER_DEVICE_SMS_ENABLED_URL = `${config.fxaContentRoot}connect_another_device?forceExperiment=sendSms&forceExperimentGroup=signinCodes`;
 const ENTER_EMAIL_URL = `${config.fxaContentRoot}?context=fx_desktop_v3&service=sync&action=email`;
 
-const CHANNEL_COMMAND_CAN_LINK_ACCOUNT = 'fxaccounts:can_link_account';
-
 const {
   clearBrowserState,
   createEmail,
@@ -55,11 +53,6 @@ registerSuite('connect_another_device', {
         .then(
           openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
             query: { forceUA },
-            webChannelResponses: {
-              [CHANNEL_COMMAND_CAN_LINK_ACCOUNT]: {
-                ok: true,
-              },
-            },
           })
         )
         .then(fillOutEmailFirstSignUp(email, PASSWORD))
@@ -99,11 +92,6 @@ registerSuite('connect_another_device', {
         .then(
           openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
             query: { forceUA },
-            webChannelResponses: {
-              [CHANNEL_COMMAND_CAN_LINK_ACCOUNT]: {
-                ok: true,
-              },
-            },
           })
         )
         .then(fillOutEmailFirstSignUp(email, PASSWORD))

--- a/packages/fxa-content-server/tests/functional/fx_browser_relier.js
+++ b/packages/fxa-content-server/tests/functional/fx_browser_relier.js
@@ -52,7 +52,6 @@ registerSuite('Firefox Desktop non-sync', {
                 forceUA: uaStrings['desktop_firefox_71'],
               },
               webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
                 'fxaccounts:fxa_status': {
                   signedInUser: null,
                   clientId: FIREFOX_CLIENT_ID,
@@ -85,7 +84,6 @@ registerSuite('Firefox Desktop non-sync', {
                 forceUA: uaStrings['desktop_firefox_71'],
               },
               webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
                 'fxaccounts:fxa_status': {
                   signedInUser: null,
                   clientId: FIREFOX_CLIENT_ID,
@@ -115,7 +113,6 @@ registerSuite('Firefox Desktop non-sync', {
               forceUA: uaStrings['desktop_firefox_71'],
             },
             webChannelResponses: {
-              'fxaccounts:can_link_account': { ok: true },
               'fxaccounts:fxa_status': {
                 signedInUser: null,
                 clientId: FIREFOX_CLIENT_ID,
@@ -154,7 +151,6 @@ registerSuite('Firefox Desktop non-sync', {
               forceUA: uaStrings['desktop_firefox_71'],
             },
             webChannelResponses: {
-              'fxaccounts:can_link_account': { ok: true },
               'fxaccounts:fxa_status': {
                 signedInUser: null,
                 clientId: FIREFOX_CLIENT_ID,

--- a/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js
+++ b/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js
@@ -248,15 +248,7 @@ registerSuite('Firefox desktop user info handshake', {
 
     'Sync - no user signed into browser, no user signed in locally': function() {
       return this.remote
-        .then(
-          openPage(SYNC_ENTER_EMAIL_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
-            webChannelResponses: {
-              'fxaccounts:fxa_status': {
-                signedInUser: null,
-              },
-            },
-          })
-        )
+        .then(openPage(SYNC_ENTER_EMAIL_PAGE_URL, selectors.ENTER_EMAIL.HEADER))
         .then(testElementValueEquals(selectors.ENTER_EMAIL.EMAIL, ''));
     },
 
@@ -264,29 +256,14 @@ registerSuite('Firefox desktop user info handshake', {
       return (
         this.remote
           // First, sign in the user to populate localStorage
-          .then(
-            openPage(ENTER_EMAIL_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
-              webChannelResponses: {
-                'fxaccounts:fxa_status': {
-                  signedInUser: null,
-                },
-              },
-            })
-          )
+          .then(openPage(ENTER_EMAIL_PAGE_URL, selectors.ENTER_EMAIL.HEADER))
           .then(fillOutEmailFirstSignIn(otherEmail, PASSWORD))
           .then(testElementExists(selectors.SETTINGS.HEADER))
 
           .then(
             openPage(
               SYNC_ENTER_EMAIL_PAGE_URL,
-              selectors.SIGNIN_PASSWORD.HEADER,
-              {
-                webChannelResponses: {
-                  'fxaccounts:fxa_status': {
-                    signedInUser: null,
-                  },
-                },
-              }
+              selectors.SIGNIN_PASSWORD.HEADER
             )
           )
 
@@ -388,51 +365,23 @@ registerSuite('Firefox desktop user info handshake', {
 
     'Sync settings page - no user signed into browser': function() {
       return this.remote.then(
-        openPage(SYNC_SETTINGS_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
-          webChannelResponses: {
-            'fxaccounts:fxa_status': {
-              signedInUser: null,
-            },
-          },
-        })
+        openPage(SYNC_SETTINGS_PAGE_URL, selectors.ENTER_EMAIL.HEADER)
       );
     },
 
     'Non-Sync settings page - no user signed into browser, no user signed in locally': function() {
       return this.remote.then(
-        openPage(SETTINGS_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
-          webChannelResponses: {
-            'fxaccounts:fxa_status': {
-              signedInUser: null,
-            },
-          },
-        })
+        openPage(SETTINGS_PAGE_URL, selectors.ENTER_EMAIL.HEADER)
       );
     },
 
     'Non-Sync settings page - no user signed into browser, user signed in locally': function() {
       return this.remote
-        .then(
-          openPage(ENTER_EMAIL_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
-            webChannelResponses: {
-              'fxaccounts:fxa_status': {
-                signedInUser: null,
-              },
-            },
-          })
-        )
+        .then(openPage(ENTER_EMAIL_PAGE_URL, selectors.ENTER_EMAIL.HEADER))
         .then(fillOutEmailFirstSignIn(otherEmail, PASSWORD))
         .then(testElementExists(selectors.SETTINGS.HEADER))
 
-        .then(
-          openPage(SETTINGS_PAGE_URL, selectors.SETTINGS.HEADER, {
-            webChannelResponses: {
-              'fxaccounts:fxa_status': {
-                signedInUser: null,
-              },
-            },
-          })
-        )
+        .then(openPage(SETTINGS_PAGE_URL, selectors.SETTINGS.HEADER))
 
         .then(
           testElementTextEquals(selectors.SETTINGS.PROFILE_HEADER, otherEmail)

--- a/packages/fxa-content-server/tests/functional/oauth_sync_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sync_sign_in.js
@@ -53,17 +53,7 @@ registerSuite('signin with OAuth after Sync', {
       return (
         this.remote
           .then(createUser(email, PASSWORD, { preVerified: true }))
-          .then(
-            openPage(SYNC_EMAIL_FIRST_URL, selectors.ENTER_EMAIL.HEADER, {
-              webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
-                'fxaccounts:fxa_status': {
-                  capabilities: null,
-                  signedInUser: null,
-                },
-              },
-            })
-          )
+          .then(openPage(SYNC_EMAIL_FIRST_URL, selectors.ENTER_EMAIL.HEADER))
 
           .then(fillOutEmailFirstSignIn(email, PASSWORD))
           .then(testElementExists(selectors.SIGNIN_TOKEN_CODE.HEADER))
@@ -143,17 +133,7 @@ registerSuite('signin to Sync after OAuth', {
         .then(fillOutEmailFirstSignIn(email, PASSWORD))
         .then(testElementTextEquals(selectors['123DONE'].AUTHENTICATED, email))
 
-        .then(
-          openPage(SYNC_EMAIL_FIRST_URL, selectors.SIGNIN_PASSWORD.HEADER, {
-            webChannelResponses: {
-              'fxaccounts:can_link_account': { ok: true },
-              'fxaccounts:fxa_status': {
-                capabilities: null,
-                signedInUser: null,
-              },
-            },
-          })
-        )
+        .then(openPage(SYNC_EMAIL_FIRST_URL, selectors.SIGNIN_PASSWORD.HEADER))
         .then(
           testElementTextEquals(
             selectors.SIGNIN_PASSWORD.EMAIL_NOT_EDITABLE,

--- a/packages/fxa-content-server/tests/functional/password_strength.js
+++ b/packages/fxa-content-server/tests/functional/password_strength.js
@@ -28,13 +28,7 @@ registerSuite('password strength balloon', {
 
     return this.remote
       .then(clearBrowserState({ force: true }))
-      .then(
-        openPage(PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
-          webChannelResponses: {
-            'fxaccounts:can_link_account': { ok: true },
-          },
-        })
-      )
+      .then(openPage(PAGE_URL, selectors.ENTER_EMAIL.HEADER))
       .then(type(selectors.ENTER_EMAIL.EMAIL, email))
       .then(
         click(selectors.ENTER_EMAIL.SUBMIT, selectors.SIGNUP_PASSWORD.HEADER)

--- a/packages/fxa-content-server/tests/functional/recovery_key.js
+++ b/packages/fxa-content-server/tests/functional/recovery_key.js
@@ -95,16 +95,7 @@ registerSuite('Recovery key', {
     'can reset password with recovery key': function() {
       return (
         this.remote
-          .then(
-            openPage(RESET_PASSWORD_URL, selectors.RESET_PASSWORD.HEADER, {
-              webChannelResponses: {
-                'fxaccounts:fxa_status': {
-                  capabilities: null,
-                  signedInUser: null,
-                },
-              },
-            })
-          )
+          .then(openPage(RESET_PASSWORD_URL, selectors.RESET_PASSWORD.HEADER))
           .then(fillOutResetPassword(email))
           .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
           .then(openVerificationLinkInSameTab(email, 2))
@@ -143,16 +134,7 @@ registerSuite('Recovery key', {
     'can reset password when forgot recovery key': function() {
       return (
         this.remote
-          .then(
-            openPage(RESET_PASSWORD_URL, selectors.RESET_PASSWORD.HEADER, {
-              webChannelResponses: {
-                'fxaccounts:fxa_status': {
-                  capabilities: null,
-                  signedInUser: null,
-                },
-              },
-            })
-          )
+          .then(openPage(RESET_PASSWORD_URL, selectors.RESET_PASSWORD.HEADER))
           .then(fillOutResetPassword(email))
           .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
           .then(openVerificationLinkInSameTab(email, 2))
@@ -183,16 +165,7 @@ registerSuite('Recovery key', {
     'can not re-use recovery key': function() {
       return (
         this.remote
-          .then(
-            openPage(RESET_PASSWORD_URL, selectors.RESET_PASSWORD.HEADER, {
-              webChannelResponses: {
-                'fxaccounts:fxa_status': {
-                  capabilities: null,
-                  signedInUser: null,
-                },
-              },
-            })
-          )
+          .then(openPage(RESET_PASSWORD_URL, selectors.RESET_PASSWORD.HEADER))
           .then(fillOutResetPassword(email))
           .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
           .then(openVerificationLinkInSameTab(email, 2))

--- a/packages/fxa-content-server/tests/functional/sign_in_recovery_code.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_recovery_code.js
@@ -102,13 +102,6 @@ registerSuite('recovery code', {
           .then(
             openPage(SYNC_ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {},
-              webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
-                'fxaccounts:fxa_status': {
-                  capabilities: null,
-                  signedInUser: null,
-                },
-              },
             })
           )
 
@@ -138,13 +131,6 @@ registerSuite('recovery code', {
           .then(
             openPage(SYNC_ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {},
-              webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
-                'fxaccounts:fxa_status': {
-                  capabilities: null,
-                  signedInUser: null,
-                },
-              },
             })
           )
 
@@ -164,13 +150,6 @@ registerSuite('recovery code', {
           .then(
             openPage(SYNC_ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
               query: {},
-              webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
-                'fxaccounts:fxa_status': {
-                  capabilities: null,
-                  signedInUser: null,
-                },
-              },
             })
           )
 

--- a/packages/fxa-content-server/tests/functional/sign_in_totp.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_totp.js
@@ -118,13 +118,6 @@ registerSuite('TOTP', {
         .then(
           openPage(SYNC_ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
             query: {},
-            webChannelResponses: {
-              'fxaccounts:can_link_account': { ok: true },
-              'fxaccounts:fxa_status': {
-                capabilities: null,
-                signedInUser: null,
-              },
-            },
           })
         )
 

--- a/packages/fxa-content-server/tests/functional/sign_up.js
+++ b/packages/fxa-content-server/tests/functional/sign_up.js
@@ -327,11 +327,6 @@ registerSuite('signup here', {
             query: {
               forceUA: UA_STRINGS['desktop_firefox_58'],
             },
-            webChannelResponses: {
-              'fxaccounts:fxa_status': {
-                signedInUser: null,
-              },
-            },
           })
         )
         .then(click(selectors.ENTER_EMAIL.LINK_SUGGEST_SYNC))

--- a/packages/fxa-content-server/tests/functional/sync_v3_email_first.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_email_first.js
@@ -49,13 +49,7 @@ registerSuite('Firefox Desktop Sync v3 email first', {
       return (
         this.remote
           // redirected immediately to the / page
-          .then(
-            openPage(SIGNUP_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
-              webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
-              },
-            })
-          )
+          .then(openPage(SIGNUP_PAGE_URL, selectors.ENTER_EMAIL.HEADER))
           .then(type(selectors.ENTER_EMAIL.EMAIL, email))
           .then(
             click(
@@ -76,13 +70,7 @@ registerSuite('Firefox Desktop Sync v3 email first', {
         this.remote
           .then(createUser(email, PASSWORD, { preVerified: true }))
           // redirected immediately to the / page
-          .then(
-            openPage(SIGNIN_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
-              webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
-              },
-            })
-          )
+          .then(openPage(SIGNIN_PAGE_URL, selectors.ENTER_EMAIL.HEADER))
           .then(type(selectors.ENTER_EMAIL.EMAIL, email))
           .then(
             click(
@@ -100,13 +88,7 @@ registerSuite('Firefox Desktop Sync v3 email first', {
 
     'enter a firefox.com address': function() {
       return this.remote
-        .then(
-          openPage(INDEX_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
-            webChannelResponses: {
-              'fxaccounts:can_link_account': { ok: true },
-            },
-          })
-        )
+        .then(openPage(INDEX_PAGE_URL, selectors.ENTER_EMAIL.HEADER))
         .then(visibleByQSA(selectors.ENTER_EMAIL.SUB_HEADER))
 
         .then(type(selectors.ENTER_EMAIL.EMAIL, 'testuser@firefox.com'))
@@ -122,13 +104,7 @@ registerSuite('Firefox Desktop Sync v3 email first', {
     signup: function() {
       return (
         this.remote
-          .then(
-            openPage(INDEX_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
-              webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
-              },
-            })
-          )
+          .then(openPage(INDEX_PAGE_URL, selectors.ENTER_EMAIL.HEADER))
           .then(visibleByQSA(selectors.ENTER_EMAIL.SUB_HEADER))
           .then(type(selectors.ENTER_EMAIL.EMAIL, email))
           .then(
@@ -202,9 +178,6 @@ registerSuite('Firefox Desktop Sync v3 email first', {
             query: {
               coppa: 'false',
             },
-            webChannelResponses: {
-              'fxaccounts:can_link_account': { ok: true },
-            },
           })
         )
         .then(visibleByQSA(selectors.ENTER_EMAIL.SUB_HEADER))
@@ -227,13 +200,7 @@ registerSuite('Firefox Desktop Sync v3 email first', {
     'merge cancelled': function() {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(
-          openPage(INDEX_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
-            webChannelResponses: {
-              'fxaccounts:can_link_account': { ok: false },
-            },
-          })
-        )
+        .then(openPage(INDEX_PAGE_URL, selectors.ENTER_EMAIL.HEADER))
 
         .then(visibleByQSA(selectors.ENTER_EMAIL.SUB_HEADER))
         .then(type(selectors.ENTER_EMAIL.EMAIL, email))
@@ -250,9 +217,6 @@ registerSuite('Firefox Desktop Sync v3 email first', {
           openPage(INDEX_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
             query: {
               email: invalidEmail,
-            },
-            webChannelResponses: {
-              'fxaccounts:can_link_account': { ok: true },
             },
           })
         )
@@ -275,9 +239,6 @@ registerSuite('Firefox Desktop Sync v3 email first', {
             query: {
               email: emptyEmail,
             },
-            webChannelResponses: {
-              'fxaccounts:can_link_account': { ok: true },
-            },
           })
         )
         .then(testElementValueEquals(selectors.ENTER_EMAIL.EMAIL, emptyEmail))
@@ -297,9 +258,6 @@ registerSuite('Firefox Desktop Sync v3 email first', {
             openPage(INDEX_PAGE_URL, selectors.SIGNUP_PASSWORD.HEADER, {
               query: {
                 email,
-              },
-              webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
               },
             })
           )
@@ -324,9 +282,6 @@ registerSuite('Firefox Desktop Sync v3 email first', {
             openPage(INDEX_PAGE_URL, selectors.SIGNIN_PASSWORD.HEADER, {
               query: {
                 email,
-              },
-              webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
               },
             })
           )
@@ -367,17 +322,7 @@ registerSuite('Firefox Desktop Sync v3 email first', {
       return (
         this.remote
           .then(createUser(email, PASSWORD, { preVerified: true }))
-          .then(
-            openPage(INDEX_PAGE_URL, selectors.ENTER_EMAIL.HEADER, {
-              webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
-                'fxaccounts:fxa_status': {
-                  capabilities: null,
-                  signedInUser: null,
-                },
-              },
-            })
-          )
+          .then(openPage(INDEX_PAGE_URL, selectors.ENTER_EMAIL.HEADER))
 
           .then(type(selectors.ENTER_EMAIL.EMAIL, email))
           .then(
@@ -397,17 +342,7 @@ registerSuite('Firefox Desktop Sync v3 email first', {
           .then(fillOutSignInTokenCode(email, 0))
 
           // Use cached credentials form last time, but user must enter password
-          .then(
-            openPage(INDEX_PAGE_URL, selectors.SIGNIN_PASSWORD.HEADER, {
-              webChannelResponses: {
-                'fxaccounts:can_link_account': { ok: true },
-                'fxaccounts:fxa_status': {
-                  capabilities: null,
-                  signedInUser: null,
-                },
-              },
-            })
-          )
+          .then(openPage(INDEX_PAGE_URL, selectors.SIGNIN_PASSWORD.HEADER))
           .then(testElementValueEquals(selectors.SIGNIN_PASSWORD.EMAIL, email))
           // user wants to use a different email
           .then(

--- a/packages/fxa-content-server/tests/functional/sync_v3_force_auth.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_force_auth.js
@@ -283,15 +283,6 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
               service: 'sync',
               uid: createUID(),
             },
-            webChannelResponses: {
-              'fxaccounts:can_link_account': {
-                ok: true,
-              },
-              'fxaccounts:fxa_status': {
-                capabilities: null,
-                signedInUser: null,
-              },
-            },
           })
         )
         .then(noSuchBrowserNotification('fxaccounts:logout'))

--- a/packages/fxa-content-server/tests/functional/sync_v3_reset_password.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_reset_password.js
@@ -40,9 +40,6 @@ const setupTest = thenify(function(query) {
       .then(
         openPage(RESET_PASSWORD_URL, selectors.RESET_PASSWORD.HEADER, {
           query,
-          webChannelResponses: {
-            'fxaccounts:fxa_status': { capabilities: null, signedInUser: null },
-          },
         })
       )
       .then(fillOutResetPassword(email))

--- a/packages/fxa-content-server/tests/functional/sync_v3_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_sign_in.js
@@ -54,10 +54,6 @@ const setupTest = thenify(function(options = {}) {
     .then(
       openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
         query,
-        webChannelResponses: {
-          'fxaccounts:can_link_account': { ok: true },
-          'fxaccounts:fxa_status': { capabilities: null, signedInUser: null },
-        },
       })
     )
     .then(fillOutEmailFirstSignIn(signInEmail, PASSWORD))
@@ -83,13 +79,6 @@ registerSuite('Firefox Desktop Sync v3 signin', {
         .then(
           openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
             query,
-            webChannelResponses: {
-              'fxaccounts:can_link_account': { ok: true },
-              'fxaccounts:fxa_status': {
-                capabilities: null,
-                signedInUser: null,
-              },
-            },
           })
         )
         .then(fillOutEmailFirstSignIn(email, PASSWORD))

--- a/packages/fxa-content-server/tests/functional/sync_v3_sign_up.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_sign_up.js
@@ -48,9 +48,6 @@ registerSuite('Firefox Desktop Sync v3 signup', {
                 forceUA: uaStrings['desktop_firefox_58'],
               },
               webChannelResponses: {
-                'fxaccounts:can_link_account': {
-                  ok: true,
-                },
                 'fxaccounts:fxa_status': {
                   signedInUser: null,
                   capabilities: {
@@ -99,14 +96,6 @@ registerSuite('Firefox Desktop Sync v3 signup', {
                 forceExperimentGroup: 'treatment',
                 forceUA: uaStrings.desktop_firefox_58,
               },
-              webChannelResponses: {
-                'fxaccounts:can_link_account': {
-                  ok: true,
-                },
-                'fxaccounts:fxa_status': {
-                  signedInUser: null,
-                },
-              },
             })
           )
           .then(storeWebChannelMessageData('fxaccounts:login'))
@@ -142,14 +131,6 @@ registerSuite('Firefox Desktop Sync v3 signup', {
               query: {
                 forceUA: uaStrings['desktop_firefox_58'],
               },
-              webChannelResponses: {
-                'fxaccounts:can_link_account': {
-                  ok: true,
-                },
-                'fxaccounts:fxa_status': {
-                  signedInUser: null,
-                },
-              },
             })
           )
           .then(storeWebChannelMessageData('fxaccounts:login'))
@@ -184,9 +165,6 @@ registerSuite('Firefox Desktop Sync v3 signup', {
                 forceUA: uaStrings['desktop_firefox_58'],
               },
               webChannelResponses: {
-                'fxaccounts:can_link_account': {
-                  ok: true,
-                },
                 'fxaccounts:fxa_status': {
                   signedInUser: null,
                 },
@@ -213,9 +191,6 @@ registerSuite('Firefox Desktop Sync v3 signup', {
                 forceUA: uaStrings['desktop_firefox_58'],
               },
               webChannelResponses: {
-                'fxaccounts:can_link_account': {
-                  ok: true,
-                },
                 'fxaccounts:fxa_status': {
                   capabilities: {
                     engines: [],
@@ -245,9 +220,6 @@ registerSuite('Firefox Desktop Sync v3 signup', {
                 forceUA: uaStrings['desktop_firefox_58'],
               },
               webChannelResponses: {
-                'fxaccounts:can_link_account': {
-                  ok: true,
-                },
                 'fxaccounts:fxa_status': {
                   capabilities: {
                     engines: ['creditcards', 'addresses'],
@@ -290,13 +262,6 @@ registerSuite(
                   forceExperiment: 'signupPasswordCWTS',
                   forceExperimentGroup: 'treatment',
                   forceUA: uaStrings['desktop_firefox_71'],
-                },
-                webChannelResponses: {
-                  'fxaccounts:can_link_account': { ok: true },
-                  'fxaccounts:fxa_status': {
-                    capabilities: null,
-                    signedInUser: null,
-                  },
                 },
               })
             )


### PR DESCRIPTION
This simplifies developer lives by hooking up default WebChannel
responses in applicable environments if none are specified.