### PR TITLE
Changes for train 151.4

### DIFF
--- a/packages/fxa-payments-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-payments-server/server/lib/routes/post-metrics.js
@@ -64,11 +64,7 @@ module.exports = {
         // performance event.
         logPerformanceEvent(event, request, { ...data, requestReceivedTime });
       } else {
-        event.time =
-          data.perfStartTime +
-          event.offset +
-          requestReceivedTime -
-          data.flushTime;
+        event.time = data.flushTime;
         amplitude(event, request, data, requestReceivedTime);
       }
     });


### PR DESCRIPTION
Just discovered I've been doing the branch management wrong; now going with the "Another Option for a Patch Release" process from [the docs](https://mozilla.github.io/ecosystem-platform/docs/fxa-engineering/release-process#another-option-for-a-patch-release).

fix(metrics): use flush time as Payments Amplitude event time

Since Payments server currently does not queue up and the send multiple
events in a single metrics request, the flush time is representative of
the event time.