### PR TITLE
feat(event-broker): add remaining RP events

### DIFF
--- a/packages/fxa-event-broker/README.md
+++ b/packages/fxa-event-broker/README.md
@@ -15,6 +15,61 @@ A relying party will get webhook calls for events. These events are encoded in
 [SET][set]s with the following formats. See the [SET RFC][set] for definitions and other
 examples.
 
+### Password Change
+
+Sent when a user has reset or changed their password. Services receiving this event
+should terminate user login sessions that were established prior to the event.
+
+- Event Identifier
+  - `https://schemas.accounts.firefox.com/event/password-change`
+- Event Payload
+  - [Password Event Identifier]
+    - changeTime
+      - Time when the password reset took place. All logins established before this
+        time should be terminated.
+
+### Example Password Change Event
+
+    {
+     "iss": "https://accounts.firefox.com/",
+     "sub": "FXA_USER_ID",
+     "aud": "REMOTE_SYSTEM",
+     "iat": 1565720808,
+     "jti": "e19ed6c5-4816-4171-aa43-56ffe80dbda1",
+     "events": {
+       "https://schemas.accounts.firefox.com/event/password-change": {
+           "changeTime": 1565721242227
+       }
+     }
+
+### Profile Change
+
+Sent when a user has changed their profile data in some manner. Updates to their
+profile may include a new primary email address, display name, or 2FA status. This
+event does not include what changed and the profile data a service has access to
+may not show any changes if the data changed was outside the OAuth scope the service
+was granted.
+
+Services should update any cached profile data they hold about the user.
+
+- Event Identifier
+  - `https://schemas.accounts.firefox.com/event/profile-change`
+- Event Payload
+  - [Profile Event Identifier]
+    - `{}`
+
+### Example Profile Change Event
+
+    {
+     "iss": "https://accounts.firefox.com/",
+     "sub": "FXA_USER_ID",
+     "aud": "REMOTE_SYSTEM",
+     "iat": 1565720808,
+     "jti": "e19ed6c5-4816-4171-aa43-56ffe80dbda1",
+     "events": {
+       "https://schemas.accounts.firefox.com/event/profile-change": {}
+     }
+
 ### Subscription State Change
 
 Sent when a user's subscription state has changed to RPs that provide the changed
@@ -112,10 +167,12 @@ Where `CAPABILITIES` is a comma-seperated string of capabilities to include.
 
 #### Usage
 
-    $ npm run build
-    $ export LOG_FORMAT=pretty
-    $ node dist/bin/simulate-webhook-call.js a9238ba https://example.com/webhook capability_1
-    fxa-event-broker.simulateWebhookCall.INFO: webhookCall {"statusCode":200,"body":"ok\n"}
-    $
+```bash
+$ npm run build
+$ export LOG_FORMAT=pretty
+$ node dist/bin/simulate-webhook-call.js a9238ba https://example.com/webhook capability_1
+fxa-event-broker.simulateWebhookCall.INFO: webhookCall {"statusCode":200,"body":"ok\n"}
+$
+```
 
 [set]: https://tools.ietf.org/html/rfc8417

--- a/packages/fxa-event-broker/architecture.md
+++ b/packages/fxa-event-broker/architecture.md
@@ -40,7 +40,7 @@ sequenceDiagram
 
 <br /><br /><br /><br /><br />
 
-## Subscription State Change Events
+## Relying Party Events
 
 Note: SQS participant not shown here to save space.
 
@@ -53,13 +53,13 @@ sequenceDiagram
     participant RP as Relying Party
     participant FS as Google Firestore
 
-    Auth->>Ev: SubscriptionEvent via SQS
+    Auth->>Ev: RelyingPartyEvent via SQS
     Ev-->>+FS: Get RPs the User has logged into (FetchClientIds)
     FS-->>-Ev: List of Client Ids
 
-    loop on clientIds
-    Ev->>PS: StateChangeEvent
+    Ev->>PS: RPEvent
 
+    loop on clientIds
     PS-->>+Ev: POST /proxy/{clientId}
     Ev-->>+RP: POST /client/webhook
     RP-->>-Ev: {Status: 200}

--- a/packages/fxa-event-broker/lib/api/proxy-controller.ts
+++ b/packages/fxa-event-broker/lib/api/proxy-controller.ts
@@ -9,7 +9,14 @@ import requests from 'request-promise-native';
 
 import { JWT } from '../jwts';
 import { ClientWebhookService } from '../selfUpdatingService/clientWebhookService';
-import { DELETE_EVENT, SUBSCRIPTION_UPDATE_EVENT } from '../serviceNotifications';
+import {
+  DELETE_EVENT,
+  PASSWORD_CHANGE_EVENT,
+  PASSWORD_RESET_EVENT,
+  PRIMARY_EMAIL_EVENT,
+  PROFILE_CHANGE_EVENT,
+  SUBSCRIPTION_UPDATE_EVENT
+} from '../serviceNotifications';
 import { version } from '../version';
 import { proxyPayload } from './proxy-validator';
 
@@ -117,6 +124,21 @@ export default class ProxyController {
       }
       case DELETE_EVENT: {
         return await this.jwt.generateDeleteSET({
+          clientId,
+          uid: message.uid
+        });
+      }
+      case PASSWORD_RESET_EVENT:
+      case PASSWORD_CHANGE_EVENT: {
+        return await this.jwt.generatePasswordSET({
+          changeTime: message.changeTime,
+          clientId,
+          uid: message.uid
+        });
+      }
+      case PRIMARY_EMAIL_EVENT:
+      case PROFILE_CHANGE_EVENT: {
+        return await this.jwt.generateProfileSET({
           clientId,
           uid: message.uid
         });

--- a/packages/fxa-event-broker/lib/jwts.ts
+++ b/packages/fxa-event-broker/lib/jwts.ts
@@ -6,15 +6,24 @@ import jwtool from 'fxa-jwtool';
 import uuid from 'uuid';
 
 // SET Event identifiers
+export const DELETE_EVENT_ID = 'https://schemas.accounts.firefox.com/event/delete-user';
+export const PASSWORD_EVENT_ID = 'https://schemas.accounts.firefox.com/event/password-change';
+export const PROFILE_EVENT_ID = 'https://schemas.accounts.firefox.com/event/profile-change';
 export const SUBSCRIPTION_STATE_EVENT_ID =
   'https://schemas.accounts.firefox.com/event/subscription-state-change';
-
-export const DELETE_USER_EVENT_ID = 'https://schemas.accounts.firefox.com/event/delete-user';
 
 type deleteEvent = {
   clientId: string;
   uid: string;
 };
+
+type passwordEvent = {
+  uid: string;
+  clientId: string;
+  changeTime: number;
+};
+
+type profileEvent = deleteEvent;
 
 type securityEvent = {
   uid: string;
@@ -67,6 +76,38 @@ export class JWT {
   }
 
   /**
+   * Generate a Password Security Event Token.
+   *
+   * @param  passEvent
+   */
+  public generatePasswordSET(passEvent: passwordEvent): Promise<string> {
+    return this.generateSET({
+      clientId: passEvent.clientId,
+      events: {
+        [PASSWORD_EVENT_ID]: {
+          changeTime: passEvent.changeTime
+        }
+      },
+      uid: passEvent.uid
+    });
+  }
+
+  /**
+   * Generate a Profile Security Event Token.
+   *
+   * @param  proEvent
+   */
+  public generateProfileSET(proEvent: profileEvent): Promise<string> {
+    return this.generateSET({
+      clientId: proEvent.clientId,
+      events: {
+        [PROFILE_EVENT_ID]: {}
+      },
+      uid: proEvent.uid
+    });
+  }
+
+  /**
    * Generate a Subscription Security Event Token.
    *
    * @param subEvent
@@ -94,7 +135,7 @@ export class JWT {
     return this.generateSET({
       clientId: delEvent.clientId,
       events: {
-        [DELETE_USER_EVENT_ID]: {}
+        [DELETE_EVENT_ID]: {}
       },
       uid: delEvent.uid
     });

--- a/packages/fxa-event-broker/package-lock.json
+++ b/packages/fxa-event-broker/package-lock.json
@@ -68,28 +68,28 @@
       }
     },
     "@google-cloud/paginator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-2.0.1.tgz",
-      "integrity": "sha512-HZ6UTGY/gHGNriD7OCikYWL/Eu0sTEur2qqse2w6OVsz+57se3nTkqH14JIPxtf0vlEJ8IJN5w3BdZ22pjCB8g==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-2.0.2.tgz",
+      "integrity": "sha512-PCddVtZWvw0iZ3BLIsCXMBQvxUcS9O5CgfHBu8Zd8T3DCiML+oQED1odsbl3CQ9d3RrvBaj+eIh7Dv12D15PbA==",
       "requires": {
         "arrify": "^2.0.0",
         "extend": "^3.0.2"
       }
     },
     "@google-cloud/precise-date": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-1.0.1.tgz",
-      "integrity": "sha512-nmH/UG87qUHc4OH7cwxVUNBd+5jGaNr6muUAbF0meauqborh/5qUGiz4AVmin6SBnFUazndldDbozU2zpWTfSw=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-1.0.2.tgz",
+      "integrity": "sha512-EXk9MYAoKz3hD0ITklFIe4aPK+tHk/3WL2DvTD28wAPpYiIMClXTUqX9fanhdurhO1KUU06HBoU3+Rks32yTTQ=="
     },
     "@google-cloud/projectify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-1.0.1.tgz",
-      "integrity": "sha512-xknDOmsMgOYHksKc1GPbwDLsdej8aRNIA17SlSZgQdyrcC0lx0OGo4VZgYfwoEU1YS8oUxF9Y+6EzDOb0eB7Xg=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-1.0.2.tgz",
+      "integrity": "sha512-WnkGxvk4U1kAJpoS/Ehk+3MZXVW+XHHhwc/QyD6G8Za4xml3Fv+NRn/bYffl1TxSg+gE0N0mj9Shgc7e8+fl8A=="
     },
     "@google-cloud/promisify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.2.tgz",
-      "integrity": "sha512-7WfV4R/3YV5T30WRZW0lqmvZy9hE2/p9MvpI34WuKa2Wz62mLu5XplGTFEMK6uTbJCLWUxTcZ4J4IyClKucE5g=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.3.tgz",
+      "integrity": "sha512-Rufgfl3TnkIil3CjsH33Q6093zeoVqyqCdvtvgHuCqRJxCZYfaVPIyr8JViMeLTD4Ja630pRKKZVSjKggoVbNg=="
     },
     "@google-cloud/pubsub": {
       "version": "1.1.5",
@@ -1679,9 +1679,9 @@
       }
     },
     "deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
-      "integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
       "requires": {
         "is-arguments": "^1.0.4",
         "is-date-object": "^1.0.1",


### PR DESCRIPTION
Because:

* Only the subscription state and delete events were propagated.
* RPs need to know about password reset/change and profile updates.

This commit:

* Sends password change and profile change events to RPs.

Closes #3481