### PR TITLE
fix(payments): use the correct type for updatePaymentAndRefresh

### DIFF
--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -47,7 +47,7 @@ export type SubscriptionsProps = {
   reactivateSubscription: ActionFunctions['reactivateSubscription'];
   fetchSubscriptionsRouteResources: SequenceFunctions['fetchSubscriptionsRouteResources'];
   resetReactivateSubscription: ActionFunctions['resetReactivateSubscription'];
-  updatePayment: SequenceFunctions['updateSubscriptionPlanAndRefresh'];
+  updatePayment: SequenceFunctions['updatePaymentAndRefresh'];
   resetUpdatePayment: ActionFunctions['resetUpdatePayment'];
   manageSubscriptionsMounted: ActionFunctions['manageSubscriptionsMounted'];
   manageSubscriptionsEngaged: ActionFunctions['manageSubscriptionsEngaged'];


### PR DESCRIPTION
Small tab-completion oopsie.

Although updatePaymentAndRefresh and updateSubscriptionPlanAndRefresh
share the same function signature, they are indeed different things.

Doesn't cause any test failures or functional problems, but may cause a
surprise if updateSubscriptionPlanAndRefresh is changed in the future