### PR TITLE
chore(ci): divide functional tests into groups

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - run: ../../.circleci/deploy.sh << parameters.module >>
 
   fxa-content-server:
-    resource_class: xlarge
+    resource_class: medium+
     parallelism: 6
     docker:
       - image: mozilla/fxa-circleci

--- a/.circleci/test-content-server.sh
+++ b/.circleci/test-content-server.sh
@@ -28,8 +28,13 @@ function check() {
 
 function test_suite() {
   local suite=$1
-  node tests/intern.js --suites=${suite} --firefoxBinary=./firefox/firefox || \
-  node tests/intern.js --suites=${suite} --firefoxBinary=./firefox/firefox --grep="$(<rerun.txt)"
+  local numGroups=4
+
+  for i in $(seq $numGroups)
+  do
+    node tests/intern.js --suites=${suite} --groupsCount=${numGroups} --groupNum=${i} --firefoxBinary=./firefox/firefox || \
+    node tests/intern.js --suites=${suite} --groupsCount=${numGroups} --groupNum=${i} --firefoxBinary=./firefox/firefox --grep="$(<rerun.txt)"
+  done
 }
 
 if grep -e "$MODULE" -e 'all' $DIR/../packages/test.list; then

--- a/packages/fxa-content-server/tests/functional_circle.js
+++ b/packages/fxa-content-server/tests/functional_circle.js
@@ -10,7 +10,7 @@
  * exactly the same size and will take a different amount of time to run,
  * but this is a good place to start.
  */
-function selectCircleTests(allTests) {
+function selectCircleTests(allTests, groupsCount, groupNum) {
   var testsToRun = allTests;
 
   if (process.env.CIRCLE_NODE_TOTAL) {
@@ -26,7 +26,14 @@ function selectCircleTests(allTests) {
     });
   }
 
+  if (groupsCount && groupNum) {
+    testsToRun = testsToRun.slice(
+      Math.floor(((groupNum - 1) / groupsCount) * testsToRun.length),
+      Math.floor((groupNum / groupsCount) * testsToRun.length)
+    );
+  }
+
   return testsToRun;
 }
 
-module.exports = selectCircleTests(require('./functional'));
+module.exports = selectCircleTests;

--- a/packages/fxa-content-server/tests/intern.js
+++ b/packages/fxa-content-server/tests/intern.js
@@ -9,7 +9,11 @@ const firefoxProfile = require('./tools/firefox_profile');
 
 // Tests
 const testsMain = require('./functional');
-const testsCircleCi = require('./functional_circle');
+const testsCircleCi = require('./functional_circle')(
+  testsMain,
+  args.groupsCount,
+  args.groupNum
+);
 const testsPairing = require('./functional_pairing');
 const testsServer = require('./tests_server');
 const testsServerResources = require('./tests_server_resources');


### PR DESCRIPTION
We switched to using xlarge resource class in CircleCI for content
server tests due to suspected OOM errors.  This patch splits the tests
into groups, thus forcing Firefox to restart and release its memory
between each group.

Fixes #3515 (for now at least)

@mozilla/fxa-devs r?