### PR TITLE
fix(fenix): Do not use Sync Optional with Fenix

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/base.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/base.js
@@ -596,6 +596,10 @@ const BaseAuthenticationBroker = Backbone.Model.extend({
      */
     supportsPairing: false,
     /**
+     * Does this environment support the Sync Optional flow?
+     */
+    syncOptional: false,
+    /**
      * Are token codes flow supported?
      */
     tokenCode: true,

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-sync.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-sync.js
@@ -55,6 +55,10 @@ export default BaseAuthenticationBroker.extend({
     const multiService =
       response.capabilities && response.capabilities.multiService;
     this.relier.set('multiService', multiService);
+    this.setCapability(
+      'syncOptional',
+      multiService && this.relier.get('service') !== 'sync'
+    );
     if (multiService) {
       // we get the OAuth client id for the browser
       // in order to replicate the uses of the 'service' param on the backend.
@@ -70,6 +74,7 @@ export default BaseAuthenticationBroker.extend({
     if (syncEngines && additionalEngineIds) {
       this.addAdditionalSyncEngines(additionalEngineIds);
     }
+    return proto.onFxaStatus.call(this, response);
   },
 
   /**

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
@@ -72,6 +72,7 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
       });
       return this.set('chooseWhatToSyncWebV1Engines', syncEngines);
     }
+    return proto.onFxaStatus.call(this, response);
   },
 
   createChannel() {

--- a/packages/fxa-content-server/app/scripts/views/mixins/signup-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signup-mixin.js
@@ -61,8 +61,8 @@ export default {
             !this.isCWTSOnSignupPasswordEnabled())
         ) {
           return this.navigate('choose_what_to_sync', {
-            account: account,
-            allowToDisableSync: this.relier.get('service') !== 'sync',
+            account,
+            allowToDisableSync: this.broker.hasCapability('syncOptional'),
             pollVerification: this.relier.get('service') === 'sync',
             // choose_what_to_sync screen will call onSubmitComplete
             // with an updated account

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync.js
@@ -55,7 +55,7 @@ describe('models/auth_brokers/fx-sync', () => {
     windowMock = null;
   });
 
-  describe('chooseWhatToSyncWebV1Engines', () => {
+  describe('chooseWhatToSyncWebV1Engines capability', () => {
     let response;
     beforeEach(() => {
       response = {
@@ -81,6 +81,36 @@ describe('models/auth_brokers/fx-sync', () => {
         const syncEngines = broker.get('chooseWhatToSyncWebV1Engines');
         assert.ok(syncEngines.get('creditcards'));
       });
+    });
+  });
+
+  describe('syncOptional capability', () => {
+    it('sets `syncOptional` to false if no multiService capability', () => {
+      relier.set('service', 'foo');
+      broker.onFxaStatus({ capabilities: {} });
+
+      assert.isFalse(broker.hasCapability('syncOptional'));
+    });
+
+    it('sets `syncOptional` to false if multiService: false', () => {
+      relier.set('service', 'foo');
+      broker.onFxaStatus({ capabilities: { multiService: false } });
+
+      assert.isFalse(broker.hasCapability('syncOptional'));
+    });
+
+    it('sets `syncOptional` to false if service===sync', () => {
+      relier.set('service', 'sync');
+      broker.onFxaStatus({ capabilities: { multiService: true } });
+
+      assert.isFalse(broker.hasCapability('syncOptional'));
+    });
+
+    it('sets `syncOptional` to true if multiService and not sync', () => {
+      relier.set('service', 'foo');
+      broker.onFxaStatus({ capabilities: { multiService: true } });
+
+      assert.isTrue(broker.hasCapability('syncOptional'));
     });
   });
 

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/signup-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/signup-mixin.js
@@ -122,6 +122,7 @@ describe('views/mixins/signup-mixin', function() {
     describe('choose what to sync not displayed when entering password', function() {
       beforeEach(function() {
         broker.set('chooseWhatToSyncWebV1Engines', new Model());
+        broker.setCapability('syncOptional', true);
 
         return view.signUp(account, 'password');
       });
@@ -145,6 +146,7 @@ describe('views/mixins/signup-mixin', function() {
         var args = view.navigate.args[0];
         assert.equal(args[0], 'choose_what_to_sync');
         assert.deepEqual(args[1].account, account);
+        assert.isTrue(args[1].allowToDisableSync);
         assert.isFunction(args[1].onSubmitComplete);
       });
 

--- a/packages/fxa-content-server/tests/functional/oauth_webchannel.js
+++ b/packages/fxa-content-server/tests/functional/oauth_webchannel.js
@@ -20,6 +20,7 @@ const {
   fillOutEmailFirstSignIn,
   fillOutEmailFirstSignUp,
   fillOutSignUpCode,
+  noSuchElement,
   openPage,
   openFxaFromRp,
   testElementExists,
@@ -66,6 +67,7 @@ registerSuite('oauth webchannel', {
         .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
         .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.ENGINE_BOOKMARKS))
         .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.ENGINE_HISTORY))
+        .then(noSuchElement(selectors.CHOOSE_WHAT_TO_SYNC.DO_NOT_SYNC))
         .then(click(selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT))
 
         .then(testElementExists(selectors.CONFIRM_SIGNUP_CODE.HEADER))

--- a/packages/fxa-content-server/tests/functional/sync_v3_sign_up.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_sign_up.js
@@ -53,6 +53,9 @@ registerSuite('Firefox Desktop Sync v3 signup', {
                 },
                 'fxaccounts:fxa_status': {
                   signedInUser: null,
+                  capabilities: {
+                    multiService: true,
+                  },
                 },
               },
             })
@@ -66,6 +69,7 @@ registerSuite('Firefox Desktop Sync v3 signup', {
           .then(
             noSuchElement(selectors.CHOOSE_WHAT_TO_SYNC.ENGINE_CREDIT_CARDS)
           )
+          .then(noSuchElement(selectors.CHOOSE_WHAT_TO_SYNC.DO_NOT_SYNC))
 
           .then(testIsBrowserNotified('fxaccounts:can_link_account'))
           .then(noSuchBrowserNotification('fxaccounts:login'))


### PR DESCRIPTION
Add a new capability `syncOptional` to auth_brokers, only
enable this capability in fx_desktop_v3 *if* the `multiService`
capability is returned from the browser.

fixes #3553

@vladikoff - r?

If approved, this needs to be uplifted to train-151