### PR TITLE
fix(buttons): Add `Not now` button back to sms page

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
@@ -21,6 +21,7 @@
     </div>
     <div class="links">
       <a href="/sms/why" data-flow-event="link.why" class="left">{{#t}}Why sign in on another device?{{/t}}</a>
+      <a href='https://www.mozilla.org/firefox/accounts' class="btn-not-now" data-flow-event="link.not_now">{{#t}}Not now{{/t}}</a>
     </div>
     <aside class="child-view"></aside>
 </div>

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -442,6 +442,7 @@ module.exports = {
     LINK_MARKETING: '.marketing-link',
     LINK_MARKETING_ANDROID: '.marketing-link-android',
     LINK_MARKETING_IOS: '.marketing-link-ios',
+    LINK_NOT_NOW: 'a[href="https://www.mozilla.org/firefox/accounts"]',
     LINK_START_BROWSING: 'a[href="https://www.mozilla.org/firefox/accounts"]',
     LINK_WHY_IS_THIS_REQUIRED: 'a[href="/sms/why"]',
     PHONE_NUMBER: 'input[type="tel"]',

--- a/packages/fxa-content-server/tests/functional/send_sms.js
+++ b/packages/fxa-content-server/tests/functional/send_sms.js
@@ -192,6 +192,12 @@ const suite = {
         .then(testElementExists(selectors.SMS_SEND.HEADER));
     },
 
+    'not now': function() {
+      return this.remote
+        .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))
+        .then(testElementExists(selectors.SMS_SEND.LINK_NOT_NOW));
+    },
+
     'empty phone number': function() {
       return this.remote
         .then(openPage(SEND_SMS_URL, selectors.SMS_SEND.HEADER))


### PR DESCRIPTION
Fixes #3597 

From https://github.com/mozilla/fxa/issues/3597#issuecomment-563440152, I opted to use `Not now`. Clicking the link will take you to the FxA product page in the same window.

<img width="560" alt="Screen Shot 2019-12-09 at 5 31 26 PM" src="https://user-images.githubusercontent.com/1295288/70478739-ca0f0a80-1aa9-11ea-9261-d43f21f3e981.png">


