### PR TITLE
feat(event-broker): use proper hapi/sqs filtering

### DIFF
--- a/packages/fxa-auth-server/lib/sentry.js
+++ b/packages/fxa-auth-server/lib/sentry.js
@@ -73,7 +73,7 @@ function filterSentryEvent(event, hint) {
     }
   }
   if (event.tags && event.tags.url) {
-    event.tags.url = event.request.url.replace(TOKENREGEX, FILTERED);
+    event.tags.url = event.tags.url.replace(TOKENREGEX, FILTERED);
   }
   return event;
 }

--- a/packages/fxa-event-broker/bin/worker.ts
+++ b/packages/fxa-event-broker/bin/worker.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { PubSub } from '@google-cloud/pubsub';
-import * as sentry from '@sentry/node';
 import { SQS } from 'aws-sdk';
 import mozlog from 'mozlog';
 
@@ -14,10 +13,11 @@ import { ServiceNotificationProcessor } from '../lib/notificationProcessor';
 import { proxyServerInit, ServerEnvironment } from '../lib/proxy-server';
 import { ClientCapabilityService } from '../lib/selfUpdatingService/clientCapabilityService';
 import { ClientWebhookService } from '../lib/selfUpdatingService/clientWebhookService';
+import { configureHapiSentry, configureSentry } from '../lib/sentry';
 import { version } from '../lib/version';
 
 // Initialize Sentry as early as possible
-sentry.init({ dsn: Config.get('sentryDsn'), release: version.version });
+configureSentry({ dsn: Config.get('sentryDsn'), release: version.version });
 
 const logger = mozlog(Config.get('log'))('notificationProcessor');
 
@@ -86,6 +86,7 @@ async function main() {
     metrics,
     webhookService
   );
+  configureHapiSentry(server);
   try {
     await server.start();
   } catch (err) {

--- a/packages/fxa-event-broker/bin/workerDev.ts
+++ b/packages/fxa-event-broker/bin/workerDev.ts
@@ -5,7 +5,6 @@
 import { Firestore } from '@google-cloud/firestore';
 import { PubSub } from '@google-cloud/pubsub';
 import * as grpc from '@grpc/grpc-js';
-import { init as sentryInit } from '@sentry/node';
 import AWS from 'aws-sdk';
 import { SQS } from 'aws-sdk';
 import { StatsD } from 'hot-shots';
@@ -17,9 +16,10 @@ import { ServiceNotificationProcessor } from '../lib/notificationProcessor';
 import { proxyServerInit, ServerEnvironment } from '../lib/proxy-server';
 import { ClientCapabilityService } from '../lib/selfUpdatingService/clientCapabilityService';
 import { ClientWebhookService } from '../lib/selfUpdatingService/clientWebhookService';
+import { configureHapiSentry, configureSentry } from '../lib/sentry';
 import { version } from '../lib/version';
 
-sentryInit({ enabled: false, release: version.version });
+configureSentry({ enabled: false, release: version.version });
 
 const NODE_ENV = Config.get('env');
 const logger = mozlog(Config.get('log'))('notificationProcessor');
@@ -160,6 +160,7 @@ async function main() {
     metrics,
     webhookService
   );
+  configureHapiSentry(server);
   await server.start();
 }
 

--- a/packages/fxa-event-broker/lib/notificationProcessor.ts
+++ b/packages/fxa-event-broker/lib/notificationProcessor.ts
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { PubSub } from '@google-cloud/pubsub';
-import * as sentry from '@sentry/node';
 import { SQS } from 'aws-sdk';
 import { StatsD } from 'hot-shots';
 import { Logger } from 'mozlog';
@@ -12,6 +11,7 @@ import { Consumer } from 'sqs-consumer';
 import { Datastore } from './db';
 import { ClientCapabilityService } from './selfUpdatingService/clientCapabilityService';
 import { ClientWebhookService } from './selfUpdatingService/clientWebhookService';
+import { configureSqsSentry } from './sentry';
 import {
   DELETE_EVENT,
   deleteSchema,
@@ -56,14 +56,15 @@ class ServiceNotificationProcessor {
     });
 
     this.app.on('error', err => {
-      sentry.captureException(err);
       logger.error('consumerError', { err });
     });
 
     this.app.on('processing_error', err => {
-      sentry.captureException(err);
       logger.error('processingError', { err });
     });
+
+    // Sentry error handling
+    configureSqsSentry(this.app);
 
     this.capabilityService = capabilityService;
     this.webhookService = webhookService;

--- a/packages/fxa-event-broker/lib/sentry.ts
+++ b/packages/fxa-event-broker/lib/sentry.ts
@@ -1,0 +1,180 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Hapi from '@hapi/hapi';
+import Hoek from '@hapi/hoek';
+import * as Sentry from '@sentry/node';
+import { SQS } from 'aws-sdk';
+import { Consumer } from 'sqs-consumer';
+import { PassThrough } from 'stream';
+
+// Matches uid, session, oauth and other common tokens which we would
+// prefer not to include in Sentry reports.
+const TOKENREGEX = /[a-fA-F0-9]{32,}/gi;
+// RFC 5322 generalized email regex, ~ 99.99% accurate.
+const EMAILREGEX = /(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/gi;
+const FILTERED = '[Filtered]';
+const URIENCODEDFILTERED = encodeURIComponent(FILTERED);
+
+interface HapiSentryRequest extends Hapi.Request {
+  sentryScope?: Sentry.Scope;
+}
+
+/**
+ * Filters all of an objects string properties to remove tokens.
+ *
+ * @param obj Object to filter values on
+ */
+function filterObject(obj: object) {
+  if (typeof obj === 'object' && obj) {
+    for (const [key, value] of Object.entries(obj)) {
+      if (typeof value === 'string') {
+        // Typescript can't quite infer that this is the value that was
+        // at that index, so a cast is needed.
+        (obj as any)[key] = value.replace(TOKENREGEX, FILTERED).replace(EMAILREGEX, FILTERED);
+      }
+    }
+  }
+  return obj;
+}
+
+/**
+ * Filter a sentry event for PII in addition to the default filters.
+ *
+ * Current replacements:
+ *   - A 32-char hex string that typically is a FxA user-id.
+ *
+ * Data Removed:
+ *   - Request body.
+ *
+ * @param event
+ */
+function filterSentryEvent(event: Sentry.Event, hint: unknown) {
+  if (event.message) {
+    event.message = event.message.replace(TOKENREGEX, FILTERED);
+  }
+  if (event.breadcrumbs) {
+    for (const bc of event.breadcrumbs) {
+      if (bc.message) {
+        bc.message = bc.message.replace(TOKENREGEX, FILTERED);
+      }
+      if (bc.data) {
+        bc.data = filterObject(bc.data);
+      }
+    }
+  }
+  if (event.request) {
+    if (event.request.url) {
+      event.request.url = event.request.url.replace(TOKENREGEX, FILTERED);
+    }
+    if (event.request.query_string) {
+      event.request.query_string = event.request.query_string.replace(
+        TOKENREGEX,
+        URIENCODEDFILTERED
+      );
+    }
+    if (event.request.headers) {
+      (event as any).request.headers = filterObject(event.request.headers);
+    }
+    if (event.request.data) {
+      // Remove request data entirely
+      delete event.request.data;
+    }
+  }
+  if (event.tags && event.tags.url) {
+    event.tags.url = event.tags.url.replace(TOKENREGEX, FILTERED);
+  }
+  return event;
+}
+
+/**
+ * Capture a SQS Error to Sentry with additional context.
+ *
+ * @param err Error object to capture.
+ * @param message SQS Message to include with error.
+ */
+function captureSqsError(err: Error, message?: SQS.Message) {
+  Sentry.withScope(scope => {
+    if (message?.Body) {
+      if (typeof message.Body === 'string') {
+        message.Body = message.Body.replace(TOKENREGEX, FILTERED).replace(EMAILREGEX, FILTERED);
+      }
+      scope.setContext('SQS Message', message);
+    }
+    Sentry.captureException(err);
+  });
+}
+
+/**
+ * Configure Sentry with additional Sentry event filtering.
+ *
+ * @param options Sentry options to include.
+ */
+export function configureSentry(options?: Sentry.NodeOptions) {
+  Sentry.init({
+    ...options,
+    beforeSend(event, hint) {
+      return filterSentryEvent(event, hint);
+    }
+  });
+}
+
+/**
+ * Configure Sentry to capture SQS Consumer errors.
+ *
+ * @param consumer SQS Consumer to capture errors on.
+ */
+export function configureSqsSentry(consumer: Consumer) {
+  consumer.on('error', (err, message) => {
+    captureSqsError(err, message);
+  });
+
+  consumer.on('processing_error', (err, message) => {
+    captureSqsError(err, message);
+  });
+}
+
+/**
+ * Configure Sentry to capture Hapi errors and include additional context.
+ *
+ * @param server Hapi Server to capture errors for.
+ */
+export function configureHapiSentry(server: Hapi.Server) {
+  // Attach a new Sentry scope to the request for breadcrumbs/tags/extras
+  server.ext({
+    type: 'onRequest',
+    method(request: HapiSentryRequest, h) {
+      request.sentryScope = new Sentry.Scope();
+      return h.continue;
+    }
+  });
+
+  // Sentry handler for hapi errors
+  server.events.on({ name: 'request', channels: 'error' }, (request: HapiSentryRequest, event) => {
+    const err = event?.error as Error | undefined;
+    let exception = '';
+    if (err?.stack) {
+      try {
+        exception = err.stack.split('\n')[0];
+      } catch (e) {
+        // ignore bad stack frames
+      }
+    }
+
+    Sentry.withScope(scope => {
+      scope.addEventProcessor(scopedSentryEvent => {
+        const sentryEvent = Sentry.Handlers.parseRequest(scopedSentryEvent, request.raw.req);
+        sentryEvent.level = Sentry.Severity.Error;
+        return sentryEvent;
+      });
+      scope.setExtra('exception', exception);
+
+      // Merge the request scope into the temp scope
+      if (request.sentryScope) {
+        Hoek.merge(scope, request.sentryScope);
+      }
+      Sentry.captureException(err);
+    });
+  });
+}

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -31,6 +31,7 @@
     "@google-cloud/firestore": "^2.6.0",
     "@google-cloud/pubsub": "^1.1.5",
     "@hapi/hapi": "^18.4.0",
+    "@hapi/hoek": "^8.5.0",
     "@hapi/joi": "^16.1.7",
     "@sentry/node": "^5.8.0",
     "aws-sdk": "^2.569.0",

--- a/packages/fxa-event-broker/test/lib/notificationProcessor.spec.ts
+++ b/packages/fxa-event-broker/test/lib/notificationProcessor.spec.ts
@@ -29,7 +29,7 @@ const baseMessage = {
   event: 'login',
   timestamp: now,
   ts: now / 1000,
-  uid: '1e2122ba'
+  uid: '993d26bac72b471991b197b3d298a5de'
 };
 
 const baseLoginMessage = {

--- a/packages/fxa-event-broker/test/lib/sentry.ts
+++ b/packages/fxa-event-broker/test/lib/sentry.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'sinon';
+
+import { configureSentry } from '../../lib/sentry';
+
+describe('Sentry', () => {
+  it('can be set up when sentry is enabled', async () => {
+    const dsn = 'https://deadbeef:deadbeef@127.0.0.1/123';
+    try {
+      await configureSentry({ dsn });
+    } catch (err) {
+      assert.fail('Should not throw');
+    }
+  });
+
+  it('can be set up when sentry is not enabled', async () => {
+    try {
+      await configureSentry({ enabled: false });
+    } catch (err) {
+      assert.fail('Should not throw');
+    }
+  });
+});


### PR DESCRIPTION
Because:

* The stock Sentry plugin has limitations on what details it filters
  from the error details.
* We've customized Hapi error reporting Sentry for auth-server and have
  not used those elsewhere.

This commit:

* Brings over the Hapi Sentry configuration used in auth-server that
  filters out additional PII such as uid's.
* Add's a new SQS Sentry configuration that capatures additional Sentry
  details for SQS processing failures.

Closes #3422