### PR TITLE
fix(metrics): Ensure metrics are flushed before redirecting to external links

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
@@ -99,8 +99,8 @@ export default BaseAuthenticationBroker.extend({
    * @returns {Promise}
    */
   sendOAuthResultToRelier(result) {
-    return Promise.resolve().then(() => {
-      var extraParams = {};
+    return this._metrics.flush().then(() => {
+      const extraParams = {};
       if (result.error) {
         extraParams.error = result.error;
       }
@@ -349,18 +349,18 @@ export default BaseAuthenticationBroker.extend({
   finishOAuthFlow(account, additionalResultData) {
     this.session.clear('oauth');
 
-    return Promise.resolve().then(() => {
-      // There are no ill side effects if the Original Tab Marker is
-      // cleared in the a tab other than the original. Always clear it just
-      // to make sure the bases are covered.
-      this.clearOriginalTabMarker();
-      return this.getOAuthResult(account).then(result => {
-        result = _.extend(result, additionalResultData);
-
-        return this._metrics.flush().then(() => {
-          return this.sendOAuthResultToRelier(result, account);
-        });
-      });
+    // There are no ill side effects if the Original Tab Marker is
+    // cleared in the a tab other than the original. Always clear it just
+    // to make sure the bases are covered.
+    this.clearOriginalTabMarker();
+    return this.getOAuthResult(account).then(result => {
+      return this.sendOAuthResultToRelier(
+        {
+          ...result,
+          ...additionalResultData,
+        },
+        account
+      );
     });
   },
 

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
@@ -112,8 +112,9 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
     if (state) {
       result.state = state;
     }
-
-    return this.send(this.getCommand('OAUTH_LOGIN'), result);
+    return this._metrics.flush().then(() => {
+      return this.send(this.getCommand('OAUTH_LOGIN'), result);
+    });
   },
 });
 

--- a/packages/fxa-content-server/app/scripts/views/mixins/external-links-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/external-links-mixin.js
@@ -28,7 +28,6 @@ export default {
    * Interceptor function. Flushes metrics before redirecting.
    *
    * @param {Event} event - click event
-   * @returns {Promise}
    */
   _onExternalLinkClick(event) {
     if (this._shouldIgnoreClick(event)) {
@@ -37,7 +36,7 @@ export default {
 
     event.preventDefault();
 
-    return this._flushMetricsThenRedirect(event.currentTarget.href);
+    this.navigateAway(event.currentTarget.href);
   },
 
   /**
@@ -80,20 +79,5 @@ export default {
    */
   _doesLinkOpenInAnotherTab($targetEl) {
     return !!$targetEl.attr('target');
-  },
-
-  /**
-   * Flush metrics, then redirect to `url`.
-   *
-   * @param {String} url
-   * @returns {Promise}
-   * @private
-   */
-  _flushMetricsThenRedirect(url) {
-    // Safari for iOS will not flush the metrics in an `unload`
-    // handler, so do it manually before redirecting.
-    return this.metrics.flush().then(() => {
-      this.window.location = url;
-    });
   },
 };

--- a/packages/fxa-content-server/app/scripts/views/ready.js
+++ b/packages/fxa-content-server/app/scripts/views/ready.js
@@ -133,7 +133,7 @@ const View = FormView.extend({
   },
 
   gotoProductPage() {
-    this.window.location.href = FXA_PRODUCT_PAGE_URL;
+    this.navigateAway(FXA_PRODUCT_PAGE_URL);
   },
 
   gotoSettings() {

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-redirect.js
@@ -89,13 +89,9 @@ describe('models/auth_brokers/oauth-redirect', () => {
 
   describe('afterSignInConfirmationPoll', () => {
     it('calls sendOAuthResultToRelier with the correct options', () => {
-      sinon.stub(broker, 'sendOAuthResultToRelier').callsFake(() => {
-        return Promise.resolve();
-      });
+      sinon.stub(broker, 'sendOAuthResultToRelier').resolves();
 
       return broker.afterSignInConfirmationPoll(account).then(behavior => {
-        assert.isTrue(metrics.flush.calledOnce);
-        assert.lengthOf(metrics.flush.getCall(0).args, 0);
         assert.isTrue(
           broker.finishOAuthFlow.calledWith(account, {
             action: Constants.OAUTH_ACTION_SIGNIN,
@@ -263,17 +259,12 @@ describe('models/auth_brokers/oauth-redirect', () => {
 
   describe('sendOAuthResultToRelier', () => {
     describe('with no error', () => {
-      it('prepares window to be closed', () => {
-        return broker
-          .sendOAuthResultToRelier({
-            redirect: REDIRECT_TO,
-          })
-          .then(() => {
-            assert.equal(
-              windowMock.location.href,
-              `${REDIRECT_TO}?state=state`
-            );
-          });
+      it('flushes metrics, prepares window to be closed', async () => {
+        await broker.sendOAuthResultToRelier({
+          redirect: REDIRECT_TO,
+        });
+        assert.isTrue(metrics.flush.calledOnce);
+        assert.equal(windowMock.location.href, `${REDIRECT_TO}?state=state`);
       });
     });
 

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
@@ -145,98 +145,93 @@ describe('models/auth_brokers/oauth-webchannel-v1', () => {
     });
   });
 
-  it('passes code and state', () => {
-    return broker
-      .sendOAuthResultToRelier({
-        code: 'code',
-        state: 'state',
-      })
-      .then(() => {
-        const loginMsg = broker.send.getCall(0).args;
-        assert.equal(loginMsg[0], OAUTH_LOGIN_MESSAGE);
-        assert.deepEqual(loginMsg[1], {
-          code: 'code',
-          state: 'state',
-          redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
-        });
-      });
+  it('passes code and state', async () => {
+    await broker.sendOAuthResultToRelier({
+      code: 'code',
+      state: 'state',
+    });
+
+    assert.isTrue(metrics.flush.calledOnce);
+    const loginMsg = broker.send.getCall(0).args;
+    assert.equal(loginMsg[0], OAUTH_LOGIN_MESSAGE);
+    assert.deepEqual(loginMsg[1], {
+      code: 'code',
+      state: 'state',
+      redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
+    });
   });
 
-  it('handles declinedSyncEngines and offeredSyncEngines', () => {
+  it('handles declinedSyncEngines and offeredSyncEngines', async () => {
     account.set('declinedSyncEngines', ['history']);
     account.set('offeredSyncEngines', ['history']);
 
-    return broker
-      .sendOAuthResultToRelier(
-        {
-          redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
-        },
-        account
-      )
-      .then(() => {
-        const loginMsg = broker.send.getCall(0).args;
-        assert.equal(loginMsg[0], OAUTH_LOGIN_MESSAGE);
-        assert.deepEqual(loginMsg[1], {
-          declinedSyncEngines: ['history'],
-          offeredSyncEngines: ['history'],
-          redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
-          state: 'state',
-        });
-      });
+    await broker.sendOAuthResultToRelier(
+      {
+        redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
+      },
+      account
+    );
+
+    assert.isTrue(metrics.flush.calledOnce);
+    const loginMsg = broker.send.getCall(0).args;
+    assert.equal(loginMsg[0], OAUTH_LOGIN_MESSAGE);
+    assert.deepEqual(loginMsg[1], {
+      declinedSyncEngines: ['history'],
+      offeredSyncEngines: ['history'],
+      redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
+      state: 'state',
+    });
   });
 
   describe('login with an error', () => {
-    it('appends an error query parameter', () => {
-      return broker
-        .sendOAuthResultToRelier({
-          error: 'error',
-        })
-        .then(() => {
-          const loginMsg = broker.send.getCall(0).args;
-          assert.equal(loginMsg[0], OAUTH_LOGIN_MESSAGE);
-          assert.deepEqual(loginMsg[1], {
-            error: 'error',
-            redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
-            state: 'state',
-          });
-        });
+    it('appends an error query parameter', async () => {
+      await broker.sendOAuthResultToRelier({
+        error: 'error',
+      });
+
+      assert.isTrue(metrics.flush.calledOnce);
+      const loginMsg = broker.send.getCall(0).args;
+      assert.equal(loginMsg[0], OAUTH_LOGIN_MESSAGE);
+      assert.deepEqual(loginMsg[1], {
+        error: 'error',
+        redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
+        state: 'state',
+      });
     });
   });
 
   describe('login with an action', () => {
-    it('appends an action query parameter', () => {
+    it('appends an action query parameter', async () => {
       const action = Constants.OAUTH_ACTION_SIGNIN;
-      return broker
-        .sendOAuthResultToRelier({
-          action: action,
-        })
-        .then(() => {
-          const loginMsg = broker.send.getCall(0).args;
-          assert.equal(loginMsg[0], OAUTH_LOGIN_MESSAGE);
-          assert.deepEqual(loginMsg[1], {
-            action: action,
-            redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
-            state: 'state',
-          });
-        });
+      await broker.sendOAuthResultToRelier({
+        action: action,
+      });
+
+      assert.isTrue(metrics.flush.calledOnce);
+      const loginMsg = broker.send.getCall(0).args;
+      assert.equal(loginMsg[0], OAUTH_LOGIN_MESSAGE);
+      assert.deepEqual(loginMsg[1], {
+        action: action,
+        redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
+        state: 'state',
+      });
     });
   });
 
   describe('login with existing query parameters', () => {
-    it('passes through existing parameters unchanged', () => {
-      return broker
-        .sendOAuthResultToRelier({
-          error: 'error',
-        })
-        .then(() => {
-          const loginMsg = broker.send.getCall(0).args;
-          assert.equal(loginMsg[0], OAUTH_LOGIN_MESSAGE);
-          assert.deepEqual(loginMsg[1], {
-            error: 'error',
-            redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
-            state: 'state',
-          });
-        });
+    it('passes through existing parameters unchanged', async () => {
+      await broker.sendOAuthResultToRelier({
+        error: 'error',
+      });
+
+      assert.isTrue(metrics.flush.calledOnce);
+      const loginMsg = broker.send.getCall(0).args;
+      assert.equal(loginMsg[0], OAUTH_LOGIN_MESSAGE);
+      assert.deepEqual(loginMsg[1], {
+        error: 'error',
+        redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
+        state: 'state',
+      });
     });
   });
 });

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/external-links-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/external-links-mixin.js
@@ -45,27 +45,22 @@ describe('views/mixins/external-links-mixin', function() {
   describe('_onExternalLinkClick', () => {
     it('does nothing of the link is ignored', () => {
       sinon.stub(view, '_shouldIgnoreClick').callsFake(() => true);
-      sinon
-        .stub(view, '_flushMetricsThenRedirect')
-        .callsFake(() => Promise.resolve());
+      sinon.stub(view, 'navigateAway');
 
       const event = {
         preventDefault: sinon.spy(),
         stopImmediatePropagation: sinon.spy(),
       };
 
-      return view._onExternalLinkClick(event).then(() => {
-        assert.isFalse(event.preventDefault.called);
-        assert.isFalse(event.stopImmediatePropagation.called);
-        assert.isFalse(view._flushMetricsThenRedirect.called);
-      });
+      view._onExternalLinkClick(event);
+      assert.isFalse(event.preventDefault.called);
+      assert.isFalse(event.stopImmediatePropagation.called);
+      assert.isFalse(view.navigateAway.called);
     });
 
     it('handles links that should be handled (cancel event, flush metrics)', () => {
       sinon.stub(view, '_shouldIgnoreClick').callsFake(() => false);
-      sinon
-        .stub(view, '_flushMetricsThenRedirect')
-        .callsFake(() => Promise.resolve());
+      sinon.stub(view, 'navigateAway');
 
       const event = {
         currentTarget: {
@@ -74,11 +69,9 @@ describe('views/mixins/external-links-mixin', function() {
         preventDefault: sinon.spy(),
       };
 
-      return view._onExternalLinkClick(event).then(() => {
-        assert.isTrue(event.preventDefault.calledOnce);
-        assert.isTrue(view._flushMetricsThenRedirect.calledOnce);
-        assert.isTrue(view._flushMetricsThenRedirect.calledWith('url'));
-      });
+      view._onExternalLinkClick(event);
+      assert.isTrue(event.preventDefault.calledOnce);
+      assert.isTrue(view.navigateAway.calledOnceWith('url'));
     });
   });
 
@@ -175,17 +168,6 @@ describe('views/mixins/external-links-mixin', function() {
       };
 
       assert.isFalse(view._doesLinkOpenInAnotherTab($targetEl));
-    });
-  });
-
-  describe('_flushMetricsThenRedirect', () => {
-    it('flushes the metrics, then redirects', () => {
-      sinon.stub(metrics, 'flush').callsFake(() => Promise.resolve());
-
-      return view._flushMetricsThenRedirect('url').then(() => {
-        assert.isTrue(metrics.flush.calledOnce);
-        assert.equal(windowMock.location, 'url');
-      });
     });
   });
 });

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/sync-suggestion-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/sync-suggestion-mixin.js
@@ -143,12 +143,7 @@ describe('views/mixins/sync-suggestion-mixin', () => {
     });
 
     it('logs the link.signin event', () => {
-      // Without the _flusthMetricsThenRedirect override, the test
-      // causes the page to redirect.
       sinon.stub(view, 'isSyncSuggestionEnabled').callsFake(() => true);
-      sinon
-        .stub(view, '_flushMetricsThenRedirect')
-        .callsFake(() => Promise.resolve());
       sinon.stub(view, 'logFlowEvent').callsFake(() => {});
 
       return view.render().then(() => {


### PR DESCRIPTION
Metrics were not always flushed before redirecting to external sites,
e.g., the product page on /*_confirmed and even sometimes when
redirecting back to an OAuth RP.

This ensures metrics are always flushed before setting the
href.

fixes #3619

@mozilla/fxa-devs - r?