### PR TITLE
chore(test): Remove duplicate "settings unverified" tests

### DIFF
--- a/packages/fxa-content-server/tests/functional/settings.js
+++ b/packages/fxa-content-server/tests/functional/settings.js
@@ -246,30 +246,6 @@ registerSuite('settings', {
   },
 });
 
-registerSuite('settings unverified', {
-  beforeEach: function() {
-    email = TestHelpers.createEmail();
-
-    return this.remote
-      .then(createUser(email, FIRST_PASSWORD))
-      .then(clearBrowserState({ force: true }))
-
-      .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-      .then(fillOutEmailFirstSignIn(email, FIRST_PASSWORD))
-
-      .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER));
-  },
-  tests: {
-    'visit settings page with an unverified account redirects to confirm': function() {
-      return (
-        this.remote
-          // Expect to get redirected to confirm since the account is unverified
-          .then(openPage(SETTINGS_URL, selectors.CONFIRM_SIGNUP.HEADER))
-      );
-    },
-  },
-});
-
 registerSuite('settings with expired session', {
   beforeEach: function() {
     email = TestHelpers.createEmail();


### PR DESCRIPTION
These tests are duplicates of https://github.com/mozilla/fxa/blob/8ae67865ea9f277a6cab4381837c0ba3dd85abe6/packages/fxa-content-server/tests/functional/settings_common.js#L42.
No point having 2.

Not attached to an issue

@mozilla/fxa-devs - r?