### PR TITLE
Set `service` tag for metrics events based on fxa_status response.

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/metrics.js
+++ b/packages/fxa-content-server/app/scripts/lib/metrics.js
@@ -585,6 +585,17 @@ _.extend(Metrics.prototype, Backbone.Events, {
   },
 
   /**
+   * Set the `service` parameter to use for all future metrics.
+   * This is useful in cases where don't learn the appropriate
+   * service value until after the app has been initialized.
+   *
+   * @param {String} [service] The service identifier
+   */
+  setService(service) {
+    this._service = service || NOT_REPORTED_VALUE;
+  },
+
+  /**
    * Set the view name prefix for metrics that contain a viewName.
    * This is used to differentiate between flows when the same
    * URL can appear in more than one place in the flow, e.g., the

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-sync.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-sync.js
@@ -67,6 +67,7 @@ export default BaseAuthenticationBroker.extend({
         // the service in the query parameter currently overrides the status message
         // this is due to backwards compatibility
         this.relier.set('service', response.clientId);
+        this._metrics.setService(response.clientId);
       }
     }
     const additionalEngineIds =

--- a/packages/fxa-content-server/app/tests/spec/lib/metrics.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/metrics.js
@@ -704,6 +704,15 @@ describe('lib/metrics', () => {
     });
   });
 
+  describe('setService', function() {
+    it('sets the service identifier', function() {
+      metrics.setService('00112233445566');
+      const { service } = metrics.getFilteredData();
+
+      assert.equal(service, '00112233445566');
+    });
+  });
+
   describe('isCollectionEnabled', () => {
     it('reports that collection is enabled if `isSampledUser===true`', () => {
       assert.isTrue(metrics.isCollectionEnabled());


### PR DESCRIPTION
Because:

* Metrics events for the sync-optional flow currently have a missing
  `service` attribute.
* The sync-optional flow does not learn the client_id of the
  connecting application until it receives the `fxa_status` message.

This commit:

* Explicitly sets the `service` attribute on the metrics object
  when handling the `fxa_status` message response.

Fixes #3611.