### PR TITLE
fix(metrics): Flush metrics any time messages are sent to the browser

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-ios-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/fx-ios-v1.js
@@ -83,17 +83,6 @@ export default FxSyncChannelAuthenticationBroker.extend({
   },
 
   /**
-   * Notify the relier of login.
-   *
-   * @param {Object} account
-   * @returns {Promise}
-   * @private
-   */
-  _notifyRelierOfLogin(account) {
-    return proto._notifyRelierOfLogin.call(this, account);
-  },
-
-  /**
    * Notify the relier that a sign-in with a code was performed.
    *
    * @param {Object} account

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
@@ -36,7 +36,6 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
     this.session = options.session;
     this._channel = options.channel;
     this._scopedKeys = ScopedKeys;
-    this._metrics = options.metrics;
     options.fxaStatus = true;
 
     proto.initialize.call(this, options);
@@ -112,9 +111,7 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
     if (state) {
       result.state = state;
     }
-    return this._metrics.flush().then(() => {
-      return this.send(this.getCommand('OAUTH_LOGIN'), result);
-    });
+    return this.send(this.getCommand('OAUTH_LOGIN'), result);
   },
 });
 

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-fennec-v1.js
@@ -23,6 +23,7 @@ describe('models/auth_brokers/fx-fennec-v1', function() {
   beforeEach(function() {
     channel = new NullChannel();
     metrics = {
+      flush: sinon.stub().resolves({}),
       setViewNamePrefix: sinon.spy(),
     };
     relier = new Relier();

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync-channel.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/fx-sync-channel.js
@@ -17,10 +17,15 @@ describe('models/auth_brokers/fx-sync-channel', () => {
   let broker;
   let relier;
   let channelMock;
+  let metrics;
   let user;
   let windowMock;
 
   function createAuthBroker(options = {}) {
+    metrics = {
+      flush: sinon.stub().resolves({}),
+      setViewNamePrefix: sinon.spy(),
+    };
     broker = new FxSyncChannelAuthenticationBroker({
       channel: channelMock,
       commands: {
@@ -34,9 +39,7 @@ describe('models/auth_brokers/fx-sync-channel', () => {
         */
         VERIFIED: 'verified',
       },
-      metrics: {
-        setViewNamePrefix: sinon.spy(),
-      },
+      metrics,
       window: windowMock,
       relier,
       ...options,
@@ -85,6 +88,7 @@ describe('models/auth_brokers/fx-sync-channel', () => {
   describe('afterLoaded', () => {
     it('sends a `loaded` message', () => {
       return broker.afterLoaded().then(() => {
+        assert.isTrue(metrics.flush.calledOnce);
         assert.isTrue(channelMock.send.calledWith('loaded'));
       });
     });
@@ -95,8 +99,8 @@ describe('models/auth_brokers/fx-sync-channel', () => {
       channelMock.request = sinon.spy(() => Promise.resolve({ ok: true }));
 
       return broker.beforeSignIn(account).then(() => {
-        assert.isTrue(channelMock.request.calledOnce);
-        assert.isTrue(channelMock.request.calledWith('can_link_account'));
+        assert.isTrue(metrics.flush.calledOnce);
+        assert.isTrue(channelMock.request.calledOnceWith('can_link_account'));
       });
     });
 


### PR DESCRIPTION
While writing docs on how to ensure metrics are flushed before
FxA closes, I realized we could probably automate this. Any
time we send a notice to the browser, flush metrics first.

issue #3213

@mozilla/fxa-devs - r?