### PR TITLE
refactor(tests): Expose all TestHelpers within FunctionalHelpers.

### DIFF
--- a/packages/fxa-content-server/tests/functional/avatar.js
+++ b/packages/fxa-content-server/tests/functional/avatar.js
@@ -7,7 +7,6 @@
 const { registerSuite } = intern.getInterface('object');
 const assert = intern.getPlugin('chai').assert;
 const path = require('path');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const uaStrings = require('./lib/ua-strings');
 const selectors = require('./lib/selectors');
@@ -36,6 +35,7 @@ let email;
 const {
   clearBrowserState,
   click,
+  createEmail,
   createUser,
   fillOutEmailFirstSignIn,
   imageLoadedByQSA,
@@ -48,7 +48,7 @@ const {
 
 registerSuite('settings/avatar', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote
       .then(createUser(email, PASSWORD, { preVerified: true }))

--- a/packages/fxa-content-server/tests/functional/bounced_email.js
+++ b/packages/fxa-content-server/tests/functional/bounced_email.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
@@ -22,6 +21,7 @@ const {
   clearBrowserState,
   click,
   closeCurrentWindow,
+  createEmail,
   createUser,
   fillOutEmailFirstSignIn,
   fillOutEmailFirstSignUp,
@@ -40,8 +40,8 @@ const {
 
 registerSuite('signup with an email that bounces', {
   beforeEach: function() {
-    bouncedEmail = TestHelpers.createEmail();
-    deliveredEmail = TestHelpers.createEmail();
+    bouncedEmail = createEmail();
+    deliveredEmail = createEmail();
     return (
       this.remote
         .then(clearBrowserState())
@@ -116,7 +116,7 @@ registerSuite('signup with an email that bounces', {
 
 const setUpBouncedSignIn = thenify(function(email) {
   const client = getFxaClient();
-  email = email || TestHelpers.createEmail('sync{id}');
+  email = email || createEmail('sync{id}');
 
   return this.parent
     .then(clearBrowserState({ force: true }))
@@ -150,7 +150,7 @@ registerSuite('signin with an email that bounces', {
     },
 
     'click back': function() {
-      const email = TestHelpers.createEmail('sync{id}');
+      const email = createEmail('sync{id}');
       return this.remote
         .then(setUpBouncedSignIn(email))
         .then(click(selectors.SIGNIN_BOUNCED.BACK))

--- a/packages/fxa-content-server/tests/functional/change_password.js
+++ b/packages/fxa-content-server/tests/functional/change_password.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -21,6 +20,7 @@ let email;
 const {
   clearBrowserState,
   click,
+  createEmail,
   createUser,
   denormalizeStoredEmail,
   fillOutChangePassword,
@@ -54,7 +54,7 @@ const setupTest = thenify(function(options = {}) {
 
 registerSuite('change_password', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
   },
 
   tests: {

--- a/packages/fxa-content-server/tests/functional/complete_sign_up.js
+++ b/packages/fxa-content-server/tests/functional/complete_sign_up.js
@@ -6,7 +6,7 @@
 
 const { registerSuite } = intern.getInterface('object');
 const Constants = require('../../app/scripts/lib/constants');
-const { createEmail, createRandomHexString } = require('../lib/helpers');
+const { createRandomHexString } = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -19,6 +19,7 @@ let code;
 let uid;
 
 const {
+  createEmail,
   createUser,
   getVerificationLink,
   noSuchElement,

--- a/packages/fxa-content-server/tests/functional/connect_another_device.js
+++ b/packages/fxa-content-server/tests/functional/connect_another_device.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const UA_STRINGS = require('./lib/ua-strings');
 const selectors = require('./lib/selectors');
@@ -30,6 +29,7 @@ const CHANNEL_COMMAND_CAN_LINK_ACCOUNT = 'fxaccounts:can_link_account';
 
 const {
   clearBrowserState,
+  createEmail,
   fillOutEmailFirstSignUp,
   noSuchElement,
   openPage,
@@ -42,7 +42,7 @@ const PASSWORD = 'password12345678';
 
 registerSuite('connect_another_device', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
 
     return this.remote.then(clearBrowserState({ force: true }));
   },

--- a/packages/fxa-content-server/tests/functional/delete_account.js
+++ b/packages/fxa-content-server/tests/functional/delete_account.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const config = intern._config;
@@ -18,6 +17,7 @@ let email;
 const {
   clearBrowserState,
   click,
+  createEmail,
   createUser,
   fillOutDeleteAccount,
   fillOutEmailFirstSignIn,
@@ -29,7 +29,7 @@ const {
 
 registerSuite('delete_account', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote
       .then(clearBrowserState({ force: true }))

--- a/packages/fxa-content-server/tests/functional/email_opt_in.js
+++ b/packages/fxa-content-server/tests/functional/email_opt_in.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const PAGE_URL = intern._config.fxaContentRoot + '?action=email';
@@ -15,6 +14,7 @@ const PASSWORD = '12345678';
 
 const {
   clearBrowserState,
+  createEmail,
   createUser,
   fillOutEmailFirstSignIn,
   openPage,
@@ -27,7 +27,7 @@ registerSuite('communication preferences', {
   beforeEach: function() {
     // The plus sign is to ensure the email address is URI-encoded when
     // passed to basket. See a43061d3
-    email = TestHelpers.createEmail('signup{id}+extra');
+    email = createEmail('signup{id}+extra');
     return this.remote
       .then(createUser(email, PASSWORD, { preVerified: true }))
       .then(clearBrowserState());

--- a/packages/fxa-content-server/tests/functional/email_service.js
+++ b/packages/fxa-content-server/tests/functional/email_service.js
@@ -6,12 +6,12 @@
 
 const { registerSuite } = intern.getInterface('object');
 const assert = intern.getPlugin('chai').assert;
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
 const {
   clearBrowserState,
+  createEmail,
   fillOutEmailFirstSignUp,
   getEmailHeaders,
   openPage,
@@ -28,13 +28,12 @@ registerSuite('email_service', {
 
   tests: {
     'email_service works': function() {
-      const email = TestHelpers.createEmail('emailservice.{id}');
-      const user = TestHelpers.emailToUser(email);
+      const email = createEmail('emailservice.{id}');
 
       return this.remote
         .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
         .then(fillOutEmailFirstSignUp(email, PASSWORD))
-        .then(getEmailHeaders(user, 0))
+        .then(getEmailHeaders(email, 0))
         .then(headers => {
           assert.equal(
             headers['x-email-service'],

--- a/packages/fxa-content-server/tests/functional/force_auth.js
+++ b/packages/fxa-content-server/tests/functional/force_auth.js
@@ -5,13 +5,14 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
+const { createUID } = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
 const {
   clearBrowserState,
   click,
+  createEmail,
   createUser,
   fillOutForceAuth,
   openForceAuth,
@@ -33,7 +34,7 @@ let email;
 
 registerSuite('force_auth', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote.then(clearBrowserState());
   },
@@ -111,7 +112,7 @@ registerSuite('force_auth', {
           openForceAuth({
             query: {
               email: email,
-              uid: TestHelpers.createUID(),
+              uid: createUID(),
             },
           })
         )
@@ -172,7 +173,7 @@ registerSuite('force_auth', {
             openForceAuth({
               query: {
                 email: email,
-                uid: TestHelpers.createUID(),
+                uid: createUID(),
               },
             })
           )

--- a/packages/fxa-content-server/tests/functional/force_auth_blocked.js
+++ b/packages/fxa-content-server/tests/functional/force_auth_blocked.js
@@ -5,28 +5,30 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 var config = intern._config;
 var PAGE_URL = config.fxaContentRoot + 'force_auth';
 var PASSWORD = 'password';
 var email;
 
-var clearBrowserState = FunctionalHelpers.clearBrowserState;
-var createUser = FunctionalHelpers.createUser;
-var fillOutForceAuth = FunctionalHelpers.fillOutForceAuth;
-var fillOutSignInUnblock = FunctionalHelpers.fillOutSignInUnblock;
-var openPage = FunctionalHelpers.openPage;
-var testErrorTextInclude = FunctionalHelpers.testErrorTextInclude;
-var testElementExists = FunctionalHelpers.testElementExists;
-var testElementTextInclude = FunctionalHelpers.testElementTextInclude;
-var visibleByQSA = FunctionalHelpers.visibleByQSA;
+const {
+  clearBrowserState,
+  createEmail,
+  createUser,
+  fillOutForceAuth,
+  fillOutSignInUnblock,
+  openPage,
+  testErrorTextInclude,
+  testElementExists,
+  testElementTextInclude,
+  visibleByQSA,
+} = FunctionalHelpers;
 
 var forceAuthPageUrl;
 
 registerSuite('force_auth blocked', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('blocked{id}');
+    email = createEmail('blocked{id}');
 
     forceAuthPageUrl = PAGE_URL + '?email=' + encodeURIComponent(email);
 

--- a/packages/fxa-content-server/tests/functional/fx_browser_relier.js
+++ b/packages/fxa-content-server/tests/functional/fx_browser_relier.js
@@ -6,7 +6,6 @@
 
 const { assert } = intern.getPlugin('chai');
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
@@ -27,6 +26,7 @@ const PASSWORD = 'passwordvx2';
 const {
   clearBrowserState,
   click,
+  createEmail,
   createUser,
   fillOutEmailFirstSignUp,
   fillOutSignUpCode,
@@ -38,7 +38,7 @@ const {
 
 registerSuite('Firefox Desktop non-sync', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
     return this.remote.then(clearBrowserState({ force: true }));
   },
 
@@ -189,7 +189,7 @@ registerSuite('Firefox Desktop non-sync', {
 
 registerSuite('Firefox Desktop non-sync - CWTS on signup', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('signupPasswordCWTS.treatment{id}');
+    email = createEmail('signupPasswordCWTS.treatment{id}');
     return this.remote.then(clearBrowserState());
   },
 

--- a/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js
+++ b/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
@@ -46,6 +45,8 @@ const PASSWORD = '12345678';
 const {
   click,
   clearBrowserState,
+  createEmail,
+  createPhoneNumber,
   createUser,
   deleteAllSms,
   disableInProd,
@@ -63,7 +64,7 @@ const ensureUsers = thenify(function() {
   return this.parent
     .then(() => {
       if (!browserSignedInAccount) {
-        browserSignedInEmail = TestHelpers.createEmail();
+        browserSignedInEmail = createEmail();
         return this.parent
           .then(
             createUser(browserSignedInEmail, PASSWORD, { preVerified: true })
@@ -77,7 +78,7 @@ const ensureUsers = thenify(function() {
     })
     .then(() => {
       if (!otherAccount) {
-        otherEmail = TestHelpers.createEmail();
+        otherEmail = createEmail();
         return this.parent
           .then(createUser(otherEmail, PASSWORD, { preVerified: true }))
           .then(_otherAccount => {
@@ -187,7 +188,7 @@ registerSuite('Firefox desktop user info handshake', {
     },
 
     'Sync - user signed into browser, signin code': disableInProd(function() {
-      const testPhoneNumber = TestHelpers.createPhoneNumber();
+      const testPhoneNumber = createPhoneNumber();
       let signinUrlWithSigninCode;
 
       return (

--- a/packages/fxa-content-server/tests/functional/fx_fennec_v1_force_auth.js
+++ b/packages/fxa-content-server/tests/functional/fx_fennec_v1_force_auth.js
@@ -5,12 +5,12 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
 const {
   clearBrowserState,
+  createEmail,
   createUser,
   fillOutForceAuth,
   fillOutSignInTokenCode,
@@ -57,7 +57,7 @@ const setupTest = thenify(function(options) {
 
 registerSuite('Fx Fennec Sync v1 force_auth', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
   },
   tests: {
     'verified, verify same browser': function() {
@@ -85,7 +85,7 @@ registerSuite('Fx Fennec Sync v1 force_auth', {
     },
 
     'verified, blocked': function() {
-      email = TestHelpers.createEmail('blocked{id}');
+      email = createEmail('blocked{id}');
 
       return this.remote
         .then(setupTest({ blocked: true, preVerified: true }))

--- a/packages/fxa-content-server/tests/functional/fx_fennec_v1_settings.js
+++ b/packages/fxa-content-server/tests/functional/fx_fennec_v1_settings.js
@@ -5,13 +5,13 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
 const {
   click,
   clearBrowserState,
+  createEmail,
   createUser,
   fillOutChangePassword,
   fillOutDeleteAccount,
@@ -38,7 +38,7 @@ let email;
 
 registerSuite('Fx Fennec Sync v1 settings', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
 
     return (
       this.remote

--- a/packages/fxa-content-server/tests/functional/fx_fennec_v1_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/fx_fennec_v1_sign_in.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -19,6 +18,8 @@ const PASSWORD = '12345678';
 const {
   clearBrowserState,
   click,
+  createEmail,
+  createPhoneNumber,
   createUser,
   deleteAllSms,
   disableInProd,
@@ -51,7 +52,7 @@ const setupTest = thenify(function(successSelector, options = {}) {
 
 registerSuite('Fx Fennec Sync v1 sign_in', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
   },
   tests: {
     verified: function() {
@@ -86,7 +87,7 @@ registerSuite('Fx Fennec Sync v1 sign_in', {
     },
 
     'blocked, valid code entered': function() {
-      email = TestHelpers.createEmail('block{id}');
+      email = createEmail('block{id}');
 
       return this.remote
         .then(
@@ -107,7 +108,7 @@ registerSuite('Fx Fennec Sync v1 sign_in', {
 
     'signup in desktop, send an SMS, open deferred deeplink in Fennec': disableInProd(
       function() {
-        const testPhoneNumber = TestHelpers.createPhoneNumber();
+        const testPhoneNumber = createPhoneNumber();
 
         return (
           this.remote

--- a/packages/fxa-content-server/tests/functional/fx_fennec_v1_sign_up.js
+++ b/packages/fxa-content-server/tests/functional/fx_fennec_v1_sign_up.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 var config = intern._config;
@@ -17,6 +16,7 @@ var PASSWORD = 'password12345678';
 
 const {
   click,
+  createEmail,
   fillOutSignUpCode,
   noSuchBrowserNotification,
   openPage,
@@ -31,7 +31,7 @@ const {
 
 registerSuite('Fx Fennec Sync v1 sign_up', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
     return this.remote.then(FunctionalHelpers.clearBrowserState());
   },
 

--- a/packages/fxa-content-server/tests/functional/fx_ios_v1_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/fx_ios_v1_sign_in.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const FxDesktopHelpers = require('./lib/fx-desktop');
 const selectors = require('./lib/selectors');
@@ -22,6 +21,8 @@ const PASSWORD = '12345678';
 const {
   clearBrowserState,
   click,
+  createEmail,
+  createPhoneNumber,
   createUser,
   deleteAllSms,
   disableInProd,
@@ -68,7 +69,7 @@ const setupTest = thenify(function(options = {}) {
 
 registerSuite('FxiOS v1 signin', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
 
     return this.remote.then(clearBrowserState({ force: true }));
   },
@@ -156,7 +157,7 @@ registerSuite('FxiOS v1 signin', {
     },
 
     'blocked, valid code entered': function() {
-      email = TestHelpers.createEmail('block{id}');
+      email = createEmail('block{id}');
       const forceUA = UA_STRINGS['ios_firefox_6_1'];
       const query = { forceUA };
 
@@ -178,7 +179,7 @@ registerSuite('FxiOS v1 signin', {
 
     'signup in desktop, send an SMS, open deferred deeplink in Fx for iOS': disableInProd(
       function() {
-        const testPhoneNumber = TestHelpers.createPhoneNumber();
+        const testPhoneNumber = createPhoneNumber();
         const forceUA = UA_STRINGS['ios_firefox_6_1'];
         const query = { forceUA };
 

--- a/packages/fxa-content-server/tests/functional/fx_ios_v1_sign_up.js
+++ b/packages/fxa-content-server/tests/functional/fx_ios_v1_sign_up.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const FxDesktopHelpers = require('./lib/fx-desktop');
 const UA_STRINGS = require('./lib/ua-strings');
@@ -21,6 +20,7 @@ const PASSWORD = 'password12345678';
 const {
   click,
   clearBrowserState,
+  createEmail,
   fillOutEmailFirstSignUp,
   fillOutSignUpCode,
   openPage,
@@ -32,7 +32,7 @@ const { listenForFxaCommands, testIsBrowserNotifiedOfLogin } = FxDesktopHelpers;
 
 registerSuite('FxiOS v1 sign_up', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
     return this.remote.then(clearBrowserState());
   },
 

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -2502,6 +2502,7 @@ const subscribeToTestProduct = thenify(function() {
 });
 
 module.exports = {
+  ...TestHelpers,
   cleanMemory,
   clearBrowserNotifications,
   clearBrowserState,

--- a/packages/fxa-content-server/tests/functional/oauth_force_auth.js
+++ b/packages/fxa-content-server/tests/functional/oauth_force_auth.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -14,6 +13,7 @@ var OAUTH_APP = config.fxaOAuthApp;
 
 const {
   clearBrowserState,
+  createEmail,
   createUser,
   fillOutEmailFirstSignUp,
   fillOutForceAuth,
@@ -33,7 +33,7 @@ let email;
 
 registerSuite('oauth force_auth', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
     return this.remote.then(
       clearBrowserState({
         '123done': true,
@@ -87,7 +87,7 @@ registerSuite('oauth force_auth', {
     },
 
     'verified, blocked': function() {
-      email = TestHelpers.createEmail('blocked{id}');
+      email = createEmail('blocked{id}');
 
       return (
         this.remote

--- a/packages/fxa-content-server/tests/functional/oauth_handshake.js
+++ b/packages/fxa-content-server/tests/functional/oauth_handshake.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
@@ -23,6 +22,7 @@ const PASSWORD = '12345678';
 const {
   click,
   clearBrowserState,
+  createEmail,
   createUser,
   fillOutEmailFirstSignIn,
   openFxaFromRp,
@@ -35,7 +35,7 @@ const ensureUsers = thenify(function() {
   return this.parent
     .then(() => {
       if (!browserSignedInAccount) {
-        browserSignedInEmail = TestHelpers.createEmail();
+        browserSignedInEmail = createEmail();
         return this.parent
           .then(
             createUser(browserSignedInEmail, PASSWORD, { preVerified: true })
@@ -49,7 +49,7 @@ const ensureUsers = thenify(function() {
     })
     .then(() => {
       if (!otherAccount) {
-        otherEmail = TestHelpers.createEmail();
+        otherEmail = createEmail();
         return this.parent
           .then(createUser(otherEmail, PASSWORD, { preVerified: true }))
           .then(_otherAccount => {

--- a/packages/fxa-content-server/tests/functional/oauth_permissions.js
+++ b/packages/fxa-content-server/tests/functional/oauth_permissions.js
@@ -6,7 +6,6 @@
 
 const { registerSuite } = intern.getInterface('object');
 const assert = intern.getPlugin('chai').assert;
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -25,6 +24,7 @@ let email;
 const {
   click,
   closeCurrentWindow,
+  createEmail,
   createUser,
   fillOutForceAuth,
   fillOutEmailFirstSignIn,
@@ -46,7 +46,7 @@ const {
 registerSuite('oauth permissions for untrusted reliers', {
   beforeEach: function() {
     this.timeout = TIMEOUT;
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote.then(
       FunctionalHelpers.clearBrowserState({
@@ -363,7 +363,7 @@ registerSuite('oauth permissions for untrusted reliers', {
 
 registerSuite('oauth permissions for trusted reliers', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote.then(
       FunctionalHelpers.clearBrowserState({

--- a/packages/fxa-content-server/tests/functional/oauth_prompt_none.js
+++ b/packages/fxa-content-server/tests/functional/oauth_prompt_none.js
@@ -6,7 +6,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const { createEmail } = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const config = intern._config;
 const selectors = require('./lib/selectors');
@@ -20,6 +19,7 @@ let email;
 const {
   clearBrowserState,
   click,
+  createEmail,
   createUser,
   destroySessionForEmail,
   fillOutEmailFirstSignIn,

--- a/packages/fxa-content-server/tests/functional/oauth_require_totp.js
+++ b/packages/fxa-content-server/tests/functional/oauth_require_totp.js
@@ -6,7 +6,6 @@
 
 const { registerSuite } = intern.getInterface('object');
 const assert = intern.getPlugin('chai').assert;
-const { createEmail } = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const config = intern._config;
 const OAUTH_APP = config.fxaOAuthApp;
@@ -22,6 +21,7 @@ const {
   clearBrowserState,
   click,
   confirmTotpCode,
+  createEmail,
   createUser,
   fillOutEmailFirstSignIn,
   fillOutEmailFirstSignUp,

--- a/packages/fxa-content-server/tests/functional/oauth_reset_password.js
+++ b/packages/fxa-content-server/tests/functional/oauth_reset_password.js
@@ -7,7 +7,6 @@
 const config = intern._config;
 const { registerSuite } = intern.getInterface('object');
 const FunctionalHelpers = require('./lib/helpers');
-const TestHelpers = require('../lib/helpers');
 const selectors = require('./lib/selectors');
 
 const PASSWORD = 'passwordzxcv';
@@ -22,6 +21,7 @@ const {
   clearBrowserState,
   click,
   closeCurrentWindow,
+  createEmail,
   createUser,
   enableTotp,
   fillOutCompleteResetPassword,
@@ -45,7 +45,7 @@ registerSuite('oauth reset password', {
   beforeEach: function() {
     // timeout after 90 seconds
     this.timeout = TIMEOUT;
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote
       .then(
@@ -205,7 +205,7 @@ registerSuite('oauth reset password with TOTP', {
   beforeEach: function() {
     // timeout after 90 seconds
     this.timeout = TIMEOUT;
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote
       .then(

--- a/packages/fxa-content-server/tests/functional/oauth_settings_clients.js
+++ b/packages/fxa-content-server/tests/functional/oauth_settings_clients.js
@@ -6,7 +6,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 var config = intern._config;
 var CONTENT_SERVER = config.fxaContentRoot;
@@ -20,6 +19,7 @@ const {
   clearBrowserState,
   click,
   closeCurrentWindow,
+  createEmail,
   fillOutEmailFirstSignUp,
   fillOutSignUpCode,
   noSuchElement,
@@ -35,7 +35,7 @@ var email;
 
 registerSuite('oauth settings clients', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote.then(
       clearBrowserState({

--- a/packages/fxa-content-server/tests/functional/oauth_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sign_in.js
@@ -7,7 +7,6 @@
 
 const { registerSuite } = intern.getInterface('object');
 const assert = intern.getPlugin('chai').assert;
-const { createEmail } = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const config = intern._config;
 const OAUTH_APP = config.fxaOAuthApp;
@@ -33,6 +32,7 @@ const {
   clearBrowserState,
   click,
   confirmTotpCode,
+  createEmail,
   createUser,
   destroySessionForEmail,
   fillOutEmailFirstSignIn,

--- a/packages/fxa-content-server/tests/functional/oauth_sign_in_token_code.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sign_in_token_code.js
@@ -6,7 +6,6 @@
 
 const assert = intern.getPlugin('chai').assert;
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -16,6 +15,7 @@ let email;
 const {
   clearBrowserState,
   click,
+  createEmail,
   createUser,
   destroySessionForEmail,
   fillOutEmailFirstSignIn,
@@ -49,7 +49,7 @@ const experimentParams = {
 registerSuite('OAuth signin token code', {
   beforeEach: function() {
     // The `sync` prefix is needed to force confirmation.
-    email = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
 
     return this.remote
       .then(

--- a/packages/fxa-content-server/tests/functional/oauth_sign_up.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sign_up.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const config = intern._config;
@@ -17,6 +16,7 @@ let bouncedEmail;
 
 const {
   clearBrowserState,
+  createEmail,
   fillOutEmailFirstSignUp,
   fillOutSignUpCode,
   getFxaClient,
@@ -30,8 +30,8 @@ const {
 
 registerSuite('oauth signup', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
-    bouncedEmail = TestHelpers.createEmail();
+    email = createEmail();
+    bouncedEmail = createEmail();
 
     // clear localStorage to avoid polluting other tests.
     // Without the clear, /signup tests fail because of the info stored

--- a/packages/fxa-content-server/tests/functional/oauth_sync_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sync_sign_in.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const config = intern._config;
@@ -19,6 +18,7 @@ const PASSWORD = 'passwordzxcv';
 
 const {
   click,
+  createEmail,
   createUser,
   fillOutEmailFirstSignIn,
   fillOutEmailFirstSignUp,
@@ -35,8 +35,8 @@ const {
 
 registerSuite('signin with OAuth after Sync', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
-    email2 = TestHelpers.createEmail();
+    email = createEmail('sync{id}');
+    email2 = createEmail();
 
     // clear localStorage to avoid pollution from other tests.
     return this.remote.then(
@@ -120,8 +120,8 @@ registerSuite('signin with OAuth after Sync', {
 
 registerSuite('signin to Sync after OAuth', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
-    email2 = TestHelpers.createEmail();
+    email = createEmail('sync{id}');
+    email2 = createEmail();
 
     // clear localStorage to avoid pollution from other tests.
     return this.remote.then(

--- a/packages/fxa-content-server/tests/functional/oauth_webchannel.js
+++ b/packages/fxa-content-server/tests/functional/oauth_webchannel.js
@@ -6,7 +6,6 @@
 
 const config = intern._config;
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -16,6 +15,7 @@ let email;
 
 const {
   click,
+  createEmail,
   createUser,
   fillOutEmailFirstSignIn,
   fillOutEmailFirstSignUp,
@@ -30,7 +30,7 @@ const {
 
 registerSuite('oauth webchannel', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote.then(
       FunctionalHelpers.clearBrowserState({

--- a/packages/fxa-content-server/tests/functional/pairing.js
+++ b/packages/fxa-content-server/tests/functional/pairing.js
@@ -7,7 +7,6 @@
 const { registerSuite } = intern.getInterface('object');
 const assert = intern.getPlugin('chai').assert;
 const selectors = require('./lib/selectors');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const config = intern._config;
 
@@ -29,6 +28,7 @@ const {
   createUser,
   click,
   closeCurrentWindow,
+  createEmail,
   confirmTotpCode,
   generateTotpCode,
   openPage,
@@ -109,7 +109,7 @@ registerSuite('pairing', {
   tests: {
     'it can pair': function() {
       let secret;
-      email = TestHelpers.createEmail();
+      email = createEmail();
 
       return (
         this.remote

--- a/packages/fxa-content-server/tests/functional/password_strength.js
+++ b/packages/fxa-content-server/tests/functional/password_strength.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -17,6 +16,7 @@ let email;
 const {
   clearBrowserState,
   click,
+  createEmail,
   openPage,
   testElementExists,
   type,
@@ -24,7 +24,7 @@ const {
 
 registerSuite('password strength balloon', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
 
     return this.remote
       .then(clearBrowserState({ force: true }))

--- a/packages/fxa-content-server/tests/functional/password_visibility.js
+++ b/packages/fxa-content-server/tests/functional/password_visibility.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const { createEmail } = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -15,6 +14,7 @@ const ENTER_EMAIL_URL = config.fxaContentRoot;
 const {
   clearBrowserState,
   click,
+  createEmail,
   mousedown,
   noSuchAttribute,
   openPage,

--- a/packages/fxa-content-server/tests/functional/pp.js
+++ b/packages/fxa-content-server/tests/functional/pp.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const { createEmail } = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -15,6 +14,7 @@ const PP_URL = intern._config.fxaContentRoot + 'legal/privacy';
 const {
   clearBrowserState,
   click,
+  createEmail,
   noSuchElement,
   openPage,
   type,

--- a/packages/fxa-content-server/tests/functional/recovery_key.js
+++ b/packages/fxa-content-server/tests/functional/recovery_key.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -20,6 +19,7 @@ const NEW_PASSWORD = '()()():|';
 let email, recoveryKey;
 
 const {
+  createEmail,
   createUser,
   clearBrowserState,
   click,
@@ -43,7 +43,7 @@ const {
 
 registerSuite('Recovery key', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
     const remote = this.remote;
 
     return (
@@ -226,7 +226,7 @@ registerSuite('Recovery key', {
 
 registerSuite('Recovery key - unverified session', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
 
     return (
       this.remote

--- a/packages/fxa-content-server/tests/functional/reset_password.js
+++ b/packages/fxa-content-server/tests/functional/reset_password.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -28,6 +27,8 @@ const {
   clearBrowserState,
   click,
   closeCurrentWindow,
+  createEmail,
+  createRandomHexString,
   createUser,
   fillOutCompleteResetPassword,
   fillOutResetPassword,
@@ -48,8 +49,6 @@ const {
   type,
   visibleByQSA,
 } = FunctionalHelpers;
-
-const createRandomHexString = TestHelpers.createRandomHexString;
 
 /**
  * Programatically initiate a reset password using the
@@ -99,7 +98,7 @@ registerSuite('reset_password', {
   beforeEach: function() {
     this.timeout = TIMEOUT;
 
-    email = TestHelpers.createEmail();
+    email = createEmail();
     return this.remote
       .then(() => getFxaClient())
       .then(_client => {
@@ -124,7 +123,7 @@ registerSuite('reset_password', {
     },
 
     'open /reset_password page from /signin': function() {
-      const updatedEmail = TestHelpers.createEmail();
+      const updatedEmail = createEmail();
       return (
         this.remote
           .then(openPage(ENTER_EMAIL_PAGE_URL, selectors.ENTER_EMAIL.HEADER))
@@ -198,13 +197,12 @@ registerSuite('reset_password', {
     },
 
     'open confirm_reset_password page, click resend': function() {
-      const user = TestHelpers.emailToUser(email);
       return (
         this.remote
           .then(fillOutResetPassword(email))
           .then(click(selectors.CONFIRM_RESET_PASSWORD.LINK_RESEND))
 
-          .then(testEmailExpected(user, 1))
+          .then(testEmailExpected(email, 1))
 
           // Success is showing the success message
           .then(testSuccessWasShown())
@@ -464,7 +462,7 @@ registerSuite('reset_password', {
 registerSuite('try to re-use a link', {
   beforeEach: function() {
     this.timeout = TIMEOUT;
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote
       .then(createUser(email, PASSWORD, { preVerified: true }))
@@ -506,7 +504,7 @@ registerSuite('try to re-use a link', {
 
 registerSuite('reset_password with email specified on URL', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
     return this.remote
       .then(createUser(email, PASSWORD, { preVerified: true }))
       .then(clearBrowserState());
@@ -533,7 +531,7 @@ registerSuite('reset_password with email specified on URL', {
 
 registerSuite('password change while at confirm_reset_password screen', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote
       .then(createUser(email, PASSWORD, { preVerified: true }))
@@ -565,7 +563,7 @@ registerSuite('password change while at confirm_reset_password screen', {
 
 registerSuite('reset_password with unknown email', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
     return this.remote.then(clearBrowserState());
   },
   tests: {

--- a/packages/fxa-content-server/tests/functional/security_events.js
+++ b/packages/fxa-content-server/tests/functional/security_events.js
@@ -8,11 +8,11 @@ const config = intern._config;
 const { registerSuite } = intern.getInterface('object');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
-const TestHelpers = require('../lib/helpers');
 
 const {
   clearBrowserState,
   click,
+  createEmail,
   createUser,
   fillOutCompleteResetPassword,
   fillOutEmailFirstSignIn,
@@ -73,7 +73,7 @@ const openCompleteResetPassword = thenify(function(email, token, code, header) {
 
 registerSuite('security_events', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote
       .then(createUser(email, PASSWORD, { preVerified: true }))

--- a/packages/fxa-content-server/tests/functional/send_sms.js
+++ b/packages/fxa-content-server/tests/functional/send_sms.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -36,6 +35,8 @@ const {
   click,
   clearBrowserState,
   closeCurrentWindow,
+  createEmail,
+  createPhoneNumber,
   deleteAllSms,
   disableInProd,
   fillOutEmailFirstSignUp,
@@ -76,8 +77,8 @@ function testSmsSupportedCountryForm(country, expectedPrefix) {
 
 const suite = {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
-    testPhoneNumber = TestHelpers.createPhoneNumber();
+    email = createEmail();
+    testPhoneNumber = createPhoneNumber();
     formattedPhoneNumber = `${testPhoneNumber.substr(
       0,
       3

--- a/packages/fxa-content-server/tests/functional/settings.js
+++ b/packages/fxa-content-server/tests/functional/settings.js
@@ -6,7 +6,6 @@
 
 const { registerSuite } = intern.getInterface('object');
 const assert = intern.getPlugin('chai').assert;
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -20,6 +19,7 @@ const {
   clearBrowserState,
   click,
   closeCurrentWindow,
+  createEmail,
   createUser,
   denormalizeStoredEmail,
   destroySessionForEmail,
@@ -43,7 +43,7 @@ var accountData;
 
 registerSuite('settings', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote
       .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
@@ -248,7 +248,7 @@ registerSuite('settings', {
 
 registerSuite('settings with expired session', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote
       .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))
@@ -276,7 +276,7 @@ registerSuite('settings with expired session', {
 
 registerSuite('settings with recent activity link', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote
       .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))

--- a/packages/fxa-content-server/tests/functional/settings_change_email.js
+++ b/packages/fxa-content-server/tests/functional/settings_change_email.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -24,6 +23,7 @@ const {
   clearBrowserState,
   click,
   closeCurrentWindow,
+  createEmail,
   fillOutChangePassword,
   fillOutResetPassword,
   fillOutCompleteResetPassword,
@@ -46,8 +46,8 @@ const {
 
 registerSuite('settings change email', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
-    secondaryEmail = TestHelpers.createEmail();
+    email = createEmail();
+    secondaryEmail = createEmail();
     return (
       this.remote
         .then(clearBrowserState())
@@ -270,10 +270,10 @@ registerSuite('settings change email', {
 
 registerSuite('settings change email - unblock', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     // Create a new primary email that is always forced through the unblock flow
-    newPrimaryEmail = TestHelpers.createEmail('block{id}');
+    newPrimaryEmail = createEmail('block{id}');
     return (
       this.remote
         .then(clearBrowserState())

--- a/packages/fxa-content-server/tests/functional/settings_clients.js
+++ b/packages/fxa-content-server/tests/functional/settings_clients.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -26,6 +25,7 @@ let accountData;
 const {
   clearBrowserState,
   click,
+  createEmail,
   createUser,
   fillOutEmailFirstSignIn,
   noSuchElement,
@@ -40,7 +40,7 @@ const {
 
 registerSuite('settings clients', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
     client = FunctionalHelpers.getFxaClient();
     return this.remote
       .then(createUser(email, FIRST_PASSWORD, { preVerified: true }))

--- a/packages/fxa-content-server/tests/functional/settings_common.js
+++ b/packages/fxa-content-server/tests/functional/settings_common.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const selectors = require('./lib/selectors');
 
 const config = intern._config;
@@ -20,7 +19,9 @@ let accountData;
 const {
   clearBrowserState,
   click,
+  createEmail,
   createUser,
+  createUID,
   destroySessionForEmail,
   fillOutEmailFirstSignIn,
   openPage,
@@ -41,7 +42,7 @@ const SETTINGS_PAGES = {
 
 const unverifiedSuite = {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote
       .then(clearBrowserState())
@@ -71,7 +72,7 @@ function unverifiedAccountTest(suite, page) {
 
 const verifiedSuite = {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
 
     return this.remote
       .then(clearBrowserState({ force: true }))
@@ -155,7 +156,7 @@ function verifiedAccountTest(suite, page, pageHeader) {
         // Expect to get redirected to signin password since the uid is unknown
         .then(
           openPage(
-            url + '?uid=' + TestHelpers.createUID(),
+            url + '?uid=' + createUID(),
             // TODO - this should go to enter email rather than signin password
             selectors.SIGNIN_PASSWORD.HEADER
           )

--- a/packages/fxa-content-server/tests/functional/settings_secondary_emails.js
+++ b/packages/fxa-content-server/tests/functional/settings_secondary_emails.js
@@ -6,7 +6,6 @@
 
 const { registerSuite } = intern.getInterface('object');
 const assert = intern.getPlugin('chai').assert;
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
@@ -23,6 +22,7 @@ const {
   clearBrowserState,
   click,
   closeCurrentWindow,
+  createEmail,
   createUser,
   fillOutEmailFirstSignIn,
   fillOutEmailFirstSignUp,
@@ -45,8 +45,8 @@ const {
 
 registerSuite('settings secondary emails', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
-    secondaryEmail = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
+    secondaryEmail = createEmail('sync{id}');
     client = FunctionalHelpers.getFxaClient();
 
     return this.remote.then(clearBrowserState({ force: true }));
@@ -148,7 +148,7 @@ registerSuite('settings secondary emails', {
           .then(visibleByQSA(selectors.EMAIL.TOOLTIP))
 
           // add secondary email, resend and remove
-          .then(type(selectors.EMAIL.INPUT, TestHelpers.createEmail()))
+          .then(type(selectors.EMAIL.INPUT, createEmail()))
           .then(click(selectors.EMAIL.ADD_BUTTON))
           .then(testElementExists(selectors.EMAIL.NOT_VERIFIED_LABEL))
 
@@ -186,8 +186,8 @@ registerSuite('settings secondary emails', {
     },
 
     'add secondary email that is primary to another account': function() {
-      const existingUnverified = TestHelpers.createEmail();
-      const existingVerified = TestHelpers.createEmail();
+      const existingUnverified = createEmail();
+      const existingVerified = createEmail();
 
       return (
         this.remote
@@ -244,7 +244,7 @@ registerSuite('settings secondary emails', {
     },
 
     'unblock code is sent to secondary emails': function() {
-      email = TestHelpers.createEmail('blocked{id}');
+      email = createEmail('blocked{id}');
 
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
@@ -296,7 +296,7 @@ registerSuite('settings secondary emails', {
     'signin confirmation is sent to secondary emails': function() {
       const SETTINGS_URL = `${config.fxaContentRoot}settings?context=fx_desktop_v3&service=sync`;
 
-      email = TestHelpers.createEmail('sync{id}');
+      email = createEmail('sync{id}');
 
       return (
         this.remote

--- a/packages/fxa-content-server/tests/functional/sign_in.js
+++ b/packages/fxa-content-server/tests/functional/sign_in.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const { createEmail } = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const fxaProduction = intern._config.fxaProduction;
@@ -19,6 +18,7 @@ const {
   clearBrowserState,
   click,
   closeCurrentWindow,
+  createEmail,
   createUser,
   fillOutEmailFirstSignIn,
   fillOutEmailFirstSignUp,

--- a/packages/fxa-content-server/tests/functional/sign_in_blocked.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_blocked.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -18,6 +17,7 @@ const {
   clearBrowserState,
   click,
   closeCurrentWindow,
+  createEmail,
   createUser,
   fillOutEmailFirstSignIn,
   fillOutSignInTokenCode,
@@ -35,7 +35,7 @@ const {
 
 registerSuite('signin blocked', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('blocked{id}');
+    email = createEmail('blocked{id}');
 
     return this.remote
       .then(createUser(email, PASSWORD, { preVerified: true }))
@@ -332,7 +332,7 @@ registerSuite('signin blocked', {
     },
 
     unverified: function() {
-      email = TestHelpers.createEmail('blocked{id}');
+      email = createEmail('blocked{id}');
 
       return (
         this.remote

--- a/packages/fxa-content-server/tests/functional/sign_in_cached.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_cached.js
@@ -6,7 +6,6 @@
 
 const { registerSuite } = intern.getInterface('object');
 const assert = intern.getPlugin('chai').assert;
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const { FX_DESKTOP_V3_CONTEXT } = require('../../app/scripts/lib/constants');
 const selectors = require('./lib/selectors');
@@ -25,6 +24,7 @@ const {
   clearBrowserState,
   clearSessionStorage,
   click,
+  createEmail,
   createUser,
   denormalizeStoredEmail,
   destroySessionForEmail,
@@ -44,8 +44,8 @@ const {
 
 registerSuite('cached signin', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
-    email2 = TestHelpers.createEmail();
+    email = createEmail('sync{id}');
+    email2 = createEmail();
     return this.remote
       .then(clearBrowserState({ force: true }))
       .then(createUser(email, PASSWORD, { preVerified: true }))
@@ -189,7 +189,7 @@ registerSuite('cached signin', {
     },
 
     'unverified cached signin redirects to confirm email': function() {
-      const email = TestHelpers.createEmail();
+      const email = createEmail();
 
       return (
         this.remote

--- a/packages/fxa-content-server/tests/functional/sign_in_recovery_code.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_recovery_code.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -23,6 +22,7 @@ let secret;
 const {
   clearBrowserState,
   click,
+  createEmail,
   fillOutEmailFirstSignIn,
   fillOutEmailFirstSignUp,
   fillOutSignUpCode,
@@ -38,7 +38,7 @@ const {
 
 registerSuite('recovery code', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
     const self = this;
     return (
       this.remote

--- a/packages/fxa-content-server/tests/functional/sign_in_totp.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_totp.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -26,6 +25,7 @@ const {
   clearBrowserState,
   click,
   closeCurrentWindow,
+  createEmail,
   createUser,
   fillOutCompleteResetPassword,
   fillOutDeleteAccount,
@@ -49,7 +49,7 @@ const {
 
 registerSuite('TOTP', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
     return (
       this.remote
         .then(clearBrowserState({ force: true }))
@@ -267,7 +267,7 @@ registerSuite('TOTP', {
 
 registerSuite('TOTP - unverified session', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
 
     return this.remote
       .then(createUser(email, PASSWORD, { preVerified: true }))

--- a/packages/fxa-content-server/tests/functional/sign_up.js
+++ b/packages/fxa-content-server/tests/functional/sign_up.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const { createEmail } = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const UA_STRINGS = require('./lib/ua-strings');
@@ -20,6 +19,7 @@ const {
   click,
   clearBrowserState,
   closeCurrentWindow,
+  createEmail,
   fillOutEmailFirstSignIn,
   fillOutEmailFirstSignUp,
   fillOutSignUpCode,

--- a/packages/fxa-content-server/tests/functional/sign_up_with_code.js
+++ b/packages/fxa-content-server/tests/functional/sign_up_with_code.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const config = intern._config;
@@ -16,6 +15,7 @@ let email;
 const {
   click,
   clearBrowserState,
+  createEmail,
   fillOutEmailFirstSignUp,
   fillOutSignUpCode,
   getFxaClient,
@@ -42,7 +42,7 @@ function testAtConfirmScreen(email) {
 
 registerSuite('signup with code', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
     return this.remote.then(clearBrowserState({ force: true }));
   },
 

--- a/packages/fxa-content-server/tests/functional/support.js
+++ b/packages/fxa-content-server/tests/functional/support.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -17,6 +16,7 @@ const PASSWORD = 'amazingpassword';
 const {
   clearBrowserState,
   click,
+  createEmail,
   createUser,
   fillOutEmailFirstSignIn,
   openPage,
@@ -39,7 +39,7 @@ registerSuite('support form without valid session', {
 registerSuite('support form without active subscriptions', {
   tests: {
     'go to support form, redirects to subscription management, then back to settings': function() {
-      const email = TestHelpers.createEmail();
+      const email = createEmail();
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
@@ -55,7 +55,7 @@ registerSuite('support form without active subscriptions', {
 registerSuite('support form with an active subscription', {
   tests: {
     'go to support form, submits the form': function() {
-      const email = TestHelpers.createEmail();
+      const email = createEmail();
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(clearBrowserState())
@@ -84,7 +84,7 @@ registerSuite('support form with an active subscription', {
     },
 
     'go to support form, cancel, redirects to subscription management': function() {
-      const email = TestHelpers.createEmail();
+      const email = createEmail();
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
         .then(clearBrowserState())

--- a/packages/fxa-content-server/tests/functional/sync_v3_email_first.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_email_first.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
@@ -23,6 +22,7 @@ const PASSWORD_WITH_TYPO = 'PASSWORD1234';
 const {
   clearBrowserState,
   click,
+  createEmail,
   createUser,
   fillOutSignUpCode,
   fillOutSignInTokenCode,
@@ -39,7 +39,7 @@ const {
 
 registerSuite('Firefox Desktop Sync v3 email first', {
   beforeEach() {
-    email = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
 
     return this.remote.then(clearBrowserState({ force: true }));
   },

--- a/packages/fxa-content-server/tests/functional/sync_v3_force_auth.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_force_auth.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
@@ -16,7 +15,9 @@ const PASSWORD = 'password12345678';
 const {
   clearBrowserState,
   click,
+  createEmail,
   createUser,
+  createUID,
   fillOutEmailFirstSignUp,
   fillOutForceAuth,
   fillOutSignInTokenCode,
@@ -34,7 +35,7 @@ const {
 
 registerSuite('Firefox Desktop Sync v3 force_auth', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
 
     return this.remote.then(clearBrowserState({ force: true }));
   },
@@ -116,7 +117,7 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
               email: email,
               forceUA: uaStrings['desktop_firefox_71'],
               service: 'sync',
-              uid: TestHelpers.createUID(),
+              uid: createUID(),
             },
             webChannelResponses: {
               'fxaccounts:can_link_account': {
@@ -245,7 +246,7 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
                 context: 'fx_desktop_v3',
                 email: email,
                 service: 'sync',
-                uid: TestHelpers.createUID(),
+                uid: createUID(),
               },
               webChannelResponses: {
                 'fxaccounts:can_link_account': {
@@ -270,7 +271,7 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
     },
 
     'verified, blocked': function() {
-      email = TestHelpers.createEmail('blocked{id}');
+      email = createEmail('blocked{id}');
 
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))
@@ -280,7 +281,7 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
               context: 'fx_desktop_v3',
               email: email,
               service: 'sync',
-              uid: TestHelpers.createUID(),
+              uid: createUID(),
             },
             webChannelResponses: {
               'fxaccounts:can_link_account': {

--- a/packages/fxa-content-server/tests/functional/sync_v3_reset_password.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_reset_password.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
@@ -20,6 +19,7 @@ let email;
 const {
   clearBrowserState,
   closeCurrentWindow,
+  createEmail,
   createUser,
   fillOutResetPassword,
   fillOutCompleteResetPassword,
@@ -72,7 +72,7 @@ registerSuite('Firefox Desktop Sync v3 reset password', {
     // timeout after 90 seconds
     this.timeout = 90000;
 
-    email = TestHelpers.createEmail();
+    email = createEmail();
     return this.remote.then(clearBrowserState());
   },
 

--- a/packages/fxa-content-server/tests/functional/sync_v3_settings.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_settings.js
@@ -5,13 +5,13 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
 const {
   click,
   clearBrowserState,
+  createEmail,
   createUser,
   fillOutChangePassword,
   fillOutDeleteAccount,
@@ -38,7 +38,7 @@ let email;
 
 registerSuite('Firefox Desktop Sync v3 settings', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
 
     return (
       this.remote

--- a/packages/fxa-content-server/tests/functional/sync_v3_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_sign_in.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
@@ -19,6 +18,7 @@ const PASSWORD = '12345678';
 const {
   clearBrowserState,
   click,
+  createEmail,
   createUser,
   fillOutEmailFirstSignIn,
   fillOutSignInTokenCode,
@@ -67,14 +67,14 @@ const setupTest = thenify(function(options = {}) {
 
 registerSuite('Firefox Desktop Sync v3 signin', {
   beforeEach: function() {
-    email = TestHelpers.createEmail('sync{id}');
+    email = createEmail('sync{id}');
 
     return this.remote.then(clearBrowserState({ force: true }));
   },
 
   tests: {
     'verified, does not need to confirm ': function() {
-      email = TestHelpers.createEmail();
+      email = createEmail();
       const query = {
         forceUA: uaStrings['desktop_firefox_58'],
       };
@@ -168,7 +168,7 @@ registerSuite('Firefox Desktop Sync v3 signin', {
     },
 
     'verified, blocked': function() {
-      email = TestHelpers.createEmail('blocked{id}');
+      email = createEmail('blocked{id}');
       return this.remote
         .then(setupTest({ blocked: true, preVerified: true }))
 
@@ -179,7 +179,7 @@ registerSuite('Firefox Desktop Sync v3 signin', {
     },
 
     'verified, blocked, incorrect email case': function() {
-      const signUpEmail = TestHelpers.createEmail('blocked{id}');
+      const signUpEmail = createEmail('blocked{id}');
       const signInEmail = signUpEmail.toUpperCase();
       return (
         this.remote

--- a/packages/fxa-content-server/tests/functional/sync_v3_sign_up.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_sign_up.js
@@ -6,7 +6,6 @@
 
 const { assert } = intern.getPlugin('chai');
 const { registerSuite } = intern.getInterface('object');
-const TestHelpers = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 const uaStrings = require('./lib/ua-strings');
@@ -20,6 +19,7 @@ const PASSWORD = 'password12345678';
 const {
   clearBrowserState,
   click,
+  createEmail,
   fillOutEmailFirstSignUp,
   fillOutSignUpCode,
   getWebChannelMessageData,
@@ -34,7 +34,7 @@ const {
 
 registerSuite('Firefox Desktop Sync v3 signup', {
   beforeEach: function() {
-    email = TestHelpers.createEmail();
+    email = createEmail();
     return this.remote.then(clearBrowserState({ force: true }));
   },
 
@@ -281,7 +281,7 @@ registerSuite(
 
     tests: {
       treatment: function() {
-        email = TestHelpers.createEmail();
+        email = createEmail();
         return (
           this.remote
             .then(

--- a/packages/fxa-content-server/tests/functional/tos.js
+++ b/packages/fxa-content-server/tests/functional/tos.js
@@ -5,14 +5,13 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
-const { createEmail } = require('../lib/helpers');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
 const ENTER_EMAIL_URL = intern._config.fxaContentRoot;
 const TOS_URL = intern._config.fxaContentRoot + 'legal/terms';
 
-const { click, noSuchElement, openPage, type } = FunctionalHelpers;
+const { click, createEmail, noSuchElement, openPage, type } = FunctionalHelpers;
 
 registerSuite('terms of service', {
   beforeEach: function() {


### PR DESCRIPTION
While writing the functional test deep dive, I found myself thinking
it odd I had to explain that two files had to be included to create
a user. So I decided to make it so one file needed to be included
by exposing all TestHelper methods in FunctionalHelpers.

Not attached to an issue.

ref https://github.com/mozilla/ecosystem-platform/pull/47