### PR TITLE
chore(subhub): handle subscription upgrades in stub API

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -56,13 +56,29 @@
           "product_id": "123doneProProduct",
           "product_name": "123done Pro",
           "product_metadata": {
-            "upgradeCTA": "Interested in an upgrade? <a href=\"https://getfirefox.com\">Get Firefox!</a>",
+            "productSet": "123done_product",
+            "productSetOrder": "1",
+            "upgradeCTA": "Interested in an upgrade? <a href=\"http://127.0.0.1:3030/subscriptions/products/123doneProPlusProduct \">Get Pro+!</a>",
             "webIconURL": "http://placekitten.com/512/512?image=6",
             "emailIconURL": "http://placekitten.com/512/512?image=0",
             "downloadURL": "http://127.0.0.1:8080/"
           },
           "interval": "month",
           "amount": 50,
+          "currency": "usd"
+        },
+        {
+          "plan_id": "123doneProPlusMonthly",
+          "plan_name": "123done Pro Plus Monthly",
+          "product_id": "123doneProPlusProduct",
+          "product_name": "123done Pro+",
+          "product_metadata": {
+            "downloadURL": "http://127.0.0.1:8080/",
+            "productSet": "123done_product",
+            "productSetOrder": "2"
+          },
+          "interval": "month",
+          "amount": 75,
           "currency": "usd"
         },
         {

--- a/packages/fxa-auth-server/test/local/subhub/stubAPI.js
+++ b/packages/fxa-auth-server/test/local/subhub/stubAPI.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const { mockLog } = require('../../mocks');
+const mockConfig = {
+  publicUrl: 'https://accounts.example.com',
+  subhub: {
+    enabled: true,
+    url: 'https://foo.bar',
+    key: 'foo',
+  },
+};
+
+const subhubApiClient = require('../../../lib/subhub/client').client(
+  mockLog,
+  mockConfig
+);
+const subhubStubApi = require('../../../lib/subhub/stubAPI').buildStubAPI(
+  mockLog,
+  mockConfig
+);
+
+describe('subhub stub api', () => {
+  it('should have the same interface as the actual SubHub client', () => {
+    const clientProps = Object.keys(subhubApiClient);
+    const stubProps = Object.keys(subhubStubApi);
+    const diff = clientProps.filter(x => !stubProps.includes(x));
+
+    assert.equal(
+      diff.length,
+      0,
+      `Stub SubHub API is missing the following functions: ${diff.join(', ')}`
+    );
+  });
+});


### PR DESCRIPTION
This patch add the missing `updateSubscription` function to the SubHub
stub API.

Fixes #3650 

@mozilla/fxa-devs r?