### PR TITLE
chore(refactor): Add await to `request.app.devices` where needed

### DIFF
--- a/packages/fxa-auth-server/lib/routes/attached-clients.js
+++ b/packages/fxa-auth-server/lib/routes/attached-clients.js
@@ -122,7 +122,7 @@ module.exports = (log, db, oauthdb, devices, clientUtils) => {
         // XXX TODO: we could obtain `sessions` and `devices` in a single query to the DB,
         // but would need to add a new db-server endpoint because each set can contain items
         // that the other does not.
-        const devicesP = request.app.devices;
+        const devicesList = await request.app.devices;
         const oauthClientsP = oauthdb.listAuthorizedClients(
           request.auth.credentials
         );
@@ -133,7 +133,7 @@ module.exports = (log, db, oauthdb, devices, clientUtils) => {
         // with the other lists.
         const clientsBySessionTokenId = new Map();
         const clientsByRefreshTokenId = new Map();
-        for (const device of await devicesP) {
+        for (const device of devicesList) {
           const client = {
             ...defaultFields,
             sessionTokenId: device.sessionTokenId || null,

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -391,7 +391,7 @@ module.exports = (
         await accountAndTokenVerification(isAccountVerification, account);
 
         if (device) {
-          const devices = request.app.devices;
+          const devices = await request.app.devices;
           const otherDevices = devices.filter(d => d.id !== device.id);
           await push.notifyDeviceConnected(uid, otherDevices, device.name);
         }
@@ -770,7 +770,7 @@ module.exports = (
         if (!secondaryEmail.isPrimary) {
           await db.setPrimaryEmail(uid, secondaryEmail.normalizedEmail);
 
-          const devices = request.app.devices;
+          const devices = await request.app.devices;
           push.notifyProfileUpdated(uid, devices);
 
           log.notifyAttachedServices('primaryEmailChanged', request, {


### PR DESCRIPTION
From https://github.com/mozilla/fxa/pull/3639#discussion_r357219474, looks like the `request.app.devices` was not properly being awaited on in the emails routes. This fixes that and removes the bluebird dependency in db.js