### PR TITLE
feat(signin): Cached signin w/ unverified account uses codes now.

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
@@ -211,6 +211,18 @@ export default {
         return this.navigate('confirm_signup_code', { account });
       }
 
+      if (
+        verificationReason === VerificationReasons.SIGN_UP &&
+        typeof verificationMethod === 'undefined'
+      ) {
+        // cached signin with an unverified account. A code
+        // is not re-sent automatically, so send a new one
+        // and then go to the confirm screen.
+        return account.verifySessionResendCode().then(() => {
+          this.navigate('confirm_signup_code', { account });
+        });
+      }
+
       return this.navigate('confirm', { account });
     }
 

--- a/packages/fxa-content-server/tests/functional/oauth_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sign_in.js
@@ -239,7 +239,10 @@ registerSuite('oauth signin', {
 
           // success is using a cached login and being redirected
           // to a confirmation screen
-          .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
+          .then(testElementExists(selectors.CONFIRM_SIGNUP_CODE.HEADER))
+          // get the second email, the first was sent via fillOutEmailFirstSignUp above.
+          .then(fillOutSignInTokenCode(email, 1))
+          .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
       );
     },
 

--- a/packages/fxa-content-server/tests/functional/sign_in_cached.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_cached.js
@@ -202,7 +202,10 @@ registerSuite('cached signin', {
           .then(click(selectors.SIGNIN_PASSWORD.SUBMIT_USE_SIGNED_IN))
 
           // cached login should still go to email confirmation screen for unverified accounts
-          .then(testElementExists(selectors.CONFIRM_SIGNUP.HEADER))
+          .then(testElementExists(selectors.CONFIRM_SIGNUP_CODE.HEADER))
+          // get the second email, the first was sent via fillOutEmailFirstSignUp above.
+          .then(fillOutSignInTokenCode(email, 1))
+          .then(testElementExists(selectors.SETTINGS.HEADER))
       );
     },
 


### PR DESCRIPTION
Before this signing in to an OAuth RP with a cached unverified account
would send the user to /confirm, which would have resent verification
links.

This converts that flow to use codes instead.

fixes #3649