### PR TITLE
feat(signup): Use signup codes when visiting /settings w/ unverified account

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/base.js
+++ b/packages/fxa-content-server/app/scripts/views/base.js
@@ -362,12 +362,19 @@ var BaseView = Backbone.View.extend({
       return this.user.sessionStatus().then(
         account => {
           if (this.mustVerify && !account.get('verified')) {
-            var targetScreen;
+            this.relier.set('redirectTo', this.currentPage);
+            let targetScreen;
 
             if (
               account.get('verificationReason') === VerificationReasons.SIGN_UP
             ) {
-              targetScreen = 'confirm';
+              // Trying to use an unverified account. A code
+              // is not re-sent automatically, so send a new one
+              // and then go to the confirm screen.
+              return account.verifySessionResendCode().then(() => {
+                this.navigate('confirm_signup_code', { account });
+                return false;
+              });
             } else if (
               account.get('verificationReason') === VerificationReasons.SIGN_IN
             ) {
@@ -382,7 +389,7 @@ var BaseView = Backbone.View.extend({
             }
 
             this.navigate(targetScreen, {
-              account: account,
+              account,
             });
 
             return false;

--- a/packages/fxa-content-server/app/tests/spec/views/base.js
+++ b/packages/fxa-content-server/app/tests/spec/views/base.js
@@ -304,7 +304,7 @@ describe('views/base', function() {
       });
     });
 
-    it('redirects to `/confirm` if mustVerify flag is set and account is unverified', function() {
+    it('redirects to `/confirm_signup_code` if mustVerify flag is set and account is unverified', function() {
       view.mustVerify = true;
       const account = user.initAccount({
         email: 'a@a.com',
@@ -314,13 +314,13 @@ describe('views/base', function() {
         verificationReason: VerificationReasons.SIGN_UP,
         verified: false,
       });
-      sinon
-        .stub(user, 'sessionStatus')
-        .callsFake(() => Promise.resolve(account));
+      sinon.stub(user, 'sessionStatus').resolves(account);
+      sinon.stub(account, 'verifySessionResendCode').resolves();
 
       sinon.spy(view, 'navigate');
       return view.render().then(function() {
-        assert.isTrue(view.navigate.calledWith('confirm'));
+        assert.isTrue(account.verifySessionResendCode.calledOnce);
+        assert.isTrue(view.navigate.calledWith('confirm_signup_code'));
       });
     });
 


### PR DESCRIPTION
Before this we'd send users to /confirm which was the link flow.

This changes that to use a code based flow

fixes #3648

@vbudhram - r?