### PR TITLE
feat(reminders): Test verification reminders.

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -403,5 +403,9 @@
         "hasScopedKeys": true
       }
     ]
+  },
+  "verificationReminders": {
+    "firstInterval": "5s",
+    "secondInterval": "10s"
   }
 }

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -15,7 +15,6 @@ module.exports = [
   'tests/functional/back_button_after_start.js',
   'tests/functional/bounced_email.js',
   'tests/functional/change_password.js',
-  'tests/functional/complete_sign_up.js',
   'tests/functional/confirm.js',
   'tests/functional/connect_another_device.js',
   'tests/functional/cookies_disabled.js',
@@ -77,6 +76,7 @@ module.exports = [
   'tests/functional/sync_v3_reset_password.js',
   'tests/functional/sync_v3_settings.js',
   'tests/functional/tos.js',
+  'tests/functional/verification_reminders.js',
 ];
 
 // Mocha tests are only exposed during local dev, not on prod-like

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -2,17 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const restmail = require('../../lib/restmail');
-const TestHelpers = require('../../lib/helpers');
-const selectors = require('./selectors');
-const pollUntil = require('@theintern/leadfoot/helpers/pollUntil').default;
-const Url = require('url');
-const Querystring = require('querystring');
-const nodeXMLHttpRequest = require('xmlhttprequest');
-const assert = intern.getPlugin('chai').assert;
-const mkdirp = require('mkdirp');
-const fs = require('fs');
+const { assert } = intern.getPlugin('chai');
+const cp = require('child_process');
 const crypto = require('crypto');
+const fs = require('fs');
+const mkdirp = require('mkdirp');
+const nodeXMLHttpRequest = require('xmlhttprequest');
+const path = require('path');
+const pollUntil = require('@theintern/leadfoot/helpers/pollUntil').default;
+const Querystring = require('querystring');
+const restmail = require('../../lib/restmail');
+const selectors = require('./selectors');
+const TestHelpers = require('../../lib/helpers');
+const Url = require('url');
 
 // Default options for TOTP
 const otplib = require('otplib');
@@ -2501,6 +2503,32 @@ const subscribeToTestProduct = thenify(function() {
   );
 });
 
+/**
++ * Send verification reminder emails
++ */
+const sendVerificationReminders = thenify(function() {
+  return this.parent.then(() => {
+    const cwd = path.join(
+      __dirname,
+      '..',
+      '..',
+      '..',
+      '..',
+      'fxa-auth-server',
+      'scripts'
+    );
+    return cp.execSync('node verification-reminders.js', {
+      cwd,
+      env: {
+        ...process.env,
+        NODE_ENV: 'dev',
+      },
+      stdio: 'ignore',
+      timeout: this.timeout,
+    });
+  });
+});
+
 module.exports = {
   ...TestHelpers,
   cleanMemory,
@@ -2575,6 +2603,7 @@ module.exports = {
   pollUntilGoneByQSA,
   pollUntilHiddenByQSA,
   respondToWebChannelMessage,
+  sendVerificationReminders,
   storeWebChannelMessageData,
   subscribeToTestProduct,
   switchToWindow,


### PR DESCRIPTION
Convert the `complete_sign_up` tests to be the `verification reminders`
tests. The only flow that sends signup verification links now are the
reminders, so re-purposing this module seemed appropriate.

Not attached to an issue.

@mozilla/fxa-devs - r?