### PR TITLE
fix(user-agent): Parse user agents as 'tablet' for iPads in FF sending desktop headers

### DIFF
--- a/packages/fxa-auth-server/test/local/user_agent.js
+++ b/packages/fxa-auth-server/test/local/user_agent.js
@@ -539,4 +539,22 @@ describe('userAgent, real dependency', () => {
       formFactor: undefined,
     });
   });
+
+  it('correctly parses iPad user agents requesting a desktop site', () => {
+    // Note: the iOS version is not included in this type of user agent
+    // and `osVersion` is therefore not accurate
+    assert.deepEqual(
+      userAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/20.2 Safari/605.1.15'
+      ),
+      {
+        browser: 'Firefox iOS',
+        browserVersion: '20.2',
+        os: 'Mac OS X',
+        osVersion: '10.15',
+        deviceType: 'tablet',
+        formFactor: 'iPad',
+      }
+    );
+  });
 });

--- a/packages/fxa-content-server/app/scripts/lib/user-agent.js
+++ b/packages/fxa-content-server/app/scripts/lib/user-agent.js
@@ -24,7 +24,17 @@ const UserAgent = function(userAgent) {
      * @returns {Boolean}
      */
     isIos() {
-      return this.os.name === 'iOS';
+      return this.os.name === 'iOS' || this.isDesktopFirefoxOnIpad();
+    },
+
+    /**
+     * iPads using FF iOS 13+ send a desktop UA.
+     * The OS shows as a Mac, but 'Firefox iOS' in the UA family.
+     *
+     * @returns {Boolean}
+     */
+    isDesktopFirefoxOnIpad() {
+      return /Mac/.test(this.os.name) && /FxiOS/.test(this.ua);
     },
 
     /**

--- a/packages/fxa-content-server/app/tests/spec/lib/user-agent.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/user-agent.js
@@ -97,6 +97,33 @@ describe('lib/user-agent', () => {
     });
   });
 
+  describe('isDesktopFirefoxOnIpad', () => {
+    it('returns `true` if a Macintosh OS and iOS is reported', () => {
+      const iosUserAgentStrings = [
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/20.2 Safari/605.1.15',
+      ];
+
+      iosUserAgentStrings.forEach(userAgentString => {
+        const uap = new UserAgent(userAgentString);
+        assert.isTrue(uap.isDesktopFirefoxOnIpad());
+      });
+    });
+
+    it('returns `false` if another OS with iOS is reported', () => {
+      const isNotIosDesktopUserAgentStrings = [
+        // iPhone
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4',
+        // non-desktop iPad
+        'Mozilla/5.0 (iPad; CPU OS 10_1_1 like Mac OS X) AppleWebKit/602.2.14 (KHTML, like Gecko) Version/10.0 Mobile/14B100 Safari/602.1',
+      ];
+
+      isNotIosDesktopUserAgentStrings.forEach(userAgentString => {
+        const uap = new UserAgent(userAgentString);
+        assert.isFalse(uap.isDesktopFirefoxOnIpad());
+      });
+    });
+  });
+
   describe('isFirefox', () => {
     it('returns `true` if in Firefox', () => {
       const firefoxUserAgentStrings = [


### PR DESCRIPTION
Fixes #2352 

As of iOS 12/13, Safari and Firefox on iPads have dropped the ‘iPad’ OS and have been updated to reflect _desktop_ user agents.

Before:
```
Mozilla/5.0 (iPad; CPU OS 12_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/18.2b15817 Mobile/15E148 Safari/605.1.15
```

After (Firefox):
```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/20.2 Safari/605.1.15
```

This change allows us to check iPad user agents logging as `Mac` OS / `FxiOS` and return the correct `deviceType` / `formFactor`.

When logging in with my iPad on Safari, "Web Session, Safari 13" is displayed instead of the device. I've added this [as a comment](https://github.com/mozilla/fxa/issues/3577#issuecomment-565536759) in #3577 as it seems more relevant there than here, since a login in Safari doesn't show the device and seems like a separate issue from #2352. 

Note: at the time of writing on iOS 13, the FF UA does not include `FxiOS`. The `firefox-ios` team (via Slack) let me know this was a bug that was just fixed, and the next update to hit the App Store would include it in their UA.