### PR TITLE
chore(sentry): wrap dns query errors by error code

### DIFF
--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -123,6 +123,7 @@
         "ua-parser-js": "git://github.com/vladikoff/ua-parser-js.git#fxa-version",
         "uglifyjs-webpack-plugin": "1.2.7",
         "underscore": "1.8.3",
+        "verror": "1.10.0",
         "webpack": "^4.41.2",
         "webpack-cli": "^3.3.10"
     },


### PR DESCRIPTION
This patch wraps errors from DNS queries in the email domain MX
record validation route by their error codes.  The main goal of this
exercise is to reduce the number of unique errors reported to Sentry.

Fixes #3572

@mozilla/fxa-devs  r?