### PR TITLE
fix(metrics): Fix sms experiment metrics

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/send-sms-install-link.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/send-sms-install-link.js
@@ -46,7 +46,7 @@ module.exports = class SmsGroupingRule extends BaseGroupingRule {
       choice = 'signinCodes';
     } else if (rolloutRate >= 1) {
       // country is fully rolled out.
-      choice = true;
+      choice = subject.country;
     } else if (this.bernoulliTrial(rolloutRate, subject.uniqueUserId)) {
       // country is in the process of being rolled out.
       choice = this.uniformChoice(

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/send-sms-install-link.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/send-sms-install-link.js
@@ -53,14 +53,15 @@ describe('lib/experiments/grouping-rules/send-sms-install-link', () => {
         delete CountryTelephoneInfo.GB.rolloutRate;
       });
 
-      it('returns `false', () => {
+      it('returns `false`', () => {
         assert.isFalse(
           experiment.choose({ account, country, uniqueUserId: 'user-id' })
         );
       });
 
       it('featureFlags take precedence', () => {
-        assert.isTrue(
+        assert.equal(
+          'GB',
           experiment.choose({
             account,
             country,
@@ -116,9 +117,10 @@ describe('lib/experiments/grouping-rules/send-sms-install-link', () => {
         );
       });
 
-      it('fully rolled out countries return `true`', () => {
+      it('fully rolled out countries return country', () => {
         CountryTelephoneInfo.GB.rolloutRate = 1.0;
-        assert.isTrue(
+        assert.equal(
+          'GB',
           experiment.choose({ account, country, uniqueUserId: 'user-id' })
         );
       });


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/3691

I believe that this was introduced in https://github.com/mozilla/fxa/pull/3570, which refactored the way experiments are created. This updates the `sendSms` experiment to return the country string when fully rolled out. This is still truthy and correctly posts the metrics.

<img width="250" alt="Screen Shot 2019-12-16 at 5 27 01 PM" src="https://user-images.githubusercontent.com/1295288/70948953-a3614e80-202a-11ea-9677-c3fa515d109c.png">

Targetted against train-152 so we can do a point release.