### PR TITLE
fix(payments): add payments-server as a module dependency for content-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
         "fxa-js-client",
         "fxa-shared",
         "fxa-profile-server",
-        "fxa-oauth-server"
+        "fxa-oauth-server",
+        "fxa-payments-server"
       ],
       "fxa-auth-server": [
         "fxa-auth-db-mysql",


### PR DESCRIPTION
I liked that test runs for commits to payment-server finished fast. But, at least twice now we've broken content-server tests in master after merging a payment-server PR. So, one's obviously dependent on the other.