### PR TITLE
feat(support): add location to support ticket

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -1533,6 +1533,26 @@ const conf = convict({
       env: 'ZENDESK_PRODUCT_NAME_FIELD_ID',
       format: String,
     },
+    locationCityFieldId: {
+      doc: 'Zendesk support ticket custom field for the city of the location',
+      default: '360026463311',
+      env: 'ZENDESK_LOCATION_CITY_FIELD_ID',
+      format: String,
+    },
+    locationStateFieldId: {
+      doc:
+        'Zendesk support ticket custom field for the state/region of the location',
+      default: '360026463491',
+      env: 'ZENDESK_LOCATION_STATE_FIELD_ID',
+      format: String,
+    },
+    locationCountryFieldId: {
+      doc:
+        'Zendesk support ticket custom field for the country of the location',
+      default: '360026463511',
+      env: 'ZENDESK_LOCATION_COUNTRY_FIELD_ID',
+      format: String,
+    },
   },
   otp: {
     step: {

--- a/packages/fxa-auth-server/test/local/routes/support.js
+++ b/packages/fxa-auth-server/test/local/routes/support.js
@@ -212,9 +212,9 @@ describe('support', () => {
           `${requestOptions.payload.topic} for ${requestOptions.payload.plan}: ${requestOptions.payload.subject}`
         );
         assert.equal(zendeskReq.comment.body, requestOptions.payload.message);
-        assert.equal(
-          zendeskReq[config.zendesk.productNameFieldId],
-          'FxA - 123done Pro'
+        assert.deepEqual(
+          zendeskReq.custom_fields.map(field => field.value),
+          ['FxA - 123done Pro', 'Mountain View', 'California', 'United States']
         );
         assert.deepEqual(res, { success: true, ticket: 91 });
         nock.isDone();
@@ -255,9 +255,9 @@ describe('support', () => {
           `${requestOptions.payload.topic} for ${requestOptions.payload.plan}: ${requestOptions.payload.subject}`
         );
         assert.equal(zendeskReq.comment.body, requestOptions.payload.message);
-        assert.equal(
-          zendeskReq[config.zendesk.productNameFieldId],
-          'FxA - 123done Pro'
+        assert.deepEqual(
+          zendeskReq.custom_fields.map(field => field.value),
+          ['FxA - 123done Pro', 'Mountain View', 'California', 'United States']
         );
         assert.deepEqual(res, { success: true, ticket: 91 });
         nock.isDone();


### PR DESCRIPTION
This patch adds the IP based location of the support form request into
the support ticket.  The location info might be helpful to the support
staff.

Fixes #2675 

@mozilla/fxa-devs r?