### PR TITLE
docs(support-panel): add README and JSDoc

### DIFF
--- a/packages/fxa-support-panel/README.md
+++ b/packages/fxa-support-panel/README.md
@@ -1,3 +1,29 @@
-# Support Panel
+# fxa-support-panel
 
-This is a small internal tool to help Mozilla support agents view some Firefox Accounts information
+The Firefox Accounts Support Panel is a small web service that is intended for use as
+an embedded iframe in the Zendesk Support UX. It's intended to show Subscription Support
+Agents relevant data about a users Firefox Account so that they may assist the users
+support request.
+
+## Software Architecture
+
+The primary source of truth on FxA user data is the fxa-auth-server. That service is
+configured to use OAuth for user and service access to account data, and has write access
+to the user data. Since this view is intended purely for read-only access to user data for
+assisting a support agent, this service instead queries a read-restricted version of the
+fxa-auth-db-mysql service (fxa-auth-server uses a full read/write fxa-auth-db-mysql
+service).
+
+Read-only access is enforced on the database by using a MySQL user restricted to the stored
+procedures needed to run the queries that fetch basic profile information.
+
+### Code Organization
+
+- `bin/` - Program directory (Note the runnable versions will be under `dist/` when compiled)
+  - `worker` - Primary entry point for running the support-panel in production.
+- `config/` - Configuration loader and `.json` files for runtime environments.
+- `lib/`
+  - `api` - Hapi routes and controller.
+  - `server` - Hapi server setup and CSP configuration for above `api`.
+- `test` - Unit tests, organized in matching heirarchy with the root supprt-panel directory.
+- `types` - Additional TypeScript definitions for dependencies missing type information.

--- a/packages/fxa-support-panel/bin/worker.ts
+++ b/packages/fxa-support-panel/bin/worker.ts
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/**
+ * Primary entry point for running the support panel in production.
+ *
+ * @module
+ */
 import mozlog from 'mozlog';
 
 import Config from '../config';

--- a/packages/fxa-support-panel/lib/api.ts
+++ b/packages/fxa-support-panel/lib/api.ts
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/**
+ * Hapi routes and controller for support panel.
+ *
+ * @module
+ */
 import hapi from '@hapi/hapi';
 import hapiJoi from '@hapi/joi';
 import fs from 'fs';
@@ -10,11 +15,6 @@ import { Logger } from 'mozlog';
 import path from 'path';
 import requests from 'request-promise-native';
 import joi from 'typesafe-joi';
-
-export type SupportConfig = {
-  authHeader: string;
-  authdbUrl: string;
-};
 
 const queryValidator = joi
   .object()
@@ -33,8 +33,9 @@ const queryValidator = joi
 
 type supportQuery = joi.Literal<typeof queryValidator>;
 
-// Note that these are purely for access to known response keys and
-// not an attempt to validate the return payloads from fxa-auth-db-mysql
+// Note that these `*.Response` interfaces are purely for access to known
+// response keys and not an attempt to validate the return payloads from
+// fxa-auth-db-mysql.
 export interface AccountResponse {
   email: string;
   emailVerified: boolean;
@@ -65,6 +66,12 @@ export interface TotpTokenResponse {
   verified: boolean;
   enabled: boolean;
 }
+
+/** SupportController configuration */
+export type SupportConfig = {
+  authHeader: string;
+  authdbUrl: string;
+};
 
 class SupportController {
   constructor(
@@ -105,6 +112,7 @@ class SupportController {
       this.logger.error('infoFetch', { err });
       return h.response('<h1>Unable to fetch user</h1>').code(500);
     }
+
     let totpEnabled: boolean;
     try {
       const totpResponse = await requests.get({
@@ -121,6 +129,7 @@ class SupportController {
         return h.response('<h1>Unable to fetch user</h1>').code(500);
       }
     }
+
     const context = {
       created: String(new Date(account.createdAt)),
       devices: devices.map(d => {
@@ -142,6 +151,7 @@ class SupportController {
   }
 }
 
+/** Initialize the provided Hapi server with the support routes */
 export function init(
   logger: Logger,
   config: SupportConfig,

--- a/packages/fxa-support-panel/lib/server.ts
+++ b/packages/fxa-support-panel/lib/server.ts
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+/**
+ * Hapi server initialization and setup.
+ *
+ * @module
+ */
 import hapi from '@hapi/hapi';
 import Scooter from '@hapi/scooter';
 import Blankie from 'blankie';


### PR DESCRIPTION
Because:

* README was empty and not helpful
* Some files were missing JSDoc

This commit:

* Add's a descriptive README documenting what this does, its
  architecture rationale, and JSDoc.

Closes #3687