### PR TITLE
fix(payments): add survey embed URL to CSP and use https

### DIFF
--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -233,6 +233,22 @@ const conf = convict({
         format: 'url',
       },
     },
+    accountsCdn: {
+      url: {
+        default: 'https://accounts-static.cdn.mozilla.net',
+        doc: 'The URL of the Firefox Accounts static content CDN',
+        env: 'FXA_STATIC_CDN_URL',
+        format: 'url',
+      },
+    },
+    surveyGizmo: {
+      url: {
+        default: 'https://www.surveygizmo.com',
+        doc: 'The Survey Gizmo iframe embed url',
+        env: 'SURVEY_GIZMO_EMBED_URL',
+        format: 'url',
+      },
+    },
   },
   staticResources: {
     directory: {

--- a/packages/fxa-payments-server/server/lib/csp.test.js
+++ b/packages/fxa-payments-server/server/lib/csp.test.js
@@ -41,9 +41,10 @@ describe('CSP blocking rules', () => {
   it('has correct frameSrc directives', () => {
     const { frameSrc } = directives;
 
-    expect(frameSrc).toHaveLength(2);
+    expect(frameSrc).toHaveLength(3);
     expect(frameSrc).toContain(Sources.STRIPE_SCRIPT_URL);
     expect(frameSrc).toContain(Sources.STRIPE_HOOKS_URL);
+    expect(frameSrc).toContain(Sources.SURVEY_GIZMO_IFRAME_EMBED_URL);
   });
 
   it('has correct imgSrc directives', () => {

--- a/packages/fxa-payments-server/server/lib/csp/blocking.js
+++ b/packages/fxa-payments-server/server/lib/csp/blocking.js
@@ -21,7 +21,7 @@ module.exports = function(config) {
   const CDN_URL = config.get('staticResources.url');
   const DATA = 'data:';
   const GRAVATAR = 'https://secure.gravatar.com';
-  const ACCOUNTS_STATIC_CDN = 'https://accounts-static.cdn.mozilla.net/';
+  const ACCOUNTS_STATIC_CDN = getOrigin(config.get('servers.accountsCdn.url'));
   const SENTRY_SERVER = getOrigin(config.get('sentry.url'));
   const OAUTH_SERVER = getOrigin(config.get('servers.oauth.url'));
   const PROFILE_SERVER = getOrigin(config.get('servers.profile.url'));
@@ -34,6 +34,9 @@ module.exports = function(config) {
   const STRIPE_API_URL = getOrigin(config.get('stripe.apiUrl'));
   const STRIPE_HOOKS_URL = getOrigin(config.get('stripe.hooksUrl'));
   const STRIPE_SCRIPT_URL = getOrigin(config.get('stripe.scriptUrl'));
+  const SURVEY_GIZMO_IFRAME_EMBED_URL = getOrigin(
+    config.get('servers.surveyGizmo.url')
+  );
 
   const EXTRA_IMG_SRC = config.get('csp.extraImgSrc');
 
@@ -66,7 +69,11 @@ module.exports = function(config) {
       ],
       defaultSrc: [SELF],
       fontSrc: addCdnRuleIfRequired([SELF]),
-      frameSrc: [STRIPE_SCRIPT_URL, STRIPE_HOOKS_URL],
+      frameSrc: [
+        STRIPE_SCRIPT_URL,
+        STRIPE_HOOKS_URL,
+        SURVEY_GIZMO_IFRAME_EMBED_URL,
+      ],
       imgSrc: addCdnRuleIfRequired([
         SELF,
         DATA,
@@ -96,6 +103,7 @@ module.exports = function(config) {
       HOT_RELOAD_WEBSOCKET,
       PROFILE_IMAGES_SERVER,
       ACCOUNTS_STATIC_CDN,
+      SURVEY_GIZMO_IFRAME_EMBED_URL,
       PROFILE_SERVER,
       PUBLIC_URL,
       SENTRY_SERVER,

--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -57,6 +57,9 @@ module.exports = () => {
       profile: {
         url: config.get('servers.profile.url'),
       },
+      surveyGizmo: {
+        url: config.get('servers.surveyGizmo.url'),
+      },
     },
     stripe: {
       apiKey: config.get('stripe.apiKey'),

--- a/packages/fxa-payments-server/src/lib/config.test.ts
+++ b/packages/fxa-payments-server/src/lib/config.test.ts
@@ -139,6 +139,9 @@ const expectedMergedConfig = {
     profile: {
       url: '',
     },
+    surveyGizmo: {
+      url: '',
+    },
   },
   stripe: {
     apiKey: '',

--- a/packages/fxa-payments-server/src/lib/config.ts
+++ b/packages/fxa-payments-server/src/lib/config.ts
@@ -28,6 +28,9 @@ export interface Config {
     profile: {
       url: string;
     };
+    surveyGizmo: {
+      url: string;
+    };
   };
   stripe: {
     apiKey: string;
@@ -61,6 +64,9 @@ export function defaultConfig(): Config {
         url: '',
       },
       profile: {
+        url: '',
+      },
+      surveyGizmo: {
         url: '',
       },
     },

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionRedirect/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionRedirect/index.tsx
@@ -15,11 +15,17 @@ export const SubscriptionRedirect = ({ plan }: SubscriptionRedirectProps) => {
   const { product_id } = plan;
   const { downloadURL } = metadataFromPlan(plan);
   const {
-    config: { env, productRedirectURLs },
+    config: {
+      env,
+      productRedirectURLs,
+      servers: {
+        surveyGizmo: { url: surveyGizmoUrl },
+      },
+    },
     navigateToUrl,
   } = useContext(AppContext);
 
-  const surveyEmbedUrl = `http://www.surveygizmo.com/s3/5294819/VPN-Subscription?__no_style=true&env=${env}`;
+  const surveyEmbedUrl = `${surveyGizmoUrl}/s3/5294819/VPN-Subscription?__no_style=true&env=${env}`;
 
   const redirectUrl =
     downloadURL || productRedirectURLs[product_id] || defaultProductRedirectURL;


### PR DESCRIPTION
- also add new server config vars for both Survey Monkey and Accounts
  CDN hosts

- add https:// to Survey Gizmo embed URL by default

issue #3456