### PR TITLE
chore(dependency cleanup): eliminate hapi-fxa-oath dependency

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -448,6 +448,20 @@ AppError.invalidNonce = function() {
   });
 };
 
+AppError.unauthorized = function unauthorized(reason) {
+  return new AppError(
+    {
+      code: 401,
+      error: 'Unauthorized',
+      errno: ERRNO.INVALID_TOKEN,
+      message: 'Unauthorized for route',
+    },
+    {
+      detail: reason,
+    }
+  );
+};
+
 AppError.missingContentLength = function() {
   return new AppError({
     code: 411,

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/auth-oauth.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/auth-oauth.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const AppError = require('../../error');
+const logger = require('../../oauth/logging')('server.auth-oauth');
+const token = require('../../oauth/token');
+
+const authName = 'fxa-oauth';
+
+exports.AUTH_SCHEME = authName;
+
+exports.strategy = function() {
+  return {
+    authenticate: async function(req, h) {
+      var auth = req.headers.authorization;
+
+      if (!auth || auth.indexOf('Bearer') !== 0) {
+        throw AppError.unauthorized('Bearer token not provided');
+      }
+
+      var tok = auth.split(' ')[1];
+
+      return token.verify(tok).then(
+        function tokenFound(info) {
+          info.scope = info.scope.getScopeValues();
+          return h.authenticated({
+            credentials: info,
+          });
+        },
+        function noToken(err) {
+          logger.debug(authName + '.error', err);
+          throw AppError.unauthorized('Bearer token invalid');
+        }
+      );
+    },
+  };
+};

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -14,6 +14,7 @@ const userAgent = require('./userAgent');
 const schemeRefreshToken = require('./routes/auth-schemes/refresh-token');
 const schemeServerJWT = require('./routes/auth-schemes/serverJWT');
 const authBearer = require('./routes/auth-schemes/auth-bearer');
+const authOauth = require('./routes/auth-schemes/auth-oauth');
 const { HEX_STRING, IP_ADDRESS } = require('./routes/validators');
 const { configureSentry } = require('./sentry');
 
@@ -335,9 +336,9 @@ async function create(log, error, config, routes, db, oauthdb, translator) {
     getCredentialsFunc: makeCredentialFn(db.passwordChangeToken.bind(db)),
     hawk: hawkOptions,
   });
-  await server.register(require('hapi-fxa-oauth'));
 
-  server.auth.strategy('oauthToken', 'fxa-oauth', config.oauth);
+  server.auth.scheme(authOauth.AUTH_SCHEME, authOauth.strategy);
+  server.auth.strategy('oauthToken', authOauth.AUTH_SCHEME, config.oauth);
 
   server.auth.scheme(
     'fxa-oauth-refreshToken',

--- a/packages/fxa-auth-server/package-lock.json
+++ b/packages/fxa-auth-server/package-lock.json
@@ -3095,25 +3095,6 @@
         }
       }
     },
-    "hapi-fxa-oauth": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hapi-fxa-oauth/-/hapi-fxa-oauth-3.0.0.tgz",
-      "integrity": "sha512-ec+DEWDJhacePFkXQqbvTknXXUCpIFApxZAO2hRk7TAGgp1PtMZ4imVxhgx/UwVkH6a5qkr+8o1IcP5oO5ilTw==",
-      "requires": {
-        "boom": "7.2.0",
-        "poolee": "1.0.1"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
-          "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
-          "requires": {
-            "hoek": "5.x.x"
-          }
-        }
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -6908,7 +6889,7 @@
       "dev": true
     },
     "uap-core": {
-      "version": "git://github.com/ua-parser/uap-core.git#2e6c983e42e7aae7d957a263cb4d3de7ccbd92af",
+      "version": "git://github.com/ua-parser/uap-core.git#9db18c34f47ee8a30fcd1615ffcbb3ba4e02f287",
       "from": "git://github.com/ua-parser/uap-core.git"
     },
     "uap-ref-impl": {

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -60,7 +60,6 @@
     "hapi": "17.8.3",
     "hapi-auth-hawk": "4.0.0",
     "hapi-error": "1.8.0",
-    "hapi-fxa-oauth": "3.0.0",
     "hkdf": "0.0.2",
     "hot-shots": "^6.4.1",
     "i18n-abide": "0.0.26",

--- a/packages/fxa-auth-server/test/local/routes/auth-schemes/auth-oauth.js
+++ b/packages/fxa-auth-server/test/local/routes/auth-schemes/auth-oauth.js
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { assert } = require('chai');
+const proxyquire = require('proxyquire');
+const AppError = require('../../../../lib/error');
+const OauthAppError = require('../../../../lib/oauth/error');
+const P = require('../../../../lib/promise');
+const ScopeSet = require('../../../../../fxa-shared').oauth.scopes;
+
+const authOauthPath = '../../../../lib/routes/auth-schemes/auth-oauth';
+const mockRequest = {
+  headers: {
+    authorization:
+      'Bearer 0000000000000000000000000000000000000000000000000000000000000000',
+  },
+};
+const mockTokenInfo = {
+  user: 'testuser',
+  scope: ScopeSet.fromArray(['bar:foo', 'clients:write']),
+};
+
+describe('lib/routes/auth-schemes/auth-oauth', () => {
+  let authOauth;
+  const tokenStub = {};
+
+  before(() => {
+    authOauth = proxyquire(authOauthPath, { '../../oauth/token': tokenStub });
+  });
+
+  it('exports auth configuration', () => {
+    assert.equal(authOauth.AUTH_SCHEME, 'fxa-oauth');
+    assert.ok(authOauth.strategy);
+  });
+
+  describe('authenticate', () => {
+    describe('when a Bearer token is not provided', () => {
+      it('throws an AppError of type unauthorized', () => {
+        return authOauth
+          .strategy()
+          .authenticate({
+            headers: {},
+          })
+          .then(assert.fail, err => {
+            assert.isTrue(err instanceof AppError);
+            assert.equal(err.output.statusCode, 401);
+            assert.equal(err.output.payload.code, 401);
+            assert.equal(err.output.payload.errno, 110);
+            assert.equal(err.output.payload.error, 'Unauthorized');
+            assert.equal(err.output.payload.message, 'Unauthorized for route');
+            assert.equal(
+              err.output.payload.detail,
+              'Bearer token not provided'
+            );
+          });
+      });
+    });
+
+    describe('when the Bearer token is invalid', () => {
+      before(() => {
+        tokenStub.verify = token => {
+          return P.reject(OauthAppError.invalidToken());
+        };
+      });
+
+      it('throws an AppError of type unauthorized', () => {
+        return authOauth
+          .strategy()
+          .authenticate(mockRequest)
+          .then(assert.fail, err => {
+            assert.isTrue(err instanceof AppError);
+            assert.equal(err.output.statusCode, 401);
+            assert.equal(err.output.payload.code, 401);
+            assert.equal(err.output.payload.errno, 110);
+            assert.equal(err.output.payload.error, 'Unauthorized');
+            assert.equal(err.output.payload.message, 'Unauthorized for route');
+            assert.equal(err.output.payload.detail, 'Bearer token invalid');
+          });
+      });
+    });
+
+    describe('when a valid Bearer token is provided', () => {
+      let mockReply;
+      before(() => {
+        mockReply = function(err) {
+          throw err;
+        };
+
+        tokenStub.verify = token => {
+          return P.resolve(mockTokenInfo);
+        };
+      });
+
+      it('returns successfully with the credentials from the verified token', done => {
+        mockReply.authenticated = function(result) {
+          assert.equal(result.credentials.user, 'testuser');
+          done();
+        };
+        authOauth.strategy().authenticate(mockRequest, mockReply);
+      });
+    });
+  });
+});


### PR DESCRIPTION
within fxa-oauth-server package:
- removes reference to hapi-fxa-oauth
- removes hapi-fxa-oath from depencencies
- adds new route auth scheme
- adds unit test for auth scheme
- updates remote tests affected by the auth scheme update
fixes https://github.com/mozilla/fxa/issues/3049