### PR TITLE
feat(content-server): Improve password advice functionality

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/password-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/password-mixin.js
@@ -15,6 +15,7 @@ export default {
     'blur #vpassword': 'hidePasswordHelper',
     'keyup #vpassword': 'onVPasswordChanged',
     'mousedown .show-password-label': 'onShowPasswordMouseDown',
+    'mouseup .show-password-label': 'onShowPasswordMouseUp',
     'touchstart .show-password-label': 'onShowPasswordMouseDown',
     'keydown input.show-password': 'onShowPasswordTV',
   },
@@ -100,6 +101,13 @@ export default {
     this.togglePasswordVisibility($passwordEl);
   },
 
+  onShowPasswordMouseUp(event) {
+    // return focus to input
+    this.$(event.target)
+      .siblings('.password')
+      .focus();
+  },
+
   togglePasswordVisibility($el) {
     if ($el.attr('type') === 'text') {
       this.hidePassword($el);
@@ -109,7 +117,7 @@ export default {
   },
 
   getAffectedPasswordInputs(button) {
-    var $passwordEl = this.$(button).siblings('.password');
+    let $passwordEl = this.$(button).siblings('.password');
     if (this.$(button).data('synchronizeShow')) {
       $passwordEl = this.$('.password[data-synchronize-show]');
     }

--- a/packages/fxa-content-server/app/scripts/views/password_strength/password_with_strength_balloon.js
+++ b/packages/fxa-content-server/app/scripts/views/password_strength/password_with_strength_balloon.js
@@ -23,8 +23,9 @@ const DELAY_BEFORE_UPDATE_MODEL_MS = 1000;
 const PasswordWithStrengthBalloonView = FormView.extend({
   events: {
     change: 'updateModelAfterDelay',
-    focus: 'createBalloonIfNeeded',
+    focus: 'focusHandler',
     keypress: 'updateModelAfterDelay',
+    blur: 'blurHandler',
   },
 
   initialize(options = {}) {
@@ -46,6 +47,17 @@ const PasswordWithStrengthBalloonView = FormView.extend({
       () => this.updateModel(),
       delayBeforeUpdateModelMS
     );
+  },
+
+  focusHandler() {
+    this.model.set('inputFocused', true);
+    this.createBalloonIfNeeded();
+  },
+
+  // Allow a `change:inputFocused` event to hide the balloon only if the user
+  // has moved focus away from the input
+  blurHandler() {
+    this.model.set('inputFocused', false);
   },
 
   createBalloonIfNeeded() {

--- a/packages/fxa-content-server/app/tests/spec/views/password_strength/password_strength_balloon.js
+++ b/packages/fxa-content-server/app/tests/spec/views/password_strength/password_strength_balloon.js
@@ -103,35 +103,37 @@ describe('views/password_strength/password_strength_balloon', () => {
   describe('update', () => {
     beforeEach(() => {
       sinon.spy(view, 'render');
-      sinon.spy(view, 'hideAfterDelay');
     });
 
-    it('renders, does not hide if error', () => {
-      model.validationError = AuthErrors.toError('PASSWORD_SAME_AS_EMAIL');
-
+    it('renders', () => {
       return view.update().then(() => {
         assert.isTrue(view.render.calledOnce);
-        assert.isFalse(view.hideAfterDelay.called);
-      });
-    });
-
-    it('hides if the model is valid', () => {
-      model.validationError = null;
-
-      return view.update().then(() => {
-        assert.isTrue(view.render.calledOnce);
-        assert.isTrue(view.hideAfterDelay.calledOnce);
       });
     });
   });
 
-  it('hideAfterDelay hides after a delay', () => {
-    sinon.stub(view, 'setTimeout').callsFake(callback => callback.call(view));
-    sinon.stub(view, 'hide');
+  describe('shouldHide', () => {
+    beforeEach(() => {
+      sinon.spy(view, 'shouldHide');
+      sinon.spy(view, 'hide');
+    });
 
-    view.hideAfterDelay();
+    it('does not hide if error', () => {
+      model.validationError = AuthErrors.toError('PASSWORD_SAME_AS_EMAIL');
+      view.shouldHide();
+      assert.isFalse(view.hide.called);
+    });
 
-    assert.isTrue(view.setTimeout.calledOnce);
-    assert.isTrue(view.hide.calledOnce);
+    it('does not hide if input is focused', () => {
+      model.set('inputFocused', true);
+      view.shouldHide();
+      assert.isFalse(view.hide.called);
+    });
+
+    it('hides onblur if no error', () => {
+      model.set('inputFocused', false);
+      view.shouldHide();
+      assert.isTrue(view.hide.called);
+    });
   });
 });


### PR DESCRIPTION
fixes #607 

It was determined the issue could be closed out with the following features:
- Update copy + key image for “repeat password": taken care of in #3235
- Make “repeat password” popup occur in mobile: I'm not sure if this was worked on in another issue, but I'm seeing the popup now. I tested in Safari emulator and XCode iOS. <img src="https://user-images.githubusercontent.com/13018240/71117685-44234b80-219c-11ea-9cbc-bbba1f86104a.png" width="200px">
- Persist first password tooltip until onblur: this PR✅ 
- Return focus to last focused password field after 👁 is toggled on: this PR✅