### PR TITLE
chore(build): [blocked by #3828] Revert allowing Node 10 in check.sh, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you get an `error` status for any of the servers please verify that you insta
 
 > Required developer dependencies:
 > [Git](http://git-scm.com/book/en/v2/Getting-Started-Installing-Git),
-> [node.js **10+** with npm 6](http://nodejs.org/),
+> [node.js **12+** with npm 6](http://nodejs.org/),
 > [Python 2.6+](https://www.python.org/),
 > [Java 8+](https://www.java.com/en/download/),
 > [Rust nightly+](https://doc.rust-lang.org/1.5.0/book/nightly-rust.html),
@@ -139,14 +139,14 @@ sudo service docker restart
 
 #### Installing Node.js
 
-We currently use Node 10.
+We currently use Node 12.
 See https://nodejs.org
 
 Alternatively, the [Node Version Manager](https://github.com/nvm-sh/nvm) makes working with different versions of Node easy.
 
 ```
-nvm install 10
-nvm alias default 10
+nvm install 12
+nvm alias default 12
 ```
 
 #### Installing Java

--- a/_scripts/check.sh
+++ b/_scripts/check.sh
@@ -3,8 +3,8 @@
 set -ex
 
 node_version="$(node -v | cut -f 1 -d '.' | cut -f 2 -d 'v')"
-if [ "$node_version" -ne "10" ]; then
-  echo "intall node 10 to continue installation"
+if [ "$node_version" -ne "12" ]; then
+  echo "install node 12 to continue installation"
   echo "http://nodejs.org/"
   exit 1
 fi

--- a/_scripts/check.sh
+++ b/_scripts/check.sh
@@ -3,9 +3,8 @@
 set -ex
 
 node_version="$(node -v | cut -f 1 -d '.' | cut -f 2 -d 'v')"
-
-if [ "$node_version" -ne "12" ] && [ "$node_version" -ne "10" ]; then
-  echo "install node 12 or node 10 to continue installation"
+if [ "$node_version" -ne "10" ]; then
+  echo "intall node 10 to continue installation"
   echo "http://nodejs.org/"
   exit 1
 fi


### PR DESCRIPTION
Since the CI image appears to pull from `master`, we had to allow Node 10 as an option for the train 152.1 point release which was still on Node 10.

This PR should be merged before the Node 12 upgrade is placed on a release, _after_ any other point releases.

I left these as separate commits for the history, I can squash them if preferred. 🤷‍♀️