### PR TITLE
fix(css): Add privacy links to sign-in page

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -25,6 +25,10 @@
         <button id="submit-btn" {{^isPasswordNeeded}}class="use-logged-in"{{/isPasswordNeeded}} type="submit">{{#t}}Sign in{{/t}}</button>
       </div>
 
+        <div class="tos-pp faint">
+            {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
+        </div>
+
       <div class="links">
         <a href="/" class="left use-different" data-flow-event="use-different-account">{{#t}}Use a different account{{/t}}</a>
         <a href="/reset_password" class="right reset-password" data-flow-event="forgot-password">{{#t}}Forgot password?{{/t}}</a>

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_password.js
@@ -90,6 +90,7 @@ describe('views/sign_in_password', () => {
       assert.lengthOf(view.$('input[type=password]'), 1);
       assert.isTrue(notifier.trigger.calledOnce);
       assert.isTrue(notifier.trigger.calledWith('flow.initialize'));
+      assert.lengthOf(view.$('.tos-pp'), 1);
     });
   });
 


### PR DESCRIPTION
Fixes #3743 

Turns out the links don't exist on the sign-in page 🧐

<img width="549" alt="Screen Shot 2019-12-23 at 1 19 45 PM" src="https://user-images.githubusercontent.com/1295288/71373952-f2593780-2586-11ea-8be6-3c30d1d0c56a.png">

<img width="291" alt="Screen Shot 2019-12-23 at 1 23 29 PM" src="https://user-images.githubusercontent.com/1295288/71374099-6dbae900-2587-11ea-9158-ef2981a8b9d0.png">
