### PR TITLE
fix(css): improve line-height of input placeholders in webkit browsers

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_input-row.scss
+++ b/packages/fxa-content-server/app/styles/modules/_input-row.scss
@@ -13,7 +13,6 @@
 
     &::placeholder {
       color: $input-placeholder-color !important;
-      font-size: 17px;
       font-weight: $font-weight-body-20;
       opacity: 1;
     }
@@ -21,7 +20,7 @@
     &::-webkit-input-placeholder {
       // Fixes a problem in Safari/Fx for iOS where placeholder
       // text is not vertically centered and becomes cut-off.
-      line-height: 1 !important;
+      line-height: 1.3 !important;
     }
 
     // disable arrows on HTML5 number inputs


### PR DESCRIPTION
Closes #1743

This is my attempt at fixing the janky line-height on input fields in iOS. Because the selector being modified targets Webkit browsers we also have to take desktop Safari into consideration.

One thing I noticed adjacent to this issue was that the placeholder psuedo selector had a font-size of 17px, where as far as I can see the value type for these fields are font-size 16px. Removing this helped with consistency, but I am also unaware of why it was added so any insight here is valuable.

Some previews:

![iOS](https://user-images.githubusercontent.com/6392049/71427500-5d8a3300-2687-11ea-883d-ab6f785db037.png)

![Safari](https://user-images.githubusercontent.com/6392049/71427502-624ee700-2687-11ea-98bc-c39927c52111.png)

You'll notice that the "after" for Safari is still off by a pixel or so, but the iOS fix looks a noticeably better. My thinking is that iOS should take priority here as we'll encounter more instances of this jankiness in Firefox iOS (which is just iOS Safari, whereas someone who has an FxA would probably use true Firefox on desktop - speculation on my part).
