### PR TITLE
refactor(settings): change actions in 2fa, recovery, and avatar modals from anchors to buttons

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/account_recovery/recovery_key.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/account_recovery/recovery_key.mustache
@@ -13,27 +13,27 @@
 
         {{^isIos}}
             <div class="button-row save-options">
-                <a href="#" class="save-option download-option">
+                <button class="save-option download-option">
                     <div class="graphic graphic-download-option"></div>
                     <p class="name">{{#t}}Download{{/t}}</p>
-                </a>
-                <a href="#" class="save-option copy-option">
+                </button>
+                <button class="save-option copy-option">
                     <div class="graphic graphic-copy-option"></div>
                     <p class="name">{{#t}}Copy{{/t}}</p>
-                </a>
-                <a href="#" class="save-option print-option">
+                </button>
+                <button class="save-option print-option">
                     <div class="graphic graphic-print-option"></div>
                     <p class="name">{{#t}}Print{{/t}}</p>
-                </a>
+                </button>
             </div>
         {{/isIos}}
 
         {{#isIos}}
             <div class="button-row">
-                <a href="#" class="save-option copy-option">
+                <button class="save-option copy-option">
                     <div class="graphic graphic-copy-option"></div>
                     <p class="name">{{#t}}Copy{{/t}}</p>
-                </a>
+                </button>
             </div>
         {{/isIos}}
 

--- a/packages/fxa-content-server/app/scripts/templates/settings/avatar_change.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/avatar_change.mustache
@@ -9,10 +9,12 @@
 
     <nav id="avatar-options">
       <input type="file" id="imageLoader" name="imageLoader" accept="image/png, image/jpeg"/>
-      <a href="#" id="file">{{#t}}Upload{{/t}}</a>
-      <a href="/settings/avatar/camera" id="camera">{{#t}}Camera{{/t}}</a>
+      <button id="file">{{#t}}Upload{{/t}}</button>
+
+      <a href="/settings/avatar/camera" id="camera" role="button">{{#t}}Camera{{/t}}</a>
+
       {{^avatarDefault}}
-      <a href="#" class="remove">{{#t}}Clear{{/t}}</a>
+        <button class="remove">{{#t}}Clear{{/t}}</button>
       {{/avatarDefault}}
     </nav>
 

--- a/packages/fxa-content-server/app/scripts/templates/settings/recovery_codes.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/recovery_codes.mustache
@@ -36,27 +36,27 @@
 
             {{^isIos}}
                 <div class="button-row save-options">
-                    <a href="#" class="save-option download-option">
+                    <button type="button" class="save-option download-option">
                         <div class="graphic graphic-download-option"></div>
                         <p class="name">{{#t}}Download{{/t}}</p>
-                    </a>
-                    <a href="#" class="save-option copy-option">
+                    </button>
+                    <button type="button" class="save-option copy-option">
                         <div class="graphic graphic-copy-option"></div>
                         <p class="name">{{#t}}Copy{{/t}}</p>
-                    </a>
-                    <a href="#" class="save-option print-option">
+                    </button>
+                    <button type="button" class="save-option print-option">
                         <div class="graphic graphic-print-option"></div>
                         <p class="name">{{#t}}Print{{/t}}</p>
-                    </a>
+                    </button>
                 </div>
             {{/isIos}}
 
             {{#isIos}}
                 <div class="button-row">
-                    <a href="#" class="save-option copy-option">
+                    <button type="button" class="save-option copy-option">
                         <div class="graphic graphic-copy-option"></div>
                         <p class="name">{{#t}}Copy{{/t}}</p>
-                    </a>
+                    </button>
                 </div>
             {{/isIos}}
         {{/showRecoveryCodes}}

--- a/packages/fxa-content-server/app/styles/modules/_avatar.scss
+++ b/packages/fxa-content-server/app/styles/modules/_avatar.scss
@@ -199,19 +199,25 @@
     margin: 0 -40px -20px -40px;
     padding: 25px 20px 20px;
 
+    button,
     a {
       background: {
+        color: transparent;
         repeat: no-repeat;
         size: 48%;
       }
+      color: $link-color-default;
       display: inline-block;
+      font-weight: 400;
+      font-size: 14px;
       line-height: 1.1;
       padding-top: 11%;
       text-decoration: none;
+      width: initial;
 
       @include respond-to('big') {
         height: 80px;
-        margin: 5px;
+        margin: 5px 5px 10px;
         min-width: 80px;
         padding-top: 52px;
       }
@@ -239,6 +245,7 @@
 
       &#camera {
         background-image: image-url('glyph-camera-32.svg');
+        background-position-y: 0.45vw;
       }
 
       &#file {

--- a/packages/fxa-content-server/app/styles/modules/_settings-totp.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings-totp.scss
@@ -146,11 +146,26 @@
 
 .save-options {
   display: flex;
-  margin-top: 25px;
+  margin: 15px 0 10px;
 }
 
 .save-option {
+  background-color: transparent;
+  color: $link-color-default;
+  display: inline-block;
+  font-weight: 400;
+  height: initial;
+  padding: 10px 0;
   width: 33%;
+
+  &:hover {
+    background-color: transparent;
+    filter: hue-rotate(3deg) saturate(1.1) brightness(0.85);
+  }
+
+  &:active {
+    filter: hue-rotate(3deg) saturate(1.1) brightness(0.75);
+  }
 
   .name {
     font-size: 14px;


### PR DESCRIPTION
Closes #624

Hey all. I decided to take a crack at this. The issue was pretty straightforward, but I'm going to break my changes down a bit.

- First and foremost, I've updated the actions in the Two-step authentication, Account recovery, and Account picture modals from `<a>`s to `<button>`s, with one exception: the action to toggle the camera takes you to a new modal and URL, so I felt it appropriate to leave it as an anchor,
- I made sure to use `type="button"` on them all so as to avoid accidental page submissions.
- The previous Two-step authentication and Account recovery actions had an underline effect on hover, whereas the Account picture modal ones had a color shift on hover. I decided to make these consistent and apply the color shift to the former ones, removing their hover underline.
- The Two-step authentication and Account recovery actions were lacking some padding that make tab-focus a little tight looking. I updated that.

Would love to hear your thoughts.