### PR TITLE
fix(avatar): update avatar image cropper to work at smaller window sizes

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/settings/avatar_crop.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/avatar_crop.js
@@ -13,9 +13,6 @@ import ModalSettingsPanelMixin from '../mixins/modal-settings-panel-mixin';
 import ProfileImage from '../../models/profile-image';
 import Template from 'templates/settings/avatar_crop.mustache';
 
-var HORIZONTAL_GUTTER = 90;
-var VERTICAL_GUTTER = 0;
-
 const proto = FormView.prototype;
 const View = FormView.extend({
   template: Template,
@@ -55,14 +52,12 @@ const View = FormView.extend({
         displayLength: Constants.PROFILE_IMAGE_DISPLAY_SIZE,
         exportLength: Constants.PROFILE_IMAGE_EXPORT_SIZE,
         height: height,
-        horizontalGutter: HORIZONTAL_GUTTER,
         onRotate: this._onRotate.bind(this),
         onTranslate: this._onTranslate.bind(this),
         onZoomIn: this._onZoomIn.bind(this),
         onZoomOut: this._onZoomOut.bind(this),
         onZoomRangeChange: this._onZoomRangeChange.bind(this),
         src: src,
-        verticalGutter: VERTICAL_GUTTER,
         width: width,
       });
     } catch (e) {

--- a/packages/fxa-content-server/app/styles/modules/_cropper.scss
+++ b/packages/fxa-content-server/app/styles/modules/_cropper.scss
@@ -1,11 +1,18 @@
 .cropper {
   .wrapper {
     background-color: $cropper-background-color;
+    box-sizing: content-box;
     height: $avatar-size;
     margin: 0 -30px;
     overflow: hidden;
+    padding: 0 30px;
     position: relative;
-    width: $avatar-size + 180px;
+    width: 100%;
+
+    @include respond-to('small') {
+      margin: 0 -10px;
+      padding: 0 10px;
+    }
 
     img {
       position: absolute;
@@ -15,7 +22,7 @@
   .mask {
     background: image-url('crop-mask.svg');
     height: $avatar-size;
-    left: (420 - $avatar-size) / 2;
+    left: calc((100% - #{$avatar-size}) / 2);
     position: relative;
     top: 0;
     width: $avatar-size;
@@ -23,22 +30,22 @@
 
     &::before,
     &::after {
-      background-color: rgba($cropper-background-color, 0.5);
+      background-color: rgba($cropper-background-color, 0.545);
       content: '';
       display: block;
       height: $avatar-size;
       position: absolute;
       top: 0;
-      width: (420 - $avatar-size) / 2;
+      width: 100%;
       z-index: 1;
     }
 
     &::before {
-      left: -(420 - $avatar-size) / 2;
+      left: -100%;
     }
 
     &::after {
-      right: -(420 - $avatar-size) / 2;
+      right: -100%;
     }
   }
 


### PR DESCRIPTION
Closes #674

This should address the avatar image cropper at smaller window sizes.

~The change was relatively simple in that I kept the same height across all window sizes, used relative positioning for the X axis of the cropping circle, and only changed the margin offsets at different window sizes.~

This was actually a bit of a doozy, since the cropper sizing was hard coded. The remedies I've used are:

- Update all the cropper component styles to be a little more fluid.
- Remove the ability to specify explicit vertical and horizontal gutters, instead relying on the calculated width of the wrapper versus the size of the cropping box.
- Position accordingly on page load and on window resize (debounced).

[Here's a demo video](https://i.imgur.com/v2qU6AK.mp4) of the cropping container at various window sizes.

![Screen Shot 2019-12-28 at 01 04 18](https://user-images.githubusercontent.com/6392049/71539685-03e76a00-290e-11ea-904a-adc86fbbfbcd.png)

