### PR TITLE
chore(tests): Remove vesitigial reference to `serviceUri` in tests.

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/views/permissions.js
+++ b/packages/fxa-content-server/app/tests/spec/views/permissions.js
@@ -35,7 +35,6 @@ describe('views/permissions', function() {
   var CLIENT_ID = 'relier';
   var PERMISSIONS = ['profile:email', 'profile:uid'];
   var SERVICE_NAME = 'Relier';
-  var SERVICE_URI = 'relier.com';
 
   beforeEach(function() {
     broker = new Broker();
@@ -51,7 +50,6 @@ describe('views/permissions', function() {
       clientId: CLIENT_ID,
       permissions: PERMISSIONS,
       serviceName: SERVICE_NAME,
-      serviceUri: SERVICE_URI,
     });
 
     user = new User({});


### PR DESCRIPTION
Because:

* The relier field `serviceUri` was [removed many years ago](https://github.com/mozilla/fxa-content-server/commit/b361aba35df3215105e8d57f108db3f64007e886).
* I happened to be grepping around and noticed that one test still had a reference to that field in its setup logic.

This commit:

* Deletes the test setup code that initializes this vestigial field.