### PR TITLE
fix(oauth): Force serviceName="Firefox Sync" when connecting to sync.

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -68,10 +68,12 @@ module.exports = {
     'profile:email',
     'profile:uid',
   ],
+  OAUTH_OLDSYNC_SCOPE: 'https://identity.mozilla.com/apps/oldsync',
   OAUTH_WEBCHANNEL_REDIRECT:
     'urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel',
 
   RELIER_DEFAULT_SERVICE_NAME: 'Account Settings',
+  RELIER_SYNC_SERVICE_NAME: 'Firefox Sync',
   RELIER_KEYS_LENGTH: 32,
   RELIER_KEYS_CONTEXT_INFO_PREFIX: 'identity.mozilla.com/picl/v1/oauth/',
 

--- a/packages/fxa-content-server/app/scripts/models/reliers/browser.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/browser.js
@@ -8,6 +8,7 @@
 
 import _ from 'underscore';
 import AuthErrors from '../../lib/auth-errors';
+import Constants from '../../lib/constants';
 import CountryTelephoneInfo from '../../lib/country-telephone-info';
 import Relier from './relier';
 import Vat from '../../lib/vat';
@@ -57,10 +58,10 @@ export default Relier.extend({
     return Relier.prototype.fetch.call(this).then(() => {
       this.importSearchParamsUsingSchema(QUERY_PARAMETER_SCHEMA, AuthErrors);
 
-      if (this.get('service')) {
-        this.set('serviceName', t('Firefox Sync'));
+      // Customize the serviceName based on *why* the user is signing in.
+      if (this.get('service') === 'sync') {
+        this.set('serviceName', t(Constants.RELIER_SYNC_SERVICE_NAME));
       } else {
-        // if no service provided, then we are just signing into the browser
         this.set('serviceName', t('Firefox'));
       }
     });

--- a/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
@@ -14,6 +14,8 @@ import Relier from './relier';
 import Transform from '../../lib/transform';
 import Vat from '../../lib/vat';
 
+const t = msg => msg;
+
 /*eslint-disable camelcase*/
 const CLIENT_INFO_SCHEMA = {
   id: Vat.hex()
@@ -163,6 +165,12 @@ var OAuthRelier = Relier.extend({
 
     this.set('scope', permissions.join(' '));
     this.set('permissions', permissions);
+
+    // As a special case for UX purposes, any client requesting access to
+    // the user's sync data must have a display name of "Firefox Sync".
+    if (permissions.includes(Constants.OAUTH_OLDSYNC_SCOPE)) {
+      this.set('serviceName', t(Constants.RELIER_SYNC_SERVICE_NAME));
+    }
   },
 
   isOAuth() {

--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -633,8 +633,7 @@ section.modal-panel {
 
   &[data-name='Fenix'],
   &[data-name='Android Components Reference Browser'],
-  // It's a hack, but the only OAuth client named "Firefox Sync" is on Android.
-  &[data-name='Firefox Sync'] {
+  &[data-name='Firefox Preview'] {
     background-image: url('/images/icon-device-phone-android.svg');
   }
 

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
@@ -36,6 +36,7 @@ describe('models/reliers/oauth', () => {
   var PROMPT = OAuthPrompt.CONSENT;
   var QUERY_REDIRECT_URI = 'http://127.0.0.1:8080/api/oauth';
   var SCOPE = 'profile:email profile:uid';
+  var SCOPE_OLDSYNC = 'https://identity.mozilla.com/apps/oldsync';
   var SCOPE_PROFILE = Constants.OAUTH_TRUSTED_PROFILE_SCOPE;
   var SCOPE_PROFILE_EXPANDED = Constants.OAUTH_TRUSTED_PROFILE_SCOPE_EXPANSION.join(
     ' '
@@ -266,6 +267,28 @@ describe('models/reliers/oauth', () => {
       return relier.fetch().then(() => {
         assert.equal(relier.get('serviceName'), SERVICE_NAME);
         assert.equal(relier.get('redirectUri'), SERVER_REDIRECT_URI);
+      });
+    });
+
+    it('overrides serviceName to be "Firefox Sync" if the client is requesting access to Sync', () => {
+      windowMock.location.search = toSearchString({
+        action: ACTION,
+        client_id: CLIENT_ID,
+        redirect_uri: QUERY_REDIRECT_URI,
+        scope: SCOPE_OLDSYNC,
+        state: STATE,
+      });
+
+      sinon.stub(relier, 'isTrusted').callsFake(() => {
+        return true;
+      });
+      sinon.stub(relier, '_validateKeyScopeRequest').callsFake(() => {
+        return true;
+      });
+
+      return relier.fetch().then(() => {
+        assert.notEqual(relier.get('serviceName'), SERVICE_NAME);
+        assert.equal(relier.get('serviceName'), 'Firefox Sync');
       });
     });
 


### PR DESCRIPTION
Because:

* We want the signin UX to say "continue to Firefox Sync" for any
  client that's requesting access to sync, even OAuth clients.
* We currently ensure this by setting the OAuth client name for
  Fenix to be "Firefox Sync", which produces confusing UX in other
  other parts of the product (such as notifications popping up to
  say that "Firefox Sync has connected to Firefox Sync").

This commit:

* Makes the OAuth Relier model responsible for enforcing this special-case
  behaviour, so that it's localized to just the signin UX.

Connects to #1531.