### PR TITLE
feat(codes): Add js-client routes for verify secondary email via code

### DIFF
--- a/packages/fxa-js-client/client/FxAccountClient.js
+++ b/packages/fxa-js-client/client/FxAccountClient.js
@@ -2053,7 +2053,11 @@ FxAccountClient.prototype.recoveryEmails = function(sessionToken) {
  * @param {String} sessionToken SessionToken obtained from signIn
  * @param {String} email new email to be added
  */
-FxAccountClient.prototype.recoveryEmailCreate = function(sessionToken, email) {
+FxAccountClient.prototype.recoveryEmailCreate = function(
+  sessionToken,
+  email,
+  options
+) {
   var request = this.request;
 
   return Promise.resolve()
@@ -2067,6 +2071,10 @@ FxAccountClient.prototype.recoveryEmailCreate = function(sessionToken, email) {
       var data = {
         email: email,
       };
+
+      if (options && options.verificationMethod) {
+        data.verificationMethod = options.verificationMethod;
+      }
 
       return request.send('/recovery_email', 'POST', creds, data);
     });
@@ -2121,6 +2129,74 @@ FxAccountClient.prototype.recoveryEmailSetPrimaryEmail = function(
         email: email,
       };
       return request.send('/recovery_email/set_primary', 'POST', creds, data);
+    });
+};
+
+/**
+ * Verify a secondary email via a short code.
+ *
+ * @method recoveryEmailSecondaryVerifyCode
+ * @param {String} sessionToken SessionToken obtained from signIn
+ * @param {String} email Email to verify
+ * @param {String} code Code to verify with
+ */
+FxAccountClient.prototype.recoveryEmailSecondaryVerifyCode = function(
+  sessionToken,
+  email,
+  code
+) {
+  var request = this.request;
+  return Promise.resolve()
+    .then(function() {
+      required(sessionToken, 'sessionToken');
+      required(email, 'email');
+      required(code, 'code');
+
+      return hawkCredentials(sessionToken, 'sessionToken', HKDF_SIZE);
+    })
+    .then(function(creds) {
+      var data = {
+        email: email,
+        code: code,
+      };
+      return request.send(
+        '/recovery_email/secondary/verify_code',
+        'POST',
+        creds,
+        data
+      );
+    });
+};
+
+/**
+ * Resend secondary email verification code.
+ *
+ * @method recoveryEmailSecondaryVerifyCode
+ * @param {String} sessionToken SessionToken obtained from signIn
+ * @param {String} email Email to resend verification code
+ */
+FxAccountClient.prototype.recoveryEmailSecondaryResendCode = function(
+  sessionToken,
+  email
+) {
+  var request = this.request;
+  return Promise.resolve()
+    .then(function() {
+      required(sessionToken, 'sessionToken');
+      required(email, 'email');
+
+      return hawkCredentials(sessionToken, 'sessionToken', HKDF_SIZE);
+    })
+    .then(function(creds) {
+      var data = {
+        email: email,
+      };
+      return request.send(
+        '/recovery_email/secondary/resend_code',
+        'POST',
+        creds,
+        data
+      );
     });
 };
 

--- a/packages/fxa-js-client/tests/lib/emails.js
+++ b/packages/fxa-js-client/tests/lib/emails.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const assert = require('chai').assert;
+const sinon = require('sinon');
 
 var user2;
 var user2Email;
@@ -15,7 +16,10 @@ describe('emails', function() {
   var client;
   var RequestMocks;
   var account;
-  let env;
+  var env;
+  var xhr;
+  var xhrOpen;
+  var xhrSend;
 
   beforeEach(function() {
     env = new Environment();
@@ -27,13 +31,26 @@ describe('emails', function() {
 
     user2 = 'anotherEmail' + new Date().getTime();
     user2Email = user2 + '@restmail.net';
+
+    xhr = env.xhr;
+    xhrOpen = sinon.spy(xhr.prototype, 'open');
+    xhrSend = sinon.spy(xhr.prototype, 'send');
   });
 
-  function recoveryEmailCreate() {
+  afterEach(function() {
+    xhrOpen.restore();
+    xhrSend.restore();
+  });
+
+  function recoveryEmailCreate(options = {}) {
     return accountHelper.newVerifiedAccount().then(function(res) {
       account = res;
       return respond(
-        client.recoveryEmailCreate(account.signIn.sessionToken, user2Email),
+        client.recoveryEmailCreate(
+          account.signIn.sessionToken,
+          user2Email,
+          options
+        ),
         RequestMocks.recoveryEmailCreate
       );
     }, handleError);
@@ -182,6 +199,118 @@ describe('emails', function() {
 
         assert.equal(res[1].verified, true, 'returned verified');
         assert.equal(res[1].isPrimary, false, 'returned isPrimary false');
+      }, handleError);
+  });
+
+  it('#recoveryEmailSecondaryVerifyCode', function() {
+    var code;
+    return recoveryEmailCreate({
+      verificationMethod: 'email-otp',
+    })
+      .then(function(res) {
+        assert.ok(res);
+
+        return respond(mail.wait(user2, 1), RequestMocks.mailUnverifiedEmail);
+      }, handleError)
+      .then(function(emails) {
+        code = emails[0].headers['x-verify-code'];
+
+        return respond(
+          client.recoveryEmailSecondaryVerifyCode(
+            account.signIn.sessionToken,
+            user2Email,
+            code,
+            {}
+          ),
+          RequestMocks.verifyCode
+        );
+      }, handleError)
+      .then(function(res) {
+        assert.ok(res);
+
+        assert.equal(xhrOpen.args[6][0], 'POST', 'method is correct');
+        assert.include(
+          xhrOpen.args[6][1],
+          '/recovery_email/secondary/verify_code',
+          'path is correct'
+        );
+        var sentData = JSON.parse(xhrSend.args[6][0]);
+        assert.equal(Object.keys(sentData).length, 2);
+        assert.equal(sentData.code, code, 'code is correct');
+
+        return respond(
+          client.recoveryEmails(account.signIn.sessionToken),
+          RequestMocks.recoveryEmailsVerified
+        );
+      }, handleError)
+      .then(function(res) {
+        assert.ok(res);
+        assert.equal(res.length, 2, 'returned one email');
+        assert.equal(res[1].verified, true, 'returned verified');
+      }, handleError);
+  });
+
+  it('#recoveryEmailSecondaryResendCode', function() {
+    var code;
+    return recoveryEmailCreate({
+      verificationMethod: 'email-otp',
+    })
+      .then(function(res) {
+        assert.ok(res);
+        return respond(mail.wait(user2, 1), RequestMocks.mailUnverifiedEmail);
+      }, handleError)
+      .then(function() {
+        return respond(
+          client.recoveryEmailSecondaryResendCode(
+            account.signIn.sessionToken,
+            user2Email
+          ),
+          RequestMocks.verifyCode
+        );
+      }, handleError)
+      .then(function(res) {
+        assert.ok(res);
+
+        assert.equal(xhrOpen.args[6][0], 'POST', 'method is correct');
+        assert.include(
+          xhrOpen.args[6][1],
+          '/recovery_email/secondary/resend_code',
+          'path is correct'
+        );
+        var sentData = JSON.parse(xhrSend.args[6][0]);
+        assert.equal(Object.keys(sentData).length, 1);
+        assert.equal(sentData.email, user2Email, 'email is correct');
+
+        return respond(
+          mail.wait(user2, 2),
+          RequestMocks.mailUnverifiedEmailResend
+        );
+      }, handleError)
+      .then(function(emails) {
+        code = emails[1].headers['x-verify-code'];
+
+        return respond(
+          client.recoveryEmailSecondaryVerifyCode(
+            account.signIn.sessionToken,
+            user2Email,
+            code,
+            {}
+          ),
+          RequestMocks.verifyCode
+        );
+      }, handleError)
+      .then(function(res) {
+        assert.ok(res);
+
+        return respond(
+          client.recoveryEmails(account.signIn.sessionToken),
+          RequestMocks.recoveryEmailsVerified
+        );
+      }, handleError)
+      .then(function(res) {
+        assert.ok(res);
+        assert.equal(res.length, 2, 'returned one email');
+        assert.equal(res[1].verified, true, 'returned verified');
       }, handleError);
   });
 });

--- a/packages/fxa-js-client/tests/mocks/request.js
+++ b/packages/fxa-js-client/tests/mocks/request.js
@@ -114,7 +114,12 @@ module.exports = {
   },
   mailUnverifiedEmail: {
     status: 200,
-    body: '[{"html":"Mocked code=9001"}]',
+    body: '[{"html":"Mocked code=9001", "headers":{"x-verify-code":"123123"}}]',
+  },
+  mailUnverifiedEmailResend: {
+    status: 200,
+    body:
+      '[{"html":"Mocked code=9001", "headers":{"x-verify-code":"123123"}}, {"html":"Mocked code=9001", "headers":{"x-verify-code":"123123"}}]',
   },
   mailSignUpLang: {
     status: 200,


### PR DESCRIPTION
Extracted from https://github.com/mozilla/fxa/pull/3733

Adds the js-client routes to verify a secondary email via code.