### PR TITLE
fix(content-server): separate client and server sentry dsn

### DIFF
--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -531,6 +531,13 @@ const conf = (module.exports = convict({
     },
   },
   sentry: {
+    client_errors_dsn: {
+      default: undefined,
+      doc:
+        'Sentry config for client side errors. If not set, then no errors reported.',
+      env: 'SENTRY_CLIENT_ERRORS_DSN',
+      format: String,
+    },
     server_errors_dsn: {
       default: undefined,
       doc:

--- a/packages/fxa-content-server/server/lib/routes/get-index.js
+++ b/packages/fxa-content-server/server/lib/routes/get-index.js
@@ -28,7 +28,7 @@ module.exports = function(config) {
   const MARKETING_EMAIL_PREFERENCES_URL = config.get(
     'marketing_email.preferences_url'
   );
-  const SENTRY_DSN = config.get('sentry')['server_errors_dsn'];
+  const SENTRY_CLIENT_DSN = config.get('sentry')['client_errors_dsn'];
   const OAUTH_SERVER_URL = config.get('oauth_url');
   const PAIRING_CHANNEL_URI = config.get('pairing.server_base_uri');
   const PAIRING_CLIENTS = config.get('pairing.clients');
@@ -63,7 +63,7 @@ module.exports = function(config) {
     release: RELEASE,
     scopedKeysEnabled: SCOPED_KEYS_ENABLED,
     scopedKeysValidation: SCOPED_KEYS_VALIDATION,
-    sentryDsn: SENTRY_DSN,
+    sentryDsn: SENTRY_CLIENT_DSN,
     staticResourceUrl: STATIC_RESOURCE_URL,
     subscriptions: SUBSCRIPTIONS,
     webpackPublicPath: WEBPACK_PUBLIC_PATH,


### PR DESCRIPTION
- fixes #3600


SENTRY_CLIENT_ERRORS_DSN needs to now be set on next deploy cc/ @jrgm 