### PR TITLE
fix(password-balloon): Hide balloon when user enters invalid password, then valid password, then changes focus

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/password_strength/password_strength_balloon.js
+++ b/packages/fxa-content-server/app/scripts/views/password_strength/password_strength_balloon.js
@@ -55,14 +55,18 @@ class PasswordStrengthBalloonView extends BaseView {
     if (!this.model.validationError && !this.model.get('inputFocused')) {
       return this.hide();
     }
+    // OneVisibleOfTypeMixin uses 'show' to destroy any other
+    // tooltip-like views.
+    return this.show();
   }
 
   afterRender() {
-    if (this.model.validationError) {
-      // OneVisibleOfTypeMixin uses 'show' to destroy any other
-      // tooltip-like views.
-      this.show();
-    }
+    // We want to conditionally hide after rendering because
+    // users can type an invalid password, and then type a valid
+    // password and quickly change focus to beat the debounce
+    // on the password change event. This allows the model to
+    // update but hides the balloon in that scenario. Ref #3750
+    this.shouldHide();
   }
 
   update() {


### PR DESCRIPTION
fixes #3750 

This is a simple solution for a slightly little tricky problem since we're chasing the debounce initialized in `password_with_strength_balloon`, set from options or a default. I don't like `setTimeOut`s where we don't need them, and we can't conditionally run `this.render()` in the `update` function because then there's still a red border around the input if the previous password was invalid.

Note: When making this recording, I noticed the strength balloon doesn't fade out as slowly as it does outside of this edgecase. We're using a `setTimeout` for the transition because (per a comment) "`transitionend` is not fired for an unknown reason", referring to the jQ method `.hide`. It looks like for some reason, neither `transitionend` or `setTimeout` work in this edgecase to fade out the balloon. It works normally otherwise. I can create a follow-up issue but it'll definitely be a P5 issue thrown into the backlog.

![pw](https://user-images.githubusercontent.com/13018240/71636209-90d24200-2bf2-11ea-9303-61777e87688c.gif)