### PR TITLE
fix(password-balloon): Improve password strength balloon edgecases

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/password_strength/password_strength_balloon.js
+++ b/packages/fxa-content-server/app/scripts/views/password_strength/password_strength_balloon.js
@@ -30,7 +30,7 @@ class PasswordStrengthBalloonView extends BaseView {
 
   initialize(config = {}) {
     this.listenTo(this.model, 'change:password', this.update);
-    this.listenTo(this.model, 'change:inputFocused', this.shouldHide);
+    this.listenTo(this.model, 'change:inputFocused', this.hideOrShow);
   }
 
   setInitialContext(context) {
@@ -51,18 +51,22 @@ class PasswordStrengthBalloonView extends BaseView {
     });
   }
 
-  shouldHide() {
+  hideOrShow() {
     if (!this.model.validationError && !this.model.get('inputFocused')) {
       return this.hide();
     }
+    // OneVisibleOfTypeMixin uses 'show' to destroy any other
+    // tooltip-like views.
+    return this.show();
   }
 
   afterRender() {
-    if (this.model.validationError) {
-      // OneVisibleOfTypeMixin uses 'show' to destroy any other
-      // tooltip-like views.
-      this.show();
-    }
+    // We want to conditionally hide after rendering because
+    // users can type an invalid password, and then type a valid
+    // password and quickly change focus to beat the debounce
+    // on the password change event. This allows the model to
+    // update but hides the balloon in that scenario. Ref #3750
+    this.hideOrShow();
   }
 
   update() {

--- a/packages/fxa-content-server/app/scripts/views/password_strength/password_with_strength_balloon.js
+++ b/packages/fxa-content-server/app/scripts/views/password_strength/password_with_strength_balloon.js
@@ -24,7 +24,7 @@ const PasswordWithStrengthBalloonView = FormView.extend({
   events: {
     blur: 'updateModelAfterDelay',
     focus: 'focusHandler',
-    keypress: 'updateModelAfterDelay',
+    keydown: 'updateModelAfterDelay',
   },
 
   initialize(options = {}) {

--- a/packages/fxa-content-server/app/scripts/views/password_strength/password_with_strength_balloon.js
+++ b/packages/fxa-content-server/app/scripts/views/password_strength/password_with_strength_balloon.js
@@ -22,10 +22,9 @@ const DELAY_BEFORE_UPDATE_MODEL_MS = 1000;
 
 const PasswordWithStrengthBalloonView = FormView.extend({
   events: {
-    change: 'updateModelAfterDelay',
+    blur: 'updateModelAfterDelay',
     focus: 'focusHandler',
     keypress: 'updateModelAfterDelay',
-    blur: 'blurHandler',
   },
 
   initialize(options = {}) {
@@ -44,7 +43,7 @@ const PasswordWithStrengthBalloonView = FormView.extend({
     const delayBeforeUpdateModelMS =
       options.delayBeforeUpdateModelMS || DELAY_BEFORE_UPDATE_MODEL_MS;
     this.updateModelAfterDelay = debounce(
-      () => this.updateModel(),
+      event => this.updateModel(event.type),
       delayBeforeUpdateModelMS
     );
   },
@@ -52,12 +51,6 @@ const PasswordWithStrengthBalloonView = FormView.extend({
   focusHandler() {
     this.model.set('inputFocused', true);
     this.createBalloonIfNeeded();
-  },
-
-  // Allow a `change:inputFocused` event to hide the balloon only if the user
-  // has moved focus away from the input
-  blurHandler() {
-    this.model.set('inputFocused', false);
   },
 
   createBalloonIfNeeded() {
@@ -116,8 +109,16 @@ const PasswordWithStrengthBalloonView = FormView.extend({
   /**
    * Updates the model after some sort of user action.
    */
-  updateModel() {
+  updateModel(eventType = null) {
     this.model.set('password', this.$el.val());
+
+    // `updateModelAfterDelay` debounces this method on `blur` and
+    // `keydown`. `inputFocused` should only be updated on `blur`
+    // and _after_ the model password is updated so we can check
+    // for a validation error on focus change.
+    if (eventType === 'blur') {
+      this.model.set('inputFocused', false);
+    }
   },
 
   updateStyles() {

--- a/packages/fxa-content-server/app/tests/spec/views/password_strength/password_strength_balloon.js
+++ b/packages/fxa-content-server/app/tests/spec/views/password_strength/password_strength_balloon.js
@@ -112,27 +112,27 @@ describe('views/password_strength/password_strength_balloon', () => {
     });
   });
 
-  describe('shouldHide', () => {
+  describe('hideOrShow', () => {
     beforeEach(() => {
-      sinon.spy(view, 'shouldHide');
+      sinon.spy(view, 'hideOrShow');
       sinon.spy(view, 'hide');
     });
 
     it('does not hide if error', () => {
       model.validationError = AuthErrors.toError('PASSWORD_SAME_AS_EMAIL');
-      view.shouldHide();
+      view.hideOrShow();
       assert.isFalse(view.hide.called);
     });
 
     it('does not hide if input is focused', () => {
       model.set('inputFocused', true);
-      view.shouldHide();
+      view.hideOrShow();
       assert.isFalse(view.hide.called);
     });
 
     it('hides onblur if no error', () => {
       model.set('inputFocused', false);
-      view.shouldHide();
+      view.hideOrShow();
       assert.isTrue(view.hide.called);
     });
   });

--- a/packages/fxa-content-server/app/tests/spec/views/password_strength/password_with_strength_balloon.js
+++ b/packages/fxa-content-server/app/tests/spec/views/password_strength/password_with_strength_balloon.js
@@ -103,6 +103,16 @@ describe('views/password_strength/password_with_strength_ballon', () => {
     assert.equal(model.get('password'), 'password');
   });
 
+  it('delegates `inputFocused` to the model as expected', () => {
+    requiresFocus(() => {
+      view.$el.trigger('focus');
+      assert.equal(model.get('inputFocused'), true);
+    });
+
+    view.updateModel('blur');
+    assert.equal(model.get('inputFocused'), false);
+  });
+
   it('the element is marked as invalid if password has been entered and is invalid', () => {
     sinon.stub(view, 'markElementValid');
     sinon.stub(view, 'markElementInvalid');


### PR DESCRIPTION
Fixes #3750 
Fixes #3465
Partial fix for #3575 (fixes the first issue mentioned)

Also:
- Fixes edgecase shown at the bottom of #3792
- The balloon now updates on keyboard paste. 🎉 While the balloon does not update on mouse paste, it _does_ update when you paste and then tab away (not new).

![pw](https://user-images.githubusercontent.com/13018240/71700059-26eba100-2d88-11ea-8989-775780e28dc0.gif)