### PR TITLE
fix(client): Move `grunt sjcl` from `postinstall` to setup

### DIFF
--- a/packages/fxa-js-client/package.json
+++ b/packages/fxa-js-client/package.json
@@ -6,12 +6,12 @@
   "license": "MPL-2.0",
   "scripts": {
     "start": "grunt",
-    "postinstall": "grunt sjcl",
     "lint": "npm-run-all --parallel lint:*",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint:eslint": "eslint .",
     "test": "npm run lint && mocha tests/lib --reporter dot --timeout 5000",
     "test-local": "AUTH_SERVER_URL=http://127.0.0.1:9000 npm test",
+    "setup": "npm install && grunt sjcl",
     "contributors": "git shortlog -s | cut -c8- | sort -f > CONTRIBUTORS.md",
     "format": "prettier '**' --write"
   },


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/3799

The change in https://github.com/mozilla/fxa/pull/1192 got reverted and was causing build error when doing `npm i` in content server.