### PR TITLE
feat(ready-view): Display serviceName if user is signed in

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/ready.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/ready.mustache
@@ -27,10 +27,15 @@
       {{^isFromRelyingParty}}
         {{#emailVerified}}
           <p class="account-ready-service">{{{escapedEmailReadyText}}}</p>
+          <button class="button-link btn-goto-account">{{#t}}Continue to my account{{/t}}</button>
         {{/emailVerified}}
-
         {{^emailVerified}}
-          <p class="account-ready-generic">{{#t}}Your account is ready!{{/t}}</p>
+          {{#isSignedIn}}
+            <p class="account-ready-service">{{#t}}You are now ready to use %(serviceName)s{{/t}}</p>
+          {{/isSignedIn}}
+          {{^isSignedIn}}
+            <p class="account-ready-generic">{{#t}}Your account is ready!{{/t}}</p>
+          {{/isSignedIn}}
         {{/emailVerified}}
       {{/isFromRelyingParty}}
     {{/isSync}}

--- a/packages/fxa-content-server/app/scripts/views/ready.js
+++ b/packages/fxa-content-server/app/scripts/views/ready.js
@@ -117,6 +117,7 @@ const View = FormView.extend({
       secondaryEmailVerified:
         this.getSearchParam('secondary_email_verified') || null,
       showContinueButton: !!this.model.get('continueBrokerMethod'),
+      isSignedIn: this.user.isSignedInAccount(this.getSignedInAccount()),
     });
   },
 

--- a/packages/fxa-content-server/app/styles/modules/_marketing.scss
+++ b/packages/fxa-content-server/app/styles/modules/_marketing.scss
@@ -1,5 +1,7 @@
 .marketing-area {
-  margin-top: 20px;
+  &:not(:empty) {
+    margin-top: 20px;
+  }
 
   .links {
     // Links have `overflow: auto` by default, which causes a scrollbar to


### PR DESCRIPTION
fixes #3623 

Per Ryan F.'s request, the ready view should show `You are now ready to use ${serviceName}` (defaults to "Account Settings") instead of `Your account is ready!`. In #3569, Shane brought up that we still need to use the latter when a user is not signed in. This PR takes both into consideration.

I added the "Continue to my account" button per Shane's suggestion in #3623, which I agree makes sense here. I also wrapped the `margin-top` marketing style in `&:not(:empty)` because otherwise, there's 20px of extra margin below the text/button.

I double checked these via `/primary_email_verified`.

Hitting this page with `primary_email_verified=true` param:
<img src="https://user-images.githubusercontent.com/13018240/71752012-1fd59900-2e43-11ea-93af-4570977c7349.png" width="300">

Hitting this page without this param (not sure if it’s actually possible to hit “primary email” without it, just wanted to verify the copy displayed correctly):
<img src="https://user-images.githubusercontent.com/13018240/71752030-29f79780-2e43-11ea-998c-c738ac98e2b1.png" width="300">

And hitting this page while not signed in:
<img src="https://user-images.githubusercontent.com/13018240/71752038-324fd280-2e43-11ea-977d-b7309e1bb074.png" width="300">
