### PR TITLE
feat(totp): show the "Can't scan code?" secret in a modal

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -53,6 +53,7 @@ import SmsSentView from '../views/sms_sent';
 import Storage from './storage';
 import SubscriptionsProductRedirectView from '../views/subscriptions_product_redirect';
 import SubscriptionsManagementRedirectView from '../views/subscriptions_management_redirect';
+import TotpSecretView from '../views/settings/totp_secret';
 import TwoStepAuthenticationView from '../views/settings/two_step_authentication';
 import VerificationReasons from './verification-reasons';
 import WouldYouLikeToSync from '../views/would_you_like_to_sync';
@@ -223,6 +224,10 @@ const Router = Backbone.Router.extend({
     ),
     'settings/two_step_authentication/recovery_codes(/)': createChildViewHandler(
       RecoveryCodesView,
+      SettingsView
+    ),
+    'settings/two_step_authentication/secret(/)': createChildViewHandler(
+      TotpSecretView,
       SettingsView
     ),
     'signin(/)': createViewHandler(SignInPasswordView),

--- a/packages/fxa-content-server/app/scripts/templates/settings/totp_secret.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/totp_secret.mustache
@@ -1,0 +1,13 @@
+<div id="recovery-codes">
+    <section class="modal-panel">
+      <h2>{{#t}}Enter code manually{{/t}}</h2>
+      <br>
+      <p class="description">{{#t}}Enter this secret key into your authentication app:{{/t}}</p>
+      <div class="code">{{secret}}</div>
+      <br>
+      <p class="description">{{#t}}Once complete, it will begin generating security codes for you to enter.{{/t}}</p>
+      <form novalidate>
+        <button type="submit" class="settings-button primary-button">{{#t}}Ready{{/t}}</button>
+      <form novalidate>
+    </section>
+</div>

--- a/packages/fxa-content-server/app/scripts/templates/settings/two_step_authentication.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/two_step_authentication.mustache
@@ -71,11 +71,6 @@
                     <a href="#" class="show-code-link">{{#t}}Can’t scan code?{{/t}}</a>
                 </p>
 
-                <div class="manual-code hidden">
-                    <p class="setup-description">{{#t}}Manually enter this secret key into your authentication app:{{/t}}</p>
-                    <div class="code"></div>
-                </div>
-
                 <div class="input-row">
                     <input type="number" pattern="\d+" length="6" class="tooltip-below totp-code" placeholder="{{#t}}Security code{{/t}}" value="{{ code }}" required autofocus autocomplete="off"/>
                 </div>

--- a/packages/fxa-content-server/app/scripts/views/mixins/modal-settings-panel-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/modal-settings-panel-mixin.js
@@ -69,6 +69,9 @@ const Mixin = assign({}, ModalPanelMixin, {
         }
         this._returnToTwoFactorAuthentication();
         break;
+      case 'settings/two_step_authentication/secret':
+        this._returnToTwoFactorAuthentication();
+        break;
       case 'settings/account_recovery/recovery_key':
         this._returnToAccountRecovery(true);
         break;

--- a/packages/fxa-content-server/app/scripts/views/settings.js
+++ b/packages/fxa-content-server/app/scripts/views/settings.js
@@ -36,6 +36,7 @@ import Template from 'templates/settings.mustache';
 import UserAgentMixin from '../lib/user-agent-mixin';
 
 import TwoStepAuthenticationView from './settings/two_step_authentication';
+import TotpSecretView from './settings/totp_secret';
 import RecoveryCodesView from './settings/recovery_codes';
 
 var PANEL_VIEWS = [
@@ -48,6 +49,7 @@ var PANEL_VIEWS = [
   AccountRecoveryConfirmRevokeView,
   AccountRecoveryKeyView,
   TwoStepAuthenticationView,
+  TotpSecretView,
   RecoveryCodesView,
   ClientsView,
   ClientDisconnectView,

--- a/packages/fxa-content-server/app/scripts/views/settings/totp_secret.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/totp_secret.js
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Cocktail from 'cocktail';
+import FormView from '../form';
+import ModalSettingsPanelMixin from '../mixins/modal-settings-panel-mixin';
+import Template from 'templates/settings/totp_secret.mustache';
+
+const View = FormView.extend({
+  template: Template,
+  className: 'recovery-codes',
+  viewName: 'settings.two-step-authentication.secret',
+
+  beforeRender() {
+    if (!this.model.get('secret')) {
+      this.navigate('settings/two_step_authentication');
+    }
+  },
+
+  submit() {
+    this.closePanel();
+  },
+
+  setInitialContext(context) {
+    context.set({
+      secret: this.model.get('secret'),
+    });
+  },
+});
+
+Cocktail.mixin(View, ModalSettingsPanelMixin);
+
+export default View;

--- a/packages/fxa-content-server/app/scripts/views/settings/two_step_authentication.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/two_step_authentication.js
@@ -55,8 +55,10 @@ const View = FormView.extend({
   },
 
   _showCode() {
-    this.$('.manual-code').removeClass('hidden');
-    this.$('.show-code-link').addClass('hidden');
+    const secret = this.model.get('secret');
+    this.navigate('/settings/two_step_authentication/secret', {
+      secret,
+    });
   },
 
   _getFormattedCode(code) {
@@ -126,8 +128,7 @@ const View = FormView.extend({
         'alt',
         this.translate(qrImageAltText, { code: result.secret })
       );
-
-      this.$('.code').text(this._getFormattedCode(result.secret));
+      this.model.set('secret', this._getFormattedCode(result.secret));
       this._showQrCode();
       this._hideStatus();
     });
@@ -148,7 +149,7 @@ const View = FormView.extend({
 
   submit() {
     const code = this.getElementValue('input.totp-code');
-    const secret = this.$('.code').text();
+    const secret = this.model.get('secret');
 
     //preverify code
     return this.checkCode(secret, code).then(ok => {

--- a/packages/fxa-content-server/app/styles/modules/_settings-totp.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings-totp.scss
@@ -78,6 +78,7 @@
   }
 
   .description {
+    color: $faint-text-color;
     font-size: 12px;
     text-align: center;
   }
@@ -123,6 +124,11 @@
   .nav {
     display: flex;
     justify-content: space-between;
+  }
+
+  .code {
+    font-family: monospace;
+    font-weight: 600;
   }
 }
 

--- a/packages/fxa-content-server/app/tests/spec/views/settings/two_step_authentication.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/two_step_authentication.js
@@ -148,20 +148,6 @@ describe('views/settings/two_step_authentication', () => {
         metrics.logUserPreferences.calledWith(view.className, false)
       );
     });
-
-    describe('should show code and hide `show code link`', () => {
-      beforeEach(() => {
-        assert.equal(view.$('.manual-code.hidden').length, 1);
-        assert.equal(view.$('.show-code-link:not(hidden)').length, 1);
-        return view.$('.show-code-link').click();
-      });
-
-      it('shows correct links', () => {
-        assert.equal(view.$('.code')[0].innerText, 'MZEE 4ODK');
-        assert.equal(view.$('.manual-code:not(hidden)').length, 1);
-        assert.equal(view.$('.show-code-link.hidden').length, 1);
-      });
-    });
   });
 
   describe('should display error for invalid code', () => {

--- a/packages/fxa-content-server/server/lib/routes/get-frontend.js
+++ b/packages/fxa-content-server/server/lib/routes/get-frontend.js
@@ -56,6 +56,7 @@ module.exports = function() {
     'settings/emails',
     'settings/two_step_authentication',
     'settings/two_step_authentication/recovery_codes',
+    'settings/two_step_authentication/secret',
     'signin',
     'signin_bounced',
     'signin_token_code',

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -2484,10 +2484,8 @@ const enableTotp = thenify(function() {
       .then(secretKey => {
         secret = secretKey;
       })
-      .end()
-      .then(() => {
-        return this.parent.then(confirmTotpCode(secret));
-      })
+      .then(() => this.parent.then(click(selectors.TOTP.KEY_OK_BUTTON)))
+      .then(() => this.parent.then(confirmTotpCode(secret)))
       .then(() => secret)
   );
 });

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -487,6 +487,7 @@ module.exports = {
     UNLOCK_REFRESH_BUTTON:
       '.two-step-authentication .refresh-verification-state',
     UNLOCK_SEND_VERIFY: '.two-step-authentication .send-verification-email',
+    KEY_OK_BUTTON: '.modal-panel button',
   },
   TOTP_SIGNIN: {
     HEADER: '#fxa-totp-code-header',

--- a/packages/fxa-content-server/tests/functional/oauth_require_totp.js
+++ b/packages/fxa-content-server/tests/functional/oauth_require_totp.js
@@ -114,10 +114,8 @@ registerSuite('oauth require totp', {
             secret = secretKey;
           })
           .end()
-
-          .then(() => {
-            return this.remote.then(confirmTotpCode(secret));
-          })
+          .then(() => this.remote.then(click(selectors.TOTP.KEY_OK_BUTTON)))
+          .then(() => this.remote.then(confirmTotpCode(secret)))
           .then(clearBrowserState({ force: true }))
           .then(
             openFxaFromRp('two-step-authentication', {

--- a/packages/fxa-content-server/tests/functional/oauth_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sign_in.js
@@ -572,6 +572,7 @@ registerSuite('oauth signin - TOTP', {
           secret = secretKey;
         })
         .end()
+        .then(() => this.remote.then(click(selectors.TOTP.KEY_OK_BUTTON)))
     );
   },
 

--- a/packages/fxa-content-server/tests/functional/pairing.js
+++ b/packages/fxa-content-server/tests/functional/pairing.js
@@ -181,7 +181,9 @@ registerSuite('pairing', {
           .getVisibleText()
           .then(secretKey => {
             secret = secretKey;
-
+          })
+          .then(() => this.remote.then(click(selectors.TOTP.KEY_OK_BUTTON)))
+          .then(() => {
             return this.remote.then(confirmTotpCode(secret));
           })
           .end()

--- a/packages/fxa-content-server/tests/functional/sign_in_recovery_code.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_recovery_code.js
@@ -68,6 +68,7 @@ registerSuite('recovery code', {
           secret = secretKey;
           return (
             self.remote
+              .then(click(selectors.TOTP.KEY_OK_BUTTON))
               .then(
                 type(
                   selectors.TOTP.CONFIRM_CODE_INPUT,

--- a/packages/fxa-content-server/tests/functional/sign_in_totp.js
+++ b/packages/fxa-content-server/tests/functional/sign_in_totp.js
@@ -78,6 +78,7 @@ registerSuite('TOTP', {
           secret = secretKey;
         })
         .end()
+        .then(() => this.remote.then(click(selectors.TOTP.KEY_OK_BUTTON)))
     );
   },
 


### PR DESCRIPTION
To help prevent people from copy/pasting the totp secret into
the verification code field, show the secret in a modal instead
of just above the input field.

fixes #3804