### PR TITLE
fix(copy):Headline change

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/choose_what_to_sync.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/choose_what_to_sync.mustache
@@ -6,7 +6,7 @@
     <form id="choose-what-to-sync" novalidate>
       <header>
         <h1 id="fxa-choose-what-to-sync-header">
-          {{#t}}Sync these everywhere you sign in:{{/t}}
+          {{#t}}Choose what to sync:{{/t}}
         </h1>
       </header>
       <div class="two-col-items">


### PR DESCRIPTION
`Choose what to sync:` is more generic than `Sync these everywhere you sign in:` because not every signed-in device will be syncing.