### PR TITLE
Enable post verify secondary emails experiment

### DIFF
--- a/packages/fxa-auth-server/test/mail_helper.js
+++ b/packages/fxa-auth-server/test/mail_helper.js
@@ -27,9 +27,9 @@ module.exports = printLogs => {
   const console = printLogs
     ? global.console
     : {
-      log() {},
-      error() {},
-    };
+        log() {},
+        error() {},
+      };
   return new P((resolve, reject) => {
     const smtp = simplesmtp.createSimpleServer(
       {
@@ -61,7 +61,7 @@ module.exports = printLogs => {
           if (vsc) {
             console.log('\x1B[34mSignin code', vsc, '\x1B[39m');
           } else if (vc) {
-            console.log('\x1B[32m', link, '\x1B[39m');
+            console.log('\x1B[32m', link || vc, '\x1B[39m');
           } else if (sc) {
             console.log('\x1B[32mToken code: ', sc, '\x1B[39m');
           } else if (rc) {

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
@@ -17,6 +17,7 @@ const experimentGroupingRules = [
   require('./send-sms-install-link'),
   require('./sentry'),
   require('./email-mx-validation'),
+  require('./secondary-email-after-signup'),
 ].map(ExperimentGroupingRule => new ExperimentGroupingRule());
 
 class ExperimentChoiceIndex {

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/secondary-email-after-signup.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/secondary-email-after-signup.js
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const BaseGroupingRule = require('./base');
+
+const EXPERIMENT_NAME = 'secondaryEmailAfterSignup';
+const GROUPS = ['control', 'treatment'];
+
+class SecondaryEmailAfterSignup extends BaseGroupingRule {
+  constructor() {
+    super();
+    this.name = EXPERIMENT_NAME;
+    this.ROLLOUT_RATE = 0.0;
+  }
+
+  /**
+   * Use `subject` data to make a choice.
+   *
+   * @param {Object} subject data used to decide
+   * @returns {Any}
+   */
+  choose(subject) {
+    if (!this._isValidSubject(subject)) {
+      return false;
+    }
+
+    if (this.bernoulliTrial(this.ROLLOUT_RATE, subject.uniqueUserId)) {
+      return this.uniformChoice(GROUPS, subject.uniqueUserId);
+    }
+
+    return false;
+  }
+
+  /**
+   * Is the subject valid?
+   *
+   * @param {Object} subject
+   * @returns {Boolean}
+   * @private
+   */
+  _isValidSubject(subject) {
+    return !!(subject && subject.uniqueUserId);
+  }
+}
+
+module.exports = SecondaryEmailAfterSignup;

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/secondary_email/add_secondary_email.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/secondary_email/add_secondary_email.mustache
@@ -26,7 +26,7 @@
                 <button id="submit-btn" type="submit">{{#t}}Continue{{/t}}</button>
             </div>
             <div class="links">
-                <a id="maybe-later-btn" href="/connect_another_device" data-flow-event="link.maybe-later" class="left">{{#t}}Maybe later{{/t}}</a>
+                <a id="maybe-later-btn" data-flow-event="link.maybe-later" class="left">{{#t}}Maybe later{{/t}}</a>
             </div>
         </form>
     </section>

--- a/packages/fxa-content-server/app/scripts/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/scripts/views/connect_another_device.js
@@ -31,6 +31,14 @@ class ConnectAnotherDeviceView extends FormView {
   template = Template;
 
   beforeRender() {
+    // If the user is eligible for post verify add secondary email experiment, navigate to
+    // those views.
+    if (this.isEligibleForSecondaryEmailAfterSignup()) {
+      return this.replaceCurrentPage(
+        'post_verify/secondary_email/add_secondary_email'
+      );
+    }
+
     const account = this.getAccount();
     // If the user is eligible for SMS, send them to the SMS screen.
     // This allows the browser to link directly to /connect_another_device

--- a/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -19,6 +19,7 @@
 import ExperimentMixin from './experiment-mixin';
 import UserAgentMixin from '../../lib/user-agent-mixin';
 import VerificationReasonMixin from './verification-reason-mixin';
+import VerificationReasons from '../../lib/verification-reasons';
 
 const REASON_ANDROID = 'sms.ineligible.android';
 const REASON_CONTROL_GROUP = 'sms.ineligible.control_group';
@@ -31,6 +32,22 @@ const REASON_XHR_ERROR = 'sms.ineligible.xhr_error';
 
 export default {
   dependsOn: [ExperimentMixin, UserAgentMixin, VerificationReasonMixin],
+
+  /**
+   * Is `account` eligible for secondary email after signup experiment?
+   *
+   * @returns {Boolean}
+   */
+  isEligibleForSecondaryEmailAfterSignup() {
+    const account = this.getSignedInAccount();
+    if (account.get('verificationReason') !== VerificationReasons.SIGN_UP) {
+      return false;
+    }
+    const experimentGroup = this.getAndReportExperimentGroup(
+      'secondaryEmailAfterSignup'
+    );
+    return experimentGroup === 'treatment';
+  },
 
   /**
    * Is `account` eligible for connect another device?

--- a/packages/fxa-content-server/app/scripts/views/post_verify/secondary_email/add_secondary_email.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/secondary_email/add_secondary_email.js
@@ -5,18 +5,23 @@
 /**
  * Post verify view that start the process of creating a secondary email via a code.
  */
-import _ from 'underscore';
+import { _, assign } from 'underscore';
 import Cocktail from 'cocktail';
 import FormView from '../../form';
 import ServiceMixin from '../..//mixins/service-mixin';
 import Template from 'templates/post_verify/secondary_email/add_secondary_email.mustache';
 import VerificationMethods from '../../../lib/verification-methods';
+import preventDefaultThen from '../../decorators/prevent_default_then';
 
 const EMAIL_INPUT_SELECTOR = 'input.new-email';
 
 class AddSecondaryEmail extends FormView {
   template = Template;
   viewName = 'add-secondary-email';
+
+  events = assign(this.events, {
+    'click #maybe-later-btn': preventDefaultThen('_clickMaybeLater'),
+  });
 
   beforeRender() {
     const account = this.getSignedInAccount();
@@ -53,6 +58,12 @@ class AddSecondaryEmail extends FormView {
       .catch(err =>
         this.showValidationError(this.$(EMAIL_INPUT_SELECTOR), err)
       );
+  }
+
+  _clickMaybeLater() {
+    const account = this.getSignedInAccount();
+    account.unset('verificationReason');
+    return this.invokeBrokerMethod('afterCompleteSignUp', account);
   }
 }
 

--- a/packages/fxa-content-server/app/scripts/views/post_verify/verified.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/verified.js
@@ -43,13 +43,9 @@ class Verified extends FormView {
   submit() {
     return Promise.resolve()
       .then(() => {
-        const { account, continueBrokerMethod } = this.model.toJSON();
-        console.log(account, continueBrokerMethod);
-        if (continueBrokerMethod && account) {
-          return this.invokeBrokerMethod(continueBrokerMethod, account);
-        }
-
-        this.navigate('/settings');
+        const account = this.getSignedInAccount();
+        account.unset('verificationReason');
+        return this.invokeBrokerMethod('afterCompleteSignUp', account);
       })
       .catch(err => this.displayError(err));
   }

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 
 describe('lib/experiments/grouping-rules/index', () => {
   it('EXPERIMENT_NAMES is exported', () => {
-    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 6);
+    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 7);
   });
 
   describe('choose', () => {

--- a/packages/fxa-content-server/tests/functional/post_verify/secondary_email.js
+++ b/packages/fxa-content-server/tests/functional/post_verify/secondary_email.js
@@ -91,6 +91,23 @@ registerSuite('post_verify_secondary_email', {
       );
     },
 
+    'ignore for sign-in': function() {
+      return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(
+          openPage(ENTER_EMAIL_SYNC_URL, selectors.ENTER_EMAIL.HEADER, {
+            query: {
+              forceExperiment: 'secondaryEmailAfterSignup',
+              forceExperimentGroup: 'treatment',
+            },
+          })
+        )
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+        .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+        .then(testIsBrowserNotified('fxaccounts:login'))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER));
+    },
+
     'navigate directly to create secondary email': function() {
       return this.remote
         .then(createUser(email, PASSWORD, { preVerified: true }))

--- a/packages/fxa-content-server/tests/functional/post_verify/secondary_email.js
+++ b/packages/fxa-content-server/tests/functional/post_verify/secondary_email.js
@@ -9,7 +9,8 @@ const FunctionalHelpers = require('./../lib/helpers');
 const selectors = require('./../lib/selectors');
 const config = intern._config;
 
-const ENTER_EMAIL_URL = config.fxaContentRoot;
+const ENTER_EMAIL_SYNC_URL = `${config.fxaContentRoot}?context=fx_desktop_v3&service=sync`;
+const ENTER_EMAIL_WEB_URL = config.fxaContentRoot;
 const ENTER_SECONDARY_EMAIL =
   config.fxaContentRoot + 'post_verify/secondary_email/add_secondary_email';
 
@@ -23,8 +24,11 @@ const {
   createUser,
   fillOutPostVerifySecondaryEmailCode,
   fillOutEmailFirstSignIn,
+  fillOutEmailFirstSignUp,
+  fillOutSignUpCode,
   openPage,
   testElementExists,
+  testIsBrowserNotified,
   type,
 } = FunctionalHelpers;
 
@@ -33,15 +37,64 @@ registerSuite('post_verify_secondary_email', {
     email = createEmail();
     secondaryEmail = createEmail();
 
-    return this.remote
-      .then(clearBrowserState({ force: true }))
-      .then(createUser(email, PASSWORD, { preVerified: true }));
+    return this.remote.then(clearBrowserState({ force: true }));
   },
 
   tests: {
-    'create secondary email': function() {
+    'sync post verify - create secondary email': function() {
+      return (
+        this.remote
+          .then(
+            openPage(ENTER_EMAIL_SYNC_URL, selectors.ENTER_EMAIL.HEADER, {
+              query: {
+                forceExperiment: 'secondaryEmailAfterSignup',
+                forceExperimentGroup: 'treatment',
+              },
+            })
+          )
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
+
+          // user should be transitioned to /choose_what_to_sync
+          .then(testElementExists(selectors.CHOOSE_WHAT_TO_SYNC.HEADER))
+
+          .then(testIsBrowserNotified('fxaccounts:can_link_account'))
+
+          .then(click(selectors.CHOOSE_WHAT_TO_SYNC.SUBMIT))
+
+          // user should be transitioned to the "go confirm your address" page
+          .then(testElementExists(selectors.CONFIRM_SIGNUP_CODE.HEADER))
+
+          // verify the user
+          .then(fillOutSignUpCode(email, 0))
+
+          // the login message is only sent after the sync preferences screen
+          // has been cleared.
+          .then(testIsBrowserNotified('fxaccounts:login'))
+
+          .then(
+            type(
+              selectors.POST_VERIFY_ADD_SECONDARY_EMAIL.EMAIL,
+              secondaryEmail
+            )
+          )
+          .then(click(selectors.POST_VERIFY_ADD_SECONDARY_EMAIL.SUBMIT))
+
+          .then(
+            testElementExists(
+              selectors.POST_VERIFY_CONFIRM_SECONDARY_EMAIL.HEADER
+            )
+          )
+          .then(fillOutPostVerifySecondaryEmailCode(secondaryEmail, 0))
+
+          .then(click(selectors.POST_VERIFY_VERIFIED.SUBMIT))
+          .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
+      );
+    },
+
+    'navigate directly to create secondary email': function() {
       return this.remote
-        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openPage(ENTER_EMAIL_WEB_URL, selectors.ENTER_EMAIL.HEADER))
         .then(fillOutEmailFirstSignIn(email, PASSWORD))
         .then(testElementExists(selectors.SETTINGS.HEADER))
 
@@ -64,7 +117,9 @@ registerSuite('post_verify_secondary_email', {
         )
         .then(fillOutPostVerifySecondaryEmailCode(secondaryEmail, 0))
 
-        .then(testElementExists(selectors.POST_VERIFY_VERIFIED.READY));
+        .then(testElementExists(selectors.POST_VERIFY_VERIFIED.READY))
+        .then(click(selectors.POST_VERIFY_VERIFIED.SUBMIT))
+        .then(testElementExists(selectors.SETTINGS.HEADER));
     },
   },
 });


### PR DESCRIPTION
This PR enables the experiment in https://github.com/mozilla/fxa/pull/3733. Marking as a draft since we need to confirm UX and document more details about the experiment.