### PR TITLE
fix(geo): Add scripts to create custom fxa geodb mmdb file

### DIFF
--- a/packages/fxa-geodb/scripts/mmdb/create-mmdb.pl
+++ b/packages/fxa-geodb/scripts/mmdb/create-mmdb.pl
@@ -1,0 +1,134 @@
+#!/usr/bin/env perl
+
+# This file creates a custom Maxmind mmdb that can be loaded by
+# fxa-geodb. For testing purposes this only adds two IP addresses.
+#
+# Reference https://metacpan.org/pod/MaxMind::DB::Writer::Tree
+# for more API details.
+
+use MaxMind::DB::Writer::Tree;
+
+my %types = (
+    city => 'map',
+    geoname_id => 'uint32',
+    names => 'map',
+    en => 'utf8_string',
+    continent => 'map',
+    country => 'map',
+    iso_code => 'utf8_string',
+    location => 'map',
+    accuracy_radius => 'int32',
+    latitude => 'double',
+    longitude => 'double',
+    metro_code => 'int32',
+    time_zone => 'utf8_string',
+    postal => 'map',
+    code => 'int32',
+    registered_country => 'map',
+    subdivisions => ['array', 'map'],
+);
+
+my $tree = MaxMind::DB::Writer::Tree->new(
+    ip_version            => 6,
+    record_size           => 24,
+    database_type         => 'FxA-IP-Data',
+    languages             => ['en'],
+    description           => { en => 'FxA database of IP data' },
+    map_key_type_callback => sub { $types{ $_[0] } },
+);
+
+$tree->insert_network(
+    '63.245.221.32/24',
+    {
+        city => {
+            geoname_id => 5375480,
+            names  => {
+                en => 'Mountain View'
+            }
+        },
+        continent => {
+            geoname_id => 6255149,
+            names => {
+                en => 'North America'
+            }
+        },
+        country => {
+            geoname_id => 6252001,
+            iso_code => 'US',
+            names => {
+                en => 'United States'
+            }
+        },
+        location => {
+            accuracy_radius => 50,
+            latitude => 37.3897,
+            longitude => -122.0832,
+            metro_code => 807,
+            time_zone => 'America/Los_Angeles'
+        },
+        postal => {
+            code => 94041
+        },
+        subdivisions => [ {
+            iso_code => 'CA',
+            names => {
+                en => 'California'
+            }
+        }, ]
+    },
+);
+
+$tree->insert_network(
+    '64.11.221.194/24',
+    {
+        continent => {
+            geoname_id => 6255149,
+            names => {
+                en => 'North America'
+            }
+        },
+        country => {
+            geoname_id => 6252001,
+            iso_code => 'US',
+            names => {
+                en => 'United States'
+            }
+        },
+        location => {
+            accuracy_radius => 50,
+            latitude => 37.3897,
+            longitude => -122.0832,
+            metro_code => 807,
+            time_zone => 'America/Chicago'
+        },
+    },
+);
+
+$tree->insert_network(
+    '8.8.8.8/24',
+    {
+        continent => {
+            geoname_id => 6255149,
+            names => {
+                en => 'North America'
+            }
+        },
+        country => {
+            geoname_id => 6252001,
+            iso_code => 'US',
+            names => {
+                en => 'United States'
+            }
+        },
+        location => {
+            accuracy_radius => 50,
+            latitude => 37.3897,
+            longitude => -122.0832,
+            metro_code => 807,
+            time_zone => 'America/Chicago'
+        },
+    },
+);
+
+open my $fh, '>:raw', './cities-db.mmdb';
+$tree->write_tree($fh);

--- a/packages/fxa-geodb/scripts/mmdb/read-mmdb.pl
+++ b/packages/fxa-geodb/scripts/mmdb/read-mmdb.pl
@@ -1,0 +1,14 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use feature qw( say );
+
+use Data::Printer;
+use MaxMind::DB::Reader;
+
+my $reader = MaxMind::DB::Reader->new( file => './cities-db.mmdb' );
+
+my $record = $reader->record_for_address('63.245.221.32');
+
+say np $record;


### PR DESCRIPTION
Fixes #3773

This patch adds perl scripts to create a custom mmdb file for dev and CI purposes. I've run the script and hosted the file at https://fxa-geodb.s3-us-west-2.amazonaws.com/cities-db.mmdb.gz.

No code changes are needed since fxa-geodb was already configured to load from this url [here](https://github.com/mozilla/fxa/blob/2c480cf13f0ebb25d9fff0f54c263916797f9610/packages/fxa-geodb/sources.json#L2).
 
Output:
```
vijaybudhram-ms:mmdb vijaybudhram$ perl read-mmdb.pl 
{
    city        {
        geoname_id   5375480,
        names        {
            en   "Mountain View"
        }
    },
    continent   {
        geoname_id   6255149,
        names        {
            en   "North America"
        }
    },
    country     {
        geoname_id   6252001,
        iso_code     "US",
        names        {
            en   "United States"
        }
    },
    location    {
        accuracy_radius   50,
        latitude          37.3897,
        longitude         -122.0832,
        metro_code        807,
        time_zone         "America/Los_Angeles"
    },
    postal      {
        code   94041
    },
    subdivisions   [
        [0] {
                iso_code   "CA",
                names      {
                    en   "California"
                }
            }
    ]
}
```

Bonus: New mmdb file is 3kb vs 58mb, so we should in theory see some faster CI times.