### PR TITLE
fix(metrics): send navigationTiming with 'loaded' event

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/metrics.js
+++ b/packages/fxa-content-server/app/scripts/lib/metrics.js
@@ -452,10 +452,21 @@ _.extend(Metrics.prototype, Backbone.Events, {
     var allowedData = _.pick(this.getAllData(), ALLOWED_FIELDS);
 
     return _.pick(allowedData, (value, key) => {
-      // navigationTiming is sent in the first flush, no need to re-send it.
-      if (this._lastFlushedData && key === 'navigationTiming') {
-        return false;
+      // navigationTiming is sent once, with 'loaded' event.
+      if (key === 'navigationTiming') {
+        if (this._navigationTimingFlushed) {
+          return false;
+        }
+
+        this._navigationTimingFlushed =
+          allowedData.events &&
+          allowedData.events.some(x => x.type === 'loaded');
+
+        // return false until the first true,
+        // once true, the if above will return false.
+        return this._navigationTimingFlushed;
       }
+
       return !_.isUndefined(value) && value !== '';
     });
   },


### PR DESCRIPTION
Commit f267b21 updated metrics flushing timing so that the `loaded`
event is (usually? probably always) not in the first flush.  This patch
fixes the data filtering so that the `navigationTiming` data is sent
with the 'loaded' event.

Fixes #3815 

@mozilla/fxa-devs r?