### PR TITLE
fix(email): Ignore cargo audit errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
           at: ~/
       - run: |
           ./scripts/test_with_authdb.sh
-          cargo audit
+          cargo audit --ignore RUSTSEC-2019-0033 --ignore RUSTSEC-2018-0015 --ignore RUSTSEC-2019-0034
           mkdir -m 755 bin
           mkdir -m 755 bin/config
           cargo build --release


### PR DESCRIPTION
This patch ignores warnings in https://github.com/mozilla/fxa/issues/3866 since they are not applicable to fxa.

RUSTSEC-2019-0033
RUSTSEC-2019-0034
RUSTSEC-2018-0015