### PR TITLE
fix(sms): expose sms polling interval as a config option

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -1404,6 +1404,12 @@ const conf = convict({
       format: 'nat',
       env: 'SMS_MINIMUM_CREDIT_THRESHOLD',
     },
+    pollCurrentSpendInterval: {
+      doc: 'Interval to poll SNS and Cloudwatch for SMS spending data',
+      default: '1 hour',
+      format: 'duration',
+      env: 'SMS_POLL_CURRENT_SPEND_INTERVAL',
+    },
   },
   secondaryEmail: {
     minUnverifiedAccountTime: {

--- a/packages/fxa-auth-server/lib/senders/sms.js
+++ b/packages/fxa-auth-server/lib/senders/sms.js
@@ -13,7 +13,6 @@ const time = require('../time');
 
 const SECONDS_PER_MINUTE = 60;
 const MILLISECONDS_PER_MINUTE = SECONDS_PER_MINUTE * 1000;
-const MILLISECONDS_PER_HOUR = MILLISECONDS_PER_MINUTE * 60;
 const PERIOD_IN_MINUTES = 5;
 
 class MockCloudwatch {
@@ -28,7 +27,10 @@ module.exports = (log, translator, templates, config, statsd) => {
   const cloudwatch = initService(config, Cloudwatch, MockCloudwatch);
   const sns = initService(config, Sns, MockSns);
 
-  const { minimumCreditThresholdUSD: CREDIT_THRESHOLD } = config.sms;
+  const {
+    minimumCreditThresholdUSD: CREDIT_THRESHOLD,
+    pollCurrentSpendInterval: POLL_CURRENT_SPEND_INTERVAL,
+  } = config.sms;
 
   let isBudgetOk = true;
 
@@ -152,7 +154,7 @@ module.exports = (log, translator, templates, config, statsd) => {
         // If we failed to query the data, assume current spend is fine
         isBudgetOk = true;
       })
-      .then(() => setTimeout(pollCurrentSpend, MILLISECONDS_PER_HOUR));
+      .then(() => setTimeout(pollCurrentSpend, POLL_CURRENT_SPEND_INTERVAL));
   }
 
   function getMessage(templateName, acceptLanguage, signinCode) {


### PR DESCRIPTION
During this week's SMS burst, it became apparent that we might want the option in the future of shortening the polling interval for checking the available budget. (It's a tradeoff of how often you poll against how large the "safety buffer" needs to be to deal with the current spending rate).

This makes the polling interval a configurable option.

r? - @mozilla/fxa-devs 