### PR TITLE
refactor(auth-server): async and setup stripeHelper

### DIFF
--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -20,7 +20,8 @@ module.exports = function(
   zendeskClient,
   subhub,
   statsd,
-  profile
+  profile,
+  stripeHelper
 ) {
   // Various extra helpers.
   const push = require('../push')(log, db, config);
@@ -156,7 +157,8 @@ module.exports = function(
     push,
     mailer,
     subhub,
-    profile
+    profile,
+    stripeHelper
   );
   const support = require('./support')(log, db, config, customs, zendeskClient);
   const util = require('./util')(log, config, config.smtp.redirectDomain);

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -8,7 +8,6 @@ const error = require('../error');
 const isA = require('joi');
 const ScopeSet = require('../../../fxa-shared').oauth.scopes;
 const validators = require('./validators');
-const StripeHelper = require('../payments/stripe');
 const { metadataFromPlan } = require('./utils/subscriptions');
 
 const createRoutes = (
@@ -19,16 +18,13 @@ const createRoutes = (
   push,
   mailer,
   subhub,
-  profile
+  profile,
+  stripeHelper
 ) => {
   // Skip routes if the subscriptions feature is not configured & enabled
   if (!config.subscriptions || !config.subscriptions.enabled) {
     return [];
   }
-
-  let stripeHelper = config.subscriptions.stripeApiKey
-    ? new StripeHelper(log, config)
-    : undefined;
 
   // For testing with Stripe, we attach the stripehelper to the subhub object
   if (subhub.stripeHelper) {


### PR DESCRIPTION
Because:

* Multiple upcoming PR's will need the stripeHelper.
* key_server main was a yucky promise chain.

This commit:

* Makes stripeHelper available in routing.
* Uses async/await to clean-up the main function in key_server.