### PR TITLE
feat(subscriptions): invalidate cache on 'customer.updated' event

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -687,6 +687,12 @@ const conf = convict({
       format: String,
       doc: 'Stripe API key for direct Stripe integration',
     },
+    stripeWebhookSecret: {
+      default: '',
+      env: 'STRIPE_WEBHOOK_SECRET',
+      format: String,
+      doc: 'A shared secret to authenticate Stripe webhook requests',
+    },
   },
   oauth: {
     url: {

--- a/packages/fxa-auth-server/lib/payments/stripe.js
+++ b/packages/fxa-auth-server/lib/payments/stripe.js
@@ -12,6 +12,7 @@ const stripe = require('stripe').Stripe;
 /** @typedef {import('stripe').Stripe.Plan} Plan */
 /** @typedef {import('stripe').Stripe.Subscription} Subscription */
 /** @typedef {import('stripe').Stripe.ApiList<Subscription>} Subscriptions */
+/** @typedef {import('stripe').Stripe.Event} StripeEvent */
 
 /**
  * @typedef AbbrevProduct
@@ -94,6 +95,7 @@ class StripeHelper {
     this.cacheTtlSeconds =
       config.subhub.plansCacheTtlSeconds ||
       config.subscriptions.cacheTtlSeconds;
+    this.webhookSecret = config.subscriptions.stripeWebhookSecret;
     const redis =
       this.cacheTtlSeconds &&
       require('../redis')(
@@ -413,6 +415,21 @@ class StripeHelper {
       });
     }
     return subs;
+  }
+
+  /**
+   * Use the Stripe lib to authenticate and get a webhook event.
+   *
+   * @param {any} payload
+   * @param {string | string[]} signature
+   * @returns {StripeEvent}
+   */
+  constructWebhookEvent(payload, signature) {
+    return this.stripe.webhooks.constructEvent(
+      payload,
+      signature,
+      this.webhookSecret
+    );
   }
 }
 


### PR DESCRIPTION
This patch adds a route to handle Stripe webhook events.  The only event
it processes at this point is 'customer.updated', during which the
cached customer will be invalidated.

Fixes #3812 

@mozilla/fxa-devs r?