### PR TITLE
fix(devices): maintain the device id during the token exchange

### DIFF
--- a/packages/fxa-auth-server/lib/routes/utils/oauth.js
+++ b/packages/fxa-auth-server/lib/routes/utils/oauth.js
@@ -57,9 +57,12 @@ module.exports = {
     credentials.tokenVerified = true;
     credentials.client = await oauthdb.getClientInfo(clientId);
 
-    // The following upsert gets no `deviceInfo`.
-    // However, `credentials.client` lets it generate a default name for the device.
-    await devices.upsert(request, credentials, {});
+    // Connect the new refreshToken to the existing device record, or create a new placeholder if there isn't one.
+    await devices.upsert(request, credentials, {
+      // We don't provide any other device info, but credentials.client will let it generate a default name for the device.
+      // Pass in the deviceId associated with the credential to reuse the existing device id.
+      id: credentials.deviceId,
+    });
 
     const geoData = request.app.geo;
     const ip = request.app.clientAddress;

--- a/packages/fxa-auth-server/test/local/routes/utils/oauth.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/oauth.js
@@ -22,6 +22,7 @@ const MOCK_CHECK_RESPONSE = {
   client_id: OAUTH_CLIENT_ID,
   scope: ['https://identity.mozilla.com/apps/oldsync', 'openid'],
 };
+const MOCK_DEVICE_ID = 'a72ed885e66cb9c96a12fde247112daa';
 
 describe('newTokenNotification', () => {
   let db;
@@ -129,5 +130,29 @@ describe('newTokenNotification', () => {
     assert.equal(devices.upsert.callCount, 1);
     const args = devices.upsert.args[0];
     assert.equal(args[1].refreshTokenId, MOCK_REFRESH_TOKEN_ID_2);
+    assert.isUndefined(args[2].id);
+  });
+
+  it('updates the device record using the deviceId', async () => {
+    credentials = {
+      uid: MOCK_UID,
+      deviceId: MOCK_DEVICE_ID,
+    };
+    request = mocks.mockRequest({ credentials });
+    await oauthUtils.newTokenNotification(
+      db,
+      oauthdb,
+      mailer,
+      devices,
+      request,
+      grant
+    );
+
+    assert.equal(oauthdb.checkAccessToken.callCount, 0);
+    assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 1);
+    assert.equal(devices.upsert.callCount, 1);
+    const args = devices.upsert.args[0];
+    assert.equal(args[1].refreshTokenId, MOCK_REFRESH_TOKEN_ID_2);
+    assert.equal(args[2].id, MOCK_DEVICE_ID);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/2473

@rfk This fixes the CLI use case.

Draft PR until I add tests.