### PR TITLE
feat(auth-server): use Stripe data for subscriptions & capabilities

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -7,7 +7,6 @@
 const error = require('../lib/error');
 const jwtool = require('fxa-jwtool');
 const StatsD = require('hot-shots');
-const StripeHelper = require('../lib/payments/stripe');
 
 async function run(config) {
   const statsd = config.statsd.enabled
@@ -26,10 +25,11 @@ async function run(config) {
   const log = require('../lib/log')({ ...config.log, statsd });
   require('../lib/oauth/logging')(log);
 
-  /** @type {undefined | import('../lib/payments/stripe')} */
+  /** @type {undefined | import('../lib/payments/stripe').StripeHelper} */
   let stripeHelper = undefined;
   if (config.subscriptions && config.subscriptions.stripeApiKey) {
-    stripeHelper = new StripeHelper(log, config);
+    const createStripeHelper = require('../lib/payments/stripe');
+    stripeHelper = createStripeHelper(log, config);
   }
 
   const DB = require('../lib/db')(

--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -666,12 +666,14 @@ const conf = convict({
       default: 'YOU MUST CHANGE ME',
       env: 'SUBSCRIPTIONS_SHARED_SECRET',
     },
+    // TODO: issue #3913 - remove support for capabilities from server config
     productCapabilities: {
       doc: 'Mappings from product names to subscription capability names',
       format: Object,
       env: 'SUBSCRIPTIONS_PRODUCT_CAPABILITIES',
       default: {},
     },
+    // TODO: issue #3913 - remove support for capabilities from server config
     clientCapabilities: {
       doc:
         'Mappings from OAuth client IDs to relevant subscription capabilities',

--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -56,6 +56,10 @@ let authdb = {};
 module.exports.setDB = function(db) {
   authdb = db;
 };
+let stripeHelper = null;
+module.exports.setStripeHelper = function(val) {
+  stripeHelper = val;
+};
 
 // Given a set of verified user identity claims, can the given client
 // be granted the specified access to the user's data?
@@ -244,7 +248,9 @@ exports.generateAccessToken = async function generateAccessToken(grant) {
       {},
       authdb,
       hex(grant.userId),
-      grant.clientId
+      grant.clientId,
+      stripeHelper,
+      grant.email
     );
     // To avoid mutating the input grant, create a
     // copy and add the new property there.

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -50,7 +50,9 @@ module.exports = function(
   const defaults = require('./defaults')(log, db);
   const idp = require('./idp')(log, serverPublicKeys);
   const oauthServer = require('../oauth/routes');
-  require('../oauth/grant').setDB(db);
+  const grant = require('../oauth/grant');
+  grant.setDB(db);
+  grant.setStripeHelper(stripeHelper);
   const account = require('./account')(
     log,
     db,
@@ -62,7 +64,8 @@ module.exports = function(
     signinUtils,
     push,
     verificationReminders,
-    require('../oauth/db')
+    require('../oauth/db'),
+    stripeHelper
   );
   const oauth = require('./oauth')(
     log,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -543,11 +543,16 @@ describe('subscriptions', () => {
 
       beforeEach(() => {
         payments = sinon.stub({});
+        payments.verifyPlanUpgradeForSubscription = sinon.fake();
+        payments.changeSubscriptionPlan = sinon.fake.returns(subscription2);
+        payments.deleteCachedCustomer = sinon.fake();
+        payments.subscriptionForCustomer = sinon.fake.returns({
+          id: SUBSCRIPTION_ID_1,
+          plan: { product: PLANS[0].product_id },
+        });
       });
 
       it('should allow updating of subscription plan', async () => {
-        payments.verifyPlanUpgradeForSubscription = sinon.fake();
-        payments.changeSubscriptionPlan = sinon.fake.returns(subscription2);
         await runTest(
           '/oauth/subscriptions/active/{subscriptionId}',
           {
@@ -1211,6 +1216,7 @@ describe.skip('subscriptions (using direct stripe access)', () => {
       it('should allow updating of subscription plan', async () => {
         payments.verifyPlanUpgradeForSubscription = sinon.fake();
         payments.changeSubscriptionPlan = sinon.fake.returns(subscription2);
+        payments.deleteCachedCustomer = sinon.fake();
         await runTest(
           '/oauth/subscriptions/active/{subscriptionId}',
           {
@@ -1225,6 +1231,7 @@ describe.skip('subscriptions (using direct stripe access)', () => {
         assert.deepEqual(payments.verifyPlanUpgradeForSubscription.args, [
           [PLANS[0].product_id, PLAN_ID_1],
         ]);
+        assert.equal(payments.deleteCachedCustomer.callCount, 1);
       });
 
       it('should correctly handle an error from stripeHelper', async () => {

--- a/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
@@ -16,6 +16,7 @@ const {
 } = require('../../../../lib/routes/utils/subscriptions');
 
 const UID = 'uid8675309';
+const EMAIL = 'user@example.com';
 const NOW = Date.now();
 const MOCK_SUBSCRIPTIONS = [
   {
@@ -59,7 +60,145 @@ describe('routes/utils/subscriptions', () => {
     );
   });
 
-  describe('determineClientVisibleSubscriptionCapabilities', () => {
+  describe('determineClientVisibleSubscriptionCapabilities using Stripe customer', () => {
+    let mockStripeHelper;
+
+    beforeEach(() => {
+      mockStripeHelper = {
+        customer: sinon.spy(async () => ({
+          subscriptions: {
+            data: [
+              { plan: { product: 'prod_123456' } },
+              { plan: { product: 'prod_876543' } },
+            ],
+          },
+        })),
+        allPlans: sinon.spy(async () => [
+          {
+            product_id: 'prod_123456',
+            product_metadata: {
+              'capabilities:c1': 'cap4,cap5',
+              'capabilities:c2': 'cap5,cap6',
+            },
+          },
+          {
+            product_id: 'prod_876543',
+            product_metadata: {
+              'capabilities:c2': 'capC,capD',
+              'capabilities:c3': 'capD,capE',
+            },
+          },
+          {
+            product_id: 'prod_ABCDEF',
+            product_metadata: {
+              'capabilities:c3': 'capZ,capW',
+            },
+          },
+        ]),
+      };
+    });
+
+    async function assertExpectedCapabilities(clientId, expectedCapabilities) {
+      assert.deepEqual(
+        await determineClientVisibleSubscriptionCapabilities(
+          MOCK_CONFIG,
+          auth,
+          db,
+          UID,
+          // null client represents sessionToken auth from content-server, unfiltered by client
+          clientId === 'null' ? null : clientId,
+          mockStripeHelper,
+          EMAIL
+        ),
+        expectedCapabilities
+      );
+    }
+
+    it('only reveals capabilities relevant to the client', async () => {
+      const expected = {
+        c0: undefined,
+        c1: ['cap4', 'cap5'],
+        c2: ['cap5', 'cap6', 'capC', 'capD', 'capSubscribed'],
+        c3: ['capD', 'capE', 'capRegistered'],
+        null: ['cap4', 'cap5', 'cap6', 'capC', 'capD', 'capE'],
+      };
+      for (const clientId in expected) {
+        await assertExpectedCapabilities(clientId, expected[clientId]);
+      }
+    });
+
+    it('supports capabilities visible to all clients', async () => {
+      mockStripeHelper.allPlans = sinon.spy(async () => [
+        {
+          product_id: 'prod_123456',
+          product_metadata: {
+            capabilities: 'cap1,cap2,cap3',
+          },
+        },
+        {
+          product_id: 'prod_876543',
+          product_metadata: {
+            capabilities: 'capA,capB,capC',
+          },
+        },
+        {
+          product_id: 'prod_ABCDEF',
+          product_metadata: {
+            capabilities: 'cap00,cap01,cap02',
+          },
+        },
+      ]);
+
+      for (const clientId of ['c0', 'c1', 'c2', 'c3', 'null']) {
+        const expected = ['cap1', 'cap2', 'cap3', 'capA', 'capB', 'capC'];
+        if (clientId === 'c2') {
+          expected.push('capSubscribed');
+        }
+        if (clientId === 'c3') {
+          expected.push('capRegistered');
+        }
+        await assertExpectedCapabilities(clientId, expected);
+      }
+    });
+
+    // TODO: This capability still comes from server config, not stripe metadata
+    it('implicitly includes subscribed default product for users with at least one subscription', async () => {
+      const client = 'c2';
+      const result = await determineClientVisibleSubscriptionCapabilities(
+        MOCK_CONFIG,
+        auth,
+        db,
+        UID,
+        client,
+        mockStripeHelper,
+        EMAIL
+      );
+      assert.include(result, 'capSubscribed');
+    });
+
+    // TODO: This capability still comes from server config, not stripe metadata
+    it('implicitly includes registered default product even for users with no subscriptions', async () => {
+      const client = 'c3';
+      mockStripeHelper.customer = sinon.spy(async () => ({
+        subscriptions: {
+          data: [],
+        },
+      }));
+      const result = await determineClientVisibleSubscriptionCapabilities(
+        MOCK_CONFIG,
+        auth,
+        db,
+        UID,
+        client,
+        mockStripeHelper,
+        EMAIL
+      );
+      assert.deepEqual(result, ['capRegistered']);
+    });
+  });
+
+  // TODO: issue #3846 - remove these tests
+  describe('determineClientVisibleSubscriptionCapabilities with local DB table', () => {
     afterEach(() => {
       // Each of these tests should cause a fetch of subscriptions
       assert.deepEqual(db.fetchAccountSubscriptions.args, [[UID]]);

--- a/packages/fxa-auth-server/test/remote/account_profile_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_profile_tests.js
@@ -17,8 +17,11 @@ describe('fetch user profile data', function() {
   this.timeout(15000);
 
   let server, client, email, password;
-
   before(async () => {
+    if (config.subscriptions) {
+      config.subscriptions.enabled = false;
+    }
+    config.oauth.url = 'http://127.0.0.1:9000';
     server = await TestServer.start(config, false);
   });
 

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -28,6 +28,7 @@ describe('remote subscriptions:', function() {
   this.timeout(10000);
 
   before(async () => {
+    config.subscriptions.stripeApiKey = null;
     config.subhub.useStubs = true;
     config.subhub.stubs = {
       plans: [
@@ -61,11 +62,190 @@ describe('remote subscriptions:', function() {
     };
   });
 
+  describe('config.subscriptions.enabled = true and direct stripe access:', function() {
+    this.timeout(15000);
+
+    let client, server, tokens;
+    const mockStripeHelper = {};
+
+    before(async () => {
+      config.subscriptions.enabled = true;
+      config.subscriptions.stripeApiKey = 'sk_34523452345';
+      mockStripeHelper.allPlans = async () => [
+        {
+          plan_id: PLAN_ID,
+          plan_name: PLAN_NAME,
+          product_id: PRODUCT_ID,
+          product_name: PRODUCT_NAME,
+          interval: 'month',
+          amount: 50,
+          currency: 'usd',
+        },
+      ];
+      mockStripeHelper.customer = async (uid, email) => ({});
+      server = await testServerFactory.start(config, false, {
+        authServerMockDependencies: {
+          '../lib/payments/stripe': () => mockStripeHelper,
+        },
+      });
+    });
+
+    after(async () => {
+      await server.stop();
+    });
+
+    beforeEach(async () => {
+      client = await clientFactory.createAndVerify(
+        config.publicUrl,
+        server.uniqueEmail(),
+        'wibble',
+        server.mailbox
+      );
+
+      const tokenResponse1 = await client.grantOAuthTokensFromSessionToken({
+        grant_type: 'fxa-credentials',
+        client_id: CLIENT_ID_FOR_DEFAULT,
+        scope: 'profile:subscriptions',
+      });
+
+      const tokenResponse2 = await client.grantOAuthTokensFromSessionToken({
+        grant_type: 'fxa-credentials',
+        client_id: CLIENT_ID,
+        scope: 'profile:subscriptions',
+      });
+
+      const tokenResponse3 = await client.grantOAuthTokensFromSessionToken({
+        grant_type: 'fxa-credentials',
+        client_id: CLIENT_ID,
+        scope: 'profile https://identity.mozilla.com/account/subscriptions',
+      });
+
+      tokens = [
+        tokenResponse1.access_token,
+        tokenResponse2.access_token,
+        tokenResponse3.access_token,
+      ];
+    });
+
+    describe('with no subscriptions', () => {
+      beforeEach(() => {
+        mockStripeHelper.customer = async (uid, email) => ({
+          subscriptions: { data: [] },
+        });
+        mockStripeHelper.subscriptionsToResponse = async subscriptions => [];
+      });
+
+      it('should return default capability with session token', async () => {
+        const response = await client.accountProfile();
+        assert.deepEqual(response.subscriptions, ['isRegistered']);
+      });
+
+      it('should return default capability with refresh token', async () => {
+        const response = await client.accountProfile(tokens[0]);
+        assert.deepEqual(response.subscriptions, ['isRegistered']);
+      });
+
+      it('should not return any subscription capabilities', async () => {
+        const response = await client.accountProfile(tokens[1]);
+        assert.isUndefined(response.subscriptions);
+      });
+
+      it('should return no active subscriptions', async () => {
+        let result = await client.getActiveSubscriptions(tokens[2]);
+        assert.deepEqual(result, []);
+
+        result = await client.account();
+        assert.deepEqual(result.subscriptions, []);
+      });
+    });
+
+    describe('with a subscription', () => {
+      const subscriptionId = 'sub_12345';
+      beforeEach(() => {
+        mockStripeHelper.customer = async (uid, email) => ({
+          subscriptions: {
+            data: [
+              {
+                id: subscriptionId,
+                created: Date.now() / 1000,
+                cancelled_at: null,
+                plan: {
+                  product: PRODUCT_ID,
+                },
+              },
+            ],
+          },
+        });
+        mockStripeHelper.subscriptionsToResponse = async subscriptions => [
+          {
+            subscription_id: subscriptionId,
+            plan_id: PLAN_ID,
+            current_period_end: Date.now() / 1000,
+            current_period_start: Date.now() / 1000,
+            cancel_at_period_end: false,
+            end_at: null,
+            plan_name: 'foo',
+            status: 'active',
+            failure_code: undefined,
+            failure_message: undefined,
+          },
+        ];
+      });
+
+      it('should return client capabilities with shared secret', async () => {
+        const response = await client.getSubscriptionClients('wibble');
+        assert.deepEqual(response, [
+          {
+            clientId: CLIENT_ID,
+            capabilities: ['123donePro', 'ILikePie', 'MechaMozilla', 'FooBar'],
+          },
+          {
+            clientId: CLIENT_ID_FOR_DEFAULT,
+            capabilities: ['isRegistered', 'isSubscribed'],
+          },
+        ]);
+      });
+
+      it('should not return client capabilities with invalid shared secret', async () => {
+        let succeeded = false;
+
+        try {
+          await client.getSubscriptionClients('blee');
+          succeeded = true;
+        } catch (err) {
+          assert.equal(err.code, 401);
+          assert.equal(err.errno, error.ERRNO.INVALID_TOKEN);
+        }
+
+        assert.isFalse(succeeded);
+      });
+
+      it('should return active subscriptions', async () => {
+        let result = await client.getActiveSubscriptions(tokens[2]);
+        assert.isArray(result);
+        assert.lengthOf(result, 1);
+        assert.isAbove(result[0].createdAt, Date.now() - 1000);
+        assert.isAtMost(result[0].createdAt, Date.now());
+        assert.equal(result[0].productId, PRODUCT_ID);
+        assert.equal(result[0].uid, client.uid);
+        assert.isNull(result[0].cancelledAt);
+
+        result = await client.account();
+        assert.isArray(result.subscriptions);
+        assert.lengthOf(result.subscriptions, 1);
+        assert.equal(result.subscriptions[0].subscription_id, subscriptionId);
+        assert.equal(result.subscriptions[0].plan_id, PLAN_ID);
+      });
+    });
+  });
+
   describe('config.subscriptions.enabled = true:', () => {
     let client, server, tokens;
 
     before(async () => {
       config.subscriptions.enabled = true;
+      config.subscriptions.stripeApiKey = null;
+      config.subscriptions.stripeApiUrl = null;
       server = await testServerFactory.start(config);
     });
 
@@ -330,6 +510,8 @@ describe('remote subscriptions:', function() {
 
     before(async () => {
       config.subscriptions.enabled = false;
+      config.subscriptions.stripeApiKey = null;
+      config.subscriptions.stripeApiUrl = null;
       server = await testServerFactory.start(config);
     });
 


### PR DESCRIPTION
- lib/routes/subscriptions.js routes no longer use accountSubscriptions
  DB table, instead relying on cached Stripe customer data and deleting
  the cache on changes

- reworked determineClientVisibleSubscriptionCapabilities to use
  StripeHelper when available for customer subscriptions and
  capabilities from plan/product metadata

- local unit and remote subscription route tests that exercise the
  reworked determineClientVisibleSubscriptionCapabilities with mocked
  Stripe API

- lib/routes/accounts.js and lib/routes/subscriptions.js directRoutes
  now get StripeHelper from key_server.js init

- GET /account now uses cached customer data from StripeHelper

- supply lib/oauth/grant.js with a StripeHelper to use in determining
  subscription capabilities for a user in JWT access tokens

- add support to StripeHelper for cached customer and cache deletion

- sprinkled in TODOs for follow up cleaning in issues #3913 & #3846

- more tests around Redis caching for StripeHelper

- switch to a factory function in bin/key_server.js to create
  StripeHelper to make proxyquire mocking easier in remote tests

- tweaks to rename "payments" to "stripeHelper" in various places

fixes #3808
fixes #3418