### PR TITLE
feat(avatar spinner): Replace avatar spinner with 'signin' spinner across our views

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/avatar_change.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/avatar_change.mustache
@@ -1,8 +1,7 @@
 <div id="avatar-change">
   <section class="modal-panel">
     <div class="main-avatar">
-      <div id="loading-avatar-spinner"></div>
-      <p id="image-holder" class="avatar-wrapper"></p>
+      <div id="image-holder" class="avatar-wrapper"></div>
     </div>
 
     <div class="error"></div>

--- a/packages/fxa-content-server/app/scripts/views/mixins/user-card-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/user-card-mixin.js
@@ -23,7 +23,7 @@ export default {
 
   afterVisible() {
     const account = this.getAccount();
-    return this.displayAccountProfileImage(account, { spinner: true });
+    return this.displayAccountProfileImage(account);
   },
 
   setInitialContext(context) {

--- a/packages/fxa-content-server/app/scripts/views/settings.js
+++ b/packages/fxa-content-server/app/scripts/views/settings.js
@@ -175,7 +175,7 @@ const View = BaseView.extend({
 
   _setupAvatarChangeLinks() {
     if (this.supportsAvatarUpload()) {
-      this.$('.avatar-wrapper > *').wrap(
+      this.$('.change-avatar-inner').wrap(
         '<a href="/settings/avatar/change" class="change-avatar"></a>'
       );
     } else {

--- a/packages/fxa-content-server/app/styles/modules/_avatar.scss
+++ b/packages/fxa-content-server/app/styles/modules/_avatar.scss
@@ -86,8 +86,7 @@
   }
 
   &.avatar-settings-view {
-    border: 2px solid $avatar-border-color;
-    box-shadow: $card-box-low;
+    border: 2px solid transparent;
     display: block;
     flex-shrink: 0;
     margin: 0;
@@ -98,6 +97,15 @@
 
     &:not(.nohover):active {
       box-shadow: 0 0 0 1px $color-orange;
+    }
+
+    &.spinner-completed {
+      border: 2px solid $avatar-border-color;
+      box-shadow: $card-box-low;
+    }
+
+    .change-avatar:focus {
+      box-shadow: none;
     }
 
     @include respond-to('big') {

--- a/packages/fxa-content-server/app/styles/modules/_avatar_spinner.scss
+++ b/packages/fxa-content-server/app/styles/modules/_avatar_spinner.scss
@@ -5,7 +5,7 @@
   $center-expand-delay: 200ms;
   $center-expand-duration: 200ms;
   $complete-duration: 200ms;
-  $fade-in-delay: 200ms;
+  $fade-in-delay: 0ms;
   $fade-in-duration: 200ms;
   $rotation-period: 2s; // Time for the spinner to make a single rotation
   $solid-part-width: 75%;
@@ -104,7 +104,5 @@
 }
 
 .with-spinner .profile-image {
-  @extend %fill-avatar;
   animation: $profile-image-fade-in-duration ease-in-out 1 both fadein;
-  position: relative;
 }

--- a/packages/fxa-content-server/app/styles/modules/_spinner.scss
+++ b/packages/fxa-content-server/app/styles/modules/_spinner.scss
@@ -22,20 +22,6 @@
   top: 0;
 }
 
-#loading-avatar-spinner {
-  animation: 0.9s spin infinite linear;
-  background-image: url('/images/spinnerlight.svg');
-  background-repeat: no-repeat;
-  background-size: 100%;
-  display: inline-block;
-  height: $avatar-size;
-  margin: 0 0 5px;
-  overflow: hidden;
-  position: relative;
-  white-space: nowrap;
-  width: $avatar-size;
-}
-
 .spinner {
   @include hidpi-background-image('spinnerlight', 36px 36px);
   animation: 0.9s spin infinite linear;

--- a/packages/fxa-content-server/app/tests/spec/views/force_auth.js
+++ b/packages/fxa-content-server/app/tests/spec/views/force_auth.js
@@ -364,11 +364,8 @@ describe('/views/force_auth', function() {
       it('delegates to `displayAccountProfileImage` with the correct email', function() {
         assert.isTrue(view.displayAccountProfileImage.called);
 
-        var account = view.displayAccountProfileImage.args[0][0];
+        const account = view.displayAccountProfileImage.args[0][0];
         assert.instanceOf(account, Account);
-
-        var options = view.displayAccountProfileImage.args[0][1];
-        assert.isTrue(options.spinner);
       });
 
       it('isValid is successful when the password is filled out', function() {

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -295,7 +295,7 @@ module.exports = {
     SUCCESS: '.settings-success',
   },
   SETTINGS_AVATAR: {
-    AVATAR: '.change-avatar > img',
+    AVATAR: '.change-avatar > .change-avatar-inner',
     BACK: '.modal-panel #back',
     BUTTON_CAMERA: '#camera',
     BUTTON_ROTATE: '.rotate',


### PR DESCRIPTION
fixes #3148

This PR:
* Shows the avatar spinner previously only implemented in the ‘signin' view in every view the avatar is loaded
* In views where there is a `border`/`box-shadow`, adds these styles only after the spinner completes via `spinner-completed`
* Changes 'image-holder' element from `p` tag to`div`
* Cleans up `displayAccountProfileImage`, clears the setTimeout, makes what we're doing with the change-avatar link more obvious
* Tweaks the avatar spinner load times and other CSS, approved by UX
* Adds missing tests and cleans up/modernizes some other tests

I added a 500ms delay for the screenshots so we can see the spinner when it's being fairly slow. It also looks smoother than this, Licecap looks laggy.

![profilepic1](https://user-images.githubusercontent.com/13018240/72651337-abbde980-3948-11ea-8991-d39b8a3323ab.gif)
![profilepic2](https://user-images.githubusercontent.com/13018240/72651341-ad87ad00-3948-11ea-9c07-b9416ceddd54.gif)

