### PR TITLE
feat(autocomplete): Add protonmail.com and pm.me to signup domain autocomplete

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/email-autocomplete-domains-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/email-autocomplete-domains-mixin.js
@@ -33,6 +33,8 @@ export const DOMAINS = [
   'comcast.net',
   'hotmail.co.uk',
   'hotmail.fr',
+  'protonmail.com',
+  'pm.me',
 ];
 
 export default {


### PR DESCRIPTION
fixes #3898 

<img width="510" alt="image" src="https://user-images.githubusercontent.com/13018240/72841959-0dd66180-3c5d-11ea-89ab-ae2ccfaac157.png">
