### PR TITLE
fix(css): Center `Not now` button on CAD

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
@@ -19,7 +19,7 @@
     <div class="sms-disclaimer faint">
       {{#unsafeTranslate}}SMS service only available in certain countries. SMS &amp; data rates may apply. The intended recipient of the email or SMS must have consented. <a %(escapedLearnMoreAttributes)s>Learn more</a>{{/unsafeTranslate}}
     </div>
-    <div class="links">
+    <div class="links centered">
       <a href="/sms/why" data-flow-event="link.why" class="left">{{#t}}Why sign in on another device?{{/t}}</a>
       <a href='https://www.mozilla.org/firefox/accounts' class="btn-not-now" data-flow-event="link.not_now">{{#t}}Not now{{/t}}</a>
     </div>


### PR DESCRIPTION
Fixes #3820 

<img width="676" alt="Screen Shot 2020-01-21 at 4 21 46 PM" src="https://user-images.githubusercontent.com/1295288/72844331-46306c80-3c6a-11ea-86fd-93e3451588ec.png">