### PR TITLE
feat(keys): Add ability to enable/disable recovery key

### DIFF
--- a/packages/fxa-auth-db-mysql/db-server/index.js
+++ b/packages/fxa-auth-db-mysql/db-server/index.js
@@ -42,7 +42,10 @@ function createServer(db) {
 
   function withSpreadParams(fn) {
     return reply(function(params, body, query) {
-      return fn.apply(db, Object.keys(params).map(k => params[k]));
+      return fn.apply(
+        db,
+        Object.keys(params).map(k => params[k])
+      );
     });
   }
 
@@ -327,6 +330,10 @@ function createServer(db) {
   api.get('/account/:id/recoveryKey', withIdAndBody(db.recoveryKeyExists));
   api.del('/account/:id/recoveryKey', withParams(db.deleteRecoveryKey));
   api.post('/account/:id/recoveryKey', withIdAndBody(db.createRecoveryKey));
+  api.post(
+    '/account/:id/recoveryKey/update',
+    withIdAndBody(db.updateRecoveryKey)
+  );
 
   api.get(
     '/account/:id/subscriptions/:subscriptionId',

--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -1603,7 +1603,9 @@ module.exports = function(log, error) {
       });
   };
 
-  const CREATE_RECOVERY_KEY = 'CALL createRecoveryKey_3(?, ?, ?)';
+  // Create : recoveryKeys
+  // Where  : uid = $1, recoveryKeyId = $2, recoveryData = $3, createdAt = $4, enabled = $5
+  const CREATE_RECOVERY_KEY = 'CALL createRecoveryKey_4(?, ?, ?, ?, ?)';
   MySql.prototype.createRecoveryKey = function(uid, data) {
     const recoveryKeyIdHash = dbUtil.createHash(data.recoveryKeyId);
     const recoveryData = data.recoveryData;
@@ -1611,6 +1613,8 @@ module.exports = function(log, error) {
       uid,
       recoveryKeyIdHash,
       recoveryData,
+      Date.now(),
+      data.enabled,
     ])
       .then(() => {
         return {};
@@ -1624,7 +1628,7 @@ module.exports = function(log, error) {
       });
   };
 
-  const GET_RECOVERY_KEY = 'CALL getRecoveryKey_3(?)';
+  const GET_RECOVERY_KEY = 'CALL getRecoveryKey_4(?)';
   MySql.prototype.getRecoveryKey = function(options) {
     return this.readFirstResult(GET_RECOVERY_KEY, [options.id]).then(
       results => {
@@ -1647,11 +1651,10 @@ module.exports = function(log, error) {
   };
 
   MySql.prototype.recoveryKeyExists = function(uid) {
-    let exists = true;
     return this.read(GET_RECOVERY_KEY, [uid]).then(results => {
-      if (results[0].length === 0) {
-        exists = false;
-      }
+      // A recovery key is considered to exist if and only if there is one key
+      // that is enabled.
+      const exists = results[0].some(k => k.enabled);
 
       return { exists };
     });
@@ -1662,6 +1665,29 @@ module.exports = function(log, error) {
     return this.write(DELETE_RECOVERY_KEY, [options.id]).then(() => {
       return {};
     });
+  };
+
+  // Update : recoveryKeys
+  // Where  : uid = $1, recoveryKeyId = $2, verifiedAt = $3, enabled = $4
+  const UPDATE_RECOVERY_KEY = 'CALL updateRecoveryKey_1(?, ?, ?, ?)';
+  MySql.prototype.updateRecoveryKey = async function(uid, options) {
+    const recoveryKeyIdHash = dbUtil.createHash(options.recoveryKeyId);
+
+    try {
+      await this.write(UPDATE_RECOVERY_KEY, [
+        uid,
+        recoveryKeyIdHash,
+        options.verifiedAt,
+        options.enabled,
+      ]);
+    } catch (err) {
+      if (err.errno === ER_SIGNAL_NOT_FOUND) {
+        throw error.notFound();
+      }
+      throw err;
+    }
+
+    return {};
   };
 
   const CREATE_ACCOUNT_SUBSCRIPTION =
@@ -1708,9 +1734,10 @@ module.exports = function(log, error) {
 
   const DELETE_ACCOUNT_SUBSCRIPTION = 'CALL deleteAccountSubscription_2(?,?)';
   MySql.prototype.deleteAccountSubscription = function(uid, subscriptionId) {
-    return this.write(DELETE_ACCOUNT_SUBSCRIPTION, [uid, subscriptionId]).then(
-      result => ({})
-    );
+    return this.write(DELETE_ACCOUNT_SUBSCRIPTION, [
+      uid,
+      subscriptionId,
+    ]).then(result => ({}));
   };
 
   const CANCEL_ACCOUNT_SUBSCRIPTION = 'CALL cancelAccountSubscription_2(?,?,?)';

--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 106;
+module.exports.level = 107;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-106-107.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-106-107.sql
@@ -1,0 +1,95 @@
+-- This migration updates recoveryKey table to store createdAt, verifiedAt and enabled. This
+-- will allow us to let the user confirm the key before actually enabling the feature.
+-- Users that have setup account recovery before this migration are considered to have the feature
+-- enabled.
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('106');
+
+-- Add columns `createdAt`, `verifiedAt` and `enabled` to help manage account recovery
+-- keys state
+ALTER TABLE `recoveryKeys`
+ADD COLUMN `createdAt` BIGINT UNSIGNED NOT NULL,
+ADD COLUMN `verifiedAt` BIGINT UNSIGNED,
+ADD COLUMN `enabled` BOOLEAN DEFAULT TRUE,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+CREATE PROCEDURE `createRecoveryKey_4` (
+  IN `uidArg` BINARY(16),
+  IN `recoveryKeyIdHashArg` BINARY(32),
+  IN `recoveryDataArg` TEXT,
+  IN `createdAtArg` BIGINT UNSIGNED,
+  IN `enabledArg` BOOLEAN
+)
+BEGIN
+
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  SET @accountCount = 0;
+
+  -- Signal error if no user found
+  SELECT COUNT(*) INTO @accountCount FROM `accounts` WHERE `uid` = `uidArg`;
+  IF @accountCount = 0 THEN
+    SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1643, MESSAGE_TEXT = 'Can not create recovery key for unknown user.';
+  END IF;
+
+  INSERT INTO recoveryKeys (
+    uid,
+    recoveryKeyIdHash,
+    recoveryData,
+    createdAt,
+    enabled
+  )
+  VALUES (
+    uidArg,
+    recoveryKeyIdHashArg,
+    recoveryDataArg,
+    createdAtArg,
+    enabledArg
+  );
+
+  UPDATE accounts SET profileChangedAt = (UNIX_TIMESTAMP(NOW(3)) * 1000) WHERE uid = uidArg;
+
+  COMMIT;
+END;
+
+CREATE PROCEDURE `getRecoveryKey_4` (
+  IN `uidArg` BINARY(16)
+)
+BEGIN
+
+  SELECT recoveryKeyIdHash, recoveryData, createdAt, verifiedAt, enabled FROM recoveryKeys WHERE uid = uidArg;
+
+END;
+
+CREATE PROCEDURE `updateRecoveryKey_1` (
+  IN `uidArg` BINARY(16),
+  IN `recoveryKeyIdHashArg` BINARY(32),
+  IN `verifiedAtArg` BIGINT UNSIGNED,
+  IN `enabledArg` BOOLEAN
+)
+BEGIN
+
+  UPDATE recoveryKeys
+  SET
+    verifiedAt = verifiedAtArg,
+    enabled = enabledArg
+  WHERE uid = uidArg
+  AND recoveryKeyIdHash = recoveryKeyIdHashArg;
+
+  SELECT ROW_COUNT() INTO @updateCount;
+
+  IF @updateCount = 0 THEN
+    SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1643, MESSAGE_TEXT = 'No recoveryKey found.';
+  END IF;
+
+  UPDATE accounts SET profileChangedAt = (UNIX_TIMESTAMP(NOW(3)) * 1000) WHERE uid = uidArg;
+END;
+
+UPDATE dbMetadata SET value = '107' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-107-106.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-107-106.sql
@@ -1,0 +1,13 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- ALTER TABLE `recoveryKeys`
+-- DROP COLUMN `createdAt` BIGINT,
+-- DROP COLUMN `verifiedAt` BIGINT UNSIGNED,
+-- DROP COLUMN `enabled` BOOLEAN,
+-- ALGORITHM = INPLACE, LOCK = NONE;
+
+-- DROP PROCEDURE `createRecoveryKey_4`;
+-- DROP PROCEDURE `getRecoveryKey_4`;
+-- DROP PROCEDURE `updateRecoveryKey_1`;
+
+-- UPDATE dbMetadata SET value = '106' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -1335,7 +1335,8 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   DB.prototype.createRecoveryKey = async function(
     uid,
     recoveryKeyId,
-    recoveryData
+    recoveryData,
+    enabled
   ) {
     log.trace('DB.createRecoveryKey', { uid });
 
@@ -1343,7 +1344,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
       return await this.pool.post(
         SAFE_URLS.createRecoveryKey,
         { uid },
-        { recoveryKeyId, recoveryData }
+        { recoveryKeyId, recoveryData, enabled }
       );
     } catch (err) {
       if (isRecordAlreadyExistsError(err)) {
@@ -1395,6 +1396,20 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     log.trace('DB.deleteRecoveryKey', { uid });
 
     return this.pool.del(SAFE_URLS.deleteRecoveryKey, { uid });
+  };
+
+  SAFE_URLS.updateRecoveryKey = new SafeUrl(
+    '/account/:uid/recoveryKey/update',
+    'db.updateRecoveryKey'
+  );
+  DB.prototype.updateRecoveryKey = async function(uid, recoveryKeyId, enabled) {
+    log.trace('DB.updateRecoveryKey', { uid });
+
+    return this.pool.post(SAFE_URLS.updateRecoveryKey, {
+      uid,
+      recoveryKeyId,
+      enabled,
+    });
   };
 
   SAFE_URLS.createAccountSubscription = new SafeUrl(

--- a/packages/fxa-auth-server/lib/routes/recovery-key.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-key.js
@@ -21,6 +21,7 @@ module.exports = (log, db, Password, verifierVersion, customs, mailer) => {
           payload: {
             recoveryKeyId: validators.recoveryKeyId,
             recoveryData: validators.recoveryData,
+            enabled: isA.boolean().default(true),
           },
         },
       },
@@ -34,35 +35,77 @@ module.exports = (log, db, Password, verifierVersion, customs, mailer) => {
         }
 
         const { uid } = sessionToken;
-        const { recoveryKeyId, recoveryData } = request.payload;
+        const { recoveryKeyId, recoveryData, enabled } = request.payload;
 
-        await db.createRecoveryKey(uid, recoveryKeyId, recoveryData);
+        await db.createRecoveryKey(uid, recoveryKeyId, recoveryData, enabled);
 
         log.info('account.recoveryKey.created', { uid });
 
-        await request.emitMetricsEvent('recoveryKey.created', { uid });
+        if (enabled) {
+          await request.emitMetricsEvent('recoveryKey.created', { uid });
 
-        const account = await db.account(uid);
+          const account = await db.account(uid);
 
-        const { acceptLanguage, clientAddress: ip, geo, ua } = request.app;
-        const emailOptions = {
-          acceptLanguage,
-          ip,
-          location: geo.location,
-          timeZone: geo.timeZone,
-          uaBrowser: ua.browser,
-          uaBrowserVersion: ua.browserVersion,
-          uaOS: ua.os,
-          uaOSVersion: ua.osVersion,
-          uaDeviceType: ua.deviceType,
-          uid,
-        };
+          const { acceptLanguage, clientAddress: ip, geo, ua } = request.app;
+          const emailOptions = {
+            acceptLanguage,
+            ip,
+            location: geo.location,
+            timeZone: geo.timeZone,
+            uaBrowser: ua.browser,
+            uaBrowserVersion: ua.browserVersion,
+            uaOS: ua.os,
+            uaOSVersion: ua.osVersion,
+            uaDeviceType: ua.deviceType,
+            uid,
+          };
 
-        await mailer.sendPostAddAccountRecoveryEmail(
-          account.emails,
-          account,
-          emailOptions
-        );
+          await mailer.sendPostAddAccountRecoveryEmail(
+            account.emails,
+            account,
+            emailOptions
+          );
+        }
+
+        return {};
+      },
+    },
+    {
+      method: 'POST',
+      path: '/recoveryKey/verify',
+      options: {
+        auth: {
+          strategy: 'sessionToken',
+        },
+        validate: {
+          payload: {
+            recoveryKeyId: validators.recoveryKeyId,
+          },
+        },
+      },
+      handler: async function(request) {
+        log.begin('verifyRecoveryKey', request);
+
+        const sessionToken = request.auth.credentials;
+        const { uid } = sessionToken;
+
+        if (sessionToken.tokenVerificationId) {
+          throw errors.unverifiedSession();
+        }
+
+        // This route can let you check if a key is valid therefore we
+        // rate limit it.
+        await customs.checkAuthenticated(request, uid, 'getRecoveryKey');
+
+        const { recoveryKeyId } = request.payload;
+
+        // Attempt to retrieve a recovery key, if it exists and is not already enabled,
+        // then we enable it.
+        const recoveryKeyData = await db.getRecoveryKey(uid, recoveryKeyId);
+
+        if (!recoveryKeyData.enabled) {
+          await db.updateRecoveryKey(uid, recoveryKeyId, true);
+        }
 
         return {};
       },

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -1044,12 +1044,14 @@ module.exports = config => {
   ClientApi.prototype.createRecoveryKey = function(
     sessionTokenHex,
     recoveryKeyId,
-    recoveryData
+    recoveryData,
+    enabled = true
   ) {
     return tokens.SessionToken.fromHex(sessionTokenHex).then(token => {
       return this.doRequest('POST', `${this.baseURL}/recoveryKey`, token, {
         recoveryKeyId,
         recoveryData,
+        enabled,
       });
     });
   };

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -661,11 +661,16 @@ module.exports = config => {
     return this.api.consumeRecoveryCode(this.sessionToken, code, options);
   };
 
-  Client.prototype.createRecoveryKey = function(recoveryKeyId, recoveryData) {
+  Client.prototype.createRecoveryKey = function(
+    recoveryKeyId,
+    recoveryData,
+    enabled = true
+  ) {
     return this.api.createRecoveryKey(
       this.sessionToken,
       recoveryKeyId,
-      recoveryData
+      recoveryData,
+      enabled
     );
   };
 

--- a/packages/fxa-auth-server/test/local/routes/recovery-keys.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-keys.js
@@ -23,7 +23,7 @@ describe('POST /recoveryKey', () => {
       const requestOptions = {
         credentials: { uid, email },
         log,
-        payload: { recoveryKeyId, recoveryData },
+        payload: { recoveryKeyId, recoveryData, enabled: true },
       };
       return setup({ db: { email } }, {}, '/recoveryKey', requestOptions).then(
         r => (response = r)
@@ -45,10 +45,11 @@ describe('POST /recoveryKey', () => {
     it('called db.createRecoveryKey correctly', () => {
       assert.equal(db.createRecoveryKey.callCount, 1);
       const args = db.createRecoveryKey.args[0];
-      assert.equal(args.length, 3);
+      assert.equal(args.length, 4);
       assert.equal(args[0], uid);
       assert.equal(args[1], recoveryKeyId);
       assert.equal(args[2], recoveryData);
+      assert.equal(args[3], true);
     });
 
     it('called log.info correctly', () => {
@@ -82,6 +83,71 @@ describe('POST /recoveryKey', () => {
       const args = mailer.sendPostAddAccountRecoveryEmail.args[0];
       assert.equal(args.length, 3);
       assert.equal(args[0][0].email, email);
+    });
+  });
+
+  describe('should create disabled recovery key', () => {
+    beforeEach(() => {
+      const requestOptions = {
+        credentials: { uid, email },
+        log,
+        payload: { recoveryKeyId, recoveryData, enabled: false },
+      };
+      return setup({ db: { email } }, {}, '/recoveryKey', requestOptions).then(
+        r => (response = r)
+      );
+    });
+
+    it('returned the correct response', () => {
+      assert.deepEqual(response, {});
+    });
+
+    it('called db.createRecoveryKey correctly', () => {
+      assert.equal(db.createRecoveryKey.callCount, 1);
+      const args = db.createRecoveryKey.args[0];
+      assert.equal(args.length, 4);
+      assert.equal(args[0], uid);
+      assert.equal(args[1], recoveryKeyId);
+      assert.equal(args[2], recoveryData);
+      assert.equal(args[3], false);
+    });
+  });
+
+  describe('should verify recovery key', () => {
+    beforeEach(() => {
+      const requestOptions = {
+        credentials: { uid, email },
+        log,
+        payload: { recoveryKeyId, enabled: false },
+      };
+      return setup(
+        { db: { email } },
+        {},
+        '/recoveryKey/verify',
+        requestOptions
+      ).then(r => (response = r));
+    });
+
+    it('returned the correct response', () => {
+      assert.deepEqual(response, {});
+    });
+
+    it('called customs.checkAuthenticated correctly', () => {
+      assert.equal(customs.checkAuthenticated.callCount, 1);
+      const args = customs.checkAuthenticated.args[0];
+      assert.equal(args.length, 3);
+      assert.deepEqual(args[0], request);
+      assert.equal(args[1], uid);
+      assert.equal(args[2], 'getRecoveryKey');
+    });
+
+    it('called db.updateRecoveryKey correctly', () => {
+      assert.equal(db.updateRecoveryKey.callCount, 1);
+      const args = db.updateRecoveryKey.args[0];
+      assert.equal(args.length, 3);
+      assert.equal(args[0], uid);
+      assert.equal(args[1], recoveryKeyId);
+      assert.equal(args[2], true);
     });
   });
 

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -80,6 +80,7 @@ const DB_METHOD_NAMES = [
   'totpToken',
   'updateDevice',
   'updateLocale',
+  'updateRecoveryKey',
   'updateSessionToken',
   'updateTotpToken',
   'verifyEmail',

--- a/packages/fxa-auth-server/test/remote/recovery_key_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_key_tests.js
@@ -220,7 +220,7 @@ describe('remote recovery keys', function() {
 
   describe('check recovery key status', () => {
     describe('with sessionToken', () => {
-      it('should return true if recovery key exists', () => {
+      it('should return true if recovery key exists and enabled', () => {
         return client.getRecoveryKeyExists().then(res => {
           assert.equal(res.exists, true, 'recovery key exists');
         });
@@ -242,6 +242,30 @@ describe('remote recovery keys', function() {
           .then(res => {
             assert.equal(res.exists, false, 'recovery key doesnt exists');
           });
+      });
+
+      it('should return false if recovery key exist but not enabled', async () => {
+        const email2 = server.uniqueEmail();
+        const client2 = await Client.createAndVerify(
+          config.publicUrl,
+          email2,
+          password,
+          server.mailbox,
+          { keys: true }
+        );
+        const recoveryKeyMock = await createMockRecoveryKey(
+          client2.uid,
+          keys.kB
+        );
+        let res = await client2.createRecoveryKey(
+          recoveryKeyMock.recoveryKeyId,
+          recoveryKeyMock.recoveryData,
+          false
+        );
+        assert.deepEqual(res, {});
+
+        res = await client2.getRecoveryKeyExists();
+        assert.equal(res.exists, false, 'recovery key doesnt exists');
       });
     });
 


### PR DESCRIPTION
Fixes #3936 

This PR adds the DB support and auth-server support for enabling a recovery key. The enable flag is specified when creating the recovery key.

Some notes

* Added `enabled` column on recoveryKey table
* New db method `updateRecoveryKey_1` to update column value
* New route `/recoveryKey/verify` can enable a recovery key