### PR TITLE
fix(oauth): Don't send "new device" email when oauth tokens reuse existing device.

### DIFF
--- a/packages/fxa-auth-server/lib/routes/utils/oauth.js
+++ b/packages/fxa-auth-server/lib/routes/utils/oauth.js
@@ -64,18 +64,26 @@ module.exports = {
       id: credentials.deviceId,
     });
 
-    const geoData = request.app.geo;
-    const ip = request.app.clientAddress;
-    const emailOptions = {
-      acceptLanguage: request.app.acceptLanguage,
-      ip,
-      location: geoData.location,
-      service: clientId,
-      timeZone: geoData.timeZone,
-      uid: credentials.uid,
-    };
+    // Email the user about their new device connection
+    // (but don't send anything if it was an existing device)
+    if (!credentials.deviceId) {
+      const geoData = request.app.geo;
+      const ip = request.app.clientAddress;
+      const emailOptions = {
+        acceptLanguage: request.app.acceptLanguage,
+        ip,
+        location: geoData.location,
+        service: clientId,
+        timeZone: geoData.timeZone,
+        uid: credentials.uid,
+      };
 
-    const account = await db.account(credentials.uid);
-    await mailer.sendNewDeviceLoginEmail(account.emails, account, emailOptions);
+      const account = await db.account(credentials.uid);
+      await mailer.sendNewDeviceLoginEmail(
+        account.emails,
+        account,
+        emailOptions
+      );
+    }
   },
 };

--- a/packages/fxa-auth-server/test/local/routes/utils/oauth.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/oauth.js
@@ -149,7 +149,7 @@ describe('newTokenNotification', () => {
     );
 
     assert.equal(oauthdb.checkAccessToken.callCount, 0);
-    assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 1);
+    assert.equal(mailer.sendNewDeviceLoginEmail.callCount, 0);
     assert.equal(devices.upsert.callCount, 1);
     const args = devices.upsert.args[0];
     assert.equal(args[1].refreshTokenId, MOCK_REFRESH_TOKEN_ID_2);


### PR DESCRIPTION
When users create an OAuth refresh token with "oldsync" scope we ensure
it is connected to a device record, creating one if necessary.

Previously, the logic for handling this would trigger a "new device"
push notification only for newly-created device records, but would
send an email for both old and new devices.

With this commit, we align the email-sending behaviour with the
push notification behaviour, sending both only when it's a new
device record.

(Draft for now so CI can tell me what tests I need to change/add, if any)