### PR TITLE
refactor(support-panel): get subscriptions from auth-server

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -42,7 +42,7 @@ async function run(config) {
   try {
     database = await DB.connect(config[config.db.backend]);
   } catch (err) {
-    log.error({ op: 'DB.connect', err: { message: err.message } });
+    log.error('DB.connect', { err: { message: err.message } });
     process.exit(1);
   }
 
@@ -112,13 +112,11 @@ async function run(config) {
 
   try {
     await server.start();
-    log.info({
-      op: 'server.start.1',
+    log.info('server.start.1', {
       msg: `running on ${server.info.uri}`,
     });
   } catch (err) {
-    log.error({
-      op: 'server.start.1',
+    log.error('server.start.1', {
       msg: 'failed startup with error',
       err: { message: err.message },
     });
@@ -128,7 +126,7 @@ async function run(config) {
     server,
     log: log,
     async close() {
-      log.info({ op: 'shutdown' });
+      log.info('shutdown');
       await server.stop();
       await customs.close();
       oauthdb.close();
@@ -138,10 +136,7 @@ async function run(config) {
         senders.email.stop();
       } catch (e) {
         // XXX: simplesmtp module may quit early and set socket to `false`, stopping it may fail
-        log.warn({
-          op: 'shutdown',
-          message: 'Mailer client already disconnected',
-        });
+        log.warn('shutdown', { message: 'Mailer client already disconnected' });
       }
       await database.close();
     },
@@ -153,14 +148,11 @@ async function main() {
   try {
     const server = await run(config.getProperties());
     process.on('uncaughtException', err => {
-      server.log.fatal(err);
+      server.log.fatal('uncaughtException', err);
       process.exit(8);
     });
     process.on('unhandledRejection', (reason, promise) => {
-      server.log.fatal({
-        op: 'promise.unhandledRejection',
-        error: reason,
-      });
+      server.log.fatal('promise.unhandledRejection', { error: reason });
     });
     const shutdown = async () => {
       await server.close();
@@ -170,7 +162,7 @@ async function main() {
     server.log.on('error', shutdown);
 
     if (config.get('env') !== 'prod') {
-      server.log.info(config.toString(), 'starting config');
+      server.log.info('startConfig', { config: config.toString() });
     }
   } catch (err) {
     console.error(err); // eslint-disable-line no-console

--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -1604,6 +1604,15 @@ const conf = convict({
       },
     },
   },
+  supportPanel: {
+    secretBearerToken: {
+      default: 'YOU MUST CHANGE ME',
+      doc:
+        'Shared secret to access certain endpoints.  Please only use for GET.  No state mutation allowed!',
+      env: 'SUPPORT_PANEL_AUTH_SECRET_BEARER_TOKEN',
+      format: 'String',
+    },
+  },
 });
 
 // handle configuration files.  you can specify a CSV list of configuration
@@ -1735,6 +1744,7 @@ if (conf.get('isProduction')) {
     'oauth.jwtSecretKeys',
     'oauth.secretKey',
     'profileServer.secretBearerToken',
+    'supportPanel.secretBearerToken',
   ];
   for (const key of SECRET_SETTINGS) {
     if (conf.get(key) === conf.default(key)) {

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/shared-secret.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/shared-secret.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const AppError = require('../../error');
+const crypto = require('crypto');
+
+const constantTimeCompare = (subject, object) => {
+  const size = Buffer.byteLength(object);
+  return (
+    crypto.timingSafeEqual(Buffer.alloc(size, subject), Buffer.from(object)) &&
+    subject.length === object.length
+  );
+};
+
+exports.strategy = secret => (server, options) => ({
+  authenticate: (request, h) => {
+    if (constantTimeCompare(request.headers.authorization, secret)) {
+      return h.authenticated({ credentials: {} });
+    }
+
+    throw AppError.invalidToken();
+  },
+});

--- a/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
@@ -72,7 +72,7 @@ const SubscriptionUtils = (module.exports = {
 async function fetchSubscribedProductsFromStripe(uid, stripeHelper, email) {
   const customer = await stripeHelper.customer(uid, email);
   if (!customer || !customer.subscriptions.data) {
-    return;
+    return [];
   }
   // All accounts get this psuedo-product
   const subscribedProducts = [PRODUCT_REGISTERED];

--- a/packages/fxa-auth-server/test/local/config/index.js
+++ b/packages/fxa-auth-server/test/local/config/index.js
@@ -31,7 +31,7 @@ describe('Config', () => {
     it('errors when secret settings have their default values', () => {
       assert.throws(() => {
         proxyquire(`${ROOT_DIR}/config`, {});
-      // eslint-disable-next-line no-useless-escape
+        // eslint-disable-next-line no-useless-escape
       }, /Config \'[a-zA-Z.]+\' must be set in production/);
     });
 
@@ -41,6 +41,10 @@ describe('Config', () => {
       mockEnv('OAUTH_SERVER_SECRET_KEY', 'production secret here');
       mockEnv(
         'PROFILE_SERVER_AUTH_SECRET_BEARER_TOKEN',
+        'production secret here'
+      );
+      mockEnv(
+        'SUPPORT_PANEL_AUTH_SECRET_BEARER_TOKEN',
         'production secret here'
       );
       assert.doesNotThrow(() => {

--- a/packages/fxa-auth-server/test/local/routes/auth-schemes/shared-secret.js
+++ b/packages/fxa-auth-server/test/local/routes/auth-schemes/shared-secret.js
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { assert } = require('chai');
+const AppError = require('../../../../lib/error');
+const SharedSecretScheme = require('../../../../lib/routes/auth-schemes/shared-secret');
+const authStrategy = SharedSecretScheme.strategy('goodsecret')();
+const sinon = require('sinon');
+
+describe('lib/routes/auth-schemes/auth-oauth', () => {
+  it('should throws an invalid token error if the secrets do not match', () => {
+    const request = { headers: { authorization: 'badsecret' } };
+
+    try {
+      authStrategy.authenticate(request, {});
+      assert.fail('Unmatching secrets should have thrown an error');
+    } catch (err) {
+      assert.deepEqual(err, AppError.invalidToken());
+    }
+  });
+
+  it('should call authenticated when the secrets match', () => {
+    const faker = sinon.fake();
+    const request = { headers: { authorization: 'goodsecret' } };
+    authStrategy.authenticate(request, { authenticated: faker });
+    assert.isTrue(faker.calledOnceWith({ credentials: {} }));
+  });
+});

--- a/packages/fxa-auth-server/test/local/server.js
+++ b/packages/fxa-auth-server/test/local/server.js
@@ -646,6 +646,9 @@ function getConfig() {
     subscriptions: {
       sharedSecret: 'abc',
     },
+    supportPanel: {
+      secretBearerToken: 'topsecrets',
+    },
     verificationReminders: {},
   };
 }

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -745,6 +745,7 @@ function mockRequest(data, errors) {
     },
     auth: {
       credentials: data.credentials,
+      ...data.auth,
     },
     clearMetricsContext: metricsContext.clear,
     emitMetricsEvent: events.emit,

--- a/packages/fxa-support-panel/config/index.ts
+++ b/packages/fxa-support-panel/config/index.ts
@@ -13,6 +13,26 @@ const conf = convict({
     env: 'AUTH_HEADER',
     format: String,
   },
+  authServer: {
+    secretBearerToken: {
+      default: 'CHANGE ME!',
+      doc: 'Shared secret for accessing certain auth server endpoints',
+      env: 'AUTH_SECRET_BEARER_TOKEN',
+      format: 'String',
+    },
+    subscriptionsSearchPath: {
+      default: '/v1/oauth/subscriptions/search',
+      doc: 'Auth server path for subscriptions search endpoint',
+      env: 'AUTH_SERVER_SUBS_SEARCH_PATH',
+      format: String,
+    },
+    url: {
+      default: 'http://localhost:9000',
+      doc: 'URL for auth server',
+      env: 'AUTH_SERVER_URL',
+      format: String,
+    },
+  },
   authdbUrl: {
     default: 'http://localhost:8000',
     doc: 'fxa-auth-db-mysql url',
@@ -27,7 +47,7 @@ const conf = convict({
   },
   listen: {
     host: {
-      default: '127.0.0.1',
+      default: '0.0.0.0',
       doc: 'The ip address the server should bind',
       env: 'IP_ADDRESS',
       format: 'ipaddress',

--- a/packages/fxa-support-panel/lib/templates/index.html
+++ b/packages/fxa-support-panel/lib/templates/index.html
@@ -45,5 +45,31 @@
       </tr>
     </table>
 
+    {{#subscriptionStatus}}
+    <h3>Subscriptions</h3>
+    {{#subscriptions}}
+    <table>
+
+      <tr>
+        <th>Subscription:</th>
+        <td>{{ plan_name }}</td>
+      </tr>
+      <tr>
+        <th>Status:</th>
+        <td>{{ status }}</td>
+      </tr>
+      <tr>
+        <th>Last Payment:</th>
+        <td>{{ current_period_start }}</td>
+      </tr>
+      <tr>
+        <th>Next Payment:</th>
+        <td>{{ current_period_end }}</td>
+      </tr>
+    </table>
+    <br/>
+    {{/subscriptions}}
+    {{/subscriptionStatus}}
+
   </body>
 </html>


### PR DESCRIPTION
This patch removes the support panel's dependency on SubHub by fetching
a FxA user's subscriptions from the auth server instead.  The requests
are authenticated by a shared secret between the support panel and the
auth server.

Fixes #3794 

@mozilla/fxa-devs r?