### PR TITLE
 test(account-recovery): Modify 'render view' test for default serviceName

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/account_recovery_confirm_key.js
+++ b/packages/fxa-content-server/app/scripts/views/account_recovery_confirm_key.js
@@ -9,7 +9,7 @@ import FormView from './form';
 import FlowEventsMixin from './mixins/flow-events-mixin';
 import preventDefaultThen from './decorators/prevent_default_then';
 import PasswordResetMixin from './mixins/password-reset-mixin';
-import ServiceNameMixin from './mixins/service-mixin';
+import ServiceMixin from './mixins/service-mixin';
 import ResendMixin from './mixins/resend-mixin';
 import Template from 'templates/account_recovery_confirm_key.mustache';
 import Url from '../lib/url';
@@ -111,7 +111,7 @@ Cocktail.mixin(
   FlowEventsMixin,
   PasswordResetMixin,
   ResendMixin,
-  ServiceNameMixin
+  ServiceMixin
 );
 
 export default View;

--- a/packages/fxa-content-server/app/tests/spec/views/account_recovery_confirm_key.js
+++ b/packages/fxa-content-server/app/tests/spec/views/account_recovery_confirm_key.js
@@ -8,7 +8,7 @@ import Broker from 'models/auth_brokers/base';
 import AuthErrors from 'lib/auth-errors';
 import Metrics from 'lib/metrics';
 import Notifier from 'lib/channels/notifier';
-import Relier from 'models/reliers/base';
+import Relier from 'models/reliers/relier';
 import SentryMetrics from 'lib/sentry';
 import sinon from 'sinon';
 import TestHelpers from '../../lib/helpers';
@@ -65,10 +65,7 @@ describe('views/account_recovery_confirm_key', () => {
     metrics = new Metrics({ notifier, sentryMetrics });
     user = new User();
     account = user.initAccount();
-    relier = new Relier({
-      service: 'sync',
-      serviceName: 'Firefox Sync',
-    });
+    relier = new Relier();
     windowMock = new WindowMock();
     windowMock.location.search = `?code=${code}&email=${email}&token=${token}&uid=${uid}`;
 
@@ -84,12 +81,12 @@ describe('views/account_recovery_confirm_key', () => {
     });
   });
 
-  it('renders view', () => {
+  it('renders the view with the default serviceName from the relier', () => {
     return initView().then(() => {
       assert.lengthOf(view.$('#account-recovery-confirm-password'), 1);
       assert.include(
         view.$('#fxa-recovery-key-confirm').text(),
-        'Firefox Sync'
+        'Account Settings'
       );
       assert.lengthOf(view.$('#recovery-key'), 1);
       assert.lengthOf(view.$('#submit-btn'), 1);


### PR DESCRIPTION
Follow-up to #3959

Straightforward changes:

* Change `serviceNameMixin` references to `serviceMixin` to match all other imports of this file
* Import the `relier` instead of the `base` relier in the test file (this was the cause of some "wut" feelings earlier today, heh 🤦‍♀️)
* Update test to check for the default `serviceName` from the relier which covers the original issue. Setting other services on the relier are covered in other tests, it seemed superfluous to have two tests here for the relier.

@vbudhram tagging you for an r+ since you wrote the test.