### PR TITLE
fix(style): Change background for 'button-link' class from white to transparent

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings-account-recovery.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings-account-recovery.scss
@@ -143,6 +143,6 @@
 }
 
 button.button-link {
-  background: $color-white;
+  background: transparent;
   color: $color-blue;
 }


### PR DESCRIPTION
fixes #3843 

Looks correct across all breakpoints.