### PR TITLE
feat(support-panel): display geo info

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -32,6 +32,11 @@ async function run(config) {
     stripeHelper = createStripeHelper(log, config);
   }
 
+  const redis = require('../lib/redis')(
+    { ...config.redis, ...config.redis.sessionTokens },
+    log
+  );
+
   const DB = require('../lib/db')(
     config,
     log,
@@ -40,7 +45,7 @@ async function run(config) {
   );
   let database = null;
   try {
-    database = await DB.connect(config[config.db.backend]);
+    database = await DB.connect({ ...config[config.db.backend], redis });
   } catch (err) {
     log.error('DB.connect', { err: { message: err.message } });
     process.exit(1);
@@ -96,7 +101,8 @@ async function run(config) {
     subhub,
     statsd,
     profile,
-    stripeHelper
+    stripeHelper,
+    redis
   );
 
   const Server = require('../lib/server');

--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -50,10 +50,12 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     }
 
     this.pool = new Pool(options.url, pooleeOptions);
-    this.redis = require('./redis')(
-      { ...config.redis, ...config.redis.sessionTokens },
-      log
-    );
+    this.redis =
+      options.redis ||
+      require('./redis')(
+        { ...config.redis, ...config.redis.sessionTokens },
+        log
+      );
   }
 
   DB.connect = async function(options) {

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -21,7 +21,8 @@ module.exports = function(
   subhub,
   statsd,
   profile,
-  stripeHelper
+  stripeHelper,
+  redis
 ) {
   // Various extra helpers.
   const push = require('../push')(log, db, config);
@@ -83,7 +84,8 @@ module.exports = function(
     push,
     pushbox,
     devicesImpl,
-    clientUtils
+    clientUtils,
+    redis
   );
   const attachedClients = require('./attached-clients')(
     log,

--- a/packages/fxa-support-panel/config/index.ts
+++ b/packages/fxa-support-panel/config/index.ts
@@ -20,6 +20,12 @@ const conf = convict({
       env: 'AUTH_SECRET_BEARER_TOKEN',
       format: 'String',
     },
+    signinLocationsSearchPath: {
+      default: '/v1/account/sessions/locations',
+      doc: 'Auth server path session token metadata locations',
+      env: 'AUTH_SERVER_LOCATIONS_SEARCH_PATH',
+      format: String,
+    },
     subscriptionsSearchPath: {
       default: '/v1/oauth/subscriptions/search',
       doc: 'Auth server path for subscriptions search endpoint',

--- a/packages/fxa-support-panel/lib/templates/index.html
+++ b/packages/fxa-support-panel/lib/templates/index.html
@@ -26,6 +26,14 @@
         <th>Locale:</th>
         <td>{{locale}}</td>
       </tr>
+      {{#signinLocations}}
+      <tr>
+        <th>Signin Location:</th>
+        <td>
+          {{city}}, {{stateCode}}, {{countryCode}} on {{lastAccessTime}}
+        </td>
+      </tr>
+      {{/signinLocations}}
       {{#devices}}
       <tr>
         <th>Device:</th>


### PR DESCRIPTION
This patch displays all the available geo info from a user's session
token meta data in Support Panel.  A new route is added to auth server
to support this feature.

Fixes #2677 

@mozilla/fxa-devs r?