### PR TITLE
feat(coverage): Add coveralls coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,9 @@ jobs:
       db:
         type: boolean
         default: false
+      upload_coverage:
+        type: boolean
+        default: false
     working_directory: ~/project/packages/<< parameters.module >>
     steps:
       - attach_workspace:
@@ -78,6 +81,37 @@ jobs:
                 command: docker pull jdlk7/firestore-emulator && docker run -d --name gcloud-firestore -p 8006:9090 jdlk7/firestore-emulator
 
       - run: ../../.circleci/build-test-deploy.sh << parameters.test >>
+
+      - when:
+          condition: << parameters.upload_coverage >>
+          steps:
+            - run:
+                name: Update coverage files
+                command: sed 's,SF:/app,SF:/home/circleci/project/packages/<< parameters.module >>,' ./coverage/lcov.info > ./coverage/lcov-updated.info
+            - store_artifacts:
+                path: ./coverage
+            - run: |
+                sudo npm install -g coveralls
+                if [ ! $COVERALLS_REPO_TOKEN ]; then
+                  export COVERALLS_REPO_TOKEN=COVERALLS_REPO_TOKEN
+                fi
+                export COVERALLS_ENDPOINT=https://coveralls.io
+                export COVERALLS_FLAG_NAME="<< parameters.module >>"
+                export COVERALLS_PARALLEL=true
+
+                # check for lcov file presence:
+                if [ ! -r ./coverage/lcov-updated.info ]; then
+                  echo "Please specify a valid 'path_to_lcov' parameter."
+                  exit 1
+                fi
+                cd ../..
+                cat ./packages/<< parameters.module >>/coverage/lcov-updated.info | coveralls --verbose
+
+                if << parameters.module >> = "fxa-auth-server"; then
+                  curl "https://coveralls.io/webhook?repo_token=COVERALLS_REPO_TOKEN" \
+                    -d "payload[build_num]=$CIRCLE_BUILD_NUM&payload[status]=done"
+                  exit 0
+                fi
 
   deploy-module:
     executor: nodejs
@@ -277,6 +311,7 @@ workflows:
           name: fxa-auth-db-mysql
           module: fxa-auth-db-mysql
           db: true
+          upload_coverage: true
           requires:
             - install
       - build-module:
@@ -284,6 +319,7 @@ workflows:
           module: fxa-auth-server
           db: true
           test: test-ci
+          upload_coverage: true
           requires:
             - install
       - build-module:
@@ -306,6 +342,7 @@ workflows:
       - build-module:
           name: fxa-profile-server
           module: fxa-profile-server
+          upload_coverage: true
           requires:
             - install
       - build-module:

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -7,11 +7,15 @@ DIR=$(dirname "$0")
 if grep -e "$MODULE" -e 'all' $DIR/../packages/test.list; then
   if [ "${MODULE}" == 'fxa-auth-server' ]; then
     docker build -f Dockerfile-test -t ${MODULE}:test ..
-    docker run --net="host" ${MODULE}:test npm test
+    docker run --net="host" --name="${MODULE}" ${MODULE}:test npm test
+
+    docker cp ${MODULE}:/app/coverage ./coverage || true
   elif [[ -e Dockerfile-test ]]; then
     docker build -f Dockerfile-test -t ${MODULE}:test .
 
-    docker run --net="host" ${MODULE}:test npm run ${TEST:-test}
+    docker run --net="host" --name="${MODULE}" ${MODULE}:test npm run ${TEST:-test}
+
+    docker cp ${MODULE}:/app/coverage ./coverage || true
 
     if grep eslint "$DIR/../packages/$MODULE/Gruntfile.js"; then
       docker run --net="host" ${MODULE}:test /app/node_modules/.bin/grunt eslint

--- a/packages/fxa-auth-db-mysql/scripts/mocha-coverage.js
+++ b/packages/fxa-auth-db-mysql/scripts/mocha-coverage.js
@@ -22,13 +22,15 @@ const NYC_BIN = path.join(
   'nyc'
 );
 
-let bin = NYC_BIN;
-let argv = ['--cache', MOCHA_BIN];
-
-if (process.env.NO_COVERAGE) {
-  bin = MOCHA_BIN;
-  argv = [];
-}
+const bin = NYC_BIN;
+const argv = [
+  '--cache',
+  '--no-clean',
+  '--reporter=lcov',
+  '--reporter=text',
+  '--report-dir=coverage',
+  MOCHA_BIN,
+];
 
 const p = spawn(bin, argv.concat(process.argv.slice(2)), {
   stdio: 'inherit',

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -15,7 +15,7 @@
     "lint:eslint": "eslint .",
     "postinstall": "scripts/download_l10n.sh",
     "start": "npm run gen-keys && node ./bin/key_server.js",
-    "test": "VERIFIER_VERSION=0 NO_COVERAGE=1 scripts/test-local.sh",
+    "test": "VERIFIER_VERSION=0 scripts/test-local.sh",
     "test-oauth": "fxa-oauth-server/scripts/test-local.sh",
     "test-ci": "npm run gen-keys && scripts/test-local.sh && npm run test-e2e && npm run test-scripts",
     "test-e2e": "NODE_ENV=dev mocha test/e2e",

--- a/packages/fxa-auth-server/scripts/mocha-coverage.js
+++ b/packages/fxa-auth-server/scripts/mocha-coverage.js
@@ -22,13 +22,15 @@ const NYC_BIN = path.join(
   'nyc'
 );
 
-let bin = NYC_BIN;
-let argv = ['--cache', '--no-clean', MOCHA_BIN];
-
-if (process.env.NO_COVERAGE) {
-  bin = MOCHA_BIN;
-  argv = [];
-}
+const bin = NYC_BIN;
+const argv = [
+  '--cache',
+  '--no-clean',
+  '--reporter=lcov',
+  '--reporter=text',
+  '--report-dir=coverage',
+  MOCHA_BIN,
+];
 
 const p = spawn(bin, argv.concat(process.argv.slice(2)), {
   stdio: 'inherit',

--- a/packages/fxa-profile-server/coverage/blanket.js
+++ b/packages/fxa-profile-server/coverage/blanket.js
@@ -1,7 +1,0 @@
-var path = require('path');
-var srcDir = path.join(__dirname, '..', 'lib');
-
-require('blanket')({
-  // Only files that match the pattern will be instrumented
-  pattern: srcDir,
-});

--- a/packages/fxa-profile-server/scripts/mocha-coverage.js
+++ b/packages/fxa-profile-server/scripts/mocha-coverage.js
@@ -22,13 +22,15 @@ const NYC_BIN = path.join(
   'nyc'
 );
 
-let bin = NYC_BIN;
-let argv = ['--cache', MOCHA_BIN];
-
-if (process.env.NO_COVERAGE) {
-  bin = MOCHA_BIN;
-  argv = [];
-}
+const bin = NYC_BIN;
+const argv = [
+  '--cache',
+  '--no-clean',
+  '--reporter=lcov',
+  '--reporter=text',
+  '--report-dir=coverage',
+  MOCHA_BIN,
+];
 
 const p = spawn(bin, argv.concat(process.argv.slice(2)), {
   stdio: 'inherit',


### PR DESCRIPTION
Adds test coverage reporting to coveralls for

- fxa-auth-server
- fxa-auth-db-mysql
- fxa-profile-server

You can view current coverage at https://coveralls.io/github/mozilla/fxa. The reports are also uploaded as test artifacts in circleci.

Connects to https://github.com/mozilla/fxa/issues/3994