### PR TITLE
fix(viewport): Update viewport metatag to include minimum-scale, and make value consistent across all instances

### DIFF
--- a/packages/123done/static/about.html
+++ b/packages/123done/static/about.html
@@ -5,7 +5,7 @@
     <title>123done - your tasks, simplified</title>
     <meta type="description" content="" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes" />
     <link type="text/css" rel="stylesheet" href="/en/drsugiyama/fonts.css" />
     <link rel="stylesheet" href="css/styles.css" type="text/css" />
     <link rel="stylesheet" href="css/bootstrap.css" type="text/css" />

--- a/packages/123done/static/index.html
+++ b/packages/123done/static/index.html
@@ -5,7 +5,7 @@
     <title>123done + Do Stuff</title>
     <meta type="description" content="" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes" />
     <meta name="firefox-accounts" content="supported" />
     <link
       rel="stylesheet"

--- a/packages/fortress/static/download.html
+++ b/packages/fortress/static/download.html
@@ -5,7 +5,7 @@
     <title>Firefox Fortress</title>
     <meta type="description" content="" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes" />
     <meta name="firefox-accounts" content="supported" />
     <link
       rel="stylesheet"

--- a/packages/fortress/static/index.html
+++ b/packages/fortress/static/index.html
@@ -5,7 +5,7 @@
     <title>Firefox Fortress</title>
     <meta type="description" content="" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes" />
     <meta name="firefox-accounts" content="supported" />
     <link
       rel="stylesheet"

--- a/packages/fxa-content-server/server/templates/pages/src/404.html
+++ b/packages/fxa-content-server/server/templates/pages/src/404.html
@@ -5,7 +5,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <title>{{#t}}Firefox Accounts{{/t}}</title>
         <meta name="description" content="" />
-        <meta name="viewport" content="width=device-width" />
+        <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes" />
         <meta name="referrer" content="origin" />
         <meta name="robots" content="noindex,nofollow" />
 

--- a/packages/fxa-content-server/server/templates/pages/src/500.html
+++ b/packages/fxa-content-server/server/templates/pages/src/500.html
@@ -5,7 +5,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <title>{{#t}}Firefox Accounts{{/t}}</title>
         <meta name="description" content="" />
-        <meta name="viewport" content="width=device-width" />
+        <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes" />
         <meta name="referrer" content="origin" />
         <meta name="robots" content="noindex,nofollow" />
 

--- a/packages/fxa-content-server/server/templates/pages/src/502.html
+++ b/packages/fxa-content-server/server/templates/pages/src/502.html
@@ -5,7 +5,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <title>{{#t}}Firefox Accounts{{/t}}</title>
         <meta name="description" content="" />
-        <meta name="viewport" content="width=device-width" />
+        <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes" />
         <meta name="referrer" content="origin" />
         <meta name="robots" content="noindex,nofollow" />
 

--- a/packages/fxa-content-server/server/templates/pages/src/503.html
+++ b/packages/fxa-content-server/server/templates/pages/src/503.html
@@ -5,7 +5,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <title>{{#t}}Firefox Accounts{{/t}}</title>
         <meta name="description" content="" />
-        <meta name="viewport" content="width=device-width" />
+        <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes" />
         <meta name="referrer" content="origin" />
         <meta name="robots" content="noindex,nofollow" />
 

--- a/packages/fxa-content-server/server/templates/pages/src/index.html
+++ b/packages/fxa-content-server/server/templates/pages/src/index.html
@@ -11,7 +11,7 @@
         <meta name="fxa-feature-flags" content="{{ featureFlags }}" />
         <meta
             name="viewport"
-            content="width=device-width, initial-scale=1.0, maximum-scale=2.0, user-scalable=yes"
+            content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes"
         />
 
         <!--iOS Smart Banner-->

--- a/packages/fxa-content-server/server/templates/pages/src/privacy.html
+++ b/packages/fxa-content-server/server/templates/pages/src/privacy.html
@@ -5,7 +5,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <title>{{#t}}Firefox Accounts{{/t}}: {{#t}}Privacy Notice{{/t}}</title>
         <meta name="description" content="" />
-        <meta name="viewport" content="width=device-width" />
+        <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes" />
         <meta name="referrer" content="origin" />
         <meta name="robots" content="noindex,nofollow" />
 

--- a/packages/fxa-content-server/server/templates/pages/src/terms.html
+++ b/packages/fxa-content-server/server/templates/pages/src/terms.html
@@ -7,7 +7,7 @@
             {{#t}}Firefox Accounts{{/t}}: {{#t}}Terms of Service{{/t}}
         </title>
         <meta name="description" content="" />
-        <meta name="viewport" content="width=device-width" />
+        <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes" />
         <meta name="referrer" content="origin" />
         <meta name="robots" content="noindex,nofollow" />
 

--- a/packages/fxa-content-server/server/templates/pages/src/update_firefox.html
+++ b/packages/fxa-content-server/server/templates/pages/src/update_firefox.html
@@ -9,7 +9,7 @@
         <meta name="robots" content="noindex,nofollow" />
         <meta
             name="viewport"
-            content="width=device-width, initial-scale=1.0, maximum-scale=2.0, user-scalable=yes"
+            content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes"
         />
 
         <!--iOS Smart Banner-->

--- a/packages/fxa-payments-server/public/404.html
+++ b/packages/fxa-payments-server/public/404.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Firefox Accounts</title>
     <meta name="description" content="" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes" />
     <meta name="referrer" content="origin" />
     <meta name="robots" content="noindex,nofollow" />
     <link rel="stylesheet" href="styles/main.css" />

--- a/packages/fxa-payments-server/public/index.html
+++ b/packages/fxa-payments-server/public/index.html
@@ -9,7 +9,7 @@
     <meta name="robots" content="noindex,nofollow" />
     <meta
       name="viewport"
-      content="width=device-width,initial-scale=1,maximum-scale=2,user-scalable=yes"
+      content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes"
     />
     <meta
       name="apple-itunes-app"


### PR DESCRIPTION
fixes #3887 

I could not reproduce this in an emulator, only on my old physical Android device (and note: FF also does not have to be the default browser).

`minimum-zoom=1` should* disable zooming _out_ on Android, but from an a11y standpoint, this is acceptable because we still allow users to zoom _in_ up to 200%. I don't quite understand why a deep link would seemingly ignore our already-present `width=device-width,initial-scale=1` metatag, but this appears to fix the problem for me on my physical device.

*I'm not sure why, but I was not able to zoom out on the sign up page _before_ the change, and iOS appears to ignore the scaling tags. In other words, on my devices, our pages act identically on iOS and Android before and after this change but this appears to fix the problem described in the bug.

I went ahead and made our `viewport` metatag consistent across all of our pages.