### PR TITLE
fix(content): bump git sha of legal-docs dependency

### DIFF
--- a/packages/fxa-content-server/package-lock.json
+++ b/packages/fxa-content-server/package-lock.json
@@ -8317,7 +8317,7 @@
             }
         },
         "legal-docs": {
-            "version": "git://github.com/mozilla/legal-docs.git#c99707983486f30fb4d1cbe10ea9d221fed28da1",
+            "version": "git://github.com/mozilla/legal-docs.git#b25535303486d4b3d8069cdeea1eb882af5edf1d",
             "from": "git://github.com/mozilla/legal-docs.git#master"
         },
         "levn": {


### PR DESCRIPTION
fixes (for now) https://jira.mozilla.com/browse/FXA-1023, by getting it to current master git sha of legal-docs

r? - @mozilla/fxa-core 