### PR TITLE
Add nsp exception for cryptiles entropy advisory

### DIFF
--- a/packages/fxa-customs-server/.nsprc
+++ b/packages/fxa-customs-server/.nsprc
@@ -1,1 +1,6 @@
-{"exceptions": []}
+{
+  "comment_1464": "Exception added for insufficient entropy error in 'cryptiles' in hapi 17 (cryptiles 3.x), fixed in hapi 18 (@hapi/cryptiles 4.1.2). See https://github.com/mozilla/fxa/issues/4035",
+  "exceptions": [
+    "https://npmjs.com/advisories/1464"
+  ]
+}

--- a/packages/fxa-profile-server/.nsprc
+++ b/packages/fxa-profile-server/.nsprc
@@ -1,6 +1,8 @@
 {
   "comment_1168": "Exception added for 'subtext' vulnerability in hapi 17, fixed in hapi 18 branch. See https://github.com/mozilla/fxa/issues/2601",
+  "comment_1464": "Exception added for insufficient entropy error in 'cryptiles' in hapi 17 (cryptiles 3.x), fixed in hapi 18 (@hapi/cryptiles 4.1.2). See https://github.com/mozilla/fxa/issues/4035",
   "exceptions": [
-    "https://npmjs.com/advisories/1168"
+    "https://npmjs.com/advisories/1168",
+    "https://npmjs.com/advisories/1464"
   ]
 }


### PR DESCRIPTION
This PR adds an nsp exception to the profile and customs servers for the newly-reported cryptiles <4.1.2 insufficient entropy advisory.

Updating cryptiles will require updating hapi across a major version boundary, which is work we want to do (#2601), but not before unblocking git push for everyone.

I've also filed #4035 to remind us to remove these exceptions once we do the hapi version upgrade.