### PR TITLE
fix(payments): ensure correct product name used in reactivation confirm dialog

### DIFF
--- a/packages/fxa-payments-server/.storybook/components/MockApp.tsx
+++ b/packages/fxa-payments-server/.storybook/components/MockApp.tsx
@@ -5,6 +5,7 @@ import { MockLoader } from './MockLoader';
 import { AppContext, AppContextType } from '../../src/lib/AppContext';
 import { config } from '../../src/lib/config';
 import ScreenInfo from '../../src/lib/screen-info';
+import AppLocalizationProvider from '../../src/lib/AppLocalizationProvider';
 
 declare global {
   interface Window {
@@ -77,11 +78,16 @@ export const MockApp = ({
   }, []);
 
   return (
-    <StripeProvider stripe={mockStripe}>
-      <AppContext.Provider value={appContextValue}>
-        <MockLoader>{children}</MockLoader>
-      </AppContext.Provider>
-    </StripeProvider>
+    <AppContext.Provider value={appContextValue}>
+      <AppLocalizationProvider
+        userLocales={navigator.languages}
+        bundles={['main']}
+      >
+        <StripeProvider stripe={mockStripe}>
+          <MockLoader>{children}</MockLoader>
+        </StripeProvider>
+      </AppLocalizationProvider>
+    </AppContext.Provider>
   );
 };
 

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -19,7 +19,7 @@
     "test:frontend": "react-scripts test --coverage --verbose",
     "test:server": "jest --coverage --verbose --config server/jest.config.js",
     "format": "prettier '**' --write",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "start-storybook -s ./public -p 6006",
     "build-storybook": "build-storybook"
   },
   "repository": {

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -107,11 +107,11 @@ pay-update-card-exp = Expires { $expirationDate }
 pay-update-change-btn = Change
 
 ## reactivate
-reactivate-confirm-dialog-header = Want to keep using { $productName }?
+reactivate-confirm-dialog-header = Want to keep using { $name }?
 reactivate-confirm-copy =
     Your access to { $name } will continue, and your billing cycle
-    and payment will stay the same. Your next charge will be $
-    { $amount } to the card ending in { $last } on { $endDate }.
+    and payment will stay the same. Your next charge will be
+    ${ $amount } to the card ending in { $last } on { $endDate }.
 reactivate-confirm-button = Resubscribe
 reactivate-panel-date = You cancelled your subscription on { $date }.
 reactivate-panel-copy = You will lose access to { $name } on <strong>{ $date }</strong>.

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
@@ -31,7 +31,10 @@ export default ({
         height="48"
         width="48"
       />
-      <Localized id="reactivate-confirm-dialog-header">
+      <Localized
+        id="reactivate-confirm-dialog-header"
+        $name={plan.product_name}
+      >
         <h4>Want to keep using {plan.product_name}?</h4>
       </Localized>
       {/* TO DO: display card type, IE 'to the Visa card ending...' */}


### PR DESCRIPTION
- also get l10n working under Storybook, which made reproducing the issue easier

fixes #3819
fixes #4026