### PR TITLE
feat(auth-server): add hapi route metric timings

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -113,7 +113,8 @@ async function run(config) {
     routes,
     database,
     oauthdb,
-    translator
+    translator,
+    statsd
   );
 
   try {


### PR DESCRIPTION
Because:

* We'd like to know what are the slow/fast routes in our application.

This commit:

* Add a prePostResponse metric emitter modeled on hapi-statsd that works
  with our hotshots based metric reporter.

Closes #4056