### PR TITLE
fix(auth-server): pass missing zen/stripe args

### DIFF
--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -102,7 +102,9 @@ module.exports = function(
     customs,
     push,
     verificationReminders,
-    signupUtils
+    signupUtils,
+    zendeskClient,
+    stripeHelper
   );
   const password = require('./password')(
     log,


### PR DESCRIPTION
Because:

* The zendeskClient and stripeHelper were not passed into the emails
  route where they were needed.

This commit:

* Passes them in as needed.

Fixes #4051