### PR TITLE
feat(logging): Log details of the grant when generating OAuth tokens.

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -162,6 +162,14 @@ module.exports.validateRequestedGrant = async function validateRequestedGrant(
 // This function does *not* perform any authentication or validation, assuming that
 // the specified grant has been sufficiently vetted by calling code.
 module.exports.generateTokens = async function generateTokens(grant) {
+  logger.info('oauth.generateTokens', {
+    grantType: grant.grantType,
+    keys: !!grant.keysJwe,
+    scope: grant.scope.getScopeValues(),
+    service: hex(grant.clientId),
+    resource: grant.resource,
+  });
+
   // We always generate an access_token.
   const access = await exports.generateAccessToken(grant);
 

--- a/packages/fxa-auth-server/lib/oauth/routes/authorization.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/authorization.js
@@ -217,6 +217,7 @@ async function generateImplicitGrant(client, payload, grant) {
   }
   return generateTokens({
     ...grant,
+    grantType: 'fxa-credentials',
     resource: payload.resource,
     ttl: payload.ttl,
   });

--- a/packages/fxa-auth-server/lib/oauth/routes/token.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/token.js
@@ -215,6 +215,7 @@ async function validateGrantParameters(client, params) {
       logger.critical('joi.grant_type', { grant_type: params.grant_type });
       throw Error('unreachable');
   }
+  requestedGrant.grantType = params.grant_type;
   requestedGrant.ppidSeed = params.ppid_seed;
   requestedGrant.resource = params.resource;
   requestedGrant.ttl = params.ttl;


### PR DESCRIPTION
Because:

* We need to understand the current rate of OAuth token creation in
  order to understand the potential operational impact of new clients
  such as Fenix.
* The current web logs don't provide enough information to determine
  the volume of tokens created through each different grant type.

This commit:

* Logs an explicit event when creating OAuth tokens, with the appropriate
  details such as grant type and scope.