### PR TITLE
feat(codes): Add auth-server verify recovery key route

### DIFF
--- a/packages/fxa-auth-db-mysql/index.js
+++ b/packages/fxa-auth-db-mysql/index.js
@@ -6,7 +6,7 @@ var config = require('./config');
 var dbServer = require('./db-server');
 var error = dbServer.errors;
 var logger = require('./lib/logging')('bin.server');
-var DB = require('./lib/db/mem')(logger, error);
+var DB = require('./lib/db/mysql')(logger, error);
 
 module.exports = function() {
   return DB.connect(config).then(function(db) {

--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -1651,10 +1651,16 @@ module.exports = function(log, error) {
   };
 
   MySql.prototype.recoveryKeyExists = function(uid) {
-    let exists = true;
+    let exists = false;
     return this.read(GET_RECOVERY_KEY, [uid]).then(results => {
-      if (results[0].length === 0) {
-        exists = false;
+      // A recovery key is considered to exist iff there is one key
+      // that is enabled.
+      for (let i = 0; i < results[0].length; i++) {
+        const key = results[0][i];
+        if (key.enabled) {
+          exists = true;
+          break;
+        }
       }
 
       return { exists };

--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -1335,7 +1335,8 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   DB.prototype.createRecoveryKey = async function(
     uid,
     recoveryKeyId,
-    recoveryData
+    recoveryData,
+    enabled
   ) {
     log.trace('DB.createRecoveryKey', { uid });
 
@@ -1343,7 +1344,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
       return await this.pool.post(
         SAFE_URLS.createRecoveryKey,
         { uid },
-        { recoveryKeyId, recoveryData }
+        { recoveryKeyId, recoveryData, enabled }
       );
     } catch (err) {
       if (isRecordAlreadyExistsError(err)) {
@@ -1395,6 +1396,20 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     log.trace('DB.deleteRecoveryKey', { uid });
 
     return this.pool.del(SAFE_URLS.deleteRecoveryKey, { uid });
+  };
+
+  SAFE_URLS.updateRecoveryKey = new SafeUrl(
+    '/account/:uid/recoveryKey/update',
+    'db.updateRecoveryKey'
+  );
+  DB.prototype.updateRecoveryKey = async function(uid, recoveryKeyId, enabled) {
+    log.trace('DB.updateRecoveryKey', { uid });
+
+    return this.pool.post(SAFE_URLS.updateRecoveryKey, {
+      uid,
+      recoveryKeyId,
+      enabled,
+    });
   };
 
   SAFE_URLS.createAccountSubscription = new SafeUrl(

--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -1044,12 +1044,14 @@ module.exports = config => {
   ClientApi.prototype.createRecoveryKey = function(
     sessionTokenHex,
     recoveryKeyId,
-    recoveryData
+    recoveryData,
+    enabled = true
   ) {
     return tokens.SessionToken.fromHex(sessionTokenHex).then(token => {
       return this.doRequest('POST', `${this.baseURL}/recoveryKey`, token, {
         recoveryKeyId,
         recoveryData,
+        enabled,
       });
     });
   };

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -661,11 +661,16 @@ module.exports = config => {
     return this.api.consumeRecoveryCode(this.sessionToken, code, options);
   };
 
-  Client.prototype.createRecoveryKey = function(recoveryKeyId, recoveryData) {
+  Client.prototype.createRecoveryKey = function(
+    recoveryKeyId,
+    recoveryData,
+    enabled = true
+  ) {
     return this.api.createRecoveryKey(
       this.sessionToken,
       recoveryKeyId,
-      recoveryData
+      recoveryData,
+      enabled
     );
   };
 

--- a/packages/fxa-auth-server/test/local/routes/recovery-keys.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-keys.js
@@ -23,7 +23,7 @@ describe('POST /recoveryKey', () => {
       const requestOptions = {
         credentials: { uid, email },
         log,
-        payload: { recoveryKeyId, recoveryData },
+        payload: { recoveryKeyId, recoveryData, enabled: true },
       };
       return setup({ db: { email } }, {}, '/recoveryKey', requestOptions).then(
         r => (response = r)
@@ -45,10 +45,11 @@ describe('POST /recoveryKey', () => {
     it('called db.createRecoveryKey correctly', () => {
       assert.equal(db.createRecoveryKey.callCount, 1);
       const args = db.createRecoveryKey.args[0];
-      assert.equal(args.length, 3);
+      assert.equal(args.length, 4);
       assert.equal(args[0], uid);
       assert.equal(args[1], recoveryKeyId);
       assert.equal(args[2], recoveryData);
+      assert.equal(args[3], true);
     });
 
     it('called log.info correctly', () => {
@@ -82,6 +83,62 @@ describe('POST /recoveryKey', () => {
       const args = mailer.sendPostAddAccountRecoveryEmail.args[0];
       assert.equal(args.length, 3);
       assert.equal(args[0][0].email, email);
+    });
+  });
+
+  describe('should create disabled recovery key', () => {
+    beforeEach(() => {
+      const requestOptions = {
+        credentials: { uid, email },
+        log,
+        payload: { recoveryKeyId, recoveryData, enabled: false },
+      };
+      return setup({ db: { email } }, {}, '/recoveryKey', requestOptions).then(
+        r => (response = r)
+      );
+    });
+
+    it('returned the correct response', () => {
+      assert.deepEqual(response, {});
+    });
+
+    it('called db.createRecoveryKey correctly', () => {
+      assert.equal(db.createRecoveryKey.callCount, 1);
+      const args = db.createRecoveryKey.args[0];
+      assert.equal(args.length, 4);
+      assert.equal(args[0], uid);
+      assert.equal(args[1], recoveryKeyId);
+      assert.equal(args[2], recoveryData);
+      assert.equal(args[3], false);
+    });
+  });
+
+  describe('should verify recovery key', () => {
+    beforeEach(() => {
+      const requestOptions = {
+        credentials: { uid, email },
+        log,
+        payload: { recoveryKeyId, enabled: false },
+      };
+      return setup(
+        { db: { email } },
+        {},
+        '/recoveryKey/verify',
+        requestOptions
+      ).then(r => (response = r));
+    });
+
+    it('returned the correct response', () => {
+      assert.deepEqual(response, {});
+    });
+
+    it('called db.updateRecoveryKey correctly', () => {
+      assert.equal(db.updateRecoveryKey.callCount, 1);
+      const args = db.updateRecoveryKey.args[0];
+      assert.equal(args.length, 3);
+      assert.equal(args[0], uid);
+      assert.equal(args[1], recoveryKeyId);
+      assert.equal(args[2], true);
     });
   });
 

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -80,6 +80,7 @@ const DB_METHOD_NAMES = [
   'totpToken',
   'updateDevice',
   'updateLocale',
+  'updateRecoveryKey',
   'updateSessionToken',
   'updateTotpToken',
   'verifyEmail',

--- a/packages/fxa-auth-server/test/remote/recovery_key_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_key_tests.js
@@ -220,7 +220,7 @@ describe('remote recovery keys', function() {
 
   describe('check recovery key status', () => {
     describe('with sessionToken', () => {
-      it('should return true if recovery key exists', () => {
+      it('should return true if recovery key exists and enabled', () => {
         return client.getRecoveryKeyExists().then(res => {
           assert.equal(res.exists, true, 'recovery key exists');
         });
@@ -242,6 +242,30 @@ describe('remote recovery keys', function() {
           .then(res => {
             assert.equal(res.exists, false, 'recovery key doesnt exists');
           });
+      });
+
+      it('should return false if recovery key exist but not enabled', async () => {
+        const email2 = server.uniqueEmail();
+        const client2 = await Client.createAndVerify(
+          config.publicUrl,
+          email2,
+          password,
+          server.mailbox,
+          { keys: true }
+        );
+        const recoveryKeyMock = await createMockRecoveryKey(
+          client2.uid,
+          keys.kB
+        );
+        let res = await client2.createRecoveryKey(
+          recoveryKeyMock.recoveryKeyId,
+          recoveryKeyMock.recoveryData,
+          false
+        );
+        assert.deepEqual(res, {});
+
+        res = await client2.getRecoveryKeyExists();
+        assert.equal(res.exists, false, 'recovery key doesnt exists');
       });
     });
 


### PR DESCRIPTION
Builds off https://github.com/mozilla/fxa/pull/3957 which should be reviewed first.
Connects to #3936 

This PR adds the supporting auth-server routes to verify a recovery key before enabling it. Marking as draft until I can clean the code up a bit.