### PR TITLE
fix(auth-server): Return expected 'plan_name' for subscriptions based on subhub implementation

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.js
+++ b/packages/fxa-auth-server/lib/payments/stripe.js
@@ -413,6 +413,24 @@ class StripeHelper {
   }
 
   /**
+   *
+   * Returns the product name of a given product.
+   *
+   * @param {String | Product} product
+   * @returns {Promise<String>} product name
+   */
+  async getProductName(product) {
+    if (typeof product === 'string') {
+      const fetchedProducts = await this.fetchAllProducts();
+      const matchingProduct = fetchedProducts.find(
+        fetchedProduct => fetchedProduct.product_id === product
+      );
+      return matchingProduct ? matchingProduct.product_name : '';
+    }
+    return product.name;
+  }
+
+  /**
    * Formats Stripe subscriptions for a customer into an appropriate response.
    *
    * @param {Subscriptions} subscriptions Subscriptions to finesse
@@ -439,15 +457,29 @@ class StripeHelper {
         failure_code = charge.failure_code;
         failure_message = charge.failure_message;
       }
+
+      // enforce type because it _could_ be a DeletedProduct (but shouldn't be)
+      const productName = await this.getProductName(
+        /** @type {String | Product} */ (sub.plan.product)
+      );
+      const intervalDict = {
+        day: 'Daily',
+        week: 'Weekly',
+        month: 'Monthly',
+        year: 'Yearly',
+      };
+
+      const planName = `${productName} ${intervalDict[sub.plan.interval]}`;
+
       // FIXME: Note that the plan is only set if the subscription contains a single
-      //        plan. Multiple product support will require changes here to fetch all
-      //        plans for this subscription.
+      // plan. Multiple product support will require changes here to fetch all
+      // plans for this subscription.
       subs.push({
         current_period_end: sub.current_period_end,
         current_period_start: sub.current_period_start,
         cancel_at_period_end: sub.cancel_at_period_end,
         end_at: sub.ended_at,
-        plan_name: sub.plan.nickname,
+        plan_name: planName,
         plan_id: sub.plan.id,
         status: sub.status,
         subscription_id: sub.id,


### PR DESCRIPTION
fixes #4024 

[Subhub](https://github.com/mozilla/subhub/blob/3691e92182b88162b572a5378d761f8fe09e1097/src/shared/utils.py#L10) set the nickname via product name + formatted interval. This change reflects that, necessary for our arch 2.0 changes.

Also fixes the name displayed in the `delete_account` view.

@jackiemunroe is working on tests for this file. TY @bbangert for getting me setup for auth server debugging. 😁

<img width="742" alt="image" src="https://user-images.githubusercontent.com/13018240/73964212-65b8cd80-48d7-11ea-90d2-4aa5d2eba3ef.png">
