### PR TITLE
fix(auth-server): screen profile stripe subs

### DIFF
--- a/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
@@ -69,6 +69,13 @@ const SubscriptionUtils = (module.exports = {
   },
 });
 
+/**
+ * Fetch subscribed products from Stripe and format appropriately
+ *
+ * @param {string} uid
+ * @param {import('../../payments/stripe').StripeHelper} stripeHelper
+ * @param {string} email
+ */
 async function fetchSubscribedProductsFromStripe(uid, stripeHelper, email) {
   const customer = await stripeHelper.customer(uid, email);
   if (!customer || !customer.subscriptions.data) {
@@ -78,9 +85,10 @@ async function fetchSubscribedProductsFromStripe(uid, stripeHelper, email) {
   const subscribedProducts = [
     // All accounts get this psuedo-product
     PRODUCT_REGISTERED,
-    ...customer.subscriptions.data.map(
-      ({ plan: { product: productId } }) => productId
-    ),
+    ...customer.subscriptions.data
+      // TODO: Centralize subscription filtering logic for active subs
+      .filter(sub => ['active', 'trialing', 'past_due'].includes(sub.status))
+      .map(({ plan: { product: productId } }) => productId),
   ];
 
   // Accounts with at least one subscription get this product

--- a/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
@@ -68,8 +68,9 @@ describe('routes/utils/subscriptions', () => {
         customer: sinon.spy(async () => ({
           subscriptions: {
             data: [
-              { plan: { product: 'prod_123456' } },
-              { plan: { product: 'prod_876543' } },
+              { plan: { product: 'prod_123456' }, status: 'active' },
+              { plan: { product: 'prod_876543' }, status: 'active' },
+              { plan: { product: 'prod_456789' }, status: 'incomplete' },
             ],
           },
         })),
@@ -90,6 +91,12 @@ describe('routes/utils/subscriptions', () => {
           },
           {
             product_id: 'prod_ABCDEF',
+            product_metadata: {
+              'capabilities:c3': 'capZ,capW',
+            },
+          },
+          {
+            product_id: 'prod_456789',
             product_metadata: {
               'capabilities:c3': 'capZ,capW',
             },

--- a/packages/fxa-auth-server/test/oauth/grant.js
+++ b/packages/fxa-auth-server/test/oauth/grant.js
@@ -367,8 +367,9 @@ describe('generateTokens', () => {
       customer: sinon.spy(async () => ({
         subscriptions: {
           data: [
-            { plan: { product: 'prod0' } },
-            { plan: { product: 'prod1' } },
+            { plan: { product: 'prod0' }, status: 'active' },
+            { plan: { product: 'prod1' }, status: 'active' },
+            { plan: { product: 'prod2' }, status: 'incomplete' },
           ],
         },
       })),


### PR DESCRIPTION
Because:

* Direct stripe integration wasn't screening valid subsfrom the profile
  server results.
* Profile server could erroroneously indicate a user has a subscription
  valid when they do not.

This commit:

* Properly screens the subscriptions for the profile server.

Fixes FXA-1045