### PR TITLE
fix(tooltip): Adjust tooltip inline PW validation position for tablet/large mobile

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/tooltip.js
+++ b/packages/fxa-content-server/app/scripts/views/tooltip.js
@@ -16,9 +16,9 @@ const PADDING_BELOW_TOOLTIP_PX = 2;
 const PADDING_ABOVE_TOOLTIP_PX = 4;
 
 // These values should be the same as
-// https://github.com/mozilla/fxa-content-server/blob/0eab619612897dcda43e8074dafdf55e8cbe11ee/app/styles/_breakpoints.scss#L6
+// https://github.com/mozilla/fxa/blob/master/packages/fxa-content-server/app/styles/_breakpoints.scss#L8
 const MIN_HEIGHT_TO_SHOW_TOOLTIP_BELOW = 480;
-const MIN_WIDTH_TO_SHOW_TOOLTIP_BELOW = 520;
+const MIN_WIDTH_TO_SHOW_TOOLTIP_BELOW = 960;
 
 const proto = BaseView.prototype;
 const Tooltip = BaseView.extend({

--- a/packages/fxa-content-server/app/tests/spec/views/tooltip.js
+++ b/packages/fxa-content-server/app/tests/spec/views/tooltip.js
@@ -170,13 +170,13 @@ describe('views/tooltip', function() {
     }
 
     it('returns true if screen is large enough', () => {
-      setScreenSize(520, 480);
+      setScreenSize(960, 480);
 
       assert.isTrue(tooltip.canShowTooltipBelow());
     });
 
     it('returns false if screen is not wide enough', () => {
-      setScreenSize(519, 480);
+      setScreenSize(959, 480);
 
       assert.isFalse(tooltip.canShowTooltipBelow());
     });


### PR DESCRIPTION
fixes #3990 

This issue became significantly easier when I realized we had a solve for this already under 520px wide. ;)

We move the password balloon from under the input to the side of the input at 960px. Now, the inline "passwords do not match" validation positioning matches - that is, it is above the input whenever the balloon is below the iput.

<img width="497" alt="image" src="https://user-images.githubusercontent.com/13018240/73982457-e4266700-48f9-11ea-92df-7a683112faa6.png">
