### PR TITLE
fix(auth-server): use tags for paths/method

### DIFF
--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -411,7 +411,6 @@ function defineLazyGetter(object, key, getter) {
  *    https://github.com/mac-/hapi-statsd/blob/master/lib/hapi-statsd.js
  */
 function metricFactory(statsdClient) {
-  const template = '{path}.{method}.{statusCode}';
   const pathSeparator = '_';
 
   function normalizePath(path) {
@@ -439,14 +438,11 @@ function metricFactory(statsdClient) {
       path = '/{cors*}';
     }
 
-    var statName = template
-      .replace('{path}', normalizePath(path))
-      .replace('{method}', request.method.toUpperCase())
-      .replace('{statusCode}', statusCode);
-
-    statName = statName.indexOf('.') === 0 ? statName.substr(1) : statName;
-    statsdClient.increment(statName);
-    statsdClient.timing(statName, Date.now() - startDate.getTime());
+    statsdClient.timing('url_request', Date.now() - startDate.getTime(), 1, {
+      path: normalizePath(path),
+      method: request.method.toUpperCase(),
+      statusCode,
+    });
   }
   return reportMetrics;
 }

--- a/packages/fxa-auth-server/test/local/server.js
+++ b/packages/fxa-auth-server/test/local/server.js
@@ -90,7 +90,7 @@ describe('lib/server', () => {
         })),
         getLocale: sinon.spy(() => locale),
       };
-      statsd = { increment: sinon.fake(), timing: sinon.fake() };
+      statsd = { timing: sinon.fake() };
     });
 
     describe('create:', () => {
@@ -141,10 +141,7 @@ describe('lib/server', () => {
           assert.equal(statusCode, 401);
           assert.equal(result.code, 401);
           assert.equal(result.errno, error.ERRNO.INVALID_TOKEN);
-          assert.equal(
-            statsd.increment.getCall(0).args[0],
-            'oauth_subscriptions_clients.GET.401'
-          );
+          assert.equal(statsd.timing.getCall(0).args[0], 'url_request');
         });
 
         it('authenticated valid subscription shared secret', async () => {


### PR DESCRIPTION
Because:

* We can't bracket on metric name, only tags.

This commit:

* Uses tags for path/method/status code so that we can select all
  and then filter results as desired by path/method.