### PR TITLE
fix(auth-server): use cached stripe customer

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -1465,7 +1465,12 @@ module.exports = (
         if (config.subscriptions.enabled) {
           try {
             if (stripeHelper) {
-              const customer = await stripeHelper.customer(uid, email);
+              const customer = await stripeHelper.customer(
+                uid,
+                email,
+                false,
+                true
+              );
               if (!customer) {
                 throw error.unknownCustomer(uid);
               }

--- a/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
@@ -77,7 +77,7 @@ const SubscriptionUtils = (module.exports = {
  * @param {string} email
  */
 async function fetchSubscribedProductsFromStripe(uid, stripeHelper, email) {
-  const customer = await stripeHelper.customer(uid, email);
+  const customer = await stripeHelper.customer(uid, email, false, true);
   if (!customer || !customer.subscriptions.data) {
     return [];
   }

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -290,6 +290,18 @@ describe('StripeHelper', () => {
       });
     });
 
+    describe('subscriptionForCustomer', () => {
+      it('uses only cached customer data to look up a subscription', async () => {
+        assert.deepEqual(
+          await stripeHelper.customer('nonexistentuid', email, false, true),
+          undefined
+        );
+        assert(mockRedis.get.calledOnce);
+        assert.equal(mockRedis.set.callCount, 0);
+        assert.equal(stripeHelper.stripe.customers.list.callCount, 0);
+      });
+    });
+
     describe('fetchAllSubscriptionsForCustomer', () => {
       it('calls Stripe with the correct arguments', async () => {
         sandbox


### PR DESCRIPTION
Because:

* We can't hit Stripe for every account lookup.

This commit:

* Restricts the customer lookup to our cached Redis copy only.

Fixes #4090