### PR TITLE
fix(deps): handle hoek nsp warning https://npmjs.com/advisories/1468

### DIFF
--- a/packages/fxa-auth-server/.nsprc
+++ b/packages/fxa-auth-server/.nsprc
@@ -1,10 +1,8 @@
 {
   "comment_766": "766 is sandbox breakout in sandbox.",
   "comment_1168": "Exception added for 'subtext' vulnerability in hapi 17, fixed in hapi 18 branch. See https://github.com/mozilla/fxa/issues/2601",
-  "comment_1468": "1468 is a hoek vulnerability that only applies if the library is used outside hapi",
   "exceptions": [
     "https://npmjs.com/advisories/766",
-    "https://npmjs.com/advisories/1168",
-    "https://npmjs.com/advisories/1468"
+    "https://npmjs.com/advisories/1168"
   ]
 }

--- a/packages/fxa-auth-server/.nsprc
+++ b/packages/fxa-auth-server/.nsprc
@@ -1,8 +1,10 @@
 {
   "comment_766": "766 is sandbox breakout in sandbox.",
   "comment_1168": "Exception added for 'subtext' vulnerability in hapi 17, fixed in hapi 18 branch. See https://github.com/mozilla/fxa/issues/2601",
+  "comment_1468": "1468 is a hoek vulnerability that only applies if the library is used outside hapi",
   "exceptions": [
     "https://npmjs.com/advisories/766",
-    "https://npmjs.com/advisories/1168"
+    "https://npmjs.com/advisories/1168",
+    "https://npmjs.com/advisories/1468"
   ]
 }

--- a/packages/fxa-auth-server/package-lock.json
+++ b/packages/fxa-auth-server/package-lock.json
@@ -161,9 +161,9 @@
       }
     },
     "@hapi/hoek": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
     },
     "@sentry/core": {
       "version": "5.7.1",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -38,7 +38,7 @@
   "author": "Mozilla (https://mozilla.org/)",
   "readmeFilename": "README.md",
   "dependencies": {
-    "@hapi/hoek": "^8.3.2",
+    "@hapi/hoek": "^8.5.1",
     "@sentry/node": "^5.7.1",
     "ajv": "4.1.7",
     "aws-sdk": "2.77.0",

--- a/packages/fxa-event-broker/.nsprc
+++ b/packages/fxa-event-broker/.nsprc
@@ -1,4 +1,6 @@
 {
-    "exceptions": [
-    ]
+  "comment_1468": "1468 is a hoek vulnerability that only applies if the library is used outside hapi",
+  "exceptions": [
+    "https://npmjs.com/advisories/1468"
+  ]
 }

--- a/packages/fxa-event-broker/.nsprc
+++ b/packages/fxa-event-broker/.nsprc
@@ -1,6 +1,4 @@
 {
-  "comment_1468": "1468 is a hoek vulnerability that only applies if the library is used outside hapi",
   "exceptions": [
-    "https://npmjs.com/advisories/1468"
   ]
 }

--- a/packages/fxa-event-broker/package-lock.json
+++ b/packages/fxa-event-broker/package-lock.json
@@ -315,9 +315,9 @@
       }
     },
     "@hapi/hoek": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
-      "integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
     },
     "@hapi/iron": {
       "version": "5.1.4",

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -31,7 +31,7 @@
     "@google-cloud/firestore": "^2.6.0",
     "@google-cloud/pubsub": "^1.1.5",
     "@hapi/hapi": "^18.4.0",
-    "@hapi/hoek": "^8.5.0",
+    "@hapi/hoek": "^8.5.1",
     "@hapi/joi": "^16.1.7",
     "@sentry/node": "^5.8.0",
     "aws-sdk": "^2.569.0",

--- a/packages/fxa-payments-server/.nsprc
+++ b/packages/fxa-payments-server/.nsprc
@@ -1,8 +1,10 @@
 {
-  "comment_1426": "1426 is Cross-Site Scripting (XSS) in serialize-javascript, used by dev dep @storybook/react",
   "comment_961": "961 is a DOS against node-sass",
+  "comment_1426": "1426 is Cross-Site Scripting (XSS) in serialize-javascript, used by dev dep @storybook/react",
+  "comment_1468": "1468 is a hoek vulnerability that only applies if the library is used outside hapi",
   "exceptions": [
+    "https://npmjs.com/advisories/961",
     "https://npmjs.com/advisories/1426",
-    "https://npmjs.com/advisories/961"
+    "https://npmjs.com/advisories/1468"
   ]
 }

--- a/packages/fxa-shared/.nsprc
+++ b/packages/fxa-shared/.nsprc
@@ -1,3 +1,6 @@
 {
-  "exceptions": []
+  "comment_1468": "1468 is a hoek vulnerability that only applies if the library is used outside hapi",
+  "exceptions": [
+    "https://npmjs.com/advisories/1468"
+  ]
 }


### PR DESCRIPTION
The hoek library is a sub-dependency in a number of our monorepo packages. According to the [security warning](https://npmjs.com/advisories/1468),

> "This issue does not affect hapi applications since the framework protects against such malicious inputs. Applications that use @hapi/hoek outside of the hapi ecosystem may be vulnerable."

Edit: The auth and event-broker servers use hoek directly, so I've added a commit to this PR that updates hoek for those packages.