### PR TITLE
fix(auth-server): handle stripe webhooks correctly

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/fixtures/subscription_created.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/subscription_created.json
@@ -1,0 +1,118 @@
+{
+  "id": "evt_1GB5YwKb9q6OnNsL5j2KbWmG",
+  "object": "event",
+  "api_version": "2019-12-03",
+  "created": 1581453749,
+  "data": {
+    "object": {
+      "id": "sub_GiX3TpyO37x5BW",
+      "object": "subscription",
+      "application_fee_percent": null,
+      "billing_cycle_anchor": 1581453748,
+      "billing_thresholds": null,
+      "cancel_at": null,
+      "cancel_at_period_end": false,
+      "canceled_at": null,
+      "collection_method": "charge_automatically",
+      "created": 1581453748,
+      "current_period_end": 1581540148,
+      "current_period_start": 1581453748,
+      "customer": "cus_GiX3P6izX4lG5p",
+      "days_until_due": null,
+      "default_payment_method": null,
+      "default_source": null,
+      "default_tax_rates": [],
+      "discount": null,
+      "ended_at": null,
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_GiWcAgBaWUwwZx",
+            "object": "subscription_item",
+            "billing_thresholds": null,
+            "created": 1581453749,
+            "metadata": {},
+            "plan": {
+              "id": "plan_GWScEDK6LT8cSV",
+              "object": "plan",
+              "active": true,
+              "aggregate_usage": null,
+              "amount": 199,
+              "amount_decimal": "199",
+              "billing_scheme": "per_unit",
+              "created": 1578671226,
+              "currency": "usd",
+              "interval": "day",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {
+                "downloadURL": "https://fpn.firefox.com/vpn/download?utm_medium=email&utm_source=email&utm_campaign=subscription-download",
+                "webIconURL": "https://accounts-static.cdn.mozilla.net/product-icons/fpn.svg"
+              },
+              "nickname": "daily",
+              "product": "prod_FUUNYnlDso7FeB",
+              "tiers": null,
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "quantity": 1,
+            "subscription": "sub_GiWcHwJbYsxS9q",
+            "tax_rates": []
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/subscription_items?subscription=sub_GiWcHwJbYsxS9q"
+      },
+      "latest_invoice": "in_1GB5YuKb9q6OnNsL1vebOMR7",
+      "livemode": false,
+      "metadata": {},
+      "next_pending_invoice_item_invoice": null,
+      "pending_invoice_item_interval": null,
+      "pending_setup_intent": null,
+      "pending_update": null,
+      "plan": {
+        "id": "plan_GWScEDK6LT8cSV",
+        "object": "plan",
+        "active": true,
+        "aggregate_usage": null,
+        "amount": 199,
+        "amount_decimal": "199",
+        "billing_scheme": "per_unit",
+        "created": 1578671226,
+        "currency": "usd",
+        "interval": "day",
+        "interval_count": 1,
+        "livemode": false,
+        "metadata": {
+          "downloadURL": "https://fpn.firefox.com/vpn/download?utm_medium=email&utm_source=email&utm_campaign=subscription-download",
+          "webIconURL": "https://accounts-static.cdn.mozilla.net/product-icons/fpn.svg"
+        },
+        "nickname": "daily",
+        "product": "prod_FUUNYnlDso7FeB",
+        "tiers": null,
+        "tiers_mode": null,
+        "transform_usage": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      },
+      "quantity": 1,
+      "schedule": null,
+      "start_date": 1581453748,
+      "status": "active",
+      "tax_percent": null,
+      "trial_end": null,
+      "trial_start": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 2,
+  "request": {
+    "id": "req_OrSeVJZfnPXQ6m",
+    "idempotency_key": "da9a8474bbf04b02bb137b5814ddc2c9"
+  },
+  "type": "customer.subscription.created"
+}

--- a/packages/fxa-auth-server/test/local/payments/fixtures/subscription_created_incomplete.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/subscription_created_incomplete.json
@@ -1,0 +1,116 @@
+{
+  "id": "evt_1GB5zNJNcmPzuWtReVGchv0P",
+  "object": "event",
+  "api_version": "2019-12-03",
+  "created": 1581455388,
+  "data": {
+    "object": {
+      "id": "sub_GiX3TpyO37x5BW",
+      "object": "subscription",
+      "application_fee_percent": null,
+      "billing_cycle_anchor": 1581455387,
+      "billing_thresholds": null,
+      "cancel_at": null,
+      "cancel_at_period_end": false,
+      "canceled_at": null,
+      "collection_method": "charge_automatically",
+      "created": 1581455387,
+      "current_period_end": 1583960987,
+      "current_period_start": 1581455387,
+      "customer": "cus_GiX3P6izX4lG5p",
+      "days_until_due": null,
+      "default_payment_method": null,
+      "default_source": null,
+      "default_tax_rates": [],
+      "discount": null,
+      "ended_at": null,
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_GiX3aXqKxf9ID2",
+            "object": "subscription_item",
+            "billing_thresholds": null,
+            "created": 1581455387,
+            "metadata": {},
+            "plan": {
+              "id": "plan_FxFGE9jvhYvCMe",
+              "object": "plan",
+              "active": true,
+              "aggregate_usage": null,
+              "amount": 499,
+              "amount_decimal": "499",
+              "billing_scheme": "per_unit",
+              "created": 1570549157,
+              "currency": "usd",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {
+                "upgrades": "plan_FiII5wajzrxfrl"
+              },
+              "nickname": "Monthly",
+              "product": "prod_FxFGtsTRZ8NHbi",
+              "tiers": null,
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "quantity": 1,
+            "subscription": "sub_GiX3TpyO37x5BW",
+            "tax_rates": []
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/subscription_items?subscription=sub_GiX3TpyO37x5BW"
+      },
+      "latest_invoice": "in_1GB5zLJNcmPzuWtRAHGXcHcN",
+      "livemode": false,
+      "metadata": {},
+      "next_pending_invoice_item_invoice": null,
+      "pending_invoice_item_interval": null,
+      "pending_setup_intent": null,
+      "pending_update": null,
+      "plan": {
+        "id": "plan_FxFGE9jvhYvCMe",
+        "object": "plan",
+        "active": true,
+        "aggregate_usage": null,
+        "amount": 499,
+        "amount_decimal": "499",
+        "billing_scheme": "per_unit",
+        "created": 1570549157,
+        "currency": "usd",
+        "interval": "month",
+        "interval_count": 1,
+        "livemode": false,
+        "metadata": {
+          "upgrades": "plan_FiII5wajzrxfrl"
+        },
+        "nickname": "Monthly",
+        "product": "prod_FxFGtsTRZ8NHbi",
+        "tiers": null,
+        "tiers_mode": null,
+        "transform_usage": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      },
+      "quantity": 1,
+      "schedule": null,
+      "start_date": 1581455387,
+      "status": "incomplete",
+      "tax_percent": null,
+      "trial_end": null,
+      "trial_start": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 2,
+  "request": {
+    "id": "req_6dQ5Oi9uvnSYS6",
+    "idempotency_key": "stripe-node-retry-ae60c520-0424-4fd0-9aaa-9d59e0e3cb10"
+  },
+  "type": "customer.subscription.created"
+}

--- a/packages/fxa-auth-server/test/local/payments/fixtures/subscription_deleted.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/subscription_deleted.json
@@ -1,0 +1,116 @@
+{
+  "id": "evt_1GB4fgKb9q6OnNsLBGVcHQST",
+  "object": "event",
+  "api_version": "2019-12-03",
+  "created": 1581450323,
+  "data": {
+    "object": {
+      "id": "sub_GiX3TpyO37x5BW",
+      "object": "subscription",
+      "application_fee_percent": null,
+      "billing_cycle_anchor": 1581449989,
+      "billing_thresholds": null,
+      "cancel_at": null,
+      "cancel_at_period_end": false,
+      "canceled_at": 1581450078,
+      "collection_method": "charge_automatically",
+      "created": 1581449989,
+      "current_period_end": 1583955589,
+      "current_period_start": 1581449989,
+      "customer": "cus_GiX3P6izX4lG5p",
+      "days_until_due": null,
+      "default_payment_method": null,
+      "default_source": null,
+      "default_tax_rates": [],
+      "discount": null,
+      "ended_at": 1581450323,
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_GiVbZCo1K4JXci",
+            "object": "subscription_item",
+            "billing_thresholds": null,
+            "created": 1581449989,
+            "metadata": {},
+            "plan": {
+              "id": "plan_FiJ55YK6UYftPa",
+              "object": "plan",
+              "active": true,
+              "aggregate_usage": null,
+              "amount": 999,
+              "amount_decimal": "999",
+              "billing_scheme": "per_unit",
+              "created": 1567103726,
+              "currency": "usd",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {
+                "downloadURL": "https://stage.guardian.nonprod.cloudops.mozgcp.net/vpn/download?utm_medium=email&utm_source=email&utm_campaign=subscription-download"
+              },
+              "nickname": "guardian_monthly",
+              "product": "prod_FiJ42WCzZNRSbS",
+              "tiers": null,
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "quantity": 1,
+            "subscription": "sub_GiVbeUvwkJj6x1",
+            "tax_rates": []
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/subscription_items?subscription=sub_GiVbeUvwkJj6x1"
+      },
+      "latest_invoice": "in_1GB4aHKb9q6OnNsLC9pbVY5a",
+      "livemode": false,
+      "metadata": {},
+      "next_pending_invoice_item_invoice": null,
+      "pending_invoice_item_interval": null,
+      "pending_setup_intent": null,
+      "pending_update": null,
+      "plan": {
+        "id": "plan_FiJ55YK6UYftPa",
+        "object": "plan",
+        "active": true,
+        "aggregate_usage": null,
+        "amount": 999,
+        "amount_decimal": "999",
+        "billing_scheme": "per_unit",
+        "created": 1567103726,
+        "currency": "usd",
+        "interval": "month",
+        "interval_count": 1,
+        "livemode": false,
+        "metadata": {
+          "downloadURL": "https://stage.guardian.nonprod.cloudops.mozgcp.net/vpn/download?utm_medium=email&utm_source=email&utm_campaign=subscription-download"
+        },
+        "nickname": "guardian_monthly",
+        "product": "prod_FiJ42WCzZNRSbS",
+        "tiers": null,
+        "tiers_mode": null,
+        "transform_usage": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      },
+      "quantity": 1,
+      "schedule": null,
+      "start_date": 1581449989,
+      "status": "canceled",
+      "tax_percent": null,
+      "trial_end": null,
+      "trial_start": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_0Hhb1j3UqSE7Pr",
+    "idempotency_key": null
+  },
+  "type": "customer.subscription.deleted"
+}

--- a/packages/fxa-auth-server/test/local/payments/fixtures/subscription_updated.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/subscription_updated.json
@@ -1,0 +1,122 @@
+{
+  "id": "evt_1GAkaaJNcmPzuWtROjnqHuK4",
+  "object": "event",
+  "api_version": "2019-03-14",
+  "created": 1581373128,
+  "data": {
+    "object": {
+      "id": "sub_GXgckhuJP2pO91",
+      "object": "subscription",
+      "application_fee_percent": null,
+      "billing": "charge_automatically",
+      "billing_cycle_anchor": 1578953926,
+      "billing_thresholds": null,
+      "cancel_at": null,
+      "cancel_at_period_end": false,
+      "canceled_at": null,
+      "collection_method": "charge_automatically",
+      "created": 1578953926,
+      "current_period_end": 1581459526,
+      "current_period_start": 1581373126,
+      "customer": "cus_GXgcekfH0gjUCx",
+      "days_until_due": null,
+      "default_payment_method": null,
+      "default_source": null,
+      "default_tax_rates": [],
+      "discount": null,
+      "ended_at": null,
+      "invoice_customer_balance_settings": {
+        "consume_applied_balance_on_void": true
+      },
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_GXgcutBljLsmjp",
+            "object": "subscription_item",
+            "billing_thresholds": null,
+            "created": 1578953926,
+            "metadata": {},
+            "plan": {
+              "id": "plan_GW6OpLvKbFhlwD",
+              "object": "plan",
+              "active": true,
+              "aggregate_usage": null,
+              "amount": 399,
+              "amount_decimal": "399",
+              "billing_scheme": "per_unit",
+              "created": 1578588557,
+              "currency": "usd",
+              "interval": "day",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {},
+              "nickname": "daily",
+              "product": "prod_G93mdk6bGPJ7wy",
+              "tiers": null,
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "quantity": 1,
+            "subscription": "sub_GXgckhuJP2pO91",
+            "tax_rates": []
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/subscription_items?subscription=sub_GXgckhuJP2pO91"
+      },
+      "latest_invoice": "in_1GAkaZJNcmPzuWtR22uQmK9t",
+      "livemode": false,
+      "metadata": {},
+      "next_pending_invoice_item_invoice": null,
+      "pending_invoice_item_interval": null,
+      "pending_setup_intent": null,
+      "pending_update": null,
+      "plan": {
+        "id": "plan_GW6OpLvKbFhlwD",
+        "object": "plan",
+        "active": true,
+        "aggregate_usage": null,
+        "amount": 399,
+        "amount_decimal": "399",
+        "billing_scheme": "per_unit",
+        "created": 1578588557,
+        "currency": "usd",
+        "interval": "day",
+        "interval_count": 1,
+        "livemode": false,
+        "metadata": {},
+        "nickname": "daily",
+        "product": "prod_G93mdk6bGPJ7wy",
+        "tiers": null,
+        "tiers_mode": null,
+        "transform_usage": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      },
+      "quantity": 1,
+      "schedule": null,
+      "start": 1578953926,
+      "start_date": 1578953926,
+      "status": "active",
+      "tax_percent": null,
+      "trial_end": null,
+      "trial_start": null
+    },
+    "previous_attributes": {
+      "current_period_end": 1581373126,
+      "current_period_start": 1581286726,
+      "latest_invoice": "in_1GAO76JNcmPzuWtR3wc4uW2A"
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": null,
+    "idempotency_key": null
+  },
+  "type": "customer.subscription.updated"
+}

--- a/packages/fxa-auth-server/test/local/payments/fixtures/subscription_updated_from_incomplete.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/subscription_updated_from_incomplete.json
@@ -1,0 +1,119 @@
+{
+  "id": "evt_1GB60xJNcmPzuWtRzmkwiXL8",
+  "object": "event",
+  "api_version": "2019-12-03",
+  "created": 1581455487,
+  "data": {
+    "object": {
+      "id": "sub_GiX3TpyO37x5BW",
+      "object": "subscription",
+      "application_fee_percent": null,
+      "billing_cycle_anchor": 1581455387,
+      "billing_thresholds": null,
+      "cancel_at": null,
+      "cancel_at_period_end": false,
+      "canceled_at": null,
+      "collection_method": "charge_automatically",
+      "created": 1581455387,
+      "current_period_end": 1583960987,
+      "current_period_start": 1581455387,
+      "customer": "cus_GiX3P6izX4lG5p",
+      "days_until_due": null,
+      "default_payment_method": null,
+      "default_source": null,
+      "default_tax_rates": [],
+      "discount": null,
+      "ended_at": null,
+      "items": {
+        "object": "list",
+        "data": [
+          {
+            "id": "si_GiX3aXqKxf9ID2",
+            "object": "subscription_item",
+            "billing_thresholds": null,
+            "created": 1581455387,
+            "metadata": {},
+            "plan": {
+              "id": "plan_FxFGE9jvhYvCMe",
+              "object": "plan",
+              "active": true,
+              "aggregate_usage": null,
+              "amount": 499,
+              "amount_decimal": "499",
+              "billing_scheme": "per_unit",
+              "created": 1570549157,
+              "currency": "usd",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {
+                "upgrades": "plan_FiII5wajzrxfrl"
+              },
+              "nickname": "Monthly",
+              "product": "prod_FxFGtsTRZ8NHbi",
+              "tiers": null,
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "quantity": 1,
+            "subscription": "sub_GiX3TpyO37x5BW",
+            "tax_rates": []
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/subscription_items?subscription=sub_GiX3TpyO37x5BW"
+      },
+      "latest_invoice": "in_1GB5zLJNcmPzuWtRAHGXcHcN",
+      "livemode": false,
+      "metadata": {},
+      "next_pending_invoice_item_invoice": null,
+      "pending_invoice_item_interval": null,
+      "pending_setup_intent": null,
+      "pending_update": null,
+      "plan": {
+        "id": "plan_FxFGE9jvhYvCMe",
+        "object": "plan",
+        "active": true,
+        "aggregate_usage": null,
+        "amount": 499,
+        "amount_decimal": "499",
+        "billing_scheme": "per_unit",
+        "created": 1570549157,
+        "currency": "usd",
+        "interval": "month",
+        "interval_count": 1,
+        "livemode": false,
+        "metadata": {
+          "upgrades": "plan_FiII5wajzrxfrl"
+        },
+        "nickname": "Monthly",
+        "product": "prod_FxFGtsTRZ8NHbi",
+        "tiers": null,
+        "tiers_mode": null,
+        "transform_usage": null,
+        "trial_period_days": null,
+        "usage_type": "licensed"
+      },
+      "quantity": 1,
+      "schedule": null,
+      "start_date": 1581455387,
+      "status": "active",
+      "tax_percent": null,
+      "trial_end": null,
+      "trial_start": null
+    },
+    "previous_attributes": {
+      "status": "incomplete"
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 2,
+  "request": {
+    "id": "req_Qff2FFJWDjlg2m",
+    "idempotency_key": "stripe-node-retry-54c147fc-3b60-49d3-8905-e5fe48ba7e3e"
+  },
+  "type": "customer.subscription.updated"
+}


### PR DESCRIPTION
Because:

* `customer.updated` does not include subscription information as we
  previously assumed.
* We were not sending out the SQS subscription state change event.

This commit:

* Handles `customer.subscription.(created/updated/deleted)` so that we
  properly emit subscription state changes and refresh the cached
  customer at the appropriate time.

Closes #4040

Co-authored-by: Lauren Zugai <lauren@zugai.com>