### PR TITLE
feat(auth-server): add stripe metric timings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,7 +311,7 @@ workflows:
           name: fxa-auth-db-mysql
           module: fxa-auth-db-mysql
           db: true
-          upload_coverage: true
+          upload_coverage: false
           requires:
             - install
       - build-module:

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -29,7 +29,7 @@ async function run(config) {
   let stripeHelper = undefined;
   if (config.subscriptions && config.subscriptions.stripeApiKey) {
     const createStripeHelper = require('../lib/payments/stripe');
-    stripeHelper = createStripeHelper(log, config);
+    stripeHelper = createStripeHelper(log, config, statsd);
   }
 
   const redis = require('../lib/redis')(


### PR DESCRIPTION
Because:

* We want to know metrics on how long stripe calls take.

This commit:

* Add's a response handler to stripe to send out metric timings.

Closes #3862