### PR TITLE
fix(subscriptions): return an empty list when a FxA user is not a customer

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -642,8 +642,10 @@ class DirectStripeRoutes {
 
     const { uid, email } = await this.getUidEmail(request);
     const customer = await this.stripeHelper.customer(uid, email);
+
+    // A FxA user isn't always a customer.
     if (!customer) {
-      throw error.unknownCustomer(uid);
+      return [];
     }
 
     const response = await this.stripeHelper.subscriptionsToResponse(

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -937,7 +937,7 @@ describe('subscriptions directRoutes', () => {
     });
   });
 
-  describe.skip('GET /oauth/subscriptions/search', () => {
+  describe('GET /oauth/subscriptions/search', () => {
     let reqOpts, stripeHelper;
     const formatter = subs => subs.data.map(s => ({ subscription_id: s.id }));
 
@@ -954,23 +954,23 @@ describe('subscriptions directRoutes', () => {
       };
     });
 
-    it('should report error for unknown customer', async () => {
+    it('should return empty list unknown customer', async () => {
       stripeHelper.fetchCustomer = sinon.fake.throws(
         error.unknownCustomer(reqOpts.query.uid)
       );
 
-      try {
-        await runTest('/oauth/subscriptions/search', reqOpts, stripeHelper);
-        assert.fail();
-      } catch (err) {
-        assert.isTrue(
-          stripeHelper.customer.calledOnceWith(
-            reqOpts.query.uid,
-            reqOpts.query.email
-          )
-        );
-        assert.deepEqual(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION_CUSTOMER);
-      }
+      const response = await runTest(
+        '/oauth/subscriptions/search',
+        reqOpts,
+        stripeHelper
+      );
+      assert.isTrue(
+        stripeHelper.customer.calledOnceWith(
+          reqOpts.query.uid,
+          reqOpts.query.email
+        )
+      );
+      assert.deepEqual(response, formatter(customerFixture.subscriptions));
     });
 
     it('should return a formatted list of subscriptions in the customer response', async () => {


### PR DESCRIPTION
This patch fixes the bug where an endpoint[0] on auth server for fetching a
list of subscriptions given a UID and email address is returning a 404
when the FxA user is not a customer in Stripe.  Now it returns an empty
list.

[0] It's used only by the support panel.

Fixes #4006 

@mozilla/fxa-devs r?