### PR TITLE
feat(auth-server): support topic as custom fld

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -1573,6 +1573,12 @@ const conf = convict({
       env: 'ZENDESK_LOCATION_COUNTRY_FIELD_ID',
       format: String,
     },
+    topicFieldId: {
+      doc: 'Zendesk support ticket custom field for topic',
+      default: '360028484432',
+      env: 'ZENDESK_TOPIC_FIELD_ID',
+      format: String,
+    },
   },
   otp: {
     step: {

--- a/packages/fxa-auth-server/lib/routes/support.js
+++ b/packages/fxa-auth-server/lib/routes/support.js
@@ -68,7 +68,7 @@ module.exports = (log, db, config, customs, zendeskClient) => {
         const { uid, email } = await handleAuth(request.auth, true);
         const { location } = request.app.geo;
         await customs.check(request, email, 'supportRequest');
-        let subject = `${request.payload.topic} for ${request.payload.plan}`;
+        let subject = `${request.payload.plan}`;
         if (request.payload.subject) {
           subject = subject.concat(': ', request.payload.subject);
         }
@@ -77,6 +77,7 @@ module.exports = (log, db, config, customs, zendeskClient) => {
           locationCityFieldId,
           locationStateFieldId,
           locationCountryFieldId,
+          topicFieldId,
         } = config.zendesk;
 
         const zendeskReq = {
@@ -88,6 +89,7 @@ module.exports = (log, db, config, customs, zendeskClient) => {
           },
           custom_fields: [
             { id: productNameFieldId, value: request.payload.productName },
+            { id: topicFieldId, value: request.payload.topic },
             { id: locationCityFieldId, value: location.city },
             { id: locationStateFieldId, value: location.state },
             { id: locationCountryFieldId, value: location.country },

--- a/packages/fxa-auth-server/test/local/routes/support.js
+++ b/packages/fxa-auth-server/test/local/routes/support.js
@@ -209,12 +209,18 @@ describe('support', () => {
         const zendeskReq = spy.firstCall.args[0].request;
         assert.equal(
           zendeskReq.subject,
-          `${requestOptions.payload.topic} for ${requestOptions.payload.plan}: ${requestOptions.payload.subject}`
+          `${requestOptions.payload.plan}: ${requestOptions.payload.subject}`
         );
         assert.equal(zendeskReq.comment.body, requestOptions.payload.message);
         assert.deepEqual(
           zendeskReq.custom_fields.map(field => field.value),
-          ['FxA - 123done Pro', 'Mountain View', 'California', 'United States']
+          [
+            'FxA - 123done Pro',
+            requestOptions.payload.topic,
+            'Mountain View',
+            'California',
+            'United States',
+          ]
         );
         assert.deepEqual(res, { success: true, ticket: 91 });
         nock.isDone();
@@ -252,12 +258,18 @@ describe('support', () => {
         const zendeskReq = spy.firstCall.args[0].request;
         assert.equal(
           zendeskReq.subject,
-          `${requestOptions.payload.topic} for ${requestOptions.payload.plan}: ${requestOptions.payload.subject}`
+          `${requestOptions.payload.plan}: ${requestOptions.payload.subject}`
         );
         assert.equal(zendeskReq.comment.body, requestOptions.payload.message);
         assert.deepEqual(
           zendeskReq.custom_fields.map(field => field.value),
-          ['FxA - 123done Pro', 'Mountain View', 'California', 'United States']
+          [
+            'FxA - 123done Pro',
+            requestOptions.payload.topic,
+            'Mountain View',
+            'California',
+            'United States',
+          ]
         );
         assert.deepEqual(res, { success: true, ticket: 91 });
         nock.isDone();


### PR DESCRIPTION
Because:

* Support wants to easily filter on topic.

This commit:

* Moves the support topic to a custom field.

Closes #3883