### PR TITLE
fix(payments): fix subscription create route with missing awaits

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -104,7 +104,7 @@ class DirectStripeRoutes {
     let subscription;
 
     if (!customer) {
-      subscription = this.createSubscriptionNewCustomer(
+      subscription = await this.createSubscriptionNewCustomer(
         uid,
         email,
         displayName,
@@ -112,7 +112,7 @@ class DirectStripeRoutes {
         selectedPlan
       );
     } else {
-      subscription = this.createSubscriptionExistingCustomer(
+      subscription = await this.createSubscriptionExistingCustomer(
         customer,
         paymentToken,
         selectedPlan


### PR DESCRIPTION
Didn't update tests around this, but noticed some internal service errors on subscription create that this seems to solve.