### PR TITLE
fix(auth-server): use cached customer only

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -408,14 +408,13 @@ class DirectStripeRoutes {
   async listPlans(request) {
     this.log.begin('subscriptions.listPlans', request);
     await handleAuth(this.db, request.auth);
-    const plans = await this.stripeHelper.allPlans();
-    return plans;
+    return this.stripeHelper.allPlans();
   }
 
   async listActive(request) {
     this.log.begin('subscriptions.listActive', request);
     const { uid, email } = await handleAuth(this.db, request.auth, true);
-    const customer = await this.stripeHelper.customer(uid, email);
+    const customer = await this.stripeHelper.customer(uid, email, false, true);
     const activeSubscriptions = [];
 
     if (customer && customer.subscriptions) {
@@ -641,7 +640,7 @@ class DirectStripeRoutes {
     this.log.begin('subscriptions.getSubscriptions', request);
 
     const { uid, email } = await this.getUidEmail(request);
-    const customer = await this.stripeHelper.customer(uid, email);
+    const customer = await this.stripeHelper.customer(uid, email, false, true);
 
     // A FxA user isn't always a customer.
     if (!customer) {


### PR DESCRIPTION
Because:

* Routes that hit Stripe should be minimized to when we know the user
  is a customer.

This commit:

* Uses only the Redis copy of stripe data in more routes that we could
  accidentally hit in settings pages for all FxA users.