### PR TITLE
fix(l10n): Remove empty `value` field since that fails to extract string

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/recovery_codes.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/recovery_codes.mustache
@@ -72,7 +72,7 @@
             {{#t}}To ensure that you will be able to regain access to your account, in the event of a lost device, please enter one of your saved recovery codes.{{/t}}
         </p>
         <div class="input-row">
-            <input type="text" class="tooltip-below recovery-code" placeholder="{{#t}}Recovery code{{/t}}" value="" required autofocus autocomplete="off"/>
+            <input type="text" class="tooltip-below recovery-code" placeholder="{{#t}}Recovery code{{/t}}" required autofocus autocomplete="off"/>
         </div>
         <div class="button-row">
             <button type="submit" class="primary-button recovery-confirm-code">{{#t}}Confirm{{/t}}</button>


### PR DESCRIPTION
Fixes #4088 

Turns out that this wasn't a circleci issue but the string extraction script error. The script fails to extract empty string values like `value=""`. I've removed this and the extraction should work as expected.