### PR TITLE
feat(css): Add new breakpoints and corresponding mixins

### DIFF
--- a/packages/fxa-content-server/app/styles/_breakpoints.scss
+++ b/packages/fxa-content-server/app/styles/_breakpoints.scss
@@ -1,8 +1,7 @@
 // Breakpoint management
 // http://www.sitepoint.com/managing-responsive-breakpoints-sass/
-$breakpoints: (
-  small:
-    '(max-width: 520px), (orientation: landscape) and (max-width: 640px)',
+$media-queries: (
+  small: '(max-width: 520px), (orientation: landscape) and (max-width: 640px)',
   big: '(min-width: 521px), (orientation: landscape) and (min-width: 641px)',
   balloonSmall: '(max-width: 959px)',
   balloonBig: '(min-width: 960px)',
@@ -12,12 +11,52 @@ $breakpoints: (
 );
 
 @mixin respond-to($breakpoint) {
-  @if map-has-key($breakpoints, $breakpoint) {
-    @media #{map-get($breakpoints, $breakpoint)} {
+  @include breakpoint-error-check($breakpoint, $media-queries) {
+    @media #{map-get($media-queries, $breakpoint)} {
       @content;
     }
+  }
+}
+
+// NOTE: We will replace the `media-queries` map and `respond-to` mixin
+// with the `breakpoints` map, `min-width` mixin, and `max-width`
+// mixin. Once this is complete we can remove the former pair.
+// TODO: add example outputs to our documentation
+$breakpoints: (
+  mobileLandscape: 480,
+  tablet: 768,
+  desktop: 1024,
+  desktopXl: 1441
+);
+
+@mixin breakpoint-error-check($breakpoint, $map: $breakpoints) {
+  @if map-has-key($map, $breakpoint) {
+    @content;
   } @else {
-    @warn 'Unfortunately, no value could be retrieved from `#{$breakpoint}`. '
-    + 'Please make sure it is defined in `$breakpoints` map.';
+    @error 'Unfortunately, no value could be retrieved from `#{$breakpoint}`. Ensure it is defined in the map: `#{$map}`';
+  }
+}
+
+@mixin min-width($breakpoint) {
+  @include breakpoint-error-check($breakpoint) {
+    @if $breakpoint == 'tablet' {
+      @media (min-width: #{map-get($breakpoints, $breakpoint) + 0px}) and (min-height: (#{map-get($breakpoints, 'mobileLandscape') + 1px})) {
+        @content;
+      }
+    } @else {
+      @media (min-width: #{map-get($breakpoints, $breakpoint) + 0px}) {
+        @content;
+      }
+    }
+  }
+}
+
+// This mixin should be used sparingly.
+// Favor the mobile-first `min-width` query.
+@mixin max-width($breakpoint) {
+  @include breakpoint-error-check($breakpoint) {
+    @media (max-width: #{map-get($breakpoints, $breakpoint) - 1px}) {
+      @content;
+    }
   }
 }


### PR DESCRIPTION
[See this doc](https://docs.google.com/document/d/1JL3dgpAvzmSrGIZg9MB0APNoYFG325n2kJaUlb1hYDo) for more details on why these values and media queries were chosen.

No associated issue. We intended on adding these new breakpoints when our CSS is updated from the impending settings redesign, but it seemed prudent to add them now for use in the payments server for the FPN mobile updates/enhancements. Current functionality has not been changed.

`$breakpoints` seemed like an appropriate map name for the new values. I changed the old map name to `$media-queries` since that more accurately describes what they are (although technically the media query includes `@media` but… I digress). The `respond-to` mixin still uses this map. These can be removed when we don't use them anymore.

I checked:
- the error message showed correctly in the logs for both maps
- that all the current media queries work properly
- the output of every new breakpoint using both `@include min-width` and `@include max-width` to ensure the CSS was valid and as expected

Example usage:
```
.some-class {
  @include min-width('tablet') {
    background: hotpink;
  }
}
```

Example output:
```
@media (min-width: 768px) and (min-height: 481px) {
  .some-class {
      background: hotpink; 
  } 
}
```

NOTE: use the `max-width` mixin sparingly as the comment states, we want to stay as mobile-first as possible.
The `mobileLandscape` and `desktopXl` breakpoints will also not be used often. Typical usage will be `@include min-width` with `tablet` or `desktop` set. No media query of course means mobile styles.

@mozilla/fxa-devs r?
Tagging @johngruen and @meandavejustice for visibility.