### PR TITLE
fix(delete_account): Change manage subscription link conditional from 'for' loop to 'if at least one'

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/delete_account.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/delete_account.mustache
@@ -12,11 +12,11 @@
 
   <div class="settings-unit-details">
     <div class="error"></div>
-    {{#subscriptions}}
+    {{#subscriptions.0}}
       <p class="subscription-link">
         {{#unsafeTranslate}}Looking to cancel a paid subscription? Go to <a href="/subscriptions">Manage Subscriptions</a>.{{/unsafeTranslate}}
       </p>
-    {{/subscriptions}}
+    {{/subscriptions.0}}
 
     <div class="delete-account-product-container {{#hideProductContainer}}hide{{/hideProductContainer}}">
       <p>{{#t}}You've connected your Firefox account to Mozilla products that keep you secure and productive on the web:{{/t}}</p>

--- a/packages/fxa-content-server/app/tests/spec/views/settings/delete_account.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/delete_account.js
@@ -310,6 +310,29 @@ describe('views/settings/delete_account', function() {
           });
       });
 
+      it('renders only one link if the user has more than one subscription', () => {
+        activeSubscriptions = [
+          {
+            plan_id: '321doneProMonthly',
+            plan_name: '321done Pro Monthly',
+            status: 'active',
+          },
+          {
+            plan_id: '321doneProYearly',
+            plan_name: '321done Pro Yearly',
+            status: 'active',
+          },
+        ];
+
+        return view
+          .render()
+          .then(() => view.openPanel())
+          .then(() => {
+            assert.lengthOf(view.$('.delete-account-product-subscription'), 2);
+            assert.lengthOf(view.$('.subscription-link'), 1);
+          });
+      });
+
       it('does not render if user does not have any subscriptions', () => {
         activeSubscriptions = [];
 


### PR DESCRIPTION
fixes #4041 

Added a test to make sure this doesn't reoccur.

@mozilla/fxa-devs r?

Co-authored-by: Ben Bangert <ben@groovie.org>