### PR TITLE
fix(metrics): add Amplitude events for /pair on content server

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/pair/index.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/index.js
@@ -4,6 +4,7 @@
 
 import FormView from '../form';
 import Cocktail from 'cocktail';
+import FlowEventsMixin from '../mixins/flow-events-mixin';
 import Template from '../../templates/pair/index.mustache';
 import UserAgentMixin from '../../lib/user-agent-mixin';
 import PairingGraphicsMixin from '../mixins/pairing-graphics-mixin';
@@ -52,6 +53,7 @@ class PairIndexView extends FormView {
 
 Cocktail.mixin(
   PairIndexView,
+  FlowEventsMixin,
   PairingGraphicsMixin,
   PairingTotpMixin(),
   UserAgentMixin,

--- a/packages/fxa-content-server/app/tests/spec/views/pair/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/index.js
@@ -6,6 +6,7 @@ import { assert } from 'chai';
 import sinon from 'sinon';
 import View from 'views/pair/index';
 import BaseBroker from 'models/auth_brokers/base';
+import Notifier from 'lib/channels/notifier';
 import Relier from 'models/reliers/relier';
 import User from 'models/user';
 import WindowMock from '../../../mocks/window';
@@ -20,11 +21,13 @@ describe('views/pair/index', () => {
   let user;
   let view;
   let broker;
+  let notifier;
   let relier;
   let windowMock;
 
   beforeEach(() => {
     windowMock = new WindowMock();
+    notifier = new Notifier();
     relier = new Relier(
       {},
       {
@@ -46,6 +49,7 @@ describe('views/pair/index', () => {
     });
     view = new View({
       broker,
+      notifier,
       relier,
       viewName: 'pairIndex',
       window: windowMock,

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -126,6 +126,7 @@ const EVENTS = {
 const VIEW_ENGAGE_SUBMIT_EVENT_GROUPS = {
   'enter-email': GROUPS.emailFirst,
   'force-auth': GROUPS.login,
+  pair: GROUPS.connectDevice,
   'rp-button': GROUPS.button,
   settings: GROUPS.settings,
   signin: GROUPS.login,

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -1936,5 +1936,57 @@ registerSuite('amplitude', {
       assert.equal(arg.time, 'a');
       assert.equal(arg.user_id, 'ca11ab1efo1dab1e5a1eab1e5ca1ab1e');
     },
+
+    'screen.pair': () => {
+      amplitude(
+        {
+          time: '1582051365965',
+          type: 'screen.pair',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1582051366041',
+          flowId:
+            '5447c7149042981c04bb47e8c3b717d12cfc9f2e21222b9d2b1837e193eb0d0ac',
+          uid: 'none',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_connect_device - view');
+      assert.equal(arg.event_properties.connect_device_flow, 'pairing');
+    },
+
+    'flow.pair.submit': () => {
+      amplitude(
+        {
+          time: '1582051365965',
+          type: 'flow.pair.submit',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1582051366041',
+          flowId:
+            '5447c7149042981c04bb47e8c3b717d12cfc9f2e21222b9d2b1837e193eb0d0ac',
+          uid: 'none',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_connect_device - submit');
+      assert.equal(arg.event_properties.connect_device_flow, 'pairing');
+    },
   },
 });

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -32,6 +32,7 @@ const GROUPS = {
 const CONNECT_DEVICE_FLOWS = {
   'app-store': 'store_buttons',
   install_from: 'store_buttons',
+  pair: 'pairing',
   signin_from: 'signin',
   sms: 'sms',
 };


### PR DESCRIPTION
This patch adds a couple missing Amplitude events to /pair on the
content server.  The events are 'fxa_connect_device - view' and
'fxa_connect_device - submit' with the event property
'connect_device_flow' set to 'pairing'.

Fixes #4103 

@mozilla/fxa-devs r?