### PR TITLE
fix(css): Fix account recovery flow button CSS bug + line-height, fix .warning-button CSS

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/complete_reset_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/complete_reset_password.mustache
@@ -68,7 +68,7 @@
       </div>
 
       <div class="button-row ">
-          <button type="submit" class="{{^showAccountRecoveryInfo}}warning-button{{/showAccountRecoveryInfo}} {{#showAccountRecoveryInfo}}primary-button{{/showAccountRecoveryInfo}}">{{#t}}Reset password{{/t}}</button>
+          <button type="submit">{{#t}}Reset password{{/t}}</button>
           <button class="button-link remember-password">{{#t}}Remember password? Sign in{{/t}}</button>
       </div>
     </form>

--- a/packages/fxa-content-server/app/scripts/templates/reset_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/reset_password.mustache
@@ -24,7 +24,7 @@
       </div>
 
       <div class="button-row">
-        <button id="submit-btn" type="submit" class="warning-button">{{#t}}Begin reset{{/t}}</button>
+        <button id="submit-btn" type="submit">{{#t}}Begin reset{{/t}}</button>
       </div>
     </form>
 

--- a/packages/fxa-content-server/app/styles/modules/_button-row.scss
+++ b/packages/fxa-content-server/app/styles/modules/_button-row.scss
@@ -62,11 +62,20 @@ button {
     border: 0;
     color: $message-text-color;
 
-    &:hover:enabled {
-      background: darken($error-background-color, 5);
+    &:disabled,
+    &:enabled {
+      background: $error-background-color;
+    }
 
-      &:active {
+    // 'type' is needed for selector specificity
+    &[type="submit"] {
+      &:active:enabled,
+      &:active:enabled:hover {
         background: darken($error-background-color, 10);
+      }
+
+      &:hover:enabled {
+        background: darken($error-background-color, 5);
       }
     }
   }

--- a/packages/fxa-content-server/app/styles/modules/_settings-account-recovery.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings-account-recovery.scss
@@ -139,6 +139,7 @@
 
   .description {
     font-size: 14px;
+    line-height: 1.5;
   }
 }
 


### PR DESCRIPTION
fixes #4137 

I removed the class check from the PW recovery flow… It receives the blue styles by default. See screens.

I noticed this was also affecting the “delete account” button. I conferred with Ryan Feeley about this who said this button should be red and gave the thumbs up on the styling.

Also fixed a line-height issue while I was at it.

#4137 is resolved:
![create-pw-fix](https://user-images.githubusercontent.com/13018240/74783575-97cd1680-526b-11ea-8226-ef9fd1306eae.gif)

Delete account change:
![delete-account-red](https://user-images.githubusercontent.com/13018240/74783577-98fe4380-526b-11ea-8254-1ed12ceefadb.gif)


Line-height before:
<img src="https://user-images.githubusercontent.com/13018240/74783531-8257ec80-526b-11ea-8d0d-2cacf6398d9c.png" width="400">
Now: 
<img src="https://user-images.githubusercontent.com/13018240/74783545-87b53700-526b-11ea-8c3f-5a2475dc576e.png" width="400">

@mozilla/fxa-devs r?