### PR TITLE
chore(CI): update three jobs to use node 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,7 +183,7 @@ jobs:
 
   js-client:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:12
     working_directory: ~/project/packages/fxa-js-client
     steps:
       - attach_workspace:
@@ -192,7 +192,7 @@ jobs:
 
   fxa-email-event-proxy:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:12
     working_directory: ~/project/packages/fxa-email-event-proxy
     steps:
       - attach_workspace:
@@ -203,7 +203,7 @@ jobs:
 
   fxa-email-event-proxy-tag:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:12
     working_directory: ~/project/packages/fxa-email-event-proxy
     steps:
       - attach_workspace:


### PR DESCRIPTION
Because node:8 is three years old, and the default JRE version on it is
old enough that the fxa-js-client is failing on:

- E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/o/openjdk-8/openjdk-8-jre-headless_8u232-b09-1~deb9u1_amd64.deb  404  Not Found
- E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/o/openjdk-8/openjdk-8-jre_8u232-b09-1~deb9u1_amd64.deb  404  Not Found

@mozilla/fxa-devs r?