### PR TITLE
fix(webchannel): ignore native Gecko WebChannel errors for the OAuth WebChannel

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/app-start.js
+++ b/packages/fxa-content-server/app/scripts/lib/app-start.js
@@ -431,6 +431,7 @@ Start.prototype = {
       );
       this._notificationChannel.initialize({
         window: this._window,
+        isOAuthWebChannel: this.isOAuthWebChannel(),
       });
     }
   },

--- a/packages/fxa-content-server/app/scripts/lib/channels/web.js
+++ b/packages/fxa-content-server/app/scripts/lib/channels/web.js
@@ -60,6 +60,7 @@ _.extend(WebChannel.prototype, new DuplexChannel(), {
   initialize(options = {}) {
     const win = (this.window = options.window || window);
     const webChannelId = this._id;
+    this.isOAuthWebChannel = options.isOAuthWebChannel;
 
     var sender = (this._sender = new WebChannelSender());
     sender.initialize({
@@ -101,7 +102,11 @@ _.extend(WebChannel.prototype, new DuplexChannel(), {
 
     // Browser does not support WebChannels sent on this channel,
     // or from this domain.
-    if (/no such channel/i.test(errorMessage)) {
+    // In addition: There's a hacky workaround to make sure the OAuthWebChannel
+    // is not disabled if we use it in GeckoView + Android WebChannel component
+    // In the cases where it is the OAuthWebchannel we let the requests time out
+    // See details in https://github.com/mozilla/application-services/issues/2650
+    if (/no such channel/i.test(errorMessage) && !this.isOAuthWebChannel) {
       // Since the channel is not supported, reject all outstanding
       // requests to avoid hanging until the requests time out.
       this.rejectAllOutstandingRequests(

--- a/packages/fxa-content-server/app/tests/spec/lib/channels/web.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/channels/web.js
@@ -204,6 +204,25 @@ describe('lib/channels/web', () => {
       });
     });
 
+    describe('OAuth WebChannel', () => {
+      it('does not reject outstanding requests for the OAuth WebChannel', () => {
+        channel = new WebChannel('MyChannel');
+        channel.initialize({
+          window: windowMock,
+          isOAuthWebChannel: true,
+        });
+        sandbox
+          .stub(channel, 'rejectAllOutstandingRequests')
+          .callsFake(() => {});
+
+        const webChannelError = {
+          error: new Error('No Such Channel'),
+        };
+        channel.onErrorReceived(webChannelError);
+        assert.isFalse(channel.rejectAllOutstandingRequests.called);
+      });
+    });
+
     describe('with another WebChannel error', () => {
       it('delegates ot the parent method', () => {
         const webChannelError = {


### PR DESCRIPTION
@rfk r?

Fixes #3116