### PR TITLE
fix(email): Minor CSS tweaks for subscription email

### DIFF
--- a/packages/fxa-auth-server/lib/senders/templates/downloadSubscription.html
+++ b/packages/fxa-auth-server/lib/senders/templates/downloadSubscription.html
@@ -1,7 +1,7 @@
 {{> icon}}
 
 <tr style="page-break-before: always">
-  <td align="center" valign="top" style="padding: 20px 30px 0;">
+  <td align="center" valign="top" style="padding: 0 30px">
     <h1 style="font-size: 22px; color: #464646;text-align:center !important;">
       {{subject}}
     </h1>
@@ -10,7 +10,7 @@
 
 <tr style="page-break-before: always">
   <td align="left" valign="top" style="padding: 0 30px 30px;">
-    <p style="font-size: 16px; line-height: 22px; color: #555555; padding-top: 16px;text-align:center !important;">
+    <p style="font-size: 16px; line-height: 22px; color: #555555; text-align:center !important;">
       If you haven&#x27;t already downloaded {{product}}, let&#x27;s get started using all the features included in your subscription.
     </p>
   </td>
@@ -19,7 +19,7 @@
 {{> button}}
 
 <tr style="page-break-before: always">
-  <td align="left" valign="top" style="padding: 30px 80px 15px;">
+  <td align="left" valign="top" style="padding: 0 80px 15px;">
     <p style="max-width: 500px !important; font-size: 16px; line-height: 22px; color: #555555; padding-top: 16px;text-align:center !important;">
       Questions about your subscription? Our <a href="{{{subscriptionSupportUrl}}}">support team</a> is here to help you.
     </p>

--- a/packages/fxa-auth-server/lib/senders/templates/partials/icon.html
+++ b/packages/fxa-auth-server/lib/senders/templates/partials/icon.html
@@ -1,6 +1,6 @@
 {{#if icon}}
 <tr style="page-break-before: always">
-  <td align="center" style="padding: 20px 0;">
+  <td align="center" style="padding: 20px 0 10px;">
     <img src="{{{icon}}}" width="58" height="58" alt="" style="-ms-interpolation-mode: bicubic;" />
   </td>
 </tr>


### PR DESCRIPTION
fixes #3875 

Pretty minor tweaks of the inline-styles. The `icon` partial is only used by `downloadSubscription`.

Before:
<img src="https://user-images.githubusercontent.com/13018240/74858039-3c9e3100-530a-11ea-8f51-9f6b0bf8fe4a.png" width="400">


After:
<img src="https://user-images.githubusercontent.com/13018240/74858050-432ca880-530a-11ea-8ba3-f24008223255.png" width="400">

@meandavejustice I didn't PR this into your mobile FPN tweaks branch since this is separate from payments. I'll wait for your approval here since it falls under your epic.
