### PR TITLE
fix(support-panel): encode email addr in subscriptions request

### DIFF
--- a/packages/fxa-support-panel/lib/api.ts
+++ b/packages/fxa-support-panel/lib/api.ts
@@ -145,7 +145,9 @@ class SupportController {
     try {
       subscriptions = await requests.get({
         ...authServerRequestOptions,
-        url: `${this.config.authServer.url}${this.config.authServer.subscriptionsSearchPath}?uid=${uid}&email=${account.email}`,
+        url: `${this.config.authServer.url}${
+          this.config.authServer.subscriptionsSearchPath
+        }?uid=${uid}&email=${encodeURIComponent(account.email)}`,
       });
     } catch (err) {
       this.logger.error('subscriptionsFetch', { err });

--- a/packages/fxa-support-panel/test/lib/api.spec.ts
+++ b/packages/fxa-support-panel/test/lib/api.spec.ts
@@ -34,16 +34,18 @@ type MockCallsResponse = {
   totp: MockCallResponse<TotpTokenResponse>;
 };
 
+const now = new Date().getTime();
+const accountResponse = {
+  createdAt: now,
+  email: 'test+quux@example.com',
+  emailVerified: true,
+  locale: 'en-us',
+};
+
 function createDefaults(): MockCallsResponse {
-  const now = new Date().getTime();
   return {
     account: {
-      response: {
-        createdAt: now,
-        email: 'test@example.com',
-        emailVerified: true,
-        locale: 'en-us',
-      },
+      response: accountResponse,
       status: 200,
     },
     devices: {
@@ -121,7 +123,10 @@ describe('Support Controller', () => {
       .reply(obj.totp.status, obj.totp.response);
     nock(authServerConfig.url)
       .get(authServerConfig.subscriptionsSearchPath)
-      .query(() => true)
+      .query(
+        queryParams =>
+          queryParams.uid === uid && queryParams.email === accountResponse.email
+      )
       .reply(obj.subscriptions.status, obj.subscriptions.response);
     nock(authServerConfig.url)
       .get(authServerConfig.signinLocationsSearchPath)


### PR DESCRIPTION
This patch URI encodes the email address of the FxA user for whom the
support panel is fetching a list of subscriptions from the auth server.
Previously the request fails when the email address contains a '+'.

Fixes #4193 

@mozilla/fxa-devs r?