### PR TITLE
fix(docker): don't rm /tmp after npm i

### DIFF
--- a/packages/fxa-auth-db-mysql/Dockerfile-build
+++ b/packages/fxa-auth-db-mysql/Dockerfile-build
@@ -1,7 +1,5 @@
 FROM node:12-alpine
 
-RUN npm install -g npm@6 && rm -rf ~app/.npm /tmp/*
-
 RUN apk add --no-cache make git gcc g++ python
 
 RUN addgroup -g 10001 app && \
@@ -18,6 +16,6 @@ USER app
 COPY package-lock.json package-lock.json
 COPY package.json package.json
 
-RUN npm install --production && rm -rf ~app/.npm /tmp/*
+RUN npm install --production && rm -rf ~app/.npm
 
 COPY . /app

--- a/packages/fxa-auth-server/Dockerfile-build
+++ b/packages/fxa-auth-server/Dockerfile-build
@@ -24,7 +24,7 @@ WORKDIR /fxa-shared
 RUN npm ci
 
 WORKDIR /app
-RUN npm ci --production && rm -rf ~app/.npm /tmp/*
+RUN npm ci --production && rm -rf ~app/.npm
 RUN node scripts/gen_keys.js
 RUN NODE_ENV=dev node scripts/oauth_gen_keys.js
 RUN node scripts/gen_vapid_keys.js

--- a/packages/fxa-customs-server/Dockerfile-build
+++ b/packages/fxa-customs-server/Dockerfile-build
@@ -11,6 +11,6 @@ USER app
 COPY --chown=app:app package-lock.json package-lock.json
 COPY --chown=app:app package.json package.json
 
-RUN npm ci --production && rm -rf ~app/.npm /tmp/*
+RUN npm ci --production && rm -rf ~app/.npm
 
 COPY --chown=app:app . /app

--- a/packages/fxa-profile-server/Dockerfile-build
+++ b/packages/fxa-profile-server/Dockerfile-build
@@ -1,7 +1,5 @@
 FROM node:12-alpine AS builder
 
-RUN npm install -g npm@6 && rm -rf ~app/.npm /tmp/*
-
 RUN addgroup -g 10001 app && \
     adduser -D -G app -h /app -u 10001 app
 
@@ -19,7 +17,7 @@ COPY --chown=app:app ["fxa-shared", "../fxa-shared/"]
 USER app
 WORKDIR /app
 
-RUN npm install --production && rm -rf ~app/.npm /tmp/*
+RUN npm install --production && rm -rf ~app/.npm
 
 WORKDIR /fxa-shared
 RUN npm ci
@@ -30,8 +28,6 @@ USER app
 
 # Build final image by copying from builder
 FROM node:12-alpine
-
-RUN npm install -g npm@6 && rm -rf ~app/.npm /tmp/*
 
 RUN addgroup -g 10001 app && \
     adduser -D -G app -h /app -u 10001 app

--- a/packages/fxa-support-panel/Dockerfile-build
+++ b/packages/fxa-support-panel/Dockerfile-build
@@ -3,8 +3,6 @@ FROM node:12-alpine
 # To handle 'not get uid/gid'
 RUN npm config set unsafe-perm true
 
-RUN npm install -g npm@6 && rm -rf ~app/.npm /tmp/*
-
 RUN apk add --no-cache git make gcc g++
 
 RUN addgroup -g 10001 app && \
@@ -16,7 +14,7 @@ USER app
 COPY package.json package.json
 COPY package-lock.json package-lock.json
 
-RUN npm ci && rm -rf ~app/.npm /tmp/*
+RUN npm ci && rm -rf ~app/.npm
 
 COPY . /app
 RUN npm run build


### PR DESCRIPTION
an upstream update changed the ownership of /tmp and broke our build.
deleting /tmp isn't that important, only a couple mb.