### PR TITLE
test(routes/subscriptions.js): Coverage for updateCustomerAndSendStatus

### DIFF
--- a/packages/fxa-auth-server/.vscode/launch.json
+++ b/packages/fxa-auth-server/.vscode/launch.json
@@ -95,7 +95,8 @@
         "999999",
         "--colors",
         "${workspaceFolder}/test/local/payments/stripe.js",
-        "${workspaceFolder}/test/local/routes/subscriptions.js"
+        "${workspaceFolder}/test/local/routes/subscriptions.js",
+        "--exit"
       ],
       "env": { "NODE_ENV": "dev" },
       "console": "integratedTerminal",


### PR DESCRIPTION
- added coverage for the specified function
- updated vscode script for Arch 2.0 coverage

fixes #4233