### PR TITLE
test(auth-server): Coverage for getUidEmail

### DIFF
--- a/packages/fxa-auth-server/.vscode/launch.json
+++ b/packages/fxa-auth-server/.vscode/launch.json
@@ -95,7 +95,8 @@
         "999999",
         "--colors",
         "${workspaceFolder}/test/local/payments/stripe.js",
-        "${workspaceFolder}/test/local/routes/subscriptions.js"
+        "${workspaceFolder}/test/local/routes/subscriptions.js",
+        "--exit"
       ],
       "env": { "NODE_ENV": "dev" },
       "console": "integratedTerminal",

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -2074,4 +2074,39 @@ describe('DirectStripeRoutes', () => {
       });
     });
   });
+
+  describe('getUidEmail', () => {
+    let handleAuthSpy;
+
+    beforeEach(() => {
+      handleAuthSpy = sandbox.spy(handleAuth);
+    });
+
+    describe('when the auth strategy is supportPanelSecret', () => {
+      it('returns the uid and email from reques.query', async () => {
+        const expected = { uid: '12345', email: 'test@example.com' };
+        const request = {
+          auth: {
+            strategy: 'supportPanelSecret',
+          },
+          query: expected,
+        };
+
+        const actual = await directStripeRoutesInstance.getUidEmail(request);
+        assert.deepEqual(actual, expected);
+        assert.isFalse(handleAuthSpy.called);
+      });
+    });
+    describe('when the auth strategy is not supportPanelSecret', () => {
+      it('returns the uid and email from handleAuth', async () => {
+        const expected = { uid: UID, email: TEST_EMAIL };
+
+        const actual = await directStripeRoutesInstance.getUidEmail(
+          VALID_REQUEST
+        );
+        assert.deepEqual(actual, expected);
+        assert.isFalse(handleAuthSpy.called);
+      });
+    });
+  });
 });


### PR DESCRIPTION
- added coverage for the specified function
- updated vscode script for Arch 2.0 coverage

fixes #4236