### PR TITLE
test(auth-server): Coverage for Delete Subscription

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.js
+++ b/packages/fxa-auth-server/lib/payments/stripe.js
@@ -491,6 +491,29 @@ class StripeHelper {
   }
 
   /**
+   * Cancel a givel subscription for a customer
+   * If the subscription does not belong to the customer, throw an error
+   *
+   * @param {string} uid
+   * @param {string} email
+   * @param {Subscription[id]} subscriptionId
+   */
+  async cancelSubscriptionForCustomer(uid, email, subscriptionId) {
+    const hasSubscription = await this.subscriptionForCustomer(
+      uid,
+      email,
+      subscriptionId
+    );
+    if (!hasSubscription) {
+      throw error.unknownSubscription();
+    }
+
+    await this.stripe.subscriptions.update(subscriptionId, {
+      cancel_at_period_end: true,
+    });
+  }
+
+  /**
    *
    * Returns the product name of a given product.
    *

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -258,18 +258,11 @@ class DirectStripeRoutes {
 
     const subscriptionId = request.params.subscriptionId;
 
-    const hasSubscription = await this.stripeHelper.subscriptionForCustomer(
+    await this.stripeHelper.cancelSubscriptionForCustomer(
       uid,
       email,
       subscriptionId
     );
-    if (!hasSubscription) {
-      throw error.unknownSubscription();
-    }
-
-    await this.stripeHelper.stripe.subscriptions.update(subscriptionId, {
-      cancel_at_period_end: true,
-    });
 
     await this.customerChanged(request, uid, email);
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -2021,7 +2021,32 @@ describe('DirectStripeRoutes', () => {
     });
   });
 
-  describe('deleteSubscription', () => {});
+  describe('deleteSubscription', () => {
+    const deleteSubRequest = {
+      auth: {
+        credentials: {
+          scope: MOCK_SCOPES,
+          user: `${UID}`,
+          email: `${TEST_EMAIL}`,
+        },
+      },
+      app: {
+        devices: ['deviceId1', 'deviceId2'],
+      },
+      params: { subscriptionId: subscription2.id },
+    };
+
+    it('returns the subscription id', async () => {
+      const expected = { subscriptionId: subscription2.id };
+
+      directStripeRoutesInstance.stripeHelper.cancelSubscriptionForCustomer.resolves();
+      const actual = await directStripeRoutesInstance.deleteSubscription(
+        deleteSubRequest
+      );
+
+      assert.deepEqual(actual, expected);
+    });
+  });
 
   describe('updatePayment', () => {});
 


### PR DESCRIPTION
- refactored deleteSubscription, so as to not call stripe library directly
- added coverage for deleteSubscription in subscriptions.js DirectStripeRoutes
- added coverage for new cancelSubscriptionForCustomer in stripe.js StripeHelper

fixes #4225