### PR TITLE
fix(auth-server): stripe refresh on primary change

### DIFF
--- a/packages/fxa-auth-server/.vscode/launch.json
+++ b/packages/fxa-auth-server/.vscode/launch.json
@@ -70,7 +70,8 @@
         "--timeout",
         "999999",
         "--colors",
-        "${workspaceFolder}/${relativeFile}"
+        "${workspaceFolder}/${relativeFile}",
+        "--exit"
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",


### PR DESCRIPTION
Because:

* We were failing to refresh our cached customer record for Stripe
  subscriptions on primary email change.
* Our cached copy is keyed by email + uid, so the email change meant
  we lost our local reference.

This commit:

* Refreshes the Redis record for a customer to the new email address.

Fixes #4247