### PR TITLE
test(auth-server): Coverage for reactivateSubscription

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -307,32 +307,11 @@ class DirectStripeRoutes {
 
     const { subscriptionId } = request.payload;
 
-    const hasSubscription = await this.stripeHelper.subscriptionForCustomer(
+    await this.stripeHelper.reactivateSubscriptionForCustomer(
       uid,
       email,
       subscriptionId
     );
-    if (!hasSubscription) {
-      throw error.unknownSubscription();
-    }
-
-    const subscription = await this.stripeHelper.stripe.subscriptions.update(
-      subscriptionId,
-      {
-        cancel_at_period_end: false,
-      }
-    );
-    if (!['active', 'trialing'].includes(subscription.status)) {
-      const err = new Error(
-        `Reactivated subscription (${subscriptionId}) is not active/trialing`
-      );
-      throw error.backendServiceFailure(
-        'stripe',
-        'reactivateSubscription',
-        {},
-        err
-      );
-    }
 
     await this.customerChanged(request, uid, email);
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -1898,82 +1898,6 @@ describe('DirectStripeRoutes', () => {
     });
   });
 
-  describe('updateSubscription', () => {
-    describe('when the plan is a valid upgrade', () => {
-      it('returns the subscription id', async () => {
-        const subscriptionId = 'sub_123';
-        const expected = { subscriptionId: subscriptionId };
-
-        directStripeRoutesInstance.stripeHelper.subscriptionForCustomer.resolves(
-          subscription2
-        );
-        directStripeRoutesInstance.stripeHelper.verifyPlanUpgradeForSubscription.resolves();
-        directStripeRoutesInstance.stripeHelper.changeSubscriptionPlan.resolves();
-
-        sinon.stub(directStripeRoutesInstance, 'customerChanged').resolves();
-
-        VALID_REQUEST.params = { subscriptionId: subscriptionId };
-        VALID_REQUEST.payload = { planId: 'plan_123' };
-
-        const actual = await directStripeRoutesInstance.updateSubscription(
-          VALID_REQUEST
-        );
-
-        assert.deepEqual(actual, expected);
-      });
-    });
-
-    describe('when the orginal subscription is not found', () => {
-      it('throws an exception', async () => {
-        directStripeRoutesInstance.stripeHelper.subscriptionForCustomer.resolves();
-        VALID_REQUEST.params = { subscriptionId: 'sub_123' };
-        VALID_REQUEST.payload = { planId: 'plan_123' };
-
-        return directStripeRoutesInstance
-          .updateSubscription(VALID_REQUEST)
-          .then(
-            () => Promise.reject(new Error('Method expected to reject')),
-            err => {
-              assert.instanceOf(err, WError);
-              assert.equal(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION);
-              assert.equal(err.message, 'Unknown subscription');
-            }
-          );
-      });
-    });
-  });
-
-  describe('listPlans', () => {
-    it('returns the available plans when auth headers are valid', async () => {
-      const expected = PLANS;
-
-      directStripeRoutesInstance.stripeHelper.allPlans.returns(PLANS);
-      const actual = await directStripeRoutesInstance.listPlans(VALID_REQUEST);
-
-      assert.deepEqual(actual, expected);
-    });
-
-    it('results in an error when auth headers are invalid', async () => {
-      const invalid_request = {
-        auth: {
-          credentials: {
-            scope: ['profile'],
-            user: `${UID}`,
-            email: `${TEST_EMAIL}`,
-          },
-        },
-      };
-
-      return directStripeRoutesInstance.listPlans(invalid_request).then(
-        () => Promise.reject(new Error('Method expected to reject')),
-        err => {
-          assert.instanceOf(err, WError);
-          assert.equal(err.message, 'Requested scopes are not allowed');
-        }
-      );
-    });
-  });
-
   describe('findCustomerSubscriptionByPlanId', () => {
     describe('Customer has Single One-Plan Subscription', () => {
       const customer = Object.create(customerFixture);
@@ -2094,6 +2018,113 @@ describe('DirectStripeRoutes', () => {
   });
 
   describe('updatePayment', () => {});
+
+  describe('reactivateSubscription', () => {
+    const reactivateRequest = {
+      auth: {
+        credentials: {
+          scope: MOCK_SCOPES,
+          user: `${UID}`,
+          email: `${TEST_EMAIL}`,
+        },
+      },
+      app: {
+        devices: ['deviceId1', 'deviceId2'],
+      },
+      payload: { subscriptionId: subscription2.id },
+    };
+
+    it('returns an empty object', async () => {
+      directStripeRoutesInstance.stripeHelper.reactivateSubscriptionForCustomer.resolves();
+      const actual = await directStripeRoutesInstance.reactivateSubscription(
+        reactivateRequest
+      );
+
+      assert.isEmpty(actual);
+    });
+  });
+
+  describe('updateSubscription', () => {
+    describe('when the plan is a valid upgrade', () => {
+      it('returns the subscription id', async () => {
+        const subscriptionId = 'sub_123';
+        const expected = { subscriptionId: subscriptionId };
+
+        directStripeRoutesInstance.stripeHelper.subscriptionForCustomer.resolves(
+          subscription2
+        );
+        directStripeRoutesInstance.stripeHelper.verifyPlanUpgradeForSubscription.resolves();
+        directStripeRoutesInstance.stripeHelper.changeSubscriptionPlan.resolves();
+
+        sinon.stub(directStripeRoutesInstance, 'customerChanged').resolves();
+
+        VALID_REQUEST.params = { subscriptionId: subscriptionId };
+        VALID_REQUEST.payload = { planId: 'plan_123' };
+
+        const actual = await directStripeRoutesInstance.updateSubscription(
+          VALID_REQUEST
+        );
+
+        assert.deepEqual(actual, expected);
+      });
+    });
+
+    describe('when the orginal subscription is not found', () => {
+      it('throws an exception', async () => {
+        directStripeRoutesInstance.stripeHelper.subscriptionForCustomer.resolves();
+        VALID_REQUEST.params = { subscriptionId: 'sub_123' };
+        VALID_REQUEST.payload = { planId: 'plan_123' };
+
+        return directStripeRoutesInstance
+          .updateSubscription(VALID_REQUEST)
+          .then(
+            () => Promise.reject(new Error('Method expected to reject')),
+            err => {
+              assert.instanceOf(err, WError);
+              assert.equal(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION);
+              assert.equal(err.message, 'Unknown subscription');
+            }
+          );
+      });
+    });
+  });
+
+  describe('listPlans', () => {
+    it('returns the available plans when auth headers are valid', async () => {
+      const expected = PLANS;
+
+      directStripeRoutesInstance.stripeHelper.allPlans.returns(PLANS);
+      const actual = await directStripeRoutesInstance.listPlans(VALID_REQUEST);
+
+      assert.deepEqual(actual, expected);
+    });
+
+    it('results in an error when auth headers are invalid', async () => {
+      const invalid_request = {
+        auth: {
+          credentials: {
+            scope: ['profile'],
+            user: `${UID}`,
+            email: `${TEST_EMAIL}`,
+          },
+        },
+      };
+
+      return directStripeRoutesInstance.listPlans(invalid_request).then(
+        () => Promise.reject(new Error('Method expected to reject')),
+        err => {
+          assert.instanceOf(err, WError);
+          assert.equal(err.message, 'Requested scopes are not allowed');
+        }
+      );
+    });
+  });
+
+  describe('listActive', () => {});
+
+  describe('getCustomer', () => {});
+
+  describe('sendSubscriptionStatusToSqs', () => {});
 
   describe('updateCustomerAndSendStatus', () => {
     let event;
@@ -2246,6 +2277,10 @@ describe('DirectStripeRoutes', () => {
       });
     });
   });
+
+  describe('getCustomerUidEmailFromSubscription', () => {});
+
+  describe('getSubscriptions', () => {});
 
   describe('getUidEmail', () => {
     let handleAuthSpy;


### PR DESCRIPTION
- refactored reactivateSubscription, so as to not call stripe library directly
- added coverage for reactivateSubscription in subscriptions.js DirectStripeRoutes
- added coverage for new reactivateSubscriptionForCustomer in stripe.js StripeHelper
- added placeholders for upcoming tests to reduce likelihood of merge conflicts

fixes #4230