### PR TITLE
chore(auth-server): remove subscription capabilities in server config

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -56,6 +56,7 @@
           "product_id": "123doneProProduct",
           "product_name": "123done Pro",
           "product_metadata": {
+            "capabilities:dcdb5ae7add825d2": "123donePro",
             "productSet": "123done_product",
             "productSetOrder": "1",
             "upgradeCTA": "Interested in an upgrade? <a href=\"http://127.0.0.1:3030/subscriptions/products/123doneProPlusProduct \">Get Pro+!</a>",
@@ -73,6 +74,7 @@
           "product_id": "123doneProPlusProduct",
           "product_name": "123done Pro+",
           "product_metadata": {
+            "capabilities:dcdb5ae7add825d2": "123donePro",
             "downloadURL": "http://127.0.0.1:8080/",
             "productSet": "123done_product",
             "productSetOrder": "2"
@@ -87,6 +89,7 @@
           "product_id": "321doneProProduct",
           "product_name": "321done Pro",
           "product_metadata": {
+            "capabilities:325b4083e32fe8e7": "321donePro",
             "webIconURL": "http://placekitten.com/512/512?image=7",
             "emailIconURL": "http://placekitten.com/512/512?image=1",
             "downloadURL": "http://127.0.0.1:8080/"
@@ -101,6 +104,8 @@
           "product_id": "allDoneProProduct",
           "product_name": "123done Pro and 321done Pro",
           "product_metadata": {
+            "capabilities:dcdb5ae7add825d2": "123donePro",
+            "capabilities:325b4083e32fe8e7": "321donePro",
             "webIconURL": "http://placekitten.com/512/512?image=8",
             "emailIconURL": "http://placekitten.com/512/512?image=2",
             "downloadURL": "http://127.0.0.1:8080/"
@@ -115,6 +120,7 @@
           "product_id": "fortressProProduct",
           "product_name": "Fortress Pro",
           "product_metadata": {
+            "capabilities": "fortress",
             "webIconURL": "http://placekitten.com/512/512?image=9",
             "emailIconURL": "http://placekitten.com/512/512?image=3",
             "downloadURL": "http://127.0.0.1:9292/"
@@ -129,6 +135,7 @@
           "product_id": "321doneProProduct",
           "product_name": "321done Pro",
           "product_metadata": {
+            "capabilities:325b4083e32fe8e7": "321donePro",
             "webIconURL": "http://placekitten.com/512/512?image=10",
             "emailIconURL": "http://placekitten.com/512/512?image=4",
             "downloadURL": "http://127.0.0.1:8080/"
@@ -143,6 +150,8 @@
           "product_id": "allDoneProProduct",
           "product_name": "123done Pro and 321done Pro",
           "product_metadata": {
+            "capabilities:dcdb5ae7add825d2": "123donePro",
+            "capabilities:325b4083e32fe8e7": "321donePro",
             "webIconURL": "http://placekitten.com/512/512?image=11",
             "emailIconURL": "http://placekitten.com/512/512?image=5",
             "downloadURL": "http://127.0.0.1:8080/"
@@ -156,35 +165,7 @@
   },
   "subscriptions": {
     "enabled": true,
-    "productCapabilities": {
-      "123doneProProduct": ["123donePro"],
-      "321doneProProduct": ["321donePro"],
-      "allDoneProProduct": ["123donePro", "321donePro"],
-      "exampleProd1": ["exampleCap1", "exampleCap2", "exampleCap3"],
-      "exampleProd2": ["exampleCap4", "exampleCap5"],
-      "exampleProd3": [
-        "exampleCap1",
-        "exampleCap2",
-        "exampleCap3",
-        "exampleCap4",
-        "exampleCap5"
-      ]
-    },
-    "sharedSecret": "devsecret",
-    "clientCapabilities": {
-      "dcdb5ae7add825d2": [
-        "123donePro",
-        "exampleCap1",
-        "exampleCap3",
-        "exampleCap5"
-      ],
-      "325b4083e32fe8e7": [
-        "321donePro",
-        "exampleCap2",
-        "exampleCap4",
-        "exampleCap6"
-      ]
-    }
+    "sharedSecret": "devsecret"
   },
   "totp": {
     "recoveryCodes": {

--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -666,21 +666,6 @@ const conf = convict({
       default: 'YOU MUST CHANGE ME',
       env: 'SUBSCRIPTIONS_SHARED_SECRET',
     },
-    // TODO: issue #3913 - remove support for capabilities from server config
-    productCapabilities: {
-      doc: 'Mappings from product names to subscription capability names',
-      format: Object,
-      env: 'SUBSCRIPTIONS_PRODUCT_CAPABILITIES',
-      default: {},
-    },
-    // TODO: issue #3913 - remove support for capabilities from server config
-    clientCapabilities: {
-      doc:
-        'Mappings from OAuth client IDs to relevant subscription capabilities',
-      format: Object,
-      env: 'SUBSCRIPTIONS_CLIENT_CAPABILITIES',
-      default: {},
-    },
     stripeApiKey: {
       default: '',
       env: 'SUBHUB_STRIPE_APIKEY',

--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -17,12 +17,6 @@ const amplitude = require('./metrics/amplitude')(
   config.getProperties()
 );
 const sub = require('./jwt_sub');
-const subConfig = {
-  subscriptions: {
-    productCapabilities: config.get('subscriptions.productCapabilities'),
-    clientCapabilities: config.get('subscriptions.clientCapabilities'),
-  },
-};
 const {
   determineClientVisibleSubscriptionCapabilities,
 } = require('../routes/utils/subscriptions');
@@ -52,10 +46,6 @@ const UNTRUSTED_CLIENT_ALLOWED_SCOPES = ScopeSet.fromArray([
   'profile:email',
   'profile:display_name',
 ]);
-let authdb = {};
-module.exports.setDB = function(db) {
-  authdb = db;
-};
 let stripeHelper = null;
 module.exports.setStripeHelper = function(val) {
   stripeHelper = val;
@@ -252,12 +242,9 @@ exports.generateAccessToken = async function generateAccessToken(grant) {
 
   if (grant.scope.contains('profile:subscriptions')) {
     const capabilities = await determineClientVisibleSubscriptionCapabilities(
-      subConfig,
-      {},
-      authdb,
+      stripeHelper,
       hex(grant.userId),
       grant.clientId,
-      stripeHelper,
       grant.email
     );
     // To avoid mutating the input grant, create a

--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -996,12 +996,9 @@ module.exports = (
           scope.contains('profile:subscriptions')
         ) {
           const capabilities = await determineClientVisibleSubscriptionCapabilities(
-            config,
-            auth,
-            db,
+            stripeHelper,
             uid,
             client_id,
-            stripeHelper,
             account.primaryEmail.email
           );
           if (capabilities) {

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -52,7 +52,6 @@ module.exports = function(
   const idp = require('./idp')(log, serverPublicKeys);
   const oauthServer = require('../oauth/routes');
   const grant = require('../oauth/grant');
-  grant.setDB(db);
   grant.setStripeHelper(stripeHelper);
   const account = require('./account')(
     log,

--- a/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
@@ -9,8 +9,6 @@ const assert = require('chai').assert;
 const mocks = require('../../../mocks');
 
 const {
-  PRODUCT_SUBSCRIBED,
-  PRODUCT_REGISTERED,
   determineClientVisibleSubscriptionCapabilities,
   metadataFromPlan,
 } = require('../../../../lib/routes/utils/subscriptions');
@@ -32,28 +30,11 @@ const MOCK_SUBSCRIPTIONS = [
     createdAt: NOW,
   },
 ];
-const MOCK_CONFIG = {
-  subscriptions: {
-    productCapabilities: {
-      p1: ['cap1', 'cap2', 'cap3'],
-      p2: ['cap4', 'cap5', 'cap6'],
-      p3: ['cap7', 'cap8', 'cap9'],
-      [PRODUCT_SUBSCRIBED]: ['capSubscribed'],
-      [PRODUCT_REGISTERED]: ['capRegistered'],
-    },
-    clientCapabilities: {
-      c1: ['cap1', 'cap5', 'cap9'],
-      c2: ['capSubscribed'],
-      c3: ['capRegistered'],
-    },
-  },
-};
 
 describe('routes/utils/subscriptions', () => {
-  let auth, db;
+  let db;
 
   beforeEach(async () => {
-    auth = { strategy: 'oauthToken' };
     db = mocks.mockDB();
     db.fetchAccountSubscriptions = sinon.spy(async uid =>
       MOCK_SUBSCRIPTIONS.filter(s => s.uid === uid)
@@ -78,6 +59,7 @@ describe('routes/utils/subscriptions', () => {
           {
             product_id: 'prod_123456',
             product_metadata: {
+              capabilities: 'capAll',
               'capabilities:c1': 'cap4,cap5',
               'capabilities:c2': 'cap5,cap6',
             },
@@ -85,20 +67,20 @@ describe('routes/utils/subscriptions', () => {
           {
             product_id: 'prod_876543',
             product_metadata: {
-              'capabilities:c2': 'capC,capD',
-              'capabilities:c3': 'capD,capE',
+              'capabilities:c2': 'capC,   capD',
+              'capabilities:c3': 'capD, capE',
             },
           },
           {
             product_id: 'prod_ABCDEF',
             product_metadata: {
-              'capabilities:c3': 'capZ,capW',
+              'capabilities:c3': ' capZ,   capW   ',
             },
           },
           {
             product_id: 'prod_456789',
             product_metadata: {
-              'capabilities:c3': 'capZ,capW',
+              'capabilities:c3': '   capZ,capW',
             },
           },
         ]),
@@ -108,13 +90,10 @@ describe('routes/utils/subscriptions', () => {
     async function assertExpectedCapabilities(clientId, expectedCapabilities) {
       assert.deepEqual(
         await determineClientVisibleSubscriptionCapabilities(
-          MOCK_CONFIG,
-          auth,
-          db,
+          mockStripeHelper,
           UID,
           // null client represents sessionToken auth from content-server, unfiltered by client
           clientId === 'null' ? null : clientId,
-          mockStripeHelper,
           EMAIL
         ),
         expectedCapabilities
@@ -123,11 +102,11 @@ describe('routes/utils/subscriptions', () => {
 
     it('only reveals capabilities relevant to the client', async () => {
       const expected = {
-        c0: undefined,
-        c1: ['cap4', 'cap5'],
-        c2: ['cap5', 'cap6', 'capC', 'capD', 'capSubscribed'],
-        c3: ['capD', 'capE', 'capRegistered'],
-        null: ['cap4', 'cap5', 'cap6', 'capC', 'capD', 'capE'],
+        c0: ['capAll'],
+        c1: ['capAll', 'cap4', 'cap5'],
+        c2: ['capAll', 'cap5', 'cap6', 'capC', 'capD'],
+        c3: ['capAll', 'capD', 'capE'],
+        null: ['capAll', 'cap4', 'cap5', 'cap6', 'capC', 'capD', 'capE'],
       };
       for (const clientId in expected) {
         await assertExpectedCapabilities(clientId, expected[clientId]);
@@ -151,134 +130,15 @@ describe('routes/utils/subscriptions', () => {
         {
           product_id: 'prod_ABCDEF',
           product_metadata: {
-            capabilities: 'cap00,cap01,cap02',
+            capabilities: 'cap00,  cap01,cap02',
           },
         },
       ]);
 
       for (const clientId of ['c0', 'c1', 'c2', 'c3', 'null']) {
         const expected = ['cap1', 'cap2', 'cap3', 'capA', 'capB', 'capC'];
-        if (clientId === 'c2') {
-          expected.push('capSubscribed');
-        }
-        if (clientId === 'c3') {
-          expected.push('capRegistered');
-        }
         await assertExpectedCapabilities(clientId, expected);
       }
-    });
-
-    // TODO: This capability still comes from server config, not stripe metadata
-    it('implicitly includes subscribed default product for users with at least one subscription', async () => {
-      const client = 'c2';
-      const result = await determineClientVisibleSubscriptionCapabilities(
-        MOCK_CONFIG,
-        auth,
-        db,
-        UID,
-        client,
-        mockStripeHelper,
-        EMAIL
-      );
-      assert.include(result, 'capSubscribed');
-    });
-
-    // TODO: This capability still comes from server config, not stripe metadata
-    it('implicitly includes registered default product even for users with no subscriptions', async () => {
-      const client = 'c3';
-      mockStripeHelper.customer = sinon.spy(async () => ({
-        subscriptions: {
-          data: [],
-        },
-      }));
-      const result = await determineClientVisibleSubscriptionCapabilities(
-        MOCK_CONFIG,
-        auth,
-        db,
-        UID,
-        client,
-        mockStripeHelper,
-        EMAIL
-      );
-      assert.deepEqual(result, ['capRegistered']);
-    });
-  });
-
-  // TODO: issue #3846 - remove these tests
-  describe('determineClientVisibleSubscriptionCapabilities with local DB table', () => {
-    afterEach(() => {
-      // Each of these tests should cause a fetch of subscriptions
-      assert.deepEqual(db.fetchAccountSubscriptions.args, [[UID]]);
-    });
-
-    it('should reveal all subscribed capabilities to a sessionToken client', async () => {
-      auth.strategy = 'sessionToken';
-      const result = await determineClientVisibleSubscriptionCapabilities(
-        MOCK_CONFIG,
-        auth,
-        db,
-        UID,
-        null
-      );
-      assert.deepEqual(result, [
-        'capRegistered',
-        'cap1',
-        'cap2',
-        'cap3',
-        'cap4',
-        'cap5',
-        'cap6',
-        'capSubscribed',
-      ]);
-    });
-
-    it('should only reveal capabilities relevant to the client', async () => {
-      const client = 'c1';
-      const result = await determineClientVisibleSubscriptionCapabilities(
-        MOCK_CONFIG,
-        auth,
-        db,
-        UID,
-        client
-      );
-      assert.deepEqual(result, ['cap1', 'cap5']);
-    });
-
-    it('should return undefined if no capabilities are visible to client', async () => {
-      const client = 'someRando';
-      const result = await determineClientVisibleSubscriptionCapabilities(
-        MOCK_CONFIG,
-        auth,
-        db,
-        UID,
-        client
-      );
-      assert.deepEqual(result, undefined);
-    });
-
-    it('should implicitly include subscribed default product for users with at least one subscription', async () => {
-      const client = 'c2';
-      const result = await determineClientVisibleSubscriptionCapabilities(
-        MOCK_CONFIG,
-        auth,
-        db,
-        UID,
-        client
-      );
-      assert.deepEqual(result, ['capSubscribed']);
-    });
-
-    it('should implicitly include registered default product for all users', async () => {
-      const client = 'c3';
-      db.fetchAccountSubscriptions = sinon.spy(async uid => []);
-      const result = await determineClientVisibleSubscriptionCapabilities(
-        MOCK_CONFIG,
-        auth,
-        db,
-        UID,
-        client
-      );
-      assert.deepEqual(result, ['capRegistered']);
     });
   });
 

--- a/packages/fxa-auth-server/test/oauth/grant.js
+++ b/packages/fxa-auth-server/test/oauth/grant.js
@@ -278,16 +278,6 @@ describe('generateTokens', () => {
           case 'oauthServer.jwtAccessTokens.enabledClientIds': {
             return ['9876543210'];
           }
-          case 'subscriptions.productCapabilities': {
-            return {
-              prod0: 'my-sub',
-            };
-          }
-          case 'subscriptions.clientCapabilities': {
-            return {
-              '9876543210': 'my-sub',
-            };
-          }
           default: {
             return config.get(key);
           }
@@ -312,12 +302,6 @@ describe('generateTokens', () => {
       './metrics/amplitude': () => mockAmplitude,
     });
 
-    grantModule.setDB({
-      fetchAccountSubscriptions: sinon.spy(async () => [
-        { productId: 'prod0' },
-      ]),
-    });
-
     grantModule.setStripeHelper(undefined);
 
     generateTokens = grantModule.generateTokens;
@@ -329,31 +313,6 @@ describe('generateTokens', () => {
     assert.isFalse(mockJWTAccessToken.create.called);
 
     assert.strictEqual(result.access_token, 'token');
-    assert.isNumber(result.expires_in);
-    assert.strictEqual(result.token_type, 'access_token');
-    assert.strictEqual(
-      result.scope,
-      'profile:uid profile:email profile:subscriptions'
-    );
-
-    assert.isFalse('auth_at' in result);
-    assert.isFalse('keys_jwe' in result);
-    assert.isFalse('refresh_token' in result);
-    assert.isFalse('id_token' in result);
-  });
-
-  it('should generate a JWT access token if enabled, client_id allowed', async () => {
-    requestedGrant.clientId = '9876543210';
-    const result = await generateTokens(requestedGrant);
-    assert.isTrue(mockDB.generateAccessToken.calledOnceWith(requestedGrant));
-    assert.strictEqual(result.access_token, 'signed jwt access token');
-    assert.isTrue(
-      mockJWTAccessToken.create.calledOnceWith(mockAccessToken, {
-        ...requestedGrant,
-        'fxa-subscriptions': ['my-sub'],
-      })
-    );
-
     assert.isNumber(result.expires_in);
     assert.strictEqual(result.token_type, 'access_token');
     assert.strictEqual(
@@ -400,7 +359,7 @@ describe('generateTokens', () => {
     assert.isTrue(
       mockJWTAccessToken.create.calledOnceWith(mockAccessToken, {
         ...requestedGrant,
-        'fxa-subscriptions': ['cap1', 'my-sub'],
+        'fxa-subscriptions': ['cap1'],
       })
     );
 


### PR DESCRIPTION
- remove support and tests for subscription capabilities sourced from
  server config

- add support for capabilities from Stripe metadata in
  /oauth/subscriptions/clients getClients API

- ensure subscription status SQS messages include product capabilities
  from Stripe metadata

- ensure plans are sanitized to remove capabilities in API responses

- add better handling for varied whitespace in capability lists

https://jira.mozilla.com/browse/FXA-944
fixes #3913