### PR TITLE
test(auth-server): Coverage for createSubscriptionExistingCustomer

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -186,17 +186,10 @@ class DirectStripeRoutes {
       // Note that if the customer already exists and we were not
       // passed a paymentToken value, we will not update it and use
       // the default source.
-      try {
-        await this.stripeHelper.updateCustomerPaymentMethod(
-          customer.id,
-          paymentToken
-        );
-      } catch (err) {
-        if (err.type === 'StripeCardError') {
-          throw error.rejectedSubscriptionPaymentToken(err.message, err);
-        }
-        throw err;
-      }
+      await this.stripeHelper.updateCustomerPaymentMethod(
+        customer.id,
+        paymentToken
+      );
     }
 
     // Check if the customer already has subscribed to this plan.


### PR DESCRIPTION
- added code coverage for specified function
- removed duplicate code. the stripe error handling was already being taken care of by the method being called

fixes #4227