### PR TITLE
Fix typo in RECOVERY_KEY text

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/post_verify/verified.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/verified.js
@@ -18,7 +18,7 @@ const TEMPLATE_INFO = {
     headerId: 'fxa-account-recovery-complete-header',
     headerTitle: t('Your sync data is protected'),
     readyText: t(
-      'If you lose access to your account, youll be able to restore your sync data.'
+      'If you lose access to your account, you’ll be able to restore your sync data.'
     ),
     buttonText: t('Start browsing'),
   },


### PR DESCRIPTION
Just noticed this while localizing the string. A quotation mark is missing.