### PR TITLE
feat(oauth): store access tokens in redis

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -206,7 +206,9 @@
     },
     "clientIdToServiceNames": {
       "dcdb5ae7add825d2": "123done",
-      "98e6508e88680e1a": "fxa-settings"
+      "98e6508e88680e1a": "fxa-settings",
+      "7377719276ad44ee": "pocket-mobile",
+      "749818d3f2e7857f": "pocket-web"
     },
     "clients": [
       {

--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -890,6 +890,9 @@ const conf = convict({
       },
     },
     clientIdToServiceNames: {
+      // This is used by oauth/db/index.js to identify pocket client ids so that it
+      // can store them separately in mysql.
+      // It's also used for amplitude stats
       doc:
         'Mappings from client id to service name: { "id1": "name-1", "id2": "name-2" }',
       default: {},

--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -337,6 +337,24 @@ const conf = convict({
       format: 'port',
       doc: 'Port for Redis server',
     },
+    accessTokens: {
+      host: {
+        default: '127.0.0.1',
+        env: 'ACCESS_TOKEN_REDIS_HOST',
+        format: String,
+      },
+      port: {
+        default: 6379,
+        env: 'ACCESS_TOKEN_REDIS_PORT',
+        format: 'port',
+      },
+      prefix: {
+        default: 'at:',
+        env: 'ACCESS_TOKEN_REDIS_KEY_PREFIX',
+        format: String,
+        doc: 'Key prefix for access tokens in Redis',
+      },
+    },
     sessionTokens: {
       enabled: {
         default: true,

--- a/packages/fxa-auth-server/lib/luaScripts/removeAccessToken_1.lua
+++ b/packages/fxa-auth-server/lib/luaScripts/removeAccessToken_1.lua
@@ -1,8 +1,6 @@
-local tokenId = KEYS[1]
-local _, _, prefix = tokenId:find('(%a+:)')
-local value = redis.call('get', tokenId)
-if value then
-  local token = cjson.decode(value)
-  redis.call('srem', prefix..token.userId, tokenId)
-  return redis.call('del', tokenId)
+local id = KEYS[1]
+local exists = redis.call('exists', id)
+if exists then
+  redis.call('del', id)
 end
+return exists

--- a/packages/fxa-auth-server/lib/luaScripts/removeAccessTokensForPublicClients_1.lua
+++ b/packages/fxa-auth-server/lib/luaScripts/removeAccessTokensForPublicClients_1.lua
@@ -1,18 +1,20 @@
 local uid = KEYS[1]
 local ids = redis.call('smembers', uid)
 local toDel = {}
-for _, id in ipairs(ids) do
-  local v = redis.call('get', id)
-  if v then
-    local t = cjson.decode(v)
-    if t.canGrant or t.publicClient then
-      table.insert(toDel, id)
+if #ids > 0 then
+  local values = redis.call('mget', unpack(ids))
+  for i, value in ipairs(values) do
+    if value then
+      local token = cjson.decode(value)
+      if token.canGrant or token.publicClient then
+        table.insert(toDel, ids[i])
+      end
+    else
+      table.insert(toDel, ids[i])
     end
-  else
-    table.insert(toDel, id)
   end
-end
-if #toDel > 0 then
-  redis.call('srem', uid, unpack(toDel))
-  redis.call('unlink', unpack(toDel))
+  if #toDel > 0 then
+    redis.call('srem', uid, unpack(toDel))
+    redis.call('unlink', unpack(toDel))
+  end
 end

--- a/packages/fxa-auth-server/lib/luaScripts/removeAccessTokensForUser_1.lua
+++ b/packages/fxa-auth-server/lib/luaScripts/removeAccessTokensForUser_1.lua
@@ -3,5 +3,5 @@ local ids = redis.call('smembers', uid)
 
 if #ids > 0 then
   redis.call('unlink', unpack(ids))
+  redis.call('del', uid)
 end
-redis.call('del', uid)

--- a/packages/fxa-auth-server/lib/luaScripts/setAccessToken_2.lua
+++ b/packages/fxa-auth-server/lib/luaScripts/setAccessToken_2.lua
@@ -8,4 +8,4 @@ if ttl then
   table.insert(args, ttl)
 end
 redis.call('set', tokenId, unpack(args))
-return redis.call('sadd', userId, tokenId)
+redis.call('sadd', userId, tokenId)

--- a/packages/fxa-auth-server/lib/oauth/db/accessToken.js
+++ b/packages/fxa-auth-server/lib/oauth/db/accessToken.js
@@ -40,8 +40,7 @@ class AccessToken {
     /** @type {Buffer} */
     this.token = token || unique.token();
     /** @type {Date} */
-    this.createdAt = createdAt || new Date();
-    this.createdAt.setMilliseconds(0);
+    this.createdAt = createdAt || new Date(new Date().setMilliseconds(0));
     /** @type {number} */
     this.profileChangedAt = profileChangedAt || 0;
     /** @type {Date} */

--- a/packages/fxa-auth-server/lib/oauth/db/accessToken.js
+++ b/packages/fxa-auth-server/lib/oauth/db/accessToken.js
@@ -39,7 +39,7 @@ class AccessToken {
     this.scope = scope;
     /** @type {Buffer} */
     this.token = token || unique.token();
-    /** @type {Date} */
+    /** @type {Date} truncated to the second to match mysql */
     this.createdAt = createdAt || new Date(new Date().setMilliseconds(0));
     /** @type {number} */
     this.profileChangedAt = profileChangedAt || 0;

--- a/packages/fxa-auth-server/lib/oauth/db/accessToken.js
+++ b/packages/fxa-auth-server/lib/oauth/db/accessToken.js
@@ -41,6 +41,7 @@ class AccessToken {
     this.token = token || unique.token();
     /** @type {Date} */
     this.createdAt = createdAt || new Date();
+    this.createdAt.setMilliseconds(0);
     /** @type {number} */
     this.profileChangedAt = profileChangedAt || 0;
     /** @type {Date} */
@@ -61,6 +62,14 @@ class AccessToken {
 
   get ttl() {
     return this.expiresAt.getTime() - Date.now();
+  }
+
+  get lastAccessTime() {
+    return this.createdAt;
+  }
+
+  get id() {
+    return this.clientId;
   }
 
   /**

--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -61,7 +61,10 @@ class OauthDB {
       vals.ttl
     );
     if (POCKET_IDS.includes(hex(vals.clientId))) {
-      // since Pocket access tokens are long lived store them in mysql
+      // Pocket tokens are persisted past their expiration for legacy
+      // reasons: https://bugzilla.mozilla.org/show_bug.cgi?id=1547902
+      // since they are long lived we continue to store them in mysql
+      // so that redis can be exclusively ephemeral
       const db = await this.mysql;
       await db._generateAccessToken(token);
     } else {

--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -93,9 +93,8 @@ class OauthDB {
   async getActiveClientsByUid(uid) {
     const tokens = await this.redis.getAccessTokens(uid);
     const activeClientTokens = [];
-    const now = new Date();
     for (const token of tokens) {
-      if (token.expiresAt > now && !token.canGrant) {
+      if (!token.canGrant) {
         activeClientTokens.push(token);
       }
     }

--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -31,7 +31,10 @@ class OauthDB {
       await preClients();
       await scopes();
     });
-    this.redis = redis({ enabled: true, prefix: 'oauth:' }, logger); //TODO oauth redis config
+    this.redis = redis(
+      { ...config.get('redis.accessTokens'), enabled: true },
+      logger
+    );
     Object.keys(mysql.prototype).forEach(key => {
       const self = this;
       this[key] = async function() {

--- a/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
@@ -557,7 +557,7 @@ MysqlStore.prototype = {
    * @param {String} uid User Id as Hex
    * @returns {Promise}
    */
-  _deleteClientAuthorization: function deleteClientAuthorization(
+  _deleteClientAuthorization: function _deleteClientAuthorization(
     clientId,
     uid
   ) {
@@ -597,7 +597,7 @@ MysqlStore.prototype = {
    * @param {String} uid User Id as Hex
    * @returns {Promise} `true` if the token was found and deleted, `false` otherwise
    */
-  _deleteClientRefreshToken: async function deleteClientRefreshToken(
+  _deleteClientRefreshToken: async function _deleteClientRefreshToken(
     refreshTokenId,
     clientId,
     uid
@@ -910,7 +910,7 @@ MysqlStore.prototype = {
       });
   },
 
-  _removeUser: function removeUser(userId) {
+  _removeUser: function _removeUser(userId) {
     // TODO this should be a transaction or stored procedure
     var id = buf(userId);
     return this._write(QUERY_ACCESS_TOKEN_DELETE_USER, [id])

--- a/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
@@ -10,15 +10,12 @@ const moment = require('moment');
 const mysql = require('mysql');
 const MysqlPatcher = require('mysql-patcher');
 
-const config = require('../../../../config');
 const encrypt = require('../../encrypt');
-const helpers = require('../helpers');
 const P = require('../../../promise');
 const ScopeSet = require('../../../../../fxa-shared').oauth.scopes;
 const unique = require('../../unique');
 const patch = require('./patch');
 
-const MAX_TTL = config.get('oauthServer.expiration.accessToken');
 const REQUIRED_SQL_MODES = ['STRICT_ALL_TABLES', 'NO_ENGINE_SUBSTITUTION'];
 const REQUIRED_CHARSET = 'UTF8MB4_UNICODE_CI';
 
@@ -469,30 +466,18 @@ MysqlStore.prototype = {
     var hash = encrypt.hash(code);
     return this._write(QUERY_CODE_DELETE, [hash]);
   },
-  generateAccessToken: function generateAccessToken(vals) {
-    var t = {
-      clientId: buf(vals.clientId),
-      userId: buf(vals.userId),
-      email: vals.email,
-      scope: vals.scope,
-      token: unique.token(),
-      type: 'bearer',
-      expiresAt:
-        vals.expiresAt || new Date(Date.now() + (vals.ttl * 1000 || MAX_TTL)),
-      profileChangedAt: vals.profileChangedAt || 0,
-    };
+
+  _generateAccessToken: function _generateAccessToken(accessToken) {
     return this._write(QUERY_ACCESS_TOKEN_INSERT, [
-      t.clientId,
-      t.userId,
-      t.email,
-      t.scope.toString(),
-      t.type,
-      t.expiresAt,
-      encrypt.hash(t.token),
-      t.profileChangedAt,
-    ]).then(function() {
-      return t;
-    });
+      accessToken.clientId,
+      accessToken.userId,
+      accessToken.email,
+      accessToken.scope.toString(),
+      accessToken.type,
+      accessToken.expiresAt,
+      accessToken.tokenId,
+      accessToken.profileChangedAt,
+    ]);
   },
 
   /**
@@ -500,7 +485,7 @@ MysqlStore.prototype = {
    * @param id Token Id
    * @returns {*}
    */
-  getAccessToken: function getAccessToken(id) {
+  _getAccessToken: function _getAccessToken(id) {
     return this._readOne(QUERY_ACCESS_TOKEN_FIND, [buf(id)]).then(function(t) {
       if (t) {
         t.scope = ScopeSet.fromString(t.scope);
@@ -514,7 +499,7 @@ MysqlStore.prototype = {
    * @param id
    * @returns {*}
    */
-  removeAccessToken: function removeAccessToken(id) {
+  _removeAccessToken: function _removeAccessToken(id) {
     return this._write(QUERY_ACCESS_TOKEN_DELETE, [buf(id)]);
   },
 
@@ -523,7 +508,7 @@ MysqlStore.prototype = {
    * @param {String} uid User ID as hex
    * @returns {Promise}
    */
-  getActiveClientsByUid: function getActiveClientsByUid(uid) {
+  _getActiveClientsByUid: function _getActiveClientsByUid(uid) {
     return this._read(QUERY_ACTIVE_CLIENT_TOKENS_BY_UID, [
       buf(uid),
       buf(uid),
@@ -531,7 +516,7 @@ MysqlStore.prototype = {
       activeClientTokens.forEach(t => {
         t.scope = ScopeSet.fromString(t.scope);
       });
-      return helpers.aggregateActiveClients(activeClientTokens);
+      return activeClientTokens;
     });
   },
 
@@ -540,7 +525,7 @@ MysqlStore.prototype = {
    * @param {String} uid User ID as hex
    * @returns {Promise}
    */
-  getAccessTokensByUid: async function getAccessTokensByUid(uid) {
+  _getAccessTokensByUid: async function _getAccessTokensByUid(uid) {
     const accessTokens = await this._read(QUERY_LIST_ACCESS_TOKENS_BY_UID, [
       buf(uid),
     ]);
@@ -572,7 +557,10 @@ MysqlStore.prototype = {
    * @param {String} uid User Id as Hex
    * @returns {Promise}
    */
-  deleteClientAuthorization: function deleteClientAuthorization(clientId, uid) {
+  _deleteClientAuthorization: function deleteClientAuthorization(
+    clientId,
+    uid
+  ) {
     const deleteCodes = this._write(DELETE_ACTIVE_CODES_BY_CLIENT_AND_UID, [
       buf(clientId),
       buf(uid),
@@ -609,7 +597,7 @@ MysqlStore.prototype = {
    * @param {String} uid User Id as Hex
    * @returns {Promise} `true` if the token was found and deleted, `false` otherwise
    */
-  deleteClientRefreshToken: async function deleteClientRefreshToken(
+  _deleteClientRefreshToken: async function deleteClientRefreshToken(
     refreshTokenId,
     clientId,
     uid
@@ -922,7 +910,7 @@ MysqlStore.prototype = {
       });
   },
 
-  removeUser: function removeUser(userId) {
+  _removeUser: function removeUser(userId) {
     // TODO this should be a transaction or stored procedure
     var id = buf(userId);
     return this._write(QUERY_ACCESS_TOKEN_DELETE_USER, [id])
@@ -933,10 +921,10 @@ MysqlStore.prototype = {
   /**
    * Removes user's tokens and refreshTokens for canGrant and publicClient clients
    *
-   * @param userId
+   * @param {Buffer | string} userId
    * @returns {Promise}
    */
-  removePublicAndCanGrantTokens: function removePublicAndCanGrantTokens(
+  _removePublicAndCanGrantTokens: function _removePublicAndCanGrantTokens(
     userId
   ) {
     const uid = buf(userId);

--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -138,9 +138,11 @@ module.exports.validateRequestedGrant = async function validateRequestedGrant(
   //   * Is this client allowed to request ACCESS_TYPE_OFFLINE?
   //   * Is this client allowed to request all the non-key-bearing scopes?
   //   * Do we expect this client to be using OIDC?
-
   return {
     clientId: client.id,
+    name: client.name,
+    canGrant: client.canGrant,
+    publicClient: client.publicClient,
     userId: buf(verifiedClaims.uid),
     email: verifiedClaims['fxa-verifiedEmail'],
     scope: requestedGrant.scope,

--- a/packages/fxa-auth-server/lib/oauth/routes/token.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/token.js
@@ -215,6 +215,9 @@ async function validateGrantParameters(client, params) {
       logger.critical('joi.grant_type', { grant_type: params.grant_type });
       throw Error('unreachable');
   }
+  requestedGrant.name = client.name;
+  requestedGrant.canGrant = client.canGrant;
+  requestedGrant.publicClient = client.publicClient;
   requestedGrant.grantType = params.grant_type;
   requestedGrant.ppidSeed = params.ppid_seed;
   requestedGrant.resource = params.resource;

--- a/packages/fxa-auth-server/lib/redis.js
+++ b/packages/fxa-auth-server/lib/redis.js
@@ -112,7 +112,8 @@ class FxaRedis {
    */
   setAccessToken(token) {
     if (token.ttl < 1) {
-      return 0;
+      this.log.error('redis', new Error('invalid ttl on access token'));
+      return;
     }
     return this.redis.setAccessToken(
       token.userId.toString('hex'),

--- a/packages/fxa-auth-server/lib/redis.js
+++ b/packages/fxa-auth-server/lib/redis.js
@@ -83,7 +83,7 @@ class FxaRedis {
    */
   async getAccessToken(tokenId) {
     try {
-      const value = await this.redis.getAccessToken(hex(tokenId));
+      const value = await this.redis.get(hex(tokenId));
       return AccessToken.parse(value);
     } catch (e) {
       this.log.error('redis', e);
@@ -111,6 +111,9 @@ class FxaRedis {
    * @param {AccessToken} token
    */
   setAccessToken(token) {
+    if (token.ttl < 1) {
+      return 0;
+    }
     return this.redis.setAccessToken(
       token.userId.toString('hex'),
       token.tokenId.toString('hex'),
@@ -122,9 +125,13 @@ class FxaRedis {
   /**
    *
    * @param {Buffer | string} id
+   * @returns {Promise<boolean>} done
    */
-  removeAccessToken(id) {
-    return this.redis.removeAccessToken(hex(id));
+  async removeAccessToken(id) {
+    // This does not remove the id from the user's index
+    // because getAccessTokens cleans up expired/missing tokens
+    const done = await this.redis.removeAccessToken(hex(id));
+    return !!done;
   }
 
   /**

--- a/packages/fxa-auth-server/test/lib/oauth-test.json
+++ b/packages/fxa-auth-server/test/lib/oauth-test.json
@@ -16,7 +16,8 @@
       "imageUri": "https://example.domain/logo",
       "redirectUri": "https://example.domain/return?foo=bar",
       "trusted": true,
-      "canGrant": false
+      "canGrant": false,
+      "allowedScopes": "https://identity.mozilla.com/apps/notes https://identity.mozilla.com/apps/lockbox"
     },
     {
       "id": "98e6508e88680e1a",

--- a/packages/fxa-auth-server/test/oauth/grant.js
+++ b/packages/fxa-auth-server/test/oauth/grant.js
@@ -44,6 +44,9 @@ const CLAIMS = {
 
 const CLIENT = {
   id: Buffer.from('0123456789', 'hex'),
+  name: 'Mocha',
+  canGrant: true,
+  publicClient: false,
   trusted: true,
 };
 
@@ -62,6 +65,9 @@ describe('validateRequestedGrant', () => {
     const grant = await validateRequestedGrant(CLAIMS, CLIENT, { scope });
     assert.deepEqual(grant, {
       clientId: CLIENT.id,
+      name: CLIENT.name,
+      canGrant: CLIENT.canGrant,
+      publicClient: CLIENT.publicClient,
       userId: Buffer.from(CLAIMS.uid, 'hex'),
       sessionTokenId: undefined,
       email: CLAIMS['fxa-verifiedEmail'],


### PR DESCRIPTION
The intent here is to store oauth access tokens in redis instead of mysql in order to move load off of mysql in anticipation of increased load from Fenix. We also have a legacy use case that [tokens for Pocket are kept indefinitely](https://bugzilla.mozilla.org/show_bug.cgi?id=1547902) that we need to keep supporting. Instead of putting new Pocket tokens in redis and having to support them in two places I opted to keep them going into mysql while vanilla oauth access tokens only go into redis where they can expire with a set TTL.