### PR TITLE
feat(admin-server): add db and resolvers

### DIFF
--- a/packages/fxa-admin-server/package-lock.json
+++ b/packages/fxa-admin-server/package-lock.json
@@ -187,6 +187,12 @@
       "integrity": "sha512-NeXgZj+MFL4izGqA4sapdYzkzQG+MtGra9vhQ58dnmDY++VgJaRUws+aLVV5zRJCYJl/8s9IjMmhiUw1WsKSmw==",
       "dev": true
     },
+    "@types/chance": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/chance/-/chance-1.0.8.tgz",
+      "integrity": "sha512-S1VWROFGexiUYyBFsP0NRjp6PkJ4rKECQ3HQJ0cJKW/2BcNyas9lXATRdnTNnN4CsICjEXTltAalAo8dJQQLKg==",
+      "dev": true
+    },
     "@types/connect": {
       "version": "3.4.33",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
@@ -198,7 +204,8 @@
     "@types/convict": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@types/convict/-/convict-4.2.1.tgz",
-      "integrity": "sha512-2cd51m3i0yeY1i3dKxcqJKeS5Q4jZnjP37OseoNeIX1OM0AhmGPuuYmwJ9OqtsU35YrREQxdb2VeX5sM3cwGMQ=="
+      "integrity": "sha512-2cd51m3i0yeY1i3dKxcqJKeS5Q4jZnjP37OseoNeIX1OM0AhmGPuuYmwJ9OqtsU35YrREQxdb2VeX5sM3cwGMQ==",
+      "dev": true
     },
     "@types/cookies": {
       "version": "0.7.4",
@@ -997,6 +1004,12 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "chance": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.4.tgz",
+      "integrity": "sha512-pXPDSu3knKlb6H7ahQfpq//J9mSOxYK8SMtp8MV/nRJh8aLRDIl0ipLH8At8+nVogVwtvPZzyIzY/EbcY/cLuQ==",
+      "dev": true
     },
     "check-error": {
       "version": "1.0.2",

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -9,7 +9,7 @@
     "lint:tslint": "./node_modules/tslint/bin/tslint -p .",
     "watch": "tsc -w",
     "start-dev": "npm run build && NODE_ENV=development node ./dist/bin/main.js",
-    "test": "./node_modules/mocha/bin/mocha -r ts-node/register src/test/**/*.spec.ts src/test/**/**/*.spec.ts"
+    "test": "./node_modules/mocha/bin/mocha -r ts-node/register src/test/**/*.spec.ts src/test/**/**/*.spec.ts src/test/**/**/**/*.spec.ts"
   },
   "repository": {
     "type": "git",
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/mozilla/fxa#readme",
   "readmeFilename": "README.md",
   "dependencies": {
-    "@types/convict": "^4.2.1",
     "apollo-server": "^2.9.16",
     "convict": "^5.2.0",
     "graphql": "^14.5.8",
@@ -39,12 +38,15 @@
   },
   "devDependencies": {
     "@types/chai": "^4.2.9",
+    "@types/chance": "^1.0.8",
+    "@types/convict": "^4.2.1",
     "@types/graphql": "^14.5.0",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.1.8",
     "@types/sinon": "^7.5.1",
     "audit-filter": "^0.5.0",
     "chai": "^4.2.0",
+    "chance": "^1.1.4",
     "mocha": "^7.0.1",
     "nodemon": "^2.0.2",
     "npm-run-all": "^4.1.5",

--- a/packages/fxa-admin-server/src/config.ts
+++ b/packages/fxa-admin-server/src/config.ts
@@ -7,6 +7,38 @@ import fs from 'fs';
 import path from 'path';
 
 const conf = convict({
+  database: {
+    database: {
+      default: 'fxa',
+      doc: 'MySQL database',
+      env: 'DB_DATABASE',
+      format: String
+    },
+    host: {
+      default: 'localhost',
+      doc: 'MySQL host',
+      env: 'DB_HOST',
+      format: String
+    },
+    password: {
+      default: '',
+      doc: 'MySQL password',
+      env: 'DB_PASSWORD',
+      format: String
+    },
+    port: {
+      default: 3306,
+      doc: 'MySQL port',
+      env: 'DB_PORT',
+      format: Number
+    },
+    user: {
+      default: 'root',
+      doc: 'MySQL username',
+      env: 'DB_USERNAME',
+      format: String
+    }
+  },
   env: {
     default: 'production',
     doc: 'The current node.js environment',

--- a/packages/fxa-admin-server/src/lib/db/index.ts
+++ b/packages/fxa-admin-server/src/lib/db/index.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Knex from 'knex';
+import { Model } from 'objection';
+
+export type DatabaseConfig = {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+};
+
+export function setupDatabase(opts: DatabaseConfig): Knex {
+  const knex = Knex({ connection: opts, client: 'mysql' });
+  Model.knex(knex);
+  return knex;
+}

--- a/packages/fxa-admin-server/src/lib/db/models/account.ts
+++ b/packages/fxa-admin-server/src/lib/db/models/account.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Model } from 'objection';
+
+import { intBoolTransformer, uuidTransformer } from '../transformers';
+import { Emails } from './emails';
+
+export class Account extends Model {
+  public static tableName = 'accounts';
+  public static idColumn = 'uid';
+
+  public static relationMappings = {
+    emails: {
+      join: {
+        from: 'accounts.uid',
+        to: 'emails.uid'
+      },
+      modelClass: Emails,
+      relation: Model.HasManyRelation
+    }
+  };
+
+  public uid!: string;
+  public email!: string;
+  public emailVerified!: boolean;
+  public normalizedEmail!: string;
+  public createdAt!: number;
+
+  public $parseDatabaseJson(json: any) {
+    json = super.$parseDatabaseJson(json);
+    if (json.uid) {
+      json.uid = uuidTransformer.from(json.uid);
+    }
+    if (json.emailVerified) {
+      json.emailVerified = intBoolTransformer.from(json.emailVerified);
+    }
+    return json;
+  }
+
+  public $formatDatabaseJson(json: any) {
+    json = super.$formatDatabaseJson(json);
+
+    if (json.uid) {
+      json.uid = uuidTransformer.to(json.uid);
+    }
+    if (json.emailVerified) {
+      json.emailVerified = intBoolTransformer.to(json.emailVerified);
+    }
+    return json;
+  }
+}

--- a/packages/fxa-admin-server/src/lib/db/models/email-bounces.ts
+++ b/packages/fxa-admin-server/src/lib/db/models/email-bounces.ts
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Model } from 'objection';
+
+export class EmailBounces extends Model {
+  public static tableName = 'emailBounces';
+  public static idColumn = ['email', 'createdAt'];
+
+  public readonly email!: string;
+  public createdAt!: number;
+  public bounceType!: number;
+  public bounceSubType!: number;
+}

--- a/packages/fxa-admin-server/src/lib/db/models/emails.ts
+++ b/packages/fxa-admin-server/src/lib/db/models/emails.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Model } from 'objection';
+
+import { intBoolTransformer, uuidTransformer } from '../transformers';
+
+const binaryFields = ['uid', 'emailCode'];
+const booleanFields = ['isVerified', 'isPrimary'];
+
+export class Emails extends Model {
+  public static tableName = 'emails';
+
+  public normalizedEmail!: string;
+  public email!: string;
+  public uid!: string;
+  public isVerified!: boolean;
+  public isPrimary!: boolean;
+  public emailCode!: string;
+  public verifiedAt?: number;
+  public createdAt!: number;
+
+  public $parseDatabaseJson(json: any) {
+    json = super.$parseDatabaseJson(json);
+    for (const field of binaryFields) {
+      if (json[field]) {
+        json[field] = uuidTransformer.from(json[field]);
+      }
+    }
+    for (const field of booleanFields) {
+      if (json[field]) {
+        json[field] = intBoolTransformer.from(json[field]);
+      }
+    }
+    return json;
+  }
+
+  public $formatDatabaseJson(json: any) {
+    json = super.$formatDatabaseJson(json);
+    for (const field of binaryFields) {
+      if (json[field]) {
+        json[field] = uuidTransformer.to(json[field]);
+      }
+    }
+    for (const field of booleanFields) {
+      if (json[field]) {
+        json[field] = intBoolTransformer.to(json[field]);
+      }
+    }
+    return json;
+  }
+}

--- a/packages/fxa-admin-server/src/lib/db/models/index.ts
+++ b/packages/fxa-admin-server/src/lib/db/models/index.ts
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Account } from './account';
+import { EmailBounces } from './email-bounces';
+import { Emails } from './emails';
+
+export { Account, Emails, EmailBounces };

--- a/packages/fxa-admin-server/src/lib/db/transformers.ts
+++ b/packages/fxa-admin-server/src/lib/db/transformers.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/;
+
+function unbuffer(val: string | Buffer) {
+  return Buffer.isBuffer(val) ? val.toString('hex') : val;
+}
+
+function buffer(value: string | Buffer) {
+  // Don't convert things with no value, but we still want
+  // to bufferize falsy things like the empty string.
+  if (typeof value !== 'undefined' && value !== null) {
+    if (typeof value !== 'string' || !HEX_STRING.test(value)) {
+      throw new Error('Invalid hex data for ' + value + '"');
+    }
+    return Buffer.from(value, 'hex');
+  }
+  return value;
+}
+
+export const uuidTransformer = { to: (v: any) => buffer(v), from: (v: any) => unbuffer(v) };
+
+export const intBoolTransformer = { to: (v: any) => (v ? 1 : 0), from: (v: any) => !!v };

--- a/packages/fxa-admin-server/src/lib/resolvers/account-resolver.ts
+++ b/packages/fxa-admin-server/src/lib/resolvers/account-resolver.ts
@@ -2,19 +2,39 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Arg, Query, Resolver } from 'type-graphql';
+import { Arg, FieldResolver, Query, Resolver, Root } from 'type-graphql';
 
+import { Account, EmailBounces } from '../db/models';
+import { uuidTransformer } from '../db/transformers';
 import { Account as AccountType } from './types/account';
 
 @Resolver(of => AccountType)
 export class AccountResolver {
   @Query(returns => AccountType, { nullable: true })
   public accountByUid(@Arg('uid', { nullable: false }) uid: string) {
-    return;
+    let uidBuffer;
+    try {
+      uidBuffer = uuidTransformer.to(uid);
+    } catch (err) {
+      return;
+    }
+    return Account.query().findOne({ uid: uidBuffer });
   }
 
   @Query(returns => AccountType, { nullable: true })
   public accountByEmail(@Arg('email', { nullable: false }) email: string) {
-    return;
+    return Account.query()
+      .innerJoin('emails', 'emails.uid', 'accounts.uid')
+      .where('emails.normalizedEmail', email)
+      .first();
+  }
+
+  @FieldResolver()
+  public async emailBounces(@Root() account: Account) {
+    const uidBuffer = uuidTransformer.to(account.uid);
+    const result = await EmailBounces.query()
+      .innerJoin('emails', 'emailBounces.email', 'emails.normalizedEmail')
+      .where('emails.uid', uidBuffer);
+    return result;
   }
 }

--- a/packages/fxa-admin-server/src/lib/resolvers/email-bounce-resolver.ts
+++ b/packages/fxa-admin-server/src/lib/resolvers/email-bounce-resolver.ts
@@ -4,12 +4,16 @@
 
 import { Arg, Mutation, Resolver } from 'type-graphql';
 
+import { EmailBounces } from '../db/models';
 import { EmailBounce } from './types/email-bounces';
 
 @Resolver(of => EmailBounce)
 export class EmailBounceResolver {
   @Mutation(returns => Boolean)
   public async clearEmailBounce(@Arg('email') email: string) {
-    return false;
+    const result = await EmailBounces.query()
+      .delete()
+      .where('email', email);
+    return !!result;
   }
 }

--- a/packages/fxa-admin-server/src/lib/server.ts
+++ b/packages/fxa-admin-server/src/lib/server.ts
@@ -6,12 +6,16 @@ import { ApolloServer } from 'apollo-server';
 import * as TypeGraphQL from 'type-graphql';
 import { Container } from 'typedi';
 
+import { DatabaseConfig, setupDatabase } from './db';
 import { AccountResolver } from './resolvers/account-resolver';
 import { EmailBounceResolver } from './resolvers/email-bounce-resolver';
 
-type ServerConfig = {};
+type ServerConfig = {
+  database: DatabaseConfig;
+};
 
 export async function createServer(config: ServerConfig): Promise<ApolloServer> {
+  setupDatabase(config.database);
   const schema = await TypeGraphQL.buildSchema({
     container: Container,
     resolvers: [AccountResolver, EmailBounceResolver]

--- a/packages/fxa-admin-server/src/test/lib/db/models/account.spec.ts
+++ b/packages/fxa-admin-server/src/test/lib/db/models/account.spec.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import 'reflect-metadata';
+
+import { assert } from 'chai';
+import Knex from 'knex';
+import 'mocha';
+
+import { chance, randomAccount, testDatabaseSetup } from './helpers';
+
+import { Account } from '../../../../lib/db/models/account';
+import { uuidTransformer } from '../../../../lib/db/transformers';
+
+const USER_1 = randomAccount();
+
+describe('account model', () => {
+  let knex: Knex;
+
+  before(async () => {
+    knex = await testDatabaseSetup();
+    // Load the user in
+    await Account.query().insertGraph(USER_1);
+  });
+
+  after(async () => {
+    await knex.destroy();
+  });
+
+  it('looks up the user by email', async () => {
+    const result = await Account.query().findOne({ normalizedEmail: USER_1.normalizedEmail });
+    assert.equal(result.uid, USER_1.uid);
+    assert.equal(result.email, USER_1.email);
+  });
+
+  it('looks up the user by uid buffer', async () => {
+    const uidBuffer = uuidTransformer.to(USER_1.uid);
+    const result = await Account.query().findOne({ uid: uidBuffer });
+    assert.equal(result.uid, USER_1.uid);
+    assert.equal(result.email, USER_1.email);
+  });
+
+  it('does not find a non-existent user', async () => {
+    let result = await Account.query().findOne({ normalizedEmail: chance.email() });
+    assert.isUndefined(result);
+
+    const uid = chance.guid({ version: 4 }).replace(/-/g, '');
+    const uidBuffer = uuidTransformer.to(uid);
+    result = await Account.query().findOne({ uid: uidBuffer });
+    assert.isUndefined(result);
+  });
+});

--- a/packages/fxa-admin-server/src/test/lib/db/models/accounts.sql
+++ b/packages/fxa-admin-server/src/test/lib/db/models/accounts.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `accounts` (
+  `uid` binary(16) NOT NULL,
+  `normalizedEmail` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `email` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `emailCode` binary(16) NOT NULL,
+  `emailVerified` tinyint(1) NOT NULL DEFAULT '0',
+  `kA` binary(32) NOT NULL,
+  `wrapWrapKb` binary(32) NOT NULL,
+  `authSalt` binary(32) NOT NULL,
+  `verifyHash` binary(32) NOT NULL,
+  `verifierVersion` tinyint(3) unsigned NOT NULL,
+  `verifierSetAt` bigint(20) unsigned NOT NULL,
+  `createdAt` bigint(20) unsigned NOT NULL,
+  `locale` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `lockedAt` bigint(20) unsigned DEFAULT NULL,
+  `profileChangedAt` bigint(20) unsigned DEFAULT NULL,
+  `keysChangedAt` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`uid`),
+  UNIQUE KEY `normalizedEmail` (`normalizedEmail`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci

--- a/packages/fxa-admin-server/src/test/lib/db/models/email-bounces.spec.ts
+++ b/packages/fxa-admin-server/src/test/lib/db/models/email-bounces.spec.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import 'reflect-metadata';
+
+import { assert } from 'chai';
+import Knex from 'knex';
+import 'mocha';
+
+import { chance, randomAccount, randomEmailBounce, testDatabaseSetup } from './helpers';
+
+import { EmailBounces } from '../../../../lib/db/models/email-bounces';
+
+const USER_1 = randomAccount();
+const EMAIL_BOUNCE = randomEmailBounce(USER_1.email);
+
+describe('emailBounces model', () => {
+  let knex: Knex;
+
+  before(async () => {
+    knex = await testDatabaseSetup();
+    // Load the emailBounce in
+    await EmailBounces.query().insertGraph(EMAIL_BOUNCE);
+  });
+
+  after(async () => {
+    await knex.destroy();
+  });
+
+  it('looks up the email bounce', async () => {
+    const result = await EmailBounces.query().findOne({ email: EMAIL_BOUNCE.email });
+    assert.equal(result.email, EMAIL_BOUNCE.email);
+    assert.equal(result.bounceType, EMAIL_BOUNCE.bounceType);
+  });
+
+  it('does not find a non-existent email bounce', async () => {
+    const result = await EmailBounces.query().findOne({ email: chance.email() });
+    assert.isUndefined(result);
+  });
+});

--- a/packages/fxa-admin-server/src/test/lib/db/models/email-bounces.sql
+++ b/packages/fxa-admin-server/src/test/lib/db/models/email-bounces.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `emailBounces` (
+  `email` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `bounceType` tinyint(3) unsigned NOT NULL,
+  `bounceSubType` tinyint(3) unsigned NOT NULL,
+  `createdAt` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`email`,`createdAt`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci

--- a/packages/fxa-admin-server/src/test/lib/db/models/emails.sql
+++ b/packages/fxa-admin-server/src/test/lib/db/models/emails.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `emails` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `normalizedEmail` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `email` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `uid` binary(16) NOT NULL,
+  `emailCode` binary(16) NOT NULL,
+  `isVerified` tinyint(1) NOT NULL DEFAULT '0',
+  `isPrimary` tinyint(1) NOT NULL DEFAULT '0',
+  `verifiedAt` bigint(20) unsigned DEFAULT NULL,
+  `createdAt` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `normalizedEmail` (`normalizedEmail`),
+  KEY `emails_uid` (`uid`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci

--- a/packages/fxa-admin-server/src/test/lib/db/models/helpers.ts
+++ b/packages/fxa-admin-server/src/test/lib/db/models/helpers.ts
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import fs from 'fs';
+import path from 'path';
+
+import Chance from 'chance';
+import Knex from 'knex';
+
+import { setupDatabase } from '../../../../lib/db';
+import { Account } from '../../../../lib/db/models/account';
+
+export const chance = new Chance();
+
+const thisDir = path.dirname(__filename);
+export const accountTable = fs.readFileSync(path.join(thisDir, './accounts.sql'), 'utf8');
+export const emailsTable = fs.readFileSync(path.join(thisDir, './emails.sql'), 'utf8');
+export const emailBouncesTable = fs.readFileSync(path.join(thisDir, './email-bounces.sql'), 'utf8');
+
+export function randomAccount() {
+  const email = chance.email();
+  return {
+    authSalt: Buffer.from('0', 'hex'),
+    createdAt: chance.timestamp(),
+    email,
+    emailCode: Buffer.from('0', 'hex'),
+    emailVerified: true,
+    kA: Buffer.from('0', 'hex'),
+    normalizedEmail: email,
+    uid: chance.guid({ version: 4 }).replace(/-/g, ''),
+    verifierSetAt: chance.timestamp(),
+    verifierVersion: 0,
+    verifyHash: Buffer.from('0', 'hex'),
+    wrapWrapKb: Buffer.from('0', 'hex')
+  };
+}
+
+export function randomEmailBounce(email: string) {
+  return {
+    bounceSubType: chance.integer({ min: 0, max: 14 }),
+    bounceType: chance.integer({ min: 0, max: 3 }),
+    createdAt: chance.timestamp(),
+    email
+  };
+}
+
+interface AccountIsh {
+  uid: string;
+  email: string;
+  normalizedEmail: string;
+}
+
+export function randomEmail(account: AccountIsh, primary = true) {
+  return {
+    createdAt: chance.timestamp(),
+    email: account.email,
+    emailCode: '',
+    isPrimary: primary,
+    isVerified: true,
+    normalizedEmail: account.normalizedEmail,
+    uid: account.uid
+  };
+}
+
+export async function testDatabaseSetup(): Promise<Knex> {
+  // Create the db if it doesn't exist
+  let knex = Knex({
+    client: 'mysql',
+    connection: {
+      charset: 'utf8',
+      host: 'localhost',
+      password: '',
+      port: 3306,
+      user: 'root'
+    }
+  });
+
+  await knex.raw('DROP DATABASE IF EXISTS testAdmin');
+  await knex.raw('CREATE DATABASE testAdmin');
+  await knex.destroy();
+
+  knex = setupDatabase({
+    database: 'testAdmin',
+    host: 'localhost',
+    password: '',
+    port: 3306,
+    user: 'root'
+  });
+
+  await knex.raw(accountTable);
+  await knex.raw(emailsTable);
+  await knex.raw(emailBouncesTable);
+
+  /* Debugging Assistance
+  knex.on('query', data => {
+    console.dir(data);
+  });
+  */
+
+  return knex;
+}

--- a/packages/fxa-admin-server/src/test/lib/resolvers/account-resolver.spec.ts
+++ b/packages/fxa-admin-server/src/test/lib/resolvers/account-resolver.spec.ts
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import 'reflect-metadata';
+
+import { assert } from 'chai';
+import { graphql, GraphQLSchema } from 'graphql';
+import Knex from 'knex';
+import 'mocha';
+import { buildSchema } from 'type-graphql';
+
+import {
+  randomAccount,
+  randomEmail,
+  randomEmailBounce,
+  testDatabaseSetup
+} from '../db/models/helpers';
+
+import { Account, EmailBounces } from '../../../lib/db/models';
+import { AccountResolver } from '../../../lib/resolvers/account-resolver';
+import { EmailBounceResolver } from '../../../lib/resolvers/email-bounce-resolver';
+import { BounceSubType, BounceType } from '../../../lib/resolvers/types/email-bounces';
+
+const USER_1 = randomAccount();
+const EMAIL_1 = randomEmail(USER_1);
+const EMAIL_BOUNCE_1 = randomEmailBounce(USER_1.email);
+
+const USER_2 = randomAccount();
+
+describe('accountResolver', () => {
+  let knex: Knex;
+  let schema: GraphQLSchema;
+
+  before(async () => {
+    knex = await testDatabaseSetup();
+    // Load the users in
+    await (Account as any).query().insertGraph({ ...USER_1, emails: [EMAIL_1] });
+    await EmailBounces.query().insert(EMAIL_BOUNCE_1);
+    schema = await buildSchema({ resolvers: [AccountResolver, EmailBounceResolver] });
+  });
+
+  after(async () => {
+    await knex.destroy();
+  });
+
+  it('locates the user by uid', async () => {
+    const query = `query {
+      accountByUid(uid: "${USER_1.uid}") {
+        uid
+        email
+      }
+    }`;
+    const result = (await graphql(schema, query)) as any;
+    assert.isDefined(result.data);
+    assert.isDefined(result.data.accountByUid);
+    assert.deepEqual(result.data.accountByUid, { uid: USER_1.uid, email: USER_1.email });
+  });
+
+  it('does not locate non-existent users by uid', async () => {
+    const query = `query {
+      accountByUid(uid: "${USER_2.uid}") {
+        uid
+        email
+      }
+    }`;
+    const result = (await graphql(schema, query)) as any;
+    assert.isDefined(result.data);
+    assert.isNull(result.data.accountByUid);
+  });
+
+  it('locates the user by email', async () => {
+    const query = `query {
+      accountByEmail(email: "${USER_1.email}") {
+        uid
+        email
+      }
+    }`;
+    const result = (await graphql(schema, query)) as any;
+    assert.isDefined(result.data);
+    assert.isDefined(result.data.accountByEmail);
+    assert.deepEqual(result.data.accountByEmail, { uid: USER_1.uid, email: USER_1.email });
+  });
+
+  it('does not locate non-existent users by email', async () => {
+    const query = `query {
+      accountByEmail(email: "${USER_2.email}") {
+        uid
+        email
+      }
+    }`;
+    const result = (await graphql(schema, query)) as any;
+    assert.isDefined(result.data);
+    assert.isNull(result.data.accountByEmail);
+  });
+
+  it('loads emailBounces with field resolver', async () => {
+    const query = `query {
+      accountByEmail(email: "${USER_1.email}") {
+        uid
+        email
+        emailBounces {
+          email
+          bounceType
+          bounceSubType
+          createdAt
+        }
+      }
+    }`;
+    const result = (await graphql(schema, query)) as any;
+    assert.isDefined(result.data);
+    assert.isDefined(result.data.accountByEmail);
+    assert.deepEqual(result.data.accountByEmail, {
+      email: USER_1.email,
+      emailBounces: [
+        {
+          bounceSubType: BounceSubType[EMAIL_BOUNCE_1.bounceSubType],
+          bounceType: BounceType[EMAIL_BOUNCE_1.bounceType],
+          createdAt: EMAIL_BOUNCE_1.createdAt,
+          email: EMAIL_BOUNCE_1.email
+        }
+      ],
+      uid: USER_1.uid
+    });
+  });
+});

--- a/packages/fxa-admin-server/src/test/lib/resolvers/email-bounce-resolver.spec.ts
+++ b/packages/fxa-admin-server/src/test/lib/resolvers/email-bounce-resolver.spec.ts
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import 'reflect-metadata';
+
+import { assert } from 'chai';
+import { graphql, GraphQLSchema } from 'graphql';
+import Knex from 'knex';
+import 'mocha';
+import { buildSchema } from 'type-graphql';
+
+import {
+  randomAccount,
+  randomEmail,
+  randomEmailBounce,
+  testDatabaseSetup
+} from '../db/models/helpers';
+
+import { Account, EmailBounces } from '../../../lib/db/models';
+import { AccountResolver } from '../../../lib/resolvers/account-resolver';
+import { EmailBounceResolver } from '../../../lib/resolvers/email-bounce-resolver';
+
+const USER_1 = randomAccount();
+const EMAIL_1 = randomEmail(USER_1);
+const EMAIL_BOUNCE_1 = randomEmailBounce(USER_1.email);
+
+const USER_2 = randomAccount();
+
+describe('emailBounceResolver', () => {
+  let knex: Knex;
+  let schema: GraphQLSchema;
+
+  before(async () => {
+    knex = await testDatabaseSetup();
+    // Load the users in
+    await (Account as any).query().insertGraph({ ...USER_1, emails: [EMAIL_1] });
+    await EmailBounces.query().insert(EMAIL_BOUNCE_1);
+    schema = await buildSchema({ resolvers: [AccountResolver, EmailBounceResolver] });
+  });
+
+  after(async () => {
+    await knex.destroy();
+  });
+
+  it('clears an email bounce', async () => {
+    const query = `query {
+      accountByEmail(email: "${USER_1.email}") {
+        uid
+        email
+        emailBounces {
+          email
+          bounceType
+          bounceSubType
+          createdAt
+        }
+      }
+    }`;
+    let result = (await graphql(schema, query)) as any;
+    assert.isDefined(result.data);
+    assert.isDefined(result.data.accountByEmail);
+    assert.lengthOf(result.data.accountByEmail.emailBounces, 1);
+
+    const mutation = `mutation {
+      clearEmailBounce(email: "${USER_1.email}")
+    }`;
+    result = (await graphql(schema, mutation)) as any;
+    assert.isDefined(result.data);
+    assert.isTrue(result.data.clearEmailBounce);
+
+    result = (await graphql(schema, query)) as any;
+    assert.isDefined(result.data);
+    assert.isDefined(result.data.accountByEmail);
+    assert.lengthOf(result.data.accountByEmail.emailBounces, 0);
+  });
+
+  it('fails to clear a non-existent bounce', async () => {
+    const mutation = `mutation {
+      clearEmailBounce(email: "${USER_2.email}")
+    }`;
+    const result = (await graphql(schema, mutation)) as any;
+    assert.isDefined(result.data);
+    assert.isFalse(result.data.clearEmailBounce);
+  });
+});


### PR DESCRIPTION
Because:

* User admin needs to talk to the db and resolve the graphql
  objects.

This commit:

* Adds the db models to talk to the necessary tables in the database.
* Adds the resolvers to lookup the data and return it.

Fixes #4202, #4206, #4207