### PR TITLE
feat(metrics): collect navigation timing on Payments with StatsD

### DIFF
--- a/packages/fxa-payments-server/package-lock.json
+++ b/packages/fxa-payments-server/package-lock.json
@@ -4557,6 +4557,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -8580,6 +8589,12 @@
         }
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
     "filesize": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
@@ -9496,6 +9511,14 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
       "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
+    },
+    "hot-shots": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-7.0.0.tgz",
+      "integrity": "sha512-w4A+hWszZB60e24A6hZkUBcPL8VtEx+E2tEqop20QgXlV1i9yMlVLoEdnipvu5zGVoEh8SubhB87n1dHm3dCWQ==",
+      "requires": {
+        "unix-dgram": "2.0.x"
+      }
     },
     "hpack.js": {
       "version": "2.1.6",
@@ -19136,10 +19159,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==",
-      "dev": true
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
     },
     "uglify-js": {
       "version": "3.4.10",
@@ -19233,6 +19255,16 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "unix-dgram": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.3.tgz",
+      "integrity": "sha512-Bay5CkSLcdypcBCsxvHEvaG3mftzT5FlUnRToPWEAVxwYI8NI/8zSJ/Gknlp86MPhV6hBA8I8TBsETj2tssoHQ==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.3.0",
+        "nan": "^2.13.2"
+      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -109,6 +109,7 @@
     "express": "^4.16.4",
     "fluent-intl-polyfill": "^0.1.0",
     "helmet": "3.21.1",
+    "hot-shots": "^7.0.0",
     "joi": "^14.3.1",
     "morgan": "^1.9.1",
     "mozlog": "^2.2.0",
@@ -128,7 +129,8 @@
     "redux-promise-middleware": "^6.1.2",
     "redux-thunk": "^2.3.0",
     "serve-static": "^1.13.2",
-    "type-to-reducer": "^1.2.0"
+    "type-to-reducer": "^1.2.0",
+    "ua-parser-js": "^0.7.21"
   },
   "engines": {
     "node": ">=10",

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -270,6 +270,44 @@ const conf = convict({
       format: 'url',
     },
   },
+  statsd: {
+    enabled: {
+      doc: 'Enable StatsD',
+      format: Boolean,
+      default: false,
+      env: 'STATSD_ENABLE',
+    },
+    sampleRate: {
+      doc: 'Sampling rate for StatsD',
+      format: Number,
+      default: 1,
+      env: 'STATSD_SAMPLE_RATE',
+    },
+    maxBufferSize: {
+      doc: 'StatsD message buffer size in number of characters',
+      format: Number,
+      default: 500,
+      env: 'STATSD_BUFFER_SIZE',
+    },
+    host: {
+      doc: 'StatsD host to report to',
+      format: String,
+      default: 'localhost',
+      env: 'DD_AGENT_HOST',
+    },
+    port: {
+      doc: 'Port number of StatsD server',
+      format: Number,
+      default: 8125,
+      env: 'DD_DOGSTATSD_PORT',
+    },
+    prefix: {
+      doc: 'StatsD metrics name prefix',
+      format: String,
+      default: 'fxa-payments.',
+      env: 'STATSD_PREFIX',
+    },
+  },
   stripe: {
     apiKey: {
       default: 'pk_test_UrTy6gLWGrc0aOHtbZZz0UBs005mSI4AS2',

--- a/packages/fxa-payments-server/server/lib/routes/index.js
+++ b/packages/fxa-payments-server/server/lib/routes/index.js
@@ -2,4 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = [require('./post-metrics')];
+module.exports = (geolocate, UAParser, statsd) => [
+  require('./post-metrics'),
+  require('./navigation-timing')(geolocate, UAParser, statsd),
+];

--- a/packages/fxa-payments-server/server/lib/routes/index.test.js
+++ b/packages/fxa-payments-server/server/lib/routes/index.test.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const routes = require('./index');
+const mockNavTiming = jest.fn();
+jest.mock('./post-metrics', () => ({}));
+jest.mock('./navigation-timing', () => mockNavTiming);
+
+const geolocate = {};
+const UAParser = {};
+const statsd = {};
+
+describe('Route dependencies', () => {
+  test('navigation-timing should receive the correct dependencies', () => {
+    routes(geolocate, UAParser, statsd);
+    expect(mockNavTiming).toHaveBeenCalledTimes(1);
+    expect(mockNavTiming).toHaveBeenCalledWith(geolocate, UAParser, statsd);
+  });
+});

--- a/packages/fxa-payments-server/server/lib/routes/navigation-timing.js
+++ b/packages/fxa-payments-server/server/lib/routes/navigation-timing.js
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const joi = require('joi');
+const URL = require('url').URL;
+
+const TIMESTAMP_MS = joi
+  .number()
+  .integer()
+  .required();
+// Validate the subset of PerformanceNavgationTiming properties used here.
+// (Ref: https://www.w3.org/TR/navigation-timing-2/#dom-performancenavigationtiming)
+const navigationTimingSchema = joi.object().keys({
+  domainLookupStart: TIMESTAMP_MS.min(0),
+  domComplete: TIMESTAMP_MS.min(joi.ref('domInteractive')),
+  domInteractive: TIMESTAMP_MS.min(joi.ref('responseEnd')),
+  loadEventEnd: TIMESTAMP_MS.min(joi.ref('loadEventStart')),
+  loadEventStart: TIMESTAMP_MS.min(joi.ref('domComplete')),
+  name: joi
+    .string()
+    .uri()
+    .required(),
+  redirectStart: TIMESTAMP_MS,
+  requestStart: TIMESTAMP_MS.min(joi.ref('domainLookupStart')),
+  responseEnd: TIMESTAMP_MS.min(joi.ref('responseStart')),
+  responseStart: TIMESTAMP_MS.min(joi.ref('requestStart')),
+});
+
+module.exports = (geolocate, UAParser, statsd) => ({
+  method: 'post',
+  path: '/navigation-timing',
+  validate: { body: navigationTimingSchema },
+  process(request, response) {
+    try {
+      const location = geolocate(request);
+      const tags = {};
+      const nt = request.body;
+
+      if (location && location.country) {
+        tags.country = location.country;
+      }
+
+      if (request.headers['user-agent']) {
+        const uap = new UAParser(request.headers['user-agent']);
+        const os = uap.getOS();
+        if (os) {
+          tags.os = os.name;
+        }
+      }
+
+      const url = new URL(nt.name);
+      tags.path = url.pathname
+        .split('/')
+        .filter(x => !!x)
+        .join('_');
+
+      statsd.timing(
+        'nt.network',
+        nt.responseStart - nt.domainLookupStart,
+        tags
+      );
+      statsd.timing('nt.request', nt.responseStart - nt.requestStart, tags);
+      statsd.timing('nt.response', nt.responseEnd - nt.responseStart, tags);
+      statsd.timing('nt.dom', nt.domComplete - nt.domInteractive, tags);
+      statsd.timing('nt.load', nt.loadEventEnd - nt.loadEventStart, tags);
+      statsd.timing('nt.total', nt.loadEventEnd - nt.redirectStart, tags);
+    } catch (e) {
+      // NOOP
+    }
+
+    response.status(200).end();
+  },
+});

--- a/packages/fxa-payments-server/server/lib/routes/navigation-timing.test.js
+++ b/packages/fxa-payments-server/server/lib/routes/navigation-timing.test.js
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const mockGeolocate = () => ({ country: 'GD' });
+const mockStatsd = { timing: jest.fn() };
+const mockUAParser = function() {
+  return { getOS: () => ({ name: 'FxOS' }) };
+};
+const mockResponse = { status: jest.fn().mockReturnValue({ end: () => {} }) };
+const navTimingRoute = require('./navigation-timing');
+const buildRoute = (
+  geolocate = mockGeolocate,
+  UAParser = mockUAParser,
+  statsd = mockStatsd
+) => navTimingRoute(geolocate, UAParser, statsd);
+const route = buildRoute();
+const validRequestBody = {
+  domainLookupStart: 0,
+  domComplete: 1111,
+  domInteractive: 1000,
+  loadEventEnd: 1111,
+  loadEventStart: 1111,
+  name: 'https://testo.example.io/a/b/c',
+  redirectStart: 0,
+  requestStart: 22,
+  responseEnd: 898,
+  responseStart: 222,
+};
+const invalidRequestBody = { ...validRequestBody, domInteractive: 897 };
+
+describe('navigation-timing route', () => {
+  describe('http method', () => {
+    test('should be post', () => {
+      expect(route.method).toEqual('post');
+    });
+  });
+  describe('path', () => {
+    test('should be /navigation-timing', () => {
+      expect(route.path).toEqual('/navigation-timing');
+    });
+  });
+  describe('request body validation', () => {
+    test('should pass when given a validate request body', () => {
+      const result = route.validate.body.validate(validRequestBody);
+      expect(result.error).toBeNull();
+    });
+    test('should fail when given an invalidate request body', () => {
+      const result = route.validate.body.validate(invalidRequestBody);
+      expect(result.error).not.toBeNull();
+    });
+  });
+  describe('handler', () => {
+    beforeEach(() => {
+      mockStatsd.timing.mockClear();
+      mockResponse.status.mockClear();
+    });
+    test('should log timings with statsd', () => {
+      const request = {
+        body: validRequestBody,
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:75.0) Gecko/20100101 Firefox/75.0',
+        },
+      };
+      route.process(request, mockResponse);
+      const expectedTags = { country: 'GD', os: 'FxOS', path: 'a_b_c' };
+      expect(mockStatsd.timing).toHaveBeenCalledTimes(6);
+      expect(mockStatsd.timing).toHaveBeenNthCalledWith(
+        1,
+        'nt.network',
+        validRequestBody.responseStart - validRequestBody.domainLookupStart,
+        expectedTags
+      );
+      expect(mockStatsd.timing).toHaveBeenNthCalledWith(
+        2,
+        'nt.request',
+        validRequestBody.responseStart - validRequestBody.requestStart,
+        expectedTags
+      );
+      expect(mockStatsd.timing).toHaveBeenNthCalledWith(
+        3,
+        'nt.response',
+        validRequestBody.responseEnd - validRequestBody.responseStart,
+        expectedTags
+      );
+      expect(mockStatsd.timing).toHaveBeenNthCalledWith(
+        4,
+        'nt.dom',
+        validRequestBody.domComplete - validRequestBody.domInteractive,
+        expectedTags
+      );
+      expect(mockStatsd.timing).toHaveBeenNthCalledWith(
+        5,
+        'nt.load',
+        validRequestBody.loadEventEnd - validRequestBody.loadEventStart,
+        expectedTags
+      );
+      expect(mockStatsd.timing).toHaveBeenNthCalledWith(
+        6,
+        'nt.total',
+        validRequestBody.loadEventEnd - validRequestBody.redirectStart,
+        expectedTags
+      );
+      expect(mockResponse.status).toHaveBeenLastCalledWith(200);
+    });
+    test('should exclude country from tags when unavailable', () => {
+      const request = {
+        body: validRequestBody,
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:75.0) Gecko/20100101 Firefox/75.0',
+        },
+      };
+      buildRoute(() => ({})).process(request, mockResponse);
+      const expectedTags = { os: 'FxOS', path: 'a_b_c' };
+      expect(mockStatsd.timing.mock.calls[0][2]).toStrictEqual(expectedTags);
+    });
+    test('should exclude OS from tags when unavailable', () => {
+      const request = {
+        body: validRequestBody,
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:75.0) Gecko/20100101 Firefox/75.0',
+        },
+      };
+
+      const noOsUAParser = function() {
+        return { getOS: () => {} };
+      };
+      buildRoute(mockGeolocate, noOsUAParser).process(request, mockResponse);
+      const expectedTags = { country: 'GD', path: 'a_b_c' };
+      expect(mockStatsd.timing.mock.calls[0][2]).toStrictEqual(expectedTags);
+    });
+    test('should not log timings on error', () => {
+      const request = {
+        body: { ...validRequestBody, name: 'invalid/url/here' },
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:75.0) Gecko/20100101 Firefox/75.0',
+        },
+      };
+
+      buildRoute().process(request, mockResponse);
+      expect(mockStatsd.timing).not.toHaveBeenCalled();
+      expect(mockResponse.status).toHaveBeenLastCalledWith(200);
+    });
+  });
+});

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -18,6 +18,7 @@ import { SignInLayout, SettingsLayout } from './components/AppLayout';
 import ScreenInfo from './lib/screen-info';
 import { LoadingOverlay } from './components/LoadingOverlay';
 import * as FlowEvents from './lib/flow-event';
+import { observeNavigationTiming } from './lib/navigation-timing';
 
 const Product = React.lazy(() => import('./routes/Product'));
 const Subscriptions = React.lazy(() => import('./routes/Subscriptions'));
@@ -55,6 +56,8 @@ export const App = ({
     locationReload,
   };
   FlowEvents.init(queryParams);
+  observeNavigationTiming('/navigation-timing');
+
   return (
     <AppContext.Provider value={appContextValue}>
       <AppLocalizationProvider

--- a/packages/fxa-payments-server/src/index.test.tsx
+++ b/packages/fxa-payments-server/src/index.test.tsx
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+window.console.log = jest.fn();
+import './index';
+
+describe('index.tsx', () => {
+  describe('init', () => {
+    it('log an error on reject', async () => {
+      expect((window.console.log as jest.Mock).mock.calls[0][0]).toBe(
+        'init error'
+      );
+    });
+  });
+});

--- a/packages/fxa-payments-server/src/lib/navigation-timing.test.ts
+++ b/packages/fxa-payments-server/src/lib/navigation-timing.test.ts
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { observeNavigationTiming } from './navigation-timing';
+
+it('sends navigation timing with sendBeacon', () => {
+  type MockEntryList = { getEntries: () => [object] };
+  type ObsCallback = (_entries: MockEntryList, _obs: object) => undefined;
+  let cb = (_entries: MockEntryList, _obs: object) => {};
+  const observeFn = jest.fn();
+  const disconnectFn = jest.fn();
+  const getEntries = jest.fn().mockReturnValue([{ foo: 'bar' }]);
+  const mockObs = { observe: observeFn, disconnect: disconnectFn };
+  const mockPerformanceObserver = function(callback: ObsCallback) {
+    cb = callback;
+    return mockObs;
+  };
+  window.navigator.sendBeacon = jest.fn();
+  (window.PerformanceObserver as unknown) = mockPerformanceObserver;
+  observeNavigationTiming('/x/y/z');
+  cb({ getEntries }, mockObs);
+  expect(observeFn).toHaveBeenCalledWith({ entryTypes: ['navigation'] });
+  expect(window.navigator.sendBeacon).toHaveBeenCalledTimes(1);
+  const expectedBlob = new Blob([JSON.stringify({ foo: 'bar' })], {
+    type: 'application/json',
+  });
+  expect(window.navigator.sendBeacon).toHaveBeenCalledWith(
+    '/x/y/z',
+    expectedBlob
+  );
+  expect(disconnectFn).toBeCalledTimes(1);
+});

--- a/packages/fxa-payments-server/src/lib/navigation-timing.ts
+++ b/packages/fxa-payments-server/src/lib/navigation-timing.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const observeNavigationTiming = (beaconUrl: string) => {
+  if (PerformanceObserver && navigator.sendBeacon) {
+    const navTimingObs = new PerformanceObserver((entries, obs) => {
+      const timings = JSON.stringify(entries.getEntries()[0]);
+      const headers = { type: 'application/json' };
+      const reqBlob = new Blob([timings], headers);
+      navigator.sendBeacon(beaconUrl, reqBlob);
+      obs.disconnect();
+    });
+
+    navTimingObs.observe({ entryTypes: ['navigation'] });
+  }
+};
+
+export default observeNavigationTiming;

--- a/packages/fxa-payments-server/src/lib/sentry.test.js
+++ b/packages/fxa-payments-server/src/lib/sentry.test.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import chai from 'chai';
+import * as Sentry from '@sentry/browser';
 import SentryMetrics from './sentry';
 
 var assert = chai.assert;
@@ -194,6 +195,16 @@ describe('lib/sentry', function() {
       var resultUrl = sentry.__cleanUpQueryParam(expectedUrl);
 
       assert.equal(resultUrl, expectedUrl);
+    });
+  });
+
+  describe('captureException', () => {
+    it('calls Sentry.captureException', () => {
+      jest.spyOn(Sentry, 'captureException');
+      const sentry = new SentryMetrics(dsn);
+      sentry.captureException(new Error('testo'));
+      expect(Sentry.captureException).toHaveBeenCalled();
+      Sentry.captureException.mockRestore();
     });
   });
 });


### PR DESCRIPTION
This patch uses sendBeacon and Navigation Timing Level 2
(https://www.w3.org/TR/navigation-timing-2/) to report performance
timing from Payments pages.  The metrics are collected with StatsD.

Fixes #3596 

@mozilla/fxa-devs r?