### PR TITLE
fix(coverage): Remove the temporary coverage directory before running tests

### DIFF
--- a/packages/fxa-auth-server/scripts/test-local.sh
+++ b/packages/fxa-auth-server/scripts/test-local.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+rm -rf coverage
+rm -rf .nyc_output
+
 if [ -z "$NODE_ENV" ]; then export NODE_ENV=dev; fi;
 if [ -z "$CORS_ORIGIN" ]; then export CORS_ORIGIN="http://foo,http://bar"; fi;
 

--- a/packages/fxa-profile-server/scripts/test-local.sh
+++ b/packages/fxa-profile-server/scripts/test-local.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+rm -rf coverage
+rm -rf .nyc_output
+
 if [ -z "$NODE_ENV" ]; then export NODE_ENV=test; fi;
 
 set -u


### PR DESCRIPTION
Not connected to an issue, but sometimes if switching between branches and re-running tests you might get an error complaining about code coverage files.

This removes the coverage files before testing.