### PR TITLE
test(auth-server): coverage for getCustomerUidEmailFromSubscription

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -446,7 +446,10 @@ class DirectStripeRoutes {
    * @param {boolean} isActive
    */
   async updateCustomerAndSendStatus(request, event, sub, isActive) {
-    const { uid, email } = await this.getCustomerUidEmailFromSubscription(sub);
+    const {
+      uid,
+      email,
+    } = await this.stripeHelper.getCustomerUidEmailFromSubscription(sub);
     if (!uid) {
       return;
     }
@@ -510,38 +513,6 @@ class DirectStripeRoutes {
   async handleSubscriptionDeletedEvent(request, event) {
     const sub = /** @type {Subscription} */ (event.data.object);
     return this.updateCustomerAndSendStatus(request, event, sub, false);
-  }
-
-  /**
-   * Fetch a customer record from Stripe by id and return its userid metadata
-   * and the email.
-   *
-   * @param {Subscription} sub
-   * @returns {Promise<{uid: string, email: string} | {uid: undefined, email: undefined}>}
-   */
-  async getCustomerUidEmailFromSubscription(sub) {
-    const customer = await this.stripeHelper.stripe.customers.retrieve(
-      /** @type {string} */ (sub.customer)
-    );
-    if (customer.deleted) {
-      // Deleted customers lost their metadata so we can't send events for them
-      return { uid: undefined, email: undefined };
-    }
-    if (!(/** @type {Customer} */ (customer.metadata.userid))) {
-      Sentry.withScope(scope => {
-        scope.setContext('stripeEvent', {
-          customer: { id: customer.id },
-        });
-        Sentry.captureMessage(
-          'FxA UID does not exist on customer metadata.',
-          Sentry.Severity.Error
-        );
-      });
-    }
-    return {
-      uid: /** @type {Customer} */ (customer).metadata.userid,
-      email: /** @type {Customer} */ (customer).email,
-    };
   }
 
   async handleWebhookEvent(request) {

--- a/packages/fxa-auth-server/test/local/payments/fixtures/customer_deleted.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/customer_deleted.json
@@ -1,0 +1,5 @@
+{
+    "id": "cus_GiYigOJmN1t1wQ",
+    "object": "customer",
+    "deleted": true
+  }

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -2471,12 +2471,9 @@ describe('DirectStripeRoutes', () => {
 
     describe('when the customer is found from the subscription', () => {
       it('calls all the update and notification functions', async () => {
-        sinon
-          .stub(
-            directStripeRoutesInstance,
-            'getCustomerUidEmailFromSubscription'
-          )
-          .returns({ uid: UID, email: TEST_EMAIL });
+        directStripeRoutesInstance.stripeHelper.getCustomerUidEmailFromSubscription.returns(
+          { uid: UID, email: TEST_EMAIL }
+        );
 
         await directStripeRoutesInstance.updateCustomerAndSendStatus(
           VALID_REQUEST,
@@ -2497,12 +2494,9 @@ describe('DirectStripeRoutes', () => {
 
     describe('when the customer is not found from the subscription', () => {
       it('returns without calling anything', async () => {
-        sinon
-          .stub(
-            directStripeRoutesInstance,
-            'getCustomerUidEmailFromSubscription'
-          )
-          .returns({ uid: undefined, email: undefined });
+        directStripeRoutesInstance.stripeHelper.getCustomerUidEmailFromSubscription.returns(
+          { uid: undefined, email: undefined }
+        );
 
         await directStripeRoutesInstance.updateCustomerAndSendStatus(
           VALID_REQUEST,
@@ -2523,12 +2517,12 @@ describe('DirectStripeRoutes', () => {
   });
 
   describe('stripe webhooks', () => {
-    let sendStub, getCustomerStub;
+    let sendStub;
 
     beforeEach(() => {
-      getCustomerStub = sandbox
-        .stub(directStripeRoutesInstance, 'getCustomerUidEmailFromSubscription')
-        .resolves({ uid: UID, email: TEST_EMAIL });
+      directStripeRoutesInstance.stripeHelper.getCustomerUidEmailFromSubscription.resolves(
+        { uid: UID, email: TEST_EMAIL }
+      );
       sendStub = sandbox
         .stub(directStripeRoutesInstance, 'sendSubscriptionStatusToSqs')
         .resolves(true);
@@ -2678,7 +2672,10 @@ describe('DirectStripeRoutes', () => {
           {},
           updatedEvent
         );
-        assert.called(getCustomerStub);
+        assert.called(
+          directStripeRoutesInstance.stripeHelper
+            .getCustomerUidEmailFromSubscription
+        );
         assert.called(
           directStripeRoutesInstance.stripeHelper.refreshCachedCustomer
         );
@@ -2692,7 +2689,10 @@ describe('DirectStripeRoutes', () => {
           {},
           updatedEvent
         );
-        assert.notCalled(getCustomerStub);
+        assert.notCalled(
+          directStripeRoutesInstance.stripeHelper
+            .getCustomerUidEmailFromSubscription
+        );
         assert.notCalled(
           directStripeRoutesInstance.stripeHelper.refreshCachedCustomer
         );
@@ -2708,7 +2708,10 @@ describe('DirectStripeRoutes', () => {
           {},
           deletedEvent
         );
-        assert.called(getCustomerStub);
+        assert.called(
+          directStripeRoutesInstance.stripeHelper
+            .getCustomerUidEmailFromSubscription
+        );
         assert.called(
           directStripeRoutesInstance.stripeHelper.refreshCachedCustomer
         );
@@ -2724,7 +2727,10 @@ describe('DirectStripeRoutes', () => {
           {},
           createdEvent
         );
-        assert.called(getCustomerStub);
+        assert.called(
+          directStripeRoutesInstance.stripeHelper
+            .getCustomerUidEmailFromSubscription
+        );
         assert.called(
           directStripeRoutesInstance.stripeHelper.refreshCachedCustomer
         );
@@ -2738,7 +2744,10 @@ describe('DirectStripeRoutes', () => {
           {},
           createdEvent
         );
-        assert.notCalled(getCustomerStub);
+        assert.notCalled(
+          directStripeRoutesInstance.stripeHelper
+            .getCustomerUidEmailFromSubscription
+        );
         assert.notCalled(
           directStripeRoutesInstance.stripeHelper.refreshCachedCustomer
         );
@@ -2747,8 +2756,6 @@ describe('DirectStripeRoutes', () => {
       });
     });
   });
-
-  describe('getCustomerUidEmailFromSubscription', () => {});
 
   describe('getSubscriptions', () => {});
 


### PR DESCRIPTION
- moved getCustomerUidEmailFromSubscription to StripeHelper
- added coverage for getCustomerUidEmailFromSubscription
- updated references to getCustomerUidEmailFromSubscription

fixes #4232