### PR TITLE
chore(support form): add two FPN specific topics

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/support-form.js
+++ b/packages/fxa-content-server/app/scripts/models/support-form.js
@@ -15,6 +15,8 @@ const TOPICS = [
   'Connection issues',
   'Getting started',
   'Account issues',
+  'Firefox Private Network Android App',
+  'Firefox Private Network Windows App',
 ];
 
 // Translated strings for the drop down options.
@@ -24,6 +26,8 @@ const TRANSLATED_TOPICS = [
   t('Connection issues'),
   t('Getting started'),
   t('Account issues'),
+  t('Firefox Private Network Android App'),
+  t('Firefox Private Network Windows App'),
 ];
 
 // Lowercase translated strings used in the successful submission modal.


### PR DESCRIPTION
This patch adds two Firefox Private Network specific support topic
options to the support form.  They are currently hard coded.

Fixes #3876 

@mozilla/fxa-devs r?