### PR TITLE
fix(content-server): address letter dangles being cut off

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -250,7 +250,6 @@ body.settings #stage .settings {
   .card-subheader {
     overflow: hidden;
     text-overflow: ellipsis;
-    text-wrap: nowrap;
     white-space: nowrap;
   }
 
@@ -258,6 +257,7 @@ body.settings #stage .settings {
     font-size: 20px;
     line-height: 24px;
     margin-bottom: 0;
+    padding-bottom: 1px;
 
     @include respond-to('small') {
       font-size: 14px;


### PR DESCRIPTION
- fixes #4173
- also removed non existant css rule 'text-wrap'

## before
![before](https://user-images.githubusercontent.com/1844554/75394212-a778da80-58bd-11ea-8bb1-7231bbd2893a.png)

## after
![after](https://user-images.githubusercontent.com/1844554/75394221-ac3d8e80-58bd-11ea-9846-3a29313bfd12.png)
