### PR TITLE
Store refresh_token last-used-at timestamp in redis.

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -375,6 +375,30 @@ const conf = convict({
         doc: 'Maximum number of access tokens per account at any one time',
       },
     },
+    refreshTokens: {
+      enabled: {
+        default: true,
+        doc: 'Enable Redis for refresh token metadata',
+        format: Boolean,
+        env: 'REFRESH_TOKEN_REDIS_ENABLED',
+      },
+      host: {
+        default: '127.0.0.1',
+        env: 'REFRESH_TOKEN_REDIS_HOST',
+        format: String,
+      },
+      port: {
+        default: 6379,
+        env: 'REFRESH_TOKEN_REDIS_PORT',
+        format: 'port',
+      },
+      prefix: {
+        default: 'rt:',
+        env: 'REFRESH_TOKEN_REDIS_KEY_PREFIX',
+        format: String,
+        doc: 'Key prefix for refresh tokens in Redis',
+      },
+    },
     sessionTokens: {
       enabled: {
         default: true,

--- a/packages/fxa-auth-server/lib/luaScripts/getRefreshToken_1.lua
+++ b/packages/fxa-auth-server/lib/luaScripts/getRefreshToken_1.lua
@@ -1,0 +1,3 @@
+local uid = KEYS[1]
+local tokenId = ARGV[1]
+return redis.call('hget', uid, tokenId)

--- a/packages/fxa-auth-server/lib/luaScripts/getRefreshTokens_1.lua
+++ b/packages/fxa-auth-server/lib/luaScripts/getRefreshTokens_1.lua
@@ -1,0 +1,2 @@
+local uid = KEYS[1]
+return redis.call('hgetall', uid)

--- a/packages/fxa-auth-server/lib/luaScripts/pruneRefreshTokens_1.lua
+++ b/packages/fxa-auth-server/lib/luaScripts/pruneRefreshTokens_1.lua
@@ -1,0 +1,6 @@
+local uid = KEYS[1]
+local tokenIdsToPrune = cjson.decode(ARGV[1])
+
+for _, tokenId in ipairs(tokenIdsToPrune) do
+  redis.call('hdel', uid, tokenId)
+end

--- a/packages/fxa-auth-server/lib/luaScripts/removeRefreshToken_1.lua
+++ b/packages/fxa-auth-server/lib/luaScripts/removeRefreshToken_1.lua
@@ -1,0 +1,5 @@
+local uid = KEYS[1]
+local tokenId = ARGV[1]
+
+-- Returns 1 if the item was deleted, 0 if it was not present.
+return redis.call('hdel', uid, tokenId)

--- a/packages/fxa-auth-server/lib/luaScripts/removeRefreshTokensForUser_1.lua
+++ b/packages/fxa-auth-server/lib/luaScripts/removeRefreshTokensForUser_1.lua
@@ -1,0 +1,5 @@
+local uid = KEYS[1]
+
+-- Just delete the whole key for that user,
+-- rather than deleting each token individually.
+return redis.call('unlink', uid)

--- a/packages/fxa-auth-server/lib/luaScripts/schema.md
+++ b/packages/fxa-auth-server/lib/luaScripts/schema.md
@@ -1,0 +1,126 @@
+# Schema for data stored in Redis
+
+We currently store three different types of data in redis:
+
+- high-churn sessionToken metadata
+- short-lived OAuth access tokens
+- high-churn refreshToken metadata
+
+Each type of data is stored under a different (and configurable) key prefix
+to avoid collisions.
+
+## Session Token Metadata
+
+Most sessionToken data is stored in MySQL and is updated rarely, but a small
+number of fields may change much more often. Writes to these fields are sent
+to redis because it's better able to cope with the write load, and there are
+no significant consequences to losing the data.
+
+The data is stored as a single record per user, using their `uid` as the key.
+The value is a JSON object whose keys are the ids of session tokens belonging
+to that user, and whose corresponding values are the metadata for that token.
+The metadata is a JSON **_list_** where each item corresponds to a particular
+field of the session token.
+
+For example, if a user has a single session token with the following metadata:
+
+- `id`: "000111222333444555666777888999"
+- `lastAccessTime`: 1583392038878
+- `location`:
+  - city: undefined,
+  - state: undefined
+  - stateCode: undefined,
+  - country: "Australia"
+  - countryCode: "AU"
+- uaBrowser: undefined,
+- uaBrowserVersion: undefined,
+- uaOS: "Windows",
+- uaOSVersion: 10,
+- uaDeviceType: undefined,
+- uaFormFactor: undefined
+
+Then this would be stored in redis as a string value as follows:
+
+- Key: `000111222333444555666777888999`
+- Value: `[1583392038878,[,,,"Australia","AU"],,,"Windows",10,,]`
+
+This scheme is designed to minimize storage space by not encoding field names,
+but leads to some complexity when encoding and decoding.
+
+There is also a legacy format where the value is a straightforward JSON object
+with named fields.
+
+## OAuth Access Tokens
+
+OAuth access tokens are created frequently and are short-lived, making them
+suitable for storage in redis.
+
+The data for each access token is stored as an individual record with a TTL,
+using the `tokenId` as the key and a JSON serialization of the token data
+as the value.
+
+In order to allow easy enumeration of the access tokens belonging to a given
+user, we also maintain a separate record for each user. This record is a redis
+set type whose key is the `uid` and whose members as the `tokenId`s of all
+acesss tokens belonging to that user.
+
+For example, if a user has a single access token with the following metadata:
+
+- `tokenId`: "000111222333444555666777888999"
+- `clientId`: "ABCDEF123456"
+- `clientName`: "Example Client"
+- `clientCanGrant`: false
+- `publicClient`: false
+- `userId`: "AAABBBCCCDDDEEEFFF999888777666"
+- `email`: "user@example.com"
+- `scope`: "profile",
+- `createdAt`: 1583392038878
+- `profileChangedAt`: 0,
+- `expiresAt`: 1583392056878
+
+Then there would be two records in redis as follows:
+
+- Key: `000111222333444555666777888999`
+- Value:
+  ```
+  {
+    "tokenId": "000111222333444555666777888999"
+    "clientId": "ABCDEF123456"
+    "name": "Example Client"
+    "canGrant": false
+    "publicClient": false
+    "userId": "AAABBBCCCDDDEEEFFF999888777666"
+    "email": "user@example.com"
+    "scope": "profile",
+    "createdAt": 1583392038878
+    "profileChangedAt": 0,
+    "expiresAt": 1583392056878
+  }
+  ```
+- Key: `AAABBBCCCDDDEEEFFF999888777666`
+- Set Members: `[000111222333444555666777888999]`
+
+## Refresh Token Metadata
+
+Most refreshToken data is stored in MySQL and is updated rarely, but the `lastUsedAt`
+field may change much more frequently. Writes to this field are send to redis
+because it's better able to cope with the write load, and there are no significant
+consequences to losing the data.
+
+The data is stored as a single record per user, using their `uid` as the key.
+The record is a redis hash type whose fields are the `tokenId`s or refresh tokens
+held by that user, and whose corresponding values are JSON objects with metadata
+for that token.
+
+For example, if a user has a single refresh token with the following metadata:
+
+- `tokenId`: "000111222333444555666777888999"
+- `userId`: "AAABBBCCCDDDEEEFFF999888777666"
+- `lastUsedAt`: 1583392038878
+
+Then this would be stored in redis as a hash record with one field as follows:
+
+- Key: `AAABBBCCCDDDEEEFFF999888777666`
+- Hash Fields:
+  - Field: `000111222333444555666777888999`
+  - Value: `{"lastUsedAt": 1583392038878}`

--- a/packages/fxa-auth-server/lib/luaScripts/setRefreshToken_1.lua
+++ b/packages/fxa-auth-server/lib/luaScripts/setRefreshToken_1.lua
@@ -1,0 +1,7 @@
+local uid = KEYS[1]
+local tokenId = ARGV[1]
+local token = ARGV[2]
+
+-- For now, we always completely replace the data in redis.
+-- If we add more fields we might like to implement a merge here instead.
+return redis.call('hset', uid, tokenId, token)

--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -10,8 +10,13 @@ const config = require('../../../config');
 const encrypt = require('../encrypt');
 const logger = require('../logging')('db');
 const mysql = require('./mysql');
-const redis = require('../../redis');
+const redis = require('./redis');
 const AccessToken = require('./accessToken');
+const RefreshTokenMetadata = require('./refreshTokenMetadata');
+
+const REFRESH_LAST_USED_AT_UPDATE_AFTER_MS = config.get(
+  'oauthServer.refreshToken.updateAfter'
+);
 
 function getPocketIds(idNameMap) {
   return Object.entries(idNameMap)
@@ -30,14 +35,9 @@ class OauthDB {
       await preClients();
       await scopes();
     });
-    this.redis = redis(
-      {
-        ...config.get('redis.accessTokens'),
-        enabled: true,
-        maxttl: config.get('oauthServer.expiration.accessToken'),
-      },
-      logger
-    );
+
+    this.redis = redis();
+
     Object.keys(mysql.prototype).forEach(key => {
       const self = this;
       this[key] = async function() {
@@ -46,6 +46,7 @@ class OauthDB {
       };
     });
   }
+
   disconnect() {}
 
   async generateAccessToken(vals) {
@@ -83,11 +84,11 @@ class OauthDB {
     return db._getAccessToken(id);
   }
 
-  async removeAccessToken(id) {
-    const done = await this.redis.removeAccessToken(id);
+  async removeAccessToken(token) {
+    const done = await this.redis.removeAccessToken(token.tokenId);
     if (!done) {
       const db = await this.mysql;
-      return db._removeAccessToken(id);
+      return db._removeAccessToken(token.tokenId);
     }
   }
 
@@ -98,16 +99,74 @@ class OauthDB {
     return tokens.concat(otherTokens);
   }
 
+  async getRefreshToken(id) {
+    const db = await this.mysql;
+    const t = await db._getRefreshToken(id);
+    if (t) {
+      const extraMetadata = await this.redis.getRefreshToken(t.userId, id);
+      Object.assign(t, extraMetadata || {});
+    }
+    return t;
+  }
+
+  async getRefreshTokensByUid(uid) {
+    const db = await this.mysql;
+    const tokens = await db._getRefreshTokensByUid(uid);
+    const extraMetadata = await this.redis.getRefreshTokens(uid);
+    // We'll take this opportunity to clean up any tokens that exist in redis but
+    // not in mysql, so this loop deletes each token from `extraMetadata` once handled.
+    for (const t of tokens) {
+      const id = hex(t.tokenId);
+      if (id in extraMetadata) {
+        Object.assign(t, extraMetadata[id]);
+        delete extraMetadata[id];
+      }
+    }
+    // Now we can prune any tokens found in redis but not mysql.
+    const toDel = Object.keys(extraMetadata);
+    if (toDel.length > 0) {
+      await this.redis.pruneRefreshTokens(uid, toDel);
+    }
+    return tokens;
+  }
+
+  async touchRefreshToken(token) {
+    const now = new Date();
+    // Always update timestamp in redis.
+    await this.redis.setRefreshToken(
+      token.userId,
+      token.tokenId,
+      new RefreshTokenMetadata(now)
+    );
+    // Periodically update timestamp in MySQL as well.
+    if (+now - token.lastUsedAt > REFRESH_LAST_USED_AT_UPDATE_AFTER_MS) {
+      const db = await this.mysql;
+      await db._touchRefreshToken(token.tokenId, now);
+    }
+  }
+
+  async removeRefreshToken(token) {
+    await this.redis.removeRefreshToken(token.userId, token.tokenId);
+    const db = await this.mysql;
+    return db._removeRefreshToken(token.tokenId);
+  }
+
   async removePublicAndCanGrantTokens(userId) {
     await this.redis.removeAccessTokensForPublicClients(userId);
     const db = await this.mysql;
     await db._removePublicAndCanGrantTokens(userId);
+    // Note that we do not clear metadata for deleted refresh tokens from redis,
+    // because it's awkward to enumerate the list of deleted refresh token ids.
+    // Instead we rely on a future call to `getRefreshTokensByUid` for lazy cleanup.
   }
 
   async deleteClientAuthorization(clientId, uid) {
     await this.redis.removeAccessTokensForUserAndClient(uid, clientId);
     const db = await this.mysql;
     return db._deleteClientAuthorization(clientId, uid);
+    // Note that we do not clear metadata for deleted refresh tokens from redis,
+    // because it's awkward to enumerate the list of deleted refresh token ids.
+    // Instead we rely on a future call to `getRefreshTokensByUid` for lazy cleanup.
   }
 
   async deleteClientRefreshToken(refreshTokenId, clientId, uid) {
@@ -118,6 +177,7 @@ class OauthDB {
       uid
     );
     if (ok) {
+      await this.redis.removeRefreshToken(uid, refreshTokenId);
       await this.redis.removeAccessTokensForUserAndClient(uid, clientId);
     }
     return ok;
@@ -125,6 +185,7 @@ class OauthDB {
 
   async removeUser(uid) {
     await this.redis.removeAccessTokensForUser(uid);
+    await this.redis.removeRefreshTokensForUser(uid);
     const db = await this.mysql;
     await db._removeUser(uid);
   }

--- a/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
@@ -193,7 +193,12 @@ const QUERY_ACCESS_TOKEN_FIND =
   '  clients.publicClient ' +
   'FROM tokens LEFT OUTER JOIN clients ON clients.id = tokens.clientId ' +
   'WHERE tokens.token=?';
-const QUERY_REFRESH_TOKEN_FIND = 'SELECT * FROM refreshTokens where token=?';
+// Note that the `token` field stores the hash of the token rather than the raw token,
+// and hence would more properly be called `tokenId`.
+const QUERY_REFRESH_TOKEN_FIND =
+  'SELECT token AS tokenId, clientId, userId, email, scope, createdAt, ' +
+  'lastUsedAt, profileChangedAt ' +
+  'FROM refreshTokens where token=?';
 const QUERY_REFRESH_TOKEN_LAST_USED_UPDATE =
   'UPDATE refreshTokens SET lastUsedAt=? WHERE token=?';
 const QUERY_CODE_FIND = 'SELECT * FROM codes WHERE code=?';
@@ -237,7 +242,7 @@ const QUERY_LIST_ACCESS_TOKENS_BY_UID =
   'FROM tokens LEFT OUTER JOIN clients ON clients.id = tokens.clientId ' +
   'WHERE tokens.userId=?';
 const QUERY_LIST_REFRESH_TOKENS_BY_UID =
-  'SELECT refreshTokens.token AS refreshTokenId, refreshTokens.clientId, refreshTokens.createdAt, refreshTokens.lastUsedAt, ' +
+  'SELECT refreshTokens.token AS tokenId, refreshTokens.clientId, refreshTokens.createdAt, refreshTokens.lastUsedAt, ' +
   '  refreshTokens.scope, clients.name as clientName, clients.canGrant AS clientCanGrant ' +
   'FROM refreshTokens LEFT OUTER JOIN clients ON clients.id = refreshTokens.clientId ' +
   'WHERE refreshTokens.userId=?';
@@ -513,7 +518,7 @@ MysqlStore.prototype = {
    * @param {String} uid User ID as hex
    * @returns {Promise}
    */
-  getRefreshTokensByUid: async function getRefreshTokensByUid(uid) {
+  _getRefreshTokensByUid: async function _getRefreshTokensByUid(uid) {
     const refreshTokens = await this._read(QUERY_LIST_REFRESH_TOKENS_BY_UID, [
       buf(uid),
     ]);
@@ -565,19 +570,19 @@ MysqlStore.prototype = {
    * If a user has multiple refresh tokens for a given client_id, clients
    * will use their active refresh tokens to get new access tokens.
    *
-   * @param {String} refreshTokenid Refresh Token ID as Hex
+   * @param {String} tokenId Refresh Token ID as Hex
    * @param {String} clientId Client ID as Hex
    * @param {String} uid User Id as Hex
    * @returns {Promise} `true` if the token was found and deleted, `false` otherwise
    */
   _deleteClientRefreshToken: async function _deleteClientRefreshToken(
-    refreshTokenId,
+    tokenId,
     clientId,
     uid
   ) {
     const deleteRefreshTokenRes = await this._write(
       DELETE_REFRESH_TOKEN_WITH_CLIENT_AND_UID,
-      [buf(refreshTokenId), buf(clientId), buf(uid)]
+      [buf(tokenId), buf(clientId), buf(uid)]
     );
 
     // only delete access tokens if deleting the refresh
@@ -594,29 +599,30 @@ MysqlStore.prototype = {
   },
 
   generateRefreshToken: function generateRefreshToken(vals) {
-    var t = {
+    const t = {
       clientId: vals.clientId,
       userId: vals.userId,
       email: vals.email,
       scope: vals.scope,
       profileChangedAt: vals.profileChangedAt,
     };
-    var token = unique.token();
-    var hash = encrypt.hash(token);
+    const token = unique.token();
+    const tokenId = encrypt.hash(token);
     return this._write(QUERY_REFRESH_TOKEN_INSERT, [
       t.clientId,
       t.userId,
       t.email,
       t.scope.toString(),
-      hash,
+      tokenId,
       t.profileChangedAt,
     ]).then(function() {
       t.token = token;
+      t.tokenId = tokenId;
       return t;
     });
   },
 
-  getRefreshToken: function getRefreshToken(token) {
+  _getRefreshToken: function _getRefreshToken(token) {
     return this._readOne(QUERY_REFRESH_TOKEN_FIND, [buf(token)]).then(function(
       t
     ) {
@@ -627,16 +633,15 @@ MysqlStore.prototype = {
     });
   },
 
-  usedRefreshToken: function usedRefreshToken(token) {
-    var now = new Date();
+  _touchRefreshToken: function _touchRefreshToken(token, now) {
     return this._write(QUERY_REFRESH_TOKEN_LAST_USED_UPDATE, [
       now,
       // WHERE
-      token,
+      buf(token),
     ]);
   },
 
-  removeRefreshToken: function removeRefreshToken(id) {
+  _removeRefreshToken: function _removeRefreshToken(id) {
     return this._write(QUERY_REFRESH_TOKEN_DELETE, [buf(id)]);
   },
 

--- a/packages/fxa-auth-server/lib/oauth/db/redis.js
+++ b/packages/fxa-auth-server/lib/oauth/db/redis.js
@@ -1,0 +1,181 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const config = require('../../../config');
+const logger = require('../logging')('db');
+const redis = require('../../redis');
+
+// These are used only in type declarations.
+// eslint-disable-next-line no-unused-vars
+const AccessToken = require('./accessToken');
+// eslint-disable-next-line no-unused-vars
+const RefreshTokenMetadata = require('./refreshTokenMetadata');
+
+// We store both access token and refresh token data in redis, separated
+// into two namespaces by using the "key prefix" feature of our  redis library.
+// Unfortunately, the key prefix is a connection-level setting, meaning that
+// we need to use a separate connection for each type of data.
+//
+// This is a little wrapper class to present the separate access-token and
+// refresh-token connections as a single conceptual "oauth redis db", in order
+// to keep the calling code a bit simpler.
+
+class OauthRedis {
+  constructor() {
+    this.redisAccessTokens = redis(
+      {
+        ...config.get('redis.accessTokens'),
+        enabled: true,
+        maxttl: config.get('oauthServer.expiration.accessToken'),
+      },
+      logger
+    );
+    this.redisRefreshTokens = redis(config.get('redis.refreshTokens'), logger);
+  }
+
+  async close() {
+    await this.redisAccessTokens.close();
+    await this.redisRefreshTokens.close();
+  }
+
+  /**
+   *
+   * @param {Buffer | string} tokenId
+   * @return {Promise<AccessToken>}
+   */
+  async getAccessToken(tokenId) {
+    return this.redisAccessTokens.getAccessToken(tokenId);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   * @return {Promise<AccessToken[]>}
+   */
+  async getAccessTokens(uid) {
+    return this.redisAccessTokens.getAccessTokens(uid);
+  }
+
+  /**
+   *
+   * @param {AccessToken} token
+   */
+  setAccessToken(token) {
+    return this.redisAccessTokens.setAccessToken(token);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} id
+   * @returns {Promise<boolean>} done
+   */
+  async removeAccessToken(id) {
+    return this.redisAccessTokens.removeAccessToken(id);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   */
+  removeAccessTokensForPublicClients(uid) {
+    return this.redisAccessTokens.removeAccessTokensForPublicClients(uid);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   * @param {Buffer | string} clientId
+   */
+  removeAccessTokensForUserAndClient(uid, clientId) {
+    return this.redisAccessTokens.removeAccessTokensForUserAndClient(
+      uid,
+      clientId
+    );
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   */
+  removeAccessTokensForUser(uid) {
+    return this.redisAccessTokens.removeAccessTokensForUser(uid);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   * @param {Buffer | string} tokenId
+   * @return {Promise<RefreshTokenMetadata>}
+   */
+  async getRefreshToken(uid, tokenId) {
+    if (!this.redisRefreshTokens) {
+      return null;
+    }
+    return this.redisRefreshTokens.getRefreshToken(uid, tokenId);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   * @return {Promise<{[key: string]: RefreshTokenMetadata}>}
+   */
+  async getRefreshTokens(uid) {
+    if (!this.redisRefreshTokens) {
+      return {};
+    }
+    return this.redisRefreshTokens.getRefreshTokens(uid);
+  }
+
+  /**
+   * @param {Buffer | string} uid
+   * @param {Buffer | string} tokenId
+   * @param {RefreshTokenMetadata} token
+   */
+  setRefreshToken(uid, tokenId, token) {
+    if (!this.redisRefreshTokens) {
+      return null;
+    }
+    return this.redisRefreshTokens.setRefreshToken(uid, tokenId, token);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   * @param {Buffer | string} token
+   * @returns {Promise<boolean>} done
+   */
+  async removeRefreshToken(uid, token) {
+    if (!this.redisRefreshTokens) {
+      return null;
+    }
+    return this.redisRefreshTokens.removeRefreshToken(uid, token);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   */
+  removeRefreshTokensForUser(uid) {
+    if (!this.redisRefreshTokens) {
+      return null;
+    }
+    return this.redisRefreshTokens.removeRefreshTokensForUser(uid);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   * @param {(Buffer | string)[]} tokenIdsToPrune
+   */
+  pruneRefreshTokens(uid, tokenIdsToPrune) {
+    if (!this.redisRefreshTokens) {
+      return null;
+    }
+    return this.redisRefreshTokens.pruneRefreshTokens(uid, tokenIdsToPrune);
+  }
+}
+
+module.exports = () => {
+  return new OauthRedis();
+};

--- a/packages/fxa-auth-server/lib/oauth/db/refreshTokenMetadata.js
+++ b/packages/fxa-auth-server/lib/oauth/db/refreshTokenMetadata.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+class RefreshTokenMetadata {
+  constructor(lastUsedAt) {
+    /** @type {Date} */
+    this.lastUsedAt = lastUsedAt || new Date();
+  }
+
+  /**
+   *
+   * @returns {object}
+   */
+  toJSON() {
+    return {
+      lastUsedAt: this.lastUsedAt.getTime(),
+    };
+  }
+
+  /**
+   *
+   * @param {string} string
+   * @returns {RefreshTokenMetadata}
+   */
+  static parse(string) {
+    const json = JSON.parse(string);
+    return new RefreshTokenMetadata(new Date(json.lastUsedAt));
+  }
+}
+
+module.exports = RefreshTokenMetadata;

--- a/packages/fxa-auth-server/lib/oauth/routes/authorized-clients/list.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/authorized-clients/list.js
@@ -16,9 +16,7 @@ function serialize(clientIdHex, token, acceptLanguage) {
   const lastAccessTime = token.lastUsedAt.getTime();
   return {
     client_id: clientIdHex,
-    refresh_token_id: token.refreshTokenId
-      ? hex(token.refreshTokenId)
-      : undefined,
+    refresh_token_id: token.tokenId ? hex(token.tokenId) : undefined,
     client_name: token.clientName,
     created_time: createdTime,
     last_access_time: lastAccessTime,

--- a/packages/fxa-auth-server/lib/oauth/routes/destroy.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/destroy.js
@@ -73,8 +73,7 @@ module.exports = {
         client_id: hex(tokObj.clientId),
       });
     }
-
-    await db[removeToken](token);
+    await db[removeToken](tokObj);
     return {};
   },
 };

--- a/packages/fxa-auth-server/lib/oauth/routes/token.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/token.js
@@ -55,9 +55,6 @@ const GRANT_FXA_ASSERTION = 'fxa-credentials';
 const ACCESS_TYPE_ONLINE = 'online';
 const ACCESS_TYPE_OFFLINE = 'offline';
 
-const REFRESH_LAST_USED_AT_UPDATE_AFTER_MS = config.get(
-  'oauthServer.refreshToken.updateAfter'
-);
 const DISABLED_CLIENTS = new Set(config.get('oauthServer.disabledClients'));
 
 // These scopes are used to request a one-off exchange of claims or credentials,
@@ -192,7 +189,6 @@ module.exports = {
     ) {
       throw AppError.disabledClient(hex(client.id));
     }
-
     const requestedGrant = await validateGrantParameters(client, params);
     return await generateTokens(requestedGrant);
   },
@@ -333,16 +329,9 @@ async function validateRefreshTokenGrant(client, params) {
   if (tokObj.offline) {
     throw AppError.invalidRequestParameter();
   }
-  // Periodically update last-used-at timestamp in the db.
-  // We don't do this every time because of the write load.
-  var now = new Date();
-  var lastUsedAt = tokObj.lastUsedAt;
-  if (now - lastUsedAt > REFRESH_LAST_USED_AT_UPDATE_AFTER_MS) {
-    await db.usedRefreshToken(encrypt.hash(params.refresh_token));
-    logger.debug('usedRefreshToken.updated', { now });
-  } else {
-    logger.debug('usedRefreshToken.not_updated');
-  }
+  // Update last-used-at timestamp in the db.
+  // The db stores this in redis to reduce impact of write load.
+  await db.touchRefreshToken(tokObj);
   return tokObj;
 }
 

--- a/packages/fxa-auth-server/test/oauth/api.js
+++ b/packages/fxa-auth-server/test/oauth/api.js
@@ -3202,7 +3202,7 @@ describe('/v1', function() {
         email: user.email,
         scope: ScopeSet.fromArray(scope),
       });
-      return encrypt.hash(token.token).toString('hex');
+      return token.tokenId.toString('hex');
     }
 
     async function makeRefreshToken(client, user, scope) {
@@ -3212,7 +3212,7 @@ describe('/v1', function() {
         email: user.email,
         scope: ScopeSet.fromArray(scope),
       });
-      return encrypt.hash(token.token).toString('hex');
+      return token.tokenId.toString('hex');
     }
 
     beforeEach(async () => {
@@ -3490,6 +3490,7 @@ describe('/v1', function() {
             refresh_token_id: tokenId,
           }),
         });
+        console.log(res.result);
         assert.equal(res.statusCode, 200);
         assertSecurityHeaders(res);
 

--- a/packages/fxa-auth-server/test/oauth/db/index.js
+++ b/packages/fxa-auth-server/test/oauth/db/index.js
@@ -149,7 +149,7 @@ describe('db', function() {
     it('should get the right refreshToken', function() {
       var hash = encrypt.hash(refreshToken);
       return db.getRefreshToken(hash).then(function(t) {
-        assert.equal(hex(t.token), hex(hash), 'got the right refresh_token');
+        assert.equal(hex(t.tokenId), hex(hash), 'got the right refresh_token');
       });
     });
 
@@ -179,8 +179,8 @@ describe('db', function() {
       const userId = buf(randomString(16));
       const email = 'a@b' + randomString(16) + ' + .c';
       const scope = ['no_scope'];
-      let tokenIdHash;
-      let refreshTokenIdHash;
+      let accessTokenId;
+      let refreshTokenId;
 
       return db
         .registerClient({
@@ -204,7 +204,7 @@ describe('db', function() {
           });
         })
         .then(function(t) {
-          tokenIdHash = encrypt.hash(t.token.toString('hex'));
+          accessTokenId = encrypt.hash(t.token.toString('hex'));
           return db.generateRefreshToken({
             clientId: clientId,
             userId: userId,
@@ -213,22 +213,22 @@ describe('db', function() {
           });
         })
         .then(function(t) {
-          refreshTokenIdHash = encrypt.hash(t.token.toString('hex'));
+          refreshTokenId = encrypt.hash(t.token.toString('hex'));
 
           return Promise.all([
-            db.getRefreshToken(refreshTokenIdHash),
-            db.getAccessToken(tokenIdHash),
+            db.getRefreshToken(refreshTokenId),
+            db.getAccessToken(accessTokenId),
           ]);
         })
         .then(tokens => {
-          assert.ok(tokens[0].token);
+          assert.ok(tokens[0].tokenId);
           assert.ok(tokens[1].tokenId);
           return db.removePublicAndCanGrantTokens(hex(userId));
         })
         .then(t => {
           return Promise.all([
-            db.getRefreshToken(refreshTokenIdHash),
-            db.getAccessToken(tokenIdHash),
+            db.getRefreshToken(refreshTokenId),
+            db.getAccessToken(accessTokenId),
           ]);
         })
         .catch(err => {
@@ -259,7 +259,7 @@ describe('db', function() {
         canGrant: false,
         publicClient: false,
       }).then(tokens => {
-        assert.ok(tokens[0].token);
+        assert.ok(tokens[0].tokenId);
         assert.ok(tokens[1].tokenId);
       });
     });
@@ -276,94 +276,114 @@ describe('db', function() {
   });
 
   describe('refresh token lastUsedAt', function() {
-    var clientId = buf(randomString(8));
-    var userId = buf(randomString(16));
-    var email = 'a@b.c';
-    var scope = ['no_scope'];
-    var code = null;
-    var refreshToken = null;
+    const clientId = buf(randomString(8));
+    const userId = buf(randomString(16));
+    const email = 'a@b.c';
+    const scope = ['no_scope'];
+    let refreshToken = null;
+    let tokenId;
 
-    beforeEach(function() {
-      return db
-        .registerClient({
-          id: clientId,
-          name: 'lastUsedAtTest',
-          hashedSecret: randomString(32),
-          imageUri: 'https://example.domain/logo',
-          redirectUri: 'https://example.domain/return?foo=bar',
-          trusted: true,
-        })
-        .then(function() {
-          return db.generateCode({
-            clientId: clientId,
-            userId: userId,
-            email: email,
-            scope: scope,
-            authAt: 0,
-          });
-        })
-        .then(function(c) {
-          code = c;
-          return db.getCode(code);
-        })
-        .then(function(code) {
-          assert.equal(hex(code.userId), hex(userId));
-          return db.generateAccessToken({
-            clientId: clientId,
-            userId: userId,
-            email: email,
-            scope: scope,
-          });
-        })
-        .then(function(t) {
-          assert.equal(hex(t.userId), hex(userId), 'token userId');
-          return db.generateRefreshToken({
-            clientId: clientId,
-            userId: userId,
-            email: email,
-            scope: scope,
-          });
-        })
-        .then(function(t) {
-          refreshToken = t;
-        });
+    beforeEach(async () => {
+      await db.registerClient({
+        id: clientId,
+        name: 'lastUsedAtTest',
+        hashedSecret: randomString(32),
+        imageUri: 'https://example.domain/logo',
+        redirectUri: 'https://example.domain/return?foo=bar',
+        trusted: true,
+      });
+      refreshToken = await db.generateRefreshToken({
+        clientId: clientId,
+        userId: userId,
+        email: email,
+        scope: scope,
+      });
+      tokenId = refreshToken.tokenId;
     });
 
-    it('should refresh token lastUsedAt', function() {
-      var tokenFirstUsage = {};
-      var hash = encrypt.hash(refreshToken.token);
+    afterEach(async () => {
+      await db.removeClient(clientId);
+    });
 
-      return db
-        .getRefreshToken(hash)
-        .then(function(t) {
-          assert.equal(hex(t.token), hex(hash), 'same token');
+    describe('after touching a refresh token', () => {
+      let tokenFirstUsage;
 
-          tokenFirstUsage.createdAt = new Date(t.createdAt);
-          tokenFirstUsage.lastUsedAt = t.lastUsedAt;
+      beforeEach(async () => {
+        tokenFirstUsage = {};
+        const t = await db.getRefreshToken(tokenId);
+        assert.equal(hex(t.tokenId), hex(tokenId), 'same token');
+        tokenFirstUsage.createdAt = new Date(t.createdAt);
+        tokenFirstUsage.lastUsedAt = t.lastUsedAt;
 
-          return Promise.delay(1000); //ensures that creation and subsequent usage are at least 1s apart
-        })
-        .then(function() {
-          return db.usedRefreshToken(encrypt.hash(refreshToken.token));
-        })
-        .then(function() {
-          return db.getRefreshToken(hash);
-        })
-        .then(function(t) {
-          assert.equal(hex(t.token), hex(hash), 'same token');
-          var updatedLastUsedAt = new Date(t.lastUsedAt);
+        // ensures that creation and subsequent usage are at least 1s apart
+        await Promise.delay(1000);
 
-          assert.equal(
-            updatedLastUsedAt > tokenFirstUsage.lastUsedAt,
-            true,
-            'lastUsedAt was updated'
-          );
-          assert.equal(
-            t.createdAt.toString(),
-            tokenFirstUsage.createdAt.toString(),
-            'creation date not changed'
-          );
+        await db.touchRefreshToken(t);
+      });
+
+      it('should report updated lastUsedAt when getting the token', async () => {
+        const t = await db.getRefreshToken(tokenId);
+        assert.equal(hex(t.tokenId), hex(tokenId), 'same token');
+
+        const updatedLastUsedAt = new Date(t.lastUsedAt);
+        assert.equal(
+          updatedLastUsedAt > tokenFirstUsage.lastUsedAt,
+          true,
+          'lastUsedAt was updated'
+        );
+        assert.equal(
+          t.createdAt.toString(),
+          tokenFirstUsage.createdAt.toString(),
+          'creation date not changed'
+        );
+      });
+
+      it('should report updated lastUsedAt when listing all tokens for a user', async () => {
+        const ts = await db.getRefreshTokensByUid(userId);
+        assert.equal(ts.length, 1, 'only one token');
+        const t = ts[0];
+        assert.equal(hex(t.tokenId), hex(tokenId), 'same token');
+        console.log(t);
+
+        const updatedLastUsedAt = new Date(t.lastUsedAt);
+        assert.equal(
+          updatedLastUsedAt > tokenFirstUsage.lastUsedAt,
+          true,
+          'lastUsedAt was updated'
+        );
+        assert.equal(
+          t.createdAt.toString(),
+          tokenFirstUsage.createdAt.toString(),
+          'creation date not changed'
+        );
+      });
+
+      it('should not record updated lastUsedAt in mysql', async () => {
+        const mysql = await db.mysql;
+        const t = await mysql._getRefreshToken(tokenId);
+        assert.equal(hex(t.tokenId), hex(tokenId), 'same token');
+        assert.equal(
+          t.lastUsedAt.toString(),
+          tokenFirstUsage.lastUsedAt.toString(),
+          'lastUsedAt not changed'
+        );
+      });
+
+      describe('after removing the refresh token', () => {
+        beforeEach(async () => {
+          await db.removeRefreshToken(refreshToken);
         });
+
+        it('should not report that the token still exists', async () => {
+          const t = await db.getRefreshToken(tokenId);
+          assert.equal(t, null, 'no token');
+        });
+
+        it('should not include the token when listing tokens for a user', async () => {
+          const ts = await db.getRefreshTokensByUid(userId);
+          assert.equal(ts.length, 0, 'no tokens');
+        });
+      });
     });
   });
 
@@ -668,21 +688,21 @@ describe('db', function() {
         const t = await db.generateAccessToken(tokenData);
         const mysql = await db.mysql;
         const tt = await mysql._getAccessToken(t.tokenId);
-        await db.removeAccessToken(t.tokenId);
+        await db.removeAccessToken(t);
         assert.equal(hex(tt.tokenId), hex(t.tokenId));
       });
 
       it('retrieves them with getAccessToken', async () => {
         const t = await db.generateAccessToken(tokenData);
         const tt = await db.getAccessToken(t.tokenId);
-        await db.removeAccessToken(t.tokenId);
+        await db.removeAccessToken(t);
         assert.equal(hex(tt.tokenId), hex(t.tokenId));
       });
 
       it('retrieves them with getAccessTokensByUid', async () => {
         const t = await db.generateAccessToken(tokenData);
         const tokens = await db.getAccessTokensByUid(userId);
-        await db.removeAccessToken(t.tokenId);
+        await db.removeAccessToken(t);
         assert.isArray(tokens);
         assert.lengthOf(tokens, 1);
         assert.deepEqual(tokens[0].tokenId, t.tokenId);
@@ -692,7 +712,7 @@ describe('db', function() {
       it('deletes them with removeAccessToken', async () => {
         const t = await db.generateAccessToken(tokenData);
         const tt = await db.getAccessToken(t.tokenId);
-        await db.removeAccessToken(t.tokenId);
+        await db.removeAccessToken(t);
         assert.isNotNull(tt);
         const ttt = await db.getAccessToken(t.tokenId);
         assert.isUndefined(ttt);


### PR DESCRIPTION
This PR will move storage of the `lastUsedAt` field on OAuth refresh tokens into redis, where it can be written to liberally in memory without crushing disk-based storage.

It is clearly not functional yet, but I'm pushing it for early visibility and to checkin with @dannycoates on some factoring as it relates to the access-tokens-in-redis PR.

Fixes #4146.