### PR TITLE
fix: use proper email in mismatch script

### DIFF
--- a/packages/fxa-auth-server/scripts/find-stripe-sync-issues.js
+++ b/packages/fxa-auth-server/scripts/find-stripe-sync-issues.js
@@ -89,9 +89,9 @@ async function init() {
         }
       }
       // Verify the email matches
-      if (record.normalizedEmail !== email) {
+      if (record.primaryEmail.email !== email) {
         console.log(
-          `${count}: EMAIL MISMATCH ${id} / ${userid} is in database with email of ${record.normalizedEmail}`
+          `${count}: EMAIL MISMATCH ${id} / ${userid} is in database with email of ${record.primaryEmail.email}`
         );
       }
       // Verify the uid matches


### PR DESCRIPTION
Because:

* We use the primary email in support/subscriptions routes not the
  email on the accounts table.

This commit:

* Uses the proper email for comparison.