### PR TITLE
fix(auth-server): use raw email for primary updates

### DIFF
--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -847,7 +847,7 @@ module.exports = (
             Sentry.withScope(scope => {
               scope.setContext('primaryEmailChange', {
                 originalEmail: primaryEmail,
-                newEmail: secondaryEmail.normalizedEmail,
+                newEmail: secondaryEmail.email,
                 system: source,
               });
               Sentry.captureException(err);
@@ -861,7 +861,7 @@ module.exports = (
             zendeskClient,
             uid,
             primaryEmail,
-            secondaryEmail.normalizedEmail
+            secondaryEmail.email
           ).catch(err => handleCriticalError(err, 'zendesk'));
 
           if (stripeHelper) {
@@ -872,11 +872,11 @@ module.exports = (
                 stripeHelper,
                 uid,
                 primaryEmail,
-                secondaryEmail.normalizedEmail
+                secondaryEmail.email
               );
               await stripeHelper.refreshCachedCustomer(
                 uid,
-                secondaryEmail.normalizedEmail
+                secondaryEmail.email
               );
             } catch (err) {
               // Due to the work involved by this point, we cannot abort the


### PR DESCRIPTION
Because:

* We verify and key zendesk/stripe by raw email and were updating
  the primary using the normalized which wouldn't match.

This commit:

* Uses the raw email rather than normalized for consistency.

Fixes #4303