### PR TITLE
fix(style): fix rtl style for disconnect client header

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -658,6 +658,10 @@ section.modal-panel {
     font-weight: normal;
     margin-bottom: 15px;
     text-align: left;
+
+    html[dir='rtl'] & {
+      text-align: right;
+    }
   }
 }
 


### PR DESCRIPTION
This patch fixes the RTL style of the header text on the disconnect a
client modal.

Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1617720

Fixes #4262 

@mozilla/fxa-devs r?