### PR TITLE
chore(nsp): add exception for advisory 1217

### DIFF
--- a/packages/fxa-content-server/.nsprc
+++ b/packages/fxa-content-server/.nsprc
@@ -8,6 +8,7 @@
   "comment_1084": "1084 is Mem denial of service is caused by cache not being removed even with maxage prop",
   "comment_1426": "1426 is Cross-Site Scripting (XSS) in serialize-javascript, used by uglifyjs-webpack-plugin",
   "comment_961": "961 is a DOS against node-sass",
+  "comment_1217": "1217 is an arbitrary file write issue in decompress, used by @theintern/digdug",
   "exceptions": [
     "https://npmjs.com/advisories/532",
     "https://npmjs.com/advisories/577",
@@ -17,6 +18,7 @@
     "https://npmjs.com/advisories/1065",
     "https://npmjs.com/advisories/1084",
     "https://npmjs.com/advisories/1426",
-    "https://npmjs.com/advisories/961"
+    "https://npmjs.com/advisories/961",
+    "https://npmjs.com/advisories/1217"
    ]
 }


### PR DESCRIPTION
decompress is used by @theintern/digdug, so please don't write a test that'll write arbitrary files to your system.

@mozilla/fxa-devs r?