### PR TITLE
docs(contributing): update contact information to reflect move to Matrix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,13 @@
 # Contribution Guidelines for the Firefox Accounts Content Server
 
-Anyone is welcome to help with Firefox Accounts. Feel free to get in touch with other community members on IRC, the
+Anyone is welcome to help with Firefox Accounts. Feel free to get in touch with other community members on Matrix, the
 mailing list or through issues here on GitHub.
 
-- IRC: `#fxa` on `irc.mozilla.org`
+- Matrix: [#fxa:mozilla.org](https://chat.mozilla.org/#/room/#fxa:mozilla.org)
 - Mailing list: <https://mail.mozilla.org/listinfo/dev-fxacct>
 - and of course, [the issues list](https://github.com/mozilla/fxa/issues)
+
+UPDATE: On March 2020, Mozilla moved from IRC to Matrix. For more information on Matrix, check out the following wiki article: <https://wiki.mozilla.org/Matrix>.
 
 ## Code of Conduct
 

--- a/packages/fxa-auth-db-mysql/CONTRIBUTING.md
+++ b/packages/fxa-auth-db-mysql/CONTRIBUTING.md
@@ -1,11 +1,13 @@
 # Contributing
 
-Anyone is welcome to help with Firefox Accounts. Feel free to get in touch with other community members on IRC, the
+Anyone is welcome to help with Firefox Accounts. Feel free to get in touch with other community members on Matrix, the
 mailing list or through issues here on GitHub.
 
-- IRC: `#fxa` on `irc.mozilla.org`
+- Matrix: [#fxa:mozilla.org](https://chat.mozilla.org/#/room/#fxa:mozilla.org)
 - Mailing list: <https://mail.mozilla.org/listinfo/dev-fxacct>
 - and of course, [the issues list](https://github.com/mozilla/fxa-auth-db-mysql/issues)
+
+UPDATE: On March 2020, Mozilla moved from IRC to Matrix. For more information on Matrix, check out the following wiki article: <https://wiki.mozilla.org/Matrix>.
 
 ## Bug Reports
 

--- a/packages/fxa-auth-server/CONTRIBUTING.md
+++ b/packages/fxa-auth-server/CONTRIBUTING.md
@@ -1,11 +1,13 @@
 # Contributing
 
-Anyone is welcome to help with Firefox Accounts. Feel free to get in touch with other community members on IRC, the
+Anyone is welcome to help with Firefox Accounts. Feel free to get in touch with other community members on Matrix, the
 mailing list or through issues here on GitHub.
 
-- IRC: `#fxa` on `irc.mozilla.org`
+- Matrix: [#fxa:mozilla.org](https://chat.mozilla.org/#/room/#fxa:mozilla.org)
 - Mailing list: <https://mail.mozilla.org/listinfo/dev-fxacct>
 - and of course, [the issues list](https://github.com/mozilla/fxa-auth-server/issues)
+
+UPDATE: On March 2020, Mozilla moved from IRC to Matrix. For more information on Matrix, check out the following wiki article: <https://wiki.mozilla.org/Matrix>.
 
 ## Bug Reports
 

--- a/packages/fxa-content-server/docs/architecture.md
+++ b/packages/fxa-content-server/docs/architecture.md
@@ -28,15 +28,15 @@ The content server is a combination of two components, a server component and a 
 
 ### Server side Goals/Desired Quality Attributes
 
--   The server should contain very little "business" logic, the content server should only be responsible for serving UI.
--   Most content server work should be deferred to the web client.
--   The server should be able to deliver content in the user's preferred language.
+- The server should contain very little "business" logic, the content server should only be responsible for serving UI.
+- Most content server work should be deferred to the web client.
+- The server should be able to deliver content in the user's preferred language.
 
 ### Web Client Goals/Desired Quality Attributes
 
--   Can be integrated into any Web capable system.
--   Can be extended to provide an interface to Web capable native applications, e.g., a native panel within a browser.
--   Can be opened by any modern browser or rendering engine that supports HTML5.
+- Can be integrated into any Web capable system.
+- Can be extended to provide an interface to Web capable native applications, e.g., a native panel within a browser.
+- Can be opened by any modern browser or rendering engine that supports HTML5.
 
 ### Relier/Relying Party
 
@@ -246,17 +246,19 @@ Mozilla's L10n community has done an incredible job of translating Firefox Accou
 
 ## Contact
 
--   Developer mailing list: dev-fxacct@mozilla.org
--   IRC: #fxa in irc.mozilla.org
+- Developer mailing list: dev-fxacct@mozilla.org
+- Matrix: [#fxa:mozilla.org](https://chat.mozilla.org/#/room/#fxa:mozilla.org)
+
+UPDATE: On March 2020, Mozilla moved from IRC to Matrix. For more information on Matrix, check out the following wiki article: <https://wiki.mozilla.org/Matrix>.
 
 ## Additional Resources
 
--   [APIs attached to Firefox Accounts](https://developer.mozilla.org/docs/Mozilla/APIs_attached_to_Firefox_Accounts)
--   [Firefox Accounts Auth Server API](https://github.com/mozilla/fxa-auth-server/blob/master/docs/api.md)
--   [Firefox Acocunts Auth Server Codebase](https://github.com/mozilla/fxa-auth-server/)
--   [Firefox Accounts OAuth Server API](https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md)
--   [Firefox Accounts OAuth Server Codebase](https://github.com/mozilla/fxa-oauth-server/)
--   [Firefox Accounts Profile Server API](https://github.com/mozilla/fxa-profile-server/blob/master/docs/API.md)
--   [Firefox Accounts Profile Server Codebase](https://github.com/mozilla/fxa-profile-server/)
--   [OAuth 2.0 RFC 6749](http://tools.ietf.org/html/rfc6749)
--   [Firefox Accounts Pairing Flow](pairing-architecture.md)
+- [APIs attached to Firefox Accounts](https://developer.mozilla.org/docs/Mozilla/APIs_attached_to_Firefox_Accounts)
+- [Firefox Accounts Auth Server API](https://github.com/mozilla/fxa-auth-server/blob/master/docs/api.md)
+- [Firefox Acocunts Auth Server Codebase](https://github.com/mozilla/fxa-auth-server/)
+- [Firefox Accounts OAuth Server API](https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md)
+- [Firefox Accounts OAuth Server Codebase](https://github.com/mozilla/fxa-oauth-server/)
+- [Firefox Accounts Profile Server API](https://github.com/mozilla/fxa-profile-server/blob/master/docs/API.md)
+- [Firefox Accounts Profile Server Codebase](https://github.com/mozilla/fxa-profile-server/)
+- [OAuth 2.0 RFC 6749](http://tools.ietf.org/html/rfc6749)
+- [Firefox Accounts Pairing Flow](pairing-architecture.md)

--- a/packages/fxa-customs-server/CONTRIBUTING.md
+++ b/packages/fxa-customs-server/CONTRIBUTING.md
@@ -1,11 +1,13 @@
 # Contributing
 
-Anyone is welcome to help with Firefox Accounts. Feel free to get in touch with other community members on IRC, the
+Anyone is welcome to help with Firefox Accounts. Feel free to get in touch with other community members on Matrix, the
 mailing list or through issues here on GitHub.
 
-- IRC: `#fxa` on `irc.mozilla.org`
+- Matrix: [#fxa:mozilla.org](https://chat.mozilla.org/#/room/#fxa:mozilla.org)
 - Mailing list: <https://mail.mozilla.org/listinfo/dev-fxacct>
 - and of course, [the bug tracker](https://github.com/mozilla/fxa-customs-server/issues)
+
+UPDATE: On March 2020, Mozilla moved from IRC to Matrix. For more information on Matrix, check out the following wiki article: <https://wiki.mozilla.org/Matrix>.
 
 ## Bug Reports
 

--- a/packages/fxa-geodb/README.md
+++ b/packages/fxa-geodb/README.md
@@ -105,9 +105,11 @@ By default, the cron job runs every week on Wednesday at 01:30:30 (UTC -7) and u
 
 ### Getting involved
 
-Interested in contributing to the development of Firefox Accounts GeoDB repo? Great! Head over to the #fxa channel on irc.mozilla.org with questions, or jump ahead and fix any of the issues we have.
+Interested in contributing to the development of Firefox Accounts GeoDB repo? Great! Head over to the [#fxa:mozilla.org](https://chat.mozilla.org/#/room/#fxa:mozilla.org) room on Matrix with questions, or jump ahead and fix any of the issues we have.
 
 Please review and understand the [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/) before contributing to this project. Also, following the [commit guidelines](https://github.com/mozilla/fxa/blob/master/CONTRIBUTING.md#git-commit-guidelines) is greatly appreciated.
+
+UPDATE: On March 2020, Mozilla moved from IRC to Matrix. For more information on Matrix, check out the following wiki article: <https://wiki.mozilla.org/Matrix>.
 
 --
 

--- a/packages/fxa-js-client/CONTRIBUTING.md
+++ b/packages/fxa-js-client/CONTRIBUTING.md
@@ -1,11 +1,13 @@
 # Contribution guidelines to fxa-js-client
 
-Anyone is welcome to help with Firefox Accounts. Feel free to get in touch with other community members on IRC, the
+Anyone is welcome to help with Firefox Accounts. Feel free to get in touch with other community members on Matrix, the
 mailing list or through issues here on GitHub.
 
-- IRC: `#fxa` on `irc.mozilla.org`
+- Matrix: [#fxa:mozilla.org](https://chat.mozilla.org/#/room/#fxa:mozilla.org)
 - Mailing list: <https://mail.mozilla.org/listinfo/dev-fxacct>
 - and of course, [the issues list](https://github.com/mozilla/fxa-js-client/issues)
+
+UPDATE: On March 2020, Mozilla moved from IRC to Matrix. For more information on Matrix, check out the following wiki article: <https://wiki.mozilla.org/Matrix>.
 
 ## Bug Reports
 

--- a/packages/fxa-profile-server/CONTRIBUTING.md
+++ b/packages/fxa-profile-server/CONTRIBUTING.md
@@ -1,11 +1,13 @@
 # Contributing
 
-Anyone is welcome to help with Firefox Accounts. Feel free to get in touch with other community members on IRC, the
+Anyone is welcome to help with Firefox Accounts. Feel free to get in touch with other community members on Matrix, the
 mailing list or through issues here on GitHub.
 
-- IRC: `#fxa` on `irc.mozilla.org`
+- Matrix: [#fxa:mozilla.org](https://chat.mozilla.org/#/room/#fxa:mozilla.org)
 - Mailing list: <https://mail.mozilla.org/listinfo/dev-fxacct>
 - and of course, [the issues list](https://github.com/mozilla/fxa-profile-server/issues)
+
+UPDATE: On March 2020, Mozilla moved from IRC to Matrix. For more information on Matrix, check out the following wiki article: <https://wiki.mozilla.org/Matrix>.
 
 ## Bug Reports
 


### PR DESCRIPTION
Because: On March 2020, Mozilla moved from IRC to Matrix. To ensure a smooth transition, information on how to access Matrix and reach the fxa team in this new virtual space needed to be added to our documentation.