### PR TITLE
 chore(CircleCI): run content server tests on medium VM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,6 @@ jobs:
       - run: ../../.circleci/deploy.sh << parameters.module >>
 
   fxa-content-server:
-    resource_class: medium+
     parallelism: 6
     docker:
       - image: mozilla/fxa-circleci

--- a/.circleci/test-content-server.sh
+++ b/.circleci/test-content-server.sh
@@ -28,7 +28,7 @@ function check() {
 
 function test_suite() {
   local suite=$1
-  local numGroups=4
+  local numGroups=6
 
   for i in $(seq $numGroups)
   do


### PR DESCRIPTION
This patch reverts the VM size for content server tests to the default
(medium).  Now Firefox is restarted more frequently (per X test suites).

Part of #4374

@mozilla/fxa-devs r?