### PR TITLE
fix(payments): support clientId as buffer in subscription capability lookup

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -232,10 +232,11 @@ async function generateIdToken(grant, accessToken) {
 }
 
 exports.generateAccessToken = async function generateAccessToken(grant) {
+  const clientId = hex(grant.clientId).toLowerCase();
   const accessToken = await db.generateAccessToken(grant);
   if (
     !JWT_ACCESS_TOKENS_ENABLED ||
-    !JWT_ACCESS_TOKENS_CLIENT_IDS.has(hex(grant.clientId).toLowerCase())
+    !JWT_ACCESS_TOKENS_CLIENT_IDS.has(clientId)
   ) {
     // return the old style access token if JWT access tokens are
     // not globally enabled or if not enabled for the given clientId.
@@ -246,7 +247,7 @@ exports.generateAccessToken = async function generateAccessToken(grant) {
     const capabilities = await determineClientVisibleSubscriptionCapabilities(
       stripeHelper,
       hex(grant.userId),
-      grant.clientId,
+      clientId,
       grant.email
     );
     // To avoid mutating the input grant, create a

--- a/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
@@ -4,6 +4,8 @@
 
 'use strict';
 
+const hex = require('buf').to.hex;
+
 const SubscriptionUtils = (module.exports = {
   // Support some default null values for product / plan metadata and
   // allow plan metadata to override product metadata
@@ -29,9 +31,11 @@ const SubscriptionUtils = (module.exports = {
   determineClientVisibleSubscriptionCapabilities: async function(
     stripeHelper,
     uid,
-    client_id,
+    clientIdRaw,
     email
   ) {
+    const clientId =
+      clientIdRaw === null ? null : hex(clientIdRaw).toLowerCase();
     if (!stripeHelper) {
       return undefined;
     }
@@ -42,7 +46,7 @@ const SubscriptionUtils = (module.exports = {
     );
     const capabilitiesToReveal = await checkCapabilitiesFromStripe(
       subscribedProducts,
-      client_id,
+      clientId,
       stripeHelper
     );
     return capabilitiesToReveal.size > 0
@@ -63,7 +67,6 @@ async function fetchSubscribedProductsFromStripe(uid, stripeHelper, email) {
   if (!customer || !customer.subscriptions.data) {
     return [];
   }
-
   const subscribedProducts = customer.subscriptions.data
     // TODO: Centralize subscription filtering logic for active subs
     .filter(sub => ['active', 'trialing', 'past_due'].includes(sub.status))

--- a/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
@@ -93,7 +93,7 @@ describe('routes/utils/subscriptions', () => {
           mockStripeHelper,
           UID,
           // null client represents sessionToken auth from content-server, unfiltered by client
-          clientId === 'null' ? null : clientId,
+          clientId === 'null' ? null : Buffer.from(clientId, 'hex'),
           EMAIL
         ),
         expectedCapabilities

--- a/packages/fxa-auth-server/test/oauth/grant.js
+++ b/packages/fxa-auth-server/test/oauth/grant.js
@@ -358,7 +358,7 @@ describe('generateTokens', () => {
       ]),
     });
 
-    requestedGrant.clientId = clientId;
+    requestedGrant.clientId = Buffer.from(clientId, 'hex');
     const result = await generateTokens(requestedGrant);
     assert.isTrue(mockDB.generateAccessToken.calledOnceWith(requestedGrant));
     assert.strictEqual(result.access_token, 'signed jwt access token');


### PR DESCRIPTION
fixes #4370