### PR TITLE
chore(ci): skip email service tests for PRs when not required

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,16 +240,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - run: |
-          ./scripts/test_with_authdb.sh
-          cargo audit --ignore RUSTSEC-2019-0033 --ignore RUSTSEC-2018-0015 --ignore RUSTSEC-2019-0034
-          mkdir -m 755 bin
-          mkdir -m 755 bin/config
-          cargo build --release
-          cp config/* bin/config
-          cp target/release/fxa_email_send bin
-          cp target/release/fxa_email_queues bin
-          cargo clean
+      - run: ../../.circleci/test-email-service.sh
       - store_artifacts:
           path: fxa-auth-db-mysql.log
       - setup_remote_docker

--- a/.circleci/test-email-service.sh
+++ b/.circleci/test-email-service.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -ex
+
+MODULE=$(basename $(pwd))
+DIR=$(dirname "$0")
+
+if grep -e "$MODULE" -e 'all' $DIR/../packages/test.list; then
+  ./scripts/test_with_authdb.sh
+  cargo audit --ignore RUSTSEC-2019-0033 --ignore RUSTSEC-2018-0015 --ignore RUSTSEC-2019-0034
+  mkdir -m 755 bin
+  mkdir -m 755 bin/config
+  cargo build --release
+  cp config/* bin/config
+  cp target/release/fxa_email_send bin
+  cp target/release/fxa_email_queues bin
+  cargo clean
+else
+  exit 0;
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Thumbs.db
 
 # Linux
 .*
+!.circleci/
 !.gitignore
 !.git*
 !.eslintrc


### PR DESCRIPTION
I noticed [here](https://circleci.com/workflow-run/c9fa699d-d3d3-4ad3-a3b8-dd94d35977f2?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link) that email-service was building even though only content and payments were changed. email-service uses an xlarge instance so we should minimize its usage.