### PR TITLE
feat(admin-server): add vscode settings

### DIFF
--- a/packages/fxa-admin-server/.vscode/launch.json
+++ b/packages/fxa-admin-server/.vscode/launch.json
@@ -1,0 +1,57 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Local Nodemon",
+      "preLaunchTask": "tsc-watch",
+      "protocol": "auto",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "debug"],
+      "restart": true,
+      "port": 5860,
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha All",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--timeout",
+        "999999",
+        "--colors",
+        "-r",
+        "ts-node/register",
+        "${workspaceFolder}/src/test/**/*.spec.ts",
+        "${workspaceFolder}/src/test/**/**/*.spec.ts",
+        "${workspaceFolder}/src/test/**/**/**/*.spec.ts"
+      ],
+      "env": {
+        "FIRESTORE_EMULATOR_HOST": "localhost:8006",
+        "FIRESTORE_PROJECT_ID": "fx-event-broker"
+      },
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha Current File",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--timeout",
+        "999999",
+        "--colors",
+        "-r",
+        "ts-node/register",
+        "${workspaceFolder}/${relativeFile}"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}

--- a/packages/fxa-admin-server/.vscode/tasks.json
+++ b/packages/fxa-admin-server/.vscode/tasks.json
@@ -1,0 +1,30 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "tsc-watch",
+      "command": "npm",
+      "args": ["run", "watch"],
+      "type": "shell",
+      "isBackground": true,
+      "group": "build",
+      "problemMatcher": "$tsc-watch",
+      "presentation": {
+        "reveal": "always"
+      }
+    },
+    {
+      "label": "Run Current Test",
+      "type": "shell",
+      "command": "./node_modules/mocha/bin/mocha",
+      "args": ["-r", "ts-node/register", "${relativeFile}"],
+      "group": "test",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "dedicated"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Because:

* There's no existing defined settings to run the admin server or
  tests with the debugger.

This commit:

* Add's VS code settings to run the debugger for the admin-server
  and its tests.

Closes #4244