### PR TITLE
fix(customs): set config for flowIdExemptUserAgentREs to `format: Array`

### DIFF
--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -221,13 +221,14 @@ module.exports = function(fs, path, url, convict) {
         doc: 'Whether to require a flowId in payload on account login.',
         format: Boolean,
         default: false,
-        env: 'FLOW_ID_REQUIRED_ON_LOGIN'
+        env: 'FLOW_ID_REQUIRED_ON_LOGIN',
       },
       flowIdExemptUserAgentREs: {
         doc: 'An array of STRING regexes for UAs that dont require a flowId.',
-        default: [ ],
-        env: 'FLOW_ID_EXEMPT_UA_REGEXES'
-      }
+        format: Array,
+        default: [],
+        env: 'FLOW_ID_EXEMPT_UA_REGEXES',
+      },
     },
     ipBlocklist: {
       enable: {


### PR DESCRIPTION
When setting FLOW_ID_EXEMPT_UA_REGEXES in the environment, this `format: Array` is required. (Otherwise, node-convict tries to infer the type from the default, but uses `typeof` on Array, which is `object`, so node-convict tries and fails to JSON.parse the environment value.

I had a test for this, but with tests not working, I can't really tell if the tests plays nicely with the other tests. (The test needs to `delete require.cache[configModulePath]` to reload `../../lib/config`.)

r? - @mozilla/fxa-devs 