### PR TITLE
test(auth-server): add coverage for listActive

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/fixtures/subscription_cancelled.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/subscription_cancelled.json
@@ -1,0 +1,108 @@
+{
+    "id": "sub_GWSkxxni5LtLCN",
+    "object": "subscription",
+    "application_fee_percent": null,
+    "billing": "charge_automatically",
+    "billing_cycle_anchor": 1578671671,
+    "billing_thresholds": null,
+    "cancel_at": null,
+    "cancel_at_period_end": false,
+    "canceled_at": 1582720052,
+    "collection_method": "charge_automatically",
+    "created": 1578671671,
+    "current_period_end": 1582732471,
+    "current_period_start": 1582646071,
+    "customer": "cus_GWSknodAeAs3d9",
+    "days_until_due": null,
+    "default_payment_method": null,
+    "default_source": null,
+    "default_tax_rates": [
+    ],
+    "discount": null,
+    "ended_at": 1582720052,
+    "invoice_customer_balance_settings": {
+      "consume_applied_balance_on_void": true
+    },
+    "items": {
+      "object": "list",
+      "data": [
+        {
+          "id": "si_GWSkMeUMweYbNO",
+          "object": "subscription_item",
+          "billing_thresholds": null,
+          "created": 1578671671,
+          "metadata": {
+          },
+          "plan": {
+            "id": "plan_GWSd22z7QP8x3M",
+            "object": "plan",
+            "active": true,
+            "aggregate_usage": null,
+            "amount": 699,
+            "amount_decimal": "699",
+            "billing_scheme": "per_unit",
+            "created": 1578671266,
+            "currency": "usd",
+            "interval": "day",
+            "interval_count": 1,
+            "livemode": false,
+            "metadata": {
+            },
+            "nickname": "daily",
+            "product": "prod_FaoUiGcVfoGaLA",
+            "tiers": null,
+            "tiers_mode": null,
+            "transform_usage": null,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "quantity": 1,
+          "subscription": "sub_GWSkxxni5LtLCN",
+          "tax_rates": [
+          ]
+        }
+      ],
+      "has_more": false,
+      "total_count": 1,
+      "url": "/v1/subscription_items?subscription=sub_GWSkxxni5LtLCN"
+    },
+    "latest_invoice": "in_1GG5kCKb9q6OnNsLyXgkZN0e",
+    "livemode": false,
+    "metadata": {
+    },
+    "next_pending_invoice_item_invoice": null,
+    "pending_invoice_item_interval": null,
+    "pending_setup_intent": null,
+    "pending_update": null,
+    "plan": {
+      "id": "plan_GWSd22z7QP8x3M",
+      "object": "plan",
+      "active": true,
+      "aggregate_usage": null,
+      "amount": 699,
+      "amount_decimal": "699",
+      "billing_scheme": "per_unit",
+      "created": 1578671266,
+      "currency": "usd",
+      "interval": "day",
+      "interval_count": 1,
+      "livemode": false,
+      "metadata": {
+      },
+      "nickname": "daily",
+      "product": "prod_FaoUiGcVfoGaLA",
+      "tiers": null,
+      "tiers_mode": null,
+      "transform_usage": null,
+      "trial_period_days": null,
+      "usage_type": "licensed"
+    },
+    "quantity": 1,
+    "schedule": null,
+    "start": 1578671671,
+    "start_date": 1578671671,
+    "status": "canceled",
+    "tax_percent": null,
+    "trial_end": null,
+    "trial_start": null
+  }

--- a/packages/fxa-auth-server/test/local/payments/fixtures/subscription_past_due.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/subscription_past_due.json
@@ -1,0 +1,110 @@
+{
+    "id": "sub_FvOedh0SsaUVni",
+    "object": "subscription",
+    "application_fee_percent": null,
+    "billing": "charge_automatically",
+    "billing_cycle_anchor": 1570122777,
+    "billing_thresholds": null,
+    "cancel_at": null,
+    "cancel_at_period_end": false,
+    "canceled_at": null,
+    "collection_method": "charge_automatically",
+    "created": 1570122777,
+    "current_period_end": 1583255577,
+    "current_period_start": 1580749977,
+    "customer": "cus_FvOeygARlRBJI6",
+    "days_until_due": null,
+    "default_payment_method": null,
+    "default_source": null,
+    "default_tax_rates": [
+    ],
+    "discount": null,
+    "ended_at": null,
+    "invoice_customer_balance_settings": {
+      "consume_applied_balance_on_void": true
+    },
+    "items": {
+      "object": "list",
+      "data": [
+        {
+          "id": "si_FvOe13KgcXQ7Oj",
+          "object": "subscription_item",
+          "billing_thresholds": null,
+          "created": 1570122778,
+          "metadata": {
+          },
+          "plan": {
+            "id": "plan_FiJ55YK6UYftPa",
+            "object": "plan",
+            "active": true,
+            "aggregate_usage": null,
+            "amount": 999,
+            "amount_decimal": "999",
+            "billing_scheme": "per_unit",
+            "created": 1567103726,
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 1,
+            "livemode": false,
+            "metadata": {
+              "downloadURL": ""
+            },
+            "nickname": "guardian_monthly",
+            "product": "prod_FiJ42WCzZNRSbS",
+            "tiers": null,
+            "tiers_mode": null,
+            "transform_usage": null,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "quantity": 1,
+          "subscription": "sub_FvOedh0SsaUVni",
+          "tax_rates": [
+          ]
+        }
+      ],
+      "has_more": false,
+      "total_count": 1,
+      "url": "/v1/subscription_items?subscription=sub_FvOedh0SsaUVni"
+    },
+    "latest_invoice": "in_1G88U1Kb9q6OnNsLNZs0Hi90",
+    "livemode": false,
+    "metadata": {
+    },
+    "next_pending_invoice_item_invoice": null,
+    "pending_invoice_item_interval": null,
+    "pending_setup_intent": null,
+    "pending_update": null,
+    "plan": {
+      "id": "plan_FiJ55YK6UYftPa",
+      "object": "plan",
+      "active": true,
+      "aggregate_usage": null,
+      "amount": 999,
+      "amount_decimal": "999",
+      "billing_scheme": "per_unit",
+      "created": 1567103726,
+      "currency": "usd",
+      "interval": "month",
+      "interval_count": 1,
+      "livemode": false,
+      "metadata": {
+        "downloadURL": ""
+      },
+      "nickname": "guardian_monthly",
+      "product": "prod_FiJ42WCzZNRSbS",
+      "tiers": null,
+      "tiers_mode": null,
+      "transform_usage": null,
+      "trial_period_days": null,
+      "usage_type": "licensed"
+    },
+    "quantity": 1,
+    "schedule": null,
+    "start": 1570122777,
+    "start_date": 1570122777,
+    "status": "past_due",
+    "tax_percent": null,
+    "trial_end": null,
+    "trial_start": null
+  }

--- a/packages/fxa-auth-server/test/local/payments/fixtures/subscription_trialing.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/subscription_trialing.json
@@ -1,0 +1,115 @@
+{
+    "id": "sub_Go8xakzusK28jD",
+    "object": "subscription",
+    "application_fee_percent": null,
+    "billing_cycle_anchor": 1585341566,
+    "billing_thresholds": null,
+    "cancel_at": null,
+    "cancel_at_period_end": false,
+    "canceled_at": null,
+    "collection_method": "charge_automatically",
+    "created": 1582749566,
+    "current_period_end": 1585341566,
+    "current_period_start": 1582749566,
+    "customer": "cus_F9ummXtdDpSWQa",
+    "days_until_due": null,
+    "default_payment_method": null,
+    "default_source": null,
+    "default_tax_rates": [
+    ],
+    "discount": null,
+    "ended_at": null,
+    "invoice_settings": {
+      "supported_payment_methods": {
+      }
+    },
+    "items": {
+      "object": "list",
+      "data": [
+        {
+          "id": "si_Go8xe7a8SAW4HB",
+          "object": "subscription_item",
+          "billing_thresholds": null,
+          "created": 1582749566,
+          "metadata": {
+          },
+          "plan": {
+            "id": "plan_GgIlG4DEqTBE71",
+            "object": "plan",
+            "active": true,
+            "aggregate_usage": null,
+            "amount": 200,
+            "amount_decimal": "200",
+            "billing_scheme": "per_unit",
+            "created": 1580940949,
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 1,
+            "livemode": false,
+            "metadata": {
+            },
+            "name": "Product B",
+            "nickname": "Monthly",
+            "owning_merchant": "acct_1EPYo2GQOhcKSZ1L",
+            "owning_merchant_info": "acct_1EPYo2GQOhcKSZ1L",
+            "product": "prod_GgIlYvvmpprKAy",
+            "tiers": null,
+            "tiers_mode": null,
+            "transform_usage": null,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "quantity": 1,
+          "subscription": "sub_Go8xakzusK28jD",
+          "tax_rates": [
+          ]
+        }
+      ],
+      "has_more": false,
+      "total_count": 1,
+      "url": "/v1/subscription_items?subscription=sub_Go8xakzusK28jD"
+    },
+    "latest_invoice": "in_1GGWfCGQOhcKSZ1LV1RUr9X5",
+    "livemode": false,
+    "metadata": {
+    },
+    "next_pending_invoice_item_invoice": null,
+    "owning_merchant": "acct_1EPYo2GQOhcKSZ1L",
+    "owning_merchant_info": "acct_1EPYo2GQOhcKSZ1L",
+    "pending_invoice_item_interval": null,
+    "pending_setup_intent": null,
+    "pending_update": null,
+    "plan": {
+      "id": "plan_GgIlG4DEqTBE71",
+      "object": "plan",
+      "active": true,
+      "aggregate_usage": null,
+      "amount": 200,
+      "amount_decimal": "200",
+      "billing_scheme": "per_unit",
+      "created": 1580940949,
+      "currency": "usd",
+      "interval": "month",
+      "interval_count": 1,
+      "livemode": false,
+      "metadata": {
+      },
+      "name": "Product B",
+      "nickname": "Monthly",
+      "owning_merchant": "acct_1EPYo2GQOhcKSZ1L",
+      "owning_merchant_info": "acct_1EPYo2GQOhcKSZ1L",
+      "product": "prod_GgIlYvvmpprKAy",
+      "tiers": null,
+      "tiers_mode": null,
+      "transform_usage": null,
+      "trial_period_days": null,
+      "usage_type": "licensed"
+    },
+    "quantity": 1,
+    "schedule": null,
+    "start_date": 1582749566,
+    "status": "trialing",
+    "tax_percent": null,
+    "trial_end": 1585341566,
+    "trial_start": 1582749566
+  }


### PR DESCRIPTION
- add coverage for DirectStripeRoutes.listActive
- fix tests that were breaking due to shallow copies of test object by adding deepCopy function

fixes #4228