### PR TITLE
fix: lookup clientids in eventbroker

### DIFF
--- a/_scripts/pubsub.sh
+++ b/_scripts/pubsub.sh
@@ -16,8 +16,7 @@ trap on_sigint INT
 
 # Create pushbox db on start (because pushbox doesn't create it)
 docker run --rm --name=pubsub \
-  --network=host \
   -p 8005:8085 \
-  knarz/pubsub-emulator &
+  knarz/pubsub-emulator:latest &
 
 while :; do read; done

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -129,10 +129,14 @@ class DirectStripeRoutes {
     }
 
     return Object.entries(capabilitiesByClientId).map(
-      ([clientId, capabilities]) => ({
-        clientId,
-        capabilities: [...capabilitiesForAll, ...capabilities],
-      })
+      ([clientId, capabilities]) => {
+        // Merge dupes with Set
+        const capabilitySet = new Set([...capabilitiesForAll, ...capabilities]);
+        return {
+          clientId,
+          capabilities: [...capabilitySet],
+        };
+      }
     );
   }
 
@@ -492,7 +496,9 @@ class DirectStripeRoutes {
         capabilitiesForProduct.push(...splitCapabilities(metadata[key]));
       }
     }
-    return capabilitiesForProduct;
+    // Remove duplicates with Set
+    const capabilitySet = new Set(capabilitiesForProduct);
+    return [...capabilitySet];
   }
 
   /**

--- a/packages/fxa-event-broker/bin/workerDev.ts
+++ b/packages/fxa-event-broker/bin/workerDev.ts
@@ -128,11 +128,13 @@ async function main() {
     logger,
     Config.get('clientCapabilityFetch')
   );
+
   const webhookService = new ClientWebhookService(
     logger,
     Config.get('clientCapabilityFetch.refreshInterval'),
     db
   );
+
   const pubsub = new PubSub({ projectId: 'fxa-event-broker' });
   await verifyTopicConfig(pubsub, Config.get('proxy').port, webhookService);
 

--- a/packages/fxa-event-broker/package-lock.json
+++ b/packages/fxa-event-broker/package-lock.json
@@ -68,39 +68,38 @@
       }
     },
     "@google-cloud/paginator": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-2.0.2.tgz",
-      "integrity": "sha512-PCddVtZWvw0iZ3BLIsCXMBQvxUcS9O5CgfHBu8Zd8T3DCiML+oQED1odsbl3CQ9d3RrvBaj+eIh7Dv12D15PbA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-2.0.3.tgz",
+      "integrity": "sha512-kp/pkb2p/p0d8/SKUu4mOq8+HGwF8NPzHWkj+VKrIPQPyMRw8deZtrO/OcSiy9C/7bpfU5Txah5ltUNfPkgEXg==",
       "requires": {
         "arrify": "^2.0.0",
         "extend": "^3.0.2"
       }
     },
     "@google-cloud/precise-date": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-1.0.2.tgz",
-      "integrity": "sha512-EXk9MYAoKz3hD0ITklFIe4aPK+tHk/3WL2DvTD28wAPpYiIMClXTUqX9fanhdurhO1KUU06HBoU3+Rks32yTTQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/precise-date/-/precise-date-1.0.3.tgz",
+      "integrity": "sha512-wWnDGh9y3cJHLuVEY8t6un78vizzMWsS7oIWKeFtPj+Ndy+dXvHW0HTx29ZUhen+tswSlQYlwFubvuRP5kKdzQ=="
     },
     "@google-cloud/projectify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-1.0.2.tgz",
-      "integrity": "sha512-WnkGxvk4U1kAJpoS/Ehk+3MZXVW+XHHhwc/QyD6G8Za4xml3Fv+NRn/bYffl1TxSg+gE0N0mj9Shgc7e8+fl8A=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-1.0.4.tgz",
+      "integrity": "sha512-ZdzQUN02eRsmTKfBj9FDL0KNDIFNjBn/d6tHQmA/+FImH5DO6ZV8E7FzxMgAUiVAUq41RFAkb25p1oHOZ8psfg=="
     },
     "@google-cloud/promisify": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.3.tgz",
-      "integrity": "sha512-Rufgfl3TnkIil3CjsH33Q6093zeoVqyqCdvtvgHuCqRJxCZYfaVPIyr8JViMeLTD4Ja630pRKKZVSjKggoVbNg=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.4.tgz",
+      "integrity": "sha512-VccZDcOql77obTnFh0TbNED/6ZbbmHDf8UMNnzO1d5g9V0Htfm4k5cllY8P1tJsRKC3zWYGRLaViiupcgVjBoQ=="
     },
     "@google-cloud/pubsub": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-1.1.5.tgz",
-      "integrity": "sha512-gFWYWkTVRgR0qPhQzUoKXu9m21P6zcJ9ORWMX+LcHqJuc1NNBpn7MTMoQTZQIof6GPUo0bTMzvkyTrq9wVTS8A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-1.5.0.tgz",
+      "integrity": "sha512-SCuNClo/xDGjYmciExxVjX78WPY1Ul6MK5Qn5eX2tsILqxXpf5Lan+XU/jnL53pirAIFgcxt8I2CWibSdSqRww==",
       "requires": {
         "@google-cloud/paginator": "^2.0.0",
         "@google-cloud/precise-date": "^1.0.0",
         "@google-cloud/projectify": "^1.0.0",
         "@google-cloud/promisify": "^1.0.0",
-        "@sindresorhus/is": "^1.0.0",
         "@types/duplexify": "^3.6.0",
         "@types/long": "^4.0.0",
         "arrify": "^2.0.0",
@@ -115,9 +114,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.6.9.tgz",
-      "integrity": "sha512-r1nDOEEiYmAsVYBaS4DPPqdwPOXPw7YhVOnnpPdWhlNtKbYzPash6DqWTTza9gBiYMA5d2Wiq6HzrPqsRaP4yA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.7.0.tgz",
+      "integrity": "sha512-OnFiBKbjRh/mmOJzpd2ONt5W77MYLyOf5jDKdeLaocdoLIxcc3R/iboFkWm7+3pmlZWa+IqFgqYGzAmuNxNxOw==",
       "requires": {
         "semver": "^6.2.0"
       }
@@ -550,11 +549,6 @@
         "@sentry/types": "5.7.1",
         "tslib": "^1.9.3"
       }
-    },
-    "@sindresorhus/is": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-1.2.0.tgz",
-      "integrity": "sha512-mwhXGkRV5dlvQc4EgPDxDxO6WuMBVymGFd1CA+2Y+z5dG9MNspoQ+AWjl/Ld1MnpCL8AKbosZlDVohqcIwuWsw=="
     },
     "@sinonjs/commons": {
       "version": "1.6.0",
@@ -2863,6 +2857,14 @@
         "walkdir": "^0.4.0"
       },
       "dependencies": {
+        "@grpc/grpc-js": {
+          "version": "0.6.9",
+          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.6.9.tgz",
+          "integrity": "sha512-r1nDOEEiYmAsVYBaS4DPPqdwPOXPw7YhVOnnpPdWhlNtKbYzPash6DqWTTza9gBiYMA5d2Wiq6HzrPqsRaP4yA==",
+          "requires": {
+            "semver": "^6.2.0"
+          }
+        },
         "google-auth-library": {
           "version": "5.5.1",
           "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.5.1.tgz",

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -29,7 +29,8 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "@google-cloud/firestore": "^2.6.0",
-    "@google-cloud/pubsub": "^1.1.5",
+    "@google-cloud/pubsub": "^1.5.0",
+    "@grpc/grpc-js": "^0.7.0",
     "@hapi/hapi": "^18.4.1",
     "@hapi/hoek": "^8.5.1",
     "@hapi/joi": "^16.1.7",

--- a/packages/fxa-event-broker/test/lib/notificationProcessor.spec.ts
+++ b/packages/fxa-event-broker/test/lib/notificationProcessor.spec.ts
@@ -46,7 +46,7 @@ const baseSubscriptionUpdateLegacyMessage = {
   event: 'subscription:update',
   eventCreatedAt: Math.trunc(Date.now() / 1000),
   isActive: true,
-  productCapabilities: ['send:pro', 'vpn:basic'],
+  productCapabilities: ['guardian_vpn', 'secure_proxy'],
   productName: 'firefox-sub',
   subscriptionId: 'sub_123456'
 };
@@ -133,7 +133,7 @@ describe('ServiceNotificationProcessor', () => {
     });
     logger = stubInterface<Logger>();
     capabilityService = stubInterface<ClientCapabilityService>({
-      serviceData: {},
+      serviceData: { '123client': ['secure_proxy'] },
       start: Promise.resolve()
     });
     webhookService = stubInterface<ClientWebhookService>({
@@ -243,7 +243,7 @@ describe('ServiceNotificationProcessor', () => {
       start: Promise.resolve()
     });
     db = stubInterface<Datastore>({
-      fetchClientIds: ['send', 'vpn']
+      fetchClientIds: ['123client']
     });
     const topicPub = stubObject<Topic>(new Topic(pubsub, 'default'));
     pubsub = stubObject<PubSub>(new PubSub(), { topic: topicPub });
@@ -252,7 +252,7 @@ describe('ServiceNotificationProcessor', () => {
     consumer.start();
     await pEvent(consumer.app, 'message_processed');
     consumer.stop();
-    assert.calledThrice(logger.debug as SinonSpy);
+    assert.calledTwice(logger.debug as SinonSpy);
 
     // Note that we aren't resetting the sandbox here, so we have 2 log calls thus far
     db = stubInterface<Datastore>({
@@ -262,7 +262,7 @@ describe('ServiceNotificationProcessor', () => {
     consumer.start();
     await pEvent(consumer.app, 'message_processed');
     consumer.stop();
-    (logger.debug as SinonSpy).getCalls()[3].calledWith({
+    (logger.debug as SinonSpy).getCalls()[2].calledWith({
       messageId: undefined,
       topicName: 'rpQueue-send'
     });

--- a/packages/fxa-event-broker/tsconfig.json
+++ b/packages/fxa-event-broker/tsconfig.json
@@ -7,7 +7,6 @@
     "inlineSources": true,
     "inlineSourceMap": true,
     "esModuleInterop": true,
-    "sourceRoot": "/",
     "module": "commonjs",
     "moduleResolution": "node",
     "strict": true,


### PR DESCRIPTION
Because:

* The capability list assembling could result in duplicate capabilities
  for a clientId.
* When sending the subscription state SQS message, only the capabilities
  are included, not prefixed with a clientID as the event-broker had
  assumed based on a prior un-implemented concept.

This commit:

* Removes duplicates from the client/capabilities response by using a
  Set.
* Looks up the clientId based on the capability rather than assuming
  its the prefix in the productCapabilities.

Fixes #4315