### PR TITLE
[HOLD] fix(signup): change auth code input type to number

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
@@ -15,8 +15,8 @@
         <p class="verification-email-message">{{#unsafeTranslate}}Please enter the verification code that was sent to %(escapedEmail)s within 5 minutes.{{/unsafeTranslate}}</p>
         <form novalidate>
             <div class="input-row">
-                <!-- Using `type="text" inputmode="numeric"` shows the numericpad on mobile and strips out whitespace on desktop. -->
-                <input type="text" inputmode="numeric" pattern="\d[ ]*" class="tooltip-below otp-code" placeholder="{{#t}}Enter 6-digit code{{/t}}" required autofocus />
+                <!-- Not using `type="text" inputmode="numeric"` because of https://bugzilla.mozilla.org/show_bug.cgi?id=1205133 -->
+                <input type="number" inputmode="numeric" pattern="\d[ ]*" class="tooltip-below otp-code" placeholder="{{#t}}Enter 6-digit code{{/t}}" required autofocus />
             </div>
             <div class="button-row">
                 <button id="submit-btn" type="submit">{{#t}}Verify{{/t}}</button>

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_token_code.mustache
@@ -15,8 +15,8 @@
 
     <form novalidate>
       <div class="input-row otp-code-row">
-          <!-- Using `type="text" inputmode="numeric"` shows the numericpad on mobile and strips out whitespace on desktop. -->
-          <input type="text" inputmode="numeric" pattern="\d[ ]*" class="tooltip-below otp-code" placeholder="{{#t}}Enter 6-digit code{{/t}}" required autofocus />
+          <!-- Not using `type="text" inputmode="numeric"` because of https://bugzilla.mozilla.org/show_bug.cgi?id=1205133 -->
+          <input type="number" inputmode="numeric" pattern="\d[ ]*" class="tooltip-below otp-code" placeholder="{{#t}}Enter 6-digit code{{/t}}" required autofocus />
       </div>
 
       <div class="button-row">

--- a/packages/fxa-content-server/app/scripts/views/elements/otp-code-input.js
+++ b/packages/fxa-content-server/app/scripts/views/elements/otp-code-input.js
@@ -9,7 +9,7 @@ import Vat from '../../lib/vat';
 const element = Object.create(textInput);
 
 element.match = function($el) {
-  return $el.attr('type') === 'text' && $el.hasClass('otp-code');
+  return $el.attr('type') === 'number' && $el.hasClass('otp-code');
 };
 
 element.val = function(val) {

--- a/packages/fxa-content-server/app/tests/spec/views/elements/otp-code-input.js
+++ b/packages/fxa-content-server/app/tests/spec/views/elements/otp-code-input.js
@@ -8,8 +8,8 @@ import AuthErrors from 'lib/auth-errors';
 import TotpEl from 'views/elements/otp-code-input';
 
 const TEMPLATE =
-  '<input type="text" pattern="d*" class="otp-code"></input>' +
-  '<input type="text" pattern="d*" class="not-code"></input>';
+  '<input type="number" pattern="d*" class="otp-code"></input>' +
+  '<input type="number" pattern="d*" class="not-code"></input>';
 
 describe('views/elements/otp-code-input', function() {
   let $element;


### PR DESCRIPTION
This patch changes the input type for the sign up/in auth code from text
to number.  This is mainly due to
https://bugzilla.mozilla.org/show_bug.cgi?id=1205133.

With this change, the virtual keyboard for the input on Android Firefox
should be the numpad.

Fixes #4281 (and replaces PR #4341)

@mozilla/fxa-devs r?
