### PR TITLE
fix(mysql): Force MySQL connections to always use UTC timezone.

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
@@ -978,34 +978,39 @@ MysqlStore.prototype = {
         if (conn._fxa_initialized) {
           return resolve(conn);
         }
+
         // Enforce sane defaults on every new connection.
         // These *should* be set by the database by default, but it's nice
         // to have an additional layer of protection here.
-        conn.query('SELECT @@sql_mode AS mode', function(err, rows) {
-          if (err) {
-            return reject(err);
-          }
-          var modes = rows[0]['mode'].split(',');
-          var needToSetMode = false;
-          REQUIRED_SQL_MODES.forEach(function(requiredMode) {
-            if (modes.indexOf(requiredMode) === -1) {
-              modes.push(requiredMode);
-              needToSetMode = true;
+        const query = P.promisify(conn.query, { context: conn });
+        return resolve(
+          (async () => {
+            // Always communicate timestamps in UTC.
+            await query("SET time_zone = '+00:00'");
+            // Always use full 4-byte UTF-8 for communicating unicode.
+            await query('SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci;');
+            // Always have certain modes active. The complexity here is to
+            // preserve any extra modes active by default on the server.
+            // We also try to preserve the order of the existing mode flags,
+            // just in case the order has some obscure effect we don't know about.
+            const rows = await query('SELECT @@sql_mode AS mode');
+            const modes = rows[0]['mode'].split(',');
+            let needToSetMode = false;
+            for (const requiredMode of REQUIRED_SQL_MODES) {
+              if (modes.indexOf(requiredMode) === -1) {
+                modes.push(requiredMode);
+                needToSetMode = true;
+              }
             }
-          });
-          if (!needToSetMode) {
-            conn._fxa_initialized = true;
-            return resolve(conn);
-          }
-          var mode = modes.join(',');
-          conn.query("SET SESSION sql_mode = '" + mode + "'", function(err) {
-            if (err) {
-              return reject(err);
+            if (needToSetMode) {
+              const mode = modes.join(',');
+              await query("SET SESSION sql_mode = '" + mode + "'");
             }
+            // Avoid repeating all that work for existing connections.
             conn._fxa_initialized = true;
-            return resolve(conn);
-          });
-        });
+            return conn;
+          })()
+        );
       });
     }).disposer(releaseConn);
   },

--- a/packages/fxa-auth-server/test/oauth/db/mysql.js
+++ b/packages/fxa-auth-server/test/oauth/db/mysql.js
@@ -239,6 +239,8 @@ describe('db/mysql:', function() {
     });
 
     it('should force new connections into strict mode', function() {
+      mockResponses.push([null, []]);
+      mockResponses.push([null, []]);
       mockResponses.push([
         null,
         [{ mode: 'DUMMY_VALUE,NO_ENGINE_SUBSTITUTION' }],
@@ -247,12 +249,19 @@ describe('db/mysql:', function() {
       return store
         .ping()
         .then(function() {
-          assert.equal(capturedQueries.length, 2);
-          // The first query is checking the sql_mode.
-          assert.equal(capturedQueries[0], 'SELECT @@sql_mode AS mode');
-          // The second query is to set the sql_mode.
+          assert.equal(capturedQueries.length, 4);
+          // The first query sets the timezone.
+          assert.equal(capturedQueries[0], "SET time_zone = '+00:00'");
+          // The second sets utf8mb4
           assert.equal(
             capturedQueries[1],
+            'SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci;'
+          );
+          // The third is checking the sql_mode.
+          assert.equal(capturedQueries[2], 'SELECT @@sql_mode AS mode');
+          // The fourth query is to set the sql_mode.
+          assert.equal(
+            capturedQueries[3],
             "SET SESSION sql_mode = 'DUMMY_VALUE,NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES'"
           );
         })
@@ -262,23 +271,31 @@ describe('db/mysql:', function() {
         })
         .then(function() {
           // Should not re-issue the strict-mode queries.
-          assert.equal(capturedQueries.length, 2);
+          assert.equal(capturedQueries.length, 4);
         });
     });
 
     it('should not mess with connections that already have strict mode', function() {
+      mockResponses.push([null, []]);
+      mockResponses.push([null, []]);
       mockResponses.push([
         null,
         [{ mode: 'STRICT_ALL_TABLES,NO_ENGINE_SUBSTITUTION' }],
       ]);
       return store.ping().then(function() {
-        assert.equal(capturedQueries.length, 1);
-        // The only query is to check the sql_mode.
-        assert.equal(capturedQueries[0], 'SELECT @@sql_mode AS mode');
+        assert.equal(capturedQueries.length, 3);
+        assert.equal(capturedQueries[0], "SET time_zone = '+00:00'");
+        assert.equal(
+          capturedQueries[1],
+          'SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci;'
+        );
+        assert.equal(capturedQueries[2], 'SELECT @@sql_mode AS mode');
       });
     });
 
     it('should propagate any errors that happen when setting the mode', function() {
+      mockResponses.push([null, []]);
+      mockResponses.push([null, []]);
       mockResponses.push([null, [{ mode: 'SOME_NONSENSE_DEFAULT' }]]);
       mockResponses.push([new Error('failed to set mode')]);
       return store
@@ -287,7 +304,7 @@ describe('db/mysql:', function() {
           assert.fail('the ping attempt should have failed');
         })
         .catch(function(err) {
-          assert.equal(capturedQueries.length, 2);
+          assert.equal(capturedQueries.length, 4);
           assert.equal(err.message, 'failed to set mode');
         });
     });

--- a/packages/fxa-profile-server/lib/db/mysql/index.js
+++ b/packages/fxa-profile-server/lib/db/mysql/index.js
@@ -240,38 +240,35 @@ MysqlStore.prototype = {
         // Enforce sane defaults on every new connection.
         // These *should* be set by the database by default, but it's nice
         // to have an additional layer of protection here.
-        conn.query('SELECT @@sql_mode AS mode', function(err, rows) {
-          if (err) {
-            return reject(err);
-          }
-          var modes = rows[0]['mode'].split(',');
-          var needToSetMode = false;
-          REQUIRED_SQL_MODES.forEach(function(requiredMode) {
-            if (modes.indexOf(requiredMode) === -1) {
-              modes.push(requiredMode);
-              needToSetMode = true;
-            }
-          });
-          if (!needToSetMode) {
-            conn._fxa_initialized = true;
-            return resolve(conn);
-          }
-          var mode = modes.join(',');
-          conn.query("SET SESSION sql_mode = '" + mode + "'", function(err) {
-            if (err) {
-              return reject(err);
-            }
-
-            conn.query('SET NAMES utf8mb4 COLLATE utf8mb4_bin;', function(err) {
-              if (err) {
-                return reject(err);
+        const query = P.promisify(conn.query, { context: conn });
+        return resolve(
+          (async () => {
+            // Always communicate timestamps in UTC.
+            await query("SET time_zone = '+00:00'");
+            // Always use full 4-byte UTF-8 for communicating unicode.
+            await query('SET NAMES utf8mb4 COLLATE utf8mb4_bin;');
+            // Always have certain modes active. The complexity here is to
+            // preserve any extra modes active by default on the server.
+            // We also try to preserve the order of the existing mode flags,
+            // just in case the order has some obscure effect we don't know about.
+            const rows = await query('SELECT @@sql_mode AS mode');
+            const modes = rows[0]['mode'].split(',');
+            let needToSetMode = false;
+            for (const requiredMode of REQUIRED_SQL_MODES) {
+              if (modes.indexOf(requiredMode) === -1) {
+                modes.push(requiredMode);
+                needToSetMode = true;
               }
-
-              conn._fxa_initialized = true;
-              return resolve(conn);
-            });
-          });
-        });
+            }
+            if (needToSetMode) {
+              const mode = modes.join(',');
+              await query("SET SESSION sql_mode = '" + mode + "'");
+            }
+            // Avoid repeating all that work for existing connections.
+            conn._fxa_initialized = true;
+            return conn;
+          })()
+        );
       });
     }).disposer(releaseConn);
   },

--- a/packages/fxa-profile-server/test/mysql.js
+++ b/packages/fxa-profile-server/test/mysql.js
@@ -37,6 +37,8 @@ describe('mysql db backend', function() {
   });
 
   it('should force new connections into strict mode', function() {
+    mockResponses.push([null, []]);
+    mockResponses.push([null, []]);
     mockResponses.push([
       null,
       [{ mode: 'DUMMY_VALUE,NO_ENGINE_SUBSTITUTION' }],
@@ -45,18 +47,20 @@ describe('mysql db backend', function() {
     return store
       .ping()
       .then(function() {
-        assert.equal(capturedQueries.length, 3);
-        // The first query is checking the sql_mode.
-        assert.equal(capturedQueries[0], 'SELECT @@sql_mode AS mode');
-        // The second query is to set the sql_mode.
+        assert.equal(capturedQueries.length, 4);
+        // The first query sets the timezone.
+        assert.equal(capturedQueries[0], "SET time_zone = '+00:00'");
+        // The second sets utf8mb4
         assert.equal(
           capturedQueries[1],
-          "SET SESSION sql_mode = 'DUMMY_VALUE,NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES'"
-        );
-        // The third sets utf8mb4
-        assert.equal(
-          capturedQueries[2],
           'SET NAMES utf8mb4 COLLATE utf8mb4_bin;'
+        );
+        // The third is checking the sql_mode.
+        assert.equal(capturedQueries[2], 'SELECT @@sql_mode AS mode');
+        // The fourth query is to set the sql_mode.
+        assert.equal(
+          capturedQueries[3],
+          "SET SESSION sql_mode = 'DUMMY_VALUE,NO_ENGINE_SUBSTITUTION,STRICT_ALL_TABLES'"
         );
       })
       .then(function() {
@@ -65,23 +69,34 @@ describe('mysql db backend', function() {
       })
       .then(function() {
         // Should not re-issue the strict-mode queries.
-        assert.equal(capturedQueries.length, 3);
+        assert.equal(capturedQueries.length, 4);
       });
   });
 
   it('should not mess with connections that already have strict mode', function() {
+    mockResponses.push([null, []]);
+    mockResponses.push([null, []]);
     mockResponses.push([
       null,
       [{ mode: 'STRICT_ALL_TABLES,NO_ENGINE_SUBSTITUTION' }],
     ]);
     return store.ping().then(function() {
-      assert.equal(capturedQueries.length, 1);
-      // The only query is to check the sql_mode.
-      assert.equal(capturedQueries[0], 'SELECT @@sql_mode AS mode');
+      assert.equal(capturedQueries.length, 3);
+      // The only queries are to check connection parameters.
+      assert.equal(capturedQueries[0], "SET time_zone = '+00:00'");
+      // The second sets utf8mb4
+      assert.equal(
+        capturedQueries[1],
+        'SET NAMES utf8mb4 COLLATE utf8mb4_bin;'
+      );
+      // The third is checking the sql_mode.
+      assert.equal(capturedQueries[2], 'SELECT @@sql_mode AS mode');
     });
   });
 
   it('should propagate any errors that happen when setting the mode', function() {
+    mockResponses.push([null, []]);
+    mockResponses.push([null, []]);
     mockResponses.push([null, [{ mode: 'SOME_NONSENSE_DEFAULT' }]]);
     mockResponses.push([new Error('failed to set mode')]);
     return store
@@ -90,7 +105,7 @@ describe('mysql db backend', function() {
         assert.fail('the ping attempt should have failed');
       })
       .catch(function(err) {
-        assert.equal(capturedQueries.length, 2);
+        assert.equal(capturedQueries.length, 4);
         assert.equal(err.message, 'failed to set mode');
       });
   });


### PR DESCRIPTION
Because:

* Some of our security checks (such as checking whether a token
  has expired) compare a timestamp generated in JS with a timestamp
  generated in MySQL.
* MySQL returns timestamps in whatever it believes to be the local
  timezone by default.
* We try to be robust to suboptimally-configured MySQL databases,
  especially when it could lead to security issues.

This commit:

* Explicitly tells MySQL to return timestamps in UTC regardless
  of the system- or database-level timezone setting.