### PR TITLE
fix(oauth): Do not store raw access tokens in Redis.

### DIFF
--- a/packages/fxa-auth-server/grunttasks/eslint.js
+++ b/packages/fxa-auth-server/grunttasks/eslint.js
@@ -7,10 +7,7 @@
 module.exports = function(grunt) {
   grunt.config('eslint', {
     app: {
-      src: [
-        '{,bin/,config/,grunttasks/,lib/**/,scripts/**/,test/**/}*.js',
-        '{fxa-oauth-server/bin/**/,fxa-oauth-server/lib/**/,fxa-oauth-server/test/**/,fxa-oauth-server/scripts/**/}*.js',
-      ],
+      src: ['{,bin/,config/,grunttasks/,lib/**/,scripts/**/,test/**/}*.js'],
     },
   });
   grunt.registerTask('quicklint', 'lint the modified files', 'newer:eslint');

--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -46,7 +46,7 @@ class OauthDB {
   disconnect() {}
 
   async generateAccessToken(vals) {
-    const token = new AccessToken(
+    const token = AccessToken.generate(
       vals.clientId,
       vals.name,
       vals.canGrant,
@@ -54,8 +54,6 @@ class OauthDB {
       vals.userId,
       vals.email,
       vals.scope,
-      null,
-      null,
       vals.profileChangedAt,
       vals.expiresAt,
       vals.ttl
@@ -92,6 +90,9 @@ class OauthDB {
 
   async getActiveClientsByUid(uid) {
     const tokens = await this.redis.getAccessTokens(uid);
+    // Any client with an active access token needs to appear in the list
+    // *unless* they're a canGrant client, in which case they will be
+    // represented by their sessionToken held elsewhere in the system.
     const activeClientTokens = [];
     for (const token of tokens) {
       if (!token.canGrant) {

--- a/packages/fxa-auth-server/lib/oauth/db/mysql/schema.sql
+++ b/packages/fxa-auth-server/lib/oauth/db/mysql/schema.sql
@@ -35,6 +35,10 @@ CREATE TABLE IF NOT EXISTS codes (
 ) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS tokens (
+  -- Note that this column holds the *hashed* token, which in code
+  -- we refer to as the "tokenId". We do not store the unhashed token
+  -- value in the db; this is a defensive measure to prevent a database leak
+  -- on the OAuth server from leaking access to all OAuth-protected data.
   token BINARY(32) PRIMARY KEY,
   clientId BINARY(8) NOT NULL,
   INDEX tokens_client_id(clientId),
@@ -66,6 +70,10 @@ CREATE TABLE IF NOT EXISTS clientDevelopers (
 ) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS refreshTokens (
+  -- Note that this column holds the *hashed* token, which in code
+  -- we refer to as the "tokenId". We do not store the unhashed token
+  -- value in the db; this is a defensive measure to prevent a database leak
+  -- on the OAuth server from leaking access to all OAuth-protected data.
   token BINARY(32) PRIMARY KEY,
   clientId BINARY(8) NOT NULL,
   INDEX tokens_client_id(clientId),

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -16,7 +16,6 @@
     "postinstall": "scripts/download_l10n.sh",
     "start": "npm run gen-keys && node ./bin/key_server.js",
     "test": "VERIFIER_VERSION=0 scripts/test-local.sh",
-    "test-oauth": "fxa-oauth-server/scripts/test-local.sh",
     "test-ci": "npm run gen-keys && scripts/test-local.sh && npm run test-e2e && npm run test-scripts",
     "test-e2e": "NODE_ENV=dev mocha test/e2e",
     "test-scripts": "NODE_ENV=dev mocha test/scripts --exit",

--- a/packages/fxa-auth-server/test/oauth/db/index.js
+++ b/packages/fxa-auth-server/test/oauth/db/index.js
@@ -222,7 +222,7 @@ describe('db', function() {
         })
         .then(tokens => {
           assert.ok(tokens[0].token);
-          assert.ok(tokens[1].token);
+          assert.ok(tokens[1].tokenId);
           return db.removePublicAndCanGrantTokens(hex(userId));
         })
         .then(t => {
@@ -260,7 +260,7 @@ describe('db', function() {
         publicClient: false,
       }).then(tokens => {
         assert.ok(tokens[0].token);
-        assert.ok(tokens[1].token);
+        assert.ok(tokens[1].tokenId);
       });
     });
 
@@ -356,7 +356,7 @@ describe('db', function() {
           assert.equal(
             updatedLastUsedAt > tokenFirstUsage.lastUsedAt,
             true,
-            'createdAt was updated'
+            'lastUsedAt was updated'
           );
           assert.equal(
             t.createdAt.toString(),
@@ -684,14 +684,14 @@ describe('db', function() {
         const mysql = await db.mysql;
         const tt = await mysql._getAccessToken(t.tokenId);
         await db.removeAccessToken(t.tokenId);
-        assert.equal(hex(tt.token), hex(t.tokenId));
+        assert.equal(hex(tt.tokenId), hex(t.tokenId));
       });
 
       it('retrieves them with getAccessToken', async () => {
         const t = await db.generateAccessToken(tokenData);
         const tt = await db.getAccessToken(t.tokenId);
         await db.removeAccessToken(t.tokenId);
-        assert.equal(hex(tt.token), hex(t.tokenId));
+        assert.equal(hex(tt.tokenId), hex(t.tokenId));
       });
 
       it('retrieves them with getActiveClientsByUid', async () => {
@@ -710,7 +710,7 @@ describe('db', function() {
         await db.removeAccessToken(t.tokenId);
         assert.isArray(tokens);
         assert.lengthOf(tokens, 1);
-        assert.deepEqual(tokens[0].accessTokenId, t.tokenId);
+        assert.deepEqual(tokens[0].tokenId, t.tokenId);
         assert.deepEqual(tokens[0].clientId, t.clientId);
       });
 

--- a/packages/fxa-auth-server/tsconfig.json
+++ b/packages/fxa-auth-server/tsconfig.json
@@ -11,5 +11,5 @@
     // "noImplicitReturns": true,
     // "noFallthroughCasesInSwitch": true
   },
-  "exclude": ["test/**", "fxa-oauth-server/test/**"]
+  "exclude": ["test/**"]
 }


### PR DESCRIPTION
The MySQL access-token storage deliberately does not write the raw access token to disk, and instead only writes a hash. This allows us to look up a given token but prevents a db compromise from immediately leaking all tokens in useable form.

The new Redis access-token storage currently includes the raw token in its JSON serialization. We should never need this value again in practice, so I suggest we avoid storing it for all the same reasons we don't store it in MySQL. This commit changes the serialization logic to persist `tokenId` instead, while continuing to support data with the old field that may already be in redis.

Relatedly, the value returned when looking up an access token could differ depending on whether it came from Redis (in which case the `token` field would be the raw token) or from MySQL (in which case the `token` field would be the hashed token id). I've included a bit of a refactor of how the `AccessToken` class is used, so that these differences are encapsulated in the DB layer and calling code will only ever see instances of the `AccessToken` class. (This is partly motivated by making the above storage change, and partly by my own confusion on this point while working on #4304).

I've also included a bonus commit that removes some leftover mentions of the `./fxa-oauth-server` directory, because my old habit of running `npm run test-oauth` gave an error.