### PR TITLE
fix(metrics): handle race condition in Payments nav timing metrics

### DIFF
--- a/packages/fxa-payments-server/src/lib/navigation-timing.test.ts
+++ b/packages/fxa-payments-server/src/lib/navigation-timing.test.ts
@@ -4,30 +4,61 @@
 
 import { observeNavigationTiming } from './navigation-timing';
 
-it('sends navigation timing with sendBeacon', () => {
-  type MockEntryList = { getEntries: () => [object] };
-  type ObsCallback = (_entries: MockEntryList, _obs: object) => undefined;
-  let cb = (_entries: MockEntryList, _obs: object) => {};
-  const observeFn = jest.fn();
-  const disconnectFn = jest.fn();
-  const getEntries = jest.fn().mockReturnValue([{ foo: 'bar' }]);
-  const mockObs = { observe: observeFn, disconnect: disconnectFn };
-  const mockPerformanceObserver = function(callback: ObsCallback) {
-    cb = callback;
-    return mockObs;
-  };
-  window.navigator.sendBeacon = jest.fn();
-  (window.PerformanceObserver as unknown) = mockPerformanceObserver;
-  observeNavigationTiming('/x/y/z');
-  cb({ getEntries }, mockObs);
-  expect(observeFn).toHaveBeenCalledWith({ entryTypes: ['navigation'] });
-  expect(window.navigator.sendBeacon).toHaveBeenCalledTimes(1);
-  const expectedBlob = new Blob([JSON.stringify({ foo: 'bar' })], {
-    type: 'application/json',
+type MockEntryList = { getEntries: () => [object] };
+type ObsCallback = (_entries: MockEntryList, _obs: object) => undefined;
+let cb = (_entries: MockEntryList, _obs: object) => {};
+const observeFn = jest.fn();
+const disconnectFn = jest.fn();
+const getEntries = jest.fn().mockReturnValue([{ foo: 'bar' }]);
+const mockObs = { observe: observeFn, disconnect: disconnectFn };
+const mockPerformanceObserver = function(callback: ObsCallback) {
+  cb = callback;
+  return mockObs;
+};
+const mockGetEntriesByType = (perfEntries: PerformanceEntry[]) =>
+  (window.performance.getEntriesByType = jest
+    .fn()
+    .mockReturnValue(perfEntries));
+window.navigator.sendBeacon = jest.fn();
+(window.PerformanceObserver as unknown) = mockPerformanceObserver;
+
+// "queue" below is referring to
+// https://www.w3.org/TR/performance-timeline-2/#queue-a-performanceentry
+
+describe('lib/navigation-timing', () => {
+  beforeEach(() => {
+    (<jest.Mock>window.navigator.sendBeacon).mockClear();
   });
-  expect(window.navigator.sendBeacon).toHaveBeenCalledWith(
-    '/x/y/z',
-    expectedBlob
-  );
-  expect(disconnectFn).toBeCalledTimes(1);
+  describe('executes before PerformanceNavigationTiming object is queued', () => {
+    it('uses PerformanceObserver', () => {
+      mockGetEntriesByType([{ duration: 0 } as PerformanceEntry]);
+      observeNavigationTiming('/x/y/z');
+      cb({ getEntries }, mockObs);
+      expect(observeFn).toHaveBeenCalledWith({ entryTypes: ['navigation'] });
+      expect(window.navigator.sendBeacon).toHaveBeenCalledTimes(1);
+      const expectedBlob = new Blob([JSON.stringify({ foo: 'bar' })], {
+        type: 'application/json',
+      });
+      expect(window.navigator.sendBeacon).toHaveBeenCalledWith(
+        '/x/y/z',
+        expectedBlob
+      );
+      expect(disconnectFn).toBeCalledTimes(1);
+    });
+  });
+  describe('executes after PerformanceNavigationTiming has queued', () => {
+    it('sends performance metrics from peformance.getEntriesByType', () => {
+      const navTiming = { duration: 1289 };
+      mockGetEntriesByType([navTiming as PerformanceEntry]);
+      observeNavigationTiming('/x/y/z');
+      expect(window.navigator.sendBeacon).toHaveBeenCalledTimes(1);
+      const expectedBlob = new Blob([JSON.stringify(navTiming)], {
+        type: 'application/json',
+      });
+      expect(window.navigator.sendBeacon).toHaveBeenCalledWith(
+        '/x/y/z',
+        expectedBlob
+      );
+    });
+  });
 });

--- a/packages/fxa-payments-server/src/lib/navigation-timing.ts
+++ b/packages/fxa-payments-server/src/lib/navigation-timing.ts
@@ -2,17 +2,43 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export const observeNavigationTiming = (beaconUrl: string) => {
-  if (PerformanceObserver && navigator.sendBeacon) {
-    const navTimingObs = new PerformanceObserver((entries, obs) => {
-      const timings = JSON.stringify(entries.getEntries()[0]);
-      const headers = { type: 'application/json' };
-      const reqBlob = new Blob([timings], headers);
-      navigator.sendBeacon(beaconUrl, reqBlob);
-      obs.disconnect();
-    });
+const sendNavTiming = (
+  url: string,
+  performanceNavTiming: PerformanceNavigationTiming
+) => {
+  const timings = JSON.stringify(performanceNavTiming);
+  const headers = { type: 'application/json' };
+  const reqBlob = new Blob([timings], headers);
+  navigator.sendBeacon(url, reqBlob);
+};
 
-    navTimingObs.observe({ entryTypes: ['navigation'] });
+export const observeNavigationTiming = (beaconUrl: string) => {
+  if (
+    performance.getEntriesByType &&
+    PerformanceObserver &&
+    navigator.sendBeacon
+  ) {
+    // By the time this is called, the event might've completed.  Use the
+    // PerformanceObserver API if it hasn't, otherwise send the data.
+    const NAV_ENTRY_TYPE = 'navigation';
+    const navTiming = performance.getEntriesByType(
+      NAV_ENTRY_TYPE
+    )[0] as PerformanceNavigationTiming;
+
+    // Once duration is recorded the event is over
+    if (navTiming.duration > 0) {
+      sendNavTiming(beaconUrl, navTiming);
+    } else {
+      const navTimingObs = new PerformanceObserver((entries, obs) => {
+        sendNavTiming(
+          beaconUrl,
+          entries.getEntries()[0] as PerformanceNavigationTiming
+        );
+        obs.disconnect();
+      });
+
+      navTimingObs.observe({ entryTypes: [NAV_ENTRY_TYPE] });
+    }
   }
 };
 


### PR DESCRIPTION
This patch fixes a race condition where the PerformanceObserver instance
is created after the navigation timing performance entry has already
queued.

Fixes #4396 

@mozilla/fxa-devs r?