### PR TITLE
fix(settings): Don't show signout when oauth clients that request oldsync scope

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
@@ -177,6 +177,14 @@ var OAuthRelier = Relier.extend({
     return true;
   },
 
+  containsOldSyncScope() {
+    const permissions = this.scopeStrToArray(this.get('scope'));
+    if (permissions.includes(Constants.OAUTH_OLDSYNC_SCOPE)) {
+      return true;
+    }
+    return false;
+  },
+
   _isVerificationFlow() {
     return !!this.getSearchParam('code');
   },

--- a/packages/fxa-content-server/app/scripts/views/settings.js
+++ b/packages/fxa-content-server/app/scripts/views/settings.js
@@ -93,7 +93,12 @@ const View = BaseView.extend({
       ccExpired: !!this._ccExpired,
       escapedCcExpiredLinkAttrs: 'href="/subscriptions" class="alert-link"',
       securityEventsVisible: this.displaySecurityEvents(),
-      showSignOut: !account.isFromSync(),
+      showSignOut:
+        // Note: For sync clients and oauth based sync clients, they have their
+        // own UX for signing a user out, typically within their own app.
+        // In these scenarios we don't show the sign out button.
+        !account.isFromSync() &&
+        !(this.relier.isOAuth() && this.relier.containsOldSyncScope()),
       unsafeHeaderHTML: this._getHeaderHTML(account),
     });
   },

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
@@ -292,6 +292,27 @@ describe('models/reliers/oauth', () => {
       });
     });
 
+    it('containsOldSyncScope returns true when requesting access to Sync', () => {
+      windowMock.location.search = toSearchString({
+        action: ACTION,
+        client_id: CLIENT_ID,
+        redirect_uri: QUERY_REDIRECT_URI,
+        scope: SCOPE_OLDSYNC,
+        state: STATE,
+      });
+
+      sinon.stub(relier, 'isTrusted').callsFake(() => {
+        return true;
+      });
+      sinon.stub(relier, '_validateKeyScopeRequest').callsFake(() => {
+        return true;
+      });
+
+      return relier.fetch().then(() => {
+        assert.isTrue(relier.containsOldSyncScope());
+      });
+    });
+
     describe('query parameter validation', () => {
       describe('access_type', () => {
         var validValues = [undefined, 'offline', 'online'];

--- a/packages/fxa-content-server/app/tests/spec/views/settings.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings.js
@@ -262,6 +262,22 @@ describe('views/settings', function() {
         assert.equal(error.message, 'WIBBLE');
       });
     });
+
+    describe('beforeRender with oauth client and oldsync scope', () => {
+      beforeEach(() => {
+        relier.containsOldSyncScope = () => {
+          return true;
+        };
+        sinon.stub(relier, 'isOAuth').callsFake(() => true);
+        return view.beforeRender();
+      });
+
+      it('set showSignOut to false', () => {
+        view.setInitialContext(context);
+        assert.equal(context.set.callCount, 1);
+        assert.isFalse(context.set.args[0][0].showSignOut);
+      });
+    });
   });
 
   describe('with uid', function() {


### PR DESCRIPTION
Fixes #4284 

I went back and forth on a decent way to do this, but settled on the simple approach verses doing a larger refactor. This PR checks to see if the old sync scope is requested for the oauth client, if so then the `Sign out` button will not appear in the settings view. The expectation is that the client will have its own sign out button.

I considered checking the entrypoint, for ios settings it is `?entrypoint=ios_settings_manage` but that seemed more likely to change so stuck with checking scope.

Note that I wasn't actually able to test this locally because it requires application services library to build built and run against local servers. However, I feel good about the tests so it should work as expected.