### PR TITLE
Check for local services on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The Firefox Accounts (fxa) monorepo
    npm start
    ```
 
+Note this starts up all required services, including Redis, MySQL, and Memcached. It is recommended that you don't run these services yourself, or occupy any of the [server ports](https://github.com/mozilla/fxa/blob/master/mysql_servers.json). Doing so may result in errors.
+
 4. Visit [127.0.0.1:3030](http://127.0.0.1:3030/).
 
 Use the [PM2 tool](https://github.com/Unitech/PM2#main-features) to stop and start the servers, and read server logs.

--- a/_scripts/check_ports.sh
+++ b/_scripts/check_ports.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -ex
+
+PORTS=(
+  3306 # MySQL server
+  6379 # redis
+  11211 # memcached
+  4100 # Fake SQS/SNS
+  8005 # google-pubsub-emulator
+  8006 # google-firestore-emulator
+  5000 # sync server
+  8001 # email-service
+  8000 # auth-server db mysql
+  9000 # auth-server key server
+  3030 # content-server
+  1111 # profile-server
+  9292 # Fortress
+  8080 # 123done
+  10139 # 321done
+  5050 # browserid-verifier
+  3031 # payments server
+  7100 # support admin panel
+  8002 # pushbox
+)
+
+occupied=()
+
+for port in ${PORTS[@]}; do
+  if echo PING | nc localhost $port >/dev/null; then
+    occupied=("${occupied[@]}" $port)
+  fi
+done
+
+if [ ${#occupied[@]} -ge 1 ]; then
+  echo "\033[0;33mHeads up!\033[0m Some required ports are already occupied and may cause problems: \033[0;31m${occupied[@]}\033[0m\n"
+fi

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "_scripts/install_all.sh",
     "npm-ci-all": "lerna exec --parallel --ignore fxa-amplitude-send -- npm ci",
     "audit": "lerna run audit --parallel",
-    "start": "pm2 start mysql_servers.json && echo \"Use 'npm stop' to stop all the servers\"",
+    "start": "sh _scripts/check_ports.sh && pm2 start mysql_servers.json && echo \"Use 'npm stop' to stop all the servers\"",
     "stop": "pm2 kill",
     "firefox": "./packages/fxa-dev-launcher/bin/fxa-dev-launcher",
     "start-firefox": "npm run firefox",


### PR DESCRIPTION
Closes https://github.com/mozilla/fxa/issues/4343

1. Updates README setup instructions to note that you shouldn't be running any services yourself.
2. Modifies root `npm start` to perform a pre-check on any ports our servers use. Doesn't abort, but warns you if anything is already running on those ports.

<img width="894" alt="Screen Shot 2020-03-04 at 4 04 44 PM" src="https://user-images.githubusercontent.com/6392049/75922874-e8c73800-5e31-11ea-892b-ee4095ad6665.png">
