### PR TITLE
Enforce a max header size of 998 characters in emails

### DIFF
--- a/packages/fxa-email-service/src/types/headers/mod.rs
+++ b/packages/fxa-email-service/src/types/headers/mod.rs
@@ -28,6 +28,10 @@ use hyperx::{
     header::{parsing::from_one_raw_str, Formatter, Raw as RawHeader},
 };
 
+// No header's total length should be greater than 998 characters
+// See: https://tools.ietf.org/html/rfc5322#section-2.1.1
+const HEADER_MAX_LENGTH: usize = 998;
+
 macro_rules! custom_header {
     ($struct_name:ident, $header_name:expr) => {
         #[derive(Clone, Debug)]
@@ -36,7 +40,8 @@ macro_rules! custom_header {
         }
 
         impl $struct_name {
-            pub fn new(value: String) -> Self {
+            pub fn new(mut value: String) -> Self {
+                value.truncate(HEADER_MAX_LENGTH - $header_name.len());
                 Self { value }
             }
         }

--- a/packages/fxa-email-service/src/types/headers/test.rs
+++ b/packages/fxa-email-service/src/types/headers/test.rs
@@ -138,3 +138,16 @@ fn verify_code() {
     assert_eq!(header.to_string(), "wibble");
     assert_eq!(VerifyCode::header_name(), "X-Verify-Code");
 }
+
+#[test]
+fn any_header_length() {
+    // No header value should be longer than 998 characters, minus the length of the header name
+    let header = Link::new(std::iter::repeat("X").take(999).collect::<String>().to_owned());
+    assert!(header.to_string().chars().count() <= HEADER_MAX_LENGTH - Link::header_name().len());
+
+    let header = DeviceId::new(std::iter::repeat("X").take(999).collect::<String>().to_owned());
+    assert!(header.to_string().chars().count() <= HEADER_MAX_LENGTH - DeviceId::header_name().len());
+
+    let header = ReportSigninLink::new(std::iter::repeat("X").take(999).collect::<String>().to_owned());
+    assert!(header.to_string().chars().count() <= HEADER_MAX_LENGTH - ReportSigninLink::header_name().len());
+}


### PR DESCRIPTION
Closes https://github.com/mozilla/fxa/issues/4390

Enforces a maximum header size of 998 characters per [RFC 5322](https://tools.ietf.org/html/rfc5322#section-2.1.1) recommendation. This is a hopeful solution to a failed mail delivery noted in [Bugzilla 1618831](https://bugzilla.mozilla.org/show_bug.cgi?id=1618831).

Note this is 998 characters total (key + value).