### PR TITLE
feat(event-broker): use tags for unique metrics

### DIFF
--- a/packages/fxa-event-broker/test/lib/notificationProcessor.spec.ts
+++ b/packages/fxa-event-broker/test/lib/notificationProcessor.spec.ts
@@ -175,6 +175,7 @@ describe('ServiceNotificationProcessor', () => {
       await pEvent(consumer.app, 'message_processed');
       consumer.stop();
       assert.calledWith(db.fetchClientIds as SinonSpy);
+      assert.calledOnce(logger.debug as SinonSpy);
     });
   }
 


### PR DESCRIPTION
Because:

* We were storing clientId's, status codes, and event types in the
  metric name itself.
* Repeated a chunk of mostly identical code 3 times.

This commit:

* Uses tags for the metrics.
* Has a small refactor into one generic fanout method.

Fixes #4418