### PR TITLE
fix(auth-server): pass all redis set args

### DIFF
--- a/packages/fxa-auth-server/lib/redis.js
+++ b/packages/fxa-auth-server/lib/redis.js
@@ -175,8 +175,8 @@ class FxaRedis {
     return this.redis.get(key);
   }
 
-  set(key, val) {
-    return this.redis.set(key, val);
+  set(key, val, ...args) {
+    return this.redis.set(key, val, ...args);
   }
   zadd(key, ...args) {
     return this.redis.zadd(key, ...args);

--- a/packages/fxa-auth-server/package-lock.json
+++ b/packages/fxa-auth-server/package-lock.json
@@ -897,6 +897,15 @@
         "@types/shot": "*"
       }
     },
+    "@types/ioredis": {
+      "version": "4.14.8",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.14.8.tgz",
+      "integrity": "sha512-ww38Psb0jj/8h9UYjRuT9RYF46E5O3j+03XSEBx6OQvCIkgPV52kF8DshVLh8DMSZs3fEjeoEzmyM3KP9n53tQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/iron": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/iron/-/iron-5.0.1.tgz",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -95,6 +95,7 @@
     "@types/chai": "^4.2.4",
     "@types/convict": "^4.2.1",
     "@types/hapi": "^18.0.2",
+    "@types/ioredis": "^4.14.8",
     "@types/joi": "^14.3.3",
     "@types/jsonwebtoken": "^8.3.5",
     "@types/jws": "^3.2.0",


### PR DESCRIPTION
Because:

* We originally didn't use additional redis.set arguments, our set
  pass-through function dropped anything other than key/value.

This commit:

* Retains all redis.set arguments supported by the ioredis library we
  use.

Fixes #4413