### PR TITLE
test(auth-server): add coverage for subscriptionsToResponse

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/fixtures/charge_failed.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/charge_failed.json
@@ -1,0 +1,93 @@
+{
+    "id": "ch_1EaouEJNcmPzuWtRIabj08KN",
+    "object": "charge",
+    "amount": 1000,
+    "amount_refunded": 0,
+    "application": null,
+    "application_fee": null,
+    "application_fee_amount": null,
+    "balance_transaction": "txn_1GISfBJNcmPzuWtRWAFoncCF",
+    "billing_details": {
+      "address": {
+        "city": null,
+        "country": null,
+        "line1": null,
+        "line2": null,
+        "postal_code": null,
+        "state": null
+      },
+      "email": null,
+      "name": null,
+      "phone": null
+    },
+    "captured": false,
+    "created": 1558033578,
+    "currency": "usd",
+    "customer": "cus_F4yl2VV15h6ahh",
+    "description": "Payment for invoice 1D1C1268-0002",
+    "disputed": false,
+    "failure_code": "card_declined",
+    "failure_message": "Your card was declined.",
+    "fraud_details": {
+      "stripe_report": "fraudulent"
+    },
+    "invoice": "in_1EaouDJNcmPzuWtReWEFz6j0",
+    "livemode": false,
+    "metadata": {},
+    "on_behalf_of": null,
+    "order": null,
+    "outcome": {
+      "network_status": "not_sent_to_network",
+      "reason": "merchant_blacklist",
+      "risk_level": "highest",
+      "risk_score": 76,
+      "seller_message": "Stripe blocked this payment.",
+      "type": "blocked"
+    },
+    "paid": false,
+    "payment_intent": "pi_1EaouDJNcmPzuWtRSbo5ntSi",
+    "payment_method": "card_1EaosmJNcmPzuWtRa3ygzXId",
+    "payment_method_details": {
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": null,
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "exp_month": 12,
+        "exp_year": 2023,
+        "fingerprint": "bMt3PVLFsmMUsiqx",
+        "funding": "credit",
+        "installments": null,
+        "last4": "0019",
+        "network": "visa",
+        "three_d_secure": {
+          "authenticated": false,
+          "succeeded": true,
+          "version": "1.0"
+        },
+        "wallet": null
+      },
+      "type": "card"
+    },
+    "receipt_email": null,
+    "receipt_number": "2159-3910",
+    "receipt_url": "https://pay.stripe.com/receipts/acct_1EJOaaJNcmPzuWtR/ch_1EaouEJNcmPzuWtRIabj08KN/rcpt_F4yrXrJVsUxcXUB932zUcgWhpkNOIDM",
+    "refunded": false,
+    "refunds": {
+      "object": "list",
+      "data": [],
+      "has_more": false,
+      "url": "/v1/charges/ch_1EaouEJNcmPzuWtRIabj08KN/refunds"
+    },
+    "review": null,
+    "shipping": null,
+    "source_transfer": null,
+    "statement_descriptor": null,
+    "statement_descriptor_suffix": null,
+    "status": "failed",
+    "transfer_data": null,
+    "transfer_group": null
+  }

--- a/packages/fxa-auth-server/test/local/payments/fixtures/customer1.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/customer1.json
@@ -49,6 +49,7 @@
         "id": "sub_test1",
         "object": "subscription",
         "application_fee_percent": null,
+        "created": 1582765012,
         "current_period_start": 1565895370,
         "current_period_end": 1568573770,
         "cancel_at_period_end": false,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -57,12 +57,6 @@ const ACCOUNT_LOCALE = 'en-US';
 const TEST_EMAIL = 'test@email.com';
 const UID = uuid.v4('binary').toString('hex');
 const NOW = Date.now();
-const CUSTOMER = {
-  payment_type: 'card',
-  last4: 8675,
-  exp_month: 8,
-  exp_year: 2020,
-};
 const PLAN_ID_1 = 'plan_G93lTs8hfK7NNG';
 const PLANS = [
   {
@@ -282,12 +276,12 @@ describe('subscriptions directRoutes', () => {
     });
   });
 
-  describe.skip('listActive', () => {
+  describe('listActive', () => {
     it('should list active subscriptions', async () => {
       const stripeHelper = mocks.mockStripeHelper(['customer']);
 
       stripeHelper.customer = sinon.spy(async (uid, customer) => {
-        return CUSTOMER;
+        return customerFixture;
       });
 
       directStripeRoutes = new DirectStripeRoutes(
@@ -301,10 +295,17 @@ describe('subscriptions directRoutes', () => {
         stripeHelper
       );
 
+      const expected = [
+        {
+          cancelledAt: null,
+          createdAt: 1582765012000,
+          productId: 'prod_test1',
+          subscriptionId: 'sub_test1',
+          uid: UID,
+        },
+      ];
       const res = await directStripeRoutes.listActive(VALID_REQUEST);
-      assert.equal(db.fetchAccountSubscriptions.callCount, 1);
-      assert.equal(db.fetchAccountSubscriptions.args[0][0], UID);
-      assert.deepEqual(res, ACTIVE_SUBSCRIPTIONS);
+      assert.deepEqual(res, expected);
     });
   });
 
@@ -1423,11 +1424,11 @@ describe('DirectStripeRoutes', () => {
         ...PLANS,
         {
           plan_id: subscription2.plan.id,
-          product_id:  subscription2.plan.product,
+          product_id: subscription2.plan.product,
           product_metadata: {
-            capabilities: "foo, bar, baz",
+            capabilities: 'foo, bar, baz',
           },
-        }
+        },
       ]);
 
       await directStripeRoutesInstance.sendSubscriptionStatusToSqs(


### PR DESCRIPTION
- add coverage to StripeHelper.subscriptionsToResponse
- extract plan name formatter function to ease testing
- add coverage for new function to ensure it works as expected
- fix skip test

fixes #4222