### PR TITLE
fix(account-recovery): Only display recovery confirmation if you're coming from the confirmation page

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/base.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/base.js
@@ -308,6 +308,30 @@ const BaseAuthenticationBroker = Backbone.Model.extend({
   },
 
   /**
+   * Called after the post-verify recovery setup is complete.
+   *
+   * @param {Object} account
+   * @return {Promise}
+   */
+  afterCompleteAddPostVerifyRecovery(account) {
+    return this.unpersistVerificationData(account).then(() =>
+      this.getBehavior('afterCompleteAddPostVerifyRecovery')
+    );
+  },
+
+  /**
+   * Called after the post-verify recovery setup is aborted, via "Maybe later" links.
+   *
+   * @param {Object} account
+   * @return {Promise}
+   */
+  afterAbortAddPostVerifyRecovery(account) {
+    return this.unpersistVerificationData(account).then(() =>
+      this.getBehavior('afterAbortAddPostVerifyRecovery')
+    );
+  },
+
+  /**
    * Called after primary email verification, in the verification tab.
    *
    * @param {Object} account

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/web.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/web.js
@@ -27,6 +27,17 @@ const redirectToSettingsAfterResetBehavior = new NavigateBehavior('settings', {
 export default BaseBroker.extend({
   defaultBehaviors: _.extend({}, proto.defaultBehaviors, {
     afterCompleteResetPassword: redirectToSettingsAfterResetBehavior,
+    afterCompleteAddPostVerifyRecovery: new SettingsIfSignedInBehavior(
+      proto.defaultBehaviors.afterCompleteSignIn,
+      { success: t('Account recovery enabled') }
+    ),
+    afterAbortAddPostVerifyRecovery: new SettingsIfSignedInBehavior(
+      proto.defaultBehaviors.afterCompleteSignIn,
+      // Because the default is to display the verification message
+      // we need to override it with an undefined value to prevent
+      // the message from being displayed at all
+      { success: undefined }
+    ),
     afterCompleteSignIn: new SettingsIfSignedInBehavior(
       proto.defaultBehaviors.afterCompleteSignIn
     ),

--- a/packages/fxa-content-server/app/scripts/views/behaviors/settings.js
+++ b/packages/fxa-content-server/app/scripts/views/behaviors/settings.js
@@ -26,7 +26,9 @@ export default function(defaultBehavior, options = {}) {
         let success = t('Account verified successfully');
         let endpoint = 'settings';
 
-        if (options.success) {
+        // Strict comparison because undefined == null, but undefined !== null, and
+        // we want to be able to intentionally unset this value via options.success.
+        if (options.success !== null) {
           success = options.success;
         }
 

--- a/packages/fxa-content-server/app/scripts/views/post_verify/account_recovery/add_recovery_key.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/account_recovery/add_recovery_key.js
@@ -44,7 +44,7 @@ class AddAccountRecovery extends FormView {
 
   clickMaybeLater() {
     const account = this.getSignedInAccount();
-    this.invokeBrokerMethod('afterCompleteSignIn', account);
+    this.invokeBrokerMethod('afterAbortAddPostVerifyRecovery', account);
   }
 }
 

--- a/packages/fxa-content-server/app/scripts/views/post_verify/account_recovery/confirm_password.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/account_recovery/confirm_password.js
@@ -75,7 +75,7 @@ class ConfirmPassword extends FormView {
 
   clickMaybeLater() {
     const account = this.getSignedInAccount();
-    this.invokeBrokerMethod('afterCompleteSignIn', account);
+    this.invokeBrokerMethod('afterAbortAddPostVerifyRecovery', account);
   }
 }
 

--- a/packages/fxa-content-server/app/scripts/views/post_verify/verified.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/verified.js
@@ -54,7 +54,10 @@ class Verified extends FormView {
 
   submit() {
     const account = this.getSignedInAccount();
-    return this.invokeBrokerMethod('afterCompleteSignIn', account);
+    return this.invokeBrokerMethod(
+      'afterCompleteAddPostVerifyRecovery',
+      account
+    );
   }
 
   _getHeaderId() {

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/base.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/base.js
@@ -394,6 +394,28 @@ describe('models/auth_brokers/base', function() {
     });
   });
 
+  describe('afterCompleteAddPostVerifyRecovery', function() {
+    it('unpersist VerificationData, returns the expected behavior', function() {
+      sinon.spy(broker, 'unpersistVerificationData');
+      return broker.afterCompleteSignIn(account).then(behavior => {
+        assert.isTrue(broker.unpersistVerificationData.calledWith(account));
+        assert.equal(behavior.type, 'navigate');
+        assert.equal(behavior.endpoint, 'signin_verified');
+      });
+    });
+  });
+
+  describe('afterAbortAddPostVerifyRecovery', function() {
+    it('unpersist VerificationData, returns the expected behavior', function() {
+      sinon.spy(broker, 'unpersistVerificationData');
+      return broker.afterCompleteSignIn(account).then(behavior => {
+        assert.isTrue(broker.unpersistVerificationData.calledWith(account));
+        assert.equal(behavior.type, 'navigate');
+        assert.equal(behavior.endpoint, 'signin_verified');
+      });
+    });
+  });
+
   describe('afterCompleteSignUp', function() {
     it('unpersist VerificationData, returns the expected behavior', function() {
       sinon.spy(broker, 'unpersistVerificationData');

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/web.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/web.js
@@ -47,4 +47,6 @@ describe('models/auth_brokers/web', function() {
 
   testRedirectsToSettingsIfSignedIn('afterCompleteSignIn');
   testRedirectsToSettingsIfSignedIn('afterCompleteSignUp');
+  testRedirectsToSettingsIfSignedIn('afterCompleteAddPostVerifyRecovery');
+  testRedirectsToSettingsIfSignedIn('afterAbortAddPostVerifyRecovery');
 });

--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/account_recovery/add_recovery_key.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/account_recovery/add_recovery_key.js
@@ -137,7 +137,10 @@ describe('views/post_verify/account_recovery/add_recovery_key', () => {
 
       it('calls correct broker methods', () => {
         assert.isTrue(
-          view.invokeBrokerMethod.calledWith('afterCompleteSignIn', account)
+          view.invokeBrokerMethod.calledWith(
+            'afterAbortAddPostVerifyRecovery',
+            account
+          )
         );
       });
     });

--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/account_recovery/confirm_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/account_recovery/confirm_password.js
@@ -176,7 +176,10 @@ describe('views/post_verify/account_recovery/confirm_password', () => {
 
       it('calls correct broker methods', () => {
         assert.isTrue(
-          view.invokeBrokerMethod.calledWith('afterCompleteSignIn', account)
+          view.invokeBrokerMethod.calledWith(
+            'afterAbortAddPostVerifyRecovery',
+            account
+          )
         );
       });
     });

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -246,7 +246,7 @@ module.exports = {
   POST_VERIFY_ADD_RECOVERY_KEY: {
     ERROR: '.error',
     HEADER: '#fxa-add-account-recovery-header',
-    MAYBE_LATER: '.maybe-later-btn',
+    MAYBE_LATER: '#maybe-later-btn',
     SUBMIT: 'button[type="submit"]',
   },
   POST_VERIFY_CONFIRM_PASSWORD: {
@@ -255,6 +255,7 @@ module.exports = {
     PASSWORD: 'input[type=password]',
     SUBMIT: 'button[type="submit"]',
     TOOLTIP: 'input[type=password] ~ .tooltip',
+    MAYBE_LATER: '#maybe-later-btn',
   },
   POST_VERIFY_SAVE_RECOVERY_KEY: {
     ERROR: '.error',

--- a/packages/fxa-content-server/tests/functional/post_verify/account_recovery.js
+++ b/packages/fxa-content-server/tests/functional/post_verify/account_recovery.js
@@ -26,6 +26,8 @@ const {
   testElementExists,
   testElementTextInclude,
   testElementTextNotEmpty,
+  testSuccessWasShown,
+  testSuccessWasNotShown,
   thenify,
   type,
 } = FunctionalHelpers;
@@ -120,8 +122,39 @@ registerSuite('post_verify_account_recovery', {
               testElementExists(
                 selectors.POST_VERIFY_RECOVERY_KEY_VERIFIED.HEADER
               )
-            );
+            )
+            .then(click(selectors.POST_VERIFY_RECOVERY_KEY_VERIFIED.SUBMIT))
+            .then(testSuccessWasShown('Account recovery enabled'));
         });
+    },
+    'abort account recovery at add_recovery_key': function() {
+      return this.remote
+        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+        .then(testElementExists(selectors.SETTINGS.HEADER))
+        .then(
+          openPage(
+            ACCOUNT_RECOVERY_URL,
+            selectors.POST_VERIFY_ADD_RECOVERY_KEY.HEADER
+          )
+        )
+        .then(click(selectors.POST_VERIFY_ADD_RECOVERY_KEY.MAYBE_LATER))
+        .then(testSuccessWasNotShown());
+    },
+    'abort account recovery at confirm_password': function() {
+      return this.remote
+        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+        .then(testElementExists(selectors.SETTINGS.HEADER))
+        .then(
+          openPage(
+            ACCOUNT_RECOVERY_URL,
+            selectors.POST_VERIFY_ADD_RECOVERY_KEY.HEADER
+          )
+        )
+        .then(click(selectors.POST_VERIFY_ADD_RECOVERY_KEY.SUBMIT))
+        .then(click(selectors.POST_VERIFY_CONFIRM_PASSWORD.MAYBE_LATER))
+        .then(testSuccessWasNotShown());
     },
   },
 });


### PR DESCRIPTION
Closes https://github.com/mozilla/fxa/issues/4369

- Only display "Account recovery enabled" message if you're coming from the final step of the post-verify recovery key setup flow.
- Otherwise, don't display any success message, including from "Maybe later" clicks, unless one is provided via `options.success`.

Additionally, beef up tests with

- Assert that the success and error messages were shown with a specific message
- Refute that success and error messages were shown at all

---

@vbudhram this is one of my first stabs at this stack, so I am 100% cool with if this isn't the right approach, or if my assumptions were off.