### PR TITLE
bug(auth-server): add payment_intent check in handling open invoices

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.js
+++ b/packages/fxa-auth-server/lib/payments/stripe.js
@@ -721,6 +721,19 @@ class StripeHelper {
   }
 
   /**
+   * Retrieve a PaymentIntent from an invoice
+   *
+   * @param {Invoice} invoice
+   * @returns {Promise<PaymentIntent>}
+   */
+  async fetchPaymentIntentFromInvoice(invoice) {
+    if (typeof invoice.payment_intent !== 'string') {
+      return invoice.payment_intent;
+    }
+    return this.stripe.paymentIntents.retrieve(invoice.payment_intent);
+  }
+
+  /**
    * Formats Stripe subscriptions for a customer into an appropriate response.
    *
    * @param {Subscriptions} subscriptions Subscriptions to finesse

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -276,8 +276,9 @@ class DirectStripeRoutes {
    * @param {Invoice} invoice
    */
   async handleOpenInvoice(invoice) {
-    const payment_intent =
-      /** @type {PaymentIntent} */ (invoice.payment_intent);
+    const payment_intent = await this.stripeHelper.fetchPaymentIntentFromInvoice(
+      invoice
+    );
 
     if (payment_intent.status !== 'requires_payment_method') {
       throw error.backendServiceFailure('stripe', 'invoice status', {

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -1081,6 +1081,42 @@ describe('StripeHelper', () => {
     });
   });
 
+  describe('fetchPaymentIntentFromInvoice', () => {
+    beforeEach(() => {
+      sandbox
+        .stub(stripeHelper.stripe.paymentIntents, 'retrieve')
+        .returns(unsuccessfulPaymentIntent);
+    });
+
+    describe('when the payment_intent is loaded', () => {
+      it('returns the payment_intent from the Invoice object', async () => {
+        const invoice = deepCopy(unpaidInvoice);
+        invoice.payment_intent = unsuccessfulPaymentIntent;
+
+        const expected = invoice.payment_intent;
+        const actual = await stripeHelper.fetchPaymentIntentFromInvoice(
+          invoice
+        );
+
+        assert.deepEqual(actual, expected);
+        assert.isTrue(stripeHelper.stripe.paymentIntents.retrieve.notCalled);
+      });
+    });
+
+    describe('when the payment_intnet is not loaded', () => {
+      it('fetches the payment_intent from Stripe', async () => {
+        const invoice = deepCopy(unpaidInvoice);
+        const expected = unsuccessfulPaymentIntent;
+        const actual = await stripeHelper.fetchPaymentIntentFromInvoice(
+          invoice
+        );
+
+        assert.deepEqual(actual, expected);
+        assert.isTrue(stripeHelper.stripe.paymentIntents.retrieve.calledOnce);
+      });
+    });
+  });
+
   describe('getProductName', () => {
     describe('when provided a Product object', () => {
       it('returns the name of the product', async () => {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -895,7 +895,9 @@ describe('DirectStripeRoutes', () => {
     describe('when the payment_intent status requires payment method', () => {
       it('calls payInvoice', async () => {
         const invoice = deepCopy(openInvoice);
-        invoice.payment_intent = deepCopy(openPaymentIntent);
+        directStripeRoutesInstance.stripeHelper.fetchPaymentIntentFromInvoice.resolves(
+          openPaymentIntent
+        );
 
         directStripeRoutesInstance.stripeHelper.payInvoice.resolves();
 
@@ -913,7 +915,9 @@ describe('DirectStripeRoutes', () => {
     describe('when the payment_intent status is in any other state', () => {
       it('thows a backendServiceFailure error', async () => {
         const invoice = deepCopy(openInvoice);
-        invoice.payment_intent = deepCopy(closedPaymementIntent);
+        directStripeRoutesInstance.stripeHelper.fetchPaymentIntentFromInvoice.resolves(
+          closedPaymementIntent
+        );
 
         return directStripeRoutesInstance.handleOpenInvoice(invoice).then(
           () => Promise.reject(new Error('Method expected to reject')),


### PR DESCRIPTION
- add function to ensure that the payment intent is loaded prior to evaulating the status

because:
- users have been reporting errors when attempting to signup for a subscription when their initial payment failed. after verifying that the stripe payment_intent objects appear to be in correct "payment_method_required" state, a potentialcause is that the payment_intent object is not actually loaded. this adds a StripeHelper function to ensure we are working with an object and not a string.

fixes #4437