### PR TITLE
refactor(sms page): cosmetic/copy updates and validation functionality for SMS page

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/marketing_snippet.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/marketing_snippet.mustache
@@ -50,8 +50,8 @@
 
     {{#isOther}}
       <div class="links clearfix">
-        <a target="_blank" class="marketing-link marketing-link-ios left" href="{{ downloadLinkIos }}" data-flow-event="link.app-store.ios" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="45" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
-        <a target="_blank" class="marketing-link marketing-link-android right" href="{{ downloadLinkAndroid }}" data-flow-event="link.app-store.android" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45"  src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
+        <a target="_blank" class="marketing-link marketing-link-ios" href="{{ downloadLinkIos }}" data-flow-event="link.app-store.ios" data-marketing-id="{{ marketingId }}" data-marketing-type="ios"><img width="152" height="45" src="{{ appStoreImage }}" alt="{{#t}}Download Firefox for iOS!{{/t}}" /></a>
+        <a target="_blank" class="marketing-link marketing-link-android" href="{{ downloadLinkAndroid }}" data-flow-event="link.app-store.android" data-marketing-id="{{ marketingId }}" data-marketing-type="android"><img width="152" height="45"  src="{{ playStoreImage }}" alt="{{#t}}Download Firefox for Android.{{/t}}" /></a>
       </div>
     {{/isOther}}
   {{/isAutumn2016}}

--- a/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
@@ -19,7 +19,7 @@
       <form novalidate>
         <div class="input-row sms-row">
           <input name="phoneNumber" class="phone-number" type="tel" data-country="{{country}}" value="{{phoneNumber}}" placeholder="{{#t}}Mobile phone number{{/t}}" required autofocus="autofocus" />
-          <button type="submit" class="sms-send primary-button">{{#t}}Send{{/t}}</button>
+          <button type="submit" class="sms-send secondary-button" disabled>{{#t}}Send{{/t}}</button>
         </div>
       </form>
     </section>

--- a/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
@@ -23,12 +23,12 @@
         </div>
       </form>
     </section>
-    <div class="marketing-area"></div>
     <div class="sms-disclaimer faint">
-      {{#unsafeTranslate}}SMS service only available in certain countries. SMS &amp; data rates may apply. The intended recipient of the email or SMS must have consented. <a %(escapedLearnMoreAttributes)s>Learn more</a>{{/unsafeTranslate}}
+      {{#unsafeTranslate}}SMS &amp; data rates may apply. The recipient’s consent is required. <a %(escapedLearnMoreAttributes)s>Learn more</a>{{/unsafeTranslate}}
     </div>
+    <div class="marketing-area"></div>
     <div class="links centered">
-      <a href="/sms/why" data-flow-event="link.why" class="left">{{#t}}Why sign in on another device?{{/t}}</a>
+      <a href="/sms/why" data-flow-event="link.why" class="left">{{#t}}Why sync multiple devices?{{/t}}</a>
       <a href='https://www.mozilla.org/firefox/accounts' class="btn-not-now" data-flow-event="link.not_now">{{#t}}Not now{{/t}}</a>
     </div>
     <aside class="child-view"></aside>

--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -36,6 +36,10 @@
   }
 }
 
+#main-content.send-sms::before {
+  content: initial;
+}
+
 #about-mozilla {
   @include respond-to('big') {
     background: image-url('mozilla.svg') no-repeat center center;
@@ -175,7 +179,7 @@
 .sms-disclaimer {
   font-size: 12px;
   line-height: 1.5;
-  margin: 20px 0;
+  margin: 20px 0 22px;
   padding: 0 20px;
 }
 

--- a/packages/fxa-content-server/app/styles/modules/_marketing.scss
+++ b/packages/fxa-content-server/app/styles/modules/_marketing.scss
@@ -19,6 +19,8 @@
     display: inline-block;
     height: 45px;
     width: 152px;
+    margin-left: 10px;
+    margin-right: 10px;
   }
 }
 


### PR DESCRIPTION
Closes #4431, Closes #4433

Various updates as part of FXA-878

- Validates phone number as you type, conditionally enabling submit button (see code comment)
- Disable Firefox logo in container
- Update SMS disclaimer and multi-device explanation copy
- Groups app download links closer together (I think this also addresses #1215?)

![Screen Shot 2020-03-06 at 11 48 28 AM](https://user-images.githubusercontent.com/6392049/76103861-6ad56f00-5fa0-11ea-8186-7cb2dac9c416.png)

Note the disabled button is not gray, per the guidelines, but faded blue as this was what already exists in our design patterns/CSS. Happy to change to the gray version if desired.