### PR TITLE
bug(auth-server): Add missing `await` to var assignment

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.js
+++ b/packages/fxa-auth-server/lib/payments/stripe.js
@@ -772,7 +772,7 @@ class StripeHelper {
         failure_message = /** @type {Charge} */ (charge).failure_message;
       }
 
-      const planName = this.formatPlanDisplayName(sub.plan);
+      const planName = await this.formatPlanDisplayName(sub.plan);
 
       // FIXME: Note that the plan is only set if the subscription contains a single
       // plan. Multiple product support will require changes here to fetch all
@@ -797,6 +797,7 @@ class StripeHelper {
    * Format the plan name for display
    *
    * @param {Plan} plan
+   * @returns {Promise<string>}
    */
   async formatPlanDisplayName(plan) {
     // enforce type because it _could_ be a DeletedProduct (but shouldn't be)


### PR DESCRIPTION
- a variable being assigned with the result of an asynction was missing the keyword `await`, this commit adds the missing keyword and adds to the async function's docblock

fixes #4449