### PR TITLE
fix(avatar): update avatar image cropper to work effectively at all window sizes

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/cropper.js
+++ b/packages/fxa-content-server/app/scripts/lib/cropper.js
@@ -6,7 +6,6 @@ import _ from 'underscore';
 
 var DEFAULT_DISPLAY_LENGTH = 240;
 var DEFAULT_EXPORT_LENGTH = 480;
-var DEFAULT_GUTTER = 40;
 
 /*
  * options: {
@@ -14,8 +13,6 @@ var DEFAULT_GUTTER = 40;
  *  src: The image source. Data URIs are okay.
  *  width: The image width. Required if src is set.
  *  height: The image height. Required if src is set.
- *  horizontalGutter: The amount of space between the crop zone and the sides of the wrapper
- *  verticalGutter: The amount of space between the crop zone and the top/bottom of the wrapper
  *  displayLength: The length of the crop square during cropping
  *  exportLength: The length of the final cropped image
  *  onRotate: Function to call back when the rotation button is clicked
@@ -33,30 +30,48 @@ function Cropper(options) {
   this.left = 0;
   this.yCenter = 0;
   this.xCenter = 0;
-  this.verticalGutter = _.result(options, 'verticalGutter', DEFAULT_GUTTER);
-  this.horizontalGutter = _.result(options, 'horizontalGutter', DEFAULT_GUTTER);
   this.onRotate = options.onRotate || _.noop;
   this.onTranslate = options.onTranslate || _.noop;
   this.onZoomIn = options.onZoomIn || _.noop;
   this.onZoomOut = options.onZoomOut || _.noop;
   this.onZoomRangeChange = options.onZoomRangeChange || _.noop;
 
+  this.resizeAdjustment = _.throttle(() => {
+    this.updateMeasurements();
+
+    const pos = this.updatePosition();
+    this.img.css(pos);
+  }, 300);
+
   if (!options.container) {
     throw new Error('A container element is required');
   }
+
   this._setupElements(options.container);
 
+  window.addEventListener('resize', this.resizeAdjustment);
+
   if (options.src) {
-    var img = options;
+    let img = options;
 
     // we want the extra resolution to be able to zoom in later (up to 200%)
-    var maxLength = this.exportLength * 2;
+    const maxLength = this.exportLength * 2;
     if (img.width > maxLength || img.height > maxLength) {
-      var scale = maxLength / Math.max(img.width, img.height);
+      const scale = maxLength / Math.max(img.width, img.height);
       img = this.resize(img, scale);
     }
     this.setImageSrc(img.src, img.width, img.height);
   }
+
+  // There is an issue where `this.updateMeasurements` is called before
+  // the DOM is finished laying out elements, so we're forcing the cropper
+  // to perform its checks after initial layout and execution is finished.
+  setTimeout(() => {
+    this.updateMeasurements();
+
+    const pos = this.updatePosition();
+    this.img.css(pos);
+  });
 }
 
 Cropper.prototype._setupElements = function(container) {
@@ -110,18 +125,43 @@ Cropper.prototype._setupElements = function(container) {
     $sliderEl.val(this.scale);
     this.onZoomIn();
   });
-
-  // Cache some invariants
-  this._wrapperHeight = this.wrapper.height();
-  this._wrapperWidth = this.wrapper.width();
 };
 
-Cropper.prototype.updatePosition = function(pos) {
+Cropper.prototype.destroy = function() {
+  window.removeEventListener('resize', this.resizeAdjustment);
+};
+
+Cropper.prototype.updateMeasurements = function() {
+  this._wrapperHeight = this.wrapper.outerHeight();
+  this._wrapperWidth = this.wrapper.outerWidth();
+
+  this.verticalGutter = (this._wrapperHeight - DEFAULT_DISPLAY_LENGTH) / 2;
+  this.horizontalGutter = (this._wrapperWidth - DEFAULT_DISPLAY_LENGTH) / 2;
+
+  // initialize the center to the middle of the wrapper
+  this.yCenter = this._wrapperHeight / 2;
+  this.xCenter = this._wrapperWidth / 2;
+};
+
+Cropper.prototype.updatePosition = function(_pos) {
+  const pos =
+    _pos ||
+    this.getBoundedPosition(
+      this.yCenter - this._height / 2,
+      this.xCenter - this._width / 2
+    );
+
   this.yCenter = pos.top + this._height / 2;
+  this.yCenter = pos.top + this._height / 2;
+  this.xCenter = pos.left + this._width / 2;
   this.xCenter = pos.left + this._width / 2;
 
   this.top = pos.top;
+  this.top = pos.top;
   this.left = pos.left;
+  this.left = pos.left;
+
+  return pos;
 };
 
 Cropper.prototype.setImageSrc = function(src, width, height) {
@@ -140,10 +180,6 @@ Cropper.prototype.setImageSrc = function(src, width, height) {
   this.slider.val(this.scale);
 
   img.attr('src', this.src);
-
-  // initialize the center to the middle of the wrapper
-  this.yCenter = this._wrapperHeight / 2;
-  this.xCenter = this._wrapperWidth / 2;
 
   if (
     typeof width !== 'number' ||
@@ -229,11 +265,7 @@ Cropper.prototype.zoom = function zoom(scale) {
 
   this.updateSize(length);
 
-  var pos = this.getBoundedPosition(
-    this.yCenter - this._height / 2,
-    this.xCenter - this._width / 2
-  );
-  this.updatePosition(pos);
+  const pos = this.updatePosition();
   this.img.css(pos);
 };
 

--- a/packages/fxa-content-server/app/scripts/views/settings/avatar_crop.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/avatar_crop.js
@@ -13,9 +13,6 @@ import ModalSettingsPanelMixin from '../mixins/modal-settings-panel-mixin';
 import ProfileImage from '../../models/profile-image';
 import Template from 'templates/settings/avatar_crop.mustache';
 
-var HORIZONTAL_GUTTER = 90;
-var VERTICAL_GUTTER = 0;
-
 const proto = FormView.prototype;
 const View = FormView.extend({
   template: Template,
@@ -55,14 +52,12 @@ const View = FormView.extend({
         displayLength: Constants.PROFILE_IMAGE_DISPLAY_SIZE,
         exportLength: Constants.PROFILE_IMAGE_EXPORT_SIZE,
         height: height,
-        horizontalGutter: HORIZONTAL_GUTTER,
         onRotate: this._onRotate.bind(this),
         onTranslate: this._onTranslate.bind(this),
         onZoomIn: this._onZoomIn.bind(this),
         onZoomOut: this._onZoomOut.bind(this),
         onZoomRangeChange: this._onZoomRangeChange.bind(this),
         src: src,
-        verticalGutter: VERTICAL_GUTTER,
         width: width,
       });
     } catch (e) {
@@ -110,6 +105,10 @@ const View = FormView.extend({
         this.navigate('settings');
         return result;
       });
+  },
+
+  remove() {
+    this.cropper.destroy();
   },
 
   _onRotate() {

--- a/packages/fxa-content-server/app/styles/modules/_cropper.scss
+++ b/packages/fxa-content-server/app/styles/modules/_cropper.scss
@@ -1,11 +1,18 @@
 .cropper {
   .wrapper {
     background-color: $cropper-background-color;
+    box-sizing: content-box;
     height: $avatar-size;
     margin: 0 -30px;
     overflow: hidden;
+    padding: 0 30px;
     position: relative;
-    width: $avatar-size + 180px;
+    width: 100%;
+
+    @include respond-to('small') {
+      margin: 0 -10px;
+      padding: 0 10px;
+    }
 
     img {
       position: absolute;
@@ -15,7 +22,7 @@
   .mask {
     background: image-url('crop-mask.svg');
     height: $avatar-size;
-    left: (420 - $avatar-size) / 2;
+    left: calc((100% - #{$avatar-size}) / 2);
     position: relative;
     top: 0;
     width: $avatar-size;
@@ -23,22 +30,22 @@
 
     &::before,
     &::after {
-      background-color: rgba($cropper-background-color, 0.5);
+      background-color: rgba($cropper-background-color, 0.52);
       content: '';
       display: block;
       height: $avatar-size;
       position: absolute;
       top: 0;
-      width: (420 - $avatar-size) / 2;
+      width: 100%;
       z-index: 1;
     }
 
     &::before {
-      left: -(420 - $avatar-size) / 2;
+      left: -100%;
     }
 
     &::after {
-      right: -(420 - $avatar-size) / 2;
+      right: -100%;
     }
   }
 

--- a/packages/fxa-content-server/app/tests/spec/lib/cropper.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/cropper.js
@@ -108,8 +108,9 @@ describe('lib/cropper', function() {
           verticalGutter: 0,
         });
 
-        cropper._wrapperHeight = 240;
-        cropper._wrapperWidth = 320;
+        cropper.wrapper.width(240);
+        cropper.wrapper.height(320);
+        cropper.updateMeasurements();
 
         cropper.canvas = new CanvasMock();
       });
@@ -121,16 +122,17 @@ describe('lib/cropper', function() {
 
     it('sets image src after', function() {
       cropper.setImageSrc(pngSrc, 100, 100);
+      cropper.img.css(cropper.updatePosition());
 
-      assert.equal(cropper.yCenter, 120);
-      assert.equal(cropper.xCenter, 160);
+      assert.equal(cropper.yCenter, 160);
+      assert.equal(cropper.xCenter, 120);
       assert.equal(cropper.isLandscape, false);
       assert.equal(cropper._originalWidth, 100);
       assert.equal(cropper._originalHeight, 100);
       assert.equal(cropper._height, 240);
       assert.equal(cropper._width, 240);
-      assert.equal(cropper.verticalGutter, 0);
-      assert.equal(cropper.horizontalGutter, 40);
+      assert.equal(cropper.verticalGutter, 40);
+      assert.equal(cropper.horizontalGutter, 0);
     });
 
     it('rotates and sets landscape mode', function() {
@@ -181,25 +183,25 @@ describe('lib/cropper', function() {
 
       assert.equal(
         cropper.getBoundedPosition(0, 50).left,
-        40,
+        0,
         'left edge does not exceed gutter length'
       );
 
       assert.equal(
         cropper.getBoundedPosition(10, 0).top,
-        0,
+        40,
         'top edge does not exceed gutter length'
       );
 
       assert.equal(
         cropper.getBoundedPosition(0, -220).left,
-        -200,
+        -220,
         'right edge does not exceed gutter length'
       );
 
       assert.equal(
         cropper.getBoundedPosition(-10, 0).top,
-        0,
+        40,
         'bottom edge does not exceed gutter length'
       );
     });


### PR DESCRIPTION
Closes #674

This should address the avatar image cropper at smaller window sizes.
This was actually a bit of a doozy, since the cropper sizing was hard coded. The remedies I've used are:

- Update all the cropper component styles to be a little more fluid.
- Remove the ability to specify explicit vertical and horizontal gutters, instead relying on the calculated width of the wrapper versus the size of the cropping box.
- Position accordingly on page load and on window resize (debounced).

[Here's a demo video](https://imgur.com/v2qU6AK) of the cropping container at various window sizes.

![Screen Shot 2020-03-07 at 9 36 04 PM](https://user-images.githubusercontent.com/6392049/76155599-22ab6f00-60bc-11ea-96ce-442a8e17c9dd.png)