### PR TITLE
feat(sms): Conditionally render heading text based on mobile deviceType presence

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
@@ -3,7 +3,15 @@
       <div class="error"></div>
     </header>
     <section class="send-sms">
-      <div class="graphic {{graphicId}}">{{#t}}Success{{/t}}</div>
+      <div class="graphic {{graphicId}}" role="img" aria-label="{{#t}}Connect another device{{/t}}"></div>
+      <h1>
+        {{^userHasAttachedMobileDevice}}
+          {{#t}}Would you like to sync your phone?{{/t}}
+        {{/userHasAttachedMobileDevice}}
+        {{#userHasAttachedMobileDevice}}
+          {{#t}}Still adding devices?{{/t}}
+        {{/userHasAttachedMobileDevice}}
+      </h1>
       <p>
         {{#t}}Send Firefox directly to your smartphone and sign in to complete set-up{{/t}}
       </p>

--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -106,9 +106,10 @@
 }
 
 .send-sms {
-  h2 {
-    font-size: 17px;
-    margin-bottom: 10px;
+  h1 {
+    font-size: 22px;
+    font-weight: 400;
+    margin-bottom: 16px;
   }
 
   p {


### PR DESCRIPTION
Also adds aria-label and role to a graphic for for ADA purposes.

fixes #4435 

---

We don't have to worry about potential lag between a device just verifying and then fetching from `attachedClients` because #4432 should redirect users that register with a mobile device.

I expect to have merge conflicts if #4454 is merged first.