### PR TITLE
fix(recovery): Add recovery key graphic on confirmation screen

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/post_verify/account_recovery/confirm_recovery_key.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/account_recovery/confirm_recovery_key.mustache
@@ -15,6 +15,8 @@
         <div class="success"></div>
         <div class="error"></div>
 
+        <div class="graphic graphic-recovery-codes"></div>
+
         <p class="verification-email-message">{{#t}}Enter your recovery key to confirm that you've saved a copy.{{/t}}</p>
 
         <form novalidate>

--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/account_recovery/confirm_recovery_key.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/account_recovery/confirm_recovery_key.js
@@ -82,6 +82,7 @@ describe('views/post_verify/account_recovery/confirm_recovery_key', () => {
   describe('render', () => {
     it('renders the view', () => {
       assert.lengthOf(view.$('#fxa-confirm-recovery-key-header'), 1);
+      assert.lengthOf(view.$('.graphic-recovery-codes'), 1);
       assert.lengthOf(view.$('#recovery-key'), 1);
       assert.lengthOf(view.$('#submit-btn'), 1);
       assert.lengthOf(view.$('#back-btn'), 1);


### PR DESCRIPTION
Fixes #4367

This PR adds the recovery graphic on the confirmation page.

<img width="536" alt="Screen Shot 2020-03-10 at 11 06 08 AM" src="https://user-images.githubusercontent.com/1295288/76326596-41c61e80-62bf-11ea-9bcd-a86e6c7e9d72.png">
