### PR TITLE
fix(style): update rtl padding for Firefox services list

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_marketing.scss
+++ b/packages/fxa-content-server/app/styles/modules/_marketing.scss
@@ -46,7 +46,6 @@
       }
 
       html[dir='rtl'] & {
-        padding-right: 10px;
         text-align: right;
       }
     }
@@ -80,6 +79,7 @@
       }
 
       html[dir='rtl'] & {
+        padding: 0 0 10px 10px;
         text-align: right;
       }
 


### PR DESCRIPTION
This patch updates how the alignment between the h2 and the Firefox
services product list items are accomplished for RTL.

Fixes #4383 

@mozilla/fxa-devs r?