### PR TITLE
feat(auth-server): add created to subscription response

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.js
+++ b/packages/fxa-auth-server/lib/payments/stripe.js
@@ -778,6 +778,7 @@ class StripeHelper {
       // plan. Multiple product support will require changes here to fetch all
       // plans for this subscription.
       subs.push({
+        created: sub.created,
         current_period_end: sub.current_period_end,
         current_period_start: sub.current_period_start,
         cancel_at_period_end: sub.cancel_at_period_end,

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -302,6 +302,7 @@ module.exports.activeSubscriptionValidator = isA.object({
 
 // This is subhub's perspective on an active subscription
 module.exports.subscriptionsSubscriptionValidator = isA.object({
+  created: isA.number().required(),
   current_period_end: isA.number().required(),
   current_period_start: isA.number().required(),
   cancel_at_period_end: isA.boolean().required(),

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -1199,6 +1199,7 @@ describe('StripeHelper', () => {
       describe('when there is a charge-automatically payment that is past due', () => {
         const expected = [
           {
+            created: pastDueSubscription.created,
             current_period_end: pastDueSubscription.current_period_end,
             current_period_start: pastDueSubscription.current_period_start,
             cancel_at_period_end: false,
@@ -1260,6 +1261,7 @@ describe('StripeHelper', () => {
             const input = { data: [subscription1] };
             const expected = [
               {
+                created: subscription1.created,
                 current_period_end: subscription1.current_period_end,
                 current_period_start: subscription1.current_period_start,
                 cancel_at_period_end: false,
@@ -1285,6 +1287,7 @@ describe('StripeHelper', () => {
             const input = { data: [subscription] };
             const expected = [
               {
+                created: subscription.created,
                 current_period_end: subscription.current_period_end,
                 current_period_start: subscription.current_period_start,
                 cancel_at_period_end: true,
@@ -1308,6 +1311,7 @@ describe('StripeHelper', () => {
             const input = { data: [cancelledSubscription] };
             const expected = [
               {
+                created: cancelledSubscription.created,
                 current_period_end: cancelledSubscription.current_period_end,
                 current_period_start:
                   cancelledSubscription.current_period_start,

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -179,13 +179,14 @@ describe('remote subscriptions:', function() {
 
     describe('with a subscription', () => {
       const subscriptionId = 'sub_12345';
+      const date = Date.now();
       beforeEach(() => {
         mockStripeHelper.customer = async (uid, email) => ({
           subscriptions: {
             data: [
               {
                 id: subscriptionId,
-                created: Date.now() / 1000,
+                created: date,
                 cancelled_at: null,
                 plan: {
                   product: PRODUCT_ID,
@@ -199,8 +200,9 @@ describe('remote subscriptions:', function() {
           {
             subscription_id: subscriptionId,
             plan_id: PLAN_ID,
-            current_period_end: Date.now() / 1000,
-            current_period_start: Date.now() / 1000,
+            created: date,
+            current_period_end: date,
+            current_period_start: date,
             cancel_at_period_end: false,
             end_at: null,
             plan_name: 'foo',
@@ -230,8 +232,7 @@ describe('remote subscriptions:', function() {
         let result = await client.getActiveSubscriptions(tokens[2]);
         assert.isArray(result);
         assert.lengthOf(result, 1);
-        assert.isAbove(result[0].createdAt, Date.now() - 1000);
-        assert.isAtMost(result[0].createdAt, Date.now());
+        assert.equal(result[0].createdAt, date * 1000);
         assert.equal(result[0].productId, PRODUCT_ID);
         assert.equal(result[0].uid, client.uid);
         assert.isNull(result[0].cancelledAt);


### PR DESCRIPTION
- add created timestamp to the subscription response

Because:
- as a part of allowing longer duration subscriptions, we need to provide support agents with the date the subscription began for the purpose of time-sensitive refunds

issue #3981