### PR TITLE
fix(sms page): display "This Firefox is connected" after sign in or registration via sync occurs

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
@@ -1,6 +1,11 @@
 <div id="main-content" class="card send-sms">
     <header id="fxa-send-sms-header">
       <div class="error"></div>
+      {{#showSuccessMessage}}
+        {{#isSignedIn}}
+          <div class="success success-authenticated visible">{{#t}}This Firefox is connected{{/t}}</div>
+        {{/isSignedIn}}
+      {{/showSuccessMessage}}
     </header>
     <section class="send-sms">
       <div class="graphic {{graphicId}}" role="img" aria-label="{{#t}}Connect another device{{/t}}"></div>

--- a/packages/fxa-content-server/app/scripts/views/sms_send.js
+++ b/packages/fxa-content-server/app/scripts/views/sms_send.js
@@ -113,6 +113,7 @@ class SmsSendView extends FormView {
 
     context.set({
       userHasAttachedMobileDevice: this._userHasAttachedMobileDevice,
+      isSignedIn: this._isSignedIn(),
       country,
       escapedLearnMoreAttributes,
       graphicId,
@@ -139,6 +140,29 @@ class SmsSendView extends FormView {
     return this._sendSms(
       this._getNormalizedPhoneNumber(),
       FIREFOX_MOBILE_INSTALL
+    );
+  }
+
+  /**
+   * Check if the current user is already signed in.
+   *
+   * @returns {Boolean}
+   * @private
+   */
+  _isSignedIn() {
+    // If a user verifies at CWTS, the browser will not have yet received
+    // the fxaccounts:login message, and the fxaccounts:fxa_status request on
+    // startup will return `signedInUser: null`, resulting in us believing no
+    // user is signed in. Users that aren't signed in are asked to sign in.
+    // Whoops.
+    // Fortunately, we can guess that the user *will* be signed in
+    // if we know the user is verifying in the same browser. Some data
+    // is written in CWTS to let us know the user is verifying in the same
+    // browser. If this is the case, assume the user is signed in.
+    // See #5554
+    return (
+      this.user.isSignedInAccount(this.getAccount()) ||
+      this.broker.get('isVerificationSameBrowser')
     );
   }
 

--- a/packages/fxa-content-server/app/styles/modules/_branding.scss
+++ b/packages/fxa-content-server/app/styles/modules/_branding.scss
@@ -36,8 +36,20 @@
   }
 }
 
-#main-content.send-sms::before {
-  content: initial;
+// Note this is non-standard styling for #main-content. It would
+// generally have a greater top padding value and the Firefox logo
+// across the top. But here we are intentionally making these
+// changes to a simpler look.
+#main-content.send-sms {
+  padding-top: 40px;
+
+  @include respond-to('small') {
+    padding-top: 52px;
+  }
+
+  &::before {
+    content: initial;
+  }
 }
 
 #about-mozilla {

--- a/packages/fxa-content-server/app/tests/spec/views/sms_send.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sms_send.js
@@ -310,6 +310,54 @@ describe('views/sms_send', () => {
     });
   });
 
+  describe('_isSignedIn', () => {
+    it('returns `true` if the account is signed', () => {
+      sinon.stub(user, 'isSignedInAccount').callsFake(() => true);
+      broker.set('isVerificationSameBrowser', false);
+
+      assert.isTrue(view._isSignedIn());
+      assert.isTrue(user.isSignedInAccount.calledOnce);
+      assert.isTrue(user.isSignedInAccount.calledWith(account));
+    });
+
+    it('returns `true` if verifying in the same browser', () => {
+      sinon.stub(user, 'isSignedInAccount').callsFake(() => false);
+      broker.set('isVerificationSameBrowser', true);
+
+      assert.isTrue(view._isSignedIn());
+    });
+
+    it('returns `false` otherwise', () => {
+      sinon.stub(user, 'isSignedInAccount').callsFake(() => false);
+      broker.set('isVerificationSameBrowser', false);
+
+      assert.isFalse(view._isSignedIn());
+    });
+
+    describe('displaying the "This Firefox is connected" banner', () => {
+      function shouldShowConnectedBanner() {
+        return view._isSignedIn() && view.model.get('showSuccessMessage');
+      }
+
+      it('should not when `showSuccessMessage` returns `false`', () => {
+        sinon.stub(user, 'isSignedInAccount').callsFake(() => true);
+        view.model.set('showSuccessMessage', false);
+        assert.isFalse(shouldShowConnectedBanner());
+      });
+
+      it('should not when `_isSignedIn` returns `false`', () => {
+        sinon.stub(view, '_isSignedIn').callsFake(() => false);
+        assert.isFalse(shouldShowConnectedBanner());
+      });
+
+      it('should when both `_isSignedIn` and `showSuccessMessage` return `true`', () => {
+        view.model.set('showSuccessMessage', true);
+        sinon.stub(view, '_isSignedIn').callsFake(() => true);
+        assert.isTrue(shouldShowConnectedBanner());
+      });
+    });
+  });
+
   describe('_onSendSmsSuccess', () => {
     it('navigates to `sms/sent`', () => {
       sinon.spy(view, 'navigate');


### PR DESCRIPTION
Closes https://github.com/mozilla/fxa/issues/4436

We currently display the success banner "This Firefox is connected" on the Connect Another Device screen after a successful sign in or registration via Sync, but there are cases where the user can be shown the SMS screen (skipping CAD altogether), so we want to show that same confirmation message here.

This should only appear in the following scenario:

1. You have just signed in (returning or new registration)
2. You are in a state that is eligible to receive SMS messages

You should not be seeing this message if you hit any variation of `/sms` directly. Even reloading the page when you first see the banner should not show it again.

<img width="581" alt="Screen Shot 2020-03-10 at 9 52 16 AM" src="https://user-images.githubusercontent.com/6392049/76347971-db9cc400-62dd-11ea-88a8-191818d7baad.png">
