### PR TITLE
fix(test): fixed race in event-broker test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
       SKIP_DOCKER: true
     steps:
       - base-install
-      - run: ./packages/fxa-content-server/scripts/test-ci.sh
+      - run: ./.circleci/test-package.sh fxa-content-server
       - store_artifacts:
           path: ~/.pm2/logs
           destination: logs

--- a/packages/fxa-event-broker/scripts/test-ci.sh
+++ b/packages/fxa-event-broker/scripts/test-ci.sh
@@ -1,8 +1,0 @@
-#!/bin/bash -ex
-
-DIR=$(dirname "$0")
-
-cd $DIR/..
-npm ci
-# TODO enable when tests pass
-#npm test


### PR DESCRIPTION
There's a race in here somewhere... `await` on the set can complete before the webhook triggers.

This isn't the most elegant fix. There's prob a better way.

fixes #4469 