### PR TITLE
fix(ci): exclude train branches from assert-branch.sh

### DIFF
--- a/.circleci/assert-branch.sh
+++ b/.circleci/assert-branch.sh
@@ -2,6 +2,12 @@
 
 DIR=$(dirname "$0")
 
+if [[ $CIRCLE_BRANCH =~ ^train-.* ]]; then
+  # train PRs should be excluded from this check
+  echo "Train branch, skipping package check"
+  exit 0
+fi
+
 if grep -e 'fxa-email-service' $DIR/../packages/test.list; then
   if [[ ! $CIRCLE_BRANCH =~ ^email-service-.* ]]; then
     echo "Please create a new PR from a branch name starting with 'email-service-'"


### PR DESCRIPTION
Train branches update the package.json and Changelog
for all the packages whether there were code changes
or not. These PRs are already in the release so there's
no need to test email-service here now.

Sorry to Jackie for breaking your PR.