### PR TITLE
refactor(sms): SMS Clarity - replace subheader text

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
@@ -18,7 +18,7 @@
         {{/userHasAttachedMobileDevice}}
       </h1>
       <p>
-        {{#t}}Send Firefox directly to your smartphone and sign in to complete set-up{{/t}}
+        {{#t}}Send a link by SMS to install Firefox on your phone.{{/t}}
       </p>
 
       <form novalidate>

--- a/packages/fxa-content-server/app/tests/spec/views/sms_send.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sms_send.js
@@ -167,11 +167,8 @@ describe('views/sms_send', () => {
       sinon.stub(view, 'isSignIn').callsFake(() => true);
       return view.render().then(() => {
         assert.include(
-          view
-            .$('.send-sms > p')
-            .text()
-            .toLowerCase(),
-          'send firefox directly to your smartphone'
+          view.$('.send-sms > p').text(),
+          'Send a link by SMS to install Firefox on your phone.'
         );
       });
     });


### PR DESCRIPTION
A simple copy update. This should have been part of #4431 but I missed including it in the bullet points of things to do.