### PR TITLE
fix(ios): Don't show signout button with Firefox iOS client

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -160,4 +160,6 @@ module.exports = {
   CC_EXPIRED: 'expired_card',
 
   SIGNUP_CODE_LENGTH: 6,
+
+  FIREFOX_IOS_OAUTH_ENTRYPOINT: 'ios_settings_manage',
 };

--- a/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
@@ -177,14 +177,6 @@ var OAuthRelier = Relier.extend({
     return true;
   },
 
-  containsOldSyncScope() {
-    const permissions = this.scopeStrToArray(this.get('scope'));
-    if (permissions.includes(Constants.OAUTH_OLDSYNC_SCOPE)) {
-      return true;
-    }
-    return false;
-  },
-
   _isVerificationFlow() {
     return !!this.getSearchParam('code');
   },

--- a/packages/fxa-content-server/app/scripts/views/settings.js
+++ b/packages/fxa-content-server/app/scripts/views/settings.js
@@ -94,11 +94,13 @@ const View = BaseView.extend({
       escapedCcExpiredLinkAttrs: 'href="/subscriptions" class="alert-link"',
       securityEventsVisible: this.displaySecurityEvents(),
       showSignOut:
-        // Note: For sync clients and oauth based sync clients, they have their
-        // own UX for signing a user out, typically within their own app.
-        // In these scenarios we don't show the sign out button.
         !account.isFromSync() &&
-        !(this.relier.isOAuth() && this.relier.containsOldSyncScope()),
+        // Firefox iOS using the Rust client doesn't not seem to load
+        // FxA settings page correctly. The relier reports that it is not
+        // an Oauth client and doesn't use keys (which it does). This is less than ideal,
+        // but a simple workaround until #4509 can get resolved.
+        this.relier.get('entrypoint') !==
+          Constants.FIREFOX_IOS_OAUTH_ENTRYPOINT,
       unsafeHeaderHTML: this._getHeaderHTML(account),
     });
   },

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
@@ -292,27 +292,6 @@ describe('models/reliers/oauth', () => {
       });
     });
 
-    it('containsOldSyncScope returns true when requesting access to Sync', () => {
-      windowMock.location.search = toSearchString({
-        action: ACTION,
-        client_id: CLIENT_ID,
-        redirect_uri: QUERY_REDIRECT_URI,
-        scope: SCOPE_OLDSYNC,
-        state: STATE,
-      });
-
-      sinon.stub(relier, 'isTrusted').callsFake(() => {
-        return true;
-      });
-      sinon.stub(relier, '_validateKeyScopeRequest').callsFake(() => {
-        return true;
-      });
-
-      return relier.fetch().then(() => {
-        assert.isTrue(relier.containsOldSyncScope());
-      });
-    });
-
     describe('query parameter validation', () => {
       describe('access_type', () => {
         var validValues = [undefined, 'offline', 'online'];

--- a/packages/fxa-content-server/app/tests/spec/views/settings.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings.js
@@ -263,12 +263,9 @@ describe('views/settings', function() {
       });
     });
 
-    describe('beforeRender with oauth client and oldsync scope', () => {
+    describe('beforeRender with Firefox iOS entrypoint', () => {
       beforeEach(() => {
-        relier.containsOldSyncScope = () => {
-          return true;
-        };
-        sinon.stub(relier, 'isOAuth').callsFake(() => true);
+        relier.set('entrypoint', 'ios_settings_manage');
         return view.beforeRender();
       });
 

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -517,6 +517,7 @@ const conf = (module.exports = convict({
             'https://accounts.firefox.com/oauth/success/85da77264642d6a1', // Firefox for FireTV
             'https://accounts.firefox.com/oauth/success/1b1a3e44c54fbb58', // Firefox for iOS
             'urn:ietf:wg:oauth:2.0:oob:pair-auth-webchannel',
+            'urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel', // Firefox for iOS Rust client
           ],
         },
         'https://identity.mozilla.com/apps/send': {


### PR DESCRIPTION
Follow up fix to #4284

Trying to avoid spinning my wheels too hard on this, I created a follow up to fix what I think the underlying problem is in #4509. In the meantime, this checks to see if the page is being loaded from an iOS client and doesn't show the signout button if it is.

This time I was able to verify it works locally.

![Screen Shot 2020-03-11 at 1 15 51 PM](https://user-images.githubusercontent.com/1295288/76445982-b58a2900-639c-11ea-833e-68b303415deb.png)
