### PR TITLE
fix(tests): change port that selenium tests run on from 9090 to 9091

### DIFF
--- a/packages/fxa-content-server/tests/intern.js
+++ b/packages/fxa-content-server/tests/intern.js
@@ -72,8 +72,8 @@ const config = {
 
   pageLoadTimeout: 20000,
   reporters: 'runner',
-  serverPort: 9090,
-  serverUrl: 'http://127.0.0.1:9090',
+  serverPort: 9091,
+  serverUrl: 'http://127.0.0.1:9091',
   socketPort: 9077,
   tunnelOptions: {
     drivers: [


### PR DESCRIPTION
You currently encounter errors running content server functional tests locally because it conflicts with our firestore port, set to 9090.