### PR TITLE
feat(ci): optimize when 'npm ci' is run on circleci

### DIFF
--- a/.circleci/base-install.sh
+++ b/.circleci/base-install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ex
+
+MODULE=$1
+DIR=$(dirname "$0")
+
+cd $DIR/..
+
+# npm install just enough to run these scripts
+npm ci --ignore-scripts --no-optional --only=prod
+node .circleci/modules-to-test.js | tee packages/test.list
+./.circleci/assert-branch.sh
+./.circleci/create-version-json.sh
+
+# only run a full npm install if required
+if [[ "$MODULE" == "all" ]] || grep -e "$MODULE" -e 'all' packages/test.list > /dev/null; then
+  npm ci
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,16 +2,13 @@ version: 2.1
 
 commands:
   base-install:
+    parameters:
+      package:
+        type: string
+        default: all
     steps:
       - checkout
-      - run: npm ci
-      - run:
-          name: Create version.json
-          command: .circleci/create-version-json.sh
-      - run:
-          name: Figure out what to test
-          command: node .circleci/modules-to-test.js | tee packages/test.list
-      - run: ./.circleci/assert-branch.sh
+      - run: ./.circleci/base-install.sh << parameters.package >>
 
 jobs:
   test-package:
@@ -28,7 +25,8 @@ jobs:
       SKIP_PACKAGES: true
       SKIP_DOCKER: true
     steps:
-      - base-install
+      - base-install:
+          package: << parameters.package >>
       - run: ./.circleci/test-package.sh << parameters.package >>
 
   test-many:
@@ -85,7 +83,8 @@ jobs:
       SKIP_PACKAGES: false
       SKIP_DOCKER: true
     steps:
-      - base-install
+      - base-install:
+          package: fxa-content-server
       - run: ./.circleci/test-package.sh fxa-content-server
       - store_artifacts:
           path: ~/.pm2/logs
@@ -95,7 +94,7 @@ jobs:
           destination: screenshots
 
   test-email-service:
-    resource_class: xlarge
+    resource_class: large
     docker:
       - image: mozilla/fxa-circleci
       - image: mysql:5.7.27
@@ -108,7 +107,8 @@ jobs:
       SKIP_PACKAGES: true
       SKIP_DOCKER: true
     steps:
-      - base-install
+      - base-install:
+          package: fxa-email-service
       - run: ./packages/fxa-email-service/scripts/test-ci.sh
       - store_artifacts:
           path: artifacts
@@ -121,7 +121,8 @@ jobs:
       SKIP_PACKAGES: true
       SKIP_DOCKER: true
     steps:
-      - base-install
+      - base-install:
+          package: fxa-circleci
       - setup_remote_docker
       - run: ./.circleci/build.sh fxa-circleci
 


### PR DESCRIPTION
A full `npm ci` sometimes takes a long time for whatever
reason. Before this change it always ran, even if the
tests were going to be skipped. Now it checks whether
the tests are going to run first.