### PR TITLE
fix(post verify): add selector so downloaded/copied/printed messaging can appear

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/post_verify/account_recovery/save_recovery_key.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/account_recovery/save_recovery_key.mustache
@@ -1,4 +1,4 @@
-<div id="main-content" class="card save-recovery-key">
+<div id="main-content" class="card save-recovery-key modal">
     <header>
         <h1 id="fxa-save-recovery-key-header">
             {{#serviceName}}
@@ -11,8 +11,8 @@
         </h1>
     </header>
 
-    <section>
-        <div class="success"></div>
+    <section class="modal-panel">
+        <p class="modal-success bottom-spaced"></p>
 
         <p class="description">Store it in a safe place on your computer or a printed copy that is easily accessed by only you.</p>
 

--- a/packages/fxa-content-server/app/styles/modules/_modal.scss
+++ b/packages/fxa-content-server/app/styles/modules/_modal.scss
@@ -33,6 +33,10 @@
       display: block;
       font-size: $base-font;
       margin: 0 auto;
+
+      &.bottom-spaced {
+        margin-bottom: 15px;
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #4366

All the functionality is there in the mixin, the selector and styling was just needed.

![Screen Shot 2020-03-11 at 5 07 34 PM](https://user-images.githubusercontent.com/6392049/76464235-57b90980-63bb-11ea-8ecd-a211bb024174.png)
