### PR TITLE
feat(ci): added build-ci script to fxa-circleci

### DIFF
--- a/packages/fxa-circleci/Dockerfile
+++ b/packages/fxa-circleci/Dockerfile
@@ -26,4 +26,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH=/home/circleci/.cargo/bin:$PATH
 RUN cargo install cargo-audit
 
+# copy this Dockerfile into the image so we can compare it later
+COPY --chown=circleci:circleci Dockerfile /
+
 CMD ["/bin/sh"]

--- a/packages/fxa-circleci/scripts/build-ci.sh
+++ b/packages/fxa-circleci/scripts/build-ci.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -ex
+
+# In order to save time this script pulls the latest docker image and compares
+# it to the current Dockerfile. If there are no changes the build is skipped.
+
+DIR=$(dirname "$0")
+
+cd $DIR/..
+
+docker pull mozilla/fxa-circleci:latest
+
+if docker run --rm -it mozilla/fxa-circleci:latest cat /Dockerfile | diff -b -q Dockerfile - ; then
+  echo "The source is unchanged. Tagging latest as build"
+  docker tag mozilla/fxa-circleci:latest fxa-circleci:build
+else
+  docker build -t fxa-circleci:build .
+fi


### PR DESCRIPTION
This checks the diff of the current Dockerfile
with the one pulled from latest. If they are
the same it skips the build in order to save time.

Like #4512 (but hopefully works) - _I've got a follow up to that one coming_