### PR TITLE
fix(metrics): send nav timing as text/plain

### DIFF
--- a/packages/fxa-payments-server/server/lib/routes/navigation-timing.js
+++ b/packages/fxa-payments-server/server/lib/routes/navigation-timing.js
@@ -7,10 +7,7 @@
 const joi = require('joi');
 const URL = require('url').URL;
 
-const TIMESTAMP_MS = joi
-  .number()
-  .integer()
-  .required();
+const TIMESTAMP_MS = joi.number().required();
 // Validate the subset of PerformanceNavgationTiming properties used here.
 // (Ref: https://www.w3.org/TR/navigation-timing-2/#dom-performancenavigationtiming)
 const navigationTimingSchema = joi.object().keys({
@@ -33,6 +30,18 @@ module.exports = (geolocate, UAParser, statsd) => ({
   method: 'post',
   path: '/navigation-timing',
   validate: { body: navigationTimingSchema },
+  preProcess: function(req, res, next) {
+    // convert text/plain to JSON
+    if (req.get('content-type').startsWith('text/plain')) {
+      try {
+        req.body = JSON.parse(req.body);
+      } catch (error) {
+        req.body = {};
+      }
+    }
+
+    next();
+  },
   process(request, response) {
     try {
       const location = geolocate(request);

--- a/packages/fxa-payments-server/src/lib/navigation-timing.test.ts
+++ b/packages/fxa-payments-server/src/lib/navigation-timing.test.ts
@@ -36,12 +36,10 @@ describe('lib/navigation-timing', () => {
       cb({ getEntries }, mockObs);
       expect(observeFn).toHaveBeenCalledWith({ entryTypes: ['navigation'] });
       expect(window.navigator.sendBeacon).toHaveBeenCalledTimes(1);
-      const expectedBlob = new Blob([JSON.stringify({ foo: 'bar' })], {
-        type: 'application/json',
-      });
+      const expectedJson = JSON.stringify({ foo: 'bar' });
       expect(window.navigator.sendBeacon).toHaveBeenCalledWith(
         '/x/y/z',
-        expectedBlob
+        expectedJson
       );
       expect(disconnectFn).toBeCalledTimes(1);
     });
@@ -52,12 +50,10 @@ describe('lib/navigation-timing', () => {
       mockGetEntriesByType([navTiming as PerformanceEntry]);
       observeNavigationTiming('/x/y/z');
       expect(window.navigator.sendBeacon).toHaveBeenCalledTimes(1);
-      const expectedBlob = new Blob([JSON.stringify(navTiming)], {
-        type: 'application/json',
-      });
+      const expectedJson = JSON.stringify(navTiming);
       expect(window.navigator.sendBeacon).toHaveBeenCalledWith(
         '/x/y/z',
-        expectedBlob
+        expectedJson
       );
     });
   });

--- a/packages/fxa-payments-server/src/lib/navigation-timing.ts
+++ b/packages/fxa-payments-server/src/lib/navigation-timing.ts
@@ -2,16 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const sendNavTiming = (
-  url: string,
-  performanceNavTiming: PerformanceNavigationTiming
-) => {
-  const timings = JSON.stringify(performanceNavTiming);
-  const headers = { type: 'application/json' };
-  const reqBlob = new Blob([timings], headers);
-  navigator.sendBeacon(url, reqBlob);
-};
-
 export const observeNavigationTiming = (beaconUrl: string) => {
   if (
     performance.getEntriesByType &&
@@ -27,12 +17,12 @@ export const observeNavigationTiming = (beaconUrl: string) => {
 
     // Once duration is recorded the event is over
     if (navTiming.duration > 0) {
-      sendNavTiming(beaconUrl, navTiming);
+      navigator.sendBeacon(beaconUrl, JSON.stringify(navTiming));
     } else {
       const navTimingObs = new PerformanceObserver((entries, obs) => {
-        sendNavTiming(
+        navigator.sendBeacon(
           beaconUrl,
-          entries.getEntries()[0] as PerformanceNavigationTiming
+          JSON.stringify(entries.getEntries()[0])
         );
         obs.disconnect();
       });


### PR DESCRIPTION
This patch updates the navigation timing reporting request to send its
content as text/plain.  Some users were seeing blank pages on Payments
due to errors caused by the blob's content-type.

Fixes #4522 (FXA-1351)

@mozilla/fxa-devs r?