### PR TITLE
feat(account deletion): add checkbox to deletion confirming that your developer extensions and themes will be deleted

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/delete_account.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/delete_account.mustache
@@ -61,6 +61,11 @@
         </li>
 
         <li class='delete-account-checkbox-list-item'>
+          <input id="delete-account-amo" type="checkbox" value="delete-account-amo" class="delete-account-checkbox" required />
+          <label for="delete-account-amo">{{#t}}Any extensions and themes that you published to addons.mozilla.org will be deleted{{/t}}</label>
+        </li>
+
+        <li class='delete-account-checkbox-list-item'>
           <input id="delete-account-saved-info" type="checkbox" value="delete-account-saved-info" class="delete-account-checkbox" required />
           <label for="delete-account-saved-info">{{#t}}You may lose saved information and features within Mozilla products{{/t}}</label>
         </li>


### PR DESCRIPTION
Closes #4467

No test changes as it's already covered [here](https://github.com/mozilla/fxa/blob/master/packages/fxa-content-server/app/tests/spec/views/settings/delete_account.js#L531) and [here](https://github.com/mozilla/fxa/blob/master/packages/fxa-content-server/tests/functional/delete_account.js).