### PR TITLE
fix(ci): changed diff flag on fxa-circleci build-ci.sh

### DIFF
--- a/packages/fxa-circleci/scripts/build-ci.sh
+++ b/packages/fxa-circleci/scripts/build-ci.sh
@@ -9,7 +9,7 @@ cd $DIR/..
 
 docker pull mozilla/fxa-circleci:latest
 
-if docker run --rm -it mozilla/fxa-circleci:latest cat /Dockerfile | diff -b -q Dockerfile - ; then
+if docker run --rm -it mozilla/fxa-circleci:latest cat /Dockerfile | diff -w Dockerfile - ; then
   echo "The source is unchanged. Tagging latest as build"
   docker tag mozilla/fxa-circleci:latest fxa-circleci:build
 else


### PR DESCRIPTION
My local version of `diff` is 2.8.1 while the one run
in circleci/node:12 is 3.5 and they apparently treat
-b differently. Let's try -w. But there's still the
underlying question of why line 12 in the script
is changing the line endings from LF to CRLF in the
piped file?