### PR TITLE
fix(ci): changed diff method of fxa-circleci build-ci.sh

### DIFF
--- a/packages/fxa-circleci/scripts/build-ci.sh
+++ b/packages/fxa-circleci/scripts/build-ci.sh
@@ -1,17 +1,20 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 # In order to save time this script pulls the latest docker image and compares
 # it to the current Dockerfile. If there are no changes the build is skipped.
 
 DIR=$(dirname "$0")
 
-cd $DIR/..
+cd "$DIR/.."
 
 docker pull mozilla/fxa-circleci:latest
+ID=$(docker create mozilla/fxa-circleci:latest)
+docker cp "$ID":Dockerfile /tmp
 
-if docker run --rm -it mozilla/fxa-circleci:latest cat /Dockerfile | diff -b -q Dockerfile - ; then
+if diff Dockerfile /tmp/Dockerfile; then
   echo "The source is unchanged. Tagging latest as build"
   docker tag mozilla/fxa-circleci:latest fxa-circleci:build
 else
   docker build -t fxa-circleci:build .
 fi
+docker rm -v "$ID"


### PR DESCRIPTION
My local version of `diff` is 2.8.1 while the one run
in circleci/node:12 is 3.5 and they apparently treat
-b differently. Let's try -w. But there's still the
underlying question of why line 12 in the script
is changing the line endings from LF to CRLF in the
piped file?

Edit:
after ^ didn't work...

The `cat | diff` method worked for me locally but doesn't
on CircleCI. Instead copy the Dockerfile out of the latest
image and then diff against the local one.