### PR TITLE
fix(ci): use the same diff method as fxa-circleci in email-service build-ci

### DIFF
--- a/packages/fxa-email-service/scripts/build-ci.sh
+++ b/packages/fxa-email-service/scripts/build-ci.sh
@@ -1,19 +1,22 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 # In order to save time this script pulls the latest docker image and compares
 # it to the current source. If there are no changes the build is skipped.
 
 DIR=$(dirname "$0")
 
-cd $DIR/..
+cd "$DIR/.."
 
 docker pull mozilla/fxa-email-service:latest
 
 ./scripts/hash-source.sh > .sourcehash
+ID=$(docker create mozilla/fxa-email-service:latest)
+docker cp "$ID":/app/.sourcehash /tmp
 
-if docker run --rm -it mozilla/fxa-email-service:latest cat /app/.sourcehash | diff -b -q .sourcehash - ; then
+if diff .sourcehash /tmp/.sourcehash ; then
   echo "The source is unchanged. Tagging latest as build"
   docker tag mozilla/fxa-email-service:latest fxa-email-service:build
 else
   docker build -t fxa-email-service:build .
 fi
+docker rm -v "$ID"


### PR DESCRIPTION
The `cat | diff` method worked sometimes (I've seen it!) but
not reliably. This method has worked for fxa-circleci. We'll
have this working eventually