### PR TITLE
fix(access-tokens): prune the access token index on set

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -354,6 +354,12 @@ const conf = convict({
         format: String,
         doc: 'Key prefix for access tokens in Redis',
       },
+      accessTokenLimit: {
+        default: 100,
+        env: 'ACCESS_TOKEN_REDIS_LIMIT',
+        format: Number,
+        doc: 'Maximum number of access tokens per account at any one time',
+      },
     },
     sessionTokens: {
       enabled: {

--- a/packages/fxa-auth-server/lib/luaScripts/setAccessToken_2.lua
+++ b/packages/fxa-auth-server/lib/luaScripts/setAccessToken_2.lua
@@ -1,11 +1,32 @@
 local userId = KEYS[1]
 local tokenId = KEYS[2]
 local token = ARGV[1]
-local ttl = ARGV[2]
+local limit = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+local maxttl = tonumber(ARGV[4])
 local args = {token}
+local toAdd = {tokenId}
 if ttl then
   table.insert(args, 'PX')
   table.insert(args, ttl)
 end
+local count = redis.call('scard', userId)
+if count > limit then
+  local popped = redis.call('spop', userId, math.min((count - limit) + math.floor(limit / 10), limit))
+  if #popped < limit then
+    -- only a little over. check for expired tokens
+    local values = redis.call('mget', unpack(popped))
+    for i, value in ipairs(values) do
+      if value then
+        -- token has not expired
+        table.insert(toAdd, popped[i])
+      end
+    end
+  else
+    -- a lot over. just delete them
+    redis.call('unlink', unpack(popped))
+  end
+end
 redis.call('set', tokenId, unpack(args))
-redis.call('sadd', userId, tokenId)
+redis.call('sadd', userId, unpack(toAdd))
+redis.call('expire', userId, maxttl)

--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -31,7 +31,11 @@ class OauthDB {
       await scopes();
     });
     this.redis = redis(
-      { ...config.get('redis.accessTokens'), enabled: true },
+      {
+        ...config.get('redis.accessTokens'),
+        enabled: true,
+        maxttl: config.get('oauthServer.expiration.accessToken'),
+      },
       logger
     );
     Object.keys(mysql.prototype).forEach(key => {

--- a/packages/fxa-auth-server/lib/redis.js
+++ b/packages/fxa-auth-server/lib/redis.js
@@ -33,6 +33,8 @@ function rejectInMs(ms, err = new Error('redis timeout')) {
 class FxaRedis {
   constructor(config, log) {
     config.keyPrefix = config.prefix;
+    this.accessTokenLimit = config.accessTokenLimit;
+    this.maxttl = config.maxttl;
     this.log = log;
     this.redis = new Redis(config);
     this.timeoutMs = config.timeoutMs || 1000;
@@ -119,7 +121,9 @@ class FxaRedis {
       token.userId.toString('hex'),
       token.tokenId.toString('hex'),
       JSON.stringify(token),
-      token.ttl
+      this.accessTokenLimit,
+      token.ttl,
+      this.maxttl
     );
   }
 


### PR DESCRIPTION
The access token index can grow too big since the only
chance to prune until now was when the full list was
requested, which doesn't happen often.

This change adds a limit config and prunes when a new
token is added if the index is over the limit. It makes
no effort to check expiry so in the worst case up to 10%
of the limit active tokens will be deindexed, but still active.

To limit the size of the initial pruning no more than limit
tokens will be deindexed per call.

r? @jrgm