### PR TITLE
chore(ci): improved ci build step output

### DIFF
--- a/.circleci/build-all.sh
+++ b/.circleci/build-all.sh
@@ -5,6 +5,10 @@ cd "$DIR"
 
 ./create-version-json.sh
 
+if [[ -n "${CIRCLECI}" ]]; then
+  echo "Docker logs are located in the CircleCI build artifacts"
+fi
+
 for d in ../packages/*/ ; do
   ./build.sh "$(basename "$d")"
 done

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -18,15 +18,17 @@ if grep -e "$MODULE" -e 'all' "$DIR/../packages/test.list" > /dev/null; then
   mkdir -p config
   cp ../version.json config
 
+  mkdir -p ../../artifacts
+
   ODDBALLS=("fxa-auth-server" "fxa-content-server" "fxa-profile-server" "fxa-payments-server")
 
   if [[ -x scripts/build-ci.sh ]]; then
-    ./scripts/build-ci.sh
+    time ./scripts/build-ci.sh
   elif [[ "${ODDBALLS[*]}" =~ ${MODULE} ]]; then
     cd ..
-    docker build -f "${MODULE}/Dockerfile" -t "${MODULE}:build" .
+    time docker build --progress=plain -f "${MODULE}/Dockerfile" -t "${MODULE}:build" . > "../artifacts/${MODULE}.log"
   elif [[ -r Dockerfile ]]; then
-    docker build -f Dockerfile -t "${MODULE}:build" .
+    time docker build --progress=plain -t "${MODULE}:build" . > "../../artifacts/${MODULE}.log"
   fi
 
   # for debugging:

--- a/.circleci/create-version-json.sh
+++ b/.circleci/create-version-json.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 DIR=$(dirname "$0")
 

--- a/packages/fxa-circleci/scripts/build-ci.sh
+++ b/packages/fxa-circleci/scripts/build-ci.sh
@@ -7,7 +7,7 @@ DIR=$(dirname "$0")
 
 cd "$DIR/.."
 
-docker pull mozilla/fxa-circleci:latest
+docker pull -q mozilla/fxa-circleci:latest
 ID=$(docker create mozilla/fxa-circleci:latest)
 docker cp "$ID":Dockerfile /tmp
 
@@ -15,6 +15,6 @@ if diff Dockerfile /tmp/Dockerfile; then
   echo "The source is unchanged. Tagging latest as build"
   docker tag mozilla/fxa-circleci:latest fxa-circleci:build
 else
-  docker build -t fxa-circleci:build .
+  docker build --progress=plain -t fxa-circleci:build . > ../../artifacts/fxa-circleci.log
 fi
 docker rm -v "$ID"

--- a/packages/fxa-email-event-proxy/scripts/build-ci.sh
+++ b/packages/fxa-email-event-proxy/scripts/build-ci.sh
@@ -1,8 +1,8 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 DIR=$(dirname "$0")
 
-cd $DIR/..
+cd "$DIR/.."
 npm ci
 npm run build
 

--- a/packages/fxa-email-service/scripts/build-ci.sh
+++ b/packages/fxa-email-service/scripts/build-ci.sh
@@ -7,7 +7,7 @@ DIR=$(dirname "$0")
 
 cd "$DIR/.."
 
-docker pull mozilla/fxa-email-service:latest
+docker pull -q mozilla/fxa-email-service:latest
 
 ./scripts/hash-source.sh > .sourcehash
 ID=$(docker create mozilla/fxa-email-service:latest)
@@ -17,6 +17,6 @@ if diff .sourcehash /tmp/.sourcehash ; then
   echo "The source is unchanged. Tagging latest as build"
   docker tag mozilla/fxa-email-service:latest fxa-email-service:build
 else
-  docker build -t fxa-email-service:build .
+  docker build --progress=plain -t fxa-email-service:build . > ../../artifacts/fxa-email-service.log
 fi
 docker rm -v "$ID"


### PR DESCRIPTION
The build step ci output was really noisy with docker logs
so this writes that output into log files in the build
artifacts instead.