### PR TITLE
fix(ci): circleci deploy needs no_output_timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,8 +136,13 @@ jobs:
     steps:
       - base-install
       - setup_remote_docker
-      - run: ./.circleci/build-all.sh
-      - run: ./.circleci/deploy-all.sh
+      - run:
+          name: Build docker images
+          command: ./.circleci/build-all.sh
+          no_output_timeout: 1h
+      - run:
+          name: Push to docker hub
+          command: ./.circleci/deploy-all.sh
       - store_artifacts:
           path: artifacts
 


### PR DESCRIPTION
After cleaning up build.sh in #4557 circleci errored with:

`Too long with no output (exceeded 10m0s): context deadline exceeded`

adding [no_output_timeout](https://circleci.com/docs/2.0/configuration-reference/#run) should fix it

https://app.circleci.com/pipelines/github/mozilla/fxa/8816/workflows/852a58e9-49dc-4b52-bcee-a4c3b6b9d314/jobs/160011