### PR TITLE
feat(subscriptions): implement idempotency when creating a subscriptions

### DIFF
--- a/packages/fxa-auth-server/test/client/api.js
+++ b/packages/fxa-auth-server/test/client/api.js
@@ -1187,7 +1187,8 @@ module.exports = config => {
     refreshToken,
     planId,
     paymentToken,
-    displayName
+    displayName,
+    idempotencyKey
   ) {
     return this.doRequestWithBearerToken(
       'POST',
@@ -1197,6 +1198,7 @@ module.exports = config => {
         planId,
         paymentToken,
         displayName,
+        idempotencyKey,
       }
     );
   };

--- a/packages/fxa-auth-server/test/client/index.js
+++ b/packages/fxa-auth-server/test/client/index.js
@@ -834,13 +834,15 @@ module.exports = config => {
     refreshToken,
     planId,
     paymentToken,
-    displayName
+    displayName,
+    idempotencyKey
   ) {
     return this.api.createSubscription(
       refreshToken,
       planId,
       paymentToken,
-      displayName
+      displayName,
+      idempotencyKey
     );
   };
 

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -10,6 +10,7 @@ const { assert } = require('chai');
 const { mockLog } = require('../../mocks');
 const error = require('../../../lib/error');
 const stripeError = require('stripe').Stripe.errors;
+const uuidv4 = require('uuid').v4;
 
 let mockRedis;
 const proxyquire = require('proxyquire').noPreserveCache();
@@ -520,7 +521,8 @@ describe('StripeHelper', () => {
         'uid',
         'joe@example.com',
         'Joe Cool',
-        'tok_visa'
+        'tok_visa',
+        uuidv4()
       );
 
       assert.deepEqual(actual, expected);
@@ -531,7 +533,13 @@ describe('StripeHelper', () => {
       sandbox.stub(stripeHelper.stripe.customers, 'create').rejects(apiError);
 
       return stripeHelper
-        .createCustomer('uid', 'joe@example.com', 'Joe Cool', 'tok_visa')
+        .createCustomer(
+          'uid',
+          'joe@example.com',
+          'Joe Cool',
+          'tok_visa',
+          uuidv4()
+        )
         .then(
           () => Promise.reject(new Error('Method expected to reject')),
           err => {
@@ -548,7 +556,13 @@ describe('StripeHelper', () => {
       sandbox.stub(stripeHelper.stripe.customers, 'create').rejects(apiError);
 
       return stripeHelper
-        .createCustomer('uid', 'joe@example.com', 'Joe Cool', 'tok_visa')
+        .createCustomer(
+          'uid',
+          'joe@example.com',
+          'Joe Cool',
+          'tok_visa',
+          uuidv4()
+        )
         .then(
           () => Promise.reject(new Error('Method expected to reject')),
           err => {
@@ -988,7 +1002,7 @@ describe('StripeHelper', () => {
           .stub(stripeHelper.stripe.subscriptions, 'create')
           .rejects(apiError);
 
-        return stripeHelper.createSubscription(customer1, plan1).then(
+        return stripeHelper.createSubscription(customer1, plan1, uuidv4()).then(
           () => Promise.reject(new Error('Method expected to reject')),
           err => {
             assert.equal(
@@ -1005,7 +1019,7 @@ describe('StripeHelper', () => {
           .stub(stripeHelper.stripe.subscriptions, 'create')
           .rejects(apiError);
 
-        return stripeHelper.createSubscription(customer1, plan1).then(
+        return stripeHelper.createSubscription(customer1, plan1, uuidv4()).then(
           () => Promise.reject(new Error('Method expected to reject')),
           err => {
             assert.equal(err, apiError);
@@ -1028,7 +1042,8 @@ describe('StripeHelper', () => {
 
           const actual = await stripeHelper.createSubscription(
             customer1,
-            plan1
+            plan1,
+            uuidv4()
           );
 
           assert.deepEqual(actual, expected);
@@ -1046,14 +1061,16 @@ describe('StripeHelper', () => {
             .stub(stripeHelper.stripe.subscriptions, 'create')
             .resolves(subscription);
 
-          await stripeHelper.createSubscription(customer1, plan1).then(
-            () => Promise.reject(new Error('Method expected to reject')),
-            err => {
-              failed = true;
-              assert.equal(err.errno, error.ERRNO.PAYMENT_FAILED);
-              assert.equal(err.message, 'Payment method failed');
-            }
-          );
+          await stripeHelper
+            .createSubscription(customer1, plan1, uuidv4())
+            .then(
+              () => Promise.reject(new Error('Method expected to reject')),
+              err => {
+                failed = true;
+                assert.equal(err.errno, error.ERRNO.PAYMENT_FAILED);
+                assert.equal(err.message, 'Payment method failed');
+              }
+            );
 
           assert.isTrue(failed);
         });

--- a/packages/fxa-payments-server/package-lock.json
+++ b/packages/fxa-payments-server/package-lock.json
@@ -1791,6 +1791,12 @@
           "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
           "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
           "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -5736,6 +5742,12 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.6.tgz",
       "integrity": "sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-7.0.0.tgz",
+      "integrity": "sha512-RiX1I0lK9WFLFqy2xOxke396f0wKIzk5sAll0tL4J4XDYJXURI7JOs96XQb3nP+2gEpQ/LutBb66jgiT5oQshQ==",
       "dev": true
     },
     "@types/webpack-env": {
@@ -16414,6 +16426,12 @@
             "ansi-regex": "^4.1.0"
           }
         },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        },
         "which-module": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
@@ -19536,6 +19554,11 @@
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -20833,6 +20856,13 @@
       "requires": {
         "faye-websocket": "^0.10.0",
         "uuid": "^3.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "sockjs-client": {
@@ -21194,6 +21224,12 @@
           "requires": {
             "rimraf": "^2.6.3"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -22499,9 +22535,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+      "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -24075,6 +24111,13 @@
       "requires": {
         "ansi-colors": "^3.0.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "webpack-manifest-plugin": {

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -60,6 +60,7 @@
     "@types/storybook__addon-actions": "^3.4.2",
     "@types/storybook__addon-links": "^3.3.5",
     "@types/storybook__react": "^4.0.1",
+    "@types/uuid": "^7.0.0",
     "@typescript-eslint/eslint-plugin": "^1.9.0",
     "@typescript-eslint/parser": "^1.9.0",
     "async-wait-until": "^1.2.4",
@@ -130,7 +131,8 @@
     "redux-thunk": "^2.3.0",
     "serve-static": "^1.13.2",
     "type-to-reducer": "^1.2.0",
-    "ua-parser-js": "^0.7.21"
+    "ua-parser-js": "^0.7.21",
+    "uuid": "^7.0.2"
   },
   "engines": {
     "node": ">=12"

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
@@ -56,7 +56,11 @@ type SubjectProps = Omit<
   | 'onChange'
   | 'submitNonce'
 > & {
-  onPayment?: (tokenResponse: stripe.TokenResponse, name: string) => void;
+  onPayment?: (
+    tokenResponse: stripe.TokenResponse,
+    name: string,
+    idempotencyKey: string
+  ) => void;
   onPaymentError?: (error: any) => void;
   onMounted?: () => void;
   onEngaged?: () => void;
@@ -216,7 +220,8 @@ it('renders a progress spinner when submitted, disables further submission (issu
   await waitForExpect(() =>
     expect(onPayment).toHaveBeenCalledWith(
       VALID_CREATE_TOKEN_RESPONSE,
-      'Foo Barson'
+      'Foo Barson',
+      'unique-nonce-1'
     )
   );
 
@@ -339,7 +344,8 @@ it('calls onPayment when payment processing succeeds', async () => {
   await waitForExpect(() =>
     expect(onPayment).toHaveBeenCalledWith(
       VALID_CREATE_TOKEN_RESPONSE,
-      'Foo Barson'
+      'Foo Barson',
+      'test-nonce'
     )
   );
 });

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -45,7 +45,11 @@ export type PaymentFormProps = {
   plan?: Plan;
   getString?: Function;
   onCancel?: () => void;
-  onPayment: (tokenResponse: stripe.TokenResponse, name: string) => void;
+  onPayment: (
+    tokenResponse: stripe.TokenResponse,
+    name: string,
+    idempotencyKey: string
+  ) => void;
   onPaymentError: (error: any) => void;
   validatorInitialState?: ValidatorState;
   validatorMiddlewareReducer?: ValidatorMiddlewareReducer;
@@ -107,7 +111,7 @@ export const PaymentForm = ({
         stripe
           .createToken({ name, address_zip: zip })
           .then((tokenResponse: stripe.TokenResponse) => {
-            onPayment(tokenResponse, name);
+            onPayment(tokenResponse, name, submitNonce);
           })
           .catch(err => {
             onPaymentError(err);

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -126,6 +126,7 @@ export async function apiCreateSubscription(params: {
   planId: string;
   productId: string;
   displayName: string;
+  idempotencyKey: string;
 }) {
   const metricsOptions = {
     planId: params.planId,

--- a/packages/fxa-payments-server/src/lib/hooks.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState, useEffect, useRef, ChangeEvent } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 
 export function useCallbackOnce(cb: Function, deps: any[]) {
   const called = useRef(false);
@@ -70,9 +71,7 @@ export function useClickOutsideEffect<T>(onClickOutside: Function) {
   return insideEl;
 }
 
-export function useNonce(
-  generateNonce = () => `${Date.now()}-${Math.random()}`
-): [string, () => void] {
+export function useNonce(generateNonce = uuidv4): [string, () => void] {
   const [nonce, setNonce] = useState(generateNonce());
   const refreshNonce = () => setNonce(generateNonce());
   return [nonce, refreshNonce];

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -103,12 +103,17 @@ export const SubscriptionCreate = ({
   ]);
 
   const onPayment = useCallback(
-    (tokenResponse: stripe.TokenResponse, name: string) => {
+    (
+      tokenResponse: stripe.TokenResponse,
+      name: string,
+      idempotencyKey: string
+    ) => {
       if (tokenResponse && tokenResponse.token) {
         createSubscriptionAndRefresh(
           tokenResponse.token.id,
           selectedPlan,
-          name
+          name,
+          idempotencyKey
         );
       } else {
         // This shouldn't happen with a successful createToken() call, but let's

--- a/packages/fxa-payments-server/src/store/actions/api.ts
+++ b/packages/fxa-payments-server/src/store/actions/api.ts
@@ -22,7 +22,12 @@ export default {
     ({ type: 'fetchSubscriptions', payload: apiFetchSubscriptions() } as const),
   fetchCustomer: () =>
     ({ type: 'fetchCustomer', payload: apiFetchCustomer() } as const),
-  createSubscription: (paymentToken: string, plan: Plan, displayName: string) =>
+  createSubscription: (
+    paymentToken: string,
+    plan: Plan,
+    displayName: string,
+    idempotencyKey: string
+  ) =>
     ({
       type: 'createSubscription',
       meta: { plan },
@@ -31,6 +36,7 @@ export default {
         displayName,
         planId: plan.plan_id,
         productId: plan.product_id,
+        idempotencyKey,
       }),
     } as const),
   updateSubscriptionPlan: (subscriptionId: string, plan: Plan) =>

--- a/packages/fxa-payments-server/src/store/sequences.ts
+++ b/packages/fxa-payments-server/src/store/sequences.ts
@@ -62,10 +62,11 @@ export const fetchCustomerAndSubscriptions = () => async (
 export const createSubscriptionAndRefresh = (
   paymentToken: string,
   plan: Plan,
-  displayName: string
+  displayName: string,
+  nonce: string
 ) => async (dispatch: Function) => {
   try {
-    await dispatch(createSubscription(paymentToken, plan, displayName));
+    await dispatch(createSubscription(paymentToken, plan, displayName, nonce));
     await dispatch(fetchCustomerAndSubscriptions());
   } catch (err) {
     handleThunkError(err);


### PR DESCRIPTION
Closes #4516

This centers around [Stripe's support for idempotency keys](https://stripe.com/docs/api/idempotent_requests) when performing POST requests against its API, and requires some changes in a few spots:

- Update the payment form to submit a nonce as the idempotency key (not used for creating tokens, though)
- Handle it in Payments Server, update `ClientApi.createSubscription` to support it
- Receive the key on the auth server and pass it to Stripe with each "create" request, this includes customer and subscription creation

Additionally, this is backed by replacing our previous nonce token generation from `${Date.now()}-${Math.random()}` to proper UUID v4 for _max_ entropy.

---

Note - I see the Payments Server uses Storybook. I don't think I've touched much of it, so I can understand if I'm missing some required changes there. 🤔 