### PR TITLE
chore(ci): no need to tag/push unchanged docker images

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -39,5 +39,5 @@ if [ -n "${DOCKER_TAG}" ] && [ -n "${!DOCKER_PASS}" ] && [ -n "${!DOCKER_USER}" 
   echo -e "##################################################\n"
   echo "${!DOCKER_PASS}" | docker login -u "${!DOCKER_USER}" --password-stdin
   docker tag "${MODULE}:build" "${DOCKERHUB_REPO}:${DOCKER_TAG}"
-  docker push "${DOCKERHUB_REPO}:${DOCKER_TAG}"
+  time docker push "${DOCKERHUB_REPO}:${DOCKER_TAG}"
 fi

--- a/packages/fxa-circleci/scripts/build-ci.sh
+++ b/packages/fxa-circleci/scripts/build-ci.sh
@@ -12,8 +12,7 @@ ID=$(docker create mozilla/fxa-circleci:latest)
 docker cp "$ID":Dockerfile /tmp
 
 if diff Dockerfile /tmp/Dockerfile; then
-  echo "The source is unchanged. Tagging latest as build"
-  docker tag mozilla/fxa-circleci:latest fxa-circleci:build
+  echo "The source is unchanged. Skipping build"
 else
   docker build --progress=plain -t fxa-circleci:build . > ../../artifacts/fxa-circleci.log
 fi

--- a/packages/fxa-email-service/scripts/build-ci.sh
+++ b/packages/fxa-email-service/scripts/build-ci.sh
@@ -14,8 +14,7 @@ ID=$(docker create mozilla/fxa-email-service:latest)
 docker cp "$ID":/app/.sourcehash /tmp
 
 if diff .sourcehash /tmp/.sourcehash ; then
-  echo "The source is unchanged. Tagging latest as build"
-  docker tag mozilla/fxa-email-service:latest fxa-email-service:build
+  echo "The source is unchanged. Skipping build"
 else
   docker build --progress=plain -t fxa-email-service:build . > ../../artifacts/fxa-email-service.log
 fi


### PR DESCRIPTION
This should cut master ci build times by a minute or so.