### PR TITLE
chore(metrics): update calculation of auth server route perf metrics

### DIFF
--- a/packages/fxa-auth-server/lib/log.js
+++ b/packages/fxa-auth-server/lib/log.js
@@ -90,7 +90,7 @@ Lug.prototype.summary = function(request, response) {
 
   const line = {
     status: response.isBoom ? response.output.statusCode : response.statusCode,
-    errno: response.errno || 0,
+    errno: response.errno || (response.source && response.source.errno) || 0,
     rid: request.id,
     path: request.path,
     lang: request.app.acceptLanguage,
@@ -122,7 +122,7 @@ Lug.prototype.summary = function(request, response) {
   if (line.status >= 500) {
     line.trace = request.app.traced;
     line.stack = response.stack;
-    this.error('request.summary', line, response.message);
+    this.error('request.summary', line);
   } else {
     this.info('request.summary', line);
   }

--- a/packages/fxa-auth-server/lib/metrics/events.js
+++ b/packages/fxa-auth-server/lib/metrics/events.js
@@ -224,7 +224,7 @@ module.exports = (log, config) => {
     return log.flowEvent(
       Object.assign({}, data, {
         event: `route.performance.${path}`,
-        flow_time: Date.now() - request.info.received,
+        flow_time: request.info.completed - request.info.received,
       })
     );
   }

--- a/packages/fxa-auth-server/test/local/metrics/events.js
+++ b/packages/fxa-auth-server/test/local/metrics/events.js
@@ -1177,6 +1177,7 @@ describe('metrics/events', () => {
         },
       },
       received: time - 42,
+      completed: time,
     });
     return events.emitRouteFlowEvent
       .call(request, { statusCode: 200 })

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -758,6 +758,7 @@ function mockRequest(data, errors) {
     },
     info: {
       received: data.received || Date.now() - 1,
+      completed: data.completed || 0,
     },
     method: data.method || undefined,
     params: data.params || {},


### PR DESCRIPTION
This patch makes two updates to the auth server's route perf metrics:
 - Hapi's `request.info.responded` timestamp is now used to calculate
   the duration
 - The identical value is reported to Redshift and InfluxDB

Fixes #4429 (FXA-1296)

@mozilla/fxa-devs r?