### PR TITLE
refactor(env): implement ability to supply your secret and publishable Stripe keys in a `local.env` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ public-key.json
 secret-key.json
 secret*
 *.gpg
+secrets.json
 
 # Build and temp files
 **/build

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The Firefox Accounts (fxa) monorepo
 [Getting Started](#getting-started)\
 [Contributing](#contributing)\
 [Dependencies](#dependencies)\
+[Secrets](#secrets)\
 [Firefox Custom Profile](#firefox-custom-profile)\
 [Functional Tests](#functional-tests)\
 [Node debugging](#node-debugging)\
@@ -204,6 +205,17 @@ npm install -g grunt-cli
 ---
 
 ---
+
+---
+
+### Secrets
+
+When developing locally you may need to set up some secrets in order to effectively work with certain servers. These secrets are managed at the package level.
+
+Check out the Secrets section in the following READMEs:
+
+- [fxa-auth-server](https://github.com/mozilla/fxa/tree/master/packages/fxa-auth-server#secrets)
+- [fxa-payments-server](https://github.com/mozilla/fxa/tree/master/packages/fxa-payments-server#secrets)
 
 ---
 

--- a/mysql_servers.json
+++ b/mysql_servers.json
@@ -91,7 +91,8 @@
         "IP_ADDRESS": "0.0.0.0",
         "SIGNIN_UNBLOCK_FORCED_EMAILS": "^block.*@restmail\\.net$",
         "SIGNIN_CONFIRMATION_ENABLED": "true",
-        "SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX": "^sync.*@restmail\\.net$"
+        "SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX": "^sync.*@restmail\\.net$",
+        "CONFIG_FILES": "config/secrets.json"
       },
       "max_restarts": "1",
       "min_uptime": "2m"
@@ -173,7 +174,8 @@
       "min_uptime": "2m",
       "env": {
         "LOGGING_FORMAT": "pretty",
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
+        "CONFIG_FILES": "server/config/secrets.json"
       }
     },
     {

--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -48,6 +48,22 @@ To start the server in dev MySQL store mode (ie. `NODE_ENV=dev`), run:
 
     npm run start-mysql
 
+## Secrets
+
+Create the following file: `config/secrets.json`. It will not be tracked in Git.
+
+Use the following as a template, and fill in your own values:
+
+```json
+{
+  "subscriptions": {
+    "stripeApiKey": "sk_test_123"
+  }
+}
+```
+
+- `stripeApiKey` should be a test Stripe Secret Key
+
 ## Testing
 
 Run tests with:

--- a/packages/fxa-payments-server/README.md
+++ b/packages/fxa-payments-server/README.md
@@ -14,6 +14,22 @@ In local development, `npm run storybook` should start a Storybook server at <ht
 
 On Mac OS, `npm run test` may trigger an `EMFILE` error. In this case, to get tests running, you may need to `brew install watchman`. (If the watchman postinstall step fails, follow the instructions [here](https://stackoverflow.com/a/41320226) to change `/usr/local` ownership from root to your user account.)
 
+## Secrets
+
+Create the following file: `server/config/secrets.json`. It will not be tracked in Git.
+
+Use the following as a template, and fill in your own values:
+
+```json
+{
+  "stripe": {
+    "apiKey": "pk_test_123"
+  }
+}
+```
+
+- `apiKey` should be a test Stripe Publishable Key
+
 ## License
 
 MPL-2.0


### PR DESCRIPTION
Closes #4483

**Problem**: developers need to manually modify Auth and Payment server files with their own Stripe keys, which results in changes to tracked files in git. It has resulted in accidental commits of these secrets, and of course don't want to be committing secrets! It's also just a pain to be updating these because of how spread out they are.

~**Solution**: add the ability to create a file called `local.env` at the root level of this repo, where you can supply your Stripe publishable and secret keys, so they can be supplied to the servers that require them.~

**Solution:** in places where we use convict we're already checking and loading in a file that is set at the `CONFIG_FILES` env var, so I've gone ahead and updated the pm2 server script to automatically check for a specific JSON file for two of our servers, so we can load in Stripe credentials. I've also documented this in the root and individual package READMEs.