### PR TITLE
fix(recovery key): update post-verify recovery key styling to not look like a modal on mobile

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/post_verify/account_recovery/save_recovery_key.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/account_recovery/save_recovery_key.mustache
@@ -1,4 +1,4 @@
-<div id="main-content" class="card save-recovery-key modal">
+<div id="main-content" class="card save-recovery-key">
     <header>
         <h1 id="fxa-save-recovery-key-header">
             {{#serviceName}}
@@ -11,8 +11,8 @@
         </h1>
     </header>
 
-    <section class="modal-panel">
-        <p class="modal-success bottom-spaced"></p>
+    <section>
+        <p class="success"></p>
 
         <p class="description">Store it in a safe place on your computer or a printed copy that is easily accessed by only you.</p>
 

--- a/packages/fxa-content-server/app/scripts/views/mixins/save-options-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/save-options-mixin.js
@@ -84,16 +84,40 @@ const Mixin = {
 
   _displaySuccess(msg) {
     this.$('.error').addClass('hidden');
-    this.$('.modal-success').removeClass('hidden');
-    this.$('.modal-success').addClass('success');
-    this.$('.modal-success').text(this.translate(msg));
+
+    const modalSuccess = this.$('.modal-success');
+    const regularSuccess = this.$('.success');
+    let successBanner;
+
+    if (modalSuccess.length) {
+      successBanner = modalSuccess;
+      successBanner.addClass('success');
+    } else if (regularSuccess.length) {
+      successBanner = regularSuccess;
+      successBanner.addClass('visible');
+    }
+
+    successBanner.removeClass('hidden').text(this.translate(msg));
   },
 
   _displayError(msg) {
-    this.$('.error').removeClass('hidden');
-    this.$('.modal-success').addClass('hidden');
-    this.$('.modal-success').removeClass('success');
-    this.$('.error').text(this.translate(msg));
+    const modalSuccess = this.$('.modal-success');
+    const regularSuccess = this.$('.success');
+    let successBanner;
+
+    if (modalSuccess.length) {
+      successBanner = modalSuccess;
+      successBanner.removeClass('success');
+    } else if (regularSuccess.length) {
+      successBanner = regularSuccess;
+      successBanner.removeClass('visible');
+    }
+
+    successBanner.addClass('hidden');
+
+    this.$('.error')
+      .removeClass('hidden')
+      .text(this.translate(msg));
   },
 };
 

--- a/packages/fxa-content-server/app/styles/modules/_modal.scss
+++ b/packages/fxa-content-server/app/styles/modules/_modal.scss
@@ -33,10 +33,6 @@
       display: block;
       font-size: $base-font;
       margin: 0 auto;
-
-      &.bottom-spaced {
-        margin-bottom: 15px;
-      }
     }
   }
 }


### PR DESCRIPTION
Closes #4547

This issue was introduced by me in 3332874bce6bac3679b49b522cebcf1094609288.

Instead of modifying the style of the success banner to work like the variety that lives in the modal, I've updated the Javascript that gets called when a copy-print-download button is clicked to target our success banner.