### PR TITLE
fix(payments): end-to-end subscription functional test with profile caching bugfix

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -18,6 +18,7 @@ const amplitude = require('./metrics/amplitude')(
 );
 const sub = require('./jwt_sub');
 const {
+  determineSubscriptionCapabilities,
   determineClientVisibleSubscriptionCapabilities,
 } = require('../routes/utils/subscriptions');
 
@@ -245,10 +246,12 @@ exports.generateAccessToken = async function generateAccessToken(grant) {
 
   if (grant.scope.contains('profile:subscriptions')) {
     const capabilities = await determineClientVisibleSubscriptionCapabilities(
-      stripeHelper,
-      hex(grant.userId),
-      clientId,
-      grant.email
+      hex(clientId),
+      await determineSubscriptionCapabilities(
+        stripeHelper,
+        hex(grant.userId),
+        grant.email
+      )
     );
     // To avoid mutating the input grant, create a
     // copy and add the new property there.

--- a/packages/fxa-auth-server/scripts/clean-up-old-ci-stripe-customers.js
+++ b/packages/fxa-auth-server/scripts/clean-up-old-ci-stripe-customers.js
@@ -47,15 +47,15 @@ async function init() {
     process.env.SUBHUB_STRIPE_APIKEY = program.stripeKey;
   }
 
-  if (!/.*_test_.*/.test(process.env.SUBHUB_STRIPE_APIKEY)) {
+  const config = require('../config').getProperties();
+  const log = require('../lib/log')(config.log.level);
+
+  if (!/.*_test_.*/.test(config.subscriptions.stripeApiKey)) {
     console.error(
       'Stripe API key appears not to be a test mode key! Bailing out!'
     );
     process.exit(1);
   }
-
-  const config = require('../config').getProperties();
-  const log = require('../lib/log')(config.log.level);
 
   const createStripeHelper = require('../lib/payments/stripe');
   const stripeHelper = createStripeHelper(log, config, null);

--- a/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
@@ -9,6 +9,7 @@ const assert = require('chai').assert;
 const mocks = require('../../../mocks');
 
 const {
+  determineSubscriptionCapabilities,
   determineClientVisibleSubscriptionCapabilities,
   metadataFromPlan,
 } = require('../../../../lib/routes/utils/subscriptions');
@@ -88,16 +89,17 @@ describe('routes/utils/subscriptions', () => {
     });
 
     async function assertExpectedCapabilities(clientId, expectedCapabilities) {
-      assert.deepEqual(
-        await determineClientVisibleSubscriptionCapabilities(
-          mockStripeHelper,
-          UID,
-          // null client represents sessionToken auth from content-server, unfiltered by client
-          clientId === 'null' ? null : Buffer.from(clientId, 'hex'),
-          EMAIL
-        ),
-        expectedCapabilities
+      const allCapabilities = await determineSubscriptionCapabilities(
+        mockStripeHelper,
+        UID,
+        EMAIL
       );
+      const resultCapabilities = await determineClientVisibleSubscriptionCapabilities(
+        // null client represents sessionToken auth from content-server, unfiltered by client
+        clientId === 'null' ? null : Buffer.from(clientId, 'hex'),
+        allCapabilities
+      );
+      assert.deepEqual(resultCapabilities.sort(), expectedCapabilities.sort());
     }
 
     it('only reveals capabilities relevant to the client', async () => {

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -213,19 +213,25 @@ describe('remote subscriptions:', function() {
         ];
       });
 
-      it('should not return any subscription capabilities by default with session token', async () => {
+      it('should return all subscription capabilities with session token', async () => {
         const response = await client.accountProfile();
-        assert.deepEqual(response.subscriptions, ['123donePro', 'ILikePie']);
+        assert.deepEqual(response.subscriptionsByClientId, {
+          [CLIENT_ID]: ['123donePro', 'ILikePie'],
+        });
       });
 
-      it('should not return any subscription capabilities for client without capabilities', async () => {
+      it('should return all subscription capabilities for client without capabilities', async () => {
         const response = await client.accountProfile(tokens[0]);
-        assert.isUndefined(response.subscriptions);
+        assert.deepEqual(response.subscriptionsByClientId, {
+          [CLIENT_ID]: ['123donePro', 'ILikePie'],
+        });
       });
 
-      it('should return subscription capabilities for client with capabilities', async () => {
+      it('should return all subscription capabilities for client with capabilities', async () => {
         const response = await client.accountProfile(tokens[1]);
-        assert.deepEqual(response.subscriptions, ['123donePro', 'ILikePie']);
+        assert.deepEqual(response.subscriptionsByClientId, {
+          [CLIENT_ID]: ['123donePro', 'ILikePie'],
+        });
       });
 
       it('should return active subscriptions', async () => {

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -67,6 +67,7 @@ module.exports = [
   'tests/functional/sign_in_recovery_code.js',
   'tests/functional/sign_in_totp.js',
   'tests/functional/sign_up.js',
+  'tests/functional/subscriptions.js',
   'tests/functional/support.js',
   'tests/functional/sync_v1.js',
   'tests/functional/sync_v2.js',

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -41,6 +41,8 @@ module.exports = {
     BUTTON_PROMPT_NONE: '.ready .prompt-none',
     BUTTON_SIGNUP: '.sign-in-button.signup',
     LINK_LOGOUT: '#logout',
+    BUTTON_SUBSCRIBE: '#subscriptionCTA .btn-subscribe',
+    SUBSCRIBED: '.pro-status',
   },
   '400': {
     ERROR: '.error',

--- a/packages/fxa-content-server/tests/functional/subscriptions.js
+++ b/packages/fxa-content-server/tests/functional/subscriptions.js
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { registerSuite } = intern.getInterface('object');
+const FunctionalHelpers = require('./lib/helpers');
+const selectors = require('./lib/selectors');
+
+const config = intern._config;
+const ENTER_EMAIL_URL = config.fxaContentRoot;
+const PASSWORD = 'amazingpassword';
+
+const {
+  clearBrowserState,
+  click,
+  createEmail,
+  createUser,
+  fillOutEmailFirstSignIn,
+  openPage,
+  openRP,
+  subscribeToTestProduct,
+  testElementExists,
+  visibleByQSA,
+} = FunctionalHelpers;
+
+registerSuite('subscriptions', {
+  tests: {
+    'sign up, subscribe for 123Done Pro, sign into 123Done to verify subscription': function() {
+      if (
+        process.env.CIRCLECI === 'true' &&
+        !process.env.SUBHUB_STRIPE_APIKEY
+      ) {
+        this.skip('missing Stripe API key in CircleCI run');
+      }
+      const email = createEmail();
+      return this.remote
+        .then(
+          clearBrowserState({
+            '123done': true,
+            force: true,
+          })
+        )
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+        .then(testElementExists(selectors.SETTINGS.HEADER))
+
+        .then(openRP())
+        .then(click(selectors['123DONE'].BUTTON_SIGNIN))
+        .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER))
+        .then(click(selectors['SIGNIN_PASSWORD'].SUBMIT_USE_SIGNED_IN))
+        .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
+        .then(visibleByQSA(selectors['123DONE'].BUTTON_SUBSCRIBE))
+
+        .then(click(selectors['123DONE'].LINK_LOGOUT))
+        .then(visibleByQSA(selectors['123DONE'].BUTTON_SIGNIN))
+
+        .then(subscribeToTestProduct())
+
+        .then(openRP())
+        .then(click(selectors['123DONE'].BUTTON_SIGNIN))
+        .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER))
+        .then(click(selectors['SIGNIN_PASSWORD'].SUBMIT_USE_SIGNED_IN))
+        .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
+        .then(visibleByQSA(selectors['123DONE'].SUBSCRIBED));
+    },
+  },
+});

--- a/packages/fxa-profile-server/lib/routes/_core_profile.js
+++ b/packages/fxa-profile-server/lib/routes/_core_profile.js
@@ -39,6 +39,9 @@ module.exports = {
       subscriptions: Joi.array()
         .items(Joi.string().required())
         .optional(),
+      subscriptionsByClientId: Joi.object()
+        .unknown(true)
+        .optional(),
       profileChangedAt: Joi.number().optional(),
     },
   },
@@ -102,6 +105,9 @@ module.exports = {
         }
         if (typeof body.subscriptions !== 'undefined') {
           result.subscriptions = body.subscriptions;
+        }
+        if (typeof body.subscriptionsByClientId !== 'undefined') {
+          result.subscriptionsByClientId = body.subscriptionsByClientId;
         }
         if (typeof body.profileChangedAt !== 'undefined') {
           result.profileChangedAt = body.profileChangedAt;

--- a/packages/fxa-profile-server/lib/routes/profile.js
+++ b/packages/fxa-profile-server/lib/routes/profile.js
@@ -5,6 +5,9 @@
 const Joi = require('joi');
 const checksum = require('checksum');
 const P = require('../promise');
+const {
+  determineClientVisibleSubscriptionCapabilities,
+} = require('../subscriptions');
 
 const logger = require('../logging')('routes.profile');
 
@@ -55,6 +58,16 @@ module.exports = {
 
       if (creds.scope.indexOf('openid') !== -1) {
         result.sub = creds.user;
+      }
+
+      // Need to filter subscriptions by client ID for the request, since ALL
+      // capabilities for all clients is what we cache on user ID.
+      if (result.subscriptionsByClientId) {
+        result.subscriptions = determineClientVisibleSubscriptionCapabilities(
+          req.auth.credentials.client_id,
+          result.subscriptionsByClientId
+        );
+        delete result.subscriptionsByClientId;
       }
 
       let rep = reply(result);

--- a/packages/fxa-profile-server/lib/routes/subscriptions.js
+++ b/packages/fxa-profile-server/lib/routes/subscriptions.js
@@ -3,6 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const Joi = require('joi');
+const {
+  determineClientVisibleSubscriptionCapabilities,
+} = require('../subscriptions');
 
 module.exports = {
   auth: {
@@ -29,9 +32,18 @@ module.exports = {
         if (res.statusCode !== 200) {
           return reply(res);
         }
+        let subscriptions = [];
+        if (res.result.subscriptionsByClientId) {
+          subscriptions = determineClientVisibleSubscriptionCapabilities(
+            req.auth.credentials.client_id,
+            res.result.subscriptionsByClientId
+          );
+        } else if (res.result.subscriptions) {
+          subscriptions = res.result.subscriptions;
+        }
         return reply({
           // If auth server omits subscriptions, just use an empty list
-          subscriptions: res.result.subscriptions || [],
+          subscriptions,
         });
       }
     );

--- a/packages/fxa-profile-server/lib/subscriptions.js
+++ b/packages/fxa-profile-server/lib/subscriptions.js
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This is an abbreviated version of the function from
+// fxa-auth-server/lib/routes/utils/subscriptions.js
+exports.determineClientVisibleSubscriptionCapabilities = function(
+  clientId,
+  allCapabilities
+) {
+  const capabilitiesToReveal = new Set([
+    ...(allCapabilities['*'] || []),
+    ...(allCapabilities[clientId] || []),
+  ]);
+  return capabilitiesToReveal.size > 0
+    ? Array.from(capabilitiesToReveal).sort()
+    : undefined;
+};


### PR DESCRIPTION
- end-to-end functional test in content-server that exercises
  subscription flow

- fix an issue where the profile-server caching only retained subscription
  capabilities per user based on the first client ID that fetched the
  profile on a cache miss

- separate gathering up subscription capabilities from filtering by
  relevant client ID

- send all subscription capabilities from auth-server /account/profile
  endpoint so that profile-server can do client ID filtering

- cache all subscription capabilities in profile-server, filter by
  client ID at request time

- small bugfix for clean-up-old-ci-stripe-customers asserting pattern
  for Stripe test key

FXA-1278
fixes #4394