### PR TITLE
fix(emails): update usage of button partial in emails to fix broken HTML structure

### DIFF
--- a/packages/fxa-auth-server/lib/senders/templates/downloadSubscription.html
+++ b/packages/fxa-auth-server/lib/senders/templates/downloadSubscription.html
@@ -87,7 +87,9 @@
                                     subscription.
                                     <br />
                                     <br />
-                                    {{> button}}
+                                    <table style="background-color: #FFFFFF; min-width: 100%;">
+                                      {{> button}}
+                                    </table>
                                     <br />
                                     Questions about your subscription? Our
                                     <a href="{{{subscriptionSupportUrl}}}"

--- a/packages/fxa-auth-server/lib/senders/templates/partials/button.html
+++ b/packages/fxa-auth-server/lib/senders/templates/partials/button.html
@@ -1,5 +1,3 @@
-<table style="background-color: #FFFFFF; min-width: 100%; ">
-
 <tr height="50">
   <td align="center" valign="top">
     <table
@@ -39,4 +37,3 @@
     </table>
   </td>
 </tr>
-</table>

--- a/packages/fxa-auth-server/lib/senders/templates/verifySecondary.html
+++ b/packages/fxa-auth-server/lib/senders/templates/verifySecondary.html
@@ -12,7 +12,7 @@
 
 <tr style="page-break-before: always">
   <td border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
-    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 24px 0 0 0; text-align: center;">{{t "Once verified, this address will begin receiving security notifications and confirmations."}}
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 24px 0 0 0; text-align: center;">{{t "Once verified, this address will begin receiving security notifications and confirmations."}}</p>
   </td>
 </tr>
 


### PR DESCRIPTION
Closes #4543

The content in the emails noted is misaligned because of a non-semantic HTML structure where the layout ends up being:

```html
<tr>...</tr>
<table>...</table>
<tr>...</tr>
```

Some email clients ignore it, but some don't like it.

The reason this is happening is because we [started](https://github.com/mozilla/fxa/commit/fa1d31440555e72a9e4a0ccb92423adf76261449#diff-ad28990900043fd71d26e323cb2eb9f4) wrapping our `button` partial in `<table>` tags in order to satisfy a layout issue in [this email](https://github.com/mozilla/fxa/commit/fa1d31440555e72a9e4a0ccb92423adf76261449#diff-a121c68141a89cb12e131f4e9eda0163R90).

Since this is the only place where a surrounding `<table>` is expected, and all other instances of the `button` partial usage expect a surrounding `<tr>`, I've gone ahead and removed that change from the partial, and just manually added it to that one email in particular.