### PR TITLE
fix(emails): Update cached email after changing primary email

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/url.js
+++ b/packages/fxa-content-server/app/scripts/lib/url.js
@@ -209,4 +209,23 @@ export default {
     const cleanedQueryParams = this.searchParams(search, allowedFields);
     return base + this.objToSearchString(cleanedQueryParams);
   },
+
+  /**
+   * Set a new value for the query search string in place. This does
+   * not reload the page but rather updates the window state history.
+   *
+   * @param {String} param - param to update
+   * @param {String} value - value to set
+   */
+  setSearchString(param, value) {
+    const params = new URLSearchParams(this.window.location.search);
+    params.set(param, value);
+
+    // This will update the url with new params inplace
+    this.window.history.replaceState(
+      {},
+      '',
+      `${this.window.location.pathname}?${params}`
+    );
+  },
 };

--- a/packages/fxa-content-server/app/scripts/views/settings/emails.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/emails.js
@@ -14,6 +14,7 @@ import UpgradeSessionMixin from '../mixins/upgrade-session-mixin';
 import Strings from '../../lib/strings';
 import showProgressIndicator from '../decorators/progress_indicator';
 import Template from 'templates/settings/emails.mustache';
+import Url from '../../lib/url';
 
 const t = msg => msg;
 
@@ -148,6 +149,8 @@ var View = FormView.extend({
     const account = this.getSignedInAccount();
     return account.setPrimaryEmail(email).then(() => {
       this.updateDisplayEmail(email);
+      account.unset('originalLoginEmail');
+      this.setSearchString('email', email);
       this.displaySuccess(
         Strings.interpolate(t('Primary email set to %(email)s'), { email }),
         {
@@ -167,7 +170,8 @@ Cocktail.mixin(
   }),
   AvatarMixin,
   LastCheckedTimeMixin,
-  SettingsPanelMixin
+  SettingsPanelMixin,
+  Url
 );
 
 export default View;

--- a/packages/fxa-content-server/app/tests/spec/views/settings/emails.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/emails.js
@@ -364,6 +364,8 @@ describe('views/settings/emails', function() {
           },
         ];
 
+        sinon.spy(windowMock.history, 'replaceState');
+
         return initView().then(function() {
           // click events require the view to be in the DOM
           $('#container').html(view.el);
@@ -405,7 +407,7 @@ describe('views/settings/emails', function() {
         );
       });
 
-      it('can change email', done => {
+      it('can set primary email', done => {
         $(
           '.email-address .settings-button.secondary-button.set-primary'
         ).click();
@@ -415,6 +417,19 @@ describe('views/settings/emails', function() {
               account.get('email'),
               newEmail,
               'account email updated'
+            );
+            assert.equal(
+              account.get('originalLoginEmail'),
+              undefined,
+              'originalLoginEmail is unset'
+            );
+
+            assert.isTrue(
+              windowMock.history.replaceState.calledOnceWith(
+                {},
+                '',
+                '/?email=secondary%40email.com'
+              )
             );
           }, done);
         }, 150);


### PR DESCRIPTION
Fixes #4504

This PR fixes the above issue by doing the following

* On primary email change, update the query email param to reflect new email. When a user signs out, the login page treats the `?email=something` as gospel and prefills the page.
* Unset the `originalLoginEmail` value on the account if present. This should only be set if user is attempting to login.