### PR TITLE
fix(experiment): update sendSmsHeader frontend experiment to include previous control option

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/send-sms-header.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/send-sms-header.js
@@ -25,7 +25,7 @@ module.exports = class SendSmsHeaderGroupingRule extends BaseGroupingRule {
    * @returns {Any}
    */
   choose(subject = {}) {
-    const GROUPS = ['syncPhone', 'syncBrowser'];
+    const GROUPS = ['control', 'syncPhone', 'syncBrowser'];
     return this.uniformChoice(GROUPS, subject.uniqueUserId);
   }
 };

--- a/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sms_send.mustache
@@ -9,21 +9,26 @@
     </header>
     <section class="send-sms">
       <div class="graphic {{graphicId}}" role="img" aria-label="{{#t}}Connect another device{{/t}}"></div>
-      <h1 data-id="prompt-header">
-        {{^userHasAttachedMobileDevice}}
-          {{#isInExperimentGroupSyncBrowser}}
-            {{#t}}Sync this browser with your phone{{/t}}
-          {{/isInExperimentGroupSyncBrowser}}
-          {{^isInExperimentGroupSyncBrowser}}
-            {{#t}}Would you like to sync your phone?{{/t}}
-          {{/isInExperimentGroupSyncBrowser}}
-        {{/userHasAttachedMobileDevice}}
-        {{#userHasAttachedMobileDevice}}
-          {{#t}}Still adding devices?{{/t}}
-        {{/userHasAttachedMobileDevice}}
-      </h1>
-      <p>
-        {{#t}}Send a link by SMS to install Firefox on your phone.{{/t}}
+
+      {{^userHasAttachedMobileDevice}}
+        {{#isSmsHeaderGroupSyncBrowser}}
+          <h1 data-id="prompt-header">{{#t}}Sync this browser with your phone{{/t}}</h1>
+        {{/isSmsHeaderGroupSyncBrowser}}
+        {{#isSmsHeaderGroupSyncPhone}}
+          <h1 data-id="prompt-header">{{#t}}Would you like to sync your phone?{{/t}}</h1>
+        {{/isSmsHeaderGroupSyncPhone}}
+      {{/userHasAttachedMobileDevice}}
+      {{#userHasAttachedMobileDevice}}
+        <h1 data-id="prompt-header">{{#t}}Still adding devices?{{/t}}</h1>
+      {{/userHasAttachedMobileDevice}}
+
+      <p data-id="prompt-subheader">
+        {{#isSmsHeaderGroupControl}}
+          {{#t}}Send Firefox directly to your smartphone and sign in to complete set-up{{/t}}
+        {{/isSmsHeaderGroupControl}}
+        {{^isSmsHeaderGroupControl}}
+          {{#t}}Send a link by SMS to install Firefox on your phone.{{/t}}
+        {{/isSmsHeaderGroupControl}}
       </p>
 
       <form novalidate>

--- a/packages/fxa-content-server/app/scripts/views/sms_send.js
+++ b/packages/fxa-content-server/app/scripts/views/sms_send.js
@@ -112,10 +112,14 @@ class SmsSendView extends FormView {
     const isSignIn = this.isSignIn();
     const graphicId = this.getGraphicsId();
 
-    let isInExperimentGroupSyncBrowser = false;
+    let isSmsHeaderGroupControl,
+      isSmsHeaderGroupSyncPhone,
+      isSmsHeaderGroupSyncBrowser;
     if (!this._userHasAttachedMobileDevice) {
-      const experimentGroup = this.getAndReportExperimentGroup('sendSmsHeader');
-      isInExperimentGroupSyncBrowser = experimentGroup === 'syncBrowser';
+      const group = this.getAndReportExperimentGroup('sendSmsHeader');
+      isSmsHeaderGroupControl = group === 'control';
+      isSmsHeaderGroupSyncPhone = group === 'syncPhone';
+      isSmsHeaderGroupSyncBrowser = group === 'syncBrowser';
     }
 
     context.set({
@@ -126,7 +130,9 @@ class SmsSendView extends FormView {
       graphicId,
       isSignIn,
       phoneNumber,
-      isInExperimentGroupSyncBrowser,
+      isSmsHeaderGroupControl,
+      isSmsHeaderGroupSyncPhone,
+      isSmsHeaderGroupSyncBrowser,
       showSuccessMessage: this.model.get('showSuccessMessage'),
     });
   }

--- a/packages/fxa-content-server/app/tests/spec/views/sms_send.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sms_send.js
@@ -45,6 +45,9 @@ describe('views/sms_send', () => {
     sinon
       .stub(view, 'checkAuthorization')
       .callsFake(() => Promise.resolve(true));
+    sinon
+      .stub(view, 'getAndReportExperimentGroup')
+      .callsFake(() => 'syncPhone');
   }
 
   beforeEach(() => {

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -492,6 +492,7 @@ module.exports = {
   SMS_SEND: {
     HEADER: '#fxa-send-sms-header',
     PROMPT_HEADER: '[data-id="prompt-header"]',
+    PROMPT_SUBHEADER: '[data-id="prompt-subheader"]',
     LINK_LEARN_MORE: 'a#learn-more',
     LINK_MARKETING: '.marketing-link',
     LINK_MARKETING_ANDROID: '.marketing-link-android',

--- a/packages/fxa-content-server/tests/functional/send_sms.js
+++ b/packages/fxa-content-server/tests/functional/send_sms.js
@@ -113,6 +113,23 @@ const suite = {
     );
   },
   tests: {
+    'displays expected subheader with `control` experiment group': function() {
+      return this.remote
+        .then(
+          openPage(SEND_SMS_HEADER_URL, selectors.SMS_SEND.HEADER, {
+            query: {
+              forceExperimentGroup: 'control',
+            },
+          })
+        )
+        .then(noSuchElement(selectors.SMS_SEND.PROMPT_HEADER))
+        .then(
+          testElementTextInclude(
+            selectors.SMS_SEND.PROMPT_SUBHEADER,
+            'Send Firefox directly to your smartphone and sign in to complete set-up'
+          )
+        );
+    },
     'displays expected header with `syncPhone` experiment group': function() {
       return this.remote
         .then(
@@ -126,6 +143,12 @@ const suite = {
           testElementTextInclude(
             selectors.SMS_SEND.PROMPT_HEADER,
             'Would you like to sync your phone?'
+          )
+        )
+        .then(
+          testElementTextInclude(
+            selectors.SMS_SEND.PROMPT_SUBHEADER,
+            'Send a link by SMS to install Firefox on your phone.'
           )
         );
     },
@@ -142,6 +165,12 @@ const suite = {
           testElementTextInclude(
             selectors.SMS_SEND.PROMPT_HEADER,
             'Sync this browser with your phone'
+          )
+        )
+        .then(
+          testElementTextInclude(
+            selectors.SMS_SEND.PROMPT_SUBHEADER,
+            'Send a link by SMS to install Firefox on your phone.'
           )
         );
     },


### PR DESCRIPTION
This addresses a misunderstanding in the experiment where we neglected to use a "control". More can be found in [this Slack discussion](https://mozilla.slack.com/archives/C4D36CAJW/p1584452512384100).

Here are the three versions now:

`control`:

![Screen Shot 2020-03-18 at 1 40 34 PM](https://user-images.githubusercontent.com/6392049/76992021-f5af5580-6920-11ea-8fe3-31ea91320745.png)

`syncPhone`:

![Screen Shot 2020-03-18 at 1 40 44 PM](https://user-images.githubusercontent.com/6392049/76992036-fb0ca000-6920-11ea-86bb-3deff12ca3b5.png)

`syncBrowser`:

![Screen Shot 2020-03-18 at 1 40 55 PM](https://user-images.githubusercontent.com/6392049/76992063-03fd7180-6921-11ea-8698-9a90b1396fb0.png)
