### PR TITLE
feat(metrics): send nav timing metrics to statsd/influxdb

### DIFF
--- a/packages/fxa-content-server/package-lock.json
+++ b/packages/fxa-content-server/package-lock.json
@@ -2521,6 +2521,15 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
             "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
         },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
         "bl": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -5059,6 +5068,12 @@
             "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
             "dev": true
         },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "optional": true
+        },
         "fill-keys": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
@@ -6942,6 +6957,14 @@
             "version": "2.8.5",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
             "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
+        },
+        "hot-shots": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-7.1.0.tgz",
+            "integrity": "sha512-O0ubzu4UmoRna8DweA+KSnFwqF9Xkg+Mu0/Q8DWK2nu97n8ZFWcEGao7aJ8tqIPD0Mz09ApypwJN7SOxI66Ujw==",
+            "requires": {
+                "unix-dgram": "2.0.x"
+            }
         },
         "hpkp": {
             "version": "2.0.0",
@@ -13087,6 +13110,16 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        },
+        "unix-dgram": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.3.tgz",
+            "integrity": "sha512-Bay5CkSLcdypcBCsxvHEvaG3mftzT5FlUnRToPWEAVxwYI8NI/8zSJ/Gknlp86MPhV6hBA8I8TBsETj2tssoHQ==",
+            "optional": true,
+            "requires": {
+                "bindings": "^1.3.0",
+                "nan": "^2.13.2"
+            }
         },
         "unpipe": {
             "version": "1.0.0",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -83,6 +83,7 @@
         "grunt-z-schema": "0.1.0",
         "handlebars": "^4.5.2",
         "helmet": "3.21.1",
+        "hot-shots": "^7.1.0",
         "i18n-abide": "0.0.26",
         "joi": "^14.3.1",
         "jquery": "3.4.0",

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -588,6 +588,44 @@ const conf = (module.exports = convict({
     env: 'SOURCE_MAP_TYPE',
     format: String,
   },
+  statsd: {
+    enabled: {
+      doc: 'Enable StatsD',
+      format: Boolean,
+      default: false,
+      env: 'METRIC_ENABLED',
+    },
+    sampleRate: {
+      doc: 'Sampling rate for StatsD',
+      format: Number,
+      default: 1,
+      env: 'METRIC_SAMPLE_RATE',
+    },
+    maxBufferSize: {
+      doc: 'StatsD message buffer size in number of characters',
+      format: Number,
+      default: 500,
+      env: 'METRIC_BUFFER_SIZE',
+    },
+    host: {
+      doc: 'StatsD host to report to',
+      format: String,
+      default: 'localhost',
+      env: 'METRIC_HOST',
+    },
+    port: {
+      doc: 'Port number of StatsD server',
+      format: Number,
+      default: 8125,
+      env: 'METRIC_PORT',
+    },
+    prefix: {
+      doc: 'StatsD metrics name prefix',
+      format: String,
+      default: 'fxa-content.',
+      env: 'METRIC_PREFIX',
+    },
+  },
   static_directory: {
     default: 'app',
     doc: 'Directory that static files are served from.',

--- a/packages/fxa-content-server/server/lib/statsd.js
+++ b/packages/fxa-content-server/server/lib/statsd.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+const config = require('./configuration').get('statsd');
+const log = require('./logging/log')('server.statsd');
+const NOOP = () => {};
+const StatsD = require('hot-shots');
+
+const noopStatsd = () => {
+  const mock = {};
+  Object.keys(StatsD.prototype).forEach(x => {
+    if (typeof StatsD.prototype[x] === 'function') {
+      mock[x] = NOOP;
+    }
+  });
+};
+
+const statsd = config.enabled
+  ? new StatsD({
+      ...config,
+      errorHandler: err => {
+        // eslint-disable-next-line no-use-before-define
+        log.error('statsd.error', err);
+      },
+    })
+  : noopStatsd();
+
+module.exports = statsd;

--- a/packages/fxa-content-server/tests/server/flow-event.js
+++ b/packages/fxa-content-server/tests/server/flow-event.js
@@ -43,6 +43,7 @@ registerSuite('flow-event', {
         },
         locale: 'en',
       },
+      statsd: { timing: sinon.stub() },
       time: 1479127399349,
     };
     flowEvent = proxyquire(path.resolve('server/lib/flow-event'), {
@@ -50,6 +51,7 @@ registerSuite('flow-event', {
       './configuration': mocks.config,
       './flow-metrics': mocks.flowMetrics,
       '../../../fxa-shared/express/geo-locate': mocks.geolocate,
+      './statsd': mocks.statsd,
     }).metricsRequest;
   },
 
@@ -345,6 +347,33 @@ registerSuite('flow-event', {
 
         'amplitude was called once': () => {
           assert.equal(mocks.amplitude.callCount, 1);
+        },
+
+        'statsd timing was called four times': () => {
+          assert.equal(mocks.statsd.timing.callCount, 4);
+        },
+
+        'statsd timing was called with the correct arguments': () => {
+          assert.deepEqual(mocks.statsd.timing.firstCall.args, [
+            'nt.total',
+            2000,
+            { view: 'signup' },
+          ]);
+          assert.deepEqual(mocks.statsd.timing.secondCall.args, [
+            'nt.network',
+            300,
+            { view: 'signup' },
+          ]);
+          assert.deepEqual(mocks.statsd.timing.thirdCall.args, [
+            'nt.server',
+            100,
+            { view: 'signup' },
+          ]);
+          assert.deepEqual(mocks.statsd.timing.lastCall.args, [
+            'nt.client',
+            200,
+            { view: 'signup' },
+          ]);
         },
       },
     },


### PR DESCRIPTION
This patch sends the navigation timing performance metrics to InfluxDB.
It's a step in replacing the performance dashboard in Redash, and
removing our dependency on Redshift.

Fixes #4589  (FXA-1295)

@mozilla/fxa-devs r?