### PR TITLE
chore(deps): Updates to address nsp advisory 1179

### DIFF
--- a/packages/123done/.nsprc
+++ b/packages/123done/.nsprc
@@ -1,3 +1,6 @@
 {
-  "exceptions": []
+  "comment_1179": "1179 is prototype pollution in minimist, used by eslint. Doesn't affect us, as we don't pass untrusted external inputs to eslint.",
+  "exceptions": [
+    "https://npmjs.com/advisories/1179"
+  ]
 }

--- a/packages/browserid-verifier/.nsprc
+++ b/packages/browserid-verifier/.nsprc
@@ -1,12 +1,14 @@
 {
   "comment": "532, 534, 545 are various ReDoS that don't affect us.",
   "comment_566": "Hoek merge vuln, which we don't use.",
+  "comment_1179": "1179 is prototype pollution in minimist, used by eslint, optimist, and mocha. Doesn't affect us, as we don't pass untrusted external inputs to any of these.",
   "comment_1488": "Acorn DoS vuln (dep of browserify), only applies if passed untrusted user input.",
   "exceptions": [
     "https://nodesecurity.io/advisories/532",
     "https://nodesecurity.io/advisories/534",
     "https://nodesecurity.io/advisories/535",
     "https://nodesecurity.io/advisories/566",
+    "https://npmjs.com/advisories/1179",
     "https://npmjs.com/advisories/1488"
   ]
 }

--- a/packages/fortress/.nsprc
+++ b/packages/fortress/.nsprc
@@ -1,3 +1,6 @@
 {
-  "exceptions": []
+  "comment_1179": "1179 is prototype pollution in minimist, used by eslint. Doesn't affect us, as we don't pass untrusted external inputs to eslint.",
+  "exceptions": [
+    "https://npmjs.com/advisories/1179"
+  ]
 }

--- a/packages/fxa-admin-server/.nsprc
+++ b/packages/fxa-admin-server/.nsprc
@@ -1,4 +1,6 @@
 {
+  "comment_1179": "1179 is prototype pollution in minimist, used by tslint, ts-node-dev, mocha, knex. Doesn't affect us, as we don't pass untrusted external inputs to these libraries.",
   "exceptions": [
+    "https://npmjs.com/advisories/1179"
   ]
 }

--- a/packages/fxa-auth-db-mysql/.nsprc
+++ b/packages/fxa-auth-db-mysql/.nsprc
@@ -1,4 +1,6 @@
 {
+  "comment_1179": "1179 is prototype pollution in minimist, used by eslint, mocha. Doesn't affect us, as we don't pass untrusted external inputs to those libraries.",
   "exceptions": [
+    "https://npmjs.com/advisories/1179"
   ]
 }

--- a/packages/fxa-auth-server/.nsprc
+++ b/packages/fxa-auth-server/.nsprc
@@ -1,8 +1,10 @@
 {
   "comment_766": "766 is sandbox breakout in sandbox.",
+  "comment_1179": "1179 is prototype pollution in minimist, used by eslint, mocha, handlebars. Shouldn't affect us, as we don't pass untrusted external inputs to those libraries, but see https://github.com/mozilla/fxa/issues/4592 to investigate whether handlebars might have a vulnerability.",
   "comment_1488": "Denial of Service vulnerability in acorn. Doesn't affect us, as it's only used by i18n libraries.",
   "exceptions": [
     "https://npmjs.com/advisories/766",
+    "https://npmjs.com/advisories/1179",
     "https://npmjs.com/advisories/1488"
   ]
 }

--- a/packages/fxa-content-server/.nsprc
+++ b/packages/fxa-content-server/.nsprc
@@ -7,6 +7,7 @@
   "comment_961": "961 is a DOS against node-sass",
   "comment_1065": "1065  is prototype pollution in lodash, used by convict, grunt-usemin, grunt-z-schema.",
   "comment_1084": "1084 is Mem denial of service is caused by cache not being removed even with maxage prop",
+  "comment_1179": "1179 is prototype pollution in minimist, used by eslint, grunt, webpack, i18n-abide, and handlebars. See https://github.com/mozilla/fxa/issues/4592 to investigate whether handlebars might have a vulnerability.",
   "comment_1426": "1426 is Cross-Site Scripting (XSS) in serialize-javascript, used by uglifyjs-webpack-plugin",
   "comment_1217": "1217 is an arbitrary file write issue in decompress, used by @theintern/digdug",
   "comment_1488": "1488 is DoS against acorn, used in i18n libraries, grunt-sass-lint, and webpack. It only applies if untrusted user content is passed in.",
@@ -19,6 +20,7 @@
     "https://npmjs.com/advisories/961",
     "https://npmjs.com/advisories/1065",
     "https://npmjs.com/advisories/1084",
+    "https://npmjs.com/advisories/1179",
     "https://npmjs.com/advisories/1217",
     "https://npmjs.com/advisories/1426",
     "https://npmjs.com/advisories/1488"

--- a/packages/fxa-customs-server/.nsprc
+++ b/packages/fxa-customs-server/.nsprc
@@ -1,6 +1,8 @@
 {
+  "comment_1179": "1179 is prototype pollution in minimist, used by eslint, restify, bunyan. Doesn't affect us, as we don't pass untrusted external inputs to the customs server.",
   "comment_1464": "Exception added for insufficient entropy error in 'cryptiles' in hapi 17 (cryptiles 3.x), fixed in hapi 18 (@hapi/cryptiles 4.1.2). See https://github.com/mozilla/fxa/issues/4035",
   "exceptions": [
+    "https://npmjs.com/advisories/1179",
     "https://npmjs.com/advisories/1464"
   ]
 }

--- a/packages/fxa-dev-launcher/.nsprc
+++ b/packages/fxa-dev-launcher/.nsprc
@@ -1,3 +1,6 @@
 {
-  "exceptions": []
+  "comment_1179": "1179 is prototype pollution in minimist, used by foxfire. Doesn't affect us, as we don't pass untrusted external inputs to foxfire.",
+  "exceptions": [
+    "https://npmjs.com/advisories/1179"
+  ]
 }

--- a/packages/fxa-email-event-proxy/.nsprc
+++ b/packages/fxa-email-event-proxy/.nsprc
@@ -1,3 +1,6 @@
 {
-  "exceptions": []
+  "comment_1179": "1179 is prototype pollution in minimist, used by eslint and mocha. Doesn't affect us, as we don't pass untrusted external inputs to those libraries.",
+  "exceptions": [
+    "https://npmjs.com/advisories/1179"
+  ]
 }

--- a/packages/fxa-event-broker/.nsprc
+++ b/packages/fxa-event-broker/.nsprc
@@ -1,4 +1,6 @@
 {
+  "comment_1179": "1179 is prototype pollution in minimist, used by eslint, mocha. Doesn't affect us, as we don't pass untrusted external inputs to those libraries.",
   "exceptions": [
+    "https://npmjs.com/advisories/1179"
   ]
 }

--- a/packages/fxa-geodb/.nsprc
+++ b/packages/fxa-geodb/.nsprc
@@ -1,4 +1,6 @@
 {
+  "comment_1179": "1179 is prototype pollution in minimist, used by eslint, mocha. Doesn't affect us, as we don't pass untrusted external inputs to those libraries.",
   "exceptions": [
+    "https://npmjs.com/advisories/1179"
   ]
 }

--- a/packages/fxa-js-client/.nsprc
+++ b/packages/fxa-js-client/.nsprc
@@ -1,6 +1,8 @@
 {
-  "exception_1488": "1488 is a DoS against acorn (via webpack), which only applies if untrusted user content is passed in.",
+  "comment_1179": "1179 is prototype pollution in minimist, used by eslint, grunt, webpack. Doesn't affect us, as we don't pass untrusted external inputs to those libraries.",
+  "comment_1488": "1488 is a DoS against acorn (via webpack), which only applies if untrusted user content is passed in.",
   "exceptions": [
+    "https://npmjs.com/advisories/1179",
     "https://npmjs.com/advisories/1488"
   ]
 }

--- a/packages/fxa-metrics-processor/.nsprc
+++ b/packages/fxa-metrics-processor/.nsprc
@@ -1,3 +1,6 @@
 {
-  "exceptions": []
+  "comment_1179": "1179 is prototype pollution in minimist, used by eslint, tslint, mocha. Doesn't affect us, as we don't pass untrusted external inputs to these libraries.",
+  "exceptions": [
+    "https://npmjs.com/advisories/1179"
+  ]
 }

--- a/packages/fxa-payments-server/.nsprc
+++ b/packages/fxa-payments-server/.nsprc
@@ -1,10 +1,12 @@
 {
   "comment_961": "961 is a DOS against node-sass",
+  "comment_1179": "1179 is prototype pollution in minimist, used by react-scripts, other libraries. See https://github.com/mozilla/fxa/issues/4592 to investigate whether handlebars might have a vulnerability.",
   "comment_1426": "1426 is Cross-Site Scripting (XSS) in serialize-javascript, used by dev dep @storybook/react",
   "comment_1468": "1468 is a hoek vulnerability that only applies if the library is used outside hapi",
   "comment_1488": "1488 is a DoS against acorn (via webpack), which only applies if untrusted user content is passed in.",
   "exceptions": [
     "https://npmjs.com/advisories/961",
+    "https://npmjs.com/advisories/1179",
     "https://npmjs.com/advisories/1426",
     "https://npmjs.com/advisories/1468",
     "https://npmjs.com/advisories/1488"

--- a/packages/fxa-profile-server/.nsprc
+++ b/packages/fxa-profile-server/.nsprc
@@ -1,5 +1,6 @@
 {
   "comment_1168": "Exception added for 'subtext' vulnerability in hapi 17, fixed in hapi 18 branch. See https://github.com/mozilla/fxa/issues/2601",
+  "comment_1179": "1179 is prototype pollution in minimist, used by eslint, mocha, and grunt tools. Doesn't affect us, as we don't pass untrusted external inputs to those libraries.",
   "comment_1464": "Exception added for insufficient entropy error in 'cryptiles' in hapi 17 (cryptiles 3.x), fixed in hapi 18 (@hapi/cryptiles 4.1.2). See https://github.com/mozilla/fxa/issues/4035",
   "comment_1472": "Denial of Service vulnerability.  Need to upgrade to @hapi/@hapi.  See https://github.com/mozilla/fxa/issues/2601",
   "comment_1478": "Denial of Service vulnerability.  Need to upgrade to @hapi/@hapi.  See https://github.com/mozilla/fxa/issues/2601",
@@ -7,6 +8,7 @@
   "comment_1481": "Denial of Service vulnerability.  Need to upgrade to @hapi/@hapi.  See https://github.com/mozilla/fxa/issues/2601",
   "exceptions": [
     "https://npmjs.com/advisories/1168",
+    "https://npmjs.com/advisories/1179",
     "https://npmjs.com/advisories/1464",
     "https://npmjs.com/advisories/1472",
     "https://npmjs.com/advisories/1478",

--- a/packages/fxa-support-panel/.nsprc
+++ b/packages/fxa-support-panel/.nsprc
@@ -1,3 +1,6 @@
 {
-  "exceptions": []
+  "comment_1179": "1179 is prototype pollution in minimist, used by tslint, mocha, handlebars. Doesn't affect us, as this library is only used by support agents, so untrusted external inputs aren't passed to handlebars.",
+  "exceptions": [
+    "https://npmjs.com/advisories/1179"
+  ]
 }


### PR DESCRIPTION
Can't finish today's release without addressing this.

Not 100% sure we aren't ever passing untrusted input to handlebars, which is affected; filed https://github.com/mozilla/fxa/issues/4592 to follow up.