### PR TITLE
fix(metrics): restrict content-server nav timing metric names

### DIFF
--- a/packages/fxa-content-server/server/lib/flow-event.js
+++ b/packages/fxa-content-server/server/lib/flow-event.js
@@ -206,12 +206,18 @@ function logFlowEvent(event, data, request) {
 }
 
 function logStatsdPerfEvent(eventData) {
+  // See https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/docs/metrics-events.md#success-event-names
   if (eventData.event.startsWith('flow.performance.')) {
+    const navTimingMetricNames = PERFORMANCE_TIMINGS.map(x => x.event);
     const perfMetricNameParts = eventData.event.split('.');
     const view = perfMetricNameParts[2];
-    const metricName =
-      perfMetricNameParts.length === 3 ? 'total' : perfMetricNameParts[3];
-    statsd.timing(`nt.${metricName}`, eventData.flow_time, { view });
+    if (perfMetricNameParts.length === 3) {
+      statsd.timing('nt.total', eventData.flow_time, { view });
+    } else if (navTimingMetricNames.includes(perfMetricNameParts[3])) {
+      statsd.timing(`nt.${perfMetricNameParts[3]}`, eventData.flow_time, {
+        view,
+      });
+    }
   }
 }
 


### PR DESCRIPTION
This patch restricts the navigation timing statsd metric names to those
defined in fxa-shared/metrics/flow-performance.js.

Fixes #4599 (FXA-1391)

@mozilla/fxa-devs r?