### PR TITLE
chore(metrics): reduce nav timing metric tags in Payments

### DIFF
--- a/packages/fxa-payments-server/package-lock.json
+++ b/packages/fxa-payments-server/package-lock.json
@@ -22245,11 +22245,6 @@
       "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
-    "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
-    },
     "uglify-js": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -131,7 +131,6 @@
     "redux-thunk": "^2.3.0",
     "serve-static": "^1.13.2",
     "type-to-reducer": "^1.2.0",
-    "ua-parser-js": "^0.7.21",
     "uuid": "^7.0.2"
   },
   "engines": {

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -70,20 +70,6 @@ const conf = convict({
     env: 'FLOW_ID_EXPIRY',
     format: 'duration',
   },
-  geodb: {
-    dbPath: {
-      default: path.resolve(__dirname, '../../../fxa-geodb/db/cities-db.mmdb'),
-      doc: 'Path to maxmind database file',
-      env: 'GEODB_DBPATH',
-      format: String,
-    },
-    enabled: {
-      default: true,
-      doc: 'Feature flag for geolocation',
-      env: 'GEODB_ENABLED',
-      format: Boolean,
-    },
-  },
   hstsEnabled: {
     default: true,
     doc: 'Send a Strict-Transport-Security header',

--- a/packages/fxa-payments-server/server/lib/routes/index.js
+++ b/packages/fxa-payments-server/server/lib/routes/index.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = (geolocate, UAParser, statsd) => [
+module.exports = statsd => [
   require('./post-metrics'),
-  require('./navigation-timing')(geolocate, UAParser, statsd),
+  require('./navigation-timing')(statsd),
 ];

--- a/packages/fxa-payments-server/server/lib/routes/index.test.js
+++ b/packages/fxa-payments-server/server/lib/routes/index.test.js
@@ -7,14 +7,12 @@ const mockNavTiming = jest.fn();
 jest.mock('./post-metrics', () => ({}));
 jest.mock('./navigation-timing', () => mockNavTiming);
 
-const geolocate = {};
-const UAParser = {};
 const statsd = {};
 
 describe('Route dependencies', () => {
   test('navigation-timing should receive the correct dependencies', () => {
-    routes(geolocate, UAParser, statsd);
+    routes(statsd);
     expect(mockNavTiming).toHaveBeenCalledTimes(1);
-    expect(mockNavTiming).toHaveBeenCalledWith(geolocate, UAParser, statsd);
+    expect(mockNavTiming).toHaveBeenCalledWith(statsd);
   });
 });

--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -30,19 +30,7 @@ module.exports = () => {
   const { cors, routing } = require('../../../fxa-shared/express')();
 
   const NOOP = () => {};
-  const UAParser = require('ua-parser-js');
   const StatsD = require('hot-shots');
-  const geodbConfig = config.get('geodb');
-  let geolocate = NOOP;
-  if (geodbConfig.enabled) {
-    const geodb = require('../../../fxa-geodb/lib/fxa-geodb.js')(geodbConfig);
-    const remoteAddress = require('../../../fxa-shared/express/remote-address')(
-      config.get('clientAddressDepth')
-    );
-    geolocate = require('../../../fxa-shared/express/geo-locate.js')(geodb)(
-      remoteAddress
-    )(log('geolocate'));
-  }
   const statsdConfig = config.get('statsd');
   const statsd = statsdConfig.enabled
     ? new StatsD({
@@ -56,7 +44,7 @@ module.exports = () => {
         timing: NOOP,
       };
 
-  const routes = require('./routes')(geolocate, UAParser, statsd);
+  const routes = require('./routes')(statsd);
 
   const app = express();
 

--- a/packages/fxa-payments-server/server/lib/server.test.js
+++ b/packages/fxa-payments-server/server/lib/server.test.js
@@ -58,8 +58,6 @@ describe('Test simple server routes', () => {
 
 describe('Test route dependencies', () => {
   test('server.js should pass the correct dependencies to routes', () => {
-    const mockUAParser = () => {};
-    const mockGeolocate = jest.fn();
     const mockStatsdInstance = {};
     const mockStatsd = function() {
       return mockStatsdInstance;
@@ -81,20 +79,11 @@ describe('Test route dependencies', () => {
         }
       },
     }));
-    jest.mock('ua-parser-js', () => mockUAParser);
-    jest.mock(
-      '../../../fxa-shared/express/geo-locate.js',
-      () => () => () => () => mockGeolocate
-    );
     jest.mock('hot-shots', () => mockStatsd);
     jest.mock('./routes', () => mockRoutes);
     require('./server')();
 
     expect(mockRoutes).toHaveBeenCalledTimes(1);
-    expect(mockRoutes).toHaveBeenLastCalledWith(
-      mockGeolocate,
-      mockUAParser,
-      mockStatsdInstance
-    );
+    expect(mockRoutes).toHaveBeenLastCalledWith(mockStatsdInstance);
   });
 });


### PR DESCRIPTION
This patch removes the country, OS, and user-agent name tags from statsd
metric.  It helps to lower the amount of metrics in InfluxDB.

Fixes #4594 (FXA-1387)

@mozilla/fxa-devs r?