### PR TITLE
fix(style): fix rtl style of delete account panel

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -417,13 +417,24 @@ section.modal-panel {
   &-product-list {
     line-height: 24px;
     margin: 0 0 24px;
-    padding-left: 14px;
+    html[dir='ltr'] & {
+      padding-left: 14px;
+    }
+    html[dir='rtl'] & {
+      padding-right: 14px;
+    }
   }
 
   &-checkbox-list {
     list-style: none;
     margin: 0 0 32px;
-    padding-left: 0;
+
+    html[dir='ltr'] & {
+      padding-left: 0;
+    }
+    html[dir='rtl'] & {
+      padding-right: 0;
+    }
 
     &-item {
       display: grid;


### PR DESCRIPTION
This patch fixes the left/right paddings of the product list and
checkbox list of the delete account panel in settings.

Fixes #4559 (FXA-1377)

@mozilla/fxa-devs r?