### PR TITLE
feat(auth-server + payments-server): add billing_name to customer response

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -486,6 +486,7 @@ class DirectStripeRoutes {
       if (src.object === 'card') {
         response = {
           ...response,
+          billing_name: src.name,
           payment_type: src.funding,
           last4: src.last4,
           exp_month: src.exp_month,

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -352,6 +352,7 @@ module.exports.subscriptionsPlanValidator = isA.object({
 });
 
 module.exports.subscriptionsCustomerValidator = isA.object({
+  billing_name: isA.alternatives(isA.string(), isA.any().allow(null)),
   exp_month: isA.number().required(),
   exp_year: isA.number().required(),
   last4: isA.string().required(),

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -1291,6 +1291,10 @@ describe('StripeHelper', () => {
       });
 
       describe('when there is a charge-automatically payment that is past due', () => {
+        const failedChargeCopy = deepCopy(failedCharge);
+        const subscription = deepCopy(pastDueSubscription);
+        const invoice = deepCopy(unpaidInvoice);
+
         const expected = [
           {
             created: pastDueSubscription.created,
@@ -1302,23 +1306,21 @@ describe('StripeHelper', () => {
             plan_id: pastDueSubscription.plan.id,
             status: 'past_due',
             subscription_id: pastDueSubscription.id,
-            failure_code: failedCharge.failure_code,
-            failure_message: failedCharge.failure_message,
-            latest_invoice: failedCharge.latest_invoice,
+            failure_code: failedChargeCopy.failure_code,
+            failure_message: failedChargeCopy.failure_message,
+            latest_invoice: invoice.number,
           },
         ];
 
         beforeEach(() => {
           sandbox
             .stub(stripeHelper.stripe.charges, 'retrieve')
-            .returns(failedCharge);
+            .returns(failedChargeCopy);
         });
 
         describe('when the charge is already expanded', () => {
           it('includes charge failure information with the subscription data', async () => {
-            const subscription = deepCopy(pastDueSubscription);
-            const invoice = deepCopy(unpaidInvoice);
-            invoice.charge = failedCharge;
+            invoice.charge = failedChargeCopy;
             subscription.latest_invoice = invoice;
 
             const input = { data: [subscription] };
@@ -1334,8 +1336,7 @@ describe('StripeHelper', () => {
 
         describe('when the charge is not expanded', () => {
           it('expands the charge and includes charge failure information with the subscription data', async () => {
-            const subscription = deepCopy(pastDueSubscription);
-            const invoice = deepCopy(unpaidInvoice);
+            invoice.charge = 'ch_123';
             subscription.latest_invoice = invoice;
 
             const input = { data: [subscription] };

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -1373,6 +1373,7 @@ describe('DirectStripeRoutes', () => {
 
             const expected = {
               subscriptions: [],
+              billing_name: customer.sources.data[0].name,
               brand: customer.sources.data[0].brand,
               payment_type: customer.sources.data[0].funding,
               last4: customer.sources.data[0].last4,

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
@@ -26,6 +26,7 @@ const selectedPlan: Plan = {
 };
 
 const customer: Customer = {
+  billing_name: 'Jane Doe',
   payment_type: 'credit',
   last4: '5309',
   exp_month: '02',

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
@@ -27,6 +27,7 @@ const selectedPlan = {
 };
 
 const customer: Customer = {
+  billing_name: 'Jane Doe',
   payment_type: 'credit',
   last4: '5309',
   exp_month: '02',

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -27,7 +27,7 @@ export const wait = (delay: number) =>
 
 export function expectNockScopesDone(scopes: nock.Scope[]) {
   for (const scope of scopes) {
-    if (!scope.isDone()) console.log("SCOPE NOT DONE::::::::", scope);
+    if (!scope.isDone()) console.log('SCOPE NOT DONE::::::::', scope);
     expect(scope.isDone()).toBeTruthy();
   }
 }
@@ -354,7 +354,8 @@ export const MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION = [
 ];
 
 export const MOCK_CUSTOMER = {
-  payment_type: 'tok_1F7TltEOSeHhIAfQo9u6eqTc',
+  billing_name: 'Jane Doe',
+  payment_type: 'card',
   brand: 'Visa',
   last4: '8675',
   exp_month: 8,

--- a/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
@@ -227,6 +227,7 @@ const PLANS: Plan[] = [
 ];
 
 const CUSTOMER: Customer = {
+  billing_name: 'Jane Doe',
   payment_type: 'credit',
   last4: '5309',
   exp_month: '02',

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -291,6 +291,7 @@ const subscribedProps: SubscriptionsProps = {
     loading: false,
     error: null,
     result: {
+      billing_name: 'Jane Doe',
       payment_type: 'card',
       last4: '8675',
       exp_month: '12',

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -82,6 +82,7 @@ export interface CustomerSubscription {
 }
 
 export interface Customer {
+  billing_name: string | null;
   payment_type: string;
   last4: string;
   exp_month: string;


### PR DESCRIPTION
- updated the getCustomer response to include the billing_name
- updated tests and validators

fixes #4612