### PR TITLE
feat(payment-server): update legal checkbox text on payments page

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -85,7 +85,27 @@ payment-cvc =
   .label = CVC
 payment-zip =
   .label = ZIP code
-payment-confirm = I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${ $amount } per { $interval }</strong>, according to payment terms, until I cancel my subscription.
+  
+payment-confirm-day = { $intervalCount -> 
+  [one] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${$amount} daily</strong>, according to payment terms, until I cancel my subscription.
+  *[other] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${$amount} every {$intervalCount} days</strong>, according to payment terms, until I cancel my subscription.
+}
+
+payment-confirm-week = { $intervalCount -> 
+  [one] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${$amount} weekly</strong>, according to payment terms, until I cancel my subscription.
+  *[other] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${$amount} every {$intervalCount} weeks</strong>, according to payment terms, until I cancel my subscription.
+}
+
+payment-confirm-month = { $intervalCount -> 
+  [one] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${$amount} monthly</strong>, according to payment terms, until I cancel my subscription.
+  *[other] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${$amount} every {$intervalCount} months</strong>, according to payment terms, until I cancel my subscription.
+}
+
+payment-confirm-year = { $intervalCount -> 
+  [one] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${$amount} yearly</strong>, according to payment terms, until I cancel my subscription.
+  *[other] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${$amount} every {$intervalCount} years</strong>, according to payment terms, until I cancel my subscription.
+}
+
 payment-cancel-btn = Cancel
 payment-update-btn = Update
 

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
+import TestRenderer from 'react-test-renderer';
 import { render, cleanup, act, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import waitForExpect from 'wait-for-expect';
+import fs from 'fs';
+import path from 'path';
+import { FluentBundle } from 'fluent';
 import { Omit } from '../../lib/types';
+import { Plan } from '../../store/types';
 
 jest.mock('../../lib/sentry');
 
@@ -10,6 +15,7 @@ import {
   mockStripeElementOnChangeFns,
   mockStripeElementOnBlurFns,
   elementChangeResponse,
+  MOCK_PLANS,
 } from '../../lib/test-utils';
 
 import {
@@ -21,6 +27,14 @@ import {
   DEFAULT_LINE_HEIGHT,
 } from './index';
 
+const findMockPlan = (planId: string): Plan => {
+  const plan = MOCK_PLANS.find(x => x.plan_id === planId);
+  if (plan) {
+    return plan;
+  }
+  throw new Error('unable to find suitable Plan object for test execution.');
+};
+
 const MOCK_PLAN = {
   plan_id: 'plan_123',
   plan_name: 'Example Plan',
@@ -29,6 +43,7 @@ const MOCK_PLAN = {
   currency: 'USD',
   amount: 1050,
   interval: 'month',
+  interval_count: 1,
 };
 
 const VALID_CREATE_TOKEN_RESPONSE: stripe.TokenResponse = {
@@ -195,6 +210,298 @@ it('includes the confirmation checkbox when confirm = true and plan supplied', (
     <Subject {...{ confirm: true, plan: MOCK_PLAN }} />
   );
   expect(queryByTestId('confirm')).toBeInTheDocument();
+});
+
+describe('Legal', () => {
+  describe('rendering the legal checkbox Localized component', () => {
+    it('renders Localized for daily plan with correct props and displays correct default string', async () => {
+      const plan_id = 'plan_daily';
+      const plan = findMockPlan(plan_id);
+      const expectedMsgId = 'payment-confirm-day';
+      const expectedMsg =
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to payment terms, until I cancel my subscription.';
+
+      const testRenderer = TestRenderer.create(
+        <Subject {...{ confirm: true, plan: plan }} />
+      );
+      const testInstance = testRenderer.root;
+      const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+      expect(legalCheckbox.props.$amount).toBe('5.00');
+      expect(legalCheckbox.props.$intervalCount).toBe(1);
+      expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+    });
+
+    it('renders Localized for 6 days plan with correct props and displays correct default string', async () => {
+      const plan_id = 'plan_6days';
+      const plan = findMockPlan(plan_id);
+      const expectedMsgId = 'payment-confirm-day';
+      const expectedMsg =
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to payment terms, until I cancel my subscription.';
+
+      const testRenderer = TestRenderer.create(
+        <Subject {...{ confirm: true, plan: plan }} />
+      );
+      const testInstance = testRenderer.root;
+      const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+      expect(legalCheckbox.props.$amount).toBe('5.00');
+      expect(legalCheckbox.props.$intervalCount).toBe(6);
+      expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+    });
+
+    it('renders Localized for weekly plan with correct props and displays correct default string', async () => {
+      const plan_id = 'plan_weekly';
+      const plan = findMockPlan(plan_id);
+      const expectedMsgId = 'payment-confirm-week';
+      const expectedMsg =
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to payment terms, until I cancel my subscription.';
+
+      const testRenderer = TestRenderer.create(
+        <Subject {...{ confirm: true, plan: plan }} />
+      );
+      const testInstance = testRenderer.root;
+      const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+      expect(legalCheckbox.props.$amount).toBe('5.00');
+      expect(legalCheckbox.props.$intervalCount).toBe(1);
+      expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+    });
+
+    it('renders Localized for 6 weeks plan with correct props and displays correct default string', async () => {
+      const plan_id = 'plan_6weeks';
+      const plan = findMockPlan(plan_id);
+      const expectedMsgId = 'payment-confirm-week';
+      const expectedMsg =
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to payment terms, until I cancel my subscription.';
+
+      const testRenderer = TestRenderer.create(
+        <Subject {...{ confirm: true, plan: plan }} />
+      );
+      const testInstance = testRenderer.root;
+      const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+      expect(legalCheckbox.props.$amount).toBe('5.00');
+      expect(legalCheckbox.props.$intervalCount).toBe(6);
+      expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+    });
+
+    it('renders Localized for monthly plan with correct props and displays correct default string', async () => {
+      const plan_id = 'plan_monthly';
+      const plan = findMockPlan(plan_id);
+      const expectedMsgId = 'payment-confirm-month';
+      const expectedMsg =
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to payment terms, until I cancel my subscription.';
+
+      const testRenderer = TestRenderer.create(
+        <Subject {...{ confirm: true, plan: plan }} />
+      );
+      const testInstance = testRenderer.root;
+      const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+      expect(legalCheckbox.props.$amount).toBe('5.00');
+      expect(legalCheckbox.props.$intervalCount).toBe(1);
+      expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+    });
+
+    it('renders Localized for 6 months plan with correct props and displays correct default string', async () => {
+      const plan_id = 'plan_6months';
+      const plan = findMockPlan(plan_id);
+      const expectedMsgId = 'payment-confirm-month';
+      const expectedMsg =
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to payment terms, until I cancel my subscription.';
+
+      const testRenderer = TestRenderer.create(
+        <Subject {...{ confirm: true, plan: plan }} />
+      );
+      const testInstance = testRenderer.root;
+      const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+      expect(legalCheckbox.props.$amount).toBe('5.00');
+      expect(legalCheckbox.props.$intervalCount).toBe(6);
+      expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+    });
+
+    it('renders Localized for yearly plan with correct props and displays correct default string', async () => {
+      const plan_id = 'plan_yearly';
+      const plan = findMockPlan(plan_id);
+      const expectedMsgId = 'payment-confirm-year';
+      const expectedMsg =
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to payment terms, until I cancel my subscription.';
+
+      const testRenderer = TestRenderer.create(
+        <Subject {...{ confirm: true, plan: plan }} />
+      );
+      const testInstance = testRenderer.root;
+      const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+      expect(legalCheckbox.props.$amount).toBe('5.00');
+      expect(legalCheckbox.props.$intervalCount).toBe(1);
+      expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+    });
+
+    it('renders Localized for years plan with correct props and displays correct default string', async () => {
+      const plan_id = 'plan_6years';
+      const plan = findMockPlan(plan_id);
+      const expectedMsgId = 'payment-confirm-year';
+      const expectedMsg =
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to payment terms, until I cancel my subscription.';
+
+      const testRenderer = TestRenderer.create(
+        <Subject {...{ confirm: true, plan: plan }} />
+      );
+      const testInstance = testRenderer.root;
+      const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+      expect(legalCheckbox.props.$amount).toBe('5.00');
+      expect(legalCheckbox.props.$intervalCount).toBe(6);
+      expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+    });
+  });
+
+  describe('Fluent Localized Text', () => {
+    let bundle: FluentBundle;
+    const args = {
+      amount: '5.00',
+    };
+
+    beforeEach(async () => {
+      const filepath = path.join(
+        __dirname,
+        '..',
+        '..',
+        '..',
+        'public',
+        'locales',
+        'en-US',
+        'main.ftl'
+      );
+
+      const enUS = (await fs.readFileSync(filepath)).toString();
+      bundle = new FluentBundle('en-US');
+      bundle.addMessages(enUS);
+    });
+
+    describe('when the localized id is payment-confirm-day', () => {
+      const msgID = 'payment-confirm-day';
+
+      it('returns the correct string for an interval count of 1', () => {
+        const expected =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to payment terms, until I cancel my subscription.';
+
+        const msg = bundle.getMessage(msgID);
+        const actual = bundle.format(msg, {
+          ...args,
+          intervalCount: 1,
+        });
+
+        expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+      });
+
+      it('returns the correct string for an interval count greater than 1', () => {
+        const expected =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to payment terms, until I cancel my subscription.';
+
+        const msg = bundle.getMessage(msgID);
+        const actual = bundle.format(msg, {
+          ...args,
+          intervalCount: 6,
+        });
+
+        expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+      });
+    });
+
+    describe('when the localized id is payment-confirm-week', () => {
+      const msgID = 'payment-confirm-week';
+
+      it('returns the correct string for an interval count of 1', () => {
+        const expected =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to payment terms, until I cancel my subscription.';
+
+        const msg = bundle.getMessage(msgID);
+        const actual = bundle.format(msg, {
+          ...args,
+          intervalCount: 1,
+        });
+
+        expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+      });
+
+      it('returns the correct string for an interval count greater than 1', () => {
+        const expected =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to payment terms, until I cancel my subscription.';
+
+        const msg = bundle.getMessage(msgID);
+        const actual = bundle.format(msg, {
+          ...args,
+          intervalCount: 6,
+        });
+
+        expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+      });
+    });
+
+    describe('when the localized id is payment-confirm-month', () => {
+      const msgID = 'payment-confirm-month';
+
+      it('returns the correct string for an interval count of 1', () => {
+        const expected =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to payment terms, until I cancel my subscription.';
+
+        const msg = bundle.getMessage(msgID);
+        const actual = bundle.format(msg, {
+          ...args,
+          intervalCount: 1,
+        });
+
+        expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+      });
+
+      it('returns the correct string for an interval count greater than 1', async () => {
+        const expected =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to payment terms, until I cancel my subscription.';
+
+        const msg = bundle.getMessage(msgID);
+        const actual = bundle.format(msg, {
+          ...args,
+          intervalCount: 6,
+        });
+
+        expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+      });
+    });
+
+    describe('when the localized id is payment-confirm-year', () => {
+      const msgID = 'payment-confirm-year';
+
+      it('returns the correct string for an interval count of 1', () => {
+        const expected =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to payment terms, until I cancel my subscription.';
+
+        const msg = bundle.getMessage(msgID);
+        const actual = bundle.format(msg, {
+          ...args,
+          intervalCount: 1,
+        });
+
+        expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+      });
+
+      it('returns the correct string for an interval count greater than 1', () => {
+        const expected =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to payment terms, until I cancel my subscription.';
+
+        const msg = bundle.getMessage(msgID);
+        const actual = bundle.format(msg, {
+          ...args,
+          intervalCount: 6,
+        });
+
+        expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+      });
+    });
+  });
 });
 
 it('renders a progress spinner when submitted, disables further submission (issue #4386 / FXA-1275)', async () => {

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -56,6 +56,32 @@ export type PaymentFormProps = {
   submitNonce: string;
 };
 
+function getDefaultPaymentConfirmText(
+  amount: number,
+  interval: string,
+  intervalCount: number
+) {
+  const pre = `I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$${formatCurrencyInCents(
+    amount
+  )}`;
+  const post =
+    '</strong>, according to payment terms, until I cancel my subscription.';
+  switch (interval) {
+    case 'day':
+      if (intervalCount === 1) return `${pre} daily${post}`;
+      return `${pre} every ${intervalCount} days${post}`;
+    case 'week':
+      if (intervalCount === 1) return `${pre} weekly${post}`;
+      return `${pre} every ${intervalCount} weeks${post}`;
+    case 'month':
+      if (intervalCount === 1) return `${pre} monthly${post}`;
+      return `${pre} every ${intervalCount} months${post}`;
+    case 'year':
+      if (intervalCount === 1) return `${pre} yearly${post}`;
+      return `${pre} every ${intervalCount} years${post}`;
+  }
+}
+
 export const PaymentForm = ({
   inProgress = false,
   confirm = true,
@@ -204,18 +230,17 @@ export const PaymentForm = ({
 
       {confirm && plan && (
         <Localized
-          id="payment-confirm"
-          $interval={plan.interval}
+          id={`payment-confirm-${plan.interval}`}
+          $intervalCount={plan.interval_count}
           $amount={formatCurrencyInCents(plan.amount)}
           strong={<strong></strong>}
         >
           <Checkbox data-testid="confirm" name="confirm" required>
-            I authorize Mozilla, maker of Firefox products, to charge my payment
-            method{' '}
-            <strong>
-              ${`${formatCurrencyInCents(plan.amount)} per ${plan.interval}`}
-            </strong>
-            , according to payment terms, until I cancel my subscription.
+            {getDefaultPaymentConfirmText(
+              plan.amount,
+              plan.interval,
+              plan.interval_count
+            )}
           </Checkbox>
         </Localized>
       )}


### PR DESCRIPTION
- updated legal checkbox text on payment confirmation page to handle various billing intervals and interval counts

issue #3987