### PR TITLE
fix(metrics): return the mocked statsd instance

### DIFF
--- a/packages/fxa-content-server/server/lib/statsd.js
+++ b/packages/fxa-content-server/server/lib/statsd.js
@@ -15,6 +15,7 @@ const noopStatsd = () => {
       mock[x] = NOOP;
     }
   });
+  return mock;
 };
 
 const statsd = config.enabled


### PR DESCRIPTION
When statsd metrics are disabled on the content server, a mocked object
with NOOP functions is used.  However, there was a bug where the object
was not returned from the function where it was created.

@mozilla/fxa-devs r?