### PR TITLE
feat(payment-server): update legal checkbox text on tiers page

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -130,10 +130,27 @@ sub-update-copy =
     Your plan will change immediately, and you’ll be charged an adjusted
     amount for the rest of your billing cycle. Starting { $startingDate }
     you’ll be charged the full amount.
-sub-update-confirm =
-    I authorize Mozilla, maker of Firefox products, to charge my payment
-    <strong>${ $amount }/{ $interval }</strong>
-    , according to payment terms, until I cancel my subscription.
+
+sub-update-confirm-day = { $intervalCount -> 
+  [one] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${ $amount } daily</strong>, according to payment terms, until I cancel my subscription.
+  *[other] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${ $amount } every {$intervalCount} days</strong>, according to payment terms, until I cancel my subscription.
+}
+
+sub-update-confirm-week = { $intervalCount -> 
+  [one] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${ $amount } weekly</strong>, according to payment terms, until I cancel my subscription.
+  *[other] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${ $amount } every {$intervalCount} weeks</strong>, according to payment terms, until I cancel my subscription.
+}
+
+sub-update-confirm-month = { $intervalCount -> 
+  [one] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${ $amount } monthly</strong>, according to payment terms, until I cancel my subscription.
+  *[other] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${ $amount } every {$intervalCount} months</strong>, according to payment terms, until I cancel my subscription.
+}
+
+sub-update-confirm-year = { $intervalCount -> 
+  [one] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${ $amount } yearly</strong>, according to payment terms, until I cancel my subscription.
+  *[other] I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${ $amount } every {$intervalCount} years</strong>, according to payment terms, until I cancel my subscription.
+}
+
 sub-update-submit = Change Plans
 sub-update-indicator =
   .aria-label = upgrade indicator

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import { render, cleanup, act, fireEvent } from '@testing-library/react';
+import TestRenderer from 'react-test-renderer';
+import { render, cleanup, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import fs from 'fs';
+import path from 'path';
+import { FluentBundle } from 'fluent';
 
 import { APIError } from '../../../lib/apiClient';
+import { Plan } from '../../../store/types';
 
 jest.mock('../../../lib/sentry');
 
@@ -12,13 +17,21 @@ import {
 } from '../../../lib/amplitude';
 jest.mock('../../../lib/amplitude');
 
-import { MockApp } from '../../../lib/test-utils';
+import { MockApp, MOCK_PLANS } from '../../../lib/test-utils';
 
 import { PROFILE, CUSTOMER, SELECTED_PLAN, UPGRADE_FROM_PLAN } from './mocks';
 
 import { SignInLayout } from '../../../components/AppLayout';
 
 import SubscriptionUpgrade, { SubscriptionUpgradeProps } from './index';
+
+const findMockPlan = (planId: string): Plan => {
+  const plan = MOCK_PLANS.find(x => x.plan_id === planId);
+  if (plan) {
+    return plan;
+  }
+  throw new Error('unable to find suitable Plan object for test execution.');
+};
 
 describe('routes/Product/SubscriptionUpgrade', () => {
   afterEach(() => {
@@ -110,6 +123,344 @@ describe('routes/Product/SubscriptionUpgrade', () => {
     fireEvent.click(getByTestId('confirm'));
     expect(updateSubscriptionPlanMounted).toBeCalledTimes(1);
     expect(updateSubscriptionPlanEngaged).toBeCalledTimes(1);
+  });
+
+  describe('Legal', () => {
+    describe('rendering the legal checkbox Localized component', () => {
+      const baseProps = {
+        customer: CUSTOMER,
+        profile: PROFILE,
+        upgradeFromPlan: UPGRADE_FROM_PLAN,
+        upgradeFromSubscription: CUSTOMER.subscriptions[0],
+        updateSubscriptionPlanStatus: {
+          error: null,
+          loading: false,
+          result: null,
+        },
+        updateSubscriptionPlanAndRefresh: jest.fn(),
+        resetUpdateSubscriptionPlan: jest.fn(),
+      };
+
+      it('renders Localized for daily plan with correct props and displays correct default string', async () => {
+        const plan_id = 'plan_daily';
+        const plan = findMockPlan(plan_id);
+        const expectedMsgId = 'sub-update-confirm-day';
+        const expectedMsg =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to payment terms, until I cancel my subscription.';
+
+        const props = {
+          ...baseProps,
+          selectedPlan: plan,
+        };
+        const testRenderer = TestRenderer.create(
+          <SubscriptionUpgrade {...props} />
+        );
+        const testInstance = testRenderer.root;
+        const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+        expect(legalCheckbox.props.$amount).toBe('5.00');
+        expect(legalCheckbox.props.$intervalCount).toBe(1);
+        expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+      });
+
+      it('renders Localized for 6 days plan with correct props and displays correct default string', async () => {
+        const plan_id = 'plan_6days';
+        const plan = findMockPlan(plan_id);
+        const expectedMsgId = 'sub-update-confirm-day';
+        const expectedMsg =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to payment terms, until I cancel my subscription.';
+
+        const props = {
+          ...baseProps,
+          selectedPlan: plan,
+        };
+        const testRenderer = TestRenderer.create(
+          <SubscriptionUpgrade {...props} />
+        );
+        const testInstance = testRenderer.root;
+        const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+        expect(legalCheckbox.props.$amount).toBe('5.00');
+        expect(legalCheckbox.props.$intervalCount).toBe(6);
+        expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+      });
+
+      it('renders Localized for weekly plan with correct props and displays correct default string', async () => {
+        const plan_id = 'plan_weekly';
+        const plan = findMockPlan(plan_id);
+        const expectedMsgId = 'sub-update-confirm-week';
+        const expectedMsg =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to payment terms, until I cancel my subscription.';
+
+        const props = {
+          ...baseProps,
+          selectedPlan: plan,
+        };
+        const testRenderer = TestRenderer.create(
+          <SubscriptionUpgrade {...props} />
+        );
+        const testInstance = testRenderer.root;
+        const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+        expect(legalCheckbox.props.$amount).toBe('5.00');
+        expect(legalCheckbox.props.$intervalCount).toBe(1);
+        expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+      });
+
+      it('renders Localized for 6 weeks plan with correct props and displays correct default string', async () => {
+        const plan_id = 'plan_6weeks';
+        const plan = findMockPlan(plan_id);
+        const expectedMsgId = 'sub-update-confirm-week';
+        const expectedMsg =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to payment terms, until I cancel my subscription.';
+
+        const props = {
+          ...baseProps,
+          selectedPlan: plan,
+        };
+        const testRenderer = TestRenderer.create(
+          <SubscriptionUpgrade {...props} />
+        );
+        const testInstance = testRenderer.root;
+        const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+        expect(legalCheckbox.props.$amount).toBe('5.00');
+        expect(legalCheckbox.props.$intervalCount).toBe(6);
+        expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+      });
+
+      it('renders Localized for monthly plan with correct props and displays correct default string', async () => {
+        const plan_id = 'plan_monthly';
+        const plan = findMockPlan(plan_id);
+        const expectedMsgId = 'sub-update-confirm-month';
+        const expectedMsg =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to payment terms, until I cancel my subscription.';
+
+        const props = {
+          ...baseProps,
+          selectedPlan: plan,
+        };
+        const testRenderer = TestRenderer.create(
+          <SubscriptionUpgrade {...props} />
+        );
+        const testInstance = testRenderer.root;
+        const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+        expect(legalCheckbox.props.$amount).toBe('5.00');
+        expect(legalCheckbox.props.$intervalCount).toBe(1);
+        expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+      });
+
+      it('renders Localized for 6 months plan with correct props and displays correct default string', async () => {
+        const plan_id = 'plan_6months';
+        const plan = findMockPlan(plan_id);
+        const expectedMsgId = 'sub-update-confirm-month';
+        const expectedMsg =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to payment terms, until I cancel my subscription.';
+
+        const props = {
+          ...baseProps,
+          selectedPlan: plan,
+        };
+        const testRenderer = TestRenderer.create(
+          <SubscriptionUpgrade {...props} />
+        );
+        const testInstance = testRenderer.root;
+        const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+        expect(legalCheckbox.props.$amount).toBe('5.00');
+        expect(legalCheckbox.props.$intervalCount).toBe(6);
+        expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+      });
+
+      it('renders Localized for yearly plan with correct props and displays correct default string', async () => {
+        const plan_id = 'plan_yearly';
+        const plan = findMockPlan(plan_id);
+        const expectedMsgId = 'sub-update-confirm-year';
+        const expectedMsg =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to payment terms, until I cancel my subscription.';
+
+        const props = {
+          ...baseProps,
+          selectedPlan: plan,
+        };
+        const testRenderer = TestRenderer.create(
+          <SubscriptionUpgrade {...props} />
+        );
+        const testInstance = testRenderer.root;
+        const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+        expect(legalCheckbox.props.$amount).toBe('5.00');
+        expect(legalCheckbox.props.$intervalCount).toBe(1);
+        expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+      });
+
+      it('renders Localized for years plan with correct props and displays correct default string', async () => {
+        const plan_id = 'plan_6years';
+        const plan = findMockPlan(plan_id);
+        const expectedMsgId = 'sub-update-confirm-year';
+        const expectedMsg =
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to payment terms, until I cancel my subscription.';
+
+        const props = {
+          ...baseProps,
+          selectedPlan: plan,
+        };
+        const testRenderer = TestRenderer.create(
+          <SubscriptionUpgrade {...props} />
+        );
+        const testInstance = testRenderer.root;
+        const legalCheckbox = testInstance.findByProps({ id: expectedMsgId });
+
+        expect(legalCheckbox.props.$amount).toBe('5.00');
+        expect(legalCheckbox.props.$intervalCount).toBe(6);
+        expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+      });
+    });
+
+    describe('Fluent Localized Text', () => {
+      let bundle: FluentBundle;
+      const args = {
+        amount: '5.00',
+      };
+
+      beforeEach(async () => {
+        const filepath = path.join(
+          __dirname,
+          '..',
+          '..',
+          '..',
+          '..',
+          'public',
+          'locales',
+          'en-US',
+          'main.ftl'
+        );
+        const enUS = (await fs.readFileSync(filepath)).toString();
+        bundle = new FluentBundle('en-US');
+        bundle.addMessages(enUS);
+      });
+
+      describe('when the localized id is sub-update-confirm-day', () => {
+        const msgID = 'sub-update-confirm-day';
+
+        it('returns the correct string for an interval count of 1', () => {
+          const expected =
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to payment terms, until I cancel my subscription.';
+
+          const msg = bundle.getMessage(msgID);
+          const actual = bundle.format(msg, {
+            ...args,
+            intervalCount: 1,
+          });
+
+          expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+        });
+
+        it('returns the correct string for an interval count greater than 1', () => {
+          const expected =
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to payment terms, until I cancel my subscription.';
+
+          const msg = bundle.getMessage(msgID);
+          const actual = bundle.format(msg, {
+            ...args,
+            intervalCount: 6,
+          });
+
+          expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+        });
+      });
+
+      describe('when the localized id is sub-update-confirm-week', () => {
+        const msgID = 'sub-update-confirm-week';
+
+        it('returns the correct string for an interval count of 1', () => {
+          const expected =
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to payment terms, until I cancel my subscription.';
+
+          const msg = bundle.getMessage(msgID);
+          const actual = bundle.format(msg, {
+            ...args,
+            intervalCount: 1,
+          });
+
+          expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+        });
+
+        it('returns the correct string for an interval count greater than 1', () => {
+          const expected =
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to payment terms, until I cancel my subscription.';
+
+          const msg = bundle.getMessage(msgID);
+          const actual = bundle.format(msg, {
+            ...args,
+            intervalCount: 6,
+          });
+
+          expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+        });
+      });
+
+      describe('when the localized id is sub-update-confirm-month', () => {
+        const msgID = 'sub-update-confirm-month';
+
+        it('returns the correct string for an interval count of 1', () => {
+          const expected =
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to payment terms, until I cancel my subscription.';
+
+          const msg = bundle.getMessage(msgID);
+          const actual = bundle.format(msg, {
+            ...args,
+            intervalCount: 1,
+          });
+
+          expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+        });
+
+        it('returns the correct string for an interval count greater than 1', () => {
+          const expected =
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to payment terms, until I cancel my subscription.';
+
+          const msg = bundle.getMessage(msgID);
+          const actual = bundle.format(msg, {
+            ...args,
+            intervalCount: 6,
+          });
+
+          expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+        });
+      });
+
+      describe('when the localized id is sub-update-confirm-year', () => {
+        const msgID = 'sub-update-confirm-year';
+
+        it('returns the correct string for an interval count of 1', () => {
+          const expected =
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to payment terms, until I cancel my subscription.';
+
+          const msg = bundle.getMessage(msgID);
+          const actual = bundle.format(msg, {
+            ...args,
+            intervalCount: 1,
+          });
+
+          expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+        });
+
+        it('returns the correct string for an interval count greater than 1', () => {
+          const expected =
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to payment terms, until I cancel my subscription.';
+
+          const msg = bundle.getMessage(msgID);
+          const actual = bundle.format(msg, {
+            ...args,
+            intervalCount: 6,
+          });
+
+          expect(actual.replace(/(\u2068|\u2069)/gu, '')).toEqual(expected);
+        });
+      });
+    });
   });
 });
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -29,6 +29,32 @@ import './index.scss';
 
 import { ProductProps } from '../index';
 
+function getDefaultConfirmText(
+  amount: number,
+  interval: string,
+  intervalCount: number
+) {
+  const pre = `I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$${formatCurrencyInCents(
+    amount
+  )}`;
+  const post =
+    '</strong>, according to payment terms, until I cancel my subscription.';
+  switch (interval) {
+    case 'day':
+      if (intervalCount === 1) return `${pre} daily${post}`;
+      return `${pre} every ${intervalCount} days${post}`;
+    case 'week':
+      if (intervalCount === 1) return `${pre} weekly${post}`;
+      return `${pre} every ${intervalCount} weeks${post}`;
+    case 'month':
+      if (intervalCount === 1) return `${pre} monthly${post}`;
+      return `${pre} every ${intervalCount} months${post}`;
+    case 'year':
+      if (intervalCount === 1) return `${pre} yearly${post}`;
+      return `${pre} every ${intervalCount} years${post}`;
+  }
+}
+
 export type SubscriptionUpgradeProps = {
   customer: Customer;
   profile: Profile;
@@ -183,21 +209,17 @@ export const SubscriptionUpgrade = ({
           required
         >
           <Localized
-            id="sub-update-confirm"
+            id={`sub-update-confirm-${selectedPlan.interval}`}
             strong={<strong></strong>}
             $amount={formatCurrencyInCents(selectedPlan.amount)}
-            $interval={selectedPlan.interval}
+            $intervalCount={selectedPlan.interval_count}
           >
             <p>
-              I authorize Mozilla, maker of Firefox products, to charge my
-              payment method{' '}
-              <strong>
-                $
-                {`${formatCurrencyInCents(selectedPlan.amount)}/${
-                  selectedPlan.interval
-                }`}
-              </strong>
-              , according to payment terms, until I cancel my subscription.
+              {getDefaultConfirmText(
+                selectedPlan.amount,
+                selectedPlan.interval,
+                selectedPlan.interval_count
+              )}
             </p>
           </Localized>
         </Checkbox>


### PR DESCRIPTION
- updated legal checkbox text on subscription upgrade confirmation page to handle various billing intervals and interval counts

issue #3987