### PR TITLE
fix(payment-server): configure DSN later

### DIFF
--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -81,6 +81,7 @@ module.exports = () => {
     stripe: {
       apiKey: config.get('stripe.apiKey'),
     },
+    version: version.version,
   };
 
   // This is a list of all the paths that should resolve to index.html:

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -6,7 +6,7 @@ import { Localized } from 'fluent-react';
 import DocumentTitle from 'react-document-title';
 
 import AppLocalizationProvider from './lib/AppLocalizationProvider';
-import SentryMetrics from './lib/sentry';
+import sentryMetrics from './lib/sentry';
 import { QueryParams } from './lib/types';
 import { Config, config } from './lib/config';
 import { getErrorMessage } from './lib/errors';
@@ -25,8 +25,6 @@ const Subscriptions = React.lazy(() => import('./routes/Subscriptions'));
 
 // TODO: Come up with a better fallback component for lazy-loaded routes
 const RouteFallback = () => <LoadingOverlay isLoading={true} />;
-
-const sentryMetrics = new SentryMetrics(config.sentry.dsn);
 
 type AppProps = {
   config: Config;

--- a/packages/fxa-payments-server/src/index.tsx
+++ b/packages/fxa-payments-server/src/index.tsx
@@ -8,11 +8,13 @@ import './index.scss';
 import * as Amplitude from './lib/amplitude';
 import App from './App';
 import ScreenInfo from './lib/screen-info';
+import sentryMetrics from './lib/sentry';
 
 import { actions } from './store/actions';
 
 async function init() {
   readConfigFromMeta(headQuerySelector);
+  sentryMetrics.configure(config.sentry.dsn, config.version);
 
   const store = createAppStore();
 

--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -1,10 +1,8 @@
-import SentryMetrics from './sentry';
+import sentryMetrics from './sentry';
 import { logAmplitudeEvent } from './flow-event';
 import { config } from './config';
 import { selectors } from '../store/selectors';
 import { Store } from '../store';
-
-const sentryMetrics = new SentryMetrics(config.sentry.dsn);
 
 const eventGroupNames = {
   createSubscription: 'subPaySetup',

--- a/packages/fxa-payments-server/src/lib/config.ts
+++ b/packages/fxa-payments-server/src/lib/config.ts
@@ -35,6 +35,7 @@ export interface Config {
   stripe: {
     apiKey: string;
   };
+  version: string | undefined;
 }
 
 export const config: Config = defaultConfig();
@@ -73,6 +74,7 @@ export function defaultConfig(): Config {
     stripe: {
       apiKey: '',
     },
+    version: undefined,
   };
 }
 

--- a/packages/fxa-payments-server/src/lib/flow-event.test.ts
+++ b/packages/fxa-payments-server/src/lib/flow-event.test.ts
@@ -1,7 +1,6 @@
 import FlowEvent from './flow-event';
 
-import SentryMetrics from './sentry';
-jest.mock('./sentry');
+import sentryMetrics from './sentry';
 
 const eventGroup = 'testo';
 const eventType = 'quuz';
@@ -36,6 +35,9 @@ it('remains uninitialized when any flow param is empty', () => {
 });
 
 it('logs and captures an exception from postMetrics', () => {
+  const mockCapture = jest
+    .spyOn(sentryMetrics, 'captureException')
+    .mockImplementation();
   const error = 'oops';
   (window.navigator.sendBeacon as jest.Mock).mockImplementation(() => {
     throw error;
@@ -46,9 +48,7 @@ it('logs and captures an exception from postMetrics', () => {
     flow_id: 'ipsoandfacto',
   });
   FlowEvent.logAmplitudeEvent(eventGroup, eventType, {});
-  expect(
-    (SentryMetrics as jest.Mock).mock.instances[0].captureException
-  ).toBeCalledWith(error);
+  expect(mockCapture).toBeCalledWith(error);
   expect(global.console.error).toBeCalledWith('AppError', error);
 });
 

--- a/packages/fxa-payments-server/src/lib/flow-event.ts
+++ b/packages/fxa-payments-server/src/lib/flow-event.ts
@@ -1,7 +1,5 @@
-import SentryMetrics from './sentry';
+import sentryMetrics from './sentry';
 import { config } from './config';
-
-const sentryMetrics = new SentryMetrics(config.sentry.dsn);
 
 interface FlowEventParams {
   device_id?: string;

--- a/packages/fxa-payments-server/src/lib/sentry.test.js
+++ b/packages/fxa-payments-server/src/lib/sentry.test.js
@@ -4,7 +4,7 @@
 
 import chai from 'chai';
 import * as Sentry from '@sentry/browser';
-import SentryMetrics from './sentry';
+import sentryMetrics from './sentry';
 
 var assert = chai.assert;
 const dsn = 'https://public:private@host:port/1';
@@ -20,17 +20,9 @@ describe('lib/sentry', function() {
   });
 
   describe('init', function() {
-    it('properly inits', function() {
+    it('properly configures with dsn', function() {
       try {
-        void new SentryMetrics();
-      } catch (e) {
-        assert.isNull(e);
-      }
-    });
-
-    it('properly inits with dsn', function() {
-      try {
-        void new SentryMetrics(dsn);
+        sentryMetrics.configure(dsn);
       } catch (e) {
         assert.isNull(e);
       }
@@ -38,12 +30,13 @@ describe('lib/sentry', function() {
   });
 
   describe('beforeSend', function() {
+    sentryMetrics.configure(dsn);
+
     it('works without request url', function() {
       var data = {
         key: 'value',
       };
-      var sentry = new SentryMetrics(dsn);
-      var resultData = sentry.__beforeSend(data);
+      var resultData = sentryMetrics.__beforeSend(data);
 
       assert.equal(data, resultData);
     });
@@ -58,8 +51,7 @@ describe('lib/sentry', function() {
           errno: 100,
         },
       };
-      var sentry = new SentryMetrics(dsn);
-      var resultData = sentry.__beforeSend(data);
+      var resultData = sentryMetrics.__beforeSend(data);
 
       assert.equal(
         resultData.fingerprint[0],
@@ -86,8 +78,7 @@ describe('lib/sentry', function() {
         },
       };
 
-      var sentry = new SentryMetrics(dsn);
-      var resultData = sentry.__beforeSend(badData);
+      var resultData = sentryMetrics.__beforeSend(badData);
 
       assert.equal(resultData.key, goodData.key);
       assert.equal(resultData.url, goodData.url);
@@ -114,8 +105,7 @@ describe('lib/sentry', function() {
         },
       };
 
-      var sentry = new SentryMetrics(dsn);
-      var resultData = sentry.__beforeSend(badData);
+      var resultData = sentryMetrics.__beforeSend(badData);
       assert.equal(
         resultData.request.headers.Referer,
         goodData.request.headers.Referer
@@ -152,8 +142,7 @@ describe('lib/sentry', function() {
         },
       };
 
-      var sentry = new SentryMetrics(dsn);
-      var resultData = sentry.__beforeSend(data);
+      var resultData = sentryMetrics.__beforeSend(data);
 
       assert.equal(
         resultData.exception.values[0].stacktrace.frames[0].abs_path,
@@ -172,8 +161,7 @@ describe('lib/sentry', function() {
         'https://accounts.firefox.com/complete_reset_password?token=foo&code=bar&email=some%40restmail.net';
       var expectedUrl1 =
         'https://accounts.firefox.com/complete_reset_password?token=VALUE&code=VALUE&email=VALUE';
-      var sentry = new SentryMetrics(dsn);
-      var resultUrl1 = sentry.__cleanUpQueryParam(fixtureUrl1);
+      var resultUrl1 = sentryMetrics.__cleanUpQueryParam(fixtureUrl1);
 
       assert.equal(resultUrl1, expectedUrl1);
     });
@@ -183,16 +171,14 @@ describe('lib/sentry', function() {
         'https://accounts.firefox.com/signup?client_id=foo&service=sync';
       var expectedUrl2 =
         'https://accounts.firefox.com/signup?client_id=foo&service=sync';
-      var sentry = new SentryMetrics(dsn);
-      var resultUrl2 = sentry.__cleanUpQueryParam(fixtureUrl2);
+      var resultUrl2 = sentryMetrics.__cleanUpQueryParam(fixtureUrl2);
 
       assert.equal(resultUrl2, expectedUrl2);
     });
 
     it('properly returns the url when there is no query', function() {
       var expectedUrl = 'https://accounts.firefox.com/signup';
-      var sentry = new SentryMetrics(dsn);
-      var resultUrl = sentry.__cleanUpQueryParam(expectedUrl);
+      var resultUrl = sentryMetrics.__cleanUpQueryParam(expectedUrl);
 
       assert.equal(resultUrl, expectedUrl);
     });
@@ -201,8 +187,7 @@ describe('lib/sentry', function() {
   describe('captureException', () => {
     it('calls Sentry.captureException', () => {
       jest.spyOn(Sentry, 'captureException');
-      const sentry = new SentryMetrics(dsn);
-      sentry.captureException(new Error('testo'));
+      sentryMetrics.captureException(new Error('testo'));
       expect(Sentry.captureException).toHaveBeenCalled();
       Sentry.captureException.mockRestore();
     });


### PR DESCRIPTION
Because:

* Sentry was being configured at import time before the config had been
  loaded.

This commit:

* Switches the SentryMetrics default export to be a sentryMetrics
  singleton that can be configured after the config is loaded.

Fixes #4531