### PR TITLE
fix(docker): Improve detection of Docker running on Windows.

### DIFF
--- a/_scripts/syncserver.sh
+++ b/_scripts/syncserver.sh
@@ -2,7 +2,7 @@
 
 DOCKER_OS="`docker info --format '{{.OperatingSystem}}'`"
 
-if [ "$DOCKER_OS" = 'Docker for Windows' -o "$DOCKER_OS" = 'Docker for Mac' ]; then
+if [ "$DOCKER_OS" = 'Docker for Windows' -o "$DOCKER_OS" = 'Docker for Mac' -o "$DOCKER_OS" = 'Docker Desktop' ]; then
   HOST_ADDR='host.docker.internal'
 else
   HOST_ADDR='127.0.0.1'


### PR DESCRIPTION
Because:

* When running the syncserver docker image for local development, we need to
  configure it with a different verifier URL depending on whether it can reach
  the verifier process over localhost (which it can on Linux) or whether it
  needs to talk to a special hostname (necessary on Mac and Windows).
* The latest Docker Desktop for Windows seems to report its operating system
  as "Docker Desktop" rathert than anything with the word "Windows" in it.

This commit:

* Treats "Docker Desktop" as another case where we have to the special hostname
  for accessing other services running under docker.
* Works on my machine, but hasn't been tested on yours.