### PR TITLE
chore(config): Default to a useable Fenix OAuth config in local dev

### DIFF
--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -18,7 +18,17 @@
     "level": "debug"
   },
   "scopedKeys": {
-    "enabled": true
+    "enabled": true,
+    "validation": {
+      "https://identity.mozilla.com/apps/oldsync": {
+        "redirectUris": [
+         "http://127.0.0.1:3030/oauth/success/a2270f727f45f648",
+         "http://127.0.0.1:3030/oauth/success/1b1a3e44c54fbb58",
+         "urn:ietf:wg:oauth:2.0:oob:pair-auth-webchannel",
+         "urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel"
+        ]
+      }
+    }
   },
   "static_directory": "app",
   "subscriptions": {


### PR DESCRIPTION
Because:

* The fxa-auth-server dev config defaults Fenix and Firefox-iOS to
  using OAuth redirect URIs on https://127.0.0.1:3030.
* The fxa-content-server dev config defaults to checking OAuth scoped
  key access against production OAuth redirect URIs.
* The resulting mis-match means you can't sign in to Fenix using
  a local dev server in the default config.

This commit:

* Changes the default local config for fxa-content-server to check
  OAuth scoped key access against the development OAuth redirect URIs.