### PR TITLE
feat(email): add rel="noopener noreferrer" to any email links that have target="_blank"

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1935,7 +1935,7 @@ module.exports = function(log, config, oauthdb) {
       templateName,
       'account-settings'
     );
-    links.accountSettingsLinkAttributes = `href="${links.accountSettingsUrl}" target="_blank" style="color:#ffffff;font-weight:500;"`;
+    links.accountSettingsLinkAttributes = `href="${links.accountSettingsUrl}" target="_blank" rel="noopener noreferrer" style="color:#ffffff;font-weight:500;"`;
     links.subscriptionTermsUrl = this._generateUTMLink(
       this.subscriptionTermsUrl,
       {},

--- a/packages/fxa-auth-server/lib/senders/templates/layouts/subscription.html
+++ b/packages/fxa-auth-server/lib/senders/templates/layouts/subscription.html
@@ -267,12 +267,14 @@
                                         <a
                                           href="{{{subscriptionTermsUrl}}}"
                                           target="_blank"
+                                          rel="noopener noreferrer"
                                           style="color:#ffffff;font-weight:500;"
                                           alias="TermsofService"
                                           >{{t "Terms and cancellation policy" }}</a>
                                           &nbsp;&nbsp;&#8226;&nbsp;&nbsp;<a
                                           href="{{{cancelSubscriptionUrl}}}"
                                           target="_blank"
+                                          rel="noopener noreferrer"
                                           style="color:#ffffff;font-weight:normal;"
                                           alias="CancelSubscription"
                                           >{{t "Cancel subscription" }}</a
@@ -280,6 +282,7 @@
                                         <a
                                           href="{{{updateBillingUrl}}}"
                                           target="_blank"
+                                          rel="noopener noreferrer"
                                           style="color:#ffffff;font-weight:500;"
                                           alias="UpdateBillingInformation"
                                           >{{t "Update billing information" }}</a
@@ -299,6 +302,7 @@
                                           href="https://www.mozilla.org"
                                           alias="footer_newwater"
                                           target="_blank"
+                                          rel="noopener noreferrer"
                                           ><img
                                             src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/5/75347105-3854-4a13-902c-4b45cd80bf54.png"
                                             alt="Mozilla"
@@ -314,12 +318,14 @@
                                         <a
                                           href="https://www.mozilla.org/about/legal/terms/services/"
                                           target="_blank"
+                                          rel="noopener noreferrer"
                                           style="color:#ffffff;font-weight:500;"
                                           alias="textlink1"
                                           >{{t "Legal" }}</a
                                         >&nbsp;&nbsp;&#8226;&nbsp;&nbsp;<a
                                           href="{{{privacyUrl}}}"
                                           target="_blank"
+                                          rel="noopener noreferrer"
                                           style="color:#ffffff;font-weight:normal;"
                                           alias="textlink2"
                                           >{{t "Privacy" }}</a


### PR DESCRIPTION
Closes #4591

This attempts to address a potential attack vector where clicking a link can redirect you to a malicious website. More info: https://dev.to/dhilipkmr/why-should-you-use-noopener-beware-of-security-flaws-3i57

This sort of attack is less likely to occur in email, but is technically still possible in a web client. More info: https://stackoverflow.com/a/51194051/717633