### PR TITLE
fix(settings): wrap overflowing settings group headers so they don't break layout

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -282,13 +282,13 @@ body.settings #stage .settings {
 .settings-unit-stub {
   align-items: center;
   display: flex;
-  height: 72px;
+  min-height: 72px;
 
   @include respond-to('big') {
-    padding: 0 32px;
+    padding: 16px 32px;
   }
   @include respond-to('small') {
-    padding: 0 16px;
+    padding: 18px 16px;
   }
 
   .settings-unit-summary {
@@ -331,15 +331,8 @@ body.settings #stage .settings {
     margin: 5px 0 0 0;
   }
 
-  .settings-unit-title,
-  .settings-unit-subtitle {
-    text-overflow: ellipsis;
-    text-wrap: nowrap;
-    white-space: nowrap;
-  }
-
   .settings-unit-title:only-child {
-    line-height: 35px;
+    line-height: 26px;
   }
 }
 


### PR DESCRIPTION
Addresses https://github.com/mozilla-mobile/firefox-ios/issues/6130

In English none of our settings titles are long enough to bump up against the right side button. Lucky us. However in localized versions of the settings panel these titles can get quite long. Currently long strings push the content of the element out, effectively breaking the settings layout.

<img width="519" alt="Screen Shot 2020-03-23 at 3 12 27 PM" src="https://user-images.githubusercontent.com/6392049/77354949-09402f00-6d1a-11ea-8d75-7515cd1e6491.png">

This fix allows the text to wrap to a new line. To accommodate this I've changed the explicit height of the settings row to a minimum height, and added vertical padding equivalent to the space between the right-side button and the top/bottom of the container.

<img width="521" alt="Screen Shot 2020-03-23 at 3 12 07 PM" src="https://user-images.githubusercontent.com/6392049/77355042-31c82900-6d1a-11ea-9c75-78072fb04853.png">

This is more unlikely, but works on desktop as well:

![Screen Shot 2020-03-23 at 3 11 03 PM](https://user-images.githubusercontent.com/6392049/77355101-3d1b5480-6d1a-11ea-96f6-7a3445e2a38f.png)
