### PR TITLE
Fix settings refresh buttons styles

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/emails.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/emails.mustache
@@ -72,7 +72,7 @@
 
             <div class="button-row">
                 {{#hasSecondaryEmail}}
-                    <button type="submit" class="settings-button email-refresh secondary-button enabled" title="{{ lastCheckedTime }}">{{#t}}Refresh status{{/t}}</button>
+                    <button type="submit" class="settings-button email-refresh primary-button enabled" title="{{ lastCheckedTime }}">{{#t}}Refresh status{{/t}}</button>
 
                     <button
                         class="settings-button {{#hasSecondaryVerifiedEmail}}cancel secondary-button enabled{{/hasSecondaryVerifiedEmail}}

--- a/packages/fxa-content-server/app/styles/modules/_button-row.scss
+++ b/packages/fxa-content-server/app/styles/modules/_button-row.scss
@@ -82,9 +82,12 @@ button {
 
   &:disabled,
   &.disabled {
-    background: $button-background-color-default;
     cursor: not-allowed;
     opacity: 0.4;
+
+    &:not(.primary-button) {
+      background: $button-background-color-default;
+    }
   }
 }
 


### PR DESCRIPTION
Closes #4602 #4597

**For #4602**

This matches the pattern set forth in the refresh buttons in the Devices & apps and Account recovery sections:

![Screen Shot 2020-03-23 at 4 43 19 PM](https://user-images.githubusercontent.com/6392049/77361483-be2c1900-6d25-11ea-84d9-550e504ea064.png)
![Screen Shot 2020-03-23 at 4 43 37 PM](https://user-images.githubusercontent.com/6392049/77361485-bec4af80-6d25-11ea-9209-8c9bcc81f133.png)
![Screen Shot 2020-03-23 at 4 44 20 PM](https://user-images.githubusercontent.com/6392049/77361486-bf5d4600-6d25-11ea-9700-51617b26b40e.png)

**For #4597**

Just apply `type="submit"` to the button, like it is done with the other refresh buttons, so it applies the disabled-blue styling to the button as expected

<img width="680" alt="Screen Shot 2020-03-23 at 5 11 47 PM" src="https://user-images.githubusercontent.com/6392049/77363624-727b6e80-6d29-11ea-832b-f232d0720110.png">
