### PR TITLE
fix(profile): Fix 500 error in the root of the profile server

### DIFF
--- a/packages/fxa-profile-server/lib/routes/root.js
+++ b/packages/fxa-profile-server/lib/routes/root.js
@@ -43,7 +43,7 @@ module.exports = {
     }
 
     // figure it out from .git
-    const gitDir = path.resolve(__dirname, '..', '..', '.git');
+    const gitDir = path.resolve(__dirname, '..', '..', '..', '..', '.git');
     exec('git rev-parse HEAD', { cwd: gitDir }, (err, stdout) => {
       // eslint-disable-line handle-callback-err
       commitHash = stdout.replace(/\s+/, '');


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/128755/77446664-0f3f1a00-6dc5-11ea-8347-5044b1c46efb.png)

Navigating to `/` will result in a 500 if a `version.json` is not present