### PR TITLE
fix(metrics): fix undefined nav timing perf entry bug on Safari for Payments

### DIFF
--- a/packages/fxa-payments-server/src/lib/navigation-timing.ts
+++ b/packages/fxa-payments-server/src/lib/navigation-timing.ts
@@ -16,7 +16,7 @@ export const observeNavigationTiming = (beaconUrl: string) => {
     )[0] as PerformanceNavigationTiming;
 
     // Once duration is recorded the event is over
-    if (navTiming.duration > 0) {
+    if (navTiming && navTiming.duration > 0) {
       navigator.sendBeacon(beaconUrl, JSON.stringify(navTiming));
     } else {
       const navTimingObs = new PerformanceObserver((entries, obs) => {


### PR DESCRIPTION
This patch fixes a Safari only bug where the navigation timing
performance entry is undefined prior to the completion of the navigation
event.

Fixes #4630 (FXA-1401)

@mozilla/fxa-devs r?