### PR TITLE
fix(profile): Call `notifyAttachedServices` when profile-server data changes

### DIFF
--- a/packages/fxa-auth-server/lib/profile/updates.js
+++ b/packages/fxa-auth-server/lib/profile/updates.js
@@ -14,6 +14,18 @@ module.exports = function(log) {
       try {
         const devices = await db.devices(uid);
         await push.notifyProfileUpdated(uid, devices);
+
+        // Notify our RP/Event broker of profile-server based
+        // updates (display name/avatar changes). The profile
+        // server is also listening for these events but will only
+        // clear its cache when received.
+        await log.notifyAttachedServices(
+          'profileDataChanged',
+          {},
+          {
+            uid,
+          }
+        );
       } catch (err) {
         log.error('handleProfileUpdated', {
           uid,

--- a/packages/fxa-auth-server/test/local/profile/updates.js
+++ b/packages/fxa-auth-server/test/local/profile/updates.js
@@ -4,10 +4,10 @@
 
 'use strict';
 
-const { assert } = require('chai');
+const sinon = require('sinon');
+const assert = { ...sinon.assert, ...require('chai').assert };
 
 const EventEmitter = require('events').EventEmitter;
-const sinon = require('sinon');
 const { mockDB, mockLog } = require('../../mocks');
 const profileUpdates = require('../../../lib/profile/updates');
 const P = require('../../../lib/promise');
@@ -52,7 +52,7 @@ describe('profile updates', () => {
       });
   });
 
-  it('should send push notifications', () => {
+  it('should send notifications', () => {
     const log = mockLog();
     const uid = '1e2122ba';
 
@@ -67,6 +67,14 @@ describe('profile updates', () => {
         assert.equal(mockPush.notifyProfileUpdated.callCount, 2);
         const args = mockPush.notifyProfileUpdated.getCall(1).args;
         assert.equal(args[0], uid);
+
+        assert.ok(
+          log.notifyAttachedServices.calledWithExactly(
+            'profileDataChanged',
+            {},
+            { uid }
+          )
+        );
       });
   });
 });


### PR DESCRIPTION
Fixes #4499 

This PR will notify our event broker and RP listening for `profileDataChanged` messages when a user's display name or avatar has changed. 

I was originally concerned about the profile server emitting a push notification when it processed the `profileDataChanged` event, but it only clears the profile-server cache. There shouldn't be a feedback loop of messages.