### PR TITLE
feat(payment-server): update plan billing text on tiers page

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -155,6 +155,27 @@ sub-update-submit = Change Plans
 sub-update-indicator =
   .aria-label = upgrade indicator
 
+## subscription upgrade plan details
+plan-price-day = { $intervalCount ->
+  [one] ${ $amount } daily
+  *[other] ${ $amount } every {$intervalCount} days
+}
+
+plan-price-week = { $intervalCount ->
+  [one] ${ $amount } weekly
+  *[other] ${ $amount } every {$intervalCount} weeks
+}
+
+plan-price-month = { $intervalCount ->
+  [one] ${ $amount } monthly
+  *[other] ${ $amount } every {$intervalCount} months
+}
+
+plan-price-year = { $intervalCount ->
+  [one] ${ $amount } yearly
+  *[other] ${ $amount } every {$intervalCount} years
+}
+
 ## payment update
 pay-update-billing-description =
   You are billed ${ $amount } per { $interval }

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -248,18 +248,45 @@ export const SubscriptionUpgrade = ({
   );
 };
 
-const PlanDetail = ({ plan }: { plan: Plan }) => {
-  const { product_name: productName, amount, interval } = plan;
+function getPlanPrice(interval: string, intervalCount: number, amount: string) {
+  switch (interval) {
+    case 'day':
+      if (intervalCount === 1) return `$${amount} daily`;
+      return `$${amount} every ${intervalCount} days`;
+    case 'week':
+      if (intervalCount === 1) return `$${amount} weekly`;
+      return `$${amount} every ${intervalCount} weeks`;
+    case 'month':
+      if (intervalCount === 1) return `$${amount} monthly`;
+      return `$${amount} every ${intervalCount} months`;
+    case 'year':
+      if (intervalCount === 1) return `$${amount} yearly`;
+      return `$${amount} every ${intervalCount} years`;
+  }
+}
+
+export const PlanDetail = ({ plan }: { plan: Plan }) => {
+  const { product_name: productName, amount, interval, interval_count } = plan;
   const { webIconURL } = metadataFromPlan(plan);
+  const planPrice = getPlanPrice(
+    interval,
+    interval_count,
+    formatCurrencyInCents(amount)
+  );
+
   return (
     <div className="upgrade-plan-detail">
       {webIconURL && (
         <img src={webIconURL} alt={productName} height="49" width="49" />
       )}
       <span className="product-name">{productName}</span>
-      <span className="plan-price">
-        ${formatCurrencyInCents(amount)}/{interval}
-      </span>
+      <Localized
+        id={`plan-price-${interval}`}
+        $amount={formatCurrencyInCents(amount)}
+        $intervalCount={interval_count}
+      >
+        <span className="plan-price">{planPrice}</span>
+      </Localized>
     </div>
   );
 };


### PR DESCRIPTION
- updated plan billing text on subscription upgrade confirmation page to handle various billing intervals and interval counts

issue #3987