### PR TITLE
fix(payments): bugfix to subscription upgrade verification

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -58,7 +58,7 @@
           "product_metadata": {
             "capabilities:dcdb5ae7add825d2": "123donePro",
             "productSet": "123done_product",
-            "productSetOrder": "1",
+            "productOrder": "1",
             "upgradeCTA": "Interested in an upgrade? <a href=\"http://127.0.0.1:3030/subscriptions/products/123doneProPlusProduct \">Get Pro+!</a>",
             "webIconURL": "http://placekitten.com/512/512?image=6",
             "emailIconURL": "http://placekitten.com/512/512?image=0",
@@ -77,7 +77,7 @@
             "capabilities:dcdb5ae7add825d2": "123donePro",
             "downloadURL": "http://127.0.0.1:8080/",
             "productSet": "123done_product",
-            "productSetOrder": "2"
+            "productOrder": "2"
           },
           "interval": "month",
           "amount": 75,

--- a/packages/fxa-auth-server/lib/payments/stripe.js
+++ b/packages/fxa-auth-server/lib/payments/stripe.js
@@ -62,8 +62,8 @@ function validateProductUpgrade(oldMetadata, newMetadata) {
     // Incompatible product sets
     return false;
   }
-  const oldOrder = Number.parseInt(oldMetadata.productSetOrder);
-  const newOrder = Number.parseInt(newMetadata.productSetOrder);
+  const oldOrder = Number.parseInt(oldMetadata.productOrder);
+  const newOrder = Number.parseInt(newMetadata.productOrder);
   if (isNaN(oldOrder) || isNaN(newOrder)) {
     throw error.unknownSubscriptionPlan();
   }

--- a/packages/fxa-auth-server/test/local/payments/fixtures/plan1.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/plan1.json
@@ -26,7 +26,7 @@
     "livemode": false,
     "metadata": {
       "productSet": "fpn_product",
-      "productSetOrder": "1"
+      "productOrder": "1"
     },
     "name": "FPN Tier 1",
     "package_dimensions": null,

--- a/packages/fxa-auth-server/test/local/payments/fixtures/plan2.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/plan2.json
@@ -26,7 +26,7 @@
     "livemode": false,
     "metadata": {
       "productSet": "fpn_product",
-      "productSetOrder": "2"
+      "productOrder": "2"
     },
     "name": "FPN Tier 2",
     "package_dimensions": null,

--- a/packages/fxa-auth-server/test/local/payments/fixtures/product1.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/product1.json
@@ -11,7 +11,7 @@
   "livemode": false,
   "metadata": {
     "productSet": "fpn_product",
-    "productSetOrder": "1"
+    "productOrder": "1"
   },
   "name": "FPN Tier 1",
   "package_dimensions": null,

--- a/packages/fxa-auth-server/test/local/payments/fixtures/product2.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/product2.json
@@ -11,7 +11,7 @@
   "livemode": false,
   "metadata": {
     "productSet": "fpn_product",
-    "productSetOrder": "2"
+    "productOrder": "2"
   },
   "name": "FPN Tier 2",
   "package_dimensions": null,


### PR DESCRIPTION
Stripe metadata key [is defined as productOrder][1], but verify logic expects
productSetOrder. This fixes that.

[1]: https://mozilla.github.io/ecosystem-platform/docs/fxa-engineering/fxa-sub-platform#product-metadata