### PR TITLE
refactor(stripe): remove usage of lineHeight property when styling Stripe input fields

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
@@ -369,15 +369,3 @@ it('calls onPaymentError when payment processing fails', async () => {
     expect(onPaymentError).toHaveBeenCalledWith('BAD THINGS')
   );
 });
-
-it('shows adjusts form styles on smaller devices', async () => {
-  const updatedElementStylesObjectSmallDev = mkStripeElementStyles(true);
-  expect(updatedElementStylesObjectSmallDev.base.lineHeight).toEqual(
-    SMALL_DEVICE_LINE_HEIGHT
-  );
-
-  const updatedElementStylesObject = mkStripeElementStyles(false);
-  expect(updatedElementStylesObject.base.lineHeight).toEqual(
-    DEFAULT_LINE_HEIGHT
-  );
-});

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -293,9 +293,6 @@ export const SMALL_DEVICE_LINE_HEIGHT = '40px';
 export const DEFAULT_LINE_HEIGHT = '48px';
 
 export function mkStripeElementStyles(useSmallDeviceStyles: boolean) {
-  let lh = useSmallDeviceStyles
-    ? SMALL_DEVICE_LINE_HEIGHT
-    : DEFAULT_LINE_HEIGHT;
   // ref: https://stripe.com/docs/stripe-js/reference#the-elements-object
   return {
     base: {
@@ -304,7 +301,6 @@ export function mkStripeElementStyles(useSmallDeviceStyles: boolean) {
         'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
       fontSize: '14px',
       fontWeight: '500',
-      lineHeight: lh,
     },
     invalid: {
       color: '#0c0c0d',

--- a/packages/fxa-payments-server/src/index.scss
+++ b/packages/fxa-payments-server/src/index.scss
@@ -77,6 +77,9 @@ h3.billing-title {
 
     .StripeElement {
       @include input-element();
+      display: flex;
+      align-items: center;
+      cursor: text;
 
       html[dir='ltr'] & {
         padding: 0 0 0 $input-left-right-padding;
@@ -90,6 +93,10 @@ h3.billing-title {
 
       &:last-child {
         margin-bottom: 0;
+      }
+
+      > div {
+        width: 100%;
       }
     }
 


### PR DESCRIPTION
Closes #2580

Stripe doesn't want us doing this.

Visually accommodate by vertically aligning the frame inside the faux input container

Updated look (the same):

Desktop
![Screen Shot 2020-03-24 at 8 18 46 PM](https://user-images.githubusercontent.com/6392049/77489116-90220400-6e0d-11ea-8052-531276d9555d.png)

Mobile
![Screen Shot 2020-03-24 at 8 18 37 PM](https://user-images.githubusercontent.com/6392049/77489118-90ba9a80-6e0d-11ea-87cb-413f8c4f677f.png)
