### PR TITLE
fix(ui): don't target submit buttons with gray disabled background state

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_button-row.scss
+++ b/packages/fxa-content-server/app/styles/modules/_button-row.scss
@@ -85,7 +85,7 @@ button {
     cursor: not-allowed;
     opacity: 0.4;
 
-    &:not(.primary-button) {
+    &:not(.primary-button):not([type="submit"]) {
       background: $button-background-color-default;
     }
   }


### PR DESCRIPTION
My style change to address #4597 earlier this week was a little overzealous and inadvertently allowed disabled primary `[type='submit']` buttons to have a gray background applied. I noticed this on the subscription checkout.

![Screen Shot 2020-03-25 at 10 27 10 AM](https://user-images.githubusercontent.com/6392049/77550204-2f371200-6e87-11ea-811c-eaee4169f105.png)

Note .secondary-button and .warning-button disabled states still look good.