### PR TITLE
fix(recovery): Send `postAddAccountRecoveryEmail` when recovery key verified

### DIFF
--- a/packages/fxa-auth-server/lib/routes/recovery-key.js
+++ b/packages/fxa-auth-server/lib/routes/recovery-key.js
@@ -124,6 +124,29 @@ module.exports = (log, db, Password, verifierVersion, customs, mailer) => {
 
         if (!recoveryKeyData.enabled) {
           await db.updateRecoveryKey(uid, recoveryKeyId, true);
+
+          await request.emitMetricsEvent('recoveryKey.created', { uid });
+
+          const account = await db.account(uid);
+          const { acceptLanguage, clientAddress: ip, geo, ua } = request.app;
+          const emailOptions = {
+            acceptLanguage,
+            ip,
+            location: geo.location,
+            timeZone: geo.timeZone,
+            uaBrowser: ua.browser,
+            uaBrowserVersion: ua.browserVersion,
+            uaOS: ua.os,
+            uaOSVersion: ua.osVersion,
+            uaDeviceType: ua.deviceType,
+            uid,
+          };
+
+          await mailer.sendPostAddAccountRecoveryEmail(
+            account.emails,
+            account,
+            emailOptions
+          );
         }
 
         return {};

--- a/packages/fxa-auth-server/test/local/routes/recovery-keys.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-keys.js
@@ -149,6 +149,32 @@ describe('POST /recoveryKey', () => {
       assert.equal(args[1], recoveryKeyId);
       assert.equal(args[2], true);
     });
+
+    it('called request.emitMetricsEvent correctly', () => {
+      assert.equal(
+        request.emitMetricsEvent.callCount,
+        1,
+        'called emitMetricsEvent'
+      );
+      const args = request.emitMetricsEvent.args[0];
+      assert.equal(
+        args[0],
+        'recoveryKey.created',
+        'called emitMetricsEvent with correct event'
+      );
+      assert.equal(
+        args[1]['uid'],
+        uid,
+        'called emitMetricsEvent with correct event'
+      );
+    });
+
+    it('called mailer.sendPostAddAccountRecoveryEmail correctly', () => {
+      assert.equal(mailer.sendPostAddAccountRecoveryEmail.callCount, 1);
+      const args = mailer.sendPostAddAccountRecoveryEmail.args[0];
+      assert.equal(args.length, 3);
+      assert.equal(args[0][0].email, email);
+    });
   });
 
   describe('should fail for unverified session', () => {


### PR DESCRIPTION
Fixes #4613 

This PR correctly sends the `postAddAccountRecoveryEmail` when a user verifies their recovery key in the standalone flow.