### PR TITLE
Remove Reference to Chromeless param

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/models/reliers/relier.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/relier.js
@@ -110,7 +110,7 @@ describe('models/reliers/relier', function() {
     });
   });
 
-  ['trailhead-1', 'chromeless'].forEach(value => {
+  ['trailhead-1'].forEach(value => {
     testInvalidQueryParam('style', value);
   });
 


### PR DESCRIPTION
Fixes - #828 
>Removed the instance of "Chromeless" from [packages/fxa-content-server/app/tests/spec/models/reliers/relier.js] .