### PR TITLE
fix(redis): Don't log an error if an access token is `null` in redis.

### DIFF
--- a/packages/fxa-auth-server/lib/redis.js
+++ b/packages/fxa-auth-server/lib/redis.js
@@ -86,6 +86,9 @@ class FxaRedis {
   async getAccessToken(tokenId) {
     try {
       const value = await this.redis.get(hex(tokenId));
+      if (!value) {
+        return null;
+      }
       return AccessToken.parse(value);
     } catch (e) {
       this.log.error('redis', e);


### PR DESCRIPTION
Because:

* It's normal and expected to have access token lookup return `null`.
* Emitting error logs for things that are expected makes it harder to
  find the error logs for things that aren't expeted.
* I happened to be poking around in bigquery and saw lots of error logs
  about this.

This commit:

* Avoids emitting an error log when redis access-token lookup returns `null`.