### PR TITLE
fix(settings): replace Subscriptions & Payments section title encoded "&amp;" with "&"

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/subscription.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/subscription.mustache
@@ -1,7 +1,7 @@
 <div id="manage-subscription" class="settings-unit">
   <div class="settings-unit-stub">
     <header class="settings-unit-summary">
-      <h2 class="settings-unit-title">{{#t}}Subscriptions &amp; Payments{{/t}}</h2>
+      <h2 class="settings-unit-title">{{#t}}Subscriptions & Payments{{/t}}</h2>
     </header>
     <button class="settings-button primary-button settings-unit-toggle">
       <span class="change-button">{{#t}}Manage…{{/t}}</span>


### PR DESCRIPTION
Closes #4675

Looks like this was introduced [here](https://github.com/mozilla/fxa/commit/09be98757fc6aef1606d024a89f05ae4c08c5627#diff-6c4fc621920a9a78dfd234a6e3e4a125) and our translated strings don't like encoded characters.