### PR TITLE
task(auth-server): add app links to download email

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -193,6 +193,8 @@ class DirectStripeRoutes {
       productName: selectedPlan.product_name,
       planEmailIconURL: planMetadata.emailIconURL,
       planDownloadURL: planMetadata.downloadURL,
+      appStoreLink: planMetadata.appStoreLink,
+      playStoreLink: planMetadata.playStoreLink,
     });
     this.log.info('subscriptions.createSubscription.success', {
       uid,

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -335,6 +335,8 @@ module.exports.subscriptionProductMetadataValidator = isA
     iconURL: isA.string().optional(),
     upgradeCTA: isA.string().optional(),
     downloadURL: isA.string().optional(),
+    appStoreLink: isA.string().optional(),
+    playStoreLink: isA.string().optional(),
   })
   .unknown(true);
 

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1845,13 +1845,15 @@ module.exports = function(log, config, oauthdb) {
         message.acceptLanguage,
         invoiceDate
       ),
-      serviceLastActiveDateOnly:  this._constructLocalDateString(
+      serviceLastActiveDateOnly: this._constructLocalDateString(
         message.timeZone,
         message.acceptLanguage,
         serviceLastActiveDate
       ),
     };
-    const subject = translator.gettext('Your %(productName)s subscription has been cancelled');
+    const subject = translator.gettext(
+      'Your %(productName)s subscription has been cancelled'
+    );
 
     return this.send({
       ...message,
@@ -2046,6 +2048,8 @@ module.exports = function(log, config, oauthdb) {
       planEmailIconURL,
       planDownloadURL,
       uid,
+      appStoreLink,
+      playStoreLink,
     } = message;
 
     log.trace('mailer.downloadSubscription', { email, productId, uid });
@@ -2057,14 +2061,17 @@ module.exports = function(log, config, oauthdb) {
       planDownloadURL,
       message,
       query,
-      template
+      template,
+      appStoreLink,
+      playStoreLink
     );
+
     const headers = {
       'X-Link': links.link,
     };
 
     const translatorParams = { productName, uid, email };
-    const subject = translator.gettext('Welcome to %(productName)s!');
+    const subject = translator.gettext('Welcome to %(productName)s');
     const action = translator.gettext('Download %(productName)s');
 
     return this.send({
@@ -2123,7 +2130,9 @@ module.exports = function(log, config, oauthdb) {
     primaryLink,
     { email, uid },
     query,
-    templateName
+    templateName,
+    appStoreLink,
+    playStoreLink
   ) {
     // Generate all possible links. The option to use a specific link
     // is left up to the template.
@@ -2139,6 +2148,25 @@ module.exports = function(log, config, oauthdb) {
         utmContent
       );
     }
+
+    if (appStoreLink && utmContent) {
+      links['appStoreLink'] = this._generateUTMLink(
+        appStoreLink,
+        query,
+        templateName,
+        utmContent
+      );
+    }
+
+    if (playStoreLink && utmContent) {
+      links['playStoreLink'] = this._generateUTMLink(
+        playStoreLink,
+        query,
+        templateName,
+        utmContent
+      );
+    }
+
     links['privacyUrl'] = this.createPrivacyLink(templateName);
 
     links['supportLinkAttributes'] = this._supportLinkAttributes(templateName);

--- a/packages/fxa-auth-server/lib/senders/templates/downloadSubscription.html
+++ b/packages/fxa-auth-server/lib/senders/templates/downloadSubscription.html
@@ -44,7 +44,7 @@
                     <tr>
                       <td
                         class="featured-story__content-inner"
-                        style="padding: 32px 30px 45px;"
+                        style="padding: 20px 30px 45px;"
                       >
                         <table cellspacing="0" cellpadding="0">
                           <tr>
@@ -78,8 +78,8 @@
                               <table cellspacing="0" cellpadding="0">
                                 <tr>
                                   <td
-                                    style="font-family:Helvetica, Geneva, Tahoma, Verdana, sans-serif; font-size: 16px; line-height: 22px; color: #555555; padding-top: 16px;text-align:left !important;"
-                                    align="left"
+                                    style="font-family:Helvetica, Geneva, Tahoma, Verdana, sans-serif; font-size: 16px; line-height: 22px; color: #555555; padding-top: 16px;text-align:center !important;"
+                                    align="center"
                                   >
                                     {{t "If you haven't already downloaded %(productName)s, let's get started using all the features included in your subscription:" }}
                                     <br />
@@ -87,8 +87,33 @@
                                     <table style="background-color: #FFFFFF; min-width: 100%;">
                                       {{> button}}
                                     </table>
-                                    <br />
+                                    {{#if (or appStoreLink playStoreLink)}}
+                                    <tr>
+                                      <td align="center" style="padding: 36px 0 0 0;">
+                                        {{#if appStoreLink}}
+                                          <a href={{appStoreLink}}>
+                                            <img style="padding: 0 20px"
+                                                 src="https://accounts-static.cdn.mozilla.net/product-icons/apple-app-store.png" width="135" height="40"
+                                                 alt="" style="-ms-interpolation-mode: bicubic;" /></a>
+                                        {{/if}}
+                                        {{#if playStoreLink}}
+                                          <a href={{playStoreLink}}>
+                                            <img style="padding: 0 20px"
+                                                 src="https://accounts-static.cdn.mozilla.net/product-icons/google-play.png" width="135" height="40"
+                                                 alt="" style="-ms-interpolation-mode: bicubic;" /></a>
+                                        {{/if}}
+                                      </td>
+                                    </tr>
+                                    <tr>
+                                      <td style="font-family:Helvetica, Geneva, Tahoma, Verdana, sans-serif; font-size: 16px; line-height: 22px; color: #555555; padding-top: 32px;text-align:center !important;"
+                                      align="left">
+                                      {{{t "Questions about your subscription? Our <a href=\"%(subscriptionSupportUrl)s\">support team</a> is here to help you." }}}
+                                      </td>
+                                    </tr>
+                                    {{else}}
+                                    <br/>
                                     {{{t "Questions about your subscription? Our <a href=\"%(subscriptionSupportUrl)s\">support team</a> is here to help you." }}}
+                                    {{/if}}
                                   </td>
                                 </tr>
                               </table>

--- a/packages/fxa-auth-server/lib/senders/templates/index.js
+++ b/packages/fxa-auth-server/lib/senders/templates/index.js
@@ -32,6 +32,20 @@ async function init(log) {
 
   handlebars.html.registerHelper('t', translate);
   handlebars.txt.registerHelper('t', translate);
+  handlebars.html.registerHelper('or', orHelper);
+  handlebars.txt.registerHelper('or', orHelper);
+
+  // helpers from https://gist.github.com/servel333/21e1eedbd70db5a7cfff327526c72bc5
+  const reduceOp = function(args, reducer) {
+    args = Array.from(args);
+    args.pop(); // => options
+    var first = args.shift();
+    return args.reduce(reducer, first);
+  };
+
+  function orHelper() {
+    return reduceOp(arguments, (a, b) => a || b);
+  }
 
   await forEachTemplate(PARTIALS_DIR, (template, name, type) => {
     handlebars[type].registerPartial(name, template);

--- a/packages/fxa-auth-server/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/scripts/write-emails-to-disk.js
@@ -84,6 +84,7 @@ function sendMail(mailer, messageToSend) {
 
   const message = {
     acceptLanguage: 'en;q=0.8,en-US;q=0.5,en;q=0.3"',
+    appStoreLink: 'https://example.com/app-store',
     code: '123123',
     email: 'testuser+testbox@testuser.com',
     ip: '10.246.67.38',
@@ -98,6 +99,7 @@ function sendMail(mailer, messageToSend) {
     productName: 'Firefox Fortress',
     planEmailIconURL: 'http://placekitten.com/512/512',
     planDownloadURL: 'http://getfirefox.com/',
+    playStoreLink: 'https://example.com/play-store',
     invoiceNumber: '8675309',
     invoiceTotal: 99.99,
     proratedAmount: 5.23,

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -29,6 +29,7 @@ const TEMPLATE_VERSIONS = require(`${ROOT_DIR}/lib/senders/templates/_versions.j
 
 const MESSAGE = {
   acceptLanguage: 'en',
+  appStoreLink: 'https://example.com/app-store',
   code: 'abc123',
   deviceId: 'foo',
   location: {
@@ -48,6 +49,7 @@ const MESSAGE = {
   productName: 'Firefox Fortress',
   planEmailIconURL: 'http://example.com/icon.jpg',
   planDownloadURL: 'http://getfirefox.com/',
+  playStoreLink: 'https://example.com/play-store',
   invoiceNumber: '8675309',
   invoiceTotal: 99.99,
   proratedAmount: 5.23,
@@ -145,7 +147,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['downloadSubscriptionEmail', new Map([
-    ['subject', { test: 'equal', expected: `Welcome to ${MESSAGE.productName}!` }],
+    ['subject', { test: 'equal', expected: `Welcome to ${MESSAGE.productName}` }],
     ['headers', new Map([
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('downloadSubscription') }],
       ['X-Template-Name', { test: 'equal', expected: 'downloadSubscription' }],
@@ -154,10 +156,12 @@ const TESTS = new Map([
     ['html', [
       { test: 'include', expected: configHref('privacyUrl', 'new-subscription', 'privacy') },
       { test: 'include', expected: MESSAGE.planDownloadURL },
+      { test: 'include', expected: MESSAGE.appStoreLink },
+      { test: 'include', expected: MESSAGE.playStoreLink },
       { test: 'include', expected: configHref('subscriptionSettingsUrl', 'new-subscription', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email') },
       { test: 'include', expected: configHref('subscriptionTermsUrl', 'new-subscription', 'subscription-terms') },
       { test: 'include', expected: configHref('subscriptionSupportUrl', 'new-subscription', 'subscription-support') },
-      { test: 'include', expected: `Welcome to ${MESSAGE.productName}!` },
+      { test: 'include', expected: `Welcome to ${MESSAGE.productName}` },
       { test: 'include', expected: `already downloaded ${MESSAGE.productName}` },
       { test: 'include', expected: `>Download ${MESSAGE.productName}</a>` },
       { test: 'notInclude', expected: 'utm_source=email' },
@@ -168,7 +172,7 @@ const TESTS = new Map([
       { test: 'include', expected: configUrl('subscriptionSettingsUrl', 'new-subscription', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email') },
       { test: 'include', expected: configUrl('subscriptionTermsUrl', 'new-subscription', 'subscription-terms') },
       { test: 'include', expected: configUrl('subscriptionSupportUrl', 'new-subscription', 'subscription-support') },
-      { test: 'include', expected: `Welcome to ${MESSAGE.productName}!` },
+      { test: 'include', expected: `Welcome to ${MESSAGE.productName}` },
       { test: 'include', expected: `already downloaded ${MESSAGE.productName}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],


### PR DESCRIPTION
- fixes #3872

Opening this up to get some feedback before I get it pixel perfect

cc/ @johngruen I'm wondering about the box shadow border, are we adding this to all emails or just this one?

cc/ @jackiemunroe This patch is assuming app store and play store links will be stored in Stripe, does this seem correct to you? (comment in diff)

This is what our email looks like with the changes in this patch
![image](https://user-images.githubusercontent.com/1844554/77703097-5af1ef00-6f90-11ea-8cea-27f89266dcc6.png)

Here is the design from the jira issue.
![email-wanted](https://user-images.githubusercontent.com/1844554/77703064-457cc500-6f90-11ea-9ca1-b47f29b10f02.png)
