### PR TITLE
fix(tests): Run auth server script tests in CI

### DIFF
--- a/packages/fxa-auth-server/scripts/test-local.sh
+++ b/packages/fxa-auth-server/scripts/test-local.sh
@@ -28,6 +28,9 @@ if [ -z "$GLOB" ]; then
   echo "Remote tests"
   ./scripts/mocha-coverage.js $DEFAULT_ARGS test/remote
 
+  echo "Script tests"
+  ./scripts/mocha-coverage.js $DEFAULT_ARGS test/scripts
+
 else
   ./scripts/mocha-coverage.js $DEFAULT_ARGS $GLOB
 fi

--- a/packages/fxa-auth-server/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/scripts/write-emails-to-disk.js
@@ -29,6 +29,9 @@ const path = require('path');
 
 const OUTPUT_DIRECTORY = path.join(__dirname, '..', '.mail_output');
 
+// Subscription emails are behind a feature flag, enable it
+config.subscriptions.transactionalEmails.enabled = true;
+
 const mailSender = {
   sendMail: function(emailConfig, done) {
     const templateName = emailConfig.headers['X-Template-Name'];


### PR DESCRIPTION
Not connected to an issue, we currently don't run tests for our scripts in auth-server.