### PR TITLE
fix(docker): Configure docker syncserver to correctly verify oauth tokens.

### DIFF
--- a/_scripts/syncserver.sh
+++ b/_scripts/syncserver.sh
@@ -11,6 +11,8 @@ fi
 docker run --rm --name syncserver \
   -p 5000:5000 \
   -e SYNCSERVER_PUBLIC_URL=http://127.0.0.1:5000 \
+  -e SYNCSERVER_IDENTITY_PROVIDER=http://$HOST_ADDR:3030 \
+  -e SYNCSERVER_OAUTH_VERIFIER=http://$HOST_ADDR:9000 \
   -e SYNCSERVER_BROWSERID_VERIFIER=http://$HOST_ADDR:5050 \
   -e SYNCSERVER_SECRET=5up3rS3kr1t \
   -e SYNCSERVER_SQLURI=sqlite:////tmp/syncserver.db \


### PR DESCRIPTION
Because:

* The syncserver docker container used for local development needs to
  talk to the local FxA server to verify OAuth tokens.

This commit:

* Passes appropriate environment variables to configure syncserver to
  use the local FxA server as its identity provider.
* Requires an update to the syncserver docker image in order to work around
  some network access issues; ref https://github.com/mozilla-services/syncserver/pull/209