### PR TITLE
task(subscriptions): remove references to plan.name and plan.nickname

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -52,7 +52,6 @@
       "plans": [
         {
           "plan_id": "123doneProMonthly",
-          "plan_name": "123done Pro Monthly",
           "product_id": "123doneProProduct",
           "product_name": "123done Pro",
           "product_metadata": {
@@ -70,7 +69,6 @@
         },
         {
           "plan_id": "123doneProPlusMonthly",
-          "plan_name": "123done Pro Plus Monthly",
           "product_id": "123doneProPlusProduct",
           "product_name": "123done Pro+",
           "product_metadata": {
@@ -85,7 +83,6 @@
         },
         {
           "plan_id": "321doneProMonthly",
-          "plan_name": "321done Pro Monthly",
           "product_id": "321doneProProduct",
           "product_name": "321done Pro",
           "product_metadata": {
@@ -100,7 +97,6 @@
         },
         {
           "plan_id": "allDoneProMonthly",
-          "plan_name": "123done Pro and 321done Pro Monthly",
           "product_id": "allDoneProProduct",
           "product_name": "123done Pro and 321done Pro",
           "product_metadata": {
@@ -116,7 +112,6 @@
         },
         {
           "plan_id": "fortressProMonthly",
-          "plan_name": "Fortress Pro Monthly",
           "product_id": "fortressProProduct",
           "product_name": "Fortress Pro",
           "product_metadata": {
@@ -131,7 +126,6 @@
         },
         {
           "plan_id": "321doneProWeekly",
-          "plan_name": "321done Pro Weekly",
           "product_id": "321doneProProduct",
           "product_name": "321done Pro",
           "product_metadata": {
@@ -146,7 +140,6 @@
         },
         {
           "plan_id": "allDoneProWeekly",
-          "plan_name": "123done Pro and 321done Pro Weekly",
           "product_id": "allDoneProProduct",
           "product_name": "123done Pro and 321done Pro",
           "product_metadata": {

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -309,8 +309,9 @@ module.exports.subscriptionsSubscriptionValidator = isA.object({
   end_at: isA.alternatives(isA.number(), isA.any().allow(null)),
   failure_code: isA.string().optional(),
   failure_message: isA.string().optional(),
-  plan_name: isA.string().required(),
   plan_id: module.exports.subscriptionsPlanId.required(),
+  product_id: module.exports.subscriptionsProductId.required(),
+  product_name: isA.string().required(),
   status: isA.string().required(),
   subscription_id: module.exports.subscriptionsSubscriptionId.required(),
 });
@@ -339,7 +340,6 @@ module.exports.subscriptionProductMetadataValidator = isA
 
 module.exports.subscriptionsPlanValidator = isA.object({
   plan_id: module.exports.subscriptionsPlanId.required(),
-  plan_name: isA.string().required(),
   plan_metadata: module.exports.subscriptionPlanMetadataValidator.optional(),
   product_id: module.exports.subscriptionsProductId.required(),
   product_name: isA.string().required(),

--- a/packages/fxa-auth-server/package-lock.json
+++ b/packages/fxa-auth-server/package-lock.json
@@ -7159,7 +7159,7 @@
       "dev": true
     },
     "uap-core": {
-      "version": "git://github.com/ua-parser/uap-core.git#2e6c983e42e7aae7d957a263cb4d3de7ccbd92af",
+      "version": "git://github.com/ua-parser/uap-core.git#9db18c34f47ee8a30fcd1615ffcbb3ba4e02f287",
       "from": "git://github.com/ua-parser/uap-core.git"
     },
     "uap-ref-impl": {

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -2803,7 +2803,6 @@ describe('/account', () => {
     end_at: null,
     failure_code: 'expired_card',
     failure_message: 'The card is expired',
-    plan_name: 'wibble',
     plan_id: 'blee',
     status: 'ok',
     subscription_id: 'mngh',

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -63,7 +63,6 @@ const PLAN_ID_1 = 'plan_G93lTs8hfK7NNG';
 const PLANS = [
   {
     plan_id: 'firefox_pro_basic_823',
-    plan_name: 'Firefox Pro Basic Weekly',
     product_id: 'firefox_pro_basic',
     product_name: 'Firefox Pro Basic',
     interval: 'week',
@@ -78,7 +77,6 @@ const PLANS = [
   },
   {
     plan_id: 'firefox_pro_basic_999',
-    plan_name: 'Firefox Pro Pro Monthly',
     product_id: 'firefox_pro_pro',
     product_name: 'Firefox Pro Pro',
     interval: 'month',
@@ -90,7 +88,6 @@ const PLANS = [
   },
   {
     plan_id: PLAN_ID_1,
-    plan_name: 'Basic FN',
     product_id: 'prod_G93l8Yn7XJHYUs',
     product_name: 'FN Tier 1',
     interval: 'month',
@@ -155,7 +152,6 @@ describe('sanitizePlans', () => {
     const expected = [
       {
         plan_id: 'firefox_pro_basic_823',
-        plan_name: 'Firefox Pro Basic Weekly',
         product_id: 'firefox_pro_basic',
         product_name: 'Firefox Pro Basic',
         interval: 'week',
@@ -168,7 +164,6 @@ describe('sanitizePlans', () => {
       },
       {
         plan_id: 'firefox_pro_basic_999',
-        plan_name: 'Firefox Pro Pro Monthly',
         product_id: 'firefox_pro_pro',
         product_name: 'Firefox Pro Pro',
         interval: 'month',
@@ -178,7 +173,6 @@ describe('sanitizePlans', () => {
       },
       {
         plan_id: PLAN_ID_1,
-        plan_name: 'Basic FN',
         product_id: 'prod_G93l8Yn7XJHYUs',
         product_name: 'FN Tier 1',
         interval: 'month',

--- a/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/subscriptions.js
@@ -156,7 +156,6 @@ describe('routes/utils/subscriptions', () => {
 
     const PLAN = {
       plan_id: 'plan_8675309',
-      plan_name: 'Example plan',
       product_id: 'prod_8675309',
       product_name: 'Example product',
       currency: 'usd',

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -406,7 +406,6 @@ describe('lib/routes/validators:', () => {
 
     const basePlan = {
       plan_id: 'plan_8675309',
-      plan_name: 'example plan',
       product_id: 'prod_8675309',
       product_name: 'example product',
       interval: 'month',

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -18,7 +18,6 @@ const validClients = config.oauthServer.clients.filter(
 const CLIENT_ID = validClients.pop().id;
 const CLIENT_ID_FOR_DEFAULT = validClients.pop().id;
 const PLAN_ID = 'allDoneProMonthly';
-const PLAN_NAME = 'All Done Pro Monthly';
 const PRODUCT_ID = 'megaProductHooray';
 const PRODUCT_NAME = 'All Done Pro';
 
@@ -44,7 +43,6 @@ describe('remote subscriptions:', function() {
       mockStripeHelper.allPlans = async () => [
         {
           plan_id: PLAN_ID,
-          plan_name: PLAN_NAME,
           product_id: PRODUCT_ID,
           product_name: PRODUCT_NAME,
           interval: 'month',
@@ -56,7 +54,6 @@ describe('remote subscriptions:', function() {
         },
         {
           plan_id: 'plan_1a',
-          plan_name: 'plan 1a',
           product_id: 'prod_1a',
           product_name: 'product 1a',
           interval: 'month',
@@ -65,7 +62,6 @@ describe('remote subscriptions:', function() {
         },
         {
           plan_id: 'plan_1b',
-          plan_name: 'plan 1b',
           product_id: 'prod_1b',
           product_name: 'product 1b',
           interval: 'month',
@@ -200,12 +196,13 @@ describe('remote subscriptions:', function() {
           {
             subscription_id: subscriptionId,
             plan_id: PLAN_ID,
+            product_name: PRODUCT_NAME,
+            product_id: PRODUCT_ID,
             created: date,
             current_period_end: date,
             current_period_start: date,
             cancel_at_period_end: false,
             end_at: null,
-            plan_name: 'foo',
             status: 'active',
             failure_code: undefined,
             failure_message: undefined,

--- a/packages/fxa-content-server/app/scripts/models/support-form.js
+++ b/packages/fxa-content-server/app/scripts/models/support-form.js
@@ -42,12 +42,7 @@ const topicOptions = _.zipWith(
 
 const SupportForm = Backbone.Model.extend({
   validate: function(attrs) {
-    if (
-      attrs.message !== '' &&
-      attrs.plan !== '' &&
-      attrs.productName &&
-      attrs.topic !== ''
-    ) {
+    if (attrs.message !== '' && attrs.productName && attrs.topic !== '') {
       return;
     }
 

--- a/packages/fxa-content-server/app/scripts/templates/settings/delete_account.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/delete_account.mustache
@@ -23,11 +23,11 @@
 
       <ul class="delete-account-product-list {{#hasTwoColumnProductList}}two-col{{/hasTwoColumnProductList}}">
         {{#subscriptions}}
-          {{#plan_name}}
-            <li class="delete-account-product-subscription" title="{{plan_name}}">
-              {{plan_name}}
+          {{#product_name}}
+            <li class="delete-account-product-subscription" title="{{product_name}}">
+              {{product_name}}
             </li>
-          {{/plan_name}}
+          {{/product_name}}
         {{/subscriptions}}
 
         {{#uniqueBrowserNames}}

--- a/packages/fxa-content-server/app/scripts/templates/support.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/support.mustache
@@ -33,13 +33,13 @@
             <form id="fxa-support" novalidate>
               <div class="support-field">
                 <div class="form-label">
-                  <label for="plan" id="plan-label">{{#t}}What are you contacting us about?{{/t}}</label>
+                  <label for="product" id="product-label">{{#t}}What are you contacting us about?{{/t}}</label>
                 </div>
                 <div class="input-row">
-                  <select id="plan" name="plan" data-placeholder="{{optionPlaceholder}}">
+                  <select id="product" name="product" data-placeholder="{{optionPlaceholder}}">
                     <option value=""></option>
                     {{#subscriptions}}
-                    <option value="{{plan_name}}">{{plan_name}}</option>
+                    <option value="{{product_name}}">{{product_name}}</option>
                     {{/subscriptions}}
                     <option value="Other">{{#t}}Other{{/t}}</option>
                   </select>

--- a/packages/fxa-content-server/app/tests/spec/models/support-form.js
+++ b/packages/fxa-content-server/app/tests/spec/models/support-form.js
@@ -18,11 +18,6 @@ describe('models/support-form', function() {
     });
   });
 
-  it('requires a plan', function() {
-    supportForm.set('plan', '');
-    assert.isFalse(supportForm.isValid());
-  });
-
   it('requires a product name', function() {
     supportForm.set('productName', '');
     assert.isFalse(supportForm.isValid());

--- a/packages/fxa-content-server/app/tests/spec/views/settings/delete_account.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/delete_account.js
@@ -114,23 +114,27 @@ describe('views/settings/delete_account', function() {
 
     subscriptions = [
       {
-        plan_id: '321doneProMonthly',
-        plan_name: '321done Pro Monthly',
+        plan_id: 'plan_1',
+        product_id: 'prod_123',
+        product_name: '321Done Pro',
         status: 'active',
       },
       {
-        plan_id: '321doneProYearly',
-        plan_name: '321done Pro Yearly',
+        plan_id: 'plan_2',
+        product_id: 'prod_123',
+        product_name: '321Done Pro',
         status: 'cancelled',
       },
       {
-        plan_id: '321doneProHourly',
-        plan_name: '321done Pro Hourly',
+        plan_id: 'plan_3',
+        product_id: 'prod_123',
+        product_name: '321Done Pro',
         status: 'trialing',
       },
       {
-        plan_id: '321doneProDaily',
-        plan_name: '321done Pro Daily',
+        plan_id: 'plan_4',
+        product_id: 'prod_123',
+        product_name: '321Done Pro',
         status: 'past_due',
       },
     ];
@@ -312,12 +316,12 @@ describe('views/settings/delete_account', function() {
         subscriptions = [
           {
             plan_id: '321doneProMonthly',
-            plan_name: '321done Pro Monthly',
+            product_name: '321done Pro',
             status: 'active',
           },
           {
             plan_id: '321doneProYearly',
-            plan_name: '321done Pro Yearly',
+            product_name: '321done Pro',
             status: 'cancelled',
           },
         ];
@@ -377,7 +381,7 @@ describe('views/settings/delete_account', function() {
       it('renders subscription title attributes', () => {
         assert.equal(
           view.$('.delete-account-product-subscription').attr('title'),
-          '321done Pro Monthly'
+          '321Done Pro'
         );
       });
 
@@ -483,8 +487,9 @@ describe('views/settings/delete_account', function() {
           ]);
           subscriptions = [
             {
-              plan_id: '321doneProHourly',
-              plan_name: '321done Pro Hourly',
+              plan_id: 'plan_123',
+              product_id: 'prod_234',
+              product_name: 'Example Product',
               status: 'trialing',
             },
           ];

--- a/packages/fxa-content-server/app/tests/spec/views/support.js
+++ b/packages/fxa-content-server/app/tests/spec/views/support.js
@@ -31,7 +31,6 @@ describe('views/support', function() {
   const UID = TestHelpers.createUid();
   const subscriptionsConfig = { managementClientId: 'OVER9000' };
   const supportTicket = {
-    plan: '123done',
     productName: 'FxA - 123Done Pro',
     topic: 'General inquiries',
     subject: '',
@@ -82,13 +81,16 @@ describe('views/support', function() {
       verified: true,
     });
     sinon.stub(account, 'fetchProfile').returns(Promise.resolve());
-    sinon
-      .stub(account, 'getSubscriptions')
-      .resolves([{ plan_id: '123done_9001', plan_name: '123done' }]);
+    sinon.stub(account, 'getSubscriptions').resolves([
+      {
+        plan_id: '123done_9001',
+        product_id: '123done_xyz',
+        product_name: '123Done Pro',
+      },
+    ]);
     sinon.stub(account, 'fetchSubscriptionPlans').resolves([
       {
         plan_id: '123done_9001',
-        plan_name: '123done',
         product_id: '123done_xyz',
         product_name: '123Done Pro',
       },
@@ -134,7 +136,7 @@ describe('views/support', function() {
         })
         .then(function() {
           view
-            .$('#plan option:eq(1)')
+            .$('#product option:eq(1)')
             .prop('selected', true)
             .trigger('change');
           assert.equal(
@@ -153,12 +155,13 @@ describe('views/support', function() {
         })
         .then(function() {
           view
-            .$('#plan option:eq(1)')
+            .$('#product option:eq(1)')
             .prop('selected', true)
             .trigger('change');
           assert.equal(notifier.trigger.callCount, 5);
           const args = notifier.trigger.args[4];
           assert.lengthOf(args, 3);
+          console.log(args);
           assert.equal(args[0], 'subscription.initialize');
           assert.instanceOf(args[1], SubscriptionModel);
           assert.equal(args[1].get('planId'), '123done_9001');
@@ -175,7 +178,7 @@ describe('views/support', function() {
         })
         .then(function() {
           view
-            .$('#plan option:eq(2)')
+            .$('#product option:eq(2)')
             .prop('selected', true)
             .trigger('change');
           assert.equal(view.supportForm.get('productName'), 'FxA - Other');
@@ -196,7 +199,7 @@ describe('views/support', function() {
             TestHelpers.isEventLogged(metrics, 'flow.support.engage')
           );
           view
-            .$('#plan option:eq(1)')
+            .$('#product option:eq(1)')
             .prop('selected', true)
             .trigger('change');
           assert.isTrue(
@@ -218,7 +221,7 @@ describe('views/support', function() {
         });
     });
 
-    it('should be enabled once a plan, a topic, and a message is entered', function() {
+    it('should be enabled once a product, a topic, and a message is entered', function() {
       return view
         .render()
         .then(function() {
@@ -227,7 +230,7 @@ describe('views/support', function() {
         })
         .then(function() {
           view
-            .$('#plan option:eq(1)')
+            .$('#product option:eq(1)')
             .prop('selected', true)
             .trigger('change');
           assert.ok(view.$('form button[type=submit]').hasClass('disabled'));
@@ -254,7 +257,7 @@ describe('views/support', function() {
           $('#container').append(view.el);
         })
         .then(function() {
-          view.$('#plan option:eq(1)').prop('selected', true);
+          view.$('#product option:eq(1)').prop('selected', true);
           view.$('#topic option:eq(1)').prop('selected', true);
           view
             .$('#message')
@@ -284,7 +287,7 @@ describe('views/support', function() {
           $('#container').append(view.el);
         })
         .then(function() {
-          view.$('#plan option:eq(1)').prop('selected', true);
+          view.$('#product option:eq(1)').prop('selected', true);
           view.$('#topic option:eq(1)').prop('selected', true);
           view
             .$('#message')
@@ -321,7 +324,7 @@ describe('views/support', function() {
           $('#container').append(view.el);
         })
         .then(function() {
-          view.$('#plan option:eq(1)').prop('selected', true);
+          view.$('#product option:eq(1)').prop('selected', true);
           view.$('#topic option:eq(1)').prop('selected', true);
           view
             .$('#message')

--- a/packages/fxa-js-client/tests/mocks/request.js
+++ b/packages/fxa-js-client/tests/mocks/request.js
@@ -565,7 +565,7 @@ module.exports = {
   getSubscriptionPlans: {
     status: 200,
     body:
-      '[{ "plan_id": "123doneProMonthly", "plan_name": "123done Pro Monthly", "product_id": "123doneProProduct", "product_name": "123done Pro", "interval": "month", "amount": 50, "currency": "usd" }]',
+      '[{ "plan_id": "123doneProMonthly", "product_id": "123doneProProduct", "product_name": "123done Pro", "interval": "month", "amount": 50, "currency": "usd" }]',
   },
   getActiveSubscriptions: {
     status: 200,

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
@@ -38,7 +38,6 @@ const PRODUCT_ID = 'product_8675309';
 const PLAN_ID = 'plan_123';
 const PLAN = {
   plan_id: PLAN_ID,
-  plan_name: 'Example Plan',
   product_id: PRODUCT_ID,
   product_name: 'Example Product',
   currency: 'USD',

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
@@ -37,7 +37,6 @@ const findMockPlan = (planId: string): Plan => {
 
 const MOCK_PLAN = {
   plan_id: 'plan_123',
-  plan_name: 'Example Plan',
   product_id: '123doneProProduct',
   product_name: 'Example Product',
   currency: 'USD',

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -266,8 +266,6 @@ export const STRIPE_FIELDS = [
 
 export const PLAN_ID = 'plan_12345';
 
-export const PLAN_NAME = 'Plan 12345 monthly';
-
 export const PRODUCT_ID = 'product_8675309';
 
 export const PRODUCT_NAME = 'Firefox Tanooki Suit';
@@ -279,7 +277,6 @@ export const PRODUCT_REDIRECT_URLS = {
 export const MOCK_PLANS: Plan[] = [
   {
     plan_id: PLAN_ID,
-    plan_name: PLAN_NAME,
     product_id: PRODUCT_ID,
     product_name: PRODUCT_NAME,
     interval: 'month',
@@ -293,7 +290,6 @@ export const MOCK_PLANS: Plan[] = [
   },
   {
     plan_id: '123doneProMonthly',
-    plan_name: '123done Pro Monthly',
     product_id: '123donepro',
     product_name: '123doneProProduct',
     interval: 'month',
@@ -307,7 +303,6 @@ export const MOCK_PLANS: Plan[] = [
   },
   {
     plan_id: 'plan_upgrade',
-    plan_name: 'Upgrade Plan',
     product_id: 'prod_upgrade',
     product_name: 'Upgrade Product',
     interval: 'month',
@@ -320,7 +315,6 @@ export const MOCK_PLANS: Plan[] = [
   },
   {
     plan_id: 'plan_daily',
-    plan_name: 'FPN Daily',
     product_id: 'prod_fpn',
     product_name: 'FPN',
     interval: 'day',
@@ -333,7 +327,6 @@ export const MOCK_PLANS: Plan[] = [
   },
   {
     plan_id: 'plan_6days',
-    plan_name: 'FPN 6 days',
     product_id: 'prod_fpn',
     product_name: 'FPN',
     interval: 'day',
@@ -346,7 +339,6 @@ export const MOCK_PLANS: Plan[] = [
   },
   {
     plan_id: 'plan_weekly',
-    plan_name: 'FPN Weekly',
     product_id: 'prod_fpn',
     product_name: 'FPN',
     interval: 'week',
@@ -359,7 +351,6 @@ export const MOCK_PLANS: Plan[] = [
   },
   {
     plan_id: 'plan_6weeks',
-    plan_name: 'FPN 6 Weeks',
     product_id: 'prod_fpn',
     product_name: 'FPN',
     interval: 'week',
@@ -372,7 +363,6 @@ export const MOCK_PLANS: Plan[] = [
   },
   {
     plan_id: 'plan_monthly',
-    plan_name: 'FPN monthly',
     product_id: 'prod_fpn',
     product_name: 'FPN',
     interval: 'month',
@@ -385,7 +375,6 @@ export const MOCK_PLANS: Plan[] = [
   },
   {
     plan_id: 'plan_6months',
-    plan_name: 'FPN 6 months',
     product_id: 'prod_fpn',
     product_name: 'FPN',
     interval: 'month',
@@ -398,7 +387,6 @@ export const MOCK_PLANS: Plan[] = [
   },
   {
     plan_id: 'plan_yearly',
-    plan_name: 'FPN Yearly',
     product_id: 'prod_fpn',
     product_name: 'FPN',
     interval: 'year',
@@ -411,7 +399,6 @@ export const MOCK_PLANS: Plan[] = [
   },
   {
     plan_id: 'plan_6years',
-    plan_name: 'FPN 6 years',
     product_id: 'prod_fpn',
     product_name: 'FPN',
     interval: 'year',
@@ -470,7 +457,8 @@ export const MOCK_CUSTOMER = {
     {
       subscription_id: 'sub0.28964929339372136',
       plan_id: '123doneProMonthly',
-      plan_name: '123done Pro Monthly',
+      product_id: 'prod_123',
+      product_name: '123done Pro',
       status: 'active',
       cancel_at_period_end: false,
       current_period_start: 1565816388.815,
@@ -486,7 +474,6 @@ export const MOCK_CUSTOMER_AFTER_SUBSCRIPTION = {
     {
       subscription_id: 'sub0.21234123424',
       plan_id: PLAN_ID,
-      plan_name: 'Plan 12345',
       status: 'active',
       cancel_at_period_end: false,
       current_period_start: 1565816388.815,

--- a/packages/fxa-payments-server/src/routes/Product/PlanDetails/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PlanDetails/index.test.tsx
@@ -50,7 +50,6 @@ describe('PlanDetails Component', () => {
 
   const MOCK_PLAN = {
     plan_id: 'plan_123',
-    plan_name: 'Example Plan',
     product_id: '123doneProProduct',
     product_name: 'Example Product',
     currency: 'USD',

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionRedirect/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionRedirect/index.test.tsx
@@ -55,7 +55,6 @@ function assertRedirectForProduct(
 
 const MOCK_PLAN = {
   plan_id: 'plan_123',
-  plan_name: 'Example Plan',
   product_id: '123doneProProduct',
   product_name: 'Example Product',
   currency: 'USD',

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/mocks.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/mocks.tsx
@@ -20,7 +20,8 @@ export const CUSTOMER: Customer = {
     {
       subscription_id: 'sub0.28964929339372136',
       plan_id: '123doneProMonthly',
-      nickname: '123done Pro Monthly',
+      product_id: 'prod_123',
+      product_name: '123done Pro',
       status: 'active',
       cancel_at_period_end: false,
       current_period_end: Date.now() / 1000 + 86400 * 31,
@@ -34,7 +35,6 @@ export const PRODUCT_ID = 'product_8675309';
 
 export const SELECTED_PLAN: Plan = {
   plan_id: 'plan_123',
-  plan_name: 'Better Upgrade Plan',
   product_id: PRODUCT_ID,
   product_name: 'Better Upgrade Product',
   currency: 'USD',
@@ -48,7 +48,6 @@ export const SELECTED_PLAN: Plan = {
 
 export const UPGRADE_FROM_PLAN: Plan = {
   plan_id: 'plan_abc',
-  plan_name: 'Example Plan',
   product_id: PRODUCT_ID,
   product_name: 'Example Product',
   currency: 'USD',

--- a/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
@@ -33,7 +33,8 @@ function init() {
               current_period_start: Date.now() / 1000 - 86400,
               cancel_at_period_end: false,
               end_at: null,
-              nickname: 'Example Plan',
+              product_name: 'Example Product',
+              product_id: 'prod_123',
               plan_id: 'plan_123',
               status: 'active',
               subscription_id: 'sk_78987',
@@ -213,7 +214,6 @@ const PROFILE: Profile = {
 const PLANS: Plan[] = [
   {
     plan_id: 'plan_123',
-    plan_name: 'Example Plan',
     product_id: PRODUCT_ID,
     product_name: 'Example Product',
     currency: 'USD',
@@ -235,7 +235,8 @@ const CUSTOMER: Customer = {
     {
       subscription_id: 'sub0.28964929339372136',
       plan_id: '123doneProMonthly',
-      nickname: '123done Pro Monthly',
+      product_id: 'prod_123',
+      product_name: '123done Pro',
       status: 'active',
       cancel_at_period_end: false,
       current_period_end: Date.now() / 1000 + 86400 * 31,

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -227,7 +227,6 @@ const PROFILE = {
 const PLANS = [
   {
     plan_id: PLAN_ID,
-    plan_name: 'Example Plan',
     product_id: PRODUCT_ID,
     product_name: 'Example Product',
     currency: 'USD',
@@ -305,8 +304,9 @@ const subscribedProps: SubscriptionsProps = {
       current_period_start: (Date.now() - 86400) / 1000,
       cancel_at_period_end: false,
       end_at: null,
-      nickname: 'Example Plan',
       plan_id: PLAN_ID,
+      product_id: 'product_123',
+      product_name: 'Example Product',
       status: 'active',
       subscription_id: 'sub_5551212',
     },

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
@@ -400,7 +400,8 @@ describe('routes/Subscriptions', () => {
           {
             subscription_id: 'sub0.28964929339372136',
             plan_id: '123doneProMonthly',
-            plan_name: '123done Pro Monthly',
+            product_id: 'prod_123',
+            product_name: '123done Pro',
             status: 'active',
             cancel_at_period_end: true,
             current_period_start: 1565816388.815,
@@ -482,7 +483,8 @@ describe('routes/Subscriptions', () => {
           {
             subscription_id: 'sub0.28964929339372136',
             plan_id: '123doneProMonthly',
-            plan_name: '123done Pro Monthly',
+            product_id: 'prod_123',
+            product_name: '123done Pro',
             status: 'active',
             cancel_at_period_end: true,
             current_period_start: 1565816388.815,
@@ -509,7 +511,8 @@ describe('routes/Subscriptions', () => {
           {
             subscription_id: 'sub0.28964929339372136',
             plan_id: '123doneProMonthly',
-            plan_name: '123done Pro Monthly',
+            product_id: 'prod_123',
+            product_name: '123done Pro',
             status: 'active',
             cancel_at_period_end: false,
             current_period_start: 1565816388.815,

--- a/packages/fxa-payments-server/src/store/actions/index.test.ts
+++ b/packages/fxa-payments-server/src/store/actions/index.test.ts
@@ -31,7 +31,6 @@ const assertActionPayload = (
 
 const PLAN: Plan = {
   plan_id: 'plan_8675309',
-  plan_name: 'Example plan',
   product_id: 'prod_8675309',
   product_name: 'Example product',
   currency: 'usd',

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -36,7 +36,6 @@ export interface Token {
 
 export interface Plan {
   plan_id: string;
-  plan_name: string;
   plan_metadata?: PlanMetadata;
   product_id: string;
   product_name: string;
@@ -75,8 +74,9 @@ export interface CustomerSubscription {
   current_period_end: number;
   current_period_start: number;
   end_at: number | null;
-  nickname: string;
   plan_id: string;
+  product_id: string;
+  product_name: string;
   status: string;
   subscription_id: string;
 }

--- a/packages/fxa-payments-server/src/store/utils.test.tsx
+++ b/packages/fxa-payments-server/src/store/utils.test.tsx
@@ -58,7 +58,6 @@ const NULL_METADATA = {
 
 const PLAN: Plan = {
   plan_id: 'plan_8675309',
-  plan_name: 'Example plan',
   product_id: 'prod_8675309',
   product_name: 'Example product',
   currency: 'usd',

--- a/packages/fxa-support-panel/lib/api.ts
+++ b/packages/fxa-support-panel/lib/api.ts
@@ -57,7 +57,9 @@ interface Subscription {
   created: number;
   current_period_end: number;
   current_period_start: number;
-  plan_name: string;
+  plan_id: string;
+  product_id: string;
+  product_name: string;
   status: string;
   subscription_id: string;
 }

--- a/packages/fxa-support-panel/lib/templates/index.html
+++ b/packages/fxa-support-panel/lib/templates/index.html
@@ -60,7 +60,7 @@
 
       <tr>
         <th>Subscription:</th>
-        <td>{{ plan_name }}</td>
+        <td>{{ product_name }}</td>
       </tr>
       <tr>
         <th>Created:</th>

--- a/packages/fxa-support-panel/test/lib/api.spec.ts
+++ b/packages/fxa-support-panel/test/lib/api.spec.ts
@@ -79,7 +79,9 @@ function createDefaults(): MockCallsResponse {
           created: 1555354567,
           current_period_end: 1579716673,
           current_period_start: 1579630273,
-          plan_name: 'Learn to Code (Monthly)',
+          plan_id: 'plan_123',
+          product_id: 'prod_123',
+          product_name: 'Example Product',
           status: 'active',
           subscription_id: 'sub_GZ7WKEJp1YGZ86',
         },
@@ -281,7 +283,7 @@ describe('Support Controller', () => {
     cassert.equal(result.statusCode, 200);
     const headingMatch = result.payload.match(/<h3>Subscriptions<\/h3>/g);
     const nameMatch = result.payload.match(
-      /<th>Subscription:<\/th>\s*<td>Learn to Code \(Monthly\)<\/td>/g
+      /<th>Subscription:<\/th>\s*<td>Example Product<\/td>/g
     );
     cassert.isTrue(headingMatch?.length === 1 && nameMatch?.length === 1);
   });


### PR DESCRIPTION
Because
- with the introduction of longer duration subscriptions, the current plan_name string is no longer applicable. Instead of using this custom formatted name, we will use the product_name along with plan billing data (interval + interval_count)

fixes #4693