### PR TITLE
refactor(oauth): finish removing the "email" field in oauth /v1/verify response

### DIFF
--- a/packages/fxa-auth-server/docs/oauth/api.md
+++ b/packages/fxa-auth-server/docs/oauth/api.md
@@ -532,7 +532,7 @@ A valid request will return JSON with these properties:
 - `user`: The uid of the respective user.
 - `client_id`: The client_id of the respective client.
 - `scope`: An array of scopes allowed for this token.
-- `email`: **DEPRECATED** The email of the respective user.
+- `email`: **REMOVED** The email of the respective user.
 
 **Example:**
 

--- a/packages/fxa-auth-server/lib/oauth/routes/verify.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/verify.js
@@ -18,7 +18,6 @@ module.exports = {
   validate: {
     payload: {
       token: validators.accessToken.required(),
-      email: Joi.boolean().optional(),
     },
   },
   response: {
@@ -33,13 +32,6 @@ module.exports = {
   handler: async function verify(req) {
     const info = await token.verify(req.payload.token);
     info.scope = info.scope.getScopeValues();
-    if (req.payload.email !== undefined) {
-      logger.warn('email.requested', {
-        user: info.user,
-        client_id: info.client_id,
-        scope: info.scope,
-      });
-    }
     delete info.email;
     logger.info('verify.success', {
       client_id: info.client_id,

--- a/packages/fxa-auth-server/test/oauth/routes/verify.js
+++ b/packages/fxa-auth-server/test/oauth/routes/verify.js
@@ -79,7 +79,6 @@ describe('/verify POST', () => {
     it('fails with no token', () => {
       const err = validate({
         token: undefined,
-        email: true,
       });
       joiRequired(err, 'token');
     });
@@ -87,7 +86,6 @@ describe('/verify POST', () => {
     it('no validation errors', () => {
       const err = validate({
         token: TOKEN,
-        email: true,
       });
       assert.strictEqual(err, null);
     });

--- a/packages/fxa-profile-server/lib/server/web.js
+++ b/packages/fxa-profile-server/lib/server/web.js
@@ -126,7 +126,6 @@ exports.create = async function createServer() {
                 url: url,
                 json: {
                   token: token,
-                  email: false, // disables email fetching of oauth server
                 },
               },
               function(err, resp, body) {

--- a/packages/fxa-profile-server/test/lib/mock.js
+++ b/packages/fxa-profile-server/test/lib/mock.js
@@ -119,18 +119,14 @@ module.exports = async function mock(options) {
     tokenGood: function tokenGood() {
       var parts = url.parse(config.get('oauth.url'));
       return nock(parts.protocol + '//' + parts.host)
-        .post(parts.path + '/verify', function(body) {
-          return body.email === false;
-        })
+        .post(parts.path + '/verify')
         .reply(200, TOKEN_GOOD);
     },
 
     token: function token(tok) {
       var parts = url.parse(config.get('oauth.url'));
       return nock(parts.protocol + '//' + parts.host)
-        .post(parts.path + '/verify', function(body) {
-          return body.email === false;
-        })
+        .post(parts.path + '/verify')
         .reply(200, JSON.stringify(tok));
     },
 


### PR DESCRIPTION
Issue #488

One follow up to this would be to:

* Drop the email column from codes and tokens and refreshTokens tables