### PR TITLE
feat(stats): Add statsd block rate reporting

### DIFF
--- a/packages/fxa-customs-server/lib/server.js
+++ b/packages/fxa-customs-server/lib/server.js
@@ -334,7 +334,7 @@ module.exports = function createServer(config, log) {
     }
 
     function createResponse(result) {
-      const { block, unblock, suspect } = result;
+      const { block, unblock, suspect, blockReason } = result;
 
       allowWhitelisted(result, ip, email, phoneNumber);
 
@@ -347,12 +347,19 @@ module.exports = function createServer(config, log) {
         unblock,
         suspect,
       });
-      res.send({
+
+      const response = {
         block: result.block,
         retryAfter: result.retryAfter,
         unblock: result.unblock,
         suspect: result.suspect,
-      });
+      };
+
+      if (blockReason) {
+        response['blockReason'] = blockReason;
+      }
+
+      res.send(response);
 
       optionallyReportIp(result, ip, action);
     }
@@ -509,11 +516,17 @@ module.exports = function createServer(config, log) {
             suspect: result.suspect,
           });
 
-          res.send({
+          const response = {
             block: result.block,
             retryAfter: result.retryAfter,
             suspect: result.suspect,
-          });
+          };
+
+          if (result.blockReason) {
+            response['blockReason'] = result.blockReason;
+          }
+
+          res.send(response);
 
           optionallyReportIp(result, ip, action);
         },

--- a/packages/fxa-customs-server/test/remote/check_reputation_tests.js
+++ b/packages/fxa-customs-server/test/remote/check_reputation_tests.js
@@ -227,7 +227,11 @@ ENDPOINTS.forEach(endpoint => {
       .spread(function(req, res, obj) {
         t.equal(res.statusCode, 200, 'check returns 200');
         t.equal(obj.block, true, 'action blocked');
-        t.equal(obj.blockReason, undefined, 'block reason not returned');
+        t.equal(
+          obj.blockReason,
+          'ip_reputation_too_low',
+          'block reason returned'
+        );
         return Promise.delay(TEST_DELAY_MS);
       })
       .then(function() {

--- a/packages/fxa-customs-server/test/remote/ip_blocklist_tests.js
+++ b/packages/fxa-customs-server/test/remote/ip_blocklist_tests.js
@@ -68,6 +68,7 @@ ENDPOINTS.forEach(endpoint => {
       { ip: BLOCK_IP_INRANGE, email: TEST_EMAIL, action: ACTION },
       function(err, req, res, obj) {
         t.equal(obj.block, true, 'request is blocked');
+        t.equal(obj.blockReason, 'ip_in_blocklist', 'blockReason set');
         t.end();
       }
     );


### PR DESCRIPTION
Fixes #4653 

This PR adds statsd reporting for customs server block rates. I opted to add this into the auth-server library that interacts with the customs-server because it is already configured and required less changes.

Running `nc -klvu 127.0.0.1 8125`, reports values as
```
fxa-auth-server.customs.request.check:1|c|#action:accountLogin,block:true,unblock:true,suspect:false,blockReason:other
fxa-auth-server.customs.request.check:1|c|#action:sendUnblockCode,block:true,unblock:true,suspect:false,blockReason:other
```