### PR TITLE
feat(auth-server): prevent users from purchasing the same product with different plans

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -1258,6 +1258,15 @@ AppError.subscriptionAlreadyExists = () => {
   });
 };
 
+AppError.userAlreadySubscribedToProduct = () => {
+  return new AppError({
+    code: 409,
+    error: 'Already subscribed to product with different plan',
+    errno: ERRNO.SUBSCRIPTION_ALREADY_EXISTS,
+    message: 'User already subscribed to product with different plan.',
+  });
+};
+
 AppError.insufficientACRValues = foundValue => {
   return new AppError(
     {


### PR DESCRIPTION
Because:
- We are going to be offering variable billing cycles for products, we want to prevent users from accidentally purchasing multiple subscriptions to the same product

fixes #4701