### PR TITLE
fix(localdev): Help local dev environment work with mobile browsers.

### DIFF
--- a/_scripts/adb-reverse.sh
+++ b/_scripts/adb-reverse.sh
@@ -4,4 +4,5 @@ adb reverse tcp:3030 tcp:3030 # Content server
 adb reverse tcp:9000 tcp:9000 # Auth server
 adb reverse tcp:9010 tcp:9010 # OAuth server
 adb reverse tcp:1111 tcp:1111 # Profile server
+adb reverse tcp:1111 tcp:1112 # Profile server "CDN"
 adb reverse tcp:5000 tcp:5000 # Sync server

--- a/_scripts/syncserver.sh
+++ b/_scripts/syncserver.sh
@@ -17,6 +17,6 @@ docker run --rm --name syncserver \
   -e SYNCSERVER_SECRET=5up3rS3kr1t \
   -e SYNCSERVER_SQLURI=sqlite:////tmp/syncserver.db \
   -e SYNCSERVER_BATCH_UPLOAD_ENABLED=true \
-  -e SYNCSERVER_FORCE_WSGI_ENVIRON=false \
+  -e SYNCSERVER_FORCE_WSGI_ENVIRON=true \
   -e PORT=5000 \
   mozilla/syncserver:latest

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -329,6 +329,17 @@
         "publicClient": true
       },
       {
+        "id": "1b1a3e44c54fbb58",
+        "name": "Firefox for iOS",
+        "hashedSecret": "4a892c55feaceb4ef2dbfffaaaa3d8eea94b5c205c815dddfc90170741cd4c19",
+        "imageUri": "",
+        "redirectUri": "http://127.0.0.1:3030/oauth/success/1b1a3e44c54fbb58",
+        "canGrant": true,
+        "trusted": true,
+        "allowedScopes": "https://identity.mozilla.com/apps/oldsync https://identity.mozilla.com/tokens/session",
+        "publicClient": true
+      },
+      {
         "id": "59cceb6f8c32317c",
         "name": "Firefox Accounts Subscriptions",
         "hashedSecret": "220e560d48cf91dbba0219b986ca242a0b278eab8467bb07442fdfed1b245788",


### PR DESCRIPTION
This commit addresses the following papercuts that I found while testing
various mobile browsers against a local FxA stack:

* The profile-server runs a pretend CDN on port 1112, which the device
  needs to be able to reach in order to fetch profile images. I've added
  this to `adb reverse` alongside the existing ports.

* Fennec has a bug where it doesn't correctly send the port number
  in the Host header, causing auth errors on the tokenserver;
  Ref https://bugzilla.mozilla.org/show_bug.cgi?id=1482462
  I've set `force_wsgi_environ` to allow it to work. This setting is
  generally not advised as it can mask security problems, but they're
  not relevant for us in local dev.

* The Firefox for iOS OAuth client id was not in the default local dev
  configuration for auth-server. I've added it.