### PR TITLE
feat(metrics): log raw Amplitude events in content server

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -14,6 +14,7 @@
 
 'use strict';
 
+const _ = require('lodash');
 const {
   GROUPS,
   initialize,
@@ -398,6 +399,48 @@ module.exports = receiveEvent;
 function receiveEvent(event, request, data) {
   if (amplitude.disabled || !event || !request || !data) {
     return;
+  }
+
+  if (amplitude.rawEvents) {
+    const rawEvent = {
+      event,
+      context: {
+        eventSource: 'content',
+        version: VERSION,
+        emailTypes: EMAIL_TYPES,
+        userAgent: request.headers['user-agent'],
+        ..._.pick(data, [
+          'deviceId',
+          'devices',
+          'emailDomain',
+          'emailSender',
+          'emailService',
+          'entrypoint_experiment',
+          'entrypoint_variation',
+          'entrypoint',
+          'experiments',
+          'flowBeginTime',
+          'flowId',
+          'lang',
+          'location',
+          'marketingOptIn',
+          'newsletters',
+          'planId',
+          'productId',
+          'service',
+          'syncEngines',
+          'templateVersion',
+          'uid',
+          'userPreferences',
+          'utm_campaign',
+          'utm_content',
+          'utm_medium',
+          'utm_source',
+          'utm_term',
+        ]),
+      },
+    };
+    logger.info('rawAmplitudeData', rawEvent);
   }
 
   const userAgent = ua.parse(request.headers['user-agent']);

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -39,6 +39,12 @@ const conf = (module.exports = convict({
       env: 'AMPLITUDE_DISABLED',
       format: Boolean,
     },
+    rawEvents: {
+      default: false,
+      doc: 'Log raw Amplitude events',
+      env: 'AMPLITUDE_RAW_EVENTS',
+      format: Boolean,
+    },
   },
   are_dist_resources: {
     default: false,

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -13,6 +13,7 @@ const logger = {
 };
 const amplitudeConfig = {
   disabled: false,
+  rawEvents: false,
 };
 
 const amplitude = proxyquire(path.resolve('server/lib/amplitude'), {
@@ -36,6 +37,7 @@ const APP_VERSION = /([0-9]+)\.([0-9])$/.exec(pkg.version)[0];
 registerSuite('amplitude', {
   beforeEach: function() {
     amplitudeConfig.disabled = false;
+    amplitudeConfig.rawEvents = false;
     sinon.stub(process.stderr, 'write').callsFake(() => {});
   },
 
@@ -58,6 +60,7 @@ registerSuite('amplitude', {
     'disable writing amplitude events': {
       'logger.info was not called': () => {
         amplitudeConfig.disabled = true;
+        amplitudeConfig.rawEvents = true;
         amplitude(
           {
             time: 'a',
@@ -84,6 +87,102 @@ registerSuite('amplitude', {
       assert.doesNotThrow(amplitude);
       assert.doesNotThrow(() => amplitude('foo'));
       assert.doesNotThrow(() => amplitude(null, {}));
+    },
+
+    'logs raw event with context': () => {
+      amplitudeConfig.rawEvents = true;
+      const event = {
+        type: 'oauth.signup.success',
+        offset: 3846,
+        time: 1585695795375,
+        flowTime: 3847,
+      };
+
+      const context = {
+        eventSource: 'content',
+        version: '1.164.0',
+        emailTypes: {
+          'complete-reset-password': 'reset_password',
+          'complete-signin': 'login',
+          'verify-email': 'registration',
+        },
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:40.0) Gecko/20100101 Firefox/40.0 FxATester/1.0',
+        deviceId: '6519d5fce18a427e87745ef6c25143ba',
+        devices: [{ name: 'cray-1', lastAccessTime: 1585695795375 }],
+        emailDomain: 'other',
+        entrypoint_experiment: 'herf',
+        entrypoint_variation: 'menk',
+        entrypoint: 'zoo',
+        experiments: ['abc', 'ASAP'],
+        flowBeginTime: 1585695791528,
+        flowId:
+          '804e3ce43ed994db863afcb93640809c239f6db0378a6f2b01659f7e26e25a66',
+        lang: 'en',
+        location: {
+          country: 'United States',
+          state: 'California',
+        },
+        marketingOptIn: 'none',
+        newsletters: 'none',
+        planId: 'abc',
+        productId: 'gamma',
+        service: 'dcdb5ae7add825d2',
+        syncEngines: ['bookmarks', 'history'],
+        templateVersion: '3.1',
+        uid: '66853f3ab5404b5f30674d532a2dd54e',
+        userPreferences: { yes: 'no' },
+        utm_campaign: 'none',
+        utm_content: 'none',
+        utm_medium: 'none',
+        utm_source: 'none',
+        utm_term: 'none',
+      };
+      amplitude(
+        event,
+        {
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:40.0) Gecko/20100101 Firefox/40.0 FxATester/1.0',
+          },
+        },
+        {
+          junk: 'dontpickthis',
+          deviceId: '6519d5fce18a427e87745ef6c25143ba',
+          devices: [{ name: 'cray-1', lastAccessTime: 1585695795375 }],
+          emailDomain: 'other',
+          entrypoint_experiment: 'herf',
+          entrypoint_variation: 'menk',
+          entrypoint: 'zoo',
+          experiments: ['abc', 'ASAP'],
+          flowBeginTime: 1585695791528,
+          flowId:
+            '804e3ce43ed994db863afcb93640809c239f6db0378a6f2b01659f7e26e25a66',
+          lang: 'en',
+          location: {
+            country: 'United States',
+            state: 'California',
+          },
+          marketingOptIn: 'none',
+          newsletters: 'none',
+          planId: 'abc',
+          productId: 'gamma',
+          service: 'dcdb5ae7add825d2',
+          syncEngines: ['bookmarks', 'history'],
+          templateVersion: '3.1',
+          uid: '66853f3ab5404b5f30674d532a2dd54e',
+          userPreferences: { yes: 'no' },
+          utm_campaign: 'none',
+          utm_content: 'none',
+          utm_medium: 'none',
+          utm_source: 'none',
+          utm_term: 'none',
+        }
+      );
+
+      assert.isTrue(
+        logger.info.calledOnceWith('rawAmplitudeData', { event, context })
+      );
     },
 
     'flow.reset-password.submit': () => {


### PR DESCRIPTION
This patch logs a "raw" Amplitude event in content server to stdout
along with enough context for another service to transform the raw
event into an Amplitude event identical to one that's emitted by
fxa-amplitude-send.

Fixes #4695 (FXA-1443)

@mozilla/fxa-devs r?