### PR TITLE
fix(admin panel): make HMR work on port 8091, loosen up CSP restrictions when in development

### DIFF
--- a/packages/fxa-admin-panel/.env
+++ b/packages/fxa-admin-panel/.env
@@ -3,3 +3,4 @@ PUBLIC_URL=http://127.0.0.1:8091
 # Then it proxies to this port, where the "react-scripts start" (webpack dev server) runs:
 PORT=8092
 BROWSER=none
+WDS_SOCKET_PORT=8092

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -4,7 +4,7 @@
   "description": "FxA Admin Panel",
   "scripts": {
     "start": "ts-node -P server/tsconfig.json server/bin/fxa-admin-panel.ts",
-    "start-dev": "npm-run-all --parallel server:proxy server:react-scripts",
+    "start-dev": "NODE_ENV=development npm-run-all --parallel server:proxy server:react-scripts",
     "server:proxy": "PROXY_STATIC_RESOURCES_FROM='http://127.0.0.1:8092' ts-node -P server/tsconfig.json server/bin/fxa-admin-panel.ts",
     "server:react-scripts": "react-scripts start",
     "lint:eslint": "eslint .",

--- a/packages/fxa-admin-panel/public/index.html
+++ b/packages/fxa-admin-panel/public/index.html
@@ -11,7 +11,7 @@
       name="viewport"
       content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes"
     />
-    <link rel="stylesheet" href="styles/main.css" />
+    <link href="styles/main.css" />
   </head>
   <body>
     <noscript>The FxA Admin Panel requires JavaScript.</noscript>

--- a/packages/fxa-admin-panel/server/config/index.ts
+++ b/packages/fxa-admin-panel/server/config/index.ts
@@ -110,6 +110,14 @@ const conf = convict({
         format: 'url',
       },
     },
+    hmr_websocket: {
+      url: {
+        default: 'ws://127.0.0.1:8092',
+        doc: 'The url of the fxa-admin-panel HMR WebSocket',
+        env: 'HMR_WS_SERVER_URL',
+        format: String, // convict does not recognize ws:// as a valid URL
+      },
+    },
   },
   staticResources: {
     directory: {


### PR DESCRIPTION
With this change you would not longer need to develop on port 8092; everything can work on 8091.

_(It's worth noting that you can still work from 8092 if you need/want to; everything should still be working properly over there. This change just facilitates the ability to combine both the React app with the Express server **while in development**.)_

- Permit both unsafe-inline styles and the development websocket address source for scripts in CSP, only in development.
- Modify `react-scripts start` to always look for the websocket on port 8092, instead of the current page's port. This, plus the CSP change, permits you to run everything (the express server and HMR) all on port 8091 when in development.

Additionally, I've removed `rel="stylesheet"` from static HTML page's style tag to address mime type sniffing console error.