### PR TITLE
fix(email-event): remove redundant require of bluebird

### DIFF
--- a/packages/fxa-email-event-proxy/index.js
+++ b/packages/fxa-email-event-proxy/index.js
@@ -6,7 +6,6 @@
 
 const crypto = require('crypto');
 const qs = require('qs');
-const Promise = require('bluebird');
 const AWS = require('aws-sdk');
 const P = require('bluebird');
 
@@ -125,7 +124,7 @@ function createHash(value) {
 }
 
 async function processEvents(events) {
-  return Promise.all(
+  return P.all(
     events
       .map(provider.marshallEvent)
       .filter(event => !!event)


### PR DESCRIPTION
Minor nit, noticed when looking at this code. There's no need to require bluebird as two variable names.

r? - @mozilla/fxa-devs 