### PR TITLE
fix(admin panel): permit unsafe-inline styles when in development

### DIFF
--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -4,7 +4,7 @@
   "description": "FxA Admin Panel",
   "scripts": {
     "start": "ts-node -P server/tsconfig.json server/bin/fxa-admin-panel.ts",
-    "start-dev": "npm-run-all --parallel server:proxy server:react-scripts",
+    "start-dev": "NODE_ENV=development npm-run-all --parallel server:proxy server:react-scripts",
     "server:proxy": "PROXY_STATIC_RESOURCES_FROM='http://127.0.0.1:8092' ts-node -P server/tsconfig.json server/bin/fxa-admin-panel.ts",
     "server:react-scripts": "react-scripts start",
     "lint:eslint": "eslint .",

--- a/packages/fxa-admin-panel/public/index.html
+++ b/packages/fxa-admin-panel/public/index.html
@@ -11,7 +11,6 @@
       name="viewport"
       content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes"
     />
-    <link rel="stylesheet" href="styles/main.css" />
   </head>
   <body>
     <noscript>The FxA Admin Panel requires JavaScript.</noscript>

--- a/packages/fxa-admin-panel/server/lib/csp/blocking.ts
+++ b/packages/fxa-admin-panel/server/lib/csp/blocking.ts
@@ -27,12 +27,20 @@ export default function cspBlocking(config: { [key: string]: any }) {
   //
   const NONE = "'none'";
   const SELF = "'self'";
+  const UNSAFE_INLINE = "'unsafe-inline'";
 
   function addCdnRuleIfRequired(target: Array<string>) {
     if (CDN_URL !== PUBLIC_URL) {
       target.push(CDN_URL);
     }
     return target;
+  }
+
+  let styleSrc: ("'self'" | "'unsafe-inline'")[] = [SELF];
+  if (process.env.NODE_ENV === 'development') {
+    // Permit unsafe-inline styles in development so you can
+    // access the React app on 8091 with Express running
+    styleSrc.push(UNSAFE_INLINE);
   }
 
   const rules = {
@@ -44,7 +52,7 @@ export default function cspBlocking(config: { [key: string]: any }) {
       fontSrc: addCdnRuleIfRequired([SELF]),
       imgSrc: addCdnRuleIfRequired([SELF]),
       scriptSrc: addCdnRuleIfRequired([SELF]),
-      styleSrc: addCdnRuleIfRequired([SELF]),
+      styleSrc: addCdnRuleIfRequired(styleSrc),
       reportUri: config.get('csp.reportUri'),
     },
     reportOnly: false,


### PR DESCRIPTION
This permits you to use port 8091 in development without CSP violations.

Also remove extraneous stylesheet reference.

In place of #4720