### PR TITLE
task(payments-server): diplay amex logo in confirmation billing details

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.scss
@@ -83,7 +83,7 @@
     background: url('./images/mastercard.svg') no-repeat;
   }
 
-  .amex::before {
+  .american::before {
     background: url('./images/amex.svg') no-repeat;
   }
 


### PR DESCRIPTION
fixes #4732 

![image](https://user-images.githubusercontent.com/1844554/78276486-19f26100-74e1-11ea-9c31-41391338110c.png)
