### PR TITLE
refactor(emails): move all email normalization and equality checks to helper functions

### DIFF
--- a/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
@@ -8,6 +8,7 @@ const { assert } = require('chai');
 const crypto = require('crypto');
 const P = require('bluebird');
 const util = require('../../../lib/db/util');
+const { normalizeEmail } = require('../../../../fxa-shared/email/helpers');
 
 const zeroBuffer16 = Buffer.from('00000000000000000000000000000000', 'hex');
 const zeroBuffer32 = Buffer.from(
@@ -39,7 +40,7 @@ function createAccount() {
     createdAt: now,
     locale: 'en_US',
   };
-  account.normalizedEmail = account.email.toLowerCase();
+  account.normalizedEmail = normalizeEmail(account.email);
   account.emailBuffer = Buffer.from(account.email);
   return account;
 }
@@ -54,7 +55,7 @@ function createEmail(data) {
     createdAt: Date.now(),
   };
   email.email = data.email || email.email;
-  email.normalizedEmail = email.email.toLowerCase();
+  email.normalizedEmail = normalizeEmail(email.email);
 
   return email;
 }

--- a/packages/fxa-auth-db-mysql/db-server/test/fake.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/fake.js
@@ -3,6 +3,7 @@
 
 var crypto = require('crypto');
 var base64url = require('base64url');
+const { normalizeEmail } = require('../../../fxa-shared/email/helpers');
 
 function hex(len) {
   return crypto.randomBytes(len).toString('hex');
@@ -60,7 +61,7 @@ module.exports.newUserDataHex = function() {
     verifierSetAt: Date.now(),
     createdAt: Date.now(),
   };
-  data.account.normalizedEmail = data.account.email.toLowerCase();
+  data.account.normalizedEmail = normalizeEmail(data.account.email);
 
   // sessionToken
   data.sessionTokenId = hex32();
@@ -157,7 +158,7 @@ module.exports.newUserDataHex = function() {
     verifiedAt: undefined,
     createdAt: Date.now(),
   };
-  data.email.normalizedEmail = data.email.email.toLowerCase();
+  data.email.normalizedEmail = normalizeEmail(data.email.email);
 
   data.totp = {
     sharedSecret: hex(10),
@@ -186,7 +187,7 @@ module.exports.newUserDataBuffer = function() {
     verifierSetAt: Date.now(),
     createdAt: Date.now(),
   };
-  data.account.normalizedEmail = data.account.email.toLowerCase();
+  data.account.normalizedEmail = normalizeEmail(data.account.email);
 
   // sessionToken
   data.sessionTokenId = buf32();

--- a/packages/fxa-auth-db-mysql/scripts/createAccounts.js
+++ b/packages/fxa-auth-db-mysql/scripts/createAccounts.js
@@ -12,6 +12,7 @@ const log = require('../test/lib/log');
 const DB = require('../lib/db/mysql')(log, dbServer.errors);
 const config = require('../config');
 const crypto = require('crypto');
+const { normalizeEmail } = require('../../fxa-shared/email/helpers');
 
 function randomBuffer16() {
   return crypto.randomBytes(16);
@@ -44,7 +45,7 @@ function create() {
     createdAt: now(),
     locale: 'en_US',
   };
-  account.normalizedEmail = account.email.toLowerCase();
+  account.normalizedEmail = normalizeEmail(account.email);
 
   return db
     .createAccount(uid, account)

--- a/packages/fxa-auth-db-mysql/scripts/migration-lint.js
+++ b/packages/fxa-auth-db-mysql/scripts/migration-lint.js
@@ -40,6 +40,7 @@ const cp = require('child_process');
 const fs = require('fs');
 const Mysql = require('../lib/db/mysql');
 const Promise = require('../lib/promise');
+const { normalizeEmail } = require('../../fxa-shared/email/helpers');
 
 const log = {
   error: () => {},
@@ -137,7 +138,7 @@ function populateDatabase(db, iteration) {
 function createAccount(db) {
   const email = (Math.random() + '').substr(2) + '@example.com';
   const emailCode = crypto.randomBytes(16);
-  const normalizedEmail = email.toLowerCase();
+  const normalizedEmail = normalizeEmail(email);
   const time = Date.now();
   const uid = crypto.randomBytes(16);
 
@@ -178,7 +179,7 @@ function createAccount(db) {
       return db.createEmail(uid, {
         email: secondaryEmail,
         emailCode: crypto.randomBytes(16),
-        normalizedEmail: secondaryEmail.toLowerCase(),
+        normalizedEmail: normalizeEmail(secondaryEmail),
         isVerified: true,
         uid,
         verifiedAt: time,

--- a/packages/fxa-auth-db-mysql/scripts/populate-session-tokens.js
+++ b/packages/fxa-auth-db-mysql/scripts/populate-session-tokens.js
@@ -23,6 +23,7 @@ var log = {
 var DB = require('../lib/db/mysql')(log, require('../db-server').errors);
 var config = require('../config');
 var crypto = require('crypto');
+const { normalizeEmail } = require('../../fxa-shared/email/helpers');
 
 var zeroBuffer16 = Buffer.from('00000000000000000000000000000000', 'hex');
 var zeroBuffer32 = Buffer.from(
@@ -81,7 +82,7 @@ if (count > 0) {
         var email = (Math.random() + '').substr(2) + '@dummy.org';
         return db.createAccount(uid, {
           email: email,
-          normalizedEmail: email.toLowerCase(),
+          normalizedEmail: normalizeEmail(email),
           emailCode: zeroBuffer16,
           emailVerified: true,
           verifierVersion: 1,

--- a/packages/fxa-auth-db-mysql/test/local/metrics_tests.js
+++ b/packages/fxa-auth-db-mysql/test/local/metrics_tests.js
@@ -14,6 +14,7 @@ const P = require('../../lib/promise');
 const crypto = require('crypto');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
+const { normalizeEmail } = require('../../../fxa-shared/email/helpers');
 
 const zeroBuffer16 = Buffer.from('00000000000000000000000000000000', 'hex');
 const zeroBuffer32 = Buffer.from(
@@ -571,7 +572,7 @@ describe('DB metrics', () => {
     var email = ('' + Math.random()).substr(2) + '@foo.com';
     return db.createAccount(uid, {
       email: email,
-      normalizedEmail: email.toLowerCase(),
+      normalizedEmail: normalizeEmail(email),
       emailCode: zeroBuffer16,
       emailVerified: emailVerified,
       verifierVersion: 1,

--- a/packages/fxa-auth-db-mysql/test/local/mysql_tests.js
+++ b/packages/fxa-auth-db-mysql/test/local/mysql_tests.js
@@ -10,6 +10,7 @@ const DB = require('../../lib/db/mysql')(log, dbServer.errors);
 const config = require('../../config');
 const P = require('../../lib/promise');
 const crypto = require('crypto');
+const { normalizeEmail } = require('../../../fxa-shared/email/helpers');
 
 const zeroBuffer16 = Buffer.from('00000000000000000000000000000000', 'hex');
 const zeroBuffer32 = Buffer.from(
@@ -359,7 +360,7 @@ describe('MySQL', () => {
       createdAt: now,
       locale: 'en_US',
     };
-    account.normalizedEmail = account.email.toLowerCase();
+    account.normalizedEmail = normalizeEmail(account.email);
 
     return db
       .createAccount(uid, account)

--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -7,6 +7,7 @@
 const error = require('./error');
 const Pool = require('./pool');
 const random = require('./crypto/random');
+const { normalizeEmail } = require('../../fxa-shared/email/helpers');
 
 module.exports = (config, log, Token, UnblockCode = null) => {
   const features = require('./features')(config);
@@ -82,7 +83,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     const { uid, email } = data;
     log.trace('DB.createAccount', { uid, email });
     data.createdAt = data.verifierSetAt = Date.now();
-    data.normalizedEmail = data.email.toLowerCase();
+    data.normalizedEmail = normalizeEmail(data.email);
     try {
       await this.pool.put(SAFE_URLS.createAccount, { uid }, data);
       return data;

--- a/packages/fxa-auth-server/lib/routes/password.js
+++ b/packages/fxa-auth-server/lib/routes/password.js
@@ -13,6 +13,7 @@ const isA = require('@hapi/joi');
 const P = require('../promise');
 const random = require('../crypto/random');
 const requestHelper = require('../routes/utils/request_helper');
+const { emailsMatch } = require('../../../fxa-shared/email/helpers');
 
 const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;
 
@@ -454,7 +455,7 @@ module.exports = function(
           .then(db.accountRecord.bind(db, email))
           .then(accountRecord => {
             if (
-              accountRecord.primaryEmail.normalizedEmail !== email.toLowerCase()
+              !emailsMatch(accountRecord.primaryEmail.normalizedEmail, email)
             ) {
               throw error.cannotResetPasswordWithSecondaryEmail();
             }

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -10,6 +10,7 @@ const validators = require('../validators');
 const P = require('../../promise');
 const butil = require('../../crypto/butil');
 const error = require('../../error');
+const { emailsMatch } = require('../../../../fxa-shared/email/helpers');
 
 const BASE_36 = validators.BASE_36;
 
@@ -82,8 +83,10 @@ module.exports = (log, config, customs, db, mailer) => {
       }
       // Logging in with a secondary email address is not currently supported.
       if (
-        originalLoginEmail.toLowerCase() !==
-        accountRecord.primaryEmail.normalizedEmail
+        !emailsMatch(
+          originalLoginEmail,
+          accountRecord.primaryEmail.normalizedEmail
+        )
       ) {
         throw error.cannotLoginWithSecondaryEmail();
       }

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -17,6 +17,7 @@ const crypto = require('crypto');
 const error = require('../../../lib/error');
 const log = require('../../../lib/log');
 const otplib = require('otplib');
+const { normalizeEmail } = require('../../../../fxa-shared/email/helpers');
 
 const TEST_EMAIL = 'foo@gmail.com';
 
@@ -1481,7 +1482,7 @@ describe('/account/login', () => {
           emailVerified: false,
           emailCode: emailCode,
           primaryEmail: {
-            normalizedEmail: TEST_EMAIL.toLowerCase(),
+            normalizedEmail: normalizeEmail(TEST_EMAIL),
             email: TEST_EMAIL,
             isVerified: false,
             isPrimary: true,
@@ -1560,7 +1561,7 @@ describe('/account/login', () => {
           email: TEST_EMAIL,
           emailVerified: true,
           primaryEmail: {
-            normalizedEmail: TEST_EMAIL.toLowerCase(),
+            normalizedEmail: normalizeEmail(TEST_EMAIL),
             email: TEST_EMAIL,
             isVerified: true,
             isPrimary: true,
@@ -1641,7 +1642,7 @@ describe('/account/login', () => {
           email: 'test@mozilla.com',
           emailVerified: true,
           primaryEmail: {
-            normalizedEmail: email.toLowerCase(),
+            normalizedEmail: normalizeEmail(email),
             email: email,
             isVerified: true,
             isPrimary: true,
@@ -1712,7 +1713,7 @@ describe('/account/login', () => {
           email: mockRequest.payload.email,
           emailVerified: false,
           primaryEmail: {
-            normalizedEmail: email.toLowerCase(),
+            normalizedEmail: normalizeEmail(email),
             email: email,
             isVerified: false,
             isPrimary: true,
@@ -1797,7 +1798,7 @@ describe('/account/login', () => {
             email: email,
             emailVerified: true,
             primaryEmail: {
-              normalizedEmail: email.toLowerCase(),
+              normalizedEmail: normalizeEmail(email),
               email: email,
               isVerified: true,
               isPrimary: true,
@@ -2008,7 +2009,7 @@ describe('/account/login', () => {
             email,
             emailVerified: true,
             primaryEmail: {
-              normalizedEmail: email.toLowerCase(),
+              normalizedEmail: normalizeEmail(email),
               email,
               isVerified: true,
               isPrimary: true,
@@ -2470,7 +2471,7 @@ describe('/account/login', () => {
     mockDB.accountRecord = sinon.spy(() => {
       return P.resolve({
         primaryEmail: {
-          normalizedEmail: email.toLowerCase(),
+          normalizedEmail: normalizeEmail(email),
           email: email,
           isVerified: true,
           isPrimary: false,

--- a/packages/fxa-auth-server/test/local/routes/emails.js
+++ b/packages/fxa-auth-server/test/local/routes/emails.js
@@ -16,6 +16,7 @@ const nock = require('nock');
 const P = require('../../../lib/promise');
 const proxyquire = require('proxyquire');
 const uuid = require('uuid');
+const { normalizeEmail } = require('../../../../fxa-shared/email/helpers');
 
 const CUSTOMER_1 = require('../payments/fixtures/customer1.json');
 const CUSTOMER_1_UPDATED = require('../payments/fixtures/customer1_new_email.json');
@@ -1220,7 +1221,7 @@ describe('/recovery_email', () => {
         deviceId: uuid.v4('binary').toString('hex'),
         email: TEST_EMAIL,
         emailVerified: true,
-        normalizedEmail: TEST_EMAIL.toLowerCase(),
+        normalizedEmail: normalizeEmail(TEST_EMAIL),
       },
       log: mockLog,
       payload: {
@@ -1501,7 +1502,7 @@ describe('/recovery_email', () => {
               isPrimary: true,
             },
             {
-              normalizedEmail: tempEmail.toLowerCase(),
+              normalizedEmail: normalizeEmail(tempEmail),
               email: tempEmail,
               isVerified: true,
               isPrimary: false,

--- a/packages/fxa-auth-server/test/mailer_helper.js
+++ b/packages/fxa-auth-server/test/mailer_helper.js
@@ -7,6 +7,7 @@
 'use strict';
 
 const uuid = require('uuid');
+const { normalizeEmail } = require('../../fxa-shared/email/helpers');
 
 const zeroBuffer16 = Buffer.from(
   '00000000000000000000000000000000',
@@ -33,7 +34,7 @@ function createTestAccount() {
     locale: 'da, en-gb;q=0.8, en;q=0.7',
   };
 
-  account.normalizedEmail = account.email.toLowerCase();
+  account.normalizedEmail = normalizeEmail(account.email);
 
   return account;
 }

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -15,6 +15,7 @@ const error = require('../lib/error');
 const knownIpLocation = require('./known-ip-location');
 const P = require('../lib/promise');
 const sinon = require('sinon');
+const { normalizeEmail } = require('../../fxa-shared/email/helpers');
 
 const CUSTOMS_METHOD_NAMES = [
   'check',
@@ -243,7 +244,7 @@ function mockDB(data, errors) {
         emailVerified: data.emailVerified || false,
         locale: data.locale,
         primaryEmail: {
-          normalizedEmail: data.email.toLowerCase(),
+          normalizedEmail: normalizeEmail(data.email),
           email: data.email,
           isVerified: data.emailVerified || false,
           isPrimary: true,
@@ -251,7 +252,7 @@ function mockDB(data, errors) {
         },
         emails: [
           {
-            normalizedEmail: data.email.toLowerCase(),
+            normalizedEmail: normalizeEmail(data.email),
             email: data.email,
             isVerified: data.emailVerified || false,
             isPrimary: true,
@@ -267,16 +268,16 @@ function mockDB(data, errors) {
       return P.resolve([
         {
           email: data.email || 'primary@email.com',
-          normalizedEmail: (data.email || 'primary@email.com').toLowerCase(),
+          normalizedEmail: normalizeEmail(data.email || 'primary@email.com'),
           emailCode: data.emailCode,
           isPrimary: true,
           isVerified: data.emailVerified,
         },
         {
           email: data.secondEmail || 'secondEmail@email.com',
-          normalizedEmail: (
+          normalizedEmail: normalizeEmail(
             data.secondEmail || 'secondEmail@email.com'
-          ).toLowerCase(),
+          ),
           emailCode:
             data.secondEmailCode || crypto.randomBytes(16).toString('hex'),
           isVerified: data.secondEmailisVerified || false,
@@ -295,14 +296,14 @@ function mockDB(data, errors) {
         email: data.email,
         emailVerified: data.emailVerified,
         primaryEmail: {
-          normalizedEmail: data.email.toLowerCase(),
+          normalizedEmail: normalizeEmail(data.email),
           email: data.email,
           isVerified: data.emailVerified,
           isPrimary: true,
         },
         emails: [
           {
-            normalizedEmail: data.email.toLowerCase(),
+            normalizedEmail: normalizeEmail(data.email),
             email: data.email,
             isVerified: data.emailVerified,
             isPrimary: true,
@@ -431,14 +432,14 @@ function mockDB(data, errors) {
         email: data.email,
         emailVerified: data.emailVerified,
         primaryEmail: {
-          normalizedEmail: data.email.toLowerCase(),
+          normalizedEmail: normalizeEmail(data.email),
           email: data.email,
           isVerified: data.emailVerified,
           isPrimary: true,
         },
         emails: [
           {
-            normalizedEmail: data.email.toLowerCase(),
+            normalizedEmail: normalizeEmail(data.email),
             email: data.email,
             isVerified: data.emailVerified,
             isPrimary: true,

--- a/packages/fxa-auth-server/test/remote/db_tests.js
+++ b/packages/fxa-auth-server/test/remote/db_tests.js
@@ -15,6 +15,7 @@ const UnblockCode = require('../../lib/crypto/random').base32(
   config.signinUnblock.codeLength
 );
 const uuid = require('uuid');
+const { normalizeEmail } = require('../../../fxa-shared/email/helpers');
 
 const log = { trace() {}, info() {}, error() {} };
 
@@ -111,7 +112,7 @@ describe('remote db', function() {
           const emailData = {
             email: secondEmail,
             emailCode: crypto.randomBytes(16).toString('hex'),
-            normalizedEmail: secondEmail.toLowerCase(),
+            normalizedEmail: normalizeEmail(secondEmail),
             isVerified: true,
             isPrimary: false,
             uid: account.uid,

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -17,6 +17,7 @@ import ResumeTokenMixin from './mixins/resume-token';
 import SignInReasons from '../lib/sign-in-reasons';
 import VerificationMethods from '../lib/verification-methods';
 import vat from '../lib/vat';
+import { emailsMatch } from '../../../../fxa-shared/email/helpers';
 
 // Account attributes that can be persisted
 const PERSISTENT = {
@@ -644,7 +645,7 @@ const Account = Backbone.Model.extend(
           // originally used for login.
           if (
             options.originalLoginEmail &&
-            email.toLowerCase() !== options.originalLoginEmail.toLowerCase()
+            !emailsMatch(email, options.originalLoginEmail)
           ) {
             updatedSessionData.email = options.originalLoginEmail;
           }

--- a/packages/fxa-content-server/app/scripts/models/password_strength/password_strength_balloon.js
+++ b/packages/fxa-content-server/app/scripts/models/password_strength/password_strength_balloon.js
@@ -13,6 +13,7 @@ import { assign, find } from 'underscore';
 import AuthErrors from '../../lib/auth-errors';
 import { Model } from 'backbone';
 import { PASSWORD_MIN_LENGTH } from '../../lib/constants';
+import { normalizeEmail } from '../../../../../fxa-shared/email/helpers';
 
 const BANNED_SERVICE_NAMES = [
   'addons',
@@ -67,7 +68,7 @@ export default class PasswordStrengthBalloonModel extends Model {
   }
 
   isSameAsEmail(lowercasePassword) {
-    const email = this.get('email').toLowerCase();
+    const email = normalizeEmail(this.get('email'));
     return (
       this.doesPasswordContainFullEmail(lowercasePassword, email) ||
       this.isPasswordSubstringOfEmail(lowercasePassword, email) ||

--- a/packages/fxa-shared/email/helpers.js
+++ b/packages/fxa-shared/email/helpers.js
@@ -1,0 +1,25 @@
+function normalizeEmail(originalEmail) {
+  return originalEmail.toLowerCase();
+}
+
+function emailsMatch(firstEmail, secondEmail) {
+  // This has traditionally been our comparison method
+  return firstEmail.toLowerCase() === secondEmail.toLowerCase();
+
+  // Down the road we should switch to something like this
+  // that allows comparison with better unicode support
+  // https://github.com/mozilla/fxa/pull/4736#discussion_r402647434
+  //
+  // return (
+  //   firstEmail.localeCompare(secondEmail, undefined, {
+  //     // We use 'accent' instead of 'base' here to ensure a character with
+  //     // an accent is not considered the same as that character without one
+  //     sensitivity: 'accent',
+  //   }) === 0
+  // );
+}
+
+module.exports = {
+  normalizeEmail,
+  emailsMatch,
+};


### PR DESCRIPTION
Closes #4644

~I ended up using `String.localeCompare` to check email equality, based on the responses to this [Stack Overflow question](https://stackoverflow.com/q/2140627/717633) ([this response](https://stackoverflow.com/a/51005583/717633) is particularly helpful).~

[For now](https://github.com/mozilla/fxa/pull/4736#discussion_r402647434) we're going to use the regular `toLowerCase` comparison.

In case you're curious, I put together a comparison of the three common methods for string comparison here: https://codepen.io/jodyheavener/pen/rNVbvjg