### PR TITLE
fix(payments): update line-height styles on payment inputs to address a buggy offset

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentForm/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.scss
@@ -57,6 +57,10 @@ form.payment {
       font-size: 14px;
       font-weight: 400;
       height: 45px;
+      line-height: normal;
+    }
+
+    input::-moz-placeholder {
       line-height: 45px;
     }
   }
@@ -82,8 +86,8 @@ form.payment {
 }
 
 @include respond-to('simpleSmall') {
-  .StripeElement .InputContainer .InputElement::placeholder,
-  form.payment .input-row input::placeholder {
+  .StripeElement .InputContainer .InputElement::-moz-placeholder,
+  form.payment .input-row input::-moz-placeholder {
     line-height: 38px !important;
   }
 


### PR DESCRIPTION
Closes #4725

iOS doesn't like the explicit line-heights, and does best with a value of `normal`. However, in our case at least, Firefox is not liking that so we need to target just it with the explicit value.

Firefox:

![Screen Shot 2020-04-02 at 1 40 00 PM](https://user-images.githubusercontent.com/6392049/78280929-de0eca00-74e7-11ea-8535-920ef24ea91b.png)

Chrome:

<img width="616" alt="Screen Shot 2020-04-02 at 1 40 07 PM" src="https://user-images.githubusercontent.com/6392049/78280951-e7983200-74e7-11ea-9990-c4d732793189.png">

iOS sim:

<img width="410" alt="Screen Shot 2020-04-02 at 1 40 26 PM" src="https://user-images.githubusercontent.com/6392049/78280977-f54db780-74e7-11ea-86af-cd81a18feb2e.png">