### PR TITLE
fix(sentry): Add missing sentry mocks when disabled

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -18,6 +18,7 @@ async function run(config) {
         },
       })
     : {
+        increment: () => {},
         timing: () => {},
         close: () => {},
       };

--- a/packages/fxa-auth-server/scripts/delete-account.js
+++ b/packages/fxa-auth-server/scripts/delete-account.js
@@ -59,6 +59,7 @@ DB.connect(config[config.db.backend]).then(db => {
   const push = require('../lib/push')(log, db, config);
   const oauthdb = require('../lib/oauth/db');
   const statsd = {
+    increment: () => {},
     timing: () => {},
     close: () => {},
   };


### PR DESCRIPTION
Unblock train tagging and get `latest.dev.lcip.org/` working.