### PR TITLE
feat(metrics): log raw Amplitude events in payments server

### DIFF
--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -22,6 +22,12 @@ const conf = convict({
       env: 'AMPLITUDE_SCHEMA_VALIDATION',
       format: Boolean,
     },
+    rawEvents: {
+      default: false,
+      doc: 'Log raw Amplitude events',
+      env: 'AMPLITUDE_RAW_EVENTS',
+      format: Boolean,
+    },
   },
   clientAddressDepth: {
     default: 3,

--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -34,12 +34,58 @@ const FUZZY_EVENTS = new Map([
 
 const transform = initialize({}, {}, FUZZY_EVENTS);
 
-module.exports = (event, request, data, requestReceivedTime) => {
+module.exports = (event, request, data) => {
   if (!amplitude.enabled || !event || !request || !data) {
     return;
   }
 
-  requestReceivedTime = requestReceivedTime || Date.now();
+  if (amplitude.rawEvents) {
+    const wanted = [
+      'deviceId',
+      'devices',
+      'emailDomain',
+      'emailSender',
+      'emailService',
+      'entrypoint_experiment',
+      'entrypoint_variation',
+      'entrypoint',
+      'experiments',
+      'flowBeginTime',
+      'flowId',
+      'lang',
+      'location',
+      'marketingOptIn',
+      'newsletters',
+      'planId',
+      'productId',
+      'service',
+      'syncEngines',
+      'templateVersion',
+      'uid',
+      'userPreferences',
+      'utm_campaign',
+      'utm_content',
+      'utm_medium',
+      'utm_source',
+      'utm_term',
+    ];
+    const picked = wanted.reduce((acc, v) => {
+      if (data[v] !== undefined) {
+        acc[v] = data[v];
+      }
+      return acc;
+    }, {});
+    const rawEvent = {
+      event,
+      context: {
+        eventSource: 'payments',
+        version: VERSION,
+        userAgent: request.headers['user-agent'],
+        ...picked,
+      },
+    };
+    log.info('rawAmplitudeData', rawEvent);
+  }
 
   const userAgent = ua.parse(request.headers['user-agent']);
 

--- a/packages/fxa-payments-server/server/lib/amplitude.test.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.test.js
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const pkg = require('../../package.json');
 const mockSchemaValidatorFn = jest.fn();
 const mockAmplitudeConfig = {
   enabled: true,
   schemaValidation: true,
+  rawEvents: false,
 };
 jest.mock('../../../fxa-shared/metrics/amplitude.js', () => ({
   ...jest.requireActual('../../../fxa-shared/metrics/amplitude.js'),
@@ -54,7 +56,6 @@ const mocks = {
     flowBeginTime: 1570000000000,
     flowId: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
     flushTime: 9002,
-    requestReceivedTime: 11000,
     view: 'product',
   },
   request: {
@@ -63,7 +64,6 @@ const mocks = {
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:72.0) Gecko/20100101 Firefox/72.0',
     },
   },
-  requestReceivedTime: 1570000001000,
 };
 
 const expectedOutput = {
@@ -88,70 +88,68 @@ describe('lib/amplitude', () => {
     log.error.mockClear();
     mockSchemaValidatorFn.mockReset();
     mockAmplitudeConfig.schemaValidation = true;
+    mockAmplitudeConfig.rawEvents = false;
   });
   it('logs a correctly formatted message', () => {
-    amplitude(
-      mocks.event,
-      mocks.request,
-      mocks.data,
-      mocks.requestReceivedTime
-    );
-    expect(log.info).toHaveBeenCalled();
+    amplitude(mocks.event, mocks.request, mocks.data);
+    expect(log.info).toHaveBeenCalledTimes(1);
     expect(log.info.mock.calls[0][0]).toMatch('amplitudeEvent');
     expect(log.info.mock.calls[0][1]).toMatchObject(expectedOutput);
   });
-
+  it('logs raw events', () => {
+    const expectedContext = {
+      eventSource: 'payments',
+      version: pkg.version,
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:72.0) Gecko/20100101 Firefox/72.0',
+      deviceId: '0123456789abcdef0123456789abcdef',
+      flowBeginTime: 1570000000000,
+      flowId:
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      lang: 'gd',
+    };
+    mockAmplitudeConfig.rawEvents = true;
+    amplitude(mocks.event, mocks.request, {
+      ...mocks.data,
+      useless: 'junk',
+      lang: 'gd',
+    });
+    expect(log.info).toHaveBeenCalledTimes(2);
+    expect(log.info.mock.calls[0][0]).toMatch('rawAmplitudeData');
+    expect(log.info.mock.calls[0][1]).toEqual({
+      event: mocks.event,
+      context: expectedContext,
+    });
+  });
   describe('validates inputs', () => {
     it('returns if `event` is missing', () => {
-      amplitude(
-        undefined,
-        mocks.request,
-        mocks.data,
-        mocks.requestReceivedTime
-      );
+      amplitude(undefined, mocks.request, mocks.data);
       expect(log.info).not.toHaveBeenCalled();
     });
     it('returns if `request` is missing', () => {
-      amplitude(mocks.event, undefined, mocks.data, mocks.requestReceivedTime);
+      amplitude(mocks.event, undefined, mocks.data);
       expect(log.info).not.toHaveBeenCalled();
     });
     it('returns if `data` is missing', () => {
-      amplitude(
-        mocks.event,
-        mocks.request,
-        undefined,
-        mocks.requestReceivedTime
-      );
+      amplitude(mocks.event, mocks.request);
       expect(log.info).not.toHaveBeenCalled();
     });
     it('returns if the message format does not match `amplitude.str.str`', () => {
-      amplitude(
-        mocks.invalidEventType,
-        mocks.request,
-        mocks.data,
-        mocks.requestReceivedTime
-      );
+      amplitude(mocks.invalidEventType, mocks.request, mocks.data);
       expect(log.info).not.toHaveBeenCalled();
     });
     it('calls validate to perform schema validation', () => {
-      amplitude(
-        mocks.event,
-        mocks.request,
-        mocks.data,
-        mocks.requestReceivedTime
-      );
+      amplitude(mocks.event, mocks.request, mocks.data);
       expect(mockSchemaValidatorFn).toHaveBeenCalledTimes(1);
     });
     it('logs an error when schema validation fails', () => {
       mockSchemaValidatorFn.mockImplementation(() => {
         throw new Error('QUUX IS NOT A VALID DEVICE ID');
       });
-      amplitude(
-        mocks.event,
-        mocks.request,
-        { ...mocks.data, deviceId: 'QUUX' },
-        mocks.requestReceivedTime
-      );
+      amplitude(mocks.event, mocks.request, {
+        ...mocks.data,
+        deviceId: 'QUUX',
+      });
       expect(mockSchemaValidatorFn).toHaveBeenCalledTimes(1);
       expect(log.error).toHaveBeenCalledTimes(1);
       expect(log.error.mock.calls[0][0]).toBe('amplitude.validationError');
@@ -202,12 +200,7 @@ describe('lib/amplitude', () => {
   describe('responds to configuration', () => {
     it('does not perform validation when config flag is set to false', () => {
       mockAmplitudeConfig.schemaValidation = false;
-      amplitude(
-        mocks.event,
-        mocks.request,
-        mocks.data,
-        mocks.requestReceivedTime
-      );
+      amplitude(mocks.event, mocks.request, mocks.data);
       expect(mockSchemaValidatorFn).not.toHaveBeenCalled();
     });
   });

--- a/packages/fxa-payments-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-payments-server/server/lib/routes/post-metrics.js
@@ -55,11 +55,10 @@ module.exports = {
     next();
   },
   process(request, response) {
-    const requestReceivedTime = Date.now();
     const { data, events } = request.body;
     events.forEach(event => {
       event.time = data.flushTime;
-      amplitude(event, request, data, requestReceivedTime);
+      amplitude(event, request, data);
     });
     response.status(200).end();
   },


### PR DESCRIPTION
This patch logs a "raw" Amplitude event in payments server to stdout
along with enough context for another service to transform the raw event
into an Amplitude event identical to one that's emitted by
fxa-amplitude-send.

It also removes a unused parameter from the exported amplitude function;
that change is not directly related to the raw event changes.

Fixes #4696 (FXA-1445)

@mozilla/fxa-devs r?