### PR TITLE
fix(release): remove note about fxa-admins from release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -352,7 +352,7 @@ echo "After that, you must open pull a request to merge the changes back to mast
 echo
 echo "  https://github.com/mozilla/fxa/compare/$TRAIN_BRANCH?expand=1"
 echo
-echo "Ask for review on the pull requests from @fxa-devs and @fxa-admins respectively."
+echo "Ask for review on the pull requests from @fxa-devs"
 echo
 
 if [ "$BUILD_TYPE" = "Train" ]; then


### PR DESCRIPTION
This seems to be a left-over from when we involved the fxa-private repo