### PR TITLE
feat(metrics): log raw Amplitude events in auth server

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -53,6 +53,12 @@ const conf = convict({
       env: 'AMPLITUDE_SCHEMA_VALIDATION',
       format: Boolean,
     },
+    rawEvents: {
+      default: false,
+      doc: 'Log raw Amplitude events',
+      env: 'AMPLITUDE_RAW_EVENTS',
+      format: Boolean,
+    },
   },
   memcached: {
     address: {

--- a/packages/fxa-auth-server/test/local/metrics/events.js
+++ b/packages/fxa-auth-server/test/local/metrics/events.js
@@ -14,6 +14,7 @@ const log = {
   info: sinon.spy(),
 };
 const events = require('../../../lib/metrics/events')(log, {
+  amplitude: { rawEvents: false },
   oauth: {
     clientIds: {},
   },

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -699,6 +699,7 @@ function mockRequest(data, errors) {
   const events = require('../lib/metrics/events')(
     data.log || module.exports.mockLog(),
     {
+      amplitude: { rawEvents: false },
       oauth: {
         clientIds: data.clientIds || {},
       },


### PR DESCRIPTION
This patch logs "raw" Amplitude events in auth server to stdout along
with enough context for another service to transform the raw events into
Amplitude events identical to those emitted by fxa-amplitude-send.

Fixes #4697 (FXA-1444)