### PR TITLE
chore(tests): set fixSessionCapabilities to no-detect

### DIFF
--- a/packages/fxa-content-server/tests/intern.js
+++ b/packages/fxa-content-server/tests/intern.js
@@ -53,6 +53,8 @@ const config = {
   defaultTimeout: 45000, // 30 seconds just isn't long enough for some tests.
   environments: {
     browserName: 'firefox',
+    fixSessionCapabilities: 'no-detect',
+    usesHandleParameter: true,
   },
   filterErrorStack: true,
   functionalSuites: testsMain,


### PR DESCRIPTION
By default intern.js runs a feature detection routine before each test. Since we have a large number of tests skipping it can save a significant amount of time.

https://github.com/theintern/intern/blob/master/docs/concepts.md#webdriver-feature-tests