### PR TITLE
feat(metrics): add metrics to amplitude events

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -6,7 +6,8 @@
 
 const error = require('../lib/error');
 const jwtool = require('fxa-jwtool');
-const StatsD = require('hot-shots');
+const { StatsD } = require('hot-shots');
+const { Container } = require('typedi');
 
 async function run(config) {
   const statsd = config.statsd.enabled
@@ -22,6 +23,7 @@ async function run(config) {
         timing: () => {},
         close: () => {},
       };
+  Container.set(StatsD, statsd);
 
   const log = require('../lib/log')({ ...config.log, statsd });
   require('../lib/oauth/logging')(log);

--- a/packages/fxa-auth-server/package-lock.json
+++ b/packages/fxa-auth-server/package-lock.json
@@ -7152,6 +7152,11 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typedi": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/typedi/-/typedi-0.8.0.tgz",
+      "integrity": "sha512-/c7Bxnm6eh5kXx2I+mTuO+2OvoWni5+rXA3PhXwVWCtJRYmz3hMok5s1AKLzoDvNAZqj/Q/acGstN0ri5aQoOA=="
+    },
     "typescript": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -86,6 +86,7 @@
     "safe-url-assembler": "1.3.5",
     "sandbox": "0.8.6",
     "stripe": "^8.1.0",
+    "typedi": "^0.8.0",
     "urijs": "1.19.1",
     "uuid": "1.4.1",
     "verror": "^1.10.0",

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -32,6 +32,7 @@ const { version: VERSION } = require('../../package.json');
 const SERVICES = config.get('oauth_client_id_map');
 const amplitude = config.get('amplitude');
 const Sentry = require('@sentry/node');
+const statsd = require('./statsd');
 
 // Maps view name to email type
 const EMAIL_TYPES = {
@@ -443,6 +444,7 @@ function receiveEvent(event, request, data) {
       },
     };
     logger.info('rawAmplitudeData', rawEvent);
+    statsd.increment('amplitude.event.raw');
   }
 
   const userAgent = ua.parse(request.headers['user-agent']);
@@ -458,6 +460,7 @@ function receiveEvent(event, request, data) {
       mapLocation(data.location)
     )
   );
+  statsd.increment('amplitude.event');
 
   if (amplitudeEvent) {
     if (amplitude.schemaValidation) {
@@ -486,6 +489,8 @@ function receiveEvent(event, request, data) {
     }
 
     logger.info('amplitudeEvent', amplitudeEvent);
+  } else {
+    statsd.increment('amplitude.event.dropped');
   }
 }
 

--- a/packages/fxa-payments-server/package-lock.json
+++ b/packages/fxa-payments-server/package-lock.json
@@ -12116,9 +12116,9 @@
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
     },
     "hot-shots": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-7.1.0.tgz",
-      "integrity": "sha512-O0ubzu4UmoRna8DweA+KSnFwqF9Xkg+Mu0/Q8DWK2nu97n8ZFWcEGao7aJ8tqIPD0Mz09ApypwJN7SOxI66Ujw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/hot-shots/-/hot-shots-7.4.0.tgz",
+      "integrity": "sha512-5A9WP38HdgRcatk2LHyFF5d5guGsm76V/6u+i6dgg0eZzHYGF1bndtmCZIIzIE+LTGZwci6+AP+CgV6vHW8JAQ==",
       "requires": {
         "unix-dgram": "2.0.x"
       }
@@ -22239,6 +22239,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typedi": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/typedi/-/typedi-0.8.0.tgz",
+      "integrity": "sha512-/c7Bxnm6eh5kXx2I+mTuO+2OvoWni5+rXA3PhXwVWCtJRYmz3hMok5s1AKLzoDvNAZqj/Q/acGstN0ri5aQoOA=="
+    },
     "typescript": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
@@ -22338,9 +22343,9 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unix-dgram": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.3.tgz",
-      "integrity": "sha512-Bay5CkSLcdypcBCsxvHEvaG3mftzT5FlUnRToPWEAVxwYI8NI/8zSJ/Gknlp86MPhV6hBA8I8TBsETj2tssoHQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.4.tgz",
+      "integrity": "sha512-7tpK6x7ls7J7pDrrAU63h93R0dVhRbPwiRRCawR10cl+2e1VOvF3bHlVJc6WI1dl/8qk5He673QU+Ogv7bPNaw==",
       "optional": true,
       "requires": {
         "bindings": "^1.3.0",

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -131,6 +131,7 @@
     "redux-thunk": "^2.3.0",
     "serve-static": "^1.13.2",
     "type-to-reducer": "^1.2.0",
+    "typedi": "^0.8.0",
     "uuid": "^7.0.2"
   },
   "engines": {

--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -7,6 +7,7 @@
 module.exports = () => {
   const path = require('path');
   const fs = require('fs');
+  const { Container } = require('typedi');
 
   // setup version first for the rest of the modules
   const log = require('./logging/log');
@@ -42,7 +43,9 @@ module.exports = () => {
       })
     : {
         timing: NOOP,
+        increment: NOOP,
       };
+  Container.set(StatsD, statsd);
 
   const routes = require('./routes')(statsd);
 


### PR DESCRIPTION
Because:

* We want to know how many amplitude events are dropped by the
  transform step.
* Creating ad-hoc non-uniform singletons is inconsistent and difficult
  to effectively test.

This commit:

* Add's metrics to amplitude events in content-server, auth-server, and
  payments-server.
* Uses typedi for Dependency Injection for a consistent mechanism to set
  singleton type objects and retrieve them.

Closes #4656