### PR TITLE
fix(metrics): update language property on Amplitude schema

### DIFF
--- a/packages/fxa-auth-server/lib/log.js
+++ b/packages/fxa-auth-server/lib/log.js
@@ -214,10 +214,10 @@ Lug.prototype.amplitudeEvent = function(data) {
         scope.setContext('amplitude.validationError', {
           event_type: data.event_type,
           flow_id: data.user_properties.flow_id,
-          err,
+          error: err.message,
         });
         Sentry.captureMessage(
-          'Amplitude event failed validation.',
+          `Amplitude event failed validation: ${err.message}.`,
           Sentry.Severity.Error
         );
       });

--- a/packages/fxa-auth-server/lib/oauth/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/oauth/metrics/amplitude.js
@@ -95,10 +95,10 @@ module.exports = (log, config) => {
             scope.setContext('amplitude.validationError', {
               event_type: amplitudeEvent.event_type,
               flow_id: amplitudeEvent.user_properties.flow_id,
-              err,
+              error: err.message,
             });
             Sentry.captureMessage(
-              'Amplitude event failed validation.',
+              `Amplitude event failed validation: ${err.message}.`,
               Sentry.Severity.Error
             );
           });

--- a/packages/fxa-auth-server/test/local/log.js
+++ b/packages/fxa-auth-server/test/local/log.js
@@ -674,12 +674,12 @@ describe('log', () => {
       '1ce137da67f8d5a2e5e55fafaca0a14088f015f1d6cdf25400f9fe22226ad5a6'
     );
     assert.equal(
-      sentryScope.setContext.args[0][1]['err']['message'],
+      sentryScope.setContext.args[0][1]['error'],
       'Invalid data: event.event_type should match pattern "^\\w+ - \\w+$"'
     );
     assert.isTrue(
       mockSentry.captureMessage.calledOnceWith(
-        'Amplitude event failed validation.',
+        'Amplitude event failed validation: Invalid data: event.event_type should match pattern "^\\w+ - \\w+$".',
         Sentry.Severity.Error
       )
     );

--- a/packages/fxa-auth-server/test/oauth/metrics/amplitude.js
+++ b/packages/fxa-auth-server/test/oauth/metrics/amplitude.js
@@ -154,12 +154,12 @@ describe('metrics/amplitude', () => {
         );
         assert.equal(sentryScope.setContext.args[0][1]['flow_id'], undefined);
         assert.equal(
-          sentryScope.setContext.args[0][1]['err']['message'],
+          sentryScope.setContext.args[0][1]['error'],
           'Invalid data: event.user_id should match pattern "^[a-fA-F0-9]{32}$"'
         );
         assert.isTrue(
           mockSentry.captureMessage.calledOnceWith(
-            'Amplitude event failed validation.',
+            'Amplitude event failed validation: Invalid data: event.user_id should match pattern "^[a-fA-F0-9]{32}$".',
             Sentry.Severity.Error
           )
         );

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -475,10 +475,10 @@ function receiveEvent(event, request, data) {
           scope.setContext('amplitude.validationError', {
             event_type: amplitudeEvent.event_type,
             flow_id: amplitudeEvent.user_properties.flow_id,
-            err,
+            error: err.message,
           });
           Sentry.captureMessage(
-            'Amplitude event failed validation.',
+            `Amplitude event failed validation: ${err.message}.`,
             Sentry.Severity.Error
           );
         });

--- a/packages/fxa-content-server/tests/server/amplitude-schema-validation.js
+++ b/packages/fxa-content-server/tests/server/amplitude-schema-validation.js
@@ -121,12 +121,12 @@ registerSuite('amplitude json schema validation', {
         '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484'
       );
       assert.equal(
-        scope.setContext.args[0][1]['err']['message'],
+        scope.setContext.args[0][1]['error'],
         'QUUX IS NOT A VALID DEVICE ID'
       );
       assert.isTrue(
         mockSentry.captureMessage.calledOnceWith(
-          'Amplitude event failed validation.',
+          'Amplitude event failed validation: QUUX IS NOT A VALID DEVICE ID.',
           Sentry.Severity.Error
         )
       );

--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -114,10 +114,10 @@ module.exports = (event, request, data) => {
           scope.setContext('amplitude.validationError', {
             event_type: amplitudeEvent.event_type,
             flow_id: amplitudeEvent.user_properties.flow_id,
-            err,
+            error: err.message,
           });
           Sentry.captureMessage(
-            'Amplitude event failed validation.',
+            `Amplitude event failed validation: ${err.message}.`,
             Sentry.Severity.Error
           );
         });

--- a/packages/fxa-payments-server/server/lib/amplitude.test.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.test.js
@@ -186,12 +186,12 @@ describe('lib/amplitude', () => {
       expect(scope.setContext.mock.calls[0][1]['flow_id']).toBe(
         '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
       );
-      expect(scope.setContext.mock.calls[0][1]['err']['message']).toBe(
+      expect(scope.setContext.mock.calls[0][1]['error']).toBe(
         'QUUX IS NOT A VALID DEVICE ID'
       );
       expect(mockSentry.captureMessage).toHaveBeenCalledTimes(1);
       expect(mockSentry.captureMessage).toHaveBeenCalledWith(
-        'Amplitude event failed validation.',
+        'Amplitude event failed validation: QUUX IS NOT A VALID DEVICE ID.',
         Sentry.Severity.Error
       );
       expect(log.info).toHaveBeenCalledTimes(1);

--- a/packages/fxa-shared/metrics/amplitude-event.1.schema.json
+++ b/packages/fxa-shared/metrics/amplitude-event.1.schema.json
@@ -32,7 +32,8 @@
     },
     "time": {
       "description": "Event timestamp",
-      "$ref": "#/definitions/integerLike"
+      "type": "integer",
+      "minimum": 1
     },
     "user_id": {
       "$ref": "#/definitions/hex32"
@@ -48,9 +49,9 @@
       "type": "string"
     },
     "language": {
-      "description": "BCP 47 language tags with 2alpha for the language.",
+      "description": "BCP 47 language tags, loosely.",
       "type": "string",
-      "pattern": "^[a-z]{2}(-[a-zA-Z0-9]{1,})*$"
+      "pattern": "^[a-z]{1,}(-[a-zA-Z0-9]{1,})*$"
     },
     "country": {
       "type": "string"
@@ -149,9 +150,12 @@
     }
   },
   "additionalProperties": false,
-  "required": ["op", "event_type", "event_properties", "user_properties"],
-  "anyOf": [
-    {"required": ["user_id"]},
-    {"required": ["device_id"]}
-  ]
+  "required": [
+    "op",
+    "event_type",
+    "time",
+    "event_properties",
+    "user_properties"
+  ],
+  "anyOf": [{ "required": ["user_id"] }, { "required": ["device_id"] }]
 }


### PR DESCRIPTION
This patch loosens the regular expression pattern on the language
property of the Amplitude event JSON schema.

The time property is also updated to be a positive integer as that is
what fxa-amplitude-send expects.

Fixes #4783 (FXA-1504)