### PR TITLE
chore(tests): made root level "npm test" more functional

### DIFF
--- a/_scripts/test-package.sh
+++ b/_scripts/test-package.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+PACKAGE=$1
+help="
+Usage: npm test [all|<package-name>*]
+
+examples:
+
+npm test fxa-shared
+npm test fxa-auth-db-mysql fxa-auth-server
+npm test all
+"
+
+scopes=""
+for scope in "$@"
+do
+  scopes="$scopes --scope $scope"
+done
+
+if [[ -z "$PACKAGE" ]]; then
+  >&2 echo "$help"
+  exit 1
+elif [[ "$PACKAGE" == "all" ]]; then
+  lerna run test --stream --no-prefix --loglevel success --concurrency 1 --ignore fxa-amplitude-send
+else
+  echo "$scopes" | xargs lerna run test --stream --no-prefix --loglevel success --concurrency 1
+fi

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "firefox": "./packages/fxa-dev-launcher/bin/fxa-dev-launcher",
     "start-firefox": "npm run firefox",
     "adb-reverse": "./_scripts/adb-reverse.sh",
-    "test": "lerna run test",
+    "test": "_scripts/test-package.sh",
     "config-fxios": "node _scripts/config-fxios.js",
     "format": "lerna run format"
   },


### PR DESCRIPTION
IDK that anyone should ever use the `all` case, and I doubt it would pass right now but I wanted a top-level command for running an individual package's tests.