### PR TITLE
Add `id_token_hint` support to `prompt=none` flow

### DIFF
--- a/packages/fxa-auth-server/docs/oauth/api.md
+++ b/packages/fxa-auth-server/docs/oauth/api.md
@@ -303,8 +303,7 @@ content-server page.
   - `signin` triggers the signin flow. (will become deprecated and replaced by `email`)
   - `signup` triggers the signup flow. (will become deprecated and replaced by `email`)
   - `force_auth` requires the user to sign in using the address specified in `email`.
-- `email`: Optional if `action` is `email`, `signup` or `signin`. Required if `action`
-  is `force_auth` or `prompt=none`.
+- `email`: Optional if `action` is `email`, `signup`, `signin`. Optional, but deprecated, if `prompt` is `none` (use `login_hint` instead in this case). Required if `action` is `force_auth`.
   - if `action` is `email`, the email address will be used to determine whether to display the signup or signin form, but the user is free to change it.
   - If `action` is `signup` or `signin`, the email address will be pre-filled into the account form, but the user is free to change it.
   - If `action` is `signin`, the literal string `blank` will force the user to enter an email address and the last signed in email address will be ignored.
@@ -312,6 +311,7 @@ content-server page.
     signed in email address will be used as the default.
   - If `action` is `force_auth`, the user is unable to modify the email
     address and is unable to sign up if the address is not registered.
+- `id_token_hint`: An OpenID ID Token for the user being logged in silently via `prompt=none`. If this parameter and `login_hint` are both included in a `prompt=none` request, this parameter will be used, and the `login_hint` will be ignored. See the [prompt=none doc][prompt-none] for more info.
 - `login_hint`: An alias to `email`
 - `prompt`: Specifies whether the Authorization Server prompts the End-User for reauthentication and consent.
   - `consent`: The Authorization Server SHOULD prompt the End-User for consent before returning information to the Client.

--- a/packages/fxa-auth-server/docs/oauth/prompt-none.md
+++ b/packages/fxa-auth-server/docs/oauth/prompt-none.md
@@ -1,10 +1,10 @@
 # prompt=none
 
-`prompt=none` is a flow described by the [OpenID Connect spec][#oidc-spec] as:
+`prompt=none` enables authorized RPs to check a user's authentication state and receive an OAuth grant or access token without requiring user interaction.
+
+More formally, `prompt=none` is a flow described by the [OpenID Connect spec][#oidc-spec] as:
 
 > The Authorization Server MUST NOT display any authentication or consent user interface pages. An error is returned if an End-User is not already authenticated or the Client does not have pre-configured consent for the requested Claims or does not fulfill other conditions for processing the request. The error code will typically be login_required, interaction_required, or another code defined in Section 3.1.2.6. This can be used as a method to check for existing authentication and/or consent.
-
-`prompt=none` enables authorized RPs to check a user's authentication state and receive an OAuth grant or access token without requiring user interaction.
 
 ## prompt=none usage is controlled
 
@@ -13,13 +13,13 @@ it bypasses the normal authorization flow and use could easily fall afoul of use
 
 ## Requesting `prompt=none` during authorization
 
-[`prompt=none` and `login_hint=<email>`][#authorization-api-doc] are appended onto the query parameters when opening the `/authorization` endpoint.
+[`prompt=none` and either `login_hint=<email>` or `id_token_hint=<ID Token>`][#authorization-api-doc] are appended onto the query parameters when opening the `/authorization` endpoint.
 
 ```
 GET https://accounts.firefox.com/authorization?client_id=ea3ca969f8c6bb0d&state=2sfas415FSSF@A5f&scope=profile&prompt=none&login_hint=conscious.chooser%40mozilla.com
 ```
 
-If a different user is currently signed in to the email specified by `login_hint`, an [`account_selection_required` error will be returned](#handling-errors).
+If a different user is currently signed in to the email specified by the `login_hint` or `id_token_hint`, an [`account_selection_required` error will be returned](#handling-errors).
 
 ## Handling errors
 
@@ -32,6 +32,7 @@ The following is a table of [OIDC compliant error codes][#oidc-error-codes] &rar
 | `invalid_request`              | prompt=none is not enabled                |
 | &nbsp;                         | OR `login_hint` is missing                |
 | &nbsp;                         | OR scoped keys are requested              |
+| &nbsp;                         | OR the `id_token_hint` token is invalid   |
 | `unauthorized_client`          | prompt=none is not enabled for the client |
 | `* interaction_required`       | account or session is not verified        |
 | `* login_required`             | user is not signed in                     |
@@ -98,7 +99,7 @@ For users that are already authenticated to Firefox Accounts, `prompt=none` bypa
 
 ## Future directions
 
-Once FxA [accepts the id_token_hint query parameter][#oidc-id-token-hint-github-issue], support for `prompt=none` may be expanded to allow any RP to check the user's FxA login state. Since RPs not on the [authorized list](#prompt=none-usage-is-controlled) can only obtain an [id_token][#oidc-id-token] by going through the normal authorization flow, it is safe to assume an RP presenting the `id_token` as part of a `prompt=none` flow has already been granted authorization.
+Now that FxA accepts the id_token_hint query parameter, support for `prompt=none` [could be expanded][#oidc-id-token-hint-discussion-issue] to allow any RP to check the user's FxA login state. Since RPs not on the [authorized list](#prompt=none-usage-is-controlled) can only obtain an [id_token][#oidc-id-token] by going through the normal authorization flow, it is safe to assume an RP presenting the `id_token` as part of a `prompt=none` flow has already been granted authorization.
 
 Support for [OIDC RP Initiated Logout][#oidc-rp-initiated-logout-github-issue] may go some way to reducing user confusion on what it means to sign out of an RP and whether they should have to enter their password again. Upon signing out of the RP, RPs that support the OIDC RP Initiated Logout protocol will redirect the user to FxA where they are given the option to destroy their FxA session as well.
 
@@ -106,7 +107,7 @@ Support for [OIDC RP Initiated Logout][#oidc-rp-initiated-logout-github-issue] m
 [#fxa-devices-and-apps]: https://accounts.firefox.com/settings/clients
 [#oauth-server-api-destroy]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/api.md#post-v1destroy
 [#oidc-error-codes]: https://openid.net/specs/openid-connect-core-1_0.html#AuthError
-[#oidc-id-token-hint-github-issue]: https://github.com/mozilla/fxa/issues/590#issuecomment-506153249
+[#oidc-id-token-hint-discussion-issue]: https://github.com/mozilla/fxa/issues/4963
 [#oidc-id-token]: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 [#oidc-logout-flows]: https://medium.com/@robert.broeckelmann/openid-connect-logout-eccc73df758f
 [#oidc-rp-initiated-logout-github-issue]: https://github.com/mozilla/fxa/issues/1979

--- a/packages/fxa-auth-server/lib/oauth/jwt_id_token.js
+++ b/packages/fxa-auth-server/lib/oauth/jwt_id_token.js
@@ -1,0 +1,128 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const AppError = require('./error');
+const jwt = require('./jwt');
+const logger = require('./logging')('jwt_id_token');
+
+/**
+ * Verify an OIDC ID Token, following the flow in 3.1.3.7 of the spec:
+ * https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
+ *
+ * This token verification flow is normally used by relying parties to validate
+ * tokens provided by the OpenID Provider. In this case, we (the OpenID
+ * Provider) use it to validate an ID Token passed in by a relying party, as an
+ * id_login_hint. Some steps in the flow don't apply to our use case, and are
+ * skipped. All steps in the flow are indicated in comments, to hopefully
+ * ease future maintenance.
+ *
+ * @param {String} idToken
+ * @param {String} clientId
+ * @throws `invalidToken` error if ID Token is invalid.
+ * @returns {Promise<Object>} resolves with claims in Token
+ */
+exports.verify = async function verify(idToken, clientId) {
+  // Step 1 is skipped, as we don't support JWE tokens.
+  //
+  // 1. If the ID Token is encrypted, decrypt it using the keys and algorithms
+  //    that the Client specified during Registration that the OP was to use to
+  //    encrypt the ID Token. If encryption was negotiated with the OP at
+  //    Registration time and the ID Token is not encrypted, the RP SHOULD
+  //    reject it.
+
+  // Step 2 is handled by the `jwt.verify()` function.
+  //
+  // 2. The Issuer Identifier for the OpenID Provider MUST exactly match the
+  //    value of the `iss` (issuer) Claim.
+  let claims;
+  try {
+    claims = await jwt.verify(idToken);
+  } catch (err) {
+    logger.debug('verify.error.jwtverify', err);
+    throw AppError.invalidToken();
+  }
+
+  // For Step 3, we just need to verify the audience claim matches the
+  // clientId. FxA controls the list of relying parties, so there's no chance
+  // an untrusted audience could be present.
+  //
+  // 3. The Client MUST validate that the aud (audience) Claim contains its
+  //    client_id value registered at the Issuer identified by the iss (issuer)
+  //    Claim as an audience. The aud (audience) Claim MAY contain an array
+  //    with more than one element. The ID Token MUST be rejected if the ID
+  //    Token does not list the Client as a valid audience, or if it contains
+  //    additional audiences not trusted by the Client.
+  if (typeof claims.aud === 'string' && claims.aud !== clientId) {
+    logger.debug('verify.error.aud', { aud: claims.aud, clientId });
+    throw AppError.invalidToken();
+  } else if (!claims.aud.includes(clientId)) {
+    logger.debug('verify.error.aud', { aud: claims.aud, clientId });
+    throw AppError.invalidToken();
+  }
+
+  // Steps 4 and 5 are skipped, because FxA doesn't support the Authorized
+  // Party (azp) Claim.
+  //
+  // 4. If the ID Token contains multiple audiences, the Client SHOULD verify
+  //    that an 'azp' field is present.
+  // 5. If an 'azp' Claim is present, the Client SHOULD verify that its
+  //    client_id is the Claim Value.
+
+  // Step 6 is skipped, because it doesn't apply to our use case.
+  //
+  // 6. If the ID Token is received via direct communication between the Client
+  //    and the Token Endpoint (which it is in this flow), the TLS server
+  //    validation MAY be used to validate the issuer in place of checking the
+  //    token signature. The Client MUST validate the signature of all other ID
+  //    Tokens according to JWS using the algorithm specified in the JWT 'alg'
+  //    Header Parameter. The Client MUST use the keys provided by the Issuer.
+
+  // Step 7 is handled by the `jwt.verify()` function call above.
+  //
+  // 7. The 'alg' value SHOULD be the default of RS256 or the algorithm sent
+  //    by the Client in the 'id_token_signed_response_alg' parameter during
+  //    Registration.
+
+  // Step 8 can be safely skipped for now, as FxA currently uses RS256.
+  //
+  // 8. If the JWT `alg` Header Parameter uses a MAC based algorithm such as
+  //    `HS256`, `HS384`, or `HS512`, the octets of the UTF-8 representation of
+  //    the `client_secret` corresponding to the `client_id` contained in the
+  //    `aud` (audience) Claim are used as the key to validate the signature.
+  //    For MAC based algorithms, the behavior is unspecified if the `aud` is
+  //    multi-valued or if an `azp` value is present that is different than
+  //    the `aud` value.
+
+  // 9. The current time MUST be before the time represented by the `exp`
+  //    Claim.
+  //
+  // Note that this time is specified to be in seconds, not milliseconds.
+  const currentTime = Math.round(Date.now() / 1000);
+  if (claims.exp < currentTime) {
+    logger.debug('verify.error.exp', { exp: claims.exp, currentTime });
+    throw AppError.invalidToken();
+  }
+
+  // The remaining steps don't apply to our use case, so they are skipped.
+  //
+  // 10. The `iat` claim can be used to reject tokens issued too far away from
+  //     the current time, limiting the amount of time that nonces need to be
+  //     stored to prevent attacks. The acceptable range is Client specific.
+  //
+  // 11. If a nonce value was sent in the Authentication Request, a `nonce`
+  //     Claim MUST be present and its value checked to verify that it is the
+  //     same value as the one that was sent in the Authentication Request.
+  //     The Client SHOULD check the nonce value for replay attacks. The
+  //     precise method for detecting replay attacks is Client specific.
+  //
+  // 12. If the `acr` Claim was requested, Client SHOULD check the asserted
+  //     Claim Value is appropriate. The meaning and processing of `acr` Claim
+  //     Values is out of scope for the OIDC spec.
+  //
+  // 13. If the `auth_time` Claim was requested, either specifically or by
+  //     using the `max_age` parameter, the Client SHOULD check the `auth_time`
+  //     Claim Value and request re-authentication if it determines too much
+  //     time has elapsed since the last End-User authentication.
+  return claims;
+};

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -92,6 +92,7 @@ module.exports.service = isA
 module.exports.hexString = isA.string().regex(HEX_STRING);
 module.exports.clientId = module.exports.hexString.length(16);
 module.exports.clientSecret = module.exports.hexString;
+module.exports.idToken = module.exports.jwt;
 module.exports.refreshToken = module.exports.hexString.length(64);
 module.exports.sessionToken = module.exports.hexString.length(64);
 module.exports.sessionTokenId = module.exports.hexString.length(64);

--- a/packages/fxa-auth-server/test/oauth/jwt_id_token.js
+++ b/packages/fxa-auth-server/test/oauth/jwt_id_token.js
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { assert } = require('chai');
+const jsonwebtoken = require('jsonwebtoken');
+
+const AppError = require('../../lib/oauth/error');
+const config = require('../../config');
+const JWTIdToken = require('../../lib/oauth/jwt_id_token');
+const {
+  SIGNING_PEM,
+  SIGNING_KID,
+  SIGNING_ALG,
+} = require('../../lib/oauth/keys');
+
+const CLIENT_ID = '59cceb6f8c32317c';
+const ISSUER = config.get('oauthServer.openid.issuer');
+const USER_ID = 'bcbe7c934446fe13aae5be4afed3161d';
+
+describe('lib/jwt_id_token', () => {
+  let claims;
+
+  // Note: in order to verify that invalid issuer claims are caught, we need
+  // to sign a claim with the wrong issuer. lib/oauth/jwt.js does not allow
+  // the issuer to be set, so we need to use jsonwebtoken directly.
+  const sign = (claims, algorithm = SIGNING_ALG) => {
+    return jsonwebtoken.sign(claims, SIGNING_PEM, {
+      algorithm,
+      keyid: SIGNING_KID,
+    });
+  };
+
+  // Helper function that signs a set of invalid claims, calls the verifier,
+  // and expects (asserts) that the token verifier will throw an error.
+  const signAndAssertInvalid = async (claims, algorithm) => {
+    const invalidToken = sign(claims, algorithm);
+    try {
+      await JWTIdToken.verify(invalidToken, CLIENT_ID);
+      assert.fail();
+    } catch (err) {
+      assert.instanceOf(err, AppError);
+    }
+  };
+
+  beforeEach(() => {
+    const now = Date.now() / 1000;
+    claims = {
+      iss: ISSUER,
+      alg: SIGNING_ALG,
+      aud: CLIENT_ID,
+      exp: now + 1000,
+      sub: USER_ID,
+      iat: now,
+    };
+  });
+
+  describe('verify', () => {
+    it('fails if the input is not a JWT', async () => {
+      try {
+        await JWTIdToken.verify('invalid token', CLIENT_ID);
+        assert.fail();
+      } catch (err) {
+        assert.instanceOf(err, AppError);
+      }
+    });
+
+    it(`fails if the Issuer Claim doesn't match the expected issuer`, async () => {
+      claims.iss = 'http://example.com';
+      await signAndAssertInvalid(claims);
+    });
+
+    it(`fails if the Audience Claim doesn't match the client ID`, async () => {
+      claims.aud = 'bad1bad1bad1bad1';
+      await signAndAssertInvalid(claims);
+    });
+
+    it(`fails if the Audience Claim is a list that doesn't include the client ID`, async () => {
+      claims.aud = ['bad1bad1bad1bad1', 'bad2bad2bad2bad2'];
+      await signAndAssertInvalid(claims);
+    });
+
+    it(`fails if the Algorithm used isn't the expected default algorithm (RS256)`, async () => {
+      const algorithm = 'HS256';
+      await signAndAssertInvalid(claims, algorithm);
+    });
+
+    it(`fails if the Expiration Time Claim is in the past`, async () => {
+      claims.exp = Math.round((Date.now() - 1000) / 1000);
+      await signAndAssertInvalid(claims);
+    });
+
+    it('succeeds if valid', async () => {
+      const validToken = sign(claims);
+      const parsedClaims = await JWTIdToken.verify(validToken, CLIENT_ID);
+      assert.deepEqual(parsedClaims, claims);
+    });
+  });
+});

--- a/packages/fxa-content-server/app/scripts/lib/oauth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/oauth-errors.js
@@ -177,6 +177,11 @@ var ERRORS = {
     message: t('Unverified user or session'),
     response_error_code: 'interaction_required',
   },
+  PROMPT_NONE_INVALID_ID_TOKEN_HINT: {
+    errno: 1013,
+    message: t('Invalid id_token_hint'),
+    response_error_code: 'invalid_request',
+  },
 };
 
 export default _.extend({}, Errors, {

--- a/packages/fxa-content-server/app/scripts/lib/vat.js
+++ b/packages/fxa-content-server/app/scripts/lib/vat.js
@@ -24,6 +24,7 @@ Vat.register(
 Vat.register('codeChallengeMethod', Vat.string().valid('S256'));
 Vat.register('email', Vat.string().test(Validate.isEmailValid));
 Vat.register('hex', Vat.string().test(Validate.isHexValid));
+Vat.register('idToken', Vat.string().test(Validate.isBase64Url));
 Vat.register('keyFetchToken', Vat.string());
 Vat.register('keysJwk', Vat.string().test(Validate.isBase64Url));
 Vat.register(

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -1644,6 +1644,17 @@ const Account = Backbone.Model.extend(
         )
         .then(this.set.bind(this));
     },
+
+    /**
+     * Verify the OIDC ID Token associated with an account.
+     *
+     * @param {String} idToken - the ID Token
+     * @param {String} clientId - the client ID, used to verify the 'aud' claim
+     * @returns {Promise} resolves with response when complete.
+     */
+    verifyIdToken(idToken, clientId) {
+      return this._fxaClient.verifyIdToken(idToken, clientId);
+    },
   },
   {
     ALLOWED_KEYS: ALLOWED_KEYS,

--- a/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
@@ -46,6 +46,7 @@ const SIGNIN_SIGNUP_QUERY_PARAM_SCHEMA = {
     'codeChallengeMethod'
   ),
   keys_jwk: Vat.keysJwk().renameTo('keysJwk'),
+  id_token_hint: Vat.idToken().renameTo('idTokenHint'),
   login_hint: Vat.email().renameTo('loginHint'),
   prompt: Vat.prompt(),
   redirect_uri: Vat.url()
@@ -388,6 +389,10 @@ var OAuthRelier = Relier.extend({
           throw OAuthErrors.toError('PROMPT_NONE_NOT_ENABLED');
         }
 
+        // `prompt=none` access was controlled when we only used `login_hint`,
+        // but we should consider loosening this restriction, and instead allow
+        // all RPs to use `id_token_hint`. See the discussion issue:
+        // https://github.com/mozilla/fxa/issues/4963
         if (!this._config.isPromptNoneEnabledForClient) {
           throw OAuthErrors.toError('PROMPT_NONE_NOT_ENABLED_FOR_CLIENT');
         }
@@ -396,23 +401,44 @@ var OAuthRelier = Relier.extend({
           throw OAuthErrors.toError('PROMPT_NONE_WITH_KEYS');
         }
 
-        const requestedEmail = this.get('email');
-        if (!requestedEmail) {
-          // yeah yeah, it's a bit strange to look at `email`
-          // and then say `login_hint` is missing. `login_hint`
-          // is the OIDC spec compliant name, we supported `email` first
-          // and don't want to break backwards compatibility.
-          // `login_hint` is copied to the `email` field if no `email`
-          // is specified. If neither is available, throw an error
-          // about `login_hint` since it's spec compliant.
-          throw OAuthErrors.toMissingParameterError('login_hint');
-        }
         if (account.isDefault() || !account.get('sessionToken')) {
           throw OAuthErrors.toError('PROMPT_NONE_NOT_SIGNED_IN');
         }
 
-        if (requestedEmail !== account.get('email')) {
-          throw OAuthErrors.toError('PROMPT_NONE_DIFFERENT_USER_SIGNED_IN');
+        // If `id_token_hint` is present, ignore `login_hint` / `email`.
+        const idTokenHint = this.get('idTokenHint');
+        if (idTokenHint) {
+          return account
+            .verifyIdToken(idTokenHint, this.get('clientId'))
+            .catch(err => {
+              throw OAuthErrors.toError('PROMPT_NONE_INVALID_ID_TOKEN_HINT');
+            })
+            .then(claims => {
+              if (claims.sub !== account.get('uid')) {
+                throw OAuthErrors.toError(
+                  'PROMPT_NONE_DIFFERENT_USER_SIGNED_IN'
+                );
+              }
+            });
+        } else {
+          const requestedEmail = this.get('email');
+
+          if (!requestedEmail) {
+            // yeah yeah, it's a bit strange to look at `email`
+            // and then say `login_hint` is missing. `login_hint`
+            // is the OIDC spec compliant name, we supported `email` first
+            // and don't want to break backwards compatibility.
+            // `login_hint` is copied to the `email` field if no `email`
+            // is specified. If neither is available, throw an error
+            // about `login_hint` since it's spec compliant.
+            //
+            // (Should the error mention id_token_hint as well?)
+            throw OAuthErrors.toMissingParameterError('login_hint');
+          }
+
+          if (requestedEmail !== account.get('email')) {
+            throw OAuthErrors.toError('PROMPT_NONE_DIFFERENT_USER_SIGNED_IN');
+          }
         }
 
         // account has all the right bits associated with it,

--- a/packages/fxa-content-server/tests/functional/oauth_prompt_none.js
+++ b/packages/fxa-content-server/tests/functional/oauth_prompt_none.js
@@ -99,7 +99,13 @@ registerSuite('oauth prompt=none', {
     },
 
     'fails if no login_hint': function() {
+      const email = createEmail();
+      // We do the session check before the login_hint/id_token_hint check,
+      // so need a session to generate this error.
       return this.remote
+        .then(createUser(email, PASSWORD, { preVerified: true }))
+        .then(openPage(EMAIL_FIRST_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
         .then(
           openRP({
             query: { return_on_error: false },

--- a/packages/fxa-js-client/client/FxAccountClient.js
+++ b/packages/fxa-js-client/client/FxAccountClient.js
@@ -2600,6 +2600,26 @@ FxAccountClient.prototype.verifyRecoveryKey = function(
 };
 
 /**
+ * @param {String} idToken, an OIDC ID Token
+ * @param {String} clientId, used to check the Audience Claim ('aud') in the
+ *   token matches the current client.
+ */
+FxAccountClient.prototype.verifyIdToken = function(idToken, clientId) {
+  var request = this.request;
+  return Promise.resolve()
+    .then(function() {
+      required(idToken, 'idToken');
+      required(clientId, 'clientId');
+    })
+    .then(function(creds) {
+      return request.send('/oauth/id-token-verify', 'POST', null, {
+        id_token: idToken,
+        client_id: clientId,
+      });
+    });
+};
+
+/**
  * Create an OAuth code using `sessionToken`
  *
  * @param {String} sessionToken

--- a/packages/fxa-js-client/tests/lib/oauth.js
+++ b/packages/fxa-js-client/tests/lib/oauth.js
@@ -6,6 +6,8 @@ const assert = require('chai').assert;
 const Environment = require('../addons/environment');
 
 const CLIENT_ID = 'dcdb5ae7add825d2';
+const ID_TOKEN =
+  '001122334455.66778899aabbccddeeff00112233445566778899.aabbccddeeff';
 const PUBLIC_CLIENT_ID = 'a2270f727f45f648';
 
 describe('oauth', function() {
@@ -189,6 +191,48 @@ describe('oauth', function() {
             'profile'
           ),
           RequestMocks.getOAuthScopedKeyData
+        );
+      })
+      .then(function(resp) {
+        assert.ok(resp);
+      }, assert.fail);
+  });
+
+  it('#verifyIdToken - missing idToken', function() {
+    return accountHelper
+      .newVerifiedAccount()
+      .then(function(account) {
+        return respond(
+          client.verifyIdToken(null, CLIENT_ID),
+          RequestMocks.verifyIdToken
+        );
+      })
+      .then(assert.fail, function(error) {
+        assert.include(error.message, 'Missing idToken');
+      });
+  });
+
+  it('#verifyIdToken - missing clientId', function() {
+    return accountHelper
+      .newVerifiedAccount()
+      .then(function(account) {
+        return respond(
+          client.verifyIdToken(ID_TOKEN, null),
+          RequestMocks.verifyIdToken
+        );
+      })
+      .then(assert.fail, function(error) {
+        assert.include(error.message, 'Missing clientId');
+      });
+  });
+
+  it('#verifyIdToken', function() {
+    return accountHelper
+      .newVerifiedAccount()
+      .then(function(account) {
+        return respond(
+          client.verifyIdToken(ID_TOKEN, CLIENT_ID),
+          RequestMocks.verifyIdToken
         );
       })
       .then(function(resp) {

--- a/packages/fxa-js-client/tests/mocks/request.js
+++ b/packages/fxa-js-client/tests/mocks/request.js
@@ -575,4 +575,9 @@ module.exports = {
     status: 200,
     body: '{"success": true, "ticket": "abc123xyz"}',
   },
+  verifyIdToken: {
+    status: 200,
+    body:
+      '{"aud": "59cceb6f8c32317c", "iss": "http://127.0.0.1:3030", "alg": "RS256", "exp": 1587024184, "iat": 1587023184, "sub": "0577e7a5fbf448e3bc60dacbff5dcd5c"}',
+  },
 };


### PR DESCRIPTION
Adds a server-side id token verifier and threads the token verification
step through fxa-js-client and the account and oauth relier models.