### PR TITLE
chore(audit): only audit on push once per day

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ secrets.json
 .es5cache
 /artifacts
 /packages/test.list
+.last-audit
 
 # Dependencies
 **/node_modules

--- a/_scripts/audit.sh
+++ b/_scripts/audit.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+FILE=.last-audit
+NOW=$(date +%s)
+
+function run_audit() {
+  npm run audit
+  echo $NOW > $FILE
+}
+
+if [ -f "$FILE" ]; then
+  THRESHOLD=86400 # 24 hours
+  EXISTING=$(< $FILE)
+  DIFFERENCE=$(($NOW - $EXISTING))
+
+  if [ "$DIFFERENCE" -ge "$THRESHOLD" ]; then
+    run_audit
+  else
+    echo "Audited within the last 24 hours, skipping"
+  fi
+else
+  echo "Creating an inital audit record"
+  run_audit
+fi

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "npm run audit"
+      "pre-push": "_scripts/audit.sh"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Totally fine if this idea gets rejected, but it was quick so I wanted to get everyone's take on it.

I am consistently running into issues with the NPM audit service, and am frequently having to push with `--no-verify`. This PR changes the pre-push hook to run a script that checks if you've audited within the last 24 hours. If you have, skip it, and audit again when 24 hours has passed.

To be clear, it doesn't solve the problem with auditing, buuuut it reduces the amount of times you could encounter the issue. Plus, with the number of people pushing to the repo there are absolutely going to be checks less than 24 hours apart.

Thoughts?