### PR TITLE
test(functional): add missing scenarios to the delete account and display name test

### DIFF
--- a/packages/fxa-content-server/tests/functional/delete_account.js
+++ b/packages/fxa-content-server/tests/functional/delete_account.js
@@ -20,7 +20,6 @@ const {
   createEmail,
   createUser,
   type,
-  fillOutDeleteAccount,
   fillOutEmailFirstSignIn,
   testElementTextInclude,
   openPage,
@@ -40,7 +39,7 @@ registerSuite('delete_account', {
   },
 
   tests: {
-    'sign in, delete account with incorrect password': function() {
+    'sign in, delete account': function() {
       return (
         this.remote
           .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
@@ -57,8 +56,13 @@ registerSuite('delete_account', {
           .findAllByCssSelector(selectors.SETTINGS_DELETE_ACCOUNT.CHECKBOXES)
           .then(checkboxes => checkboxes.map(checkbox => checkbox.click()))
           .end()
+
+          //enter incorrect password
           .then(
-            type(selectors.SETTINGS_DELETE_ACCOUNT.INPUT_PASSWORD, 'PASSWORD')
+            type(
+              selectors.SETTINGS_DELETE_ACCOUNT.INPUT_PASSWORD,
+              'incorrect password'
+            )
           )
           .then(click(selectors.SETTINGS_DELETE_ACCOUNT.SUBMIT))
           .then(
@@ -66,24 +70,12 @@ registerSuite('delete_account', {
               selectors.SETTINGS_DELETE_ACCOUNT.TOOLTIP_INCORRECT_PASSWORD
             )
           )
-      );
-    },
 
-    'sign in, delete account with correct password': function() {
-      return (
-        this.remote
-          .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-          .then(fillOutEmailFirstSignIn(email, PASSWORD))
-          .then(testElementExists(selectors.SETTINGS.HEADER))
-
-          // Go to delete account screen
+          //enter correct password
           .then(
-            click(
-              selectors.SETTINGS_DELETE_ACCOUNT.MENU_BUTTON,
-              selectors.SETTINGS_DELETE_ACCOUNT.DETAILS
-            )
+            type(selectors.SETTINGS_DELETE_ACCOUNT.INPUT_PASSWORD, PASSWORD)
           )
-          .then(fillOutDeleteAccount(PASSWORD))
+          .then(click(selectors.SETTINGS_DELETE_ACCOUNT.SUBMIT))
           .then(testElementExists(selectors.ENTER_EMAIL.HEADER))
           .then(testSuccessWasShown())
           .then(type(selectors.ENTER_EMAIL.EMAIL, email))

--- a/packages/fxa-content-server/tests/functional/delete_account.js
+++ b/packages/fxa-content-server/tests/functional/delete_account.js
@@ -19,10 +19,13 @@ const {
   click,
   createEmail,
   createUser,
+  type,
   fillOutDeleteAccount,
   fillOutEmailFirstSignIn,
+  testElementTextInclude,
   openPage,
   pollUntilHiddenByQSA,
+  visibleByQSA,
   testElementExists,
   testSuccessWasShown,
 } = FunctionalHelpers;
@@ -37,7 +40,36 @@ registerSuite('delete_account', {
   },
 
   tests: {
-    'sign in, delete account': function() {
+    'sign in, delete account with incorrect password': function() {
+      return (
+        this.remote
+          .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
+          .then(testElementExists(selectors.SETTINGS.HEADER))
+
+          // Go to delete account screen
+          .then(
+            click(
+              selectors.SETTINGS_DELETE_ACCOUNT.MENU_BUTTON,
+              selectors.SETTINGS_DELETE_ACCOUNT.DETAILS
+            )
+          )
+          .findAllByCssSelector(selectors.SETTINGS_DELETE_ACCOUNT.CHECKBOXES)
+          .then(checkboxes => checkboxes.map(checkbox => checkbox.click()))
+          .end()
+          .then(
+            type(selectors.SETTINGS_DELETE_ACCOUNT.INPUT_PASSWORD, 'PASSWORD')
+          )
+          .then(click(selectors.SETTINGS_DELETE_ACCOUNT.SUBMIT))
+          .then(
+            visibleByQSA(
+              selectors.SETTINGS_DELETE_ACCOUNT.TOOLTIP_INCORRECT_PASSWORD
+            )
+          )
+      );
+    },
+
+    'sign in, delete account with correct password': function() {
       return (
         this.remote
           .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
@@ -52,9 +84,11 @@ registerSuite('delete_account', {
             )
           )
           .then(fillOutDeleteAccount(PASSWORD))
-
           .then(testElementExists(selectors.ENTER_EMAIL.HEADER))
           .then(testSuccessWasShown())
+          .then(type(selectors.ENTER_EMAIL.EMAIL, email))
+          .then(click(selectors.ENTER_EMAIL.SUBMIT))
+          .then(visibleByQSA(selectors.SIGNUP_PASSWORD.HEADER))
       );
     },
 
@@ -72,8 +106,17 @@ registerSuite('delete_account', {
             )
           )
 
+          .findAllByCssSelector(selectors.SETTINGS_DELETE_ACCOUNT.CHECKBOXES)
+          .then(checkboxes => checkboxes.map(checkbox => checkbox.click()))
+          .end()
+          .then(
+            type(selectors.SETTINGS_DELETE_ACCOUNT.INPUT_PASSWORD, PASSWORD)
+          )
           .then(click(selectors.SETTINGS_DELETE_ACCOUNT.CANCEL))
           .then(pollUntilHiddenByQSA(selectors.SETTINGS_DELETE_ACCOUNT.DETAILS))
+          .then(
+            testElementTextInclude(selectors.SETTINGS.PROFILE_HEADER, email)
+          )
       );
     },
   },

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -365,6 +365,7 @@ module.exports = {
     CHECKBOXES: '#delete-account .delete-account-checkbox',
     INPUT_PASSWORD: '#delete-account form input.password',
     SUBMIT: '#delete-account button[type="submit"]',
+    TOOLTIP_INCORRECT_PASSWORD: 'input[type=password] ~ .tooltip',
   },
   SETTINGS_DISPLAY_NAME: {
     INPUT_DISPLAY_NAME: '#display-name input[type=text]',

--- a/packages/fxa-content-server/tests/functional/settings.js
+++ b/packages/fxa-content-server/tests/functional/settings.js
@@ -24,6 +24,7 @@ const {
   denormalizeStoredEmail,
   destroySessionForEmail,
   fillOutEmailFirstSignIn,
+  testElementTextInclude,
   focus,
   noSuchElement,
   openPage,
@@ -207,20 +208,45 @@ registerSuite('settings', {
 
     'sign in, open settings and add a display name': function() {
       var name = 'joe';
-      return this.remote
-        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-        .then(fillOutEmailFirstSignIn(email, FIRST_PASSWORD, true))
-        .then(
-          click(
-            selectors.SETTINGS_DISPLAY_NAME.MENU_BUTTON,
-            selectors.SETTINGS_DISPLAY_NAME.INPUT_DISPLAY_NAME
+      return (
+        this.remote
+          .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+          .then(fillOutEmailFirstSignIn(email, FIRST_PASSWORD, true))
+          .then(
+            click(
+              selectors.SETTINGS_DISPLAY_NAME.MENU_BUTTON,
+              selectors.SETTINGS_DISPLAY_NAME.INPUT_DISPLAY_NAME
+            )
           )
-        )
-        .then(type(selectors.SETTINGS_DISPLAY_NAME.INPUT_DISPLAY_NAME, name))
-        .then(click(selectors.SETTINGS_DISPLAY_NAME.SUBMIT))
-        .then(visibleByQSA(selectors.SETTINGS_DISPLAY_NAME.MENU_BUTTON))
-        .then(testElementTextEquals(selectors.SETTINGS.PROFILE_HEADER, name));
+          .then(type(selectors.SETTINGS_DISPLAY_NAME.INPUT_DISPLAY_NAME, name))
+          .then(click(selectors.SETTINGS_DISPLAY_NAME.SUBMIT))
+          .then(visibleByQSA(selectors.SETTINGS_DISPLAY_NAME.MENU_BUTTON))
+          .then(testElementTextEquals(selectors.SETTINGS.PROFILE_HEADER, name))
+
+          //To change the Display name
+          .then(
+            click(
+              selectors.SETTINGS_DISPLAY_NAME.MENU_BUTTON,
+              selectors.SETTINGS_DISPLAY_NAME.INPUT_DISPLAY_NAME
+            )
+          )
+          .then(
+            type(
+              selectors.SETTINGS_DISPLAY_NAME.INPUT_DISPLAY_NAME,
+              'Test User'
+            )
+          )
+
+          .then(click(selectors.SETTINGS_DISPLAY_NAME.SUBMIT))
+          .then(
+            testElementTextInclude(
+              selectors.SETTINGS.PROFILE_HEADER,
+              'Test User'
+            )
+          )
+      );
     },
+
     'sign in, open settings in a second tab, sign out': function() {
       return (
         this.remote


### PR DESCRIPTION
I made the following changes:
- added scenario for "delete account with **incorrect** password" in the delete_account.js, selectors.js file
- made small changes to the "delete account with **correct password** and **click cancel** testcases" in delete_account.js file
- added scenario for 'changing display name' in the settings.js file

@vbudhram - Please review.
