### PR TITLE
fix(settings): don't allow display name or email to break page layout

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -252,6 +252,7 @@ body.settings #stage .settings {
   align-items: center;
   display: flex;
   flex-direction: row;
+  max-width: 100vw;
 
   @include respond-to('big') {
     padding: 0 32px;


### PR DESCRIPTION
Closes #4775

Also, the name in my screenshot is [real](https://www.historyrundown.com/top-5-people-with-the-longest-names/#3David_Fearn).

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-04-09 at 15 52 28](https://user-images.githubusercontent.com/6392049/78935190-4165a280-7a7a-11ea-82e8-708434c99234.png)
