### PR TITLE
refactor(config): replace 127.0.0.1 with localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The Firefox Accounts (fxa) monorepo
 
 Note this starts up all required services, including Redis, MySQL, and Memcached. It is recommended that you don't run these services yourself, or occupy any of the [server ports](https://github.com/mozilla/fxa/blob/master/mysql_servers.json). Doing so may result in errors.
 
-4. Visit [127.0.0.1:3030](http://127.0.0.1:3030/).
+4. Visit [localhost:3030](http://localhost:3030/).
 
 Use the [PM2 tool](https://github.com/Unitech/PM2#main-features) to stop and start the servers, and read server logs.
 
@@ -88,7 +88,7 @@ Once you are back working on FxA just use the `npm start` command to bring the s
 
 Use the `./pm2 logs` command to get the logs of all servers. You may also use `./pm2 logs [id]` to just see the logs for that particular server.
 
-When you signup for an account using the form on `127.0.0.1:3030/signup` the "inbox" logs will print out the verification code that you need to copy paste into your browser to verify your account locally:
+When you signup for an account using the form on `localhost:3030/signup` the "inbox" logs will print out the verification code that you need to copy paste into your browser to verify your account locally:
 
 ![](https://i.imgur.com/cdh9Xrl.png)
 

--- a/_scripts/config-fxios.js
+++ b/_scripts/config-fxios.js
@@ -1,46 +1,53 @@
 #!/usr/bin/env node
 
-var path = require('path');
+var path = require("path");
 
-var r = require('replace-in-file');
+var r = require("replace-in-file");
 
 var ios_path = process.env.FIREFOX_IOS_HOME;
 
-if (! ios_path) {
-  throw new Error('FIREFOX_IOS_HOME is not set');
+if (!ios_path) {
+  throw new Error("FIREFOX_IOS_HOME is not set");
 }
 
-var config_path = path.join(ios_path, 'Account', 'FirefoxAccountConfiguration.swift');
+var config_path = path.join(
+  ios_path,
+  "Account",
+  "FirefoxAccountConfiguration.swift"
+);
 
 function replace(options) {
-  return new Promise(function (resolve, reject) {
+  return new Promise(function(resolve, reject) {
     r(options, function(err) {
       if (err) reject(err);
       resolve();
-    })
+    });
   });
 }
 
 return replace({
   files: config_path,
   replace: /https:\/\/accounts.firefox.com/g,
-  with: 'http://127.0.0.1:3030'
-}).then(function () {
-  return replace({
-    files: config_path,
-    replace: 'https://api.accounts.firefox.com/v1',
-    with: 'http://127.0.0.1:9000/v1'
+  with: "http://localhost:3030"
+})
+  .then(function() {
+    return replace({
+      files: config_path,
+      replace: "https://api.accounts.firefox.com/v1",
+      with: "http://localhost:9000/v1"
+    });
+  })
+  .then(function() {
+    return replace({
+      files: config_path,
+      replace: "https://oauth.accounts.firefox.com/v1",
+      with: "http://localhost:9010/v1"
+    });
+  })
+  .then(function() {
+    return replace({
+      files: config_path,
+      replace: "https://profile.accounts.firefox.com/v1",
+      with: "http://localhost:1111/v1"
+    });
   });
-}).then(function () {
-  return replace({
-    files: config_path,
-    replace: 'https://oauth.accounts.firefox.com/v1',
-    with: 'http://127.0.0.1:9010/v1'
-  });
-}).then(function () {
-  return replace({
-    files: config_path,
-    replace: 'https://profile.accounts.firefox.com/v1',
-    with: 'http://localhost:1111/v1'
-  });
-});

--- a/_scripts/configs/loop.json
+++ b/_scripts/configs/loop.json
@@ -2,8 +2,8 @@
   "fxaOAuth": {
     "client_id": "263ceaa5546dce83",
     "client_secret": "852ae8d050d6805a402272e0c776193cfba263ceaa5546dce837191be98db91e",
-    "content_uri": "http://127.0.0.1:3030",
-    "profile_uri": "http://127.0.0.1:1111/v1",
-    "oauth_uri": "http://127.0.0.1:9000/v1"
+    "content_uri": "http://localhost:3030",
+    "profile_uri": "http://localhost:1111/v1",
+    "oauth_uri": "http://localhost:9000/v1"
   }
 }

--- a/_scripts/syncserver.sh
+++ b/_scripts/syncserver.sh
@@ -5,14 +5,14 @@ DOCKER_OS="$(docker info --format '{{.OperatingSystem}}')"
 if [ "$DOCKER_OS" = 'Docker for Windows' ] || [ "$DOCKER_OS" = 'Docker for Mac' ] || [ "$DOCKER_OS" = 'Docker Desktop' ]; then
   HOST_ADDR='host.docker.internal'
 else
-  HOST_ADDR='127.0.0.1'
+  HOST_ADDR='localhost'
 fi
 
 "${0%/*}/check-url.sh" "http://$HOST_ADDR:3030/.well-known/fxa-client-configuration"
 
 docker run --rm --name syncserver \
   -p 5000:5000 \
-  -e SYNCSERVER_PUBLIC_URL=http://127.0.0.1:5000 \
+  -e SYNCSERVER_PUBLIC_URL=http://localhost:5000 \
   -e SYNCSERVER_IDENTITY_PROVIDER=http://$HOST_ADDR:3030 \
   -e SYNCSERVER_OAUTH_VERIFIER=http://$HOST_ADDR:9000 \
   -e SYNCSERVER_BROWSERID_VERIFIER=http://$HOST_ADDR:5050 \

--- a/packages/123done/README.md
+++ b/packages/123done/README.md
@@ -8,7 +8,7 @@
 1. install dependencies: `npm install`
 1. generate keys `node scripts/gen_keys.js`
 1. run the server: `npm start`
-1. visit it in your browser: `http://127.0.0.1:8080/`
+1. visit it in your browser: `http://localhost:8080/`
 1. hack and reload! (web resources don't require a server restart)
 
 [git]: http://git-scm.org

--- a/packages/123done/ansible/playbooks/roles/common/files/supervisord.conf
+++ b/packages/123done/ansible/playbooks/roles/common/files/supervisord.conf
@@ -14,7 +14,7 @@ chown=root:supervsr         ; socket file uid:gid owner
 ;password=123               ; (default is no password (open server))
 
 ;[inet_http_server]         ; inet (TCP) server disabled by default
-;port=127.0.0.1:9001        ; (ip_address:port specifier, *:port for all iface)
+;port=localhost:9001        ; (ip_address:port specifier, *:port for all iface)
 ;username=user              ; (default is no username (open server))
 ;password=123               ; (default is no password (open server))
 
@@ -44,7 +44,7 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
 serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
-;serverurl=http://127.0.0.1:9001 ; use an http:// url to specify an inet socket
+;serverurl=http://localhost:9001 ; use an http:// url to specify an inet socket
 ;username=chris              ; should be same as http_username if set
 ;password=123                ; should be same as http_password if set
 ;prompt=mysupervisor         ; cmd line prompt (default "supervisor")

--- a/packages/123done/ansible/playbooks/roles/nginx/templates/nginx.conf.j2
+++ b/packages/123done/ansible/playbooks/roles/nginx/templates/nginx.conf.j2
@@ -28,7 +28,7 @@ http {
     }
 
     upstream 123done_upstream {
-      server 127.0.0.1:10000;
+      server localhost:10000;
       keepalive 64;
     }
 
@@ -49,7 +49,7 @@ http {
     }
 
     upstream 321done_upstream {
-      server 127.0.0.1:11000;
+      server localhost:11000;
       keepalive 64;
     }
 

--- a/packages/123done/config-local-untrusted.json
+++ b/packages/123done/config-local-untrusted.json
@@ -2,7 +2,7 @@
   "cookieName": "321done",
   "client_id": "325b4083e32fe8e7",
   "client_secret": "a084f4c36501ea1eb2de33258421af97b2e67ffbe107d2812f4a14f3579900ef",
-  "redirect_uri": "http://127.0.0.1:10139/api/oauth",
-  "issuer_uri": "http://127.0.0.1:3030",
+  "redirect_uri": "http://localhost:10139/api/oauth",
+  "issuer_uri": "http://localhost:3030",
   "scopes": "profile:display_name profile:email profile:uid openid"
 }

--- a/packages/123done/config-local.json
+++ b/packages/123done/config-local.json
@@ -1,9 +1,9 @@
 {
   "client_id": "dcdb5ae7add825d2",
   "client_secret": "b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8",
-  "redirect_uri": "http://127.0.0.1:8080/api/oauth",
-  "issuer_uri": "http://127.0.0.1:3030",
+  "redirect_uri": "http://localhost:8080/api/oauth",
+  "issuer_uri": "http://localhost:3030",
   "scopes": "profile openid",
   "pkce_client_id": "38a6b9b3a65a1871",
-  "pkce_redirect_uri": "http://127.0.0.1:8080/?oauth_pkce_redirect=1"
+  "pkce_redirect_uri": "http://localhost:8080/?oauth_pkce_redirect=1"
 }

--- a/packages/123done/config.json
+++ b/packages/123done/config.json
@@ -3,9 +3,9 @@
   "client_secret": "b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8",
 
   "pkce_client_id": "38a6b9b3a65a1871",
-  "pkce_redirect_uri": "http://127.0.0.1:8080/?&oauth_pkce_redirect=1",
+  "pkce_redirect_uri": "http://localhost:8080/?&oauth_pkce_redirect=1",
 
-  "redirect_uri": "http://127.0.0.1:8080/api/oauth",
+  "redirect_uri": "http://localhost:8080/api/oauth",
   "issuer_uri": "https://stable.dev.lcip.org",
   "scopes": "profile openid"
 }

--- a/packages/123done/static/index.html
+++ b/packages/123done/static/index.html
@@ -24,7 +24,7 @@
       </button>
 
       <a
-        href="//127.0.0.1:3030/subscriptions/products/prod_GqM9ToKK62qjkK"
+        href="//localhost:3030/subscriptions/products/prod_GqM9ToKK62qjkK"
         class="btn btn-persona btn-subscribe"
         >Subscribe for Pro</a
       >
@@ -137,7 +137,7 @@
           <div id="loggedin"><span></span></div>
           <div id="subscriptionCTA">
             <a
-              href="//127.0.0.1:3030/subscriptions/products/prod_GqM9ToKK62qjkK"
+              href="//localhost:3030/subscriptions/products/prod_GqM9ToKK62qjkK"
               class="btn btn-persona btn-subscribe"
               >Subscribe for Pro</a
             >

--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -30,7 +30,7 @@ $(document).ready(function() {
       break;
     default:
       paymentURL =
-        '//127.0.0.1:3030/subscriptions/products/prod_GjeDrVtBRfiWjm';
+        '//localhost:3030/subscriptions/products/prod_GjeDrVtBRfiWjm';
       break;
   }
   $('.btn-subscribe').each(function(index) {

--- a/packages/browserid-verifier/lib/config.js
+++ b/packages/browserid-verifier/lib/config.js
@@ -8,8 +8,8 @@ function loadConf() {
   var conf = convict({
     ip: {
       doc: 'The IP address to bind.',
-      format: 'ipaddress',
-      default: '127.0.0.1',
+      format: String,
+      default: 'localhost',
       env: 'IP_ADDRESS',
     },
     port: {

--- a/packages/fortress/README.md
+++ b/packages/fortress/README.md
@@ -8,7 +8,7 @@
 1. install dependencies: `npm install`
 1. generate keys `node scripts/gen_keys.js`
 1. run the server: `npm start`
-1. visit it in your browser: `http://127.0.0.1:9292/`
+1. visit it in your browser: `http://localhost:9292/`
 1. hack and reload! (web resources don't require a server restart)
 
 [git]: http://git-scm.org

--- a/packages/fortress/config-local.json
+++ b/packages/fortress/config-local.json
@@ -1,5 +1,5 @@
 {
   "client_id": "dcdb5ae7add825d2",
   "client_secret": "b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8",
-  "redirect_uri": "http://127.0.0.1:9292/download"
+  "redirect_uri": "http://localhost:9292/download"
 }

--- a/packages/fortress/config.json
+++ b/packages/fortress/config.json
@@ -1,5 +1,5 @@
 {
   "client_id": "dcdb5ae7add825d2",
   "client_secret": "b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8",
-  "redirect_uri": "http://127.0.0.1:9292/download"
+  "redirect_uri": "http://localhost:9292/download"
 }

--- a/packages/fortress/static/index.html
+++ b/packages/fortress/static/index.html
@@ -29,7 +29,7 @@
         />
         <h1>Firefox Fortress</h1>
         <a
-          href="//127.0.0.1:3030/subscriptions/products/fortressProProduct"
+          href="//localhost:3030/subscriptions/products/fortressProProduct"
           class="btn btn-subscribe"
           >Subscribe for Pro</a
         >
@@ -82,7 +82,7 @@
           </h1>
           <div id="subscriptionCTA">
             <a
-              href="//127.0.0.1:3030/subscriptions/products/fortressProProduct"
+              href="//localhost:3030/subscriptions/products/fortressProProduct"
               class="btn btn-subscribe"
               >Subscribe for Pro</a
             >

--- a/packages/fortress/static/js/fortress.js
+++ b/packages/fortress/static/js/fortress.js
@@ -8,7 +8,7 @@ q$(document).ready(function() {
         'https://latest.dev.lcip.org/subscriptions/products/plan_FUUOYlhpIhWtoo';
       break;
     default:
-      paymentURL = '//127.0.0.1:3030/subscriptions/products/fortressProProduct';
+      paymentURL = '//localhost:3030/subscriptions/products/fortressProProduct';
       break;
   }
   $('.btn-subscribe').each(function(index) {

--- a/packages/fxa-admin-panel/pm2.config.js
+++ b/packages/fxa-admin-panel/pm2.config.js
@@ -14,7 +14,7 @@ module.exports = {
         LOGGING_FORMAT: 'pretty',
         NODE_ENV: 'development',
         NODE_OPTIONS: '--inspect=9140',
-        PROXY_STATIC_RESOURCES_FROM: 'http://127.0.0.1:8092',
+        PROXY_STATIC_RESOURCES_FROM: 'http://localhost:8092',
         CONFIG_FILES: 'config/secrets.json',
         PORT: '8091',
       },
@@ -27,7 +27,7 @@ module.exports = {
       min_uptime: '2m',
       env: {
         NODE_ENV: 'development',
-        PUBLIC_URL: 'http://127.0.0.1:8091',
+        PUBLIC_URL: 'http://localhost:8091',
         BROWSER: 'NONE',
         PORT: '8092',
       },

--- a/packages/fxa-admin-panel/server/config/index.ts
+++ b/packages/fxa-admin-panel/server/config/index.ts
@@ -56,10 +56,10 @@ const conf = convict({
   },
   listen: {
     host: {
-      default: '127.0.0.1',
+      default: 'localhost',
       doc: 'The ip address the server should bind',
       env: 'IP_ADDRESS',
-      format: 'ipaddress',
+      format: String,
     },
     port: {
       default: 8091,
@@ -68,7 +68,7 @@ const conf = convict({
       format: 'port',
     },
     publicUrl: {
-      default: 'http://127.0.0.1:8091',
+      default: 'http://localhost:8091',
       env: 'PUBLIC_URL',
       format: 'url',
     },
@@ -104,7 +104,7 @@ const conf = convict({
   servers: {
     admin: {
       url: {
-        default: 'http://127.0.0.1:8090',
+        default: 'http://localhost:8090',
         doc: 'The url of the fxa-admin-server instance',
         env: 'ADMIN_SERVER_URL',
         format: 'url',
@@ -125,7 +125,7 @@ const conf = convict({
       format: 'duration',
     },
     url: {
-      default: 'http://127.0.0.1:8091',
+      default: 'http://localhost:8091',
       doc: 'The origin of the static resources',
       env: 'STATIC_RESOURCE_URL',
       format: 'url',

--- a/packages/fxa-auth-db-mysql/config/config.js
+++ b/packages/fxa-auth-db-mysql/config/config.js
@@ -12,7 +12,7 @@ module.exports = function(fs, path, url, convict) {
     },
     hostname: {
       doc: 'The IP address the server should bind to',
-      default: '127.0.0.1',
+      default: 'localhost',
       env: 'HOST',
     },
     port: {
@@ -90,7 +90,7 @@ module.exports = function(fs, path, url, convict) {
       },
       host: {
         doc: 'The host to connect to for MySql',
-        default: '127.0.0.1',
+        default: 'localhost',
         env: 'MYSQL_HOST',
       },
       port: {
@@ -133,7 +133,7 @@ module.exports = function(fs, path, url, convict) {
       },
       host: {
         doc: 'The host to connect to for MySql',
-        default: '127.0.0.1',
+        default: 'localhost',
         env: 'MYSQL_SLAVE_HOST',
       },
       port: {

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -1,6 +1,6 @@
 {
   "contentServer": {
-    "url": "http://127.0.0.1:3030"
+    "url": "http://localhost:3030"
   },
   "customsUrl": "none",
   "lockoutEnabled": true,
@@ -13,10 +13,10 @@
     "useMock": true
   },
   "smtp": {
-    "host": "127.0.0.1",
+    "host": "localhost",
     "port": 9999,
     "secure": false,
-    "redirectDomain": "127.0.0.1",
+    "redirectDomain": "localhost",
     "subscriptionTermsUrl": "https://www.mozilla.org/about/legal/terms/firefox-private-network/"
   },
   "snsTopicArn": "arn:aws:sns:local-01:000000000000:local-topic1",
@@ -34,7 +34,7 @@
     "jwtSecretKeys": ["megaz0rd"]
   },
   "profileServer": {
-    "url": "http://127.0.0.1:1111",
+    "url": "http://localhost:1111",
     "secretBearerToken": "8675309jenny"
   },
   "pushbox": {
@@ -45,7 +45,7 @@
   },
   "subhub": {
     "enabled": true,
-    "url": "http://127.0.0.1:8012/",
+    "url": "http://localhost:8012/",
     "key": "abcde",
     "useStubs": true,
     "stubs": {
@@ -58,10 +58,10 @@
             "capabilities:dcdb5ae7add825d2": "123donePro",
             "productSet": "123done_product",
             "productOrder": "1",
-            "upgradeCTA": "Interested in an upgrade? <a href=\"http://127.0.0.1:3030/subscriptions/products/123doneProPlusProduct \">Get Pro+!</a>",
+            "upgradeCTA": "Interested in an upgrade? <a href=\"http://localhost:3030/subscriptions/products/123doneProPlusProduct \">Get Pro+!</a>",
             "webIconURL": "http://placekitten.com/512/512?image=6",
             "emailIconURL": "http://placekitten.com/512/512?image=0",
-            "downloadURL": "http://127.0.0.1:8080/"
+            "downloadURL": "http://localhost:8080/"
           },
           "interval": "month",
           "amount": 50,
@@ -73,7 +73,7 @@
           "product_name": "123done Pro+",
           "product_metadata": {
             "capabilities:dcdb5ae7add825d2": "123donePro",
-            "downloadURL": "http://127.0.0.1:8080/",
+            "downloadURL": "http://localhost:8080/",
             "productSet": "123done_product",
             "productOrder": "2"
           },
@@ -89,7 +89,7 @@
             "capabilities:325b4083e32fe8e7": "321donePro",
             "webIconURL": "http://placekitten.com/512/512?image=7",
             "emailIconURL": "http://placekitten.com/512/512?image=1",
-            "downloadURL": "http://127.0.0.1:8080/"
+            "downloadURL": "http://localhost:8080/"
           },
           "interval": "month",
           "amount": 50,
@@ -104,7 +104,7 @@
             "capabilities:325b4083e32fe8e7": "321donePro",
             "webIconURL": "http://placekitten.com/512/512?image=8",
             "emailIconURL": "http://placekitten.com/512/512?image=2",
-            "downloadURL": "http://127.0.0.1:8080/"
+            "downloadURL": "http://localhost:8080/"
           },
           "interval": "month",
           "amount": 50,
@@ -118,7 +118,7 @@
             "capabilities": "fortress",
             "webIconURL": "http://placekitten.com/512/512?image=9",
             "emailIconURL": "http://placekitten.com/512/512?image=3",
-            "downloadURL": "http://127.0.0.1:9292/"
+            "downloadURL": "http://localhost:9292/"
           },
           "interval": "month",
           "amount": 50,
@@ -132,7 +132,7 @@
             "capabilities:325b4083e32fe8e7": "321donePro",
             "webIconURL": "http://placekitten.com/512/512?image=10",
             "emailIconURL": "http://placekitten.com/512/512?image=4",
-            "downloadURL": "http://127.0.0.1:8080/"
+            "downloadURL": "http://localhost:8080/"
           },
           "interval": "week",
           "amount": 5,
@@ -147,7 +147,7 @@
             "capabilities:325b4083e32fe8e7": "321donePro",
             "webIconURL": "http://placekitten.com/512/512?image=11",
             "emailIconURL": "http://placekitten.com/512/512?image=5",
-            "downloadURL": "http://127.0.0.1:8080/"
+            "downloadURL": "http://localhost:8080/"
           },
           "interval": "week",
           "amount": 5,
@@ -171,10 +171,10 @@
   },
   "oauthServer": {
     "browserid": {
-      "issuer": "127.0.0.1:9000",
-      "verificationUrl": "http://127.0.0.1:5050/v2"
+      "issuer": "localhost:9000",
+      "verificationUrl": "http://localhost:5050/v2"
     },
-    "contentUrl": "http://127.0.0.1:3030/oauth/",
+    "contentUrl": "http://localhost:3030/oauth/",
     "clientManagement": {
       "enabled": true
     },
@@ -190,7 +190,7 @@
         "hashedSecret": "289a885946ee316844d9ffd0d725ee714901548a1e6507f1a40fb3c2ae0c99f1",
         "name": "123Done",
         "imageUri": "https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.png",
-        "redirectUri": "http://127.0.0.1:8080/api/oauth",
+        "redirectUri": "http://localhost:8080/api/oauth",
         "trusted": true,
         "canGrant": false
       },
@@ -199,7 +199,7 @@
         "hashedSecret": "289a885946ee316844d9ffd0d725ee714901548a1e6507f1a40fb3c2ae0c99f1",
         "name": "123Done PKCE",
         "imageUri": "https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.png",
-        "redirectUri": "http://127.0.0.1:8080/?oauth_pkce_redirect=1",
+        "redirectUri": "http://localhost:8080/?oauth_pkce_redirect=1",
         "trusted": true,
         "canGrant": false,
         "publicClient": true
@@ -222,7 +222,7 @@
         "hashedSecret": "ded3c396f28123f3fe6b152784e8eab7357c6806cb5175805602a2cd67f85080",
         "name": "321Done Untrusted",
         "imageUri": "https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.png",
-        "redirectUri": "http://127.0.0.1:10139/api/oauth",
+        "redirectUri": "http://localhost:10139/api/oauth",
         "trusted": false,
         "canGrant": false
       },
@@ -264,8 +264,8 @@
       },
       {
         "name": "FxA OAuth Console",
-        "redirectUri": "http://127.0.0.1:10137/oauth/redirect",
-        "imageUri": "http://127.0.0.1:10137/assets/firefox.png",
+        "redirectUri": "http://localhost:10137/oauth/redirect",
+        "imageUri": "http://localhost:10137/assets/firefox.png",
         "id": "24bdbfa45cd300c5",
         "hashedSecret": "dfe56d5c816d6b7493618f6a1567cfed4aa9c25f85d59c6804631c48774ba545",
         "trusted": true,
@@ -304,7 +304,7 @@
         "name": "Android Components Reference Browser",
         "hashedSecret": "a7ee3482fab1782f5d3945cde06bb911605a8dfc1a45e4b77bc76615d5671e51",
         "imageUri": "",
-        "redirectUri": "http://127.0.0.1:3030/oauth/success/3c49430b43dfba77",
+        "redirectUri": "http://localhost:3030/oauth/success/3c49430b43dfba77",
         "canGrant": true,
         "trusted": true,
         "allowedScopes": "https://identity.mozilla.com/apps/oldsync https://identity.mozilla.com/tokens/session",
@@ -315,7 +315,7 @@
         "name": "Fenix",
         "hashedSecret": "4a892c55feaceb4ef2dbfffaaaa3d8eea94b5c205c815dddfc90170741cd4c19",
         "imageUri": "",
-        "redirectUri": "http://127.0.0.1:3030/oauth/success/a2270f727f45f648",
+        "redirectUri": "http://localhost:3030/oauth/success/a2270f727f45f648",
         "canGrant": true,
         "trusted": true,
         "allowedScopes": "https://identity.mozilla.com/apps/oldsync https://identity.mozilla.com/tokens/session",
@@ -326,7 +326,7 @@
         "name": "Firefox for iOS",
         "hashedSecret": "4a892c55feaceb4ef2dbfffaaaa3d8eea94b5c205c815dddfc90170741cd4c19",
         "imageUri": "",
-        "redirectUri": "http://127.0.0.1:3030/oauth/success/1b1a3e44c54fbb58",
+        "redirectUri": "http://localhost:3030/oauth/success/1b1a3e44c54fbb58",
         "canGrant": true,
         "trusted": true,
         "allowedScopes": "https://identity.mozilla.com/apps/oldsync https://identity.mozilla.com/tokens/session",
@@ -336,7 +336,7 @@
         "id": "59cceb6f8c32317c",
         "name": "Firefox Accounts Subscriptions",
         "hashedSecret": "220e560d48cf91dbba0219b986ca242a0b278eab8467bb07442fdfed1b245788",
-        "redirectUri": "http://127.0.0.1:3031/",
+        "redirectUri": "http://localhost:3031/",
         "imageUri": "",
         "canGrant": true,
         "termsUri": "",
@@ -349,7 +349,7 @@
         "hashedSecret": "289a885946ee316844d9ffd0d725ee714901548a1e6507f1a40fb3c2ae0c99f1",
         "name": "Disabled Client",
         "imageUri": "https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.png",
-        "redirectUri": "http://127.0.0.1:8080/?oauth_pkce_redirect=1",
+        "redirectUri": "http://localhost:8080/?oauth_pkce_redirect=1",
         "trusted": true,
         "canGrant": false,
         "publicClient": true
@@ -366,7 +366,7 @@
       ]
     },
     "openid": {
-      "issuer": "http://127.0.0.1:3030",
+      "issuer": "http://localhost:3030",
       "keyFile": "config/key.json",
       "newKeyFile": "config/newKey.json",
       "oldKeyFile": "config/oldKey.json"

--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -64,7 +64,7 @@ const conf = convict({
     address: {
       doc:
         'Address:port of the memcached server (or `none` to disable memcached)',
-      default: '127.0.0.1:11211',
+      default: 'localhost:11211',
       env: 'MEMCACHE_METRICS_CONTEXT_ADDRESS',
     },
     idle: {
@@ -82,7 +82,7 @@ const conf = convict({
   },
   publicUrl: {
     format: 'url',
-    default: 'http://127.0.0.1:9000',
+    default: 'http://localhost:9000',
     env: 'PUBLIC_URL',
   },
   domain: {
@@ -148,15 +148,15 @@ const conf = convict({
   httpdb: {
     url: {
       doc: 'database api url',
-      default: 'http://127.0.0.1:8000',
+      default: 'http://localhost:8000',
       env: 'HTTPDB_URL',
     },
   },
   listen: {
     host: {
       doc: 'The ip address the server should bind',
-      default: '127.0.0.1',
-      format: 'ipaddress',
+      default: 'localhost',
+      format: String,
       env: 'IP_ADDRESS',
     },
     port: {
@@ -168,21 +168,21 @@ const conf = convict({
   },
   customsUrl: {
     doc: "fraud / abuse server url; set to the string 'none' to disable",
-    default: 'http://127.0.0.1:7000',
+    default: 'http://localhost:7000',
     env: 'CUSTOMS_SERVER_URL',
   },
   contentServer: {
     url: {
       doc: 'The url of the corresponding fxa-content-server instance',
-      default: 'http://127.0.0.1:3030',
+      default: 'http://localhost:3030',
       env: 'CONTENT_SERVER_URL',
     },
   },
   emailService: {
     host: {
       doc: 'host for fxa-email-service',
-      format: 'ipaddress',
-      default: '127.0.0.1',
+      format: String,
+      default: 'localhost',
       env: 'EMAIL_SERVICE_HOST',
     },
     port: {
@@ -203,7 +203,7 @@ const conf = convict({
     api: {
       host: {
         doc: 'host for test/mail_helper.js',
-        default: '127.0.0.1',
+        default: 'localhost',
         env: 'MAILER_HOST',
       },
       port: {
@@ -340,7 +340,7 @@ const conf = convict({
   },
   redis: {
     host: {
-      default: '127.0.0.1',
+      default: 'localhost',
       env: 'REDIS_HOST',
       format: String,
       doc: 'IP address or host name for Redis server',
@@ -353,7 +353,7 @@ const conf = convict({
     },
     accessTokens: {
       host: {
-        default: '127.0.0.1',
+        default: 'localhost',
         env: 'ACCESS_TOKEN_REDIS_HOST',
         format: String,
       },
@@ -731,7 +731,7 @@ const conf = convict({
     url: {
       format: 'url',
       doc: 'URL at which to verify OAuth tokens',
-      default: 'http://127.0.0.1:9000',
+      default: 'http://localhost:9000',
       env: 'OAUTH_URL',
     },
     keepAlive: {
@@ -827,7 +827,7 @@ const conf = convict({
     audience: {
       doc: 'audience for oauth JWTs',
       format: 'url',
-      default: 'http://127.0.0.1:9000',
+      default: 'http://localhost:9000',
       env: 'OAUTH_URL',
     },
     auth: {
@@ -852,7 +852,7 @@ const conf = convict({
         env: 'AUTH_SERVER_SHARED_SECRET',
       },
       url: {
-        default: 'http://127.0.0.1:9000',
+        default: 'http://localhost:9000',
         doc: 'The auth-server public URL',
         env: 'AUTH_SERVER_URL',
         format: 'url',
@@ -1023,7 +1023,7 @@ const conf = convict({
       },
     },
     localRedirects: {
-      doc: 'When true, `localhost` and `127.0.0.1` always are legal redirects.',
+      doc: 'When true, `localhost` and `localhost` always are legal redirects.',
       default: false,
       env: 'FXA_OAUTH_LOCAL_REDIRECTS',
     },
@@ -1032,7 +1032,7 @@ const conf = convict({
       user: { default: 'root', env: 'MYSQL_USERNAME' },
       password: { default: '', env: 'MYSQL_PASSWORD' },
       database: { default: 'fxa_oauth', env: 'MYSQL_DATABASE' },
-      host: { default: '127.0.0.1', env: 'MYSQL_HOST' },
+      host: { default: 'localhost', env: 'MYSQL_HOST' },
       port: { default: '3306', env: 'MYSQL_PORT' },
       connectionLimit: {
         doc: 'The maximum number of connections that the pool can use at once.',
@@ -1136,15 +1136,15 @@ const conf = convict({
     },
     publicUrl: {
       format: 'url',
-      default: 'http://127.0.0.1:9000',
+      default: 'http://localhost:9000',
       env: 'PUBLIC_URL',
     },
     server: {
-      host: { env: 'HOST', default: '127.0.0.1' },
+      host: { env: 'HOST', default: 'localhost' },
       port: { env: 'PORT', format: 'port', default: 9000 },
     },
     serverInternal: {
-      host: { env: 'HOST_INTERNAL', default: '127.0.0.1' },
+      host: { env: 'HOST_INTERNAL', default: 'localhost' },
       port: { env: 'PORT_INTERNAL', format: 'port', default: 9011 },
     },
     i18n: {

--- a/packages/fxa-auth-server/docs/oauth/clients.md
+++ b/packages/fxa-auth-server/docs/oauth/clients.md
@@ -20,7 +20,7 @@ If you want to pre-approve your own web applications and prevent users in your a
 
 Use the [fxa-oauth-client][] CLI tool for registering new clients with your server.
 
-FxA OAuth development environments support `127.0.0.1` and `localhost` as valid `redirectUri` values to ease development.
+FxA OAuth development environments support `localhost` and `localhost` as valid `redirectUri` values to ease development.
 
 [fxa-oauth-client]: https://github.com/mozilla/fxa-oauth-client
 

--- a/packages/fxa-auth-server/lib/oauth/routes/authorization.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/authorization.js
@@ -36,7 +36,7 @@ if (config.get('oauthServer.allowHttpRedirects') === true) {
 
 function isLocalHost(url) {
   var host = new URI(url).hostname();
-  return host === 'localhost' || host === '127.0.0.1';
+  return host === 'localhost' || host === 'localhost';
 }
 
 module.exports = {

--- a/packages/fxa-auth-server/test/bench/bot.js
+++ b/packages/fxa-auth-server/test/bench/bot.js
@@ -8,7 +8,7 @@
 const Client = require('../client')();
 
 const config = {
-  origin: 'http://127.0.0.1:9000',
+  origin: 'http://localhost:9000',
   email: `${Math.random()}benchmark@example.com`,
   password: 'password',
   duration: 120000,

--- a/packages/fxa-auth-server/test/config/mock_oauth.json
+++ b/packages/fxa-auth-server/test/config/mock_oauth.json
@@ -1,5 +1,5 @@
 {
   "oauth": {
-    "url": "http://127.0.0.1:9000"
+    "url": "http://localhost:9000"
   }
 }

--- a/packages/fxa-auth-server/test/lib/oauth-test.json
+++ b/packages/fxa-auth-server/test/lib/oauth-test.json
@@ -1,8 +1,8 @@
 {
   "oauthServer" : {
   "browserid": {
-    "issuer": "127.0.0.1:9000",
-    "verificationUrl": "http://127.0.0.1:5050/v2"
+    "issuer": "localhost:9000",
+    "verificationUrl": "http://localhost:5050/v2"
   },
   "clientManagement": {
     "enabled": true
@@ -123,7 +123,7 @@
       "hashedSecret": "289a885946ee316844d9ffd0d725ee714901548a1e6507f1a40fb3c2ae0c99f1",
       "name": "Disabled Client",
       "imageUri": "https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.png",
-      "redirectUri": "http://127.0.0.1:8080/?oauth_pkce_redirect=1",
+      "redirectUri": "http://localhost:8080/?oauth_pkce_redirect=1",
       "trusted": true,
       "canGrant": false,
       "publicClient": true
@@ -140,7 +140,7 @@
     ]
   },
   "openid": {
-    "issuer": "http://127.0.0.1:3030",
+    "issuer": "http://localhost:3030",
     "keyFile": "config/key.json",
     "newKeyFile": "config/newKey.json",
     "oldKeyFile": "config/oldKey.json"

--- a/packages/fxa-auth-server/test/local/cache.js
+++ b/packages/fxa-auth-server/test/local/cache.js
@@ -25,7 +25,7 @@ describe('cache:', () => {
       log,
       {
         memcached: {
-          address: '127.0.0.1:1121',
+          address: 'localhost:1121',
           idle: 500,
           lifetime: 30,
         },

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -53,7 +53,7 @@ const mockConfig = {
 };
 
 const mockRedisConfig = {
-  host: '127.0.0.1',
+  host: 'localhost',
   port: 6379,
   maxPending: 1000,
   retryCount: 5,

--- a/packages/fxa-auth-server/test/local/routes/attached-clients.js
+++ b/packages/fxa-auth-server/test/local/routes/attached-clients.js
@@ -19,7 +19,7 @@ function makeRoutes(options = {}, requireMocks) {
   const config = options.config || {};
   config.smtp = config.smtp || {};
   config.memcached = config.memcached || {
-    address: '127.0.0.1:1121',
+    address: 'localhost:1121',
     idle: 500,
     lifetime: 30,
   };

--- a/packages/fxa-auth-server/test/local/routes/auth-schemes/refresh-token.js
+++ b/packages/fxa-auth-server/test/local/routes/auth-schemes/refresh-token.js
@@ -52,7 +52,7 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
           name: OAUTH_CLIENT_NAME,
           trusted: true,
           image_uri: '',
-          redirect_uri: `http://127.0.0.1:3030/oauth/success/${OAUTH_CLIENT_ID}`,
+          redirect_uri: `http://localhost:3030/oauth/success/${OAUTH_CLIENT_ID}`,
         })
       ),
     };
@@ -140,7 +140,7 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
         id: OAUTH_CLIENT_ID,
         image_uri: '',
         name: OAUTH_CLIENT_NAME,
-        redirect_uri: `http://127.0.0.1:3030/oauth/success/${OAUTH_CLIENT_ID}`,
+        redirect_uri: `http://localhost:3030/oauth/success/${OAUTH_CLIENT_ID}`,
         trusted: true,
       },
       refreshTokenId:

--- a/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
@@ -23,7 +23,7 @@ function makeRoutes(options = {}, requireMocks) {
   config.oauth = config.oauth || {};
   config.smtp = config.smtp || {};
   config.memcached = config.memcached || {
-    address: '127.0.0.1:1121',
+    address: 'localhost:1121',
     idle: 500,
     lifetime: 30,
   };

--- a/packages/fxa-auth-server/test/local/routes/sms.js
+++ b/packages/fxa-auth-server/test/local/routes/sms.js
@@ -682,7 +682,7 @@ describe('/sms/status with disabled geo-ip lookup', () => {
     routes = makeRoutes({ log, config, sms });
     route = getRoute(routes, '/sms/status');
     request = mocks.mockRequest({
-      clientAddress: '127.0.0.1',
+      clientAddress: 'localhost',
       credentials: {
         email: 'foo@example.org',
       },

--- a/packages/fxa-auth-server/test/local/senders/oauth_client_info.js
+++ b/packages/fxa-auth-server/test/local/senders/oauth_client_info.js
@@ -25,7 +25,7 @@ describe('lib/senders/oauth_client_info:', () => {
     let mockOAuthDB;
     const mockConfig = {
       oauth: {
-        url: 'http://127.0.0.1:9000',
+        url: 'http://localhost:9000',
         clientInfoCacheTTL: 5,
       },
     };

--- a/packages/fxa-auth-server/test/local/sentry.js
+++ b/packages/fxa-auth-server/test/local/sentry.js
@@ -28,7 +28,7 @@ describe('Sentry', () => {
   });
 
   it('can be set up when sentry is enabled', async () => {
-    config.sentryDsn = 'https://deadbeef:deadbeef@127.0.0.1/123';
+    config.sentryDsn = 'https://deadbeef:deadbeef@localhost/123';
     let throws = false;
     try {
       await configureSentry(server, config);
@@ -49,7 +49,7 @@ describe('Sentry', () => {
   });
 
   it('adds EndpointError details to a reported error', async () => {
-    config.sentryDsn = 'https://deadbeef:deadbeef@127.0.0.1/123';
+    config.sentryDsn = 'https://deadbeef:deadbeef@localhost/123';
     await configureSentry(server, config);
     const endError = new EndpointError(
       'An internal server error has occurred',
@@ -62,7 +62,7 @@ describe('Sentry', () => {
       }
     );
     endError.output = {
-      error: '127.0.0.1 error',
+      error: 'localhost error',
       message: 'Underlying error',
       statusCode: 500,
     };

--- a/packages/fxa-auth-server/test/local/server.js
+++ b/packages/fxa-auth-server/test/local/server.js
@@ -664,13 +664,13 @@ function getConfig() {
     corsOrigin: ['*'],
     maxEventLoopDelay: 0,
     listen: {
-      host: '127.0.0.1',
+      host: 'localhost',
       port: 9000,
     },
     useHttps: false,
     oauth: {
       clientIds: {},
-      url: 'http://127.0.0.1:9000',
+      url: 'http://localhost:9000',
       keepAlive: false,
     },
     env: 'prod',

--- a/packages/fxa-auth-server/test/mailbox.js
+++ b/packages/fxa-auth-server/test/mailbox.js
@@ -10,7 +10,7 @@ const EventEmitter = require('events').EventEmitter;
 
 /* eslint-disable no-console */
 module.exports = function(host, port, printLogs) {
-  host = host || '127.0.0.1';
+  host = host || 'localhost';
   port = port || 9001;
 
   const eventEmitter = new EventEmitter();

--- a/packages/fxa-auth-server/test/oauth/api.js
+++ b/packages/fxa-auth-server/test/oauth/api.js
@@ -596,13 +596,13 @@ describe('/v1', function() {
             });
         });
 
-        it('can be 127.0.0.1 with config set', function() {
+        it('can be localhost with config set', function() {
           mockAssertion().reply(200, VERIFY_GOOD);
           return Server.api
             .post({
               url: '/authorization',
               payload: authParams({
-                redirect_uri: 'http://127.0.0.1:8080/derp',
+                redirect_uri: 'http://localhost:8080/derp',
               }),
             })
             .then(function(res) {

--- a/packages/fxa-auth-server/test/remote/account_profile_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_profile_tests.js
@@ -21,7 +21,7 @@ describe('fetch user profile data', function() {
     if (config.subscriptions) {
       config.subscriptions.enabled = false;
     }
-    config.oauth.url = 'http://127.0.0.1:9000';
+    config.oauth.url = 'http://localhost:9000';
     server = await TestServer.start(config, false);
   });
 

--- a/packages/fxa-auth-server/test/remote/base_path_tests.js
+++ b/packages/fxa-auth-server/test/remote/base_path_tests.js
@@ -15,7 +15,7 @@ describe('remote base path', function() {
   let server, config;
   before(() => {
     config = require('../../config').getProperties();
-    config.publicUrl = 'http://127.0.0.1:9000/auth';
+    config.publicUrl = 'http://localhost:9000/auth';
 
     return TestServer.start(config).then(s => {
       server = s;
@@ -55,7 +55,7 @@ describe('remote base path', function() {
   });
 
   it('.well-known did not move', () => {
-    return request('http://127.0.0.1:9000/.well-known/browserid').spread(
+    return request('http://localhost:9000/.well-known/browserid').spread(
       (res, body) => {
         assert.equal(res.statusCode, 200);
         const json = JSON.parse(body);

--- a/packages/fxa-auth-server/test/remote/sign_key_tests.js
+++ b/packages/fxa-auth-server/test/remote/sign_key_tests.js
@@ -25,7 +25,7 @@ describe('remote sign key', function() {
   });
 
   it('.well-known/browserid has keys', () => {
-    return request('http://127.0.0.1:9000/.well-known/browserid').spread(
+    return request('http://localhost:9000/.well-known/browserid').spread(
       (res, body) => {
         assert.equal(res.statusCode, 200);
         const json = JSON.parse(body);

--- a/packages/fxa-content-server/README.md
+++ b/packages/fxa-content-server/README.md
@@ -21,7 +21,7 @@ Static server that hosts [Firefox Account sign up](https://accounts.firefox.com)
 
 Clone the repository, make sure you have [required prerequisites](https://github.com/mozilla/fxa-local-dev#dependencies) installed.
 Run `npm install` and `npm run start-remote`.
-This will start a local fxa-content-server on [http://127.0.0.1:3030](http://127.0.0.1:3030) that works with remote Firefox Accounts servers.
+This will start a local fxa-content-server on [http://localhost:3030](http://localhost:3030) that works with remote Firefox Accounts servers.
 
 If you want to install all Firefox Accounts servers locally follow the instructions on:
 [fxa-local-dev](https://github.com/mozilla/fxa-local-dev) to get a full development setup running.
@@ -72,7 +72,7 @@ xvfb-run -s "-screen 0 1920x1200x16" npm run test-functional
 
 ### Unit Tests
 
-If you want to test only the unit tests (not Selenium/function tests) you can visit http://127.0.0.1:3030/tests/index.html and you can select specific tests with something like http://127.0.0.1:3030/tests/index.html?grep=fxa-client
+If you want to test only the unit tests (not Selenium/function tests) you can visit http://localhost:3030/tests/index.html and you can select specific tests with something like http://localhost:3030/tests/index.html?grep=fxa-client
 
 ---
 

--- a/packages/fxa-content-server/app/tests/mocks/oauth_servers.js
+++ b/packages/fxa-content-server/app/tests/mocks/oauth_servers.js
@@ -23,11 +23,11 @@ function MockOAuthServers() {
         'Content-Type': 'application/json',
       },
       JSON.stringify({
-        authServerUrl: 'http://127.0.0.1:9000',
+        authServerUrl: 'http://localhost:9000',
         cookiesEnabled: true,
         language: 'en_US',
         metricsSampleRate: 1,
-        oauthUrl: 'http://127.0.0.1:9000',
+        oauthUrl: 'http://localhost:9000',
       })
     );
   });
@@ -45,7 +45,7 @@ function MockOAuthServers() {
           image_uri:
             'https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.png', //eslint-disable-line camelcase
           name: '123Done',
-          redirect_uri: 'http://127.0.0.1:8080/api/oauth', //eslint-disable-line camelcase
+          redirect_uri: 'http://localhost:8080/api/oauth', //eslint-disable-line camelcase
         })
       );
     }

--- a/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
@@ -16,7 +16,7 @@ import testHelpers from '../../lib/helpers';
 import VerificationMethods from 'lib/verification-methods';
 import VerificationReasons from 'lib/verification-reasons';
 
-var AUTH_SERVER_URL = 'http://127.0.0.1:9000';
+var AUTH_SERVER_URL = 'http://localhost:9000';
 var NON_SYNC_SERVICE = 'chronicle';
 var REDIRECT_TO = 'https://sync.firefox.com';
 var STATE = 'state';

--- a/packages/fxa-content-server/app/tests/spec/lib/oauth-client.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/oauth-client.js
@@ -8,7 +8,7 @@ import OAuthErrors from 'lib/oauth-errors';
 import sinon from 'sinon';
 import Xhr from 'lib/xhr';
 
-var OAUTH_URL = 'http://127.0.0.1:9000';
+var OAUTH_URL = 'http://localhost:9000';
 var assert = chai.assert;
 var client;
 var server;

--- a/packages/fxa-content-server/app/tests/spec/lib/profile-client.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/profile-client.js
@@ -7,13 +7,13 @@ import ProfileClient from 'lib/profile-client';
 import Session from 'lib/session';
 import sinon from 'sinon';
 
-var PROFILE_URL = 'http://127.0.0.1:1111';
+var PROFILE_URL = 'http://localhost:1111';
 var assert = chai.assert;
 var client;
 var server;
 var EMAIL = 'user@example.domain';
 var UID = '6d940dd41e636cc156074109b8092f96';
-var URL = 'http://127.0.0.1:1112/avatar/example.jpg';
+var URL = 'http://localhost:1112/avatar/example.jpg';
 var token = 'deadbeef';
 
 describe('lib/profile-client', function() {

--- a/packages/fxa-content-server/app/tests/spec/models/account.js
+++ b/packages/fxa-content-server/app/tests/spec/models/account.js
@@ -39,7 +39,7 @@ describe('models/account', function() {
   var PROFILE_CLIENT_METHODS = ['getAvatar', 'deleteAvatar', 'uploadAvatar'];
   var SESSION_TOKEN = 'abc123';
   var UID = '6d940dd41e636cc156074109b8092f96';
-  var URL = 'http://127.0.0.1:1112/avatar/example.jpg';
+  var URL = 'http://localhost:1112/avatar/example.jpg';
 
   beforeEach(function() {
     fxaClient = new FxaClientWrapper();

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-redirect.js
@@ -29,7 +29,7 @@ function generateOAuthCode() {
   return code;
 }
 
-const REDIRECT_URI = 'https://127.0.0.1:8080';
+const REDIRECT_URI = 'https://localhost:8080';
 const VALID_OAUTH_CODE = generateOAuthCode();
 const VALID_OAUTH_CODE_REDIRECT_URL = `${REDIRECT_URI}?code=${VALID_OAUTH_CODE}&state=state`;
 

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
@@ -26,7 +26,7 @@ function generateOAuthCode() {
 
 const OAUTH_STATUS_MESSAGE = 'fxaccounts:fxa_status';
 const OAUTH_LOGIN_MESSAGE = 'fxaccounts:oauth_login';
-const REDIRECT_URI = 'https://127.0.0.1:8080';
+const REDIRECT_URI = 'https://localhost:8080';
 const VALID_OAUTH_CODE = generateOAuthCode();
 
 describe('models/auth_brokers/oauth-webchannel-v1', () => {

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
@@ -34,7 +34,7 @@ describe('models/reliers/oauth', () => {
   var CLIENT_IMAGE_URI =
     'https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.pngx';
   var PROMPT = OAuthPrompt.CONSENT;
-  var QUERY_REDIRECT_URI = 'http://127.0.0.1:8080/api/oauth';
+  var QUERY_REDIRECT_URI = 'http://localhost:8080/api/oauth';
   var SCOPE = 'profile:email profile:uid';
   var SCOPE_OLDSYNC = 'https://identity.mozilla.com/apps/oldsync';
   var SCOPE_PROFILE = Constants.OAUTH_TRUSTED_PROFILE_SCOPE;
@@ -44,7 +44,7 @@ describe('models/reliers/oauth', () => {
   var PERMISSIONS = ['profile:email', 'profile:uid'];
   var SCOPE_WITH_EXTRAS = 'profile:email profile:uid profile:non_whitelisted';
   var SCOPE_WITH_OPENID = 'profile:email profile:uid openid';
-  var SERVER_REDIRECT_URI = 'http://127.0.0.1:8080/api/oauth';
+  var SERVER_REDIRECT_URI = 'http://localhost:8080/api/oauth';
   var SERVICE = 'service';
   var SERVICE_NAME = '123Done';
   var STATE = 'fakestatetoken';

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/pairing/authority.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/pairing/authority.js
@@ -16,7 +16,7 @@ const ACTION = 'email';
 const ACCESS_TYPE = 'offline';
 const CLIENT_ID = 'dcdb5ae7add825d2';
 const SCOPE = 'profile:email profile:uid';
-const SERVER_REDIRECT_URI = 'http://127.0.0.1:8080/api/oauth';
+const SERVER_REDIRECT_URI = 'http://localhost:8080/api/oauth';
 const SERVICE_NAME = '123Done';
 const STATE = 'fakestatetoken';
 

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/pairing/supplicant.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/pairing/supplicant.js
@@ -19,7 +19,7 @@ const CODE_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
 const CODE_CHALLENGE_METHOD = 'S256';
 const KEYS_JWK = 'keysJwk';
 const SCOPE = 'profile:email profile:uid';
-const SERVER_REDIRECT_URI = 'http://127.0.0.1:8080/api/oauth';
+const SERVER_REDIRECT_URI = 'http://localhost:8080/api/oauth';
 const SERVICE_NAME = '123Done';
 const STATE = 'fakestatetoken';
 /*eslint-disable camelcase*/

--- a/packages/fxa-content-server/app/tests/spec/models/user.js
+++ b/packages/fxa-content-server/app/tests/spec/models/user.js
@@ -21,7 +21,7 @@ const CODE = 'verification code';
 const EMAIL = 'a@a.com';
 const SESSION_TOKEN = 'session token';
 const UUID = '12345678-1234-1234-1234-1234567890ab';
-const DSN = 'https://deadbeef:deadbeef@127.0.0.1/123';
+const DSN = 'https://deadbeef:deadbeef@localhost/123';
 
 describe('models/user', function() {
   let fxaClientMock;

--- a/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
@@ -86,7 +86,7 @@ describe('views/subscriptions_product_redirect', function() {
     });
 
     it('works with a local redirect with no query params', () => {
-      windowMock.location.href = `http://127.0.0.1:3030/subscriptions/products/${PRODUCT_ID}`;
+      windowMock.location.href = `http://localhost:3030/subscriptions/products/${PRODUCT_ID}`;
       windowMock.location.search = '';
       return render().then(() => {
         assert.isTrue(

--- a/packages/fxa-content-server/scripts/test-ci.sh
+++ b/packages/fxa-content-server/scripts/test-ci.sh
@@ -34,11 +34,11 @@ npx lerna run start \
   --concurrency 1 > /dev/null
 npx pm2 ls
 # ensure email-service is ready
-_scripts/check-url.sh 127.0.0.1:8001/__heartbeat__
+_scripts/check-url.sh localhost:8001/__heartbeat__
 # ensure payments-server is ready
-_scripts/check-url.sh 127.0.0.1:3031/__lbheartbeat__
+_scripts/check-url.sh localhost:3031/__lbheartbeat__
 # ensure content-server is ready
-_scripts/check-url.sh 127.0.0.1:3030/bundle/app.bundle.js
+_scripts/check-url.sh localhost:3030/bundle/app.bundle.js
 
 cd packages/fxa-content-server
 mozinstall /firefox.tar.bz2

--- a/packages/fxa-content-server/server/config/fxaci.json
+++ b/packages/fxa-content-server/server/config/fxaci.json
@@ -8,6 +8,6 @@
     "oauth_url": "https://oauth-fxaci.dev.lcip.org",
     "profile_images_url": "https://fxaci.dev.lcip.org/profile",
     "profile_url": "https://fxaci.dev.lcip.org/profile",
-    "public_url": "http://127.0.0.1:3030",
+    "public_url": "http://localhost:3030",
     "use_https": false
 }

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -1,9 +1,9 @@
 {
-  "public_url": "http://127.0.0.1:3030",
+  "public_url": "http://localhost:3030",
   "oauth_client_id": "98e6508e88680e1a",
-  "oauth_url": "http://127.0.0.1:9000",
-  "profile_url": "http://127.0.0.1:1111",
-  "profile_images_url": "http://127.0.0.1:1112",
+  "oauth_url": "http://localhost:9000",
+  "profile_url": "http://localhost:1111",
+  "profile_images_url": "http://localhost:1112",
   "client_sessions": {
     "cookie_name": "session",
     "secret": "YOU MUST CHANGE ME",
@@ -22,8 +22,8 @@
     "validation": {
       "https://identity.mozilla.com/apps/oldsync": {
         "redirectUris": [
-         "http://127.0.0.1:3030/oauth/success/a2270f727f45f648",
-         "http://127.0.0.1:3030/oauth/success/1b1a3e44c54fbb58",
+         "http://localhost:3030/oauth/success/a2270f727f45f648",
+         "http://localhost:3030/oauth/success/1b1a3e44c54fbb58",
          "urn:ietf:wg:oauth:2.0:oob:pair-auth-webchannel",
          "urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel"
         ]
@@ -34,8 +34,8 @@
   "subscriptions": {
     "enabled": true
   },
-  "allowed_metrics_flow_cors_origins": ["http://127.0.0.1:8001"],
-  "allowed_parent_origins": ["http://127.0.0.1:8080"],
+  "allowed_metrics_flow_cors_origins": ["http://localhost:8001"],
+  "allowed_parent_origins": ["http://localhost:8080"],
   "sourceMapType": "cheap-source-map",
   "csp": {
     "enabled": true,

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -69,7 +69,7 @@ const conf = (module.exports = convict({
       format: Number,
     },
     api_url: {
-      default: 'http://127.0.0.1:10140',
+      default: 'http://localhost:10140',
       doc: 'DEPRECATED - Url for the Basket API server',
       format: String,
     },
@@ -79,7 +79,7 @@ const conf = (module.exports = convict({
       format: String,
     },
     proxy_url: {
-      default: 'http://127.0.0.1:1114',
+      default: 'http://localhost:1114',
       doc: 'DEPRECATED - Url for the Basket proxy server',
       format: String,
     },
@@ -186,7 +186,7 @@ const conf = (module.exports = convict({
     },
     redis: {
       host: {
-        default: '127.0.0.1',
+        default: 'localhost',
         doc: 'Redis host name or IP address',
         env: 'FEATURE_FLAGS_REDIS_HOST',
         format: String,
@@ -256,7 +256,7 @@ const conf = (module.exports = convict({
     },
   },
   fxaccount_url: {
-    default: 'http://127.0.0.1:9000',
+    default: 'http://localhost:9000',
     doc: 'The url of the Firefox Account auth server',
     env: 'FXA_URL',
     format: 'url',
@@ -369,7 +369,7 @@ const conf = (module.exports = convict({
   },
   marketing_email: {
     api_url: {
-      default: 'http://127.0.0.1:1114',
+      default: 'http://localhost:1114',
       doc: 'DEPRECATED - User facing URL of the Marketing Email Server',
       env: 'FXA_MARKETING_EMAIL_API_URL',
       format: 'url',
@@ -404,7 +404,7 @@ const conf = (module.exports = convict({
     format: Object,
   },
   oauth_url: {
-    default: 'http://127.0.0.1:9000',
+    default: 'http://localhost:9000',
     doc: 'The url of the Firefox Account OAuth server',
     env: 'FXA_OAUTH_URL',
     format: 'url',
@@ -471,19 +471,19 @@ const conf = (module.exports = convict({
   },
   process_type: 'ephemeral',
   profile_images_url: {
-    default: 'http://127.0.0.1:1112',
+    default: 'http://localhost:1112',
     doc: 'The url of the Firefox Account Profile Image Server',
     env: 'FXA_PROFILE_IMAGES_URL',
     format: 'url',
   },
   profile_url: {
-    default: 'http://127.0.0.1:1111',
+    default: 'http://localhost:1111',
     doc: 'The url of the Firefox Account Profile Server',
     env: 'FXA_PROFILE_URL',
     format: 'url',
   },
   public_url: {
-    default: 'http://127.0.0.1:3030',
+    default: 'http://localhost:3030',
     doc: 'The publically visible URL of the deployment',
     env: 'PUBLIC_URL',
   },
@@ -684,14 +684,14 @@ const conf = (module.exports = convict({
       format: 'nat',
     },
     managementUrl: {
-      default: 'http://127.0.0.1:3031',
+      default: 'http://localhost:3031',
       doc: 'The publicly visible URL of the subscription management server',
       env: 'SUBSCRIPTIONS_MANAGEMENT_URL',
       format: String,
     },
   },
   sync_tokenserver_url: {
-    default: 'http://127.0.0.1:5000/token',
+    default: 'http://localhost:5000/token',
     doc: 'The url of the Firefox Sync tokenserver',
     env: 'SYNC_TOKENSERVER_URL',
     format: 'url',

--- a/packages/fxa-content-server/tests/functional/oauth_query_param_validation.js
+++ b/packages/fxa-content-server/tests/functional/oauth_query_param_validation.js
@@ -244,7 +244,7 @@ registerSuite('oauth query parameter validation', {
         .then(
           openEmailFirstExpect400({
             client_id: TRUSTED_CLIENT_ID,
-            redirectTo: '127.0.0.1',
+            redirectTo: 'localhost',
             scope: TRUSTED_SCOPE,
           })
         )
@@ -257,7 +257,7 @@ registerSuite('oauth query parameter validation', {
         openEmailFirstExpect200({
           client_id: TRUSTED_CLIENT_ID,
           redirect_uri: TRUSTED_REDIRECT_URI,
-          redirectTo: 'http://127.0.0.1',
+          redirectTo: 'http://localhost',
           scope: TRUSTED_SCOPE,
         })
       );
@@ -268,7 +268,7 @@ registerSuite('oauth query parameter validation', {
         .then(
           openEmailFirstExpect400({
             client_id: TRUSTED_CLIENT_ID,
-            redirect_uri: '127.0.0.1',
+            redirect_uri: 'localhost',
             scope: TRUSTED_SCOPE,
           })
         )

--- a/packages/fxa-content-server/tests/intern.js
+++ b/packages/fxa-content-server/tests/intern.js
@@ -18,16 +18,16 @@ const testsPairing = require('./functional_pairing');
 const testsServer = require('./tests_server');
 const testsServerResources = require('./tests_server_resources');
 
-const fxaAuthRoot = args.fxaAuthRoot || 'http://127.0.0.1:9000/v1';
-const fxaContentRoot = args.fxaContentRoot || 'http://127.0.0.1:3030/';
-const fxaOAuthRoot = args.fxaOAuthRoot || 'http://127.0.0.1:9000';
-const fxaProfileRoot = args.fxaProfileRoot || 'http://127.0.0.1:1111';
-const fxaTokenRoot = args.fxaTokenRoot || 'http://127.0.0.1:5000/token';
-const fxaEmailRoot = args.fxaEmailRoot || 'http://127.0.0.1:9001';
-const fxaOAuthApp = args.fxaOAuthApp || 'http://127.0.0.1:8080/';
+const fxaAuthRoot = args.fxaAuthRoot || 'http://localhost:9000/v1';
+const fxaContentRoot = args.fxaContentRoot || 'http://localhost:3030/';
+const fxaOAuthRoot = args.fxaOAuthRoot || 'http://localhost:9000';
+const fxaProfileRoot = args.fxaProfileRoot || 'http://localhost:1111';
+const fxaTokenRoot = args.fxaTokenRoot || 'http://localhost:5000/token';
+const fxaEmailRoot = args.fxaEmailRoot || 'http://localhost:9001';
+const fxaOAuthApp = args.fxaOAuthApp || 'http://localhost:8080/';
 const fxaUntrustedOauthApp =
-  args.fxaUntrustedOauthApp || 'http://127.0.0.1:10139/';
-const fxaPaymentsRoot = args.fxaPaymentsRoot || 'http://127.0.0.1:3031/';
+  args.fxaUntrustedOauthApp || 'http://localhost:10139/';
+const fxaPaymentsRoot = args.fxaPaymentsRoot || 'http://localhost:3031/';
 
 // "fxaProduction" is a little overloaded in how it is used in the tests.
 // Sometimes it means real "stage" or real production configuration, but
@@ -75,7 +75,7 @@ const config = {
   pageLoadTimeout: 20000,
   reporters: 'runner',
   serverPort: 9091,
-  serverUrl: 'http://127.0.0.1:9091',
+  serverUrl: 'http://localhost:9091',
   socketPort: 9077,
   tunnelOptions: {
     drivers: [

--- a/packages/fxa-content-server/tests/tools/certs/generate_certs.sh
+++ b/packages/fxa-content-server/tests/tools/certs/generate_certs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 printf ">> Create ca.key, use a password phrase when asked.\n"
-printf ">> When asked 'Common Name (e.g. server FQDN or YOUR name) []:' use your hostname, i.e '127.0.0.1'\n\n"
+printf ">> When asked 'Common Name (e.g. server FQDN or YOUR name) []:' use your hostname, i.e 'localhost'\n\n"
 openssl genrsa -des3 -out ca.key 1024
 openssl req -new -key ca.key -out ca.csr
 openssl x509 -req -days 365 -in ca.csr -out ca.crt -signkey ca.key

--- a/packages/fxa-customs-server/README.md
+++ b/packages/fxa-customs-server/README.md
@@ -15,7 +15,7 @@ Install memcached
     You'll need to [install memcached](http://www.memcached.org/downloads),
     otherwise all requests will be blocked.
     By default, the customs server tries to connect to memcached
-    using port `11211` on `127.0.0.1`.
+    using port `11211` on `localhost`.
     You can specify a different port and IP address
     using the `memcache.address` configuration setting
     or the `MEMCACHE_ADDRESS` environment variable.
@@ -24,7 +24,7 @@ To start the server, run:
 
     npm start
 
-It will listen on http://127.0.0.1:7000 by default.
+It will listen on http://localhost:7000 by default.
 
 ## Docker Based Development
 

--- a/packages/fxa-customs-server/docs/api.md
+++ b/packages/fxa-customs-server/docs/api.md
@@ -46,7 +46,7 @@ Used by internal services to temporarily ban requests associated with a given em
 ```sh
 curl -v \
 -H "Content-Type: application/json" \
-"http://127.0.0.1:7000/blockEmail" \
+"http://localhost:7000/blockEmail" \
 -d '{
   "email": "me@example.com"
 }'
@@ -79,7 +79,7 @@ Used by internal services to temporarily ban requests associated with a given IP
 ```sh
 curl -v \
 -H "Content-Type: application/json" \
-"http://127.0.0.1:7000/blockIp" \
+"http://localhost:7000/blockIp" \
 -d '{
   "ip": "192.0.2.1"
 }'
@@ -118,7 +118,7 @@ of [actions](https://github.com/mozilla/fxa-customs-server/blob/master/lib/actio
 ```sh
 curl -v \
 -H "Content-Type: application/json" \
-"http://127.0.0.1:7000/check" \
+"http://localhost:7000/check" \
 -d '{
   "email": "me@example.com",
   "ip": "192.0.2.1",
@@ -162,7 +162,7 @@ should be blocked based only on the request IP.
 ```sh
 curl -v \
 -H "Content-Type: application/json" \
-"http://127.0.0.1:7000/checkIpOnly" \
+"http://localhost:7000/checkIpOnly" \
 -d '{
   "ip": "192.0.2.1",
   "action": "accountCreate"
@@ -204,7 +204,7 @@ check whether or not the action should be blocked.
 ```sh
 curl -v \
 -H "Content-Type: application/json" \
-"http://127.0.0.1:7000/checkAuthenticated" \
+"http://localhost:7000/checkAuthenticated" \
 -d '{
   "action": "devicesNotify"
   "ip": "192.0.2.1",
@@ -250,7 +250,7 @@ its policies.
 ```sh
 curl -v \
 -H "Content-Type: application/json" \
-"http://127.0.0.1:7000/failedLoginAttempt" \
+"http://localhost:7000/failedLoginAttempt" \
 -d '{
   "email": "me@example.com",
   "ip": "192.0.2.1"
@@ -288,7 +288,7 @@ bad logins for example).
 ```sh
 curl -v \
 -H "Content-Type: application/json" \
-"http://127.0.0.1:7000/passwordReset" \
+"http://localhost:7000/passwordReset" \
 -d '{
   "email": "me@example.com"
 }'

--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -18,14 +18,14 @@ module.exports = function(fs, path, url, convict) {
     },
     publicUrl: {
       format: 'url',
-      default: 'http://127.0.0.1:7000',
+      default: 'http://localhost:7000',
       env: 'PUBLIC_URL',
     },
     listen: {
       host: {
         doc: 'The ip address the server should bind',
-        default: '127.0.0.1',
-        format: 'ipaddress',
+        default: 'localhost',
+        format: String,
         env: 'IP_ADDRESS',
       },
       port: {
@@ -179,7 +179,7 @@ module.exports = function(fs, path, url, convict) {
     memcache: {
       address: {
         doc: 'Hostname/IP:Port of the memcache server',
-        default: '127.0.0.1:11211',
+        default: 'localhost:11211',
         env: 'MEMCACHE_ADDRESS',
       },
       recordLifetimeSeconds: {
@@ -283,7 +283,7 @@ module.exports = function(fs, path, url, convict) {
       },
       baseUrl: {
         doc: 'The reputation service base url.',
-        default: 'http://127.0.0.1:8080/',
+        default: 'http://localhost:8080/',
         format: 'url',
         env: 'REPUTATION_SERVICE_BASE_URL',
       },

--- a/packages/fxa-customs-server/test/integration/reputation/iprepd_tests.js
+++ b/packages/fxa-customs-server/test/integration/reputation/iprepd_tests.js
@@ -59,7 +59,7 @@ process.env.REPUTATION_SERVICE_HAWK_KEY = config.reputationService.hawkKey;
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/memcache-helper.js
+++ b/packages/fxa-customs-server/test/memcache-helper.js
@@ -10,7 +10,7 @@ P.promisifyAll(Memcached.prototype);
 
 var config = {
   memcache: {
-    address: process.env.MEMCACHE_ADDRESS || '127.0.0.1:11211',
+    address: process.env.MEMCACHE_ADDRESS || 'localhost:11211',
   },
   limits: {
     blockIntervalSeconds: 1,

--- a/packages/fxa-customs-server/test/remote/block_email_tests.js
+++ b/packages/fxa-customs-server/test/remote/block_email_tests.js
@@ -15,7 +15,7 @@ const config = require('../../lib/config').getProperties();
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/block_ip_tests.js
+++ b/packages/fxa-customs-server/test/remote/block_ip_tests.js
@@ -18,7 +18,7 @@ config.allowedIPs = [ALLOWED_IP];
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/check_ip_only_tests.js
+++ b/packages/fxa-customs-server/test/remote/check_ip_only_tests.js
@@ -20,7 +20,7 @@ const config = {
 const testServer = new TestServer(config);
 
 const client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 test('startup', async function(t) {

--- a/packages/fxa-customs-server/test/remote/check_reputation_tests.js
+++ b/packages/fxa-customs-server/test/remote/check_reputation_tests.js
@@ -29,7 +29,7 @@ config.reputationService = {
   suspectBelow: 60,
   hawkId: 'root',
   hawkKey: 'toor',
-  baseUrl: 'http://127.0.0.1:9009',
+  baseUrl: 'http://localhost:9009',
   timeout: 25,
 };
 
@@ -48,7 +48,7 @@ var repJSClient = new ipr(repJSClientConfig);
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/check_tests.js
+++ b/packages/fxa-customs-server/test/remote/check_tests.js
@@ -39,7 +39,7 @@ test('clear everything', function(t) {
 });
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 Promise.promisifyAll(client, { multiArgs: true });
 

--- a/packages/fxa-customs-server/test/remote/config_update_tests.js
+++ b/packages/fxa-customs-server/test/remote/config_update_tests.js
@@ -13,7 +13,7 @@ config.updatePollIntervalSeconds = 1;
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 var IP = '10.0.0.5';

--- a/packages/fxa-customs-server/test/remote/email_normalization.js
+++ b/packages/fxa-customs-server/test/remote/email_normalization.js
@@ -19,7 +19,7 @@ config.limits.maxVerifyCodes = 3;
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/failed_login_attempt_tests.js
+++ b/packages/fxa-customs-server/test/remote/failed_login_attempt_tests.js
@@ -30,7 +30,7 @@ test('clear everything', function(t) {
 });
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 test('well-formed request', function(t) {

--- a/packages/fxa-customs-server/test/remote/flow_id_checks.js
+++ b/packages/fxa-customs-server/test/remote/flow_id_checks.js
@@ -31,7 +31,7 @@ test('clear everything', function(t) {
 });
 
 var client = clients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 Promise.promisifyAll(client, { multiArgs: true });
 

--- a/packages/fxa-customs-server/test/remote/ip_blocklist_disable.js
+++ b/packages/fxa-customs-server/test/remote/ip_blocklist_disable.js
@@ -35,7 +35,7 @@ test('clear everything', function(t) {
 });
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/ip_blocklist_tests.js
+++ b/packages/fxa-customs-server/test/remote/ip_blocklist_tests.js
@@ -37,7 +37,7 @@ test('clear everything', function(t) {
 });
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/memcache_error_tests.js
+++ b/packages/fxa-customs-server/test/remote/memcache_error_tests.js
@@ -28,7 +28,7 @@ test('clear everything', function(t) {
 });
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 test('request with disconnected memcache', function(t) {

--- a/packages/fxa-customs-server/test/remote/never_blocked.js
+++ b/packages/fxa-customs-server/test/remote/never_blocked.js
@@ -15,7 +15,7 @@ const config = require('../../lib/config').getProperties();
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/password_reset_clears_bad_logins.js
+++ b/packages/fxa-customs-server/test/remote/password_reset_clears_bad_logins.js
@@ -19,7 +19,7 @@ var config = {
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/password_reset_tests.js
+++ b/packages/fxa-customs-server/test/remote/password_reset_tests.js
@@ -29,7 +29,7 @@ test('clear everything', function(t) {
 });
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 test('well-formed request', function(t) {

--- a/packages/fxa-customs-server/test/remote/root_tests.js
+++ b/packages/fxa-customs-server/test/remote/root_tests.js
@@ -20,7 +20,7 @@ test('startup', async function(t) {
 });
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 test('version check', function(t) {

--- a/packages/fxa-customs-server/test/remote/send_violations_tests.js
+++ b/packages/fxa-customs-server/test/remote/send_violations_tests.js
@@ -30,7 +30,7 @@ config.reputationService = {
   suspectBelow: 60,
   hawkId: 'root',
   hawkKey: 'toor',
-  baseUrl: 'http://127.0.0.1:9009',
+  baseUrl: 'http://localhost:9009',
   timeout: 25,
 };
 
@@ -46,7 +46,7 @@ var testServer = new TestServer(config);
 var reputationServer = new ReputationServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 var reputationClient = restifyClients.createJsonClient({
   url: config.reputationService.baseUrl,

--- a/packages/fxa-customs-server/test/remote/too_many_account_status_check.js
+++ b/packages/fxa-customs-server/test/remote/too_many_account_status_check.js
@@ -19,7 +19,7 @@ config.limits.ipRateLimitBanDurationSeconds = 1;
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/too_many_authenticated_checks.js
+++ b/packages/fxa-customs-server/test/remote/too_many_authenticated_checks.js
@@ -22,7 +22,7 @@ config.limits.uidRateLimit.banDurationSeconds = 2;
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/too_many_bad_logins.js
+++ b/packages/fxa-customs-server/test/remote/too_many_bad_logins.js
@@ -16,7 +16,7 @@ config.limits.rateLimitIntervalSeconds = 1;
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/too_many_emails.js
+++ b/packages/fxa-customs-server/test/remote/too_many_emails.js
@@ -16,7 +16,7 @@ config.limits.rateLimitIntervalSeconds = 1;
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/too_many_login_checks.js
+++ b/packages/fxa-customs-server/test/remote/too_many_login_checks.js
@@ -20,7 +20,7 @@ const config = require('../../lib/config').getProperties();
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/too_many_signin_codes.js
+++ b/packages/fxa-customs-server/test/remote/too_many_signin_codes.js
@@ -20,7 +20,7 @@ config.limits.ipRateLimitBanDurationSeconds = 1;
 const testServer = new TestServer(config);
 
 const client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/too_many_sms.js
+++ b/packages/fxa-customs-server/test/remote/too_many_sms.js
@@ -30,7 +30,7 @@ var mcHelper = require('../memcache-helper');
 var testServer = new TestServer(config);
 
 var client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/too_many_verify_codes.js
+++ b/packages/fxa-customs-server/test/remote/too_many_verify_codes.js
@@ -19,7 +19,7 @@ config.limits.ipRateLimitBanDurationSeconds = 1;
 const testServer = new TestServer(config);
 
 const client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/unblock_tests.js
+++ b/packages/fxa-customs-server/test/remote/unblock_tests.js
@@ -17,7 +17,7 @@ const config = require('../../lib/config').getProperties();
 const testServer = new TestServer(config);
 
 const client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/remote/user_defined_rules.js
+++ b/packages/fxa-customs-server/test/remote/user_defined_rules.js
@@ -30,7 +30,7 @@ const ACTIONS = ['verifyTotpCode', 'verifyTokenCode'];
 const testServer = new TestServer(config);
 
 const client = restifyClients.createJsonClient({
-  url: 'http://127.0.0.1:' + config.listen.port,
+  url: 'http://localhost:' + config.listen.port,
 });
 
 Promise.promisifyAll(client, { multiArgs: true });

--- a/packages/fxa-customs-server/test/test_server.js
+++ b/packages/fxa-customs-server/test/test_server.js
@@ -7,7 +7,7 @@ const Server = require('../lib/server');
 const config = require('../lib/config').getProperties();
 
 function TestServer(configUpdates) {
-  this.url = 'http://127.0.0.1:' + configUpdates.listen.port;
+  this.url = 'http://localhost:' + configUpdates.listen.port;
   this.server = null;
   this.config = Object.assign({}, config, configUpdates);
   this.log = {

--- a/packages/fxa-dev-launcher/profile.js
+++ b/packages/fxa-dev-launcher/profile.js
@@ -1,13 +1,12 @@
-var path = require("path");
 var chalk = require("chalk");
 
 var CONFIGS = {
   local: {
-    auth: "http://127.0.0.1:9000/v1",
-    content: "http://127.0.0.1:3030/",
+    auth: "http://localhost:9000/v1",
+    content: "http://localhost:3030/",
     token: "http://localhost:5000/token/1.0/sync/1.5",
     loop: "http://localhost:10222",
-    oauth: "http://127.0.0.1:9000/v1",
+    oauth: "http://localhost:9000/v1",
     profile: "http://localhost:1111/v1"
   },
   latest: {
@@ -19,7 +18,7 @@ var CONFIGS = {
   },
   "start-remote": {
     auth: "https://fxaci.dev.lcip.org/auth/v1",
-    content: "http://127.0.0.1:3030/",
+    content: "http://localhost:3030/",
     token: "https://fxaci.dev.lcip.org/syncserver/token/1.0/sync/1.5",
     oauth: "https://oauth-fxaci.dev.lcip.org/v1",
     profile: "https://fxaci.dev.lcip.org/profile/v1"
@@ -65,7 +64,6 @@ if (!fxaEnv) {
   };
 }
 
-var FXA_DESKTOP_CONTEXT = process.env.FXA_DESKTOP_CONTEXT || "fx_desktop_v3";
 var fxaProfile = {
   // enable debugger and toolbox
   "devtools.chrome.enabled": true,
@@ -87,7 +85,7 @@ var fxaProfile = {
   "services.sync.log.appender.file.logOnSuccess": true,
   "services.sync.log.appender.console": "Debug",
   "browser.uitour.testingOrigins":
-    "http://127.0.0.1:8001,http://127.0.0.1:8000,https://www.mozilla.org,https://www.allizom.org,https://www-demo5.allizom.org,https://www-dev.allizom.org",
+    "http://localhost:8001,http://localhost:8000,https://www.mozilla.org,https://www.allizom.org,https://www-demo5.allizom.org,https://www-dev.allizom.org",
   "browser.uitour.requireSecure": false,
   "services.sync.log.appender.dump": "Debug",
   "identity.fxaccounts.auth.uri": fxaEnv.auth,

--- a/packages/fxa-email-service/config/default.json
+++ b/packages/fxa-email-service/config/default.json
@@ -1,6 +1,6 @@
 {
   "authdb": {
-    "baseuri": "http://127.0.0.1:8000/"
+    "baseuri": "http://localhost:8000/"
   },
   "aws": {
     "region": "us-west-2"
@@ -20,7 +20,7 @@
     ]
   },
   "hmackey": "YOU MUST CHANGE ME",
-  "host": "127.0.0.1",
+  "host": "localhost",
   "log": {
     "level": "off",
     "format": "mozlog"
@@ -31,7 +31,7 @@
     "forcedefault": false
   },
   "redis": {
-    "host": "127.0.0.1",
+    "host": "localhost",
     "port": 6379
   },
   "secretkey": "youmustchangethisfortheproductionenvironment",
@@ -40,7 +40,7 @@
     "name": "Firefox Accounts"
   },
   "smtp": {
-    "host": "127.0.0.1",
+    "host": "localhost",
     "port": 25
   }
 }

--- a/packages/fxa-email-service/src/bin/service.rs
+++ b/packages/fxa-email-service/src/bin/service.rs
@@ -7,7 +7,7 @@
 //! that exposes one endpoint: `POST /send`
 //!
 //! Configuration is via [`settings::Settings`][settings].
-//! By default the server listens on `127.0.0.1:8001`.
+//! By default the server listens on `localhost:8001`.
 //!
 //! [settings]: ../fxa_email_service/settings/struct.Settings.html
 

--- a/packages/fxa-email-service/src/db/delivery_problems/test.rs
+++ b/packages/fxa-email-service/src/db/delivery_problems/test.rs
@@ -53,7 +53,7 @@ fn create_settings(delivery_problem_limits: Json) -> Settings {
     let mut settings = Settings::default();
     settings.deliveryproblemlimits =
         serde_json::from_value(delivery_problem_limits).expect("JSON error");
-    settings.redis.host = Host(String::from("127.0.0.1"));
+    settings.redis.host = Host(String::from("localhost"));
     settings.redis.port = 6379;
     settings
 }

--- a/packages/fxa-email-service/src/types/validate/test.rs
+++ b/packages/fxa-email-service/src/types/validate/test.rs
@@ -67,7 +67,7 @@ fn invalid_aws_secret() {
 fn base_uri() {
     assert!(validate::base_uri("http://localhost/"));
     assert!(validate::base_uri("http://localhost:8080/"));
-    assert!(validate::base_uri("http://127.0.0.1/"));
+    assert!(validate::base_uri("http://localhost/"));
     assert!(validate::base_uri("https://localhost/"));
     assert!(validate::base_uri("http://localhost/foo/"));
 }
@@ -133,7 +133,7 @@ fn invalid_email_address() {
 fn host() {
     assert!(validate::host("foo"));
     assert!(validate::host("foo.bar"));
-    assert!(validate::host("127.0.0.1"));
+    assert!(validate::host("localhost"));
 }
 
 #[test]
@@ -143,7 +143,7 @@ fn invalid_host() {
     assert_eq!(validate::host("foo bar"), false);
     assert_eq!(validate::host("foo "), false);
     assert_eq!(validate::host(" foo"), false);
-    assert_eq!(validate::host("127.0.0.1:25"), false);
+    assert_eq!(validate::host("localhost:25"), false);
 }
 
 #[test]

--- a/packages/fxa-event-broker/config/development.json
+++ b/packages/fxa-event-broker/config/development.json
@@ -9,7 +9,7 @@
     "level": "debug"
   },
   "openid": {
-    "issuer": "http://127.0.0.1:3030",
+    "issuer": "http://localhost:3030",
     "key": {}
   },
   "firestore": {

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -10,7 +10,7 @@
     "watch": "tsc -w",
     "test": "mocha -r ts-node/register src/test/**/*.spec.ts src/test/**/**/*.spec.ts",
     "start-prod": "npm run build && node ./dist/bin/worker.js",
-    "prestart": "../../_scripts/check-url.sh 127.0.0.1:9000/__heartbeat__",
+    "prestart": "../../_scripts/check-url.sh localhost:9000/__heartbeat__",
     "start": "pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js"

--- a/packages/fxa-event-broker/src/test/lib/sentry.ts
+++ b/packages/fxa-event-broker/src/test/lib/sentry.ts
@@ -8,7 +8,7 @@ import { configureSentry } from '../../lib/sentry';
 
 describe('Sentry', () => {
   it('can be set up when sentry is enabled', async () => {
-    const dsn = 'https://deadbeef:deadbeef@127.0.0.1/123';
+    const dsn = 'https://deadbeef:deadbeef@localhost/123';
     try {
       await configureSentry({ dsn });
     } catch (err) {

--- a/packages/fxa-js-client/package.json
+++ b/packages/fxa-js-client/package.json
@@ -11,7 +11,7 @@
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint:eslint": "eslint .",
     "test": "npm run lint && mocha tests/lib --reporter dot --timeout 5000",
-    "test-local": "AUTH_SERVER_URL=http://127.0.0.1:9000 npm test",
+    "test-local": "AUTH_SERVER_URL=http://localhost:9000 npm test",
     "contributors": "git shortlog -s | cut -c8- | sort -f > CONTRIBUTORS.md",
     "format": "prettier '**' --write"
   },

--- a/packages/fxa-js-client/tests/addons/environment.js
+++ b/packages/fxa-js-client/tests/addons/environment.js
@@ -11,10 +11,10 @@ const RequestMocks = require('../mocks/request');
 const ErrorMocks = require('../mocks/errors');
 function Environment() {
   var self = this;
-  this.authServerUrl = process.env.AUTH_SERVER_URL || 'http://127.0.0.1:9000';
+  this.authServerUrl = process.env.AUTH_SERVER_URL || 'http://localhost:9000';
   this.useRemoteServer = !!process.env.AUTH_SERVER_URL;
   this.mailServerUrl = this.authServerUrl.match(/^http:\/\/127/)
-    ? 'http://127.0.0.1:9001'
+    ? 'http://localhost:9001'
     : 'http://restmail.net';
 
   if (this.useRemoteServer) {

--- a/packages/fxa-js-client/tests/examples/example.html
+++ b/packages/fxa-js-client/tests/examples/example.html
@@ -100,7 +100,7 @@
       /**
        * Server URL, adjust this to test with a proxy.
        */
-      var server = 'http://127.0.0.1:9000';
+      var server = 'http://localhost:9000';
       // Proxy:
       // var server = 'http://localhost:9133';
       var client = new FxAccountClient(server);

--- a/packages/fxa-js-client/tests/examples/proxy.js
+++ b/packages/fxa-js-client/tests/examples/proxy.js
@@ -13,7 +13,7 @@ var httpProxy = require('http-proxy');
 
 var proxy = httpProxy.createProxyServer();
 var port = 9133;
-var targetAuthServer = 'http://127.0.0.1:9000';
+var targetAuthServer = 'http://localhost:9000';
 
 http
   .createServer(function(req, res) {

--- a/packages/fxa-js-client/tests/lib/account.js
+++ b/packages/fxa-js-client/tests/lib/account.js
@@ -336,7 +336,7 @@ describe('account', function() {
     var account;
     var opts = {
       service: 'sync',
-      redirectTo: 'https://sync.127.0.0.1/after_reset',
+      redirectTo: 'https://sync.localhost/after_reset',
       resume: 'resumejwt',
     };
 

--- a/packages/fxa-js-client/tests/lib/recoveryEmail.js
+++ b/packages/fxa-js-client/tests/lib/recoveryEmail.js
@@ -54,7 +54,7 @@ describe('recoveryEmail', function() {
     var user;
     var opts = {
       service: 'sync',
-      redirectTo: 'https://sync.127.0.0.1/after_reset',
+      redirectTo: 'https://sync.localhost/after_reset',
       resume: 'resumejwt',
       type: 'upgradeSession',
     };

--- a/packages/fxa-js-client/tests/lib/session.js
+++ b/packages/fxa-js-client/tests/lib/session.js
@@ -306,7 +306,7 @@ describe('session', function() {
         },
         originalLoginEmail: email.toUpperCase(),
         reason: 'password_change',
-        redirectTo: 'http://127.0.0.1',
+        redirectTo: 'http://localhost',
         resume: 'RESUME_TOKEN',
         service: 'sync',
         verificationMethod: 'email-2fa',

--- a/packages/fxa-js-client/tests/lib/signIn.js
+++ b/packages/fxa-js-client/tests/lib/signIn.js
@@ -94,7 +94,7 @@ describe('signIn', function() {
       metricsContext: {
         context: 'fx_desktop_v2',
       },
-      redirectTo: 'http://sync.127.0.0.1/after_reset',
+      redirectTo: 'http://sync.localhost/after_reset',
       service: 'sync',
     };
 
@@ -130,7 +130,7 @@ describe('signIn', function() {
       metricsContext: {
         context: 'fx_desktop_v2',
       },
-      redirectTo: 'http://sync.127.0.0.1/after_reset',
+      redirectTo: 'http://sync.localhost/after_reset',
       resume: 'resumejwt',
       service: 'sync',
     };

--- a/packages/fxa-js-client/tests/lib/signUp.js
+++ b/packages/fxa-js-client/tests/lib/signUp.js
@@ -112,7 +112,7 @@ describe('signUp', function() {
     var password = 'iliketurtles';
     var opts = {
       service: 'sync',
-      redirectTo: 'https://sync.127.0.0.1/after_reset',
+      redirectTo: 'https://sync.localhost/after_reset',
       resume: 'resumejwt',
     };
 
@@ -174,7 +174,7 @@ describe('signUp', function() {
     var email = user + '@restmail.net';
     var password = 'iliketurtles';
     var opts = {
-      redirectTo: 'http://sync.127.0.0.1/after_reset',
+      redirectTo: 'http://sync.localhost/after_reset',
     };
 
     return respond(client.signUp(email, password, opts), RequestMocks.signUp)

--- a/packages/fxa-payments-server/pm2.config.js
+++ b/packages/fxa-payments-server/pm2.config.js
@@ -14,7 +14,7 @@ module.exports = {
         LOGGING_FORMAT: 'pretty',
         NODE_ENV: 'development',
         NODE_OPTIONS: '--inspect=9170',
-        PROXY_STATIC_RESOURCES_FROM: 'http://127.0.0.1:3032',
+        PROXY_STATIC_RESOURCES_FROM: 'http://localhost:3032',
         CONFIG_FILES: 'config/secrets.json',
         PORT: '3031',
       },
@@ -27,7 +27,7 @@ module.exports = {
       min_uptime: '2m',
       env: {
         NODE_ENV: 'development',
-        PUBLIC_URL: 'http://127.0.0.1:3031',
+        PUBLIC_URL: 'http://localhost:3031',
         BROWSER: 'NONE',
         PORT: '3032',
       },

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -114,7 +114,7 @@ const conf = convict({
       default: '0.0.0.0',
       doc: 'The ip address the server should bind',
       env: 'IP_ADDRESS',
-      format: 'ipaddress',
+      format: String,
     },
     port: {
       default: 3031,
@@ -123,7 +123,7 @@ const conf = convict({
       format: 'port',
     },
     publicUrl: {
-      default: 'http://127.0.0.1:3031',
+      default: 'http://localhost:3031',
       env: 'PUBLIC_URL',
       format: 'url',
     },
@@ -158,8 +158,8 @@ const conf = convict({
   },
   productRedirectURLs: {
     default: {
-      '123doneProProduct': 'http://127.0.0.1:8080/',
-      fortressProProduct: 'http://127.0.0.1:9292/download',
+      '123doneProProduct': 'http://localhost:8080/',
+      fortressProProduct: 'http://localhost:9292/download',
       prod_FUUNYnlDso7FeB: 'https://fortress-latest.dev.lcip.org/',
       prod_Ex9Z1q5yVydhyk: 'https://123done-latest.dev.lcip.org/',
       // todo get new prod_id for 123done stage
@@ -193,7 +193,7 @@ const conf = convict({
   servers: {
     auth: {
       url: {
-        default: 'http://127.0.0.1:9000',
+        default: 'http://localhost:9000',
         doc: 'The url of the fxa-auth-server instance',
         env: 'AUTH_SERVER_URL',
         format: 'url',
@@ -201,7 +201,7 @@ const conf = convict({
     },
     content: {
       url: {
-        default: 'http://127.0.0.1:3030',
+        default: 'http://localhost:3030',
         doc: 'The url of the corresponding fxa-content-server instance',
         env: 'CONTENT_SERVER_URL',
         format: 'url',
@@ -209,7 +209,7 @@ const conf = convict({
     },
     oauth: {
       url: {
-        default: 'http://127.0.0.1:9000',
+        default: 'http://localhost:9000',
         doc: 'The url of the corresponding fxa-oauth-server instance',
         env: 'OAUTH_SERVER_URL',
         format: 'url',
@@ -217,7 +217,7 @@ const conf = convict({
     },
     profile: {
       url: {
-        default: 'http://127.0.0.1:1111',
+        default: 'http://localhost:1111',
         doc: 'The url of the corresponding fxa-profile-server instance',
         env: 'PROFILE_SERVER_URL',
         format: 'url',
@@ -225,7 +225,7 @@ const conf = convict({
     },
     profileImages: {
       url: {
-        default: 'http://127.0.0.1:1112',
+        default: 'http://localhost:1112',
         doc: 'The url of the Firefox Account Profile Image Server',
         env: 'FXA_PROFILE_IMAGES_URL',
         format: 'url',
@@ -262,7 +262,7 @@ const conf = convict({
       format: 'duration',
     },
     url: {
-      default: 'http://127.0.0.1:3031',
+      default: 'http://localhost:3031',
       doc: 'The origin of the static resources',
       env: 'STATIC_RESOURCE_URL',
       format: 'url',

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -212,8 +212,8 @@ export const defaultAppContextValue = (): AppContextType => ({
       addListener: jest.fn(),
       addEventListener: jest.fn(),
       removeListener: jest.fn(),
-      removeEventListener: jest.fn()
-    }
+      removeEventListener: jest.fn(),
+    };
   }),
   navigateToUrl: jest.fn(),
   getScreenInfo: () => new ScreenInfo(window),
@@ -428,7 +428,7 @@ export const MOCK_PROFILE = {
   amrValues: ['pwd', 'email'],
   twoFactorAuthentication: false,
   uid: 'a90fef48240b49b2b6a33d333aee9b13',
-  avatar: 'http://127.0.0.1:1112/a/00000000000000000000000000000000',
+  avatar: 'http://localhost:1112/a/00000000000000000000000000000000',
   avatarDefault: true,
 };
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
@@ -18,7 +18,7 @@ it('performs a redirect to the expected URL for local product', () => {
   assertRedirectForProduct(
     '123doneProProduct',
     'local',
-    'http://127.0.0.1:8080/'
+    'http://localhost:8080/'
   );
 });
 
@@ -35,7 +35,7 @@ function assertRedirectForProduct(
     ...defaultConfig,
     env: 'testing',
     productRedirectURLs: {
-      '123doneProProduct': 'http://127.0.0.1:8080/',
+      '123doneProProduct': 'http://localhost:8080/',
     },
   };
   const navigateToUrl = jest.fn();

--- a/packages/fxa-profile-server/config/worker.sample.json
+++ b/packages/fxa-profile-server/config/worker.sample.json
@@ -2,7 +2,7 @@
   "img": {
     "driver": "aws",
     "providers": {
-      "fxa": "^http://127.0.0.1:1112/a/[0-9a-f]{32}$"
+      "fxa": "^http://localhost:1112/a/[0-9a-f]{32}$"
     },
     "uploads": {
       "dest": {
@@ -12,7 +12,7 @@
     "url": "https://a.p.firefoxusercontent.net/a/{id}"
   },
   "worker": {
-    "host": "127.0.0.1",
+    "host": "localhost",
     "port": 1113
   }
 }

--- a/packages/fxa-profile-server/lib/config.js
+++ b/packages/fxa-profile-server/lib/config.js
@@ -19,7 +19,7 @@ const conf = convict({
       doc: 'URL of fxa-auth-server',
       env: 'AUTH_SERVER_URL',
       format: 'url',
-      default: 'http://127.0.0.1:9000/v1',
+      default: 'http://localhost:9000/v1',
     },
   },
   clientAddressDepth: {
@@ -77,7 +77,7 @@ const conf = convict({
       },
       fxa: {
         doc: 'Patterns to match a URL to ensure we only accept certain URLs.',
-        default: '^http://127.0.0.1:1112/a/[0-9a-f]{32}$',
+        default: '^http://localhost:1112/a/[0-9a-f]{32}$',
         env: 'IMG_PROVIDERS_FXA',
       },
     },
@@ -141,7 +141,7 @@ const conf = convict({
     },
     url: {
       doc: 'Pattern to generate FxA avatar URLs. {id} will be replaced.',
-      default: 'http://127.0.0.1:1112/a/{id}',
+      default: 'http://localhost:1112/a/{id}',
       env: 'IMG_URL',
     },
     defaultAvatarId: {
@@ -187,7 +187,7 @@ const conf = convict({
       env: 'MYSQL_DATABASE',
     },
     host: {
-      default: '127.0.0.1',
+      default: 'localhost',
       env: 'MYSQL_HOST',
     },
     port: {
@@ -200,7 +200,7 @@ const conf = convict({
       doc: 'URL of fxa-oauth-server',
       format: 'url',
       env: 'OAUTH_SERVER_URL',
-      default: 'http://127.0.0.1:9000/v1',
+      default: 'http://localhost:9000/v1',
     },
   },
   customsUrl: {
@@ -211,12 +211,12 @@ const conf = convict({
   publicUrl: {
     format: 'url',
     env: 'PUBLIC_URL',
-    default: 'http://127.0.0.1:1111',
+    default: 'http://localhost:1111',
   },
   server: {
     host: {
       env: 'HOST',
-      default: '127.0.0.1',
+      default: 'localhost',
     },
     port: {
       env: 'PORT',
@@ -227,7 +227,7 @@ const conf = convict({
   worker: {
     host: {
       env: 'WORKER_HOST',
-      default: '127.0.0.1',
+      default: 'localhost',
     },
     port: {
       env: 'WORKER_PORT',
@@ -235,7 +235,7 @@ const conf = convict({
       default: 1113,
     },
     url: {
-      default: 'http://127.0.0.1:1113',
+      default: 'http://localhost:1113',
       env: 'WORKER_URL',
     },
   },
@@ -257,7 +257,7 @@ const conf = convict({
   serverCache: {
     redis: {
       host: {
-        default: '127.0.0.1',
+        default: 'localhost',
         env: 'REDIS_HOST',
         format: String,
         doc: 'Url for redis host',

--- a/packages/fxa-profile-server/test/customs.js
+++ b/packages/fxa-profile-server/test/customs.js
@@ -4,7 +4,7 @@
 
 var nock = require('nock');
 
-var CUSTOMS_URL_REAL = 'http://127.0.0.1:7000';
+var CUSTOMS_URL_REAL = 'http://localhost:7000';
 
 var customs = require('../lib/customs.js')({
   url: CUSTOMS_URL_REAL,

--- a/packages/fxa-profile-server/test/lib/static.js
+++ b/packages/fxa-profile-server/test/lib/static.js
@@ -5,9 +5,9 @@
 const Static = require('../../lib/server/_static');
 
 function request(options) {
-  return Static.create().then((server) => {
+  return Static.create().then(server => {
     return server.inject(options);
-  })
+  });
 }
 
 function opts(options) {
@@ -19,7 +19,7 @@ function opts(options) {
 
 exports.get = function get(options) {
   options = opts(options);
-  options.url = options.url.replace('http://127.0.0.1:1112', '');
+  options.url = options.url.replace('http://localhost:1112', '');
   options.method = 'GET';
   return request(options);
 };

--- a/packages/fxa-shared/scripts/feature-flags.js
+++ b/packages/fxa-shared/scripts/feature-flags.js
@@ -11,7 +11,7 @@ const Promise = require('../promise');
 const redis = require('../redis')(
   {
     enabled: true,
-    host: process.env.REDIS_HOST || '127.0.0.1',
+    host: process.env.REDIS_HOST || 'localhost',
     port: process.env.REDIS_PORT || 6379,
     prefix: 'featureFlags:',
     maxConnections: 2,

--- a/packages/fxa-shared/test/feature-flags/index.js
+++ b/packages/fxa-shared/test/feature-flags/index.js
@@ -95,7 +95,7 @@ describe('feature-flags/index:', () => {
           interval: 300000,
           redis: {
             enabled: false,
-            host: '127.0.0.1',
+            host: 'localhost',
             port: 6379,
             prefix: 'wibble:',
           },
@@ -120,7 +120,7 @@ describe('feature-flags/index:', () => {
       assert.lengthOf(args, 2);
       assert.deepEqual(args[0], {
         enabled: true,
-        host: '127.0.0.1',
+        host: 'localhost',
         port: 6379,
         prefix: 'featureFlags:',
       });

--- a/packages/fxa-shared/test/feature-flags/integration.js
+++ b/packages/fxa-shared/test/feature-flags/integration.js
@@ -12,7 +12,7 @@ describe('featureFlags integration:', () => {
   before(() => {
     config = {
       interval: 10000,
-      host: process.env.REDIS_HOST || '127.0.0.1',
+      host: process.env.REDIS_HOST || 'localhost',
       port: process.env.REDIS_PORT || 6379,
       maxConnections: process.env.REDIS_POOL_MAX_CONNECTIONS || 1,
       minConnections: process.env.REDIS_POOL_MIN_CONNECTIONS || 1,

--- a/packages/fxa-shared/test/redis/integration.js
+++ b/packages/fxa-shared/test/redis/integration.js
@@ -15,7 +15,7 @@ describe('redis integration:', () => {
   before(() => {
     config = {
       enabled: true,
-      host: process.env.REDIS_HOST || '127.0.0.1',
+      host: process.env.REDIS_HOST || 'localhost',
       port: process.env.REDIS_PORT || 6379,
       prefix: process.env.REDIS_PREFIX || 'fxa-shared-test:',
       maxConnections: process.env.REDIS_POOL_MAX_CONNECTIONS || 200,

--- a/packages/fxa-shared/test/scripts/feature-flags.js
+++ b/packages/fxa-shared/test/scripts/feature-flags.js
@@ -17,7 +17,7 @@ cp.execAsync = Promise.promisify(cp.exec);
 const redis = require(`${ROOT_DIR}/redis`)(
   {
     enabled: true,
-    host: process.env.REDIS_HOST || '127.0.0.1',
+    host: process.env.REDIS_HOST || 'localhost',
     port: process.env.REDIS_PORT || 6379,
     prefix: 'featureFlags:',
     maxConnections: 2,
@@ -79,15 +79,19 @@ describe('scripts/feature-flags:', () => {
     });
 
     it(`${command} fails if stdin is not valid JSON`, () => {
-      return cp
-        .execAsync(`echo "wibble" | ${SCRIPT} ${command}`, { cwd })
-        .then(() => assert(false, 'script should have failed'), () => {});
+      return cp.execAsync(`echo "wibble" | ${SCRIPT} ${command}`, { cwd }).then(
+        () => assert(false, 'script should have failed'),
+        () => {}
+      );
     });
 
     it(`${command} fails if stdin contains unexpected key`, () => {
       return cp
         .execAsync(`echo '{"wibble":{}}' | ${SCRIPT} ${command}`, { cwd })
-        .then(() => assert(false, 'script should have failed'), () => {});
+        .then(
+          () => assert(false, 'script should have failed'),
+          () => {}
+        );
     });
 
     it(`${command} does not fail with valid communicationPrefLanguages`, () => {
@@ -103,7 +107,10 @@ describe('scripts/feature-flags:', () => {
           `echo '{"communicationPrefLanguages":{"0":"en"}}' | ${SCRIPT} ${command}`,
           { cwd }
         )
-        .then(() => assert(false, 'script should have failed'), () => {});
+        .then(
+          () => assert(false, 'script should have failed'),
+          () => {}
+        );
     });
 
     it(`${command} fails if communicationPrefLanguages contains empty string`, () => {
@@ -112,7 +119,10 @@ describe('scripts/feature-flags:', () => {
           `echo '{"communicationPrefLanguages":["en",""]}' | ${SCRIPT} ${command}`,
           { cwd }
         )
-        .then(() => assert(false, 'script should have failed'), () => {});
+        .then(
+          () => assert(false, 'script should have failed'),
+          () => {}
+        );
     });
 
     it(`${command} fails if communicationPrefLanguages contains object`, () => {
@@ -121,7 +131,10 @@ describe('scripts/feature-flags:', () => {
           `echo '{"communicationPrefLanguages":[{}]}' | ${SCRIPT} ${command}`,
           { cwd }
         )
-        .then(() => assert(false, 'script should have failed'), () => {});
+        .then(
+          () => assert(false, 'script should have failed'),
+          () => {}
+        );
     });
 
     it(`${command} does not fail with metricsSampleRate 0`, () => {
@@ -150,7 +163,10 @@ describe('scripts/feature-flags:', () => {
         .execAsync(`echo '{"metricsSampleRate":-0.1}' | ${SCRIPT} ${command}`, {
           cwd,
         })
-        .then(() => assert(false, 'script should have failed'), () => {});
+        .then(
+          () => assert(false, 'script should have failed'),
+          () => {}
+        );
     });
 
     it(`${command} fails if metricsSampleRate is greater than 1`, () => {
@@ -158,7 +174,10 @@ describe('scripts/feature-flags:', () => {
         .execAsync(`echo '{"metricsSampleRate":1.1}' | ${SCRIPT} ${command}`, {
           cwd,
         })
-        .then(() => assert(false, 'script should have failed'), () => {});
+        .then(
+          () => assert(false, 'script should have failed'),
+          () => {}
+        );
     });
 
     it(`${command} does not fail with sentrySampleRate 0`, () => {
@@ -187,7 +206,10 @@ describe('scripts/feature-flags:', () => {
         .execAsync(`echo '{"sentrySampleRate":-0.1}' | ${SCRIPT} ${command}`, {
           cwd,
         })
-        .then(() => assert(false, 'script should have failed'), () => {});
+        .then(
+          () => assert(false, 'script should have failed'),
+          () => {}
+        );
     });
 
     it(`${command} fails if sentrySampleRate is greater than 1`, () => {
@@ -195,7 +217,10 @@ describe('scripts/feature-flags:', () => {
         .execAsync(`echo '{"sentrySampleRate":1.1}' | ${SCRIPT} ${command}`, {
           cwd,
         })
-        .then(() => assert(false, 'script should have failed'), () => {});
+        .then(
+          () => assert(false, 'script should have failed'),
+          () => {}
+        );
     });
 
     it(`${command} does not fail with valid tokenCodeClients`, () => {
@@ -211,7 +236,10 @@ describe('scripts/feature-flags:', () => {
           `echo '{"tokenCodeClients":{"0123456789abcdef":{"enableTestEmails":1,"groups":["treatment"],"name":"wibble","rolloutRate":1}}}' | ${SCRIPT} ${command}`,
           { cwd }
         )
-        .then(() => assert(false, 'script should have failed'), () => {});
+        .then(
+          () => assert(false, 'script should have failed'),
+          () => {}
+        );
     });
 
     it(`${command} fails if tokenCodeClients contains empty groups string`, () => {
@@ -220,7 +248,10 @@ describe('scripts/feature-flags:', () => {
           `echo '{"tokenCodeClients":{"0123456789abcdef":{"enableTestEmails":true,"groups":[""],"name":"wibble","rolloutRate":1}}}' | ${SCRIPT} ${command}`,
           { cwd }
         )
-        .then(() => assert(false, 'script should have failed'), () => {});
+        .then(
+          () => assert(false, 'script should have failed'),
+          () => {}
+        );
     });
 
     it(`${command} fails if tokenCodeClients contains empty name`, () => {
@@ -229,7 +260,10 @@ describe('scripts/feature-flags:', () => {
           `echo '{"tokenCodeClients":{"0123456789abcdef":{"enableTestEmails":true,"groups":["treatment"],"name":"","rolloutRate":1}}}' | ${SCRIPT} ${command}`,
           { cwd }
         )
-        .then(() => assert(false, 'script should have failed'), () => {});
+        .then(
+          () => assert(false, 'script should have failed'),
+          () => {}
+        );
     });
 
     it(`${command} fails if tokenCodeClients contains rolloutRate greater than 1`, () => {
@@ -238,7 +272,10 @@ describe('scripts/feature-flags:', () => {
           `echo '{"tokenCodeClients":{"0123456789abcdef":{"enableTestEmails":true,"groups":["treatment"],"name":"wibble","rolloutRate":1.1}}}' | ${SCRIPT} ${command}`,
           { cwd }
         )
-        .then(() => assert(false, 'script should have failed'), () => {});
+        .then(
+          () => assert(false, 'script should have failed'),
+          () => {}
+        );
     });
   });
 

--- a/packages/fxa-support-panel/config/index.ts
+++ b/packages/fxa-support-panel/config/index.ts
@@ -56,7 +56,7 @@ const conf = convict({
       default: '0.0.0.0',
       doc: 'The ip address the server should bind',
       env: 'IP_ADDRESS',
-      format: 'ipaddress',
+      format: String,
     },
     port: {
       default: 7100,
@@ -65,7 +65,7 @@ const conf = convict({
       format: 'port',
     },
     publicUrl: {
-      default: 'http://127.0.0.1:3031',
+      default: 'http://localhost:3031',
       env: 'PUBLIC_URL',
       format: 'url',
     },


### PR DESCRIPTION
why, after all these years? 

because there's a few annoying cases where the loopback
makes dev harder. When you try to test a flow from a not
local machine, like a tv, mobile device, or a saucelabs
proxy session. With localhost it's easy enough to forward
but loopback not so much. And now that we're in a monorepo, 
the change shouldn't be a nightmare.

enough is enough