### PR TITLE
fix(devices + apps): update styles to allow overflowing long device names

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -501,17 +501,22 @@ section.modal-panel {
 
   .client-name {
     line-height: 1.2;
+    word-break: break-word;
 
     html[dir='ltr'] & {
-      margin-right: 110px;
+      margin-right: 130px;
+
+      @include respond-to('small') {
+        margin-right: 0;
+      }
     }
 
     html[dir='rtl'] & {
-      margin-left: 110px;
-    }
+      margin-left: 130px;
 
-    @include respond-to('small') {
-      margin: 0;
+      @include respond-to('small') {
+        margin-left: 0;
+      }
     }
   }
 


### PR DESCRIPTION
Closes #4888

Before:

![Screen Shot 2020-04-15 at 11 30 44 AM](https://user-images.githubusercontent.com/6392049/79356352-d2ba9600-7f0c-11ea-8ee8-6477ceb4abd6.png)

After:

![Screen Shot 2020-04-15 at 11 31 17 AM](https://user-images.githubusercontent.com/6392049/79356361-d817e080-7f0c-11ea-9973-b13cdde96212.png)

Additionally, I made a small tweak to allow full text width on mobile.

Before:

![Screen Shot 2020-04-15 at 11 29 13 AM](https://user-images.githubusercontent.com/6392049/79356423-f382eb80-7f0c-11ea-8b56-96ddf1da7829.png)

After:

![Screen Shot 2020-04-15 at 11 29 36 AM](https://user-images.githubusercontent.com/6392049/79356447-fa116300-7f0c-11ea-993a-3ebaf48ad31b.png)
