### PR TITLE
fix(password input): use 1px less border radius on password revealer button

### DIFF
--- a/packages/fxa-content-server/app/styles/_variables.scss
+++ b/packages/fxa-content-server/app/styles/_variables.scss
@@ -97,6 +97,7 @@ $header-color: rgb(32, 18, 59);
 $input-height: 48px;
 $input-height-small: 40px;
 $input-border-radius: 4px;
+$input-inner-border-radius: 3px;
 
 $input-background-color-default: $color-white;
 

--- a/packages/fxa-content-server/app/styles/modules/_password-row.scss
+++ b/packages/fxa-content-server/app/styles/modules/_password-row.scss
@@ -231,12 +231,12 @@
     }
 
     html[dir='ltr'] & {
-      border-radius: 0 $input-border-radius $input-border-radius 0;
+      border-radius: 0 $input-inner-border-radius $input-inner-border-radius 0;
       right: 1px;
     }
 
     html[dir='rtl'] & {
-      border-radius: $input-border-radius 0 0 $input-border-radius;
+      border-radius: $input-inner-border-radius 0 0 $input-inner-border-radius;
       left: 1px;
     }
   }


### PR DESCRIPTION
Closes #4917

Before:

![Screen Shot 2020-04-15 at 11 51 30 AM](https://user-images.githubusercontent.com/6392049/79358833-bff59080-7f0f-11ea-9dde-aa9c0fe25684.png)

After:

![Screen Shot 2020-04-15 at 11 51 07 AM](https://user-images.githubusercontent.com/6392049/79358906-dac80500-7f0f-11ea-8ba3-26b667763406.png)

For those of you saying "wait, I can still see a _little_ but of the white!", this is what it looks like (unfocused) when we go 1px further:

![Screen Shot 2020-04-15 at 11 54 09 AM](https://user-images.githubusercontent.com/6392049/79358973-f6cba680-7f0f-11ea-8ced-119ca2c504a3.png)
