### PR TITLE
fix(payments): ensure 'invoices' is valid expandable Stripe resource

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -877,12 +877,8 @@ class DirectStripeRoutes {
    * @param {Subscription} subscription
    */
   async sendSubscriptionDeletedEmail(subscription) {
-    const invoice = await this.stripeHelper.expandResource(
-      subscription.latest_invoice,
-      'invoices'
-    );
     const invoiceDetails = await this.stripeHelper.extractInvoiceDetailsForEmail(
-      invoice
+      subscription.latest_invoice
     );
     const { uid, email } = invoiceDetails;
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -2032,11 +2032,6 @@ describe('DirectStripeRoutes', () => {
       const deletedEvent = deepCopy(subscriptionDeleted);
       const subscription = deletedEvent.data.object;
 
-      const mockInvoice = { test: 'fake' };
-      directStripeRoutesInstance.stripeHelper.expandResource.resolves(
-        mockInvoice
-      );
-
       const mockInvoiceDetails = {
         uid: '1234',
         test: 'fake',
@@ -2059,13 +2054,8 @@ describe('DirectStripeRoutes', () => {
       );
 
       assert.calledWith(
-        directStripeRoutesInstance.stripeHelper.expandResource,
-        subscription.latest_invoice,
-        'invoices'
-      );
-      assert.calledWith(
         directStripeRoutesInstance.stripeHelper.extractInvoiceDetailsForEmail,
-        mockInvoice
+        subscription.latest_invoice
       );
 
       if (accountFound) {


### PR DESCRIPTION
- ensure 'invoices' is accepted as a valid Stripe resource to expand

- move call to expand latest subscription invoice out of webhook handler
  and into StripeHelper

- replace a few resource name strings with constant references

- fix error log call on an attempt to expand an invalid Stripe resource

- update tests

FXA-1634