### PR TITLE
fix(payments): bugfix for creating default mock stubs for stripe JS API

### DIFF
--- a/packages/fxa-payments-server/.storybook/components/MockApp.tsx
+++ b/packages/fxa-payments-server/.storybook/components/MockApp.tsx
@@ -41,9 +41,10 @@ export const defaultAppContextValue: AppContextType = {
   locationReload: action('locationReload'),
 };
 
-export const defaultStripeStubs = (stripe: stripe.Stripe) => {
-  stripe.createToken = (element: stripe.elements.Element | string) => {
-    return Promise.resolve({
+export const defaultStripeStubs = (stripe: stripe.Stripe) => ({
+  ...stripe,
+  createToken: (element: stripe.elements.Element | string) =>
+    Promise.resolve({
       token: {
         id: 'asdf',
         object: 'mock_object',
@@ -53,10 +54,8 @@ export const defaultStripeStubs = (stripe: stripe.Stripe) => {
         type: 'card',
         used: false,
       },
-    });
-  };
-  return stripe;
-};
+    }),
+});
 
 export const MockApp = ({
   children,

--- a/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
@@ -155,15 +155,14 @@ function init() {
     ))
     .add('stripe.createToken() fails on submit', () => {
       const validatorInitialState = mkValidPaymentFormState();
-      const applyStubsToStripe = (stripe: stripe.Stripe) => {
-        stripe.createToken = (element: stripe.elements.Element | string) => {
-          return Promise.reject({
+      const applyStubsToStripe = (stripe: stripe.Stripe) => ({
+        ...stripe,
+        createToken: (element: stripe.elements.Element | string) =>
+          Promise.reject({
             type: 'api_error',
             message: 'The Stripe system is down.',
-          });
-        };
-        return stripe;
-      };
+          }),
+      });
       return (
         <ProductRoute
           applyStubsToStripe={applyStubsToStripe}


### PR DESCRIPTION
Noticed this error when trying to view some stories. Seems like the Stripe JS API has changed to freeze some object properties we were manipulating in place? This PR seems to fix

![Annotation 2020-04-15 170951](https://user-images.githubusercontent.com/21687/79401121-13320800-7f3d-11ea-92e4-d408a29a2e83.png)
