### PR TITLE
chore(cleanup): Remove the `marketingOptIn` param

### DIFF
--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -2032,15 +2032,6 @@ not just the one being attached to the Firefox account.
 
   <!--end-request-body-post-recovery_emailverify_code-type-->
 
-- `marketingOptIn`: _boolean_
-
-  <!--begin-request-body-post-recovery_emailverify_code-marketingOptIn-->
-
-  Set to true if the user has opted-in to our marketing. When verified,
-  the auth-server will notify Basket.
-
-  <!--end-request-body-post-recovery_emailverify_code-marketingOptIn-->
-
 ##### Error responses
 
 Failing requests may be caused

--- a/packages/fxa-auth-server/docs/service_notifications.md
+++ b/packages/fxa-auth-server/docs/service_notifications.md
@@ -63,7 +63,6 @@ Message Properties:
 - `uid`: The userid of the account being that was created.
 - `email`: The primary email address that was verified for the account.
 - `locale`: The accept-language header supplies by the user at account creation.
-- `marketingOptIn`: Optional, boolean, whether the user opted-in to marketing emails.
 
 Receiving services should use this message to initialize any state
 that needs to exist for _all_ Firefox Accounts.

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -142,7 +142,6 @@ const DEBUGGABLE_PAYLOAD_KEYS = new Set([
   'duration',
   'excluded',
   'features',
-  'marketingOptIn',
   'messageId',
   'metricsContext',
   'name',

--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -227,7 +227,6 @@ module.exports = (log, config) => {
         'entrypoint',
         'experiments',
         'location',
-        'marketingOptIn',
         'newsletters',
         'syncEngines',
         'templateVersion',

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -397,7 +397,8 @@ module.exports = (
               .string()
               .allow(['trailhead'])
               .optional(),
-            marketingOptIn: isA.boolean(),
+            // The `marketingOptIn` is safe to remove after train-167+
+            marketingOptIn: isA.boolean().optional(),
             newsletters: validators.newsletters,
           },
         },

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -344,6 +344,7 @@ module.exports = function(
             code: validators.DIGITS,
             service: validators.service,
             style: validators.style,
+            // The `marketingOptIn` is safe to remove after train-167+
             marketingOptIn: isA.boolean().optional(),
             newsletters: validators.newsletters,
           },

--- a/packages/fxa-auth-server/lib/routes/utils/signup.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signup.js
@@ -13,7 +13,7 @@ module.exports = (log, db, mailer, push, verificationReminders) => {
      */
     verifyAccount: async (request, account, options) => {
       const { uid } = account;
-      const { marketingOptIn, newsletters, service, reminder, style } = options;
+      const { newsletters, service, reminder, style } = options;
       await db.verifyEmail(account, account.primaryEmail.emailCode);
 
       const geoData = request.app.geo;
@@ -33,16 +33,12 @@ module.exports = (log, db, mailer, push, verificationReminders) => {
           countryCode,
           email: account.primaryEmail.email,
           locale: account.locale,
-          marketingOptIn: marketingOptIn ? true : undefined,
           newsletters,
           service,
           uid,
           userAgent: request.headers['user-agent'],
         }),
         request.emitMetricsEvent('account.verified', {
-          // The content server omits marketingOptIn in the false case.
-          // Force it so that we emit the appropriate newsletter state.
-          marketingOptIn: marketingOptIn || false,
           deviceId,
           flowId,
           flowBeginTime,

--- a/packages/fxa-auth-server/test/local/metrics/amplitude.js
+++ b/packages/fxa-auth-server/test/local/metrics/amplitude.js
@@ -543,44 +543,6 @@ describe('metrics/amplitude', () => {
       });
     });
 
-    describe('account.verified, marketingOptIn=true', () => {
-      beforeEach(() => {
-        return amplitude('account.verified', mocks.mockRequest({}), {
-          marketingOptIn: true,
-        });
-      });
-
-      it('did not call log.error', () => {
-        assert.equal(log.error.callCount, 0);
-      });
-
-      it('called log.amplitudeEvent correctly', () => {
-        assert.equal(log.amplitudeEvent.callCount, 1);
-        const args = log.amplitudeEvent.args[0];
-        assert.equal(args[0].event_type, 'fxa_reg - email_confirmed');
-        assert.equal(args[0].user_properties.newsletter_state, 'subscribed');
-      });
-    });
-
-    describe('account.verified, marketingOptIn=false', () => {
-      beforeEach(() => {
-        return amplitude('account.verified', mocks.mockRequest({}), {
-          marketingOptIn: false,
-        });
-      });
-
-      it('did not call log.error', () => {
-        assert.equal(log.error.callCount, 0);
-      });
-
-      it('called log.amplitudeEvent correctly', () => {
-        assert.equal(log.amplitudeEvent.callCount, 1);
-        const args = log.amplitudeEvent.args[0];
-        assert.equal(args[0].event_type, 'fxa_reg - email_confirmed');
-        assert.equal(args[0].user_properties.newsletter_state, 'unsubscribed');
-      });
-    });
-
     describe('account.verified, newsletters is empty', () => {
       beforeEach(() => {
         return amplitude('account.verified', mocks.mockRequest({}), {

--- a/packages/fxa-auth-server/test/local/routes/emails.js
+++ b/packages/fxa-auth-server/test/local/routes/emails.js
@@ -795,7 +795,6 @@ describe('/recovery_email/verify_code', () => {
         let args = mockLog.notifyAttachedServices.args[0];
         assert.equal(args[0], 'verified');
         assert.equal(args[2].uid, uid);
-        assert.equal(args[2].marketingOptIn, undefined);
         assert.equal(args[2].service, 'sync');
         assert.equal(args[2].country, 'United States', 'set country');
         assert.equal(args[2].countryCode, 'US', 'set country code');
@@ -828,7 +827,6 @@ describe('/recovery_email/verify_code', () => {
           {
             country: 'United States',
             event: 'account.verified',
-            marketingOptIn: false,
             newsletters: undefined,
             region: 'California',
             service: 'sync',
@@ -853,11 +851,6 @@ describe('/recovery_email/verify_code', () => {
           args[0].event_type,
           'fxa_reg - email_confirmed',
           'first call to amplitudeEvent was email_confirmed event'
-        );
-        assert.equal(
-          args[0].user_properties.newsletter_state,
-          'unsubscribed',
-          'newsletter_state was correct'
         );
 
         assert.equal(
@@ -911,41 +904,6 @@ describe('/recovery_email/verify_code', () => {
       });
     });
 
-    it('with marketingOptIn', () => {
-      mockRequest.payload.marketingOptIn = true;
-      return runTest(route, mockRequest, response => {
-        assert.equal(
-          mockLog.notifyAttachedServices.callCount,
-          1,
-          'logs verified'
-        );
-        let args = mockLog.notifyAttachedServices.args[0];
-        assert.equal(args[0], 'verified');
-        assert.equal(args[2].uid, uid);
-        assert.equal(args[2].marketingOptIn, true);
-        assert.equal(args[2].service, 'sync');
-
-        assert.equal(
-          mockLog.amplitudeEvent.callCount,
-          2,
-          'amplitudeEvent was called twice'
-        );
-        args = mockLog.amplitudeEvent.args[1];
-        assert.equal(
-          args[0].event_type,
-          'fxa_reg - email_confirmed',
-          'second call to amplitudeEvent was email_confirmed event'
-        );
-        assert.equal(
-          args[0].user_properties.newsletter_state,
-          'subscribed',
-          'newsletter_state was correct'
-        );
-
-        assert.equal(JSON.stringify(response), '{}');
-      });
-    });
-
     it('with newsletters', () => {
       mockRequest.payload.newsletters = ['test-pilot', 'firefox-pilot'];
       return runTest(route, mockRequest, response => {
@@ -962,10 +920,10 @@ describe('/recovery_email/verify_code', () => {
 
         assert.equal(
           mockLog.amplitudeEvent.callCount,
-          3,
+          2,
           'amplitudeEvent was called 3 times'
         );
-        args = mockLog.amplitudeEvent.args[2];
+        args = mockLog.amplitudeEvent.args[1];
         assert.equal(
           args[0].event_type,
           'fxa_reg - email_confirmed',

--- a/packages/fxa-auth-server/test/local/routes/utils/signup.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/signup.js
@@ -86,7 +86,6 @@ describe('verifyAccount', () => {
       args = log.notifyAttachedServices.args[0];
       assert.equal(args[0], 'verified');
       assert.equal(args[2].uid, TEST_UID);
-      assert.equal(args[2].marketingOptIn, undefined);
       assert.equal(args[2].service, 'sync');
       assert.equal(args[2].country, 'United States', 'set country');
       assert.equal(args[2].countryCode, 'US', 'set country code');

--- a/packages/fxa-content-server/app/scripts/models/resume-token.js
+++ b/packages/fxa-content-server/app/scripts/models/resume-token.js
@@ -18,7 +18,6 @@ const ALLOWED_KEYS = [
   'entrypointVariation',
   'flowBegin',
   'flowId',
-  'needsOptedInToMarketingEmail',
   'newsletters',
   'planId',
   'productId',

--- a/packages/fxa-content-server/app/tests/spec/models/account.js
+++ b/packages/fxa-content-server/app/tests/spec/models/account.js
@@ -1188,7 +1188,6 @@ describe('models/account', function() {
 
   describe('signUp', function() {
     beforeEach(function() {
-      account.set('needsOptedInToMarketingEmail', true);
       sinon.stub(fxaClient, 'signUp').callsFake(function() {
         return Promise.resolve({
           sessionToken: SESSION_TOKEN,
@@ -1242,36 +1241,14 @@ describe('models/account', function() {
       notifier.trigger.resetHistory();
     });
 
-    describe('without email opt-in', function() {
-      beforeEach(function() {
-        sinon.stub(fxaClient, 'verifyCode').callsFake(function() {
-          return Promise.resolve();
-        });
-
-        account.set('uid', UID);
-        return account.verifySignUp('CODE');
-      });
-
-      it('delegates to the fxaClient', function() {
-        const options = sinon.match({
-          marketingOptIn: sinon.match.typeOf('undefined'),
-        });
-        assert.isTrue(fxaClient.verifyCode.calledWith(UID, 'CODE', options));
-      });
-
-      it('did not call notifier.trigger', () => {
-        assert.equal(notifier.trigger.callCount, 0);
-      });
-    });
-
-    describe('with email opt-in', function() {
+    describe('with newsletters', function() {
       beforeEach(function() {
         sinon.stub(fxaClient, 'verifyCode').callsFake(function() {
           return Promise.resolve();
         });
 
         account.set({
-          needsOptedInToMarketingEmail: true,
+          newsletters: ['knowledge-is-power'],
           uid: UID,
         });
 
@@ -1279,7 +1256,7 @@ describe('models/account', function() {
       });
 
       it('delegates to the fxaClient', function() {
-        const options = sinon.match.has('marketingOptIn', true);
+        const options = sinon.match.has('newsletters', ['knowledge-is-power']);
         assert.isTrue(fxaClient.verifyCode.calledWith(UID, 'CODE', options));
       });
 

--- a/packages/fxa-content-server/app/tests/spec/models/resume-token.js
+++ b/packages/fxa-content-server/app/tests/spec/models/resume-token.js
@@ -17,7 +17,6 @@ const TOKEN_OBJ = {
   entrypointVariation: 'entrypoint-experiment',
   flowBegin: Date.now(),
   flowId: 'a-big-flow-id',
-  needsOptedInToMarketingEmail: true,
   newsletters: ['knowledge-is-power'],
   planId: 'wibble',
   productId: 'blee',
@@ -33,7 +32,7 @@ const TOKEN_OBJ = {
 
 describe('models/resume-token', function() {
   it('expected fields are allowed in resume token', () => {
-    assert.lengthOf(ResumeToken.ALLOWED_KEYS, 19);
+    assert.lengthOf(ResumeToken.ALLOWED_KEYS, 18);
     assert.sameMembers(ResumeToken.ALLOWED_KEYS, Object.keys(TOKEN_OBJ));
   });
 

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -426,7 +426,6 @@ function receiveEvent(event, request, data) {
           'flowId',
           'lang',
           'location',
-          'marketingOptIn',
           'newsletters',
           'planId',
           'productId',

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -129,7 +129,6 @@ registerSuite('amplitude', {
           country: 'United States',
           state: 'California',
         },
-        marketingOptIn: 'none',
         newsletters: 'none',
         planId: 'abc',
         productId: 'gamma',
@@ -169,7 +168,6 @@ registerSuite('amplitude', {
             country: 'United States',
             state: 'California',
           },
-          marketingOptIn: 'none',
           newsletters: 'none',
           planId: 'abc',
           productId: 'gamma',
@@ -1620,58 +1618,6 @@ registerSuite('amplitude', {
         logger.info.args[0][1].event_type,
         'fxa_pref - two_step_authentication_view'
       );
-    },
-
-    'settings.communication-preferences.optIn.success': () => {
-      amplitude(
-        {
-          time: '1585321743',
-          type: 'settings.communication-preferences.optIn.success',
-        },
-        {
-          connection: {},
-          headers: {
-            'x-forwarded-for': '63.245.221.32',
-          },
-        },
-        {
-          flowBeginTime: '1585261624219',
-          flowId:
-            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
-          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
-        }
-      );
-
-      assert.equal(logger.info.callCount, 1);
-      const arg = logger.info.args[0][1];
-      assert.equal(arg.event_type, 'fxa_pref - newsletter');
-      assert.equal(arg.user_properties.newsletter_state, 'subscribed');
-    },
-
-    'settings.communication-preferences.optOut.success': () => {
-      amplitude(
-        {
-          time: '1585321743',
-          type: 'settings.communication-preferences.optOut.success',
-        },
-        {
-          connection: {},
-          headers: {
-            'x-forwarded-for': '63.245.221.32',
-          },
-        },
-        {
-          flowBeginTime: '1585261624219',
-          flowId:
-            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
-          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
-        }
-      );
-
-      assert.equal(logger.info.callCount, 1);
-      const arg = logger.info.args[0][1];
-      assert.equal(arg.event_type, 'fxa_pref - newsletter');
-      assert.equal(arg.user_properties.newsletter_state, 'unsubscribed');
     },
 
     'flow.signin-totp-code.success': () => {

--- a/packages/fxa-js-client/client/FxAccountClient.js
+++ b/packages/fxa-js-client/client/FxAccountClient.js
@@ -323,8 +323,6 @@ FxAccountClient.prototype.signIn = function(email, password, options) {
  *   Reminder that was used to verify the account
  *   @param {String} [options.type]
  *   Type of code being verified, only supports `secondary` otherwise will verify account/sign-in
- *   @param {Boolean} [options.marketingOptIn]
- *   If `true`, notifies marketing of opt-in intent.
  *   @param {Array} [options.newsletters]
  *   Array of newsletters to opt into.
  *   @param {String} [options.style]
@@ -354,10 +352,6 @@ FxAccountClient.prototype.verifyCode = function(uid, code, options) {
 
       if (options.type) {
         data.type = options.type;
-      }
-
-      if (options.marketingOptIn) {
-        data.marketingOptIn = true;
       }
 
       if (options.newsletters) {
@@ -1013,8 +1007,6 @@ FxAccountClient.prototype.sessionStatus = function(sessionToken) {
  * @param {Object} [options={}] Options
  *   @param {String} [options.service]
  *   Service being used
- *   @param {Boolean} [options.marketingOptIn]
- *   If `true`, notifies marketing of opt-in intent.
  *   @param {Array} [options.newsletters]
  *   Array of newsletters to opt into.
  *   @param {String} [options.style]
@@ -1038,10 +1030,6 @@ FxAccountClient.prototype.sessionVerifyCode = function(
 
   if (options.service) {
     data.service = options.service;
-  }
-
-  if (options.marketingOptIn) {
-    data.marketingOptIn = options.marketingOptIn;
   }
 
   if (options.newsletters) {

--- a/packages/fxa-js-client/tests/lib/session.js
+++ b/packages/fxa-js-client/tests/lib/session.js
@@ -383,7 +383,6 @@ describe('session', function() {
       const allOptions = {
         service: 'sync',
         style: 'trailhead',
-        marketingOptIn: true,
         newsletters: ['test-pilot'],
       };
       const response = await respond(
@@ -399,11 +398,10 @@ describe('session', function() {
       const payload = JSON.parse(
         xhr.prototype.send.args[xhr.prototype.send.args.length - 1][0]
       );
-      assert.equal(Object.keys(payload).length, 5);
+      assert.equal(Object.keys(payload).length, 4);
       assert.equal(payload.code, code);
       assert.equal(payload.service, allOptions.service);
       assert.equal(payload.style, allOptions.style);
-      assert.equal(payload.marketingOptIn, allOptions.marketingOptIn);
       assert.deepEqual(payload.newsletters, allOptions.newsletters);
     });
 

--- a/packages/fxa-js-client/tests/lib/verifyCode.js
+++ b/packages/fxa-js-client/tests/lib/verifyCode.js
@@ -185,41 +185,6 @@ describe('verifyCode', function() {
       }, assert.fail);
   });
 
-  it('#verifyEmail with marketingOptIn param', function() {
-    var user = 'test7' + new Date().getTime();
-    var email = user + '@restmail.net';
-    var password = 'iliketurtles';
-    var uid;
-
-    return respond(client.signUp(email, password), RequestMocks.signUp)
-      .then(function(result) {
-        uid = result.uid;
-        assert.ok(uid, 'uid is returned');
-
-        return respond(mail.wait(user), RequestMocks.mail);
-      })
-      .then(function(emails) {
-        var code = emails[0].html.match(/code=([A-Za-z0-9]+)/)[1];
-        assert.ok(code, 'code is returned');
-
-        return respond(
-          client.verifyCode(uid, code, { marketingOptIn: true }),
-          RequestMocks.verifyCode
-        );
-      })
-      .then(function(result) {
-        assert.ok(result);
-        assert.equal(xhrOpen.args[2][0], 'POST', 'method is correct');
-        assert.include(
-          xhrOpen.args[2][1],
-          '/recovery_email/verify_code',
-          'path is correct'
-        );
-        var sentData = JSON.parse(xhrSend.args[2][0]);
-        assert.equal(sentData.marketingOptIn, true);
-      }, assert.fail);
-  });
-
   it('#verifyEmail with newsletters param', function() {
     var user = 'test7' + new Date().getTime();
     var email = user + '@restmail.net';

--- a/packages/fxa-payments-server/server/lib/amplitude.js
+++ b/packages/fxa-payments-server/server/lib/amplitude.js
@@ -57,7 +57,6 @@ module.exports = (event, request, data) => {
       'flowId',
       'lang',
       'location',
-      'marketingOptIn',
       'newsletters',
       'planId',
       'productId',

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -41,11 +41,6 @@ const CONNECT_DEVICE_FLOWS = {
   sms: 'sms',
 };
 
-const NEWSLETTER_STATES = {
-  optIn: 'subscribed',
-  optOut: 'unsubscribed',
-};
-
 const EVENT_PROPERTIES = {
   [GROUPS.activity]: NOP,
   [GROUPS.button]: NOP,
@@ -323,7 +318,6 @@ module.exports = {
         mapAppendProperties(data),
         mapSyncDevices(data),
         mapSyncEngines(data),
-        mapNewsletterState(eventCategory, data),
         mapNewsletters(data)
       );
     }
@@ -430,22 +424,6 @@ function mapSyncEngines(data) {
 
   if (Array.isArray(sync_engines) && sync_engines.length > 0) {
     return { sync_engines };
-  }
-}
-
-function mapNewsletterState(eventCategory, data) {
-  let newsletter_state = NEWSLETTER_STATES[eventCategory];
-
-  if (!newsletter_state) {
-    const { marketingOptIn } = data;
-
-    if (marketingOptIn === true || marketingOptIn === false) {
-      newsletter_state = marketingOptIn ? 'subscribed' : 'unsubscribed';
-    }
-  }
-
-  if (newsletter_state) {
-    return { newsletter_state };
   }
 }
 

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -162,7 +162,6 @@ describe('metrics/amplitude:', () => {
             flowId: 'l',
             formFactor: 'm',
             lang: 'n',
-            marketingOptIn: 'o',
             os: 'p',
             osVersion: 'q',
             planId: 'plid',
@@ -364,21 +363,6 @@ describe('metrics/amplitude:', () => {
       });
     });
 
-    describe('transform an event with newsletter optIn properties:', () => {
-      let result;
-
-      before(() => {
-        result = transform({ type: 'newsletter.optIn.wibble' }, {});
-      });
-
-      it('returned the correct event data', () => {
-        assert.equal(result.event_type, 'fxa_pref - newsletterEvent');
-        assert.deepEqual(result.user_properties, {
-          newsletter_state: 'subscribed',
-        });
-      });
-    });
-
     describe('transform an event with newsletters optIn properties:', () => {
       let result;
 
@@ -394,7 +378,6 @@ describe('metrics/amplitude:', () => {
       it('returned the correct event data', () => {
         assert.equal(result.event_type, 'fxa_pref - newsletters');
         assert.deepEqual(result.user_properties, {
-          newsletter_state: 'subscribed',
           newsletters: ['test_pilot'],
         });
       });


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/4919

This PR removes the last remains of the `marketingOptIn` param. 

Confirmed with marketing/basket teams that they have moved away from the `marketingOptIn` param and this is safe to merge.