### PR TITLE
fix(delete): Specify `await` on `this.sessionPost` so error get caught

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/auth/client.ts
+++ b/packages/fxa-content-server/app/scripts/lib/auth/client.ts
@@ -454,9 +454,13 @@ export default class AuthClient {
     };
     try {
       if (sessionToken) {
-        return this.sessionPost('/account/destroy', sessionToken, payload);
+        return await this.sessionPost(
+          '/account/destroy',
+          sessionToken,
+          payload
+        );
       } else {
-        return this.request('POST', '/account/destroy', payload);
+        return await this.request('POST', '/account/destroy', payload);
       }
     } catch (error) {
       if (

--- a/packages/fxa-content-server/tests/functional/settings_change_email.js
+++ b/packages/fxa-content-server/tests/functional/settings_change_email.js
@@ -265,6 +265,33 @@ registerSuite('settings change email', {
           .then(testElementExists(selectors.SETTINGS.HEADER))
       );
     },
+
+    'can change primary email, delete account': function() {
+      return (
+        this.remote
+          // go to delete account screen
+          .then(
+            click(
+              selectors.SETTINGS_DELETE_ACCOUNT.MENU_BUTTON,
+              selectors.SETTINGS_DELETE_ACCOUNT.DETAILS
+            )
+          )
+          .findAllByCssSelector(selectors.SETTINGS_DELETE_ACCOUNT.CHECKBOXES)
+          .then(checkboxes => checkboxes.map(checkbox => checkbox.click()))
+          .end()
+
+          // enter correct password
+          .then(
+            type(selectors.SETTINGS_DELETE_ACCOUNT.INPUT_PASSWORD, PASSWORD)
+          )
+          .then(click(selectors.SETTINGS_DELETE_ACCOUNT.SUBMIT))
+          .then(testElementExists(selectors.ENTER_EMAIL.HEADER))
+          .then(testSuccessWasShown())
+          .then(type(selectors.ENTER_EMAIL.EMAIL, email))
+          .then(click(selectors.ENTER_EMAIL.SUBMIT))
+          .then(visibleByQSA(selectors.SIGNUP_PASSWORD.HEADER))
+      );
+    },
   },
 });
 


### PR DESCRIPTION
Fixes #5002 

I'm a bit of noob at typescript but reading through the [blog](https://itnext.io/error-handling-with-async-await-in-js-26c3f20bc06a) they recommended adding the `await` keyword so that errors get caught correctly. Maybe a better way to do this? Also added a test so we catch it next time.

I've targeted as a point release on train-167 since it breaks account delete when users have changed their primary email. cc @dannycoates 