### PR TITLE
feat(metrics-processor): add's queue worker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ jobs:
             'fxa-event-broker' \
             'fxa-geodb' \
             'fxa-js-client' \
+            'fxa-metrics-processor' \
             'fxa-payments-server' \
             'fxa-profile-server' \
             'fxa-settings' \

--- a/packages/fxa-metrics-processor/.prettierrc
+++ b/packages/fxa-metrics-processor/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 100,
+  "singleQuote": true,
+}

--- a/packages/fxa-metrics-processor/.vscode/launch.json
+++ b/packages/fxa-metrics-processor/.vscode/launch.json
@@ -1,0 +1,55 @@
+{
+  // Use IntelliSense to learn about possible Node.js debug attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Local Nodemon",
+      "preLaunchTask": "tsc-watch",
+      "protocol": "auto",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "debug"],
+      "restart": true,
+      "port": 5858,
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha All",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--timeout",
+        "999999",
+        "--colors",
+        "-r",
+        "ts-node/register",
+        "${workspaceFolder}/test/**/*.spec.ts",
+        "${workspaceFolder}/test/**/**/*.spec.ts"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha Current File",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--timeout",
+        "999999",
+        "--colors",
+        "-r",
+        "ts-node/register",
+        "${workspaceFolder}/${relativeFile}"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}

--- a/packages/fxa-metrics-processor/.vscode/tasks.json
+++ b/packages/fxa-metrics-processor/.vscode/tasks.json
@@ -1,0 +1,36 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "tsc-watch",
+      "command": "npm",
+      "args": ["run", "watch"],
+      "type": "shell",
+      "isBackground": true,
+      "group": "build",
+      "problemMatcher": "$tsc-watch",
+      "presentation": {
+        "reveal": "always"
+      }
+    },
+    {
+      "label": "Run Current Test",
+      "type": "shell",
+      "command": "./node_modules/mocha/bin/mocha",
+      "options": {
+        "env": {
+          "FIRESTORE_EMULATOR_HOST": "localhost:8006",
+          "FIRESTORE_PROJECT_ID": "fx-event-broker"
+        }
+      },
+      "args": ["-r", "ts-node/register", "${relativeFile}"],
+      "group": "test",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "dedicated"
+      }
+    }
+  ]
+}

--- a/packages/fxa-metrics-processor/Dockerfile
+++ b/packages/fxa-metrics-processor/Dockerfile
@@ -1,0 +1,17 @@
+# Build image
+FROM node:12 as builder
+WORKDIR /app
+COPY . /app
+RUN npm ci
+RUN npm run build
+RUN npm ci --production
+
+# Production image
+FROM node:12-slim
+WORKDIR /app
+USER node
+COPY --from=builder --chown=node /app/dist ./dist/
+COPY --from=builder --chown=node /app/node_modules ./node_modules/
+COPY --from=builder --chown=node /app/version.json /app/version.json
+COPY --chown=node config/*.json ./config/
+COPY --chown=node package* ./

--- a/packages/fxa-metrics-processor/package-lock.json
+++ b/packages/fxa-metrics-processor/package-lock.json
@@ -49,9 +49,9 @@
       "integrity": "sha512-VccZDcOql77obTnFh0TbNED/6ZbbmHDf8UMNnzO1d5g9V0Htfm4k5cllY8P1tJsRKC3zWYGRLaViiupcgVjBoQ=="
     },
     "@google-cloud/pubsub": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-1.6.0.tgz",
-      "integrity": "sha512-RL7GJFOQaJpUcNjMDXAQ6dv+cxIIzzDc5DFwbak8KlIvK9znw/YrEybki8e8JTMdvU5Kg7FKGi5RmI6EQkWkVw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/pubsub/-/pubsub-1.7.2.tgz",
+      "integrity": "sha512-/TziioDSV4FS4wKF1sIaQ+1gvE+um83oHz1nRsZ3L87uWSoOciBjJAcocgPjqrpnW441+Nuw4w0QdSUV1Lka/g==",
       "requires": {
         "@google-cloud/paginator": "^2.0.0",
         "@google-cloud/precise-date": "^1.0.0",
@@ -71,9 +71,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.6.18.tgz",
-      "integrity": "sha512-uAzv/tM8qpbf1vpx1xPMfcUMzbfdqJtdCYAqY/LsLeQQlnTb4vApylojr+wlCyr7bZeg3AFfHvtihnNOQQt/nA==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.7.8.tgz",
+      "integrity": "sha512-zaxGrIHQ5+whDaI+tuWOY5UIb5flROk6qkTM4f8uRXtc1JhyJPqUqkO+tHZaWX1TjtDG+lTK8H8ATyCE2NwVNA==",
       "requires": {
         "semver": "^6.2.0"
       },
@@ -86,9 +86,9 @@
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.3.tgz",
-      "integrity": "sha512-8qvUtGg77G2ZT2HqdqYoM/OY97gQd/0crSG34xNmZ4ZOsv3aQT/FQV9QfZPazTGna6MIoyUd+u6AxsoZjJ/VMQ==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.4.tgz",
+      "integrity": "sha512-HTM4QpI9B2XFkPz7pjwMyMgZchJ93TVkL3kWPW8GDMDKYxsMnmf4w2TNMJK7+KNiYHS5cJrCEAFlF+AwtXWVPA==",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "protobufjs": "^6.8.6"
@@ -148,6 +148,118 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@sentry/apm": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@sentry/apm/-/apm-5.15.4.tgz",
+      "integrity": "sha512-gcW225Jls1ShyBXMWN6zZyuVJwBOIQ63sI+URI2NSFsdpBpdpZ8yennIm+oMlSfb25Nzt9SId7TRSjPhlSbTZQ==",
+      "requires": {
+        "@sentry/browser": "5.15.4",
+        "@sentry/hub": "5.15.4",
+        "@sentry/minimal": "5.15.4",
+        "@sentry/types": "5.15.4",
+        "@sentry/utils": "5.15.4",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/browser": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.15.4.tgz",
+      "integrity": "sha512-l/auT1HtZM3KxjCGQHYO/K51ygnlcuOrM+7Ga8gUUbU9ZXDYw6jRi0+Af9aqXKmdDw1naNxr7OCSy6NBrLWVZw==",
+      "requires": {
+        "@sentry/core": "5.15.4",
+        "@sentry/types": "5.15.4",
+        "@sentry/utils": "5.15.4",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.15.4.tgz",
+      "integrity": "sha512-9KP4NM4SqfV5NixpvAymC7Nvp36Zj4dU2fowmxiq7OIbzTxGXDhwuN/t0Uh8xiqlkpkQqSECZ1OjSFXrBldetQ==",
+      "requires": {
+        "@sentry/hub": "5.15.4",
+        "@sentry/minimal": "5.15.4",
+        "@sentry/types": "5.15.4",
+        "@sentry/utils": "5.15.4",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.4.tgz",
+      "integrity": "sha512-1XJ1SVqadkbUT4zLS0TVIVl99si7oHizLmghR8LMFl5wOkGEgehHSoOydQkIAX2C7sJmaF5TZ47ORBHgkqclUg==",
+      "requires": {
+        "@sentry/types": "5.15.4",
+        "@sentry/utils": "5.15.4",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/integrations": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-5.15.4.tgz",
+      "integrity": "sha512-GaEVQf4R+WBJvTOGptOHIFSylnH1JAvBQZ7c45jGIDBp+upqzeI67KD+HoM4sSNT2Y2i8DLTJCWibe34knz5Kw==",
+      "requires": {
+        "@sentry/types": "5.15.4",
+        "@sentry/utils": "5.15.4",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.4.tgz",
+      "integrity": "sha512-GL4GZ3drS9ge+wmxkHBAMEwulaE7DMvAEfKQPDAjg2p3MfcCMhAYfuY4jJByAC9rg9OwBGGehz7UmhWMFjE0tw==",
+      "requires": {
+        "@sentry/hub": "5.15.4",
+        "@sentry/types": "5.15.4",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.15.4.tgz",
+      "integrity": "sha512-OfdhNEvOJZ55ZkCUcVgctjaZkOw7rmLzO5VyDTSgevA4uLsPaTNXSAeK2GSQBXc5J0KdRpNz4sSIyuxOS4Z7Vg==",
+      "requires": {
+        "@sentry/apm": "5.15.4",
+        "@sentry/core": "5.15.4",
+        "@sentry/hub": "5.15.4",
+        "@sentry/types": "5.15.4",
+        "@sentry/utils": "5.15.4",
+        "cookie": "^0.3.1",
+        "https-proxy-agent": "^4.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
+        },
+        "https-proxy-agent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+          "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+          "requires": {
+            "agent-base": "5",
+            "debug": "4"
+          }
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.4.tgz",
+      "integrity": "sha512-quPHPpeAuwID48HLPmqBiyXE3xEiZLZ5D3CEbU3c3YuvvAg8qmfOOTI6z4Z3Eedi7flvYpnx3n7N3dXIEz30Eg=="
+    },
+    "@sentry/utils": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.4.tgz",
+      "integrity": "sha512-lO8SLBjrUDGADl0LOkd55R5oL510d/1SaI08/IBHZCxCUwI4TiYo5EPECq8mrj3XGfgCyq9osw33bymRlIDuSQ==",
+      "requires": {
+        "@sentry/types": "5.15.4",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
@@ -158,9 +270,9 @@
       }
     },
     "@sinonjs/fake-timers": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.0.tgz",
-      "integrity": "sha512-atR1J/jRXvQAb47gfzSK8zavXy7BcpnYq21ALon0U99etu99vsir0trzIO3wpeLtW+LLVY6X7EkfVTbjGSH8Ww==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
@@ -205,6 +317,11 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/convict": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@types/convict/-/convict-4.2.1.tgz",
+      "integrity": "sha512-2cd51m3i0yeY1i3dKxcqJKeS5Q4jZnjP37OseoNeIX1OM0AhmGPuuYmwJ9OqtsU35YrREQxdb2VeX5sM3cwGMQ=="
+    },
     "@types/duplexify": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.0.tgz",
@@ -221,6 +338,12 @@
         "@types/node": "*"
       }
     },
+    "@types/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-k3RS5HyBPu4h+5hTmIEfPB2rl5P3LnGdQEZrV2b9OWTJVtsUQ2VBcedqYKGqxvZqle5UALUXdSfVA8nf3HfyWQ==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
@@ -232,28 +355,40 @@
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
+    "@types/mkdirp": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
+      "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mocha": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
-      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
+      "integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.29.tgz",
-      "integrity": "sha512-yo8Qz0ygADGFptISDj3pOC9wXfln/5pQaN/ysDIzOaAWXt73cNHmtEC8zSO2Y+kse/txmwIAJzkYZ5fooaS5DQ=="
+      "version": "13.11.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
+      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g=="
     },
     "@types/prettier": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.0.tgz",
-      "integrity": "sha512-gDE8JJEygpay7IjA/u3JiIURvwZW08f0cZSZLAzFoX/ZmeqvS0Sqv+97aKuHpNsalAMMhwPe+iAS6fQbfmbt7A==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
       "dev": true
     },
     "@types/sinon": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
-      "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
-      "dev": true
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.0.tgz",
+      "integrity": "sha512-v2TkYHkts4VXshMkcmot/H+ERZ2SevKa10saGaJPGCJ8vh3lKrC4u663zYEeRZxep+VbG6YRDtQ6gVqw9dYzPA==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
     },
     "@types/sinon-chai": {
       "version": "3.2.3",
@@ -264,6 +399,12 @@
         "@types/chai": "*",
         "@types/sinon": "*"
       }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
+      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
+      "dev": true
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -291,16 +432,6 @@
       "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
       "requires": {
         "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "ajv": {
@@ -338,9 +469,9 @@
       }
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
@@ -499,8 +630,7 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "chai": {
       "version": "4.2.0",
@@ -578,14 +708,6 @@
         "es6-iterator": "^2.0.3",
         "memoizee": "^0.4.14",
         "timers-ext": "^0.1.5"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        }
       }
     },
     "cli-cursor": {
@@ -673,7 +795,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/convict/-/convict-5.2.0.tgz",
       "integrity": "sha512-C3cdUwo47cCikZNzu5Vv8AL0MuXVVeg9t/Gyr9qyK5ZpCjOkMPmJ85KUF3CowNeSfj4UtztHxS+hoO9wGRh6kg==",
-      "dev": true,
       "requires": {
         "json5": "2.1.0",
         "lodash.clonedeep": "4.5.0",
@@ -686,13 +807,17 @@
           "version": "13.0.0",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
           "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
-          "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
           }
         }
       }
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -728,10 +853,9 @@
       "integrity": "sha1-MrSzEF6IYQQ6b5rHVdgOVC02WzE="
     },
     "debug": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -739,8 +863,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -1242,9 +1365,9 @@
       "dev": true
     },
     "gaxios": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.3.2.tgz",
-      "integrity": "sha512-K/+py7UvKRDaEwEKlLiRKrFr+wjGjsMz5qH7Vs549QJS7cpSCOT/BbWL7pzqECflc46FcNPipjSfB+V1m8PAhw==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.3.4.tgz",
+      "integrity": "sha512-US8UMj8C5pRnao3Zykc4AAVr+cffoNKRTg9Rsf2GiuZCW69vgJj38VK2PzlPuQU73FZ/nTk9/Av6/JGcE1N9vA==",
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
@@ -1323,11 +1446,11 @@
       }
     },
     "google-gax": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-1.14.2.tgz",
-      "integrity": "sha512-Nde+FdqALbV3QgMA4KlkxOHfrj9busnZ3EECwy/1gDJm9vhKGwDLWzErqRU5g80OoGSAMgyY7DWIfqz7ina4Jw==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-1.15.2.tgz",
+      "integrity": "sha512-yNNiRf9QxWpZNfQQmSPz3rIDTBDDKnLKY/QEsjCaJyDxttespr6v8WRGgU5KrU/6ZM7QRlgBAYXCkxqHhJp0wA==",
       "requires": {
-        "@grpc/grpc-js": "^0.6.18",
+        "@grpc/grpc-js": "^0.7.4",
         "@grpc/proto-loader": "^0.5.1",
         "@types/fs-extra": "^8.0.1",
         "@types/long": "^4.0.0",
@@ -1338,7 +1461,7 @@
         "lodash.at": "^4.6.0",
         "lodash.has": "^4.5.2",
         "node-fetch": "^2.6.0",
-        "protobufjs": "^6.8.8",
+        "protobufjs": "^6.8.9",
         "retry-request": "^4.0.0",
         "semver": "^6.0.0",
         "walkdir": "^0.4.0"
@@ -1437,16 +1560,6 @@
       "requires": {
         "agent-base": "6",
         "debug": "4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "iconv-lite": {
@@ -1810,28 +1923,52 @@
       }
     },
     "json-schema-to-typescript": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-8.1.0.tgz",
-      "integrity": "sha512-SGGX82OofMggPDUIO6+GYc14g8bew4ETtEif9G8I9SSXYFVHPSfoNE0AaNcfTFwI/xHSepHRse4aMurAtc8+mw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-8.2.0.tgz",
+      "integrity": "sha512-yvi4v9oLeJzJCktt+Zta6kOgEu8R93gNMZUJYo83aAPxoG0qB+cXIxVg5xa6gmdNkyffjH9Ebw1rvyaJKIor5A==",
       "dev": true,
       "requires": {
+        "@types/is-glob": "^4.0.1",
         "@types/json-schema": "^7.0.3",
-        "@types/node": ">=4.5.0",
+        "@types/mkdirp": "^0.5.2",
         "@types/prettier": "^1.16.1",
         "cli-color": "^1.4.0",
+        "glob": "^7.1.4",
+        "is-glob": "^4.0.1",
         "json-schema-ref-parser": "^6.1.0",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.11",
         "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
         "mz": "^2.7.0",
         "prettier": "^1.19.1",
         "stdin": "0.0.1"
       },
       "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "prettier": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
           "dev": true
         }
       }
@@ -1857,16 +1994,14 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
       "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-      "dev": true,
       "requires": {
         "minimist": "^1.2.0"
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -1952,8 +2087,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -2007,6 +2141,11 @@
       "requires": {
         "es5-ext": "~0.10.2"
       }
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "make-error": {
       "version": "1.3.6",
@@ -2077,9 +2216,9 @@
       }
     },
     "mocha": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.0.tgz",
-      "integrity": "sha512-MymHK8UkU0K15Q/zX7uflZgVoRWiTjy0fXE/QjKts6mowUvGxOdPhZ2qj3b0iZdUrNZlW9LAIMFHB4IW+2b3EQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.1.tgz",
+      "integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -2095,7 +2234,7 @@
         "js-yaml": "3.13.1",
         "log-symbols": "3.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
+        "mkdirp": "0.5.3",
         "ms": "2.1.1",
         "node-environment-flags": "1.0.6",
         "object.assign": "4.1.0",
@@ -2103,16 +2242,41 @@
         "supports-color": "6.0.0",
         "which": "1.3.1",
         "wide-align": "1.1.3",
-        "yargs": "13.3.0",
-        "yargs-parser": "13.1.1",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
         "yargs-unparser": "1.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
       }
     },
     "moment": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "dev": true
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "mozlog": {
       "version": "2.2.0",
@@ -2323,9 +2487,9 @@
       "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
     },
     "p-limit": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -2414,9 +2578,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
     "pidtree": {
@@ -2438,9 +2602,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
+      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==",
       "dev": true
     },
     "process-nextick-args": {
@@ -2455,9 +2619,9 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.9.tgz",
+      "integrity": "sha512-j2JlRdUeL/f4Z6x4aU4gj9I2LECglC+5qR2TrWb193Tla1qfdaNQTZ8I27Pt7K0Ajmvjjpft7O3KWTGciz4gpw==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2475,9 +2639,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-          "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+          "version": "10.17.19",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.19.tgz",
+          "integrity": "sha512-46/xThm3zvvc9t9/7M3AaLEqtOpqlYYYcCZbpYVAQHG20+oMZBkae/VMrn4BTi6AJ8cpack0mEXhGiKmDNbLrQ=="
         }
       }
     },
@@ -2532,6 +2696,11 @@
         "picomatch": "^2.0.4"
       }
     },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -2582,16 +2751,6 @@
       "requires": {
         "debug": "^4.1.1",
         "through2": "^3.0.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "rimraf": {
@@ -2672,20 +2831,29 @@
       "dev": true
     },
     "sinon": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.0.tgz",
-      "integrity": "sha512-c4bREcvuK5VuEGyMW/Oim9I3Rq49Vzb0aMdxouFaA44QCFpilc5LJOugrX+mkrvikbqCimxuK+4cnHVNnLR41g==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
+      "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.7.0",
-        "@sinonjs/fake-timers": "^6.0.0",
-        "@sinonjs/formatio": "^5.0.0",
-        "@sinonjs/samsam": "^5.0.1",
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.0.3",
         "diff": "^4.0.2",
         "nise": "^4.0.1",
         "supports-color": "^7.1.0"
       },
       "dependencies": {
+        "@sinonjs/commons": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
+          "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
+          "dev": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
         "diff": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -2857,6 +3025,14 @@
       "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
       }
     },
     "strip-bom": {
@@ -2992,16 +3168,16 @@
       }
     },
     "ts-node": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.0.tgz",
-      "integrity": "sha512-fbG32iZEupNV2E2Fd2m2yt1TdAwR3GTCrJQBHDevIiEBNy1A8kqnyl1fv7jmRmmbtcapFab2glZXHJvfD1ed0Q==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.8.2.tgz",
+      "integrity": "sha512-duVj6BpSpUpD/oM4MfhO98ozgkp3Gt9qIp3jGxwU2DFvl/3IRaEAvbLa8G60uS7C77457e/m5TMowjedeRxI1Q==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
         "source-map-support": "^0.5.6",
-        "yn": "^3.0.0"
+        "yn": "3.1.1"
       },
       "dependencies": {
         "diff": {
@@ -3049,6 +3225,12 @@
           "version": "11.15.7",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.7.tgz",
           "integrity": "sha512-3c3Kc7VIdE5UpqpmztRy7FU+turZgIurGnwpGFy/fRFOirfPc7ZnoFL83qVoqEDENJENqDhtGyQZ5fkXNQ6Qkw==",
+          "dev": true
+        },
+        "@types/sinon": {
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
+          "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
           "dev": true
         },
         "nise": {
@@ -3104,13 +3286,12 @@
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
-      "dev": true
+      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "tslint": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.1.tgz",
+      "integrity": "sha512-kd6AQ/IgPRpLn6g5TozqzPdGNZ0q0jtXW4//hRcj10qLYBaa3mTUU2y2MCG+RXZm8Zx+KZi0eA+YCrMyNlF4UA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -3121,10 +3302,10 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
+        "mkdirp": "^0.5.3",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
-        "tslib": "^1.8.0",
+        "tslib": "^1.10.0",
         "tsutils": "^2.29.0"
       },
       "dependencies": {
@@ -3133,6 +3314,21 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
           "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
         }
       }
     },
@@ -3143,9 +3339,9 @@
       "dev": true
     },
     "tslint-plugin-prettier": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-2.1.0.tgz",
-      "integrity": "sha512-nMCpU+QSpXtydcWXeZF+3ljIbG/K8SHVZwB7K/MtuoQQFXxXN6watqTSBpVXCInuPFvmjiWkhxeMoUW4N0zgSg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-2.3.0.tgz",
+      "integrity": "sha512-F9e4K03yc9xuvv+A0v1EmjcnDwpz8SpCD8HzqSDe0eyg34cBinwn9JjmnnRrNAs4HdleRQj7qijp+P/JTxt4vA==",
       "dev": true,
       "requires": {
         "eslint-plugin-prettier": "^2.2.0",
@@ -3189,6 +3385,11 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
+    "typedi": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/typedi/-/typedi-0.8.0.tgz",
+      "integrity": "sha512-/c7Bxnm6eh5kXx2I+mTuO+2OvoWni5+rXA3PhXwVWCtJRYmz3hMok5s1AKLzoDvNAZqj/Q/acGstN0ri5aQoOA=="
+    },
     "typescript": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
@@ -3214,9 +3415,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
       "dev": true
     },
     "v8-compile-cache": {
@@ -3238,8 +3439,7 @@
     "validator": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
-      "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg==",
-      "dev": true
+      "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg=="
     },
     "walkdir": {
       "version": "0.4.1",
@@ -3341,9 +3541,9 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yargs": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
       "dev": true,
       "requires": {
         "cliui": "^5.0.0",
@@ -3355,7 +3555,7 @@
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.1"
+        "yargs-parser": "^13.1.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3387,9 +3587,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/packages/fxa-metrics-processor/package.json
+++ b/packages/fxa-metrics-processor/package.json
@@ -9,7 +9,8 @@
     "lint": "npm-run-all --parallel lint:*",
     "lint:tslint": "./node_modules/tslint/bin/tslint -p .",
     "start": "echo \"Error: no start script specified\" && exit 1",
-    "test": "echo \"Error: no test specified\" && exit 0",
+    "test": "mocha -r ts-node/register src/test/**/*.spec.ts",
+    "start-prod": "npm run build && node ./dist/bin/queueWorker.js",
     "watch": "tsc -w"
   },
   "author": "Mozilla (https://mozilla.org/)",
@@ -27,29 +28,34 @@
   "homepage": "https://github.com/mozilla/fxa#readme",
   "readmeFilename": "README.md",
   "dependencies": {
-    "@google-cloud/pubsub": "^1.5.0",
+    "@google-cloud/pubsub": "^1.7.2",
+    "@sentry/integrations": "^5.15.4",
+    "@sentry/node": "^5.15.4",
+    "@types/convict": "^4.2.1",
     "ajv": "^6.12.0",
-    "mozlog": "^2.2.0"
+    "convict": "^5.2.0",
+    "mozlog": "^2.2.0",
+    "reflect-metadata": "^0.1.13",
+    "typedi": "^0.8.0"
   },
   "devDependencies": {
-    "@types/mocha": "^5.2.7",
-    "@types/node": "^12.12.7",
-    "@types/sinon": "^7.5.0",
+    "@types/mocha": "^7.0.2",
+    "@types/node": "^13.11.1",
+    "@types/sinon": "^9.0.0",
     "audit-filter": "^0.5.0",
     "chai": "^4.2.0",
-    "convict": "^5.2.0",
     "eslint": "^6.8.0",
-    "json-schema-to-typescript": "^8.1.0",
-    "mocha": "^7.1.0",
+    "json-schema-to-typescript": "^8.2.0",
+    "mocha": "^7.1.1",
     "npm-run-all": "^4.1.5",
-    "prettier": "1.19.1",
-    "sinon": "^9.0.0",
-    "ts-node": "8.5.0",
+    "prettier": "2.0.4",
+    "sinon": "^9.0.2",
+    "ts-node": "8.8.2",
     "ts-sinon": "^1.0.25",
-    "tslint": "5.20.1",
+    "tslint": "6.1.1",
     "tslint-config-prettier": "^1.18.0",
-    "tslint-plugin-prettier": "^2.0.1",
+    "tslint-plugin-prettier": "^2.3.0",
     "typescript": "^3.8.3",
-    "uuid": "^3.3.3"
+    "uuid": "^7.0.3"
   }
 }

--- a/packages/fxa-metrics-processor/src/bin/queueWorker.ts
+++ b/packages/fxa-metrics-processor/src/bin/queueWorker.ts
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import 'reflect-metadata';
+
+import { Container } from 'typedi';
+import Sentry from '@sentry/node';
+
+import { version } from '../lib/version';
+import Config from '../config';
+import { QueueProcessor } from '../lib/pubsub';
+import mozlog from 'mozlog';
+
+const logger = mozlog(Config.get('log'))('queueWorker');
+const config = Config.getProperties();
+
+function main() {
+  Sentry.init({
+    dsn: config.sentryDsn,
+    release: version.version,
+    integrations: [new Sentry.Integrations.LinkedErrors()]
+  });
+  Sentry.configureScope(scope => {
+    scope.setTag('process', 'metrics_queue_worker');
+  });
+  const queueProcessor = Container.get(QueueProcessor);
+  process.on('beforeExit', async () => {
+    await queueProcessor.stop();
+    await Sentry.close();
+    logger.info('exitComplete', {});
+  });
+  return queueProcessor.start();
+}
+
+main().catch(err => {
+  logger.error('runtime', err);
+});

--- a/packages/fxa-metrics-processor/src/config.ts
+++ b/packages/fxa-metrics-processor/src/config.ts
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import convict from 'convict';
+import fs from 'fs';
+import path from 'path';
+
+const conf = convict({
+  env: {
+    default: 'production',
+    doc: 'The current node.js environment',
+    env: 'NODE_ENV',
+    format: ['development', 'test', 'stage', 'production']
+  },
+  logging: {
+    app: { default: 'fxa-user-admin-server' },
+    fmt: {
+      default: 'heka',
+      env: 'LOGGING_FORMAT',
+      format: ['heka', 'pretty']
+    },
+    level: {
+      default: 'info',
+      env: 'LOG_LEVEL'
+    },
+    routes: {
+      enabled: {
+        default: true,
+        doc: 'Enable route logging. Set to false to trim CI logs.',
+        env: 'ENABLE_ROUTE_LOGGING'
+      },
+      format: {
+        default: 'default_fxa',
+        format: ['default_fxa', 'dev_fxa', 'default', 'dev', 'short', 'tiny']
+      }
+    }
+  },
+  queues: {
+    pubsubProjectId: {
+      default: 'default-project',
+      doc: 'GCP Pub/Sub Project Id the queues are under',
+      env: 'PUBSUB_PROJECT_ID',
+      format: 'String'
+    },
+    rawEvents: {
+      default: 'fxa-metrics-raw-events',
+      doc: 'GCP Pub/Sub Queue for FxA Raw events',
+      env: 'PUBSUB_RAW_EVENT_QUEUE',
+      format: 'String'
+    },
+    deadLetterTopic: {
+      default: 'fxa-metrics-dead-letter',
+      doc: 'GCP Pub/Sub topic for FxA metric event failures',
+      env: 'PUBSUB_DEADLETTER_QUEUE',
+      format: 'String'
+    },
+    amplitudeTopic: {
+      default: 'fxa-metrics-amplitude',
+      doc: 'GCP Pub/Sub topic for transformed Amplitude events',
+      env: 'PUBSUB_AMPLITUDE_QUEUE',
+      format: 'String'
+    },
+    maxEventsPerBatch: {
+      default: 500,
+      doc: 'GCP Pub/Sub events to pull per batch',
+      env: 'PUBSUB_MAX_EVENT_BATCH',
+      format: 'Number'
+    }
+  },
+  sentryDsn: {
+    default: '',
+    doc: 'Sentry DSN for error and log reporting',
+    env: 'SENTRY_DSN',
+    format: 'String'
+  }
+});
+
+// handle configuration files.  you can specify a CSV list of configuration
+// files to process, which will be overlayed in order, in the CONFIG_FILES
+// environment variable.
+
+// Need to move two dirs up as we're in the compiled directory now
+const configDir = path.dirname(path.dirname(__dirname));
+let envConfig = path.join(configDir, 'config', `${conf.get('env')}.json`);
+envConfig = `${envConfig},${process.env.CONFIG_FILES || ''}`;
+const files = envConfig.split(',').filter(fs.existsSync);
+conf.loadFile(files);
+conf.validate({ allowed: 'strict' });
+
+const Config = conf;
+
+export default Config;

--- a/packages/fxa-metrics-processor/src/lib/message-processor/index.ts
+++ b/packages/fxa-metrics-processor/src/lib/message-processor/index.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Service } from 'typedi';
+import { Message } from '@google-cloud/pubsub';
+
+@Service()
+export class MessageProcessor {
+  public processMessage(message: Message): object | null {
+    return {};
+  }
+}

--- a/packages/fxa-metrics-processor/src/lib/pubsub.ts
+++ b/packages/fxa-metrics-processor/src/lib/pubsub.ts
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Service, Inject } from 'typedi';
+import { v1, Message, PubSub } from '@google-cloud/pubsub';
+import * as Sentry from '@sentry/node';
+import { EventEmitter, once } from 'events';
+
+import Config from '../config';
+import { MessageProcessor } from '../lib/message-processor';
+
+const queueConfig = Config.getProperties().queues;
+
+@Service()
+export class QueueProcessor {
+  private subClient: any;
+  private pubSubClient: PubSub;
+  private formattedRawEventSubscription: any;
+  private shouldStop = false;
+  private emitter = new EventEmitter();
+  private sentry = Sentry;
+
+  @Inject()
+  private messageProcessor!: MessageProcessor;
+
+  constructor() {
+    this.subClient = new v1.SubscriberClient();
+    this.pubSubClient = new PubSub({ projectId: queueConfig.pubsubProjectId });
+    this.formattedRawEventSubscription = this.subClient.subscriptionPath(
+      queueConfig.pubsubProjectId,
+      queueConfig.rawEvents
+    );
+  }
+
+  /**
+   * Retrieve a given batch of messages from the raw event queue.
+   */
+  private async pullMessageBatch(): Promise<Message[]> {
+    const request = {
+      subscription: this.formattedRawEventSubscription,
+      maxMessages: queueConfig.maxEventsPerBatch
+    };
+    const [response] = await this.subClient.pull(request);
+    return response.receivedMessages;
+  }
+
+  /**
+   * Handle an error from the message transformation.
+   *
+   * @param message Message that caused the error
+   * @param err Error processing the message
+   */
+  private async handleMessageError(message: Message, err: Error): Promise<boolean> {
+    let messageId: string | undefined;
+    let handled = true;
+    try {
+      messageId = await this.pubSubClient.topic(queueConfig.deadLetterTopic).publish(message.data);
+    } catch (publishErr) {
+      // Replace our error and link to the original one
+      publishErr.cause = err;
+      err = publishErr;
+      handled = false;
+    }
+    this.sentry.withScope(scope => {
+      scope.setContext('message', {
+        id: message.id,
+        deadLetterId: messageId,
+        publishTime: message.publishTime,
+        data: message.data.toString(),
+        attributes: JSON.stringify(message.attributes)
+      });
+      this.sentry.captureException(err);
+    });
+    return handled;
+  }
+
+  /**
+   * Process a batch of messages with the `messageProcessor` from the PubSub
+   * topic.
+   *
+   * For a given message batch, for each message this will:
+   *   1. Apply the messageProcessor to transform/filter the raw message
+   *   2. Handle messageProcessor errors by sending them to a dead letter topic
+   *      and report them to Sentry.
+   *   3. Acknowledge the batch of messages.
+   */
+  private async processBatch() {
+    const messages = await this.pullMessageBatch();
+    const ackIds: string[] = [];
+    for (const message of messages) {
+      try {
+        const newMessage = this.messageProcessor.processMessage(message);
+        if (newMessage) {
+          await this.pubSubClient.topic(queueConfig.amplitudeTopic).publishJSON(newMessage);
+        }
+        ackIds.push(message.ackId);
+      } catch (err) {
+        const handled = await this.handleMessageError(message, err);
+        // Only after we're sure we published this to the dead letter topic
+        // and reported it can we ack it.
+        if (handled) {
+          ackIds.push(message.ackId);
+        }
+      }
+    }
+    const ackRequest = {
+      subscription: this.formattedRawEventSubscription,
+      ackIds
+    };
+    await this.subClient.acknowledge(ackRequest);
+  }
+
+  public async start() {
+    while (!this.shouldStop) {
+      await this.processBatch();
+    }
+    this.emitter.emit('stopped');
+  }
+
+  public async stop() {
+    this.shouldStop = true;
+    await once(this.emitter, 'stopped');
+  }
+}

--- a/packages/fxa-metrics-processor/src/lib/version.ts
+++ b/packages/fxa-metrics-processor/src/lib/version.ts
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * Return version info based on package.json, the git sha, and source repo
+ *
+ * Try to statically determine commitHash and sourceRepo at startup.
+ *
+ * If commitHash cannot be found from `version.json` (i.e., this is not
+ * production or stage), then an attempt will be made to determine commitHash
+ * and sourceRepo dynamically from `git`. If it cannot be found with `git`,
+ * just show 'unknown' for commitHash and sourceRepo.
+ *
+ * This module may be called as ./dist/lib/version.js, or when testing,
+ * ./lib/version.ts so we need to look for `package.json` and `version.json`
+ * in two possible locations.
+ */
+
+import cp from 'child_process';
+import path from 'path';
+
+function readJson(filepath: string) {
+  try {
+    return require(filepath);
+  } catch (e) {
+    /* ignore */
+  }
+
+  return;
+}
+
+function getValue(name: string, command: string): string {
+  const value =
+    readJson(path.resolve(__dirname, '..', 'version.json')) ||
+    readJson(path.resolve(__dirname, '..', '..', 'version.json'));
+
+  if (value?.version?.[name]) {
+    return value.version[name];
+  }
+
+  let stdout = 'unknown';
+  try {
+    stdout = cp.execSync(command, { cwd: __dirname }).toString('utf8');
+  } catch (e) {
+    /* ignore */
+  }
+
+  return stdout?.toString().trim();
+}
+
+interface Version {
+  commit: string;
+  source: string;
+  version: string;
+}
+
+function getVersionInfo(): Version {
+  const commit = getValue('hash', 'git rev-parse HEAD');
+  const source = getValue('source', 'git config --get remote.origin.url');
+
+  const packageInfo =
+    readJson(path.resolve(__dirname, '..', '..', 'package.json')) ||
+    readJson(path.resolve(__dirname, '..', '..', '..', 'package.json'));
+
+  return {
+    commit,
+    source,
+    version: packageInfo?.version
+  };
+}
+
+export const version = getVersionInfo();

--- a/packages/fxa-metrics-processor/src/test/lib/pubsub.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/pubsub.spec.ts
@@ -1,0 +1,205 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import 'reflect-metadata';
+
+import { Container } from 'typedi';
+import 'mocha';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import { EventEmitter, once } from 'events';
+
+import { QueueProcessor } from '../../lib/pubsub';
+
+import Config from '../../config';
+
+const queueConfig = Config.getProperties().queues;
+
+const sandbox = sinon.createSandbox();
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('PubSub', () => {
+  describe('QueueProcessor', () => {
+    let queueProcessor: any;
+    let messageProcessor: any;
+
+    beforeEach(() => {
+      messageProcessor = {
+        processMessage: sandbox.stub().returns({ message: 'test' })
+      };
+      queueProcessor = Container.get(QueueProcessor);
+      queueProcessor.messageProcessor = messageProcessor;
+    });
+
+    afterEach(() => {
+      Container.reset(QueueProcessor);
+      sandbox.reset();
+    });
+
+    describe('pullMessageBatch', () => {
+      it('should return messages', async () => {
+        queueProcessor.subClient = { pull: sandbox.stub().resolves([{ receivedMessages: [] }]) };
+        const results = await queueProcessor.pullMessageBatch();
+        sinon.assert.calledOnce(queueProcessor.subClient.pull);
+        assert.deepEqual(results, []);
+      });
+    });
+
+    describe('handleMessageError', () => {
+      let mockErr: { message: string };
+      let mockScope: { setContext: sinon.SinonStub };
+      let captureExceptionSpy: sinon.SinonSpy;
+      let withScopeStub: sinon.SinonStub;
+      let cb: (scope: typeof mockScope) => void;
+
+      beforeEach(() => {
+        mockErr = { message: 'oops' };
+        mockScope = { setContext: sandbox.stub() };
+        captureExceptionSpy = sandbox.spy(queueProcessor.sentry, 'captureException');
+        withScopeStub = sandbox
+          .stub(queueProcessor.sentry, 'withScope')
+          .callsFake(callback => (cb = callback));
+      });
+
+      afterEach(() => {
+        captureExceptionSpy.restore();
+        withScopeStub.restore();
+      });
+
+      it('should run without error', async () => {
+        const publishStub = sandbox.stub().resolves('wibble');
+        queueProcessor.pubSubClient = { topic: sandbox.stub().returns({ publish: publishStub }) };
+        const actual = await queueProcessor.handleMessageError(
+          {
+            id: 9001,
+            publishTime: 1549622069481320032,
+            data: { foo: 'bar' },
+            attributes: { fizz: 'buzz' }
+          },
+          mockErr
+        );
+        ((cb as unknown) as (scope: typeof mockScope) => void)(mockScope);
+
+        sinon.assert.calledOnceWithExactly(
+          queueProcessor.pubSubClient.topic,
+          queueConfig.deadLetterTopic
+        );
+        sinon.assert.calledOnceWithExactly(publishStub, { foo: 'bar' });
+        sinon.assert.calledOnce(withScopeStub);
+        sinon.assert.calledOnceWithExactly(mockScope.setContext, 'message', {
+          id: 9001,
+          deadLetterId: 'wibble',
+          publishTime: 1549622069481320032,
+          data: `${{ foo: 'bar' }}`,
+          attributes: JSON.stringify({ fizz: 'buzz' })
+        });
+        sinon.assert.calledOnceWithExactly(captureExceptionSpy, mockErr);
+        assert.isTrue(actual);
+      });
+
+      it('should handle a publishing error', async () => {
+        const publishStub = sandbox.stub().rejects('wibble');
+        queueProcessor.pubSubClient = { topic: sandbox.stub().returns({ publish: publishStub }) };
+        const actual = await queueProcessor.handleMessageError(
+          {
+            id: 9001,
+            publishTime: 1549622069481320032,
+            data: { foo: 'bar' },
+            attributes: { fizz: 'buzz' }
+          },
+          mockErr
+        );
+        ((cb as unknown) as (scope: typeof mockScope) => void)(mockScope);
+        assert.property(captureExceptionSpy.args[0][0], 'cause');
+        assert.isFalse(actual);
+      });
+    });
+
+    describe('processBatch', () => {
+      beforeEach(() => {
+        queueProcessor.pullMessageBatch = sandbox
+          .stub()
+          .resolves([{ ackId: 1234, data: Buffer.from(JSON.stringify({})) }]);
+        queueProcessor.pubSubClient = {
+          topic: sinon.stub()
+        };
+        queueProcessor.subClient = { acknowledge: sandbox.stub().resolves({}) };
+      });
+
+      it('should process messages without error', async () => {
+        const publishStub = sandbox.stub().resolves({});
+        queueProcessor.pubSubClient = {
+          topic: sandbox.stub().returns({ publishJSON: publishStub })
+        };
+        await queueProcessor.processBatch();
+        sinon.assert.calledOnce(queueProcessor.pubSubClient.topic);
+        sinon.assert.calledOnce(queueProcessor.subClient.acknowledge);
+        sinon.assert.calledOnce(publishStub);
+        sinon.assert.calledWithExactly(queueProcessor.subClient.acknowledge, {
+          subscription: 'projects/default-project/subscriptions/fxa-metrics-raw-events',
+          ackIds: [1234]
+        });
+        sinon.assert.calledWithExactly(publishStub, { message: 'test' });
+      });
+
+      it('should not publish filtered messages', async () => {
+        queueProcessor.messageProcessor = { processMessage: sandbox.stub().returns(null) };
+        await queueProcessor.processBatch();
+        sinon.assert.notCalled(queueProcessor.pubSubClient.topic);
+        sinon.assert.calledOnce(queueProcessor.subClient.acknowledge);
+        sinon.assert.calledWithExactly(queueProcessor.subClient.acknowledge, {
+          subscription: 'projects/default-project/subscriptions/fxa-metrics-raw-events',
+          ackIds: [1234]
+        });
+      });
+
+      it('should handle errors processing messages', async () => {
+        queueProcessor.messageProcessor = { processMessage: sandbox.stub().throws() };
+        queueProcessor.handleMessageError = sinon.stub().resolves(true);
+        await queueProcessor.processBatch();
+        sinon.assert.notCalled(queueProcessor.pubSubClient.topic);
+        sinon.assert.calledOnce(queueProcessor.subClient.acknowledge);
+        sinon.assert.calledWithExactly(queueProcessor.subClient.acknowledge, {
+          subscription: 'projects/default-project/subscriptions/fxa-metrics-raw-events',
+          ackIds: [1234]
+        });
+      });
+
+      it('should handle errors that fail to publish to dead letter queue', async () => {
+        queueProcessor.messageProcessor = { processMessage: sandbox.stub().throws() };
+        queueProcessor.handleMessageError = sinon.stub().resolves(false);
+        await queueProcessor.processBatch();
+        sinon.assert.notCalled(queueProcessor.pubSubClient.topic);
+        sinon.assert.calledOnce(queueProcessor.subClient.acknowledge);
+        sinon.assert.calledWithExactly(queueProcessor.subClient.acknowledge, {
+          subscription: 'projects/default-project/subscriptions/fxa-metrics-raw-events',
+          ackIds: []
+        });
+      });
+    });
+
+    describe('start and stop', () => {
+      it('works', async () => {
+        const emitter = new EventEmitter();
+        queueProcessor.processBatch = () => once(emitter, 'next');
+        assert.equal(queueProcessor.shouldStop, false);
+        // Don't wait for the promise
+        queueProcessor.start();
+
+        // Iterate the loop and yield event loop so it runs
+        emitter.emit('next');
+        await sleep(0);
+
+        // Feed the event loop with one more so it can stop
+        emitter.emit('next');
+        await queueProcessor.stop();
+
+        assert.equal(queueProcessor.shouldStop, true);
+      });
+    });
+  });
+});

--- a/packages/fxa-metrics-processor/tslint.json
+++ b/packages/fxa-metrics-processor/tslint.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["tslint:recommended", "tslint-config-prettier"],
+  "rulesDirectory": ["tslint-plugin-prettier"],
+  "rules": {
+    "interface-name": [true, "never-prefix"],
+    "interface-over-type-literal": false,
+    "prettier": [true, ".prettierrc"]
+  }
+}


### PR DESCRIPTION
Because:

* Metrics processor should be run on raw event queue.

This commit:

* Add's the queue worker with base metric processor class that
  consumes using polling from the PubSub raw event queue and
  outputs processed messages to the amplitude topic. Messages
  that failed to process are added to the dead letter topic.

Closes #4698

Co-authored-by: Barry Chen <chenba@gmail.com>