### PR TITLE
fix(verifier): remove ENTRYPOINT/CMD

### DIFF
--- a/packages/browserid-verifier/Dockerfile
+++ b/packages/browserid-verifier/Dockerfile
@@ -19,5 +19,3 @@ RUN apk add --update build-base ca-certificates git python gmp-dev && \
 COPY . /app
 
 USER app
-ENTRYPOINT ["npm"]
-CMD ["start"]


### PR DESCRIPTION
I don't recall if this ENTRYPOINT and/or CMD were particularly needed here for some reason. Anyways, `npm start` will now trigger a `pm2` command, so should remove these now.