### PR TITLE
feat(metrics): transform a "raw" Amplitude event into a HTTP payload

### DIFF
--- a/packages/fxa-metrics-processor/.prettierrc
+++ b/packages/fxa-metrics-processor/.prettierrc
@@ -1,4 +1,4 @@
 {
   "printWidth": 100,
-  "singleQuote": true,
+  "singleQuote": true
 }

--- a/packages/fxa-metrics-processor/Dockerfile
+++ b/packages/fxa-metrics-processor/Dockerfile
@@ -1,5 +1,18 @@
 # Build image
 FROM node:12 as builder
+COPY --chown=app:app ["fxa-shared/metrics/user-agent.js", "../fxa-shared/metrics/user-agent.js"]
+COPY --chown=app:app ["fxa-shared/metrics/user-agent.d.ts", "../fxa-shared/metrics/user-agent.d.ts"]
+COPY --chown=app:app ["fxa-shared/package.json", "../fxa-shared/package.json"]
+COPY --chown=app:app ["fxa-shared/package-lock.json", "../fxa-shared/package-lock.json"]
+# Also need to copy over the tsconfig.json, or the linter will fail
+COPY --chown=app:app ["fxa-shared/tsconfig.json", "../fxa-shared/tsconfig.json"]
+# And the linter also needs the nsprc...
+COPY --chown=app:app ["fxa-shared/.nsprc", "../fxa-shared/.nsprc"]
+RUN mkdir /fxa-shared/node_modules
+WORKDIR /fxa-shared
+USER app
+RUN npm ci
+
 WORKDIR /app
 COPY . /app
 RUN npm ci

--- a/packages/fxa-metrics-processor/package-lock.json
+++ b/packages/fxa-metrics-processor/package-lock.json
@@ -306,9 +306,9 @@
       "dev": true
     },
     "@types/chai": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.10.tgz",
-      "integrity": "sha512-TlWWgb21+0LdkuFqEqfmy7NEgfB/7Jjux15fWQAh3P93gbmXuwTM/vxEdzW89APIcI2BgKR48yjeAkdeH+4qvQ==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
+      "integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
       "dev": true
     },
     "@types/color-name": {
@@ -371,9 +371,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
-      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g=="
+      "version": "12.12.36",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.36.tgz",
+      "integrity": "sha512-hmmypvyO/uTLFYCYu6Hlb3ydeJ11vXRxg8/WJ0E3wvwmPO0y47VqnfmXFVuWlysO0Zyj+je1Y33rQeuYkZ51GQ=="
     },
     "@types/prettier": {
       "version": "1.19.1",

--- a/packages/fxa-metrics-processor/package.json
+++ b/packages/fxa-metrics-processor/package.json
@@ -9,7 +9,7 @@
     "lint": "npm-run-all --parallel lint:*",
     "lint:tslint": "./node_modules/tslint/bin/tslint -p .",
     "start": "echo \"Error: no start script specified\" && exit 1",
-    "test": "mocha -r ts-node/register src/test/**/*.spec.ts",
+    "test": "mocha -r ts-node/register 'src/test/**/*.spec.ts'",
     "start-prod": "npm run build && node ./dist/bin/queueWorker.js",
     "watch": "tsc -w"
   },
@@ -39,8 +39,9 @@
     "typedi": "^0.8.0"
   },
   "devDependencies": {
+    "@types/chai": "^4.2.11",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^13.11.1",
+    "@types/node": "^12.12.7",
     "@types/sinon": "^9.0.0",
     "audit-filter": "^0.5.0",
     "chai": "^4.2.0",

--- a/packages/fxa-metrics-processor/scripts/test-ci.sh
+++ b/packages/fxa-metrics-processor/scripts/test-ci.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -ex
+
+cd ../fxa-shared
+npm ci
+
+cd ../fxa-metrics-processor
+npm ci
+npm test

--- a/packages/fxa-metrics-processor/src/config.ts
+++ b/packages/fxa-metrics-processor/src/config.ts
@@ -7,6 +7,14 @@ import fs from 'fs';
 import path from 'path';
 
 const conf = convict({
+  amplitude: {
+    hmac_key: {
+      default: '',
+      doc: 'A key used to create an Amplitude insert id and hash the UID',
+      env: 'AMPLITUDE_HMAC_KEY',
+      format: 'String'
+    }
+  },
   env: {
     default: 'production',
     doc: 'The current node.js environment',

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/amplitude-event.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/amplitude-event.ts
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  PlainEvents,
+  FuzzyEvents,
+  RawEvent,
+  EventContext,
+  AmplitudeHttpEvent,
+  Services
+} from './types';
+import { createEventTypeMapper, createAmplitudeEventType } from './event-type';
+import { sha256Hmac, tee, mapLocation, createServiceNameAndClientIdMapper, prune } from './common';
+import { getVersion } from './version';
+import { mapOs, mapDeviceModel } from './user-agent';
+import { parse } from '../../../../../fxa-shared/metrics/user-agent';
+import { mapAmplitudeUserProperties } from './user-properties';
+import { createAmplitudeEventPropertiesMapper } from './event-properties';
+
+import Config from '../../../config';
+const config = Config.getProperties();
+const HMAC_KEY = config.amplitude.hmac_key;
+
+export type AmplitudeEventTransformer = (
+  rawEvent: RawEvent,
+  context: EventContext
+) => AmplitudeHttpEvent | null;
+
+/**
+ * Create a transform function with the given maps.
+ *
+ * @param {Object} services An object of client-id:service-name mappings.
+ *
+ * @param {Object} events   An object of name:definition event mappings, where
+ *                          each definition value is itself an object with `group`
+ *                          and `event` string properties.
+ *
+ * @param {Map} fuzzyEvents A map of regex:definition event mappings. Each regex
+ *                          key may include up to two capturing groups. The first
+ *                          group is used as the event "category" and the second is
+ *                          used as the event "target". Again each definition value
+ *                          is an object containing `group` and `event` properties
+ *                          but here `group` can be a string or a function. If it's
+ *                          a function, it will be passed the matched category
+ *                          as its argument and should return the group string.
+ *
+ * @returns {Function}      The mapper function.
+ */
+export function createAmplitudeEventTransformer(
+  services: Services,
+  events: PlainEvents,
+  fuzzyEvents: FuzzyEvents
+): AmplitudeEventTransformer {
+  const eventTypeMapper = createEventTypeMapper(events, fuzzyEvents);
+  const servicePropsMapper = createServiceNameAndClientIdMapper(services);
+  const mapAmplitudeEventProperties = createAmplitudeEventPropertiesMapper(servicePropsMapper);
+
+  /**
+   * Create a request payload suitable for Amplitude's http/batch API.
+   */
+  return (rawEvent: RawEvent, evtContext: EventContext) => {
+    const event = eventTypeMapper(rawEvent.type);
+
+    // @TODO HMAC_KEY should've been checked before we get deep into here
+    if (!event || !HMAC_KEY) {
+      return null;
+    }
+
+    const context = prune(evtContext) as EventContext;
+
+    const { time, device_id, session_id, language, user_id } = tee(rawEvent, context);
+
+    let hashedUserId;
+    if (user_id) {
+      hashedUserId = sha256Hmac(HMAC_KEY, user_id);
+    }
+
+    // tslint:disable-next-line: variable-name
+    const event_type = createAmplitudeEventType(event);
+    // tslint:disable-next-line: variable-name
+    const insert_id = sha256Hmac(HMAC_KEY, hashedUserId, device_id, session_id, event_type, time);
+
+    const userAgent = parse(context.userAgent);
+
+    return {
+      insert_id,
+      op: 'amplitudeEvent',
+      event_type,
+      time,
+      user_id: hashedUserId,
+      device_id,
+      session_id,
+      app_version: getVersion(context.version),
+      language,
+      ...mapLocation(context),
+      ...mapOs(userAgent),
+      ...mapDeviceModel(userAgent),
+      event_properties: prune(mapAmplitudeEventProperties(event, context)),
+      user_properties: prune(mapAmplitudeUserProperties(event, context, userAgent))
+    };
+  };
+}

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/common.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/common.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import crypto from 'crypto';
+import { EventContext, Services, RawEvent } from './types';
+
+type ServiceProperties = {
+  serviceName: string | undefined;
+  clientId: string | undefined;
+};
+export type ServiceNameAndClientIdMapper = (context: EventContext) => ServiceProperties;
+
+export function createServiceNameAndClientIdMapper(services: Services) {
+  return (context: EventContext): ServiceProperties => {
+    let serviceName;
+    let clientId;
+    const { service } = context;
+    if (service && service !== 'content-server') {
+      if (service === 'sync') {
+        serviceName = service;
+      } else {
+        serviceName = services[service] || 'undefined_oauth';
+        clientId = service;
+      }
+    }
+
+    return { serviceName, clientId };
+  };
+}
+
+export type LocationProperties = {
+  country: string;
+  region: string;
+};
+export function mapLocation(context: EventContext): LocationProperties | {} {
+  if (context.location) {
+    const { location } = context;
+
+    if (('country' in location && location.country) || ('state' in location && location.state)) {
+      return {
+        country: location?.country,
+        region: location?.state
+      };
+    }
+  }
+
+  return {};
+}
+
+export function prune(xs: { [key: string]: any }): { [key: string]: {} } {
+  return Object.keys(xs).reduce((acc: { [key: string]: {} }, k) => {
+    if ((xs[k] && xs[k] !== 'none') || xs[k] === false) {
+      acc[k] = xs[k];
+    }
+    return acc;
+  }, {});
+}
+
+/**
+ * 'tee' as in the CLI program.  A function for straight up copying values.
+ */
+export function tee(rawEvent: RawEvent, context: EventContext) {
+  return {
+    time: rawEvent.time,
+    device_id: context.deviceId,
+    session_id: context.flowBeginTime,
+    language: context.lang,
+    user_id: context.uid
+  };
+}
+
+export function toSnakeCase(camelS: string) {
+  return camelS
+    .replace(/([a-z])([A-Z])/g, (s, c1, c2) => `${c1}_${c2.toLowerCase()}`)
+    .replace(/([A-Z])/g, c => c.toLowerCase())
+    .replace(/\./g, '_')
+    .replace(/-/g, '_');
+}
+
+export function sha256Hmac(HMAC_KEY: string, ...properties: any[]) {
+  const hmac = crypto.createHmac('sha256', HMAC_KEY);
+  properties.forEach(property => {
+    if (property) {
+      hmac.update(`${property}`);
+    }
+  });
+
+  return hmac.digest('hex');
+}

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/event-properties.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/event-properties.ts
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { GROUPS, Group, Event, EventContext, Services } from './types';
+import { ServiceNameAndClientIdMapper } from './common';
+
+function NOP() {
+  return {};
+}
+
+const EVENT_PROPERTIES: {
+  [key in Group]: (
+    evt: Event,
+    ctx: EventContext
+  ) => ReturnType<typeof mapAmplitudeEventPropertiesFromGroup>;
+} = {
+  [GROUPS.activity]: NOP,
+  [GROUPS.button]: NOP,
+  [GROUPS.connectDevice]: mapConnectDeviceFlow,
+  [GROUPS.email]: mapEmailType,
+  [GROUPS.emailFirst]: NOP,
+  [GROUPS.login]: NOP,
+  [GROUPS.notify]: NOP,
+  [GROUPS.registration]: mapDomainValidationResult,
+  [GROUPS.rp]: NOP,
+  [GROUPS.settings]: mapDisconnectReason,
+  [GROUPS.sms]: NOP,
+  [GROUPS.sub]: NOP,
+  [GROUPS.subCancel]: NOP,
+  [GROUPS.subManage]: NOP,
+  [GROUPS.subPayManage]: NOP,
+  [GROUPS.subPaySetup]: NOP,
+  [GROUPS.subPayUpgrade]: NOP,
+  [GROUPS.subSupport]: NOP
+} as const;
+
+const CONNECT_DEVICE_FLOWS = {
+  'app-store': 'store_buttons',
+  install_from: 'store_buttons',
+  pair: 'pairing',
+  signin_from: 'signin',
+  sms: 'sms'
+} as const;
+
+type ConnectDeviceFlowKeys = keyof typeof CONNECT_DEVICE_FLOWS;
+type ConnectDeviceEventProperties = {
+  connect_device_flow: string;
+  connect_device_os?: string;
+};
+type EmailTypeEventProperties = {
+  email_type: string;
+  email_provider?: string;
+  email_sender?: string;
+  email_service?: string;
+  email_template?: string;
+  email_version?: string;
+};
+type DisconnectReason = {
+  reason: string;
+};
+type ValidationResult = { validation_result: string };
+export type AmplitudeEventProperties = Partial<
+  ConnectDeviceEventProperties &
+    EmailTypeEventProperties &
+    DisconnectReason &
+    ValidationResult & {
+      plan_id: string;
+      product_id: string;
+      service: string;
+      oauth_client_id: string;
+    }
+>;
+
+export function createAmplitudeEventPropertiesMapper(
+  servicePropMapper: ServiceNameAndClientIdMapper
+) {
+  return (evt: Event, context: EventContext): AmplitudeEventProperties => {
+    const { serviceName: service, clientId: oauthClientId } = servicePropMapper(context);
+
+    return {
+      plan_id: context.planId,
+      product_id: context.productId,
+      service,
+      oauth_client_id: oauthClientId,
+      ...mapAmplitudeEventPropertiesFromGroup(evt, context)
+    };
+  };
+}
+
+function mapAmplitudeEventPropertiesFromGroup(
+  evt: Event,
+  context: EventContext
+):
+  | {}
+  | ConnectDeviceEventProperties
+  | EmailTypeEventProperties
+  | DisconnectReason
+  | ValidationResult {
+  if (evt.group in EVENT_PROPERTIES) {
+    return EVENT_PROPERTIES[evt.group as Group](evt, context);
+  }
+  return {};
+}
+
+function mapConnectDeviceFlow(evt: Event): ConnectDeviceEventProperties | {} {
+  if (evt.category && evt.category in CONNECT_DEVICE_FLOWS) {
+    const connectDeviceFlow = CONNECT_DEVICE_FLOWS[evt.category as ConnectDeviceFlowKeys];
+    const result: ConnectDeviceEventProperties = { connect_device_flow: connectDeviceFlow };
+
+    if (evt.target) {
+      result.connect_device_os = evt.target;
+    }
+
+    return result;
+  }
+
+  return {};
+}
+
+function mapEmailType(evt: Event, context: EventContext): EmailTypeEventProperties | {} {
+  if (evt.category && context.emailTypes && evt.category in context.emailTypes) {
+    const emailType = context.emailTypes[evt.category];
+    const result: EmailTypeEventProperties = {
+      email_type: emailType,
+      email_provider: context.emailDomain,
+      email_sender: context.emailSender,
+      email_service: context.emailService
+    };
+
+    const { templateVersion } = context;
+    if (templateVersion) {
+      result.email_template = evt.category;
+      result.email_version = templateVersion;
+    }
+
+    return result;
+  }
+
+  return {};
+}
+
+function mapDisconnectReason(evt: Event): DisconnectReason | {} {
+  if (evt.type === 'disconnect_device' && evt.category) {
+    return { reason: evt.category };
+  }
+  return {};
+}
+
+function mapDomainValidationResult(evt: Event): ValidationResult | {} {
+  // This function is called for all fxa_reg events, only add the event
+  // properties for the results pertaining to domain_validation_result.
+  if (evt.type === 'domain_validation_result' && evt.category) {
+    return { validation_result: evt.category };
+  }
+  return {};
+}

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/event-type.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/event-type.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { PlainEvents, FuzzyEvents, Event, FuzzyEventGroup, OptionalString } from './types';
+
+export function createEventTypeMapper(events: PlainEvents, fuzzyEvents: FuzzyEvents) {
+  return (rawEventType: string): Event | null => {
+    const mapping = events[rawEventType];
+
+    if (mapping) {
+      return { type: mapping.event, group: mapping.group };
+    }
+
+    let fuzzyEventGroupMapping: FuzzyEventGroup | null = null;
+    let evtType: OptionalString;
+    let evtGroup: OptionalString;
+    let evtCategory: OptionalString = null;
+    let evtTarget: OptionalString = null;
+
+    for (const [regex, fuzzyEventGroup] of fuzzyEvents) {
+      const match = regex.exec(rawEventType);
+
+      if (match) {
+        fuzzyEventGroupMapping = fuzzyEventGroup;
+
+        if (match.length >= 2) {
+          evtCategory = match[1];
+          if (match.length === 3) {
+            evtTarget = match[2];
+          }
+        }
+
+        break;
+      }
+    }
+
+    if (fuzzyEventGroupMapping) {
+      evtType =
+        typeof fuzzyEventGroupMapping.event === 'string'
+          ? fuzzyEventGroupMapping.event
+          : fuzzyEventGroupMapping.event(evtCategory, evtTarget);
+
+      if (evtType === null) {
+        return null;
+      }
+
+      evtGroup =
+        typeof fuzzyEventGroupMapping.group === 'string'
+          ? fuzzyEventGroupMapping.group
+          : fuzzyEventGroupMapping.group(evtCategory);
+
+      if (evtGroup === null) {
+        return null;
+      }
+
+      return {
+        type: evtType,
+        group: evtGroup,
+        category: evtCategory,
+        target: evtTarget
+      };
+    }
+
+    return null;
+  };
+}
+
+export function createAmplitudeEventType(evt: Event) {
+  return `${evt.group} - ${evt.type}`;
+}

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/types.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/types.ts
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AmplitudeUserProperties } from './user-properties';
+import { AmplitudeEventProperties } from './event-properties';
+
+export enum GROUPS {
+  activity = 'fxa_activity',
+  button = 'fxa_rp_button',
+  connectDevice = 'fxa_connect_device',
+  email = 'fxa_email',
+  emailFirst = 'fxa_email_first',
+  login = 'fxa_login',
+  notify = 'fxa_notify',
+  registration = 'fxa_reg',
+  rp = 'fxa_rp',
+  settings = 'fxa_pref',
+  sms = 'fxa_sms',
+  sub = 'fxa_subscribe',
+  subCancel = 'fxa_subscribe_cancel',
+  subManage = 'fxa_subscribe_manage',
+  subPayManage = 'fxa_pay_manage',
+  subPaySetup = 'fxa_pay_setup',
+  subPayUpgrade = 'fxa_pay_upgrade',
+  subSupport = 'fxa_subscribe_support'
+}
+
+export type OptionalString = string | null;
+export type Groups = typeof GROUPS;
+export type Group = Groups[keyof Groups];
+export type EventAndGroup = {
+  event: string;
+  group: Group;
+};
+export type PlainEvents = { [key: string]: EventAndGroup };
+export type FuzzyEventGroup = {
+  event: string | ((c: OptionalString, t: OptionalString) => OptionalString);
+  group: Group | ((c: OptionalString) => OptionalString);
+};
+export type FuzzyEvents = Map<RegExp, FuzzyEventGroup>;
+export type Event = {
+  type: string;
+  group: string;
+  category?: OptionalString;
+  target?: OptionalString;
+};
+export type Services = { [key: string]: string };
+export type Device = { lastAccessTime: number };
+type Newsletter =
+  | 'firefox-accounts-journey'
+  | 'knowledge-is-power'
+  | 'take-action-for-the-internet'
+  | 'test-pilot';
+export type Location = { state: OptionalString; country: OptionalString };
+
+export type RawEvent = {
+  type: string;
+  time: number;
+  flowTime?: number;
+  offset?: number;
+};
+export type EventContext = {
+  eventSource: 'content' | 'auth' | 'oauth' | 'payments';
+  version: string;
+  browser?: string;
+  browserVersion?: string;
+  deviceId?: string;
+  devices?: Device[];
+  emailDomain?: string;
+  emailSender?: string;
+  emailService?: string;
+  emailTypes?: { [key: string]: string };
+  entrypoint_experiment?: string;
+  entrypoint_variation?: string;
+  entrypoint?: string;
+  experiments?: { choice: string; group: string }[];
+  flowBeginTime?: number;
+  flowId?: string;
+  lang?: string;
+  location?: Location | {};
+  marketingOptIn?: boolean;
+  newsletters?: Newsletter[];
+  planId?: string;
+  productId?: string;
+  service?: string;
+  syncEngines?: string[];
+  templateVersion?: string;
+  uid?: string;
+  userAgent?: string;
+  userPreferences?: { [key: string]: string };
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_medium?: string;
+  utm_source?: string;
+  utm_term?: string;
+};
+
+export type AmplitudeHttpEvent = {
+  op: 'amplitudeEvent';
+  insert_id: string;
+  user_id?: string;
+  event_type: string;
+  time: number;
+  device_id?: string;
+  session_id?: number;
+  app_version?: string;
+  language?: string;
+  country?: string;
+  region?: string;
+  os_name?: string;
+  os_version?: string;
+  event_properties: AmplitudeEventProperties;
+  user_properties: AmplitudeUserProperties;
+};

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/user-agent.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/user-agent.ts
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ParsedUserAgentProperties } from '../../../../../fxa-shared/metrics/user-agent';
+
+export type BrowserProps = { ua_browser: string; ua_version: string };
+export type OsProps = { os_name: string; os_version: string };
+export type DeviceModel = { device_model: string };
+
+export function mapBrowser(userAgent: ParsedUserAgentProperties | undefined): BrowserProps | {} {
+  return mapUserAgentProperties(userAgent, 'ua', 'ua_browser', 'ua_version');
+}
+
+export function mapOs(userAgent: ParsedUserAgentProperties | undefined): OsProps | {} {
+  return mapUserAgentProperties(userAgent, 'os', 'os_name', 'os_version');
+}
+
+function mapUserAgentProperties(
+  userAgent: ParsedUserAgentProperties | undefined,
+  key: 'ua' | 'os',
+  familyProperty: 'ua_browser' | 'os_name',
+  versionProperty: 'ua_version' | 'os_version'
+): BrowserProps | OsProps | {} {
+  if (userAgent) {
+    const group = userAgent[key];
+    const { family } = group;
+    if (family && family !== 'Other') {
+      return {
+        [familyProperty]: family,
+        [versionProperty]: group.toVersionString()
+      };
+    }
+  }
+  return {};
+}
+
+export function mapDeviceModel(userAgent: ParsedUserAgentProperties): DeviceModel | {} {
+  const { brand, family: deviceModel } = userAgent.device;
+  if (brand && deviceModel && brand !== 'Generic') {
+    return { device_model: deviceModel };
+  }
+  return {};
+}

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/user-properties.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/user-properties.ts
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Event, EventContext, Device } from './types';
+import { toSnakeCase } from './common';
+import { ParsedUserAgentProperties } from '../../../../../fxa-shared/metrics/user-agent';
+import { mapBrowser, BrowserProps } from './user-agent';
+
+const DAY = 1000 * 60 * 60 * 24;
+const WEEK = DAY * 7;
+const FOUR_WEEKS = WEEK * 4;
+
+const NEWSLETTER_STATES = {
+  optIn: 'subscribed',
+  optOut: 'unsubscribed'
+} as const;
+type NewsLetterStates = typeof NEWSLETTER_STATES;
+type NewsLetterStateKey = keyof NewsLetterStates;
+type NewsLetterState = NewsLetterStates[NewsLetterStateKey];
+type NewsLetterStateProp = { newsletter_state: NewsLetterState };
+type NewsLettersProp = { newsletters: string[] };
+
+type SyncDevices = {
+  sync_device_count: number;
+  sync_active_devices_day: number;
+  sync_active_devices_week: number;
+  sync_active_devices_month: number;
+};
+type SyncEngines = {
+  sync_engines: string[];
+};
+export type AmplitudeUserProperties = Partial<
+  SyncDevices &
+    SyncEngines &
+    NewsLetterStateProp &
+    NewsLettersProp &
+    BrowserProps & {
+      entrypoint?: string;
+      entrypoint_experiment?: string;
+      entrypoint_variation?: string;
+      flow_id?: string;
+      utm_campaign?: string;
+      utm_content?: string;
+      utm_medium?: string;
+      utm_source?: string;
+      utm_term?: string;
+    }
+>;
+
+export function mapAmplitudeUserProperties(
+  evt: Event,
+  context: EventContext,
+  userAgent: ParsedUserAgentProperties
+): AmplitudeUserProperties {
+  const {
+    entrypoint,
+    entrypoint_experiment,
+    entrypoint_variation,
+    flowId: flowId,
+    utm_campaign,
+    utm_content,
+    utm_medium,
+    utm_source,
+    utm_term
+  } = context;
+
+  return {
+    entrypoint,
+    entrypoint_experiment,
+    entrypoint_variation,
+    flow_id: flowId,
+    utm_campaign,
+    utm_content,
+    utm_medium,
+    utm_source,
+    utm_term,
+    ...mapBrowser(userAgent),
+    ...mapSyncDevices(context),
+    ...mapSyncEngines(context),
+    ...mapNewsletterState(evt, context),
+    ...mapNewsletters(context)
+  };
+}
+
+function mapSyncDevices(context: EventContext): SyncDevices | {} {
+  const { devices } = context;
+
+  if (Array.isArray(devices)) {
+    return {
+      sync_device_count: devices.length,
+      sync_active_devices_day: countDevices(devices, DAY),
+      sync_active_devices_week: countDevices(devices, WEEK),
+      sync_active_devices_month: countDevices(devices, FOUR_WEEKS)
+    };
+  }
+
+  return {};
+}
+
+function countDevices(devices: Device[], period: number) {
+  return devices.filter(device => device.lastAccessTime >= Date.now() - period).length;
+}
+
+function mapSyncEngines(context: EventContext): SyncEngines | {} {
+  const { syncEngines: syncEngines } = context;
+
+  if (Array.isArray(syncEngines) && syncEngines.length > 0) {
+    return { sync_engines: syncEngines };
+  }
+  return {};
+}
+
+function mapNewsletterState(evt: Event, context: EventContext): NewsLetterStateProp | {} {
+  let newsletterState;
+
+  if (evt.category && evt.category in NEWSLETTER_STATES) {
+    newsletterState = NEWSLETTER_STATES[evt.category as NewsLetterStateKey];
+  }
+
+  if (!newsletterState) {
+    const { marketingOptIn } = context;
+
+    if (marketingOptIn === true || marketingOptIn === false) {
+      newsletterState = marketingOptIn ? 'subscribed' : 'unsubscribed';
+    }
+  }
+
+  if (newsletterState) {
+    return { newsletter_state: newsletterState };
+  }
+
+  return {};
+}
+
+function mapNewsletters(context: EventContext): NewsLettersProp | {} {
+  const { newsletters: newslettersFromCtx } = context;
+  if (newslettersFromCtx) {
+    const newsletters = newslettersFromCtx.map(newsletter => {
+      return toSnakeCase(newsletter);
+    });
+    return { newsletters };
+  }
+  return {};
+}

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/version.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/version.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const VERSION_REGEX_PATTERN = /([0-9]+)\.([0-9])$/;
+
+export function getVersion(v: string): string | undefined {
+  const match = VERSION_REGEX_PATTERN.exec(v);
+  return match ? match[0] : undefined;
+}

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/amplitude-event.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/amplitude-event.spec.ts
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import 'mocha';
+import sinon from 'sinon';
+
+import Config from '../../../../config';
+const config = Config.getProperties();
+const ConfigPropertiesStub = sinon
+  .stub(Config, 'getProperties')
+  .returns({ ...config, amplitude: { hmac_key: '00000001' } });
+
+import { createAmplitudeEventTransformer } from '../../../../lib/amplitude/transforms/amplitude-event';
+import {
+  Services,
+  PlainEvents,
+  GROUPS,
+  OptionalString
+} from '../../../../lib/amplitude/transforms/types';
+
+const services: Services = { foo: 'bar', fizz: 'buzz', level: 'over9000' };
+
+const eventsMap: PlainEvents = {
+  'oauth.signup.success': {
+    group: GROUPS.registration,
+    event: 'quuxed'
+  },
+  'quuz.wibble.success': {
+    group: GROUPS.login,
+    event: 'complete'
+  }
+};
+
+const fuzzyEvents = new Map([
+  [
+    /^foo\.(bar)\.passwordStrength\.(buzz)$/,
+    {
+      group: GROUPS.registration,
+      event: (category: OptionalString) => `password_${category}`
+    }
+  ]
+]);
+
+const eventContext = {
+  eventSource: 'content' as const,
+  version: '1.165.1',
+  emailTypes: {
+    'complete-reset-password': 'reset_password',
+    'complete-signin': 'login',
+    'verify-email': 'registration'
+  },
+  userAgent:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:40.0) Gecko/20100101 Firefox/40.0 FxATester/1.0',
+  deviceId: '96695ff7380546e78f1f5e703e4b6297',
+  emailDomain: 'other',
+  entrypoint_experiment: 'none',
+  entrypoint_variation: 'none',
+  entrypoint: 'none',
+  experiments: [],
+  flowBeginTime: 1586282556983,
+  flowId: '49e98367149d8a7299c0dfdc2fe8093a6d4625fc5e28612ddce906cf3e518d01',
+  lang: 'en',
+  location: {},
+  service: 'dcdb5ae7add825d2',
+  syncEngines: ['bookmarks', 'history'],
+  uid: '98393a6d46267149d86299c25fc5e286',
+  userPreferences: {},
+  utm_campaign: 'none',
+  utm_content: 'none',
+  utm_medium: 'none',
+  utm_source: 'none',
+  utm_term: 'none'
+};
+
+describe('Amplitude event transfomer', () => {
+  const transform = createAmplitudeEventTransformer(services, eventsMap, fuzzyEvents);
+
+  after(() => {
+    ConfigPropertiesStub.restore();
+  });
+
+  it('uses the given events map to tranform a plain event correctly', () => {
+    const rawEvent = {
+      type: 'quuz.wibble.success',
+      offset: 3401,
+      time: 1586282560373,
+      flowTime: 3390
+    };
+    const actual = transform(rawEvent, eventContext);
+    const expected = {
+      insert_id: '84e4a5a990eebcc667aa87b58ec49958e6ebaa3171f7103af0d2be45231e7498',
+      op: 'amplitudeEvent' as const,
+      event_type: 'fxa_login - complete',
+      time: 1586282560373,
+      user_id: '372fa79f3632257f6421ccfd86eae2d631f7284b59ae9876d8c88fa1ae0f408f',
+      device_id: '96695ff7380546e78f1f5e703e4b6297',
+      session_id: 1586282556983,
+      app_version: '165.1',
+      language: 'en',
+      os_name: 'Mac OS X',
+      os_version: '10.10',
+      event_properties: {
+        service: 'undefined_oauth',
+        oauth_client_id: 'dcdb5ae7add825d2'
+      },
+      user_properties: {
+        flow_id: '49e98367149d8a7299c0dfdc2fe8093a6d4625fc5e28612ddce906cf3e518d01',
+        ua_browser: 'Firefox',
+        ua_version: '40.0',
+        sync_engines: ['bookmarks', 'history']
+      }
+    };
+    assert.deepEqual(actual, expected);
+  });
+
+  it('uses the given fuzzy events map to tranform a fuzzy event correctly', () => {
+    const rawEvent = {
+      type: 'foo.bar.passwordStrength.buzz',
+      offset: 3401,
+      time: 1586282560373,
+      flowTime: 3390
+    };
+    const actual = transform(rawEvent, {
+      ...eventContext,
+      planId: 'quuz',
+      productId: 'hotcakes'
+    });
+    const expected = {
+      insert_id: '89c3ccfe6dcd4cd966432f0b920ccfe40ea0635f369d9f2d84b95ad21037ec3e',
+      op: 'amplitudeEvent' as const,
+      event_type: 'fxa_reg - password_bar',
+      time: 1586282560373,
+      user_id: '372fa79f3632257f6421ccfd86eae2d631f7284b59ae9876d8c88fa1ae0f408f',
+      device_id: '96695ff7380546e78f1f5e703e4b6297',
+      session_id: 1586282556983,
+      app_version: '165.1',
+      language: 'en',
+      os_name: 'Mac OS X',
+      os_version: '10.10',
+      event_properties: {
+        service: 'undefined_oauth',
+        plan_id: 'quuz',
+        product_id: 'hotcakes',
+        oauth_client_id: 'dcdb5ae7add825d2'
+      },
+      user_properties: {
+        flow_id: '49e98367149d8a7299c0dfdc2fe8093a6d4625fc5e28612ddce906cf3e518d01',
+        ua_browser: 'Firefox',
+        ua_version: '40.0',
+        sync_engines: ['bookmarks', 'history']
+      }
+    };
+    assert.deepEqual(actual, expected);
+  });
+});

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/common.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/common.spec.ts
@@ -1,0 +1,163 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import crypto from 'crypto';
+import { assert } from 'chai';
+import 'mocha';
+import sinon from 'sinon';
+
+import {
+  createServiceNameAndClientIdMapper,
+  mapLocation,
+  tee,
+  sha256Hmac,
+  prune
+} from '../../../../lib/amplitude/transforms/common';
+import { EventContext } from '../../../../lib/amplitude/transforms/types';
+
+const mockContext: EventContext = {
+  eventSource: 'content',
+  version: '1.165.1'
+};
+const services = { foo: 'bar', fizz: 'buzz', level: 'over9000' };
+const mapper = createServiceNameAndClientIdMapper(services);
+
+describe('service name and client id mapping', () => {
+  it('should return a undefined service name and client id when "service" is not in the event context', () => {
+    const props = mapper(mockContext);
+    assert.isUndefined(props.serviceName);
+    assert.isUndefined(props.clientId);
+  });
+
+  it('should return a undefined service name and client id when "service" in context is "content-server"', () => {
+    const props = mapper({
+      ...mockContext,
+      service: 'content-server'
+    });
+    assert.isUndefined(props.serviceName);
+    assert.isUndefined(props.clientId);
+  });
+
+  it('should return "sync" as service name when "service" in context is "sync"', () => {
+    const props = mapper({
+      ...mockContext,
+      service: 'sync'
+    });
+    assert.equal(props.serviceName, 'sync');
+    assert.isUndefined(props.clientId);
+  });
+
+  it('should return service name from services map when found', () => {
+    const props = mapper({
+      ...mockContext,
+      service: 'level'
+    });
+    assert.equal(props.serviceName, 'over9000');
+    assert.equal(props.clientId, 'level');
+  });
+
+  it('should return "undefined_oauth" when service is not in services map', () => {
+    const props = mapper({
+      ...mockContext,
+      service: 'wibble'
+    });
+    assert.equal(props.serviceName, 'undefined_oauth');
+    assert.equal(props.clientId, 'wibble');
+  });
+});
+
+describe('location properties mapper', () => {
+  it('should be empty if given location is undefined', () => {
+    const actual = mapLocation(mockContext);
+    assert.deepEqual(actual, {});
+  });
+
+  it('should be empty if given location is empty', () => {
+    const actual = mapLocation({ ...mockContext, location: {} });
+    assert.deepEqual(actual, {});
+  });
+
+  it('should map the country correctly', () => {
+    const actual = mapLocation({
+      ...mockContext,
+      location: { country: 'United Devices of von Neumann', state: null }
+    });
+    assert.deepEqual(actual, {
+      country: 'United Devices of von Neumann',
+      region: null
+    });
+  });
+
+  it('should map the region correctly', () => {
+    const actual = mapLocation({
+      ...mockContext,
+      location: { country: null, state: 'Memory Palace' }
+    });
+    assert.deepEqual(actual, {
+      country: null,
+      region: 'Memory Palace'
+    });
+  });
+
+  it('should map the country and region correctly', () => {
+    const actual = mapLocation({
+      ...mockContext,
+      location: {
+        country: 'United Devices of von Neumann',
+        state: 'Memory Palace'
+      }
+    });
+    assert.deepEqual(actual, {
+      country: 'United Devices of von Neumann',
+      region: 'Memory Palace'
+    });
+  });
+});
+
+describe('property pruning', () => {
+  it('should remove null, undefined, and "none"', () => {
+    const actual = prune({
+      foo: 'bar',
+      fuuz: null,
+      fizz: undefined,
+      extra: 'none',
+      level: 9001
+    });
+    assert.deepEqual(actual, { foo: 'bar', level: 9001 });
+  });
+});
+
+describe('property copying', () => {
+  it('should copy specified values correctly', () => {
+    const actual = tee(
+      { type: 'fake.io.event', time: 9001 },
+      {
+        ...mockContext,
+        deviceId: 'wibble',
+        flowBeginTime: 1586282556983,
+        lang: 'gd',
+        uid: 'quuz'
+      }
+    );
+    assert.deepEqual(actual, {
+      time: 9001,
+      device_id: 'wibble',
+      session_id: 1586282556983,
+      language: 'gd',
+      user_id: 'quuz'
+    });
+  });
+});
+
+describe('sha256 HMAC', () => {
+  it('should hmac with crypto correctly', () => {
+    const hmacMock = { update: sinon.stub(), digest: sinon.stub() };
+    const stub = sinon.stub(crypto, 'createHmac').returns(hmacMock as any); // :(
+    sha256Hmac('coolkey', 'quuz', 'message');
+    sinon.assert.calledOnceWithExactly(stub, 'sha256', 'coolkey');
+    assert.deepEqual(hmacMock.update.args, [['quuz'], ['message']]);
+    sinon.assert.calledOnceWithExactly(hmacMock.digest, 'hex');
+    stub.restore();
+  });
+});

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/event-properties.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/event-properties.spec.ts
@@ -1,0 +1,235 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import 'mocha';
+
+import { createAmplitudeEventPropertiesMapper } from '../../../../lib/amplitude/transforms/event-properties';
+import { Event, GROUPS, EventContext } from '../../../../lib/amplitude/transforms/types';
+import { createServiceNameAndClientIdMapper } from '../../../../lib/amplitude/transforms/common';
+
+const services = { foo: 'bar', fizz: 'buzz', level: 'over9000' };
+const mockEvent: Event = { type: 'a', group: 'bs' };
+const mockContext: EventContext = {
+  eventSource: 'content',
+  version: '1.165.1'
+};
+const mapper = createAmplitudeEventPropertiesMapper(createServiceNameAndClientIdMapper(services));
+
+describe('Amplitude event properties mapper', () => {
+  describe('with subscription plan id and product id in the event context', () => {
+    it('should map the plan id and product id into the Amplitude event properties', () => {
+      const eventProperties = mapper(mockEvent, {
+        ...mockContext,
+        planId: 'quux',
+        productId: 'wibble'
+      });
+      assert.equal(eventProperties.plan_id, 'quux');
+      assert.equal(eventProperties.product_id, 'wibble');
+    });
+  });
+
+  describe('service name and client id mapping', () => {
+    it('should map properties to "service" and "oauth_client_id"', () => {
+      const eventProperties = mapper(mockEvent, {
+        ...mockContext,
+        service: 'level'
+      });
+      assert.equal(eventProperties.service, 'over9000');
+      assert.equal(eventProperties.oauth_client_id, 'level');
+    });
+  });
+
+  describe('Connect device flow properties mapping', () => {
+    it('should return an empty object when event category is not in connect device flow', () => {
+      const eventProperties = mapper({ ...mockEvent, category: 'disco' }, mockContext);
+      assert.isUndefined(eventProperties.connect_device_flow);
+      assert.isUndefined(eventProperties.connect_device_os);
+    });
+
+    it('should return the correct flow', () => {
+      const eventProperties = mapper(
+        { ...mockEvent, group: GROUPS.connectDevice, category: 'sms' },
+        mockContext
+      );
+      assert.equal(eventProperties.connect_device_flow, 'sms');
+      assert.isUndefined(eventProperties.connect_device_os);
+    });
+
+    it('should return the correct flow and os', () => {
+      const eventProperties = mapper(
+        {
+          ...mockEvent,
+          group: GROUPS.connectDevice,
+          category: 'sms',
+          target: 'os2'
+        },
+        mockContext
+      );
+      assert.equal(eventProperties.connect_device_flow, 'sms');
+      assert.equal(eventProperties.connect_device_os, 'os2');
+    });
+  });
+
+  describe('Email type mapping', () => {
+    it('should return an empty object when there is no event category', () => {
+      const eventProperties = mapper(
+        { ...mockEvent, group: GROUPS.email },
+        {
+          ...mockContext,
+          emailTypes: { 'complete-reset-password': 'reset_password' }
+        }
+      );
+      assert.isUndefined(eventProperties.email_type);
+      assert.isUndefined(eventProperties.email_provider);
+      assert.isUndefined(eventProperties.email_sender);
+      assert.isUndefined(eventProperties.email_service);
+      assert.isUndefined(eventProperties.email_template);
+      assert.isUndefined(eventProperties.email_version);
+    });
+
+    it('should return an empty object when "emailTypes" is not in the context', () => {
+      const eventProperties = mapper({ ...mockEvent, group: GROUPS.email }, mockContext);
+      assert.isUndefined(eventProperties.email_type);
+      assert.isUndefined(eventProperties.email_provider);
+      assert.isUndefined(eventProperties.email_sender);
+      assert.isUndefined(eventProperties.email_service);
+      assert.isUndefined(eventProperties.email_template);
+      assert.isUndefined(eventProperties.email_version);
+    });
+
+    it('should return an empty object when event category is not in "emailTypes"', () => {
+      const eventProperties = mapper(
+        { ...mockEvent, group: GROUPS.email, category: 'xyz' },
+        {
+          ...mockContext,
+          emailTypes: { 'complete-reset-password': 'reset_password' }
+        }
+      );
+      assert.isUndefined(eventProperties.email_type);
+      assert.isUndefined(eventProperties.email_provider);
+      assert.isUndefined(eventProperties.email_sender);
+      assert.isUndefined(eventProperties.email_service);
+      assert.isUndefined(eventProperties.email_template);
+      assert.isUndefined(eventProperties.email_version);
+    });
+
+    it('should return the correct email type properties', () => {
+      const eventProperties = mapper(
+        {
+          ...mockEvent,
+          group: GROUPS.email,
+          category: 'complete-reset-password'
+        },
+        {
+          ...mockContext,
+          emailTypes: { 'complete-reset-password': 'reset_password' },
+          emailDomain: 'gg.fail',
+          emailSender: 'abc',
+          emailService: 'xyz'
+        }
+      );
+      assert.equal(eventProperties.email_type, 'reset_password');
+      assert.equal(eventProperties.email_provider, 'gg.fail');
+      assert.equal(eventProperties.email_sender, 'abc');
+      assert.equal(eventProperties.email_service, 'xyz');
+      assert.isUndefined(eventProperties.email_template);
+      assert.isUndefined(eventProperties.email_version);
+    });
+
+    it('should return the correct email type properties with email template info', () => {
+      const eventProperties = mapper(
+        {
+          ...mockEvent,
+          group: GROUPS.email,
+          category: 'complete-reset-password'
+        },
+        {
+          ...mockContext,
+          emailTypes: { 'complete-reset-password': 'reset_password' },
+          emailDomain: 'gg.fail',
+          emailSender: 'abc',
+          emailService: 'xyz',
+          templateVersion: '9000'
+        }
+      );
+      assert.equal(eventProperties.email_type, 'reset_password');
+      assert.equal(eventProperties.email_provider, 'gg.fail');
+      assert.equal(eventProperties.email_sender, 'abc');
+      assert.equal(eventProperties.email_service, 'xyz');
+      assert.equal(eventProperties.email_template, 'complete-reset-password');
+      assert.equal(eventProperties.email_version, '9000');
+    });
+  });
+
+  describe('Disconnect reason mapping', () => {
+    it('should be undefined when the event type is not "disconnect_device"', () => {
+      const eventProperties = mapper(
+        { ...mockEvent, group: GROUPS.settings, category: 'gg' },
+        mockContext
+      );
+      assert.isUndefined(eventProperties.reason);
+    });
+
+    it('should be undefined when the there is no event category', () => {
+      const eventProperties = mapper(
+        {
+          ...mockEvent,
+          group: GROUPS.settings,
+          type: 'disconnect_device'
+        },
+        mockContext
+      );
+      assert.isUndefined(eventProperties.reason);
+    });
+
+    it('should map the disconnect reason correctly', () => {
+      const eventProperties = mapper(
+        {
+          ...mockEvent,
+          group: GROUPS.settings,
+          type: 'disconnect_device',
+          category: 'gg'
+        },
+        mockContext
+      );
+      assert.equal(eventProperties.reason, 'gg');
+    });
+  });
+
+  describe('Domain validation result mapping', () => {
+    it('should be undefined when the event type is not "domain_validation_result"', () => {
+      const eventProperties = mapper(
+        { ...mockEvent, group: GROUPS.registration, category: 'oops' },
+        mockContext
+      );
+      assert.isUndefined(eventProperties.validation_result);
+    });
+
+    it('should be undefined when the there is no event category', () => {
+      const eventProperties = mapper(
+        {
+          ...mockEvent,
+          group: GROUPS.registration,
+          type: 'domain_validation_result'
+        },
+        mockContext
+      );
+      assert.isUndefined(eventProperties.validation_result);
+    });
+
+    it('should map the domain validation result correctly', () => {
+      const eventProperties = mapper(
+        {
+          ...mockEvent,
+          group: GROUPS.registration,
+          type: 'domain_validation_result',
+          category: 'oops'
+        },
+        mockContext
+      );
+      assert.equal(eventProperties.validation_result, 'oops');
+    });
+  });
+});

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/event-type.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/event-type.spec.ts
@@ -1,0 +1,169 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import 'mocha';
+import sinon from 'sinon';
+
+import { GROUPS, OptionalString } from '../../../../lib/amplitude/transforms/types';
+import {
+  createEventTypeMapper,
+  createAmplitudeEventType
+} from '../../../../lib/amplitude/transforms/event-type';
+
+const eventCb = sinon
+  .stub()
+  .callsFake((c: OptionalString, t: OptionalString) => (t ? `testo_${c}_${t}` : `testo_${c}`));
+const groupCb = sinon.stub().callsFake((c: OptionalString) => `group_${c}`);
+const nullCb = sinon.stub().returns(null);
+
+const PLAIN_EVENTS = {
+  'foo.bar.fizz.quux': {
+    group: GROUPS.login,
+    event: 'quuxed'
+  },
+  'quuz.wibble.success': {
+    group: GROUPS.login,
+    event: 'complete'
+  }
+};
+const FUZZY_EVENTS = new Map([
+  [
+    /^experiment\.(control|chaos|rando)\.que\.(\w+)$/,
+    {
+      group: GROUPS.registration,
+      event: eventCb
+    }
+  ],
+  [
+    /^settings\.clients\.disconnect\.submit\.([a-z]+)$/,
+    {
+      group: GROUPS.settings,
+      event: eventCb
+    }
+  ],
+  [
+    /^screen\.(settings)\.two-step-authentication\.(gogo)$/,
+    {
+      group: GROUPS.settings,
+      event: nullCb
+    }
+  ],
+  [
+    /^flow\.(party)\.down$/,
+    {
+      group: groupCb,
+      event: 'shell_beach_party'
+    }
+  ],
+  [
+    /^flow\.([\w-]+)\.engage$/,
+    {
+      group: nullCb,
+      event: 'engage'
+    }
+  ]
+]);
+
+describe('event type mapper', () => {
+  const mapper = createEventTypeMapper(PLAIN_EVENTS, FUZZY_EVENTS);
+
+  beforeEach(() => {
+    eventCb.resetHistory();
+    groupCb.resetHistory();
+    nullCb.resetHistory();
+  });
+
+  it('should map a plain event correctly', () => {
+    const expected = { group: GROUPS.login, type: 'quuxed' };
+    const actual = mapper('foo.bar.fizz.quux');
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should return null if raw event type has no match', () => {
+    const actual = mapper('asdf.qwer.ty');
+    assert.isNull(actual);
+  });
+
+  it('should return null when fuzzy event type is null', () => {
+    const actual = mapper('screen.settings.two-step-authentication.gogo');
+    assert.isNull(actual);
+    sinon.assert.calledOnceWithExactly(nullCb, 'settings', 'gogo');
+  });
+
+  it('should return null when fuzzy event group is null', () => {
+    const actual = mapper('flow.transformers.engage');
+    assert.isNull(actual);
+    sinon.assert.calledOnceWithExactly(nullCb, 'transformers');
+  });
+
+  it('should map a fuzzy event correctly given a string event type', () => {
+    const expected = {
+      group: 'group_party',
+      type: 'shell_beach_party',
+      category: 'party',
+      target: null
+    };
+    const actual = mapper('flow.party.down');
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should map a fuzzy event correctly given a string event group', () => {
+    const expected = {
+      group: GROUPS.registration,
+      type: 'testo_chaos_lol',
+      category: 'chaos',
+      target: 'lol'
+    };
+    const actual = mapper('experiment.chaos.que.lol');
+    assert.deepEqual(actual, expected);
+  });
+
+  describe('a fuzzy event correctly with an event type callback', () => {
+    it('should map correctly with only an event category', () => {
+      const expected = {
+        group: GROUPS.settings,
+        type: 'testo_quux',
+        category: 'quux',
+        target: null
+      };
+      const actual = mapper('settings.clients.disconnect.submit.quux');
+      assert.deepEqual(actual, expected);
+      sinon.assert.calledOnceWithExactly(eventCb, 'quux', null);
+    });
+
+    it('should map correctly with an event category and an event target', () => {
+      const expected = {
+        group: GROUPS.registration,
+        type: 'testo_chaos_lol',
+        category: 'chaos',
+        target: 'lol'
+      };
+      const actual = mapper('experiment.chaos.que.lol');
+      assert.deepEqual(actual, expected);
+      sinon.assert.calledOnceWithExactly(eventCb, 'chaos', 'lol');
+    });
+  });
+
+  it('should map a fuzzy event correctly given an event group callback', () => {
+    const expected = {
+      group: 'group_party',
+      type: 'shell_beach_party',
+      category: 'party',
+      target: null
+    };
+    const actual = mapper('flow.party.down');
+    assert.deepEqual(actual, expected);
+    assert.isTrue(groupCb.calledOnceWithExactly('party'));
+    sinon.assert.calledOnceWithExactly(groupCb, 'party');
+  });
+});
+
+describe('Amplitude event type creator', () => {
+  it('should create a formatted event type string', () => {
+    const expected = `quux - wibble`;
+    const actual = createAmplitudeEventType({ group: 'quux', type: 'wibble' });
+    assert.equal(actual, expected);
+  });
+});

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/user-agent.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/user-agent.spec.ts
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import 'mocha';
+
+import { mapBrowser, mapOs, mapDeviceModel } from '../../../../lib/amplitude/transforms/user-agent';
+
+const mockParsedUserAgent = {
+  ua: {
+    family: 'WaterCat',
+    major: '66',
+    minor: '12',
+    patch: '0',
+    toVersionString: () => '66.12.0'
+  },
+  os: {
+    family: 'OS2',
+    major: '10',
+    minor: '135',
+    patch: '3',
+    patchMinor: 'q',
+    toVersionString: () => '10.135.3q'
+  },
+  device: {
+    family: 'iQod',
+    brand: 'Kiwi',
+    model: 'fanciest'
+  }
+};
+
+describe('browser properties mapper', () => {
+  it('should be empty when browser family is missing', () => {
+    const browserProps = mapBrowser({
+      ...mockParsedUserAgent,
+      ua: { ...mockParsedUserAgent.ua, family: null }
+    });
+    assert.deepEqual(browserProps, {});
+  });
+
+  it('should be empty when browser family is "Other"', () => {
+    const browserProps = mapBrowser({
+      ...mockParsedUserAgent,
+      ua: { ...mockParsedUserAgent.ua, family: 'Other' }
+    });
+    assert.deepEqual(browserProps, {});
+  });
+
+  it('should map the browser and its version correctly', () => {
+    const browserProps = mapBrowser(mockParsedUserAgent);
+    assert.deepEqual(browserProps, {
+      ua_browser: 'WaterCat',
+      ua_version: '66.12.0'
+    });
+  });
+});
+
+describe('OS properties mapper', () => {
+  it('should be empty when OS family is missing', () => {
+    const osProps = mapOs({
+      ...mockParsedUserAgent,
+      os: { ...mockParsedUserAgent.os, family: null }
+    });
+    assert.deepEqual(osProps, {});
+  });
+
+  it('should be empty when the OS family is "Other"', () => {
+    const osProps = mapOs({
+      ...mockParsedUserAgent,
+      os: { ...mockParsedUserAgent.os, family: 'Other' }
+    });
+    assert.deepEqual(osProps, {});
+  });
+
+  it('should map the browser and its version correctly', () => {
+    const osProps = mapOs(mockParsedUserAgent);
+    assert.deepEqual(osProps, {
+      os_name: 'OS2',
+      os_version: '10.135.3q'
+    });
+  });
+});
+
+describe('device model mapper', () => {
+  it('should be empty when device family is missing', () => {
+    const device = mapDeviceModel({
+      ...mockParsedUserAgent,
+      device: { ...mockParsedUserAgent.device, family: null }
+    });
+    assert.deepEqual(device, {});
+  });
+
+  it('should be empty when device brand is missing', () => {
+    const device = mapDeviceModel({
+      ...mockParsedUserAgent,
+      device: { ...mockParsedUserAgent.device, brand: null }
+    });
+    assert.deepEqual(device, {});
+  });
+
+  it('should be empty when device brand is "Generic"', () => {
+    const device = mapDeviceModel({
+      ...mockParsedUserAgent,
+      device: { ...mockParsedUserAgent.device, brand: 'Generic' }
+    });
+    assert.deepEqual(device, {});
+  });
+
+  it('should map device model correctly', () => {
+    const device = mapDeviceModel(mockParsedUserAgent);
+    assert.deepEqual(device, { device_model: 'iQod' });
+  });
+});

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/user-properties.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/user-properties.spec.ts
@@ -1,0 +1,213 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import 'mocha';
+
+import { mapAmplitudeUserProperties } from '../../../../lib/amplitude/transforms/user-properties';
+import { EventContext, Event } from '../../../../lib/amplitude/transforms/types';
+
+const mockEvent: Event = { type: 'a', group: 'bs' };
+const mockContext: EventContext = {
+  eventSource: 'content',
+  version: '1.165.1'
+};
+const mockParsedUserAgent = {
+  ua: {
+    family: 'WaterCat',
+    major: '66',
+    minor: '12',
+    patch: '0',
+    toVersionString: () => '66.12.0'
+  },
+  os: {
+    family: null,
+    major: null,
+    minor: null,
+    patch: null,
+    patchMinor: null,
+    toVersionString: () => ''
+  },
+  device: {
+    family: null,
+    brand: null,
+    model: null
+  }
+};
+
+describe('Amplitude user properties mapper', () => {
+  it('should copy some values directly from the context', () => {
+    const userProperties = mapAmplitudeUserProperties(
+      mockEvent,
+      {
+        ...mockContext,
+        entrypoint: 'foo',
+        entrypoint_experiment: 'wibble',
+        entrypoint_variation: 'quuz',
+        flowId: 'smoothflow',
+        utm_campaign: 'best',
+        utm_content: 'campaign',
+        utm_medium: 'of',
+        utm_source: 'all',
+        utm_term: 'time'
+      },
+      mockParsedUserAgent
+    );
+    assert.equal(userProperties.entrypoint, 'foo');
+    assert.equal(userProperties.entrypoint_experiment, 'wibble');
+    assert.equal(userProperties.entrypoint_variation, 'quuz');
+    assert.equal(userProperties.flow_id, 'smoothflow');
+    assert.equal(userProperties.utm_campaign, 'best');
+    assert.equal(userProperties.utm_content, 'campaign');
+    assert.equal(userProperties.utm_medium, 'of');
+    assert.equal(userProperties.utm_source, 'all');
+    assert.equal(userProperties.utm_term, 'time');
+  });
+
+  it('should map brower properties from user agent properties', () => {
+    const userProperties = mapAmplitudeUserProperties(mockEvent, mockContext, mockParsedUserAgent);
+    assert.equal(userProperties.ua_browser, 'WaterCat');
+    assert.equal(userProperties.ua_version, '66.12.0');
+  });
+
+  describe('sync devices mapping', () => {
+    it('should be undefined when "devices" is not in the context', () => {
+      const userProperties = mapAmplitudeUserProperties(
+        mockEvent,
+        mockContext,
+        mockParsedUserAgent
+      );
+      assert.isUndefined(userProperties.sync_device_count);
+      assert.isUndefined(userProperties.sync_active_devices_day);
+      assert.isUndefined(userProperties.sync_active_devices_week);
+      assert.isUndefined(userProperties.sync_active_devices_month);
+    });
+
+    it('should map sync device properties correctly', () => {
+      const aMomentInTime = Date.now();
+      const wiggle = 360000;
+      const lessThanADayAgo = aMomentInTime - 86400000 + wiggle;
+      const lessThanAWeekAgo = aMomentInTime - 604800000 + wiggle;
+      const lessThanAMonthAgo = aMomentInTime - 2419200000 + wiggle;
+      const moreThanAMonthAgo = aMomentInTime - 2419200000 - 2419200000;
+      const userProperties = mapAmplitudeUserProperties(
+        mockEvent,
+        {
+          ...mockContext,
+          devices: [
+            { lastAccessTime: lessThanADayAgo },
+            { lastAccessTime: lessThanADayAgo },
+            { lastAccessTime: lessThanAWeekAgo },
+            { lastAccessTime: lessThanAMonthAgo },
+            { lastAccessTime: moreThanAMonthAgo }
+          ]
+        },
+        mockParsedUserAgent
+      );
+      assert.equal(userProperties.sync_device_count, 5);
+      assert.equal(userProperties.sync_active_devices_day, 2);
+      assert.equal(userProperties.sync_active_devices_week, 3);
+      assert.equal(userProperties.sync_active_devices_month, 4);
+    });
+  });
+
+  describe('sync engines mapping', () => {
+    it('should be undefined when "syncEngines" is not in the context', () => {
+      const userProperties = mapAmplitudeUserProperties(
+        mockEvent,
+        mockContext,
+        mockParsedUserAgent
+      );
+      assert.isUndefined(userProperties.sync_engines);
+    });
+
+    it('should map sync engines correctly', () => {
+      const syncEngines = ['Firefox', 'SpaceTuna'];
+      const userProperties = mapAmplitudeUserProperties(
+        mockEvent,
+        { ...mockContext, syncEngines },
+        mockParsedUserAgent
+      );
+      assert.deepEqual(userProperties.sync_engines, syncEngines);
+    });
+  });
+
+  describe('newsletter state mapping', () => {
+    it('should be undefined when the event does not have category', () => {
+      const userProperties = mapAmplitudeUserProperties(
+        mockEvent,
+        mockContext,
+        mockParsedUserAgent
+      );
+      assert.isUndefined(userProperties.newsletter_state);
+    });
+
+    it('should be undefined when the event cateory is not a newsletter state key', () => {
+      const userProperties = mapAmplitudeUserProperties(
+        { ...mockEvent, category: 'inbetween' },
+        mockContext,
+        mockParsedUserAgent
+      );
+      assert.isUndefined(userProperties.newsletter_state);
+    });
+
+    it('should map correctly when the event category is a newsletter state key', () => {
+      let userProperties = mapAmplitudeUserProperties(
+        { ...mockEvent, category: 'optIn' },
+        mockContext,
+        mockParsedUserAgent
+      );
+      assert.equal(userProperties.newsletter_state, 'subscribed');
+
+      userProperties = mapAmplitudeUserProperties(
+        { ...mockEvent, category: 'optOut' },
+        mockContext,
+        mockParsedUserAgent
+      );
+      assert.equal(userProperties.newsletter_state, 'unsubscribed');
+    });
+
+    it('should map correctly with "marketingOptIn" in the context', () => {
+      let userProperties = mapAmplitudeUserProperties(
+        { ...mockEvent, category: 'inbetween' },
+        { ...mockContext, marketingOptIn: true },
+        mockParsedUserAgent
+      );
+      assert.equal(userProperties.newsletter_state, 'subscribed');
+
+      userProperties = mapAmplitudeUserProperties(
+        { ...mockEvent, category: 'inbetween' },
+        { ...mockContext, marketingOptIn: false },
+        mockParsedUserAgent
+      );
+      assert.equal(userProperties.newsletter_state, 'unsubscribed');
+    });
+  });
+
+  describe('newsletters mapper', () => {
+    it('should be undefined when "newsletters" is not in the context', () => {
+      const userProperties = mapAmplitudeUserProperties(
+        mockEvent,
+        mockContext,
+        mockParsedUserAgent
+      );
+      assert.isUndefined(userProperties.newsletters);
+    });
+
+    it('should map newsletters correctly', () => {
+      const userProperties = mapAmplitudeUserProperties(
+        mockEvent,
+        {
+          ...mockContext,
+          newsletters: ['firefox-accounts-journey', 'knowledge-is-power']
+        },
+        mockParsedUserAgent
+      );
+      assert.deepEqual(userProperties.newsletters, [
+        'firefox_accounts_journey',
+        'knowledge_is_power'
+      ]);
+    });
+  });
+});

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/version.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/version.spec.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import 'mocha';
+
+import { getVersion } from '../../../../lib/amplitude/transforms/version';
+
+describe('version string matcher', () => {
+  it('should return correct FxA version number', () => {
+    const expected = '166.1';
+    const actual = getVersion('1.166.1');
+    assert.equal(actual, expected);
+  });
+});

--- a/packages/fxa-shared/metrics/user-agent.d.ts
+++ b/packages/fxa-shared/metrics/user-agent.d.ts
@@ -1,0 +1,25 @@
+export type ParsedUa = {
+  family: string | null;
+  major: string | null;
+  minor: string | null;
+  patch: string | null;
+  toVersionString: () => string;
+};
+export type ParsedOs = ParsedUa & {
+  patchMinor: string | null;
+};
+export type ParsedDevice = {
+  family: string | null;
+  brand: string | null;
+  model: string | null;
+};
+
+export type ParsedUserAgentProperties = {
+  ua: ParsedUa;
+  os: ParsedOs;
+  device: ParsedDevice;
+};
+
+export function parse(uaString: string | undefined): ParsedUserAgentProperties;
+
+export function isToVersionStringSupported(ua: ParsedUa): boolean;


### PR DESCRIPTION
This patch introduces a function that takes a services map, events map,
and fuzzy events map, and returns a function that accepts a "raw"
Amplitude event and its context and produces the payload for an
Amplitude HTTP API request.

Fixes #4700 (FXA-1447)