### PR TITLE
fix(deeplink): Revert deeplink used on Android

### DIFF
--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -590,11 +590,19 @@ const conf = (module.exports = convict({
           format: String,
         },
       },
-      targetURITemplate: {
+      targetURITemplateiOS: {
         default:
           'https://app.adjust.com/jsr?url=https%3A%2F%2Fnn8g.adj.st%2Ffxa-signin%3Futm_source%3Dsms%26signin%3D${ signinCode }%26adj_t%3D${ channel }%26adj_campaign%3Dfxa-conf-page%26adj_adgroup%3Dsms%26adj_creative%3Dlink%26adjust_deeplink_js%3D1', //eslint-disable-line max-len
         doc:
-          'Redirect URI - ES6 format template string. The variables `channel` and `signinCode` are interpolated',
+          'iOS Redirect URI - ES6 format template string. The variables `channel` and `signinCode` are interpolated',
+        env: 'SMS_REDIRECT_TARGET_URI_TEMPLATE_IOS',
+        format: String,
+      },
+      targetURITemplate: {
+        default:
+          'https://app.adjust.com/${ channel }?campaign=fxa-conf-page&adgroup=sms&creative=link&deep_link=firefox%3A%2F%2Ffxa-signin%3Futm_source%3Dsms%26signin%3D${ signinCode }', //eslint-disable-line max-len
+        doc:
+          'Default Redirect URI - ES6 format template string. The variables `channel` and `signinCode` are interpolated',
         env: 'SMS_REDIRECT_TARGET_URI_TEMPLATE',
         format: String,
       },

--- a/packages/fxa-content-server/tests/server/routes/redirect-m-to-adjust.js
+++ b/packages/fxa-content-server/tests/server/routes/redirect-m-to-adjust.js
@@ -117,6 +117,42 @@ registerSuite('routes/get-app', {
             },
           },
         },
+
+        'route.process with iOS device': {
+          before: function() {
+            request = {
+              params: {
+                signinCode: '12345678',
+              },
+              query: {
+                channel: 'beta',
+              },
+              headers: {
+                'user-agent':
+                  'Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10',
+              },
+            };
+            response = { redirect: sinon.spy() };
+            instance.process(request, response);
+          },
+          tests: {
+            'response.redirect was called correctly': function() {
+              assert.equal(response.redirect.callCount, 1);
+
+              const statusCode = response.redirect.args[0][0];
+              assert.equal(statusCode, 302);
+
+              const targetUrl = response.redirect.args[0][1];
+              assert.equal(
+                targetUrl,
+                _.template(config.get('sms.redirect.targetURITemplateiOS'))({
+                  channel: config.get('sms.redirect.channels.beta'),
+                  signinCode: '12345678',
+                })
+              );
+            },
+          },
+        },
       },
     },
   },

--- a/packages/fxa-settings/tsconfig.json
+++ b/packages/fxa-settings/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -15,6 +19,8 @@
     "noEmit": true,
     "jsx": "react"
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "extends": "../fxa-components/tsconfig.common.json"
 }


### PR DESCRIPTION
Lets revert the Android deeplink in https://github.com/mozilla/fxa/pull/4777 while debugging https://github.com/mozilla/fxa/issues/5069.

This keeps the iOS deeplink since it appears to be working per this [dashboard](https://analytics.amplitude.com/mozilla-corp/chart/scj19m8).

Since this is a regression, I would like to target train-167 as a point release.