### PR TITLE
feat(metrics): create $identify Amplitude payload from raw event

### DIFF
--- a/packages/fxa-metrics-processor/src/lib/amplitude/index.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/index.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  Services,
+  PlainEvents,
+  FuzzyEvents,
+  RawEvent,
+  EventContext,
+  AmplitudeHttpEvent,
+} from './transforms/types';
+import { createServiceNameAndClientIdMapper } from './transforms/common';
+import { createAmplitudeEventTransformer } from './transforms/amplitude-event';
+import {
+  createAmplitudeIdentityEvent,
+  AmplitudeIdentifyEvent,
+} from './transforms/amplitude-identify';
+
+export type AmplitudeRequestPayloads = {
+  http: AmplitudeHttpEvent;
+  identify?: AmplitudeIdentifyEvent;
+};
+
+/**
+ * Create a transform function from the given mappings.  A transform function
+ * should be created per service (specifically for each of the "eventSource"
+ * values in RawEvent).
+ *
+ * The transform function returns an object keyed by the Amplitude API for
+ * which the value is intended.  There are two possible keys: "http" and
+ * "identify".
+ *
+ * The "identify" property is optional.  However, if it does exist, then the
+ * API request for it MUST be ahead of the request for the http API.
+ *
+ * @param services An object of client-id:service-name mappings
+ * @param plainEvents  An object of name:definition event mappings, where
+ *                     each definition value is itself an object with `group`
+ *                     and `event` string properties.
+ *
+ * @param fuzzyEvents A map of regex:definition event mappings. Each regex
+ *                    key may include up to two capturing groups. The first
+ *                    group is used as the event "category" and the second is
+ *                    used as the event "target". Again each definition value
+ *                    is an object containing `group` and `event` properties
+ *                    but here `group` can be a string or a function. If it's
+ *                    a function, it will be passed the matched category
+ *                    as its argument and should return the group string.
+ */
+export function createAmplitudePayloadsTransfromer(
+  services: Services,
+  plainEvents: PlainEvents,
+  fuzzyEvent: FuzzyEvents
+) {
+  const servicePropsMapper = createServiceNameAndClientIdMapper(services);
+  const amplitudeHttpEventTransformer = createAmplitudeEventTransformer(
+    plainEvents,
+    fuzzyEvent,
+    servicePropsMapper
+  );
+
+  return (event: RawEvent, context: EventContext): AmplitudeRequestPayloads | null => {
+    const httpApiPayload = amplitudeHttpEventTransformer(event, context);
+
+    if (!httpApiPayload) {
+      return null;
+    }
+
+    const payloads: AmplitudeRequestPayloads = {
+      http: httpApiPayload,
+    };
+
+    const identifyApiPayload = createAmplitudeIdentityEvent(
+      context,
+      httpApiPayload,
+      servicePropsMapper
+    );
+
+    if (identifyApiPayload) {
+      payloads.identify = identifyApiPayload;
+    }
+
+    return payloads;
+  };
+}

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/amplitude-identify.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/amplitude-identify.ts
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AmplitudeHttpEvent, EventContext } from './types';
+import { ServiceNameAndClientIdMapper, toSnakeCase } from './common';
+
+// See https://developers.amplitude.com/?javascript#identify-api
+
+// Event though we include all these verbs here, only $append is used in practice.
+const IDENTIFY_VERBS = ['$set', '$setOnce', '$add', '$append', '$prepend', '$unset'] as const;
+type IdentifyVerb = typeof IDENTIFY_VERBS[number];
+export type AmplitudeIdentifyEvent = {
+  device_id?: AmplitudeHttpEvent['device_id'];
+  event_type: '$identify';
+  user_id: AmplitudeHttpEvent['user_id'];
+  user_properties: IdentifyEventUserProperties;
+};
+type IdentifyEventUserProperties = {
+  [key in Exclude<IdentifyVerb, '$append'>]?: { [key: string]: {} };
+} & {
+  $append?: AppendUserProperties;
+};
+type AppendUserProperties = {
+  [key: string]: string | string[];
+};
+
+/**
+ * Create the payload for an Amplitude "identify" event.  Currently this _only_
+ * uses `$append` because historically that's what FxA services did.
+ *
+ * @param context Raw event context
+ * @param amplitudeEventHttpEvent The Amplitude http/batch API payload
+ *                                associated with the identify event
+ * @param servicePropMapper A function for mapping service names and client ids
+ */
+export function createAmplitudeIdentityEvent(
+  context: EventContext,
+  amplitudeEventHttpEvent: AmplitudeHttpEvent,
+  servicePropMapper: ServiceNameAndClientIdMapper
+): AmplitudeIdentifyEvent | null {
+  const servicesUsed = mapServicesUsed(servicePropMapper, context);
+  const experiments = mapExperiments(context);
+  const userPreferences = mapUserPreferences(context);
+
+  if (servicesUsed || experiments || userPreferences) {
+    return {
+      device_id: amplitudeEventHttpEvent.device_id,
+      event_type: '$identify',
+      user_id: amplitudeEventHttpEvent.user_id,
+      user_properties: {
+        $append: {
+          ...servicesUsed,
+          ...experiments,
+          ...userPreferences,
+        },
+      },
+    };
+  }
+
+  return null;
+}
+
+function mapServicesUsed(servicePropMapper: ServiceNameAndClientIdMapper, context: EventContext) {
+  const { serviceName } = servicePropMapper(context);
+
+  if (serviceName) {
+    return {
+      fxa_services_used: serviceName,
+    };
+  }
+
+  return null;
+}
+
+function mapExperiments(context: EventContext) {
+  const { experiments } = context;
+
+  if (Array.isArray(experiments) && experiments.length > 0) {
+    return {
+      experiments: experiments.map((e) => `${toSnakeCase(e.choice)}_${toSnakeCase(e.group)}`),
+    };
+  }
+
+  return null;
+}
+
+function mapUserPreferences(context: EventContext) {
+  const { userPreferences } = context;
+
+  // Don't send user preferences metric if there are none!
+  if (!userPreferences || Object.keys(userPreferences).length === 0) {
+    return null;
+  }
+
+  return Object.keys(userPreferences).reduce((prefs: { [key: string]: string }, k) => {
+    prefs[toSnakeCase(k)] = userPreferences[k];
+    return prefs;
+  }, {});
+}

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/common.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/common.ts
@@ -40,7 +40,7 @@ export function mapLocation(context: EventContext): LocationProperties | {} {
     if (('country' in location && location.country) || ('state' in location && location.state)) {
       return {
         country: location?.country,
-        region: location?.state
+        region: location?.state,
       };
     }
   }
@@ -66,21 +66,21 @@ export function tee(rawEvent: RawEvent, context: EventContext) {
     device_id: context.deviceId,
     session_id: context.flowBeginTime,
     language: context.lang,
-    user_id: context.uid
+    user_id: context.uid,
   };
 }
 
 export function toSnakeCase(camelS: string) {
   return camelS
     .replace(/([a-z])([A-Z])/g, (s, c1, c2) => `${c1}_${c2.toLowerCase()}`)
-    .replace(/([A-Z])/g, c => c.toLowerCase())
+    .replace(/([A-Z])/g, (c) => c.toLowerCase())
     .replace(/\./g, '_')
     .replace(/-/g, '_');
 }
 
 export function sha256Hmac(HMAC_KEY: string, ...properties: any[]) {
   const hmac = crypto.createHmac('sha256', HMAC_KEY);
-  properties.forEach(property => {
+  properties.forEach((property) => {
     if (property) {
       hmac.update(`${property}`);
     }

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/event-properties.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/event-properties.ts
@@ -32,7 +32,7 @@ const EVENT_PROPERTIES: {
   [GROUPS.subPayManage]: NOP,
   [GROUPS.subPaySetup]: NOP,
   [GROUPS.subPayUpgrade]: NOP,
-  [GROUPS.subSupport]: NOP
+  [GROUPS.subSupport]: NOP,
 } as const;
 
 const CONNECT_DEVICE_FLOWS = {
@@ -40,7 +40,7 @@ const CONNECT_DEVICE_FLOWS = {
   install_from: 'store_buttons',
   pair: 'pairing',
   signin_from: 'signin',
-  sms: 'sms'
+  sms: 'sms',
 } as const;
 
 type ConnectDeviceFlowKeys = keyof typeof CONNECT_DEVICE_FLOWS;
@@ -83,7 +83,7 @@ export function createAmplitudeEventPropertiesMapper(
       product_id: context.productId,
       service,
       oauth_client_id: oauthClientId,
-      ...mapAmplitudeEventPropertiesFromGroup(evt, context)
+      ...mapAmplitudeEventPropertiesFromGroup(evt, context),
     };
   };
 }
@@ -125,7 +125,7 @@ function mapEmailType(evt: Event, context: EventContext): EmailTypeEventProperti
       email_type: emailType,
       email_provider: context.emailDomain,
       email_sender: context.emailSender,
-      email_service: context.emailService
+      email_service: context.emailService,
     };
 
     const { templateVersion } = context;

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/event-type.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/event-type.ts
@@ -58,7 +58,7 @@ export function createEventTypeMapper(events: PlainEvents, fuzzyEvents: FuzzyEve
         type: evtType,
         group: evtGroup,
         category: evtCategory,
-        target: evtTarget
+        target: evtTarget,
       };
     }
 

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/types.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/types.ts
@@ -23,7 +23,7 @@ export enum GROUPS {
   subPayManage = 'fxa_pay_manage',
   subPaySetup = 'fxa_pay_setup',
   subPayUpgrade = 'fxa_pay_upgrade',
-  subSupport = 'fxa_subscribe_support'
+  subSupport = 'fxa_subscribe_support',
 }
 
 export type OptionalString = string | null;
@@ -79,7 +79,6 @@ export type EventContext = {
   flowId?: string;
   lang?: string;
   location?: Location | {};
-  marketingOptIn?: boolean;
   newsletters?: Newsletter[];
   planId?: string;
   productId?: string;
@@ -110,6 +109,7 @@ export type AmplitudeHttpEvent = {
   region?: string;
   os_name?: string;
   os_version?: string;
+  device_model?: string;
   event_properties: AmplitudeEventProperties;
   user_properties: AmplitudeUserProperties;
 };

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/user-agent.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/user-agent.ts
@@ -28,7 +28,7 @@ function mapUserAgentProperties(
     if (family && family !== 'Other') {
       return {
         [familyProperty]: family,
-        [versionProperty]: group.toVersionString()
+        [versionProperty]: group.toVersionString(),
       };
     }
   }

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/user-properties.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/user-properties.ts
@@ -13,7 +13,7 @@ const FOUR_WEEKS = WEEK * 4;
 
 const NEWSLETTER_STATES = {
   optIn: 'subscribed',
-  optOut: 'unsubscribed'
+  optOut: 'unsubscribed',
 } as const;
 type NewsLetterStates = typeof NEWSLETTER_STATES;
 type NewsLetterStateKey = keyof NewsLetterStates;
@@ -62,7 +62,7 @@ export function mapAmplitudeUserProperties(
     utm_content,
     utm_medium,
     utm_source,
-    utm_term
+    utm_term,
   } = context;
 
   return {
@@ -79,7 +79,7 @@ export function mapAmplitudeUserProperties(
     ...mapSyncDevices(context),
     ...mapSyncEngines(context),
     ...mapNewsletterState(evt, context),
-    ...mapNewsletters(context)
+    ...mapNewsletters(context),
   };
 }
 
@@ -91,7 +91,7 @@ function mapSyncDevices(context: EventContext): SyncDevices | {} {
       sync_device_count: devices.length,
       sync_active_devices_day: countDevices(devices, DAY),
       sync_active_devices_week: countDevices(devices, WEEK),
-      sync_active_devices_month: countDevices(devices, FOUR_WEEKS)
+      sync_active_devices_month: countDevices(devices, FOUR_WEEKS),
     };
   }
 
@@ -99,7 +99,7 @@ function mapSyncDevices(context: EventContext): SyncDevices | {} {
 }
 
 function countDevices(devices: Device[], period: number) {
-  return devices.filter(device => device.lastAccessTime >= Date.now() - period).length;
+  return devices.filter((device) => device.lastAccessTime >= Date.now() - period).length;
 }
 
 function mapSyncEngines(context: EventContext): SyncEngines | {} {
@@ -118,14 +118,6 @@ function mapNewsletterState(evt: Event, context: EventContext): NewsLetterStateP
     newsletterState = NEWSLETTER_STATES[evt.category as NewsLetterStateKey];
   }
 
-  if (!newsletterState) {
-    const { marketingOptIn } = context;
-
-    if (marketingOptIn === true || marketingOptIn === false) {
-      newsletterState = marketingOptIn ? 'subscribed' : 'unsubscribed';
-    }
-  }
-
   if (newsletterState) {
     return { newsletter_state: newsletterState };
   }
@@ -136,7 +128,7 @@ function mapNewsletterState(evt: Event, context: EventContext): NewsLetterStateP
 function mapNewsletters(context: EventContext): NewsLettersProp | {} {
   const { newsletters: newslettersFromCtx } = context;
   if (newslettersFromCtx) {
-    const newsletters = newslettersFromCtx.map(newsletter => {
+    const newsletters = newslettersFromCtx.map((newsletter) => {
       return toSnakeCase(newsletter);
     });
     return { newsletters };

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/index.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/index.spec.ts
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import 'mocha';
+import sinon from 'sinon';
+
+import Config from '../../../config';
+const config = Config.getProperties();
+sinon.stub(Config, 'getProperties').returns({ ...config, amplitude: { hmac_key: '00000001' } });
+
+import { createAmplitudePayloadsTransfromer } from '../../../../src/lib/amplitude/index';
+import { GROUPS, PlainEvents, OptionalString } from '../../../lib/amplitude/transforms/types';
+
+const services = { foo: 'bar', fizz: 'buzz', level: 'over9000' };
+const plainEvents: PlainEvents = {
+  'quuz.wibble.success': {
+    group: GROUPS.login,
+    event: 'complete',
+  },
+};
+const fuzzyEvents = new Map();
+
+const mockRawEvent = {
+  type: 'quuz.wibble.success',
+  offset: 3401,
+  time: 1586282560373,
+  flowTime: 3390,
+};
+const mockEventContext = {
+  eventSource: 'content' as const,
+  version: '1.165.1',
+  userAgent:
+    'Mozilla/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Mobile/11A465',
+  deviceId: '96695ff7380546e78f1f5e703e4b6297',
+  flowBeginTime: 1586282556983,
+  flowId: '49e98367149d8a7299c0dfdc2fe8093a6d4625fc5e28612ddce906cf3e518d01',
+  lang: 'gd',
+  uid: '98393a6d46267149d86299c25fc5e286',
+};
+
+const amplitudePayloadsMapper = createAmplitudePayloadsTransfromer(
+  services,
+  plainEvents,
+  fuzzyEvents
+);
+
+describe('Amplitude payloads transformer', () => {
+  it('should return null if no http API can be constructed', () => {
+    const actual = amplitudePayloadsMapper(
+      {
+        ...mockRawEvent,
+        type: 'quuz.endless.void.success',
+      },
+      {
+        eventSource: 'content' as const,
+        version: '1.165.1',
+      }
+    );
+    assert.isNull(actual);
+  });
+
+  it('should return only the http API payload in the "http" property', () => {
+    const actual = amplitudePayloadsMapper(mockRawEvent, mockEventContext);
+    assert.deepEqual(actual, {
+      http: {
+        app_version: '165.1',
+        device_id: '96695ff7380546e78f1f5e703e4b6297',
+        device_model: 'iPad',
+        event_properties: {},
+        event_type: 'fxa_login - complete',
+        insert_id: '84e4a5a990eebcc667aa87b58ec49958e6ebaa3171f7103af0d2be45231e7498',
+        language: 'gd',
+        op: 'amplitudeEvent',
+        os_name: 'iOS',
+        os_version: '7.0',
+        session_id: 1586282556983,
+        time: 1586282560373,
+        user_id: '372fa79f3632257f6421ccfd86eae2d631f7284b59ae9876d8c88fa1ae0f408f',
+        user_properties: {
+          flow_id: '49e98367149d8a7299c0dfdc2fe8093a6d4625fc5e28612ddce906cf3e518d01',
+        },
+      },
+    });
+  });
+
+  it('should return the http add identify API payloads', () => {
+    const actual = amplitudePayloadsMapper(mockRawEvent, {
+      ...mockEventContext,
+      service: 'dcdb5ae7add825d2',
+      syncEngines: ['bookmarks', 'history'],
+    });
+    assert.deepEqual(actual, {
+      http: {
+        app_version: '165.1',
+        device_id: '96695ff7380546e78f1f5e703e4b6297',
+        device_model: 'iPad',
+        event_properties: {
+          oauth_client_id: 'dcdb5ae7add825d2',
+          service: 'undefined_oauth',
+        },
+        event_type: 'fxa_login - complete',
+        insert_id: '84e4a5a990eebcc667aa87b58ec49958e6ebaa3171f7103af0d2be45231e7498',
+        language: 'gd',
+        op: 'amplitudeEvent',
+        os_name: 'iOS',
+        os_version: '7.0',
+        session_id: 1586282556983,
+        time: 1586282560373,
+        user_id: '372fa79f3632257f6421ccfd86eae2d631f7284b59ae9876d8c88fa1ae0f408f',
+        user_properties: {
+          flow_id: '49e98367149d8a7299c0dfdc2fe8093a6d4625fc5e28612ddce906cf3e518d01',
+          sync_engines: ['bookmarks', 'history'],
+        },
+      },
+      identify: {
+        device_id: '96695ff7380546e78f1f5e703e4b6297',
+        event_type: '$identify',
+        user_id: '372fa79f3632257f6421ccfd86eae2d631f7284b59ae9876d8c88fa1ae0f408f',
+        user_properties: {
+          $append: {
+            fxa_services_used: 'undefined_oauth',
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/amplitude-event.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/amplitude-event.spec.ts
@@ -4,33 +4,27 @@
 
 import { assert } from 'chai';
 import 'mocha';
-import sinon from 'sinon';
-
-import Config from '../../../../config';
-const config = Config.getProperties();
-const ConfigPropertiesStub = sinon
-  .stub(Config, 'getProperties')
-  .returns({ ...config, amplitude: { hmac_key: '00000001' } });
 
 import { createAmplitudeEventTransformer } from '../../../../lib/amplitude/transforms/amplitude-event';
 import {
   Services,
   PlainEvents,
   GROUPS,
-  OptionalString
+  OptionalString,
 } from '../../../../lib/amplitude/transforms/types';
+import { createServiceNameAndClientIdMapper } from '../../../../lib/amplitude/transforms/common';
 
 const services: Services = { foo: 'bar', fizz: 'buzz', level: 'over9000' };
 
 const eventsMap: PlainEvents = {
   'oauth.signup.success': {
     group: GROUPS.registration,
-    event: 'quuxed'
+    event: 'quuxed',
   },
   'quuz.wibble.success': {
     group: GROUPS.login,
-    event: 'complete'
-  }
+    event: 'complete',
+  },
 };
 
 const fuzzyEvents = new Map([
@@ -38,9 +32,9 @@ const fuzzyEvents = new Map([
     /^foo\.(bar)\.passwordStrength\.(buzz)$/,
     {
       group: GROUPS.registration,
-      event: (category: OptionalString) => `password_${category}`
-    }
-  ]
+      event: (category: OptionalString) => `password_${category}`,
+    },
+  ],
 ]);
 
 const eventContext = {
@@ -49,10 +43,10 @@ const eventContext = {
   emailTypes: {
     'complete-reset-password': 'reset_password',
     'complete-signin': 'login',
-    'verify-email': 'registration'
+    'verify-email': 'registration',
   },
   userAgent:
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:40.0) Gecko/20100101 Firefox/40.0 FxATester/1.0',
+    'Mozilla/5.0 (Linux; Android 4.4.2; Nexus 7 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36',
   deviceId: '96695ff7380546e78f1f5e703e4b6297',
   emailDomain: 'other',
   entrypoint_experiment: 'none',
@@ -71,22 +65,20 @@ const eventContext = {
   utm_content: 'none',
   utm_medium: 'none',
   utm_source: 'none',
-  utm_term: 'none'
+  utm_term: 'none',
 };
 
-describe('Amplitude event transfomer', () => {
-  const transform = createAmplitudeEventTransformer(services, eventsMap, fuzzyEvents);
+const servicePropsMapper = createServiceNameAndClientIdMapper(services);
 
-  after(() => {
-    ConfigPropertiesStub.restore();
-  });
+describe('Amplitude event transfomer', () => {
+  const transform = createAmplitudeEventTransformer(eventsMap, fuzzyEvents, servicePropsMapper);
 
   it('uses the given events map to tranform a plain event correctly', () => {
     const rawEvent = {
       type: 'quuz.wibble.success',
       offset: 3401,
       time: 1586282560373,
-      flowTime: 3390
+      flowTime: 3390,
     };
     const actual = transform(rawEvent, eventContext);
     const expected = {
@@ -96,21 +88,22 @@ describe('Amplitude event transfomer', () => {
       time: 1586282560373,
       user_id: '372fa79f3632257f6421ccfd86eae2d631f7284b59ae9876d8c88fa1ae0f408f',
       device_id: '96695ff7380546e78f1f5e703e4b6297',
+      device_model: 'Asus Nexus 7',
       session_id: 1586282556983,
       app_version: '165.1',
       language: 'en',
-      os_name: 'Mac OS X',
-      os_version: '10.10',
+      os_name: 'Android',
+      os_version: '4.4.2',
       event_properties: {
         service: 'undefined_oauth',
-        oauth_client_id: 'dcdb5ae7add825d2'
+        oauth_client_id: 'dcdb5ae7add825d2',
       },
       user_properties: {
         flow_id: '49e98367149d8a7299c0dfdc2fe8093a6d4625fc5e28612ddce906cf3e518d01',
-        ua_browser: 'Firefox',
-        ua_version: '40.0',
-        sync_engines: ['bookmarks', 'history']
-      }
+        ua_browser: 'Chrome',
+        ua_version: '31.0.1650',
+        sync_engines: ['bookmarks', 'history'],
+      },
     };
     assert.deepEqual(actual, expected);
   });
@@ -120,12 +113,12 @@ describe('Amplitude event transfomer', () => {
       type: 'foo.bar.passwordStrength.buzz',
       offset: 3401,
       time: 1586282560373,
-      flowTime: 3390
+      flowTime: 3390,
     };
     const actual = transform(rawEvent, {
       ...eventContext,
       planId: 'quuz',
-      productId: 'hotcakes'
+      productId: 'hotcakes',
     });
     const expected = {
       insert_id: '89c3ccfe6dcd4cd966432f0b920ccfe40ea0635f369d9f2d84b95ad21037ec3e',
@@ -134,23 +127,24 @@ describe('Amplitude event transfomer', () => {
       time: 1586282560373,
       user_id: '372fa79f3632257f6421ccfd86eae2d631f7284b59ae9876d8c88fa1ae0f408f',
       device_id: '96695ff7380546e78f1f5e703e4b6297',
+      device_model: 'Asus Nexus 7',
       session_id: 1586282556983,
       app_version: '165.1',
       language: 'en',
-      os_name: 'Mac OS X',
-      os_version: '10.10',
+      os_name: 'Android',
+      os_version: '4.4.2',
       event_properties: {
         service: 'undefined_oauth',
         plan_id: 'quuz',
         product_id: 'hotcakes',
-        oauth_client_id: 'dcdb5ae7add825d2'
+        oauth_client_id: 'dcdb5ae7add825d2',
       },
       user_properties: {
         flow_id: '49e98367149d8a7299c0dfdc2fe8093a6d4625fc5e28612ddce906cf3e518d01',
-        ua_browser: 'Firefox',
-        ua_version: '40.0',
-        sync_engines: ['bookmarks', 'history']
-      }
+        ua_browser: 'Chrome',
+        ua_version: '31.0.1650',
+        sync_engines: ['bookmarks', 'history'],
+      },
     };
     assert.deepEqual(actual, expected);
   });

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/amplitude-identify.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/amplitude-identify.spec.ts
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import 'mocha';
+
+import { createAmplitudeIdentityEvent } from '../../../../lib/amplitude/transforms/amplitude-identify';
+import { createServiceNameAndClientIdMapper } from '../../../../lib/amplitude/transforms/common';
+
+const services = { foo: 'bar', fizz: 'buzz', level: 'over9000' };
+const servicePropsMapper = createServiceNameAndClientIdMapper(services);
+
+const mockEventContext = {
+  eventSource: 'content' as const,
+  version: '1.165.1',
+};
+const mockAmplitudeHttpEvent = {
+  insert_id: '84e4a5a990eebcc667aa87b58ec49958e6ebaa3171f7103af0d2be45231e7498',
+  op: 'amplitudeEvent' as const,
+  event_type: 'fxa_login - complete',
+  time: 1586282560373,
+  user_id: '372fa79f3632257f6421ccfd86eae2d631f7284b59ae9876d8c88fa1ae0f408f',
+  device_id: '96695ff7380546e78f1f5e703e4b6297',
+  event_properties: {
+    service: 'undefined_oauth',
+    oauth_client_id: 'dcdb5ae7add825d2',
+  },
+  user_properties: {
+    flow_id: '49e98367149d8a7299c0dfdc2fe8093a6d4625fc5e28612ddce906cf3e518d01',
+    sync_engines: ['bookmarks', 'history'],
+  },
+};
+
+describe('Amplitude identify event transformer', () => {
+  it('should return null when there are no properties to send', () => {
+    const actual = createAmplitudeIdentityEvent(
+      mockEventContext,
+      mockAmplitudeHttpEvent,
+      servicePropsMapper
+    );
+    assert.isNull(actual);
+  });
+
+  it('should include the correct fxa_services_used', () => {
+    const actual = createAmplitudeIdentityEvent(
+      { ...mockEventContext, service: 'foo' },
+      mockAmplitudeHttpEvent,
+      servicePropsMapper
+    );
+    assert.equal(actual?.user_properties.$append?.fxa_services_used, 'bar');
+  });
+
+  it('should include the correct experiments', () => {
+    const actual = createAmplitudeIdentityEvent(
+      {
+        ...mockEventContext,
+        experiments: [
+          { choice: 'firstOne', group: 'topBunch' },
+          { choice: 'omega', group: 'alpha' },
+        ],
+      },
+      mockAmplitudeHttpEvent,
+      servicePropsMapper
+    );
+    assert.deepEqual(actual?.user_properties.$append?.experiments, [
+      'first_one_top_bunch',
+      'omega_alpha',
+    ]);
+  });
+
+  it('should include the correct user preferences', () => {
+    const actual = createAmplitudeIdentityEvent(
+      {
+        ...mockEventContext,
+        userPreferences: { yesGogo: 'ok', noNoGo: 'perhaps ok' },
+      },
+      mockAmplitudeHttpEvent,
+      servicePropsMapper
+    );
+    assert.deepEqual(actual?.user_properties.$append, {
+      yes_gogo: 'ok',
+      no_no_go: 'perhaps ok',
+    });
+  });
+
+  it('should create the identify payload correctly', () => {
+    const actual = createAmplitudeIdentityEvent(
+      {
+        ...mockEventContext,
+        experiments: [{ choice: 'firstOne', group: 'topBunch' }],
+        service: 'foo',
+        userPreferences: { yesGogo: 'ok ok' },
+      },
+      mockAmplitudeHttpEvent,
+      servicePropsMapper
+    );
+    assert.deepEqual(actual, {
+      device_id: mockAmplitudeHttpEvent.device_id,
+      event_type: '$identify',
+      user_id: mockAmplitudeHttpEvent.user_id,
+      user_properties: {
+        $append: {
+          fxa_services_used: 'bar',
+          experiments: ['first_one_top_bunch'],
+          yes_gogo: 'ok ok',
+        },
+      },
+    });
+  });
+});

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/common.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/common.spec.ts
@@ -12,13 +12,13 @@ import {
   mapLocation,
   tee,
   sha256Hmac,
-  prune
+  prune,
 } from '../../../../lib/amplitude/transforms/common';
 import { EventContext } from '../../../../lib/amplitude/transforms/types';
 
 const mockContext: EventContext = {
   eventSource: 'content',
-  version: '1.165.1'
+  version: '1.165.1',
 };
 const services = { foo: 'bar', fizz: 'buzz', level: 'over9000' };
 const mapper = createServiceNameAndClientIdMapper(services);
@@ -33,7 +33,7 @@ describe('service name and client id mapping', () => {
   it('should return a undefined service name and client id when "service" in context is "content-server"', () => {
     const props = mapper({
       ...mockContext,
-      service: 'content-server'
+      service: 'content-server',
     });
     assert.isUndefined(props.serviceName);
     assert.isUndefined(props.clientId);
@@ -42,7 +42,7 @@ describe('service name and client id mapping', () => {
   it('should return "sync" as service name when "service" in context is "sync"', () => {
     const props = mapper({
       ...mockContext,
-      service: 'sync'
+      service: 'sync',
     });
     assert.equal(props.serviceName, 'sync');
     assert.isUndefined(props.clientId);
@@ -51,7 +51,7 @@ describe('service name and client id mapping', () => {
   it('should return service name from services map when found', () => {
     const props = mapper({
       ...mockContext,
-      service: 'level'
+      service: 'level',
     });
     assert.equal(props.serviceName, 'over9000');
     assert.equal(props.clientId, 'level');
@@ -60,7 +60,7 @@ describe('service name and client id mapping', () => {
   it('should return "undefined_oauth" when service is not in services map', () => {
     const props = mapper({
       ...mockContext,
-      service: 'wibble'
+      service: 'wibble',
     });
     assert.equal(props.serviceName, 'undefined_oauth');
     assert.equal(props.clientId, 'wibble');
@@ -81,22 +81,22 @@ describe('location properties mapper', () => {
   it('should map the country correctly', () => {
     const actual = mapLocation({
       ...mockContext,
-      location: { country: 'United Devices of von Neumann', state: null }
+      location: { country: 'United Devices of von Neumann', state: null },
     });
     assert.deepEqual(actual, {
       country: 'United Devices of von Neumann',
-      region: null
+      region: null,
     });
   });
 
   it('should map the region correctly', () => {
     const actual = mapLocation({
       ...mockContext,
-      location: { country: null, state: 'Memory Palace' }
+      location: { country: null, state: 'Memory Palace' },
     });
     assert.deepEqual(actual, {
       country: null,
-      region: 'Memory Palace'
+      region: 'Memory Palace',
     });
   });
 
@@ -105,12 +105,12 @@ describe('location properties mapper', () => {
       ...mockContext,
       location: {
         country: 'United Devices of von Neumann',
-        state: 'Memory Palace'
-      }
+        state: 'Memory Palace',
+      },
     });
     assert.deepEqual(actual, {
       country: 'United Devices of von Neumann',
-      region: 'Memory Palace'
+      region: 'Memory Palace',
     });
   });
 });
@@ -122,7 +122,7 @@ describe('property pruning', () => {
       fuuz: null,
       fizz: undefined,
       extra: 'none',
-      level: 9001
+      level: 9001,
     });
     assert.deepEqual(actual, { foo: 'bar', level: 9001 });
   });
@@ -137,7 +137,7 @@ describe('property copying', () => {
         deviceId: 'wibble',
         flowBeginTime: 1586282556983,
         lang: 'gd',
-        uid: 'quuz'
+        uid: 'quuz',
       }
     );
     assert.deepEqual(actual, {
@@ -145,7 +145,7 @@ describe('property copying', () => {
       device_id: 'wibble',
       session_id: 1586282556983,
       language: 'gd',
-      user_id: 'quuz'
+      user_id: 'quuz',
     });
   });
 });

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/event-properties.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/event-properties.spec.ts
@@ -13,7 +13,7 @@ const services = { foo: 'bar', fizz: 'buzz', level: 'over9000' };
 const mockEvent: Event = { type: 'a', group: 'bs' };
 const mockContext: EventContext = {
   eventSource: 'content',
-  version: '1.165.1'
+  version: '1.165.1',
 };
 const mapper = createAmplitudeEventPropertiesMapper(createServiceNameAndClientIdMapper(services));
 
@@ -23,7 +23,7 @@ describe('Amplitude event properties mapper', () => {
       const eventProperties = mapper(mockEvent, {
         ...mockContext,
         planId: 'quux',
-        productId: 'wibble'
+        productId: 'wibble',
       });
       assert.equal(eventProperties.plan_id, 'quux');
       assert.equal(eventProperties.product_id, 'wibble');
@@ -34,7 +34,7 @@ describe('Amplitude event properties mapper', () => {
     it('should map properties to "service" and "oauth_client_id"', () => {
       const eventProperties = mapper(mockEvent, {
         ...mockContext,
-        service: 'level'
+        service: 'level',
       });
       assert.equal(eventProperties.service, 'over9000');
       assert.equal(eventProperties.oauth_client_id, 'level');
@@ -63,7 +63,7 @@ describe('Amplitude event properties mapper', () => {
           ...mockEvent,
           group: GROUPS.connectDevice,
           category: 'sms',
-          target: 'os2'
+          target: 'os2',
         },
         mockContext
       );
@@ -78,7 +78,7 @@ describe('Amplitude event properties mapper', () => {
         { ...mockEvent, group: GROUPS.email },
         {
           ...mockContext,
-          emailTypes: { 'complete-reset-password': 'reset_password' }
+          emailTypes: { 'complete-reset-password': 'reset_password' },
         }
       );
       assert.isUndefined(eventProperties.email_type);
@@ -104,7 +104,7 @@ describe('Amplitude event properties mapper', () => {
         { ...mockEvent, group: GROUPS.email, category: 'xyz' },
         {
           ...mockContext,
-          emailTypes: { 'complete-reset-password': 'reset_password' }
+          emailTypes: { 'complete-reset-password': 'reset_password' },
         }
       );
       assert.isUndefined(eventProperties.email_type);
@@ -120,14 +120,14 @@ describe('Amplitude event properties mapper', () => {
         {
           ...mockEvent,
           group: GROUPS.email,
-          category: 'complete-reset-password'
+          category: 'complete-reset-password',
         },
         {
           ...mockContext,
           emailTypes: { 'complete-reset-password': 'reset_password' },
           emailDomain: 'gg.fail',
           emailSender: 'abc',
-          emailService: 'xyz'
+          emailService: 'xyz',
         }
       );
       assert.equal(eventProperties.email_type, 'reset_password');
@@ -143,7 +143,7 @@ describe('Amplitude event properties mapper', () => {
         {
           ...mockEvent,
           group: GROUPS.email,
-          category: 'complete-reset-password'
+          category: 'complete-reset-password',
         },
         {
           ...mockContext,
@@ -151,7 +151,7 @@ describe('Amplitude event properties mapper', () => {
           emailDomain: 'gg.fail',
           emailSender: 'abc',
           emailService: 'xyz',
-          templateVersion: '9000'
+          templateVersion: '9000',
         }
       );
       assert.equal(eventProperties.email_type, 'reset_password');
@@ -177,7 +177,7 @@ describe('Amplitude event properties mapper', () => {
         {
           ...mockEvent,
           group: GROUPS.settings,
-          type: 'disconnect_device'
+          type: 'disconnect_device',
         },
         mockContext
       );
@@ -190,7 +190,7 @@ describe('Amplitude event properties mapper', () => {
           ...mockEvent,
           group: GROUPS.settings,
           type: 'disconnect_device',
-          category: 'gg'
+          category: 'gg',
         },
         mockContext
       );
@@ -212,7 +212,7 @@ describe('Amplitude event properties mapper', () => {
         {
           ...mockEvent,
           group: GROUPS.registration,
-          type: 'domain_validation_result'
+          type: 'domain_validation_result',
         },
         mockContext
       );
@@ -225,7 +225,7 @@ describe('Amplitude event properties mapper', () => {
           ...mockEvent,
           group: GROUPS.registration,
           type: 'domain_validation_result',
-          category: 'oops'
+          category: 'oops',
         },
         mockContext
       );

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/event-type.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/event-type.spec.ts
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 import { GROUPS, OptionalString } from '../../../../lib/amplitude/transforms/types';
 import {
   createEventTypeMapper,
-  createAmplitudeEventType
+  createAmplitudeEventType,
 } from '../../../../lib/amplitude/transforms/event-type';
 
 const eventCb = sinon
@@ -21,49 +21,49 @@ const nullCb = sinon.stub().returns(null);
 const PLAIN_EVENTS = {
   'foo.bar.fizz.quux': {
     group: GROUPS.login,
-    event: 'quuxed'
+    event: 'quuxed',
   },
   'quuz.wibble.success': {
     group: GROUPS.login,
-    event: 'complete'
-  }
+    event: 'complete',
+  },
 };
 const FUZZY_EVENTS = new Map([
   [
     /^experiment\.(control|chaos|rando)\.que\.(\w+)$/,
     {
       group: GROUPS.registration,
-      event: eventCb
-    }
+      event: eventCb,
+    },
   ],
   [
     /^settings\.clients\.disconnect\.submit\.([a-z]+)$/,
     {
       group: GROUPS.settings,
-      event: eventCb
-    }
+      event: eventCb,
+    },
   ],
   [
     /^screen\.(settings)\.two-step-authentication\.(gogo)$/,
     {
       group: GROUPS.settings,
-      event: nullCb
-    }
+      event: nullCb,
+    },
   ],
   [
     /^flow\.(party)\.down$/,
     {
       group: groupCb,
-      event: 'shell_beach_party'
-    }
+      event: 'shell_beach_party',
+    },
   ],
   [
     /^flow\.([\w-]+)\.engage$/,
     {
       group: nullCb,
-      event: 'engage'
-    }
-  ]
+      event: 'engage',
+    },
+  ],
 ]);
 
 describe('event type mapper', () => {
@@ -103,7 +103,7 @@ describe('event type mapper', () => {
       group: 'group_party',
       type: 'shell_beach_party',
       category: 'party',
-      target: null
+      target: null,
     };
     const actual = mapper('flow.party.down');
     assert.deepEqual(actual, expected);
@@ -114,7 +114,7 @@ describe('event type mapper', () => {
       group: GROUPS.registration,
       type: 'testo_chaos_lol',
       category: 'chaos',
-      target: 'lol'
+      target: 'lol',
     };
     const actual = mapper('experiment.chaos.que.lol');
     assert.deepEqual(actual, expected);
@@ -126,7 +126,7 @@ describe('event type mapper', () => {
         group: GROUPS.settings,
         type: 'testo_quux',
         category: 'quux',
-        target: null
+        target: null,
       };
       const actual = mapper('settings.clients.disconnect.submit.quux');
       assert.deepEqual(actual, expected);
@@ -138,7 +138,7 @@ describe('event type mapper', () => {
         group: GROUPS.registration,
         type: 'testo_chaos_lol',
         category: 'chaos',
-        target: 'lol'
+        target: 'lol',
       };
       const actual = mapper('experiment.chaos.que.lol');
       assert.deepEqual(actual, expected);
@@ -151,7 +151,7 @@ describe('event type mapper', () => {
       group: 'group_party',
       type: 'shell_beach_party',
       category: 'party',
-      target: null
+      target: null,
     };
     const actual = mapper('flow.party.down');
     assert.deepEqual(actual, expected);

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/user-agent.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/user-agent.spec.ts
@@ -13,7 +13,7 @@ const mockParsedUserAgent = {
     major: '66',
     minor: '12',
     patch: '0',
-    toVersionString: () => '66.12.0'
+    toVersionString: () => '66.12.0',
   },
   os: {
     family: 'OS2',
@@ -21,20 +21,20 @@ const mockParsedUserAgent = {
     minor: '135',
     patch: '3',
     patchMinor: 'q',
-    toVersionString: () => '10.135.3q'
+    toVersionString: () => '10.135.3q',
   },
   device: {
     family: 'iQod',
     brand: 'Kiwi',
-    model: 'fanciest'
-  }
+    model: 'fanciest',
+  },
 };
 
 describe('browser properties mapper', () => {
   it('should be empty when browser family is missing', () => {
     const browserProps = mapBrowser({
       ...mockParsedUserAgent,
-      ua: { ...mockParsedUserAgent.ua, family: null }
+      ua: { ...mockParsedUserAgent.ua, family: null },
     });
     assert.deepEqual(browserProps, {});
   });
@@ -42,7 +42,7 @@ describe('browser properties mapper', () => {
   it('should be empty when browser family is "Other"', () => {
     const browserProps = mapBrowser({
       ...mockParsedUserAgent,
-      ua: { ...mockParsedUserAgent.ua, family: 'Other' }
+      ua: { ...mockParsedUserAgent.ua, family: 'Other' },
     });
     assert.deepEqual(browserProps, {});
   });
@@ -51,7 +51,7 @@ describe('browser properties mapper', () => {
     const browserProps = mapBrowser(mockParsedUserAgent);
     assert.deepEqual(browserProps, {
       ua_browser: 'WaterCat',
-      ua_version: '66.12.0'
+      ua_version: '66.12.0',
     });
   });
 });
@@ -60,7 +60,7 @@ describe('OS properties mapper', () => {
   it('should be empty when OS family is missing', () => {
     const osProps = mapOs({
       ...mockParsedUserAgent,
-      os: { ...mockParsedUserAgent.os, family: null }
+      os: { ...mockParsedUserAgent.os, family: null },
     });
     assert.deepEqual(osProps, {});
   });
@@ -68,7 +68,7 @@ describe('OS properties mapper', () => {
   it('should be empty when the OS family is "Other"', () => {
     const osProps = mapOs({
       ...mockParsedUserAgent,
-      os: { ...mockParsedUserAgent.os, family: 'Other' }
+      os: { ...mockParsedUserAgent.os, family: 'Other' },
     });
     assert.deepEqual(osProps, {});
   });
@@ -77,7 +77,7 @@ describe('OS properties mapper', () => {
     const osProps = mapOs(mockParsedUserAgent);
     assert.deepEqual(osProps, {
       os_name: 'OS2',
-      os_version: '10.135.3q'
+      os_version: '10.135.3q',
     });
   });
 });
@@ -86,7 +86,7 @@ describe('device model mapper', () => {
   it('should be empty when device family is missing', () => {
     const device = mapDeviceModel({
       ...mockParsedUserAgent,
-      device: { ...mockParsedUserAgent.device, family: null }
+      device: { ...mockParsedUserAgent.device, family: null },
     });
     assert.deepEqual(device, {});
   });
@@ -94,7 +94,7 @@ describe('device model mapper', () => {
   it('should be empty when device brand is missing', () => {
     const device = mapDeviceModel({
       ...mockParsedUserAgent,
-      device: { ...mockParsedUserAgent.device, brand: null }
+      device: { ...mockParsedUserAgent.device, brand: null },
     });
     assert.deepEqual(device, {});
   });
@@ -102,7 +102,7 @@ describe('device model mapper', () => {
   it('should be empty when device brand is "Generic"', () => {
     const device = mapDeviceModel({
       ...mockParsedUserAgent,
-      device: { ...mockParsedUserAgent.device, brand: 'Generic' }
+      device: { ...mockParsedUserAgent.device, brand: 'Generic' },
     });
     assert.deepEqual(device, {});
   });

--- a/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/user-properties.spec.ts
+++ b/packages/fxa-metrics-processor/src/test/lib/amplitude/transforms/user-properties.spec.ts
@@ -11,7 +11,7 @@ import { EventContext, Event } from '../../../../lib/amplitude/transforms/types'
 const mockEvent: Event = { type: 'a', group: 'bs' };
 const mockContext: EventContext = {
   eventSource: 'content',
-  version: '1.165.1'
+  version: '1.165.1',
 };
 const mockParsedUserAgent = {
   ua: {
@@ -19,7 +19,7 @@ const mockParsedUserAgent = {
     major: '66',
     minor: '12',
     patch: '0',
-    toVersionString: () => '66.12.0'
+    toVersionString: () => '66.12.0',
   },
   os: {
     family: null,
@@ -27,13 +27,13 @@ const mockParsedUserAgent = {
     minor: null,
     patch: null,
     patchMinor: null,
-    toVersionString: () => ''
+    toVersionString: () => '',
   },
   device: {
     family: null,
     brand: null,
-    model: null
-  }
+    model: null,
+  },
 };
 
 describe('Amplitude user properties mapper', () => {
@@ -50,7 +50,7 @@ describe('Amplitude user properties mapper', () => {
         utm_content: 'campaign',
         utm_medium: 'of',
         utm_source: 'all',
-        utm_term: 'time'
+        utm_term: 'time',
       },
       mockParsedUserAgent
     );
@@ -100,8 +100,8 @@ describe('Amplitude user properties mapper', () => {
             { lastAccessTime: lessThanADayAgo },
             { lastAccessTime: lessThanAWeekAgo },
             { lastAccessTime: lessThanAMonthAgo },
-            { lastAccessTime: moreThanAMonthAgo }
-          ]
+            { lastAccessTime: moreThanAMonthAgo },
+          ],
         },
         mockParsedUserAgent
       );
@@ -167,22 +167,6 @@ describe('Amplitude user properties mapper', () => {
       );
       assert.equal(userProperties.newsletter_state, 'unsubscribed');
     });
-
-    it('should map correctly with "marketingOptIn" in the context', () => {
-      let userProperties = mapAmplitudeUserProperties(
-        { ...mockEvent, category: 'inbetween' },
-        { ...mockContext, marketingOptIn: true },
-        mockParsedUserAgent
-      );
-      assert.equal(userProperties.newsletter_state, 'subscribed');
-
-      userProperties = mapAmplitudeUserProperties(
-        { ...mockEvent, category: 'inbetween' },
-        { ...mockContext, marketingOptIn: false },
-        mockParsedUserAgent
-      );
-      assert.equal(userProperties.newsletter_state, 'unsubscribed');
-    });
   });
 
   describe('newsletters mapper', () => {
@@ -200,13 +184,13 @@ describe('Amplitude user properties mapper', () => {
         mockEvent,
         {
           ...mockContext,
-          newsletters: ['firefox-accounts-journey', 'knowledge-is-power']
+          newsletters: ['firefox-accounts-journey', 'knowledge-is-power'],
         },
         mockParsedUserAgent
       );
       assert.deepEqual(userProperties.newsletters, [
         'firefox_accounts_journey',
-        'knowledge_is_power'
+        'knowledge_is_power',
       ]);
     });
   });


### PR DESCRIPTION
This patch adds a function to produce the payload for Amplitude's
identify API from other FxA services' "raw" events.

It also provides a function that will accept a raw event and its context
and return the payloads for Amplitude's http, and if applicable,
identify APIs.

Fixes #4979 (FXA-1671)