### PR TITLE
chore(deps): Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,18 @@
 {
-  "automerge": false,
+  "automerge": true,
+  "major": {
+    "automerge": false
+  },
   "branchPrefix": "renovate/",
   "extends": [
-    "config:base"
+    "config:base",
+    ":maintainLockFilesWeekly"
   ],
-  "rangeStrategy": "replace",
+  "masterIssue": true,
   "prConcurrentLimit": 2,
-  "schedule": "every weekend"
+  "schedule": "after 1pm every tuesday",
+  "semanticCommits": true,
+  "stabilityDays": 7,
+  "timezone": "America/Los_Angeles",
+  "unicodeEmoji": true
 }


### PR DESCRIPTION
The past few weeks we've been talking about dependency management and I've done some asking around.  It's particularly challenging with all the packages we have, but the longer we wait the further behind we are, so...

We originally disabled renovate because it had a bug in it that failed with how we were managing one of our packages (pinning to an unpublished version, if I understood correctly).  Danny says that is fixed now.

At the time, we were also struggling with a lot of intermittent test failures and long testing times.  That has also been improved.

So, I think we should leverage automation as much as possible.  Best case, it can keep our packages up to date, but even in the worse case we'll at least be notified of updates and can decide what we need to do.

I asked several other teams for input on their dependency management strategies:
* AMO: Uses renovate and has a lot of success automerging minor patches after waiting 7 days for it to prove its stability
* SACI: They use dependabot.  They have a weekly meeting every Friday to review the dependencies and there isn't an official rotation, just whoever gets there first (which is probably the same people every week)
* Product Delivery team:  They also use dependabot and can empathize with our situation.

In this PR I'm suggesting some changes based on reading the docs and chatting with other teams.  In addition to those changes I want to continue to review PRs in our triage meeting like we did last week.  I plan on filing issues for Renovate PRs which we can triage and move through the process like normal tasks.  This should address the problem of lingering PRs.

Renovate has a lot of configuration that can be done around `ignoreDeps`, `ignorePaths`, `excludePackagePatterns`, etc. -- we should make use of that as appropriate, although I'm not setting them right out of the gate.  If we know of a package we should ignore though, let's do it.

One of the flags below is the `masterIssue` flag which I don't know if it will be interesting or not, but https://renovate.whitesourcesoftware.com/blog/introducing-renovates-master-issue/ has some use cases which could be helpful so I wanted to try it (eg. `masterIssueApproval` maybe).

I'm not sure how renovate was turned off, but if/when this lands, I can dig into how to get it re-enabled.  (note to future people who want to turn it off:  set a top level `enabled: false`)