### PR TITLE
fix(email-service): copy version.json in build-ci.sh

### DIFF
--- a/packages/fxa-email-service/scripts/build-ci.sh
+++ b/packages/fxa-email-service/scripts/build-ci.sh
@@ -16,6 +16,7 @@ docker cp "$ID":/app/.sourcehash /tmp
 if diff .sourcehash /tmp/.sourcehash ; then
   echo "The source is unchanged. Skipping build"
 else
+  cp ../version.json .
   docker build --progress=plain -t fxa-email-service:build . > ../../artifacts/fxa-email-service.log
 fi
 docker rm -v "$ID"


### PR DESCRIPTION
fixes #5103

The copy command moved out of .circleci/build.sh so this got orphaned.