### PR TITLE
feat(auth-server): emit login notif on oauth login

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/oauth.js
+++ b/packages/fxa-auth-server/test/local/routes/oauth.js
@@ -212,6 +212,12 @@ describe('/oauth/ routes', () => {
         },
       });
       const resp = await loadAndCallRoute('/oauth/authorization', mockRequest);
+      assert.calledOnce(mockLog.notifyAttachedServices);
+      const notifyCall = mockLog.notifyAttachedServices.args[0];
+      assert.equal(notifyCall[0], 'login');
+      const notification = notifyCall[2];
+      assert.equal(notification.clientId, MOCK_CLIENT_ID);
+      assert.equal(notification.service, MOCK_CLIENT_ID);
       assert.calledOnce(mockOAuthDB.createAuthorizationCode);
       assert.calledWithExactly(
         mockOAuthDB.createAuthorizationCode,


### PR DESCRIPTION
Because:

* We did not emit logins to relying parties if the user was already
  logged into their Firefox Account.

This commit:

* Will emit login events when users login to a relying party via an
  already authenticated account.

Closes #4994