### PR TITLE
feat(newsletters): Add subscribing to newsletters to signup flow for Sync

### DIFF
--- a/packages/fxa-auth-server/docs/service_notifications.md
+++ b/packages/fxa-auth-server/docs/service_notifications.md
@@ -63,6 +63,10 @@ Message Properties:
 - `uid`: The userid of the account being that was created.
 - `email`: The primary email address that was verified for the account.
 - `locale`: The accept-language header supplies by the user at account creation.
+- `country`: The estimated country (based on IP) of the user
+- `countryCode`: The country code of `country`
+- `newsletters`: Array of newsletter subscriptions for a user
+- `userAgent`: The user agent of device that completed the account verified
 
 Receiving services should use this message to initialize any state
 that needs to exist for _all_ Firefox Accounts.
@@ -216,3 +220,14 @@ so other services probably shouldn't use this.
 - `isActive`: Boolean indicating whether the subscription is active.
 - `productId`: Product id.
 - `productCapabilities`: Array of product capabilities.
+
+### Newsletter update event
+
+- `event`: The string "newsletters:update"
+- `uid`: The userid of the account being that was created.
+- `email`: The primary email address that was verified for the account.
+- `locale`: The accept-language header supplies by the user at account creation.
+- `country`: The estimated country (based on IP) of the user
+- `countryCode`: The country code of `country`
+- `newsletters`: Array of newsletter subscriptions for a user
+- `userAgent`: The user agent of device that completed the account verified

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -164,6 +164,7 @@ module.exports = function(
     stripeHelper
   );
   const support = require('./support')(log, db, config, customs, zendeskClient);
+  const newsletters = require('./newsletters')(log, db);
   const util = require('./util')(log, config, config.smtp.redirectDomain);
 
   let basePath = url.parse(config.publicUrl).path;
@@ -189,7 +190,8 @@ module.exports = function(
     util,
     recoveryKey,
     subscriptions,
-    support
+    support,
+    newsletters
   );
   v1Routes.forEach(r => {
     r.path = `${basePath}/v1${r.path}`;

--- a/packages/fxa-auth-server/lib/routes/newsletters.js
+++ b/packages/fxa-auth-server/lib/routes/newsletters.js
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const validators = require('./validators');
+
+module.exports = (log, db) => {
+  return [
+    {
+      method: 'POST',
+      path: '/newsletters',
+      options: {
+        auth: {
+          strategy: 'sessionToken',
+        },
+        validate: {
+          payload: {
+            newsletters: validators.newsletters,
+          },
+        },
+      },
+      handler: async function(request) {
+        log.begin('newsletters', request);
+
+        const { uid } = request.auth.credentials;
+
+        const { newsletters } = request.payload;
+
+        const account = await db.account(uid);
+
+        const geoData = request.app.geo;
+        const country = geoData.location && geoData.location.country;
+        const countryCode = geoData.location && geoData.location.countryCode;
+
+        log.notifyAttachedServices('newsletters:update', request, {
+          country,
+          countryCode,
+          email: account.primaryEmail.email,
+          locale: account.locale,
+          newsletters,
+          uid,
+          userAgent: request.headers['user-agent'],
+        });
+
+        return {};
+      },
+    },
+  ];
+};

--- a/packages/fxa-auth-server/test/local/routes/newsletters.js
+++ b/packages/fxa-auth-server/test/local/routes/newsletters.js
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const sinon = require('sinon');
+const assert = { ...sinon.assert, ...require('chai').assert };
+const getRoute = require('../../routes_helpers').getRoute;
+const mocks = require('../../mocks');
+
+function makeRoutes(options = {}) {
+  const log = options.log || mocks.mockLog();
+  const db = options.db || mocks.mockDB();
+  return require('../../../lib/routes/newsletters')(log, db);
+}
+
+function runTest(route, request) {
+  return route.handler(request);
+}
+
+describe('/newsletters should emit newsletters update message', () => {
+  const email = 'test@mail.com';
+  const uid = 'uid';
+  const newsletters = [
+    'firefox-accounts-journey',
+    'knowledge-is-power',
+    'take-action-for-the-internet',
+    'test-pilot',
+  ];
+
+  let request, db, log, routes, route, response;
+
+  before(() => {
+    log = mocks.mockLog();
+    db = mocks.mockDB({
+      email,
+      uid,
+    });
+    routes = makeRoutes({ log, db });
+    route = getRoute(routes, '/newsletters');
+    request = mocks.mockRequest({
+      credentials: {
+        email,
+        uid,
+      },
+      log,
+      payload: {
+        newsletters,
+      },
+    });
+
+    return runTest(route, request).then(result => (response = result));
+  });
+
+  it('returns correct response', () => {
+    assert.deepEqual(response, {});
+  });
+
+  it('called log.begin correctly', () => {
+    assert.calledOnce(log.begin);
+    assert.calledWithExactly(log.begin, 'newsletters', request);
+  });
+
+  it('called db.account correctly', () => {
+    assert.calledOnce(db.account);
+    assert.calledWithExactly(db.account, uid);
+  });
+
+  it('called log.notifyAttachedServices correctly', () => {
+    assert.calledOnce(log.notifyAttachedServices);
+    assert.calledWithExactly(
+      log.notifyAttachedServices,
+      'newsletters:update',
+      request,
+      {
+        country: 'United States',
+        countryCode: 'US',
+        email,
+        newsletters,
+        locale: undefined,
+        uid,
+        userAgent: 'test user-agent',
+      }
+    );
+  });
+});

--- a/packages/fxa-content-server/app/scripts/lib/auth/client.ts
+++ b/packages/fxa-content-server/app/scripts/lib/auth/client.ts
@@ -1104,4 +1104,10 @@ export default class AuthClient {
       })
     );
   }
+
+  async updateNewsletters(sessionToken: string, newsletters: string[]) {
+    return this.sessionPost('/newsletters', sessionToken, {
+      newsletters,
+    });
+  }
 }

--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -1361,6 +1361,14 @@ FxaClientWrapper.prototype = {
    *   - `ticket` OR `error`
    */
   createSupportTicket: createClientDelegate('createSupportTicket'),
+
+  /**
+   * Update a user newsletters subscription.
+   *
+   * @param {String[]} [newsletters]
+   * @returns {Promise} - resolves with empty response
+   */
+  updateNewsletters: createClientDelegate('updateNewsletters'),
 };
 
 export default FxaClientWrapper;

--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -170,6 +170,9 @@ const Router = Backbone.Router.extend({
         type: VerificationReasons.RECOVERY_KEY,
       }
     ),
+    'post_verify/newsletters/add_newsletters': createViewHandler(
+      'post_verify/newsletters/add_newsletters'
+    ),
     'post_verify/secondary_email/add_secondary_email': createViewHandler(
       'post_verify/secondary_email/add_secondary_email'
     ),

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -1127,6 +1127,19 @@ const Account = Backbone.Model.extend(
     },
 
     /**
+     * Update a user newsletters subscription.
+     *
+     * @param {String[]} [newsletters]
+     * @returns {Promise} - resolves with empty response
+     */
+    updateNewsletters(newsletters) {
+      return this._fxaClient.updateNewsletters(
+        this.get('sessionToken'),
+        newsletters
+      );
+    },
+
+    /**
      * Fetch an access token with subscription management scopes and a lifetime
      * of 30 seconds.
      *

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/newsletters/add_newsletters.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/newsletters/add_newsletters.mustache
@@ -1,0 +1,32 @@
+<div id="main-content" class="card add-newsletters">
+    <header>
+        <h1 id="fxa-add-newsletters-header">
+            {{#showSuccessMessage}}
+                {{#isSignedIn}}
+                    <span class="success success-authenticated visible">{{#t}}This Firefox is connected{{/t}}</span>
+                {{/isSignedIn}}
+            {{/showSuccessMessage}}
+
+            {{#t}}Sign up for more{{/t}}<span class="description">{{#t}}Practical knowledge is coming to your inbox.{{/t}}</span>
+        </h1>
+    </header>
+
+    <section>
+        <form novalidate>
+            <div class="graphic graphic-add-newsletters"></div>
+
+            {{#newsletters}}
+                <div class="input-row marketing-email-optin-row">
+                    <input id="{{slug}}" type="checkbox" class="marketing-email-optin" value="{{slug}}"><label for="{{slug}}">{{label}}</label>
+                </div>
+            {{/newsletters}}
+
+            <div class="button-row">
+                <button id="submit-btn" type="submit">{{#t}}Subscribe{{/t}}</button>
+            </div>
+            <div class="links">
+                <a id="maybe-later-btn" data-flow-event="link.maybe-later">{{#t}}Maybe later{{/t}}</a>
+            </div>
+        </form>
+    </section>
+</div>

--- a/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
+++ b/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
@@ -83,6 +83,7 @@ class ConfirmSignupCodeView extends FormView {
           });
         }
 
+        // TBD We should setup experiment rules to determine which broker method gets called.
         return this.invokeBrokerMethod('afterSignUpConfirmationPoll', account);
       })
       .catch(err => {

--- a/packages/fxa-content-server/app/scripts/views/mixins/email-opt-in-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/email-opt-in-mixin.js
@@ -82,7 +82,7 @@ export default {
    * Get a list of newsletters the user has opted in to.
    *
    * @param {Newsletter} newsletter
-   * @returns {Boolean}
+   * @returns {String[]} Array containing list of newsletters
    */
   getOptedIntoNewsletters() {
     return this._getNewsletters()

--- a/packages/fxa-content-server/app/scripts/views/post_verify/newsletters/add_newsletters.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/newsletters/add_newsletters.js
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * This view handles adding newsletters subscriptions to a user's account.
+ * Currently, users can only subscribe to newsletters. To unsubscribe for a
+ * newsletter, they must goto their email preferences.
+ */
+import { assign } from 'underscore';
+import Cocktail from 'cocktail';
+import EmailOptInMixin from '../../mixins/email-opt-in-mixin';
+import FormView from '../../form';
+import Template from 'templates/post_verify/newsletters/add_newsletters.mustache';
+import preventDefaultThen from '../../decorators/prevent_default_then';
+
+class AddNewsletters extends FormView {
+  template = Template;
+  viewName = 'add-newsletter';
+
+  events = assign(this.events, {
+    'click #maybe-later-btn': preventDefaultThen('clickMaybeLater'),
+  });
+
+  beforeRender() {
+    const account = this.getSignedInAccount();
+
+    // If no user is logged in redirect to the login page and set the `redirectTo` property
+    // to current url. After a user has logged in, they will be redirected back to this page.
+    if (account.isDefault()) {
+      this.relier.set('redirectTo', this.window.location.href);
+      return this.replaceCurrentPage('/');
+    }
+  }
+
+  submit() {
+    const optedInNewsletters = this.getOptedIntoNewsletters();
+    const account = this.getSignedInAccount();
+
+    return Promise.resolve()
+      .then(() => {
+        if (optedInNewsletters.length > 0) {
+          return account.updateNewsletters(optedInNewsletters);
+        }
+      })
+      .then(() => {
+        return this.invokeBrokerMethod('afterSignUpConfirmationPoll', account);
+      });
+  }
+
+  clickMaybeLater() {
+    const account = this.getSignedInAccount();
+    return this.invokeBrokerMethod('afterSignUpConfirmationPoll', account);
+  }
+}
+
+Cocktail.mixin(AddNewsletters, EmailOptInMixin);
+
+export default AddNewsletters;

--- a/packages/fxa-content-server/app/styles/_base.scss
+++ b/packages/fxa-content-server/app/styles/_base.scss
@@ -83,6 +83,7 @@ header {
     color: $header-color;
     line-height: 26px;
 
+    .description,
     .service,
     .email {
       display: block;

--- a/packages/fxa-content-server/app/styles/modules/_graphic.scss
+++ b/packages/fxa-content-server/app/styles/modules/_graphic.scss
@@ -61,6 +61,16 @@
   }
 }
 
+.graphic-add-newsletters {
+  background-image: image-url('graphic_mail.svg');
+  height: 138px;
+  margin-top: 20px;
+
+  @include respond-to('small') {
+    height: 70px;
+  }
+}
+
 .graphic-recovery-codes {
   background-image: image-url('graphic_recovery_codes.svg');
   height: 138px;

--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/newsletters/add_newsletters.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/newsletters/add_newsletters.js
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import _ from 'underscore';
+import { assert } from 'chai';
+import Account from 'models/account';
+import Backbone from 'backbone';
+import BaseBroker from 'models/auth_brokers/base';
+import Metrics from 'lib/metrics';
+import Relier from 'models/reliers/relier';
+import SentryMetrics from 'lib/sentry';
+import sinon from 'sinon';
+import User from 'models/user';
+import View from 'views/post_verify/newsletters/add_newsletters';
+import WindowMock from '../../../../mocks/window';
+import $ from 'jquery';
+
+describe('views/post_verify/newsletters/add_newsletters', () => {
+  let account;
+  let broker;
+  let experimentGroupingRules;
+  let metrics;
+  let model;
+  let notifier;
+  let relier;
+  let sentryMetrics;
+  let user;
+  let view;
+  let windowMock;
+
+  beforeEach(() => {
+    windowMock = new WindowMock();
+    relier = new Relier({
+      window: windowMock,
+    });
+    broker = new BaseBroker({
+      relier,
+      window: windowMock,
+    });
+    account = new Account({
+      email: 'a@a.com',
+      uid: 'uid',
+    });
+    model = new Backbone.Model({
+      account,
+    });
+    notifier = _.extend({}, Backbone.Events);
+    sentryMetrics = new SentryMetrics();
+    metrics = new Metrics({ notifier, sentryMetrics });
+    experimentGroupingRules = {
+      choose: () => true,
+    };
+    user = new User();
+    view = new View({
+      broker,
+      experimentGroupingRules,
+      metrics,
+      model,
+      notifier,
+      relier,
+      user,
+    });
+
+    sinon.stub(view, 'getSignedInAccount').callsFake(() => account);
+    sinon.stub(account, 'updateNewsletters').callsFake(() => Promise.resolve());
+    sinon.stub(view, 'invokeBrokerMethod').callsFake(() => Promise.resolve());
+
+    return view.render().then(() => $('#container').html(view.$el));
+  });
+
+  afterEach(function() {
+    metrics.destroy();
+    view.remove();
+    view.destroy();
+  });
+
+  describe('render', () => {
+    it('renders the view', () => {
+      assert.lengthOf(view.$('#fxa-add-newsletters-header'), 1);
+      assert.lengthOf(view.$('.graphic-add-newsletters'), 1);
+      assert.lengthOf(view.$('.marketing-email-optin-row'), 3);
+      assert.lengthOf(view.$('#submit-btn'), 1);
+      assert.lengthOf(view.$('#maybe-later-btn'), 1);
+    });
+
+    describe('without an account', () => {
+      beforeEach(() => {
+        account = new Account({});
+        sinon.spy(view, 'navigate');
+        return view.render();
+      });
+
+      it('redirects to the email first page', () => {
+        assert.isTrue(view.navigate.calledWith('/'));
+      });
+    });
+  });
+
+  describe('submit', () => {
+    describe('with no selected newsletters', () => {
+      beforeEach(() => {
+        return view.submit();
+      });
+
+      it('correct response', () => {
+        assert.equal(account.updateNewsletters.callCount, 0);
+        assert.isTrue(
+          view.invokeBrokerMethod.calledWith(
+            'afterSignUpConfirmationPoll',
+            account
+          )
+        );
+      });
+    });
+
+    describe('with selected newsletters', () => {
+      beforeEach(() => {
+        view.$('input[value="test-pilot"]').prop('checked', true);
+        return view.submit();
+      });
+
+      it('sends correct newsletters', () => {
+        assert.isTrue(account.updateNewsletters.calledOnceWith(['test-pilot']));
+        assert.isTrue(
+          view.invokeBrokerMethod.calledWith(
+            'afterSignUpConfirmationPoll',
+            account
+          )
+        );
+      });
+    });
+  });
+
+  describe('click maybe later', () => {
+    describe('success', () => {
+      beforeEach(() => {
+        return view.clickMaybeLater();
+      });
+
+      it('calls correct broker methods', () => {
+        assert.isTrue(
+          view.invokeBrokerMethod.calledWith(
+            'afterSignUpConfirmationPoll',
+            account
+          )
+        );
+      });
+    });
+  });
+});

--- a/packages/fxa-content-server/app/tests/test_start.js
+++ b/packages/fxa-content-server/app/tests/test_start.js
@@ -231,6 +231,7 @@ require('./spec/views/post_verify/account_recovery/add_recovery_key');
 require('./spec/views/post_verify/account_recovery/confirm_password');
 require('./spec/views/post_verify/account_recovery/save_recovery_key');
 require('./spec/views/post_verify/account_recovery/confirm_recovery_key');
+require('./spec/views/post_verify/newsletters/add_newsletters');
 require('./spec/views/post_verify/secondary_email/add_secondary_email');
 require('./spec/views/post_verify/secondary_email/confirm_secondary_email');
 require('./spec/views/progress_indicator');

--- a/packages/fxa-content-server/server/lib/routes/get-frontend.js
+++ b/packages/fxa-content-server/server/lib/routes/get-frontend.js
@@ -37,6 +37,7 @@ module.exports = function() {
     'post_verify/account_recovery/confirm_recovery_key',
     'post_verify/account_recovery/save_recovery_key',
     'post_verify/account_recovery/verified_recovery_key',
+    'post_verify/newsletters/add_newsletters',
     'post_verify/secondary_email/add_secondary_email',
     'post_verify/secondary_email/confirm_secondary_email',
     'post_verify/secondary_email/verified_secondary_email',


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa/issues/4930

* This adds the supporting view to add a newsletter subscription
* Updated client methods
* Adds auth-server endpoint to accept newsletters and send and SQS message for basket to process. Basket will be updated to handle new message per https://github.com/mozmeao/basket/issues/523

To test goto [http://localhost:3030/post_verify/newsletters/add_newsletters](http://localhost:3030/post_verify/newsletters/add_newsletters)

<img width="531" alt="Screen Shot 2020-05-04 at 3 53 15 PM" src="https://user-images.githubusercontent.com/1295288/81008149-73bbb300-8e20-11ea-8096-1f061b3b4a17.png">

Note that I will add the functional tests in the upcoming experiment PR, https://github.com/mozilla/fxa/issues/4928.