### PR TITLE
fix(chrome): fixed webcrypto check on Chrome

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/auth/crypto.ts
+++ b/packages/fxa-content-server/app/scripts/lib/auth/crypto.ts
@@ -146,14 +146,14 @@ export async function checkWebCrypto() {
     );
     await crypto.subtle.importKey(
       'raw',
-      crypto.getRandomValues(new Uint8Array(16)),
+      crypto.getRandomValues(new Uint8Array(32)),
       'HKDF',
       false,
       ['deriveKey']
     );
     await crypto.subtle.importKey(
       'raw',
-      crypto.getRandomValues(new Uint8Array(16)),
+      crypto.getRandomValues(new Uint8Array(32)),
       {
         name: 'HMAC',
         hash: 'SHA-256',
@@ -169,7 +169,7 @@ export async function checkWebCrypto() {
     return true;
   } catch (err) {
     try {
-      console.warn('loading webcrypto shim');
+      console.warn('loading webcrypto shim', err);
       // prettier-ignore
       // @ts-ignore
       window.asmCrypto = await import(/* webpackChunkName: "asmcrypto.js" */ 'asmcrypto.js');


### PR DESCRIPTION
Chrome was loading the webcrypto polyfill even though
it doesn't need it because it threw an error about the
input key length on HKDF and HMAC.