### PR TITLE
Update link to OAuth JWT access tokens spec.

### DIFF
--- a/packages/fxa-auth-server/docs/oauth/jwt-access-tokens.md
+++ b/packages/fxa-auth-server/docs/oauth/jwt-access-tokens.md
@@ -123,9 +123,9 @@ JWT access tokens are only enabled for RPs on an opt-in basis. RPs can request J
 tokens when their OAuth credentials are being provisioned.
 
 [#ietf-oauth-spec]: https://tools.ietf.org/html/rfc6749
-[#ietf-jwt-access-token-draft-spec]: https://tools.ietf.org/html/draft-bertocci-oauth-access-token-jwt-00
-[#ietf-jwt-access-token-draft-spec-structure]: https://tools.ietf.org/html/draft-bertocci-oauth-access-token-jwt-00#section-2.2
-[#ietf-jwt-access-token-draft-spec-validation]: https://tools.ietf.org/html/draft-bertocci-oauth-access-token-jwt-00#section-4
+[#ietf-jwt-access-token-draft-spec]: https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt#section-3
+[#ietf-jwt-access-token-draft-spec-structure]: https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt#section-2.2
+[#ietf-jwt-access-token-draft-spec-validation]: https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt#section-4
 [#ietf-jws-spec]: https://tools.ietf.org/html/rfc7515
 [#ietf-jwt-spec]: https://tools.ietf.org/html/rfc7519
 [#ietf-resource-indicator-draft-spec]: https://tools.ietf.org/html/draft-ietf-oauth-resource-indicators-08

--- a/packages/fxa-auth-server/docs/oauth/pairwise-pseudonymous-identifiers.md
+++ b/packages/fxa-auth-server/docs/oauth/pairwise-pseudonymous-identifiers.md
@@ -64,5 +64,5 @@ Firefox accounts does not currently support [sector identifiers][#oidc-sector-id
 [#oidc-spec]: https://openid.net/specs/oidc-core-1_0.html#Terminology
 [#oidc-id-token]: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 [#oidc-sector-identifier]: https://openid.net/specs/openid-connect-core-1_0.html#PairwiseAlg
-[#oauth-jwt-access-token]: https://tools.ietf.org/html/draft-bertocci-oauth-access-token-jwt-00
+[#oauth-jwt-access-token]: https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt
 [#hkdf]: https://tools.ietf.org/html/rfc5869

--- a/packages/fxa-auth-server/docs/oauth/signing-key-management.md
+++ b/packages/fxa-auth-server/docs/oauth/signing-key-management.md
@@ -5,7 +5,7 @@ including:
 
 - `id_token`s as defined by [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html)
 - `access_token`s as defined by [JWT Profile for OAuth 2.0 Access
-  Tokens](https://datatracker.ietf.org/doc/draft-bertocci-oauth-access-token-jwt/)
+  Tokens](https://datatracker.ietf.org/doc/draft-ietf-oauth-access-token-jwt/)
 - Security Event Tokens as defined by [RFC8417](https://tools.ietf.org/html/rfc8417)
 
 RPs are expected to verify the signatures on these JWTs by fetching our public keys via the

--- a/packages/fxa-auth-server/lib/oauth/jwt_access_token.js
+++ b/packages/fxa-auth-server/lib/oauth/jwt_access_token.js
@@ -14,16 +14,14 @@ const HEADER_TYP = 'at+JWT';
  */
 exports.create = async function generateJWTAccessToken(accessToken, grant) {
   const clientId = hex(grant.clientId);
-  // The IETF spec for `aud` refers to https://openid.net/specs/openid-connect-core-1_0.html#IDToken
-  // > REQUIRED. Audience(s) that this ID Token is intended for. It MUST contain the
-  // > OAuth 2.0 client_id of the Relying Party as an audience value. It MAY also contain
-  // > identifiers for other audiences. In the general case, the aud value is an array of
-  // > case sensitive strings. In the common special case when there is one audience, the
-  // > aud value MAY be a single case sensitive string.
+  // For historical reasons (based on an early draft of the JWT-access-token spec) we
+  // always include the client_id in the `aud` claim. A future iteration of this code
+  // should instead infer an appropriate default `aud` based on the requested scopes.
+  // Ref https://github.com/mozilla/fxa/issues/4962
   const audience = grant.resource ? [clientId, grant.resource] : clientId;
 
   // Claims list from:
-  // https://tools.ietf.org/html/draft-bertocci-oauth-access-token-jwt-00#section-2.2
+  // https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt#section-2.2
   const claims = {
     aud: audience,
     client_id: clientId,


### PR DESCRIPTION
Because:

* Our JWT access token implementation was done referencing
  an early personal draft of a spec.
* The spec has now been officially adopted by the IETF OAuth
  Working Group, with significant revisions.
* The updated spec addresses one of my personal bugbears about the
  current implementation.

This commit:

* Updates reference links to point to the latest draft.
* Rewords a comment block to indicate that some current (IMHO)
  strange behaviour was previously implied to be mandatory, but
  has been addressed in the latest draft spec.
* Doesn't actually change the behaviour, because we'd need to
  QA how that affects existing reliers.