### PR TITLE
fix(marketing): Add back the ability for account model to set `needsOptedInToMarketingEmail`

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -62,6 +62,9 @@ const DEFAULTS = _.extend(
     keyFetchToken: undefined,
     newsletters: undefined,
     offeredSyncEngines: undefined,
+    // `needsOptedInToMarketingEmail` is kept around to load from old ResumeTokens.
+    // This can be removed in post train-169+
+    needsOptedInToMarketingEmail: undefined,
     // password field intentionally omitted to avoid unintentional leaks
     unwrapBKey: undefined,
     verificationMethod: undefined,


### PR DESCRIPTION
Fixes #5135 

I believe there are still some old resume tokens that use this and it might require an additional train before it can be fully removed. This PR allows setting the property meanwhile (it still isn't used anywhere).