### PR TITLE
fix(geodb): make geodb accuracy logging optional

### DIFF
--- a/packages/fxa-auth-server/config/index.js
+++ b/packages/fxa-auth-server/config/index.js
@@ -30,6 +30,12 @@ const conf = convict({
       env: 'GEODB_ENABLED',
       format: Boolean,
     },
+    logAccuracy: {
+      doc: 'emit log lines for accuracy and confidence',
+      default: false,
+      env: 'GEODB_LOG_ACCURACY',
+      format: Boolean,
+    },
   },
   log: {
     app: {

--- a/packages/fxa-auth-server/lib/geodb.js
+++ b/packages/fxa-auth-server/lib/geodb.js
@@ -42,10 +42,12 @@ module.exports = log => {
         confidence += 'no_accuracy_data';
       }
 
-      log.info('geodb.accuracy', { accuracy });
-      log.info('geodb.accuracy_confidence', {
-        accuracy_confidence: confidence,
-      });
+      if (config.logAccuracy) {
+        log.info('geodb.accuracy', { accuracy });
+        log.info('geodb.accuracy_confidence', {
+          accuracy_confidence: confidence,
+        });
+      }
 
       return {
         location: {


### PR DESCRIPTION
Are we actually using these lines for analysis? If not, they are a large proportion of our logging costs for auth server. @davismtl @vbudhram might recall.

r? - @mozilla/fxa-devs 