### PR TITLE
fix(experiments): Enabled variation B 100% for sms header experiment

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/send-sms-header.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/send-sms-header.js
@@ -25,7 +25,7 @@ module.exports = class SendSmsHeaderGroupingRule extends BaseGroupingRule {
    * @returns {Any}
    */
   choose(subject = {}) {
-    const GROUPS = ['control', 'syncPhone', 'syncBrowser'];
-    return this.uniformChoice(GROUPS, subject.uniqueUserId);
+    // Enable the `Would you like to sync your phone?` for 100% of users.
+    return 'syncPhone';
   }
 };


### PR DESCRIPTION
This PR enables variation B `Would you like to sync your phone?` for 100% of users. 

This should be uplifted as a point release on latest train, cc @chenba