### PR TITLE
refactor(shared): use require over import to address TS compilation issue

### DIFF
--- a/packages/fxa-shared/l10n/localizeTimestamp.ts
+++ b/packages/fxa-shared/l10n/localizeTimestamp.ts
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import * as acceptLanguage from 'accept-language';
-import * as moment from 'moment';
+const acceptLanguage = require('accept-language');
+const moment = require('moment');
 
 type localizeOptions = {
   defaultLanguage: string;

--- a/packages/fxa-shared/tslint.json
+++ b/packages/fxa-shared/tslint.json
@@ -7,6 +7,7 @@
   "rules": {
     "interface-name": [true, "never-prefix"],
     "interface-over-type-literal": false,
-    "prettier": [true, ".prettierrc"]
+    "prettier": [true, ".prettierrc"],
+    "no-var-requires": false
   }
 }


### PR DESCRIPTION
Closes #5150

This prevented CI from building properly.

```
Could not find a declaration file for module 'accept-language'. '/fxa/packages/fxa-shared/node_modules/accept-language/index.js' implicitly has an 'any' type.
Try `npm install @types/accept-language` if it exists or add a new declaration (.d.ts) file containing `declare module 'accept-language';`
```

Even though that declaration [does exist](https://github.com/mozilla/fxa/blob/master/packages/fxa-shared/types/accept-language/index.d.ts) and we are [pointing at it](https://github.com/mozilla/fxa/blob/master/packages/fxa-shared/tsconfig.json#L12).

I imagine this isn't the ideal approach to take (using require over import), so TS folks if you have insight into how to address this I'm all ears.

Verified before and after builds locally.