### PR TITLE
fix(auth server): reference fxa-shared types in tsconfig

### DIFF
--- a/packages/fxa-auth-server/tsconfig.json
+++ b/packages/fxa-auth-server/tsconfig.json
@@ -14,11 +14,9 @@
     "allowSyntheticDefaultImports": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "types": [
-      "node"
-    ],
     "typeRoots": [
       "./types",
+      "../fxa-shared/types",
       "node_modules/@types"
     ]
   },


### PR DESCRIPTION
Closes #5150

This prevented CI from building properly.

```
Could not find a declaration file for module 'accept-language'. '/fxa/packages/fxa-shared/node_modules/accept-language/index.js' implicitly has an 'any' type.
Try `npm install @types/accept-language` if it exists or add a new declaration (.d.ts) file containing `declare module 'accept-language';`
```

@chenba I know your original comment was to add the type declaration file to fxa-auth-server, but I figured since the issue stemmed from a module referenced in a file from fxa-shared that we should have a single source of truth/keep it dry.