### PR TITLE
fix(l10n): temporary (hopefully) fix for l10n CI build

### DIFF
--- a/packages/fxa-shared/tsconfig.json
+++ b/packages/fxa-shared/tsconfig.json
@@ -9,7 +9,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "strict": true,
-    "typeRoots": ["./types", "node_modules/@types"],
+    "typeRoots": ["./types", "node_modules/@types", "../fxa-auth-server/node_modules/@types"],
     "skipLibCheck": true
   },
   "include": ["./**/*", "./*"],


### PR DESCRIPTION
The l10n repo build installs things differently from
this repo. The `npm ci` on fxa-auth-server is "broken"
with how deps are currently laid out. We really need
a better way to manage interpackage dependencies, but
that's a more involved issue.

In the meantime adding the @types from fxa-auth-server
to the fxa-shared tsconfig fixes the build error.

This is in response to: https://app.circleci.com/pipelines/github/mozilla/fxa-content-server-l10n/119/workflows/eec13c72-35c9-446c-a574-5dbe076fb3eb/jobs/6364

ref: https://github.com/mozilla/fxa-content-server-l10n/blob/8a5515c75395169b2f1badbdc03f36f5dd5fbd99/scripts/extract-and-pull-request.sh