### PR TITLE
fix(payments): use period end from first invoice line for reactivation billing date

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.js
+++ b/packages/fxa-auth-server/lib/payments/stripe.js
@@ -1174,7 +1174,16 @@ class StripeHelper {
   ) {
     const charge = await this.expandResource(invoice.charge, CHARGES_RESOURCE);
 
-    const { total: invoiceTotal, period_end: nextInvoiceDate } = invoice;
+    const {
+      total: invoiceTotal,
+      lines: {
+        data: [
+          {
+            period: { end: nextInvoiceDate },
+          },
+        ],
+      },
+    } = invoice;
 
     const {
       brand: cardType,

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -1656,6 +1656,13 @@ describe('StripeHelper', () => {
       default_source: { id: sourceId },
       total: 1234,
       period_end: 1587426018,
+      lines: {
+        data: [
+          {
+            period: { end: 1590018018 },
+          },
+        ],
+      },
     };
 
     const mockInvoiceUpcoming = {
@@ -2169,7 +2176,9 @@ describe('StripeHelper', () => {
           invoiceTotal: mockInvoice.total / 100.0,
           cardType: card.brand,
           lastFour: card.last4,
-          nextInvoiceDate: new Date(mockInvoice.period_end * 1000),
+          nextInvoiceDate: new Date(
+            mockInvoice.lines.data[0].period.end * 1000
+          ),
         });
       });
     });


### PR DESCRIPTION
Similar to PR #5137, another spot where we need to use a different billing date

fixes #5200