### PR TITLE
fix(docker): add graphicsmagick to base node image

### DIFF
--- a/_dev/docker/node/Dockerfile
+++ b/_dev/docker/node/Dockerfile
@@ -9,6 +9,7 @@ RUN set -x \
         --uid 10001 \
         app
 RUN apt-get update && apt-get install -y \
+    graphicsmagick \
     netcat \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
fixes #5194