### PR TITLE
feat(settings): add sentry setup

### DIFF
--- a/packages/fxa-components/AppErrorBoundary/index.tsx
+++ b/packages/fxa-components/AppErrorBoundary/index.tsx
@@ -4,6 +4,7 @@
 
 import React from "react";
 import AppErrorDialog from "../AppErrorDialog";
+import sentryMetrics from "@fxa-shared/lib/sentry";
 
 class AppErrorBoundary extends React.Component {
   state: {
@@ -19,11 +20,9 @@ class AppErrorBoundary extends React.Component {
     return { error };
   }
 
-  componentDidCatch(error: Error, errorInfo: any) {
+  componentDidCatch(error: Error) {
     console.error("AppError", error);
-
-    // TODO: Add Sentry logging
-    // sentryMetrics.captureException(error);
+    sentryMetrics.captureException(error);
   }
 
   render() {

--- a/packages/fxa-components/jest.config.js
+++ b/packages/fxa-components/jest.config.js
@@ -1,3 +1,5 @@
+const { resolve } = require("path");
+
 module.exports = {
   roots: ["<rootDir>"],
   transform: {
@@ -5,5 +7,6 @@ module.exports = {
   },
   moduleNameMapper: {
     "\\.(css|scss)$": "identity-obj-proxy",
+    "^@fxa-shared/(.*)$": resolve(__dirname, "../fxa-shared", "$1")
   }
 };

--- a/packages/fxa-components/rescripts.js
+++ b/packages/fxa-components/rescripts.js
@@ -83,9 +83,14 @@ const componentsJestMapper = {
   jest: config => {
     return {
       ...config,
-      moduleNameMapper: {
-        "^@fxa-components/(.*)$": resolve(__dirname, "$1")
-      }
+      moduleNameMapper: Object.keys(additionalJSImports).reduce(
+        (previous, key) => {
+          return Object.assign(previous, {
+            [`^${key}/(.*)$`]: resolve(additionalJSImports[key], "$1")
+          });
+        },
+        {}
+      )
     };
   }
 };

--- a/packages/fxa-components/scripts/test-ci.sh
+++ b/packages/fxa-components/scripts/test-ci.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -ex
+
+DIR=$(dirname "$0")
+
+cd "$DIR/../../../"
+
+npx lerna bootstrap \
+  --scope fxa-shared \
+  --scope fxa-components
+
+cd packages/fxa-components
+CI=yes npm test

--- a/packages/fxa-components/tsconfig.json
+++ b/packages/fxa-components/tsconfig.json
@@ -21,5 +21,6 @@
   },
   "include": [
     "."
-  ]
+  ],
+  "extends": "./tsconfig.common.json"
 }

--- a/packages/fxa-settings/package-lock.json
+++ b/packages/fxa-settings/package-lock.json
@@ -1911,6 +1911,69 @@
         "ramda": "^0.26.0"
       }
     },
+    "@sentry/browser": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.15.5.tgz",
+      "integrity": "sha512-rqDvjk/EvogfdbZ4TiEpxM/lwpPKmq23z9YKEO4q81+1SwJNua53H60dOk9HpRU8nOJ1g84TMKT2Ov8H7sqDWA==",
+      "dev": true,
+      "requires": {
+        "@sentry/core": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.15.5.tgz",
+      "integrity": "sha512-enxBLv5eibBMqcWyr+vApqeix8uqkfn0iGsD3piKvoMXCgKsrfMwlb/qo9Ox0lKr71qIlZVt+9/A2vZohdgnlg==",
+      "dev": true,
+      "requires": {
+        "@sentry/hub": "5.15.5",
+        "@sentry/minimal": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.5.tgz",
+      "integrity": "sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==",
+      "dev": true,
+      "requires": {
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.5.tgz",
+      "integrity": "sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==",
+      "dev": true,
+      "requires": {
+        "@sentry/hub": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.5.tgz",
+      "integrity": "sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw==",
+      "dev": true
+    },
+    "@sentry/utils": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.5.tgz",
+      "integrity": "sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==",
+      "dev": true,
+      "requires": {
+        "@sentry/types": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@rescripts/cli": "0.0.14",
+    "@sentry/browser": "^5.15.5",
     "eslint": "^6.8.0",
     "eslint-plugin-fxa": "^2.0.2",
     "eslint-plugin-jest": "^23.8.2",

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -6,12 +6,11 @@ import React from 'react';
 import { render } from 'react-dom';
 import './index.scss';
 import App from './components/App';
+import sentryMetrics from '@fxa-shared/lib/sentry';
+import config from './lib/config';
 
 export async function init() {
-  // TODO: Configure Sentry logging
-  // if (config.sentry.dsn) {
-  //   sentryMetrics.configure(config.sentry.dsn, config.version);
-  // }
+  sentryMetrics.configure(config.sentry.dsn, config.version);
 
   render(
     <React.StrictMode>

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -1,0 +1,17 @@
+export interface Config {
+  env: string;
+  sentry: {
+    url: string;
+    dsn: string;
+  };
+  version: string | undefined;
+}
+
+export default {
+  env: 'development',
+  version: undefined,
+  sentry: {
+    url: 'https://sentry.prod.mozaws.net',
+    dsn: '',
+  },
+} as Config;

--- a/packages/fxa-shared/lib/logger.ts
+++ b/packages/fxa-shared/lib/logger.ts
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Logging module that performs proper checks and string
+ * interpolation before logging message.
+ *
+ */
+
+interface Logger {
+  _window: Window;
+  info: (...args: any) => void;
+  trace: (...args: any) => void;
+  warn: (...args: any) => void;
+  error: (...args: any) => void;
+}
+
+interface ModuleError {
+  errorModule: {
+    toInterpolatedMessage: (arg0: ModuleError) => string;
+  };
+}
+
+/**
+ * Constructor of log module.
+ *
+ * @param {Object} logWindow Window object that contains console used for logging.
+ *
+ * @constructor
+ */
+const Logger = (function(this: Logger, logWindow?: Window) {
+  this._window = logWindow || window;
+} as any) as new (logWindow?: Window) => Logger;
+
+Logger.prototype = {
+  /**
+   * Wrapper for `console.info` function that checks for availability and
+   * then prints info.
+   *
+   */
+  info() {
+    this._window.console?.info?.apply(this._window.console, arguments);
+  },
+
+  /**
+   * Wrapper for `console.trace` function that checks for availability and then prints
+   * trace.
+   *
+   */
+  trace() {
+    this._window.console?.trace?.apply(this._window.console, arguments);
+  },
+
+  /**
+   * Wrapper for `console.warn` function that checks for availability and
+   * then prints warn.
+   *
+   */
+  warn() {
+    this._window.console?.warn?.apply(this._window.console, arguments);
+  },
+
+  /**
+   * Wrapper for `console.error` function that checks for availability and interpolates
+   * error messages if a translation exists.
+   *
+   * @param {Error} error Error object with optional errorModule.
+   */
+  error(error?: ModuleError) {
+    if (this._window.console?.error) {
+      let errorMessage = '';
+
+      // If error module is present, attempt to interpolate string, else use error object message
+      if (error?.errorModule) {
+        errorMessage = error.errorModule.toInterpolatedMessage(error);
+        this._window.console.error(errorMessage);
+      } else {
+        // Use regular console.error
+        this._window.console.error.apply(this._window.console, arguments);
+      }
+    }
+  },
+};
+
+export default Logger;

--- a/packages/fxa-shared/lib/sentry.ts
+++ b/packages/fxa-shared/lib/sentry.ts
@@ -1,0 +1,174 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import * as Sentry from '@sentry/browser';
+import Logger from './logger';
+
+const ALLOWED_QUERY_PARAMETERS = [
+  'automatedBrowser',
+  'client_id',
+  'context',
+  'entrypoint',
+  'keys',
+  'migration',
+  'redirect_uri',
+  'scope',
+  'service',
+  'setting',
+  'style',
+];
+
+/**
+ * function that gets called before data gets sent to error metrics
+ *
+ * @param {Object} data
+ *  Error object data
+ * @returns {Object} data
+ *  Modified error object data
+ * @private
+ */
+function beforeSend(data: Sentry.Event): Sentry.Event {
+  if (data.request) {
+    if (data.request.url) {
+      data.request.url = cleanUpQueryParam(data.request.url);
+    }
+
+    if (data.tags) {
+      // if this is a known errno, then use grouping with fingerprints
+      // Docs: https://docs.sentry.io/hosted/learn/rollups/#fallback-grouping
+      if (data.tags.errno) {
+        data.fingerprint = ['errno' + data.tags.errno];
+        // if it is a known error change the error level to info.
+        data.level = Sentry.Severity.Info;
+      }
+    }
+
+    if (data.exception?.values) {
+      data.exception.values.forEach((value: Sentry.Exception) => {
+        if (value.stacktrace && value.stacktrace.frames) {
+          value.stacktrace.frames.forEach((frame: { abs_path?: string }) => {
+            if (frame.abs_path) {
+              frame.abs_path = cleanUpQueryParam(frame.abs_path); // eslint-disable-line camelcase
+            }
+          });
+        }
+      });
+    }
+
+    if (data.request.headers?.Referer) {
+      data.request.headers.Referer = cleanUpQueryParam(
+        data.request.headers.Referer
+      );
+    }
+  }
+
+  return data;
+}
+
+/**
+ * Overwrites sensitive query parameters with a dummy value.
+ *
+ * @param {String} url
+ * @returns {String} url
+ * @private
+ */
+function cleanUpQueryParam(url = '') {
+  const urlObj = new URL(url);
+
+  if (!urlObj.search.length) {
+    return url;
+  }
+
+  // Iterate the search parameters.
+  urlObj.searchParams.forEach((_, key) => {
+    if (!ALLOWED_QUERY_PARAMETERS.includes(key)) {
+      // if the param is a PII (not allowed) then reset the value.
+      urlObj.searchParams.set(key, 'VALUE');
+    }
+  });
+
+  return urlObj.href;
+}
+
+/**
+ * Exception fields that are imported as tags
+ */
+const exceptionTags = ['code', 'context', 'errno', 'namespace', 'status'];
+
+interface SentryMetrics {
+  _logger: Logger;
+  configure: (arg0: string, arg1?: string) => void;
+  captureException: (arg0: Error) => void;
+  __beforeSend: (arg0: Sentry.Event) => Sentry.Event;
+  __cleanUpQueryParam: (arg0: string) => string;
+}
+
+/**
+ * Creates a SentryMetrics singleton object that starts up Sentry/browser.
+ *
+ * This must be configured with the `configure` method before use.
+ *
+ * Read more at https://docs.sentry.io/platforms/javascript
+ *
+ * @constructor
+ */
+const SentryMetrics = (function(this: SentryMetrics) {
+  this._logger = new Logger();
+} as any) as new () => SentryMetrics;
+
+SentryMetrics.prototype = {
+  /**
+   * Configure the SentryMetrics instance for this singleton.
+   *
+   * @param {String} dsn
+   * @param {String} [release] - settings release version
+   */
+  configure(dsn: string, release: string) {
+    this._logger.info('release: ' + release);
+    this._release = release;
+    if (!dsn) {
+      this._logger.error('No Sentry dsn provided');
+      return;
+    }
+
+    try {
+      Sentry.init({
+        release,
+        dsn,
+        beforeSend,
+      });
+    } catch (e) {
+      this._logger.error(e);
+    }
+  },
+  /**
+   * Capture an exception. Error fields listed in exceptionTags
+   * will be added as tags to the sentry data.
+   *
+   * @param {Error} err
+   */
+  captureException(err: Error) {
+    Sentry.withScope((scope: Sentry.Scope) => {
+      exceptionTags.forEach(tagName => {
+        if (tagName in err) {
+          scope.setTag(
+            tagName,
+            (err as {
+              [key: string]: any;
+            })[tagName]
+          );
+        }
+      });
+      Sentry.captureException(err);
+    });
+  },
+
+  // Private functions, exposed for testing
+  __beforeSend: beforeSend,
+  __cleanUpQueryParam: cleanUpQueryParam,
+};
+
+const sentryMetrics = new SentryMetrics();
+
+export default sentryMetrics;

--- a/packages/fxa-shared/package-lock.json
+++ b/packages/fxa-shared/package-lock.json
@@ -401,6 +401,69 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@sentry/browser": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.15.5.tgz",
+      "integrity": "sha512-rqDvjk/EvogfdbZ4TiEpxM/lwpPKmq23z9YKEO4q81+1SwJNua53H60dOk9HpRU8nOJ1g84TMKT2Ov8H7sqDWA==",
+      "dev": true,
+      "requires": {
+        "@sentry/core": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.15.5.tgz",
+      "integrity": "sha512-enxBLv5eibBMqcWyr+vApqeix8uqkfn0iGsD3piKvoMXCgKsrfMwlb/qo9Ox0lKr71qIlZVt+9/A2vZohdgnlg==",
+      "dev": true,
+      "requires": {
+        "@sentry/hub": "5.15.5",
+        "@sentry/minimal": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.5.tgz",
+      "integrity": "sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==",
+      "dev": true,
+      "requires": {
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.5.tgz",
+      "integrity": "sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==",
+      "dev": true,
+      "requires": {
+        "@sentry/hub": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.5.tgz",
+      "integrity": "sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw==",
+      "dev": true
+    },
+    "@sentry/utils": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.5.tgz",
+      "integrity": "sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==",
+      "dev": true,
+      "requires": {
+        "@sentry/types": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
@@ -505,6 +568,12 @@
       "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
       "dev": true
     },
+    "abab": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
+      "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+      "dev": true
+    },
     "accept-language": {
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/accept-language/-/accept-language-2.0.17.tgz",
@@ -519,10 +588,26 @@
       "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
+    "acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      }
+    },
     "acorn-jsx": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
+      "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
       "dev": true
     },
     "aggregate-error": {
@@ -633,6 +718,21 @@
         "es-abstract": "^1.5.0"
       }
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -645,6 +745,12 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
     "audit-filter": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/audit-filter/-/audit-filter-0.5.0.tgz",
@@ -653,6 +759,18 @@
       "requires": {
         "docopt": "^0.6.2"
       }
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -664,6 +782,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/bcp47/-/bcp47-1.1.2.tgz",
       "integrity": "sha1-NUvjMH/9CEM6ePXh4glYRfifx/4="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "binary-extensions": {
       "version": "2.0.0",
@@ -694,6 +821,12 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+      "dev": true
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -735,6 +868,12 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "celebrate": {
@@ -872,6 +1011,15 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -898,6 +1046,12 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cors": {
       "version": "2.8.5",
@@ -929,6 +1083,49 @@
         }
       }
     },
+    "cssom": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "requires": {
+        "cssom": "~0.3.6"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+          "dev": true
+        }
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
+      }
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -942,6 +1139,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decimal.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
       "dev": true
     },
     "deep-eql": {
@@ -984,6 +1187,12 @@
         "object-keys": "^1.0.12"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -1005,10 +1214,37 @@
         "esutils": "^2.0.2"
       }
     },
+    "domexception": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+          "dev": true
+        }
+      }
+    },
     "double-ended-queue": {
       "version": "2.1.0-0",
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -1068,6 +1304,19 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "escodegen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      }
     },
     "eslint": {
       "version": "6.8.0",
@@ -1269,6 +1518,12 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -1279,6 +1534,12 @@
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
       }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.1",
@@ -1438,6 +1699,23 @@
         }
       }
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fromentries": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
@@ -1497,6 +1775,15 @@
       "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -1540,6 +1827,22 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -1587,11 +1890,31 @@
       "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
       "dev": true
     },
+    "html-encoding-sniffer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^1.0.5"
+      }
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -1734,6 +2057,12 @@
         }
       }
     },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1798,6 +2127,12 @@
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+      "dev": true
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -1856,6 +2191,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -2047,6 +2388,52 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jsdom": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.2.2.tgz",
+      "integrity": "sha512-pDFQbcYtKBHxRaP55zGXCJWgFHkDAYbKcsXEK/3Icu9nKYZkutUXfLBwbD+09XDutkYSHcgfQLZ0qvpAAm9mvg==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.3",
+        "acorn": "^7.1.1",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.2.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.0",
+        "domexception": "^2.0.1",
+        "escodegen": "^1.14.1",
+        "html-encoding-sniffer": "^2.0.1",
+        "is-potential-custom-element-name": "^1.0.0",
+        "nwsapi": "^2.2.0",
+        "parse5": "5.1.1",
+        "request": "^2.88.2",
+        "request-promise-native": "^1.0.8",
+        "saxes": "^5.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^3.0.1",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.0.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0",
+        "ws": "^7.2.3",
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "jsdom-global": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
+      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -2059,6 +2446,12 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2068,6 +2461,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json5": {
@@ -2085,6 +2484,18 @@
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
     "just-extend": {
@@ -2148,6 +2559,12 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -2183,6 +2600,21 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.44.0"
+      }
     },
     "mimic-fn": {
       "version": "2.1.0",
@@ -2420,6 +2852,12 @@
         "string.prototype.padend": "^3.0.0"
       }
     },
+    "nwsapi": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+      "dev": true
+    },
     "nyc": {
       "version": "15.0.1",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.1.tgz",
@@ -2595,6 +3033,12 @@
           }
         }
       }
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -2814,6 +3258,12 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
+    "parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -2860,6 +3310,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "picomatch": {
@@ -2963,10 +3419,22 @@
         "resolve": "^1.11.1"
       }
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "dev": true
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "ramda": {
       "version": "0.26.1",
@@ -3027,6 +3495,84 @@
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
+      }
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+      "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
+      "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.3",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
       }
     },
     "require-directory": {
@@ -3104,6 +3650,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "dev": true,
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
     },
     "semver": {
       "version": "6.3.0",
@@ -3289,6 +3844,29 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -3375,6 +3953,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
     },
     "table": {
       "version": "5.4.6",
@@ -3468,6 +4052,26 @@
         "hoek": "6.x.x"
       }
     },
+    "tough-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+      "dev": true,
+      "requires": {
+        "ip-regex": "^2.1.0",
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+      "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
     "ts-node": {
       "version": "8.6.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
@@ -3555,6 +4159,21 @@
       "requires": {
         "tslib": "^1.8.1"
       }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -3644,6 +4263,75 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "dev": true,
+      "requires": {
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.0.0.tgz",
+      "integrity": "sha512-41ou2Dugpij8/LPO5Pq64K5q++MnRCBpEHvQr26/mArEKTkCV5aoXIqyhuYtE0pkqScXwhf2JP57rkRTYM29lQ==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^2.0.0",
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+          "dev": true
+        }
+      }
     },
     "which": {
       "version": "1.3.1",
@@ -3770,6 +4458,24 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "ws": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.5.tgz",
+      "integrity": "sha512-C34cIU4+DB2vMyAbmEKossWq2ZQDr6QEyuuCzWrM9zfw1sGc0mYiJ0UnG9zzNykt49C2Fi34hvr2vssFQRS6EA==",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/mozilla/fxa/tree/master/packages/fxa-shared#readme",
   "devDependencies": {
+    "@sentry/browser": "^5.15.5",
     "@types/chai": "^4.2.11",
     "@types/generic-pool": "^3.1.9",
     "@types/mocha": "^7.0.2",
@@ -40,6 +41,8 @@
     "chai": "^4.2.0",
     "eslint": "^6.8.0",
     "eslint-plugin-fxa": "^2.0.2",
+    "jsdom": "16.2.2",
+    "jsdom-global": "3.0.2",
     "mocha": "^7.1.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.0.1",

--- a/packages/fxa-shared/test/lib/logger.ts
+++ b/packages/fxa-shared/test/lib/logger.ts
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import 'jsdom-global/register';
+import Logger from '../../lib/logger';
+// tslint:disable-next-line: no-var-requires
+const sinon = require('sinon');
+
+let consoleFn: sinon.SinonSpy;
+
+describe('lib/logger', () => {
+  let logger: Logger;
+
+  describe('constructor', () => {
+    it('should create logger', () => {
+      consoleFn = sinon.spy(window.console, 'info');
+
+      const information = 'Hello Firefox!';
+
+      logger = new Logger();
+      logger.info(information);
+
+      sinon.assert.calledWith(consoleFn, information);
+      consoleFn.restore();
+    });
+  });
+
+  describe('info', () => {
+    beforeEach(() => {
+      logger = new Logger(window);
+      consoleFn = sinon.spy(window.console, 'info');
+    });
+
+    afterEach(() => {
+      consoleFn.restore();
+    });
+
+    it('should log from string', () => {
+      const information = 'Information about stuff!';
+      logger.info(information);
+
+      sinon.assert.calledWith(consoleFn, information);
+    });
+  });
+
+  describe('trace', () => {
+    beforeEach(() => {
+      logger = new Logger(window);
+      consoleFn = sinon.spy(window.console, 'trace');
+    });
+
+    afterEach(() => {
+      consoleFn.restore();
+    });
+
+    it('should print trace', () => {
+      logger.trace();
+
+      sinon.assert.calledOnce(consoleFn);
+    });
+  });
+
+  describe('warn', () => {
+    beforeEach(() => {
+      logger = new Logger(window);
+      consoleFn = sinon.spy(window.console, 'warn');
+    });
+
+    afterEach(() => {
+      consoleFn.restore();
+    });
+
+    it('should log from string', () => {
+      const warning = 'Warning about something!';
+      logger.warn(warning);
+
+      sinon.assert.calledWith(consoleFn, warning);
+    });
+  });
+
+  describe('error', () => {
+    beforeEach(() => {
+      logger = new Logger(window);
+      consoleFn = sinon.spy(window.console, 'error');
+    });
+
+    afterEach(() => {
+      consoleFn.restore();
+    });
+
+    it('should log from string', () => {
+      const error = 'Something went really wrong!';
+      logger.error(error);
+
+      sinon.assert.calledWith(consoleFn, error);
+    });
+
+    it('should log from object', () => {
+      const error = new Error('Something went super wrong!');
+      logger.error('Error %s', String(error));
+
+      sinon.assert.calledWith(consoleFn, 'Error %s', String(error));
+    });
+  });
+});

--- a/packages/fxa-shared/test/lib/sentry.ts
+++ b/packages/fxa-shared/test/lib/sentry.ts
@@ -1,0 +1,201 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import 'jsdom-global/register';
+import { assert } from 'chai';
+import * as Sentry from '@sentry/browser';
+import sentryMetrics from '../../lib/sentry';
+// tslint:disable-next-line: no-var-requires
+const sinon = require('sinon');
+
+const dsn = 'https://public:private@host:port/1';
+
+describe('lib/sentry', () => {
+  before(() => {
+    // Reduce console log noise in test output
+    sinon.spy(console, 'error');
+  });
+
+  after(() => {
+    (globalThis.window.console.error as sinon.SinonSpy).restore();
+  });
+
+  describe('init', () => {
+    it('properly configures with dsn', () => {
+      try {
+        sentryMetrics.configure(dsn);
+      } catch (e) {
+        assert.isNull(e);
+      }
+    });
+  });
+
+  describe('beforeSend', () => {
+    sentryMetrics.configure(dsn);
+
+    it('works without request url', () => {
+      const data = {
+        key: 'value',
+      } as Sentry.Event;
+
+      const resultData = sentryMetrics.__beforeSend(data);
+
+      assert.equal(data, resultData);
+    });
+
+    it('fingerprints errno', () => {
+      const data = {
+        request: {
+          url: 'https://example.com',
+        },
+        tags: {
+          errno: '100',
+        },
+      } as Sentry.Event;
+
+      const resultData = sentryMetrics.__beforeSend(data);
+
+      assert.equal(
+        resultData.fingerprint![0],
+        'errno100',
+        'correct fingerprint'
+      );
+      assert.equal(
+        resultData.level,
+        Sentry.Severity.Info,
+        'correct known error level'
+      );
+    });
+
+    it('properly erases sensitive information from url', () => {
+      const url = 'https://accounts.firefox.com/complete_reset_password';
+      const badQuery =
+        '?token=foo&code=bar&email=some%40restmail.net&service=sync';
+      const goodQuery = '?token=VALUE&code=VALUE&email=VALUE&service=sync';
+      const badData = {
+        request: {
+          url: url + badQuery,
+        },
+      };
+
+      const goodData = {
+        request: {
+          url: url + goodQuery,
+        },
+      };
+
+      const resultData = sentryMetrics.__beforeSend(badData);
+      assert.equal(resultData.request!.url, goodData.request.url);
+    });
+
+    it('properly erases sensitive information from referrer', () => {
+      const url = 'https://accounts.firefox.com/complete_reset_password';
+      const badQuery =
+        '?token=foo&code=bar&email=some%40restmail.net&service=sync';
+      const goodQuery = '?token=VALUE&code=VALUE&email=VALUE&service=sync';
+      const badData = {
+        request: {
+          headers: {
+            Referer: url + badQuery,
+          },
+        },
+      };
+
+      const goodData = {
+        request: {
+          headers: {
+            Referer: url + goodQuery,
+          },
+        },
+      };
+
+      const resultData = sentryMetrics.__beforeSend(badData);
+      assert.equal(
+        resultData.request?.headers?.Referer,
+        goodData.request.headers.Referer
+      );
+    });
+
+    it('properly erases sensitive information from abs_path', () => {
+      const url = 'https://accounts.firefox.com/complete_reset_password';
+      const badCulprit =
+        'https://accounts.firefox.com/scripts/57f6d4e4.main.js';
+      const badAbsPath =
+        'https://accounts.firefox.com/complete_reset_password?token=foo&code=bar&email=a@a.com&service=sync&resume=barbar';
+      const goodAbsPath =
+        'https://accounts.firefox.com/complete_reset_password?token=VALUE&code=VALUE&email=VALUE&service=sync&resume=VALUE';
+      const data = {
+        culprit: badCulprit,
+        exception: {
+          values: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    abs_path: badAbsPath, // eslint-disable-line camelcase
+                  },
+                  {
+                    abs_path: badAbsPath, // eslint-disable-line camelcase
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        request: {
+          url,
+        },
+      };
+
+      const resultData = sentryMetrics.__beforeSend(data);
+
+      assert.equal(
+        resultData.exception!.values![0].stacktrace!.frames![0].abs_path,
+        goodAbsPath
+      );
+      assert.equal(
+        resultData.exception!.values![0].stacktrace!.frames![1].abs_path,
+        goodAbsPath
+      );
+    });
+  });
+
+  describe('cleanUpQueryParam', () => {
+    it('properly erases sensitive information', () => {
+      const fixtureUrl1 =
+        'https://accounts.firefox.com/complete_reset_password?token=foo&code=bar&email=some%40restmail.net';
+      const expectedUrl1 =
+        'https://accounts.firefox.com/complete_reset_password?token=VALUE&code=VALUE&email=VALUE';
+      const resultUrl1 = sentryMetrics.__cleanUpQueryParam(fixtureUrl1);
+
+      assert.equal(resultUrl1, expectedUrl1);
+    });
+
+    it('properly erases sensitive information, keeps allowed fields', () => {
+      const fixtureUrl2 =
+        'https://accounts.firefox.com/signup?client_id=foo&service=sync';
+      const expectedUrl2 =
+        'https://accounts.firefox.com/signup?client_id=foo&service=sync';
+      const resultUrl2 = sentryMetrics.__cleanUpQueryParam(fixtureUrl2);
+
+      assert.equal(resultUrl2, expectedUrl2);
+    });
+
+    it('properly returns the url when there is no query', () => {
+      const expectedUrl = 'https://accounts.firefox.com/signup';
+      const resultUrl = sentryMetrics.__cleanUpQueryParam(expectedUrl);
+
+      assert.equal(resultUrl, expectedUrl);
+    });
+  });
+
+  describe('captureException', () => {
+    it('calls Sentry.captureException', () => {
+      const captureException = sinon.spy(Sentry, 'captureException');
+      captureException(new Error('testo'));
+      sinon.assert.calledOnce(captureException);
+      captureException.restore();
+    });
+  });
+});


### PR DESCRIPTION
Closes #5017

This PR adds the files for Sentry (and by extension a logger), and sets it up in fxa-settings.

Notes:

- The Sentry and Logging files, as well as their accompanying tests, more or less came from fxa-payments-server, and were converted to TypeScript.
- The Sentry and Logging files are in fxa-shared because they are being used in AppErrorBoundary, which is itself a shared fxa-component. I am open to directory naming suggestions.