### PR TITLE
feat(newsletters): Add experiment for newsletter subscriptions

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
@@ -17,6 +17,7 @@ const experimentGroupingRules = [
   require('./sentry'),
   require('./email-mx-validation'),
   require('./send-sms-header'),
+  require('./newsletter-sync'),
 ].map(ExperimentGroupingRule => new ExperimentGroupingRule());
 
 class ExperimentChoiceIndex {

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/newsletter-sync.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/newsletter-sync.js
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * This defines the newsletter sync experiment grouping rules. For more
+ * details please reference https://docs.google.com/document/d/1S9Mt83DNHfQHtiuU4m3dLOIyA_FhU5tPHAgJqZkGoCE/edit#.
+ */
+'use strict';
+
+const BaseGroupingRule = require('./base');
+const GROUPS = [
+  'control',
+
+  // Treatment branches
+  'trailhead-copy',
+  'new-copy',
+];
+
+// This experiment is disabled by default. If you would like to go through
+// the flow, load email-first screen and append query params
+// `?forceExperiment=newsletterSync&forceExperimentGroup=new-copy`
+const ROLLOUT_RATE = 0.0;
+
+module.exports = class NewsletterSync extends BaseGroupingRule {
+  constructor() {
+    super();
+    this.name = 'newsletterSync';
+
+    // Easier to set class properties for testability
+    this.groups = GROUPS;
+    this.rolloutRate = ROLLOUT_RATE;
+  }
+
+  /**
+   * For this experiment, we are doing a staged rollout.`
+   *
+   * @param {Object} subject data used to decide
+   *  @param {Boolean} isSync is this a sync signup?
+   * @returns {Any}
+   */
+  choose(subject = {}) {
+    let choice = false;
+
+    // Only enroll for sync users
+    if (!subject.isSync) {
+      return false;
+    }
+
+    // TODO Add restriction to `EN` locales
+
+    if (this.bernoulliTrial(this.rolloutRate, subject.uniqueUserId)) {
+      choice = this.uniformChoice(GROUPS, subject.uniqueUserId);
+    }
+    return choice;
+  }
+};

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/newsletters/add_newsletters.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/newsletters/add_newsletters.mustache
@@ -1,13 +1,19 @@
 <div id="main-content" class="card add-newsletters">
     <header>
-        <h1 id="fxa-add-newsletters-header">
-            {{#showSuccessMessage}}
-                {{#isSignedIn}}
-                    <span class="success success-authenticated visible">{{#t}}This Firefox is connected{{/t}}</span>
-                {{/isSignedIn}}
-            {{/showSuccessMessage}}
+        {{#isSignedIn}}
+            <span class="success success-authenticated visible">{{#t}}This Firefox is connected{{/t}}</span>
+        {{/isSignedIn}}
 
-            {{#t}}Sign up for more{{/t}}<span class="description">{{#t}}Practical knowledge is coming to your inbox.{{/t}}</span>
+        <h1 id="fxa-add-newsletters-header">
+            {{#t}}Sign up for more{{/t}}
+            <span class="description">
+                {{#isTrailheadCopy}}
+                  {{#t}}Practical knowledge is coming to your inbox.{{/t}}
+                {{/isTrailheadCopy}}
+                {{^isTrailheadCopy}}
+                    {{#t}}Get practical knowledge in your inbox about:{{/t}}
+                {{/isTrailheadCopy}}
+            </span>
         </h1>
     </header>
 
@@ -22,7 +28,7 @@
             {{/newsletters}}
 
             <div class="button-row">
-                <button id="submit-btn" type="submit">{{#t}}Subscribe{{/t}}</button>
+                <button id="submit-btn" type="submit">{{#t}}Subscribe %(email)s{{/t}}</button>
             </div>
             <div class="links">
                 <a id="maybe-later-btn" data-flow-event="link.maybe-later">{{#t}}Maybe later{{/t}}</a>

--- a/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
+++ b/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
@@ -7,6 +7,7 @@ import AuthErrors from '../lib/auth-errors';
 import Cocktail from '../lib/cocktail';
 import FlowEventsMixin from './mixins/flow-events-mixin';
 import FormView from './form';
+import NewsletterSyncExperiment from './mixins/newsletter-sync-experiment-mixin';
 import ServiceMixin from './mixins/service-mixin';
 import Template from 'templates/confirm_signup_code.mustache';
 import ResendMixin from './mixins/resend-mixin';
@@ -83,8 +84,16 @@ class ConfirmSignupCodeView extends FormView {
           });
         }
 
-        // TBD We should setup experiment rules to determine which broker method gets called.
-        return this.invokeBrokerMethod('afterSignUpConfirmationPoll', account);
+        if (this.isInNewsletterSyncExperimentTreatment()) {
+          this.navigate('/post_verify/newsletters/add_newsletters', {
+            account,
+          });
+        } else {
+          return this.invokeBrokerMethod(
+            'afterSignUpConfirmationPoll',
+            account
+          );
+        }
       })
       .catch(err => {
         if (
@@ -104,6 +113,7 @@ class ConfirmSignupCodeView extends FormView {
 Cocktail.mixin(
   ConfirmSignupCodeView,
   FlowEventsMixin,
+  NewsletterSyncExperiment,
   ResendMixin(),
   ServiceMixin,
   SessionVerificationPollMixin

--- a/packages/fxa-content-server/app/scripts/views/mixins/newsletter-sync-experiment-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/newsletter-sync-experiment-mixin.js
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import ExperimentMixin from './experiment-mixin';
+const EXPERIMENT_NAME = 'newsletterSync';
+
+export default {
+  dependsOn: [ExperimentMixin],
+
+  isInNewsletterSyncExperimentTreatment() {
+    return (
+      this.isInNewsletterSyncExperimentTrailheadCopy() ||
+      this.isInNewsletterSyncExperimentNewCopy()
+    );
+  },
+
+  isInNewsletterSyncExperimentTrailheadCopy() {
+    const experimentGroup = this.getAndReportExperimentGroup(EXPERIMENT_NAME, {
+      isSync: this.relier.isSync(),
+    });
+
+    return experimentGroup === 'trailhead-copy';
+  },
+
+  isInNewsletterSyncExperimentNewCopy() {
+    const experimentGroup = this.getAndReportExperimentGroup(EXPERIMENT_NAME, {
+      isSync: this.relier.isSync(),
+    });
+
+    return experimentGroup === 'new-copy';
+  },
+};

--- a/packages/fxa-content-server/app/scripts/views/post_verify/newsletters/add_newsletters.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/newsletters/add_newsletters.js
@@ -11,6 +11,7 @@ import { assign } from 'underscore';
 import Cocktail from 'cocktail';
 import EmailOptInMixin from '../../mixins/email-opt-in-mixin';
 import FormView from '../../form';
+import NewsletterSyncExperimentMixin from '../../mixins/newsletter-sync-experiment-mixin';
 import Template from 'templates/post_verify/newsletters/add_newsletters.mustache';
 import preventDefaultThen from '../../decorators/prevent_default_then';
 
@@ -31,6 +32,21 @@ class AddNewsletters extends FormView {
       this.relier.set('redirectTo', this.window.location.href);
       return this.replaceCurrentPage('/');
     }
+  }
+
+  setInitialContext(context) {
+    const account = this.getSignedInAccount();
+
+    const email = account.get('email');
+    context.set({
+      email,
+      isSignedIn: this.user.isSignedInAccount(account),
+
+      // All users that are not in the trailhead experiment group will get the
+      // new copy text. This includes users who are not in the experiment at all
+      // and navigated directly to the page.
+      isTrailheadCopy: this.isInNewsletterSyncExperimentTrailheadCopy(account),
+    });
   }
 
   submit() {
@@ -54,6 +70,6 @@ class AddNewsletters extends FormView {
   }
 }
 
-Cocktail.mixin(AddNewsletters, EmailOptInMixin);
+Cocktail.mixin(AddNewsletters, EmailOptInMixin, NewsletterSyncExperimentMixin);
 
 export default AddNewsletters;

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 
 describe('lib/experiments/grouping-rules/index', () => {
   it('EXPERIMENT_NAMES is exported', () => {
-    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 6);
+    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 7);
   });
 
   describe('choose', () => {

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/newsletter-sync.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/newsletter-sync.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import Experiment from 'lib/experiments/grouping-rules/send-sms-install-link';
+
+describe('lib/experiments/grouping-rules/newsletter-sync', () => {
+  let experiment;
+
+  beforeEach(() => {
+    experiment = new Experiment();
+  });
+
+  describe('choose', () => {
+    it('returns false if not Sync', () => {
+      assert.isFalse(
+        experiment.choose({ isSync: false, uniqueUserId: 'user-id' })
+      );
+    });
+
+    it('returns false if rollout 0%', () => {
+      experiment.rolloutRate = 0;
+      assert.isFalse(
+        experiment.choose({ isSync: true, uniqueUserId: 'user-id' })
+      );
+    });
+
+    it('returns treatment if rollout 100%', () => {
+      experiment.rolloutRate = 1;
+      assert.isTrue(
+        experiment.groups.includes(
+          experiment.choose({ isSync: true, uniqueUserId: 'user-id' })
+        )
+      );
+    });
+  });
+});

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -48,6 +48,7 @@ module.exports = [
   'tests/functional/pages.js',
   'tests/functional/password_strength.js',
   'tests/functional/password_visibility.js',
+  'tests/functional/post_verify/newsletters.js',
   'tests/functional/post_verify/account_recovery.js',
   'tests/functional/post_verify/secondary_email.js',
   'tests/functional/pp.js',

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -309,6 +309,12 @@ module.exports = {
     READY: '.account-ready-service',
     SUBMIT: 'button[type="submit"]',
   },
+  POST_VERIFY_ADD_NEWSLETTERS: {
+    DESCRIPTION: '.description',
+    HEADER: '#fxa-add-newsletters-header',
+    SUBMIT: 'button[type="submit"]',
+    NEWSLETTERS,
+  },
   RECOVERY_KEY: {
     CANCEL_BUTTON: '.cancel',
     CONFIRM_PASSWORD_CONTINUE: '.generate-key-link',

--- a/packages/fxa-content-server/tests/functional/post_verify/newsletters.js
+++ b/packages/fxa-content-server/tests/functional/post_verify/newsletters.js
@@ -1,0 +1,105 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { registerSuite } = intern.getInterface('object');
+const FunctionalHelpers = require('./../lib/helpers');
+const selectors = require('./../lib/selectors');
+const config = intern._config;
+
+const ENTER_EMAIL_URL = config.fxaContentRoot;
+const Newsletters =
+  config.fxaContentRoot + 'post_verify/newsletters/add_newsletters';
+
+const PASSWORD = 'password1234567';
+let email;
+
+const {
+  clearBrowserState,
+  click,
+  createEmail,
+  createUser,
+  fillOutEmailFirstSignIn,
+  openPage,
+  testElementExists,
+  testElementTextInclude,
+} = FunctionalHelpers;
+
+registerSuite('post_verify_newsletters', {
+  beforeEach: function() {
+    email = createEmail();
+
+    return this.remote
+      .then(clearBrowserState({ force: true }))
+      .then(createUser(email, PASSWORD, { preVerified: true }));
+  },
+
+  tests: {
+    'subscribe to newsletters': function() {
+      return this.remote
+        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+        .then(testElementExists(selectors.SETTINGS.HEADER))
+
+        .then(
+          openPage(Newsletters, selectors.POST_VERIFY_ADD_NEWSLETTERS.HEADER, {
+            query: {
+              forceExperiment: 'newsletterSync',
+              forceExperimentGroup: 'trailhead-copy',
+            },
+          })
+        )
+
+        .then(
+          click(selectors.POST_VERIFY_ADD_NEWSLETTERS.NEWSLETTERS.ONLINE_SAFETY)
+        )
+        .then(
+          click(
+            selectors.POST_VERIFY_ADD_NEWSLETTERS.NEWSLETTERS.HEALTHY_INTERNET
+          )
+        )
+
+        .then(
+          testElementTextInclude(
+            selectors.POST_VERIFY_ADD_NEWSLETTERS.SUBMIT,
+            email
+          )
+        )
+        .then(
+          testElementTextInclude(
+            selectors.POST_VERIFY_ADD_NEWSLETTERS.DESCRIPTION,
+            'Practical knowledge is coming to your inbox'
+          )
+        )
+
+        .then(click(selectors.POST_VERIFY_ADD_NEWSLETTERS.SUBMIT))
+
+        .then(testElementExists(selectors.SETTINGS.HEADER));
+    },
+
+    'treatment new copy': function() {
+      return this.remote
+        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+        .then(testElementExists(selectors.SETTINGS.HEADER))
+
+        .then(
+          openPage(Newsletters, selectors.POST_VERIFY_ADD_NEWSLETTERS.HEADER, {
+            query: {
+              forceExperiment: 'newsletterSync',
+              forceExperimentGroup: 'new-copy',
+            },
+          })
+        )
+
+        .then(
+          testElementTextInclude(
+            selectors.POST_VERIFY_ADD_NEWSLETTERS.DESCRIPTION,
+            'Get practical knowledge in your inbox about'
+          )
+        );
+    },
+  },
+});


### PR DESCRIPTION
~Blocked by https://github.com/mozilla/fxa/pull/5124~

Fixes #4928

This PR adds all the supporting logic the newsletters sync experiment per https://docs.google.com/document/d/1S9Mt83DNHfQHtiuU4m3dLOIyA_FhU5tPHAgJqZkGoCE/edit#. 

* `control` - not shown newsletters
* `trailhead-copy` - description says "Practical knowledge is coming to your inbox."
* `new-copy` - description says "Get practical knowledge in your inbox about:"

This experiment will be disabled by default, but you can test by going to these urls and signing up for an account.

#### trailhead-copy
http://localhost:3030/?service=sync&context=fx_desktop_v3&entrypoint=fxa_discoverability_native&action=email&forceExperiment=newsletterSync&forceExperimentGroup=trailhead-copy

#### new-copy
http://localhost:3030/?service=sync&context=fx_desktop_v3&entrypoint=fxa_discoverability_native&action=email&forceExperiment=newsletterSync&forceExperimentGroup=new-copy

