### PR TITLE
fix(docker): added Dockerfile for fxa-customs-server

### DIFF
--- a/packages/fxa-customs-server/Dockerfile
+++ b/packages/fxa-customs-server/Dockerfile
@@ -1,0 +1,3 @@
+FROM fxa-node:latest
+
+COPY --from=fxa-builder:latest --chown=app:app /fxa/packages/fxa-customs-server /app


### PR DESCRIPTION
since customs-server doesn't have a pm2.config.js file
it needs a Dockerfile in order to build and deploy

fixes #5208