### PR TITLE
feat(payments): make product details configurable in Stripe metadata

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -283,11 +283,6 @@ plan-details-show-button = Show details
 plan-details-hide-button = Hide details
 plan-details-total-label = Total
 
-fpn-details-1 = Device-level encryption
-fpn-details-2 = Servers in 30+ countries
-fpn-details-3 = Connect 5 devices with one subscription
-fpn-details-4 = Available for Windows, iOS and Android
-
 ## payment confirmation
 payment-confirmation-alert = Click here to download
 payment-confirmation-mobile-alert = Didn't open app? <a>Click Here</a>

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -35,6 +35,7 @@ type AppProps = {
   navigateToUrl: (url: string) => void;
   getScreenInfo: () => ScreenInfo;
   locationReload: () => void;
+  navigatorLanguages: readonly string[];
 };
 
 export const App = ({
@@ -46,6 +47,7 @@ export const App = ({
   navigateToUrl,
   getScreenInfo,
   locationReload,
+  navigatorLanguages = ['en-US', 'en'],
 }: AppProps) => {
   const appContextValue: AppContextType = {
     config,
@@ -55,6 +57,7 @@ export const App = ({
     navigateToUrl,
     getScreenInfo,
     locationReload,
+    navigatorLanguages,
   };
   FlowEvents.init(queryParams);
   observeNavigationTiming('/navigation-timing');
@@ -62,7 +65,7 @@ export const App = ({
   return (
     <AppContext.Provider value={appContextValue}>
       <AppLocalizationProvider
-        userLocales={navigator.languages}
+        userLocales={navigatorLanguages}
         bundles={['main']}
       >
         <Localized id="document" attrs={{ title: true }}>

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
@@ -3,6 +3,8 @@ import { storiesOf } from '@storybook/react';
 import MockApp from '../../../.storybook/components/MockApp';
 import PlanDetails from './index';
 
+import { defaultAppContext } from '../../lib/AppContext';
+
 const userProfile = {
   avatar: 'http://placekitten.com/256/256',
   displayName: 'Foxy77',
@@ -23,11 +25,42 @@ const selectedPlan = {
   amount: 935,
   interval: 'month' as const,
   interval_count: 1,
+  plan_metadata: {
+    'product:subtitle': 'Really keen product',
+    'product:details:1':
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+    'product:details:2': 'Sed ut perspiciatis unde omnis iste natus',
+    'product:details:3': 'Nemo enim ipsam voluptatem',
+    'product:details:4':
+      'Ut enim ad minima veniam, quis nostrum exercitationem',
+    'product:subtitle:xx-pirate': 'VPN fer yer full-device',
+    'product:details:1:xx-pirate': 'Device-level encryption arr',
+    'product:details:2:xx-pirate': 'Servers is 30+ countries matey',
+    'product:details:3:xx-pirate': "Connects 5 devices wit' one subscription",
+    'product:details:4:xx-pirate': "Available fer Windows, iOS an' Android",
+  },
 };
 
 storiesOf('components/PlanDetail', module)
   .add('default', () => (
     <MockApp>
+      <PlanDetails
+        {...{
+          profile: userProfile,
+          showExpandButton: false,
+          selectedPlan,
+          isMobile: false,
+        }}
+      />
+    </MockApp>
+  ))
+  .add('localized to xx-pirate', () => (
+    <MockApp
+      appContextValue={{
+        ...defaultAppContext,
+        navigatorLanguages: ['xx-pirate'],
+      }}
+    >
       <PlanDetails
         {...{
           profile: userProfile,

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.test.tsx
@@ -31,6 +31,12 @@ const selectedPlan = {
   amount: 935,
   interval: 'month' as const,
   interval_count: 1,
+  plan_metadata: {
+    'product:subtitle': 'FPN subtitle',
+    'product:details:1': 'Detail 1',
+    'product:details:2': 'Detail 2',
+    'product:details:3': 'Detail 3',
+  },
 };
 
 afterEach(cleanup);
@@ -50,9 +56,12 @@ describe('PlanDetails', () => {
       );
     };
 
-    const { queryByTestId } = subject();
+    const { queryByTestId, queryByText } = subject();
     const productLogo = queryByTestId('product-logo');
     expect(productLogo).toHaveAttribute('alt', selectedPlan.product_name);
+    expect(
+      queryByText(selectedPlan.plan_metadata['product:subtitle'])
+    ).toBeInTheDocument();
 
     const footer = queryByTestId('footer');
     expect(footer).toBeVisible();
@@ -96,11 +105,16 @@ describe('PlanDetails', () => {
       );
     };
 
-    const { getByTestId, queryByTestId } = subject();
+    const { getByTestId, queryByTestId, queryByText } = subject();
 
     fireEvent.click(getByTestId('button'));
 
     expect(queryByTestId('list')).toBeVisible();
+
+    for (let idx = 1; idx <= 3; idx++) {
+      const item = selectedPlan.plan_metadata[`product:details:${idx}`];
+      expect(queryByText(item)).toBeInTheDocument();
+    }
 
     fireEvent.click(getByTestId('button'));
 

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { Localized } from '@fluent/react';
 import { getLocalizedCurrency, formatPlanPricing } from '../../lib/formats';
-import { metadataFromPlan } from '../../store/utils';
+import { metadataFromPlan, productDetailsFromPlan } from '../../store/utils';
+import { AppContext } from '../../lib/AppContext';
 
 // this is a fallback incase webIconURL is undefined,
 // this is a rare case, but it also keeps typescript
@@ -24,6 +25,7 @@ export const PlanDetails = ({
   showExpandButton = false,
   className = 'default',
 }: PlanDetailsProps) => {
+  const { navigatorLanguages } = useContext(AppContext);
   const [detailsHidden, setDetailsState] = useState(showExpandButton);
   const {
     product_name,
@@ -33,6 +35,10 @@ export const PlanDetails = ({
     interval_count,
   } = selectedPlan;
   const { webIconURL } = metadataFromPlan(selectedPlan);
+  const productDetails = productDetailsFromPlan(
+    selectedPlan,
+    navigatorLanguages
+  );
 
   const role = isMobile ? undefined : 'complementary';
 
@@ -66,7 +72,9 @@ export const PlanDetails = ({
                 <h3 id="plan-details-product" className="plan-details-product">
                   {product_name}
                 </h3>
-                <p className="plan-details-description">Full-device VPN</p>
+                <p className="plan-details-description">
+                  {productDetails.subtitle}
+                </p>
               </div>
             </div>
             <Localized
@@ -77,32 +85,15 @@ export const PlanDetails = ({
               <p>{planPrice}</p>
             </Localized>
           </div>
-          {!detailsHidden ? (
+          {!detailsHidden && productDetails.details ? (
             <div className="plan-details-list" data-testid="list">
               <Localized id="plan-details-header">
                 <h4>Product details</h4>
               </Localized>
               <ul>
-                <li>
-                  <Localized id="fpn-details-1">
-                    <span></span>
-                  </Localized>
-                </li>
-                <li>
-                  <Localized id="fpn-details-2">
-                    <span></span>
-                  </Localized>
-                </li>
-                <li>
-                  <Localized id="fpn-details-3">
-                    <span></span>
-                  </Localized>
-                </li>
-                <li>
-                  <Localized id="fpn-details-4">
-                    <span></span>
-                  </Localized>
-                </li>
+                {productDetails.details.map((detail, idx) => (
+                  <li key={idx}>{detail}</li>
+                ))}
               </ul>
             </div>
           ) : null}

--- a/packages/fxa-payments-server/src/index.tsx
+++ b/packages/fxa-payments-server/src/index.tsx
@@ -42,6 +42,7 @@ async function init() {
           navigateToUrl,
           getScreenInfo,
           locationReload,
+          navigatorLanguages: navigator.languages,
         }}
       />,
       document.getElementById('root')

--- a/packages/fxa-payments-server/src/lib/AppContext.tsx
+++ b/packages/fxa-payments-server/src/lib/AppContext.tsx
@@ -11,6 +11,7 @@ export type AppContextType = {
   navigateToUrl: (url: string) => void;
   getScreenInfo: () => ScreenInfo;
   locationReload: (url: string) => void;
+  navigatorLanguages?: readonly string[];
 };
 
 /* istanbul ignore next - this function does nothing worth covering */
@@ -24,6 +25,7 @@ export const defaultAppContext = {
   matchMediaDefault: (query: string) => matchMedia(query),
   navigateToUrl: noopFunction,
   queryParams: {},
+  navigatorLanguages: ['en-US', 'en'],
 };
 
 export const AppContext = React.createContext<AppContextType>(

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -310,6 +310,7 @@ export const MOCK_PLANS: Plan[] = [
     product_metadata: {
       productSet: '123done',
       webIconURL: 'http://example.com/123donepro.jpg',
+      'product:subtitle': '123DonePro subtitle',
     },
   },
   {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Localized } from '@fluent/react';
 import { getLocalizedCurrency, formatPlanPricing } from '../../../lib/formats';
-import { metadataFromPlan } from '../../../store/utils';
+import { metadataFromPlan, productDetailsFromPlan } from '../../../store/utils';
+import { AppContext } from '../../../lib/AppContext';
 
 import ffLogo from '../../../images/firefox-logo.svg';
 
@@ -76,8 +77,10 @@ export const PlanDetailsCard = ({
   plan: Plan;
   className?: string;
 }) => {
+  const { navigatorLanguages } = useContext(AppContext);
   const { product_name, amount, currency, interval, interval_count } = plan;
   const { webIconURL } = metadataFromPlan(plan);
+  const productDetails = productDetailsFromPlan(plan, navigatorLanguages);
   const planPrice = formatPlanPricing(
     amount,
     currency,
@@ -107,7 +110,7 @@ export const PlanDetailsCard = ({
             </h3>
             {/* TODO: make this configurable, issue #4741 / FXA-1484 */}
             <p className="product-description plan-details-description">
-              Full-device VPN
+              {productDetails.subtitle}
             </p>
           </div>
         </div>

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.stories.tsx
@@ -4,6 +4,7 @@ import { linkTo } from '@storybook/addon-links';
 import { storiesOf } from '@storybook/react';
 import { APIError } from '../../../lib/apiClient';
 import MockApp from '../../../../.storybook/components/MockApp';
+import { defaultAppContext, AppContextType } from '../../../lib/AppContext';
 
 import { SignInLayout } from '../../../components/AppLayout';
 
@@ -15,6 +16,19 @@ function init() {
   storiesOf('routes/Product/SubscriptionUpgrade', module)
     .add('upgrade offer', () => (
       <SubscriptionUpgradeView
+        props={{
+          ...MOCK_PROPS,
+          updateSubscriptionPlanAndRefresh: (subscriptionId, plan) =>
+            linkToUpgradeSuccess(),
+        }}
+      />
+    ))
+    .add('upgrade offer localized to xx-pirate', () => (
+      <SubscriptionUpgradeView
+        appContextValue={{
+          ...defaultAppContext,
+          navigatorLanguages: ['xx-pirate'],
+        }}
         props={{
           ...MOCK_PROPS,
           updateSubscriptionPlanAndRefresh: (subscriptionId, plan) =>
@@ -58,10 +72,12 @@ function init() {
 
 const SubscriptionUpgradeView = ({
   props = MOCK_PROPS,
+  appContextValue = defaultAppContext,
 }: {
   props?: SubscriptionUpgradeProps;
+  appContextValue?: AppContextType;
 }) => (
-  <MockApp>
+  <MockApp appContextValue={appContextValue}>
     <SignInLayout>
       <SubscriptionUpgrade {...props} />
     </SignInLayout>

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -53,8 +53,20 @@ describe('routes/Product/SubscriptionUpgrade', () => {
       '.from-plan .product-name'
     ) as Element;
     expect(fromName.textContent).toEqual(UPGRADE_FROM_PLAN.product_name);
+    const fromDesc = container.querySelector(
+      '.from-plan .product-description'
+    ) as Element;
+    expect(fromDesc.textContent).toEqual(
+      UPGRADE_FROM_PLAN.product_metadata['product:subtitle']
+    );
     const toName = container.querySelector('.to-plan .product-name') as Element;
     expect(toName.textContent).toEqual(SELECTED_PLAN.product_name);
+    const toDesc = container.querySelector(
+      '.to-plan .product-description'
+    ) as Element;
+    expect(toDesc.textContent).toEqual(
+      SELECTED_PLAN.product_metadata['product:subtitle']
+    );
   });
 
   it('can be submitted after confirmation is checked', async () => {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/mocks.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/mocks.tsx
@@ -46,6 +46,14 @@ export const SELECTED_PLAN: Plan = {
   interval_count: 1,
   product_metadata: {
     webIconURL: 'http://placekitten.com/49/49?image=2',
+    'product:subtitle': 'Even more keen product',
+    'product:details:1': 'Quis autem vel eum iure reprehenderit',
+    'product:details:2': 'Sed ut perspiciatis unde omnis iste natus',
+    'product:details:3': 'Nemo enim ipsam voluptatem',
+    'product:subtitle:xx-pirate': 'VPN fer land lubbers',
+    'product:details:1:xx-pirate': 'Device-level encryption arr',
+    'product:details:2:xx-pirate': 'Servers is 30+ countries matey',
+    'product:details:3:xx-pirate': "Connects 5 devices wit' one subscription",
   },
 };
 
@@ -59,5 +67,16 @@ export const UPGRADE_FROM_PLAN: Plan = {
   interval_count: 1,
   product_metadata: {
     webIconURL: 'http://placekitten.com/49/49?image=9',
+    'product:subtitle': 'Nifty product',
+    'product:details:1':
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+    'product:details:2': 'Sed ut perspiciatis unde omnis iste natus',
+    'product:details:3': 'Nemo enim ipsam voluptatem',
+    'product:details:4':
+      'Ut enim ad minima veniam, quis nostrum exercitationem',
+    'product:subtitle:xx-pirate': 'VPN fer yer full-device',
+    'product:details:1:xx-pirate': 'Device-level encryption arr',
+    'product:details:2:xx-pirate': 'Servers is 30+ countries matey',
+    'product:details:3:xx-pirate': "Connects 5 devices wit' one subscription",
   },
 };

--- a/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
@@ -222,6 +222,13 @@ const PLANS: Plan[] = [
     interval_count: 1,
     product_metadata: {
       webIconURL: 'http://placekitten.com/512/512',
+      'product:subtitle': 'Really keen product',
+      'product:details:1':
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+      'product:details:2': 'Sed ut perspiciatis unde omnis iste natus',
+      'product:details:3': 'Nemo enim ipsam voluptatem',
+      'product:details:4':
+        'Ut enim ad minima veniam, quis nostrum exercitationem',
     },
   },
 ];

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -235,6 +235,13 @@ const PLANS = [
     interval_count: 1,
     product_metadata: {
       webIconURL: 'http://placekitten.com/512/512',
+      'product:subtitle': 'Really keen product',
+      'product:details:1':
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+      'product:details:2': 'Sed ut perspiciatis unde omnis iste natus',
+      'product:details:3': 'Nemo enim ipsam voluptatem',
+      'product:details:4':
+        'Ut enim ad minima veniam, quis nostrum exercitationem',
     },
   },
 ];

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -36,12 +36,16 @@ export interface Token {
 
 export type PlanInterval = 'day' | 'week' | 'month' | 'year';
 
+export interface RawMetadata {
+  [propName: string]: any;
+}
+
 export interface Plan {
   plan_id: string;
-  plan_metadata?: PlanMetadata;
+  plan_metadata?: RawMetadata;
   product_id: string;
   product_name: string;
-  product_metadata?: ProductMetadata;
+  product_metadata?: RawMetadata;
   currency: string;
   amount: number;
   interval: PlanInterval;
@@ -62,6 +66,11 @@ export interface ProductMetadata {
   upgradeCTA?: string | null;
   downloadURL?: string | null;
   // capabilities:{clientID}: string // filtered out or ignored for now
+}
+
+export interface ProductDetails {
+  subtitle?: string;
+  details?: string[];
 }
 
 export interface Subscription {

--- a/packages/fxa-payments-server/src/store/utils.tsx
+++ b/packages/fxa-payments-server/src/store/utils.tsx
@@ -1,4 +1,15 @@
-import { Plan, ProductMetadata } from './types';
+import { Plan, ProductMetadata, ProductDetails } from './types';
+
+const DEFAULT_LOCALE = 'en-US';
+
+// Fallback to matches what was previously hardcoded in templates and FTL
+const DEFAULT_SUBTITLE = 'Full-device VPN';
+const DEFAULT_DETAILS = [
+  'Device-level encryption',
+  'Servers in 30+ countries',
+  'Connect 5 devices with one subscription',
+  'Available for Windows, iOS and Android',
+];
 
 // Support some default null values for product / plan metadata and
 // allow plan metadata to override product metadata
@@ -13,3 +24,98 @@ export const metadataFromPlan = (plan: Plan): ProductMetadata => ({
   ...plan.product_metadata,
   ...plan.plan_metadata,
 });
+
+/**
+ * Parses through Stripe metadata for product detail strings and localized overrides
+ *
+ * Example metadata:
+ *   product_metadata: {
+ *     'product:subtitle': 'Great Full-device VPN',
+ *     'product:details:3': 'Baz Connects 5 devices with one subscription',
+ *     'product:details:1': 'Foo Device-level encryption',
+ *     'product:details:2': 'Bar Servers in 30+ countries',
+ *     'product:details:4': 'Quux Available for Windows, iOS and Android',
+ *     'product:subtitle:xx-pirate': 'VPN fer yer full-device',
+ *     'product:details:4:xx-pirate': "Available fer Windows, iOS an' Android",
+ *     'product:details:1:xx-pirate': 'Device-level encryption arr',
+ *     'product:details:3:xx-pirate': "Connects 5 devices wit' one subscription",
+ *     'product:details:2:xx-pirate': 'Servers is 30+ countries matey',
+ *     'product:subtitle:xx-partial': 'Partial localization',
+ *     'product:name:xx-partial': true,
+ *   },
+ *
+ * @param plan {Plan}
+ * @param userLocales list of locale strings (only the first is used)
+ * @returns {ProductDetails}
+ */
+export const productDetailsFromPlan = (
+  plan: Plan,
+  userLocales: readonly string[] = [DEFAULT_LOCALE]
+): ProductDetails => {
+  // TODO: support overlaying multiple prioritized locale choices?
+  const selectedLocale = userLocales[0];
+  const metadata = {
+    ...(plan.product_metadata || {}),
+    ...(plan.plan_metadata || {}),
+  };
+  const details: {
+    default: ProductDetails;
+    selected: ProductDetails;
+  } = {
+    default: {},
+    selected: {},
+  };
+
+  const detailsForLocale = (locale: string): ProductDetails => {
+    switch (locale) {
+      case selectedLocale:
+        return details.selected;
+      case DEFAULT_LOCALE:
+        return details.default;
+      default:
+        return {};
+    }
+  };
+
+  const productDetailKeys = Object.keys(metadata)
+    // Limit to product detail metadata keys
+    .filter(k => k.startsWith('product:'))
+    // Sorting keys ensures proper order for lists
+    .sort();
+
+  for (const key of productDetailKeys) {
+    const [_, propName, ...otherKeyParts] = key.split(':');
+
+    const propValue = metadata[key];
+    if (typeof propValue !== 'string') {
+      continue;
+    }
+
+    switch (propName) {
+      // Single string detail properties (just subtitle for now)
+      case 'subtitle': {
+        const [locale = DEFAULT_LOCALE] = otherKeyParts;
+        detailsForLocale(locale)[propName] = propValue;
+        break;
+      }
+      // List detail properties (just detail for now)
+      case 'details': {
+        const [_, locale = DEFAULT_LOCALE] = otherKeyParts;
+        detailsForLocale(locale)[propName] = [
+          ...(detailsForLocale(locale)[propName] || []),
+          propValue,
+        ];
+        break;
+      }
+    }
+  }
+
+  return {
+    ...{
+      subtitle: DEFAULT_SUBTITLE,
+      details: DEFAULT_DETAILS,
+    },
+    ...details.default,
+    ...details.selected,
+  };
+};


### PR DESCRIPTION
Localizable product details in Stripe metadata. Documentation updates to
follow separately in ecosystem docs.

Example usage in Stripe metadata:

```
    product:name = "Firefox Private Network"
    product:subtitle = "Full-device VPN"
    product:details:1 = "Device-level encryption"
    product:details:2 = "Servers in 30+ countries"
    product:details:3 = "Connects 5 devices with one subscription"
    product:details:4 = "Available for Windows, iOS and Android"
    product:name:xx-pirate = "Firefox Private Network"
    product:subtitle:xx-pirate = "VPN fer yer full-device"
    product:details:1:xx-pirate = "Device-level encryption arr"
    product:details:2:xx-pirate = "Servers is 30+ countries matey"
    product:details:3:xx-pirate = "Connects 5 devices wit' one subscription"
    product:details:4:xx-pirate = "Available fer Windows, iOS an' Android"
```

https://jira.mozilla.com/browse/FXA-1484
fixes #4741