### PR TITLE
feat(newsletters): Add newsletters experiment metrics

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiment.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiment.js
@@ -25,6 +25,7 @@ const MANUAL_EXPERIMENTS = {
   // no special experiment is created.
   sendSms: BaseExperiment,
   sendSmsHeader: BaseExperiment,
+  newsletterSync: BaseExperiment,
 };
 
 const ALL_EXPERIMENTS = _.extend({}, STARTUP_EXPERIMENTS, MANUAL_EXPERIMENTS);

--- a/packages/fxa-content-server/app/scripts/lib/metrics.js
+++ b/packages/fxa-content-server/app/scripts/lib/metrics.js
@@ -59,6 +59,7 @@ const ALLOWED_FIELDS = [
   'lang',
   'marketing',
   'navigationTiming',
+  'newsletters',
   'numStoredAccounts',
   'planId',
   'productId',
@@ -161,6 +162,7 @@ function Metrics(options = {}) {
   this._marketingImpressions = {};
   this._numStoredAccounts = options.numStoredAccounts || '';
   this._referrer = this._window.document.referrer || NOT_REPORTED_VALUE;
+  this._newsletters = NOT_REPORTED_VALUE;
   this._screenHeight = options.screenHeight || NOT_REPORTED_VALUE;
   this._screenWidth = options.screenWidth || NOT_REPORTED_VALUE;
   this._sentryMetrics = options.sentryMetrics;
@@ -408,6 +410,7 @@ _.extend(Metrics.prototype, Backbone.Events, {
       lang: this._lang,
       marketing: flattenHashIntoArrayOfObjects(this._marketingImpressions),
       numStoredAccounts: this._numStoredAccounts,
+      newsletters: this._newsletters,
       // planId and productId are optional so we can physically remove
       // them from the payload instead of sending NOT_REPORTED_VALUE
       planId: this._subscriptionModel.get('planId') || undefined,
@@ -691,6 +694,15 @@ _.extend(Metrics.prototype, Backbone.Events, {
    */
   logUserPreferences(prefName, value) {
     this._userPreferences[prefName] = !!value;
+  },
+
+  /**
+   * Log subscribed newsletters for a user.
+   *
+   * @param {Array} newsletters - Array of newsletters that user belongs to
+   */
+  logNewsletters(newsletters) {
+    this._newsletters = newsletters;
   },
 
   /**

--- a/packages/fxa-content-server/app/scripts/views/post_verify/newsletters/add_newsletters.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/newsletters/add_newsletters.js
@@ -11,13 +11,14 @@ import { assign } from 'underscore';
 import Cocktail from 'cocktail';
 import EmailOptInMixin from '../../mixins/email-opt-in-mixin';
 import FormView from '../../form';
+import FlowEventsMixin from './../../mixins/flow-events-mixin';
 import NewsletterSyncExperimentMixin from '../../mixins/newsletter-sync-experiment-mixin';
 import Template from 'templates/post_verify/newsletters/add_newsletters.mustache';
 import preventDefaultThen from '../../decorators/prevent_default_then';
 
 class AddNewsletters extends FormView {
   template = Template;
-  viewName = 'add-newsletter';
+  viewName = 'add-newsletters';
 
   events = assign(this.events, {
     'click #maybe-later-btn': preventDefaultThen('clickMaybeLater'),
@@ -56,6 +57,8 @@ class AddNewsletters extends FormView {
     return Promise.resolve()
       .then(() => {
         if (optedInNewsletters.length > 0) {
+          this.metrics.logNewsletters(optedInNewsletters);
+          this.logFlowEvent('subscribe', this.viewName);
           return account.updateNewsletters(optedInNewsletters);
         }
       })
@@ -70,6 +73,11 @@ class AddNewsletters extends FormView {
   }
 }
 
-Cocktail.mixin(AddNewsletters, EmailOptInMixin, NewsletterSyncExperimentMixin);
+Cocktail.mixin(
+  AddNewsletters,
+  EmailOptInMixin,
+  NewsletterSyncExperimentMixin,
+  FlowEventsMixin
+);
 
 export default AddNewsletters;

--- a/packages/fxa-content-server/app/tests/spec/lib/metrics.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/metrics.js
@@ -288,7 +288,7 @@ describe('lib/metrics', () => {
 
     it('gets non-optional fields', () => {
       const filteredData = metrics.getFilteredData();
-      assert.lengthOf(Object.keys(filteredData), 35);
+      assert.lengthOf(Object.keys(filteredData), 36);
 
       assert.isTrue(filteredData.hasOwnProperty('events'));
       assert.isTrue(filteredData.hasOwnProperty('timers'));
@@ -311,6 +311,7 @@ describe('lib/metrics', () => {
       assert.equal(filteredData.lang, 'db_LB');
       assert.deepEqual(filteredData.marketing, []);
       assert.equal(filteredData.numStoredAccounts, 1);
+      assert.equal(filteredData.newsletters, 'none');
 
       assert.equal(filteredData.planId, 'plid');
       assert.equal(filteredData.productId, 'pid');

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -214,6 +214,16 @@ const EVENTS = {
     event: 'forgot_password_recovery_key_success',
   },
 
+  'flow.add-newsletters.subscribe': {
+    group: GROUPS.newsletters,
+    event: 'subscribe',
+  },
+
+  'flow.add-newsletters.link.maybe-later': {
+    group: GROUPS.newsletters,
+    event: 'later',
+  },
+
   'screen.connect-another-device': {
     group: GROUPS.connectDevice,
     event: 'view',
@@ -237,6 +247,7 @@ const EVENTS = {
 };
 
 const VIEW_ENGAGE_SUBMIT_EVENT_GROUPS = {
+  'add-newsletters': GROUPS.newsletters,
   'enter-email': GROUPS.emailFirst,
   'force-auth': GROUPS.login,
   pair: GROUPS.connectDevice,

--- a/packages/fxa-content-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-content-server/server/lib/routes/post-metrics.js
@@ -35,6 +35,7 @@ const {
   EXPERIMENT: EXPERIMENT_TYPE,
   HEX32: HEX32_TYPE,
   INTEGER: INTEGER_TYPE,
+  NEWSLETTERS: NEWSLETTERS,
   OFFSET: OFFSET_TYPE,
   REFERRER: REFERRER_TYPE,
   STRING: STRING_TYPE,
@@ -122,6 +123,7 @@ const BODY_SCHEMA = {
       unloadEventStart: NAVIGATION_TIMING_TYPE.required(),
     })
     .optional(),
+  newsletters: NEWSLETTERS.optional(),
   numStoredAccounts: OFFSET_TYPE.min(0).optional(),
   // TODO: Delete plan_id and product_id after the camel-cased equivalents
   //       have been in place for at least one train.

--- a/packages/fxa-content-server/server/lib/validation.js
+++ b/packages/fxa-content-server/server/lib/validation.js
@@ -50,6 +50,10 @@ const TYPES = {
     .length(64),
   HEX32: joi.string().regex(/^[0-9a-f]{32}$/),
   INTEGER: joi.number().integer(),
+  NEWSLETTERS: joi
+    .array()
+    .items(joi.string().max(30))
+    .allow('none'),
   OFFSET: joi
     .number()
     .integer()

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -19,6 +19,7 @@ const GROUPS = {
   email: 'fxa_email',
   emailFirst: 'fxa_email_first',
   login: 'fxa_login',
+  newsletters: 'fxa_newsletter',
   notify: 'fxa_notify',
   registration: 'fxa_reg',
   rp: 'fxa_rp',
@@ -48,6 +49,7 @@ const EVENT_PROPERTIES = {
   [GROUPS.email]: mapEmailType,
   [GROUPS.emailFirst]: NOP,
   [GROUPS.login]: NOP,
+  [GROUPS.newsletters]: NOP,
   [GROUPS.notify]: NOP,
   [GROUPS.registration]: mapDomainValidationResult,
   [GROUPS.rp]: NOP,
@@ -433,7 +435,7 @@ function mapNewsletters(data) {
     newsletters = newsletters.map(newsletter => {
       return toSnakeCase(newsletter);
     });
-    return { newsletters };
+    return { newsletters, newsletter_state: 'subscribed' };
   }
 }
 

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -378,6 +378,7 @@ describe('metrics/amplitude:', () => {
       it('returned the correct event data', () => {
         assert.equal(result.event_type, 'fxa_pref - newsletters');
         assert.deepEqual(result.user_properties, {
+          newsletter_state: 'subscribed',
           newsletters: ['test_pilot'],
         });
       });


### PR DESCRIPTION
Fixes #4927 

Amplitude metrics
```
{"op":"amplitudeEvent","event_type":"fxa_newsletter - view","time":1588865495023,"device_id":"b94ac7668fb843cba9e5213103107493","session_id":1588865494644,"app_version":"169.1","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"933fb9f1110616a8d582ad1681e90e005527f25d6f061145dc347f3222cfe490","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["newsletter_sync_trailhead_copy"]}}}
{"op":"amplitudeEvent","event_type":"fxa_newsletter - engage","time":1588865499011,"device_id":"b94ac7668fb843cba9e5213103107493","session_id":1588865494644,"app_version":"169.1","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"933fb9f1110616a8d582ad1681e90e005527f25d6f061145dc347f3222cfe490","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["newsletter_sync_trailhead_copy","send_sms_us","send_sms_header_sync_phone"]},"newsletters":["test_pilot"],"newsletter_state":"subscribed"}}
{"op":"amplitudeEvent","event_type":"fxa_newsletter - submit","time":1588865500000,"device_id":"b94ac7668fb843cba9e5213103107493","session_id":1588865494644,"app_version":"169.1","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"933fb9f1110616a8d582ad1681e90e005527f25d6f061145dc347f3222cfe490","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["newsletter_sync_trailhead_copy","send_sms_us","send_sms_header_sync_phone"]},"newsletters":["test_pilot"],"newsletter_state":"subscribed"}}
{"op":"amplitudeEvent","event_type":"fxa_newsletter - subscribe","time":1588865500004,"device_id":"b94ac7668fb843cba9e5213103107493","session_id":1588865494644,"app_version":"169.1","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"933fb9f1110616a8d582ad1681e90e005527f25d6f061145dc347f3222cfe490","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["newsletter_sync_trailhead_copy","send_sms_us","send_sms_header_sync_phone"]},"newsletters":["test_pilot"],"newsletter_state":"subscribed"}}
```

Maybe later
```
{"op":"amplitudeEvent","event_type":"fxa_newsletter - later","time":1588864584708,"device_id":"3fa911b769254ba4ba21659cbec01c4d","session_id":1588864576080,"app_version":"169.1","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"c4d479e980782429dfd9e35ac5a5b2a2d726a1bdf93503d708a7c2f140062bac","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["newsletter_sync_trailhead_copy","send_sms_us","send_sms_header_sync_phone"]}}}

```

Users that navigate to the page directly will still emit metrics, but won't have the experiment user property set.

cc @irrationalagent @davismtl 