### PR TITLE
feat (support + auth server): add past product information to support panel

### DIFF
--- a/packages/fxa-auth-server/.vscode/launch.json
+++ b/packages/fxa-auth-server/.vscode/launch.json
@@ -113,5 +113,57 @@
       "runtimeVersion": "12.14.0",
       "protocol": "inspector"
     },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Coverage: Mocha All (local)",
+      "program": "${workspaceFolder}/node_modules/nyc/bin/nyc.js",
+      "args": [
+        "--reporter=lcov",
+        "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+        "--require",
+        "ts-node/register",
+        "--timeout",
+        "999999",
+        "--colors",
+        "${workspaceFolder}/test/local/**/*.js",
+        "--exit"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "env": {
+        "NODE_ENV": "dev",
+        "VERIFIER_VERSION": "0",
+        "CORS_ORIGIN": "http://foo,http://bar"
+      },
+      "preLaunchTask": "Stop PM2 Auth Server",
+      "postDebugTask": "Start PM2 Auth Server"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Coverage: Mocha All (oauth)",
+      "program": "${workspaceFolder}/node_modules/nyc/bin/nyc.js",
+      "args": [
+        "--reporter=lcov",
+        "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+        "--require",
+        "ts-node/register",
+        "--timeout",
+        "999999",
+        "--colors",
+        "${workspaceFolder}/test/oauth/**/*.js",
+        "--exit"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "env": {
+        "NODE_ENV": "dev",
+        "VERIFIER_VERSION": "0",
+        "CORS_ORIGIN": "http://foo,http://bar"
+      },
+      "preLaunchTask": "Stop PM2 Auth Server",
+      "postDebugTask": "Start PM2 Auth Server"
+    },
   ]
 }

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -318,6 +318,18 @@ module.exports.subscriptionsSubscriptionValidator = isA.object({
   subscription_id: module.exports.subscriptionsSubscriptionId.required(),
 });
 
+// This is support-panel's perspective on a subscription
+module.exports.subscriptionsSubscriptionSupportValidator = isA.object({
+  created: isA.number().required(),
+  current_period_end: isA.number().required(),
+  current_period_start: isA.number().required(),
+  plan_changed: isA.alternatives(isA.number(), isA.any().allow(null)),
+  previous_product: isA.alternatives(isA.string(), isA.any().allow(null)),
+  product_name: isA.string().required(),
+  status: isA.string().required(),
+  subscription_id: module.exports.subscriptionsSubscriptionId.required(),
+});
+
 module.exports.subscriptionsSubscriptionListValidator = isA.object({
   subscriptions: isA
     .array()

--- a/packages/fxa-support-panel/lib/api.ts
+++ b/packages/fxa-support-panel/lib/api.ts
@@ -57,10 +57,9 @@ interface Subscription {
   created: number;
   current_period_end: number;
   current_period_start: number;
-  plan_id: string;
-  product_id: string;
+  plan_changed: number | null;
+  previous_product: string | null;
   product_name: string;
-  latest_invoice: string;
   status: string;
   subscription_id: string;
 }
@@ -165,6 +164,10 @@ class SupportController {
       current_period_start: String(
         new Date(s.current_period_start * MS_IN_SEC)
       ),
+      plan_changed: s.plan_changed
+        ? String(new Date(s.plan_changed * MS_IN_SEC))
+        : 'N/A',
+      previous_product: s.previous_product || 'N/A',
     }));
 
     try {

--- a/packages/fxa-support-panel/lib/templates/index.html
+++ b/packages/fxa-support-panel/lib/templates/index.html
@@ -78,6 +78,14 @@
         <th>Next Payment:</th>
         <td>{{ current_period_end }}</td>
       </tr>
+      <tr>
+        <th>Previous Product:</th>
+        <td>{{ previous_product }}</td>
+      </tr>
+      <tr>
+        <th>Plan Changed:</th>
+        <td>{{ plan_changed }}</td>
+      </tr>
     </table>
     <br/>
     {{/subscriptions}}


### PR DESCRIPTION
auth server:
- created simplified endpoint to return only the data needed for the support panel
- included past plan information from subscription metadata

support panel:
- added past plan information to subscription data displayed

Because:
- when we introduce the ability to upgrade/downgrade subscriptions, we want to ensure that our support team is aware of plan changes to allow for a better customer experience

fixes #5242