### PR TITLE
refactor(oauth): stop querying for 'email' in oauth tables

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/mysql/index.js
@@ -187,7 +187,7 @@ const QUERY_REFRESH_TOKEN_INSERT =
 // and hence would more properly be called `tokenId`.
 const QUERY_ACCESS_TOKEN_FIND =
   'SELECT tokens.token AS tokenId, tokens.clientId, tokens.createdAt, ' +
-  '  tokens.userId, tokens.email, tokens.scope, ' +
+  '  tokens.userId, tokens.scope, ' +
   '  tokens.createdAt, tokens.expiresAt, tokens.profileChangedAt, ' +
   '  clients.name as clientName, clients.canGrant AS clientCanGrant, ' +
   '  clients.publicClient ' +
@@ -230,7 +230,7 @@ const QUERY_DEVELOPER_DELETE =
 // they get deleted from the db.
 const QUERY_LIST_ACCESS_TOKENS_BY_UID =
   'SELECT tokens.token AS tokenId, tokens.clientId, tokens.createdAt, ' +
-  '  tokens.userId, tokens.email, tokens.scope, ' +
+  '  tokens.userId, tokens.scope, ' +
   '  tokens.createdAt, tokens.expiresAt, tokens.profileChangedAt, ' +
   '  clients.name as clientName, clients.canGrant AS clientCanGrant, ' +
   '  clients.publicClient ' +

--- a/packages/fxa-auth-server/lib/oauth/token.js
+++ b/packages/fxa-auth-server/lib/oauth/token.js
@@ -15,8 +15,6 @@ const { SHORT_ACCESS_TOKEN_TTL_IN_MS } = require('../constants');
 
 const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
 
-const SCOPES_REQUIRING_EMAIL = ScopeSet.fromArray(['profile:email', 'oauth']);
-
 /**
  * Get the tokenId stored in the DB for `accessToken`
  *
@@ -101,10 +99,6 @@ exports.verify = async function verify(accessToken) {
 
   if (token.profileChangedAt) {
     tokenInfo.profile_changed_at = token.profileChangedAt;
-  }
-
-  if (token.scope.intersects(SCOPES_REQUIRING_EMAIL)) {
-    tokenInfo.email = token.email;
   }
 
   return tokenInfo;


### PR DESCRIPTION
Part 1 of #4706 / #4803