### PR TITLE
Train 170 uplift 169

### DIFF
--- a/packages/fxa-auth-db-mysql/CHANGELOG.md
+++ b/packages/fxa-auth-db-mysql/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 - all: update readmes across all packages to improve testing documentation ([099163e94](https://github.com/mozilla/fxa/commit/099163e94))
 
+## 1.169.3
+
+No changes.
+
+## 1.169.2
+
+No changes.
+
 ## 1.169.1
 
 No changes.

--- a/packages/fxa-auth-server/CHANGELOG.md
+++ b/packages/fxa-auth-server/CHANGELOG.md
@@ -20,6 +20,16 @@
 
 - all: update readmes across all packages to improve testing documentation ([099163e94](https://github.com/mozilla/fxa/commit/099163e94))
 
+## 1.169.3
+
+### New features
+
+- sms: make AWS.SNS.SMS.SMSType configurable ([a169f9c00](https://github.com/mozilla/fxa/commit/a169f9c00))
+
+## 1.169.2
+
+No changes.
+
 ## 1.169.1
 
 ### Bug fixes

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1501,6 +1501,13 @@ const conf = convict({
       format: 'duration',
       env: 'SMS_POLL_CURRENT_SPEND_INTERVAL',
     },
+    smsType: {
+      doc:
+        'AWS.SNS.SMS.SMSType argument value.  "Promotional" or "Transactional".',
+      default: 'Promotional',
+      format: 'String',
+      env: 'SMS_AWS_SNS_SMSTYPE',
+    },
   },
   secondaryEmail: {
     minUnverifiedAccountTime: {

--- a/packages/fxa-auth-server/lib/senders/sms.js
+++ b/packages/fxa-auth-server/lib/senders/sms.js
@@ -38,6 +38,11 @@ module.exports = (log, translator, templates, config, statsd) => {
     setImmediate(pollCurrentSpend);
   }
 
+  const allowedSmsType = ['Promotional', 'Transactional'];
+  const smsType = allowedSmsType.includes(config.sms.smsType)
+    ? config.sms.smsType
+    : 'Promotional';
+
   return {
     isBudgetOk: () => isBudgetOk,
 
@@ -62,7 +67,7 @@ module.exports = (log, translator, templates, config, statsd) => {
             'AWS.SNS.SMS.SMSType': {
               // 'Promotional' for cheap marketing messages, 'Transactional' for critical transactions
               DataType: 'String',
-              StringValue: 'Promotional',
+              StringValue: smsType,
             },
           },
           PhoneNumber: phoneNumber,

--- a/packages/fxa-auth-server/test/local/senders/sms.js
+++ b/packages/fxa-auth-server/test/local/senders/sms.js
@@ -501,5 +501,38 @@ describe('lib/senders/sms:', () => {
         assert.equal(log.error.callCount, 0);
       });
     });
+
+    describe('send the correct type of sms:', () => {
+      it('sends a Promotional message by default', async () => {
+        await sms.send('+442078553000', 'installFirefox', 'en');
+        const args = mockSns.publish.args[0];
+        assert.equal(
+          args[0].MessageAttributes['AWS.SNS.SMS.SMSType']['StringValue'],
+          'Promotional'
+        );
+      });
+
+      it('sends the configured message type', async () => {
+        config.sms.smsType = 'Transactional';
+        sms = smsModule(log, translator, templates, config);
+        await sms.send('+442078553000', 'installFirefox', 'en');
+        const args = mockSns.publish.args[0];
+        assert.equal(
+          args[0].MessageAttributes['AWS.SNS.SMS.SMSType']['StringValue'],
+          'Transactional'
+        );
+      });
+
+      it('sends a Promotional message when given invalid config value', async () => {
+        config.sms.smsType = 'spooky';
+        sms = smsModule(log, translator, templates, config);
+        await sms.send('+442078553000', 'installFirefox', 'en');
+        const args = mockSns.publish.args[0];
+        assert.equal(
+          args[0].MessageAttributes['AWS.SNS.SMS.SMSType']['StringValue'],
+          'Promotional'
+        );
+      });
+    });
   });
 });

--- a/packages/fxa-content-server/CHANGELOG.md
+++ b/packages/fxa-content-server/CHANGELOG.md
@@ -15,6 +15,16 @@
 
 - all: update readmes across all packages to improve testing documentation ([099163e94](https://github.com/mozilla/fxa/commit/099163e94))
 
+## 1.169.3
+
+No changes.
+
+## 1.169.2
+
+### Bug fixes
+
+- sms: Enable sms for only US/CAD at 10%, reduce default max sms to 3 ([5f750ee08](https://github.com/mozilla/fxa/commit/5f750ee08))
+
 ## 1.169.1
 
 No changes.

--- a/packages/fxa-content-server/app/scripts/lib/country-telephone-info.js
+++ b/packages/fxa-content-server/app/scripts/lib/country-telephone-info.js
@@ -81,7 +81,7 @@ module.exports = {
     normalize: ensurePrefix('+43'),
     pattern: /^(?:\+43)?\d{6,}$/,
     prefix: '+43',
-    rolloutRate: 1,
+    rolloutRate: 0,
   },
   // Australia
   // https://en.wikipedia.org/wiki/Telephone_numbers_in_Australia
@@ -90,7 +90,7 @@ module.exports = {
     normalize: ensurePrefix('+61'),
     pattern: /^(?:\+61\d{9}|\d{10})$/,
     prefix: '+61',
-    rolloutRate: 1,
+    rolloutRate: 0,
   },
   // Belgium
   // https://en.wikipedia.org/wiki/Telephone_numbers_in_Belgium
@@ -99,7 +99,7 @@ module.exports = {
     normalize: ensurePrefix('+32'),
     pattern: /^(?:\+32\d{9}|\d{10})$/,
     prefix: '+32',
-    rolloutRate: 1,
+    rolloutRate: 0,
   },
   // Germany
   // https://en.wikipedia.org/wiki/Telephone_numbers_in_Germany
@@ -108,7 +108,7 @@ module.exports = {
     normalize: ensurePrefix('+49'),
     pattern: /^(?:\+49)?\d{6,13}$/,
     prefix: '+49',
-    rolloutRate: 1,
+    rolloutRate: 0,
   },
   // Denmark
   // https://en.wikipedia.org/wiki/Telephone_numbers_in_Denmark
@@ -117,7 +117,7 @@ module.exports = {
     normalize: ensurePrefix('+45'),
     pattern: /^(?:\+45)?\d{8}$/,
     prefix: '+45',
-    rolloutRate: 1,
+    rolloutRate: 0,
   },
   // Spain
   // https://en.wikipedia.org/wiki/Telephone_numbers_in_Spain
@@ -126,7 +126,7 @@ module.exports = {
     normalize: ensurePrefix('+34'),
     pattern: /^(?:\+34)?\d{9}$/,
     prefix: '+34',
-    rolloutRate: 1,
+    rolloutRate: 0,
   },
   // France
   // https://en.wikipedia.org/wiki/Telephone_numbers_in_France
@@ -135,14 +135,14 @@ module.exports = {
     normalize: ensurePrefix('+33'),
     pattern: /^(?:\+33\d{9}|\d{10})$/,
     prefix: '+33',
-    rolloutRate: 1,
+    rolloutRate: 0,
   },
   GB: {
     format: formatter('+44 ${serverPhoneNumber}'),
     normalize: ensurePrefix('+44'),
     pattern: /^(?:\+44\d{10}|\d{11})$/,
     prefix: '+44',
-    rolloutRate: 1,
+    rolloutRate: 0,
   },
   // Italy
   // https://en.wikipedia.org/wiki/Telephone_numbers_in_Italy
@@ -153,7 +153,7 @@ module.exports = {
     // are the old style and are still used.
     pattern: /^(?:\+39)?\d{9,10}$/,
     prefix: '+39',
-    rolloutRate: 1,
+    rolloutRate: 0,
   },
   // Luxembourg
   // https://en.wikipedia.org/wiki/Telephone_numbers_in_Luxembourg
@@ -171,7 +171,7 @@ module.exports = {
     normalize: ensurePrefix('+31'),
     pattern: /^(?:\+31)?\d{4,}$/, // Non-geographical numbers have no fixed length. 3 access digits + at least one other digit.
     prefix: '+31',
-    rolloutRate: 1,
+    rolloutRate: 0,
   },
   // Portugal
   // https://en.wikipedia.org/wiki/Telephone_numbers_in_Portugal
@@ -180,7 +180,7 @@ module.exports = {
     normalize: ensurePrefix('+351'),
     pattern: /^(?:\+351)?\d{9}$/,
     prefix: '+351',
-    rolloutRate: 1,
+    rolloutRate: 0,
   },
   RO: {
     format: formatter('+40 ${serverPhoneNumber}'),
@@ -196,7 +196,7 @@ module.exports = {
     // +407xxxxxxxx, allow leading 0 for sloppiness.
     pattern: /^(?:\+40)?0?7\d{8,8}$/,
     prefix: '+40',
-    rolloutRate: 1,
+    rolloutRate: 0,
   },
   US: {
     // Americans don't use country codes, just return the number
@@ -212,7 +212,7 @@ module.exports = {
     },
     pattern: /^(\+?1)?[2-9]\d{9,9}$/, // allow for a +1 or 1 prefix before the area code, area codes are all 2-9
     prefix: '+1',
-    rolloutRate: 1,
+    rolloutRate: 0.1,
   },
 };
 

--- a/packages/fxa-customs-server/CHANGELOG.md
+++ b/packages/fxa-customs-server/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 - docker: added Dockerfile for fxa-customs-server ([fb0eb9404](https://github.com/mozilla/fxa/commit/fb0eb9404))
 
+## 1.169.3
+
+No changes.
+
+## 1.169.2
+
+### Bug fixes
+
+- sms: Enable sms for only US/CAD at 10%, reduce default max sms to 3 ([5f750ee08](https://github.com/mozilla/fxa/commit/5f750ee08))
+
 ## 1.169.1
 
 ### Bug fixes

--- a/packages/fxa-customs-server/lib/config/config.js
+++ b/packages/fxa-customs-server/lib/config/config.js
@@ -135,7 +135,7 @@ module.exports = function(fs, path, url, convict) {
         maxSms: {
           doc:
             'Number of sms sent within rateLimitIntervalSeconds before throttling',
-          default: 5,
+          default: 3,
           format: 'nat',
           env: 'MAX_SMS',
         },

--- a/packages/fxa-email-service/CHANGELOG.md
+++ b/packages/fxa-email-service/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 No changes.
 
+## 1.169.3
+
+No changes.
+
+## 1.169.2
+
+No changes.
+
 ## 1.169.1
 
 No changes.

--- a/packages/fxa-event-broker/CHANGELOG.md
+++ b/packages/fxa-event-broker/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - all: update readmes across all packages to improve testing documentation ([099163e94](https://github.com/mozilla/fxa/commit/099163e94))
 
+## 1.169.3
+
+No changes.
+
+## 1.169.2
+
+No changes.
+
 ## 1.169.1
 
 No changes.

--- a/packages/fxa-geodb/CHANGELOG.md
+++ b/packages/fxa-geodb/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - all: update readmes across all packages to improve testing documentation ([099163e94](https://github.com/mozilla/fxa/commit/099163e94))
 
+## 1.169.3
+
+No changes.
+
+## 1.169.2
+
+No changes.
+
 ## 1.169.1
 
 No changes.

--- a/packages/fxa-payments-server/CHANGELOG.md
+++ b/packages/fxa-payments-server/CHANGELOG.md
@@ -16,6 +16,14 @@
 
 - all: update readmes across all packages to improve testing documentation ([099163e94](https://github.com/mozilla/fxa/commit/099163e94))
 
+## 1.169.3
+
+No changes.
+
+## 1.169.2
+
+No changes.
+
 ## 1.169.1
 
 No changes.

--- a/packages/fxa-profile-server/CHANGELOG.md
+++ b/packages/fxa-profile-server/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 No changes.
 
+## 1.169.3
+
+No changes.
+
+## 1.169.2
+
+No changes.
+
 ## 1.169.1
 
 No changes.

--- a/packages/fxa-shared/CHANGELOG.md
+++ b/packages/fxa-shared/CHANGELOG.md
@@ -15,6 +15,14 @@
 
 - all: update readmes across all packages to improve testing documentation ([099163e94](https://github.com/mozilla/fxa/commit/099163e94))
 
+## 1.169.3
+
+No changes.
+
+## 1.169.2
+
+No changes.
+
 ## 1.169.1
 
 No changes.

--- a/packages/fxa-support-panel/CHANGELOG.md
+++ b/packages/fxa-support-panel/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - all: update readmes across all packages to improve testing documentation ([099163e94](https://github.com/mozilla/fxa/commit/099163e94))
 
+## 1.169.3
+
+No changes.
+
+## 1.169.2
+
+No changes.
+
 ## 1.169.1
 
 No changes.


### PR DESCRIPTION
Uplift changes from train 169. This also fixes the change logs. Once this merges we can tag a new release on 170.