### PR TITLE
chore(auth-server): fix vscode launch.json test scripts

### DIFF
--- a/packages/fxa-auth-server/.vscode/launch.json
+++ b/packages/fxa-auth-server/.vscode/launch.json
@@ -23,6 +23,8 @@
       "name": "Mocha All (local)",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "args": [
+        "--require",
+        "ts-node/register",
         "--timeout",
         "999999",
         "--colors",
@@ -45,6 +47,8 @@
       "name": "Mocha All (oauth)",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "args": [
+        "--require",
+        "ts-node/register",
         "--timeout",
         "999999",
         "--colors",
@@ -67,6 +71,8 @@
       "name": "Mocha Current File",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "args": [
+        "--require",
+        "ts-node/register",
         "--timeout",
         "999999",
         "--colors",
@@ -92,6 +98,8 @@
       "args": [
         "--reporter=lcov",
         "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+        "--require",
+        "ts-node/register",
         "--timeout",
         "999999",
         "--colors",


### PR DESCRIPTION
Changes:
- added arguments to the mocha scripts in the launch file to load `ts-node`

Because:
- the recent addition of typescript config files caused the current test scripts to fail to run due to `MODULE NOT FOUND`