### PR TITLE
fix(bug): small fixes for id_token_hint

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/jwt.js
+++ b/packages/fxa-auth-server/lib/oauth/jwt.js
@@ -55,5 +55,6 @@ exports.verify = async function verify(jwt, options = {}) {
     json: true,
     // use the default issuer unless one is passed in.
     issuer: options.issuer || ISSUER,
+    ignoreExpiration: options.ignoreExpiration,
   });
 };

--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -89,23 +89,33 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
           payload: {
             client_id: Joi.string().required(),
             id_token: Joi.string().required(),
+            expiry_grace_period: Joi.number().default(0),
           },
         },
         response: {
-          schema: Joi.object().keys({
-            aud: Joi.string().optional(),
-            alg: Joi.string().optional(),
-            exp: Joi.number().optional(),
-            iat: Joi.number().optional(),
-            iss: Joi.string().optional(),
-            sub: Joi.string().optional(),
-          }),
+          schema: Joi.object()
+            .unknown()
+            .keys({
+              acr: Joi.string().optional(),
+              aud: Joi.string().optional(),
+              alg: Joi.string().optional(),
+              at_hash: Joi.string().optional(),
+              amr: Joi.array()
+                .items(Joi.string())
+                .optional(),
+              exp: Joi.number().optional(),
+              'fxa-aal': Joi.number().optional(),
+              iat: Joi.number().optional(),
+              iss: Joi.string().optional(),
+              sub: Joi.string().optional(),
+            }),
         },
       },
       handler: async function(request) {
         const claims = await JWTIdToken.verify(
           request.payload.id_token,
-          request.payload.client_id
+          request.payload.client_id,
+          request.payload.expiry_grace_period
         );
         return claims;
       },

--- a/packages/fxa-auth-server/test/oauth/jwt.js
+++ b/packages/fxa-auth-server/test/oauth/jwt.js
@@ -101,6 +101,18 @@ describe('lib/jwt', () => {
         }
       });
 
+      it('passes if expired and ignoreExpiration option is true', async () => {
+        const jwt = await JWT.sign({
+          exp: Math.floor((Date.now() - 2000) / 1000),
+          foo: 'bar',
+        });
+
+        const verifiedPayload = await JWT.verify(jwt, {
+          ignoreExpiration: true,
+        });
+        assert.strictEqual(verifiedPayload.foo, 'bar');
+      });
+
       it('fails if invalid issuer', async () => {
         const jwt = await JWT.sign({
           iss: 'another issuer',

--- a/packages/fxa-content-server/app/scripts/lib/auth/client.ts
+++ b/packages/fxa-content-server/app/scripts/lib/auth/client.ts
@@ -1111,4 +1111,19 @@ export default class AuthClient {
       newsletters,
     });
   }
+
+  async verifyIdToken(
+    idToken: string,
+    clientId: string,
+    expiryGracePeriod?: number
+  ) {
+    const payload = {
+      id_token: idToken,
+      client_id: clientId,
+    };
+    if (expiryGracePeriod) {
+      payload.expiry_grace_period = expiryGracePeriod;
+    }
+    return this.request('POST', '/oauth/id-token-verify', payload);
+  }
 }

--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -162,4 +162,8 @@ module.exports = {
   // This is compared against all secondary email
   // records, both verified and unverified
   MAX_SECONDARY_EMAILS: 3,
+
+  // Allow ID Tokens used as the id_token_hint argument in a prompt=none
+  // request to be this many seconds past their expiration.
+  ID_TOKEN_HINT_GRACE_PERIOD: 60 * 60 * 24 * 7,
 };

--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -1370,6 +1370,14 @@ FxaClientWrapper.prototype = {
    * @returns {Promise} - resolves with empty response
    */
   updateNewsletters: createClientDelegate('updateNewsletters'),
+
+  /**
+   * Verify an ID Token.
+   *
+   * @param {String} idToken An ID Token supplied as an id_token_hint by an RP
+   * @returns {Promise} resolves with response when complete.
+   */
+  verifyIdToken: createClientDelegate('verifyIdToken'),
 };
 
 export default FxaClientWrapper;

--- a/packages/fxa-content-server/app/scripts/lib/vat.js
+++ b/packages/fxa-content-server/app/scripts/lib/vat.js
@@ -24,7 +24,7 @@ Vat.register(
 Vat.register('codeChallengeMethod', Vat.string().valid('S256'));
 Vat.register('email', Vat.string().test(Validate.isEmailValid));
 Vat.register('hex', Vat.string().test(Validate.isHexValid));
-Vat.register('idToken', Vat.string().test(Validate.isBase64Url));
+Vat.register('idToken', Vat.string());
 Vat.register('keyFetchToken', Vat.string());
 Vat.register('keysJwk', Vat.string().test(Validate.isBase64Url));
 Vat.register(

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -1646,10 +1646,17 @@ const Account = Backbone.Model.extend(
      *
      * @param {String} idToken - the ID Token
      * @param {String} clientId - the client ID, used to verify the 'aud' claim
+     * @param {Number} expiryGracePeriod - number of **seconds** past the
+     * token expiration ('exp' claim value) for which the token will be treated
+     * as valid.
      * @returns {Promise} resolves with response when complete.
      */
-    verifyIdToken(idToken, clientId) {
-      return this._fxaClient.verifyIdToken(idToken, clientId);
+    verifyIdToken(idToken, clientId, expiryGracePeriod) {
+      return this._fxaClient.verifyIdToken(
+        idToken,
+        clientId,
+        expiryGracePeriod
+      );
     },
   },
   {

--- a/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
@@ -1849,4 +1849,18 @@ describe('lib/fxa-client', function() {
         });
     });
   });
+
+  describe('verifyIdToken', () => {
+    it('delegates to the fxa-js-client', () => {
+      sinon
+        .stub(realClient, 'verifyIdToken')
+        .callsFake(() => Promise.resolve());
+
+      return client.verifyIdToken('sometoken', 'abcd1234', 100).then(resp => {
+        assert.isTrue(
+          realClient.verifyIdToken.calledOnceWith('sometoken', 'abcd1234', 100)
+        );
+      });
+    });
+  });
 });

--- a/packages/fxa-content-server/app/tests/spec/models/account.js
+++ b/packages/fxa-content-server/app/tests/spec/models/account.js
@@ -3074,4 +3074,19 @@ describe('models/account', function() {
       });
     });
   });
+
+  describe('verifyIdToken', () => {
+    beforeEach(() => {
+      sinon
+        .stub(fxaClient, 'verifyIdToken')
+        .callsFake(() => Promise.resolve({ foo: 'bar' }));
+      account.verifyIdToken('someIDToken', 'aclientID', 100);
+    });
+    it('delegates to the fxa-client', () => {
+      assert.isTrue(fxaClient.verifyIdToken.calledOnce);
+      assert.isTrue(
+        fxaClient.verifyIdToken.calledWith('someIDToken', 'aclientID', 100)
+      );
+    });
+  });
 });

--- a/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/tests/spec/models/reliers/oauth.js
@@ -307,16 +307,13 @@ describe('models/reliers/oauth', () => {
       });
 
       describe('id_token_hint', () => {
-        const invalidValues = ['', ' ', 'unsafe/?%'];
-        it('throws if id_token_hint token is invalid', () => {
-          testInvalidQueryParams('id_token_hint', invalidValues);
-        });
-
-        it('accepts a valid id_token_hint', () => {
-          testValidQueryParams('id_token_hint', ['whatever'], 'idTokenHint', [
-            'whatever',
-          ]);
-        });
+        var validValues = ['anystring'];
+        testValidQueryParams(
+          'id_token_hint',
+          validValues,
+          'idTokenHint',
+          validValues
+        );
       });
 
       describe('login_hint', () => {


### PR DESCRIPTION
Grab bag of small fixes. Biggest change is allowing ID tokens to be used as id_token_hint for up to 7 days after being issued. Also tweaked response schema for id-token-verify auth server route, added a wrapper function to the right (new) fxa-js-client, and updated related tests.