### PR TITLE
fix(payments): record our subscription cancellation time to avoid duplicate email on account deletion

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.js
+++ b/packages/fxa-auth-server/lib/payments/stripe.js
@@ -639,17 +639,21 @@ class StripeHelper {
    * @param {Subscription[id]} subscriptionId
    */
   async cancelSubscriptionForCustomer(uid, email, subscriptionId) {
-    const hasSubscription = await this.subscriptionForCustomer(
+    const subscription = await this.subscriptionForCustomer(
       uid,
       email,
       subscriptionId
     );
-    if (!hasSubscription) {
+    if (!subscription) {
       throw error.unknownSubscription();
     }
 
     await this.stripe.subscriptions.update(subscriptionId, {
       cancel_at_period_end: true,
+      metadata: {
+        ...(subscription.metadata || {}),
+        cancelled_for_customer_at: moment().unix(),
+      },
     });
   }
 
@@ -690,6 +694,10 @@ class StripeHelper {
 
     return this.stripe.subscriptions.update(subscriptionId, {
       cancel_at_period_end: false,
+      metadata: {
+        ...(subscription.metadata || {}),
+        cancelled_for_customer_at: '',
+      },
     });
   }
 

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -941,7 +941,10 @@ class DirectStripeRoutes {
     const invoiceDetails = await this.stripeHelper.extractInvoiceDetailsForEmail(
       subscription.latest_invoice
     );
-    if (subscription.cancel_at_period_end) {
+    if (
+      subscription.metadata &&
+      subscription.metadata.cancelled_for_customer_at
+    ) {
       // Subscription already cancelled, should have triggered an email earlier
       return invoiceDetails;
     }

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -18,6 +18,7 @@ const {
 } = require('../../../lib/payments/stripe');
 const WError = require('verror').WError;
 const uuidv4 = require('uuid').v4;
+const moment = require('moment');
 
 const {
   sanitizePlans,
@@ -2138,7 +2139,9 @@ describe('DirectStripeRoutes', () => {
       const subscription = deletedEvent.data.object;
 
       if (subscriptionAlreadyCancelled) {
-        subscription.cancel_at_period_end = true;
+        subscription.metadata = {
+          cancelled_for_customer_at: moment().unix(),
+        };
       }
 
       const mockInvoiceDetails = {


### PR DESCRIPTION
Adds new cancelled_for_customer_at metadata property on Stripe
subscription. This is distinct from canceled_at and cancel_at_period_end
which are modified by immediate cancellation which happens when
account is deleted.

https://jira.mozilla.com/browse/FXA-1769
fixes #5121