### PR TITLE
feat(settings | content): store flowId post-auth in localStorage and retrieve it in settings app

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
@@ -10,6 +10,7 @@ import NavigateBehavior from '../behaviors/navigate';
 import ResumeTokenMixin from './resume-token-mixin';
 import VerificationMethods from '../../lib/verification-methods';
 import VerificationReasons from '../../lib/verification-reasons';
+import Storage from '@fxa-shared/dist/lib/storage';
 
 export default {
   dependsOn: [ResumeTokenMixin],
@@ -251,6 +252,11 @@ export default {
     // This event ties the signin success to a screen.
     // Currently, can be oauth, signin, signup, signin-unblock
     this.logViewEvent('signin.success');
+
+    // Now that the user is logged in store thier flowId in
+    // localStorage so it can be retrieved by fxa-settings
+    const { flowId } = this.metrics.getFlowEventMetadata();
+    Storage.factory('localStorage', this.window).set('flowId', flowId);
 
     const brokerMethod = this.afterSignInBrokerMethod || 'afterSignIn';
     const navigateData = this.afterSignInNavigateData || {};

--- a/packages/fxa-content-server/app/scripts/views/mixins/signup-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signup-mixin.js
@@ -5,6 +5,7 @@
 // Shared implementation of `signUp` view method
 
 import ResumeTokenMixin from './resume-token-mixin';
+import Storage from '@fxa-shared/dist/lib/storage';
 
 export default {
   dependsOn: [ResumeTokenMixin],
@@ -77,6 +78,11 @@ export default {
   onSignUpSuccess(account) {
     this.logViewEvent('success');
     this.logViewEvent('signup.success');
+
+    // Now that the user is logged in store thier flowId in
+    // localStorage so it can be retrieved by fxa-settings
+    const { flowId } = this.metrics.getFlowEventMetadata();
+    Storage.factory('localStorage', this.window).set('flowId', flowId);
 
     if (account.get('verificationMethod') === 'email-otp') {
       this.navigate('/confirm_signup_code', { account });

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/signin-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/signin-mixin.js
@@ -15,8 +15,10 @@ import sinon from 'sinon';
 import User from 'models/user';
 import VerificationMethods from 'lib/verification-methods';
 import VerificationReasons from 'lib/verification-reasons';
+import WindowMock from '../../../mocks/window';
 
 const RESUME_TOKEN = 'a big hairy resume token';
+const FLOW_ID = 'h2k3v5';
 
 describe('views/mixins/signin-mixin', function() {
   it('exports correct interface', function() {
@@ -64,6 +66,11 @@ describe('views/mixins/signin-mixin', function() {
         logEvent: sinon.spy(),
         logFlowEvent: sinon.spy(),
         logViewEvent: sinon.spy(),
+        metrics: {
+          getFlowEventMetadata: sinon.spy(() => ({
+            flowId: FLOW_ID,
+          })),
+        },
         model: model,
         navigate: sinon.spy(),
         on: sinon.spy(),
@@ -73,6 +80,7 @@ describe('views/mixins/signin-mixin', function() {
         signIn: SignInMixin.signIn,
         unsafeDisplayError: sinon.spy(),
         user: user,
+        window: new WindowMock(),
       };
     });
 
@@ -558,6 +566,16 @@ describe('views/mixins/signin-mixin', function() {
         view.onSignInSuccess(account);
         assert.equal(relier.get('uid'), account.get('uid'));
         assert.equal(relier.get('email'), account.get('email'));
+      });
+
+      it('sets the flowId on localStorage', () => {
+        view.onSignInSuccess(account);
+
+        const storedFlowId = JSON.parse(
+          view.window.localStorage.getItem('__fxa_storage.flowId')
+        );
+
+        assert.equal(storedFlowId, FLOW_ID);
       });
     });
 

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/signup-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/signup-mixin.js
@@ -9,6 +9,9 @@ import { Model } from 'backbone';
 import Relier from 'models/reliers/relier';
 import SignUpMixin from 'views/mixins/signup-mixin';
 import sinon from 'sinon';
+import WindowMock from '../../../mocks/window';
+
+const FLOW_ID = 'h2k3v5';
 
 describe('views/mixins/signup-mixin', function() {
   it('exports correct interface', function() {
@@ -51,6 +54,11 @@ describe('views/mixins/signup-mixin', function() {
         logFlowEvent: sinon.spy(),
         logViewEvent: sinon.spy(),
         navigate: sinon.spy(),
+        metrics: {
+          getFlowEventMetadata: sinon.spy(() => ({
+            flowId: FLOW_ID,
+          })),
+        },
         notifier: {
           trigger: sinon.spy(),
         },
@@ -59,6 +67,7 @@ describe('views/mixins/signup-mixin', function() {
         relier,
         signUp: SignUpMixin.signUp,
         user,
+        window: new WindowMock(),
       };
     });
 
@@ -221,6 +230,16 @@ describe('views/mixins/signup-mixin', function() {
         assert.lengthOf(args, 2);
         assert.equal(args[0], 'afterSignUp');
         assert.deepEqual(args[1], account);
+      });
+
+      it('sets the flowId on localStorage', () => {
+        view.onSignUpSuccess(account);
+
+        const storedFlowId = JSON.parse(
+          view.window.localStorage.getItem('__fxa_storage.flowId')
+        );
+
+        assert.equal(storedFlowId, FLOW_ID);
       });
     });
 

--- a/packages/fxa-content-server/tsconfig.json
+++ b/packages/fxa-content-server/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "include": ["**/*.ts"],
     "exclude": ["node_modules", "**/*.spec.ts"],
+    "extends": "../fxa-components/tsconfig.common.json",
     "compilerOptions": {
         /* Basic Options */
         "target": "ES2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,

--- a/packages/fxa-content-server/webpack.config.js
+++ b/packages/fxa-content-server/webpack.config.js
@@ -52,6 +52,8 @@ const webpackConfig = {
       'node_modules',
     ],
     alias: {
+      '@fxa-components': path.resolve(__dirname, '..', 'fxa-components'),
+      '@fxa-shared': path.resolve(__dirname, '..', 'fxa-shared'),
       'asmcrypto.js': path.resolve(
         __dirname,
         'node_modules/asmcrypto.js/asmcrypto.min.js'

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -7,7 +7,13 @@ import AppLayout from '../AppLayout';
 import AppErrorBoundary from '@fxa-components/AppErrorBoundary';
 import './index.scss';
 
-export const App = () => {
+type AppProps = {
+  flowId?: string;
+};
+
+export const App = ({ flowId }: AppProps) => {
+  console.info('flowId', flowId);
+
   return (
     <AppErrorBoundary>
       <AppLayout>

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -8,13 +8,17 @@ import './index.scss';
 import App from './components/App';
 import sentryMetrics from '@fxa-shared/lib/sentry';
 import config from './lib/config';
+import Storage from '@fxa-shared/lib/storage';
+
+const storage = Storage.factory('localStorage', window);
 
 export async function init() {
   sentryMetrics.configure(config.sentry.dsn, config.version);
+  const flowId = storage.get('flowId');
 
   render(
     <React.StrictMode>
-      <App />
+      <App {...{ flowId }} />
     </React.StrictMode>,
     document.getElementById('root')
   );

--- a/packages/fxa-shared/lib/null-storage.ts
+++ b/packages/fxa-shared/lib/null-storage.ts
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This is a memory store that's api compatible with localStorage/sessionStorage.
+// It's used for testing lib/storage.
+
+class NullStorage {
+  _storage: { [key: string]: any } = {};
+
+  getItem(key: string): string | null {
+    return key ? this._storage[key] : null;
+  }
+
+  setItem(key: string, value: any) {
+    if (!key) {
+      return;
+    }
+
+    this._storage[key] = value;
+  }
+
+  removeItem(key: string) {
+    if (!key) {
+      return;
+    }
+
+    delete this._storage[key];
+  }
+
+  clear() {
+    this._storage = {};
+  }
+}
+
+export default NullStorage;

--- a/packages/fxa-shared/lib/storage.ts
+++ b/packages/fxa-shared/lib/storage.ts
@@ -1,0 +1,174 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This module abstracts interaction with storage backends such as localStorage
+// or sessionStorage.
+
+import NullStorage from './null-storage';
+import Url from './url';
+
+const NAMESPACE = '__fxa_storage';
+
+function fullKey(key: string) {
+  return NAMESPACE + '.' + key;
+}
+
+function normalizeError(
+  error: {
+    context: string;
+    namespace: any;
+    errno: any;
+    name: any;
+    message: any;
+  },
+  type: string
+) {
+  error.context = 'storage';
+  error.namespace = type;
+  // Firefox localStorage errors contain a `name` field. Report that
+  // name if available, otherwise return the whole message.
+  error.errno = error.name || error.message;
+
+  return error;
+}
+
+interface DOMStorage {
+  getItem(arg0: string): string | null;
+  setItem(arg0: string, arg1: any): void;
+  removeItem(arg0: string): void;
+  clear(): void;
+}
+
+class Storage {
+  private _backend: DOMStorage;
+  type: string;
+
+  constructor(backend: DOMStorage, type: string) {
+    this._backend = backend || new NullStorage();
+    this.type = type;
+  }
+
+  get(key: string): any {
+    let item;
+    try {
+      item = JSON.parse(this._backend.getItem(fullKey(key)) || '');
+    } catch (e) {
+      // eslint-disable-line no-empty
+    }
+    return item;
+  }
+
+  set(key: string, val: any): void {
+    this._backend.setItem(fullKey(key), JSON.stringify(val));
+  }
+
+  remove(key: string) {
+    this._backend.removeItem(fullKey(key));
+  }
+
+  clear() {
+    this._backend.clear();
+  }
+
+  isNull() {
+    return this._backend instanceof NullStorage;
+  }
+
+  /**
+   * Test whether storage can be written to and removed from.
+   *
+   * @param {String} type - (localStorage|sessionStorage)
+   * @param {Object} [win] - window object
+   * @throws browser generated errors, `disabled for tests` if disabled for
+   *   tests.
+   */
+  static testStorage(type: string, win: Window = window) {
+    try {
+      const testData = 'storage-test';
+      let storage;
+
+      if (type === 'sessionStorage') {
+        storage = win.sessionStorage;
+      } else {
+        // HACK: Allows the functional tests to simulate disabled local storage.
+        if (
+          Url.searchParam('disable_local_storage', win.location.search) === '1'
+        ) {
+          throw new Error('disabled for tests');
+        }
+
+        storage = win.localStorage;
+      }
+
+      storage.setItem(testData, testData);
+      storage.removeItem(testData);
+    } catch (e) {
+      throw normalizeError(e, type);
+    }
+  }
+
+  /**
+   * Check if there are any problems accessing localStorage
+   *
+   * @param {Object} [win] - window object
+   * @throws {Error} throws an error if storage is disabled
+   */
+  static testLocalStorage(win: Window) {
+    Storage.testStorage('localStorage', win);
+  }
+
+  /**
+   * Check if there are any problems accessing sessionStorage
+   *
+   * @param {Object} win - window object
+   * @throws browser generated errors, `disabled for tests` if disabled for
+   *   tests.
+   */
+  static testSessionStorage(win: Window) {
+    Storage.testStorage('sessionStorage', win);
+  }
+
+  static _isStorageEnabled(type: string, win: Window): boolean {
+    try {
+      Storage.testStorage(type, win);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /**
+   * Check if localStorage is enabled
+   *
+   * @param {Window} [win]
+   * @returns {Boolean}
+   */
+  static isLocalStorageEnabled(win: Window): boolean {
+    return Storage._isStorageEnabled('localStorage', win);
+  }
+
+  /**
+   * Check if sessionStorage is enabled
+   *
+   * @param {Window} [win]
+   * @returns {Boolean}
+   */
+  static isSessionStorageEnabled(win: Window): boolean {
+    return Storage._isStorageEnabled('sessionStorage', win);
+  }
+
+  static factory(type: string, win: Window = window): Storage {
+    let storage;
+    if (type === 'localStorage' && this.isLocalStorageEnabled(win)) {
+      storage = new Storage(win.localStorage, 'local');
+    } else if (type === 'sessionStorage' && this.isSessionStorageEnabled(win)) {
+      storage = new Storage(win.sessionStorage, 'session');
+    } else {
+      storage = new Storage(new NullStorage(), 'null');
+    }
+    return storage;
+  }
+}
+
+export default Storage;

--- a/packages/fxa-shared/lib/url.ts
+++ b/packages/fxa-shared/lib/url.ts
@@ -1,0 +1,234 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// utilities to deal with urls
+
+const Uri = {
+  /**
+   * Convert a search string to its object representation, one entry
+   * per query parameter. Assumes the string is a search string and
+   * not a full URL without a search string.
+   *
+   * @param {String} [str=''] - string to convert
+   * @param {String[]} [allowedFields] - list of allowed fields. If not
+   * declared, all fields are allowed.
+   * @returns {Object}
+   */
+  searchParams(str = '', allowedFields?: string[]) {
+    // ditch everything before the ? and from # to the end
+    const search = str.replace(/(^.*\?|#.*$)/g, '').trim();
+    if (!search) {
+      return {};
+    }
+
+    return this.splitEncodedParams(search, allowedFields!);
+  },
+
+  /**
+   * Return the value of a single query parameter in the string
+   *
+   * @param {String} name - name of the query parameter
+   * @param {String} [str=''] - search string
+   * @returns {String}
+   */
+  searchParam(name: string, str?: string): string {
+    return this.searchParams(str)[name];
+  },
+
+  /**
+   * Convert a hash string to its object representation, one entry
+   * per query parameter
+   *
+   * @param {String} [str=''] - string to convert
+   * @param {String[]} [allowedFields=[]] - list of allowed fields. If not
+   * declared, all fields are allowed.
+   * @returns {Object}
+   */
+  hashParams(str = '', allowedFields: string[]) {
+    // ditch everything before the #
+    const hash = str.replace(/^.*#/, '').trim();
+    if (!hash) {
+      return {};
+    }
+
+    return this.splitEncodedParams(hash, allowedFields);
+  },
+
+  /**
+   * Convert a URI encoded string to its object representation.
+   *
+   * `&` is the expected delimiter between parameters.
+   * `=` is the delimiter between a key and a value.
+   *
+   * @param {String} [str=''] string to split
+   * @param {String[]} [allowedFields=[]] - list of allowed fields. If not
+   * declared, all fields are allowed.
+   * @returns {Object}
+   */
+  splitEncodedParams(str = '', allowedFields: string[]) {
+    const pairs = str.split('&');
+    const terms: { [key: string]: string } = {};
+
+    pairs.forEach(pair => {
+      const [key, value] = pair.split('=');
+      terms[key] = decodeURIComponent(value).trim();
+    });
+
+    if (!allowedFields) {
+      return terms;
+    }
+
+    return Object.keys(terms)
+      .filter(key => allowedFields.indexOf(key) >= 0)
+      .reduce(
+        (newObj, key) => Object.assign(newObj, { [key]: terms[key] }),
+        {}
+      );
+  },
+
+  /**
+   * Convert an object to a search string.
+   *
+   * @param {Object} [obj={}] - object to convert
+   * @returns {String}
+   */
+  objToSearchString(obj: {}) {
+    return this.objToUrlString(obj, '?');
+  },
+
+  /**
+   * Convert an object to a hash string.
+   *
+   * @param {Object} [obj={}] - object to convert
+   * @returns {String}
+   */
+  objToHashString(obj: {}) {
+    return this.objToUrlString(obj, '#');
+  },
+
+  /**
+   * Convert an object to a URL safe string
+   *
+   * @param {Object} [obj={}] - object to convert
+   * @param {String} [prefix='?'] - prefix to append
+   * @returns {String}
+   */
+  objToUrlString(obj: { [key: string]: any } = {}, prefix = '?') {
+    const params: string[] = [];
+
+    for (const paramName in obj) {
+      if (paramName) {
+        const paramValue = obj[paramName];
+        if (paramValue != null && paramValue.length) {
+          params.push(paramName + '=' + encodeURIComponent(paramValue));
+        }
+      }
+    }
+
+    if (!params.length) {
+      return '';
+    }
+
+    return prefix + params.join('&');
+  },
+
+  /**
+   * Get the origin portion of the URL
+   *
+   * @param {String} url
+   * @returns {String}
+   */
+  getOrigin(url: string): string | null {
+    if (!url) {
+      return '';
+    }
+
+    // The URL API is only supported by new browsers, a workaround is used.
+    const anchor = document.createElement('a');
+
+    // Fx 18 (& FxOS 1.*) do not support anchor.origin. Build the origin
+    // out of the protocol and host.
+    // Use setAttribute instead of a direct set or else Fx18 does not
+    // update anchor.protocol & anchor.host.
+    anchor.setAttribute('href', url);
+
+    if (!(anchor.protocol && anchor.host)) {
+      // malformed URL. Return null. This is the same behavior as URL.origin
+      return null;
+    }
+
+    // IE10 always returns port, Firefox and Chrome hide the port if it is the default port e.g 443, 80
+    // We normalize IE10 output, use the hostname if it is a default port to match Firefox and Chrome.
+    // Also IE10 returns anchor.port as String, Firefox and Chrome use Number.
+    const host =
+      Number(anchor.port) === 443 || Number(anchor.port) === 80
+        ? anchor.hostname
+        : anchor.host;
+    const origin = anchor.protocol + '//' + host;
+
+    // if only the domain is specified without a protocol, the anchor
+    // will use the page's origin as the URL's origin. Check that
+    // the created origin matches the first portion of
+    // the passed in URL. If not, then the anchor element
+    // modified the origin.
+    if (url.indexOf(origin) !== 0) {
+      return null;
+    }
+
+    return origin;
+  },
+
+  /**
+   * Update the search string in the given URL.
+   *
+   * @param {String} uri - uri to update
+   * @param {Object} newParams
+   * @returns {String}
+   */
+  updateSearchString(uri: string, newParams: {}): string {
+    let params = {};
+    const startOfParams = uri.indexOf('?');
+    if (startOfParams >= 0) {
+      params = this.searchParams(uri.substring(startOfParams + 1));
+      uri = uri.substring(0, startOfParams);
+    }
+    params = Object.assign(params, newParams);
+    return uri + this.objToSearchString(params);
+  },
+
+  /**
+   * Clean the search string by only allowing search parameters declared in
+   * `allowedFields`
+   *
+   * @param {String} uri - uri with search string to clean.
+   * @param {String[]} allowedFields - list of allowed fields.
+   * @returns {String}
+   */
+  cleanSearchString(uri: string, allowedFields?: string[]) {
+    const [base, search = ''] = uri.split('?');
+    const cleanedQueryParams = this.searchParams(search, allowedFields);
+    return base + this.objToSearchString(cleanedQueryParams);
+  },
+
+  /**
+   * Set a new value for the query search string in place. This does
+   * not reload the page but rather updates the window state history.
+   *
+   * @param {String} param - param to update
+   * @param {String} value - value to set
+   */
+  setSearchString(param: string, value: string) {
+    const params = new URLSearchParams(window.location.search);
+    params.set(param, value);
+
+    // This will update the url with new params inplace
+    window.history.replaceState(
+      {},
+      '',
+      `${window.location.pathname}?${params}`
+    );
+  },
+};
+
+export default Uri;


### PR DESCRIPTION
Closes #5019

The new Settings app needs to be able to retrieve the `flowId` for the current user.

For fxa-payments this is achieved by creating a redirect from the Content Server that appends the flowId as a query parameter, which Payments later picks up.

In the case of fxa-settings once you log in or sign up on the Content Server you might not immediately be redirected to the new Settings app, so instead of a query parameter I'm storing the value in `localStorage`, and because both fxa-content-server and fxa-settings are served from the same domain the Settings app is able to retrieve it.

Additionally, since both packages set and get values in localStorage I took this as an opportunity to move our `storage` lib and its dependents, `null-storage` and `url`, to fxa-shared. They are mostly verbatim copies from the content server, with the exception if null-storage and url becoming TS friendly.