### PR TITLE
fix(gitignore): Remove .* and subsequent .* exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ secrets.json
 /artifacts
 /packages/test.list
 .last-audit
+.eslintcache
 
 # Dependencies
 **/node_modules
@@ -49,22 +50,6 @@ coverage.html
 .\#*
 .DS_Store
 Thumbs.db
-
-# Linux
-.*
-!.circleci/
-!.dockerignore
-!.gitignore
-!.git*
-!.eslintrc
-!.editorconfig
-!.npmignore
-!.nsprc
-!.sass-lint.yml
-!.prettier*
-!.vscode
-!.rescriptsrc.js
-!.storybook
 
 ## Package-specific ##
 
@@ -112,6 +97,8 @@ packages/fxa-content-server/app/i18n
 packages/fxa-content-server/fxa-content-server-l10n/
 packages/fxa-content-server/locale/*/*/*.po
 packages/fxa-content-server/rerun.txt
+packages/fxa-content-server/.tmp
+packages/fxa-content-server/.tscompiled
 
 # fxa-customs-server
 packages/fxa-customs-server/test/mocks/temp.netset


### PR DESCRIPTION
Because:
We had to occasionally add to our list of !.* exceptions which was getting a little unwieldy. Instead, we'll manually add the ones we need ignored.

fixes #5250

--

While `.tmp` and `.tscompiled` could go under "build and temp files," they're content-server specific which is why I've stuck them in that section.

The content server's `outDir` for TS could be changed to `dist` for consistency - we could then remove line 101. I'll create a follow up ticket for that when this is approved.

Will the reviewer check into my branch and check their `git status` and poke through our `packages/` dir to help ensure I haven't missed anything? 😬