### PR TITLE
feat(payments): ignore hard email bounce errors in Stripe webhooks

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -20,6 +20,7 @@ const SUBSCRIPTIONS_MANAGEMENT_SCOPE =
 
 const IGNORABLE_STRIPE_WEBHOOK_ERRNOS = [
   error.ERRNO.UNKNOWN_SUBSCRIPTION_FOR_SOURCE,
+  error.ERRNO.BOUNCE_HARD,
 ];
 
 /** @typedef {import('hapi').Request} Request */


### PR DESCRIPTION
https://jira.mozilla.com/browse/FXA-1814
issue #5193

Still thinking if / when / how to retry email sending in general for email-related Stripe errors.

But from what I can tell, "hard" email bounces will never succeed after retries. (e.g. the example error in the issue leads to a testing email of `test@testo.com`) So, maybe we can at least just ignore those?