### PR TITLE
docs(adr): list ADRs in the READMEs of the FxA packages they impact

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The Firefox Accounts (fxa) monorepo
 [Firefox for iOS](#firefox-for-ios)\
 [Running with MailDev](#running-with-maildev)\
 [Other tasks](#other-tasks)\
+[Architectural decisions](#architectural-decisions)\
 [Documentation](#documentation)
 
 ---
@@ -379,6 +380,16 @@ sudo maildev -s 9999
 ```
 
 All emails sent can be viewed from [http://localhost:1080](http://localhost:1080).
+
+---
+
+### Architectural decisions
+
+Since [May 2019](https://github.com/mozilla/fxa/blob/master/docs/adr/0000-use-markdown-architectural-decision-records.md) the FxA team has been using [Architectural Decision Records](https://adr.github.io/) to collectively make choices that influence the structure and practices set out in the code across this monorepo. This allows us to transparently weigh our options and come to decisions as a team, and have documentation to refer to when we implement new functionality, as new team members are onboarded, or if anyone, internally or externally, asks, "why did you do it this way?".
+
+An ADR is not necessarily a permanent decision; it is the result of what we decide is the best solution for us at that moment in time. As the FxA code base evolves and standards change over time new ADRs can be written to supersede previous decisions.
+
+Check out [each package's README](#documentation), under "Architectural decisions", for its list of relevant ADRs, or you can see all of them [here](https://github.com/mozilla/fxa/tree/master/docs/adr).
 
 ---
 

--- a/packages/fxa-admin-panel/README.md
+++ b/packages/fxa-admin-panel/README.md
@@ -43,6 +43,12 @@ Note that prior to testing you may need to create a build of the React App. You 
 
 Refer to Jest's [CLI documentation](https://jestjs.io/docs/en/cli) for more advanced test configuration.
 
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)
+
 ## License
 
 MPL-2.0

--- a/packages/fxa-admin-server/README.md
+++ b/packages/fxa-admin-server/README.md
@@ -30,6 +30,12 @@ npx mocha -r ts-node/register src/test/lib/** -g "returns lbheartbeat"
 
 Refer to Mocha's [CLI documentation](https://mochajs.org/#command-line-usage) for more advanced test configuration.
 
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)
+
 ## License
 
 MPL-2.0

--- a/packages/fxa-auth-db-mysql/README.md
+++ b/packages/fxa-auth-db-mysql/README.md
@@ -174,6 +174,12 @@ mysql -u root -p -e 'DROP DATABASE fxa'
 It will be recreated automatically
 next time you run `npm start`.
 
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)
+
 ## License
 
 [MPL 2.0][license]

--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -221,6 +221,19 @@ manage this config.
   npx ts-node scripts/email-config check foo@example.com
   ```
 
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0003 - [Event Broker for Subscription Platform](https://github.com/mozilla/fxa/blob/master/docs/adr/0003-event-broker-for-subscription-platform.md)
+- 0004 - [Product Capabilities for Subscription Services](https://github.com/mozilla/fxa/blob/master/docs/adr/0004-product-capabilities-for-subscription-services.md)
+- 0005 - [Minimizing password entry](https://github.com/mozilla/fxa/blob/master/docs/adr/0005-minimize-password-entry.md)
+- 0006 - [Utilizing JSON-Schemas, SemVer, and Tooling for JSON Messaging](https://github.com/mozilla/fxa/blob/master/docs/adr/0006-json-schemas-for-messaging.md)
+- 0007 - [Placing subscription info in the fxa-subscriptions claim of JWT access tokens](https://github.com/mozilla/fxa/blob/master/docs/adr/0007-subscription-claim-jwt-access-token.md)
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)
+- 0012 - [Next Two Factor authentication in FxA](https://github.com/mozilla/fxa/blob/master/docs/adr/0012-next-two-factor-authentication.md)
+- 0014 - [Authentication in Settings Redesign](https://github.com/mozilla/fxa/blob/master/docs/adr/0014-auth-for-settings-redesign.md)
+
 ## Troubleshooting
 
 Firefox Accounts authorization is a complicated flow. You can get verbose logging by adjusting the log level in the `config.json` on your deployed instance. Add a stanza like:

--- a/packages/fxa-components/README.md
+++ b/packages/fxa-components/README.md
@@ -19,6 +19,15 @@ npm run test -- --watch
 
 Refer to Jest's [CLI documentation](https://jestjs.io/docs/en/cli) for more advanced test configuration.
 
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0002 - [Use React, Redux, and Typescript for subscription management pages](https://github.com/mozilla/fxa/blob/master/docs/adr/0002-use-react-redux-and-typescript-for-subscription-management-pages.md)
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)
+- 0013 - [React Toolchain for Settings Redesign](https://github.com/mozilla/fxa/blob/master/docs/adr/0013-react-toolchain-for-settings-redesign.md)
+- 0015 - [Use CSS Variables, Prefer SCSS over CSS-in-JS](https://github.com/mozilla/fxa/blob/master/docs/adr/0015-use-css-variables-and-scss.md)
+
 ## License
 
 MPL-2.0

--- a/packages/fxa-content-server/README.md
+++ b/packages/fxa-content-server/README.md
@@ -105,6 +105,18 @@ If you'd like to run only unit tests you can do so in your browser by navigating
 
 ---
 
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0001 - [Isolating payment content with third-party widgets from general account management](https://github.com/mozilla/fxa/blob/master/docs/adr/0001-isolating-payment-content-with-third-party-widgets-from-general-account-management.md)
+- 0002 - [Use React, Redux, and Typescript for subscription management pages](https://github.com/mozilla/fxa/blob/master/docs/adr/0002-use-react-redux-and-typescript-for-subscription-management-pages.md)
+- 0005 - [Minimizing password entry](https://github.com/mozilla/fxa/blob/master/docs/adr/0005-minimize-password-entry.md)
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)
+- 0010 - [Transition FxA from Backbone to React](https://github.com/mozilla/fxa/blob/master/docs/adr/0010-transition-fxa-from-backbone-to-react.md)
+
+---
+
 ## License
 
 MPL 2.0

--- a/packages/fxa-customs-server/README.md
+++ b/packages/fxa-customs-server/README.md
@@ -86,3 +86,9 @@ The data that these policies are based on is stored in a memcache instance (keye
 - `ip_record.js` handles blocking based only on the IP address
 
 The rate-limiting and blocking policies are conveyed to the auth server via the `block` property in the response to `/check`.
+
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)

--- a/packages/fxa-email-service/README.md
+++ b/packages/fxa-email-service/README.md
@@ -295,3 +295,9 @@ There's also a shortcut for this:
 ```
 ./rq
 ```
+
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)

--- a/packages/fxa-event-broker/README.md
+++ b/packages/fxa-event-broker/README.md
@@ -230,3 +230,10 @@ npx mocha -r ts-node/register src/test/**/** -g "queries on start"
 ```
 
 Refer to Mocha's [CLI documentation](https://mochajs.org/#command-line-usage) for more advanced test configuration.
+
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0003 - [Event Broker for Subscription Platform](https://github.com/mozilla/fxa/blob/master/docs/adr/0003-event-broker-for-subscription-platform.md)
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)

--- a/packages/fxa-geodb/README.md
+++ b/packages/fxa-geodb/README.md
@@ -138,6 +138,14 @@ This product includes GeoLite2 data created by MaxMind, available from
 
 --
 
+### Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)
+
+--
+
 ### License
 
 [MPL 2.0](LICENSE)

--- a/packages/fxa-graphql-api/README.md
+++ b/packages/fxa-graphql-api/README.md
@@ -19,6 +19,12 @@ npx mocha -r ts-node/register src/test/lib/** -g "bearer token"
 
 Refer to Mocha's [CLI documentation](https://mochajs.org/#command-line-usage) for more advanced test configuration.
 
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)
+
 ## License
 
 MPL-2.0

--- a/packages/fxa-js-client/README.md
+++ b/packages/fxa-js-client/README.md
@@ -26,3 +26,9 @@ See [Library Documentation](http://mozilla.github.io/fxa-js-client/classes/FxAcc
 ## Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details on building, developing, and testing the library.
+
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)

--- a/packages/fxa-metrics-processor/README.md
+++ b/packages/fxa-metrics-processor/README.md
@@ -23,3 +23,9 @@ npx mocha -r ts-node/register src/test/*/** -g "return messages"
 ```
 
 Refer to Mocha's [CLI documentation](https://mochajs.org/#command-line-usage) for more advanced test configuration.
+
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)

--- a/packages/fxa-payments-server/README.md
+++ b/packages/fxa-payments-server/README.md
@@ -57,6 +57,13 @@ Note that prior to testing you may need to create a build of the React App. You 
 
 Refer to Jest's [CLI documentation](https://jestjs.io/docs/en/cli) for more advanced test configuration.
 
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0001 - [Isolating payment content with third-party widgets from general account management](https://github.com/mozilla/fxa/blob/master/docs/adr/0001-isolating-payment-content-with-third-party-widgets-from-general-account-management.md)
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)
+
 ## License
 
 MPL-2.0

--- a/packages/fxa-profile-server/README.md
+++ b/packages/fxa-profile-server/README.md
@@ -47,6 +47,12 @@ Running the server locally:
 npm start
 ```
 
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)
+
 ## License
 
 [MPL v2.0](./LICENSE)

--- a/packages/fxa-settings/README.md
+++ b/packages/fxa-settings/README.md
@@ -67,6 +67,16 @@ _You will eventually be able to view the built Storybook at <http://mozilla.gith
 
 In local development, `npm run storybook` should start a Storybook server at <http://localhost:6008> with hot module replacement to reflect live changes.
 
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)
+- 0010 - [Transition FxA from Backbone to React](https://github.com/mozilla/fxa/blob/master/docs/adr/0010-transition-fxa-from-backbone-to-react.md)
+- 0011 - [Create a New React Application for the Settings Redesign Project](https://github.com/mozilla/fxa/blob/master/docs/adr/0011-create-new-react-app-for-settings-redesign.md)
+- 0013 - [React Toolchain for Settings Redesign](https://github.com/mozilla/fxa/blob/master/docs/adr/0013-react-toolchain-for-settings-redesign.md)
+- 0014 - [Authentication in Settings Redesign](https://github.com/mozilla/fxa/blob/master/docs/adr/0014-auth-for-settings-redesign.md)
+
 ## License
 
 MPL-2.0

--- a/packages/fxa-shared/README.md
+++ b/packages/fxa-shared/README.md
@@ -111,3 +111,10 @@ npx mocha -r ts-node/register -g "invalid scope values" --recursive test
 ```
 
 Refer to Mocha's [CLI documentation](https://mochajs.org/#command-line-usage) for more advanced test configuration.
+
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0008 - [Redis Lua Scripts](https://github.com/mozilla/fxa/blob/master/docs/adr/0008-redis-lua-scripts.md)
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)

--- a/packages/fxa-support-panel/README.md
+++ b/packages/fxa-support-panel/README.md
@@ -43,3 +43,9 @@ npx mocha -r ts-node/register test/*/** -g "has a heartbeat"
 ```
 
 Refer to Mocha's [CLI documentation](https://mochajs.org/#command-line-usage) for more advanced test configuration.
+
+## Architectural decisions
+
+The FxA team has made intentional decisions when it comes to the design of this package and its related packages' code bases. Learn more in the following ADRs:
+
+- 0009 - [Consistency in testing tools](https://github.com/mozilla/fxa/blob/master/docs/adr/0009-testing-stacks.md)


### PR DESCRIPTION
@LZoog had this [wonderful idea](https://github.com/mozilla/fxa/pull/5213#discussion_r420934566) to update the README of fxa-settings with links to the ADRs that influenced its architecture.

So I ran with it and updated all the package READMEs with their relevant ADRs, and added a little blurb to the root README about why and where they exist.

What do you think? Definitely open to copy changes as well.