### PR TITLE
feat(content-server): console warn if you're not using localhost

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/app-start.js
+++ b/packages/fxa-content-server/app/scripts/lib/app-start.js
@@ -76,6 +76,8 @@ function Start(options = {}) {
 
 Start.prototype = {
   startApp() {
+    this.checkLocalHost();
+
     // The delay is to give the functional tests time to hook up
     // WebChannel message response listeners.
     const START_DELAY_MS = this._isAutomatedBrowser()
@@ -87,6 +89,20 @@ Start.prototype = {
       .then(() => this.testLocalStorage())
       .then(() => this.allResourcesReady())
       .catch(err => this.fatalError(err));
+  },
+
+  checkLocalHost() {
+    const hostName = window.location.hostname;
+
+    if (this._config.env !== 'development' || hostName === 'localhost') {
+      return;
+    }
+
+    console.warn(
+      `You are viewing FxA from an unsupported host. Please use ${window.location
+        .toString()
+        .replace(hostName, 'localhost')}`
+    );
   },
 
   initializeInterTabChannel() {


### PR DESCRIPTION
Open to a no on this. Since our [switch](https://github.com/mozilla/fxa/pull/4938) from `127.0.0.1` to `localhost` we've had a few instances where someone has been confused about why their dev environment isn't working as expected, and the culprit was related to the host name (e.g. creating a CSP violation).

This PR warns you in development if you're accessing the content server from a host name other than `localhost`.