### PR TITLE
feat(content + settings): ensure visiting beta/settings/ always has flow data

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -30,6 +30,7 @@ import DeleteAccountView from '../views/settings/delete_account';
 import DisplayNameView from '../views/settings/display_name';
 import EmailsView from '../views/settings/emails';
 import ForceAuthView from '../views/force_auth';
+import GetFlowView from '../views/get_flow';
 import IndexView from '../views/index';
 import InlineTotpSetupView from '../views/inline_totp_setup';
 import InlineRecoverySetupView from '../views/inline_recovery_setup';
@@ -129,6 +130,7 @@ const Router = Backbone.Router.extend({
     ),
     'cookies_disabled(/)': createViewHandler(CookiesDisabledView),
     'force_auth(/)': createViewHandler(ForceAuthView),
+    'get_flow(/)': createViewHandler(GetFlowView),
     'inline_totp_setup(/)': createViewHandler(InlineTotpSetupView),
     'inline_recovery_setup(/)': createViewHandler(InlineRecoverySetupView),
     'legal(/)': createViewHandler('legal'),

--- a/packages/fxa-content-server/app/scripts/templates/redirect_loading.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/redirect_loading.mustache
@@ -1,0 +1,5 @@
+<div id="main-content" class="card loading redirect-loading">
+  <section>
+    <div class="spinner"></div>
+  </section>
+</div>

--- a/packages/fxa-content-server/app/scripts/templates/subscriptions_redirect.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/subscriptions_redirect.mustache
@@ -1,5 +1,0 @@
-<div id="main-content" class="card loading subscriptions-redirect">
-  <section>
-    <div class="spinner"></div>
-  </section>
-</div>

--- a/packages/fxa-content-server/app/scripts/views/get_flow.js
+++ b/packages/fxa-content-server/app/scripts/views/get_flow.js
@@ -1,0 +1,77 @@
+/* eslint-disable camelcase */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Cocktail from '../lib/cocktail';
+import FlowEventsMixin from './mixins/flow-events-mixin';
+import Url from '../lib/url';
+import BaseView from './base';
+import Template from 'templates/redirect_loading.mustache';
+
+class GetFlowView extends BaseView {
+  mustAuth = true;
+  template = Template;
+
+  initialize() {
+    // Flow events need to be initialized before the navigation
+    // so the flow_id and flow_begin_time are propagated
+    this.initializeFlowEvents();
+  }
+
+  afterRender() {
+    const { redirect_to: redirectTo } = Url.searchParams(
+      this.window.location.search
+    );
+
+    if (!redirectTo) {
+      this.window.console.error(
+        'This page requires a `redirect_to` path parameter'
+      );
+      return;
+    }
+
+    // Do not allow redirects to external addresses by
+    // trying to parse it and expect an exception
+    try {
+      // eslint-disable-next-line no-new
+      new URL(redirectTo);
+      return this.window.console.error(
+        '`redirect_to` must not be an absolute address'
+      );
+    } catch (error) {
+      // noop
+    }
+
+    const {
+      deviceId,
+      flowBeginTime,
+      flowId,
+    } = this.metrics.getFlowEventMetadata();
+
+    let redirectPath = redirectTo;
+    let redirectParams = {};
+    if (redirectTo.includes('?')) {
+      redirectPath = redirectTo.slice(0, redirectTo.indexOf('?'));
+      redirectParams = Url.searchParams(redirectTo);
+    }
+
+    const queryString = Url.objToSearchString({
+      device_id: deviceId,
+      flow_begin_time: flowBeginTime,
+      flow_id: flowId,
+      ...redirectParams,
+    });
+
+    const url = `${redirectPath}${queryString}`;
+
+    // We need to `navigateAway` and not `navigate` here
+    // because we are leaving the main content server app
+    this.navigateAway(url);
+  }
+}
+
+Cocktail.mixin(GetFlowView, FlowEventsMixin);
+
+export default GetFlowView;

--- a/packages/fxa-content-server/app/scripts/views/subscriptions_management_redirect.js
+++ b/packages/fxa-content-server/app/scripts/views/subscriptions_management_redirect.js
@@ -5,7 +5,7 @@
 import Cocktail from '../lib/cocktail';
 import FlowEventsMixin from './mixins/flow-events-mixin';
 import FormView from './form';
-import Template from 'templates/subscriptions_redirect.mustache';
+import Template from 'templates/redirect_loading.mustache';
 import PaymentServer from '../lib/payment-server';
 
 class SubscriptionsManagementRedirectView extends FormView {

--- a/packages/fxa-content-server/app/scripts/views/subscriptions_product_redirect.js
+++ b/packages/fxa-content-server/app/scripts/views/subscriptions_product_redirect.js
@@ -5,7 +5,7 @@
 import Cocktail from '../lib/cocktail';
 import FlowEventsMixin from './mixins/flow-events-mixin';
 import FormView from './form';
-import Template from 'templates/subscriptions_redirect.mustache';
+import Template from 'templates/redirect_loading.mustache';
 import PaymentServer from '../lib/payment-server';
 import Url from '../lib/url';
 

--- a/packages/fxa-content-server/app/tests/spec/views/get_flow.js
+++ b/packages/fxa-content-server/app/tests/spec/views/get_flow.js
@@ -1,0 +1,143 @@
+/* eslint-disable camelcase */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import $ from 'jquery';
+import Account from 'models/account';
+import { assert } from 'chai';
+import sinon from 'sinon';
+import User from 'models/user';
+import View from 'views/get_flow';
+import Notifier from 'lib/channels/notifier';
+import WindowMock from '../../mocks/window';
+import Url from '../../../scripts/lib/url';
+
+describe('views/get_flow', function() {
+  let account;
+  let user;
+  let view;
+
+  const flowData = {
+    deviceId: 'foo',
+    flowBeginTime: 987654,
+    flowId: 'h2k3v5',
+  };
+
+  function render() {
+    return view.render().then(() => view.afterVisible());
+  }
+
+  beforeEach(function() {
+    account = new Account();
+    user = new User();
+
+    view = new View({
+      user,
+      notifier: new Notifier(),
+      window: new WindowMock(),
+    });
+
+    sinon.stub(user, 'sessionStatus').resolves(account);
+    sinon.stub(view, 'getSignedInAccount').returns(account);
+    sinon.stub(view, 'initializeFlowEvents');
+    sinon.stub(view, 'navigateAway');
+    sinon.stub(view.metrics, 'getFlowEventMetadata').returns(flowData);
+
+    sinon.stub(view.window.console, 'error');
+  });
+
+  afterEach(function() {
+    $(view.el).remove();
+    view.window.console.error.restore();
+    view.metrics.getFlowEventMetadata.restore();
+    view.destroy();
+    view = null;
+  });
+
+  describe('render with proper params', () => {
+    const betaSettingsPath = '/beta/settings';
+    let queryParams = {
+      device_id: flowData.deviceId,
+      flow_begin_time: flowData.flowBeginTime,
+      flow_id: flowData.flowId,
+    };
+
+    describe('correct redirect_path', () => {
+      beforeEach(() => {
+        view.window.location.search = `?redirect_to=${encodeURIComponent(
+          betaSettingsPath
+        )}`;
+
+        return render();
+      });
+
+      it('renders correctly, initializes flow events, redirects back', () => {
+        assert.lengthOf(view.$('.redirect-loading'), 1);
+        sinon.assert.calledOnce(view.initializeFlowEvents);
+
+        sinon.assert.calledWithExactly(
+          view.navigateAway,
+          `${betaSettingsPath}${Url.objToSearchString(queryParams)}`
+        );
+      });
+    });
+
+    describe('correct redirect_path that has extra params', () => {
+      beforeEach(() => {
+        queryParams = Object.assign(queryParams, { science: 'rules' });
+
+        view.window.location.search = `?redirect_to=${encodeURIComponent(
+          `${betaSettingsPath}${Url.objToSearchString({
+            science: 'rules',
+          })}`
+        )}`;
+
+        return render();
+      });
+
+      it('renders correctly, initializes flow events, redirects back maintaining extra params', () => {
+        assert.lengthOf(view.$('.redirect-loading'), 1);
+        sinon.assert.calledOnce(view.initializeFlowEvents);
+
+        sinon.assert.calledWithExactly(
+          view.navigateAway,
+          `${betaSettingsPath}${Url.objToSearchString(queryParams)}`
+        );
+      });
+    });
+  });
+
+  describe('render with improper params', () => {
+    describe('no redirect_path', () => {
+      beforeEach(() => render());
+
+      it('does not redirect and errors', () => {
+        sinon.assert.calledWithExactly(
+          view.window.console.error,
+          'This page requires a `redirect_to` path parameter'
+        );
+        sinon.assert.notCalled(view.navigateAway);
+      });
+    });
+
+    describe('absolute url as redirect_path', () => {
+      beforeEach(() => {
+        view.window.location.search = `?redirect_to=${encodeURIComponent(
+          'http://bad-stuff.onion'
+        )}`;
+
+        return render();
+      });
+
+      it('does not redirect and errors', () => {
+        sinon.assert.calledWithExactly(
+          view.window.console.error,
+          '`redirect_to` must not be an absolute address'
+        );
+        sinon.assert.notCalled(view.navigateAway);
+      });
+    });
+  });
+});

--- a/packages/fxa-content-server/app/tests/spec/views/subscriptions_management_redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/views/subscriptions_management_redirect.js
@@ -66,7 +66,7 @@ describe('views/subscriptions_management_redirect', function() {
 
   describe('render', () => {
     it('renders correctly, initializes flow events, navigates to payments server', () => {
-      assert.lengthOf(view.$('.subscriptions-redirect'), 1);
+      assert.lengthOf(view.$('.redirect-loading'), 1);
       assert.isTrue(view.initializeFlowEvents.calledOnce);
       assert.deepEqual(PaymentServer.navigateToPaymentServer.args, [
         [view, config.subscriptions, 'subscriptions'],

--- a/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
@@ -72,7 +72,7 @@ describe('views/subscriptions_product_redirect', function() {
   describe('render', () => {
     it('renders, initializes flow metrics, navigates to payments server', () => {
       return render().then(() => {
-        assert.lengthOf(view.$('.subscriptions-redirect'), 1);
+        assert.lengthOf(view.$('.redirect-loading'), 1);
         assert.isTrue(view.initializeFlowEvents.calledOnce);
         assert.isTrue(
           PaymentServer.navigateToPaymentServer.calledOnceWith(

--- a/packages/fxa-content-server/app/tests/test_start.js
+++ b/packages/fxa-content-server/app/tests/test_start.js
@@ -162,6 +162,7 @@ require('./spec/views/elements/recovery-code-input');
 require('./spec/views/elements/recovery-key-input');
 require('./spec/views/force_auth');
 require('./spec/views/form');
+require('./spec/views/get_flow');
 require('./spec/views/index');
 require('./spec/views/marketing_snippet');
 require('./spec/views/mixins/account-by-uid-mixin');

--- a/packages/fxa-content-server/server/lib/routes/get-frontend.js
+++ b/packages/fxa-content-server/server/lib/routes/get-frontend.js
@@ -22,6 +22,7 @@ module.exports = function() {
     'connect_another_device/why',
     'cookies_disabled',
     'force_auth',
+    'get_flow',
     'legal',
     'oauth',
     'oauth/force_auth',

--- a/packages/fxa-content-server/tests/server/routes.js
+++ b/packages/fxa-content-server/tests/server/routes.js
@@ -44,6 +44,7 @@ var routes = {
   '/connect_another_device/why': { statusCode: 200 },
   '/cookies_disabled': { statusCode: 200 },
   '/force_auth': { statusCode: 200 },
+  '/get_flow': { statusCode: 200 },
   '/legal': { statusCode: 200 },
   '/legal/privacy': { statusCode: 200 },
   '/legal/terms': { statusCode: 200 },

--- a/packages/fxa-settings/package-lock.json
+++ b/packages/fxa-settings/package-lock.json
@@ -9524,6 +9524,15 @@
         }
       }
     },
+    "duration": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
+      "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.46"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -11,6 +11,7 @@
     "@types/node": "^12.12.35",
     "@types/react": "^16.9.34",
     "@types/react-dom": "^16.9.6",
+    "duration": "^0.2.2",
     "modern-normalize": "^0.6.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -6,7 +6,49 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import App from '.';
+import FlowEvent from '../../lib/flow-event';
+
+const appProps = {
+  queryParams: {},
+};
+
+beforeEach(() => {
+  window.location.replace = jest.fn();
+});
 
 it('renders', () => {
-  render(<App />);
+  render(<App {...appProps} />);
+});
+
+it('redirects to /get_flow when flow data is not present', () => {
+  render(<App {...appProps} />);
+
+  expect(window.location.replace).toHaveBeenCalledWith(
+    `${window.location.origin}/get_flow?redirect_to=${encodeURIComponent(
+      window.location.pathname
+    )}`
+  );
+});
+
+it('redirects to /get_flow when flow data is not present', () => {
+  const DEVICE_ID = 'yoyo';
+  const BEGIN_TIME = 123456;
+  const FLOW_ID = 'abc123';
+  const flowInit = jest.spyOn(FlowEvent, 'init');
+  const updatedAppProps = Object.assign(appProps, {
+    queryParams: {
+      device_id: DEVICE_ID,
+      flow_begin_time: BEGIN_TIME,
+      flow_id: FLOW_ID,
+    },
+  });
+
+  render(<App {...updatedAppProps} />);
+
+  expect(flowInit).toHaveBeenCalledWith({
+    device_id: DEVICE_ID,
+    flow_id: FLOW_ID,
+    flow_begin_time: BEGIN_TIME,
+  });
+  expect(window.location.replace).not.toHaveBeenCalled();
 });

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -5,9 +5,17 @@
 import React from 'react';
 import AppLayout from '../AppLayout';
 import AppErrorBoundary from '@fxa-components/AppErrorBoundary';
+import { QueryParams } from '../../lib/types';
+import FlowEvents from '../../lib/flow-event';
 import './index.scss';
 
-export const App = () => {
+type AppProps = {
+  queryParams: QueryParams;
+};
+
+export const App = ({ queryParams }: AppProps) => {
+  FlowEvents.init(queryParams);
+
   return (
     <AppErrorBoundary>
       <AppLayout>

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -8,13 +8,16 @@ import './index.scss';
 import App from './components/App';
 import sentryMetrics from '@fxa-shared/lib/sentry';
 import config from './lib/config';
+import { parseParams } from './lib/url-params';
 
 export async function init() {
   sentryMetrics.configure(config.sentry.dsn, config.version);
 
+  const queryParams = parseParams(window.location.search);
+
   render(
     <React.StrictMode>
-      <App />
+      <App {...{ queryParams }} />
     </React.StrictMode>,
     document.getElementById('root')
   );

--- a/packages/fxa-settings/src/lib/flow-event.test.ts
+++ b/packages/fxa-settings/src/lib/flow-event.test.ts
@@ -1,0 +1,88 @@
+import FlowEvent from './flow-event';
+import sentryMetrics from '@fxa-shared/lib/sentry';
+
+const eventGroup = 'testo';
+const eventType = 'quuz';
+
+const mockNow = 1002003004005;
+
+beforeEach(() => {
+  // `sendBeacon` is undefined in this context
+  window.navigator.sendBeacon = jest.fn();
+  global.console.error = jest.fn();
+});
+
+it('does not send metrics when uninitialized', () => {
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, {});
+  expect(window.navigator.sendBeacon).not.toHaveBeenCalled();
+});
+
+it('remains uninitialized when any flow param is empty', () => {
+  FlowEvent.init({});
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, {});
+
+  FlowEvent.init({ device_id: 'moz9000', flow_begin_time: 9001 });
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, {});
+
+  FlowEvent.init({ device_id: 'moz9000', flow_id: 'ipsoandfacto' });
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, {});
+
+  FlowEvent.init({ flow_begin_time: 9001, flow_id: 'ipsoandfacto' });
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, {});
+
+  expect(window.navigator.sendBeacon).not.toHaveBeenCalled();
+});
+
+it('logs and captures an exception from postMetrics', () => {
+  const mockCapture = jest
+    .spyOn(sentryMetrics, 'captureException')
+    .mockImplementation();
+  const error = 'oops';
+  (window.navigator.sendBeacon as jest.Mock).mockImplementation(() => {
+    throw error;
+  });
+  FlowEvent.init({
+    device_id: 'moz9000',
+    flow_begin_time: 9001,
+    flow_id: 'ipsoandfacto',
+  });
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, {});
+  expect(mockCapture).toBeCalledWith(error);
+  expect(global.console.error).toBeCalledWith('AppError', error);
+});
+
+it('initializes when given all flow params', () => {
+  FlowEvent.init({
+    device_id: 'moz9000',
+    flow_begin_time: 9001,
+    flow_id: 'ipsoandfacto',
+  });
+  FlowEvent.logAmplitudeEvent(eventGroup, eventType, {});
+
+  expect(window.navigator.sendBeacon).toHaveBeenCalled();
+});
+
+// FIXME: disabled under we sort out
+// data params see flow-events.ts
+//
+// it('sends the correct Amplitude metric payload', () => {
+//   FlowEvent.logAmplitudeEvent(eventGroup, eventType, {
+//     quuz: 'quux',
+//   });
+//   const [metricsPath, payload] = (window.navigator
+//     .sendBeacon as jest.Mock).mock.calls[0];
+//   expect(metricsPath).toEqual(`/metrics`);
+//   expect(JSON.parse(payload)).toMatchObject({
+//     events: [
+//       {
+//         offset: expect.any(Number),
+//         type: `amplitude.${eventGroup}.${eventType}`,
+//       },
+//     ],
+//     data: {
+//       flowId: 'ipsoandfacto',
+//       flowBeginTime: expect.any(Number),
+//       deviceId: 'moz9000',
+//     },
+//   });
+// });

--- a/packages/fxa-settings/src/lib/flow-event.ts
+++ b/packages/fxa-settings/src/lib/flow-event.ts
@@ -1,0 +1,112 @@
+import sentryMetrics from '@fxa-shared/lib/sentry';
+
+interface FlowEventParams {
+  device_id?: string;
+  flow_id?: string;
+  flow_begin_time?: number;
+}
+
+interface FlowEventData {
+  deviceId: string;
+  flowBeginTime: number;
+  flowId: string;
+}
+
+let initialized = false;
+let flowEventData: FlowEventData;
+
+function shouldSend() {
+  return initialized && window.navigator.sendBeacon;
+}
+
+function postMetrics(eventData: object) {
+  // This is not an Action insofar that it has no bearing on the app state.
+  window.navigator.sendBeacon('/metrics', JSON.stringify(eventData));
+}
+
+export function init(eventData: FlowEventParams) {
+  if (!initialized) {
+    if (eventData.device_id && eventData.flow_begin_time && eventData.flow_id) {
+      flowEventData = {
+        deviceId: eventData.device_id,
+        flowBeginTime: eventData.flow_begin_time,
+        flowId: eventData.flow_id,
+      };
+      initialized = true;
+    } else {
+      let redirectPath = window.location.pathname;
+      if (window.location.search) {
+        redirectPath += window.location.search;
+      }
+
+      return window.location.replace(
+        `${window.location.origin}/get_flow?redirect_to=${encodeURIComponent(
+          redirectPath
+        )}`
+      );
+    }
+  }
+}
+
+export function logAmplitudeEvent(
+  groupName: string,
+  eventName: string,
+  eventProperties: object
+) {
+  if (!shouldSend()) {
+    return;
+  }
+
+  try {
+    const now = Date.now();
+
+    // TODO: The following are the parameters required
+    // for the content server to receive a metrics report.
+    // They still need to be cleaned up and properly set.
+    const eventData = {
+      broker: 'web',
+      context: 'web',
+      duration: 1234,
+      experiments: [],
+      marketing: [],
+      isSampledUser: false,
+      lang: 'unknown',
+      referrer: 'none',
+      service: 'none',
+      startTime: 1234,
+      uid: 'none',
+      uniqueUserId: 'none',
+      utm_campaign: 'none',
+      utm_content: 'none',
+      utm_medium: 'none',
+      utm_source: 'none',
+      utm_term: 'none',
+      screen: {
+        clientHeight: 0,
+        clientWidth: 0,
+        devicePixelRatio: 0,
+        height: 0,
+        width: 0,
+      },
+      events: [
+        {
+          offset: now - flowEventData.flowBeginTime || 0,
+          type: `amplitude.${groupName}.${eventName}`,
+        },
+      ],
+      flushTime: now,
+      ...flowEventData,
+      ...eventProperties,
+    };
+
+    postMetrics(eventData);
+  } catch (e) {
+    console.error('AppError', e);
+    sentryMetrics.captureException(e);
+  }
+}
+
+export default {
+  init,
+  logAmplitudeEvent,
+};

--- a/packages/fxa-settings/src/lib/types.ts
+++ b/packages/fxa-settings/src/lib/types.ts
@@ -1,0 +1,7 @@
+export interface QueryParams {
+  device_id?: string;
+  flow_id?: string;
+  flow_begin_time?: number;
+}
+
+export type Hash<T> = { [key: string]: T };

--- a/packages/fxa-settings/src/lib/url-params.ts
+++ b/packages/fxa-settings/src/lib/url-params.ts
@@ -1,0 +1,11 @@
+import { Hash } from './types';
+
+export const parseParams = (params: string): Hash<string> =>
+  params
+    .substr(1)
+    .split('&')
+    .reduce((acc: Hash<string>, curr: string) => {
+      const parts = curr.split('=').map(decodeURIComponent);
+      acc[parts[0]] = parts[1];
+      return acc;
+    }, {});


### PR DESCRIPTION
Closes #5019

Alternative approach to #5282.

Here's how:
- Set up minimal library in fxa-settings to parse flow data params, and redirect you to fxa-content-server to fetch new flow data if they're not present
  - The majority of the flow-event lib comes from the existing one in the payments server, with the exception that it can optionally redirect you to the content server for flow data is it's not present
- Set up new route in fxa-content-server (`/get_flow`) to retrieve a new set of flow data, and send you back to your original address

Here's how I'm testing this:

```
// Should redirect you to /beta/settings with Flow data params
http://localhost:3030/get_flow?redirect_to=/beta/settings

// Should do nothing (console error about no redirect_to)
http://localhost:3030/get_flow

// Should do nothing (console error about using an absolute address)
http://localhost:3030/get_flow?redirect_to=http://localhost:3000/beta/settings

// Should send you to /get_flow and then redirect you to /beta/settings with Flow data params
http://localhost:3030/beta/settings

// Should send you to /get_flow and redirect you to /beta/settings with Flow data params and the custom params
http://localhost:3030/beta/settings?extra=123

// Should not send you to /get_flow
http://localhost:3030/beta/settings?device_id=devide-id&flow_begin_time=1589378014871&flow_id=flow-id&extra=123
```