### PR TITLE
feat(customs): ip-reputation-js-client 6.0.0

### DIFF
--- a/packages/fxa-customs-server/package-lock.json
+++ b/packages/fxa-customs-server/package-lock.json
@@ -3454,9 +3454,9 @@
       "integrity": "sha1-ErFilKOJJUhtYYoRA1BuTrT4spY="
     },
     "ip-reputation-js-client": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ip-reputation-js-client/-/ip-reputation-js-client-4.1.0.tgz",
-      "integrity": "sha512-bvU+JB2tU1iOOrG0WOYbxmbrBa+5TBkOuqrDk8DdHt8hciSPK/4ZEjg0D9H6s+0B42yIC+ROxegRtGqczRrsmQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ip-reputation-js-client/-/ip-reputation-js-client-6.0.0.tgz",
+      "integrity": "sha512-RP63J2few7bL0PB0VyxCT5rW3mbdY7M0cX7iOeEGbkieBaMNGTVqrZiaUU0lQyPKn3EJz2kqbDzCjC9/6VJIrg==",
       "requires": {
         "bluebird": "3.5.1",
         "joi": "13.4.0",

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -31,7 +31,7 @@
     "convict": "4.0.2",
     "deep-equal": "1.0.1",
     "ip": "1.1.3",
-    "ip-reputation-js-client": "4.1.0",
+    "ip-reputation-js-client": "6.0.0",
     "lodash.isequal": "4.5.0",
     "lodash.merge": "4.6.2",
     "memcached": "2.2.1"

--- a/packages/fxa-customs-server/test/remote/check_reputation_tests.js
+++ b/packages/fxa-customs-server/test/remote/check_reputation_tests.js
@@ -111,7 +111,7 @@ ENDPOINTS.forEach(endpoint => {
 
   test(`does not block ${endpoint} for IP with nonexistent reputation`, t => {
     return reputationClient
-      .delAsync('/' + TEST_IP)
+      .delAsync('/type/ip/' + TEST_IP)
       .spread(function(req, res, obj) {
         t.equal(res.statusCode, 200, 'clears reputation for TEST_IP');
         return client.postAsync(endpoint, {
@@ -133,11 +133,12 @@ ENDPOINTS.forEach(endpoint => {
 
   test(`does not block ${endpoint} for IP with reputation above blockBelow`, t => {
     return reputationClient
-      .delAsync('/' + TEST_IP)
+      .delAsync('/type/ip/' + TEST_IP)
       .spread(function(req, res, obj) {
         t.equal(res.statusCode, 200, 'clears reputation for TEST_IP');
-        return reputationClient.putAsync('/' + TEST_IP, {
-          ip: TEST_IP,
+        return reputationClient.putAsync('/type/ip/' + TEST_IP, {
+          object: TEST_IP,
+          type: 'ip',
           reputation: 60,
         });
       })
@@ -162,11 +163,12 @@ ENDPOINTS.forEach(endpoint => {
 
   test(`suspects ${endpoint} for IP with reputation below suspectBelow`, t => {
     return reputationClient
-      .delAsync('/' + TEST_IP)
+      .delAsync('/type/ip/' + TEST_IP)
       .spread(function(req, res, obj) {
         t.equal(res.statusCode, 200, 'clears reputation for TEST_IP');
-        return reputationClient.putAsync('/' + TEST_IP, {
-          ip: TEST_IP,
+        return reputationClient.putAsync('/type/ip/' + TEST_IP, {
+          object: TEST_IP,
+          type: 'ip',
           reputation: 55,
         });
       })
@@ -192,11 +194,12 @@ ENDPOINTS.forEach(endpoint => {
 
   test(`blocks ${endpoint} for IP with reputation below blockBelow`, t => {
     return reputationClient
-      .delAsync('/' + TEST_IP)
+      .delAsync('/type/ip/' + TEST_IP)
       .spread(function(req, res, obj) {
         t.equal(res.statusCode, 200, 'clears reputation for TEST_IP');
-        return reputationClient.putAsync('/' + TEST_IP, {
-          ip: TEST_IP,
+        return reputationClient.putAsync('/type/ip/' + TEST_IP, {
+          object: TEST_IP,
+          type: 'ip',
           reputation: 10,
         });
       })
@@ -234,11 +237,12 @@ ENDPOINTS.forEach(endpoint => {
 
   test(`does not block ${endpoint} for whitelisted IP with reputation below blockBelow`, t => {
     return reputationClient
-      .delAsync('/' + ALLOWED_IP)
+      .delAsync('/type/ip/' + ALLOWED_IP)
       .spread(function(req, res, obj) {
         t.equal(res.statusCode, 200, 'clears reputation for ALLOWED_IP');
-        return reputationClient.putAsync('/' + ALLOWED_IP, {
-          ip: ALLOWED_IP,
+        return reputationClient.putAsync('/type/ip/' + ALLOWED_IP, {
+          object: ALLOWED_IP,
+          type: 'ip',
           reputation: 10,
         });
       })

--- a/packages/fxa-customs-server/test/test_reputation_server.js
+++ b/packages/fxa-customs-server/test/test_reputation_server.js
@@ -40,7 +40,7 @@ async function init(config) {
 
   server.route({
     method: 'PUT',
-    path: '/violations/{ip}',
+    path: '/violations/type/ip/{ip}',
     handler: async req => {
       const ip = req.params.ip;
       mostRecentViolationByIp[ip] = req.payload.violation;
@@ -48,6 +48,7 @@ async function init(config) {
     },
   });
 
+  // This is not a real route in iprepd, and is only used by the tests
   server.route({
     method: 'GET',
     path: '/mostRecentViolation/{ip}',
@@ -62,6 +63,7 @@ async function init(config) {
     },
   });
 
+  // This is not a real route in iprepd, and is only used by the tests
   server.route({
     method: 'DELETE',
     path: '/mostRecentViolation/{ip}',
@@ -83,7 +85,7 @@ async function init(config) {
 
   server.route({
     method: 'GET',
-    path: '/{ip}',
+    path: '/type/ip/{ip}',
     handler: async (req, h) => {
       var ip = req.params.ip;
       if (ip === '9.9.9.9') {
@@ -98,7 +100,7 @@ async function init(config) {
 
   server.route({
     method: 'DELETE',
-    path: '/{ip}',
+    path: '/type/ip/{ip}',
     handler: async (req, h) => {
       var ip = req.params.ip;
       if (reputationsByIp.hasOwnProperty(ip)) {
@@ -110,9 +112,9 @@ async function init(config) {
 
   server.route({
     method: 'PUT',
-    path: '/{ip}',
+    path: '/type/ip/{ip}',
     handler: async (req, h) => {
-      var ip = req.payload.ip;
+      var ip = req.payload.object;
       reputationsByIp[ip] = req.payload.reputation;
       return {};
     },

--- a/packages/fxa-customs-server/test/test_reputation_server_stub.js
+++ b/packages/fxa-customs-server/test/test_reputation_server_stub.js
@@ -19,7 +19,7 @@ var mostRecentViolationByIp = {};
 // hashmap of ip -> reputation
 var reputationsByIp = {};
 
-server.put('/violations/:ip', function(req, res, next) {
+server.put('/violations/type/ip/:ip', function(req, res, next) {
   var ip = req.params.ip;
   mostRecentViolationByIp[ip] = req.body.violation;
   console.log('put req', req.url);
@@ -27,7 +27,7 @@ server.put('/violations/:ip', function(req, res, next) {
   next();
 });
 
-// not real iprepd endpoints
+// This is not a real route in iprepd, and is only used by the tests
 server.get('/mostRecentViolation/:ip', function(req, res, next) {
   var ip = req.params.ip;
   console.log('get req', req.url);
@@ -35,6 +35,7 @@ server.get('/mostRecentViolation/:ip', function(req, res, next) {
 
   next();
 });
+// This is not a real route in iprepd, and is only used by the tests
 server.del('/mostRecentViolation/:ip', function(req, res, next) {
   var ip = req.params.ip;
   console.log('delete req', req.url);
@@ -48,7 +49,7 @@ server.get('/heartbeat', function(req, res, next) {
   next();
 });
 
-server.get('/:ip', function(req, res, next) {
+server.get('/type/ip/:ip', function(req, res, next) {
   var ip = req.params.ip;
   if (ip === '9.9.9.9') {
     res.send(500);
@@ -59,7 +60,7 @@ server.get('/:ip', function(req, res, next) {
   }
   next();
 });
-server.del('/:ip', function(req, res, next) {
+server.del('/type/ip/:ip', function(req, res, next) {
   var ip = req.params.ip;
   if (reputationsByIp.hasOwnProperty(ip)) {
     delete reputationsByIp[ip];
@@ -67,7 +68,7 @@ server.del('/:ip', function(req, res, next) {
   res.send(200);
   next();
 });
-server.put('/:ip', function(req, res, next) {
+server.put('/type/ip/:ip', function(req, res, next) {
   var ip = req.params.ip;
   reputationsByIp[ip] = req.body.reputation;
   res.send(200);


### PR DESCRIPTION
Update version of ip-reputation-js-client to most recent available which
is 6.0.0.

This also adjusts the iprepd mock endpoints to emulate the new endpoints
in iprepd that the new reputation module makes use of.