### PR TITLE
chore(image): Add env to specify logging base64 screenshot error

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -106,6 +106,10 @@ const takeScreenshot = function() {
           `Screenshot saved to https://${process.env.CIRCLE_BUILD_NUM}-36831081-gh.circle-artifacts.com/${process.env.CIRCLE_NODE_INDEX}/screenshots/${rando}.png`
         );
       }
+
+      if (process.env.LOG_ERROR_SCREENSHOT) {
+        console.error(`data:image/png;base64,${buffer.toString('base64')}`);
+      }
     });
   };
 };


### PR DESCRIPTION
Not connected to an issue, but this PR prints a base64 string of the screenshot taken when a functional test errors. This would be helpful in debugging errors in non-circle ci environments (ie Team City).