### PR TITLE
fix(settings): add missing emailVerified property to GQL query

### DIFF
--- a/packages/fxa-admin-panel/src/components/EmailBlocks/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/EmailBlocks/Account/index.test.tsx
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { Account } from './index';
+
+let accountResponse = {
+  uid: 'ca1c61239f2448b2af618f0b50226cde',
+  email: 'hey@happy.com',
+  createdAt: 1589467100316,
+  emailVerified: true,
+  emailBounces: [],
+  onCleared() {},
+};
+
+it('renders without imploding', () => {
+  const { getByTestId } = render(<Account {...accountResponse} />);
+
+  expect(getByTestId('account-section')).toBeInTheDocument();
+});
+
+it('displays the account', async () => {
+  const { getByTestId, getByText } = render(<Account {...accountResponse} />);
+
+  expect(getByTestId('account-section')).toBeInTheDocument();
+  expect(getByTestId('verified-status')).toHaveTextContent('verified');
+  expect(getByTestId('email-label')).toHaveTextContent(accountResponse.email);
+  expect(getByTestId('uid-label')).toHaveTextContent(accountResponse.uid);
+  expect(getByTestId('createdat-label')).toHaveTextContent(
+    accountResponse.createdAt.toString()
+  );
+});
+
+it('displays the unverified account', async () => {
+  accountResponse.emailVerified = false;
+  const { getByTestId } = render(<Account {...accountResponse} />);
+  expect(getByTestId('verified-status')).toHaveTextContent('not verified');
+});

--- a/packages/fxa-admin-panel/src/components/EmailBlocks/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/EmailBlocks/Account/index.tsx
@@ -71,17 +71,23 @@ export const Account = ({
     <section className="account" data-testid="account-section">
       <ul>
         <li className="flex justify-space-between">
-          <h3>{email}</h3>
-          <span className={`${emailVerified ? 'verified' : 'not-verified'}`}>
+          <h3 data-testid="email-label">{email}</h3>
+          <span
+            data-testid="verified-status"
+            className={`${emailVerified ? 'verified' : 'not-verified'}`}
+          >
             {emailVerified ? 'verified' : 'not verified'}
           </span>
         </li>
         <li className="flex justify-space-between">
-          <div>
+          <div data-testid="uid-label">
             uid: <span className="result">{uid}</span>
           </div>
           <div className="created-at">
-            created at: <span className="result">{createdAt}</span>
+            created at:{' '}
+            <span className="result" data-testid="createdat-label">
+              {createdAt}
+            </span>
             <br />
             {date}
           </div>

--- a/packages/fxa-admin-panel/src/components/EmailBlocks/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/EmailBlocks/index.test.tsx
@@ -37,6 +37,7 @@ function exampleAccountResponse(email: string): MockedResponse {
           uid: 'a1b2c3',
           email,
           createdAt: chance.timestamp(),
+          emailVerified: true,
           emailBounces: [exampleBounce(email), exampleBounce(email)],
         },
       },

--- a/packages/fxa-admin-panel/src/components/EmailBlocks/index.tsx
+++ b/packages/fxa-admin-panel/src/components/EmailBlocks/index.tsx
@@ -29,6 +29,7 @@ export const GET_ACCOUNT_BY_EMAIL = gql`
       uid
       email
       createdAt
+      emailVerified
       emailBounces {
         email
         createdAt


### PR DESCRIPTION
Closes #5284 

Real simple, we were just forgetting to include the `emailVerified` response property when looking up an account.

I also added some basic UI tests.