### PR TITLE
Log push expired callbacks separately

### DIFF
--- a/packages/fxa-auth-server/test/local/push.js
+++ b/packages/fxa-auth-server/test/local/push.js
@@ -427,6 +427,31 @@ describe('push', () => {
     });
   });
 
+  it('push catches devices with expired callback', () => {
+    let count = 0;
+    const thisMockLog = mockLog({
+      info: function(op, log) {
+        if (log.name === 'push.account_verify.push_callback_expired') {
+          // device had expired callback
+          count++;
+        }
+      },
+    });
+
+    const devices = [
+      {
+        id: 'foo',
+        name: 'My Phone',
+        pushEndpointExpired: true,
+      },
+    ];
+
+    const push = require(pushModulePath)(thisMockLog, mockDb, mockConfig);
+    return push.sendPush(mockUid, devices, 'accountVerify').then(() => {
+      assert.equal(count, 1);
+    });
+  });
+
   it('push reports errors when web-push fails', () => {
     let count = 0;
     const thisMockLog = mockLog({


### PR DESCRIPTION
Looking at the [send tab metrics document](https://docs.google.com/document/d/1XxNHWuotwNpaOSzrdN3KPu0bFPe28SSxZZp4HNWezhM), I think it could be useful to figure out what's the split between push subscription missing and push subscription expired. I'm thinking of the "verified device" case where the push notification is "sent" before the new device had a chance to register the push callback. 
One thing we could also do is log the "reason" of the push (verified, command, etc) in the logs, wdyt?