### PR TITLE
fix(surveys): update survey complete message check

### DIFF
--- a/packages/fxa-react/components/Survey/index.test.tsx
+++ b/packages/fxa-react/components/Survey/index.test.tsx
@@ -11,7 +11,7 @@ afterEach(cleanup);
 describe("Survey", () => {
   it("renders as expected", () => {
     const subject = () => {
-      return render(<Survey {...{surveyURL}}/>);
+      return render(<Survey {...{ surveyURL }} />);
     };
 
     const { queryByTestId } = subject();
@@ -22,7 +22,7 @@ describe("Survey", () => {
 
   it("hides iframe and renders survey complete message", () => {
     const subject = () => {
-      return render(<Survey {...{surveyURL}} surveyComplete />);
+      return render(<Survey {...{ surveyURL }} surveyComplete />);
     };
 
     const { queryByTestId } = subject();
@@ -34,14 +34,25 @@ describe("Survey", () => {
     expect(surveyCompleteMsg).toBeVisible();
   });
 
-  it("creates the iframe message handler correctly", () => {
+  it("creates the iframe message handler correctly with default survey completion message", () => {
     const stub = jest.fn();
     const handleIframeTask = CreateHandleIframeTask(stub);
 
-    handleIframeTask(new MessageEvent('noop', {}));
+    handleIframeTask(new MessageEvent("noop", {}));
     expect(stub).not.toBeCalled();
 
-    handleIframeTask(new MessageEvent('correct', {data: 'submitted survey'}));
+    handleIframeTask(new MessageEvent("correct", { data: "survey complete" }));
+    expect(stub).toBeCalled();
+  });
+
+  it("creates the iframe message handler correctly with custom survey completion message", () => {
+    const stub = jest.fn();
+    const handleIframeTask = CreateHandleIframeTask(stub, "it is done!");
+
+    handleIframeTask(new MessageEvent("noop", {}));
+    expect(stub).not.toBeCalled();
+
+    handleIframeTask(new MessageEvent("correct", { data: "it is done!" }));
     expect(stub).toBeCalled();
   });
 });

--- a/packages/fxa-react/components/Survey/index.tsx
+++ b/packages/fxa-react/components/Survey/index.tsx
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useState } from 'react';
-import { CSSTransition } from 'react-transition-group';
+import React, { useState } from "react";
+import { CSSTransition } from "react-transition-group";
 
-import './index.scss';
+import "./index.scss";
 
 type SurveyProps = {
   surveyURL: string;
@@ -19,12 +19,15 @@ then we should be able to use the same fluent syntax in content and
 payment servers
 */
 
-export const CreateHandleIframeTask = (callback: Function) => {
+export const CreateHandleIframeTask = (
+  callback: Function,
+  evtMessage: string = "survey complete"
+) => {
   // https://github.com/mozilla/fxa/blob/26224fe8a315d8e9949a577485f9184f47e978c7/packages/fxa-payments-server/src/routes/Product/SubscriptionRedirect/index.tsx#L34
   const handleIframeTask = (evt: MessageEvent) => {
     // Note: This event is implemented in code within the SurveyGizmo iframe embed.
     // https://help.surveygizmo.com/help/adding-javascript-to-your-survey
-    if (evt.data === 'submitted survey') callback();
+    if (evt.data === evtMessage) callback();
   };
   return handleIframeTask;
 };
@@ -33,8 +36,7 @@ export const Survey = ({ surveyURL, surveyComplete = false }: SurveyProps) => {
   const [inProp, setInProp] = useState(false);
 
   const surveyCompleteElement = (
-    <div className="survey-complete-msg"
-         data-testid="survey-complete-msg">
+    <div className="survey-complete-msg" data-testid="survey-complete-msg">
       <p className="emoji">✅&nbsp;👍&nbsp;💖</p>
       <p>Thank you for your input.</p>
       <p className="small">This survey will close automatically.</p>


### PR DESCRIPTION
Because:
 - The message posted isn't always "submitted survey"

This commit:
 - Sets a default of "survey complete"
 - Accepts an argument for the message

Fixes #5309 (FXA-1881)