### PR TITLE
fix(metrics): Correctly log CAD view metrics when coming from signin/signup

### DIFF
--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -327,6 +327,13 @@ const FUZZY_EVENTS = new Map([
     },
   ],
   [
+    /^screen\.(?:signup|signin)\.(sms)$/,
+    {
+      group: GROUPS.connectDevice,
+      event: 'view',
+    },
+  ],
+  [
     /^flow\.connect-another-device\.link\.(app-store)\.([\w-]+)$/,
     {
       group: GROUPS.connectDevice,

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -1132,6 +1132,60 @@ registerSuite('amplitude', {
       assert.equal(logger.info.args[0][1].event_type, 'fxa_reg - submit');
     },
 
+    'screen.signin.sms': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'screen.signin.sms',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_connect_device - view');
+      assert.equal(arg.event_properties.connect_device_flow, 'sms');
+      assert.equal(arg.event_properties.connect_device_os, undefined);
+    },
+
+    'screen.signup.sms': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'screen.signup.sms',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_connect_device - view');
+      assert.equal(arg.event_properties.connect_device_flow, 'sms');
+      assert.equal(arg.event_properties.connect_device_os, undefined);
+    },
+
     'flow.sms.submit': () => {
       amplitude(
         {


### PR DESCRIPTION
Fixes #5290 

This PR logs the `fxa_connect_device - view` amplitude event. Currently this event will now be triggered when opening from FxA toolbar menu, signin and signup.

cc @irrationalagent @davismtl 

Content-server Amplitude logs (`./pm2 logs content | grep 'amplitudeEvent'`)

From toolbar menu connect another device
```
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_connect_device - view","time":1589815030251,"device_id":"208d6f103d084390853a46b453cfdd04","session_id":1589815029465,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync","connect_device_flow":"sms"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"bea421113027562fd4316ee8ae24236a30f5187e2eaa15e888b7ce5028aeee36","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["send_sms_us"]}}
```

From signin
```
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_email_first - view","time":1589814936397,"device_id":"674e6dd999c445339fa39fd77cb9dc9e","session_id":1589814935618,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b3424a37d626ba06eba935ca80dfd4e8df7f36321d2d0971b553ad373a0bac1c","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_email_first - engage","time":1589814941121,"device_id":"674e6dd999c445339fa39fd77cb9dc9e","session_id":1589814935618,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b3424a37d626ba06eba935ca80dfd4e8df7f36321d2d0971b553ad373a0bac1c","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_email_first - submit","time":1589814942513,"device_id":"674e6dd999c445339fa39fd77cb9dc9e","session_id":1589814935618,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b3424a37d626ba06eba935ca80dfd4e8df7f36321d2d0971b553ad373a0bac1c","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_login - view","time":1589814942632,"device_id":"674e6dd999c445339fa39fd77cb9dc9e","session_id":1589814935618,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b3424a37d626ba06eba935ca80dfd4e8df7f36321d2d0971b553ad373a0bac1c","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_login - engage","time":1589814943349,"user_id":"acab38ecffeb4a27a8835016dbf1292c","device_id":"674e6dd999c445339fa39fd77cb9dc9e","session_id":1589814935618,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b3424a37d626ba06eba935ca80dfd4e8df7f36321d2d0971b553ad373a0bac1c","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_login - submit","time":1589814947740,"user_id":"acab38ecffeb4a27a8835016dbf1292c","device_id":"674e6dd999c445339fa39fd77cb9dc9e","session_id":1589814935618,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b3424a37d626ba06eba935ca80dfd4e8df7f36321d2d0971b553ad373a0bac1c","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_connect_device - view","time":1589814960352,"user_id":"acab38ecffeb4a27a8835016dbf1292c","device_id":"674e6dd999c445339fa39fd77cb9dc9e","session_id":1589814935618,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync","connect_device_flow":"sms"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"b3424a37d626ba06eba935ca80dfd4e8df7f36321d2d0971b553ad373a0bac1c","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["send_sms_us"]}}}
```

From signup
```
{"op":"amplitudeEvent","event_type":"fxa_email_first - view","time":1589815084672,"device_id":"219de66de4784e4bb025fbf9124c4f34","session_id":1589815082375,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"0729149af6189b2aec02c42c5a60abfa9c60d0c0d25b057201d604c336954db0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
{"op":"amplitudeEvent","event_type":"fxa_email_first - engage","time":1589815088987,"device_id":"219de66de4784e4bb025fbf9124c4f34","session_id":1589815082375,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"0729149af6189b2aec02c42c5a60abfa9c60d0c0d25b057201d604c336954db0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
{"op":"amplitudeEvent","event_type":"fxa_email_first - submit","time":1589815092827,"device_id":"219de66de4784e4bb025fbf9124c4f34","session_id":1589815082375,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"0729149af6189b2aec02c42c5a60abfa9c60d0c0d25b057201d604c336954db0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
{"op":"amplitudeEvent","event_type":"fxa_reg - view","time":1589815095311,"device_id":"219de66de4784e4bb025fbf9124c4f34","session_id":1589815082375,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"0729149af6189b2aec02c42c5a60abfa9c60d0c0d25b057201d604c336954db0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
{"op":"amplitudeEvent","event_type":"fxa_reg - engage","time":1589815096058,"device_id":"219de66de4784e4bb025fbf9124c4f34","session_id":1589815082375,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"0729149af6189b2aec02c42c5a60abfa9c60d0c0d25b057201d604c336954db0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
{"op":"amplitudeEvent","event_type":"fxa_reg - submit","time":1589815106242,"device_id":"219de66de4784e4bb025fbf9124c4f34","session_id":1589815082375,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"0729149af6189b2aec02c42c5a60abfa9c60d0c0d25b057201d604c336954db0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
{"op":"amplitudeEvent","event_type":"fxa_reg - signup_code_view","time":1589815106609,"device_id":"219de66de4784e4bb025fbf9124c4f34","session_id":1589815082375,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"0729149af6189b2aec02c42c5a60abfa9c60d0c0d25b057201d604c336954db0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
{"op":"amplitudeEvent","event_type":"fxa_reg - signup_code_engage","time":1589815113064,"device_id":"219de66de4784e4bb025fbf9124c4f34","session_id":1589815082375,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"0729149af6189b2aec02c42c5a60abfa9c60d0c0d25b057201d604c336954db0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
{"op":"amplitudeEvent","event_type":"fxa_reg - signup_code_submit","time":1589815113551,"device_id":"219de66de4784e4bb025fbf9124c4f34","session_id":1589815082375,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"0729149af6189b2aec02c42c5a60abfa9c60d0c0d25b057201d604c336954db0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
{"op":"amplitudeEvent","event_type":"fxa_connect_device - view","time":1589815113794,"device_id":"219de66de4784e4bb025fbf9124c4f34","session_id":1589815082375,"app_version":"171.0","language":"en","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync","connect_device_flow":"sms"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"0729149af6189b2aec02c42c5a60abfa9c60d0c0d25b057201d604c336954db0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["send_sms_us"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
```