### PR TITLE
feat(cad): Add feature flag for CAD via QR code

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiment.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiment.js
@@ -25,6 +25,7 @@ const MANUAL_EXPERIMENTS = {
   // no special experiment is created.
   sendSms: BaseExperiment,
   newsletterSync: BaseExperiment,
+  qrCodeCad: BaseExperiment,
 };
 
 const ALL_EXPERIMENTS = _.extend({}, STARTUP_EXPERIMENTS, MANUAL_EXPERIMENTS);

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
@@ -17,6 +17,7 @@ const experimentGroupingRules = [
   require('./sentry'),
   require('./email-mx-validation'),
   require('./newsletter-sync'),
+  require('./qr-code-cad'),
 ].map(ExperimentGroupingRule => new ExperimentGroupingRule());
 
 class ExperimentChoiceIndex {

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/qr-code-cad.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/qr-code-cad.js
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * This defines the CAD via QR code experiment grouping rules. For more
+ * details please reference https://docs.google.com/document/d/1JfHd-zX47af-seUToS6fHSzpcTKG5l1WFiojGLUQYYE/edit#.
+ */
+'use strict';
+
+const BaseGroupingRule = require('./base');
+const CountryTelephoneInfo = require('../../country-telephone-info');
+
+const GROUPS = [
+  'control', // Current sms experience
+  'treatment-a', // CAD via QR design in https://mozilla.invisionapp.com/share/N2X6MA9SPD5
+  'treatment-b', // Screen displayed in non-sms markets
+];
+
+const ROLLOUT_RATE = 0.0;
+
+module.exports = class QrCodeCad extends BaseGroupingRule {
+  constructor() {
+    super();
+    this.name = 'qrCodeCad';
+
+    // Easier to set class properties for testability
+    this.groups = GROUPS;
+    this.rolloutRate = ROLLOUT_RATE;
+  }
+
+  /**
+   * For this experiment, we are doing a staged rollout.
+   *
+   * @param {Object} subject data used to decide
+   *  @param {Boolean} isSync is this a sync signup?
+   * @returns {Any}
+   */
+  choose(subject = {}) {
+    if (!subject.account || !subject.uniqueUserId || !subject.country) {
+      return false;
+    }
+
+    let telephoneInfo = CountryTelephoneInfo[subject.country];
+    const { featureFlags } = subject;
+    if (featureFlags && featureFlags.smsCountries) {
+      telephoneInfo = featureFlags.smsCountries[subject.country];
+    }
+
+    // Countries that don't support SMS can't be in the experiment
+    if (!telephoneInfo) {
+      return false;
+    }
+
+    let choice = false;
+    // If countryRollOut is not specified, assume 0.
+    const countryRollOut = telephoneInfo.rolloutRate || 0;
+
+    if (this.isTestEmail(subject.account.get('email'))) {
+      // Test users always get the new experience
+      choice = 'treatment-b';
+    } else if (countryRollOut >= 1) {
+      // This experiment should only be shown to countries that are fully
+      // rolled out with sms
+      if (this.bernoulliTrial(this.rolloutRate, subject.uniqueUserId)) {
+        choice = this.uniformChoice(this.groups, subject.uniqueUserId);
+      }
+    }
+
+    return choice;
+  }
+};

--- a/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -89,6 +89,21 @@ export default {
   },
 
   /**
+   * Replace the current page with the new CAD via QR screen.
+   *
+   * @param {Object} account
+   * @param {String} country
+   */
+  replaceCurrentPageWithQrCadScreen(account, country) {
+    const type = this.model.get('type');
+    this.replaceCurrentPage('/post_verify/cad_qr/get_started', {
+      account,
+      country,
+      type,
+    });
+  },
+
+  /**
    * Get the country to send an sms to if `account` is eligible for SMS?
    *
    * @param {Object} account
@@ -110,6 +125,7 @@ export default {
         account,
         country,
       });
+
       if (!group) {
         // Auth server said "OK" but user was not selected
         // for the experiment, this mode is not logged in
@@ -125,6 +141,27 @@ export default {
           return country;
         }
       }
+    });
+  },
+
+  getEligibleQrCodeCadGroup(account) {
+    // Initialize the flow metrics so any flow events are logged.
+    // The flow-events-mixin, even if it were mixed in, does this in
+    // `afterRender` whereas this method can be called in `beforeRender`
+    this.notifier.trigger('flow.initialize');
+
+    return this._isEligibleForSms(account).then(({ country }) => {
+      if (!country) {
+        // If no country is returned, the reason is already logged.
+        return;
+      }
+      return {
+        group: this.getAndReportExperimentGroup('qrCodeCad', {
+          account,
+          country,
+        }),
+        country,
+      };
     });
   },
 

--- a/packages/fxa-content-server/app/scripts/views/post_verify/cad_qr/scan_code.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/cad_qr/scan_code.js
@@ -17,6 +17,13 @@ class ScanCode extends FormView {
     'click #use-sms-link': preventDefaultThen('clickUseSms'),
   });
 
+  initialize() {
+    // Override the default poll time (6s) in functional tests
+    if (this.broker.isAutomatedBrowser()) {
+      this.DEVICE_CONNECTED_POLL_IN_MS = 500;
+    }
+  }
+
   _onConnected(device) {
     return this.navigate('/post_verify/cad_qr/connected', {
       device,

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 
 describe('lib/experiments/grouping-rules/index', () => {
   it('EXPERIMENT_NAMES is exported', () => {
-    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 6);
+    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 7);
   });
 
   describe('choose', () => {

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/newsletter-sync.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/newsletter-sync.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { assert } from 'chai';
-import Experiment from 'lib/experiments/grouping-rules/send-sms-install-link';
+import Experiment from 'lib/experiments/grouping-rules/newsletter-sync';
 
 describe('lib/experiments/grouping-rules/newsletter-sync', () => {
   let experiment;

--- a/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
@@ -54,6 +54,11 @@ describe('views/connect_another_device', () => {
       .callsFake(() => Promise.resolve(smsCountry));
     sinon.stub(view, 'replaceCurrentPageWithSmsScreen').callsFake(() => {});
 
+    // TODO: PUll this out into own test section
+    sinon
+      .stub(view, 'getEligibleQrCodeCadGroup')
+      .callsFake(() => Promise.resolve({ group: false }));
+
     // by default, user is ineligble to send an SMS
     smsCountry = null;
   });

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -51,6 +51,7 @@ module.exports = [
   'tests/functional/post_verify/newsletters.js',
   'tests/functional/post_verify/account_recovery.js',
   'tests/functional/post_verify/secondary_email.js',
+  'tests/functional/post_verify/cad_qr.js',
   'tests/functional/pp.js',
   'tests/functional/recovery_key.js',
   'tests/functional/refreshes_metrics.js',

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -315,6 +315,27 @@ module.exports = {
     SUBMIT: 'button[type="submit"]',
     NEWSLETTERS,
   },
+  POST_VERIFY_CAD_QR_GET_STARTED: {
+    HEADER: '#fxa-cad-qr-get-started-header',
+    SUBMIT: 'button[type="submit"]',
+    LATER: '#maybe-later-btn',
+  },
+  POST_VERIFY_CAD_QR_READY_TO_SCAN: {
+    HEADER: '#fxa-cad-qr-ready-to-scan-header',
+    SUBMIT: 'button[type="submit"]',
+    LATER: '#maybe-later-btn',
+    USE_SMS: '#use-sms-link',
+  },
+  POST_VERIFY_CAD_QR_SCAN_CODE: {
+    HEADER: '#fxa-cad-qr-connect-your-mobile-device-header',
+    USE_SMS: '#use-sms-link',
+  },
+  POST_VERIFY_CAD_QR_CONNECTED: {
+    HEADER: '#fxa-cad-qr-connected-header',
+    SUBMIT: 'button[type="submit"]',
+    USE_SMS: '#use-sms-link',
+    DONE: '#done-link',
+  },
   RECOVERY_KEY: {
     CANCEL_BUTTON: '.cancel',
     CONFIRM_PASSWORD_CONTINUE: '.generate-key-link',

--- a/packages/fxa-content-server/tests/functional/post_verify/cad_qr.js
+++ b/packages/fxa-content-server/tests/functional/post_verify/cad_qr.js
@@ -1,0 +1,224 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { registerSuite } = intern.getInterface('object');
+const FunctionalHelpers = require('./../lib/helpers');
+const selectors = require('./../lib/selectors');
+const uaStrings = require('../lib/ua-strings');
+const config = intern._config;
+
+const ENTER_EMAIL_URL = `${config.fxaContentRoot}?context=fx_desktop_v3&service=sync`;
+
+const PASSWORD = 'password1234567';
+const TEST_DEVICE_NAME = 'Test Runner Session Device';
+const TEST_DEVICE_TYPE = 'mobile';
+let email, accountData, client;
+
+const {
+  clearBrowserState,
+  click,
+  createEmail,
+  createUser,
+  fillOutEmailFirstSignIn,
+  fillOutEmailFirstSignUp,
+  fillOutSignUpCode,
+  getStoredAccountByEmail,
+  openPage,
+  testElementExists,
+} = FunctionalHelpers;
+
+registerSuite('cad_qr_signin', {
+  beforeEach: function() {
+    email = createEmail();
+    client = FunctionalHelpers.getFxaClient();
+    return this.remote
+      .then(clearBrowserState({ force: true }))
+      .then(createUser(email, PASSWORD, { preVerified: true }))
+      .then(result => {
+        accountData = result;
+      });
+  },
+
+  tests: {
+    'control - CAD via sms': function() {
+      return this.remote
+        .then(
+          openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
+            query: {
+              forceExperiment: 'qrCodeCad',
+              forceExperimentGroup: 'control',
+            },
+          })
+        )
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+        .then(testElementExists(selectors.SMS_SEND.HEADER));
+    },
+
+    'treatment a - CAD via QR code': function() {
+      return (
+        this.remote
+          .then(
+            openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
+              query: {
+                forceExperiment: 'qrCodeCad',
+                forceExperimentGroup: 'treatment-a',
+              },
+            })
+          )
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
+          .then(
+            testElementExists(selectors.POST_VERIFY_CAD_QR_GET_STARTED.HEADER)
+          )
+          .then(click(selectors.POST_VERIFY_CAD_QR_GET_STARTED.SUBMIT))
+
+          .then(
+            testElementExists(selectors.POST_VERIFY_CAD_QR_READY_TO_SCAN.HEADER)
+          )
+          .then(click(selectors.POST_VERIFY_CAD_QR_READY_TO_SCAN.SUBMIT))
+
+          .then(
+            testElementExists(selectors.POST_VERIFY_CAD_QR_SCAN_CODE.HEADER)
+          )
+
+          // This page will be polling for a new device record. This typically
+          // happens when the user successfully authenticates on a new
+          // device.
+          .then(function() {
+            return client.deviceRegister(
+              accountData.sessionToken,
+              TEST_DEVICE_NAME,
+              TEST_DEVICE_TYPE
+            );
+          })
+
+          .then(
+            testElementExists(selectors.POST_VERIFY_CAD_QR_CONNECTED.HEADER)
+          )
+      );
+    },
+
+    'treatment b - CAD via store badges': function() {
+      return this.remote
+        .then(
+          openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
+            query: {
+              forceExperiment: 'qrCodeCad',
+              forceExperimentGroup: 'treatment-b',
+            },
+          })
+        )
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER));
+    },
+  },
+});
+
+registerSuite('cad_qr_signup', {
+  beforeEach: function() {
+    email = createEmail();
+    client = FunctionalHelpers.getFxaClient();
+    return this.remote.then(clearBrowserState({ force: true }));
+  },
+
+  tests: {
+    'control - CAD via sms': function() {
+      return this.remote
+        .then(
+          openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
+            query: {
+              forceUA: uaStrings['desktop_firefox_71'],
+              forceExperiment: 'qrCodeCad',
+              forceExperimentGroup: 'control',
+            },
+            webChannelResponses: {
+              'fxaccounts:fxa_status': {
+                capabilities: {
+                  multiService: true,
+                },
+              },
+            },
+          })
+        )
+        .then(fillOutEmailFirstSignUp(email, PASSWORD))
+        .then(fillOutSignUpCode(email, 0))
+        .then(testElementExists(selectors.SMS_SEND.HEADER));
+    },
+
+    'treatment a - CAD via QR code': function() {
+      return (
+        this.remote
+          .then(
+            openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
+              query: {
+                forceUA: uaStrings['desktop_firefox_71'],
+                forceExperiment: 'qrCodeCad',
+                forceExperimentGroup: 'treatment-a',
+              },
+              webChannelResponses: {
+                'fxaccounts:fxa_status': {
+                  capabilities: {
+                    multiService: true,
+                  },
+                },
+              },
+            })
+          )
+          .then(fillOutEmailFirstSignUp(email, PASSWORD))
+          .then(fillOutSignUpCode(email, 0))
+          .then(
+            testElementExists(selectors.POST_VERIFY_CAD_QR_GET_STARTED.HEADER)
+          )
+          .then(click(selectors.POST_VERIFY_CAD_QR_GET_STARTED.SUBMIT))
+
+          .then(
+            testElementExists(selectors.POST_VERIFY_CAD_QR_READY_TO_SCAN.HEADER)
+          )
+          .then(click(selectors.POST_VERIFY_CAD_QR_READY_TO_SCAN.SUBMIT))
+
+          .then(
+            testElementExists(selectors.POST_VERIFY_CAD_QR_SCAN_CODE.HEADER)
+          )
+
+          // Add a device using a session token from the browser
+          .then(getStoredAccountByEmail(email))
+          .then(function(account) {
+            return client.deviceRegister(
+              account.sessionToken,
+              TEST_DEVICE_NAME,
+              TEST_DEVICE_TYPE
+            );
+          })
+
+          .then(
+            testElementExists(selectors.POST_VERIFY_CAD_QR_CONNECTED.HEADER)
+          )
+      );
+    },
+
+    'treatment b - CAD via store badges': function() {
+      return this.remote
+        .then(
+          openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
+            query: {
+              forceUA: uaStrings['desktop_firefox_71'],
+              forceExperiment: 'qrCodeCad',
+              forceExperimentGroup: 'treatment-b',
+            },
+            webChannelResponses: {
+              'fxaccounts:fxa_status': {
+                capabilities: {
+                  multiService: true,
+                },
+              },
+            },
+          })
+        )
+        .then(fillOutEmailFirstSignUp(email, PASSWORD))
+        .then(fillOutSignUpCode(email, 0))
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER));
+    },
+  },
+});


### PR DESCRIPTION
Fixes #5236 

This PR adds all the feature flag plumbing needed for the CAD to QR code experiment.

Steps to test are to `npm start` and then `npm start firefox` and then open the urls below

#### Control group (current sms page)

- Open http://localhost:3030/?service=sync&context=fx_desktop_v3&action=email&forceExperiment=qrCodeCad&forceExperimentGroup=control

#### Treatment A group (new CAD via QR)

- Open http://localhost:3030/?service=sync&context=fx_desktop_v3&action=email&forceExperiment=qrCodeCad&forceExperimentGroup=treatment-a

#### Treatment B group (non-sms CAD view aka only app store badges)

- Open http://localhost:3030/?service=sync&context=fx_desktop_v3&action=email&forceExperiment=qrCodeCad&forceExperimentGroup=treatment-b

This feature is setup to work with both existing and new users so the links above could be repeated for each case. I've added functional tests that exercise all of the paths above.

cc @irrationalagent @davismtl