### PR TITLE
feat(storybook): build static gh-pages site from storybook builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ secrets.json
 /packages/test.list
 .last-audit
 .eslintcache
+storybooks-publish
 
 # Dependencies
 **/node_modules

--- a/_scripts/build-storybooks-indexes.js
+++ b/_scripts/build-storybooks-indexes.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/* eslint no-use-before-define: 0 */
+const fs = require("fs");
+const path = require("path");
+
+function main() {
+  const [, , PUBLISH_ROOT] = process.argv;
+
+  const commitsPath = path.join(PUBLISH_ROOT, "commits");
+  const pullsPath = path.join(PUBLISH_ROOT, "pulls");
+
+  const pullDirs = lsDirs(pullsPath);
+  const commitDirs = lsDirs(commitsPath);
+
+  // Create an index for all pull requests
+  writeIndex(
+    pullsPath,
+    htmlDirIndex({
+      title: "Storybooks for Recent Pull Requests",
+      items: pullDirs
+    })
+  );
+
+  // Create an index for each pull request
+  for (const item of pullDirs) {
+    writeIndex(item.path, htmlPullRedirect(item));
+  }
+
+  // Create an index for all commmits
+  writeIndex(
+    commitsPath,
+    htmlDirIndex({
+      title: "Storybooks for Recent Commits",
+      items: commitDirs
+    })
+  );
+
+  // Create an index for each commit
+  for (const item of commitDirs) {
+    writeIndex(
+      item.path,
+      htmlDirIndex({
+        omitDates: true,
+        title: `Storybooks for ${item.fn}`,
+        description: item.description,
+        items: lsDirs(item.path)
+      })
+    );
+  }
+
+  // Create an index for the whole static site
+  writeIndex(
+    PUBLISH_ROOT,
+    htmlIndex({
+      pulls: pullDirs.slice(0, 7),
+      commits: commitDirs.slice(0, 7)
+    })
+  );
+}
+
+const lsDirs = root =>
+  fs
+    .readdirSync(root)
+    .map(fn => ({
+      fn,
+      path: path.join(root, fn)
+    }))
+    .map(item => ({
+      ...item,
+      ...maybeReadText(item.path, "commit", "summary", "description"),
+      stat: fs.statSync(item.path)
+    }))
+    .filter(({ fn, stat }) => !fn.startsWith(".") && stat.isDirectory())
+    .sort((a, b) => b.stat.mtimeMs - a.stat.mtimeMs);
+
+const maybeReadText = (basePath, ...fns) => {
+  const out = {};
+  for (const fn of fns) {
+    try {
+      out[fn] = fs
+        .readFileSync(path.join(basePath, `${fn}.txt`))
+        .toString()
+        .trim();
+    } catch (err) {
+      // no-op
+    }
+  }
+  return out;
+};
+
+const writeIndex = (indexPath, content) =>
+  fs.writeFileSync(path.join(indexPath, "index.html"), content);
+
+const htmlIndex = ({
+  title = "Storybooks for Firefox Accounts",
+  pulls,
+  commits
+}) =>
+  htmlPage(
+    { title },
+    html`
+      <h2>Pull Requests</h2>
+      <ul>
+        ${pulls.map(item => htmlDirItem({ basePath: "./pulls", ...item }))}
+      </ul>
+      <h2>Commits</h2>
+      <ul>
+        ${commits.map(item => htmlDirItem({ basePath: "./commits", ...item }))}
+      </ul>
+    `
+  );
+
+const htmlPullRedirect = ({ fn, commit }) =>
+  htmlPage(
+    {
+      title: `Storybook for Pull Request ${fn}`,
+      head: html`
+        <meta
+          http-equiv="refresh"
+          content="0;URL='../../commits/${commit}/index.html'"
+        />
+      `
+    },
+    html`
+      <p>
+        <a href="../../commits/${commit}/index.html"
+          >Commit ${commit} for Pull Request ${fn}</a
+        >
+      </p>
+    `
+  );
+
+const htmlDirIndex = ({ omitDates = false, title, description, items = [] }) =>
+  htmlPage(
+    { title },
+    html`
+      <ul>
+        ${items.map(item => htmlDirItem({ omitDates, ...item }))}
+      </ul>
+      ${description &&
+        html`
+          <h2>Description</h2>
+          <pre>${description}</pre>
+        `}
+    `
+  );
+
+const htmlDirItem = ({ omitDates, basePath = ".", fn, stat, summary }) => html`
+  <li>
+    <a href="${basePath}/${fn}/index.html">${fn}</a>
+    ${!omitDates &&
+      html`
+        <span class="date">
+          (${new Date(stat.mtimeMs).toISOString()})
+        </span>
+      `}
+    ${summary &&
+      html`
+        <p>${summary}</p>
+      `}
+  </li>
+`;
+
+const htmlPage = ({ title = "", head = "" }, body) => html`
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <title>${title}</title>
+      ${head}
+    </head>
+    <body>
+      <h1>${title}</h1>
+      ${body}
+    </body>
+  </html>
+`;
+
+// Simple html tagged template utility. Could do more, but it helps a bit with
+// using the lit-html extension in VSCode to keep markup in strings formatted.
+const html = (strings, ...values) =>
+  strings
+    .reduce(
+      (result, string, i) =>
+        result +
+        string +
+        (values[i]
+          ? Array.isArray(values[i])
+            ? values[i].join("")
+            : values[i]
+          : ""),
+      ""
+    )
+    .trim();
+
+main();

--- a/_scripts/build-storybooks.sh
+++ b/_scripts/build-storybooks.sh
@@ -1,0 +1,95 @@
+#!/bin/bash -ex
+
+# TODO: only build if the current commit has changes to packages with storybooks - see modules-to-test.js for some hints?
+
+# Config from env vars with defaults
+SKIP_STORYBOOK_BUILD="${SKIP_STORYBOOK_BUILD:-false}"
+PROJECT_REPO="${PROJECT_REPO:-mozilla/fxa}"
+STORYBOOKS_REPO="${STORYBOOKS_REPO:-lmorchard/fxa-storybooks}"
+STORYBOOKS_URL="${STORYBOOKS_URL:-https://lmorchard.github.io/fxa-storybooks/}"
+STORYBOOKS_BRANCH="${STORYBOOKS_BRANCH:-gh-pages}"
+PUBLISH_ROOT="${PUBLISH_ROOT:-storybooks-publish}"
+MAX_STORYBOOK_AGE="${MAX_STORYBOOK_AGE:-90}"
+
+# Context for current build
+COMMIT_HASH=$(git rev-parse HEAD)
+
+# Build all the storybooks
+if [ "$SKIP_STORYBOOK_BUILD" == false ]; then
+    # fxa-payments-server relies on fxa-content-server .scss styles, which in turn
+    # rely on some modules in package.json
+    pushd ./packages/fxa-content-server
+    npm ci
+    popd
+
+    STORYBOOKS=$(find packages -maxdepth 2 -type d -name '.storybook');
+    for STORYBOOK_PATH in $STORYBOOKS; do
+        pushd $(dirname $STORYBOOK_PATH);
+        rm -rf storybook-static;
+        npm ci;
+        npm run build-storybook;
+        popd
+    done;
+fi
+
+# Get a fresh checkout of the repo to which we'll publish
+rm -rf $PUBLISH_ROOT
+git clone --branch $STORYBOOKS_BRANCH git@github.com:$STORYBOOKS_REPO.git $PUBLISH_ROOT
+mkdir -p $PUBLISH_ROOT/{commits,pulls}
+
+# Copy all the storybooks into the publish directory for commit.
+COMMIT_PATH="$PUBLISH_ROOT/commits/$COMMIT_HASH"
+rm -rf $COMMIT_PATH
+mkdir -p $COMMIT_PATH
+for STORYBOOK_DIR in $(find . -type d -name 'storybook-static'); do
+    PACKAGE_NAME=$(basename $(dirname $STORYBOOK_DIR));
+    BUILD_PATH="$COMMIT_PATH/$PACKAGE_NAME";
+    cp -r $STORYBOOK_DIR $BUILD_PATH
+done
+
+# HACK: fixup some generated CSS paths to static media that break since the
+# storybooks are no longer at the root of the site. Would be better to
+# figure out how to reconfigure storybook to do this, but I got here faster
+for CSS_FN in $(find $COMMIT_PATH -type f -name 'main*.css'); do
+    sed --in-place 's:url(static/:url(../../static/:g' $CSS_FN
+done
+
+# Capture git logs for current commit as summary & description.
+git log -n 1 --no-color --pretty='%s' > $COMMIT_PATH/summary.txt
+git log -n 1 --no-color --pretty=medium > $COMMIT_PATH/description.txt
+
+# If this is a pull request, note a reference to the commit hash for the PR
+if [[ ! -z $CI_PULL_REQUEST ]]; then
+    PR_NUMBER=$(echo $CI_PULL_REQUEST | cut -d/ -f7);
+    PULL_PATH="$PUBLISH_ROOT/pulls/$PR_NUMBER";
+    mkdir -p $PULL_PATH;
+    cp $COMMIT_PATH/*.txt $PULL_PATH/
+    echo $COMMIT_HASH > $PULL_PATH/commit.txt;
+fi;
+
+# Delete storybooks older than 90 days
+find $PUBLISH_ROOT/commits $PUBLISH_ROOT/pulls -mindepth 1 -maxdepth 1 \
+    -type d -ctime +$MAX_STORYBOOK_AGE -exec rm -rf {} \;
+
+# Build index.html for root and commits
+./_scripts/build-storybooks-indexes.js $PUBLISH_ROOT
+
+# Check for changes
+cd $PUBLISH_ROOT
+CHANGES=$(git status --porcelain)
+if [ "$CHANGES" = "" ]; then
+    echo "Storybooks are unchanged, not deploying to GitHub Pages."
+    exit 0
+fi
+
+# Finally, deploy the publish directory to gh-pages.
+echo "Deploying Storybooks to GitHub Pages."
+git config user.name "fxa-devs"
+git config user.email "fxa-core@mozilla.com"
+git add -A .
+git commit -qm "chore(docs): rebuild storybooks for ${COMMIT_HASH} [skip ci]"
+git push -q origin gh-pages
+
+echo "Cleaning up $PUBLISH_ROOT"
+cd ..
+rm -rf $PUBLISH_ROOT

--- a/_scripts/gh-pages.sh
+++ b/_scripts/gh-pages.sh
@@ -23,9 +23,13 @@ npm run build-storybook
 
 cd ../..
 git clone --branch gh-pages git@github.com:mozilla/fxa.git docs-build
+
 cd docs-build
-rm -rf ./*
+
+rm -rf ./fxa-email-service
 mv ../packages/fxa-email-service/target/doc fxa-email-service
+
+rm -rf ./fxa-payments-server
 mv ../packages/fxa-payments-server/storybook-static fxa-payments-server
 
 CHANGES=$(git status --porcelain)

--- a/packages/fxa-payments-server/.storybook/components/MockApp.tsx
+++ b/packages/fxa-payments-server/.storybook/components/MockApp.tsx
@@ -80,6 +80,7 @@ export const MockApp = ({
   return (
     <AppContext.Provider value={appContextValue}>
       <AppLocalizationProvider
+        baseDir="./locales"
         userLocales={navigator.languages}
         bundles={['main']}
       >

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -17,7 +17,7 @@
     "test:server": "jest --coverage --verbose --config server/jest.config.js",
     "format": "prettier '**' --write",
     "storybook": "start-storybook -s ./public -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook && cp -r public/locales public/images storybook-static/"
   },
   "repository": {
     "type": "git",

--- a/packages/fxa-react/components/Survey/index.scss
+++ b/packages/fxa-react/components/Survey/index.scss
@@ -1,4 +1,4 @@
-@import '../../fxa-content-server/app/styles/variables';
+@import '../../../fxa-content-server/app/styles/variables';
 
 $shadow: 0 12px 18px 2px rgba(34, 0, 51, 0.04),
   0 6px 22px 4px rgba(7, 48, 114, 0.12), 0 6px 10px -4px rgba(14, 13, 26, 0.12);


### PR DESCRIPTION
issue #4823

I've got this script building & deploying storybooks to one of my own gh-repos with some static index.html pages for navigation:

https://lmorchard.github.io/fxa-storybooks/

Still working on this, haven't gotten it hooked up to CI yet. But, maybe worth opening as a draft and a demo of what's working so far. Could be worth some early feedback on the general approach.

There are several commits worth of builds there. However, only the newest one probably works. I had to fix some path-related issues for locales in fxa-payments-server, and had trouble with stylesheet paths in fxa-related for the Survey component. Fixed now I think.

Also there's a pull request number mentioned. That's a fake number I passed in to simulate a CI build from PR