### PR TITLE
fix(auth server): use ts-node-script shebang when executing ts-dependent scripts

### DIFF
--- a/packages/fxa-auth-server/scripts/activate-new-signing-key.js
+++ b/packages/fxa-auth-server/scripts/activate-new-signing-key.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node-script
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/packages/fxa-auth-server/scripts/clean-up-old-ci-stripe-customers.js
+++ b/packages/fxa-auth-server/scripts/clean-up-old-ci-stripe-customers.js
@@ -1,15 +1,15 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node-script
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const program = require('commander');
-const package = require('../package.json');
+const pckg = require('../package.json');
 
 async function init() {
   program
-    .version(package.version)
+    .version(pckg.version)
     .option('-c, --config [config]', 'Configuration to use. Ex. dev')
     .option(
       '-k, --stripe-key [key]',

--- a/packages/fxa-auth-server/scripts/delete-account.js
+++ b/packages/fxa-auth-server/scripts/delete-account.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node-script
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,7 +8,7 @@
 
  Usage:
 
- node scripts/delete-account.js user@example.com [...]
+ scripts/delete-account.js user@example.com [...]
 
  This script is used to manually delete a user's account,
  e.g. in response to a GDPR deletion request.  It uses the

--- a/packages/fxa-auth-server/scripts/find-stripe-sync-issues.js
+++ b/packages/fxa-auth-server/scripts/find-stripe-sync-issues.js
@@ -1,11 +1,11 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node-script
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const program = require('commander');
-const package = require('../package.json');
+const pckg = require('../package.json');
 const config = require('../config').getProperties();
 const StatsD = require('hot-shots');
 
@@ -24,7 +24,7 @@ function isNotFoundError(err) {
 
 async function init() {
   program
-    .version(package.version)
+    .version(pckg.version)
     .option('-c, --config [config]', 'Configuration to use. Ex. dev')
     .option(
       '-k, --stripe-key [key]',

--- a/packages/fxa-auth-server/scripts/gen_keys.js
+++ b/packages/fxa-auth-server/scripts/gen_keys.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node-script
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/packages/fxa-auth-server/scripts/gen_vapid_keys.js
+++ b/packages/fxa-auth-server/scripts/gen_vapid_keys.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node-script
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/packages/fxa-auth-server/scripts/must-reset.js
+++ b/packages/fxa-auth-server/scripts/must-reset.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node-script
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,7 +8,7 @@
 
  Usage:
 
- node scripts/must-reset.js -i ./reset.json
+ scripts/must-reset.js -i ./reset.json
 
  This script is used to put user accounts into a "must reset" state. It uses the
  same config file as key_server.js so should be run from a production instance.

--- a/packages/fxa-auth-server/scripts/oauth_gen_keys.js
+++ b/packages/fxa-auth-server/scripts/oauth_gen_keys.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node-script
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/packages/fxa-auth-server/scripts/populate-stripe-customer-cache.js
+++ b/packages/fxa-auth-server/scripts/populate-stripe-customer-cache.js
@@ -1,15 +1,15 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node-script
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const program = require('commander');
-const package = require('../package.json');
+const pckg = require('../package.json');
 
 async function init() {
   program
-    .version(package.version)
+    .version(pckg.version)
     .option('-c, --config [config]', 'Configuration to use. Ex. dev')
     .option(
       '-k, --stripe-key [key]',

--- a/packages/fxa-auth-server/scripts/prepare-new-signing-key.js
+++ b/packages/fxa-auth-server/scripts/prepare-new-signing-key.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node-script
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/packages/fxa-auth-server/scripts/retire-old-signing-key.js
+++ b/packages/fxa-auth-server/scripts/retire-old-signing-key.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node-script
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/packages/fxa-auth-server/scripts/sms/send.js
+++ b/packages/fxa-auth-server/scripts/sms/send.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node-script
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/packages/fxa-auth-server/scripts/test-remote-quick.js
+++ b/packages/fxa-auth-server/scripts/test-remote-quick.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node-script
 
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/packages/fxa-auth-server/scripts/verification-reminders.js
+++ b/packages/fxa-auth-server/scripts/verification-reminders.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env ts-node-script
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/packages/fxa-auth-server/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/scripts/write-emails-to-disk.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env ts-node-script
+
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -7,7 +9,7 @@
  * and ./.mail_output/<email type>.txt
  *
  * Usage:
- * node ./scripts/write-to-disk.js
+ * ./scripts/write-to-disk.js
  *
  * Emails that are written to disk can be previewed in Firefox
  * to give a rough idea of how they would render in real life.


### PR DESCRIPTION
Closes #5261

Independently executed Auth Server scripts (like `delete-account.js, the issue) that import the config, which was recently converted to TypeScript, no longer work because they're not using TS themselves.

So, I've gone ahead and updated the shebangs in these files to compile with ts-node (specifically [ts-node-script](https://www.npmjs.com/package/ts-node#shebang)). I did not modify any scripts that do not use the config.

Also, per the initial issue, I ran `delete-account.js` and it additionally fails because it can't find `../lib/subhub/client`. Sure enough, `lib/subhub` does not exist in the repo. Any ideas where this comes from?