### PR TITLE
feat(profile): Add API endpoints for ecosystem_anon_id

### DIFF
--- a/packages/fxa-profile-server/docs/API.md
+++ b/packages/fxa-profile-server/docs/API.md
@@ -63,6 +63,8 @@ The currently-defined error responses are:
 - [DELETE /v1/avatar/:id][delete]
 - [GET /v1/display_name][display_name]
 - [POST /v1/display_name][display_name-post]
+- [GET /v1/ecosystem_anon_id][ecosystem_anon_id]
+- [POST /v1/ecosystem_anon_id][ecosystem_anon_id-post]
 - [DELETE /v1/cache/:uid][cache_delete]
 
 ### GET /v1/profile
@@ -84,6 +86,7 @@ curl -v \
 ```js
 {
   "uid": "6d940dd41e636cc156074109b8092f96",
+  "ecosystemAnonId": "eyJhbGciOiJFQ0RILUVTIiwia2lkIjoiMFZFRTdmT0txbFdHVGZrY0taRUJ2WWl3dkpMYTRUUGlJVGxXMGJOcDdqVSIsImVwayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InY3Q1FlRWtVQjMwUGwxV0tPMUZUZ25OQlNQdlFyNlh0UnZxT2kzSWdzNHciLCJ5IjoiNDBKVEpaQlMwOXpWNHpxb0hHZDI5NGFDeHRqcGU5a09reGhELVctUEZsSSJ9LCJlbmMiOiJBMjU2R0NNIn0.A_wzJya943vlHKFH.yq0JhkGZiZd6UiZK6goTcEf6i4gbbBeXxvq8QV5_nC4.Knl_sYSBrrP-aa54z6B6gA",
   "email": "user@example.domain",
   "locale": "en-US",
   "amrValues": ["pwd", "otp"],
@@ -310,6 +313,57 @@ curl -v \
 {}
 ```
 
+### GET /v1/ecosystem_anon_id
+
+- scope: `profile:ecosystem_anon_id`
+
+Get the user's anonymized ecosystem account identifier.
+
+#### Request
+
+```sh
+curl -v \
+-H "Authorization: Bearer 558f9980ad5a9c279beb52123653967342f702e84d3ab34c7f80427a6a37e2c0" \
+"https://profile.accounts.firefox.com/v1/ecosystem_anon_id"
+```
+
+#### Response
+
+```json
+{
+  "ecosystemAnonId": "eyJhbGciOiJFQ0RILUVTIiwia2lkIjoiMFZFRTdmT0txbFdHVGZrY0taRUJ2WWl3dkpMYTRUUGlJVGxXMGJOcDdqVSIsImVwayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InY3Q1FlRWtVQjMwUGwxV0tPMUZUZ25OQlNQdlFyNlh0UnZxT2kzSWdzNHciLCJ5IjoiNDBKVEpaQlMwOXpWNHpxb0hHZDI5NGFDeHRqcGU5a09reGhELVctUEZsSSJ9LCJlbmMiOiJBMjU2R0NNIn0.A_wzJya943vlHKFH.yq0JhkGZiZd6UiZK6goTcEf6i4gbbBeXxvq8QV5_nC4.Knl_sYSBrrP-aa54z6B6gA"
+}
+```
+
+Returns a `204 No Content` if there is no ecosystem_anon_id for the user.
+
+### POST /v1/ecosystem_anon_id
+
+- scope: `profile:ecosystem_anon_id:write`
+
+Update the user's anonymized ecosystem account identifier.
+
+#### Request
+
+- `ecosystemAnonId` - A new anonymized ecosystem account identifier.
+
+```sh
+curl -v \
+-X POST \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer 558f9980ad5a9c279beb52123653967342f702e84d3ab34c7f80427a6a37e2c0" \
+"https://profile.accounts.firefox.com/v1/ecosystem_anon_id" \
+-d '{
+  "ecosystemAnonId": "eyJhbGciOiJFQ0RILUVTIiwia2lkIjoiMFZFRTdmT0txbFdHVGZrY0taRUJ2WWl3dkpMYTRUUGlJVGxXMGJOcDdqVSIsImVwayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InY3Q1FlRWtVQjMwUGwxV0tPMUZUZ25OQlNQdlFyNlh0UnZxT2kzSWdzNHciLCJ5IjoiNDBKVEpaQlMwOXpWNHpxb0hHZDI5NGFDeHRqcGU5a09reGhELVctUEZsSSJ9LCJlbmMiOiJBMjU2R0NNIn0.A_wzJya943vlHKFH.yq0JhkGZiZd6UiZK6goTcEf6i4gbbBeXxvq8QV5_nC4.Knl_sYSBrrP-aa54z6B6gA"
+}'
+```
+
+#### Response
+
+```json
+{}
+```
+
 ### DELETE /v1/cache/:uid
 
 Delete cached profile data for user `:uid`
@@ -331,5 +385,7 @@ Delete cached profile data for user `:uid`
 [delete]: #delete-v1avatarid
 [display_name]: #get-v1display_name
 [display_name-post]: #post-v1display_name
+[ecosystem_anon_id]: #get-v1ecosystem_anon_id
+[ecosystem_anon_id-post]: #post-v1ecosystem_anon_id
 [oauth]: https://github.com/mozilla/fxa-oauth-server
 [cache_delete]: #delete-v1cache:uid

--- a/packages/fxa-profile-server/lib/routes/_core_profile.js
+++ b/packages/fxa-profile-server/lib/routes/_core_profile.js
@@ -21,6 +21,7 @@ module.exports = {
   auth: {
     strategy: 'oauth',
     scope: [
+      'profile:ecosystem_anon_id',
       'profile:email',
       'profile:locale',
       'profile:amr',
@@ -30,6 +31,7 @@ module.exports = {
   },
   response: {
     schema: {
+      ecosystemAnonId: Joi.string().optional(),
       email: Joi.string().optional(),
       locale: Joi.string().optional(),
       amrValues: Joi.array()
@@ -115,6 +117,9 @@ module.exports = {
             }
             if (typeof body.profileChangedAt !== 'undefined') {
               result.profileChangedAt = body.profileChangedAt;
+            }
+            if (typeof body.ecosystemAnonId !== 'undefined') {
+              result.ecosystemAnonId = body.ecosystemAnonId;
             }
             return resolve(result);
           }

--- a/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/get.js
+++ b/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/get.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const Joi = require('@hapi/joi');
+
+const logger = require('../../logging')('routes.ecosystem_anon_id.get');
+
+module.exports = {
+  auth: {
+    strategy: 'oauth',
+    scope: ['profile:ecosystem_anon_id'],
+  },
+  response: {
+    schema: {
+      ecosystemAnonId: Joi.string().optional(),
+    },
+  },
+  handler: async function ecosystemAnonIdGet(req, h) {
+    const uid = req.auth.credentials.user;
+    logger.info('activityEvent', { event: 'ecosystemAnonId.get', uid: uid });
+
+    // Not implemented yet. Always return an empty 204 for now.
+    return h.response({}).code(204);
+  },
+};

--- a/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/post.js
+++ b/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/post.js
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const Joi = require('@hapi/joi');
+
+const logger = require('../../logging')('routes.ecosystem_anon_id.post');
+const notifyProfileUpdated = require('../../updates-queue');
+
+module.exports = {
+  auth: {
+    strategy: 'oauth',
+    scope: ['profile:ecosystem_anon_id:write'],
+  },
+  validate: {
+    payload: {
+      ecosystemAnonId: Joi.string().required(),
+    },
+  },
+  handler: async function ecosystemAnonIdPost(req) {
+    const uid = req.auth.credentials.user;
+    logger.info('activityEvent', { event: 'ecosystemAnonId.post', uid: uid });
+
+    await req.server.methods.profileCache.drop(uid);
+
+    // When DB is ready, insert/update req.payload.ecosystemAnonId.
+    // For now, just notify and return.
+    notifyProfileUpdated(uid);
+    return {};
+  },
+};

--- a/packages/fxa-profile-server/lib/routes/profile.js
+++ b/packages/fxa-profile-server/lib/routes/profile.js
@@ -23,6 +23,7 @@ module.exports = {
   },
   response: {
     schema: {
+      ecosystemAnonId: Joi.string().optional(),
       email: Joi.string().allow(null),
       uid: Joi.string().allow(null),
       avatar: Joi.string().allow(null),

--- a/packages/fxa-profile-server/lib/routing.js
+++ b/packages/fxa-profile-server/lib/routing.js
@@ -80,6 +80,16 @@ module.exports = [
     config: require('./routes/display_name/post'),
   },
   {
+    method: 'GET',
+    path: v('/ecosystem_anon_id'),
+    config: require('./routes/ecosystem_anon_id/get'),
+  },
+  {
+    method: 'POST',
+    path: v('/ecosystem_anon_id'),
+    config: require('./routes/ecosystem_anon_id/post'),
+  },
+  {
     method: 'DELETE',
     path: v('/cache/{uid}'),
     config: require('./routes/cache/delete'),


### PR DESCRIPTION
Starting off the AET work with an API that will need to agree with changes that ride the trains into desktop. This ecosystem_anon_id field isn't yet persisted in the core profile fields in the auth DB, that's a different bug. Not 100% sure I'm logging correctly. Still need to add tests to api.js.