### PR TITLE
feat(cad): Add metrics for the CAD via QR code

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/post_verify/cad_qr/ready_to_scan.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/cad_qr/ready_to_scan.mustache
@@ -16,7 +16,7 @@
                 <button id="submit-btn" class="qr-code-button" type="submit">{{#t}}Ready to scan{{/t}}</button>
             </div>
             <div class="links centered">
-                <a id="use-sms-link" data-flow-event="link.maybe-later">{{#t}}Use SMS instead{{/t}}</a>
+                <a id="use-sms-link" data-flow-event="link.use-sms">{{#t}}Use SMS instead{{/t}}</a>
                 <a id="maybe-later-link" data-flow-event="link.maybe-later" href="{{maybeLaterLink}}">{{#t}}I'll do this later, send me a reminder{{/t}}</a>
             </div>
         </form>

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/cad_qr/scan_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/cad_qr/scan_code.mustache
@@ -19,7 +19,7 @@
         <p class="qr-code-step-message">{{#unsafeTranslate}}<span class="number">4</span>Sign into your account{{/unsafeTranslate}}</p>
 
         <div class="links centered">
-            <a id="use-sms-link" data-flow-event="link.maybe-later">{{#t}}Use SMS instead{{/t}}</a>
+            <a id="use-sms-link" data-flow-event="link.use-sms">{{#t}}Use SMS instead{{/t}}</a>
         </div>
     </section>
 </div>

--- a/packages/fxa-content-server/app/scripts/views/post_verify/cad_qr/connected.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/cad_qr/connected.js
@@ -4,6 +4,7 @@
 
 import { assign } from 'underscore';
 import Cocktail from 'cocktail';
+import FlowEventsMixin from './../../mixins/flow-events-mixin';
 import FormView from '../../form';
 import Template from 'templates/post_verify/cad_qr/connected.mustache';
 import preventDefaultThen from '../../decorators/prevent_default_then';
@@ -11,7 +12,7 @@ import { MOZ_ORG_SYNC_GET_STARTED_LINK } from '../../../lib/constants';
 
 class ScanCode extends FormView {
   template = Template;
-  viewName = 'scan-code';
+  viewName = 'connected';
 
   events = assign(this.events, {
     'click #done-link': preventDefaultThen('clickDoneLink'),
@@ -29,10 +30,10 @@ class ScanCode extends FormView {
   }
 
   clickUseSms() {
-    return this.navigate('/connect_another_device');
+    return this.navigate('/sms');
   }
 }
 
-Cocktail.mixin(ScanCode);
+Cocktail.mixin(ScanCode, FlowEventsMixin);
 
 export default ScanCode;

--- a/packages/fxa-content-server/app/scripts/views/post_verify/cad_qr/get_started.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/cad_qr/get_started.js
@@ -4,6 +4,7 @@
 
 import { assign } from 'underscore';
 import Cocktail from 'cocktail';
+import FlowEventsMixin from './../../mixins/flow-events-mixin';
 import FormView from '../../form';
 import Template from 'templates/post_verify/cad_qr/get_started.mustache';
 import preventDefaultThen from '../../decorators/prevent_default_then';
@@ -21,10 +22,10 @@ class GetStarted extends FormView {
   }
 
   clickMaybeLater() {
-    return this.navigate('/connect_another_device');
+    return this.navigate('/sms');
   }
 }
 
-Cocktail.mixin(GetStarted);
+Cocktail.mixin(GetStarted, FlowEventsMixin);
 
 export default GetStarted;

--- a/packages/fxa-content-server/app/scripts/views/post_verify/cad_qr/ready_to_scan.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/cad_qr/ready_to_scan.js
@@ -4,6 +4,7 @@
 
 import { assign } from 'underscore';
 import Cocktail from 'cocktail';
+import FlowEventsMixin from './../../mixins/flow-events-mixin';
 import FormView from '../../form';
 import Template from 'templates/post_verify/cad_qr/ready_to_scan.mustache';
 import preventDefaultThen from '../../decorators/prevent_default_then';
@@ -28,10 +29,10 @@ class ReadyToScan extends FormView {
   }
 
   clickUseSms() {
-    return this.navigate('/connect_another_device');
+    return this.navigate('/sms');
   }
 }
 
-Cocktail.mixin(ReadyToScan);
+Cocktail.mixin(ReadyToScan, FlowEventsMixin);
 
 export default ReadyToScan;

--- a/packages/fxa-content-server/app/scripts/views/post_verify/cad_qr/scan_code.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/cad_qr/scan_code.js
@@ -25,6 +25,7 @@ class ScanCode extends FormView {
   }
 
   _onConnected(device) {
+    this.logFlowEvent('device-connected', this.viewName);
     return this.navigate('/post_verify/cad_qr/connected', {
       device,
       showSuccessMessage: true,
@@ -42,7 +43,7 @@ class ScanCode extends FormView {
   }
 
   clickUseSms() {
-    return this.navigate('/connect_another_device');
+    return this.navigate('/sms');
   }
 }
 

--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/connected.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/connected.js
@@ -99,7 +99,7 @@ describe('views/post_verify/cad_qr/connected', () => {
       });
 
       it('calls correct broker methods', () => {
-        assert.isTrue(view.navigate.calledWith('/connect_another_device'));
+        assert.isTrue(view.navigate.calledWith('/sms'));
       });
     });
   });

--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/get_started.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/get_started.js
@@ -99,7 +99,7 @@ describe('views/post_verify/cad_qr/get_started', () => {
       });
 
       it('calls correct broker methods', () => {
-        assert.isTrue(view.navigate.calledWith('/connect_another_device'));
+        assert.isTrue(view.navigate.calledWith('/sms'));
       });
     });
   });

--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/ready_to_scan.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/ready_to_scan.js
@@ -100,7 +100,7 @@ describe('views/post_verify/cad_qr/ready_to_scan', () => {
       });
 
       it('calls correct broker methods', () => {
-        assert.isTrue(view.navigate.calledWith('/connect_another_device'));
+        assert.isTrue(view.navigate.calledWith('/sms'));
       });
     });
   });

--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/scan_code.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/scan_code.js
@@ -103,6 +103,7 @@ describe('views/post_verify/cad_qr/scan_code', () => {
   describe('navigates to connected view when new device is connected', () => {
     beforeEach(() => {
       sinon.spy(view, 'navigate');
+      sinon.spy(view, 'logFlowEvent');
       view._deviceConnectedPoll.trigger('device-connected', {});
     });
 
@@ -112,6 +113,12 @@ describe('views/post_verify/cad_qr/scan_code', () => {
           device: {},
           showSuccessMessage: true,
         })
+      );
+    });
+
+    it('logs connected metric', () => {
+      assert.isTrue(
+        view.logFlowEvent.calledWith('device-connected', view.viewName)
       );
     });
   });
@@ -124,7 +131,7 @@ describe('views/post_verify/cad_qr/scan_code', () => {
       });
 
       it('calls correct broker methods', () => {
-        assert.isTrue(view.navigate.calledWith('/connect_another_device'));
+        assert.isTrue(view.navigate.calledWith('/sms'));
       });
     });
   });

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -244,6 +244,66 @@ const EVENTS = {
     group: GROUPS.registration,
     event: 'domain_validation_ignored',
   },
+
+  'screen.get-started': {
+    group: GROUPS.qrConnectDevice,
+    event: 'get_started_view',
+  },
+  'flow.get-started.submit': {
+    group: GROUPS.qrConnectDevice,
+    event: 'get_started_submit',
+  },
+  'flow.get-started.link.maybe-later': {
+    group: GROUPS.qrConnectDevice,
+    event: 'get_started_later',
+  },
+
+  'screen.ready-to-scan': {
+    group: GROUPS.qrConnectDevice,
+    event: 'ready_to_scan_view',
+  },
+  'flow.ready-to-scan.submit': {
+    group: GROUPS.qrConnectDevice,
+    event: 'ready_to_scan_submit',
+  },
+  'flow.ready-to-scan.link.maybe-later': {
+    group: GROUPS.qrConnectDevice,
+    event: 'ready_to_scan_later',
+  },
+  'flow.ready-to-scan.link.use-sms': {
+    group: GROUPS.qrConnectDevice,
+    event: 'ready_to_scan_use_sms',
+  },
+
+  'screen.scan-code': {
+    group: GROUPS.qrConnectDevice,
+    event: 'scan_code_view',
+  },
+  'flow.scan-code.link.use-sms': {
+    group: GROUPS.qrConnectDevice,
+    event: 'scan_code_use_sms',
+  },
+  'flow.scan-code.device-connected': {
+    group: GROUPS.qrConnectDevice,
+    event: 'scan_code_device_connected',
+  },
+
+  'screen.connected': {
+    group: GROUPS.qrConnectDevice,
+    event: 'connected_view',
+  },
+  'flow.connected.submit': {
+    group: GROUPS.qrConnectDevice,
+    event: 'connected_connect_another',
+  },
+  'flow.connected.link.done': {
+    group: GROUPS.qrConnectDevice,
+    event: 'connected_done',
+  },
+  'flow.connected.link.use-sms': {
+    group: GROUPS.qrConnectDevice,
+    event: 'connected_use_sms',
+  },
 };
 
 const VIEW_ENGAGE_SUBMIT_EVENT_GROUPS = {

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -32,6 +32,7 @@ const GROUPS = {
   subPaySetup: 'fxa_pay_setup',
   subPayUpgrade: 'fxa_pay_upgrade',
   subSupport: 'fxa_subscribe_support',
+  qrConnectDevice: 'fxa_qr_connect_device',
 };
 
 const CONNECT_DEVICE_FLOWS = {
@@ -62,6 +63,7 @@ const EVENT_PROPERTIES = {
   [GROUPS.subPaySetup]: NOP,
   [GROUPS.subPayUpgrade]: NOP,
   [GROUPS.subSupport]: NOP,
+  [GROUPS.qrConnectDevice]: NOP,
 };
 
 function NOP() {}


### PR DESCRIPTION
Fixes #5240

This PR adds metrics defined in https://docs.google.com/document/d/1JfHd-zX47af-seUToS6fHSzpcTKG5l1WFiojGLUQYYE/edit#. If you scroll to `Metric definitions` section you can see what amplitude metrics are emitted for which pages.

```
fxa_qr_connect_device - get_started_view
fxa_qr_connect_device - get_started_later
fxa_qr_connect_device - get_started_submit


fxa_qr_connect_device - ready_to_scan_view
fxa_qr_connect_device - ready_to_scan_use_sms
fxa_qr_connect_device - ready_to_scan_later
fxa_qr_connect_device - ready_to_scan_submit


fxa_qr_connect_device - scan_code_view
fxa_qr_connect_device - scan_code_device_connected

fxa_qr_connect_device - connected_view
fxa_qr_connect_device - connected_connect_another
fxa_qr_connect_device - connected_use_sms
fxa_qr_connect_device - connected_done
```

There is a known issue with the `use-sms` link button not emitted, but I don't think it should block this PR since I can do in a follow up.

#### Testing

View content server logs - `./pm2 logs content | grep 'amplitudeEvent'`

1. Sign into browser
2. Go through the flows via `http://localhost:3030/post_verify/cad_qr/get_started
3. See amplitude metrics above being logged