### PR TITLE
feat(graphql-api): implement security/devices resolvers

### DIFF
--- a/packages/fxa-graphql-api/package-lock.json
+++ b/packages/fxa-graphql-api/package-lock.json
@@ -1079,12 +1079,23 @@
       }
     },
     "apollo-datasource": {
-      "version": "0.7.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.1-alpha.0.tgz",
-      "integrity": "sha512-i8/YALvDtbxsvSkmc/wMdGIXzj/fv7iFPNYPE9QUwylzOhuVV2jw0N69QCHWr7Ws69Sk4UpXGmUnWxc/qPiTOQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.0.tgz",
+      "integrity": "sha512-Yja12BgNQhzuFGG/5Nw2MQe0hkuQy2+9er09HxeEyAf2rUDIPnhPrn1MDoZTB8MU7UGfjwITC+1ofzKkkrZobA==",
       "requires": {
         "apollo-server-caching": "^0.5.1",
-        "apollo-server-env": "^2.4.4-alpha.0"
+        "apollo-server-env": "^2.4.3"
+      },
+      "dependencies": {
+        "apollo-server-env": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.4.3.tgz",
+          "integrity": "sha512-23R5Xo9OMYX0iyTu2/qT0EUb+AULCBriA9w8HDfMoChB8M+lFClqUkYtaTTHDfp6eoARLW8kDBhPOBavsvKAjA==",
+          "requires": {
+            "node-fetch": "^2.1.2",
+            "util.promisify": "^1.0.0"
+          }
+        }
       }
     },
     "apollo-engine-reporting": {
@@ -1195,6 +1206,17 @@
         "sha.js": "^2.4.11",
         "subscriptions-transport-ws": "^0.9.11",
         "ws": "^6.0.0"
+      },
+      "dependencies": {
+        "apollo-datasource": {
+          "version": "0.7.1-alpha.0",
+          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.7.1-alpha.0.tgz",
+          "integrity": "sha512-i8/YALvDtbxsvSkmc/wMdGIXzj/fv7iFPNYPE9QUwylzOhuVV2jw0N69QCHWr7Ws69Sk4UpXGmUnWxc/qPiTOQ==",
+          "requires": {
+            "apollo-server-caching": "^0.5.1",
+            "apollo-server-env": "^2.4.4-alpha.0"
+          }
+        }
       }
     },
     "apollo-server-env": {

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@sentry/integrations": "^5.15.5",
     "@sentry/node": "^5.15.5",
+    "apollo-datasource": "^0.7.0",
     "apollo-server": "^2.13.1",
     "apollo-server-express": "^2.13.1",
     "convict": "^6.0.0",

--- a/packages/fxa-graphql-api/src/lib/datasources/authServer.ts
+++ b/packages/fxa-graphql-api/src/lib/datasources/authServer.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { DataSource, DataSourceConfig } from 'apollo-datasource';
+import { Client } from 'fxa-js-client';
+import { Container } from 'typedi';
+
+import { Context } from '../server';
+import { fxAccountClientToken } from '../constants';
+
+function snakeToCamel(str: string) {
+  return str.replace(/(_\w)/g, (m: string) => m[1].toUpperCase());
+}
+
+/**
+ * Converts an object with keys that are possibly snake_cased to an
+ * object with keys that are camelCased.
+ *
+ * @param obj Object with string keys
+ */
+export function snakeToCamelObject(obj: { [key: string]: any }) {
+  return Object.fromEntries(Object.entries(obj).map(([k, v]) => [snakeToCamel(k), v]));
+}
+
+export class AuthServerSource extends DataSource {
+  private authClient: Client;
+
+  constructor(private token: string = '') {
+    super();
+    this.authClient = Container.get(fxAccountClientToken);
+  }
+
+  initialize(config: DataSourceConfig<Context>) {
+    this.token = config.context.token;
+  }
+
+  public async subscriptions(): Promise<any> {
+    const result = await this.authClient.account(this.token);
+    return result.subscriptions.map(snakeToCamelObject);
+  }
+
+  public attachedClients(): Promise<any[]> {
+    return this.authClient.attachedClients(this.token);
+  }
+
+  public totp(): Promise<any> {
+    return this.authClient.checkTotpTokenExists(this.token);
+  }
+
+  public async hasRecoveryKey(): Promise<boolean> {
+    const result = await this.authClient.recoveryKeyExists(this.token);
+    return result.exists;
+  }
+}

--- a/packages/fxa-graphql-api/src/lib/resolvers/types/account.ts
+++ b/packages/fxa-graphql-api/src/lib/resolvers/types/account.ts
@@ -4,6 +4,9 @@
 
 import { Field, ID, ObjectType } from 'type-graphql';
 import { Email } from './emails';
+import { AttachedClient } from './attachedClient';
+import { Totp } from './totp';
+import { Subscription } from './subscription';
 
 @ObjectType()
 export class Account {
@@ -25,6 +28,18 @@ export class Account {
   @Field({ nullable: true })
   public locale!: string;
 
+  @Field(type => [Subscription])
+  public subscriptions!: Subscription[];
+
+  @Field(type => Totp)
+  public totp!: Totp;
+
+  @Field()
+  public recoveryKey!: boolean;
+
   @Field(type => [Email])
   public emails!: Email[];
+
+  @Field(type => [AttachedClient])
+  public attachedClients!: AttachedClient;
 }

--- a/packages/fxa-graphql-api/src/lib/resolvers/types/attachedClient.ts
+++ b/packages/fxa-graphql-api/src/lib/resolvers/types/attachedClient.ts
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Field, ObjectType } from 'type-graphql';
+
+import { Location } from './location';
+
+@ObjectType()
+export class AttachedClient {
+  @Field({ nullable: true })
+  public clientId!: string;
+
+  @Field({ nullable: true })
+  public sessionTokenId!: string;
+
+  @Field({ nullable: true })
+  public refreshTokenId!: string;
+
+  @Field({ nullable: true })
+  public deviceId!: string;
+
+  @Field({ nullable: true })
+  public deviceType!: string;
+
+  @Field()
+  public isCurrentSession!: boolean;
+
+  @Field({ nullable: true })
+  public name!: string;
+
+  @Field({ nullable: true })
+  public createdTime!: number;
+
+  @Field({ nullable: true })
+  public createdTimeFormatted!: string;
+
+  @Field({ nullable: true })
+  public lastAccessTime!: number;
+
+  @Field({ nullable: true })
+  public lastAccessTimeFormatted!: string;
+
+  @Field({ nullable: true })
+  public approximateLastAccessTime!: number;
+
+  @Field({ nullable: true })
+  public approximateLastAccessTimeFormatted!: string;
+
+  @Field(type => [String], { nullable: true })
+  public scope!: string[];
+
+  @Field({ nullable: true })
+  public location!: Location;
+
+  @Field()
+  public userAgent!: string;
+
+  @Field({ nullable: true })
+  public os!: string;
+}

--- a/packages/fxa-graphql-api/src/lib/resolvers/types/location.ts
+++ b/packages/fxa-graphql-api/src/lib/resolvers/types/location.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Field, ObjectType } from 'type-graphql';
+
+@ObjectType()
+export class Location {
+  @Field({ nullable: true })
+  public city!: string;
+
+  @Field({ nullable: true })
+  public country!: string;
+
+  @Field({ nullable: true })
+  public state!: string;
+
+  @Field({ nullable: true })
+  public stateCode!: string;
+}

--- a/packages/fxa-graphql-api/src/lib/resolvers/types/subscription.ts
+++ b/packages/fxa-graphql-api/src/lib/resolvers/types/subscription.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Field, ObjectType } from 'type-graphql';
+
+@ObjectType()
+export class Subscription {
+  @Field()
+  public created!: number;
+
+  @Field()
+  public currentPeriodEnd!: number;
+
+  @Field()
+  public currentPeriodStart!: number;
+
+  @Field()
+  public cancelAtPeriodEnd!: boolean;
+
+  @Field()
+  public endAt!: number;
+
+  @Field()
+  public latestInvoice!: string;
+
+  @Field()
+  public planId!: string;
+
+  @Field()
+  public productName!: string;
+
+  @Field()
+  public productId!: string;
+
+  @Field()
+  public status!: string;
+
+  @Field()
+  public subscriptionId!: string;
+}

--- a/packages/fxa-graphql-api/src/lib/resolvers/types/totp.ts
+++ b/packages/fxa-graphql-api/src/lib/resolvers/types/totp.ts
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Field, ObjectType } from 'type-graphql';
+
+@ObjectType()
+export class Totp {
+  @Field()
+  public exists!: boolean;
+
+  @Field()
+  public verified!: boolean;
+}

--- a/packages/fxa-graphql-api/src/test/lib/datasources/authServer.spec.ts
+++ b/packages/fxa-graphql-api/src/test/lib/datasources/authServer.spec.ts
@@ -1,0 +1,144 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import 'reflect-metadata';
+
+import { assert } from 'chai';
+import Chance from 'chance';
+import { Container } from 'typedi';
+import 'mocha';
+import sinon, { stubInterface } from 'ts-sinon';
+
+import { mockContext } from '../mocks';
+
+import { AuthServerSource, snakeToCamelObject } from '../../../lib/datasources/authServer';
+import { fxAccountClientToken } from '../../../lib/constants';
+import { DataSourceConfig } from 'apollo-datasource';
+import { Context } from '../../../lib/server';
+
+const sandbox = sinon.createSandbox();
+
+const chance = new Chance();
+
+function randomHexId() {
+  return chance.guid({ version: 4 }).replace(/-/g, '');
+}
+
+function randomSubscription() {
+  return {
+    created: chance.timestamp(),
+    current_period_end: chance.timestamp(),
+    current_period_start: chance.timestamp(),
+    cancel_at_period_end: chance.bool(),
+    end_at: chance.timestamp(),
+    latest_invoice: 'invoice_1234',
+    plan_id: 'plan_1234',
+    product_name: '123done',
+    product_id: 'product_1234',
+    status: 'active',
+    subscription_id: 'subscription_1234',
+  };
+}
+
+function randomAttachedClient() {
+  return {
+    clientId: randomHexId(),
+    deviceId: randomHexId(),
+    sessionTokenId: randomHexId(),
+    refreshTokenId: randomHexId(),
+    isCurrentSession: chance.bool(),
+    deviceType: chance.name(),
+    name: chance.name(),
+    createdTime: chance.timestamp(),
+    createdTimeFormatted: '',
+    lastAccessTime: chance.timestamp(),
+    lastAccessTimeFormatted: '',
+    approximateLastAccessTime: chance.timestamp(),
+    approximateLastAccessTimeFormatted: '',
+    scope: [],
+    location: null,
+    userAgent: chance.name(),
+    os: chance.name(),
+  };
+}
+
+describe('AuthServerSource', () => {
+  let authClient: any;
+  let context;
+  let authSource: AuthServerSource;
+
+  beforeEach(() => {
+    sandbox.resetBehavior();
+    sandbox.resetHistory();
+    authClient = {
+      account: sandbox.stub(),
+      attachedClients: sandbox.stub(),
+      checkTotpTokenExists: sandbox.stub(),
+      recoveryKeyExists: sandbox.stub(),
+      sessionStatus: sandbox.stub(),
+    };
+    Container.set(fxAccountClientToken, authClient);
+    context = mockContext();
+    authSource = new AuthServerSource();
+    const config = stubInterface<DataSourceConfig<Context>>();
+    config.context = context;
+    authSource.initialize(config);
+  });
+
+  describe('snakeToCamelObject', () => {
+    it('converts to camelCase', () => {
+      const sub = randomSubscription();
+      const alteredSub = snakeToCamelObject(sub);
+      assert.includeMembers(Object.keys(alteredSub), [
+        'currentPeriodEnd',
+        'currentPeriodStart',
+        'productId',
+        'planId',
+      ]);
+    });
+  });
+
+  describe('subscriptions', () => {
+    it('returns a transformed subscription', async () => {
+      const sub = randomSubscription();
+      const alteredSub = snakeToCamelObject(sub);
+      authClient.account.resolves({ subscriptions: [sub] });
+      const result = await authSource.subscriptions();
+      assert.deepEqual(result, [alteredSub]);
+    });
+
+    it('returns no subscriptions', async () => {
+      authClient.account.resolves({ subscriptions: [] });
+      const result = await authSource.subscriptions();
+      assert.deepEqual(result, []);
+    });
+  });
+
+  describe('attachedClients', () => {
+    it('returns an attached client', async () => {
+      const client = randomAttachedClient();
+      authClient.attachedClients.resolves([client]);
+      const result = await authSource.attachedClients();
+      assert.deepEqual(result, [client]);
+    });
+  });
+
+  describe('totp', () => {
+    it('returns totp status', async () => {
+      const totp = { exists: true, verified: false };
+      authClient.checkTotpTokenExists.resolves(totp);
+      const result = await authSource.totp();
+      assert.deepEqual(result, totp);
+    });
+  });
+
+  describe('hasRecoveryKey', () => {
+    it('returns recovery key existence', async () => {
+      const rec = { exists: true };
+      authClient.recoveryKeyExists.resolves(rec);
+      const result = await authSource.hasRecoveryKey();
+      assert.isTrue(result);
+    });
+  });
+});

--- a/packages/fxa-graphql-api/src/test/lib/mocks.ts
+++ b/packages/fxa-graphql-api/src/test/lib/mocks.ts
@@ -3,13 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Logger } from 'mozlog';
-import sinon from 'sinon';
 import { stubInterface } from 'ts-sinon';
+import { DataSources } from '../../lib/server';
+import { AuthServerSource } from '../../lib/datasources/authServer';
 
-export function mockContext() {
+export function mockContext(dataSources?: DataSources) {
+  const ds = dataSources ?? { authAPI: stubInterface<AuthServerSource>() };
   return {
     authUser: '',
-    logAction: sinon.stub(),
+    token: 'test',
     logger: stubInterface<Logger>(),
+    dataSources: ds,
   };
 }

--- a/packages/fxa-graphql-api/src/test/lib/resolvers/account-resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/test/lib/resolvers/account-resolver.spec.ts
@@ -56,7 +56,7 @@ describe('accountResolver', () => {
       accountCreated: USER_1.createdAt,
       uid: USER_1.uid,
     });
-    assert.isTrue(context.logAction.calledOnce);
+    assert.isTrue((context.logger.info as sinon.SinonSpy).calledOnce);
   });
 
   it('does not locate non-existent users by uid', async () => {
@@ -69,6 +69,6 @@ describe('accountResolver', () => {
     const result = (await graphql(schema, query, undefined, context)) as any;
     assert.isDefined(result.data);
     assert.isNull(result.data.account);
-    assert.isTrue(context.logAction.calledOnce);
+    assert.isTrue((context.logger.info as sinon.SinonSpy).calledOnce);
   });
 });

--- a/packages/fxa-graphql-api/src/test/lib/schema.spec.ts
+++ b/packages/fxa-graphql-api/src/test/lib/schema.spec.ts
@@ -46,15 +46,19 @@ describe('Schema', () => {
     ) as IntrospectionObjectType;
   }
 
+  function verifyTypeMembers(name: string, members: string[]) {
+    const typ = findTypeByName(name);
+    assert.isDefined(typ);
+    assert.lengthOf(typ.fields, members.length);
+    const typNames = typ.fields.map(it => it.name);
+    assert.sameMembers(typNames, members);
+  }
+
   it('is created with expected types', async () => {
     const queryNames = queryType.fields.map(it => it.name);
     assert.sameMembers(queryNames, ['account']);
 
-    const accountType = findTypeByName('Account');
-    assert.isDefined(accountType);
-    assert.lengthOf(accountType.fields, 7);
-    const accountTypeNames = accountType.fields.map(it => it.name);
-    assert.sameMembers(accountTypeNames, [
+    verifyTypeMembers('Account', [
       'uid',
       'accountCreated',
       'passwordCreated',
@@ -62,6 +66,45 @@ describe('Schema', () => {
       'locale',
       'emails',
       'avatarUrl',
+      'subscriptions',
+      'totp',
+      'recoveryKey',
+      'attachedClients',
     ]);
+    verifyTypeMembers('Email', ['email', 'isPrimary', 'verified']);
+    verifyTypeMembers('Totp', ['exists', 'verified']);
+    verifyTypeMembers('Subscription', [
+      'created',
+      'cancelAtPeriodEnd',
+      'currentPeriodEnd',
+      'currentPeriodStart',
+      'endAt',
+      'latestInvoice',
+      'planId',
+      'productName',
+      'productId',
+      'status',
+      'subscriptionId',
+    ]);
+    verifyTypeMembers('AttachedClient', [
+      'clientId',
+      'sessionTokenId',
+      'refreshTokenId',
+      'deviceId',
+      'deviceType',
+      'isCurrentSession',
+      'name',
+      'createdTime',
+      'createdTimeFormatted',
+      'lastAccessTime',
+      'lastAccessTimeFormatted',
+      'approximateLastAccessTime',
+      'approximateLastAccessTimeFormatted',
+      'scope',
+      'location',
+      'userAgent',
+      'os',
+    ]);
+    verifyTypeMembers('Location', ['city', 'country', 'state', 'stateCode']);
   });
 });

--- a/packages/fxa-graphql-api/types/fxa-js-client/index.d.ts
+++ b/packages/fxa-graphql-api/types/fxa-js-client/index.d.ts
@@ -7,5 +7,9 @@ declare function FxAccountClient(uri: string, config: any): FxAccountClient.Clie
 declare namespace FxAccountClient {
   export interface Client {
     sessionStatus(sessionToken: string): Promise<{ state: string; uid: string }>;
+    attachedClients(sessionToken: string): Promise<any[]>;
+    checkTotpTokenExists(sessionToken: string): Promise<{ exists: boolean; verified: boolean }>;
+    recoveryKeyExists(sessionToken: string): Promise<{ exists: boolean }>;
+    account(sessionToken: string): Promise<any>;
   }
 }


### PR DESCRIPTION
Because:

* We want to show a users attached clients and security settings.

This commit:

* Retrieves the requested graph fields from the auth-server and
  resolves them.

Closes #5230