### PR TITLE
feat(a11y settings): Improve modal a11y

### DIFF
--- a/packages/fxa-react/components/Portal/index.test.tsx
+++ b/packages/fxa-react/components/Portal/index.test.tsx
@@ -7,7 +7,7 @@ import Portal from './index';
 afterEach(cleanup);
 
 it('renders children in a new element outside original DOM parent', () => {
-  const { debug, container, getByTestId } = render(
+  const { container, getByTestId } = render(
     <div data-testid="portal-parent">
       <Portal id="foo">
         <div data-testid="children">Hi mom</div>
@@ -18,10 +18,14 @@ it('renders children in a new element outside original DOM parent', () => {
   expect(getByTestId('portal-parent')).not.toContainElement(childrenEl);
   const containerParent = container.parentNode as ParentNode;
   expect(containerParent.querySelector('#foo')).toContainElement(childrenEl);
+  expect(containerParent.querySelector('#foo')).toHaveAttribute(
+    'role',
+    'dialog'
+  );
 });
 
 it('renders multiple instances with the same ID to the same DOM parent', () => {
-  const { debug, container, getByTestId } = render(
+  const { container, getByTestId } = render(
     <div data-testid="portal-parent">
       <Portal id="foo">
         <div data-testid="p1">Hi mom</div>
@@ -43,4 +47,37 @@ it('renders multiple instances with the same ID to the same DOM parent', () => {
   expect(fooPortal).toContainElement(getByTestId('p1'));
   expect(fooPortal).toContainElement(getByTestId('p2'));
   expect(fooPortal).not.toContainElement(getByTestId('p3'));
+});
+
+it('applies a11y improvements when id is set to "modal"', () => {
+  document.body.innerHTML = `
+    <div data-testid="root"></div>
+    <div data-testid="adjacent-to-root"></div>
+  `;
+
+  const headerId = 'some-header-id';
+  const descId = 'some-desc-id';
+
+  const { getByTestId } = render(
+    <Portal id="modal" {...{ headerId, descId }}>
+      <div>Hi mom</div>
+    </Portal>
+  );
+
+  const body = document.body;
+  const root = getByTestId('root');
+  const adjacentToRoot = getByTestId('adjacent-to-root');
+  const modal = body.querySelector('#modal');
+
+  expect(body.classList).toContain('overflow-hidden');
+
+  expect(root).toHaveAttribute('aria-hidden', 'true');
+  expect(adjacentToRoot).toHaveAttribute('aria-hidden', 'true');
+
+  expect(root.classList).toContain('pointer-events-none');
+  expect(adjacentToRoot.classList).toContain('pointer-events-none');
+
+  expect(modal).not.toHaveAttribute('aria-hidden', 'true');
+  expect(modal).toHaveAttribute('aria-labelledby', headerId);
+  expect(modal).toHaveAttribute('aria-describedby', descId);
 });

--- a/packages/fxa-react/lib/hooks.test.tsx
+++ b/packages/fxa-react/lib/hooks.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { render, cleanup, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import { useClickOutsideEffect, useBooleanState } from './hooks';

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -23,7 +23,7 @@
     "restart": "npm run build-postcss && pm2 restart pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
     "build": "tsc --build ../fxa-react && NODE_ENV=production npm run build-postcss && SKIP_PREFLIGHT_CHECK=true INLINE_RUNTIME_CHUNK=false rescripts build",
-    "test": "rescripts test",
+    "test": "SKIP_PREFLIGHT_CHECK=true rescripts test",
     "eject": "react-scripts eject",
     "lint": "npm-run-all --parallel lint:eslint lint:sass",
     "lint:eslint": "eslint .",

--- a/packages/fxa-settings/src/components/Modal/index.test.tsx
+++ b/packages/fxa-settings/src/components/Modal/index.test.tsx
@@ -3,11 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import {
-  render,
-  cleanup,
-  fireEvent,
-} from '@testing-library/react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import Modal from './index';
@@ -17,7 +13,7 @@ afterEach(cleanup);
 it('renders as expected', () => {
   const onDismiss = jest.fn();
   const { queryByTestId } = render(
-    <Modal {...{ onDismiss }}>
+    <Modal headerId="some-header" descId="some-description" {...{ onDismiss }}>
       <div data-testid="children">Hi mom</div>
     </Modal>
   );
@@ -27,7 +23,12 @@ it('renders as expected', () => {
 it('accepts an alternate className', () => {
   const onDismiss = jest.fn();
   const { queryByTestId } = render(
-    <Modal {...{onDismiss }} className="barquux">
+    <Modal
+      headerId="some-header"
+      descId="some-description"
+      {...{ onDismiss }}
+      className="barquux"
+    >
       <div data-testid="children">Hi mom</div>
     </Modal>
   );
@@ -37,7 +38,7 @@ it('accepts an alternate className', () => {
 it('calls onDismiss on click outside', () => {
   const onDismiss = jest.fn();
   const { container, getByTestId } = render(
-    <Modal {...{onDismiss }}>
+    <Modal headerId="some-header" descId="some-description" {...{ onDismiss }}>
       <div data-testid="children">Hi mom</div>
     </Modal>
   );
@@ -47,11 +48,23 @@ it('calls onDismiss on click outside', () => {
   expect(onDismiss).toHaveBeenCalled();
 });
 
-it('hides the close button when onDismiss is not supplied', () => {
-  const { queryByTestId } = render(
-    <Modal>
+it('calls onDismiss on esc key press', () => {
+  const onDismiss = jest.fn();
+  render(
+    <Modal headerId="some-header" descId="some-description" {...{ onDismiss }}>
       <div data-testid="children">Hi mom</div>
     </Modal>
   );
-  expect(queryByTestId('modal-dismiss')).not.toBeInTheDocument();
+  fireEvent.keyDown(window, { key: 'Escape' });
+  expect(onDismiss).toHaveBeenCalled();
+});
+
+it('shifts focus to the tab fence when opened', () => {
+  const onDismiss = jest.fn();
+  const { getByTestId } = render(
+    <Modal headerId="some-header" descId="some-description" {...{ onDismiss }}>
+      <div data-testid="children">Hi mom</div>
+    </Modal>
+  );
+  expect(document.activeElement).toBe(getByTestId('tab-fence'));
 });

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -30,11 +30,15 @@ export const Settings = () => {
   const primaryEmail =
     MOCK_ACCOUNT_DATA.emails.find((email) => email.isPrimary === true) ||
     MOCK_ACCOUNT_DATA.emails[0];
+
   const [modalRevealed, revealModal, hideModal] = useBooleanState();
   const onSecondaryEmailConfirm = useCallback(() => {
     console.log('confirmed - resend verification code');
     hideModal();
   }, [hideModal]);
+
+  const modalHeaderId = 'modal-header-verify-email';
+  const modalDescId = 'modal-desc-verify-email';
 
   return (
     <main>
@@ -69,7 +73,10 @@ export const Settings = () => {
         <UnitRow
           header="Secondary email"
           headerValue={null}
-          {...{ revealModal }}
+          {...{
+            revealModal,
+            modalRevealed,
+          }}
         >
           <p>Access your account if you can't log in to your primary email.</p>
           <p>
@@ -78,9 +85,14 @@ export const Settings = () => {
           </p>
 
           {modalRevealed && (
-            <Modal onDismiss={hideModal} onConfirm={onSecondaryEmailConfirm}>
-              <h2>Verify primary email first</h2>
-              <p>
+            <Modal
+              onDismiss={hideModal}
+              onConfirm={onSecondaryEmailConfirm}
+              headerId={modalHeaderId}
+              descId={modalDescId}
+            >
+              <h2 id={modalHeaderId}>Verify primary email first</h2>
+              <p id={modalDescId}>
                 Before you can add a secondary email, you must verify your
                 primary email. To do this, you'll need access to{' '}
                 {primaryEmail.email}

--- a/packages/fxa-settings/src/components/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRow/index.tsx
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { useRef } from 'react';
+import { useFocusOnTriggeringElementOnClose } from '../../lib/hooks';
 
 type UnitRowProps = {
   header: string;
@@ -12,6 +13,7 @@ type UnitRowProps = {
   children?: React.ReactNode;
   route?: string;
   revealModal?: () => void;
+  modalRevealed?: boolean;
 };
 
 // TO DO: accept a refresh button prop to use in for secondary email
@@ -26,8 +28,12 @@ export const UnitRow = ({
   noHeaderValueText = 'None',
   noHeaderValueCtaText = 'Add',
   revealModal,
+  modalRevealed,
 }: UnitRowProps) => {
   const ctaText = headerValue ? 'Change' : noHeaderValueCtaText;
+
+  const modalTriggerElement = useRef<HTMLButtonElement>(null);
+  useFocusOnTriggeringElementOnClose(modalRevealed, modalTriggerElement);
 
   return (
     <div>
@@ -47,7 +53,11 @@ export const UnitRow = ({
         )}
 
         {revealModal && (
-          <button data-testid="unit-row-modal" onClick={revealModal}>
+          <button
+            data-testid="unit-row-modal"
+            ref={modalTriggerElement}
+            onClick={revealModal}
+          >
             {ctaText}
           </button>
         )}

--- a/packages/fxa-settings/src/lib/hooks.test.tsx
+++ b/packages/fxa-settings/src/lib/hooks.test.tsx
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useRef } from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { useFocusOnTriggeringElementOnClose } from './hooks';
+
+describe('useFocusOnTriggeringElementOnClose', () => {
+  const Subject = ({ revealed }: { revealed?: boolean }) => {
+    const triggerElement = useRef<HTMLButtonElement>(null);
+    useFocusOnTriggeringElementOnClose(revealed, triggerElement);
+
+    return (
+      <button ref={triggerElement} data-testid="trigger-element">
+        Hi
+      </button>
+    );
+  };
+
+  it('changes focus as expected', () => {
+    const { rerender, getByTestId } = render(<Subject revealed />);
+    rerender(<Subject revealed={false} />);
+
+    expect(document.activeElement).toBe(getByTestId('trigger-element'));
+  });
+
+  it('does nothing if `revealed` is not passed in', () => {
+    const { rerender, getByTestId } = render(<Subject />);
+    rerender(<Subject />);
+
+    expect(document.activeElement).not.toBe(getByTestId('trigger-element'));
+  });
+});

--- a/packages/fxa-settings/src/lib/hooks.tsx
+++ b/packages/fxa-settings/src/lib/hooks.tsx
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { useEffect, useRef } from 'react';
+
+// Focus on the element that triggered some action after the first
+// argument changes from `false` to `true`.
+export function useFocusOnTriggeringElementOnClose(
+  revealed: boolean | undefined,
+  triggerElement: React.RefObject<HTMLButtonElement>
+) {
+  const prevRevealedRef = useRef(revealed);
+  const prevRevealed = prevRevealedRef.current;
+
+  useEffect(() => {
+    if (revealed !== undefined) {
+      prevRevealedRef.current = revealed;
+    }
+    if (triggerElement.current && prevRevealed === true && revealed === false) {
+      triggerElement.current.focus();
+    }
+  }, [revealed, triggerElement, prevRevealed]);
+}


### PR DESCRIPTION
This commit:

* Allows the Modal component to close on escape key press
* Shifts focus back to the element that opened the modal when closed
* Disallows interaction with root element when modal is opened via aria-hidden, pointer events, and scroll prevention
* Adds `aria-labelledby`, `aria-describedby`, and `role='dialog'` properties
* Adds a tab fence so screenreaders are directed to the modal after opening

Because:
The current modal component needed some accessibility improvements.

Fixes #5016

This also makes `onDismiss` for `Modal` required because all of the modals in settings have a cancel/X button. I'll be opening an issue for us to backlog to better consolidate `DialogMessage` from payments with some of these updates, in the meantime I went with a check on `id` in the shared Portal component.