### PR TITLE
refactor(logging): reduce more logging

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/events.js
+++ b/packages/fxa-auth-server/lib/metrics/events.js
@@ -210,7 +210,7 @@ module.exports = (log, config) => {
 
           log.flowEvent(data);
         } else if (!OPTIONAL_FLOW_EVENTS[event]) {
-          log.error('metricsEvents.emitFlowEvent', {
+          log.trace('metricsEvents.emitFlowEvent', {
             event,
             missingFlowId: true,
           });

--- a/packages/fxa-auth-server/test/local/metrics/events.js
+++ b/packages/fxa-auth-server/test/local/metrics/events.js
@@ -868,10 +868,10 @@ describe('metrics/events', () => {
         'metricsContext.gather was called once'
       );
 
-      assert.equal(log.error.callCount, 1, 'log.error was called once');
-      assert.equal(log.error.args[0][0], 'metricsEvents.emitFlowEvent');
+      assert.equal(log.trace.callCount, 1, 'log.trace was called once');
+      assert.equal(log.trace.args[0][0], 'metricsEvents.emitFlowEvent');
       assert.deepEqual(
-        log.error.args[0][1],
+        log.trace.args[0][1],
         {
           event: 'email.verification.sent',
           missingFlowId: true,


### PR DESCRIPTION
Because:

* At the higher logging level it fills up our production logs.  At a
lower level it will still show up for debugging.

This commit:

* Changes missingFlowId logging from `info` to `trace`

Closes #5306