### PR TITLE
refactor(logging): reduce some unnecessary logging

### DIFF
--- a/packages/fxa-profile-server/lib/routes/profile.js
+++ b/packages/fxa-profile-server/lib/routes/profile.js
@@ -71,13 +71,13 @@ module.exports = {
       }
       const lastModified = cached ? new Date(cached.stored) : new Date();
       if (cached) {
-        logger.info('batch.cached', {
+        logger.trace('batch.cached', {
           storedAt: cached.stored,
           error: report && report.error,
           ttl: cached.ttl,
         });
       } else {
-        logger.info('batch.db');
+        logger.trace('batch.db');
       }
 
       return rep.header('last-modified', lastModified.toUTCString());


### PR DESCRIPTION
Because:

* At the higher logging level it fills up our production logs.  At a
lower level it will still show up for debugging.

This commit:

* Changes cache hit logging from `info` to `trace`

Closes #5311