### PR TITLE
fix(docker): need to specify types in some tsconfigs

### DIFF
--- a/_scripts/base-docker.sh
+++ b/_scripts/base-docker.sh
@@ -9,7 +9,7 @@ done
 
 # `npx yarn` because `npm i -g yarn` needs sudo
 npx yarn install
-SKIP_PREFLIGHT_CHECK=true npx yarn workspaces foreach --topological run build
+SKIP_PREFLIGHT_CHECK=true npx yarn workspaces foreach --topological-dev --verbose run build
 rm -rf node_modules
 rm -rf packages/*/node_modules
 npx yarn workspaces focus --production \

--- a/packages/fxa-admin-server/tsconfig.json
+++ b/packages/fxa-admin-server/tsconfig.json
@@ -15,7 +15,8 @@
     "forceConsistentCasingInFileNames": true,
     "noEmitHelpers": true,
     "importHelpers": true,
-    "typeRoots": ["./types", "node_modules/@types", "../../node_modules/@types"]
+    "typeRoots": ["./types", "node_modules/@types", "../../node_modules/@types"],
+    "types": ["mocha", "mozlog"]
   },
   "include": ["./src"],
   "exclude": ["node_modules"]

--- a/packages/fxa-auth-server/tsconfig.json
+++ b/packages/fxa-auth-server/tsconfig.json
@@ -14,7 +14,8 @@
     "allowSyntheticDefaultImports": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "typeRoots": ["./types", "node_modules/@types", "../../node_modules/@types", "../fxa-shared/types"]
+    "typeRoots": ["./types", "node_modules/@types", "../../node_modules/@types", "../fxa-shared/types"],
+    "types": ["accept-language", "mocha", "mozlog", "node"]
   },
   "include": [
     "bin/*",

--- a/packages/fxa-graphql-api/tsconfig.json
+++ b/packages/fxa-graphql-api/tsconfig.json
@@ -15,7 +15,8 @@
     "forceConsistentCasingInFileNames": true,
     "noEmitHelpers": true,
     "importHelpers": true,
-    "typeRoots": ["./types", "node_modules/@types", "../../node_modules/@types"]
+    "typeRoots": ["./types", "node_modules/@types", "../../node_modules/@types"],
+    "types": ["fxa-js-client", "mocha", "mozlog", "node"]
   },
   "include": ["./src"],
   "exclude": ["node_modules"]

--- a/packages/fxa-metrics-processor/tsconfig.json
+++ b/packages/fxa-metrics-processor/tsconfig.json
@@ -15,7 +15,8 @@
     "forceConsistentCasingInFileNames": true,
     "noEmitHelpers": true,
     "importHelpers": true,
-    "typeRoots": ["./types", "node_modules/@types", "../../node_modules/@types"]
+    "typeRoots": ["./types", "node_modules/@types", "../../node_modules/@types"],
+    "types": ["mocha", "mozlog", "node"]
   },
   "include": ["./src"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
since `@types` can be lifted to the top-level now
and jest and mocha have competing definitions
we need to specify the "types" config to use
the correct one.