### PR TITLE
feat(dev): added post-checkout git hook to keep deps in sync

### DIFF
--- a/_scripts/git-checkout-hook.sh
+++ b/_scripts/git-checkout-hook.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+IFS=' '
+read -ra G_PARAMS <<< "$HUSKY_GIT_PARAMS"
+PREV=${G_PARAMS[0]}
+NEXT=${G_PARAMS[1]}
+if [ "$PREV" != "$NEXT" ]; then
+  if [[ "$FXA_AUTO_INSTALL" == 0 ]] || git diff --quiet "$PREV" "$NEXT" yarn.lock; then
+    exit 0
+  elif [[ "$FXA_AUTO_INSTALL" == 1 ]]; then
+    echo "yarn.lock changed, running 'yarn install'"
+    yarn install
+  else
+    echo -e "\nyarn.lock changed. You may want to run 'yarn install'.\n"
+    echo -e "To auto install next time set FXA_AUTO_INSTALL=1 or to 0 to disable this check.\n"
+  fi
+fi

--- a/_scripts/git-merge-hook.sh
+++ b/_scripts/git-merge-hook.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ "$FXA_AUTO_INSTALL" == 0 ]] || git diff --quiet ORIG_HEAD HEAD yarn.lock; then
+  exit 0
+elif [[ "$FXA_AUTO_INSTALL" == 1 ]]; then
+  echo "yarn.lock changed, running 'yarn install'"
+  yarn install
+else
+  echo -e "\nyarn.lock changed. You may want to run 'yarn install'.\n"
+  echo -e "To auto install next time set FXA_AUTO_INSTALL=1 or to 0 to disable this check.\n"
+fi

--- a/package.json
+++ b/package.json
@@ -68,7 +68,9 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "_scripts/audit.sh"
+      "pre-push": "_scripts/audit.sh",
+      "post-checkout": "_scripts/git-checkout-hook.sh",
+      "post-merge": "_scripts/git-merge-hook.sh"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Submitting this as a proposal... It adds a tiny bit of lag when doing a `git checkout` but I've found it useful on other projects. Now that there's only one file to diff it seems worth adding.

It's easy to not notice when to run a `yarn install` either
when switching branches or doing a git pull. This adds a
hook to diff your previous yarn.lock with the one you're changing
to, and if there's changes running 'yarn install' for you.