### PR TITLE
chore(tests): clean up old Stripe customers after functional tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,11 @@ commands:
             CIRCLE_NODE_INDEX: << parameters.index >>
             CIRCLE_NODE_TOTAL: << parameters.total >>
           command: ./.circleci/test-package.sh fxa-content-server
+      - run:
+          name: Clean up old Stripe customers from testing
+          command: |
+            cd packages/fxa-auth-server && \
+            yarn run clean-up-old-ci-stripe-customers
       - store_artifacts:
           path: ~/.pm2/logs
           destination: logs

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -24,7 +24,8 @@
     "test-remote": "MAILER_HOST=restmail.net MAILER_PORT=80 CORS_ORIGIN=http://baz mocha -r ts-node/register --timeout=300000 test/remote",
     "format": "prettier '**' --write",
     "gen-keys": "ts-node ./scripts/gen_keys.js; ts-node ./scripts/oauth_gen_keys.js; ts-node ./scripts/gen_vapid_keys.js",
-    "write-emails": "node ./scripts/write-emails-to-disk.js"
+    "write-emails": "node ./scripts/write-emails-to-disk.js",
+    "clean-up-old-ci-stripe-customers": "ts-node ./scripts/clean-up-old-ci-stripe-customers.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
fixes #5326

So I *thought* there weren't going to be any code changes for this. Looks like there probably should be a few.

Also, rather than run this on a schedule, it seemed maybe easier to just tack it on after content-server functional tests. The script deletes customers with an email pattern of 'signin.*@restmail.net' that are over a day old. That should only cover testing customers and leave them around for a little while in case we have to peek at them after failed tests. Running this after each batch of functional tests should be pretty quick.