### PR TITLE
bug (content-server): remove 'Getting Started' from support form

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/support-form.js
+++ b/packages/fxa-content-server/app/scripts/models/support-form.js
@@ -13,7 +13,6 @@ const TOPICS = [
   'Payment & billing',
   'Account issues',
   'Technical issues',
-  'Getting started',
   'Provide feedback / request features',
   'Not listed',
 ];
@@ -23,7 +22,6 @@ const TRANSLATED_TOPICS = [
   t('Payment & billing'),
   t('Account issues'),
   t('Technical issues'),
-  t('Getting started'),
   t('Provide feedback / request features'),
   t('Not listed'),
 ];


### PR DESCRIPTION
Because:
- The 'Getting Started' option was supposed to be removed as a part of the initial request from the support team

This commit:
- Remove 'Getting Started' from the topic options

close #5302