### PR TITLE
fix(docker): removed need for fxa-shared postinstall script

### DIFF
--- a/packages/fxa-auth-server/config/popular-email-domains.js
+++ b/packages/fxa-auth-server/config/popular-email-domains.js
@@ -4,6 +4,6 @@
 
 'use strict';
 
-const { popularDomains } = require('../../fxa-shared').email;
+const popularDomains = require('fxa-shared/email/popularDomains');
 
 module.exports = new Set(popularDomains);

--- a/packages/fxa-auth-server/config/supportedLanguages.js
+++ b/packages/fxa-auth-server/config/supportedLanguages.js
@@ -7,4 +7,4 @@
 // The list below should be kept in sync with:
 // https://raw.githubusercontent.com/mozilla/fxa-content-server/master/server/config/production-locales.json
 
-module.exports = require('../../fxa-shared').l10n.supportedLanguages;
+module.exports = require('fxa-shared/l10n/supportedLanguages');

--- a/packages/fxa-auth-server/lib/customs.js
+++ b/packages/fxa-auth-server/lib/customs.js
@@ -7,13 +7,15 @@
 const Joi = require('@hapi/joi');
 const createBackendServiceAPI = require('./backendService');
 const config = require('../config');
-const localizeTimestamp = require('../../fxa-shared').l10n.localizeTimestamp({
-  supportedLanguages: config.get('i18n').supportedLanguages,
-  defaultLanguage: config.get('i18n').defaultLanguage,
-});
+const localizeTimestamp = require('fxa-shared/l10n/localizeTimestamp').localizeTimestamp(
+  {
+    supportedLanguages: config.get('i18n').supportedLanguages,
+    defaultLanguage: config.get('i18n').defaultLanguage,
+  }
+);
 const serviceName = 'customs';
 
-module.exports = function(log, error, statsd) {
+module.exports = function (log, error, statsd) {
   const CustomsAPI = createBackendServiceAPI(
     log,
     config,
@@ -123,10 +125,10 @@ module.exports = function(log, error, statsd) {
 
   function Customs(url) {
     if (url === 'none') {
-      const noblock = async function() {
+      const noblock = async function () {
         return { block: false };
       };
-      const noop = async function() {};
+      const noop = async function () {};
       this.api = {
         check: noblock,
         checkAuthenticated: noblock,
@@ -140,7 +142,7 @@ module.exports = function(log, error, statsd) {
     }
   }
 
-  Customs.prototype.check = async function(request, email, action) {
+  Customs.prototype.check = async function (request, email, action) {
     const result = await this.api.check({
       ip: request.app.clientAddress,
       email: email,
@@ -210,7 +212,7 @@ module.exports = function(log, error, statsd) {
     }
   }
 
-  Customs.prototype.checkAuthenticated = async function(request, uid, action) {
+  Customs.prototype.checkAuthenticated = async function (request, uid, action) {
     const result = await this.api.checkAuthenticated({
       action: action,
       ip: request.app.clientAddress,
@@ -222,7 +224,7 @@ module.exports = function(log, error, statsd) {
     return handleCustomsResult(request, result);
   };
 
-  Customs.prototype.checkIpOnly = async function(request, action) {
+  Customs.prototype.checkIpOnly = async function (request, action) {
     const result = await this.api.checkIpOnly({
       ip: request.app.clientAddress,
       action: action,
@@ -233,7 +235,7 @@ module.exports = function(log, error, statsd) {
     return handleCustomsResult(request, result);
   };
 
-  Customs.prototype.flag = async function(ip, info) {
+  Customs.prototype.flag = async function (ip, info) {
     const email = info.email;
     const errno = info.errno || error.ERRNO.UNEXPECTED_ERROR;
     // There's no useful information in the HTTP response, ignore it.
@@ -244,14 +246,14 @@ module.exports = function(log, error, statsd) {
     });
   };
 
-  Customs.prototype.reset = async function(email) {
+  Customs.prototype.reset = async function (email) {
     // There's no useful information in the HTTP response, ignore it.
     await this.api.passwordReset({
       email: email,
     });
   };
 
-  Customs.prototype.close = function() {
+  Customs.prototype.close = function () {
     return this.api.close();
   };
 

--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -7,7 +7,7 @@
 const error = require('./error');
 const Pool = require('./pool');
 const random = require('./crypto/random');
-const { normalizeEmail } = require('../../fxa-shared/email/helpers');
+const { normalizeEmail } = require('fxa-shared/email/helpers');
 
 module.exports = (config, log, Token, UnblockCode = null) => {
   const features = require('./features')(config);
@@ -32,7 +32,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     account.emails = await this.accountEmails(account.uid);
 
     // Set primary email on account object
-    account.emails.forEach(item => {
+    account.emails.forEach((item) => {
       item.isVerified = !!item.isVerified;
       item.isPrimary = !!item.isPrimary;
 
@@ -59,11 +59,11 @@ module.exports = (config, log, Token, UnblockCode = null) => {
       );
   }
 
-  DB.connect = async function(options) {
+  DB.connect = async function (options) {
     return new DB(options);
   };
 
-  DB.prototype.close = async function() {
+  DB.prototype.close = async function () {
     const promises = [this.pool.close()];
     if (this.redis) {
       promises.push(this.redis.close());
@@ -72,14 +72,14 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   };
 
   SAFE_URLS.ping = new SafeUrl('/__heartbeat__', 'db.ping');
-  DB.prototype.ping = async function() {
+  DB.prototype.ping = async function () {
     return this.pool.get(SAFE_URLS.ping);
   };
 
   // CREATE
 
   SAFE_URLS.createAccount = new SafeUrl('/account/:uid', 'db.createAccount');
-  DB.prototype.createAccount = async function(data) {
+  DB.prototype.createAccount = async function (data) {
     const { uid, email } = data;
     log.trace('DB.createAccount', { uid, email });
     data.createdAt = data.verifierSetAt = Date.now();
@@ -99,7 +99,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/sessionToken/:id',
     'db.createSessionToken'
   );
-  DB.prototype.createSessionToken = async function(authToken) {
+  DB.prototype.createSessionToken = async function (authToken) {
     const { uid } = authToken;
 
     log.trace('DB.createSessionToken', { uid });
@@ -133,7 +133,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/keyFetchToken/:id',
     'db.createKeyFetchToken'
   );
-  DB.prototype.createKeyFetchToken = async function(authToken) {
+  DB.prototype.createKeyFetchToken = async function (authToken) {
     log.trace('DB.createKeyFetchToken', { uid: authToken && authToken.uid });
     const keyFetchToken = await KeyFetchToken.create(authToken);
     const { id } = keyFetchToken;
@@ -156,7 +156,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/passwordForgotToken/:id',
     'db.createPasswordForgotToken'
   );
-  DB.prototype.createPasswordForgotToken = async function(emailRecord) {
+  DB.prototype.createPasswordForgotToken = async function (emailRecord) {
     log.trace('DB.createPasswordForgotToken', {
       uid: emailRecord && emailRecord.uid,
     });
@@ -181,7 +181,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/passwordChangeToken/:id',
     'db.createPasswordChangeToken'
   );
-  DB.prototype.createPasswordChangeToken = async function(data) {
+  DB.prototype.createPasswordChangeToken = async function (data) {
     log.trace('DB.createPasswordChangeToken', { uid: data.uid });
     const passwordChangeToken = await PasswordChangeToken.create(data);
     const { id } = passwordChangeToken;
@@ -204,7 +204,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/checkPassword',
     'db.checkPassword'
   );
-  DB.prototype.checkPassword = async function(uid, verifyHash) {
+  DB.prototype.checkPassword = async function (uid, verifyHash) {
     log.trace('DB.checkPassword', { uid, verifyHash });
     try {
       await this.pool.post(
@@ -223,7 +223,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     }
   };
 
-  DB.prototype.accountExists = async function(email) {
+  DB.prototype.accountExists = async function (email) {
     log.trace('DB.accountExists', { email: email });
     try {
       await this.accountRecord(email);
@@ -237,7 +237,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   };
 
   SAFE_URLS.sessions = new SafeUrl('/account/:uid/sessions', 'db.sessions');
-  DB.prototype.sessions = async function(uid) {
+  DB.prototype.sessions = async function (uid) {
     log.trace('DB.sessions', { uid });
     const getMysqlSessionTokens = async () => {
       let sessionTokens = await this.pool.get(SAFE_URLS.sessions, { uid });
@@ -248,7 +248,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
       const expiredSessionTokens = [];
 
       // Filter out any expired sessions
-      sessionTokens = sessionTokens.filter(sessionToken => {
+      sessionTokens = sessionTokens.filter((sessionToken) => {
         if (sessionToken.deviceId) {
           return true;
         }
@@ -291,7 +291,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     // for each db session token, if there is a matching redis token
     // overwrite the properties of the db token with the redis token values
     const lastAccessTimeEnabled = features.isLastAccessTimeEnabledForUser(uid);
-    const sessions = mysqlSessionTokens.map(sessionToken => {
+    const sessions = mysqlSessionTokens.map((sessionToken) => {
       const id = sessionToken.tokenId;
       const redisToken = redisSessionTokens[id];
       const mergedToken = Object.assign({}, sessionToken, redisToken, {
@@ -316,7 +316,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/keyFetchToken/:id',
     'db.keyFetchToken'
   );
-  DB.prototype.keyFetchToken = async function(id) {
+  DB.prototype.keyFetchToken = async function (id) {
     log.trace('DB.keyFetchToken', { id });
     let data;
     try {
@@ -331,7 +331,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/keyFetchToken/:id/verified',
     'db.keyFetchTokenWithVerificationStatus'
   );
-  DB.prototype.keyFetchTokenWithVerificationStatus = async function(id) {
+  DB.prototype.keyFetchTokenWithVerificationStatus = async function (id) {
     log.trace('DB.keyFetchTokenWithVerificationStatus', { id });
     let data;
     try {
@@ -349,7 +349,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/accountResetToken/:id',
     'db.accountResetToken'
   );
-  DB.prototype.accountResetToken = async function(id) {
+  DB.prototype.accountResetToken = async function (id) {
     log.trace('DB.accountResetToken', { id });
     let data;
     try {
@@ -364,7 +364,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/passwordForgotToken/:id',
     'db.passwordForgotToken'
   );
-  DB.prototype.passwordForgotToken = async function(id) {
+  DB.prototype.passwordForgotToken = async function (id) {
     let data;
     log.trace('DB.passwordForgotToken', { id });
     try {
@@ -379,7 +379,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/passwordChangeToken/:id',
     'db.passwordChangeToken'
   );
-  DB.prototype.passwordChangeToken = async function(id) {
+  DB.prototype.passwordChangeToken = async function (id) {
     log.trace('DB.passwordChangeToken', { id });
     let data;
     try {
@@ -395,7 +395,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
    * for all other uses.
    */
   SAFE_URLS.emailRecord = new SafeUrl('/emailRecord/:email', 'db.emailRecord');
-  DB.prototype.emailRecord = async function(email) {
+  DB.prototype.emailRecord = async function (email) {
     log.trace('DB.emailRecord', { email });
     let body;
     try {
@@ -415,7 +415,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/email/:email/account',
     'db.accountRecord'
   );
-  DB.prototype.accountRecord = async function(email) {
+  DB.prototype.accountRecord = async function (email) {
     log.trace('DB.accountRecord', { email });
     let body;
     try {
@@ -437,7 +437,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/email/:email/account/:uid',
     'db.setPrimaryEmail'
   );
-  DB.prototype.setPrimaryEmail = async function(uid, email) {
+  DB.prototype.setPrimaryEmail = async function (uid, email) {
     log.trace('DB.setPrimaryEmail', { email });
     try {
       return await this.pool.post(SAFE_URLS.setPrimaryEmail, {
@@ -453,7 +453,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   };
 
   SAFE_URLS.account = new SafeUrl('/account/:uid', 'db.account');
-  DB.prototype.account = async function(uid) {
+  DB.prototype.account = async function (uid) {
     log.trace('DB.account', { uid });
     let body;
     try {
@@ -469,7 +469,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   };
 
   SAFE_URLS.devices = new SafeUrl('/account/:uid/devices', 'db.devices');
-  DB.prototype.devices = async function(uid) {
+  DB.prototype.devices = async function (uid) {
     log.trace('DB.devices', { uid });
 
     if (!uid) {
@@ -487,7 +487,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
       const lastAccessTimeEnabled = features.isLastAccessTimeEnabledForUser(
         uid
       );
-      return devices.map(device => {
+      return devices.map((device) => {
         return mergeDeviceInfoFromRedis(
           device,
           redisSessionTokens,
@@ -503,7 +503,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   };
 
   SAFE_URLS.sessionToken = new SafeUrl('/sessionToken/:id', 'db.sessionToken');
-  DB.prototype.sessionToken = async function(id) {
+  DB.prototype.sessionToken = async function (id) {
     log.trace('DB.sessionToken', { id });
     let data;
     try {
@@ -520,7 +520,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/passwordForgotToken/:id/update',
     'db.updatePasswordForgotToken'
   );
-  DB.prototype.updatePasswordForgotToken = async function(token) {
+  DB.prototype.updatePasswordForgotToken = async function (token) {
     log.trace('DB.udatePasswordForgotToken', { uid: token && token.uid });
     const { id } = token;
     return this.pool.post(
@@ -541,7 +541,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
    * To do a more expensive write that flushes to the underlying
    * DB, use updateSessionToken instead.
    */
-  DB.prototype.touchSessionToken = async function(token, geo) {
+  DB.prototype.touchSessionToken = async function (token, geo) {
     const { id, uid } = token;
 
     log.trace('DB.touchSessionToken', { id, uid });
@@ -589,7 +589,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/sessionToken/:id/update',
     'db.updateSessionToken'
   );
-  DB.prototype.updateSessionToken = async function(sessionToken, geo) {
+  DB.prototype.updateSessionToken = async function (sessionToken, geo) {
     const { id, uid } = sessionToken;
 
     log.trace('DB.updateSessionToken', { id, uid });
@@ -612,7 +612,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     );
   };
 
-  DB.prototype.pruneSessionTokens = async function(uid, sessionTokens) {
+  DB.prototype.pruneSessionTokens = async function (uid, sessionTokens) {
     log.trace('DB.pruneSessionTokens', {
       uid,
       tokenCount: sessionTokens.length,
@@ -627,8 +627,8 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     }
 
     const tokenIds = sessionTokens
-      .filter(token => token.createdAt <= Date.now() - TOKEN_PRUNING_MAX_AGE)
-      .map(token => token.id);
+      .filter((token) => token.createdAt <= Date.now() - TOKEN_PRUNING_MAX_AGE)
+      .map((token) => token.id);
 
     if (tokenIds.length === 0) {
       return;
@@ -638,7 +638,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   };
 
   SAFE_URLS.device = new SafeUrl('/account/:uid/device/:deviceId', 'db.device');
-  DB.prototype.device = async function(uid, deviceId) {
+  DB.prototype.device = async function (uid, deviceId) {
     log.trace('DB.device', { uid: uid, id: deviceId });
 
     const promises = [this.pool.get(SAFE_URLS.device, { uid, deviceId })];
@@ -668,7 +668,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/device/:id',
     'db.createDevice'
   );
-  DB.prototype.createDevice = async function(uid, deviceInfo) {
+  DB.prototype.createDevice = async function (uid, deviceInfo) {
     log.trace('DB.createDevice', { uid: uid, id: deviceInfo.id });
     const sessionTokenId = deviceInfo.sessionTokenId;
     const refreshTokenId = deviceInfo.refreshTokenId;
@@ -733,7 +733,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/device/:id/update',
     'db.updateDevice'
   );
-  DB.prototype.updateDevice = async function(uid, deviceInfo) {
+  DB.prototype.updateDevice = async function (uid, deviceInfo) {
     const { id } = deviceInfo;
     const sessionTokenId = deviceInfo.sessionTokenId;
     const refreshTokenId = deviceInfo.refreshTokenId;
@@ -764,7 +764,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
         // to save a server round-trip for the client.
         const devices = await this.devices(uid);
         let conflictingDeviceId;
-        devices.some(device => {
+        devices.some((device) => {
           if (device.sessionTokenId === sessionTokenId) {
             conflictingDeviceId = device.id;
             return true;
@@ -780,7 +780,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   // DELETE
 
   SAFE_URLS.deleteAccount = new SafeUrl('/account/:uid', 'db.deleteAccount');
-  DB.prototype.deleteAccount = async function(authToken) {
+  DB.prototype.deleteAccount = async function (authToken) {
     const { uid } = authToken;
 
     log.trace('DB.deleteAccount', { uid });
@@ -794,7 +794,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/sessionToken/:id',
     'db.deleteSessionToken'
   );
-  DB.prototype.deleteSessionToken = async function(sessionToken) {
+  DB.prototype.deleteSessionToken = async function (sessionToken) {
     const { id, uid } = sessionToken;
 
     log.trace('DB.deleteSessionToken', { id, uid });
@@ -807,7 +807,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/keyFetchToken/:id',
     'db.deleteKeyFetchToken'
   );
-  DB.prototype.deleteKeyFetchToken = async function(keyFetchToken) {
+  DB.prototype.deleteKeyFetchToken = async function (keyFetchToken) {
     const { id, uid } = keyFetchToken;
     log.trace('DB.deleteKeyFetchToken', { id, uid });
     return this.pool.del(SAFE_URLS.deleteKeyFetchToken, { id });
@@ -817,7 +817,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/accountResetToken/:id',
     'db.deleteAccountResetToken'
   );
-  DB.prototype.deleteAccountResetToken = async function(accountResetToken) {
+  DB.prototype.deleteAccountResetToken = async function (accountResetToken) {
     const { id, uid } = accountResetToken;
     log.trace('DB.deleteAccountResetToken', { id, uid });
     return this.pool.del(SAFE_URLS.deleteAccountResetToken, { id });
@@ -827,7 +827,9 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/passwordForgotToken/:id',
     'db.deletePasswordForgotToken'
   );
-  DB.prototype.deletePasswordForgotToken = async function(passwordForgotToken) {
+  DB.prototype.deletePasswordForgotToken = async function (
+    passwordForgotToken
+  ) {
     const { id, uid } = passwordForgotToken;
     log.trace('DB.deletePasswordForgotToken', { id, uid });
     return this.pool.del(SAFE_URLS.deletePasswordForgotToken, { id });
@@ -837,7 +839,9 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/passwordChangeToken/:id',
     'db.deletePasswordChangeToken'
   );
-  DB.prototype.deletePasswordChangeToken = async function(passwordChangeToken) {
+  DB.prototype.deletePasswordChangeToken = async function (
+    passwordChangeToken
+  ) {
     const { id, uid } = passwordChangeToken;
     log.trace('DB.deletePasswordChangeToken', { id, uid });
     return this.pool.del(SAFE_URLS.deletePasswordChangeToken, { id });
@@ -847,7 +851,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/device/:deviceId',
     'db.deleteDevice'
   );
-  DB.prototype.deleteDevice = async function(uid, deviceId) {
+  DB.prototype.deleteDevice = async function (uid, deviceId) {
     log.trace('DB.deleteDevice', { uid, id: deviceId });
 
     try {
@@ -869,7 +873,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/tokens/:tokenVerificationId/device',
     'db.deviceFromTokenVerificationId'
   );
-  DB.prototype.deviceFromTokenVerificationId = async function(
+  DB.prototype.deviceFromTokenVerificationId = async function (
     uid,
     tokenVerificationId
   ) {
@@ -893,7 +897,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/reset',
     'db.resetAccount'
   );
-  DB.prototype.resetAccount = async function(accountResetToken, data) {
+  DB.prototype.resetAccount = async function (accountResetToken, data) {
     const { uid } = accountResetToken;
 
     log.trace('DB.resetAccount', { uid });
@@ -908,7 +912,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/verifyEmail/:emailCode',
     'db.verifyEmail'
   );
-  DB.prototype.verifyEmail = async function(account, emailCode) {
+  DB.prototype.verifyEmail = async function (account, emailCode) {
     const { uid } = account;
     log.trace('DB.verifyEmail', { uid, emailCode });
     return this.pool.post(SAFE_URLS.verifyEmail, { uid, emailCode });
@@ -918,7 +922,10 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/tokens/:tokenVerificationId/verify',
     'db.verifyTokens'
   );
-  DB.prototype.verifyTokens = async function(tokenVerificationId, accountData) {
+  DB.prototype.verifyTokens = async function (
+    tokenVerificationId,
+    accountData
+  ) {
     log.trace('DB.verifyTokens', { tokenVerificationId });
     try {
       return await this.pool.post(
@@ -938,7 +945,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/tokens/:tokenId/verifyWithMethod',
     'db.verifyTokensWithMethod'
   );
-  DB.prototype.verifyTokensWithMethod = async function(
+  DB.prototype.verifyTokensWithMethod = async function (
     tokenId,
     verificationMethod
   ) {
@@ -954,7 +961,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/tokens/:code/verifyCode',
     'db.verifyTokenCode'
   );
-  DB.prototype.verifyTokenCode = async function(code, accountData) {
+  DB.prototype.verifyTokenCode = async function (code, accountData) {
     log.trace('DB.verifyTokenCode', { code });
     try {
       return await this.pool.post(
@@ -976,7 +983,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/passwordForgotToken/:id/verified',
     'db.forgotPasswordVerified'
   );
-  DB.prototype.forgotPasswordVerified = async function(passwordForgotToken) {
+  DB.prototype.forgotPasswordVerified = async function (passwordForgotToken) {
     const { id, uid } = passwordForgotToken;
     log.trace('DB.forgotPasswordVerified', { uid });
     const accountResetToken = await AccountResetToken.create({ uid });
@@ -997,13 +1004,13 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/locale',
     'db.updateLocale'
   );
-  DB.prototype.updateLocale = async function(uid, locale) {
+  DB.prototype.updateLocale = async function (uid, locale) {
     log.trace('DB.updateLocale', { uid, locale });
     return this.pool.post(SAFE_URLS.updateLocale, { uid }, { locale: locale });
   };
 
   SAFE_URLS.securityEvent = new SafeUrl('/securityEvents', 'db.securityEvent');
-  DB.prototype.securityEvent = async function(event) {
+  DB.prototype.securityEvent = async function (event) {
     log.trace('DB.securityEvent', {
       securityEvent: event,
     });
@@ -1015,7 +1022,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/securityEvents/:uid/ip/:ipAddr',
     'db.securityEvents'
   );
-  DB.prototype.securityEvents = async function(params) {
+  DB.prototype.securityEvents = async function (params) {
     log.trace('DB.securityEvents', {
       params: params,
     });
@@ -1027,7 +1034,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/securityEvents/:uid',
     'db.securityEventsByUid'
   );
-  DB.prototype.securityEventsByUid = async function(params) {
+  DB.prototype.securityEventsByUid = async function (params) {
     log.trace('DB.securityEventsByUid', {
       params: params,
     });
@@ -1039,7 +1046,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/securityEvents/:uid',
     'db.deleteSecurityEventsByUid'
   );
-  DB.prototype.deleteSecurityEvents = async function(params) {
+  DB.prototype.deleteSecurityEvents = async function (params) {
     log.trace('DB.deleteSecurityEvents', {
       params: params,
     });
@@ -1051,7 +1058,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/unblock/:unblock',
     'db.createUnblockCode'
   );
-  DB.prototype.createUnblockCode = async function(uid) {
+  DB.prototype.createUnblockCode = async function (uid) {
     if (!UnblockCode) {
       return Promise.reject(new Error('Unblock has not been configured'));
     }
@@ -1078,7 +1085,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/unblock/:code',
     'db.consumeUnblockCode'
   );
-  DB.prototype.consumeUnblockCode = async function(uid, code) {
+  DB.prototype.consumeUnblockCode = async function (uid, code) {
     log.trace('DB.consumeUnblockCode', { uid });
     try {
       return await this.pool.del(SAFE_URLS.consumeUnblockCode, { uid, code });
@@ -1094,7 +1101,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/emailBounces',
     'db.createEmailBounce'
   );
-  DB.prototype.createEmailBounce = async function(bounceData) {
+  DB.prototype.createEmailBounce = async function (bounceData) {
     log.trace('DB.createEmailBounce', {
       bouceData: bounceData,
     });
@@ -1106,7 +1113,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/emailBounces/:email',
     'db.emailBounces'
   );
-  DB.prototype.emailBounces = async function(email) {
+  DB.prototype.emailBounces = async function (email) {
     log.trace('DB.emailBounces', { email });
 
     return this.pool.get(SAFE_URLS.emailBounces, {
@@ -1118,7 +1125,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/emails',
     'db.accountEmails'
   );
-  DB.prototype.accountEmails = async function(uid) {
+  DB.prototype.accountEmails = async function (uid) {
     log.trace('DB.accountEmails', { uid });
 
     return this.pool.get(SAFE_URLS.accountEmails, { uid });
@@ -1128,7 +1135,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/email/:email',
     'db.getSecondaryEmail'
   );
-  DB.prototype.getSecondaryEmail = async function(email) {
+  DB.prototype.getSecondaryEmail = async function (email) {
     log.trace('DB.getSecondaryEmail', { email });
 
     try {
@@ -1144,7 +1151,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   };
 
   SAFE_URLS.createEmail = new SafeUrl('/account/:uid/emails', 'db.createEmail');
-  DB.prototype.createEmail = async function(uid, emailData) {
+  DB.prototype.createEmail = async function (uid, emailData) {
     log.trace('DB.createEmail', {
       email: emailData.email,
       uid,
@@ -1164,7 +1171,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/emails/:email',
     'db.deleteEmail'
   );
-  DB.prototype.deleteEmail = async function(uid, email) {
+  DB.prototype.deleteEmail = async function (uid, email) {
     log.trace('DB.deleteEmail', { uid });
 
     try {
@@ -1184,7 +1191,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/signinCodes/:code',
     'db.createSigninCode'
   );
-  DB.prototype.createSigninCode = async function(uid, flowId) {
+  DB.prototype.createSigninCode = async function (uid, flowId) {
     log.trace('DB.createSigninCode');
 
     const code = await random.hex(config.signinCodeSize);
@@ -1205,7 +1212,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/signinCodes/:code/consume',
     'db.consumeSigninCode'
   );
-  DB.prototype.consumeSigninCode = async function(code) {
+  DB.prototype.consumeSigninCode = async function (code) {
     log.trace('DB.consumeSigninCode', { code });
 
     try {
@@ -1223,14 +1230,14 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/resetTokens',
     'db.resetAccountTokens'
   );
-  DB.prototype.resetAccountTokens = async function(uid) {
+  DB.prototype.resetAccountTokens = async function (uid) {
     log.trace('DB.resetAccountTokens', { uid });
 
     return this.pool.post(SAFE_URLS.resetAccountTokens, { uid });
   };
 
   SAFE_URLS.createTotpToken = new SafeUrl('/totp/:uid', 'db.createTotpToken');
-  DB.prototype.createTotpToken = async function(uid, sharedSecret, epoch) {
+  DB.prototype.createTotpToken = async function (uid, sharedSecret, epoch) {
     log.trace('DB.createTotpToken', { uid });
 
     try {
@@ -1251,7 +1258,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   };
 
   SAFE_URLS.totpToken = new SafeUrl('/totp/:uid', 'db.totpToken');
-  DB.prototype.totpToken = async function(uid) {
+  DB.prototype.totpToken = async function (uid) {
     log.trace('DB.totpToken', { uid });
 
     try {
@@ -1265,7 +1272,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   };
 
   SAFE_URLS.deleteTotpToken = new SafeUrl('/totp/:uid', 'db.deleteTotpToken');
-  DB.prototype.deleteTotpToken = async function(uid) {
+  DB.prototype.deleteTotpToken = async function (uid) {
     log.trace('DB.deleteTotpToken', { uid });
 
     try {
@@ -1282,7 +1289,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/totp/:uid/update',
     'db.updateTotpToken'
   );
-  DB.prototype.updateTotpToken = async function(uid, data) {
+  DB.prototype.updateTotpToken = async function (uid, data) {
     log.trace('DB.updateTotpToken', { uid, data });
 
     try {
@@ -1306,7 +1313,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/recoveryCodes',
     'db.replaceRecoveryCodes'
   );
-  DB.prototype.replaceRecoveryCodes = async function(uid, count) {
+  DB.prototype.replaceRecoveryCodes = async function (uid, count) {
     log.trace('DB.replaceRecoveryCodes', { uid });
 
     return this.pool.post(SAFE_URLS.replaceRecoveryCodes, { uid }, { count });
@@ -1316,7 +1323,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/recoveryCodes/:code',
     'db.consumeRecoveryCode'
   );
-  DB.prototype.consumeRecoveryCode = async function(uid, code) {
+  DB.prototype.consumeRecoveryCode = async function (uid, code) {
     log.trace('DB.consumeRecoveryCode', { uid });
 
     try {
@@ -1333,7 +1340,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/recoveryKey',
     'db.createRecoveryKey'
   );
-  DB.prototype.createRecoveryKey = async function(
+  DB.prototype.createRecoveryKey = async function (
     uid,
     recoveryKeyId,
     recoveryData,
@@ -1359,7 +1366,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/recoveryKey/:recoveryKeyId',
     'db.getRecoveryKey'
   );
-  DB.prototype.getRecoveryKey = async function(uid, recoveryKeyId) {
+  DB.prototype.getRecoveryKey = async function (uid, recoveryKeyId) {
     log.trace('DB.getRecoveryKey', { uid });
 
     try {
@@ -1383,7 +1390,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/recoveryKey',
     'db.recoveryKeyExists'
   );
-  DB.prototype.recoveryKeyExists = async function(uid) {
+  DB.prototype.recoveryKeyExists = async function (uid) {
     log.trace('DB.recoveryKeyExists', { uid });
 
     return this.pool.get(SAFE_URLS.recoveryKeyExists, { uid });
@@ -1393,7 +1400,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/recoveryKey',
     'db.deleteRecoveryKey'
   );
-  DB.prototype.deleteRecoveryKey = async function(uid) {
+  DB.prototype.deleteRecoveryKey = async function (uid) {
     log.trace('DB.deleteRecoveryKey', { uid });
 
     return this.pool.del(SAFE_URLS.deleteRecoveryKey, { uid });
@@ -1403,7 +1410,11 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     '/account/:uid/recoveryKey/update',
     'db.updateRecoveryKey'
   );
-  DB.prototype.updateRecoveryKey = async function(uid, recoveryKeyId, enabled) {
+  DB.prototype.updateRecoveryKey = async function (
+    uid,
+    recoveryKeyId,
+    enabled
+  ) {
     log.trace('DB.updateRecoveryKey', { uid });
 
     return this.pool.post(
@@ -1416,7 +1427,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     );
   };
 
-  DB.prototype.deleteSessionTokenFromRedis = async function(uid, id) {
+  DB.prototype.deleteSessionTokenFromRedis = async function (uid, id) {
     if (!this.redis) {
       return;
     }

--- a/packages/fxa-auth-server/lib/geodb.js
+++ b/packages/fxa-auth-server/lib/geodb.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const config = require('../config').get('geodb');
-const geodb = require('../../fxa-geodb')(config);
+const geodb = require('fxa-geodb')(config);
 const ACCURACY_MAX_KM = 200;
 const ACCURACY_MIN_KM = 25;
 
@@ -19,10 +19,10 @@ geodb(knownIp);
  * and catch errors. On success, returns an object with
  * `location` data. On failure, returns an empty object
  **/
-module.exports = log => {
+module.exports = (log) => {
   log.info('geodb.start', { enabled: config.enabled, dbPath: config.dbPath });
 
-  return ip => {
+  return (ip) => {
     if (config.enabled === false) {
       return {};
     }

--- a/packages/fxa-auth-server/lib/log.js
+++ b/packages/fxa-auth-server/lib/log.js
@@ -10,8 +10,7 @@ const mozlog = require('mozlog');
 const config = require('../config');
 const logConfig = config.get('log');
 const amplitudeConfig = config.get('amplitude');
-const validateAmplitudeEvent = require('../../fxa-shared/metrics/amplitude')
-  .validate;
+const validateAmplitudeEvent = require('fxa-shared/metrics/amplitude').validate;
 let statsd;
 const Sentry = require('@sentry/node');
 
@@ -34,15 +33,15 @@ function Lug(options) {
 }
 util.inherits(Lug, EventEmitter);
 
-Lug.prototype.close = function() {};
+Lug.prototype.close = function () {};
 
 // Expose the standard error/warn/info/debug/etc log methods.
 
-Lug.prototype.trace = function(op, data) {
+Lug.prototype.trace = function (op, data) {
   this.logger.debug(op, data);
 };
 
-Lug.prototype.error = function(op, data) {
+Lug.prototype.error = function (op, data) {
   // If the error object contains an email address,
   // lift it into top-level fields so that our
   // PII-scrubbing tool is able to find it.
@@ -55,23 +54,23 @@ Lug.prototype.error = function(op, data) {
   this.logger.error(op, data);
 };
 
-Lug.prototype.fatal = function(op, data) {
+Lug.prototype.fatal = function (op, data) {
   this.logger.critical(op, data);
 };
 
-Lug.prototype.warn = function(op, data) {
+Lug.prototype.warn = function (op, data) {
   this.logger.warn(op, data);
 };
 
-Lug.prototype.info = function(op, data) {
+Lug.prototype.info = function (op, data) {
   this.logger.info(op, data);
 };
 
-Lug.prototype.begin = function(op, request) {
+Lug.prototype.begin = function (op, request) {
   this.logger.debug(op);
 };
 
-Lug.prototype.stat = function(stats) {
+Lug.prototype.stat = function (stats) {
   this.logger.info('stat', stats);
 };
 
@@ -80,7 +79,7 @@ Lug.prototype.stat = function(stats) {
 // See https://mana.mozilla.org/wiki/display/CLOUDSERVICES/Logging+Standard
 // for a discussion of this format and why it's used.
 
-Lug.prototype.summary = function(request, response) {
+Lug.prototype.summary = function (request, response) {
   if (request.method === 'options') {
     return;
   }
@@ -134,7 +133,7 @@ Lug.prototype.summary = function(request, response) {
 
 // Broadcast an event to attached services, such as sync.
 // In production, these events are broadcast to relying services over SNS/SQS.
-Lug.prototype.notifyAttachedServices = async function(name, request, data) {
+Lug.prototype.notifyAttachedServices = async function (name, request, data) {
   let metricsContextData = {};
   if (request.gatherMetricsContext) {
     metricsContextData = await request.gatherMetricsContext({});
@@ -170,7 +169,7 @@ Lug.prototype.notifyAttachedServices = async function(name, request, data) {
 // These events indicate key points at which a particular
 // user has interacted with the service.
 
-Lug.prototype.activityEvent = function(data) {
+Lug.prototype.activityEvent = function (data) {
   if (!data || !data.event || !data.uid) {
     this.error('log.activityEvent', { data });
     return;
@@ -182,7 +181,7 @@ Lug.prototype.activityEvent = function(data) {
 // Log a flow metrics event.
 // These events help understand the user's sign-in or sign-up journey.
 
-Lug.prototype.flowEvent = function(data) {
+Lug.prototype.flowEvent = function (data) {
   if (!data || !data.event || !data.flow_id || !data.flow_time || !data.time) {
     return;
   }
@@ -190,7 +189,7 @@ Lug.prototype.flowEvent = function(data) {
   this.logger.info('flowEvent', data);
 };
 
-Lug.prototype.amplitudeEvent = function(data) {
+Lug.prototype.amplitudeEvent = function (data) {
   // @TODO We can remove this guard once we return early after a schema
   // validation failure.
   if (!data || !data.event_type || (!data.device_id && !data.user_id)) {
@@ -209,7 +208,7 @@ Lug.prototype.amplitudeEvent = function(data) {
       // that the schema is not too strict against existing events.  We'll
       // update the schema accordingly.  And allow the events in the
       // meantime.
-      Sentry.withScope(scope => {
+      Sentry.withScope((scope) => {
         scope.setContext('amplitude.validationError', {
           event_type: data.event_type,
           flow_id: data.user_properties.flow_id,
@@ -226,7 +225,7 @@ Lug.prototype.amplitudeEvent = function(data) {
   this.logger.info('amplitudeEvent', data);
 };
 
-module.exports = function(level, name, options = {}) {
+module.exports = function (level, name, options = {}) {
   if (arguments.length === 1 && typeof level === 'object') {
     options = level;
     level = options.level;
@@ -237,7 +236,7 @@ module.exports = function(level, name, options = {}) {
   options.fmt = logConfig.fmt;
   const log = new Lug(options);
 
-  log.stdout.on('error', err => {
+  log.stdout.on('error', (err) => {
     if (err.code === 'EPIPE') {
       log.emit('error', err);
     }

--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -15,7 +15,7 @@
 const { Container } = require('typedi');
 const { StatsD } = require('hot-shots');
 
-const { GROUPS, initialize } = require('../../../fxa-shared/metrics/amplitude');
+const { GROUPS, initialize } = require('fxa-shared/metrics/amplitude');
 const { version: VERSION } = require('../../package.json');
 
 // Maps template name to email type
@@ -102,7 +102,7 @@ const FUZZY_EVENTS = new Map([
   [
     /^email\.(\w+)\.bounced$/,
     {
-      group: eventCategory =>
+      group: (eventCategory) =>
         EMAIL_TYPES[eventCategory] ? GROUPS.email : null,
       event: 'bounced',
     },
@@ -110,7 +110,7 @@ const FUZZY_EVENTS = new Map([
   [
     /^email\.(\w+)\.sent$/,
     {
-      group: eventCategory =>
+      group: (eventCategory) =>
         EMAIL_TYPES[eventCategory] ? GROUPS.email : null,
       event: 'sent',
     },
@@ -118,7 +118,7 @@ const FUZZY_EVENTS = new Map([
   [
     /^flow\.complete\.(\w+)$/,
     {
-      group: eventCategory => GROUPS[eventCategory],
+      group: (eventCategory) => GROUPS[eventCategory],
       event: 'complete',
     },
   ],
@@ -136,7 +136,7 @@ module.exports = (log, config) => {
     log,
     config
   );
-  verificationReminders.keys.forEach(key => {
+  verificationReminders.keys.forEach((key) => {
     EMAIL_TYPES[
       `verificationReminder${key[0].toUpperCase()}${key.substr(1)}Email`
     ] = 'registration';

--- a/packages/fxa-auth-server/lib/oauth/auth_bearer.js
+++ b/packages/fxa-auth-server/lib/oauth/auth_bearer.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const ScopeSet = require('../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
 const AppError = require('./error');
 const logger = require('./logging')('server.auth_bearer');
@@ -17,7 +17,7 @@ exports.AUTH_SCHEME = authName;
 
 exports.SCOPE_CLIENT_WRITE = authOAuthScope;
 
-exports.strategy = function() {
+exports.strategy = function () {
   return {
     authenticate: async function authBearerStrategy(req, h) {
       var auth = req.headers.authorization;

--- a/packages/fxa-auth-server/lib/oauth/auth_client_management.js
+++ b/packages/fxa-auth-server/lib/oauth/auth_client_management.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const ScopeSet = require('../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
 const AppError = require('./error');
 const logger = require('./logging')('server.auth');
@@ -11,7 +11,7 @@ const validators = require('./validators');
 
 const WHITELIST = require('../../config')
   .get('oauthServer.admin.whitelist')
-  .map(function(re) {
+  .map(function (re) {
     return new RegExp(re);
   });
 
@@ -20,7 +20,7 @@ exports.AUTH_SCHEME = 'bearer';
 
 exports.SCOPE_CLIENT_MANAGEMENT = ScopeSet.fromArray(['oauth']);
 
-exports.strategy = function() {
+exports.strategy = function () {
   logger.verbose('auth_client.whitelist', WHITELIST);
 
   return {
@@ -40,7 +40,7 @@ exports.strategy = function() {
         function tokenFound(details) {
           if (details.scope.contains(exports.SCOPE_CLIENT_MANAGEMENT)) {
             logger.debug('check.whitelist');
-            var blocked = !WHITELIST.some(function(re) {
+            var blocked = !WHITELIST.some(function (re) {
               return re.test(details.email);
             });
             if (blocked) {

--- a/packages/fxa-auth-server/lib/oauth/db/accessToken.js
+++ b/packages/fxa-auth-server/lib/oauth/db/accessToken.js
@@ -6,7 +6,7 @@ const unique = require('../unique');
 const encrypt = require('../encrypt');
 const config = require('../../../config');
 const MAX_TTL = config.get('oauthServer.expiration.accessToken');
-const ScopeSet = require('../../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
 class AccessToken {
   constructor(

--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -9,7 +9,7 @@ const config = require('../../config');
 const AppError = require('./error');
 const db = require('./db');
 const util = require('./util');
-const ScopeSet = require('../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 const JWTAccessToken = require('./jwt_access_token');
 const logger = require('./logging')('grant');
 const amplitude = require('./metrics/amplitude')(
@@ -48,7 +48,7 @@ const UNTRUSTED_CLIENT_ALLOWED_SCOPES = ScopeSet.fromArray([
   'profile:display_name',
 ]);
 let stripeHelper = null;
-module.exports.setStripeHelper = function(val) {
+module.exports.setStripeHelper = function (val) {
   stripeHelper = val;
 };
 

--- a/packages/fxa-auth-server/lib/oauth/logging/summary.ts
+++ b/packages/fxa-auth-server/lib/oauth/logging/summary.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Request, UserCredentials } from 'hapi';
+import { Request, UserCredentials } from '@hapi/hapi';
 const logger = require('./')('summary');
 
 interface SummaryRequest extends Request {

--- a/packages/fxa-auth-server/lib/oauth/metrics/amplitude.ts
+++ b/packages/fxa-auth-server/lib/oauth/metrics/amplitude.ts
@@ -12,11 +12,7 @@
 const Sentry = require('@sentry/node');
 const { version: VERSION } = require('../../../package.json');
 
-import {
-  GROUPS,
-  initialize,
-  validate,
-} from '../../../../fxa-shared/metrics/amplitude';
+import { GROUPS, initialize, validate } from 'fxa-shared/metrics/amplitude';
 import { Logger } from 'mozlog';
 import { Scope } from '@sentry/node';
 import { conf } from '../../../config';

--- a/packages/fxa-auth-server/lib/oauth/routes/authorized-clients/list.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/authorized-clients/list.js
@@ -8,7 +8,7 @@ const Joi = require('@hapi/joi');
 const db = require('../../db');
 const validators = require('../../validators');
 const verifyAssertion = require('../../assertion');
-const ScopeSet = require('../../../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
 // Helper function to render each returned record in the expected form.
 function serialize(clientIdHex, token, acceptLanguage) {
@@ -39,20 +39,13 @@ module.exports = {
         client_id: validators.clientId,
         refresh_token_id: validators.token.optional(),
         client_name: Joi.string().required(),
-        created_time: Joi.number()
-          .min(0)
-          .required(),
-        last_access_time: Joi.number()
-          .min(0)
-          .required()
-          .allow(null),
-        scope: Joi.array()
-          .items(Joi.string())
-          .required(),
+        created_time: Joi.number().min(0).required(),
+        last_access_time: Joi.number().min(0).required().allow(null),
+        scope: Joi.array().items(Joi.string()).required(),
       })
     ),
   },
-  handler: async function(req) {
+  handler: async function (req) {
     const claims = await verifyAssertion(req.payload.assertion);
     const authorizedClients = [];
 
@@ -107,7 +100,7 @@ module.exports = {
     }
 
     // Sort the final list first by last_access_time, then by client_name, then by created_time.
-    authorizedClients.sort(function(a, b) {
+    authorizedClients.sort(function (a, b) {
       if (b.last_access_time > a.last_access_time) {
         return 1;
       }

--- a/packages/fxa-auth-server/lib/oauth/routes/token.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/token.js
@@ -40,7 +40,7 @@ const validators = require('../validators');
 const { validateRequestedGrant, generateTokens } = require('../grant');
 const verifyAssertion = require('../assertion');
 const { authenticateClient, clientAuthValidators } = require('../client');
-const ScopeSet = require('../../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
 const MAX_TTL_S = config.get('oauthServer.expiration.accessToken') / 1000;
 
@@ -97,11 +97,7 @@ const PAYLOAD_SCHEMA = Joi.object({
     .default(GRANT_AUTHORIZATION_CODE)
     .optional(),
 
-  ttl: Joi.number()
-    .positive()
-    .max(MAX_TTL_S)
-    .default(MAX_TTL_S)
-    .optional(),
+  ttl: Joi.number().positive().max(MAX_TTL_S).default(MAX_TTL_S).optional(),
 
   scope: Joi.alternatives()
     .when('grant_type', {
@@ -167,12 +163,8 @@ module.exports = {
       id_token: validators.assertion,
       session_token_id: validators.sessionTokenId.optional(),
       scope: validators.scope.required(),
-      token_type: Joi.string()
-        .valid('bearer')
-        .required(),
-      expires_in: Joi.number()
-        .max(MAX_TTL_S)
-        .required(),
+      token_type: Joi.string().valid('bearer').required(),
+      expires_in: Joi.number().max(MAX_TTL_S).required(),
       auth_at: Joi.number(),
       keys_jwe: validators.jwe.optional(),
     }),
@@ -372,9 +364,6 @@ async function validateAssertionGrant(client, params) {
  */
 function pkceHash(input) {
   return util.base64URLEncode(
-    crypto
-      .createHash('sha256')
-      .update(input)
-      .digest()
+    crypto.createHash('sha256').update(input).digest()
   );
 }

--- a/packages/fxa-auth-server/lib/oauth/token.js
+++ b/packages/fxa-auth-server/lib/oauth/token.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const ScopeSet = require('../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
 const AppError = require('./error');
 const config = require('../../config');

--- a/packages/fxa-auth-server/lib/oauth/validators.js
+++ b/packages/fxa-auth-server/lib/oauth/validators.js
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const Joi = require('@hapi/joi');
-const ScopeSet = require('../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 const authServerValidators = require('../routes/validators');
 
 const config = require('../../config');

--- a/packages/fxa-auth-server/lib/oauthdb/index.js
+++ b/packages/fxa-auth-server/lib/oauthdb/index.js
@@ -20,11 +20,11 @@
 
 const createBackendServiceAPI = require('../backendService');
 const { mapOAuthError, makeAssertionJWT } = require('./utils');
-const ScopeSet = require('../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 const oauthRoutes = require('../oauth/routes').routes;
 
 const routes = new Map(
-  oauthRoutes.map(route => [route.path, route.config.handler])
+  oauthRoutes.map((route) => [route.path, route.config.handler])
 );
 
 module.exports = (log, config, statsd) => {

--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -14,7 +14,7 @@ const requestHelper = require('./utils/request_helper');
 const uuid = require('uuid');
 const validators = require('./validators');
 const authMethods = require('../authMethods');
-const ScopeSet = require('../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
 const { determineSubscriptionCapabilities } = require('./utils/subscriptions');
 
@@ -72,38 +72,23 @@ module.exports = (
             redirectTo: validators
               .redirectTo(config.smtp.redirectDomain)
               .optional(),
-            resume: isA
-              .string()
-              .max(2048)
-              .optional(),
+            resume: isA.string().max(2048).optional(),
             metricsContext: METRICS_CONTEXT_SCHEMA,
-            style: isA
-              .string()
-              .allow(['trailhead'])
-              .optional(),
+            style: isA.string().allow(['trailhead']).optional(),
             verificationMethod: validators.verificationMethod.optional(),
           },
         },
         response: {
           schema: {
-            uid: isA
-              .string()
-              .regex(HEX_STRING)
-              .required(),
-            sessionToken: isA
-              .string()
-              .regex(HEX_STRING)
-              .required(),
-            keyFetchToken: isA
-              .string()
-              .regex(HEX_STRING)
-              .optional(),
+            uid: isA.string().regex(HEX_STRING).required(),
+            sessionToken: isA.string().regex(HEX_STRING).required(),
+            keyFetchToken: isA.string().regex(HEX_STRING).optional(),
             authAt: isA.number().integer(),
             verificationMethod: validators.verificationMethod.optional(),
           },
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.begin('Account.create', request);
         const form = request.payload;
         const query = request.query;
@@ -466,10 +451,7 @@ module.exports = (
               .redirectTo(config.smtp.redirectDomain)
               .optional(),
             resume: isA.string().optional(),
-            reason: isA
-              .string()
-              .max(16)
-              .optional(),
+            reason: isA.string().max(16).optional(),
             unblockCode: signinUtils.validators.UNBLOCK_CODE,
             metricsContext: METRICS_CONTEXT_SCHEMA,
             originalLoginEmail: validators.email().optional(),
@@ -478,18 +460,9 @@ module.exports = (
         },
         response: {
           schema: {
-            uid: isA
-              .string()
-              .regex(HEX_STRING)
-              .required(),
-            sessionToken: isA
-              .string()
-              .regex(HEX_STRING)
-              .required(),
-            keyFetchToken: isA
-              .string()
-              .regex(HEX_STRING)
-              .optional(),
+            uid: isA.string().regex(HEX_STRING).required(),
+            sessionToken: isA.string().regex(HEX_STRING).required(),
+            keyFetchToken: isA.string().regex(HEX_STRING).optional(),
             verificationMethod: isA.string().optional(),
             verificationReason: isA.string().optional(),
             verified: isA.boolean().required(),
@@ -497,7 +470,7 @@ module.exports = (
           },
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.begin('Account.login', request);
 
         const form = request.payload;
@@ -571,7 +544,7 @@ module.exports = (
 
             if (events.length > 0) {
               let latest = 0;
-              events.forEach(ev => {
+              events.forEach((ev) => {
                 if (ev.verified) {
                   securityEventVerified = true;
                   if (ev.createdAt > latest) {
@@ -866,15 +839,11 @@ module.exports = (
         },
         validate: {
           query: {
-            uid: isA
-              .string()
-              .min(32)
-              .max(32)
-              .regex(HEX_STRING),
+            uid: isA.string().min(32).max(32).regex(HEX_STRING),
           },
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         const sessionToken = request.auth.credentials;
         if (sessionToken) {
           return { exists: true, locale: sessionToken.locale };
@@ -909,7 +878,7 @@ module.exports = (
           },
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         const email = request.payload.email;
 
         await customs.check(request, email, 'accountStatusCheck');
@@ -937,24 +906,18 @@ module.exports = (
         response: {
           schema: {
             email: isA.string().optional(),
-            locale: isA
-              .string()
-              .optional()
-              .allow(null),
+            locale: isA.string().optional().allow(null),
             authenticationMethods: isA
               .array()
               .items(isA.string().required())
               .optional(),
             authenticatorAssuranceLevel: isA.number().min(0),
-            subscriptionsByClientId: isA
-              .object()
-              .unknown(true)
-              .optional(),
+            subscriptionsByClientId: isA.object().unknown(true).optional(),
             profileChangedAt: isA.number().min(0),
           },
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         const auth = request.auth;
         let uid, scope;
         if (auth.strategy === 'sessionToken') {
@@ -1049,7 +1012,7 @@ module.exports = (
           payload: true,
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.error('Account.UnlockCodeResend', { request: request });
         throw error.gone();
       },
@@ -1062,7 +1025,7 @@ module.exports = (
           payload: true,
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.error('Account.UnlockCodeVerify', { request: request });
         throw error.gone();
       },
@@ -1441,7 +1404,7 @@ module.exports = (
           },
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.begin('Account.get', request);
 
         const { uid, email } = request.auth.credentials;
@@ -1489,7 +1452,7 @@ module.exports = (
           payload: true,
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.error('Account.lock', { request: request });
         throw error.gone();
       },

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.js
@@ -9,7 +9,7 @@ const joi = require('@hapi/joi');
 const validators = require('../validators');
 const { BEARER_AUTH_REGEX } = validators;
 const { OAUTH_SCOPE_OLD_SYNC } = require('../../constants');
-const ScopeSet = require('../../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
 // the refresh token scheme is currently used by things connected to sync,
 // and we're at a transitionary stage of its evolution into something more generic,
@@ -66,7 +66,7 @@ module.exports = function schemeRefreshTokenScheme(config, db, oauthdb) {
 
         // use the hashed refreshToken id to find devices
         const device = devices.filter(
-          device => device.refreshTokenId === credentials.refreshTokenId
+          (device) => device.refreshTokenId === credentials.refreshTokenId
         )[0];
         if (device) {
           credentials.deviceId = device.id;

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -11,10 +11,7 @@ const isA = require('@hapi/joi');
 const random = require('../crypto/random');
 const Sentry = require('@sentry/node');
 const validators = require('./validators');
-const {
-  emailsMatch,
-  normalizeEmail,
-} = require('../../../fxa-shared/email/helpers');
+const { emailsMatch, normalizeEmail } = require('fxa-shared/email/helpers');
 
 const HEX_STRING = validators.HEX_STRING;
 const MAX_SECONDARY_EMAILS = 3;
@@ -28,7 +25,9 @@ async function updateZendeskPrimaryEmail(
   const { result: searchResult } = await zendeskClient.searchQueryAll(
     `type:user user_id:${uid}`
   );
-  const zenUser = searchResult.find(user => user.email === currentPrimaryEmail);
+  const zenUser = searchResult.find(
+    (user) => user.email === currentPrimaryEmail
+  );
   if (!zenUser) {
     return;
   }
@@ -36,7 +35,7 @@ async function updateZendeskPrimaryEmail(
     zenUser.id
   );
   const primaryIdentity = identityResult.find(
-    identity =>
+    (identity) =>
       identity.type === 'email' &&
       identity.primary &&
       identity.value !== newPrimaryEmail
@@ -107,10 +106,7 @@ module.exports = (
         },
         validate: {
           query: {
-            reason: isA
-              .string()
-              .max(16)
-              .optional(),
+            reason: isA.string().max(16).optional(),
           },
         },
         response: {
@@ -124,7 +120,7 @@ module.exports = (
           },
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.begin('Account.RecoveryEmailStatus', request);
 
         const sessionToken = request.auth.credentials;
@@ -219,14 +215,8 @@ module.exports = (
             redirectTo: validators
               .redirectTo(config.smtp.redirectDomain)
               .optional(),
-            resume: isA
-              .string()
-              .max(2048)
-              .optional(),
-            style: isA
-              .string()
-              .allow(['trailhead'])
-              .optional(),
+            resume: isA.string().max(2048).optional(),
+            style: isA.string().allow(['trailhead']).optional(),
             type: isA
               .string()
               .max(32)
@@ -236,7 +226,7 @@ module.exports = (
           },
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.begin('Account.RecoveryEmailResend', request);
 
         const email = request.payload.email;
@@ -312,7 +302,7 @@ module.exports = (
           if (email) {
             // If an email address is specified in payload, this is a request to verify
             // a secondary email. This should return the corresponding email code for verification.
-            const foundEmail = emailData.find(userEmail =>
+            const foundEmail = emailData.find((userEmail) =>
               emailsMatch(userEmail.normalizedEmail, email)
             );
 
@@ -372,38 +362,19 @@ module.exports = (
       options: {
         validate: {
           payload: {
-            uid: isA
-              .string()
-              .max(32)
-              .regex(HEX_STRING)
-              .required(),
-            code: isA
-              .string()
-              .min(32)
-              .max(32)
-              .regex(HEX_STRING)
-              .required(),
+            uid: isA.string().max(32).regex(HEX_STRING).required(),
+            code: isA.string().min(32).max(32).regex(HEX_STRING).required(),
             service: validators.service,
-            reminder: isA
-              .string()
-              .regex(REMINDER_PATTERN)
-              .optional(),
-            type: isA
-              .string()
-              .max(32)
-              .alphanum()
-              .optional(),
-            style: isA
-              .string()
-              .allow(['trailhead'])
-              .optional(),
+            reminder: isA.string().regex(REMINDER_PATTERN).optional(),
+            type: isA.string().max(32).alphanum().optional(),
+            style: isA.string().allow(['trailhead']).optional(),
             // The `marketingOptIn` is safe to remove after train-167+
             marketingOptIn: isA.boolean().optional(),
             newsletters: validators.newsletters,
           },
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.begin('Account.RecoveryEmailVerify', request);
 
         const { code, service, type, uid } = request.payload;
@@ -460,7 +431,7 @@ module.exports = (
 
         if (device) {
           const devices = await request.app.devices;
-          const otherDevices = devices.filter(d => d.id !== device.id);
+          const otherDevices = devices.filter((d) => d.id !== device.id);
           await push.notifyDeviceConnected(uid, otherDevices, device.name);
         }
 
@@ -479,7 +450,7 @@ module.exports = (
         async function verifySecondaryEmail(account) {
           let matchedEmail;
           const emails = await db.accountEmails(uid);
-          const isEmailVerification = emails.some(email => {
+          const isEmailVerification = emails.some((email) => {
             if (email.emailCode && code === email.emailCode) {
               matchedEmail = email;
               log.info('account.verifyEmail.secondary.started', {
@@ -581,14 +552,14 @@ module.exports = (
           ),
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.begin('Account.RecoveryEmailEmails', request);
 
         const sessionToken = request.auth.credentials;
         const uid = sessionToken.uid;
 
         const account = await db.account(uid);
-        return account.emails.map(email => ({
+        return account.emails.map((email) => ({
           email: email.email,
           isPrimary: !!email.isPrimary,
           verified: !!email.isVerified,
@@ -610,7 +581,7 @@ module.exports = (
         },
         response: {},
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.begin('Account.RecoveryEmailCreate', request);
 
         const sessionToken = request.auth.credentials;
@@ -630,7 +601,7 @@ module.exports = (
 
         const account = await db.account(uid);
         const secondaryEmails = account.emails.filter(
-          email => !email.isPrimary
+          (email) => !email.isPrimary
         );
         // This is compared against all secondary email
         // records, both verified and unverified
@@ -643,7 +614,9 @@ module.exports = (
         }
 
         if (
-          account.emails.map(accountEmail => accountEmail.email).includes(email)
+          account.emails
+            .map((accountEmail) => accountEmail.email)
+            .includes(email)
         ) {
           throw error.alreadyOwnsEmail();
         }
@@ -769,7 +742,7 @@ module.exports = (
         },
         response: {},
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.begin('Account.RecoveryEmailDestroy', request);
 
         const sessionToken = request.auth.credentials;
@@ -788,7 +761,7 @@ module.exports = (
         await db.resetAccountTokens(uid);
 
         // Find the email object that corresponds to the email being deleted
-        const emailIsVerified = account.emails.find(item => {
+        const emailIsVerified = account.emails.find((item) => {
           return emailsMatch(item.normalizedEmail, email) && item.isVerified;
         });
 
@@ -798,7 +771,7 @@ module.exports = (
         }
 
         // Notify any verified email address associated with the account of the deletion.
-        const emails = account.emails.filter(item => {
+        const emails = account.emails.filter((item) => {
           if (!emailsMatch(item.normalizedEmail, email)) {
             return item;
           }
@@ -826,7 +799,7 @@ module.exports = (
         },
         response: {},
       },
-      handler: async function(request) {
+      handler: async function (request) {
         const sessionToken = request.auth.credentials;
         const uid = sessionToken.uid;
         const primaryEmail = sessionToken.email;
@@ -864,7 +837,7 @@ module.exports = (
           // case we must record enough data for us to file a bug with Support
           // to update Zendesk so that this users' email matches their new primary.
           const handleCriticalError = (err, source) => {
-            Sentry.withScope(scope => {
+            Sentry.withScope((scope) => {
               scope.setContext('primaryEmailChange', {
                 originalEmail: primaryEmail,
                 newEmail: secondaryEmail.email,
@@ -882,7 +855,7 @@ module.exports = (
             uid,
             primaryEmail,
             secondaryEmail.email
-          ).catch(err => handleCriticalError(err, 'zendesk'));
+          ).catch((err) => handleCriticalError(err, 'zendesk'));
 
           if (stripeHelper) {
             // Wait here to update stripe and our local cache to avoid loss of
@@ -931,7 +904,7 @@ module.exports = (
         },
         response: {},
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.begin('Account.RecoveryEmailSecondaryResend', request);
 
         const sessionToken = request.auth.credentials;
@@ -959,7 +932,7 @@ module.exports = (
         const emails = await db.accountEmails(uid);
 
         // Get the secondary email code
-        const foundEmail = emails.find(userEmail =>
+        const foundEmail = emails.find((userEmail) =>
           emailsMatch(userEmail.normalizedEmail, email)
         );
 
@@ -1007,15 +980,11 @@ module.exports = (
         validate: {
           payload: {
             email: validators.email().required(),
-            code: isA
-              .string()
-              .max(32)
-              .regex(validators.DIGITS)
-              .required(),
+            code: isA.string().max(32).regex(validators.DIGITS).required(),
           },
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.begin('Account.RecoveryEmailSecondaryVerify', request);
 
         const sessionToken = request.auth.credentials;
@@ -1032,7 +1001,7 @@ module.exports = (
         const emails = await db.accountEmails(uid);
 
         // Get the secondary email code
-        const matchedEmail = emails.find(userEmail =>
+        const matchedEmail = emails.find((userEmail) =>
           emailsMatch(userEmail.normalizedEmail, email)
         );
 

--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -25,7 +25,7 @@ const {
 const error = require('../../error');
 const oauthRouteUtils = require('../utils/oauth');
 const { OAUTH_SCOPE_SESSION_TOKEN } = require('../../constants');
-const ScopeSet = require('../../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
 const JWTIdToken = require('../../oauth/jwt_id_token');
 
@@ -53,7 +53,7 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
           schema: oauthdb.api.getClientInfo.opts.validate.response,
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         return oauthdb.getClientInfo(request.params.client_id);
       },
     },
@@ -75,7 +75,7 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
           schema: oauthdb.api.getScopedKeyData.opts.validate.response,
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         checkDisabledClientId(request.payload);
         const sessionToken = request.auth.credentials;
         return oauthdb.getScopedKeyData(sessionToken, request.payload);
@@ -100,9 +100,7 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
               aud: Joi.string().optional(),
               alg: Joi.string().optional(),
               at_hash: Joi.string().optional(),
-              amr: Joi.array()
-                .items(Joi.string())
-                .optional(),
+              amr: Joi.array().items(Joi.string()).optional(),
               exp: Joi.number().optional(),
               'fxa-aal': Joi.number().optional(),
               iat: Joi.number().optional(),
@@ -111,7 +109,7 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
             }),
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         const claims = await JWTIdToken.verify(
           request.payload.id_token,
           request.payload.client_id,
@@ -139,7 +137,7 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
           schema: oauthdb.api.createAuthorizationCode.opts.validate.response,
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         checkDisabledClientId(request.payload);
         const geoData = request.app.geo;
         const country = geoData.location && geoData.location.country;
@@ -199,7 +197,7 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
           ),
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         const sessionToken = request.auth.credentials;
         let grant;
         switch (request.payload.grant_type) {
@@ -298,14 +296,12 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
             ),
             // The spec says we have to ignore invalid token_type_hint values,
             // but no way I'm going to accept an arbitrarily-long string here...
-            token_type_hint: Joi.string()
-              .max(64)
-              .optional(),
+            token_type_hint: Joi.string().max(64).optional(),
           },
         },
         response: {},
       },
-      handler: async function(request) {
+      handler: async function (request) {
         // This endpoint implements the API for token revocation from RFC7009,
         // which says that if we can't find the token using the provided token_type_hint
         // then we MUST search other possible types of token as well. So really

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -7,7 +7,7 @@
 const Sentry = require('@sentry/node');
 const error = require('../error');
 const isA = require('@hapi/joi');
-const ScopeSet = require('../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 const validators = require('./validators');
 const {
   metadataFromPlan,
@@ -57,7 +57,7 @@ async function handleAuth(db, auth, fetchEmail = false) {
 // sending response. We don't need to reveal those.
 // https://github.com/mozilla/fxa/issues/3273#issuecomment-552637420
 function sanitizePlans(plans) {
-  return plans.map(planIn => {
+  return plans.map((planIn) => {
     // Try not to mutate the original in case we cache plans in memory.
     const plan = { ...planIn };
     for (const metadataKey of ['plan_metadata', 'product_metadata']) {
@@ -66,7 +66,7 @@ function sanitizePlans(plans) {
         const metadata = { ...plan[metadataKey] };
         const capabilityKeys = [
           'capabilities',
-          ...Object.keys(metadata).filter(key =>
+          ...Object.keys(metadata).filter((key) =>
             key.startsWith('capabilities:')
           ),
         ];
@@ -128,7 +128,7 @@ class DirectStripeRoutes {
       if (metadata.capabilities) {
         capabilitiesForAll.push(...splitCapabilities(metadata.capabilities));
       }
-      const capabilityKeys = Object.keys(metadata).filter(key =>
+      const capabilityKeys = Object.keys(metadata).filter((key) =>
         key.startsWith('capabilities:')
       );
       for (const key of capabilityKeys) {
@@ -354,7 +354,7 @@ class DirectStripeRoutes {
 
   findCustomerSubscriptionByPlanId(customer, planId) {
     const subscription = customer.subscriptions.data.find(
-      sub => sub.items.data.find(item => item.plan.id === planId) != null
+      (sub) => sub.items.data.find((item) => item.plan.id === planId) != null
     );
 
     return subscription;
@@ -362,9 +362,9 @@ class DirectStripeRoutes {
 
   findCustomerSubscriptionByProductId(customer, productId) {
     const subscription = customer.subscriptions.data.find(
-      sub =>
+      (sub) =>
         sub.items.data.find(
-          item =>
+          (item) =>
             item.plan.product === productId ||
             item.plan.product.id === productId
         ) != null
@@ -566,7 +566,9 @@ class DirectStripeRoutes {
       const metadata = metadataFromPlan(plan);
       const capabilityKeys = [
         'capabilities',
-        ...Object.keys(metadata).filter(key => key.startsWith('capabilities:')),
+        ...Object.keys(metadata).filter((key) =>
+          key.startsWith('capabilities:')
+        ),
       ];
       for (const key of capabilityKeys) {
         capabilitiesForProduct.push(...splitCapabilities(metadata[key]));
@@ -686,7 +688,7 @@ class DirectStripeRoutes {
           await this.handleInvoicePaymentFailedEvent(request, event);
           break;
         default:
-          Sentry.withScope(scope => {
+          Sentry.withScope((scope) => {
             scope.setContext('stripeEvent', {
               event: { id: event.id, type: event.type },
             });
@@ -735,8 +737,7 @@ class DirectStripeRoutes {
    * @param {Event} event
    */
   async handleSubscriptionUpdatedEvent(request, event) {
-    const stripeData =
-      /** @type {import('stripe').Stripe.Event.Data } */ (event.data);
+    const stripeData = /** @type {import('stripe').Stripe.Event.Data } */ (event.data);
     const sub = /** @type {Subscription} */ (stripeData.object);
     const { uid, email } = await this.sendSubscriptionUpdatedEmail(event);
 
@@ -1063,7 +1064,7 @@ const directRoutes = (
           ),
         },
       },
-      handler: request => directStripeRoutes.getClients(request),
+      handler: (request) => directStripeRoutes.getClients(request),
     },
     {
       method: 'GET',
@@ -1077,7 +1078,7 @@ const directRoutes = (
           schema: isA.array().items(validators.subscriptionsPlanValidator),
         },
       },
-      handler: request => directStripeRoutes.listPlans(request),
+      handler: (request) => directStripeRoutes.listPlans(request),
     },
     {
       method: 'GET',
@@ -1091,7 +1092,7 @@ const directRoutes = (
           schema: isA.array().items(validators.activeSubscriptionValidator),
         },
       },
-      handler: request => directStripeRoutes.listActive(request),
+      handler: (request) => directStripeRoutes.listActive(request),
     },
     {
       method: 'POST',
@@ -1115,7 +1116,7 @@ const directRoutes = (
           }),
         },
       },
-      handler: request => directStripeRoutes.createSubscription(request),
+      handler: (request) => directStripeRoutes.createSubscription(request),
     },
     {
       method: 'POST',
@@ -1131,7 +1132,7 @@ const directRoutes = (
           },
         },
       },
-      handler: request => directStripeRoutes.updatePayment(request),
+      handler: (request) => directStripeRoutes.updatePayment(request),
     },
     {
       method: 'GET',
@@ -1145,7 +1146,7 @@ const directRoutes = (
           schema: validators.subscriptionsCustomerValidator,
         },
       },
-      handler: request => directStripeRoutes.getCustomer(request),
+      handler: (request) => directStripeRoutes.getCustomer(request),
     },
     {
       method: 'GET',
@@ -1168,7 +1169,7 @@ const directRoutes = (
           },
         },
       },
-      handler: request =>
+      handler: (request) =>
         directStripeRoutes.getSubscriptionsForSupport(request),
     },
     {
@@ -1193,7 +1194,7 @@ const directRoutes = (
           },
         },
       },
-      handler: request => directStripeRoutes.updateSubscription(request),
+      handler: (request) => directStripeRoutes.updateSubscription(request),
     },
     {
       method: 'DELETE',
@@ -1209,7 +1210,7 @@ const directRoutes = (
           },
         },
       },
-      handler: request => directStripeRoutes.deleteSubscription(request),
+      handler: (request) => directStripeRoutes.deleteSubscription(request),
     },
     {
       method: 'POST',
@@ -1225,7 +1226,7 @@ const directRoutes = (
           },
         },
       },
-      handler: request => directStripeRoutes.reactivateSubscription(request),
+      handler: (request) => directStripeRoutes.reactivateSubscription(request),
     },
     {
       method: 'POST',
@@ -1243,7 +1244,7 @@ const directRoutes = (
           headers: { 'stripe-signature': isA.string().required() },
         },
       },
-      handler: request => directStripeRoutes.handleWebhookEvent(request),
+      handler: (request) => directStripeRoutes.handleWebhookEvent(request),
     },
   ];
 };

--- a/packages/fxa-auth-server/lib/routes/support.js
+++ b/packages/fxa-auth-server/lib/routes/support.js
@@ -7,7 +7,7 @@
 const error = require('../error');
 const isA = require('@hapi/joi');
 const pRetry = require('p-retry');
-const ScopeSet = require('../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
 module.exports = (log, db, config, customs, zendeskClient) => {
   // Skip routes if the subscriptions feature is not configured & enabled
@@ -47,10 +47,7 @@ module.exports = (log, db, config, customs, zendeskClient) => {
           payload: isA.object().keys({
             productName: isA.string().required(),
             topic: isA.string().required(),
-            subject: isA
-              .string()
-              .allow('')
-              .optional(),
+            subject: isA.string().allow('').optional(),
             message: isA.string().required(),
           }),
         },
@@ -62,7 +59,7 @@ module.exports = (log, db, config, customs, zendeskClient) => {
           }),
         },
       },
-      handler: async function(request) {
+      handler: async function (request) {
         log.begin('support.ticket', request);
         const { uid, email } = await handleAuth(request.auth, true);
         const { location } = request.app.geo;

--- a/packages/fxa-auth-server/lib/routes/utils/clients.js
+++ b/packages/fxa-auth-server/lib/routes/utils/clients.js
@@ -11,7 +11,7 @@ module.exports = (log, config) => {
     config.lastAccessTimeUpdates.earliestSaneTimestamp;
   const { supportedLanguages, defaultLanguage } = config.i18n;
 
-  const localizeTimestamp = require('../../../../fxa-shared').l10n.localizeTimestamp(
+  const localizeTimestamp = require('fxa-shared/l10n/localizeTimestamp').localizeTimestamp(
     {
       supportedLanguages,
       defaultLanguage,

--- a/packages/fxa-auth-server/lib/routes/utils/oauth.js
+++ b/packages/fxa-auth-server/lib/routes/utils/oauth.js
@@ -6,7 +6,7 @@
 
 const encrypt = require('../../../lib/oauth/encrypt');
 const { OAUTH_SCOPE_OLD_SYNC } = require('../../constants');
-const ScopeSet = require('../../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
 // right now we only care about notifications for the following scopes
 // if not a match, then we don't notify

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -10,7 +10,7 @@ const validators = require('../validators');
 const P = require('../../promise');
 const butil = require('../../crypto/butil');
 const error = require('../../error');
-const { emailsMatch } = require('../../../../fxa-shared/email/helpers');
+const { emailsMatch } = require('fxa-shared/email/helpers');
 
 const BASE_36 = validators.BASE_36;
 
@@ -54,10 +54,10 @@ module.exports = (log, config, customs, db, mailer) => {
       }
       return password
         .verifyHash()
-        .then(verifyHash => {
+        .then((verifyHash) => {
           return db.checkPassword(accountRecord.uid, verifyHash);
         })
-        .then(match => {
+        .then((match) => {
           if (match) {
             return match;
           }
@@ -121,7 +121,7 @@ module.exports = (log, config, customs, db, mailer) => {
           }
           return customs.check(request, email, 'accountLogin');
         })
-        .catch(e => {
+        .catch((e) => {
           originalError = e;
           // Non-customs-related errors get thrown straight back to the caller.
           if (
@@ -143,11 +143,11 @@ module.exports = (log, config, customs, db, mailer) => {
             // Check for a valid unblockCode, to allow the request to proceed.
             // This requires that we load the accountRecord to learn the uid.
             const unblockCode = request.payload.unblockCode.toUpperCase();
-            return db.accountRecord(email).then(result => {
+            return db.accountRecord(email).then((result) => {
               accountRecord = result;
               return db
                 .consumeUnblockCode(accountRecord.uid, unblockCode)
-                .then(code => {
+                .then((code) => {
                   if (Date.now() - code.createdAt > unblockCodeLifetime) {
                     log.info('Account.login.unblockCode.expired', {
                       uid: accountRecord.uid,
@@ -161,7 +161,7 @@ module.exports = (log, config, customs, db, mailer) => {
                     'account.login.confirmedUnblockCode'
                   );
                 })
-                .catch(e => {
+                .catch((e) => {
                   if (e.errno !== error.ERRNO.INVALID_UNBLOCK_CODE) {
                     throw e;
                   }
@@ -178,7 +178,7 @@ module.exports = (log, config, customs, db, mailer) => {
           // If we didn't load it above while checking unblock codes,
           // it's now safe to load the account record from the db.
           if (!accountRecord) {
-            return db.accountRecord(email).then(result => {
+            return db.accountRecord(email).then((result) => {
               accountRecord = result;
             });
           }
@@ -186,7 +186,7 @@ module.exports = (log, config, customs, db, mailer) => {
         .then(() => {
           return { accountRecord, didSigninUnblock };
         })
-        .catch(e => {
+        .catch((e) => {
           // Some errors need to be flagged with customs.
           if (
             e.errno === error.ERRNO.INVALID_UNBLOCK_CODE ||
@@ -267,7 +267,7 @@ module.exports = (log, config, customs, db, mailer) => {
       }
 
       function checkNumberOfActiveSessions() {
-        return db.sessions(accountRecord.uid).then(s => {
+        return db.sessions(accountRecord.uid).then((s) => {
           sessions = s;
           if (sessions.length > MAX_ACTIVE_SESSIONS) {
             // There's no spec-compliant way to error out
@@ -399,7 +399,7 @@ module.exports = (log, config, customs, db, mailer) => {
             uid: sessionToken.uid,
           })
           .then(() => request.emitMetricsEvent('email.confirmation.sent'))
-          .catch(err => {
+          .catch((err) => {
             log.error('mailer.confirmation.error', { err });
 
             throw emailUtils.sendError(err, isUnverifiedAccount);
@@ -454,7 +454,7 @@ module.exports = (log, config, customs, db, mailer) => {
     createKeyFetchToken(request, accountRecord, password, sessionToken) {
       return password
         .unwrap(accountRecord.wrapWrapKb)
-        .then(wrapKb => {
+        .then((wrapKb) => {
           return db.createKeyFetchToken({
             uid: accountRecord.uid,
             kA: accountRecord.kA,
@@ -463,7 +463,7 @@ module.exports = (log, config, customs, db, mailer) => {
             tokenVerificationId: sessionToken.tokenVerificationId,
           });
         })
-        .then(keyFetchToken => {
+        .then((keyFetchToken) => {
           return request.stashMetricsContext(keyFetchToken).then(() => {
             return keyFetchToken;
           });

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -9,7 +9,7 @@
     "test": "test"
   },
   "scripts": {
-    "build": "NODE_ENV=dev npm run gen-keys && tsc",
+    "build": "tsc --build",
     "bump-template-versions": "node scripts/template-version-bump",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint": "eslint .",

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -17,7 +17,7 @@ const crypto = require('crypto');
 const error = require('../../../lib/error');
 const log = require('../../../lib/log');
 const otplib = require('otplib');
-const { normalizeEmail } = require('../../../../fxa-shared/email/helpers');
+const { normalizeEmail } = require('fxa-shared/email/helpers');
 
 const TEST_EMAIL = 'foo@gmail.com';
 
@@ -25,7 +25,7 @@ function hexString(bytes) {
   return crypto.randomBytes(bytes).toString('hex');
 }
 
-const makeRoutes = function(options = {}, requireMocks) {
+const makeRoutes = function (options = {}, requireMocks) {
   const config = options.config || {};
   config.oauth = config.oauth || {};
   config.verifierVersion = config.verifierVersion || 0;
@@ -172,7 +172,7 @@ describe('/account/reset', () => {
     beforeEach(() => {
       mockRequest.payload.wrapKb = hexString(32);
       mockRequest.payload.recoveryKeyId = hexString(16);
-      return runTest(route, mockRequest, result => (res = result));
+      return runTest(route, mockRequest, (result) => (res = result));
     });
 
     it('should return response', () => {
@@ -324,7 +324,7 @@ describe('/account/reset', () => {
           enabled: true,
         });
       });
-      return runTest(route, mockRequest, result => (res = result));
+      return runTest(route, mockRequest, (result) => (res = result));
     });
 
     it('should return response', () => {
@@ -370,7 +370,7 @@ describe('/account/reset', () => {
   });
 
   it('should reset account', () => {
-    return runTest(route, mockRequest, res => {
+    return runTest(route, mockRequest, (res) => {
       assert.equal(mockDB.resetAccount.callCount, 1);
       assert.equal(mockDB.resetAccountTokens.callCount, 1);
 
@@ -561,12 +561,12 @@ describe('/account/create', () => {
       db: mockDB,
       log: mockLog,
       mailer: mockMailer,
-      Password: function() {
+      Password: function () {
         return {
-          unwrap: function() {
+          unwrap: function () {
             return P.resolve('wibble');
           },
-          verifyHash: function() {
+          verifyHash: function () {
             return P.resolve('wibble');
           },
         };
@@ -956,7 +956,7 @@ describe('/account/create', () => {
 
         mockRequest.payload.verificationMethod = 'email-otp';
 
-        await runTest(route, mockRequest, res => {
+        await runTest(route, mockRequest, (res) => {
           assert.calledOnce(mockMailer.sendVerifyShortCodeEmail);
 
           const authenticator = new otplib.authenticator.Authenticator();
@@ -988,7 +988,7 @@ describe('/account/create', () => {
 
     mockMailer.sendVerifyEmail = sinon.spy(() => P.reject());
 
-    return runTest(route, mockRequest).then(assert.fail, err => {
+    return runTest(route, mockRequest).then(assert.fail, (err) => {
       assert.equal(err.message, 'Failed to send email');
       assert.equal(err.output.payload.code, 422);
       assert.equal(err.output.payload.errno, 151);
@@ -1005,7 +1005,7 @@ describe('/account/create', () => {
       P.reject(error.emailBouncedHard(42))
     );
 
-    return runTest(route, mockRequest).then(assert.fail, err => {
+    return runTest(route, mockRequest).then(assert.fail, (err) => {
       assert.equal(err.message, 'Email account hard bounced');
       assert.equal(err.output.payload.code, 400);
       assert.equal(err.output.payload.errno, 134);
@@ -1150,7 +1150,7 @@ describe('/account/login', () => {
     flag: () => P.resolve(),
   };
   const accountRoutes = makeRoutes({
-    checkPassword: function() {
+    checkPassword: function () {
       return P.resolve(true);
     },
     config: config,
@@ -1192,7 +1192,7 @@ describe('/account/login', () => {
     const now = Date.now();
     sinon.stub(Date, 'now').callsFake(() => now);
 
-    return runTest(route, mockRequest, response => {
+    return runTest(route, mockRequest, (response) => {
       assert.equal(
         mockDB.accountRecord.callCount,
         1,
@@ -1474,7 +1474,7 @@ describe('/account/login', () => {
   describe('sign-in unverified account', () => {
     it('sends email code', () => {
       const emailCode = hexString(16);
-      mockDB.accountRecord = function() {
+      mockDB.accountRecord = function () {
         return P.resolve({
           authSalt: hexString(32),
           data: hexString(32),
@@ -1488,7 +1488,7 @@ describe('/account/login', () => {
             isPrimary: true,
           },
           kA: hexString(32),
-          lastAuthAt: function() {
+          lastAuthAt: function () {
             return Date.now();
           },
           uid: uid,
@@ -1496,7 +1496,7 @@ describe('/account/login', () => {
         });
       };
 
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(
           mockMailer.sendVerifyEmail.callCount,
           1,
@@ -1554,7 +1554,7 @@ describe('/account/login', () => {
     before(() => {
       config.signinConfirmation.forcedEmailAddresses = /.+@mozilla\.com$/;
 
-      mockDB.accountRecord = function() {
+      mockDB.accountRecord = function () {
         return P.resolve({
           authSalt: hexString(32),
           data: hexString(32),
@@ -1567,7 +1567,7 @@ describe('/account/login', () => {
             isPrimary: true,
           },
           kA: hexString(32),
-          lastAuthAt: function() {
+          lastAuthAt: function () {
             return Date.now();
           },
           uid: uid,
@@ -1577,7 +1577,7 @@ describe('/account/login', () => {
     });
 
     it('is enabled by default', () => {
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(
           mockDB.createSessionToken.callCount,
           1,
@@ -1635,7 +1635,7 @@ describe('/account/login', () => {
 
     it('does not require verification when keys are not requested', () => {
       const email = 'test@mozilla.com';
-      mockDB.accountRecord = function() {
+      mockDB.accountRecord = function () {
         return P.resolve({
           authSalt: hexString(32),
           data: hexString(32),
@@ -1648,7 +1648,7 @@ describe('/account/login', () => {
             isPrimary: true,
           },
           kA: hexString(32),
-          lastAuthAt: function() {
+          lastAuthAt: function () {
             return Date.now();
           },
           uid: uid,
@@ -1656,7 +1656,7 @@ describe('/account/login', () => {
         });
       };
 
-      return runTest(route, mockRequestNoKeys, response => {
+      return runTest(route, mockRequestNoKeys, (response) => {
         assert.equal(
           mockDB.createSessionToken.callCount,
           1,
@@ -1706,7 +1706,7 @@ describe('/account/login', () => {
     it('unverified account gets account confirmation email', () => {
       const email = 'test@mozilla.com';
       mockRequest.payload.email = email;
-      mockDB.accountRecord = function() {
+      mockDB.accountRecord = function () {
         return P.resolve({
           authSalt: hexString(32),
           data: hexString(32),
@@ -1719,7 +1719,7 @@ describe('/account/login', () => {
             isPrimary: true,
           },
           kA: hexString(32),
-          lastAuthAt: function() {
+          lastAuthAt: function () {
             return Date.now();
           },
           uid: uid,
@@ -1727,7 +1727,7 @@ describe('/account/login', () => {
         });
       };
 
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(
           mockDB.createSessionToken.callCount,
           1,
@@ -1773,7 +1773,7 @@ describe('/account/login', () => {
     it('should return an error if email fails to send', () => {
       mockMailer.sendVerifyLoginEmail = sinon.spy(() => P.reject());
 
-      return runTest(route, mockRequest).then(assert.fail, err => {
+      return runTest(route, mockRequest).then(assert.fail, (err) => {
         assert.equal(err.message, 'Failed to send email');
         assert.equal(err.output.payload.code, 500);
         assert.equal(err.output.payload.errno, 151);
@@ -1790,7 +1790,7 @@ describe('/account/login', () => {
 
         const email = mockRequest.payload.email;
 
-        mockDB.accountRecord = function() {
+        mockDB.accountRecord = function () {
           return P.resolve({
             authSalt: hexString(32),
             createdAt: Date.now() - accountCreatedSince,
@@ -1804,7 +1804,7 @@ describe('/account/login', () => {
               isPrimary: true,
             },
             kA: hexString(32),
-            lastAuthAt: function() {
+            lastAuthAt: function () {
               return Date.now();
             },
             uid: uid,
@@ -1813,7 +1813,7 @@ describe('/account/login', () => {
         };
 
         const accountRoutes = makeRoutes({
-          checkPassword: function() {
+          checkPassword: function () {
             return P.resolve(true);
           },
           config: config,
@@ -1830,7 +1830,7 @@ describe('/account/login', () => {
       it('is disabled', () => {
         setup(false);
 
-        return runTest(route, mockRequest, response => {
+        return runTest(route, mockRequest, (response) => {
           assert.equal(
             mockDB.createSessionToken.callCount,
             1,
@@ -1889,7 +1889,7 @@ describe('/account/login', () => {
       it('skip sign-in confirmation on recently created account', () => {
         setup(true, 0);
 
-        return runTest(route, mockRequest, response => {
+        return runTest(route, mockRequest, (response) => {
           assert.equal(
             mockDB.createSessionToken.callCount,
             1,
@@ -1921,7 +1921,7 @@ describe('/account/login', () => {
           P.reject(error.emailBouncedHard())
         );
 
-        return runTest(route, mockRequest, response => {
+        return runTest(route, mockRequest, (response) => {
           assert.equal(
             mockDB.createSessionToken.callCount,
             1,
@@ -1966,7 +1966,7 @@ describe('/account/login', () => {
       it("don't skip sign-in confirmation on older account", () => {
         setup(true, 10);
 
-        return runTest(route, mockRequest, response => {
+        return runTest(route, mockRequest, (response) => {
           assert.equal(
             mockDB.createSessionToken.callCount,
             1,
@@ -2037,7 +2037,7 @@ describe('/account/login', () => {
       it('should not skip sign-in confirmation for specified email', () => {
         setup('not@skip.com');
 
-        return runTest(route, mockRequest, response => {
+        return runTest(route, mockRequest, (response) => {
           assert.equal(
             mockDB.createSessionToken.callCount,
             1,
@@ -2064,7 +2064,7 @@ describe('/account/login', () => {
       it('should skip sign-in confirmation for specified email', () => {
         setup('skip@confirmation.com');
 
-        return runTest(route, mockRequest, response => {
+        return runTest(route, mockRequest, (response) => {
           assert.equal(
             mockDB.createSessionToken.callCount,
             1,
@@ -2127,7 +2127,7 @@ describe('/account/login', () => {
     it('with a seen ip address', () => {
       record = undefined;
       let securityQuery;
-      mockDB.securityEvents = sinon.spy(arg => {
+      mockDB.securityEvents = sinon.spy((arg) => {
         securityQuery = arg;
         return P.resolve([
           {
@@ -2137,7 +2137,7 @@ describe('/account/login', () => {
           },
         ]);
       });
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(
           mockDB.securityEvents.callCount,
           1,
@@ -2157,7 +2157,7 @@ describe('/account/login', () => {
     it('with a seen, unverified ip address', () => {
       record = undefined;
       let securityQuery;
-      mockDB.securityEvents = sinon.spy(arg => {
+      mockDB.securityEvents = sinon.spy((arg) => {
         securityQuery = arg;
         return P.resolve([
           {
@@ -2167,7 +2167,7 @@ describe('/account/login', () => {
           },
         ]);
       });
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(
           mockDB.securityEvents.callCount,
           1,
@@ -2187,11 +2187,11 @@ describe('/account/login', () => {
       record = undefined;
 
       let securityQuery;
-      mockDB.securityEvents = sinon.spy(arg => {
+      mockDB.securityEvents = sinon.spy((arg) => {
         securityQuery = arg;
         return P.resolve([]);
       });
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(
           mockDB.securityEvents.callCount,
           1,
@@ -2212,11 +2212,11 @@ describe('/account/login', () => {
   it('records security event', () => {
     const clientAddress = mockRequest.app.clientAddress;
     let securityQuery;
-    mockDB.securityEvent = sinon.spy(arg => {
+    mockDB.securityEvent = sinon.spy((arg) => {
       securityQuery = arg;
       return P.resolve();
     });
-    return runTest(route, mockRequest, response => {
+    return runTest(route, mockRequest, (response) => {
       assert.equal(
         mockDB.securityEvent.callCount,
         1,
@@ -2253,7 +2253,7 @@ describe('/account/login', () => {
         it('without unblock code', () => {
           return runTest(route, mockRequest).then(
             () => assert.ok(false),
-            err => {
+            (err) => {
               assert.equal(
                 err.errno,
                 error.ERRNO.REQUEST_BLOCKED,
@@ -2290,7 +2290,7 @@ describe('/account/login', () => {
               P.reject(error.invalidUnblockCode());
             return runTest(route, mockRequestWithUnblockCode).then(
               () => assert.ok(false),
-              err => {
+              (err) => {
                 assert.equal(
                   err.errno,
                   error.ERRNO.INVALID_UNBLOCK_CODE,
@@ -2326,7 +2326,7 @@ describe('/account/login', () => {
               });
             return runTest(route, mockRequestWithUnblockCode).then(
               () => assert.ok(false),
-              err => {
+              (err) => {
                 assert.equal(
                   err.errno,
                   error.ERRNO.INVALID_UNBLOCK_CODE,
@@ -2360,7 +2360,7 @@ describe('/account/login', () => {
             mockDB.emailRecord = () => P.reject(new error.unknownAccount());
             return runTest(route, mockRequestWithUnblockCode).then(
               () => assert(false),
-              err => {
+              (err) => {
                 assert.equal(err.errno, error.ERRNO.REQUEST_BLOCKED);
                 assert.equal(err.output.statusCode, 400);
               }
@@ -2370,7 +2370,7 @@ describe('/account/login', () => {
           it('valid code', () => {
             mockDB.consumeUnblockCode = () =>
               P.resolve({ createdAt: Date.now() });
-            return runTest(route, mockRequestWithUnblockCode, res => {
+            return runTest(route, mockRequestWithUnblockCode, (res) => {
               assert.equal(mockLog.flowEvent.callCount, 4);
               assert.equal(
                 mockLog.flowEvent.args[0][0].event,
@@ -2411,7 +2411,7 @@ describe('/account/login', () => {
       it('without an unblock code', () => {
         return runTest(route, mockRequest).then(
           () => assert.ok(false),
-          err => {
+          (err) => {
             assert.equal(
               err.errno,
               error.ERRNO.REQUEST_BLOCKED,
@@ -2439,7 +2439,7 @@ describe('/account/login', () => {
       it('with unblock code', () => {
         return runTest(route, mockRequestWithUnblockCode).then(
           () => assert.ok(false),
-          err => {
+          (err) => {
             assert.equal(
               err.errno,
               error.ERRNO.REQUEST_BLOCKED,
@@ -2480,7 +2480,7 @@ describe('/account/login', () => {
     });
     return runTest(route, mockRequest).then(
       () => assert.ok(false),
-      err => {
+      (err) => {
         assert.equal(
           mockDB.accountRecord.callCount,
           1,
@@ -2501,7 +2501,7 @@ describe('/account/login', () => {
     mockRequest.payload.verificationMethod = 'totp-2fa';
     return runTest(route, mockRequest).then(
       () => assert.ok(false),
-      err => {
+      (err) => {
         assert.equal(mockDB.totpToken.callCount, 1, 'db.totpToken was called');
         assert.equal(err.errno, 160, 'correct errno called');
       }
@@ -2559,7 +2559,7 @@ describe('/account/keys', () => {
   const route = getRoute(accountRoutes, '/account/keys');
 
   it('verified token', () => {
-    return runTest(route, mockRequest, response => {
+    return runTest(route, mockRequest, (response) => {
       assert.deepEqual(
         response,
         { bundle: mockRequest.auth.credentials.keyBundle },
@@ -2614,7 +2614,7 @@ describe('/account/keys', () => {
     return runTest(route, mockRequest)
       .then(
         () => assert.ok(false),
-        response => {
+        (response) => {
           assert.equal(
             response.errno,
             104,
@@ -2647,7 +2647,9 @@ describe('/account/destroy', () => {
   beforeEach(async () => {
     mockDB = {
       ...mocks.mockDB({ email: email, uid: uid }),
-      fetchAccountSubscriptions: sinon.spy(async uid => expectedSubscriptions),
+      fetchAccountSubscriptions: sinon.spy(
+        async (uid) => expectedSubscriptions
+      ),
     };
     mockLog = mocks.mockLog();
     mockRequest = mocks.mockRequest({
@@ -2666,7 +2668,7 @@ describe('/account/destroy', () => {
 
   function buildRoute(subscriptionsEnabled = true) {
     const accountRoutes = makeRoutes({
-      checkPassword: function() {
+      checkPassword: function () {
         return P.resolve(true);
       },
       config: {
@@ -2808,7 +2810,7 @@ describe('/account', () => {
     ]);
     mockStripeHelper.customer = sinon.spy(async (uid, email) => mockCustomer);
     mockStripeHelper.subscriptionsToResponse = sinon.spy(
-      async subscriptions => mockSubscriptionsResponse
+      async (subscriptions) => mockSubscriptionsResponse
     );
   });
 
@@ -2826,7 +2828,7 @@ describe('/account', () => {
   }
 
   it('should return formatted Stripe subscriptions when subscriptions are enabled', () => {
-    return runTest(buildRoute(), request, result => {
+    return runTest(buildRoute(), request, (result) => {
       assert.deepEqual(mockStripeHelper.customer.args[0], [
         uid,
         email,
@@ -2848,7 +2850,7 @@ describe('/account', () => {
       throw error.unknownCustomer();
     });
 
-    return runTest(buildRoute(), request, result => {
+    return runTest(buildRoute(), request, (result) => {
       assert.deepEqual(result, {
         subscriptions: [],
       });
@@ -2875,7 +2877,7 @@ describe('/account', () => {
   });
 
   it('should not return stripe.customer result when subscriptions are disabled', () => {
-    return runTest(buildRoute(false), request, result => {
+    return runTest(buildRoute(false), request, (result) => {
       assert.deepEqual(result, {
         subscriptions: [],
       });

--- a/packages/fxa-auth-server/test/local/routes/auth-schemes/auth-oauth.js
+++ b/packages/fxa-auth-server/test/local/routes/auth-schemes/auth-oauth.js
@@ -7,7 +7,7 @@ const proxyquire = require('proxyquire');
 const AppError = require('../../../../lib/error');
 const OauthAppError = require('../../../../lib/oauth/error');
 const P = require('../../../../lib/promise');
-const ScopeSet = require('../../../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
 const authOauthPath = '../../../../lib/routes/auth-schemes/auth-oauth';
 const mockRequest = {
@@ -42,7 +42,7 @@ describe('lib/routes/auth-schemes/auth-oauth', () => {
           .authenticate({
             headers: {},
           })
-          .then(assert.fail, err => {
+          .then(assert.fail, (err) => {
             assert.isTrue(err instanceof AppError);
             assert.equal(err.output.statusCode, 401);
             assert.equal(err.output.payload.code, 401);
@@ -59,7 +59,7 @@ describe('lib/routes/auth-schemes/auth-oauth', () => {
 
     describe('when the Bearer token is invalid', () => {
       before(() => {
-        tokenStub.verify = token => {
+        tokenStub.verify = (token) => {
           return P.reject(OauthAppError.invalidToken());
         };
       });
@@ -68,7 +68,7 @@ describe('lib/routes/auth-schemes/auth-oauth', () => {
         return authOauth
           .strategy()
           .authenticate(mockRequest)
-          .then(assert.fail, err => {
+          .then(assert.fail, (err) => {
             assert.isTrue(err instanceof AppError);
             assert.equal(err.output.statusCode, 401);
             assert.equal(err.output.payload.code, 401);
@@ -83,17 +83,17 @@ describe('lib/routes/auth-schemes/auth-oauth', () => {
     describe('when a valid Bearer token is provided', () => {
       let mockReply;
       before(() => {
-        mockReply = function(err) {
+        mockReply = function (err) {
           throw err;
         };
 
-        tokenStub.verify = token => {
+        tokenStub.verify = (token) => {
           return P.resolve(mockTokenInfo);
         };
       });
 
-      it('returns successfully with the credentials from the verified token', done => {
-        mockReply.authenticated = function(result) {
+      it('returns successfully with the credentials from the verified token', (done) => {
+        mockReply.authenticated = function (result) {
           assert.equal(result.credentials.user, 'testuser');
           done();
         };

--- a/packages/fxa-auth-server/test/local/routes/emails.js
+++ b/packages/fxa-auth-server/test/local/routes/emails.js
@@ -16,7 +16,7 @@ const nock = require('nock');
 const P = require('../../../lib/promise');
 const proxyquire = require('proxyquire');
 const uuid = require('uuid');
-const { normalizeEmail } = require('../../../../fxa-shared/email/helpers');
+const { normalizeEmail } = require('fxa-shared/email/helpers');
 
 const CUSTOMER_1 = require('../payments/fixtures/customer1.json');
 const CUSTOMER_1_UPDATED = require('../payments/fixtures/customer1_new_email.json');
@@ -140,7 +140,7 @@ const updateZendeskPrimaryEmail = require('../../../lib/routes/emails')
 const updateStripeEmail = require('../../../lib/routes/emails')
   ._updateStripeEmail;
 
-const makeRoutes = function(options = {}, requireMocks) {
+const makeRoutes = function (options = {}, requireMocks) {
   const config = options.config || {};
   config.verifierVersion = config.verifierVersion || 0;
   config.smtp = config.smtp || {};
@@ -165,7 +165,7 @@ const makeRoutes = function(options = {}, requireMocks) {
   const log = options.log || mocks.mockLog();
   const db = options.db || mocks.mockDB();
   const customs = options.customs || {
-    check: function() {
+    check: function () {
       return P.resolve(true);
     },
   };
@@ -369,7 +369,7 @@ describe('/recovery_email/status', () => {
       return runTest(route, mockRequest)
         .then(
           () => assert.ok(false),
-          response => {
+          (response) => {
             assert.equal(mockDB.deleteAccount.callCount, 1);
             assert.equal(
               mockDB.deleteAccount.firstCall.args[0].email,
@@ -424,7 +424,7 @@ describe('/recovery_email/status', () => {
       return runTest(route, mockRequest)
         .then(
           () => assert.ok(false),
-          response => {
+          (response) => {
             const args = log.info.firstCall.args;
             assert.equal(args[0], 'recovery_email.status.stale');
             assert.equal(args[1].email, TEST_EMAIL_INVALID);
@@ -442,7 +442,7 @@ describe('/recovery_email/status', () => {
       mockRequest.auth.credentials.emailVerified = true;
       mockRequest.auth.credentials.tokenVerified = true;
 
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(mockDB.deleteAccount.callCount, 0);
         assert.deepEqual(response, {
           email: TEST_EMAIL_INVALID,
@@ -468,7 +468,7 @@ describe('/recovery_email/status', () => {
       },
     });
 
-    return runTest(route, mockRequest, response => {
+    return runTest(route, mockRequest, (response) => {
       assert.equal(pushCalled, true);
 
       assert.deepEqual(response, {
@@ -484,7 +484,7 @@ describe('/recovery_email/status', () => {
     mockRequest.auth.credentials.emailVerified = true;
     mockRequest.auth.credentials.tokenVerified = true;
 
-    return runTest(route, mockRequest, response => {
+    return runTest(route, mockRequest, (response) => {
       assert.deepEqual(response, {
         email: TEST_EMAIL,
         verified: true,
@@ -499,7 +499,7 @@ describe('/recovery_email/status', () => {
     mockRequest.auth.credentials.tokenVerified = false;
     mockRequest.auth.credentials.mustVerify = true;
 
-    return runTest(route, mockRequest, response => {
+    return runTest(route, mockRequest, (response) => {
       assert.deepEqual(response, {
         email: TEST_EMAIL,
         verified: false,
@@ -514,7 +514,7 @@ describe('/recovery_email/status', () => {
     mockRequest.auth.credentials.tokenVerified = false;
     mockRequest.auth.credentials.mustVerify = false;
 
-    return runTest(route, mockRequest, response => {
+    return runTest(route, mockRequest, (response) => {
       assert.deepEqual(response, {
         email: TEST_EMAIL,
         verified: true,
@@ -570,7 +570,7 @@ describe('/recovery_email/resend_code', () => {
       },
     });
 
-    return runTest(route, mockRequest, response => {
+    return runTest(route, mockRequest, (response) => {
       assert.equal(mockLog.flowEvent.callCount, 1, 'log.flowEvent called once');
       assert.equal(
         mockLog.flowEvent.args[0][0].event,
@@ -627,7 +627,7 @@ describe('/recovery_email/resend_code', () => {
       },
     });
 
-    return runTest(route, mockRequest, response => {
+    return runTest(route, mockRequest, (response) => {
       assert.equal(mockMailer.sendVerifySecondaryEmail.callCount, 1);
       assert.equal(
         mockMailer.sendVerifySecondaryEmail.args[0][2].deviceId,
@@ -688,7 +688,7 @@ describe('/recovery_email/resend_code', () => {
     });
     mockLog.flowEvent.resetHistory();
 
-    return runTest(route, mockRequest, response => {
+    return runTest(route, mockRequest, (response) => {
       assert.equal(mockLog.flowEvent.callCount, 1, 'log.flowEvent called once');
       assert.equal(
         mockLog.flowEvent.args[0][0].event,
@@ -756,7 +756,7 @@ describe('/recovery_email/verify_code', () => {
   const mockCustoms = mocks.mockCustoms();
   const verificationReminders = mocks.mockVerificationReminders();
   const accountRoutes = makeRoutes({
-    checkPassword: function() {
+    checkPassword: function () {
       return P.resolve(true);
     },
     config: {},
@@ -782,7 +782,7 @@ describe('/recovery_email/verify_code', () => {
 
   describe('verifyTokens rejects with INVALID_VERIFICATION_CODE', () => {
     it('without a reminder payload', () => {
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(mockDB.verifyTokens.callCount, 1, 'calls verifyTokens');
         assert.equal(mockDB.verifyEmail.callCount, 1, 'calls verifyEmail');
         assert.equal(mockCustoms.check.callCount, 1, 'calls customs.check');
@@ -906,7 +906,7 @@ describe('/recovery_email/verify_code', () => {
 
     it('with newsletters', () => {
       mockRequest.payload.newsletters = ['test-pilot', 'firefox-pilot'];
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(
           mockLog.notifyAttachedServices.callCount,
           1,
@@ -942,7 +942,7 @@ describe('/recovery_email/verify_code', () => {
     it('with a reminder payload', () => {
       mockRequest.payload.reminder = 'second';
 
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(mockLog.activityEvent.callCount, 1);
 
         assert.equal(mockLog.flowEvent.callCount, 3);
@@ -972,7 +972,7 @@ describe('/recovery_email/verify_code', () => {
     });
 
     it('email verification', () => {
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(mockDB.verifyTokens.callCount, 1, 'call db.verifyTokens');
         assert.equal(
           mockDB.verifyEmail.callCount,
@@ -1003,7 +1003,7 @@ describe('/recovery_email/verify_code', () => {
     });
 
     it('email verification with associated device', () => {
-      mockDB.deviceFromTokenVerificationId = function(
+      mockDB.deviceFromTokenVerificationId = function (
         uid,
         tokenVerificationId
       ) {
@@ -1013,7 +1013,7 @@ describe('/recovery_email/verify_code', () => {
           type: 'desktop',
         });
       };
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(mockDB.verifyTokens.callCount, 1, 'call db.verifyTokens');
         assert.equal(
           mockDB.verifyEmail.callCount,
@@ -1046,7 +1046,7 @@ describe('/recovery_email/verify_code', () => {
     it('sign-in confirmation', () => {
       dbData.emailCode = crypto.randomBytes(16);
 
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(mockDB.verifyTokens.callCount, 1, 'call db.verifyTokens');
         assert.equal(
           mockDB.verifyEmail.callCount,
@@ -1117,7 +1117,7 @@ describe('/recovery_email/verify_code', () => {
       mockRequest.payload.type = 'secondary';
       mockRequest.payload.verifiedEmail = dbData.secondEmail;
 
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(mockDB.verifyEmail.callCount, 1, 'call db.verifyEmail');
         let args = mockDB.verifyEmail.args[0];
         assert.equal(
@@ -1195,7 +1195,7 @@ describe('/recovery_email', () => {
     mockDB = mocks.mockDB(dbData);
     stripeHelper = mocks.mockStripeHelper();
     accountRoutes = makeRoutes({
-      checkPassword: function() {
+      checkPassword: function () {
         return P.resolve(true);
       },
       config: {
@@ -1235,7 +1235,7 @@ describe('/recovery_email', () => {
 
     it('should create email on account', () => {
       route = getRoute(accountRoutes, '/recovery_email');
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.ok(response);
         assert.equal(mockDB.createEmail.callCount, 1, 'call db.createEmail');
         assert.equal(
@@ -1262,7 +1262,7 @@ describe('/recovery_email', () => {
           assert.fail(
             'Should have failed adding secondary email with unverified primary email'
           ),
-        err => assert.equal(err.errno, 104, 'unverified account')
+        (err) => assert.equal(err.errno, 104, 'unverified account')
       );
     });
 
@@ -1275,7 +1275,7 @@ describe('/recovery_email', () => {
           assert.fail(
             'Should have failed when adding an email that is the same as your primary'
           ),
-        err =>
+        (err) =>
           assert.equal(
             err.errno,
             139,
@@ -1307,7 +1307,7 @@ describe('/recovery_email', () => {
           assert.fail(
             'Should have failed when adding an email that already belongs to the account'
           ),
-        err => assert.equal(err.errno, 189, 'already exists on your account')
+        (err) => assert.equal(err.errno, 189, 'already exists on your account')
       );
     });
 
@@ -1326,7 +1326,7 @@ describe('/recovery_email', () => {
           assert.fail(
             'Should have failed when adding secondary email when the account is at its max'
           ),
-        err =>
+        (err) =>
           assert.equal(
             err.errno,
             188,
@@ -1347,7 +1347,7 @@ describe('/recovery_email', () => {
       });
       route = getRoute(accountRoutes, '/recovery_email');
       mockRequest.payload.email = TEST_EMAIL_ADDITIONAL;
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.ok(response);
         assert.equal(
           mockDB.deleteAccount.callCount,
@@ -1384,7 +1384,7 @@ describe('/recovery_email', () => {
 
       return runTest(route, mockRequest).then(
         () => assert.fail('Should have failed when creating email'),
-        err =>
+        (err) =>
           assert.equal(
             err.errno,
             141,
@@ -1401,7 +1401,7 @@ describe('/recovery_email', () => {
 
       return runTest(route, mockRequest, () => {
         assert.fail('should have failed');
-      }).catch(err => {
+      }).catch((err) => {
         assert.equal(err.errno, 151, 'failed to send email error');
         assert.equal(err.output.payload.code, 422);
         assert.equal(mockDB.createEmail.callCount, 1, 'call db.createEmail');
@@ -1436,7 +1436,7 @@ describe('/recovery_email', () => {
   describe('/recovery_emails', () => {
     it('should get all account emails', () => {
       route = getRoute(accountRoutes, '/recovery_emails');
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.equal(response.length, 1, 'should return account email');
         assert.equal(
           response[0].email,
@@ -1451,7 +1451,7 @@ describe('/recovery_email', () => {
   describe('/recovery_email/destroy', () => {
     it('should delete email from account ', () => {
       route = getRoute(accountRoutes, '/recovery_email/destroy');
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.ok(response);
         assert.equal(mockDB.deleteEmail.callCount, 1, 'call db.deleteEmail');
       });
@@ -1459,7 +1459,7 @@ describe('/recovery_email', () => {
 
     it('should reset outstanding tokens on the account ', () => {
       route = getRoute(accountRoutes, '/recovery_email/destroy');
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.ok(response);
         assert.equal(
           mockDB.resetAccountTokens.callCount,
@@ -1496,7 +1496,7 @@ describe('/recovery_email', () => {
         });
       });
       route = getRoute(accountRoutes, '/recovery_email/destroy');
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.ok(response);
         assert.equal(mockDB.deleteEmail.callCount, 1, 'call db.deleteEmail');
         assert.equal(
@@ -1534,7 +1534,7 @@ describe('/recovery_email', () => {
         });
       });
       route = getRoute(accountRoutes, '/recovery_email/destroy');
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.ok(response);
         assert.equal(mockDB.deleteEmail.callCount, 1, 'call db.deleteEmail');
         assert.equal(
@@ -1568,7 +1568,7 @@ describe('/recovery_email', () => {
       });
 
       route = getRoute(accountRoutes, '/recovery_email/set_primary');
-      return runTest(route, mockRequest, response => {
+      return runTest(route, mockRequest, (response) => {
         assert.ok(response);
         assert.equal(
           mockDB.setPrimaryEmail.callCount,
@@ -1635,7 +1635,7 @@ describe('/recovery_email', () => {
       route = getRoute(accountRoutes, '/recovery_email/set_primary');
       return runTest(route, mockRequest).then(
         () => assert.fail('should have errored'),
-        err =>
+        (err) =>
           assert.equal(
             err.errno,
             148,
@@ -1656,7 +1656,7 @@ describe('/recovery_email', () => {
       route = getRoute(accountRoutes, '/recovery_email/set_primary');
       return runTest(route, mockRequest).then(
         () => assert.fail('should have errored'),
-        err =>
+        (err) =>
           assert.equal(
             err.errno,
             147,

--- a/packages/fxa-auth-server/test/mailer_helper.js
+++ b/packages/fxa-auth-server/test/mailer_helper.js
@@ -7,7 +7,7 @@
 'use strict';
 
 const uuid = require('uuid');
-const { normalizeEmail } = require('../../fxa-shared/email/helpers');
+const { normalizeEmail } = require('fxa-shared/email/helpers');
 
 const zeroBuffer16 = Buffer.from(
   '00000000000000000000000000000000',

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -15,7 +15,7 @@ const error = require('../lib/error');
 const knownIpLocation = require('./known-ip-location');
 const P = require('../lib/promise');
 const sinon = require('sinon');
-const { normalizeEmail } = require('../../fxa-shared/email/helpers');
+const { normalizeEmail } = require('fxa-shared/email/helpers');
 
 const CUSTOMS_METHOD_NAMES = [
   'check',
@@ -241,7 +241,7 @@ function mockDB(data, errors) {
   errors = errors || {};
 
   return mockObject(DB_METHOD_NAMES)({
-    account: sinon.spy(uid => {
+    account: sinon.spy((uid) => {
       assert.ok(typeof uid === 'string');
       return P.resolve({
         email: data.email,
@@ -268,7 +268,7 @@ function mockDB(data, errors) {
         wrapWrapKb: data.wrapWrapKb,
       });
     }),
-    accountEmails: sinon.spy(uid => {
+    accountEmails: sinon.spy((uid) => {
       assert.ok(typeof uid === 'string');
       return P.resolve([
         {
@@ -341,7 +341,7 @@ function mockDB(data, errors) {
         wrapWrapKb: data.wrapWrapKb,
       });
     }),
-    createDevice: sinon.spy(uid => {
+    createDevice: sinon.spy((uid) => {
       assert.ok(typeof uid === 'string');
       return P.resolve(
         Object.keys(data.device).reduce(
@@ -369,12 +369,12 @@ function mockDB(data, errors) {
         passCode: data.passCode,
         id: data.passwordForgotTokenId,
         uid: data.uid,
-        ttl: function() {
+        ttl: function () {
           return data.passwordForgotTokenTTL || 100;
         },
       });
     }),
-    createSessionToken: sinon.spy(opts => {
+    createSessionToken: sinon.spy((opts) => {
       return P.resolve({
         createdAt: opts.createdAt || Date.now(),
         data: crypto.randomBytes(32).toString('hex'),
@@ -408,14 +408,14 @@ function mockDB(data, errors) {
       assert.ok(typeof flowId === 'string');
       return P.resolve(data.signinCode || []);
     }),
-    devices: sinon.spy(uid => {
+    devices: sinon.spy((uid) => {
       assert.ok(typeof uid === 'string');
       return P.resolve(data.devices || []);
     }),
     device: sinon.spy((uid, deviceId) => {
       assert.ok(typeof uid === 'string');
       assert.ok(typeof deviceId === 'string');
-      const device = data.devices.find(d => d.id === deviceId);
+      const device = data.devices.find((d) => d.id === deviceId);
       assert.ok(device);
       return P.resolve(device);
     }),
@@ -500,7 +500,7 @@ function mockDB(data, errors) {
         },
       ]);
     }),
-    sessions: sinon.spy(uid => {
+    sessions: sinon.spy((uid) => {
       assert.ok(typeof uid === 'string');
       return P.resolve(data.sessions || []);
     }),
@@ -523,7 +523,7 @@ function mockDB(data, errors) {
       // SessionToken is a class, and tokenTypeID is a class attribute. Fake that.
       res.constructor.tokenTypeID = 'sessionToken';
       if (data.devices && data.devices.length > 0) {
-        Object.keys(data.devices[0]).forEach(key => {
+        Object.keys(data.devices[0]).forEach((key) => {
           const keyOnSession = `device${key
             .charAt(0)
             .toUpperCase()}${key.substr(1)}`;
@@ -559,7 +559,7 @@ function mockOAuthDB(methods = {}) {
 }
 
 function mockObject(methodNames, baseObj) {
-  return methods => {
+  return (methods) => {
     methods = methods || {};
     return methodNames.reduce((object, name) => {
       object[name] = methods[name] || sinon.spy(() => P.resolve());
@@ -570,7 +570,7 @@ function mockObject(methodNames, baseObj) {
 
 function mockPush(methods) {
   const push = Object.assign({}, methods);
-  PUSH_METHOD_NAMES.forEach(name => {
+  PUSH_METHOD_NAMES.forEach((name) => {
     if (!push[name]) {
       push[name] = sinon.spy(() => P.resolve());
     }
@@ -580,7 +580,7 @@ function mockPush(methods) {
 
 function mockPushbox(methods) {
   const pushbox = Object.assign({}, methods);
-  PUSHBOX_METHOD_NAMES.forEach(name => {
+  PUSHBOX_METHOD_NAMES.forEach((name) => {
     if (!pushbox[name]) {
       pushbox[name] = sinon.spy(() => P.resolve());
     }
@@ -590,7 +590,7 @@ function mockPushbox(methods) {
 
 function mockSubHub(methods) {
   const subscriptionsBackend = Object.assign({}, methods);
-  SUBHUB_METHOD_NAMES.forEach(name => {
+  SUBHUB_METHOD_NAMES.forEach((name) => {
     if (!subscriptionsBackend[name]) {
       subscriptionsBackend[name] = sinon.spy(() => P.resolve());
     }
@@ -600,7 +600,7 @@ function mockSubHub(methods) {
 
 function mockProfile(methods) {
   const profileBackend = Object.assign({}, methods);
-  PROFILE_METHOD_NAMES.forEach(name => {
+  PROFILE_METHOD_NAMES.forEach((name) => {
     if (!profileBackend[name]) {
       profileBackend[name] = sinon.spy(() => P.resolve());
     }
@@ -638,7 +638,7 @@ function mockMetricsContext(methods) {
   return mockObject(METRICS_CONTEXT_METHOD_NAMES)({
     gather:
       methods.gather ||
-      sinon.spy(function(data) {
+      sinon.spy(function (data) {
         const time = Date.now();
         return P.resolve().then(() => {
           if (this.payload && this.payload.metricsContext) {
@@ -676,7 +676,7 @@ function mockMetricsContext(methods) {
         });
       }),
 
-    setFlowCompleteSignal: sinon.spy(function(flowCompleteSignal) {
+    setFlowCompleteSignal: sinon.spy(function (flowCompleteSignal) {
       if (this.payload && this.payload.metricsContext) {
         this.payload.metricsContext.flowCompleteSignal = flowCompleteSignal;
       }

--- a/packages/fxa-auth-server/test/oauth/db/index.js
+++ b/packages/fxa-auth-server/test/oauth/db/index.js
@@ -7,7 +7,7 @@ const crypto = require('crypto');
 const { assert } = require('chai');
 const buf = require('buf').hex;
 const hex = require('buf').to.hex;
-const ScopeSet = require('../../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
 const encrypt = require('../../../lib/oauth/encrypt');
 const db = require('../../../lib/oauth/db');
@@ -18,10 +18,10 @@ function randomString(len) {
   return crypto.randomBytes(Math.ceil(len)).toString('hex');
 }
 
-describe('db', function() {
-  describe('utf-8', function() {
+describe('db', function () {
+  describe('utf-8', function () {
     function makeTest(clientId, clientName) {
-      return function() {
+      return function () {
         var data = {
           id: clientId,
           name: clientName,
@@ -33,18 +33,18 @@ describe('db', function() {
 
         return db
           .registerClient(data)
-          .then(function(c) {
+          .then(function (c) {
             assert.equal(c.id.toString('hex'), clientId);
             assert.equal(c.name, clientName);
             return db.getClient(c.id);
           })
-          .then(function(cli) {
+          .then(function (cli) {
             assert.equal(cli.id.toString('hex'), clientId);
             assert.equal(cli.name, clientName);
             return db.removeClient(clientId);
           })
-          .then(function() {
-            return db.getClient(clientId).then(function(cli) {
+          .then(function () {
+            return db.getClient(clientId).then(function (cli) {
               assert.equal(void 0, cli);
             });
           });
@@ -53,7 +53,7 @@ describe('db', function() {
 
     it('2-byte encoding preserved', makeTest(randomString(8), 'Düsseldorf'));
     it('3-byte encoding preserved', makeTest(randomString(8), '北京')); // Beijing
-    it('4-byte encoding throws with mysql', function() {
+    it('4-byte encoding throws with mysql', function () {
       var data = {
         id: randomString(8),
         // 'MUSICAL SYMBOL F CLEF' (U+1D122) (JS: '\uD834\uDD22', UTF8: '0xF0 0x9D 0x84 0xA2')
@@ -67,10 +67,10 @@ describe('db', function() {
 
       return db
         .registerClient(data)
-        .then(function(c) {
+        .then(function (c) {
           assert.fail('This should not have succeeded.');
         })
-        .catch(function(err) {
+        .catch(function (err) {
           assert.ok(err);
           assert.equal(err.code, 'ER_TRUNCATED_WRONG_VALUE_FOR_FIELD');
           assert.equal(err.errno, 1366);
@@ -78,9 +78,9 @@ describe('db', function() {
     });
   });
 
-  describe('getEncodingInfo', function() {
-    it('should use utf8', function() {
-      return db.getEncodingInfo().then(function(info) {
+  describe('getEncodingInfo', function () {
+    it('should use utf8', function () {
+      return db.getEncodingInfo().then(function (info) {
         assert.equal(info['character_set_connection'], 'utf8mb4');
         assert.equal(info['character_set_database'], 'utf8');
         assert.equal(info['collation_connection'], 'utf8mb4_unicode_ci');
@@ -89,7 +89,7 @@ describe('db', function() {
     });
   });
 
-  describe('removeUser', function() {
+  describe('removeUser', function () {
     var clientId = buf(randomString(8));
     var userId = buf(randomString(16));
     var email = 'a@b.c';
@@ -98,7 +98,7 @@ describe('db', function() {
     var token = null;
     var refreshToken = null;
 
-    before(function() {
+    before(function () {
       return db
         .registerClient({
           id: clientId,
@@ -108,7 +108,7 @@ describe('db', function() {
           redirectUri: 'https://example.domain/return?foo=bar',
           trusted: true,
         })
-        .then(function() {
+        .then(function () {
           return db.generateCode({
             clientId: clientId,
             userId: userId,
@@ -117,11 +117,11 @@ describe('db', function() {
             authAt: 0,
           });
         })
-        .then(function(c) {
+        .then(function (c) {
           code = c;
           return db.getCode(code);
         })
-        .then(function(code) {
+        .then(function (code) {
           assert.equal(hex(code.userId), hex(userId));
           return db.generateAccessToken({
             clientId: clientId,
@@ -130,7 +130,7 @@ describe('db', function() {
             scope: scope,
           });
         })
-        .then(function(t) {
+        .then(function (t) {
           token = t.token;
           assert.equal(hex(t.userId), hex(userId), 'token userId');
           return db.generateRefreshToken({
@@ -140,40 +140,40 @@ describe('db', function() {
             scope: scope,
           });
         })
-        .then(function(t) {
+        .then(function (t) {
           refreshToken = t.token;
           assert.equal(hex(t.userId), hex(userId), 'token userId');
         });
     });
 
-    it('should get the right refreshToken', function() {
+    it('should get the right refreshToken', function () {
       var hash = encrypt.hash(refreshToken);
-      return db.getRefreshToken(hash).then(function(t) {
+      return db.getRefreshToken(hash).then(function (t) {
         assert.equal(hex(t.token), hex(hash), 'got the right refresh_token');
       });
     });
 
-    it('should delete tokens and codes for the given userId', function() {
+    it('should delete tokens and codes for the given userId', function () {
       return db
         .removeUser(userId)
-        .then(function() {
+        .then(function () {
           return db.getCode(code);
         })
-        .then(function(c) {
+        .then(function (c) {
           assert.equal(c, undefined, 'code deleted');
           return db.getAccessToken(token);
         })
-        .then(function(t) {
+        .then(function (t) {
           assert.equal(t, undefined, 'token deleted');
           return db.getRefreshToken(encrypt.hash(refreshToken));
         })
-        .then(function(t) {
+        .then(function (t) {
           assert.equal(t, undefined, 'refresh_token deleted');
         });
     });
   });
 
-  describe('removePublicAndCanGrantTokens', function() {
+  describe('removePublicAndCanGrantTokens', function () {
     function testRemovalWithClient(clientOptions = {}) {
       const clientId = buf(randomString(8));
       const userId = buf(randomString(16));
@@ -193,7 +193,7 @@ describe('db', function() {
           canGrant: clientOptions.canGrant || false,
           publicClient: clientOptions.publicClient || false,
         })
-        .then(function() {
+        .then(function () {
           return db.generateAccessToken({
             clientId: clientId,
             canGrant: clientOptions.canGrant,
@@ -203,7 +203,7 @@ describe('db', function() {
             scope: scope,
           });
         })
-        .then(function(t) {
+        .then(function (t) {
           tokenIdHash = encrypt.hash(t.token.toString('hex'));
           return db.generateRefreshToken({
             clientId: clientId,
@@ -212,7 +212,7 @@ describe('db', function() {
             scope: scope,
           });
         })
-        .then(function(t) {
+        .then(function (t) {
           refreshTokenIdHash = encrypt.hash(t.token.toString('hex'));
 
           return Promise.all([
@@ -220,18 +220,18 @@ describe('db', function() {
             db.getAccessToken(tokenIdHash),
           ]);
         })
-        .then(tokens => {
+        .then((tokens) => {
           assert.ok(tokens[0].token);
           assert.ok(tokens[1].tokenId);
           return db.removePublicAndCanGrantTokens(hex(userId));
         })
-        .then(t => {
+        .then((t) => {
           return Promise.all([
             db.getRefreshToken(refreshTokenIdHash),
             db.getAccessToken(tokenIdHash),
           ]);
         })
-        .catch(err => {
+        .catch((err) => {
           throw err;
         });
     }
@@ -239,7 +239,7 @@ describe('db', function() {
     it('revokes tokens for canGrant', () => {
       return testRemovalWithClient({
         canGrant: true,
-      }).then(tokens => {
+      }).then((tokens) => {
         assert.equal(tokens[0], undefined);
         assert.equal(tokens[1], undefined);
       });
@@ -248,7 +248,7 @@ describe('db', function() {
     it('revokes tokens for publicClient', () => {
       return testRemovalWithClient({
         publicClient: true,
-      }).then(tokens => {
+      }).then((tokens) => {
         assert.equal(tokens[0], undefined);
         assert.equal(tokens[1], undefined);
       });
@@ -258,7 +258,7 @@ describe('db', function() {
       return testRemovalWithClient({
         canGrant: false,
         publicClient: false,
-      }).then(tokens => {
+      }).then((tokens) => {
         assert.ok(tokens[0].token);
         assert.ok(tokens[1].tokenId);
       });
@@ -268,14 +268,14 @@ describe('db', function() {
       return testRemovalWithClient({
         canGrant: true,
         publicClient: true,
-      }).then(tokens => {
+      }).then((tokens) => {
         assert.equal(tokens[0], undefined);
         assert.equal(tokens[1], undefined);
       });
     });
   });
 
-  describe('refresh token lastUsedAt', function() {
+  describe('refresh token lastUsedAt', function () {
     var clientId = buf(randomString(8));
     var userId = buf(randomString(16));
     var email = 'a@b.c';
@@ -283,7 +283,7 @@ describe('db', function() {
     var code = null;
     var refreshToken = null;
 
-    beforeEach(function() {
+    beforeEach(function () {
       return db
         .registerClient({
           id: clientId,
@@ -293,7 +293,7 @@ describe('db', function() {
           redirectUri: 'https://example.domain/return?foo=bar',
           trusted: true,
         })
-        .then(function() {
+        .then(function () {
           return db.generateCode({
             clientId: clientId,
             userId: userId,
@@ -302,11 +302,11 @@ describe('db', function() {
             authAt: 0,
           });
         })
-        .then(function(c) {
+        .then(function (c) {
           code = c;
           return db.getCode(code);
         })
-        .then(function(code) {
+        .then(function (code) {
           assert.equal(hex(code.userId), hex(userId));
           return db.generateAccessToken({
             clientId: clientId,
@@ -315,7 +315,7 @@ describe('db', function() {
             scope: scope,
           });
         })
-        .then(function(t) {
+        .then(function (t) {
           assert.equal(hex(t.userId), hex(userId), 'token userId');
           return db.generateRefreshToken({
             clientId: clientId,
@@ -324,18 +324,18 @@ describe('db', function() {
             scope: scope,
           });
         })
-        .then(function(t) {
+        .then(function (t) {
           refreshToken = t;
         });
     });
 
-    it('should refresh token lastUsedAt', function() {
+    it('should refresh token lastUsedAt', function () {
       var tokenFirstUsage = {};
       var hash = encrypt.hash(refreshToken.token);
 
       return db
         .getRefreshToken(hash)
-        .then(function(t) {
+        .then(function (t) {
           assert.equal(hex(t.token), hex(hash), 'same token');
 
           tokenFirstUsage.createdAt = new Date(t.createdAt);
@@ -343,13 +343,13 @@ describe('db', function() {
 
           return Promise.delay(1000); //ensures that creation and subsequent usage are at least 1s apart
         })
-        .then(function() {
+        .then(function () {
           return db.usedRefreshToken(encrypt.hash(refreshToken.token));
         })
-        .then(function() {
+        .then(function () {
           return db.getRefreshToken(hash);
         })
-        .then(function(t) {
+        .then(function (t) {
           assert.equal(hex(t.token), hex(hash), 'same token');
           var updatedLastUsedAt = new Date(t.lastUsedAt);
 
@@ -367,7 +367,7 @@ describe('db', function() {
     });
   });
 
-  describe('scopes', function() {
+  describe('scopes', function () {
     it('can register and fetch scopes', () => {
       const scopeName = 'https://some-scope.mozilla.org/apps/' + Math.random();
       const notFoundScope = 'https://some-scope-404.mozilla.org';
@@ -380,27 +380,27 @@ describe('db', function() {
         .then(() => {
           return db.getScope(notFoundScope);
         })
-        .then(notFoundScope => {
+        .then((notFoundScope) => {
           assert.equal(notFoundScope, undefined);
           return db.getScope(scopeName);
         })
-        .then(result => {
+        .then((result) => {
           assert.deepEqual(newScope, result);
         });
     });
   });
 
-  describe('client-tokens', function() {
-    describe('deleteClientAuthorization', function() {
+  describe('client-tokens', function () {
+    describe('deleteClientAuthorization', function () {
       var clientId = buf(randomString(8));
       var userId = buf(randomString(16));
 
-      it('should delete client tokens', function() {
+      it('should delete client tokens', function () {
         return db.deleteClientAuthorization(clientId, userId).then(
-          function(result) {
+          function (result) {
             assert.ok(result);
           },
-          function(err) {
+          function (err) {
             assert.fail(err);
           }
         );
@@ -408,60 +408,60 @@ describe('db', function() {
     });
   });
 
-  describe('developers', function() {
-    describe('removeDeveloper', function() {
-      it('should not fail on non-existent developers', function() {
+  describe('developers', function () {
+    describe('removeDeveloper', function () {
+      it('should not fail on non-existent developers', function () {
         return db.removeDeveloper('unknown@developer.com');
       });
 
-      it('should delete developers', function() {
+      it('should delete developers', function () {
         var email = 'email' + randomString(10) + '@mozilla.com';
         return db
           .activateDeveloper(email)
-          .then(function(developer) {
+          .then(function (developer) {
             assert.equal(developer.email, email);
 
             return db.removeDeveloper(email);
           })
-          .then(function() {
+          .then(function () {
             return db.getDeveloper(email);
           })
-          .then(function(developer) {
+          .then(function (developer) {
             assert.equal(developer, null);
           });
       });
     });
 
-    describe('getDeveloper', function() {
-      it('should return null if developer does not exit', function() {
+    describe('getDeveloper', function () {
+      it('should return null if developer does not exit', function () {
         return db
           .getDeveloper('unknown@developer.com')
-          .then(function(developer) {
+          .then(function (developer) {
             assert.equal(developer, null);
           });
       });
 
-      it('should throw on empty email', function() {
-        mock.log('db', rec => {
+      it('should throw on empty email', function () {
+        mock.log('db', (rec) => {
           return rec.levelname === 'ERROR' && rec.args[0] === 'getDeveloper';
         });
-        return db.getDeveloper().then(assert.fail, function(err) {
+        return db.getDeveloper().then(assert.fail, function (err) {
           assert.equal(err.message, 'Email is required');
         });
       });
     });
 
-    describe('activateDeveloper and getDeveloper', function() {
-      it('should create developers', function() {
+    describe('activateDeveloper and getDeveloper', function () {
+      it('should create developers', function () {
         var email = 'email' + randomString(10) + '@mozilla.com';
 
-        return db.activateDeveloper(email).then(function(developer) {
+        return db.activateDeveloper(email).then(function (developer) {
           assert.equal(developer.email, email);
         });
       });
 
-      it('should not allow duplicates', function() {
-        mock.log('db', rec => {
+      it('should not allow duplicates', function () {
+        mock.log('db', (rec) => {
           return (
             rec.levelname === 'ERROR' && rec.args[0] === 'activateDeveloper'
           );
@@ -470,39 +470,39 @@ describe('db', function() {
 
         return db
           .activateDeveloper(email)
-          .then(function() {
+          .then(function () {
             return db.activateDeveloper(email);
           })
           .then(
-            function() {
+            function () {
               assert.fail();
             },
-            function(err) {
+            function (err) {
               assert.equal(err.message.indexOf('ER_DUP_ENTRY') >= 0, true);
             }
           );
       });
 
-      it('should throw on empty email', function() {
-        mock.log('db', rec => {
+      it('should throw on empty email', function () {
+        mock.log('db', (rec) => {
           return (
             rec.levelname === 'ERROR' && rec.args[0] === 'activateDeveloper'
           );
         });
-        return db.activateDeveloper().then(assert.fail, function(err) {
+        return db.activateDeveloper().then(assert.fail, function (err) {
           assert.equal(err.message, 'Email is required');
         });
       });
     });
 
-    describe('registerClientDeveloper and developerOwnsClient', function() {
+    describe('registerClientDeveloper and developerOwnsClient', function () {
       var clientId = buf(randomString(8));
       var userId = buf(randomString(16));
       var email = 'a@b.c';
       var scope = ['no_scope'];
       var code = null;
 
-      before(function() {
+      before(function () {
         return db
           .registerClient({
             id: clientId,
@@ -512,7 +512,7 @@ describe('db', function() {
             redirectUri: 'https://example.domain/return?foo=bar',
             trusted: true,
           })
-          .then(function() {
+          .then(function () {
             return db.generateCode({
               clientId: clientId,
               userId: userId,
@@ -521,11 +521,11 @@ describe('db', function() {
               authAt: 0,
             });
           })
-          .then(function(c) {
+          .then(function (c) {
             code = c;
             return db.getCode(code);
           })
-          .then(function(code) {
+          .then(function (code) {
             assert.equal(hex(code.userId), hex(userId));
             return db.generateAccessToken({
               clientId: clientId,
@@ -534,30 +534,30 @@ describe('db', function() {
               scope: scope,
             });
           })
-          .then(function(t) {
+          .then(function (t) {
             assert.equal(hex(t.userId), hex(userId), 'token userId');
           });
       });
 
-      it('should attach a developer to a client', function() {
+      it('should attach a developer to a client', function () {
         var email = 'email' + randomString(10) + '@mozilla.com';
 
         return db
           .activateDeveloper(email)
-          .then(function(developer) {
+          .then(function (developer) {
             return db.registerClientDeveloper(
               hex(developer.developerId),
               hex(clientId)
             );
           })
-          .then(function() {
+          .then(function () {
             return db.getClientDevelopers(hex(clientId));
           })
-          .then(function(developers) {
+          .then(function (developers) {
             if (developers) {
               var found = false;
 
-              developers.forEach(function(developer) {
+              developers.forEach(function (developer) {
                 if (developer.email === email) {
                   found = true;
                 }
@@ -570,10 +570,10 @@ describe('db', function() {
     });
   });
 
-  describe('getLock', function() {
-    it('should return an acquired status', function() {
+  describe('getLock', function () {
+    it('should return an acquired status', function () {
       const lockName = randomString(10);
-      return db.getLock(lockName, 3).then(function(result) {
+      return db.getLock(lockName, 3).then(function (result) {
         assert.ok(result);
         assert.ok('acquired' in result);
         assert.ok(result.acquired === 1);
@@ -650,7 +650,7 @@ describe('db', function() {
         scope: ScopeSet.fromArray(['no_scope']),
       };
 
-      before(function() {
+      before(function () {
         return db.registerClient({
           id: pocketId,
           name: 'pocket',
@@ -660,7 +660,7 @@ describe('db', function() {
           trusted: true,
         });
       });
-      after(function() {
+      after(function () {
         return db.removeClient(pocketId);
       });
 

--- a/packages/fxa-auth-server/test/oauth/grant.js
+++ b/packages/fxa-auth-server/test/oauth/grant.js
@@ -6,14 +6,14 @@ const { assert } = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const config = require('../../config');
-const ScopeSet = require('../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 const AppError = require('../../lib/oauth/error');
 const { decodeJWT } = require('../lib/util');
 
 async function assertThrowsAsync(fn, errorLike, errMsgMatcher, message) {
   let threw = null;
   return fn()
-    .catch(err => {
+    .catch((err) => {
       threw = err;
     })
     .then(() => {

--- a/packages/fxa-auth-server/test/oauth/jwt_access_token.js
+++ b/packages/fxa-auth-server/test/oauth/jwt_access_token.js
@@ -6,7 +6,7 @@ const { assert } = require('chai');
 const sinon = require('sinon');
 const proxyquire = require('proxyquire');
 const AppError = require('../../lib/oauth/error');
-const ScopeSet = require('../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 const { OAUTH_SCOPE_OLD_SYNC } = require('../../lib/constants');
 const TOKEN_SERVER_URL = require('../../config').get('syncTokenserverUrl');
 

--- a/packages/fxa-auth-server/test/oauth/routes/verify.js
+++ b/packages/fxa-auth-server/test/oauth/routes/verify.js
@@ -6,7 +6,7 @@ const { assert } = require('chai');
 const Joi = require('@hapi/joi');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
-const ScopeSet = require('../../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
 const TOKEN =
   'df6dcfe7bf6b54a65db5742cbcdce5c0a84a5da81a0bb6bdf5fc793eef041fc6';

--- a/packages/fxa-auth-server/test/oauth/token.js
+++ b/packages/fxa-auth-server/test/oauth/token.js
@@ -5,11 +5,11 @@
 const { assert } = require('chai');
 const token = require('../../lib/oauth/token');
 const JWTAccessToken = require('../../lib/oauth/jwt_access_token');
-const ScopeSet = require('../../../fxa-shared/oauth/scopes');
+const ScopeSet = require('fxa-shared/oauth/scopes');
 
-describe('token', function() {
-  describe('verify', function() {
-    it('verifies short lifespan JWT tokens without the db', async function() {
+describe('token', function () {
+  describe('verify', function () {
+    it('verifies short lifespan JWT tokens without the db', async function () {
       const accessToken = await JWTAccessToken.create(
         {
           expiresAt: Date.now() + 10000,

--- a/packages/fxa-auth-server/test/remote/attached_clients_tests.js
+++ b/packages/fxa-auth-server/test/remote/attached_clients_tests.js
@@ -10,13 +10,13 @@ const Client = require('../client')();
 const config = require('../../config').getProperties();
 const tokens = require('../../lib/tokens')({ trace: () => {} }, config);
 const testUtils = require('../lib/util');
-const ScopeSet = require('../../../fxa-shared').oauth.scopes;
+const ScopeSet = require('fxa-shared/oauth/scopes');
 const buf = require('buf').hex;
 const hashRefreshToken = require('../../lib/oauth/encrypt').hash;
 
 const PUBLIC_CLIENT_ID = '3c49430b43dfba77';
 
-describe('attached clients listing', function() {
+describe('attached clients listing', function () {
   this.timeout(15000);
   let server, oauthServerDb;
   before(async () => {
@@ -91,7 +91,7 @@ describe('attached clients listing', function() {
     );
     allClients = await client.attachedClients();
     assert.equal(allClients.length, 2);
-    const one = allClients.findIndex(c => c.name === 'test device');
+    const one = allClients.findIndex((c) => c.name === 'test device');
     const zero = (one + 1) % allClients.length;
     assert.equal(allClients[zero].sessionTokenId, mySessionTokenId);
     assert.equal(allClients[zero].deviceId, device.id);

--- a/packages/fxa-auth-server/test/remote/db_tests.js
+++ b/packages/fxa-auth-server/test/remote/db_tests.js
@@ -15,7 +15,7 @@ const UnblockCode = require('../../lib/crypto/random').base32(
   config.signinUnblock.codeLength
 );
 const uuid = require('uuid');
-const { normalizeEmail } = require('../../../fxa-shared/email/helpers');
+const { normalizeEmail } = require('fxa-shared/email/helpers');
 
 const log = { trace() {}, info() {}, error() {} };
 
@@ -70,16 +70,16 @@ const zeroBuffer32 = Buffer.from(
 
 let account, secondEmail;
 
-describe('remote db', function() {
+describe('remote db', function () {
   this.timeout(20000);
   let dbServer, db;
   before(() => {
     return TestServer.start(config)
-      .then(s => {
+      .then((s) => {
         dbServer = s;
         return DB.connect(config[config.db.backend]);
       })
-      .then(x => {
+      .then((x) => {
         db = x;
       });
   });
@@ -101,7 +101,7 @@ describe('remote db', function() {
     return (
       db
         .createAccount(account)
-        .then(account => {
+        .then((account) => {
           assert.deepEqual(
             account.uid,
             account.uid,
@@ -131,13 +131,13 @@ describe('remote db', function() {
   it('account creation', () => {
     return db
       .accountExists(account.email)
-      .then(exists => {
+      .then((exists) => {
         assert.ok(exists, 'account exists for this email address');
       })
       .then(() => {
         return db.account(account.uid);
       })
-      .then(account => {
+      .then((account) => {
         assert.deepEqual(account.uid, account.uid, 'uid');
         assert.equal(account.email, account.email, 'email');
         assert.deepEqual(account.emailCode, account.emailCode, 'emailCode');
@@ -165,14 +165,14 @@ describe('remote db', function() {
     // Fetch all sessions for the account
     return db
       .sessions(account.uid)
-      .then(sessions => {
+      .then((sessions) => {
         assert.ok(Array.isArray(sessions), 'sessions is array');
         assert.equal(sessions.length, 0, 'sessions is empty');
 
         // Fetch the email record
         return db.emailRecord(account.email);
       })
-      .then(emailRecord => {
+      .then((emailRecord) => {
         emailRecord.createdAt = Date.now() - 1000;
         emailRecord.tokenVerificationId = account.tokenVerificationId;
         emailRecord.uaBrowser = 'Firefox';
@@ -184,14 +184,14 @@ describe('remote db', function() {
         // Create a session token
         return db.createSessionToken(emailRecord);
       })
-      .then(sessionToken => {
+      .then((sessionToken) => {
         assert.deepEqual(sessionToken.uid, account.uid);
         tokenId = sessionToken.id;
 
         // Fetch all sessions for the account
         return db.sessions(account.uid);
       })
-      .then(sessions => {
+      .then((sessions) => {
         assert.equal(sessions.length, 1, 'sessions contains one item');
         assert.equal(
           Object.keys(sessions[0]).length,
@@ -263,7 +263,7 @@ describe('remote db', function() {
         // Fetch the session token
         return db.sessionToken(tokenId);
       })
-      .then(sessionToken => {
+      .then((sessionToken) => {
         assert.equal(sessionToken.id, tokenId, 'token id matches');
         assert.equal(sessionToken.uaBrowser, 'Firefox');
         assert.equal(sessionToken.uaBrowserVersion, '41');
@@ -283,13 +283,13 @@ describe('remote db', function() {
         // Attempt to update the session token
         return db.touchSessionToken(sessionToken, {});
       })
-      .then(result => {
+      .then((result) => {
         assert.equal(result, undefined);
 
         // Fetch all sessions for the account
         return db.sessions(account.uid);
       })
-      .then(sessions => {
+      .then((sessions) => {
         assert.equal(sessions.length, 1, 'sessions contains one item');
         assert.equal(
           Object.keys(sessions[0]).length,
@@ -314,7 +314,7 @@ describe('remote db', function() {
         // Fetch the session token
         return db.sessionToken(tokenId);
       })
-      .then(sessionToken => {
+      .then((sessionToken) => {
         // Update the session token
         return db.touchSessionToken(
           Object.assign({}, sessionToken, {
@@ -336,7 +336,7 @@ describe('remote db', function() {
         // Fetch all sessions for the account
         return db.sessions(account.uid);
       })
-      .then(sessions => {
+      .then((sessions) => {
         assert.equal(sessions.length, 1, 'sessions contains one item');
         assert.equal(sessions[0].uid, account.uid, 'uid property is correct');
         assert.ok(
@@ -373,7 +373,7 @@ describe('remote db', function() {
         // Fetch the session token
         return db.sessionToken(tokenId);
       })
-      .then(sessionToken => {
+      .then((sessionToken) => {
         // Update the session token
         return db.touchSessionToken(
           Object.assign({}, sessionToken, {
@@ -391,7 +391,7 @@ describe('remote db', function() {
         // Fetch all sessions for the account
         return db.sessions(account.uid);
       })
-      .then(sessions => {
+      .then((sessions) => {
         assert.equal(sessions.length, 1, 'sessions still contains one item');
         assert.equal(
           sessions[0].uaBrowser,
@@ -429,7 +429,7 @@ describe('remote db', function() {
         // Fetch the session token
         return db.sessionToken(tokenId);
       })
-      .then(sessionToken => {
+      .then((sessionToken) => {
         // this returns previously stored data since sessionToken doesnt read from cache
         assert.equal(sessionToken.uaBrowser, 'Firefox');
         assert.equal(sessionToken.uaBrowserVersion, '41');
@@ -445,7 +445,7 @@ describe('remote db', function() {
         // Fetch all sessions for the account
         return db.sessions(account.uid);
       })
-      .then(sessions => {
+      .then((sessions) => {
         assert.equal(sessions.length, 1, 'sessions still contains one item');
         assert.equal(
           sessions[0].uaBrowser,
@@ -477,7 +477,7 @@ describe('remote db', function() {
         // Fetch the session token
         return db.sessionToken(tokenId);
       })
-      .then(sessionToken => {
+      .then((sessionToken) => {
         // Prune a session token that is older than maxAge
         sessionToken.createdAt = Date.now() - tokenPruning.maxAge - 1;
         return db.pruneSessionTokens(account.uid, [sessionToken]);
@@ -486,7 +486,7 @@ describe('remote db', function() {
         // Fetch all sessions for the account
         return db.sessions(account.uid);
       })
-      .then(sessions => {
+      .then((sessions) => {
         assert.equal(sessions.length, 1, 'sessions still contains one item');
         assert.equal(
           sessions[0].uaBrowser,
@@ -522,7 +522,7 @@ describe('remote db', function() {
         // Fetch the session token
         return db.sessionToken(tokenId);
       })
-      .then(sessionToken => {
+      .then((sessionToken) => {
         // Delete the session token
         return db.deleteSessionToken(sessionToken);
       })
@@ -530,15 +530,15 @@ describe('remote db', function() {
         // Fetch all sessions for the account
         return db.sessions(account.uid);
       })
-      .then(sessions => {
+      .then((sessions) => {
         assert.equal(sessions.length, 0, 'sessions is empty');
 
         // Attempt to delete the deleted session token
         return db.sessionToken(tokenId).then(
-          sessionToken => {
+          (sessionToken) => {
             assert(false, 'db.sessionToken should have failed');
           },
-          err => {
+          (err) => {
             assert.equal(
               err.errno,
               110,
@@ -557,7 +557,7 @@ describe('remote db', function() {
         // Fetch the email record again
         return db.emailRecord(account.email);
       })
-      .then(emailRecord => {
+      .then((emailRecord) => {
         emailRecord.createdAt = Date.now() - 1000;
         emailRecord.tokenVerificationId = account.tokenVerificationId;
         emailRecord.uaBrowser = 'Firefox';
@@ -573,7 +573,7 @@ describe('remote db', function() {
         // Fetch all sessions for the account
         return db.sessions(account.uid);
       })
-      .then(sessions => {
+      .then((sessions) => {
         // Make sure that the data got deleted from redis too
         assert.equal(sessions.length, 1, 'sessions contains one item');
         assert.equal(
@@ -591,7 +591,7 @@ describe('remote db', function() {
         return db.deleteSessionToken(sessions[0]);
       })
       .then(() => redis.getAsync(account.uid))
-      .then(result => assert.equal(result, null, 'redis was cleared'));
+      .then((result) => assert.equal(result, null, 'redis was cleared'));
   });
 
   it('device registration', () => {
@@ -615,7 +615,7 @@ describe('remote db', function() {
     return (
       db
         .emailRecord(account.email)
-        .then(emailRecord => {
+        .then((emailRecord) => {
           emailRecord.tokenVerificationId = account.tokenVerificationId;
           emailRecord.uaBrowser = 'Firefox Mobile';
           emailRecord.uaBrowserVersion = '41';
@@ -627,7 +627,7 @@ describe('remote db', function() {
           // Create a session token
           return db.createSessionToken(emailRecord);
         })
-        .then(result => {
+        .then((result) => {
           sessionToken = result;
           deviceInfo.sessionTokenId = sessionToken.id;
 
@@ -639,7 +639,7 @@ describe('remote db', function() {
                 'updating a non-existent device should have failed'
               );
             },
-            err => {
+            (err) => {
               assert.equal(err.errno, 123, 'err.errno === 123');
             }
           );
@@ -653,7 +653,7 @@ describe('remote db', function() {
                 'deleting a non-existent device should have failed'
               );
             },
-            err => {
+            (err) => {
               assert.equal(err.errno, 123, 'err.errno === 123');
             }
           );
@@ -664,15 +664,15 @@ describe('remote db', function() {
             assert(false, 'getting devices should not have failed');
           });
         })
-        .then(devices => {
+        .then((devices) => {
           assert.ok(Array.isArray(devices), 'devices is array');
           assert.equal(devices.length, 0, 'devices array is empty');
           // Create a device
-          return db.createDevice(account.uid, deviceInfo).catch(_err => {
+          return db.createDevice(account.uid, deviceInfo).catch((_err) => {
             assert(false, 'adding a new device should not have failed');
           });
         })
-        .then(device => {
+        .then((device) => {
           assert.ok(device.id, 'device.id is set');
           assert.ok(device.createdAt > 0, 'device.createdAt is set');
           assert.equal(device.name, deviceInfo.name, 'device.name is correct');
@@ -705,7 +705,7 @@ describe('remote db', function() {
           // Fetch the session token
           return db.sessionToken(sessionToken.id);
         })
-        .then(sessionToken => {
+        .then((sessionToken) => {
           assert.equal(sessionToken.lifetime, Infinity);
           conflictingDeviceInfo.sessionTokenId = sessionToken.id;
           // Attempt to create a device with a duplicate session token
@@ -716,7 +716,7 @@ describe('remote db', function() {
                 'adding a device with a duplicate session token should have failed'
               );
             },
-            err => {
+            (err) => {
               assert.equal(err.errno, 124, 'err.errno');
               assert.equal(err.output.payload.deviceId, deviceInfo.id);
             }
@@ -726,11 +726,11 @@ describe('remote db', function() {
           // Fetch all of the devices for the account
           return db.devices(account.uid);
         })
-        .then(devices => {
+        .then((devices) => {
           assert.equal(devices.length, 1, 'devices array contains one item');
           return devices[0];
         })
-        .then(device => {
+        .then((device) => {
           assert.ok(device.id, 'device.id is set');
           assert.ok(device.lastAccessTime > 0, 'device.lastAccessTime is set');
           assert.equal(device.name, deviceInfo.name, 'device.name is correct');
@@ -820,11 +820,11 @@ describe('remote db', function() {
             }),
           ]);
         })
-        .then(results => {
+        .then((results) => {
           // Create another session token
           return db.createSessionToken(sessionToken);
         })
-        .then(result => {
+        .then((result) => {
           anotherSessionToken = result;
           conflictingDeviceInfo.sessionTokenId = anotherSessionToken.id;
           // Create another device
@@ -840,7 +840,7 @@ describe('remote db', function() {
                 'updating a device with a duplicate session token should have failed'
               );
             },
-            err => {
+            (err) => {
               assert.equal(err.errno, 124, 'err.errno');
               assert.equal(
                 err.output.payload.deviceId,
@@ -853,7 +853,7 @@ describe('remote db', function() {
           // Fetch all of the devices for the account
           return db.devices(account.uid);
         })
-        .then(devices => {
+        .then((devices) => {
           assert.equal(devices.length, 2, 'devices array contains two items');
 
           if (devices[0].id === deviceInfo.id) {
@@ -862,14 +862,14 @@ describe('remote db', function() {
 
           return devices[1];
         })
-        .then(device => {
+        .then((device) => {
           // Fetch a single device
-          return db.device(account.uid, device.id).then(result => {
+          return db.device(account.uid, device.id).then((result) => {
             assert.deepEqual(device, result);
             return device;
           });
         })
-        .then(device => {
+        .then((device) => {
           assert.equal(
             device.lastAccessTime,
             42,
@@ -954,7 +954,7 @@ describe('remote db', function() {
           lastAccessTimeUpdates.enabled = false;
           return db.devices(account.uid);
         })
-        .then(devices => {
+        .then((devices) => {
           assert.equal(devices.length, 2, 'devices array contains two items');
           assert.equal(
             devices[0].lastAccessTime,
@@ -977,14 +977,14 @@ describe('remote db', function() {
         .then(() => db.deleteDevice(account.uid, conflictingDeviceInfo.id))
         // Deleting the devices should also have cleared the data from Redis
         .then(() => redis.getAsync(account.uid))
-        .then(result => {
+        .then((result) => {
           assert.equal(result, null, 'redis was cleared');
         })
         .then(() => {
           // Fetch all of the devices for the account
           return db.devices(account.uid);
         })
-        .then(devices => {
+        .then((devices) => {
           assert.equal(devices.length, 0, 'devices array is empty');
 
           // Delete the account
@@ -997,40 +997,40 @@ describe('remote db', function() {
     let tokenId;
     return db
       .emailRecord(account.email)
-      .then(emailRecord => {
+      .then((emailRecord) => {
         return db.createKeyFetchToken({
           uid: emailRecord.uid,
           kA: emailRecord.kA,
           wrapKb: account.wrapWrapKb,
         });
       })
-      .then(keyFetchToken => {
+      .then((keyFetchToken) => {
         assert.deepEqual(keyFetchToken.uid, account.uid);
         tokenId = keyFetchToken.id;
       })
       .then(() => {
         return db.keyFetchToken(tokenId);
       })
-      .then(keyFetchToken => {
+      .then((keyFetchToken) => {
         assert.deepEqual(keyFetchToken.id, tokenId, 'token id matches');
         assert.deepEqual(keyFetchToken.uid, account.uid);
         assert.equal(keyFetchToken.emailVerified, account.emailVerified);
         return keyFetchToken;
       })
-      .then(keyFetchToken => {
+      .then((keyFetchToken) => {
         return db.deleteKeyFetchToken(keyFetchToken);
       })
       .then(() => {
         return db.keyFetchToken(tokenId);
       })
       .then(
-        keyFetchToken => {
+        (keyFetchToken) => {
           assert(
             false,
             'The above keyFetchToken() call should fail, since the keyFetchToken has been deleted'
           );
         },
-        err => {
+        (err) => {
           assert.equal(
             err.errno,
             110,
@@ -1050,13 +1050,13 @@ describe('remote db', function() {
     let tokenId;
     return db
       .emailRecord(account.email)
-      .then(emailRecord => {
+      .then((emailRecord) => {
         return db.createPasswordForgotToken(emailRecord);
       })
-      .then(passwordForgotToken => {
+      .then((passwordForgotToken) => {
         return db
           .forgotPasswordVerified(passwordForgotToken)
-          .then(accountResetToken => {
+          .then((accountResetToken) => {
             assert.ok(
               accountResetToken.createdAt >= passwordForgotToken.createdAt,
               'account reset token should be equal or newer than password forgot token'
@@ -1064,7 +1064,7 @@ describe('remote db', function() {
             return accountResetToken;
           });
       })
-      .then(accountResetToken => {
+      .then((accountResetToken) => {
         assert.deepEqual(
           accountResetToken.uid,
           account.uid,
@@ -1073,7 +1073,7 @@ describe('remote db', function() {
         tokenId = accountResetToken.id;
         return db.accountResetToken(tokenId);
       })
-      .then(accountResetToken => {
+      .then((accountResetToken) => {
         assert.deepEqual(accountResetToken.id, tokenId, 'token id matches');
         assert.deepEqual(
           accountResetToken.uid,
@@ -1082,11 +1082,11 @@ describe('remote db', function() {
         );
         return accountResetToken;
       })
-      .then(accountResetToken => {
+      .then((accountResetToken) => {
         return db.deleteAccountResetToken(accountResetToken);
       })
       .then(() => {
-        return db.accountResetToken(tokenId).then(assert.fail, err => {
+        return db.accountResetToken(tokenId).then(assert.fail, (err) => {
           assert.equal(
             err.errno,
             110,
@@ -1107,10 +1107,10 @@ describe('remote db', function() {
     let token1tries = 0;
     return db
       .emailRecord(account.email)
-      .then(emailRecord => {
+      .then((emailRecord) => {
         return db.createPasswordForgotToken(emailRecord);
       })
-      .then(passwordForgotToken => {
+      .then((passwordForgotToken) => {
         assert.deepEqual(
           passwordForgotToken.uid,
           account.uid,
@@ -1122,7 +1122,7 @@ describe('remote db', function() {
       .then(() => {
         return db.passwordForgotToken(token1.id);
       })
-      .then(passwordForgotToken => {
+      .then((passwordForgotToken) => {
         assert.deepEqual(passwordForgotToken.id, token1.id, 'token id matches');
         assert.deepEqual(
           passwordForgotToken.uid,
@@ -1131,14 +1131,14 @@ describe('remote db', function() {
         );
         return passwordForgotToken;
       })
-      .then(passwordForgotToken => {
+      .then((passwordForgotToken) => {
         passwordForgotToken.tries -= 1;
         return db.updatePasswordForgotToken(passwordForgotToken);
       })
       .then(() => {
         return db.passwordForgotToken(token1.id);
       })
-      .then(passwordForgotToken => {
+      .then((passwordForgotToken) => {
         assert.deepEqual(
           passwordForgotToken.id,
           token1.id,
@@ -1147,20 +1147,20 @@ describe('remote db', function() {
         assert.equal(passwordForgotToken.tries, token1tries - 1, '');
         return passwordForgotToken;
       })
-      .then(passwordForgotToken => {
+      .then((passwordForgotToken) => {
         return db.deletePasswordForgotToken(passwordForgotToken);
       })
       .then(() => {
         return db.passwordForgotToken(token1.id);
       })
       .then(
-        passwordForgotToken => {
+        (passwordForgotToken) => {
           assert(
             false,
             'The above passwordForgotToken() call should fail, since the passwordForgotToken has been deleted'
           );
         },
-        err => {
+        (err) => {
           assert.equal(
             err.errno,
             110,
@@ -1179,13 +1179,13 @@ describe('remote db', function() {
   it('email verification', () => {
     return db
       .emailRecord(account.email)
-      .then(emailRecord => {
+      .then((emailRecord) => {
         return db.verifyEmail(emailRecord, emailRecord.emailCode);
       })
       .then(() => {
         return db.account(account.uid);
       })
-      .then(account => {
+      .then((account) => {
         assert.ok(account.emailVerified, 'account should now be emailVerified');
       });
   });
@@ -1194,13 +1194,13 @@ describe('remote db', function() {
     let token1;
     return db
       .emailRecord(account.email)
-      .then(emailRecord => {
+      .then((emailRecord) => {
         return db.createPasswordForgotToken(emailRecord);
       })
-      .then(passwordForgotToken => {
+      .then((passwordForgotToken) => {
         return db.forgotPasswordVerified(passwordForgotToken);
       })
-      .then(accountResetToken => {
+      .then((accountResetToken) => {
         assert.deepEqual(
           accountResetToken.uid,
           account.uid,
@@ -1211,7 +1211,7 @@ describe('remote db', function() {
       .then(() => {
         return db.accountResetToken(token1.id);
       })
-      .then(accountResetToken => {
+      .then((accountResetToken) => {
         assert.deepEqual(accountResetToken.uid, account.uid);
         return db.deleteAccountResetToken(token1);
       });
@@ -1220,7 +1220,7 @@ describe('remote db', function() {
   it('db.resetAccount', () => {
     return db
       .emailRecord(account.email)
-      .then(emailRecord => {
+      .then((emailRecord) => {
         emailRecord.tokenVerificationId = account.tokenVerificationId;
         emailRecord.uaBrowser = 'Firefox';
         emailRecord.uaBrowserVersion = '41';
@@ -1229,21 +1229,21 @@ describe('remote db', function() {
         emailRecord.uaDeviceType = emailRecord.uaFormFactor = null;
         return db.createSessionToken(emailRecord);
       })
-      .then(sessionToken => {
+      .then((sessionToken) => {
         return db.forgotPasswordVerified(sessionToken);
       })
-      .then(accountResetToken => {
+      .then((accountResetToken) => {
         return db.resetAccount(accountResetToken, account);
       })
       .then(() => {
         return redis.getAsync(account.uid);
       })
-      .then(result => {
+      .then((result) => {
         assert.equal(result, null, 'redis was cleared');
         // account should STILL exist for this email address
         return db.accountExists(account.email);
       })
-      .then(exists => {
+      .then((exists) => {
         assert.equal(exists, true, 'account should still exist');
       });
   });
@@ -1255,7 +1255,7 @@ describe('remote db', function() {
         name: 'account.create',
         uid: account.uid,
       })
-      .then(resp => {
+      .then((resp) => {
         assert.equal(typeof resp, 'object');
         assert.equal(Object.keys(resp).length, 0);
 
@@ -1265,7 +1265,7 @@ describe('remote db', function() {
           uid: account.uid,
         });
       })
-      .then(resp => {
+      .then((resp) => {
         assert.equal(typeof resp, 'object');
         assert.equal(Object.keys(resp).length, 0);
       });
@@ -1284,7 +1284,7 @@ describe('remote db', function() {
           uid: account.uid,
         });
       })
-      .then(events => {
+      .then((events) => {
         assert.equal(events.length, 1);
       });
   });
@@ -1301,7 +1301,7 @@ describe('remote db', function() {
           uid: account.uid,
         });
       })
-      .then(events => {
+      .then((events) => {
         assert.equal(events.length, 1);
       });
   });
@@ -1318,13 +1318,13 @@ describe('remote db', function() {
           uid: account.uid,
         });
       })
-      .then(events => {
+      .then((events) => {
         assert.deepEqual(events, {});
         return db.securityEventsByUid({
           uid: account.uid,
         });
       })
-      .then(events => {
+      .then((events) => {
         assert.equal(events.length, 0);
       });
   });
@@ -1333,7 +1333,7 @@ describe('remote db', function() {
     let unblockCode;
     return db
       .createUnblockCode(account.uid)
-      .then(_unblockCode => {
+      .then((_unblockCode) => {
         assert.ok(_unblockCode);
         unblockCode = _unblockCode;
 
@@ -1346,7 +1346,7 @@ describe('remote db', function() {
             'consumeUnblockCode() with an invalid unblock code should not succeed'
           );
         },
-        err => {
+        (err) => {
           assert.equal(
             err.errno,
             127,
@@ -1368,7 +1368,7 @@ describe('remote db', function() {
           // re-use unblock code, no longer valid
           return db.consumeUnblockCode(account.uid, unblockCode);
         },
-        _err => {
+        (_err) => {
           assert(
             false,
             'consumeUnblockCode() with a valid unblock code should succeed'
@@ -1382,7 +1382,7 @@ describe('remote db', function() {
             'consumeUnblockCode() with an invalid unblock code should not succeed'
           );
         },
-        err => {
+        (err) => {
           assert.equal(
             err.errno,
             127,
@@ -1405,7 +1405,7 @@ describe('remote db', function() {
     // Create a signinCode without a flowId
     return db
       .createSigninCode(account.uid)
-      .then(code => {
+      .then((code) => {
         assert.equal(
           typeof code,
           'string',
@@ -1435,7 +1435,7 @@ describe('remote db', function() {
         // and this time specifying a flowId
         return db.createSigninCode(account.uid, flowId);
       })
-      .then(code => {
+      .then((code) => {
         assert.equal(
           typeof code,
           'string',
@@ -1458,7 +1458,7 @@ describe('remote db', function() {
           db.consumeSigninCode(code),
         ]);
       })
-      .then(results => {
+      .then((results) => {
         assert.equal(
           results[0].email,
           account.email,
@@ -1482,7 +1482,7 @@ describe('remote db', function() {
         return db
           .consumeSigninCode(previousCode)
           .then(() => assert.fail('db.consumeSigninCode should have failed'))
-          .catch(err => {
+          .catch((err) => {
             assert.equal(
               err.errno,
               146,
@@ -1505,7 +1505,7 @@ describe('remote db', function() {
   it('account deletion', () => {
     return db
       .emailRecord(account.email)
-      .then(emailRecord => {
+      .then((emailRecord) => {
         assert.deepEqual(
           emailRecord.uid,
           account.uid,
@@ -1516,12 +1516,12 @@ describe('remote db', function() {
       .then(() => {
         return redis.getAsync(account.uid);
       })
-      .then(result => {
+      .then((result) => {
         assert.equal(result, null, 'redis was cleared');
         // account should no longer exist for this email address
         return db.accountExists(account.email);
       })
-      .then(exists => {
+      .then((exists) => {
         assert.equal(exists, false, 'account should no longer exist');
       });
   });
@@ -1579,7 +1579,7 @@ describe('remote db', function() {
         .then(() => {
           assert.fail('should not have retrieved non-existent account');
         })
-        .catch(err => {
+        .catch((err) => {
           assert.equal(err.errno, 102, 'unknown account error code');
         });
     });
@@ -1589,11 +1589,11 @@ describe('remote db', function() {
     it('can set primary email address', () => {
       return db
         .setPrimaryEmail(account.uid, secondEmail)
-        .then(res => {
+        .then((res) => {
           assert.ok(res, 'ok response');
           return db.accountRecord(secondEmail);
         })
-        .then(account => {
+        .then((account) => {
           assert.equal(
             account.primaryEmail.email,
             secondEmail,

--- a/packages/fxa-auth-server/tsconfig.json
+++ b/packages/fxa-auth-server/tsconfig.json
@@ -7,7 +7,9 @@
     "checkJs": false,
     "target": "ES2019",
     "module": "commonjs",
+    "skipLibCheck": true,
     "strict": true,
+    "declaration": false,
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
@@ -15,12 +17,22 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "typeRoots": ["./types", "node_modules/@types", "../../node_modules/@types", "../fxa-shared/types"],
-    "types": ["accept-language", "mocha", "mozlog", "node"]
+    "types": ["accept-language", "mocha", "mozlog", "node"],
+    "baseUrl": ".",
+    "paths": {
+      "fxa-shared/*": [
+        "../fxa-shared/*"
+      ]
+    }
   },
+  "references": [
+    { "path": "../fxa-shared" }
+  ],
   "include": [
-    "bin/*",
+    "bin/*"
   ],
   "exclude": [
+    "dist",
     "node_modules"
   ]
 }

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -4,8 +4,7 @@
   "description": "Shared module for FxA repositories",
   "main": "dist/index.js",
   "scripts": {
-    "postinstall": "tsc",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "npm run lint && node ./scripts/mocha-coverage.js -r ts-node/register --recursive test",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint": "eslint .",

--- a/packages/fxa-shared/tsconfig.json
+++ b/packages/fxa-shared/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compileOnSave": true,
   "compilerOptions": {
+    "composite": true,
     "outDir": "./dist",
     "allowJs": true,
     "target": "es6",
@@ -12,6 +13,6 @@
     "typeRoots": ["./types", "node_modules/@types", "../../node_modules/@types"],
     "skipLibCheck": true
   },
-  "include": ["./**/*", "./*"],
+  "include": ["./**/*", "./*", "./**/*.json"],
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
The postinstall of fxa-shared was a temporary hack to prevent
auth-server from failing during it's build step. This unfortunately
caused the build-builder.sh script to fail when it tried to
only include the non-dev dependencies from the docker image.

The fix was to make fxa-shared a composite ts lib and add
a reference to it in fxa-auth-server's tsconfig. This required
using a 'path' instead of direct fs access in order to work
with both ts-node for dev and tsc for prod.

### review notes

tsconfig files are the main point of interest, the rest is are updating `require` paths. No functionality changes.

_(oh lovely, this came with a bunch of prettier style changes)_