### PR TITLE
fix(payments-server): correct location for secrets.json alongside config

### DIFF
--- a/packages/fxa-payments-server/pm2.config.js
+++ b/packages/fxa-payments-server/pm2.config.js
@@ -15,7 +15,7 @@ module.exports = {
         NODE_ENV: 'development',
         NODE_OPTIONS: '--inspect=9170',
         PROXY_STATIC_RESOURCES_FROM: 'http://localhost:3032',
-        CONFIG_FILES: 'config/secrets.json',
+        CONFIG_FILES: 'server/config/secrets.json',
         PORT: '3031',
       },
       filter_env: ['npm_'],


### PR DESCRIPTION
This one took me awhile to figure out - my secrets.json with a custom Stripe API was never getting used. Turns out PM2 had the wrong path.

Someday, we should probably move payments-server config out of server/config and to just config at the root of the package