### PR TITLE
refactor(logging): reduce profile cache logging from info to verbose

### DIFF
--- a/packages/fxa-profile-server/lib/routes/profile.js
+++ b/packages/fxa-profile-server/lib/routes/profile.js
@@ -71,13 +71,13 @@ module.exports = {
       }
       const lastModified = cached ? new Date(cached.stored) : new Date();
       if (cached) {
-        logger.info('batch.cached', {
+        logger.verbose('batch.cached', {
           storedAt: cached.stored,
           error: report && report.error,
           ttl: cached.ttl,
         });
       } else {
-        logger.info('batch.db');
+        logger.verbose('batch.db');
       }
 
       return rep.header('last-modified', lastModified.toUTCString());


### PR DESCRIPTION
At the higher logging level it fills up our production logs.  At a
lower level it will still show up for debugging.

supersedes #5402 