### PR TITLE
feat(metrics): Emit statsd metrics around push message sending.

### DIFF
--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -24,7 +24,7 @@ module.exports = function (
   redis
 ) {
   // Various extra helpers.
-  const push = require('../push')(log, db, config);
+  const push = require('../push')(log, db, config, statsd);
   const pushbox = require('../pushbox')(log, config, statsd);
   const devicesImpl = require('../devices')(log, db, oauthdb, push);
   const signinUtils = require('./utils/signin')(

--- a/packages/fxa-auth-server/test/e2e/push_tests.js
+++ b/packages/fxa-auth-server/test/e2e/push_tests.js
@@ -26,13 +26,13 @@ describe('e2e/push', () => {
       let count = 0;
       const thisSpyLog = mockLog({
         info(op, log) {
-          if (log.name === 'push.account_verify.success') {
+          if (op === 'push.send.success') {
             count++;
           }
         },
       });
 
-      const push = require('../../lib/push')(thisSpyLog, mockDB(), config);
+      const push = require('../../lib/push')(thisSpyLog, mockDB(), config, { increment: () => {} });
       const options = {
         data: Buffer.from('foodata'),
       };
@@ -65,7 +65,7 @@ describe('e2e/push', () => {
           assert.equal(
             count,
             1,
-            'log.info::push.account_verify.success was called once'
+            'log.info::push.send.success was called once'
           );
         });
     });

--- a/packages/fxa-auth-server/test/local/push.js
+++ b/packages/fxa-auth-server/test/local/push.js
@@ -2,944 +2,767 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-'use strict';
+"use strict";
 
-const ROOT_DIR = '../..';
+const ROOT_DIR = "../..";
 
-const proxyquire = require('proxyquire');
-const sinon = require('sinon');
-const assert = { ...sinon.assert, ...require('chai').assert };
-const ajv = require('ajv')();
-const fs = require('fs');
-const path = require('path');
+const proxyquire = require("proxyquire");
+const sinon = require("sinon");
+const assert = { ...sinon.assert, ...require("chai").assert };
+const ajv = require("ajv")();
+const fs = require("fs");
+const path = require("path");
+const match = sinon.match;
 
-const P = require(`${ROOT_DIR}/lib/promise`);
-const mocks = require('../mocks');
-const mockLog = mocks.mockLog;
-const mockUid = 'deadbeef';
-const mockConfig = {};
+const mocks = require("../mocks");
+const mockUid = "deadbeef";
 
-const PUSH_PAYLOADS_SCHEMA_PATH = `${ROOT_DIR}/docs/pushpayloads.schema.json`;
-const TTL = '42';
+const TTL = "42";
 const pushModulePath = `${ROOT_DIR}/lib/push`;
 
-describe('push', () => {
-  let mockDb, mockDevices;
+const PUSH_PAYLOADS_SCHEMA_PATH = `${ROOT_DIR}/docs/pushpayloads.schema.json`;
+let PUSH_PAYLOADS_SCHEMA_MATCHER = null;
+match.validPushPayload = (fields) => {
+  if (!PUSH_PAYLOADS_SCHEMA_MATCHER) {
+    const schemaPath = path.resolve(__dirname, PUSH_PAYLOADS_SCHEMA_PATH);
+    const schema = JSON.parse(fs.readFileSync(schemaPath));
+    PUSH_PAYLOADS_SCHEMA_MATCHER = match((value) => {
+      return ajv.validate(schema, value);
+    }, "matches payload schema");
+  }
+  return match(fields).and(PUSH_PAYLOADS_SCHEMA_MATCHER);
+};
+
+describe("push", () => {
+  let mockDb,
+    mockLog,
+    mockConfig,
+    mockStatsD,
+    mockDevices,
+    mockSendNotification;
+
+  function loadMockedPushModule() {
+    const mocks = {
+      "web-push": {
+        sendNotification: mockSendNotification,
+      },
+    };
+    return proxyquire(pushModulePath, mocks)(
+      mockLog,
+      mockDb,
+      mockConfig,
+      mockStatsD
+    );
+  }
 
   beforeEach(() => {
     mockDb = mocks.mockDB();
+    mockLog = mocks.mockLog();
+    mockConfig = {};
     mockDevices = [
       {
-        id: '0f7aa00356e5416e82b3bef7bc409eef',
+        id: "0f7aa00356e5416e82b3bef7bc409eef",
         isCurrentDevice: true,
         lastAccessTime: 1449235471335,
-        name: 'My Phone',
-        type: 'mobile',
+        name: "My Phone",
+        type: "mobile",
         availableCommands: {},
         pushCallback:
-          'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef',
+          "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
         pushPublicKey: mocks.MOCK_PUSH_KEY,
-        pushAuthKey: 'w3b14Zjc-Afj2SDOLOyong==',
+        pushAuthKey: "w3b14Zjc-Afj2SDOLOyong==",
         pushEndpointExpired: false,
       },
       {
-        id: '3a45e6d0dae543qqdKyqjuvAiEupsnOd',
+        id: "3a45e6d0dae543qqdKyqjuvAiEupsnOd",
         isCurrentDevice: false,
         lastAccessTime: 1417699471335,
-        name: 'My Desktop',
+        name: "My Desktop",
+        uaOS: "Windows",
+        uaOSVersion: "10",
+        uaBrowser: "Firefox",
+        uaBrowserVersion: "65.4",
         type: null,
         availableCommands: {},
         pushCallback:
-          'https://updates.push.services.mozilla.com/update/d4c5b1e3f5791ef83896c27519979b93a45e6d0da34c75',
+          "https://updates.push.services.mozilla.com/update/d4c5b1e3f5791ef83896c27519979b93a45e6d0da34c75",
         pushPublicKey: mocks.MOCK_PUSH_KEY,
-        pushAuthKey: 'w3b14Zjc-Afj2SDOLOyong==',
+        pushAuthKey: "w3b14Zjc-Afj2SDOLOyong==",
         pushEndpointExpired: false,
       },
       {
-        id: '50973923bc3e4507a0aa4e285513194a',
+        id: "50973923bc3e4507a0aa4e285513194a",
         isCurrentDevice: false,
         lastAccessTime: 1402149471335,
-        name: 'My Ipad',
+        name: "My Ipad",
         type: null,
         availableCommands: {},
-        uaOS: 'iOS',
+        uaOS: "iOS",
         pushCallback:
-          'https://updates.push.services.mozilla.com/update/50973923bc3e4507a0aa4e285513194a',
+          "https://updates.push.services.mozilla.com/update/50973923bc3e4507a0aa4e285513194a",
         pushPublicKey: mocks.MOCK_PUSH_KEY,
-        pushAuthKey: 'w3b14Zjc-Afj2SDOLOyong==',
+        pushAuthKey: "w3b14Zjc-Afj2SDOLOyong==",
         pushEndpointExpired: false,
       },
     ];
-  });
-
-  it('sendPush does not reject on empty device array', () => {
-    const thisMockLog = mockLog({
-      info: function (op, log) {
-        if (log.name === 'push.account_verify.success') {
-          assert.fail('must not call push.success');
-        }
-      },
-    });
-    const push = require(pushModulePath)(thisMockLog, mockDb, mockConfig);
-
-    return push.sendPush(mockUid, [], 'accountVerify');
-  });
-
-  it('sendPush sends notifications with a TTL of 0', () => {
-    let successCalled = 0;
-    const thisMockLog = mockLog({
-      info: function (op, log) {
-        if (log.name === 'push.account_verify.success') {
-          // notification sent
-          successCalled++;
-        }
-      },
-    });
-
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          assert.equal(options.TTL, '0', 'sends the proper ttl header');
-          return P.resolve();
-        },
-      },
+    mockStatsD = {
+      increment: sinon.spy(),
     };
-
-    const push = proxyquire(pushModulePath, mocks)(
-      thisMockLog,
-      mockDb,
-      mockConfig
-    );
-    return push.sendPush(mockUid, mockDevices, 'accountVerify').then(() => {
-      assert.equal(successCalled, 2);
-    });
+    mockSendNotification = sinon.spy(async () => {});
   });
 
-  it('sendPush sends notifications with user-defined TTL', () => {
-    let successCalled = 0;
-    const thisMockLog = mockLog({
-      info: function (op, log) {
-        if (log.name === 'push.account_verify.success') {
-          // notification sent
-          successCalled++;
-        }
-      },
+  it("sendPush does not reject on empty device array", async () => {
+    const push = loadMockedPushModule();
+    await push.sendPush(mockUid, [], "accountVerify");
+    assert.callCount(mockSendNotification, 0);
+    assert.callCount(mockLog.info, 0);
+    assert.callCount(mockStatsD.increment, 0);
+  });
+
+  it("sendPush logs metrics about successful sends", async () => {
+    const push = loadMockedPushModule();
+    await push.sendPush(mockUid, mockDevices, "accountVerify");
+    assert.callCount(mockSendNotification, 2);
+
+    assert.callCount(mockLog.info, 5);
+    assert.calledWith(
+      mockLog.info.getCall(0),
+      "push.filteredUnsupportedDevice"
+    );
+    assert.calledWithExactly(mockLog.info.getCall(1), "push.send.attempt", {
+      reason: "accountVerify",
+      uid: mockUid,
+      deviceId: mockDevices[0].id,
+      uaOS: undefined,
+      uaOSVersion: undefined,
+      uaBrowser: undefined,
+      uaBrowserVersion: undefined,
+    });
+    assert.calledWithExactly(mockLog.info.getCall(2), "push.send.success", {
+      reason: "accountVerify",
+      uid: mockUid,
+      deviceId: mockDevices[0].id,
+      uaOS: undefined,
+      uaOSVersion: undefined,
+      uaBrowser: undefined,
+      uaBrowserVersion: undefined,
+    });
+    assert.calledWithExactly(mockLog.info.getCall(3), "push.send.attempt", {
+      reason: "accountVerify",
+      uid: mockUid,
+      deviceId: mockDevices[1].id,
+      uaOS: "Windows",
+      uaOSVersion: "10",
+      uaBrowser: "Firefox",
+      uaBrowserVersion: "65.4",
+    });
+    assert.calledWithExactly(mockLog.info.getCall(4), "push.send.success", {
+      reason: "accountVerify",
+      uid: mockUid,
+      deviceId: mockDevices[1].id,
+      uaOS: "Windows",
+      uaOSVersion: "10",
+      uaBrowser: "Firefox",
+      uaBrowserVersion: "65.4",
     });
 
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          assert.equal(options.TTL, TTL, 'sends the proper ttl header');
-          return P.resolve();
-        },
-      },
-    };
-
-    const push = proxyquire(pushModulePath, mocks)(
-      thisMockLog,
-      mockDb,
-      mockConfig
+    assert.callCount(mockStatsD.increment, 4);
+    assert.calledWithExactly(
+      mockStatsD.increment.getCall(0),
+      "push.send.attempt",
+      {
+        reason: "accountVerify",
+        uaOS: undefined,
+        errCode: undefined,
+      }
     );
+    assert.calledWithExactly(
+      mockStatsD.increment.getCall(1),
+      "push.send.success",
+      {
+        reason: "accountVerify",
+        uaOS: undefined,
+        errCode: undefined,
+      }
+    );
+    assert.calledWithExactly(
+      mockStatsD.increment.getCall(2),
+      "push.send.attempt",
+      {
+        reason: "accountVerify",
+        uaOS: "Windows",
+        errCode: undefined,
+      }
+    );
+    assert.calledWithExactly(
+      mockStatsD.increment.getCall(3),
+      "push.send.success",
+      {
+        reason: "accountVerify",
+        uaOS: "Windows",
+        errCode: undefined,
+      }
+    );
+  });
+
+
+  it("sendPush logs metrics about failed sends", async () => {
+    let shouldFail = false;
+    mockSendNotification = sinon.spy(async () => {
+      try {
+        if (shouldFail) {
+          throw new Error("intermittent failure");
+        }
+      } finally {
+        shouldFail = !shouldFail
+      }
+    })
+    const push = loadMockedPushModule();
+    await push.sendPush(mockUid, mockDevices, "accountVerify");
+    assert.callCount(mockSendNotification, 2);
+
+    assert.callCount(mockLog.info, 4);
+    assert.calledWith(
+      mockLog.info.getCall(0),
+      "push.filteredUnsupportedDevice"
+    );
+    assert.calledWithExactly(mockLog.info.getCall(1), "push.send.attempt", {
+      reason: "accountVerify",
+      uid: mockUid,
+      deviceId: mockDevices[0].id,
+      uaOS: undefined,
+      uaOSVersion: undefined,
+      uaBrowser: undefined,
+      uaBrowserVersion: undefined,
+    });
+    assert.calledWithExactly(mockLog.info.getCall(2), "push.send.success", {
+      reason: "accountVerify",
+      uid: mockUid,
+      deviceId: mockDevices[0].id,
+      uaOS: undefined,
+      uaOSVersion: undefined,
+      uaBrowser: undefined,
+      uaBrowserVersion: undefined,
+    });
+    assert.calledWithExactly(mockLog.info.getCall(3), "push.send.attempt", {
+      reason: "accountVerify",
+      uid: mockUid,
+      deviceId: mockDevices[1].id,
+      uaOS: "Windows",
+      uaOSVersion: "10",
+      uaBrowser: "Firefox",
+      uaBrowserVersion: "65.4",
+    });
+
+    assert.callCount(mockLog.warn, 1);
+    assert.calledWithExactly(mockLog.warn.getCall(0), "push.send.failure", {
+      reason: "accountVerify",
+      errCode: "unknown",
+      err: match.has("message", "intermittent failure"),
+      uid: mockUid,
+      deviceId: mockDevices[1].id,
+      uaOS: "Windows",
+      uaOSVersion: "10",
+      uaBrowser: "Firefox",
+      uaBrowserVersion: "65.4",
+    });
+
+    assert.callCount(mockStatsD.increment, 4);
+    assert.calledWithExactly(
+      mockStatsD.increment.getCall(0),
+      "push.send.attempt",
+      {
+        reason: "accountVerify",
+        uaOS: undefined,
+        errCode: undefined,
+      }
+    );
+    assert.calledWithExactly(
+      mockStatsD.increment.getCall(1),
+      "push.send.success",
+      {
+        reason: "accountVerify",
+        uaOS: undefined,
+        errCode: undefined,
+      }
+    );
+    assert.calledWithExactly(
+      mockStatsD.increment.getCall(2),
+      "push.send.attempt",
+      {
+        reason: "accountVerify",
+        uaOS: "Windows",
+        errCode: undefined,
+      }
+    );
+    assert.calledWithExactly(
+      mockStatsD.increment.getCall(3),
+      "push.send.failure",
+      {
+        reason: "accountVerify",
+        uaOS: "Windows",
+        errCode: "unknown",
+      }
+    );
+  });
+
+  it("sendPush sends notifications with a TTL of 0", async () => {
+    const push = loadMockedPushModule();
+    await push.sendPush(mockUid, mockDevices, "accountVerify");
+    assert.callCount(mockSendNotification, 2);
+    for (const call of mockSendNotification.getCalls()) {
+      assert.calledWithMatch(call, match.any, null, {
+        TTL: "0",
+      });
+    }
+  });
+
+  it("sendPush sends notifications with user-defined TTL", async () => {
+    const push = loadMockedPushModule();
     const options = { TTL: TTL };
-    return push
-      .sendPush(mockUid, mockDevices, 'accountVerify', options)
-      .then(() => {
-        assert.equal(successCalled, 2);
-      });
+    await push.sendPush(mockUid, mockDevices, "accountVerify", options);
+    assert.callCount(mockSendNotification, 2);
+    for (const call of mockSendNotification.getCalls()) {
+      assert.calledWithMatch(call, match.any, null, { TTL });
+    }
   });
 
-  it('sendPush sends data', () => {
-    let count = 0;
-    const data = { foo: 'bar' };
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          count++;
-          assert.ok(sub.keys.p256dh);
-          assert.ok(sub.keys.auth);
-          assert.deepEqual(payload, Buffer.from(JSON.stringify(data)));
-          return P.resolve();
-        },
-      },
-    };
-
-    const push = proxyquire(pushModulePath, mocks)(
-      mockLog(),
-      mockDb,
-      mockConfig
-    );
+  it("sendPush sends data", async () => {
+    const push = loadMockedPushModule();
+    const data = { foo: "bar" };
     const options = { data: data };
-    return push
-      .sendPush(mockUid, mockDevices, 'accountVerify', options)
-      .then(() => {
-        assert.equal(count, 2);
-      });
+    await push.sendPush(mockUid, mockDevices, "accountVerify", options);
+    assert.callCount(mockSendNotification, 2);
+    for (const call of mockSendNotification.getCalls()) {
+      assert.calledWithMatch(
+        call,
+        {
+          keys: {
+            p256dh: match.defined,
+            auth: match.defined,
+          },
+        },
+        Buffer.from(JSON.stringify(data))
+      );
+    }
   });
 
-  it("sendPush doesn't push to ios devices if it is triggered with an unsupported command", () => {
+  it("sendPush doesn't push to ios devices if it is triggered with an unsupported command", async () => {
+    const push = loadMockedPushModule();
     const data = Buffer.from(
-      JSON.stringify({ command: 'fxaccounts:non_existent_command' })
-    );
-    const endPoints = [];
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          endPoints.push(sub.endpoint);
-          return P.resolve();
-        },
-      },
-    };
-
-    const push = proxyquire(pushModulePath, mocks)(
-      mockLog(),
-      mockDb,
-      mockConfig
+      JSON.stringify({ command: "fxaccounts:non_existent_command" })
     );
     const options = { data: data };
-    return push
-      .sendPush(mockUid, mockDevices, 'devicesNotify', options)
-      .then(() => {
-        assert.equal(endPoints.length, 2);
-        assert.equal(endPoints[0], mockDevices[0].pushCallback);
-        assert.equal(endPoints[1], mockDevices[1].pushCallback);
-      });
+    await push.sendPush(mockUid, mockDevices, "devicesNotify", options);
+    assert.callCount(mockSendNotification, 2);
+    assert.calledWithMatch(mockSendNotification.getCall(0), {
+      endpoint: mockDevices[0].pushCallback,
+    });
+    assert.calledWithMatch(mockSendNotification.getCall(1), {
+      endpoint: mockDevices[1].pushCallback,
+    });
   });
 
-  it('sendPush pushes to all ios devices if it is triggered with a "commands received" command', () => {
+  it('sendPush pushes to all ios devices if it is triggered with a "commands received" command', async () => {
+    const push = loadMockedPushModule();
     const data = {
-      command: 'fxaccounts:command_received',
-      data: { foo: 'bar' },
+      command: "fxaccounts:command_received",
+      data: { foo: "bar" },
     };
-    const endPoints = [];
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          endPoints.push(sub.endpoint);
-          return P.resolve();
-        },
-      },
-    };
-
-    const push = proxyquire(pushModulePath, mocks)(
-      mockLog(),
-      mockDb,
-      mockConfig
-    );
     const options = { data: data };
-    return push
-      .sendPush(mockUid, mockDevices, 'devicesNotify', options)
-      .then(() => {
-        assert.equal(endPoints.length, 3);
-        assert.equal(endPoints[0], mockDevices[0].pushCallback);
-        assert.equal(endPoints[1], mockDevices[1].pushCallback);
-        assert.equal(endPoints[2], mockDevices[2].pushCallback);
-      });
+    await push.sendPush(mockUid, mockDevices, "devicesNotify", options);
+    assert.callCount(mockSendNotification, 3);
+    assert.calledWithMatch(mockSendNotification.getCall(0), {
+      endpoint: mockDevices[0].pushCallback,
+    });
+    assert.calledWithMatch(mockSendNotification.getCall(1), {
+      endpoint: mockDevices[1].pushCallback,
+    });
+    assert.calledWithMatch(mockSendNotification.getCall(2), {
+      endpoint: mockDevices[2].pushCallback,
+    });
   });
 
-  it('sendPush does not push to ios devices if triggered with a "collection changed" command', () => {
+  it('sendPush does not push to ios devices if triggered with a "collection changed" command', async () => {
+    const push = loadMockedPushModule();
     const data = {
-      command: 'sync:collection_changed',
-      data: { collection: 'clients', reason: 'firstsync' },
+      command: "sync:collection_changed",
+      data: { collection: "clients", reason: "firstsync" },
     };
-    const endPoints = [];
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          endPoints.push(sub.endpoint);
-          return P.resolve();
-        },
-      },
-    };
-
-    const push = proxyquire(pushModulePath, mocks)(
-      mockLog(),
-      mockDb,
-      mockConfig
-    );
     const options = { data: data };
-    return push
-      .sendPush(mockUid, mockDevices, 'devicesNotify', options)
-      .then(() => {
-        assert.equal(endPoints.length, 2);
-        assert.equal(endPoints[0], mockDevices[0].pushCallback);
-        assert.equal(endPoints[1], mockDevices[1].pushCallback);
-      });
+    await push.sendPush(mockUid, mockDevices, "devicesNotify", options);
+    assert.callCount(mockSendNotification, 2);
+    assert.calledWithMatch(mockSendNotification.getCall(0), {
+      endpoint: mockDevices[0].pushCallback,
+    });
+    assert.calledWithMatch(mockSendNotification.getCall(1), {
+      endpoint: mockDevices[1].pushCallback,
+    });
   });
 
   it('sendPush pushes to ios devices if it is triggered with a "device connected" command', async () => {
+    const push = loadMockedPushModule();
     const data = { command: 'fxaccounts:device_connected' };
-    const endPoints = [];
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          endPoints.push(sub.endpoint);
-          return P.resolve();
-        },
-      },
-    };
-
-    const push = proxyquire(pushModulePath, mocks)(
-      mockLog(),
-      mockDb,
-      mockConfig
-    );
     const options = { data: data };
     await push.sendPush(mockUid, mockDevices, 'devicesNotify', options);
-    assert.equal(endPoints.length, 3);
-    assert.equal(endPoints[0], mockDevices[0].pushCallback);
-    assert.equal(endPoints[1], mockDevices[1].pushCallback);
-    assert.equal(endPoints[2], mockDevices[2].pushCallback);
+    assert.callCount(mockSendNotification, 3);
+    assert.calledWithMatch(mockSendNotification.getCall(0), {
+      endpoint: mockDevices[0].pushCallback,
+    });
+    assert.calledWithMatch(mockSendNotification.getCall(1), {
+      endpoint: mockDevices[1].pushCallback,
+    });
+    assert.calledWithMatch(mockSendNotification.getCall(2), {
+      endpoint: mockDevices[2].pushCallback,
+    });
   });
 
-  it('push fails if data is present but both keys are not present', () => {
-    let count = 0;
-    const thisMockLog = mockLog({
-      info: function (op, log) {
-        if (log.name === 'push.account_verify.data_but_no_keys') {
-          // data detected but device had no keys
-          count++;
-        }
-      },
-    });
-
+  it("push fails if data is present but both keys are not present", async () => {
+    const push = loadMockedPushModule();
     const devices = [
       {
-        id: 'foo',
-        name: 'My Phone',
+        id: "foo",
+        name: "My Phone",
         pushCallback:
-          'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef',
-        pushAuthKey: 'bogus',
+          "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
+        pushAuthKey: "bogus",
         pushEndpointExpired: false,
       },
     ];
-
-    const push = require(pushModulePath)(thisMockLog, mockDb, mockConfig);
-    const options = { data: Buffer.from('foobar') };
-    return push
-      .sendPush(mockUid, devices, 'accountVerify', options)
-      .then(() => {
-        assert.equal(count, 1);
-      });
+    const options = { data: Buffer.from("foobar") };
+    await push.sendPush(mockUid, devices, "deviceConnected", options);
+    assert.callCount(mockLog.info, 1);
+    assert.calledWithMatch(mockLog.info, "push.send.attempt");
+    assert.callCount(mockLog.warn, 1);
+    assert.calledWithMatch(mockLog.warn, "push.send.failure", {
+      reason: "deviceConnected",
+      errCode: "noKeys",
+    });
   });
 
-  it('push catches devices with no push callback', () => {
-    let count = 0;
-    const thisMockLog = mockLog({
-      info: function (op, log) {
-        if (log.name === 'push.account_verify.no_push_callback') {
-          // device had no push callback
-          count++;
-        }
-      },
-    });
-
+  it("push catches devices with no push callback", async () => {
+    const push = loadMockedPushModule();
     const devices = [
       {
-        id: 'foo',
-        name: 'My Phone',
+        id: "foo",
+        name: "My Phone",
       },
     ];
-
-    const push = require(pushModulePath)(thisMockLog, mockDb, mockConfig);
-    return push.sendPush(mockUid, devices, 'accountVerify').then(() => {
-      assert.equal(count, 1);
+    await push.sendPush(mockUid, devices, "accountVerify");
+    assert.callCount(mockLog.info, 1);
+    assert.calledWithMatch(mockLog.info, "push.send.attempt");
+    assert.callCount(mockLog.warn, 1);
+    assert.calledWithMatch(mockLog.warn, "push.send.failure", {
+      reason: "accountVerify",
+      errCode: "noCallback",
     });
   });
 
-  it('push catches devices with expired callback', () => {
-    let count = 0;
-    const thisMockLog = mockLog({
-      info: function (op, log) {
-        if (log.name === 'push.account_verify.push_callback_expired') {
-          // device had expired callback
-          count++;
-        }
-      },
-    });
-
+  it("push catches devices with expired callback", async () => {
+    const push = loadMockedPushModule();
     const devices = [
       {
-        id: 'foo',
-        name: 'My Phone',
+        id: "foo",
+        name: "My Phone",
+        pushCallback:
+          "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
         pushEndpointExpired: true,
       },
     ];
-
-    const push = require(pushModulePath)(thisMockLog, mockDb, mockConfig);
-    return push.sendPush(mockUid, devices, 'accountVerify').then(() => {
-      assert.equal(count, 1);
+    await push.sendPush(mockUid, devices, "accountVerify");
+    assert.callCount(mockLog.info, 1);
+    assert.calledWithMatch(mockLog.info, "push.send.attempt");
+    assert.callCount(mockLog.warn, 1);
+    assert.calledWithMatch(mockLog.warn, "push.send.failure", {
+      reason: "accountVerify",
+      errCode: "expiredCallback",
     });
   });
 
-  it('push reports errors when web-push fails', () => {
-    let count = 0;
-    const thisMockLog = mockLog({
-      info: function (op, log) {
-        if (log.name === 'push.account_verify.failed') {
-          // web-push failed
-          count++;
-        }
-      },
+  it("push reports errors when web-push fails", async () => {
+    mockSendNotification = sinon.spy(async () => {
+      throw new Error("Failed with a nasty error");
     });
-
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          return P.reject(new Error('Failed'));
-        },
-      },
-    };
-
-    const push = proxyquire(pushModulePath, mocks)(
-      thisMockLog,
-      mockDb,
-      mockConfig
-    );
-    return push
-      .sendPush(mockUid, [mockDevices[0]], 'accountVerify')
-      .then(() => {
-        assert.equal(count, 1);
-      });
+    const push = loadMockedPushModule();
+    await push.sendPush(mockUid, [mockDevices[0]], "accountVerify");
+    assert.callCount(mockLog.info, 1);
+    assert.calledWithMatch(mockLog.info, "push.send.attempt");
+    assert.callCount(mockLog.warn, 1);
+    assert.calledWithMatch(mockLog.warn, "push.send.failure", {
+      reason: "accountVerify",
+      errCode: "unknown",
+      err: match.has("message", "Failed with a nasty error"),
+    });
   });
 
-  it('push logs an error when asked to send to more than 200 devices', () => {
-    const thisMockLog = mockLog({
-      error: sinon.spy(),
-    });
-
+  it("push logs a warning when asked to send to more than 200 devices", async () => {
+    const push = loadMockedPushModule();
     const devices = [];
     for (let i = 0; i < 200; i++) {
       devices.push(mockDevices[0]);
     }
+    await push.sendPush(mockUid, devices, "accountVerify");
+    assert.callCount(mockLog.warn, 0);
 
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          assert.equal(options.TTL, '0', 'sends the proper ttl header');
-          return P.resolve();
-        },
-      },
-    };
-    const push = proxyquire(pushModulePath, mocks)(
-      thisMockLog,
-      mockDb,
-      mockConfig
-    );
-
-    return push
-      .sendPush(mockUid, devices, 'accountVerify')
-      .then(() => {
-        assert.equal(
-          thisMockLog.error.callCount,
-          0,
-          'log.error was not called'
-        );
-        devices.push(mockDevices[0]);
-        return push.sendPush(mockUid, devices, 'accountVerify');
-      })
-      .then(() => {
-        assert.equal(thisMockLog.error.callCount, 1, 'log.error was called');
-        const args = thisMockLog.error.getCall(0).args;
-        assert.equal(args[0], 'push.sendPush');
-        assert.equal(
-          args[1].err.message,
-          'Too many devices connected to account'
-        );
-      });
+    devices.push(mockDevices[0]);
+    await push.sendPush(mockUid, devices, "accountVerify");
+    assert.callCount(mockLog.warn, 1);
+    assert.calledWithMatch(mockLog.warn, "push.sendPush.tooManyDevices", {
+      uid: mockUid,
+    });
   });
 
-  it('push resets device push data when push server responds with a 400 level error', () => {
-    let count = 0;
-    const thisMockLog = mockLog({
-      info: function (op, log) {
-        if (log.name === 'push.account_verify.reset_settings') {
-          // web-push failed
-          assert.equal(
-            mockDb.updateDevice.callCount,
-            1,
-            'db.updateDevice was called once'
-          );
-          const args = mockDb.updateDevice.args[0];
-          assert.equal(
-            args.length,
-            2,
-            'db.updateDevice was passed two arguments'
-          );
-          assert.equal(args[1].sessionTokenId, null, 'sessionTokenId was null');
-          count++;
-        }
-      },
+  it("push resets device push data when push server responds with a 400 level error", async () => {
+    mockSendNotification = sinon.spy(async () => {
+      const err = new Error("Failed");
+      err.statusCode = 410;
+      throw err;
     });
-
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          const err = new Error('Failed');
-          err.statusCode = 410;
-          return P.reject(err);
-        },
-      },
-    };
-
-    const push = proxyquire(pushModulePath, mocks)(
-      thisMockLog,
-      mockDb,
-      mockConfig
-    );
+    const push = loadMockedPushModule();
     // Careful, the argument gets modified in-place.
     const device = JSON.parse(JSON.stringify(mockDevices[0]));
-    return push.sendPush(mockUid, [device], 'accountVerify').then(() => {
-      assert.equal(count, 1);
+    await push.sendPush(mockUid, [device], "accountVerify");
+    assert.callCount(mockSendNotification, 1);
+    assert.callCount(mockLog.warn, 1);
+    assert.calledWithMatch(mockLog.warn, "push.send.failure", {
+      reason: "accountVerify",
+      errCode: "resetCallback",
+    });
+    assert.callCount(mockDb.updateDevice, 1);
+    assert.calledWithMatch(mockDb.updateDevice, mockUid, {
+      id: mockDevices[0].id,
+      sessionTokenId: match.falsy,
     });
   });
 
-  it('push resets device push data when a failure is caused by bad encryption keys', () => {
-    let count = 0;
-    const thisMockLog = mockLog({
-      info: function (op, log) {
-        if (log.name === 'push.account_verify.reset_settings') {
-          // web-push failed
-          assert.equal(
-            mockDb.updateDevice.callCount,
-            1,
-            'db.updateDevice was called once'
-          );
-          const args = mockDb.updateDevice.args[0];
-          assert.equal(
-            args.length,
-            2,
-            'db.updateDevice was passed two arguments'
-          );
-          assert.equal(
-            args[1].sessionTokenId,
-            null,
-            'sessionTokenId argument was null'
-          );
-          count++;
-        }
-      },
+  it("push resets device push data when a failure is caused by bad encryption keys", async () => {
+    mockSendNotification = sinon.spy(async () => {
+      throw new Error("Failed");
     });
-
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          const err = new Error('Failed');
-          return P.reject(err);
-        },
-      },
-    };
-
-    const push = proxyquire(pushModulePath, mocks)(
-      thisMockLog,
-      mockDb,
-      mockConfig
-    );
+    const push = loadMockedPushModule();
     // Careful, the argument gets modified in-place.
     const device = JSON.parse(JSON.stringify(mockDevices[0]));
     device.pushPublicKey = `E${device.pushPublicKey.substring(1)}`; // make the key invalid
-    return push.sendPush(mockUid, [device], 'accountVerify').then(() => {
-      assert.equal(count, 1);
+    await push.sendPush(mockUid, [device], "accountVerify");
+    assert.callCount(mockSendNotification, 1);
+    assert.callCount(mockLog.warn, 1);
+    assert.calledWithMatch(mockLog.warn, "push.send.failure", {
+      reason: "accountVerify",
+      errCode: "resetCallback",
+    });
+    assert.callCount(mockDb.updateDevice, 1);
+    assert.calledWithMatch(mockDb.updateDevice, mockUid, {
+      id: mockDevices[0].id,
+      sessionTokenId: match.falsy,
     });
   });
 
-  it('push does not reset device push data after an unexpected failure', () => {
-    let count = 0;
-    const thisMockLog = mockLog({
-      info: function (op, log) {
-        if (log.name === 'push.account_verify.failed') {
-          // web-push failed
-          assert.equal(
-            mockDb.updateDevice.callCount,
-            0,
-            'db.updateDevice was not called'
-          );
-          count++;
-        }
-      },
+  it("push does not reset device push data after an unexpected failure", async () => {
+    mockSendNotification = sinon.spy(async () => {
+      throw new Error("Failed unexpectedly");
     });
-
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          const err = new Error('Failed');
-          return P.reject(err);
-        },
-      },
-    };
-
-    const push = proxyquire(pushModulePath, mocks)(
-      thisMockLog,
-      mockDb,
-      mockConfig
-    );
-    return push
-      .sendPush(mockUid, [mockDevices[0]], 'accountVerify')
-      .then(() => {
-        assert.equal(count, 1);
-      });
-  });
-
-  it('notifyCommandReceived calls sendPush', () => {
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          return P.resolve();
-        },
-      },
-    };
-    const push = proxyquire(pushModulePath, mocks)(
-      mockLog(),
-      mockDb,
-      mockConfig
-    );
-    sinon.spy(push, 'sendPush');
-    return push
-      .notifyCommandReceived(
-        mockUid,
-        mockDevices[0],
-        'commandName',
-        'sendingDevice',
-        12,
-        'http://fetch.url',
-        42
-      )
-      .catch((err) => {
-        assert.fail('must not throw');
-        throw err;
-      })
-      .then(() => {
-        assert.ok(push.sendPush.calledOnce, 'sendPush was called');
-        assert.calledWithExactly(
-          push.sendPush,
-          mockUid,
-          [mockDevices[0]],
-          'commandReceived',
-          {
-            data: {
-              version: 1,
-              command: 'fxaccounts:command_received',
-              data: {
-                command: 'commandName',
-                index: 12,
-                sender: 'sendingDevice',
-                url: 'http://fetch.url',
-              },
-            },
-            TTL: 42,
-          }
-        );
-        const schemaPath = path.resolve(__dirname, PUSH_PAYLOADS_SCHEMA_PATH);
-        const schema = JSON.parse(fs.readFileSync(schemaPath));
-        assert.ok(ajv.validate(schema, push.sendPush.getCall(0).args[3].data));
-        push.sendPush.restore();
-      });
-  });
-
-  it('notifyDeviceConnected calls sendPush', () => {
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          return P.resolve();
-        },
-      },
-    };
-    const push = proxyquire(pushModulePath, mocks)(
-      mockLog(),
-      mockDb,
-      mockConfig
-    );
-    sinon.spy(push, 'sendPush');
-    const deviceName = 'My phone';
-    const expectedData = {
-      version: 1,
-      command: 'fxaccounts:device_connected',
-      data: {
-        deviceName: deviceName,
-      },
-    };
-    return push
-      .notifyDeviceConnected(mockUid, mockDevices, deviceName)
-      .catch((err) => {
-        assert.fail('must not throw');
-        throw err;
-      })
-      .then(() => {
-        assert.ok(push.sendPush.calledOnce, 'sendPush was called');
-        assert.equal(push.sendPush.getCall(0).args[0], mockUid);
-        assert.equal(push.sendPush.getCall(0).args[1], mockDevices);
-        assert.equal(push.sendPush.getCall(0).args[2], 'deviceConnected');
-        const options = push.sendPush.getCall(0).args[3];
-        assert.deepEqual(options.data, expectedData);
-        const schemaPath = path.resolve(__dirname, PUSH_PAYLOADS_SCHEMA_PATH);
-        const schema = JSON.parse(fs.readFileSync(schemaPath));
-        assert.ok(ajv.validate(schema, options.data));
-        push.sendPush.restore();
-      });
-  });
-
-  it('notifyDeviceDisconnected calls sendPush', () => {
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          return P.resolve();
-        },
-      },
-    };
-    const push = proxyquire(pushModulePath, mocks)(
-      mockLog(),
-      mockDb,
-      mockConfig
-    );
-    sinon.spy(push, 'sendPush');
-    const idToDisconnect = mockDevices[0].id;
-    const expectedData = {
-      version: 1,
-      command: 'fxaccounts:device_disconnected',
-      data: {
-        id: idToDisconnect,
-      },
-    };
-    return push
-      .notifyDeviceDisconnected(mockUid, mockDevices, idToDisconnect)
-      .catch((err) => {
-        assert.fail('must not throw');
-        throw err;
-      })
-      .then(() => {
-        assert.ok(push.sendPush.calledOnce, 'sendPush was called');
-        assert.equal(push.sendPush.getCall(0).args[0], mockUid);
-        assert.equal(push.sendPush.getCall(0).args[1], mockDevices);
-        assert.equal(push.sendPush.getCall(0).args[2], 'deviceDisconnected');
-        const options = push.sendPush.getCall(0).args[3];
-        assert.deepEqual(options.data, expectedData);
-        const schemaPath = path.resolve(__dirname, PUSH_PAYLOADS_SCHEMA_PATH);
-        const schema = JSON.parse(fs.readFileSync(schemaPath));
-        assert.ok(ajv.validate(schema, options.data));
-        assert.ok(options.TTL, 'TTL should be set');
-        push.sendPush.restore();
-      });
-  });
-
-  it('notifyPasswordChanged calls sendPush', () => {
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          return P.resolve();
-        },
-      },
-    };
-    const push = proxyquire(pushModulePath, mocks)(
-      mockLog(),
-      mockDb,
-      mockConfig
-    );
-    sinon.spy(push, 'sendPush');
-    const expectedData = {
-      version: 1,
-      command: 'fxaccounts:password_changed',
-    };
-    return push
-      .notifyPasswordChanged(mockUid, mockDevices)
-      .catch((err) => {
-        assert.fail('must not throw');
-        throw err;
-      })
-      .then(() => {
-        assert.ok(push.sendPush.calledOnce, 'sendPush was called');
-        assert.equal(push.sendPush.getCall(0).args[0], mockUid);
-        assert.equal(push.sendPush.getCall(0).args[1], mockDevices);
-        assert.equal(push.sendPush.getCall(0).args[2], 'passwordChange');
-        const options = push.sendPush.getCall(0).args[3];
-        assert.deepEqual(options.data, expectedData);
-        const schemaPath = path.resolve(__dirname, PUSH_PAYLOADS_SCHEMA_PATH);
-        const schema = JSON.parse(fs.readFileSync(schemaPath));
-        assert.ok(ajv.validate(schema, options.data));
-        push.sendPush.restore();
-      });
-  });
-
-  it('notifyPasswordReset calls sendPush', () => {
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          return P.resolve();
-        },
-      },
-    };
-    const push = proxyquire(pushModulePath, mocks)(
-      mockLog(),
-      mockDb,
-      mockConfig
-    );
-    sinon.spy(push, 'sendPush');
-    const expectedData = {
-      version: 1,
-      command: 'fxaccounts:password_reset',
-    };
-    return push
-      .notifyPasswordReset(mockUid, mockDevices)
-      .catch((err) => {
-        assert.fail('must not throw');
-        throw err;
-      })
-      .then(() => {
-        assert.ok(push.sendPush.calledOnce, 'sendPush was called');
-        assert.equal(push.sendPush.getCall(0).args[0], mockUid);
-        assert.equal(push.sendPush.getCall(0).args[1], mockDevices);
-        assert.equal(push.sendPush.getCall(0).args[2], 'passwordReset');
-        const options = push.sendPush.getCall(0).args[3];
-        assert.deepEqual(options.data, expectedData);
-        const schemaPath = path.resolve(__dirname, PUSH_PAYLOADS_SCHEMA_PATH);
-        const schema = JSON.parse(fs.readFileSync(schemaPath));
-        assert.ok(ajv.validate(schema, options.data));
-        push.sendPush.restore();
-      });
-  });
-
-  it('notifyAccountUpdated calls sendPush', () => {
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          return P.resolve();
-        },
-      },
-    };
-    const push = proxyquire(pushModulePath, mocks)(
-      mockLog(),
-      mockDb,
-      mockConfig
-    );
-    sinon.stub(push, 'sendPush').callsFake(() => P.resolve());
-
-    return push
-      .notifyAccountUpdated(mockUid, mockDevices, 'deviceConnected')
-      .catch((err) => {
-        assert.fail('must not throw');
-        throw err;
-      })
-      .then(() => {
-        assert.ok(push.sendPush.calledOnce, 'push was called');
-        assert.equal(push.sendPush.getCall(0).args[0], mockUid);
-        assert.deepEqual(push.sendPush.getCall(0).args[1], mockDevices);
-        assert.equal(push.sendPush.getCall(0).args[2], 'deviceConnected');
-        push.sendPush.restore();
-      });
-  });
-
-  it('notifyAccountDestroyed calls sendPush', () => {
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          return P.resolve();
-        },
-      },
-    };
-    const push = proxyquire(pushModulePath, mocks)(
-      mockLog(),
-      mockDb,
-      mockConfig
-    );
-    sinon.spy(push, 'sendPush');
-    const expectedData = {
-      version: 1,
-      command: 'fxaccounts:account_destroyed',
-      data: {
-        uid: mockUid,
-      },
-    };
-    return push
-      .notifyAccountDestroyed(mockUid, mockDevices)
-      .catch((err) => {
-        assert.fail('must not throw');
-        throw err;
-      })
-      .then(() => {
-        assert.ok(push.sendPush.calledOnce, 'sendPush was called');
-        assert.equal(push.sendPush.getCall(0).args[0], mockUid);
-        assert.equal(push.sendPush.getCall(0).args[1], mockDevices);
-        assert.equal(push.sendPush.getCall(0).args[2], 'accountDestroyed');
-        const options = push.sendPush.getCall(0).args[3];
-        assert.deepEqual(options.data, expectedData);
-        const schemaPath = path.resolve(__dirname, PUSH_PAYLOADS_SCHEMA_PATH);
-        const schema = JSON.parse(fs.readFileSync(schemaPath));
-        assert.ok(ajv.validate(schema, options.data));
-        push.sendPush.restore();
-      });
-  });
-
-  it('sendPush includes VAPID identification if it is configured', () => {
-    let count = 0;
-    const thisMockLog = mockLog({
-      info: function (op, log) {
-        if (log.name === 'push.account_verify.success') {
-          count++;
-        }
-      },
+    const push = loadMockedPushModule();
+    const device = JSON.parse(JSON.stringify(mockDevices[0]));
+    await push.sendPush(mockUid, [device], "accountVerify");
+    assert.callCount(mockSendNotification, 1);
+    assert.callCount(mockLog.warn, 1);
+    assert.calledWithMatch(mockLog.warn, "push.send.failure", {
+      reason: "accountVerify",
+      errCode: "unknown",
     });
-
-    const mockConfig = {
-      publicUrl: 'https://example.com',
-      vapidKeysFile: path.join(__dirname, '../config/mock-vapid-keys.json'),
-    };
-
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          assert.ok(options.vapidDetails, 'sends the VAPID params object');
-          assert.equal(
-            options.vapidDetails.subject,
-            mockConfig.publicUrl,
-            'sends the correct VAPID subject'
-          );
-          assert.equal(
-            options.vapidDetails.privateKey,
-            'private',
-            'sends the correct VAPID privkey'
-          );
-          assert.equal(
-            options.vapidDetails.publicKey,
-            'public',
-            'sends the correct VAPID pubkey'
-          );
-          return P.resolve();
-        },
-      },
-    };
-
-    const push = proxyquire(pushModulePath, mocks)(
-      thisMockLog,
-      mockDb,
-      mockConfig
-    );
-    return push.sendPush(mockUid, mockDevices, 'accountVerify').then(() => {
-      assert.equal(count, 2);
+    assert.callCount(mockLog.error, 1);
+    assert.calledWithMatch(mockLog.error, "push.sendPush.unexpectedError", {
+      err: match.has("message", "Failed unexpectedly"),
     });
+    assert.callCount(mockDb.updateDevice, 0);
   });
 
-  it('sendPush errors out cleanly if given an unknown reason argument', () => {
-    const thisMockLog = mockLog();
-    const mockConfig = {};
-    const mocks = {
-      'web-push': {
-        sendNotification: function (sub, payload, options) {
-          assert.fail('should not have called sendNotification');
-          return P.reject('Should not have called sendNotification');
-        },
-      },
-    };
-
-    const push = proxyquire(pushModulePath, mocks)(
-      thisMockLog,
-      mockDb,
-      mockConfig
+  it("notifyCommandReceived calls sendPush", async () => {
+    const push = loadMockedPushModule();
+    sinon.spy(push, "sendPush");
+    await push.notifyCommandReceived(
+      mockUid,
+      mockDevices[0],
+      "commandName",
+      "sendingDevice",
+      12,
+      "http://fetch.url",
+      42
     );
-    return push.sendPush(mockUid, mockDevices, 'anUnknownReasonString').then(
-      () => {
-        assert(false, 'calling sendPush should have failed');
-      },
-      (err) => {
-        assert.equal(err, 'Unknown push reason: anUnknownReasonString');
+    assert.calledOnceWithExactly(
+      push.sendPush,
+      mockUid,
+      [mockDevices[0]],
+      "commandReceived",
+      {
+        data: match.validPushPayload({
+          version: 1,
+          command: "fxaccounts:command_received",
+          data: {
+            command: "commandName",
+            index: 12,
+            sender: "sendingDevice",
+            url: "http://fetch.url",
+          },
+        }),
+        TTL: 42,
       }
     );
+  });
+
+  it("notifyDeviceConnected calls sendPush", async () => {
+    const push = loadMockedPushModule();
+    sinon.spy(push, "sendPush");
+    const deviceName = "My phone";
+    await push.notifyDeviceConnected(mockUid, mockDevices, deviceName);
+    assert.calledOnce(push.sendPush);
+    assert.calledWithMatch(
+      push.sendPush,
+      mockUid,
+      mockDevices,
+      "deviceConnected",
+      {
+        data: match.validPushPayload({
+          version: 1,
+          command: "fxaccounts:device_connected",
+          data: {
+            deviceName: deviceName,
+          },
+        }),
+        TTL: match.undefined,
+      }
+    );
+  });
+
+  it("notifyDeviceDisconnected calls sendPush", async () => {
+    const push = loadMockedPushModule();
+    sinon.spy(push, "sendPush");
+    const idToDisconnect = mockDevices[0].id;
+    await push.notifyDeviceDisconnected(mockUid, mockDevices, idToDisconnect);
+    assert.calledOnce(push.sendPush);
+    assert.calledWithMatch(
+      push.sendPush,
+      mockUid,
+      mockDevices,
+      "deviceDisconnected",
+      {
+        data: match.validPushPayload({
+          version: 1,
+          command: "fxaccounts:device_disconnected",
+          data: {
+            id: idToDisconnect,
+          },
+        }),
+        TTL: match.number,
+      }
+    );
+  });
+
+  it("notifyPasswordChanged calls sendPush", async () => {
+    const push = loadMockedPushModule();
+    sinon.spy(push, "sendPush");
+    await push.notifyPasswordChanged(mockUid, mockDevices);
+    assert.calledOnce(push.sendPush);
+    assert.calledWithMatch(
+      push.sendPush,
+      mockUid,
+      mockDevices,
+      "passwordChange",
+      {
+        data: match.validPushPayload({
+          version: 1,
+          command: "fxaccounts:password_changed",
+          data: match.undefined,
+        }),
+        TTL: match.number,
+      }
+    );
+  });
+
+  it("notifyPasswordReset calls sendPush", async () => {
+    const push = loadMockedPushModule();
+    sinon.spy(push, "sendPush");
+    await push.notifyPasswordReset(mockUid, mockDevices);
+    assert.calledOnce(push.sendPush);
+    assert.calledWithMatch(
+      push.sendPush,
+      mockUid,
+      mockDevices,
+      "passwordReset",
+      {
+        data: match.validPushPayload({
+          version: 1,
+          command: "fxaccounts:password_reset",
+          data: match.undefined,
+        }),
+        TTL: match.number,
+      }
+    );
+  });
+
+  it("notifyAccountUpdated calls sendPush", async () => {
+    const push = loadMockedPushModule();
+    sinon.spy(push, "sendPush");
+    await push.notifyAccountUpdated(mockUid, mockDevices, "deviceConnected");
+    assert.calledOnce(push.sendPush);
+    assert.calledWithExactly(
+      push.sendPush,
+      mockUid,
+      mockDevices,
+      "deviceConnected"
+    );
+  });
+
+  it("notifyAccountDestroyed calls sendPush", async () => {
+    const push = loadMockedPushModule();
+    sinon.spy(push, "sendPush");
+    await push.notifyAccountDestroyed(mockUid, mockDevices);
+    assert.calledOnce(push.sendPush);
+    assert.calledWithMatch(
+      push.sendPush,
+      mockUid,
+      mockDevices,
+      "accountDestroyed",
+      {
+        data: match.validPushPayload({
+          version: 1,
+          command: "fxaccounts:account_destroyed",
+          data: {
+            uid: mockUid,
+          },
+        }),
+        TTL: match.number,
+      }
+    );
+  });
+
+  it("sendPush includes VAPID identification if it is configured", async () => {
+    mockConfig = {
+      publicUrl: "https://example.com",
+      vapidKeysFile: path.join(__dirname, "../config/mock-vapid-keys.json"),
+    };
+    const push = loadMockedPushModule();
+    await push.sendPush(mockUid, mockDevices, "accountVerify");
+    assert.callCount(mockSendNotification, 2);
+    for (const call of mockSendNotification.getCalls()) {
+      assert.calledWithMatch(call, match.any, null, {
+        vapidDetails: {
+          subject: mockConfig.publicUrl,
+          privateKey: "private",
+          publicKey: "public",
+        },
+      });
+    }
+  });
+
+  it("sendPush errors out cleanly if given an unknown reason argument", async () => {
+    const push = loadMockedPushModule();
+    try {
+      await push.sendPush(mockUid, mockDevices, "anUnknownReasonString");
+      assert.fail("should have thrown");
+    } catch (err) {
+      assert.equal(err, "Unknown push reason: anUnknownReasonString");
+    }
+    assert.notCalled(mockSendNotification);
   });
 });

--- a/packages/fxa-auth-server/test/remote/push_db_tests.js
+++ b/packages/fxa-auth-server/test/remote/push_db_tests.js
@@ -16,6 +16,7 @@ const config = require('../../config').getProperties();
 const TestServer = require('../test_server');
 const Token = require('../../lib/tokens')(log);
 const DB = require('../../lib/db')(config, log, Token);
+const mockStatsD = { increment: () => {} };
 
 const zeroBuffer16 = Buffer.from(
   '00000000000000000000000000000000',
@@ -42,6 +43,7 @@ const ACCOUNT = {
 };
 const mockLog = {
   error: function () {},
+  warn: function () {},
   increment: function () {},
   trace: function () {},
   info: function () {},
@@ -125,7 +127,7 @@ describe('remote push db', function () {
         const pushWithUnknown400 = proxyquire(
           '../../lib/push',
           mocksUnknown400
-        )(mockLog, db, {});
+        )(mockLog, db, {}, mockStatsD);
         return pushWithUnknown400.sendPush(
           ACCOUNT.uid,
           devices,
@@ -155,10 +157,11 @@ describe('remote push db', function () {
           'device.pushEndpointExpired is correct'
         );
 
-        const pushWithKnown400 = proxyquire('../../lib/push', mocksKnown400)(
+        const pushWithKnown400 = proxyquire("../../lib/push", mocksKnown400)(
           mockLog,
           db,
-          {}
+          {},
+          mockStatsD,
         );
         return pushWithKnown400.sendPush(ACCOUNT.uid, devices, 'accountVerify');
       })


### PR DESCRIPTION
Because:

- Robust delivery of push messages to connected devices is an
  important part of "send tab" and other account-related experiences.
- It's hard to monitor or alert on changes to push delivery success
  rate.

This commit:

- Emits "attempt", "success" and "failure" counters to statsd,
  where they can be graphed and monitored more easily.
- Lightly refactors and adds additional metadata to push-related
  logs that go into bigquery, based on experience from recent
  ad-hoc log exploration.

Fixes #5367.

(To review this, please [ignore identation changes](https://github.com/mozilla/fxa/pull/5462/files?w=1))