### PR TITLE
feat(storybooks): Switch Storybook notification from comment post to commit status check

### DIFF
--- a/_scripts/build-storybooks.sh
+++ b/_scripts/build-storybooks.sh
@@ -108,8 +108,8 @@ if [[ ! -z $CI_PULL_REQUEST ]]; then
     curl \
         -H'Content-Type: application/json' \
         -H"Authorization: token $STORYBOOKS_GITHUB_TOKEN" \
-        --data "{\"body\":\"# Storybook Deployment\\nPull Request: $PR_URL\\nCommit: $COMMIT_URL\"}" \
-        https://api.github.com/repos/${PROJECT_REPO}/issues/${PR_NUMBER}/comments;
+        --data "{\"state\":\"success\",\"target_url\":\"$COMMIT_URL\",\"context\":\"storybooks\",\"description\":\"Storybook Deployment\"}" \
+        https://api.github.com/repos/${PROJECT_REPO}/statuses/${COMMIT_HASH};
 fi
 
 echo "Cleaning up $PUBLISH_ROOT"


### PR DESCRIPTION
fixes #5474

Realized after a skim through the API docs that this might be a super-quick change, so I figured I'd just try it.