### PR TITLE
feat(aet): add ecosystem_anon_id field to auth server core profile data

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -905,6 +905,7 @@ module.exports = (
         },
         response: {
           schema: {
+            ecosystemAnonId: isA.string().optional(),
             email: isA.string().optional(),
             locale: isA.string().optional().allow(null),
             authenticationMethods: isA
@@ -931,6 +932,9 @@ module.exports = (
         const res = {};
         const account = await db.account(uid);
 
+        if (scope.contains('profile:ecosystem_anon_id')) {
+          res.ecosystemAnonId = account.ecosystemAnonId;
+        }
         if (scope.contains('profile:email')) {
           res.email = account.primaryEmail.email;
         }

--- a/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/get.js
+++ b/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/get.js
@@ -4,8 +4,6 @@
 
 const Joi = require('@hapi/joi');
 
-const logger = require('../../logging')('routes.ecosystem_anon_id.get');
-
 module.exports = {
   auth: {
     strategy: 'oauth',
@@ -17,10 +15,32 @@ module.exports = {
     },
   },
   handler: async function ecosystemAnonIdGet(req, h) {
-    const uid = req.auth.credentials.user;
-    logger.info('activityEvent', { event: 'ecosystemAnonId.get', uid: uid });
-
-    // Not implemented yet. Always return an empty 204 for now.
-    return h.response({}).code(204);
+    return req.server
+      .inject({
+        allowInternals: true,
+        method: 'get',
+        url: '/v1/_core_profile',
+        headers: req.headers,
+        auth: {
+          credentials: req.auth.credentials,
+          // As of Hapi 18: "To use the new format simply wrap the credentials and optional
+          // artifacts with an auth object and add a new strategy key with a name matching
+          // a configured authentication strategy."
+          // Ref: https://github.com/hapijs/hapi/issues/3871
+          strategy: 'oauth',
+        },
+      })
+      .then(res => {
+        if (res.statusCode !== 200) {
+          return res;
+        }
+        if (res.result.ecosystemAnonId) {
+          return {
+            ecosystemAnonId: res.result.ecosystemAnonId,
+          };
+        } else {
+          return h.response({}).code(204);
+        }
+      });
   },
 };

--- a/packages/fxa-profile-server/test/api.js
+++ b/packages/fxa-profile-server/test/api.js
@@ -1488,9 +1488,43 @@ describe('api', function () {
     var tok = token();
 
     describe('GET', function () {
-      xit('should return an ecosystem_anon_id', function () {});
+      it('should return an ecosystem_anon_id if set', async function () {
+        const ECOSYSTEM_ANON_ID = 'foo.barzzy.123';
+        mock.coreProfile({
+          email: 'user@example.domain',
+          locale: 'en-US',
+          authenticationMethods: ['pwd'],
+          authenticatorAssuranceLevel: 1,
+          ecosystemAnonId: ECOSYSTEM_ANON_ID,
+        });
+        mock.token({
+          user: USERID,
+          scope: ['profile:ecosystem_anon_id'],
+        });
+
+        const res = await Server.api.get({
+          url: '/ecosystem_anon_id',
+          headers: {
+            authorization: 'Bearer ' + tok,
+          },
+        });
+
+        assert.equal(res.statusCode, 200);
+        assert.equal(
+          JSON.parse(res.payload).ecosystemAnonId,
+          ECOSYSTEM_ANON_ID
+        );
+        assertSecurityHeaders(res);
+      });
 
       it('should return 204 if not set', async function () {
+        // Note that ecosystemAnonId is not set in the coreProfile:
+        mock.coreProfile({
+          email: 'user@example.domain',
+          locale: 'en-US',
+          authenticationMethods: ['pwd'],
+          authenticatorAssuranceLevel: 1,
+        });
         mock.token({
           user: USERID,
           scope: ['profile:ecosystem_anon_id'],


### PR DESCRIPTION
The ecosystem_anon_id work for AET (Jira epic FXA-880) started from the
API used by desktop code, in order to unblock that work, which can be
done in parallel. This new identifier is eventually going to be part
of the core profile fields stored in the auth server DB, which means
there will be changes in mysql, auth-db, auth-server, and profile-server.

The initial no-op profile-server API implementation landed as
https://github.com/mozilla/fxa/pull/5364.

This change moves one step further down the stack, updating the
profile-server API handler from a no-op to an actual call into the
_core_profile, and adding a deceptively simple change to the auth server
that allows an ecosystemAnonId field to be passed through from auth-db.

Future commits will integrate this new field into the auth-db and
eventually into mysql.