### PR TITLE
fix(auth): fixed test-local.sh in fxa-auth-server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ executors:
           RUST_BACKTRACE: 1
     environment:
       FXA_MX_RECORD_EXCLUSIONS: restmail.dev.lcip.org
-      SKIP_PACKAGES: false
 
 commands:
   base-install:
@@ -68,8 +67,6 @@ jobs:
     parameters:
       package:
         type: string
-    environment:
-      SKIP_PACKAGES: true
     steps:
       - base-install:
           package: << parameters.package >>
@@ -85,8 +82,6 @@ jobs:
       - image: jdlk7/firestore-emulator
       - image: memcached
       - image: redis
-    environment:
-      SKIP_PACKAGES: true
     steps:
       - base-install
       - run:
@@ -166,8 +161,6 @@ jobs:
           - MYSQL_ALLOW_EMPTY_PASSWORD: yes
           - MYSQL_ROOT_PASSWORD: ''
       - image: redis
-    environment:
-      SKIP_PACKAGES: true
     steps:
       - base-install:
           package: fxa-email-service
@@ -181,7 +174,6 @@ jobs:
     docker:
       - image: circleci/node:12
     environment:
-      SKIP_PACKAGES: true
       DOCKER_BUILDKIT: 1
     steps:
       - base-install
@@ -203,7 +195,6 @@ jobs:
     docker:
       - image: circleci/node:12
     environment:
-      SKIP_PACKAGES: true
       DOCKER_BUILDKIT: 1
     steps:
       - setup_remote_docker:
@@ -220,8 +211,6 @@ jobs:
     resource_class: small
     docker:
       - image: circleci/node:12
-    environment:
-      SKIP_PACKAGES: true
     steps:
       - base-install
       - run:

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
   },
   "lint-staged": {
     "*.js": [
-      "eslint -c _dev/.eslintrc",
-      "prettier --config _dev/.prettierrc --write"
+      "prettier --config _dev/.prettierrc --write",
+      "eslint -c _dev/.eslintrc"
     ],
     "*.{ts,tsx}": [
       "prettier --config _dev/.prettierrc --write"

--- a/packages/fxa-auth-server/scripts/test-local.sh
+++ b/packages/fxa-auth-server/scripts/test-local.sh
@@ -12,11 +12,10 @@ set -u
 
 DEFAULT_ARGS="--require ts-node/register --recursive --timeout 5000 --exit"
 
-npx ts-node ./scripts/gen_keys.js
-npx ts-node ./scripts/gen_vapid_keys.js
-npx ts-node ./scripts/oauth_gen_keys.js
-node ../fxa-auth-db-mysql/bin/db_patcher > /dev/null
-npm run lint
+node -r ts-node/register ./scripts/gen_keys.js
+node -r ts-node/register ./scripts/gen_vapid_keys.js
+node -r ts-node/register ./scripts/oauth_gen_keys.js
+node -r ts-node/register ../fxa-auth-db-mysql/bin/db_patcher > /dev/null
 
 GLOB=$*
 if [ -z "$GLOB" ]; then

--- a/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
@@ -1604,110 +1604,110 @@ describe('/account/sessions', () => {
     return runTest(route, request, (result) => {
       assert.ok(Array.isArray(result));
       assert.equal(result.length, 4);
-      assert.deepEqual(result, [
-        {
-          deviceId: null,
-          deviceName: 'Firefox 50, Windows 10',
-          deviceType: 'desktop',
-          deviceAvailableCommands: { foo: 'bar' },
-          deviceCallbackURL: 'callback',
-          deviceCallbackPublicKey: 'publicKey',
-          deviceCallbackAuthKey: 'authKey',
-          deviceCallbackIsExpired: false,
-          id: 'foo',
-          isCurrentDevice: true,
-          isDevice: false,
-          lastAccessTime: times[1],
-          lastAccessTimeFormatted: moment(times[1]).locale('en').fromNow(),
-          createdTime: times[0],
-          createdTimeFormatted: 'a few seconds ago',
-          os: 'Windows',
-          userAgent: 'Firefox 50',
-          location: {
-            city: 'Toronto',
-            country: 'Canada',
-            state: 'Ontario',
-            stateCode: 'ON',
+      const noFormattedTime = ({ createdTimeFormatted, ...rest }) => rest;
+      assert.deepEqual(
+        result.map((x) => noFormattedTime(x)),
+        [
+          {
+            deviceId: null,
+            deviceName: 'Firefox 50, Windows 10',
+            deviceType: 'desktop',
+            deviceAvailableCommands: { foo: 'bar' },
+            deviceCallbackURL: 'callback',
+            deviceCallbackPublicKey: 'publicKey',
+            deviceCallbackAuthKey: 'authKey',
+            deviceCallbackIsExpired: false,
+            id: 'foo',
+            isCurrentDevice: true,
+            isDevice: false,
+            lastAccessTime: times[1],
+            lastAccessTimeFormatted: moment(times[1]).locale('en').fromNow(),
+            createdTime: times[0],
+            os: 'Windows',
+            userAgent: 'Firefox 50',
+            location: {
+              city: 'Toronto',
+              country: 'Canada',
+              state: 'Ontario',
+              stateCode: 'ON',
+            },
           },
-        },
-        {
-          deviceId: 'deviceId',
-          deviceName: 'Nightly, Android 6',
-          deviceType: 'mobile',
-          deviceAvailableCommands: { foo: 'bar' },
-          deviceCallbackURL: null,
-          deviceCallbackPublicKey: null,
-          deviceCallbackAuthKey: null,
-          deviceCallbackIsExpired: false,
-          id: 'bar',
-          isCurrentDevice: false,
-          isDevice: true,
-          lastAccessTime: EARLIEST_SANE_TIMESTAMP - 1,
-          lastAccessTimeFormatted: moment(EARLIEST_SANE_TIMESTAMP - 1)
-            .locale('en')
-            .fromNow(),
-          approximateLastAccessTime: EARLIEST_SANE_TIMESTAMP,
-          approximateLastAccessTimeFormatted: moment(EARLIEST_SANE_TIMESTAMP)
-            .locale('en')
-            .fromNow(),
-          createdTime: times[3],
-          createdTimeFormatted: 'a few seconds ago',
-          os: 'Android',
-          userAgent: 'Nightly',
-          location: {
-            city: 'Bournemouth',
-            country: 'United Kingdom',
-            state: 'England',
-            stateCode: 'EN',
+          {
+            deviceId: 'deviceId',
+            deviceName: 'Nightly, Android 6',
+            deviceType: 'mobile',
+            deviceAvailableCommands: { foo: 'bar' },
+            deviceCallbackURL: null,
+            deviceCallbackPublicKey: null,
+            deviceCallbackAuthKey: null,
+            deviceCallbackIsExpired: false,
+            id: 'bar',
+            isCurrentDevice: false,
+            isDevice: true,
+            lastAccessTime: EARLIEST_SANE_TIMESTAMP - 1,
+            lastAccessTimeFormatted: moment(EARLIEST_SANE_TIMESTAMP - 1)
+              .locale('en')
+              .fromNow(),
+            approximateLastAccessTime: EARLIEST_SANE_TIMESTAMP,
+            approximateLastAccessTimeFormatted: moment(EARLIEST_SANE_TIMESTAMP)
+              .locale('en')
+              .fromNow(),
+            createdTime: times[3],
+            os: 'Android',
+            userAgent: 'Nightly',
+            location: {
+              city: 'Bournemouth',
+              country: 'United Kingdom',
+              state: 'England',
+              stateCode: 'EN',
+            },
           },
-        },
-        {
-          deviceId: 'deviceId',
-          deviceName: '',
-          deviceType: 'tablet',
-          deviceAvailableCommands: {},
-          deviceCallbackURL: 'callback',
-          deviceCallbackPublicKey: 'publicKey',
-          deviceCallbackAuthKey: 'authKey',
-          deviceCallbackIsExpired: false,
-          id: 'baz',
-          isCurrentDevice: false,
-          isDevice: true,
-          lastAccessTime: EARLIEST_SANE_TIMESTAMP,
-          lastAccessTimeFormatted: moment(EARLIEST_SANE_TIMESTAMP)
-            .locale('en')
-            .fromNow(),
-          createdTime: times[5],
-          createdTimeFormatted: 'a few seconds ago',
-          os: null,
-          userAgent: '',
-          location: {},
-        },
-        {
-          deviceId: 'deviceId',
-          deviceName: '',
-          deviceType: 'tablet',
-          deviceAvailableCommands: null,
-          deviceCallbackURL: 'callback',
-          deviceCallbackPublicKey: 'publicKey',
-          deviceCallbackAuthKey: 'authKey',
-          deviceCallbackIsExpired: false,
-          id: 'qux',
-          isCurrentDevice: false,
-          isDevice: true,
-          lastAccessTime: 1,
-          lastAccessTimeFormatted: moment(1).locale('en').fromNow(),
-          approximateLastAccessTime: EARLIEST_SANE_TIMESTAMP,
-          approximateLastAccessTimeFormatted: moment(EARLIEST_SANE_TIMESTAMP)
-            .locale('en')
-            .fromNow(),
-          createdTime: times[7],
-          createdTimeFormatted: 'a few seconds ago',
-          os: null,
-          userAgent: '',
-          location: {},
-        },
-      ]);
+          {
+            deviceId: 'deviceId',
+            deviceName: '',
+            deviceType: 'tablet',
+            deviceAvailableCommands: {},
+            deviceCallbackURL: 'callback',
+            deviceCallbackPublicKey: 'publicKey',
+            deviceCallbackAuthKey: 'authKey',
+            deviceCallbackIsExpired: false,
+            id: 'baz',
+            isCurrentDevice: false,
+            isDevice: true,
+            lastAccessTime: EARLIEST_SANE_TIMESTAMP,
+            lastAccessTimeFormatted: moment(EARLIEST_SANE_TIMESTAMP)
+              .locale('en')
+              .fromNow(),
+            createdTime: times[5],
+            os: null,
+            userAgent: '',
+            location: {},
+          },
+          {
+            deviceId: 'deviceId',
+            deviceName: '',
+            deviceType: 'tablet',
+            deviceAvailableCommands: null,
+            deviceCallbackURL: 'callback',
+            deviceCallbackPublicKey: 'publicKey',
+            deviceCallbackAuthKey: 'authKey',
+            deviceCallbackIsExpired: false,
+            id: 'qux',
+            isCurrentDevice: false,
+            isDevice: true,
+            lastAccessTime: 1,
+            lastAccessTimeFormatted: moment(1).locale('en').fromNow(),
+            approximateLastAccessTime: EARLIEST_SANE_TIMESTAMP,
+            approximateLastAccessTimeFormatted: moment(EARLIEST_SANE_TIMESTAMP)
+              .locale('en')
+              .fromNow(),
+            createdTime: times[7],
+            os: null,
+            userAgent: '',
+            location: {},
+          },
+        ]
+      );
     });
   });
 });


### PR DESCRIPTION
with hoisted eslint dependency `npm run lint` can't find
eslint on the path. We've got linting globally as a precommit
hook, it doesn't need to run on tests.