### PR TITLE
fix(tests): run-server npx yarn and then fxa-shared tsc --build

### DIFF
--- a/packages/fxa-content-server/tests/teamcity/run-server.sh
+++ b/packages/fxa-content-server/tests/teamcity/run-server.sh
@@ -73,7 +73,9 @@ export npm_config_tmp=~/fxatemp
 
 set -o xtrace # echo the following commands
 
-npx yarn workspaces focus fxa-content-server
+npx yarn install
+# sacrifice a chicken, a.k.a., dunno why this didn't already happen
+(cd ../fxa-shared; ../../node_modules/.bin/tsc --build)
 
 FXA_TEST_CONFIG=${FXA_TEST_CONFIG:-tests/intern_server}
 


### PR DESCRIPTION
For reasons I don't know, the `tsc --build` was not happening for fxa-shared. I tried a couple of things, and this is what works. There's probably a better way to achieve this but WFM.