### PR TITLE
feat(settings-redesign): add settings_version event property for fxa_pref amplitude events

### DIFF
--- a/packages/fxa-shared/metrics/amplitude-event.1.schema.json
+++ b/packages/fxa-shared/metrics/amplitude-event.1.schema.json
@@ -87,6 +87,10 @@
           "description": "Product ID of a subscription.",
           "type": "string",
           "maxLength": 128
+        },
+        "settings_version": {
+          "description": "Settings app version (e.g. v2)",
+          "type": "string"
         }
       }
     },

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -54,7 +54,7 @@ const EVENT_PROPERTIES = {
   [GROUPS.notify]: NOP,
   [GROUPS.registration]: mapDomainValidationResult,
   [GROUPS.rp]: NOP,
-  [GROUPS.settings]: mapDisconnectReason,
+  [GROUPS.settings]: mapSettingsEventProperties,
   [GROUPS.sms]: NOP,
   [GROUPS.sub]: NOP,
   [GROUPS.subCancel]: NOP,
@@ -100,6 +100,19 @@ function mapEmailType(eventType, eventCategory, eventTarget, data) {
     }
 
     return result;
+  }
+}
+
+function mapSettingsEventProperties(...args) {
+  return {
+    ...mapDisconnectReason(...args),
+    ...mapSettingsVersion(...args),
+  };
+}
+
+function mapSettingsVersion(eventType, eventCategory, eventTarget, data) {
+  if (data && data.settings_version) {
+    return { settings_version: data.settings_version };
   }
 }
 

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -61,6 +61,10 @@ describe('metrics/amplitude:', () => {
             group: amplitude.GROUPS.sms,
             event: 'blee',
           },
+          'settings.change-password.success': {
+            group: amplitude.GROUPS.settings,
+            event: 'password',
+          },
         },
         new Map([
           [
@@ -360,6 +364,24 @@ describe('metrics/amplitude:', () => {
       it('returned the correct event data', () => {
         assert.equal(result.event_type, 'fxa_pref - disconnect_device');
         assert.deepEqual(result.event_properties, { reason: 'wibble' });
+      });
+    });
+
+    describe('transform an event with settings_version properties:', () => {
+      let result;
+
+      before(() => {
+        result = transform(
+          { type: 'settings.change-password.success' },
+          { settings_version: 'v2' }
+        );
+      });
+
+      it('returned the correct event data', () => {
+        assert.equal(result.event_type, 'fxa_pref - password');
+        assert.deepEqual(result.event_properties, {
+          settings_version: 'v2',
+        });
       });
     });
 


### PR DESCRIPTION
fixes #5070

Soaked my head in metrics & amplitude things for a day or two. Got very turned around. But, this seems to be what the issue is asking for?

Am I under-thinking this? Do we need to add this `settings_version` property to a schema or config somewhere in Amplitude?