### PR TITLE
fix(content-server): fixed content-server build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ secrets.json
 .last-audit
 .eslintcache
 storybooks-publish
+tsconfig.tsbuildinfo
 
 # Dependencies
 **/node_modules
@@ -121,6 +122,10 @@ packages/fxa-js-client/fxa-auth-server
 # fxa-profile-server
 packages/fxa-profile-server/var
 packages/fxa-profile-server/BUCKET_NAME
+
+# fxa-react
+packages/fxa-react/**/*.js
+packages/fxa-react/**/*.d.ts
 
 # fxa-settings
 packages/fxa-settings/src/styles/tailwind.out.css

--- a/_scripts/pm2-all.sh
+++ b/_scripts/pm2-all.sh
@@ -4,6 +4,8 @@ DIR=$(dirname "$0")
 COMMAND=$1
 cd "$DIR"
 
+yarn workspace fxa-react run build
+
 echo "running ${COMMAND} fxa services..."
 for d in ../packages/*/ ; do
   if [[ -r "${d}pm2.config.js" ]]; then

--- a/packages/fxa-content-server/app/scripts/views/survey.jsx
+++ b/packages/fxa-content-server/app/scripts/views/survey.jsx
@@ -11,7 +11,7 @@ import BaseView from './base';
 /*eslint-disable no-unused-vars*/
 import Survey, {
   CreateHandleIframeTask,
-} from '@fxa-react/components/Survey/index.tsx';
+} from 'fxa-react/components/Survey';
 /*eslint-enable no-unused-vars*/
 
 /*eslint-disable no-unused-vars*/

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -3,7 +3,7 @@
   "version": "1.173.0",
   "description": "Firefox Accounts Content Server",
   "scripts": {
-    "build": "NODE_ENV=production grunt build",
+    "build": "tsc --build ../fxa-react && NODE_ENV=production grunt build",
     "postinstall": "cp server/config/local.json-dist server/config/local.json && scripts/download_l10n.sh",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint": "eslint app server tests --cache",
@@ -67,6 +67,7 @@
     "fxa-geodb": "workspace:*",
     "fxa-mustache-loader": "0.0.2",
     "fxa-pairing-channel": "1.0.1",
+    "fxa-react": "workspace:*",
     "fxa-settings": "workspace:*",
     "fxa-shared": "workspace:*",
     "got": "6.7.1",

--- a/packages/fxa-content-server/tsconfig.json
+++ b/packages/fxa-content-server/tsconfig.json
@@ -3,16 +3,13 @@
   "include": ["**/*.ts"],
   "exclude": ["node_modules", "**/*.spec.ts"],
   "compilerOptions": {
-    "jsx": "react",
     "outDir": "./.tscompiled/",
     "rootDir": "./app/scripts/",
-    "rootDirs": ["./app/scripts/", "../fxa-react/"],
     "baseUrl": "./app/scripts",
-    "noImplicitAny": false,
-    "allowSyntheticDefaultImports": true
+    "noImplicitAny": false
   },
   "references": [
     { "path": "../fxa-shared" },
-    {"@fxa-react": "../fxa-react"}
+    { "path": "../fxa-react" }
   ]
 }

--- a/packages/fxa-content-server/webpack.config.js
+++ b/packages/fxa-content-server/webpack.config.js
@@ -52,7 +52,6 @@ const webpackConfig = {
       'node_modules',
     ],
     alias: {
-      '@fxa-react': path.resolve(__dirname, '..', 'fxa-react'),
       'asmcrypto.js': require.resolve('asmcrypto.js/asmcrypto.min.js'),
       'chosen-js': require.resolve('chosen-js/public/chosen.jquery'),
       'cocktail-lib': require.resolve('backbone.cocktail/Cocktail'),

--- a/packages/fxa-react/components/Survey/README.md
+++ b/packages/fxa-react/components/Survey/README.md
@@ -2,7 +2,7 @@
 
 ```javascript
 
-  import Survey, { CreateHandleIframeTask } from '@fxa-react/components/Survey';
+  import Survey, { CreateHandleIframeTask } from 'fxa-react/components/Survey';
 
   const [showSurvey, setShowSurvey] = useState(true);
   const [surveyComplete, setSurveyComplete] = useState(false);

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -18,6 +18,7 @@
     "node": ">=12"
   },
   "scripts": {
+    "build": "tsc --build",
     "test": "jest",
     "storybook": "start-storybook -p 6007",
     "build-storybook": "build-storybook",

--- a/packages/fxa-react/tsconfig.json
+++ b/packages/fxa-react/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "extends": "../../_dev/tsconfig.browser.json",
   "compilerOptions": {
-    "outDir": "./dist",
+    "allowJs": false,
     "composite": true,
-    "types": ["jest", "testing-library__jest-dom"],
-    "jsx": "react"
+    "types": ["jest", "testing-library__jest-dom"]
   },
   "include": [
     "./components",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16787,6 +16787,7 @@ fsevents@^1.2.7:
     fxa-geodb: "workspace:*"
     fxa-mustache-loader: 0.0.2
     fxa-pairing-channel: 1.0.1
+    fxa-react: "workspace:*"
     fxa-settings: "workspace:*"
     fxa-shared: "workspace:*"
     got: 6.7.1


### PR DESCRIPTION
`@fxa-react` is no longer used. content-server should reference
fxa-react through a workspace dependency.

This commit fixes references and build configs for this change.