### PR TITLE
chore(surveys): update test survey view config to reset-password

### DIFF
--- a/packages/fxa-content-server/server/config/surveys.json
+++ b/packages/fxa-content-server/server/config/surveys.json
@@ -4,7 +4,7 @@
     "conditions": {
       "browser": "firefox"
     },
-    "view": "settings",
+    "view": "reset-password",
     "url": "https://www.surveygizmo.com/s3/5622367/Password-Reset-1"
   }
 ]


### PR DESCRIPTION
Because:
 - should show the survey on reset password page

This commit:
 - update a survey's "view" config value

Fixes #5524 (FXA-2018)