### PR TITLE
refactor(fxa-react): replace imported fxa-content-server scss variables, remove dependency

### DIFF
--- a/packages/fxa-react/components/Survey/index.scss
+++ b/packages/fxa-react/components/Survey/index.scss
@@ -1,8 +1,8 @@
-@import '../../../fxa-content-server/app/styles/variables';
-
 $shadow: 0 12px 18px 2px rgba(34, 0, 51, 0.04),
   0 6px 22px 4px rgba(7, 48, 114, 0.12), 0 6px 10px -4px rgba(14, 13, 26, 0.12);
 $survey-height: 360px;
+$grey-10: #f9f9fa;
+$grey-50: #737373;
 
 .survey-component {
   align-items: flex-end;

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -25,7 +25,6 @@
     "format": "prettier --write --config ../../_dev/.prettierrc '**'"
   },
   "dependencies": {
-    "fxa-content-server": "workspace:*",
     "fxa-shared": "workspace:*",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17387,7 +17387,6 @@ fsevents@^1.2.7:
     babel-preset-react-app: ^9.1.2
     camelcase: ^6.0.0
     eslint: ^6.8.0
-    fxa-content-server: "workspace:*"
     fxa-shared: "workspace:*"
     identity-obj-proxy: ^3.0.0
     jest: ^25.3.0


### PR DESCRIPTION
Closes #5439 

In case ya wanna reference: https://github.com/FirefoxUX/photon-colors/blob/master/photon-colors.css