### PR TITLE
fix(payments): Allow subscription downgrades

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -98,7 +98,7 @@ const ERRNO = {
   REFRESH_TOKEN_UNKNOWN: 182,
   INVALID_EXPIRED_OTP_CODE: 183,
   SUBSCRIPTION_ALREADY_CHANGED: 184,
-  INVALID_PLAN_UPGRADE: 185,
+  INVALID_PLAN_UPDATE: 185,
   PAYMENT_FAILED: 186,
   SUBSCRIPTION_ALREADY_EXISTS: 187,
   UNKNOWN_SUBSCRIPTION_FOR_SOURCE: 188,
@@ -1232,12 +1232,12 @@ AppError.subscriptionAlreadyCancelled = () => {
   });
 };
 
-AppError.invalidPlanUpgrade = () => {
+AppError.invalidPlanUpdate = () => {
   return new AppError({
     code: 400,
     error: 'Bad Request',
-    errno: ERRNO.INVALID_PLAN_UPGRADE,
-    message: 'Subscription plan is not a valid upgrade',
+    errno: ERRNO.INVALID_PLAN_UPDATE,
+    message: 'Subscription plan is not a valid update',
   });
 };
 

--- a/packages/fxa-auth-server/lib/payments/stripe.js
+++ b/packages/fxa-auth-server/lib/payments/stripe.js
@@ -77,7 +77,7 @@ const SUBSCRIPTION_UPDATE_TYPES = {
  * @param {AbbrevProduct['product_metadata']} newMetadata New product metadata
  * @returns {boolean} Whether the new product is an upgrade.
  */
-function validateProductUpgrade(oldMetadata, newMetadata) {
+function validateProductUpdate(oldMetadata, newMetadata) {
   if (!oldMetadata || !newMetadata) {
     throw error.unknownSubscriptionPlan();
   }
@@ -93,7 +93,7 @@ function validateProductUpgrade(oldMetadata, newMetadata) {
   if (isNaN(oldOrder) || isNaN(newOrder)) {
     throw error.unknownSubscriptionPlan();
   }
-  return oldOrder < newOrder;
+  return oldOrder !== newOrder;
 }
 
 class StripeHelper {
@@ -572,7 +572,7 @@ class StripeHelper {
    * @param {string} newPlanId
    * @returns {Promise<void>}
    */
-  async verifyPlanUpgradeForSubscription(currentPlanId, newPlanId) {
+  async verifyPlanUpdateForSubscription(currentPlanId, newPlanId) {
     const allPlans = await this.allPlans();
     const currentPlan = allPlans
       .filter((plan) => plan.plan_id === currentPlanId)
@@ -590,12 +590,12 @@ class StripeHelper {
     }
 
     if (
-      !validateProductUpgrade(
+      !validateProductUpdate(
         currentPlan.product_metadata,
         newPlan.product_metadata
       )
     ) {
-      throw error.invalidPlanUpgrade();
+      throw error.invalidPlanUpdate();
     }
   }
 

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -468,13 +468,13 @@ class DirectStripeRoutes {
 
     const currentPlanId = subscription.plan.id;
 
-    // Verify the plan is a valid upgrade for this subscription.
-    await this.stripeHelper.verifyPlanUpgradeForSubscription(
+    // Verify the plan is a valid update for this subscription.
+    await this.stripeHelper.verifyPlanUpdateForSubscription(
       currentPlanId,
       planId
     );
 
-    // Upgrade the plan
+    // Update the plan
     await this.stripeHelper.changeSubscriptionPlan(subscriptionId, planId);
 
     await this.customerChanged(request, uid, email);

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -356,27 +356,33 @@ describe('StripeHelper', () => {
     });
   });
 
-  describe('verifyPlanUpgradeForSubscription', () => {
-    it('does nothing for valid upgrade', async () => {
+  describe('verifyPlanUpdateForSubscription', () => {
+    it('does nothing for valid upgrade or downgrade', async () => {
       assert.isUndefined(
-        await stripeHelper.verifyPlanUpgradeForSubscription(
+        await stripeHelper.verifyPlanUpdateForSubscription(
           'plan_G93lTs8hfK7NNG',
           'plan_G93mMKnIFCjZek'
+        )
+      );
+      assert.isUndefined(
+        await stripeHelper.verifyPlanUpdateForSubscription(
+          'plan_G93mMKnIFCjZek',
+          'plan_G93lTs8hfK7NNG'
         )
       );
     });
 
     describe('when the upgrade is invalid', () => {
-      it('throws an invalidPlanUpgrade error', async () => {
+      it('throws an invalidPlanUpdate error', async () => {
         return stripeHelper
-          .verifyPlanUpgradeForSubscription(
+          .verifyPlanUpdateForSubscription(
             'plan_G93lTs8hfK7NNG',
             'plan_F4G9jB3x5i6Dpj'
           )
           .then(
             () => Promise.reject(new Error('Method expected to reject')),
             (err) => {
-              assert.equal(err.errno, error.ERRNO.INVALID_PLAN_UPGRADE);
+              assert.equal(err.errno, error.ERRNO.INVALID_PLAN_UPDATE);
             }
           );
       });
@@ -385,7 +391,7 @@ describe('StripeHelper', () => {
     describe('when the current plan specified does not exist', () => {
       it('thows an unknownSubscriptionPlan error', async () => {
         return stripeHelper
-          .verifyPlanUpgradeForSubscription('plan_bad', 'plan_F4G9jB3x5i6Dpj')
+          .verifyPlanUpdateForSubscription('plan_bad', 'plan_F4G9jB3x5i6Dpj')
           .then(
             () => Promise.reject(new Error('Method expected to reject')),
             (err) => {
@@ -398,7 +404,7 @@ describe('StripeHelper', () => {
     describe('when the new plan specified does not exist', () => {
       it('thows an unknownSubscriptionPlan error', async () => {
         return stripeHelper
-          .verifyPlanUpgradeForSubscription('plan_F4G9jB3x5i6Dpj', 'plan_bad')
+          .verifyPlanUpdateForSubscription('plan_F4G9jB3x5i6Dpj', 'plan_bad')
           .then(
             () => Promise.reject(new Error('Method expected to reject')),
             (err) => {
@@ -411,7 +417,7 @@ describe('StripeHelper', () => {
     describe('when the current plan and the new plan are the same', () => {
       it('thows a subscriptionAlreadyChanged error', async () => {
         return stripeHelper
-          .verifyPlanUpgradeForSubscription(
+          .verifyPlanUpdateForSubscription(
             'plan_G93lTs8hfK7NNG',
             'plan_G93lTs8hfK7NNG'
           )

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -1319,7 +1319,7 @@ describe('DirectStripeRoutes', () => {
         directStripeRoutesInstance.stripeHelper.subscriptionForCustomer.resolves(
           subscription2
         );
-        directStripeRoutesInstance.stripeHelper.verifyPlanUpgradeForSubscription.resolves();
+        directStripeRoutesInstance.stripeHelper.verifyPlanUpdateForSubscription.resolves();
         directStripeRoutesInstance.stripeHelper.changeSubscriptionPlan.resolves();
 
         sinon.stub(directStripeRoutesInstance, 'customerChanged').resolves();


### PR DESCRIPTION
fixes #5522

Assuming we want to allow downgrades, this should enable it on the server-side. UI changes to better depict a downgrade are pending for issue #5521 

Most of the changes here are renaming "upgrades" to "updates". The real change is just changing validation to accept less than or greater than for productOrder and testing both cases.