### PR TITLE
refactor: update supported languages

### DIFF
--- a/packages/fxa-shared/l10n/supportedLanguages.json
+++ b/packages/fxa-shared/l10n/supportedLanguages.json
@@ -42,7 +42,6 @@
   "nl",
   "nb-NO",
   "nn-NO",
-  "pa",
   "pl",
   "pt",
   "pt-BR",


### PR DESCRIPTION
Because:

* Some languages aren't enabled in Pontoon

This commit:

* Removes them

Related to #5523