### PR TITLE
feat(surveys): evaluate survey conditions for the rendering view only

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/scripts/lib/survey-filter.js
@@ -6,7 +6,11 @@ import UserAgent from './user-agent';
 
 // All but the default export here is to make testing easier.
 
+// This subsitutes a (curried) comparator when we know the result is false
+// without doing the comparison.
 const falseFn = () => false;
+
+// When a condition is not found in a survey's configurations.
 export const NONE = Symbol();
 
 export const participatedRecently = (
@@ -31,56 +35,189 @@ export const getConditionWithKey = (conditions, key) => {
   return conditions[key];
 };
 
-export const createConditionCheckFn = (valSourceCheck) => (comparator) => (
-  key
-) => (conds, valSource) => {
+/**
+ * Create a function that takes a survey's configured conditions and a function (f) that fetches
+ * the value to be compared to a condition specified by the 'key' param.
+ *
+ * @param {function} valSource a function that takes a function (a) and a comparator and apply the
+ *                             return value of (a) as the first argument to the comparator
+ * @param {function} comparator a function that compares two values and returns a boolean
+ * @param {string} key the configuration key where the condition value can be found
+ * @returns {function} a function that takes conditions and (f) (see description above) and
+ *                     returns a boolean
+ */
+export const createConditionCheckFn = (valSource) => (comparator) => (key) => (
+  conds,
+  fetchFn
+) => {
   // This turned out a little janky.  But we want to return true early if the
   // condition is not in the configs.
   const condVal = getConditionWithKey(conds, key);
   if (condVal === NONE) {
     return true;
   }
-  return valSourceCheck(valSource)(comparator)(condVal);
+  return valSource(fetchFn)(comparator)(condVal);
 };
 
-export const createAsyncConditionCheckFn = (valSourceCheck) => (comparator) => (
+// Like the function above but creates an async function because (f) can be async.
+export const createAsyncConditionCheckFn = (valSource) => (comparator) => (
   key
-) => async (conds, valSource) => {
+) => async (conds, fetchFn) => {
   const condVal = getConditionWithKey(conds, key);
   if (condVal === NONE) {
     return true;
   }
-  return (await valSourceCheck(valSource)(comparator))(condVal);
+  return (await valSource(fetchFn)(comparator))(condVal);
 };
 
-let ua;
-export const checkConditionInUa = (window) => (checkUa) => {
-  if (!window || !window.navigator || !window.navigator.userAgent) {
+/**
+ * Creates a function that construct a UserAgent object when the given window
+ * object has a userAgent string and caches the UserAgent instance.
+ */
+export const createFetchUaFn = (window) => {
+  let ua;
+
+  return () => {
+    if (!window || !window.navigator || !window.navigator.userAgent) {
+      return;
+    }
+
+    ua = ua || new UserAgent(window.navigator.userAgent);
+
+    return ua;
+  };
+};
+
+/**
+ * Creates a function that gets the signed in account from the given user model
+ * and caches it.
+ */
+export const createFetchAccountFn = (user) => {
+  let account;
+
+  return () => {
+    if (!user || !(account = account || user.getSignedInAccount())) {
+      return;
+    }
+
+    return account;
+  };
+};
+
+/**
+ * Creates a function that get a property from a a model object and caches it.
+ *
+ * @param {string} getPropFnName name of the function to call to get the property
+ * @param {function} fetchFn a function to fetch the object
+ * @returns {function} an async function that returns the property or null
+ */
+export const createAsyncGetModelPropertyFn = (getPropFnName) => (fetchFn) => {
+  let prop;
+  return async () => {
+    try {
+      const m = await fetchFn();
+
+      if (m === undefined) {
+        return;
+      }
+
+      prop = prop || (await m[getPropFnName]());
+
+      return prop;
+    } catch {
+      return;
+    }
+  };
+};
+
+/**
+ * Creates a function that returns a list of plan ids for which the user has
+ * subscriptions.
+ */
+export const createFetchSubscriptionsFn = createAsyncGetModelPropertyFn(
+  'getSubscriptions'
+);
+
+/**
+ * Creates a function that returns a list of devices and apps that user is
+ * currently signed into.
+ */
+export const createFetchDeviceListFn = createAsyncGetModelPropertyFn(
+  'fetchDeviceList'
+);
+
+/**
+ * Creates a function that fetches the user's profile image (data model not
+ * image data).
+ */
+export const createFetchProfileImageFn = createAsyncGetModelPropertyFn(
+  'fetchCurrentProfileImage'
+);
+
+/**
+ *  In the case of the relier, it's just a value; we do not need to fetch and
+ *  cache it.  This function takes a value and function and apply the value to
+ *  the function.  For our purpose, it applies the value as the first argument
+ *  to a comparator.
+ */
+const applySourceVal = (sourceVal) => (checkFn) => checkFn(sourceVal);
+
+/**
+ * Fetches a value and then apply it as the first argument to comparator.
+ *
+ * @param {function} fetchFn function to get the value
+ * @param {function} checkFn comparator
+ * @returns {function} comparator with the first argument applied
+ */
+export const fetchAndApplySourceVal = (fetchFn) => (checkFn) => {
+  const x = fetchFn();
+
+  if (x === undefined) {
     return falseFn;
   }
 
-  // @TODO since sinon cannot spy on ES modules, it's difficult to test that
-  // the ua string parsing happens only once.  Consider passing a parser
-  // function as dependency.
+  return checkFn(x);
+};
 
-  if (!ua) {
-    ua = new UserAgent(window.navigator.userAgent);
+// async version of the function above
+export const asyncFetchAndApplySourceVal = (fetchFn) => async (checkFn) => {
+  const x = await fetchFn();
+
+  if (x === undefined) {
+    return falseFn;
   }
 
-  return checkUa(ua);
+  return checkFn(x);
 };
 
-const createUaConditionCheckFn = createConditionCheckFn(checkConditionInUa);
+const createUaConditionCheckFn = createConditionCheckFn(fetchAndApplySourceVal);
 
+// Comparator
 export const checkUaDeviceType = (ua) => (val) => {
-  return ua.genericDeviceType().toLowerCase() === val.toLowerCase();
+  return !!(
+    ua &&
+    ua.genericDeviceType &&
+    ua.genericDeviceType().toLowerCase() === val.toLowerCase()
+  );
 };
 
+// Comparator
 export const checkUaOsName = (ua) => (val) =>
-  ua.os.name.toLowerCase() === val.toLowerCase();
+  !!(
+    ua &&
+    ua.os &&
+    ua.os.name &&
+    ua.os.name.toLowerCase() === val.toLowerCase()
+  );
 
+// Comparator
 export const checkUaBrowser = (ua) => (val) =>
-  ua.browser.name.toLowerCase() === val.toLowerCase();
+  !!(
+    ua &&
+    ua.browser &&
+    ua.browser.name &&
+    ua.browser.name.toLowerCase() === val.toLowerCase()
+  );
 
 // Ref: https://github.com/mozilla/fxa/blob/9b2d9d1/packages/fxa-content-server/app/scripts/lib/user-agent.js#L182
 export const hasDesiredDeviceType = createUaConditionCheckFn(checkUaDeviceType)(
@@ -91,67 +228,30 @@ export const hasDesiredBrowser = createUaConditionCheckFn(checkUaBrowser)(
   'browser'
 );
 
-export const userAgentChecks = (conds, win) =>
-  hasDesiredBrowser(conds, win) &&
-  hasDesiredDeviceType(conds, win) &&
-  hasDesiredOs(conds, win);
+export const userAgentChecks = (conds, fetchUa) =>
+  hasDesiredBrowser(conds, fetchUa) &&
+  hasDesiredDeviceType(conds, fetchUa) &&
+  hasDesiredOs(conds, fetchUa);
 
-const applyWithSourceVal = (sourceVal) => (fn) => fn(sourceVal);
-
+// Comparator
 export const checkRelierClientId = (relier) => (val) =>
   relier.get('clientId') === val;
 
-export const relierClientIdCheck = createConditionCheckFn(applyWithSourceVal)(
+export const relierClientIdCheck = createConditionCheckFn(applySourceVal)(
   checkRelierClientId
 )('relier');
 
-let account, subscriptions;
-export const checkAccountSubscriptions = (user) => async (checkSubs) => {
-  try {
-    if (!user || !(account = account || user.getSignedInAccount())) {
-      return falseFn;
-    }
-
-    subscriptions = subscriptions || (await account.getSubscriptions());
-
-    if (!subscriptions) {
-      return falseFn;
-    }
-  } catch {
-    return falseFn;
-  }
-
-  return checkSubs(subscriptions);
-};
-
+// Comparator
 export const checkSubscriptions = (acctSubs) => (desiredPlanIds) => {
   const subscribedPlanIds = new Set(acctSubs.map((s) => s.plan_id));
   return desiredPlanIds.every((x) => subscribedPlanIds.has(x));
 };
 
 export const subscriptionsCheck = createAsyncConditionCheckFn(
-  checkAccountSubscriptions
+  asyncFetchAndApplySourceVal
 )(checkSubscriptions)('subscriptions');
 
-let devices;
-export const checkAccountDevices = (user) => async (checkDevices) => {
-  try {
-    if (!user || !(account = account || user.getSignedInAccount())) {
-      return falseFn;
-    }
-
-    devices = devices || (await account.fetchDeviceList());
-
-    if (!devices) {
-      return falseFn;
-    }
-  } catch {
-    return falseFn;
-  }
-
-  return checkDevices(devices);
-};
-
+// Comparator
 export const checkLocation = (devices) => (desiredLocation) => {
   const currentSession = devices.find((d) => d.isCurrentSession);
   return !!(
@@ -167,41 +267,25 @@ export const checkLocation = (devices) => (desiredLocation) => {
 };
 
 export const geoLocationCheck = createAsyncConditionCheckFn(
-  checkAccountDevices
+  asyncFetchAndApplySourceVal
 )(checkLocation)('location');
 
+// Comparator
 export const checkSignedInReliers = (devices) => (reliers) => {
   const clientIds = new Set(devices.map((d) => d.clientId));
   return reliers.every((x) => clientIds.has(x));
 };
 
 export const signedInReliersCheck = createAsyncConditionCheckFn(
-  checkAccountDevices
+  asyncFetchAndApplySourceVal
 )(checkSignedInReliers)('reliersList');
 
-let profileImage;
-export const checkAccountProfileImage = (user) => async (checkProfileImg) => {
-  try {
-    if (!user || !(account = account || user.getSignedInAccount())) {
-      return falseFn;
-    }
-    profileImage = profileImage || (await account.fetchCurrentProfileImage());
-
-    if (!profileImage) {
-      return falseFn;
-    }
-  } catch {
-    return falseFn;
-  }
-
-  return checkProfileImg(profileImage);
-};
-
+// Comparator
 export const checkNonDefaultAvatar = (profileImage) => (val) =>
   val ? !profileImage.isDefault() : profileImage.isDefault();
 
 export const nonDefaultAvatarCheck = createAsyncConditionCheckFn(
-  checkAccountProfileImage
+  asyncFetchAndApplySourceVal
 )(checkNonDefaultAvatar)('hasNonDefaultAvatar');
 
 export const createSurveyFilter = (
@@ -210,26 +294,34 @@ export const createSurveyFilter = (
   relier,
   previousParticipationTime,
   doNotBotherSpan
-) => async (surveyConfig) =>
-  !!(
-    surveyConfig &&
-    surveyConfig.conditions &&
-    Object.keys(surveyConfig.conditions).length > 0 &&
-    !participatedRecently(previousParticipationTime, doNotBotherSpan) &&
-    // User agent related checks
-    userAgentChecks(surveyConfig.conditions, window) &&
-    // Relying party (relier) check
-    relierClientIdCheck(surveyConfig.conditions, relier) &&
-    // ASYNC AHEAD
-    // Subscriptions check
-    (await subscriptionsCheck(surveyConfig.conditions, user)) &&
-    // Geo location related checks
-    // The geo location is potentially available in the device/app info
-    (await geoLocationCheck(surveyConfig.conditions, user)) &&
-    // Other signed in reliers check
-    (await signedInReliersCheck(surveyConfig.conditions, user)) &&
-    // Non-default profile image check
-    (await nonDefaultAvatarCheck(surveyConfig.conditions, user))
-  );
+) => {
+  const fetchUa = createFetchUaFn(window);
+  const fetchAccount = createFetchAccountFn(user);
+  const fetchSubscriptions = createFetchSubscriptionsFn(fetchAccount);
+  const fetchDeviceList = createFetchDeviceListFn(fetchAccount);
+  const fetchProfileImage = createFetchProfileImageFn(fetchAccount);
+
+  return async (surveyConfig) =>
+    !!(
+      surveyConfig &&
+      surveyConfig.conditions &&
+      Object.keys(surveyConfig.conditions).length > 0 &&
+      !participatedRecently(previousParticipationTime, doNotBotherSpan) &&
+      // User agent related checks
+      userAgentChecks(surveyConfig.conditions, fetchUa) &&
+      // Relying party (relier) check
+      relierClientIdCheck(surveyConfig.conditions, relier) &&
+      // ASYNC AHEAD
+      // Subscriptions check
+      (await subscriptionsCheck(surveyConfig.conditions, fetchSubscriptions)) &&
+      // Geo location related checks
+      // The geo location is potentially available in the device/app info
+      (await geoLocationCheck(surveyConfig.conditions, fetchDeviceList)) &&
+      // Other signed in reliers check
+      (await signedInReliersCheck(surveyConfig.conditions, fetchDeviceList)) &&
+      // Non-default profile image check
+      (await nonDefaultAvatarCheck(surveyConfig.conditions, fetchProfileImage))
+    );
+};
 
 export default createSurveyFilter;

--- a/packages/fxa-content-server/app/tests/spec/lib/survey-targeter.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/survey-targeter.js
@@ -6,10 +6,9 @@ import SurveyTargeter from 'lib/survey-targeter';
 import { assert } from 'chai';
 import sinon from 'sinon';
 
-import NullStorage from '../../../scripts/lib/null-storage';
+import NullStorage from 'lib/null-storage';
 
 const sandbox = sinon.createSandbox();
-const trueFn = sandbox.stub().returns(true);
 const nullFn = sandbox.stub().returns(null);
 
 describe('lib/SurveyTargeter', () => {
@@ -27,68 +26,87 @@ describe('lib/SurveyTargeter', () => {
       rate: 0.1,
       url: 'https://www.surveygizmo.com/s3/5541940/pizza',
     },
+    {
+      conditions: { browser: 'Firefox' },
+      view: 'settings',
+      url: 'https://www.surveygizmo.com/s3/5541940/pizza',
+    },
   ];
+  const relier = { get: nullFn };
+  const options = {
+    window: {
+      localStorage: new NullStorage(),
+      navigator: {
+        userAgent:
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:76.0) Gecko/20100101 Firefox/76.0',
+      },
+    },
+    relier,
+    config,
+    surveys,
+  };
+
+  const newSurveyTargeter = (opts = options) =>
+    (surveyTargeter = new SurveyTargeter(opts));
 
   beforeEach(() => {
     sandbox.resetHistory();
     sandbox.restore();
-    surveyTargeter = new SurveyTargeter({
-      window: {
-        localStorage: new NullStorage(),
-        navigator: {
-          userAgent:
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:76.0) Gecko/20100101 Firefox/76.0',
-        },
-      },
-      relier: {
-        get: nullFn,
-      },
-      user: {
-        getSignedInAccount: trueFn,
-      },
-      config,
-      surveys,
-    });
+    newSurveyTargeter(options);
   });
 
-  it('surveyTargeter returns a survey if the view matches', async () => {
+  it('constructs view name to surveys map on instantiation', () => {
+    const abc = [{ view: 'abc' }, { view: 'abc' }];
+    const xyz = [{ view: 'xyz' }, { view: 'xyz' }];
+    const surveys = [...abc, ...xyz];
+    newSurveyTargeter({ ...options, surveys });
+    assert.deepEqual(surveyTargeter._surveysByViewNameMap, { abc, xyz });
+  });
+
+  it('returns a survey if the view matches', async () => {
     const view = await surveyTargeter.getSurvey('settings');
+    view.render();
     assert.equal(view.el.className, 'survey-wrapped');
+    assert.equal(
+      view.$('iframe').first().attr('src'),
+      'https://www.surveygizmo.com/s3/5541940/pizza'
+    );
   });
 
-  it('surveyTargeter sets "lastSurvey" in localStorage if view returns', async () => {
+  it('returns false if view does not match', async () => {
+    const view = await surveyTargeter.getSurvey('non-view');
+    assert.isFalse(view);
+  });
+
+  it('returns false when no survey qualifies', async () => {
+    const surveys = [
+      {
+        conditions: { relier: 'Boring, Oregon' },
+        view: 'settings',
+      },
+      {
+        conditions: { browser: 'Dull, Perth and Kinross' },
+        view: 'settings',
+      },
+    ];
+    newSurveyTargeter({ ...options, surveys });
+    const actual = await surveyTargeter.getSurvey('settings');
+    assert.isFalse(actual);
+  });
+
+  it('selects a survey with _selectSurvey', async () => {
+    const spy = sandbox.spy(surveyTargeter, '_selectSurvey');
+    await surveyTargeter.getSurvey('settings');
+    assert.isTrue(spy.calledOnce);
+    assert.isTrue(surveys.includes(spy.firstCall.returnValue));
+  });
+
+  it('sets "lastSurvey" in localStorage if view returns', async () => {
     const setItemSpy = sandbox.spy(surveyTargeter._storage, 'set');
     await surveyTargeter.getSurvey('settings');
     const lastSurveyValue = surveyTargeter._storage.get('lastSurvey');
 
     assert(setItemSpy.calledOnce);
     assert.deepEqual(setItemSpy.args[0], ['lastSurvey', lastSurveyValue]);
-  });
-
-  it('surveyTargeter returns false if view does not match', async () => {
-    const view = await surveyTargeter.getSurvey('non-view');
-    assert.isFalse(view);
-  });
-
-  describe('surveyMap', () => {
-    it('should construct the map only once', async () => {
-      // since we cannot spy on an ES module (survey-filter), we cheat by spying on something else...
-      const reduceSpy = sandbox.spy(surveys, 'reduce');
-      const surveyMapSpy = sandbox.spy(surveyTargeter, 'surveyMap');
-      await surveyTargeter.getSurvey('settings');
-      await surveyTargeter.getSurvey('settings');
-      assert.isTrue(reduceSpy.calledOnce);
-      assert.isTrue(surveyMapSpy.calledTwice);
-    });
-
-    it('should construct the map with view name as key and array as value', async () => {
-      // not geat but an easy to get pass the lastSurvey condition so we can have a map
-      sandbox
-        .stub(surveyTargeter._storage, 'get')
-        .returns(Date.now() - doNotBotherSpan * 2);
-      const surveyMap = await surveyTargeter.surveyMap();
-      assert.isArray(surveyMap['settings']);
-      assert.deepEqual(surveyMap['settings'], surveys);
-    });
   });
 });


### PR DESCRIPTION
Because:
 - eagerly evaluating all the survey conditions can be costly and does
   not work

This commit:
 - evaluate the configured surveys for a view, and only that view, when
   the view is being rendered
 - cache model/state data at the filter function level so that they are
   up to date per navigation but cached for evaluating multiple surveys
   configured for the same view
 - DRY up the filter code

Fixes #5387 (FXA-1938)