### PR TITLE
feat(devices): Emit events for a basic "device commands" delivery funnel.

### DIFF
--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -581,6 +581,16 @@ function mockPush(methods) {
 
 function mockPushbox(methods) {
   const pushbox = Object.assign({}, methods);
+  if (!pushbox.retrieve) {
+    // Route code expects the `retrieve` method to return a properly-structured object.
+    pushbox.retrieve = sinon.spy(() =>
+      P.resolve({
+        last: true,
+        index: 0,
+        messages: [],
+      })
+    );
+  }
   PUSHBOX_METHOD_NAMES.forEach((name) => {
     if (!pushbox[name]) {
       pushbox[name] = sinon.spy(() => P.resolve());


### PR DESCRIPTION
The context for this is https://github.com/mozilla/application-services/issues/3197, and I wanted to push it early to make the proposal easier to discuss. In particular, @6a68, is this the sort of thing for which I should fill out an explicit data-review request?

~~Unfortunately some autocommit reformatter appears to be adding a bunch of noise to this PR, which I'll try to figure out tomorrow. The changes in `/lib/routes/devices-and-sessions.js` are the important bits.~~ (Formatting issues in this PR have now been resolved)

---
Because:

* We don't currently have good metrics on how many "send tab" attempts
  are successfully received by the target device.
* Client-side telemetry for send-tab appears to be rather flaky.
* We can reliably observe tabs being sent and received from FxA server
  activity (but cannot, of course, observe the tab contents).

This commit:

* Emits "command invoked", "command notified" and "command retrieved"
  info logs at key points where a device command transits the FxA
  server from one device to another.
* Includes enough metadata with each event to be able to uniquely
  correlate a particular "invoked" event to its matching "retrieved"
  event, via the combination of uid, deviceId, and pushbox index.

For analysis, a metrics pipeline ETL job will extract and export
these info logs to a place where they can be queries without direct
access to the raw FxA bigquery logs.

Connects to https://github.com/mozilla/application-services/issues/3197