### PR TITLE
fix(customs): Call setRecord instead of setRecords in dataflow

### DIFF
--- a/packages/fxa-customs-server/lib/dataflow.js
+++ b/packages/fxa-customs-server/lib/dataflow.js
@@ -26,9 +26,9 @@ const RECORD_TYPES = new Map([
  * @param {Object} config
  * @param {Object} log
  * @param {Function} fetchRecords
- * @param {Function} setRecords
+ * @param {Function} setRecord
  */
-module.exports = (config, log, fetchRecords, setRecords) => {
+module.exports = (config, log, fetchRecords, setRecord) => {
   if (!config.dataflow.enabled) {
     // no-op if not enabled
     return;
@@ -83,7 +83,7 @@ module.exports = (config, log, fetchRecords, setRecords) => {
 
         if (recordType) {
           records[recordType][action.suggested_action]();
-          await setRecords(records);
+          await setRecord(records[recordType]);
 
           level = 'info';
           op = 'dataflow.message.success';

--- a/packages/fxa-customs-server/lib/server.js
+++ b/packages/fxa-customs-server/lib/server.js
@@ -60,7 +60,12 @@ module.exports = async function createServer(config, log) {
     log
   );
 
-  const { fetchRecord, fetchRecords, setRecords } = require('./records')(
+  const {
+    fetchRecord,
+    fetchRecords,
+    setRecords,
+    setRecord,
+  } = require('./records')(
     mc,
     reputationService,
     limits,
@@ -73,7 +78,7 @@ module.exports = async function createServer(config, log) {
     setRecords
   );
 
-  dataflow(config, log, fetchRecords, setRecords);
+  dataflow(config, log, fetchRecords, setRecord);
 
   if (config.updatePollIntervalSeconds) {
     [
@@ -82,7 +87,7 @@ module.exports = async function createServer(config, log) {
       allowedPhoneNumbers,
       limits,
       requestChecks,
-    ].forEach(settings => {
+    ].forEach((settings) => {
       settings.refresh({ pushOnMissing: true }).catch(() => {});
       settings.pollForUpdates();
     });
@@ -251,7 +256,7 @@ module.exports = async function createServer(config, log) {
             var isExemptUA = false;
             var userAgent = headers['user-agent'];
             isExemptUA = requestChecks.flowIdExemptUserAgentCompiledREs.some(
-              function(re) {
+              function (re) {
                 return re.test(userAgent);
               }
             );
@@ -295,7 +300,7 @@ module.exports = async function createServer(config, log) {
           emailRecord,
           ipEmailRecord,
           smsRecord,
-        ].filter(record => !!record);
+        ].filter((record) => !!record);
         await setRecords(...recordsToSave);
         return {
           block,
@@ -356,7 +361,7 @@ module.exports = async function createServer(config, log) {
 
       return fetchRecords({ ip, email, phoneNumber })
         .then(checkRecords)
-        .then(result =>
+        .then((result) =>
           checkUserDefinedRateLimitRules(result, action, email, ip)
         )
         .then(createResponse, handleError);
@@ -389,7 +394,7 @@ module.exports = async function createServer(config, log) {
       return fetchRecords({ uid })
         .then(({ uidRecord }) => {
           var retryAfter = uidRecord.addCount(action, uid);
-          return setRecords(uidRecord).then(function() {
+          return setRecords(uidRecord).then(function () {
             return {
               block: retryAfter > 0,
               retryAfter: retryAfter,
@@ -397,7 +402,7 @@ module.exports = async function createServer(config, log) {
           });
         })
         .then(
-          function(result) {
+          function (result) {
             log.info({ op: 'request.checkAuthenticated', block: result.block });
 
             if (result.block) {
@@ -409,7 +414,7 @@ module.exports = async function createServer(config, log) {
 
             return result;
           },
-          function(err) {
+          function (err) {
             log.error({ op: 'request.checkAuthenticated', err: err });
             // Default is to block request on any server based error
 
@@ -485,7 +490,7 @@ module.exports = async function createServer(config, log) {
           }));
         })
         .then(
-          result => {
+          (result) => {
             allowWhitelisted(result, ip);
 
             log.info({
@@ -511,7 +516,7 @@ module.exports = async function createServer(config, log) {
 
             return response;
           },
-          err => {
+          (err) => {
             log.error({
               op: 'request.checkIpOnly',
               ip: ip,
@@ -550,7 +555,7 @@ module.exports = async function createServer(config, log) {
       email = normalizedEmail(email);
 
       return fetchRecords({ ip, email })
-        .then(function({ ipRecord, emailRecord, ipEmailRecord }) {
+        .then(function ({ ipRecord, emailRecord, ipEmailRecord }) {
           ipRecord.addBadLogin({ email: email, errno: errno });
           ipEmailRecord.addBadLogin();
 
@@ -562,13 +567,13 @@ module.exports = async function createServer(config, log) {
           }
 
           return setRecords(ipRecord, emailRecord, ipEmailRecord).then(
-            function() {
+            function () {
               return {};
             }
           );
         })
         .then(
-          function(result) {
+          function (result) {
             log.info({
               op: 'request.failedLoginAttempt',
               email: email,
@@ -577,7 +582,7 @@ module.exports = async function createServer(config, log) {
             });
             return result;
           },
-          function(err) {
+          function (err) {
             log.error({
               op: 'request.failedLoginAttempt',
               email: email,
@@ -628,11 +633,11 @@ module.exports = async function createServer(config, log) {
       email = normalizedEmail(email);
 
       return handleBan({ ban: { email: email } })
-        .then(function() {
+        .then(function () {
           log.info({ op: 'request.blockEmail', email: email });
           return {};
         })
-        .catch(function(err) {
+        .catch(function (err) {
           log.error({ op: 'request.blockEmail', email: email, err: err });
           return h.response(err).code(500);
         });
@@ -702,7 +707,7 @@ module.exports = async function createServer(config, log) {
     },
   });
 
-  return P.all(startupDefers).then(function() {
+  return P.all(startupDefers).then(function () {
     return api;
   });
 };

--- a/packages/fxa-customs-server/test/local/dataflow_tests.js
+++ b/packages/fxa-customs-server/test/local/dataflow_tests.js
@@ -38,7 +38,7 @@ tapTest('dataflow', async () => {
     },
   };
   const fetchRecords = sandbox.spy(async () => records);
-  const setRecords = sandbox.spy(async () => {});
+  const setRecord = sandbox.spy(async () => {});
   const subscription = {
     on: sandbox.spy(),
   };
@@ -70,7 +70,7 @@ tapTest('dataflow', async () => {
   test('dataflow disabled', () => {
     config.dataflow.enabled = false;
 
-    dataflow(config, log, fetchRecords, setRecords);
+    dataflow(config, log, fetchRecords, setRecord);
 
     assert.equal(PubSub.callCount, 0);
   });
@@ -79,20 +79,20 @@ tapTest('dataflow', async () => {
     config.dataflow.enabled = true;
     config.dataflow.gcpPubSub.projectId = null;
 
-    assert.throws(() => dataflow(config, log, fetchRecords, setRecords));
+    assert.throws(() => dataflow(config, log, fetchRecords, setRecord));
   });
 
   test('missing gcp subscriptionName', () => {
     config.dataflow.gcpPubSub.projectId = 'foo';
     config.dataflow.gcpPubSub.subscriptionName = null;
 
-    assert.throws(() => dataflow(config, log, fetchRecords, setRecords));
+    assert.throws(() => dataflow(config, log, fetchRecords, setRecord));
   });
 
   test('default config', () => {
     config.dataflow.gcpPubSub.subscriptionName = 'bar';
 
-    dataflow(config, log, fetchRecords, setRecords);
+    dataflow(config, log, fetchRecords, setRecord);
 
     assert.equal(PubSub.callCount, 1);
     let args = PubSub.args[0];
@@ -124,7 +124,7 @@ tapTest('dataflow', async () => {
     assert.equal(log.info.callCount, 0);
     assert.equal(log.warn.callCount, 0);
     assert.equal(fetchRecords.callCount, 0);
-    assert.equal(setRecords.callCount, 0);
+    assert.equal(setRecord.callCount, 0);
 
     test('invalid data', async () => {
       const message = {
@@ -154,7 +154,7 @@ tapTest('dataflow', async () => {
       assert.equal(log.info.callCount, 0);
       assert.equal(log.warn.callCount, 0);
       assert.equal(fetchRecords.callCount, 0);
-      assert.equal(setRecords.callCount, 0);
+      assert.equal(setRecord.callCount, 0);
     });
 
     test('invalid data, old message', async () => {
@@ -186,7 +186,7 @@ tapTest('dataflow', async () => {
       assert.equal(log.info.callCount, 0);
       assert.equal(log.warn.callCount, 0);
       assert.equal(fetchRecords.callCount, 0);
-      assert.equal(setRecords.callCount, 0);
+      assert.equal(setRecord.callCount, 0);
     });
 
     test('invalid suggested_action', async () => {
@@ -219,7 +219,7 @@ tapTest('dataflow', async () => {
       assert.equal(log.info.callCount, 0);
       assert.equal(log.warn.callCount, 0);
       assert.equal(fetchRecords.callCount, 0);
-      assert.equal(setRecords.callCount, 0);
+      assert.equal(setRecord.callCount, 0);
     });
 
     test('invalid indicator_type', async () => {
@@ -247,7 +247,7 @@ tapTest('dataflow', async () => {
       assert.equal(log.info.callCount, 0);
       assert.equal(log.warn.callCount, 0);
       assert.equal(fetchRecords.callCount, 0);
-      assert.equal(setRecords.callCount, 0);
+      assert.equal(setRecord.callCount, 0);
     });
 
     test('invalid indicator', async () => {
@@ -274,7 +274,7 @@ tapTest('dataflow', async () => {
       assert.equal(log.info.callCount, 0);
       assert.equal(log.warn.callCount, 0);
       assert.equal(fetchRecords.callCount, 0);
-      assert.equal(setRecords.callCount, 0);
+      assert.equal(setRecord.callCount, 0);
     });
 
     test('empty indicator', async () => {
@@ -301,7 +301,7 @@ tapTest('dataflow', async () => {
       assert.equal(log.info.callCount, 0);
       assert.equal(log.warn.callCount, 0);
       assert.equal(fetchRecords.callCount, 0);
-      assert.equal(setRecords.callCount, 0);
+      assert.equal(setRecord.callCount, 0);
     });
 
     test('old message', async () => {
@@ -342,7 +342,7 @@ tapTest('dataflow', async () => {
       assert.equal(log.info.callCount, 0);
       assert.equal(log.error.callCount, 0);
       assert.equal(fetchRecords.callCount, 0);
-      assert.equal(setRecords.callCount, 0);
+      assert.equal(setRecord.callCount, 0);
     });
 
     test('report email', async () => {
@@ -383,7 +383,7 @@ tapTest('dataflow', async () => {
       assert.equal(log.warn.callCount, 0);
       assert.equal(log.error.callCount, 0);
       assert.equal(fetchRecords.callCount, 0);
-      assert.equal(setRecords.callCount, 0);
+      assert.equal(setRecord.callCount, 0);
     });
 
     test('report sourceaddress', async () => {
@@ -413,7 +413,7 @@ tapTest('dataflow', async () => {
       assert.equal(log.warn.callCount, 0);
       assert.equal(log.error.callCount, 0);
       assert.equal(fetchRecords.callCount, 0);
-      assert.equal(setRecords.callCount, 0);
+      assert.equal(setRecord.callCount, 0);
     });
 
     test('suspect email', async () => {
@@ -435,11 +435,11 @@ tapTest('dataflow', async () => {
       assert.equal(records.emailRecord.suspect.callCount, 1);
       assert.lengthOf(records.emailRecord.suspect.args[0], 0);
 
-      assert.equal(setRecords.callCount, 1);
-      args = setRecords.args[0];
+      assert.equal(setRecord.callCount, 1);
+      args = setRecord.args[0];
       assert.lengthOf(args, 1);
-      assert.equal(args[0], records);
-      assert.isTrue(setRecords.calledAfter(records.emailRecord.suspect));
+      assert.equal(args[0], records.emailRecord);
+      assert.isTrue(setRecord.calledAfter(records.emailRecord.suspect));
 
       assert.equal(message.ack.callCount, 1);
 
@@ -493,9 +493,9 @@ tapTest('dataflow', async () => {
       assert.equal(records.ipRecord.suspect.callCount, 1);
       assert.lengthOf(records.ipRecord.suspect.args[0], 0);
 
-      assert.equal(setRecords.callCount, 1);
-      assert.equal(setRecords.args[0][0], records);
-      assert.isTrue(setRecords.calledAfter(records.ipRecord.suspect));
+      assert.equal(setRecord.callCount, 1);
+      assert.equal(setRecord.args[0][0], records.ipRecord);
+      assert.isTrue(setRecord.calledAfter(records.ipRecord.suspect));
 
       assert.equal(message.ack.callCount, 1);
 
@@ -531,9 +531,9 @@ tapTest('dataflow', async () => {
       assert.equal(records.emailRecord.block.callCount, 1);
       assert.lengthOf(records.emailRecord.block.args[0], 0);
 
-      assert.equal(setRecords.callCount, 1);
-      assert.equal(setRecords.args[0][0], records);
-      assert.isTrue(setRecords.calledAfter(records.emailRecord.block));
+      assert.equal(setRecord.callCount, 1);
+      assert.equal(setRecord.args[0][0], records.emailRecord);
+      assert.isTrue(setRecord.calledAfter(records.emailRecord.block));
 
       assert.equal(message.ack.callCount, 1);
 
@@ -569,9 +569,9 @@ tapTest('dataflow', async () => {
       assert.equal(records.emailRecord.disable.callCount, 1);
       assert.lengthOf(records.emailRecord.disable.args[0], 0);
 
-      assert.equal(setRecords.callCount, 1);
-      assert.equal(setRecords.args[0][0], records);
-      assert.isTrue(setRecords.calledAfter(records.emailRecord.disable));
+      assert.equal(setRecord.callCount, 1);
+      assert.equal(setRecord.args[0][0], records.emailRecord);
+      assert.isTrue(setRecord.calledAfter(records.emailRecord.disable));
 
       assert.equal(message.ack.callCount, 1);
 
@@ -602,14 +602,14 @@ tapTest('dataflow', async () => {
       assert.equal(log.info.callCount, 0);
       assert.equal(log.warn.callCount, 0);
       assert.equal(fetchRecords.callCount, 0);
-      assert.equal(setRecords.callCount, 0);
+      assert.equal(setRecord.callCount, 0);
     });
   });
 
   test('config.reportOnly', () => {
     config.dataflow.reportOnly = true;
 
-    dataflow(config, log, fetchRecords, setRecords);
+    dataflow(config, log, fetchRecords, setRecord);
 
     assert.equal(PubSub.callCount, 1);
     assert.equal(pubsub.subscription.callCount, 1);
@@ -624,7 +624,7 @@ tapTest('dataflow', async () => {
     assert.equal(log.info.callCount, 0);
     assert.equal(log.warn.callCount, 0);
     assert.equal(fetchRecords.callCount, 0);
-    assert.equal(setRecords.callCount, 0);
+    assert.equal(setRecord.callCount, 0);
 
     test('suspect', async () => {
       const message = {
@@ -656,7 +656,7 @@ tapTest('dataflow', async () => {
       assert.equal(log.warn.callCount, 0);
       assert.equal(log.error.callCount, 0);
       assert.equal(fetchRecords.callCount, 0);
-      assert.equal(setRecords.callCount, 0);
+      assert.equal(setRecord.callCount, 0);
     });
 
     test('block', async () => {
@@ -682,7 +682,7 @@ tapTest('dataflow', async () => {
       assert.equal(log.warn.callCount, 0);
       assert.equal(log.error.callCount, 0);
       assert.equal(fetchRecords.callCount, 0);
-      assert.equal(setRecords.callCount, 0);
+      assert.equal(setRecord.callCount, 0);
     });
 
     test('disable', async () => {
@@ -708,7 +708,7 @@ tapTest('dataflow', async () => {
       assert.equal(log.warn.callCount, 0);
       assert.equal(log.error.callCount, 0);
       assert.equal(fetchRecords.callCount, 0);
-      assert.equal(setRecords.callCount, 0);
+      assert.equal(setRecord.callCount, 0);
     });
   });
 


### PR DESCRIPTION
Since dataflow can only set one record at a time, update method to call `setRecord` instead of `setRecords`

This has a few breaking tests, fixing them up.