### PR TITLE
fix(admin-panel): Adjust input height

### DIFF
--- a/packages/fxa-admin-panel/src/components/EmailBlocks/index.scss
+++ b/packages/fxa-admin-panel/src/components/EmailBlocks/index.scss
@@ -34,10 +34,6 @@
       var(--color-black-05);
     border: var(--input-border-width) solid var(--color-black-20);
     border-left: 0;
-    height: calc(
-      var(--input-height) + calc(var(--input-border-width) * 2) +
-        calc(var(--input-padding-y) * 2)
-    );
     transition: var(--transition-duration) background-color;
     width: 45px;
 

--- a/packages/fxa-admin-panel/src/styles/_variables.scss
+++ b/packages/fxa-admin-panel/src/styles/_variables.scss
@@ -43,7 +43,7 @@ nav {
 input,
 input + button {
   --input-border-width: 1px;
-  --input-height: 30px;
+  --input-height: 42px;
   --input-padding-y: 5px;
 }
 


### PR DESCRIPTION
Not sure what changed, but this hurt my eyes when I was working on restyling the footer now shared with new settings/admin panel.

before:
<img width="427" alt="image" src="https://user-images.githubusercontent.com/13018240/83924931-6eb59080-a74b-11ea-8671-3882711f26bd.png">

after:
<img width="396" alt="image" src="https://user-images.githubusercontent.com/13018240/83924302-f0a4ba00-a749-11ea-80b5-2d6b6e172c09.png">
