### PR TITLE
chore(docs): Update fxa-settings README with Tailwind + shared component details

### DIFF
--- a/packages/fxa-settings/README.md
+++ b/packages/fxa-settings/README.md
@@ -1,26 +1,38 @@
 # Firefox Accounts Settings
 
+This documentation is up to date as of 2020-06-08.
+
 ## Development
 
-- `npm run start|stop|restart` to start, stop, and restart the server as a PM2 process
-- `npm run build` to create a production build
+- `yarn start|stop|restart` to start, stop, and restart the server as a PM2 process
+- `yarn build` to create a production build
+- `yarn test` to run unit tests
+- `yarn storybook` to open Storybook
 
 ### External imports
 
-You can import React components into this project. This is currently restricted to `fxa-react`:
+You can import React components externally from `fxa-react` into this project:
 
 ```javascript
 // e.g. assuming the component HelloWorld exists
 import HelloWorld from 'fxa-react/components/HelloWorld';
 ```
 
+Components from React packages can be moved into `fxa-react` to be shared across multiple packages. See the "Reusing components with `fxa-react`" section of this doc for more details.
+
 ### Styling components
 
 #### Tailwind
 
-The package uses [Tailwind CSS](https://tailwindcss.com/) for the bulk of its styles. If you're not familiar you're encouraged to [learn more](https://tailwindcss.com/docs/utility-first), but the idea is simple: use predefined classes on elements to layer on individual styles. **You can accomplish most of your styling needs with the classes provided.**
+The `fxa-settings`, `fxa-react`, and `fxa-admin-panel` packages are setup to share a [Tailwind CSS](https://tailwindcss.com/) configuration file found in the `fxa-react` package. Other React packages, such as `fxa-payments-server` and `fxa-content-server` will be configured to use Tailwind at a later time. If you're not familiar with Tailwind, look through [their documentation](https://tailwindcss.com/docs) to get an idea of what [utility-first](https://tailwindcss.com/docs/utility-first) (Atomic CSS) is and what you can expect while using it. The general idea is simple: use single-purpose classes on elements to layer styles until the design is achieved. **You can accomplish almost all of your styling needs with classes provided by Tailwind's default configuration or through adding them in the configuration file.**
 
-For example, here's what a large, centered, red-text paragraph with a blue background and thick padding would look like:
+Each package has its own `tailwind.[s]css` file. This file, any S/CSS files this file imports, and the Tailwind configuration file are compiled to produce `tailwind.out.css`. Rebuilding this file should happen automatically on any change. If you're not sure what specific class name corresponds with the style you need or if you need to check that a specific style exists in our utility classes, search through `tailwind.out.css` for these styles as needed. Note that if you run a build command to test a production build, you'll need to make an update to one of these files with `pm2` running or manually run `yarn build-postcss` to rebuild the dev version containing all available classes (see the "PurgeCSS" section for more details).
+
+Not every spacing value from a design hand off may be absolutely precise due to small variations from web tool processing (such as Sketch conversion to InVision or Figma) - it's important to keep in mind that our CSS system for FxA styles increase in **units of `4px`**. If a design reflects 17px, it's generally safe to go with the closest value divisible by 4, 16px (`1rem`), but it is up to the engineer to ask for clarification from visual design if this might be an intended one-off and to also potentially offer a strong recommendation to stay within our standard guidelines if a design strays from the `4px` increment standard for the sake of consistency across our products. If an exception needs to be made or if the [Tailwind default configuration](https://tailwindcss.com/docs/configuration) doesn't offer a needed value (for example, [default spacing](https://tailwindcss.com/docs/customizing-spacing#default-spacing-scale) uses `-8` to output `2rem` measurements and `-10` to output `2.5rem`, but if we need `2.75rem`, it's completely acceptable to need `-9`), use the `extends` option in the configuration file to add the class that you need. This also applies with colors and font-sizes - don't arbitrarily add these values without ensuring current values won't work for what Design intends or without conveying to them that it's different than what we've used so far.
+
+We do overwrite some of the default values provided by Tailwind, such as colors and breakpoints. Refer to the shared Tailwind config file to see how values vary.
+
+Here's an example of what a large, centered, red-text paragraph with a blue background and thick padding would look like:
 
 ```html
 <p class="text-lg text-red-600 background-white text-center p-10">
@@ -28,48 +40,147 @@ For example, here's what a large, centered, red-text paragraph with a blue backg
 </p>
 ```
 
-It's fairly straightforward once you understand how size, scales and other sequential patterns work. The [Tailwind docs](https://tailwindcss.com/docs) are very helpful in understanding these concepts (and they have an excellent search), and there are plugins for various IDEs ([VS Code](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss), [IntelliJ IDEs](https://plugins.jetbrains.com/plugin/12074-tailwindcss), [Vim](https://github.com/iamcco/coc-tailwindcss)).
+The Tailwind pattern becomes straightforward once you understand how size, scales and other sequential patterns work. The Tailwind docs are very helpful in understanding these concepts (and they have an excellent search), and there are plugins for various IDEs ([VS Code](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss), [IntelliJ IDEs](https://plugins.jetbrains.com/plugin/12074-tailwindcss), [Vim](https://github.com/iamcco/coc-tailwindcss)).
 
-Here are a few additional things to keep in mind when developing with Tailwind:
+##### Component Classes
 
-- We overwrite some of the default values provided by Tailwind, such as color and breakpoints. Refer to [tailwind.config.js](./tailwind.config.js) to see how values vary.
-- You do not need to import any custom or built-in styles/dependencies to use Tailwind. Just write your class names.
-- When it comes to time to create a production build we use PostCSS and PurgeCSS to strip out unused styles. PurgeCSS will look through all of the TSX files and identify which class names to keep styles for. In order for this to work properly it's important to avoid dynamic class names:
+When there is a pattern of commonly repeated utility combinations, it may make sense to extract this pattern into its own component or component utility class using Tailwind's `@apply`. A good rule of thumb for this is to consider if a pattern update would be expected to reflect in more than one component.
 
-  ```tsx
-  // Bad
-  const Button = ({ textColor, children }) => {
-    return <button className={`text-${textColor}`}>{children}</button>;
-  };
-  <Button textColor="green-500">Hello, world</Button>;
+For example:
 
-  // Good!
-  const Button = ({ textColor, children }) => {
-    return <button className={textColor}>{children}</button>;
-  };
-  <Button textColor="text-green-500">Hello, world</Button>;
-  ```
+```tsx
+// my-component.tsx
+<button className="block w-full py-2 text-center mt-6 bg-grey-10 border border-grey-200 transition duration-150 rounded hover:border-grey-200 hover:bg-grey-100 hover:text-grey-400 hover:transition hover:duration-150 active:border-grey-400 active:bg-grey-100 active:text-grey-400 active:transition active:duration-150">
+  Click here!
+</button>
 
-- If you find a class name is getting stripped out erroneously in production builds, it can be [whitelisted](https://purgecss.com/whitelisting.html) in [tailwind.config.js](./tailwind.config.js) or in the stylesheet itself by placing `/* purgecss ignore */` directly above the selector. Please use sparingly.
+// my-other-component.tsx
+<a href="#" className="block w-full py-2 text-center mt-6 bg-grey-10 border border-grey-200 transition duration-150 rounded hover:border-grey-200 hover:bg-grey-100 hover:text-grey-400 hover:transition hover:duration-150 active:border-grey-400 active:bg-grey-100 active:text-grey-400 active:transition active:duration-150">
+  Click here!
+</a>
+```
+
+This makes more sense as a new utility class instead of a component because sometimes we style a button and other times a link. Let's extract this instead into `ctas.scss` with a fitting name:
+
+```scss
+// ctas.scss
+.cta-neutral {
+  @apply block w-full py-2 text-center mt-6 bg-grey-10 border border-grey-200 transition duration-150 rounded;
+
+  &:hover {
+    @apply border-grey-200 bg-grey-100 text-grey-400 transition duration-150;
+  }
+
+  &:active {
+    @apply border-grey-400 bg-grey-100 text-grey-400 transition duration-150;
+  }
+}
+```
+
+Assuming this package uses `postcss-import`, all we need to do now is `@import` ctas.scss into our `tailwind.css` file and apply our new utility class:
+
+```tsx
+// my-component.tsx
+<button className="cta-neutral">
+  Click here!
+</button>
+
+// my-other-component.tsx
+<a href="#" className="cta-neutral">
+  Click here!
+</a>
+```
+
+Note that the above doesn't have to be in an external SCSS file, `@apply` and other PostCSS at-rules can be used in `.css` files, but SCSS still comes in handy for nesting.
+
+Keep in mind that custom component classes are not scoped per component and some line of thought should go into custom class names to avoid naming collisions. Generally, you should match the class name to the name of your component and it's recommended to use `[component]-[descriptor]` style (e.g. using a shared UnitRow to display secondary emails could be `unit-row-secondary-emails`). Also, use `@apply` exclusively if possible, keep the selector one level deep, never use `!important` to avoid specificity collisions, and don't use `&-` overzealously as it makes classes difficult to search for (one level deep is fine). These recommendations generally also apply to custom styles.
+
+See the [Tailwind docs on this subject](https://tailwindcss.com/docs/extracting-components/) for more detailed information and examples.
+
+#### PurgeCSS
+
+When it comes to time to create a production build we use PostCSS and PurgeCSS to strip out unused styles. PurgeCSS will look through all of the TSX files, including those of externally imported components, and identify which class names to keep styles for. In order for this to work properly it's important to avoid dynamic class names:
+
+```tsx
+// Bad
+const Button = ({ textColor, children }) => {
+  return <button className={`text-${textColor}`}>{children}</button>;
+};
+<Button textColor="green-500">Hello, world</Button>;
+
+// Good!
+const Button = ({ textColor, children }) => {
+  return <button className={textColor}>{children}</button>;
+};
+<Button textColor="text-green-500">Hello, world</Button>;
+```
+
+If you find a class name is getting stripped out erroneously in production builds, it can be [whitelisted](https://purgecss.com/whitelisting.html) in [tailwind.config.js](./tailwind.config.js) or in the stylesheet itself by placing `/* purgecss ignore */` directly above the selector. Please use sparingly.
 
 #### Custom styles
 
 In the event you need to write styles that Tailwind is not able to affectively cover you should try to keep the following guidelines in mind:
 
-- SCSS is available.
-- PurgeCSS does not currently strip styles written outside of `src/styles/tailwind.css`, so it's up to you to keep styles limited to what you're using in your component.
-- Custom styles should be restricted to the component they are being used in. Typically, this is just an `index.scss` file adjacent to your component's `index.tsx` and then imported.
-- Because custom styles, once imported, are included in the global styles you should still be careful about how you're naming classes to avoid collisions. Generally you should match the class name to the name of your component. If you're using a shared component it's recommended to use `[component]-[descriptor]` style (e.g. using a shared UnitRow to display secondary emails could be `unit-row-secondary-emails`).
+- SCSS is available if it's absolutely necessary to add a custom style.
+- Because PostCSS syntax cannot be directly loaded into a React component (`import './index.scss'`), custom stylesheets must be `@import`ed directly into a `tailwind.[s]css` file or another file that is imported into this file. Add these customs tylesheets in the `styles/` directory.
+- Imported custom styles are not scoped per component and some line of thought should go into custom class names to avoid naming collisions. Generally, you should match the class name to the name of your component and it's recommended to use a `[component]-[descriptor]` style (e.g. using a shared UnitRow to display secondary emails could be `unit-row-secondary-emails`). Also, if possible, keep the selector one to two levels deep, never use `!important` to avoid specificity collisions, and don't use `&-` overzealously as it makes classes difficult to search for (one level deep is fine). These recommendations also generally apply to custom component utility classes.
+
+### Reusing components with `fxa-react` and Tailwind
+
+Let's say there's a component in `fxa-admin-panel` that you also want to use in `fxa-settings`. You move this component into `fxa-react` to use it in both `fxa-admin-panel` and `fxa-settings` and style it with Tailwind classes:
+
+```tsx
+// fxa-react/components/MySharedComponent
+
+const MySharedComponent = () => <div className="font-bold mr-2">Some text</div>;
+export default MySharedComponent;
+```
+
+Now you can use `MySharedComponent` with the same styles in two packages. You can use it like so:
+
+```tsx
+// fxa-settings/src/components/anotherComponent
+import MySharedComponent from 'fxa-react/components/MySharedComponent';
+
+<MySharedComponent />;
+```
+
+What if you need to reuse this component later with different styles but the component has been used in several places with the classes `font-bold mr-2`? In this case, the component must be refactored to take in a `className` prop with a default set to whatever it was previously. This applies to children as well - you'll have to use `headerClassName` or `contentClassName` (or a `classes` object) or whatever prop name makes sense if any of the children need a different class. Now `MySharedComponent` becomes:
+
+```tsx
+// fxa-react/components/MySharedComponent
+const MySharedComponent = ({ className = 'font-bold mr-2' }) => (
+  <div {...{ className }}>Some text</div>
+);
+export default MySharedComponent;
+```
+
+Then, you can use it with custom classes like so:
+
+```tsx
+// fxa-settings/src/components/anotherComponent
+import MySharedComponent from 'fxa-react/components/MySharedComponent';
+
+<MySharedComponent className="mr-4" />;
+```
+
+All previous instances will still use `font-bold mr-2`.
 
 ### Working with SVGs
 
-Create React App allows us to use SVGs in a variety of ways, right out of the box.
+Create React App allows us to use SVGs in a variety of ways, right out of the box. We prefer to inline our SVGs where we can:
 
 ```javascript
 // Inline, full markup:
 import { ReactComponent as Logo } from './logo.svg';
 const LogoImage = () => <Logo role="img" aria-label="logo" />;
+```
 
+Inlining our SVGs will minimize the number of network requests our application needs to perform. `role="img"` tells screenreaders to refer to this element as an image and `aria-label` acts like `alt` text on an `img` tag does. You can also pass in `className` and other properties, and if needed, conditionally change elements inside of the SVG such as a `path`'s `fill` property.
+
+Other ways to use SVGs:
+
+```javascript
 // As an image source:
 import logoUrl from './logo.svg';
 const LogoImage = () => <img src={logoUrl} alt="Logo" />;


### PR DESCRIPTION
Because:
* The settings redesign project has introduced Tailwind into FxA and
  some standards have been set. We need a 'getting started' guide.

This commit:
* Adds to the fxa-settings README.

fixes #5552