### PR TITLE
feat(metrics): add subscription payment source country to Amplitude events

### DIFF
--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -33,6 +33,10 @@ type EventProperties = GlobalEventProperties & {
   error?: Error;
 };
 
+type SuccessfulSubscriptionEventProperties = EventProperties & {
+  sourceCountry?: string;
+};
+
 type Error = { message?: string } | null;
 
 // These can still be overwritten in the event logging function.
@@ -133,7 +137,9 @@ export function createSubscription_PENDING(eventProperties: EventProperties) {
   );
 }
 
-export function createSubscription_FULFILLED(eventProperties: EventProperties) {
+export function createSubscription_FULFILLED(
+  eventProperties: SuccessfulSubscriptionEventProperties
+) {
   safeLogAmplitudeEvent(
     eventGroupNames.createSubscription,
     eventTypeNames.success,

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -165,14 +165,21 @@ describe('API requests', () => {
     const metricsOptions = {
       planId: params.planId,
       productId: params.productId,
+      sourceCountry: 'GD',
     };
 
     it('POST {auth-server}/v1/oauth/subscriptions/active', async () => {
-      const requestMock = nock(AUTH_BASE_URL).post(path, params).reply(200, {});
-      expect(await apiCreateSubscription(params)).toEqual({});
-      expect(<jest.Mock>createSubscription_PENDING).toBeCalledWith(
-        metricsOptions
-      );
+      const requestMock = nock(AUTH_BASE_URL)
+        .post(path, params)
+        .reply(200, { subscriptionId: 'asdf', sourceCountry: 'GD' });
+      expect(await apiCreateSubscription(params)).toEqual({
+        subscriptionId: 'asdf',
+        sourceCountry: 'GD',
+      });
+      expect(<jest.Mock>createSubscription_PENDING).toBeCalledWith({
+        planId: params.planId,
+        productId: params.productId,
+      });
       expect(<jest.Mock>createSubscription_FULFILLED).toBeCalledWith(
         metricsOptions
       );
@@ -190,11 +197,13 @@ describe('API requests', () => {
         error = e;
       }
       expect(error).not.toBeNull();
-      expect(<jest.Mock>createSubscription_PENDING).toBeCalledWith(
-        metricsOptions
-      );
+      expect(<jest.Mock>createSubscription_PENDING).toBeCalledWith({
+        planId: params.planId,
+        productId: params.productId,
+      });
       expect(<jest.Mock>createSubscription_REJECTED).toBeCalledWith({
-        ...metricsOptions,
+        planId: params.planId,
+        productId: params.productId,
         error,
       });
       requestMock.done();

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -143,7 +143,10 @@ export async function apiCreateSubscription(params: {
         }),
       }
     );
-    Amplitude.createSubscription_FULFILLED(metricsOptions);
+    Amplitude.createSubscription_FULFILLED({
+      ...metricsOptions,
+      sourceCountry: result.sourceCountry,
+    });
     return result;
   } catch (error) {
     Amplitude.createSubscription_REJECTED({

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -60,7 +60,7 @@ const EVENT_PROPERTIES = {
   [GROUPS.subCancel]: NOP,
   [GROUPS.subManage]: NOP,
   [GROUPS.subPayManage]: NOP,
-  [GROUPS.subPaySetup]: NOP,
+  [GROUPS.subPaySetup]: mapSubscriptionPaymentEventProperties,
   [GROUPS.subPayUpgrade]: NOP,
   [GROUPS.subSupport]: NOP,
   [GROUPS.qrConnectDevice]: NOP,
@@ -132,6 +132,17 @@ function mapDomainValidationResult(
   // properties for the results pertaining to domain_validation_result.
   if (eventType === 'domain_validation_result' && eventCategory) {
     return { validation_result: eventCategory };
+  }
+}
+
+function mapSubscriptionPaymentEventProperties(
+  eventType,
+  eventCategory,
+  eventTarget,
+  data
+) {
+  if (data && data.sourceCountry) {
+    return { source_country: data.sourceCountry };
   }
 }
 

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -127,6 +127,13 @@ describe('metrics/amplitude:', () => {
               event: 'newsletters',
             },
           ],
+          [
+            /^(fxa_pay_setup)\.([\w-]+)/,
+            {
+              group: amplitude.GROUPS.subPaySetup,
+              event: 'payment',
+            },
+          ],
         ])
       );
     });
@@ -452,6 +459,29 @@ describe('metrics/amplitude:', () => {
       it('returned the correct event data', () => {
         assert.deepEqual(result.event_properties, {});
         assert.deepEqual(result.user_properties, {});
+      });
+    });
+
+    describe('transform an event with sourceCountry:', () => {
+      it('did not include the source country in event properties when the event was not in the fxa_pay_setup group', () => {
+        const actual = transform(
+          { type: 'wibble.blee' },
+          { sourceCountry: 'GD' }
+        );
+        assert.deepEqual(actual.event_properties, {});
+      });
+
+      it('did not include the source country in event properties when none was found', () => {
+        const actual = transform({ type: 'fxa_pay_setup.blee.quuz' }, {});
+        assert.deepEqual(actual.event_properties, {});
+      });
+
+      it('returned the correct source country event properties', () => {
+        const actual = transform(
+          { type: 'fxa_pay_setup.blee.quuz' },
+          { sourceCountry: 'GD' }
+        );
+        assert.deepEqual(actual.event_properties, { source_country: 'GD' });
       });
     });
   });


### PR DESCRIPTION
Because:
 - we like to know the geo distribution of subscriptions in Amplitude

This commit:
 - add the payment country code from a successful subscription to an
   Amplitude event as an event property

Part of and closes #5454 (closes FXA-2023); follows PR #5566