### PR TITLE
chore(formatting): Apply automated formatting to push-related code.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # prettier reformat 24-05-2020
 cc595fc2b44bc1e15857c016539622a6a750bd5d
+# additional re-formatting 09-06-2020
+81bf01d41a4bf84c2fb54c83b5c35fa00e53a2a3

--- a/packages/fxa-auth-server/lib/push.js
+++ b/packages/fxa-auth-server/lib/push.js
@@ -20,47 +20,47 @@ const PUSH_COMMANDS = {
 };
 
 const PUSH_REASONS = new Set([
- 'accountVerify',
- 'accountConfirm',
- 'passwordReset',
- 'passwordChange',
- 'deviceConnected',
- 'deviceDisconnected',
- 'profileUpdated',
- 'devicesNotify',
- 'accountDestroyed',
- 'commandReceived',
+  'accountVerify',
+  'accountConfirm',
+  'passwordReset',
+  'passwordChange',
+  'deviceConnected',
+  'deviceDisconnected',
+  'profileUpdated',
+  'devicesNotify',
+  'accountDestroyed',
+  'commandReceived',
 ]);
 
 const PUSH_ERRORS = new Set([
-  "noCallback",
-  "noKeys",
-  "expiredCallback",
-  "resetCallback",
-  "serverError",
-  "unknown",
+  'noCallback',
+  'noKeys',
+  'expiredCallback',
+  'resetCallback',
+  'serverError',
+  'unknown',
 ]);
 
 const PUSH_ERROR_MESSAGES = {
-  "noCallback": "No push callback",
-  "noKeys": "Data payload preset but missing keys",
-  "expiredCallback": "Push callback expired",
-  "resetCallback": "Push callback indicated it should be reset",
-  "unknown": "Unknown push error",
+  noCallback: 'No push callback',
+  noKeys: 'Data payload preset but missing keys',
+  expiredCallback: 'Push callback expired',
+  resetCallback: 'Push callback indicated it should be reset',
+  unknown: 'Unknown push error',
 };
 
-const ERR_NO_PUSH_CALLBACK = "noCallback";
-const ERR_DATA_BUT_NO_KEYS = "noKeys";
-const ERR_PUSH_CALLBACK_EXPIRED = "expiredCallback";
-const ERR_PUSH_CALLBACK_RESET = "resetCallback";
-const ERR_PUSH_UNKNOWN = "unknown";
+const ERR_NO_PUSH_CALLBACK = 'noCallback';
+const ERR_DATA_BUT_NO_KEYS = 'noKeys';
+const ERR_PUSH_CALLBACK_EXPIRED = 'expiredCallback';
+const ERR_PUSH_CALLBACK_RESET = 'resetCallback';
+const ERR_PUSH_UNKNOWN = 'unknown';
 
-const LOG_OP_PUSH_SEND_ATTEMPT = "push.send.attempt";
-const LOG_OP_PUSH_SEND_FAILURE = "push.send.failure";
-const LOG_OP_PUSH_SEND_SUCCESS = "push.send.success";
-const LOG_OP_PUSH_UNEXPECTED_ERROR = "push.sendPush.unexpectedError";
-const LOG_OP_TOO_MANY_DEVICES = "push.sendPush.tooManyDevices";
-const LOG_OP_DEVICE_UPDATE_FAILED = "push.sendPush.deviceUpdateFailed";
+const LOG_OP_PUSH_SEND_ATTEMPT = 'push.send.attempt';
+const LOG_OP_PUSH_SEND_FAILURE = 'push.send.failure';
+const LOG_OP_PUSH_SEND_SUCCESS = 'push.send.success';
+const LOG_OP_PUSH_UNEXPECTED_ERROR = 'push.sendPush.unexpectedError';
+const LOG_OP_TOO_MANY_DEVICES = 'push.sendPush.tooManyDevices';
+const LOG_OP_DEVICE_UPDATE_FAILED = 'push.sendPush.deviceUpdateFailed';
 
 const TTL_DEVICE_DISCONNECTED = 5 * 3600; // 5 hours
 const TTL_PASSWORD_CHANGED = 6 * 3600; // 6 hours
@@ -187,7 +187,7 @@ module.exports = function (log, db, config, statsd) {
      * @promise
      */
     notifyCommandReceived(uid, device, command, sender, index, url, ttl) {
-      if (typeof ttl === "undefined") {
+      if (typeof ttl === 'undefined') {
         ttl = TTL_COMMAND_RECEIVED;
       }
       const options = {
@@ -203,7 +203,7 @@ module.exports = function (log, db, config, statsd) {
         },
         TTL: ttl,
       };
-      return this.sendPush(uid, [device], "commandReceived", options);
+      return this.sendPush(uid, [device], 'commandReceived', options);
     },
 
     /**
@@ -215,7 +215,7 @@ module.exports = function (log, db, config, statsd) {
      * @promise
      */
     notifyDeviceConnected(uid, devices, deviceName) {
-      return this.sendPush(uid, devices, "deviceConnected", {
+      return this.sendPush(uid, devices, 'deviceConnected', {
         data: {
           version: PUSH_PAYLOAD_SCHEMA_VERSION,
           command: PUSH_COMMANDS.DEVICE_CONNECTED,
@@ -235,7 +235,7 @@ module.exports = function (log, db, config, statsd) {
      * @promise
      */
     notifyDeviceDisconnected(uid, devices, idToDisconnect) {
-      return this.sendPush(uid, devices, "deviceDisconnected", {
+      return this.sendPush(uid, devices, 'deviceDisconnected', {
         data: {
           version: PUSH_PAYLOAD_SCHEMA_VERSION,
           command: PUSH_COMMANDS.DEVICE_DISCONNECTED,
@@ -255,7 +255,7 @@ module.exports = function (log, db, config, statsd) {
      * @promise
      */
     notifyProfileUpdated(uid, devices) {
-      return this.sendPush(uid, devices, "profileUpdated", {
+      return this.sendPush(uid, devices, 'profileUpdated', {
         data: {
           version: PUSH_PAYLOAD_SCHEMA_VERSION,
           command: PUSH_COMMANDS.PROFILE_UPDATED,
@@ -271,7 +271,7 @@ module.exports = function (log, db, config, statsd) {
      * @promise
      */
     notifyPasswordChanged(uid, devices) {
-      return this.sendPush(uid, devices, "passwordChange", {
+      return this.sendPush(uid, devices, 'passwordChange', {
         data: {
           version: PUSH_PAYLOAD_SCHEMA_VERSION,
           command: PUSH_COMMANDS.PASSWORD_CHANGED,
@@ -288,7 +288,7 @@ module.exports = function (log, db, config, statsd) {
      * @promise
      */
     notifyPasswordReset(uid, devices) {
-      return this.sendPush(uid, devices, "passwordReset", {
+      return this.sendPush(uid, devices, 'passwordReset', {
         data: {
           version: PUSH_PAYLOAD_SCHEMA_VERSION,
           command: PUSH_COMMANDS.PASSWORD_RESET,
@@ -317,7 +317,7 @@ module.exports = function (log, db, config, statsd) {
      * @promise
      */
     notifyAccountDestroyed(uid, devices) {
-      return this.sendPush(uid, devices, "accountDestroyed", {
+      return this.sendPush(uid, devices, 'accountDestroyed', {
         data: {
           version: PUSH_PAYLOAD_SCHEMA_VERSION,
           command: PUSH_COMMANDS.ACCOUNT_DESTROYED,
@@ -375,7 +375,7 @@ module.exports = function (log, db, config, statsd) {
         }
         const pushSubscription = { endpoint: device.pushCallback };
         let pushPayload = null;
-        const pushOptions = { TTL: options.TTL || "0" };
+        const pushOptions = { TTL: options.TTL || '0' };
         if (options.data) {
           if (!device.pushPublicKey || !device.pushAuthKey) {
             this.reportPushFailure(ERR_DATA_BUT_NO_KEYS, metricsTags);
@@ -438,7 +438,7 @@ module.exports = function (log, db, config, statsd) {
       // Log the full callback URL for debugging purposes.
       log.trace(LOG_OP_PUSH_SEND_ATTEMPT, {
         pushCallback,
-        ...metricsTags
+        ...metricsTags,
       });
     },
 
@@ -466,7 +466,7 @@ module.exports = function (log, db, config, statsd) {
         reason: tags.reason,
         uaOS: tags.uaOS,
         errCode: tags.errCode,
-      })
-    }
+      });
+    },
   };
 };

--- a/packages/fxa-auth-server/test/local/push.js
+++ b/packages/fxa-auth-server/test/local/push.js
@@ -2,22 +2,22 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-"use strict";
+'use strict';
 
-const ROOT_DIR = "../..";
+const ROOT_DIR = '../..';
 
-const proxyquire = require("proxyquire");
-const sinon = require("sinon");
-const assert = { ...sinon.assert, ...require("chai").assert };
-const ajv = require("ajv")();
-const fs = require("fs");
-const path = require("path");
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const assert = { ...sinon.assert, ...require('chai').assert };
+const ajv = require('ajv')();
+const fs = require('fs');
+const path = require('path');
 const match = sinon.match;
 
-const mocks = require("../mocks");
-const mockUid = "deadbeef";
+const mocks = require('../mocks');
+const mockUid = 'deadbeef';
 
-const TTL = "42";
+const TTL = '42';
 const pushModulePath = `${ROOT_DIR}/lib/push`;
 
 const PUSH_PAYLOADS_SCHEMA_PATH = `${ROOT_DIR}/docs/pushpayloads.schema.json`;
@@ -28,12 +28,12 @@ match.validPushPayload = (fields) => {
     const schema = JSON.parse(fs.readFileSync(schemaPath));
     PUSH_PAYLOADS_SCHEMA_MATCHER = match((value) => {
       return ajv.validate(schema, value);
-    }, "matches payload schema");
+    }, 'matches payload schema');
   }
   return match(fields).and(PUSH_PAYLOADS_SCHEMA_MATCHER);
 };
 
-describe("push", () => {
+describe('push', () => {
   let mockDb,
     mockLog,
     mockConfig,
@@ -43,7 +43,7 @@ describe("push", () => {
 
   function loadMockedPushModule() {
     const mocks = {
-      "web-push": {
+      'web-push': {
         sendNotification: mockSendNotification,
       },
     };
@@ -61,47 +61,47 @@ describe("push", () => {
     mockConfig = {};
     mockDevices = [
       {
-        id: "0f7aa00356e5416e82b3bef7bc409eef",
+        id: '0f7aa00356e5416e82b3bef7bc409eef',
         isCurrentDevice: true,
         lastAccessTime: 1449235471335,
-        name: "My Phone",
-        type: "mobile",
+        name: 'My Phone',
+        type: 'mobile',
         availableCommands: {},
         pushCallback:
-          "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
+          'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef',
         pushPublicKey: mocks.MOCK_PUSH_KEY,
-        pushAuthKey: "w3b14Zjc-Afj2SDOLOyong==",
+        pushAuthKey: 'w3b14Zjc-Afj2SDOLOyong==',
         pushEndpointExpired: false,
       },
       {
-        id: "3a45e6d0dae543qqdKyqjuvAiEupsnOd",
+        id: '3a45e6d0dae543qqdKyqjuvAiEupsnOd',
         isCurrentDevice: false,
         lastAccessTime: 1417699471335,
-        name: "My Desktop",
-        uaOS: "Windows",
-        uaOSVersion: "10",
-        uaBrowser: "Firefox",
-        uaBrowserVersion: "65.4",
+        name: 'My Desktop',
+        uaOS: 'Windows',
+        uaOSVersion: '10',
+        uaBrowser: 'Firefox',
+        uaBrowserVersion: '65.4',
         type: null,
         availableCommands: {},
         pushCallback:
-          "https://updates.push.services.mozilla.com/update/d4c5b1e3f5791ef83896c27519979b93a45e6d0da34c75",
+          'https://updates.push.services.mozilla.com/update/d4c5b1e3f5791ef83896c27519979b93a45e6d0da34c75',
         pushPublicKey: mocks.MOCK_PUSH_KEY,
-        pushAuthKey: "w3b14Zjc-Afj2SDOLOyong==",
+        pushAuthKey: 'w3b14Zjc-Afj2SDOLOyong==',
         pushEndpointExpired: false,
       },
       {
-        id: "50973923bc3e4507a0aa4e285513194a",
+        id: '50973923bc3e4507a0aa4e285513194a',
         isCurrentDevice: false,
         lastAccessTime: 1402149471335,
-        name: "My Ipad",
+        name: 'My Ipad',
         type: null,
         availableCommands: {},
-        uaOS: "iOS",
+        uaOS: 'iOS',
         pushCallback:
-          "https://updates.push.services.mozilla.com/update/50973923bc3e4507a0aa4e285513194a",
+          'https://updates.push.services.mozilla.com/update/50973923bc3e4507a0aa4e285513194a',
         pushPublicKey: mocks.MOCK_PUSH_KEY,
-        pushAuthKey: "w3b14Zjc-Afj2SDOLOyong==",
+        pushAuthKey: 'w3b14Zjc-Afj2SDOLOyong==',
         pushEndpointExpired: false,
       },
     ];
@@ -111,26 +111,26 @@ describe("push", () => {
     mockSendNotification = sinon.spy(async () => {});
   });
 
-  it("sendPush does not reject on empty device array", async () => {
+  it('sendPush does not reject on empty device array', async () => {
     const push = loadMockedPushModule();
-    await push.sendPush(mockUid, [], "accountVerify");
+    await push.sendPush(mockUid, [], 'accountVerify');
     assert.callCount(mockSendNotification, 0);
     assert.callCount(mockLog.info, 0);
     assert.callCount(mockStatsD.increment, 0);
   });
 
-  it("sendPush logs metrics about successful sends", async () => {
+  it('sendPush logs metrics about successful sends', async () => {
     const push = loadMockedPushModule();
-    await push.sendPush(mockUid, mockDevices, "accountVerify");
+    await push.sendPush(mockUid, mockDevices, 'accountVerify');
     assert.callCount(mockSendNotification, 2);
 
     assert.callCount(mockLog.info, 5);
     assert.calledWith(
       mockLog.info.getCall(0),
-      "push.filteredUnsupportedDevice"
+      'push.filteredUnsupportedDevice'
     );
-    assert.calledWithExactly(mockLog.info.getCall(1), "push.send.attempt", {
-      reason: "accountVerify",
+    assert.calledWithExactly(mockLog.info.getCall(1), 'push.send.attempt', {
+      reason: 'accountVerify',
       uid: mockUid,
       deviceId: mockDevices[0].id,
       uaOS: undefined,
@@ -138,8 +138,8 @@ describe("push", () => {
       uaBrowser: undefined,
       uaBrowserVersion: undefined,
     });
-    assert.calledWithExactly(mockLog.info.getCall(2), "push.send.success", {
-      reason: "accountVerify",
+    assert.calledWithExactly(mockLog.info.getCall(2), 'push.send.success', {
+      reason: 'accountVerify',
       uid: mockUid,
       deviceId: mockDevices[0].id,
       uaOS: undefined,
@@ -147,87 +147,86 @@ describe("push", () => {
       uaBrowser: undefined,
       uaBrowserVersion: undefined,
     });
-    assert.calledWithExactly(mockLog.info.getCall(3), "push.send.attempt", {
-      reason: "accountVerify",
+    assert.calledWithExactly(mockLog.info.getCall(3), 'push.send.attempt', {
+      reason: 'accountVerify',
       uid: mockUid,
       deviceId: mockDevices[1].id,
-      uaOS: "Windows",
-      uaOSVersion: "10",
-      uaBrowser: "Firefox",
-      uaBrowserVersion: "65.4",
+      uaOS: 'Windows',
+      uaOSVersion: '10',
+      uaBrowser: 'Firefox',
+      uaBrowserVersion: '65.4',
     });
-    assert.calledWithExactly(mockLog.info.getCall(4), "push.send.success", {
-      reason: "accountVerify",
+    assert.calledWithExactly(mockLog.info.getCall(4), 'push.send.success', {
+      reason: 'accountVerify',
       uid: mockUid,
       deviceId: mockDevices[1].id,
-      uaOS: "Windows",
-      uaOSVersion: "10",
-      uaBrowser: "Firefox",
-      uaBrowserVersion: "65.4",
+      uaOS: 'Windows',
+      uaOSVersion: '10',
+      uaBrowser: 'Firefox',
+      uaBrowserVersion: '65.4',
     });
 
     assert.callCount(mockStatsD.increment, 4);
     assert.calledWithExactly(
       mockStatsD.increment.getCall(0),
-      "push.send.attempt",
+      'push.send.attempt',
       {
-        reason: "accountVerify",
+        reason: 'accountVerify',
         uaOS: undefined,
         errCode: undefined,
       }
     );
     assert.calledWithExactly(
       mockStatsD.increment.getCall(1),
-      "push.send.success",
+      'push.send.success',
       {
-        reason: "accountVerify",
+        reason: 'accountVerify',
         uaOS: undefined,
         errCode: undefined,
       }
     );
     assert.calledWithExactly(
       mockStatsD.increment.getCall(2),
-      "push.send.attempt",
+      'push.send.attempt',
       {
-        reason: "accountVerify",
-        uaOS: "Windows",
+        reason: 'accountVerify',
+        uaOS: 'Windows',
         errCode: undefined,
       }
     );
     assert.calledWithExactly(
       mockStatsD.increment.getCall(3),
-      "push.send.success",
+      'push.send.success',
       {
-        reason: "accountVerify",
-        uaOS: "Windows",
+        reason: 'accountVerify',
+        uaOS: 'Windows',
         errCode: undefined,
       }
     );
   });
 
-
-  it("sendPush logs metrics about failed sends", async () => {
+  it('sendPush logs metrics about failed sends', async () => {
     let shouldFail = false;
     mockSendNotification = sinon.spy(async () => {
       try {
         if (shouldFail) {
-          throw new Error("intermittent failure");
+          throw new Error('intermittent failure');
         }
       } finally {
-        shouldFail = !shouldFail
+        shouldFail = !shouldFail;
       }
-    })
+    });
     const push = loadMockedPushModule();
-    await push.sendPush(mockUid, mockDevices, "accountVerify");
+    await push.sendPush(mockUid, mockDevices, 'accountVerify');
     assert.callCount(mockSendNotification, 2);
 
     assert.callCount(mockLog.info, 4);
     assert.calledWith(
       mockLog.info.getCall(0),
-      "push.filteredUnsupportedDevice"
+      'push.filteredUnsupportedDevice'
     );
-    assert.calledWithExactly(mockLog.info.getCall(1), "push.send.attempt", {
-      reason: "accountVerify",
+    assert.calledWithExactly(mockLog.info.getCall(1), 'push.send.attempt', {
+      reason: 'accountVerify',
       uid: mockUid,
       deviceId: mockDevices[0].id,
       uaOS: undefined,
@@ -235,8 +234,8 @@ describe("push", () => {
       uaBrowser: undefined,
       uaBrowserVersion: undefined,
     });
-    assert.calledWithExactly(mockLog.info.getCall(2), "push.send.success", {
-      reason: "accountVerify",
+    assert.calledWithExactly(mockLog.info.getCall(2), 'push.send.success', {
+      reason: 'accountVerify',
       uid: mockUid,
       deviceId: mockDevices[0].id,
       uaOS: undefined,
@@ -244,94 +243,94 @@ describe("push", () => {
       uaBrowser: undefined,
       uaBrowserVersion: undefined,
     });
-    assert.calledWithExactly(mockLog.info.getCall(3), "push.send.attempt", {
-      reason: "accountVerify",
+    assert.calledWithExactly(mockLog.info.getCall(3), 'push.send.attempt', {
+      reason: 'accountVerify',
       uid: mockUid,
       deviceId: mockDevices[1].id,
-      uaOS: "Windows",
-      uaOSVersion: "10",
-      uaBrowser: "Firefox",
-      uaBrowserVersion: "65.4",
+      uaOS: 'Windows',
+      uaOSVersion: '10',
+      uaBrowser: 'Firefox',
+      uaBrowserVersion: '65.4',
     });
 
     assert.callCount(mockLog.warn, 1);
-    assert.calledWithExactly(mockLog.warn.getCall(0), "push.send.failure", {
-      reason: "accountVerify",
-      errCode: "unknown",
-      err: match.has("message", "intermittent failure"),
+    assert.calledWithExactly(mockLog.warn.getCall(0), 'push.send.failure', {
+      reason: 'accountVerify',
+      errCode: 'unknown',
+      err: match.has('message', 'intermittent failure'),
       uid: mockUid,
       deviceId: mockDevices[1].id,
-      uaOS: "Windows",
-      uaOSVersion: "10",
-      uaBrowser: "Firefox",
-      uaBrowserVersion: "65.4",
+      uaOS: 'Windows',
+      uaOSVersion: '10',
+      uaBrowser: 'Firefox',
+      uaBrowserVersion: '65.4',
     });
 
     assert.callCount(mockStatsD.increment, 4);
     assert.calledWithExactly(
       mockStatsD.increment.getCall(0),
-      "push.send.attempt",
+      'push.send.attempt',
       {
-        reason: "accountVerify",
+        reason: 'accountVerify',
         uaOS: undefined,
         errCode: undefined,
       }
     );
     assert.calledWithExactly(
       mockStatsD.increment.getCall(1),
-      "push.send.success",
+      'push.send.success',
       {
-        reason: "accountVerify",
+        reason: 'accountVerify',
         uaOS: undefined,
         errCode: undefined,
       }
     );
     assert.calledWithExactly(
       mockStatsD.increment.getCall(2),
-      "push.send.attempt",
+      'push.send.attempt',
       {
-        reason: "accountVerify",
-        uaOS: "Windows",
+        reason: 'accountVerify',
+        uaOS: 'Windows',
         errCode: undefined,
       }
     );
     assert.calledWithExactly(
       mockStatsD.increment.getCall(3),
-      "push.send.failure",
+      'push.send.failure',
       {
-        reason: "accountVerify",
-        uaOS: "Windows",
-        errCode: "unknown",
+        reason: 'accountVerify',
+        uaOS: 'Windows',
+        errCode: 'unknown',
       }
     );
   });
 
-  it("sendPush sends notifications with a TTL of 0", async () => {
+  it('sendPush sends notifications with a TTL of 0', async () => {
     const push = loadMockedPushModule();
-    await push.sendPush(mockUid, mockDevices, "accountVerify");
+    await push.sendPush(mockUid, mockDevices, 'accountVerify');
     assert.callCount(mockSendNotification, 2);
     for (const call of mockSendNotification.getCalls()) {
       assert.calledWithMatch(call, match.any, null, {
-        TTL: "0",
+        TTL: '0',
       });
     }
   });
 
-  it("sendPush sends notifications with user-defined TTL", async () => {
+  it('sendPush sends notifications with user-defined TTL', async () => {
     const push = loadMockedPushModule();
     const options = { TTL: TTL };
-    await push.sendPush(mockUid, mockDevices, "accountVerify", options);
+    await push.sendPush(mockUid, mockDevices, 'accountVerify', options);
     assert.callCount(mockSendNotification, 2);
     for (const call of mockSendNotification.getCalls()) {
       assert.calledWithMatch(call, match.any, null, { TTL });
     }
   });
 
-  it("sendPush sends data", async () => {
+  it('sendPush sends data', async () => {
     const push = loadMockedPushModule();
-    const data = { foo: "bar" };
+    const data = { foo: 'bar' };
     const options = { data: data };
-    await push.sendPush(mockUid, mockDevices, "accountVerify", options);
+    await push.sendPush(mockUid, mockDevices, 'accountVerify', options);
     assert.callCount(mockSendNotification, 2);
     for (const call of mockSendNotification.getCalls()) {
       assert.calledWithMatch(
@@ -350,10 +349,10 @@ describe("push", () => {
   it("sendPush doesn't push to ios devices if it is triggered with an unsupported command", async () => {
     const push = loadMockedPushModule();
     const data = Buffer.from(
-      JSON.stringify({ command: "fxaccounts:non_existent_command" })
+      JSON.stringify({ command: 'fxaccounts:non_existent_command' })
     );
     const options = { data: data };
-    await push.sendPush(mockUid, mockDevices, "devicesNotify", options);
+    await push.sendPush(mockUid, mockDevices, 'devicesNotify', options);
     assert.callCount(mockSendNotification, 2);
     assert.calledWithMatch(mockSendNotification.getCall(0), {
       endpoint: mockDevices[0].pushCallback,
@@ -366,11 +365,11 @@ describe("push", () => {
   it('sendPush pushes to all ios devices if it is triggered with a "commands received" command', async () => {
     const push = loadMockedPushModule();
     const data = {
-      command: "fxaccounts:command_received",
-      data: { foo: "bar" },
+      command: 'fxaccounts:command_received',
+      data: { foo: 'bar' },
     };
     const options = { data: data };
-    await push.sendPush(mockUid, mockDevices, "devicesNotify", options);
+    await push.sendPush(mockUid, mockDevices, 'devicesNotify', options);
     assert.callCount(mockSendNotification, 3);
     assert.calledWithMatch(mockSendNotification.getCall(0), {
       endpoint: mockDevices[0].pushCallback,
@@ -386,11 +385,11 @@ describe("push", () => {
   it('sendPush does not push to ios devices if triggered with a "collection changed" command', async () => {
     const push = loadMockedPushModule();
     const data = {
-      command: "sync:collection_changed",
-      data: { collection: "clients", reason: "firstsync" },
+      command: 'sync:collection_changed',
+      data: { collection: 'clients', reason: 'firstsync' },
     };
     const options = { data: data };
-    await push.sendPush(mockUid, mockDevices, "devicesNotify", options);
+    await push.sendPush(mockUid, mockDevices, 'devicesNotify', options);
     assert.callCount(mockSendNotification, 2);
     assert.calledWithMatch(mockSendNotification.getCall(0), {
       endpoint: mockDevices[0].pushCallback,
@@ -417,116 +416,116 @@ describe("push", () => {
     });
   });
 
-  it("push fails if data is present but both keys are not present", async () => {
+  it('push fails if data is present but both keys are not present', async () => {
     const push = loadMockedPushModule();
     const devices = [
       {
-        id: "foo",
-        name: "My Phone",
+        id: 'foo',
+        name: 'My Phone',
         pushCallback:
-          "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
-        pushAuthKey: "bogus",
+          'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef',
+        pushAuthKey: 'bogus',
         pushEndpointExpired: false,
       },
     ];
-    const options = { data: Buffer.from("foobar") };
-    await push.sendPush(mockUid, devices, "deviceConnected", options);
+    const options = { data: Buffer.from('foobar') };
+    await push.sendPush(mockUid, devices, 'deviceConnected', options);
     assert.callCount(mockLog.info, 1);
-    assert.calledWithMatch(mockLog.info, "push.send.attempt");
+    assert.calledWithMatch(mockLog.info, 'push.send.attempt');
     assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, "push.send.failure", {
-      reason: "deviceConnected",
-      errCode: "noKeys",
+    assert.calledWithMatch(mockLog.warn, 'push.send.failure', {
+      reason: 'deviceConnected',
+      errCode: 'noKeys',
     });
   });
 
-  it("push catches devices with no push callback", async () => {
+  it('push catches devices with no push callback', async () => {
     const push = loadMockedPushModule();
     const devices = [
       {
-        id: "foo",
-        name: "My Phone",
+        id: 'foo',
+        name: 'My Phone',
       },
     ];
-    await push.sendPush(mockUid, devices, "accountVerify");
+    await push.sendPush(mockUid, devices, 'accountVerify');
     assert.callCount(mockLog.info, 1);
-    assert.calledWithMatch(mockLog.info, "push.send.attempt");
+    assert.calledWithMatch(mockLog.info, 'push.send.attempt');
     assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, "push.send.failure", {
-      reason: "accountVerify",
-      errCode: "noCallback",
+    assert.calledWithMatch(mockLog.warn, 'push.send.failure', {
+      reason: 'accountVerify',
+      errCode: 'noCallback',
     });
   });
 
-  it("push catches devices with expired callback", async () => {
+  it('push catches devices with expired callback', async () => {
     const push = loadMockedPushModule();
     const devices = [
       {
-        id: "foo",
-        name: "My Phone",
+        id: 'foo',
+        name: 'My Phone',
         pushCallback:
-          "https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef",
+          'https://updates.push.services.mozilla.com/update/abcdef01234567890abcdefabcdef01234567890abcdef',
         pushEndpointExpired: true,
       },
     ];
-    await push.sendPush(mockUid, devices, "accountVerify");
+    await push.sendPush(mockUid, devices, 'accountVerify');
     assert.callCount(mockLog.info, 1);
-    assert.calledWithMatch(mockLog.info, "push.send.attempt");
+    assert.calledWithMatch(mockLog.info, 'push.send.attempt');
     assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, "push.send.failure", {
-      reason: "accountVerify",
-      errCode: "expiredCallback",
+    assert.calledWithMatch(mockLog.warn, 'push.send.failure', {
+      reason: 'accountVerify',
+      errCode: 'expiredCallback',
     });
   });
 
-  it("push reports errors when web-push fails", async () => {
+  it('push reports errors when web-push fails', async () => {
     mockSendNotification = sinon.spy(async () => {
-      throw new Error("Failed with a nasty error");
+      throw new Error('Failed with a nasty error');
     });
     const push = loadMockedPushModule();
-    await push.sendPush(mockUid, [mockDevices[0]], "accountVerify");
+    await push.sendPush(mockUid, [mockDevices[0]], 'accountVerify');
     assert.callCount(mockLog.info, 1);
-    assert.calledWithMatch(mockLog.info, "push.send.attempt");
+    assert.calledWithMatch(mockLog.info, 'push.send.attempt');
     assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, "push.send.failure", {
-      reason: "accountVerify",
-      errCode: "unknown",
-      err: match.has("message", "Failed with a nasty error"),
+    assert.calledWithMatch(mockLog.warn, 'push.send.failure', {
+      reason: 'accountVerify',
+      errCode: 'unknown',
+      err: match.has('message', 'Failed with a nasty error'),
     });
   });
 
-  it("push logs a warning when asked to send to more than 200 devices", async () => {
+  it('push logs a warning when asked to send to more than 200 devices', async () => {
     const push = loadMockedPushModule();
     const devices = [];
     for (let i = 0; i < 200; i++) {
       devices.push(mockDevices[0]);
     }
-    await push.sendPush(mockUid, devices, "accountVerify");
+    await push.sendPush(mockUid, devices, 'accountVerify');
     assert.callCount(mockLog.warn, 0);
 
     devices.push(mockDevices[0]);
-    await push.sendPush(mockUid, devices, "accountVerify");
+    await push.sendPush(mockUid, devices, 'accountVerify');
     assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, "push.sendPush.tooManyDevices", {
+    assert.calledWithMatch(mockLog.warn, 'push.sendPush.tooManyDevices', {
       uid: mockUid,
     });
   });
 
-  it("push resets device push data when push server responds with a 400 level error", async () => {
+  it('push resets device push data when push server responds with a 400 level error', async () => {
     mockSendNotification = sinon.spy(async () => {
-      const err = new Error("Failed");
+      const err = new Error('Failed');
       err.statusCode = 410;
       throw err;
     });
     const push = loadMockedPushModule();
     // Careful, the argument gets modified in-place.
     const device = JSON.parse(JSON.stringify(mockDevices[0]));
-    await push.sendPush(mockUid, [device], "accountVerify");
+    await push.sendPush(mockUid, [device], 'accountVerify');
     assert.callCount(mockSendNotification, 1);
     assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, "push.send.failure", {
-      reason: "accountVerify",
-      errCode: "resetCallback",
+    assert.calledWithMatch(mockLog.warn, 'push.send.failure', {
+      reason: 'accountVerify',
+      errCode: 'resetCallback',
     });
     assert.callCount(mockDb.updateDevice, 1);
     assert.calledWithMatch(mockDb.updateDevice, mockUid, {
@@ -535,20 +534,20 @@ describe("push", () => {
     });
   });
 
-  it("push resets device push data when a failure is caused by bad encryption keys", async () => {
+  it('push resets device push data when a failure is caused by bad encryption keys', async () => {
     mockSendNotification = sinon.spy(async () => {
-      throw new Error("Failed");
+      throw new Error('Failed');
     });
     const push = loadMockedPushModule();
     // Careful, the argument gets modified in-place.
     const device = JSON.parse(JSON.stringify(mockDevices[0]));
     device.pushPublicKey = `E${device.pushPublicKey.substring(1)}`; // make the key invalid
-    await push.sendPush(mockUid, [device], "accountVerify");
+    await push.sendPush(mockUid, [device], 'accountVerify');
     assert.callCount(mockSendNotification, 1);
     assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, "push.send.failure", {
-      reason: "accountVerify",
-      errCode: "resetCallback",
+    assert.calledWithMatch(mockLog.warn, 'push.send.failure', {
+      reason: 'accountVerify',
+      errCode: 'resetCallback',
     });
     assert.callCount(mockDb.updateDevice, 1);
     assert.calledWithMatch(mockDb.updateDevice, mockUid, {
@@ -557,52 +556,52 @@ describe("push", () => {
     });
   });
 
-  it("push does not reset device push data after an unexpected failure", async () => {
+  it('push does not reset device push data after an unexpected failure', async () => {
     mockSendNotification = sinon.spy(async () => {
-      throw new Error("Failed unexpectedly");
+      throw new Error('Failed unexpectedly');
     });
     const push = loadMockedPushModule();
     const device = JSON.parse(JSON.stringify(mockDevices[0]));
-    await push.sendPush(mockUid, [device], "accountVerify");
+    await push.sendPush(mockUid, [device], 'accountVerify');
     assert.callCount(mockSendNotification, 1);
     assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, "push.send.failure", {
-      reason: "accountVerify",
-      errCode: "unknown",
+    assert.calledWithMatch(mockLog.warn, 'push.send.failure', {
+      reason: 'accountVerify',
+      errCode: 'unknown',
     });
     assert.callCount(mockLog.error, 1);
-    assert.calledWithMatch(mockLog.error, "push.sendPush.unexpectedError", {
-      err: match.has("message", "Failed unexpectedly"),
+    assert.calledWithMatch(mockLog.error, 'push.sendPush.unexpectedError', {
+      err: match.has('message', 'Failed unexpectedly'),
     });
     assert.callCount(mockDb.updateDevice, 0);
   });
 
-  it("notifyCommandReceived calls sendPush", async () => {
+  it('notifyCommandReceived calls sendPush', async () => {
     const push = loadMockedPushModule();
-    sinon.spy(push, "sendPush");
+    sinon.spy(push, 'sendPush');
     await push.notifyCommandReceived(
       mockUid,
       mockDevices[0],
-      "commandName",
-      "sendingDevice",
+      'commandName',
+      'sendingDevice',
       12,
-      "http://fetch.url",
+      'http://fetch.url',
       42
     );
     assert.calledOnceWithExactly(
       push.sendPush,
       mockUid,
       [mockDevices[0]],
-      "commandReceived",
+      'commandReceived',
       {
         data: match.validPushPayload({
           version: 1,
-          command: "fxaccounts:command_received",
+          command: 'fxaccounts:command_received',
           data: {
-            command: "commandName",
+            command: 'commandName',
             index: 12,
-            sender: "sendingDevice",
-            url: "http://fetch.url",
+            sender: 'sendingDevice',
+            url: 'http://fetch.url',
           },
         }),
         TTL: 42,
@@ -610,21 +609,21 @@ describe("push", () => {
     );
   });
 
-  it("notifyDeviceConnected calls sendPush", async () => {
+  it('notifyDeviceConnected calls sendPush', async () => {
     const push = loadMockedPushModule();
-    sinon.spy(push, "sendPush");
-    const deviceName = "My phone";
+    sinon.spy(push, 'sendPush');
+    const deviceName = 'My phone';
     await push.notifyDeviceConnected(mockUid, mockDevices, deviceName);
     assert.calledOnce(push.sendPush);
     assert.calledWithMatch(
       push.sendPush,
       mockUid,
       mockDevices,
-      "deviceConnected",
+      'deviceConnected',
       {
         data: match.validPushPayload({
           version: 1,
-          command: "fxaccounts:device_connected",
+          command: 'fxaccounts:device_connected',
           data: {
             deviceName: deviceName,
           },
@@ -634,9 +633,9 @@ describe("push", () => {
     );
   });
 
-  it("notifyDeviceDisconnected calls sendPush", async () => {
+  it('notifyDeviceDisconnected calls sendPush', async () => {
     const push = loadMockedPushModule();
-    sinon.spy(push, "sendPush");
+    sinon.spy(push, 'sendPush');
     const idToDisconnect = mockDevices[0].id;
     await push.notifyDeviceDisconnected(mockUid, mockDevices, idToDisconnect);
     assert.calledOnce(push.sendPush);
@@ -644,11 +643,11 @@ describe("push", () => {
       push.sendPush,
       mockUid,
       mockDevices,
-      "deviceDisconnected",
+      'deviceDisconnected',
       {
         data: match.validPushPayload({
           version: 1,
-          command: "fxaccounts:device_disconnected",
+          command: 'fxaccounts:device_disconnected',
           data: {
             id: idToDisconnect,
           },
@@ -658,20 +657,20 @@ describe("push", () => {
     );
   });
 
-  it("notifyPasswordChanged calls sendPush", async () => {
+  it('notifyPasswordChanged calls sendPush', async () => {
     const push = loadMockedPushModule();
-    sinon.spy(push, "sendPush");
+    sinon.spy(push, 'sendPush');
     await push.notifyPasswordChanged(mockUid, mockDevices);
     assert.calledOnce(push.sendPush);
     assert.calledWithMatch(
       push.sendPush,
       mockUid,
       mockDevices,
-      "passwordChange",
+      'passwordChange',
       {
         data: match.validPushPayload({
           version: 1,
-          command: "fxaccounts:password_changed",
+          command: 'fxaccounts:password_changed',
           data: match.undefined,
         }),
         TTL: match.number,
@@ -679,20 +678,20 @@ describe("push", () => {
     );
   });
 
-  it("notifyPasswordReset calls sendPush", async () => {
+  it('notifyPasswordReset calls sendPush', async () => {
     const push = loadMockedPushModule();
-    sinon.spy(push, "sendPush");
+    sinon.spy(push, 'sendPush');
     await push.notifyPasswordReset(mockUid, mockDevices);
     assert.calledOnce(push.sendPush);
     assert.calledWithMatch(
       push.sendPush,
       mockUid,
       mockDevices,
-      "passwordReset",
+      'passwordReset',
       {
         data: match.validPushPayload({
           version: 1,
-          command: "fxaccounts:password_reset",
+          command: 'fxaccounts:password_reset',
           data: match.undefined,
         }),
         TTL: match.number,
@@ -700,33 +699,33 @@ describe("push", () => {
     );
   });
 
-  it("notifyAccountUpdated calls sendPush", async () => {
+  it('notifyAccountUpdated calls sendPush', async () => {
     const push = loadMockedPushModule();
-    sinon.spy(push, "sendPush");
-    await push.notifyAccountUpdated(mockUid, mockDevices, "deviceConnected");
+    sinon.spy(push, 'sendPush');
+    await push.notifyAccountUpdated(mockUid, mockDevices, 'deviceConnected');
     assert.calledOnce(push.sendPush);
     assert.calledWithExactly(
       push.sendPush,
       mockUid,
       mockDevices,
-      "deviceConnected"
+      'deviceConnected'
     );
   });
 
-  it("notifyAccountDestroyed calls sendPush", async () => {
+  it('notifyAccountDestroyed calls sendPush', async () => {
     const push = loadMockedPushModule();
-    sinon.spy(push, "sendPush");
+    sinon.spy(push, 'sendPush');
     await push.notifyAccountDestroyed(mockUid, mockDevices);
     assert.calledOnce(push.sendPush);
     assert.calledWithMatch(
       push.sendPush,
       mockUid,
       mockDevices,
-      "accountDestroyed",
+      'accountDestroyed',
       {
         data: match.validPushPayload({
           version: 1,
-          command: "fxaccounts:account_destroyed",
+          command: 'fxaccounts:account_destroyed',
           data: {
             uid: mockUid,
           },
@@ -736,32 +735,32 @@ describe("push", () => {
     );
   });
 
-  it("sendPush includes VAPID identification if it is configured", async () => {
+  it('sendPush includes VAPID identification if it is configured', async () => {
     mockConfig = {
-      publicUrl: "https://example.com",
-      vapidKeysFile: path.join(__dirname, "../config/mock-vapid-keys.json"),
+      publicUrl: 'https://example.com',
+      vapidKeysFile: path.join(__dirname, '../config/mock-vapid-keys.json'),
     };
     const push = loadMockedPushModule();
-    await push.sendPush(mockUid, mockDevices, "accountVerify");
+    await push.sendPush(mockUid, mockDevices, 'accountVerify');
     assert.callCount(mockSendNotification, 2);
     for (const call of mockSendNotification.getCalls()) {
       assert.calledWithMatch(call, match.any, null, {
         vapidDetails: {
           subject: mockConfig.publicUrl,
-          privateKey: "private",
-          publicKey: "public",
+          privateKey: 'private',
+          publicKey: 'public',
         },
       });
     }
   });
 
-  it("sendPush errors out cleanly if given an unknown reason argument", async () => {
+  it('sendPush errors out cleanly if given an unknown reason argument', async () => {
     const push = loadMockedPushModule();
     try {
-      await push.sendPush(mockUid, mockDevices, "anUnknownReasonString");
-      assert.fail("should have thrown");
+      await push.sendPush(mockUid, mockDevices, 'anUnknownReasonString');
+      assert.fail('should have thrown');
     } catch (err) {
-      assert.equal(err, "Unknown push reason: anUnknownReasonString");
+      assert.equal(err, 'Unknown push reason: anUnknownReasonString');
     }
     assert.notCalled(mockSendNotification);
   });


### PR DESCRIPTION
Because:

* A few small changes that I want to make in a push-related PR (#5546)
  are being swamped by a bunch of automated reformatting on commit.
* It's hard to have a discussion about said changes in a PR that's
  almost entirely formatting changes.

This commit:

* Applies said formatting changes separately.

I assume that it's expected that we now apply formatting changes on commit, and this isn't just something funky in my local setup...but if it's not expected please let me know and I'll dig deeper. I think maybe it was an in-flight collision between some recent refactoring I was doing in these routes that meant these didn't get refactored as part of #5431.