### PR TITLE
fix(experiments): Enabled QR cad, disable newsletters experiment

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/newsletter-cad-chooser.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/newsletter-cad-chooser.js
@@ -9,7 +9,7 @@
 'use strict';
 
 const BaseGroupingRule = require('./base');
-const GROUPS = ['newsletterSync', 'qrCodeCad'];
+const GROUPS = ['qrCodeCad'];
 
 module.exports = class ExperimentChooser extends BaseGroupingRule {
   constructor() {

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/newsletter-sync.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/newsletter-sync.js
@@ -20,7 +20,7 @@ const GROUPS = [
 // This experiment is disabled by default. If you would like to go through
 // the flow, load email-first screen and append query params
 // `?forceExperiment=newsletterSync&forceExperimentGroup=new-copy`
-const ROLLOUT_RATE = 1.0;
+const ROLLOUT_RATE = 0.0;
 
 module.exports = class NewsletterSync extends BaseGroupingRule {
   constructor() {

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/qr-code-cad.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/qr-code-cad.js
@@ -17,7 +17,7 @@ const GROUPS = [
   'treatment-b', // Screen displayed in non-sms markets
 ];
 
-const ROLLOUT_RATE = 0.0;
+const ROLLOUT_RATE = 1.0;
 
 module.exports = class QrCodeCad extends BaseGroupingRule {
   constructor() {


### PR DESCRIPTION
This was supposed to go onto train-173, targeting train-174 instead. Updated to enable QR CAD and disable sync experiment.