### PR TITLE
fix(devices): improve lastAccessTime accuracy for OAuth devices

### DIFF
--- a/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/refresh-token.js
@@ -46,6 +46,7 @@ module.exports = function schemeRefreshTokenScheme(config, db, oauthdb) {
 
         const credentials = {
           uid: refreshTokenInfo.sub,
+          emailVerified: true,
           tokenVerified: true,
           refreshTokenId: refreshTokenInfo.jti,
         };

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -76,6 +76,7 @@ module.exports = function (
   const devicesSessions = require('./devices-and-sessions')(
     log,
     db,
+    oauthdb,
     config,
     customs,
     push,

--- a/packages/fxa-auth-server/test/local/routes/auth-schemes/refresh-token.js
+++ b/packages/fxa-auth-server/test/local/routes/auth-schemes/refresh-token.js
@@ -133,6 +133,7 @@ describe('lib/routes/auth-schemes/refresh-token', () => {
     assert.deepEqual(response.authenticated.args[0][0].credentials, {
       uid: '620203b5773b4c1d968e1fd4505a6885',
       tokenVerified: true,
+      emailVerified: true,
       deviceId: '5eb89097bab6551de3614facaea59cab',
       deviceName: 'first device',
       deviceType: 'mobile',


### PR DESCRIPTION
I gave up trying to run the tests on my own machine at this point, so I'm running them on CI.