### PR TITLE
feat(auth): handle a password change requirement in login

### DIFF
--- a/.circleci/base-install.sh
+++ b/.circleci/base-install.sh
@@ -12,7 +12,5 @@ node .circleci/modules-to-test.js | tee packages/test.list
 
 sudo apt-get install -y graphicsmagick
 
-# only run a full npm install if required
-if [[ "$MODULE" == "all" ]]; then
-  yarn install --immutable
-fi
+yarn install --immutable
+yarn workspace fxa-shared run build

--- a/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
@@ -2424,6 +2424,7 @@ module.exports = function (config, DB) {
               account.verifierSetAt,
               'profileChangedAt matches verifierSetAt'
             );
+            assert.isNull(account.lockedAt);
           });
       });
 

--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -845,7 +845,7 @@ module.exports = function (log, error) {
   // Set    : verifyHash = $2, authSalt = $3, wrapWrapKb = $4, verifierSetAt = $5, verifierVersion = $6,
   //          keysHaveChanged = $7
   // Where  : uid = $1
-  var RESET_ACCOUNT = 'CALL resetAccount_15(?, ?, ?, ?, ?, ?, ?)';
+  var RESET_ACCOUNT = 'CALL resetAccount_16(?, ?, ?, ?, ?, ?, ?)';
 
   MySql.prototype.resetAccount = function (uid, data) {
     return this.write(RESET_ACCOUNT, [

--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 109;
+module.exports.level = 110;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-109-110.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-109-110.sql
@@ -1,0 +1,50 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('109');
+
+CREATE PROCEDURE `resetAccount_16` (
+  IN `uidArg` BINARY(16),
+  IN `verifyHashArg` BINARY(32),
+  IN `authSaltArg` BINARY(32),
+  IN `wrapWrapKbArg` BINARY(32),
+  IN `verifierSetAtArg` BIGINT UNSIGNED,
+  IN `verifierVersionArg` TINYINT UNSIGNED,
+  IN `keysHaveChangedArg` BOOLEAN
+)
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  START TRANSACTION;
+
+  DELETE FROM sessionTokens WHERE uid = uidArg;
+  DELETE FROM keyFetchTokens WHERE uid = uidArg;
+  DELETE FROM accountResetTokens WHERE uid = uidArg;
+  DELETE FROM passwordChangeTokens WHERE uid = uidArg;
+  DELETE FROM passwordForgotTokens WHERE uid = uidArg;
+  DELETE FROM recoveryKeys WHERE uid = uidArg;
+  DELETE devices, deviceCommands FROM devices LEFT JOIN deviceCommands
+    ON (deviceCommands.uid = devices.uid AND deviceCommands.deviceId = devices.id)
+    WHERE devices.uid = uidArg;  DELETE FROM unverifiedTokens WHERE uid = uidArg;
+  UPDATE accounts
+  SET
+    verifyHash = verifyHashArg,
+    authSalt = authSaltArg,
+    wrapWrapKb = wrapWrapKbArg,
+    verifierVersion = verifierVersionArg,
+    profileChangedAt = verifierSetAtArg,
+    -- The `keysChangedAt` column was added in a migration, so its default value
+    -- is NULL meaning "we don't know".  Now that we do know whether or not the keys
+    -- are being changed, ensure it gets set to some concrete non-NULL value.
+    keysChangedAt = IF(keysHaveChangedArg, verifierSetAtArg,  COALESCE(keysChangedAt, verifierSetAt, createdAt)),
+    verifierSetAt = verifierSetAtArg,
+    lockedAt = NULL
+  WHERE uid = uidArg;
+
+  COMMIT;
+END;
+
+UPDATE dbMetadata SET value = '110' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-110-109.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-110-109.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE `resetAccount_16`;
+
+-- UPDATE dbMetadata SET value = '109' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
When a password change is required the lockedAt flag is set, currently by an external script. Until the password is changed all sessions for such an account must be verified. The 'password-change' verificationReason is returned in the response to tell the frontend to show the change password ui. The resetAccount db procedure resets the lockedAt value to null when the password is changed.