### PR TITLE
fix(surveys): display the survey above other content

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_survey.scss
+++ b/packages/fxa-content-server/app/styles/modules/_survey.scss
@@ -16,6 +16,7 @@ $survey-height: 360px;
   right: 10%;
   transition: bottom 250ms ease-out;
   width: 320px;
+  z-index: 11;
 }
 
 .survey-control {

--- a/packages/fxa-react/components/Survey/index.scss
+++ b/packages/fxa-react/components/Survey/index.scss
@@ -18,6 +18,7 @@ $grey-50: #737373;
   right: 10%;
   transition: bottom 250ms ease-out;
   width: 320px;
+  z-index: 11;
 }
 
 .survey-control {


### PR DESCRIPTION
Because:
 - a survey should be displayed above other content

This commit:
 - set a z-index for the survey that's higher than others in the content server