### PR TITLE
refactor(settings): build settings with content-server config interpolation

### DIFF
--- a/packages/fxa-settings/.rescriptsrc.js
+++ b/packages/fxa-settings/.rescriptsrc.js
@@ -8,8 +8,28 @@ const {
   componentsJestMapper,
 } = require('fxa-react/configs/rescripts');
 
+function loadServerConfig(config) {
+  const serverConfig = require('../fxa-content-server/server/lib/configuration');
+
+  // CRA already uses the interpolate-html-plugin, so let's
+  // add our server config replacement string to it.
+  config.plugins.forEach((plugin) => {
+    if (
+      plugin.constructor &&
+      plugin.constructor.name === 'InterpolateHtmlPlugin'
+    ) {
+      plugin.replacements['SERVER_CONFIG'] = encodeURIComponent(
+        JSON.stringify(serverConfig)
+      );
+    }
+  });
+
+  return config;
+}
+
 module.exports = [
   permitAdditionalJSImports,
   setupAliasedPaths,
   componentsJestMapper,
+  loadServerConfig,
 ];

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@apollo/client": "^3.0.0-beta.50",
     "classnames": "^2.2.6",
+    "fxa-content-server": "workspace:*",
     "fxa-react": "workspace:*",
     "graphql": "14.5.8",
     "graphql-tag": "^2.10.3",

--- a/packages/fxa-settings/public/index.html
+++ b/packages/fxa-settings/public/index.html
@@ -10,7 +10,7 @@
   <meta name="robots" content="noindex,nofollow" />
   <meta name="viewport"
     content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=2,user-scalable=yes" />
-  <meta name="fxa-config" content="__SERVER_CONFIG__" />
+  <meta name="fxa-config" content="%SERVER_CONFIG%" />
 
   <!--iOS App Banner-->
   <meta name="apple-itunes-app" content="app-id=989804926, affiliate-data=ct=smartbanner-fxa" />

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -31,8 +31,7 @@ export function getDefault() {
     },
     servers: {
       gql: {
-        // JODY - remove this
-        url: 'http://localhost:8290',
+        url: '',
       },
       auth: {
         url: '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -17859,6 +17859,7 @@ fsevents@^1.2.7:
     eslint-plugin-fxa: ^2.0.2
     eslint-plugin-jest: ^23.8.2
     eslint-plugin-react: ^7.19.0
+    fxa-content-server: "workspace:*"
     fxa-react: "workspace:*"
     fxa-shared: "workspace:*"
     graphql: 14.5.8


### PR DESCRIPTION
Hot off the heels of #5563 Danny pointed out that we don't use the Settings CRA server in production, we only serve the pre-built static assets. So here's my proposal for an alternative solution.

The gist is, instead of modifying the body of each response as it comes through, just build the Settings index file with the content-server config baked in.

---

Because:

- Currently we are modifying the response of /beta/settings to include server config, which only applies to local development when we also need it for actual builds

This commit:

- Stops modifying any fxa-settings/fxa-content-server response to inject server config
- Utilizes the already available interpolate-html-plugin provided by CRA to inject server config during builds, both in development and production

---

Note that because I pulled out the proxied-response modification for local development you will now be required to restart your Settings CRA server if you make a change to the content-server config so it rebuilds the index.html file. I could be persuaded to leave it in, but I'm not a fan of the idea of having two completely separate spots where server config can be injected depending on NODE_ENV.