### PR TITLE
fix(devices): List refresh tokens by direct db access, not internal request routing

### DIFF
--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -51,6 +51,7 @@ module.exports = function (
   const idp = require('./idp')(log, serverPublicKeys);
   const oauthServer = require('../oauth/routes');
   const grant = require('../oauth/grant');
+  const oauthRawDB = require('../oauth/db');
   grant.setStripeHelper(stripeHelper);
   const account = require('./account')(
     log,
@@ -62,7 +63,7 @@ module.exports = function (
     signinUtils,
     push,
     verificationReminders,
-    require('../oauth/db'),
+    oauthRawDB,
     stripeHelper
   );
   const oauth = require('./oauth')(
@@ -76,7 +77,7 @@ module.exports = function (
   const devicesSessions = require('./devices-and-sessions')(
     log,
     db,
-    oauthdb,
+    oauthRawDB,
     config,
     customs,
     push,
@@ -115,7 +116,7 @@ module.exports = function (
     signinUtils,
     push,
     config,
-    require('../oauth/db')
+    oauthRawDB
   );
   const securityEvents = require('./security-events')(log, db, config);
   const session = require('./session')(


### PR DESCRIPTION
@eoger I spent a big of time trying to get #5652 working using the `oauthdb` absatraction, but it ended up getting out of hand. Then I noticed that some newer routes were just directly importing `./oauth/db` and using that, and doing similarly here makes things much easier.