### PR TITLE
fix(content-server): mark the element as invalid.

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/form.js
+++ b/packages/fxa-content-server/app/scripts/views/form.js
@@ -382,10 +382,8 @@ var FormView = BaseView.extend({
     const $invalidEl = this.$(el);
     const message = AuthErrors.toMessage(err);
 
-    const markElementInvalidAndMaybeFocus = (describedById) => {
+    const maybeFocus = () => {
       return new Promise((resolve) => {
-        this.markElementInvalid($invalidEl, describedById);
-
         if (shouldFocusEl) {
           // wait to focus otherwise
           // on screen keyboard may cover message
@@ -409,7 +407,8 @@ var FormView = BaseView.extend({
     };
 
     if (err.describedById) {
-      markElementInvalidAndMaybeFocus(err.describedById);
+      this.markElementInvalid($invalidEl, err.describedById);
+      maybeFocus();
     } else {
       // tooltipId is used to bind the invalid element
       // with the tooltip using `aria-described-by`
@@ -422,7 +421,7 @@ var FormView = BaseView.extend({
         translator: this.translator,
       });
 
-      markElementInvalidAndMaybeFocus(tooltipId).then(() => {
+      maybeFocus().then(() => {
         tooltip
           .on('destroyed', () => {
             this.markElementValid($invalidEl);
@@ -430,6 +429,7 @@ var FormView = BaseView.extend({
           })
           .render()
           .then(() => {
+            this.markElementInvalid($invalidEl, tooltipId);
             // used for testing
             this.trigger('validation_error', el, message);
           });

--- a/packages/fxa-content-server/app/tests/spec/views/form.js
+++ b/packages/fxa-content-server/app/tests/spec/views/form.js
@@ -415,6 +415,22 @@ describe('views/form', function () {
       // element is required, has no value
       view.showValidationError('#focusMe', 'Field is required');
     });
+
+    it('marks the element invalid, even if tooltip error is already displayed on form', function (done) {
+      view.markElementInvalid = sinon.spy();
+      view.markElementValid = sinon.spy();
+
+      view.showValidationError('#focusMe', 'Field is required');
+      view.showValidationError('#focusMe', 'Field is required');
+
+      p.delay(200).then(() => {
+        TestHelpers.wrapAssertion(function () {
+          assert.isTrue(
+            view.markElementInvalid.calledAfter(view.markElementValid)
+          );
+        }, done);
+      });
+    });
   });
 
   it('markElementInvalid adds the invalid class, aria-invalid attribute, and aria-described-by', () => {


### PR DESCRIPTION
fixes #5607

Because:
*  When the tooltip error was already displayed, the input wasn't marked as invalid.

This commit:
* Change the order in which the element is marked as invalid.