### PR TITLE
fix(coverage): disable codecov requirement for passing ci

### DIFF
--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -1,0 +1,20 @@
+codecov:
+  require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
Lets disable the requirement for codecov to pass ci, not all projects run on every ci build so overall fxa project coverage can vary.