### PR TITLE
feat(storybooks): link to commit rather than pull request for status check target URL

### DIFF
--- a/_scripts/build-storybooks.sh
+++ b/_scripts/build-storybooks.sh
@@ -102,14 +102,11 @@ git push -q origin gh-pages
 
 # If this is a pull request, post a comment to the PR linking to the storybooks
 if [[ ! -z $CI_PULL_REQUEST ]]; then
-    PR_NUMBER=$(echo $CI_PULL_REQUEST | cut -d/ -f7);
-    PR_URL="$STORYBOOKS_URL/pulls/$PR_NUMBER/";
     COMMIT_URL="$STORYBOOKS_URL/commits/$COMMIT_HASH/";
-
     curl \
         -H'Content-Type: application/json' \
         -H"Authorization: token $STORYBOOKS_GITHUB_TOKEN" \
-        --data "{\"state\":\"success\",\"target_url\":\"$PR_URL\",\"context\":\"storybooks: pull request\",\"description\":\"Storybook deployment for Pull Request\"}" \
+        --data "{\"state\":\"success\",\"target_url\":\"$COMMIT_URL\",\"context\":\"storybooks: pull request\",\"description\":\"Storybook deployment for $COMMIT_HASH\"}" \
         https://api.github.com/repos/${PROJECT_REPO}/statuses/${COMMIT_HASH};
 fi
 


### PR DESCRIPTION
Because:
* We'd like to have a history of storybook builds for a pull request

This commit:
* Changes the target URL for the storybook status check to point at the specific commit for the build, rather than the pull request index.

The original issue that I filed asserted that we needed to rework the pull request static index pages. But, after some thought, I decided this was unnecessary:

* Github retains the status checks for every commit - i.e. the green "✔" or red "❌" next to a commit reveals the status checks when clicked.
* A pull request in Github lists the history of commits involved, even through force-pushes
* Changing the Storybook status check target URL to point at the per-commit build - rather than the overall PR - means that we can access previous Storybook builds for a PR by looking at the status checks for previous commits in a PR.

In other words, Github already assembles the list of previous commits for a PR, and those can give access to previous Storybook builds. So, we don't need to build the history log ourselves.

fixes #5682