### PR TITLE
fix(experiment): Fix attempt for qr code cad enrollment

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/qr-code-cad.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/qr-code-cad.js
@@ -17,7 +17,7 @@ const GROUPS = [
   'treatment-b', // Screen displayed in non-sms markets
 ];
 
-const ROLLOUT_RATE = 0.0;
+const ROLLOUT_RATE = 1.0;
 
 module.exports = class QrCodeCad extends BaseGroupingRule {
   constructor() {
@@ -38,13 +38,6 @@ module.exports = class QrCodeCad extends BaseGroupingRule {
    */
   choose(subject = {}) {
     if (!subject.account || !subject.uniqueUserId || !subject.country) {
-      return false;
-    }
-
-    if (
-      subject.experimentGroupingRules.choose('newsletterCadChooser') !==
-      this.name
-    ) {
       return false;
     }
 


### PR DESCRIPTION
Fixes #5476 maybe?

This removes the `newsletterCadChooser` check that should have in theory made the qr code and newsletter experiment exclusive. Since we are not running the newsletter experiment yet, it is probably safe to remove the check to see if it was interfering with the qr code experiment.