### PR TITLE
feat(aet): Add ecosystemAnonId to auth-db and mysql

### DIFF
--- a/packages/fxa-auth-db-mysql/README.md
+++ b/packages/fxa-auth-db-mysql/README.md
@@ -45,28 +45,6 @@ To run the server tests:
 npm run test-server
 ```
 
-## Memory-store backend
-
-Implements the [backend API][dbdocs]
-as a memory store.
-
-This is the backend store
-that is loaded by the default export
-from the npm package,
-so the following call to `require`
-will return a server
-that uses the memory-store backend:
-
-```js
-var fxadb = require('fxa-auth-db-mysql');
-```
-
-To run the memory-store tests:
-
-```sh
-npm run test-mem
-```
-
 ## MySQL backend
 
 Implements the [backend API][dbdocs]

--- a/packages/fxa-auth-db-mysql/db-server/index.js
+++ b/packages/fxa-auth-db-mysql/db-server/index.js
@@ -126,6 +126,10 @@ function createServer(db) {
   );
   api.post('/account/:id/locale', withIdAndBody(db.updateLocale));
   api.get('/account/:id/sessions', withIdAndBody(db.sessions));
+  api.put(
+    '/account/:id/ecosystemAnonId',
+    withIdAndBody(db.updateEcosystemAnonId)
+  );
 
   api.get('/account/:id/emails', withIdAndBody(db.accountEmails));
   api.post('/account/:id/emails', withIdAndBody(db.createEmail));

--- a/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
@@ -16,6 +16,8 @@ const zeroBuffer32 = Buffer.from(
   'hex'
 );
 const now = Date.now();
+const anonId =
+  'eyJhbGciOiJFQ0RILUVTIiwia2lkIjoiMFZFRTdmT0txbFdHVGZrY0taRUJ2WWl3dkpMYTRUUGlJVGxXMGJOcDdqVSIsImVwayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InY3Q1FlRWtVQjMwUGwxV0tPMUZUZ25OQlNQdlFyNlh0UnZxT2kzSWdzNHciLCJ5IjoiNDBKVEpaQlMwOXpWNHpxb0hHZDI5NGFDeHRqcGU5a09reGhELVctUEZsSSJ9LCJlbmMiOiJBMjU2R0NNIn0.A_wzJya943vlHKFH.yq0JhkGZiZd6UiZK6goTcEf6i4gbbBeXxvq8QV5_nC4.Knl_sYSBrrP-aa54z6B6gA';
 
 function newUuid() {
   return crypto.randomBytes(16);
@@ -39,6 +41,7 @@ function createAccount() {
     verifierSetAt: now,
     createdAt: now,
     locale: 'en_US',
+    ecosystemAnonId: anonId,
   };
   account.normalizedEmail = normalizeEmail(account.email);
   account.emailBuffer = Buffer.from(account.email);
@@ -295,6 +298,11 @@ module.exports = function (config, DB) {
             account.createdAt,
             'profileChangedAt set to createdAt'
           );
+          assert.equal(
+            account.ecosystemAnonId,
+            accountData.ecosystemAnonId,
+            'ecosystemAnonId'
+          );
         });
       });
 
@@ -335,6 +343,11 @@ module.exports = function (config, DB) {
             false,
             'locale not returned'
           );
+          assert.equal(
+            account.ecosystemAnonId,
+            accountData.ecosystemAnonId,
+            'ecosystemAnonId'
+          );
         });
       });
     });
@@ -363,6 +376,35 @@ module.exports = function (config, DB) {
           .then((account) => {
             assert.deepEqual(account.uid, account.uid, 'uid');
             assert.lengthOf(Object.keys(account), 1);
+          });
+      });
+    });
+
+    describe('db.updateEcosystemAnonId', () => {
+      const newAnonId =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkdWRlbmVzc0Bmb28uYmFyIiwibmFtZSI6IkZvbyBCYXJtYW4iLCJpYXQiOjE1MTYyMzkwMjJ9.hVQ6sj219nUiwN8B5uClxcVpoq-SmRLQdZmXjS0w3CA';
+      it('should update ecosystemAnonId', () => {
+        return db
+          .updateEcosystemAnonId(accountData.uid, {
+            ecosystemAnonId: newAnonId,
+          })
+          .then(() => db.account(accountData.uid))
+          .then((result) => {
+            assert.equal(
+              result.ecosystemAnonId,
+              newAnonId,
+              'ecosystemAnonId was updated'
+            );
+          });
+      });
+
+      it('should return not found error if the uid is not in the database', () => {
+        const randomUid = newUuid();
+        return db
+          .updateEcosystemAnonId(randomUid, newAnonId)
+          .then(assert.fail, (err) => {
+            assert.equal(err.errno, 116, 'should return not found errno');
+            assert.equal(err.code, 404, 'should return not found code');
           });
       });
     });

--- a/packages/fxa-auth-db-mysql/db-server/test/backend/remote.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/remote.js
@@ -2982,6 +2982,40 @@ module.exports = function (cfg, makeServer) {
       });
     });
 
+    describe('ecosystem anon id', async () => {
+      let user;
+      const ecosystemAnonId = 'eyJhbGciOiJFQ0RILUVTIiwia';
+
+      beforeEach(async () => {
+        user = fake.newUserDataHex();
+        const r = await client.putThen(
+          '/account/' + user.accountId,
+          user.account
+        );
+        respOkEmpty(r);
+      });
+
+      it('should create user with ecosystem anon id', async () => {
+        const r = await client.getThen('/account/' + user.accountId);
+        const account = r.obj;
+        assert.equal(account.ecosystemAnonId, 'initialEcosystemAnonId');
+      });
+
+      it('should update ecosystem anon id', async () => {
+        let r = await client.putThen(
+          '/account/' + user.accountId + '/ecosystemAnonId',
+          {
+            ecosystemAnonId,
+          }
+        );
+        respOkEmpty(r);
+
+        r = await client.getThen('/account/' + user.accountId);
+        const account = r.obj;
+        assert.equal(account.ecosystemAnonId, ecosystemAnonId);
+      });
+    });
+
     after(() => server.close());
   });
 };

--- a/packages/fxa-auth-db-mysql/db-server/test/fake.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/fake.js
@@ -60,6 +60,7 @@ module.exports.newUserDataHex = function () {
     wrapWrapKb: hex32(),
     verifierSetAt: Date.now(),
     createdAt: Date.now(),
+    ecosystemAnonId: 'initialEcosystemAnonId',
   };
   data.account.normalizedEmail = normalizeEmail(data.account.email);
 

--- a/packages/fxa-auth-db-mysql/docs/API.md
+++ b/packages/fxa-auth-db-mysql/docs/API.md
@@ -61,6 +61,7 @@ The following datatypes are used throughout this document:
   - sessions : `GET /account/:id/sessions`
   - devices : `GET /account/:id/devices`
   - deviceFromTokenVerificationId : `GET /account/:id/tokens/:tokenVerificationId/device`
+  - updateEcosystemAnonId : `PUT /account/:id/ecosystemAnonId`
 - Devices:
   - createDevice : `PUT /account/:id/device/:deviceId`
   - updateDevice : `POST /account/:id/device/:deviceId/update`
@@ -743,6 +744,49 @@ Content-Type: application/json
   - Conditions: if something goes wrong on the server
   - Content-Type : 'application/json'
   - Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
+
+## updateEcosystemAnonId : `PUT /account/<uid>/ecosystemAnonId`
+
+The `ecosystemAnonId` is a JWE represented as a urlsafe-base64 using the JWE Compact Serialization. See the [AET doc](https://docs.google.com/document/d/1zH3eVVI_28Afg1JXe_McDrW4MTYuWhiJMQR6AQbli8I/edit#) for more details.
+
+### Example
+
+```
+curl \
+    -v \
+    -X PUT \
+    http://localhost:8000/account/6044486dd15b42e08b1fb9167415b9ac/ecosystemAnonId \
+    -d '{
+      "uid": "6044486dd15b42e08b1fb9167415b9ac",
+      "ecosystemAnonId": "eyJhbGciOiJFQ0RILUVTIiwia2lkIjoiMFZFRTdmT0txbFdHVGZrY0taRUJ2WWl3dkpMYTRUUGlJVGxXMGJOcDdqVSIsImVwayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InY3Q1FlRWtVQjMwUGwxV0tPMUZUZ25OQlNQdlFyNlh0UnZxT2kzSWdzNHciLCJ5IjoiNDBKVEpaQlMwOXpWNHpxb0hHZDI5NGFDeHRqcGU5a09reGhELVctUEZsSSJ9LCJlbmMiOiJBMjU2R0NNIn0.A_wzJya943vlHKFH.yq0JhkGZiZd6UiZK6goTcEf6i4gbbBeXxvq8QV5_nC4.Knl_sYSBrrP-aa54z6B6gA"
+    }'
+```
+
+### Request
+
+- Method : PUT
+- Path : `/account/<uid>/ecosystemAnonId`
+  - uid : hex128
+- Params:
+  - uid : hex128
+  - ecosystemAnonId: urlsafe-base64 string
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{}
+```
+
+- Status Code : 200 OK
+  - Content-Type : 'application/json'
+  - Body : {}
+- Status Code : 404 Not Found
+  - Conditions: if the `uid` is not found
+  - Content-Type : 'application/json'
+  - Body : `{"message":"Not Found"}`
 
 ## createDevice : `PUT /account/<uid>/device/<deviceId>`
 

--- a/packages/fxa-auth-db-mysql/docs/DB_API.md
+++ b/packages/fxa-auth-db-mysql/docs/DB_API.md
@@ -16,6 +16,7 @@ There are a number of methods that a DB storage backend should implement:
   - .createEmail(uid, data)
   - .deleteEmail(uid, email)
   - .resetTokens(uid)
+  - .updateEcosystemAnonId(uid, ecosystemAnonId)
 - Accounts (using `email`)
   - .emailRecord(emailBuffer)
   - .accountRecord(emailBuffer)
@@ -158,6 +159,7 @@ Returns:
   - verifierSetAt - (number) an epoch, such as that created with `Date.now()`
   - verifierVersion - (number) currently always set to 1, may be 2 or more in the future
   - profileChangedAt - (number) an epoch, such as that created with `Date.now()`
+  - ecosystemAnonId - (string) user's anonymized Account Ecosystem Telemetry identifier, a JWE in urlsafe-base64 format.
 
 - error (can be either):
   - a `error.notFound()` if this account does not exist
@@ -348,6 +350,22 @@ Returns:
     * rejects with:
         * any errors from the underlying storage engine
 
+## .updateEcosystemAnonId(uid, ecosystemAnonId)
+
+    Inserts or updates the `ecosystemAnonId` for the user's account.
+
+    Parameters:
+
+    * `uid` - (Buffer16) the uid of the account to update
+    * `ecosystemAnonId` - (string) user's anonymized Account Ecosystem Telemetry identifier, a JWE in urlsafe-base64 format.
+
+    Returns:
+
+    * resolves with:
+        * an empty object `{}`
+    * rejects with:
+        * error `{ code: 404, errno: 116 }` if the `uid` was not found in the database
+
 ## .emailRecord(emailBuffer)
 
 Gets the account record related to this (normalized) email address. The email is provided in a Buffer.
@@ -372,6 +390,7 @@ Returns:
     - verifyHash - (Buffer32)
     - authSalt - (Buffer32)
     - verifierSetAt - (number) an epoch
+    - ecosystemAnonId - (string) user's anonymized Account Ecosystem Telemetry identifier, a JWE in urlsafe-base64 format.
 - rejects: with one of:
   - `error.notFound()` if no account exists for this email address
   - any error from the underlying storage engine
@@ -403,6 +422,7 @@ Returns:
     - verifierSetAt - (number) an epoch
     - primaryEmail - (string)
     - profileChangedAt = (number) an epoch
+    - ecosystemAnonId - (string) user's anonymized Account Ecosystem Telemetry identifier, a JWE in urlsafe-base64 format.
 - rejects: with one of:
   - `error.notFound()` if no account exists for this email address
   - any error from the underlying storage engine

--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -198,9 +198,9 @@ module.exports = function (log, error) {
   // CREATE
 
   // Insert : accounts
-  // Values : uid = $1, normalizedEmail = $2, email = $3, emailCode = $4, emailVerified = $5, kA = $6, wrapWrapKb = $7, authSalt = $8, verifierVersion = $9, verifyHash = $10, verifierSetAt = $11, createdAt = $12, locale = $13
+  // Values : uid = $1, normalizedEmail = $2, email = $3, emailCode = $4, emailVerified = $5, kA = $6, wrapWrapKb = $7, authSalt = $8, verifierVersion = $9, verifyHash = $10, verifierSetAt = $11, createdAt = $12, locale = $13, ecosystemAnonId = $14
   var CREATE_ACCOUNT =
-    'CALL createAccount_7(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+    'CALL createAccount_8(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
 
   MySql.prototype.createAccount = function (uid, data) {
     return this.write(CREATE_ACCOUNT, [
@@ -217,6 +217,7 @@ module.exports = function (log, error) {
       data.verifierSetAt,
       data.createdAt,
       data.locale,
+      data.ecosystemAnonId,
     ]);
   };
 
@@ -598,9 +599,9 @@ module.exports = function (log, error) {
   };
 
   // Select : accounts
-  // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt, verifierSetAt, createdAt, lockedAt
+  // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt, verifierSetAt, createdAt, lockedAt, ecosystemAnonId
   // Where  : accounts.normalizedEmail = LOWER($1)
-  var EMAIL_RECORD = 'CALL emailRecord_4(?)';
+  var EMAIL_RECORD = 'CALL emailRecord_5(?)';
 
   MySql.prototype.emailRecord = function (emailBuffer) {
     return this.readFirstResult(EMAIL_RECORD, [emailBuffer.toString('utf8')]);
@@ -608,9 +609,9 @@ module.exports = function (log, error) {
 
   // Select : accounts
   // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt,
-  //          verifierSetAt, createdAt, locale, lockedAt, profileChangedAt, keysChangedAt
+  //          verifierSetAt, createdAt, locale, lockedAt, profileChangedAt, keysChangedAt, ecosystemAnonId
   // Where  : accounts.uid = $1
-  var ACCOUNT = 'CALL account_7(?)';
+  var ACCOUNT = 'CALL account_8(?)';
 
   // Note: `fxa-support-panel` has grants to allow execute for this
   // specific stored procedure name. If this procedure name changes in the
@@ -654,6 +655,22 @@ module.exports = function (log, error) {
       token.authAt,
       token.mustVerify,
     ]);
+  };
+
+  // Update : ecosystemAnonId
+  // Set    : ecosystemAnonId = $2
+  // Where  : uid = $1
+  var UPDATE_ECOSYSTEM_ANON_ID = `CALL updateEcosystemAnonId_1(?, ?)`;
+  MySql.prototype.updateEcosystemAnonId = function (uid, data) {
+    return this.write(
+      UPDATE_ECOSYSTEM_ANON_ID,
+      [uid, data.ecosystemAnonId],
+      (result) => {
+        if (result.affectedRows === 0) {
+          throw error.notFound();
+        }
+      }
+    );
   };
 
   // DELETE
@@ -964,10 +981,10 @@ module.exports = function (log, error) {
 
   // Select : accounts
   // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt,
-  //          verifierSetAt, createdAt, lockedAt, primaryEmail, profileChangedAt, keysChangedAt
+  //          verifierSetAt, createdAt, lockedAt, primaryEmail, profileChangedAt, keysChangedAt, ecosystemAnonId
   // Where  : emails.normalizedEmail = LOWER($1)
   //
-  var GET_ACCOUNT_RECORD = 'CALL accountRecord_6(?)';
+  var GET_ACCOUNT_RECORD = 'CALL accountRecord_7(?)';
   MySql.prototype.accountRecord = function (email) {
     return this.readFirstResult(GET_ACCOUNT_RECORD, [email]);
   };

--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 110;
+module.exports.level = 111;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-110-111.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-110-111.sql
@@ -1,0 +1,205 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('110');
+
+-- Add a column to the accounts table to track the user's current
+-- ecosystemAnonId. For simplicity, we store this JWE as a base64 URL-safe
+-- string, and don't encode or decode it here.
+ALTER TABLE accounts
+  ADD COLUMN ecosystemAnonId TEXT CHARACTER SET ascii COLLATE ascii_bin DEFAULT NULL,
+ALGORITHM = INPLACE, LOCK = NONE;
+
+-- Update the account stored procedure to return `ecosystemAnonId` along
+-- with other `account` fields.
+CREATE PROCEDURE `account_8` (
+    IN `inUid` BINARY(16)
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.createdAt,
+        a.locale,
+        a.lockedAt,
+        COALESCE(a.profileChangedAt, a.verifierSetAt, a.createdAt) AS profileChangedAt,
+        COALESCE(a.keysChangedAt, a.verifierSetAt, a.createdAt) AS keysChangedAt,
+        a.ecosystemAnonId
+    FROM
+        accounts a
+    WHERE
+        a.uid = inUid
+    ;
+END;
+
+-- Update the account record stored procedure to return `ecosystemAnonId` along
+-- with other `account` fields.
+CREATE PROCEDURE `accountRecord_7` (
+  IN `inEmail` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.createdAt,
+        a.locale,
+        a.lockedAt,
+        COALESCE(a.profileChangedAt, a.verifierSetAt, a.createdAt) AS profileChangedAt,
+        COALESCE(a.keysChangedAt, a.verifierSetAt, a.createdAt) AS keysChangedAt,
+        a.ecosystemAnonId,
+        e.normalizedEmail AS primaryEmail
+    FROM
+        accounts a,
+        emails e
+    WHERE
+        a.uid = (SELECT uid FROM emails WHERE normalizedEmail = LOWER(inEmail))
+    AND
+        a.uid = e.uid
+    AND
+        e.isPrimary = true;
+END;
+
+-- Update the email record stored procedure to return `ecosystemAnonId` along
+-- with other `account` fields.
+CREATE PROCEDURE `emailRecord_5` (
+    IN `inEmail` VARCHAR(255)
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.lockedAt,
+        a.createdAt,
+        a.ecosystemAnonId
+    FROM
+        accounts a
+    WHERE
+        a.normalizedEmail = LOWER(inEmail)
+    ;
+END;
+
+-- For symmetry, and to simplify testing, also update the create account stored
+-- procedure to optionally allow the `ecosystemAnonId` to be set.
+CREATE PROCEDURE `createAccount_8`(
+    IN `inUid` BINARY(16) ,
+    IN `inNormalizedEmail` VARCHAR(255),
+    IN `inEmail` VARCHAR(255),
+    IN `inEmailCode` BINARY(16),
+    IN `inEmailVerified` TINYINT(1),
+    IN `inKA` BINARY(32),
+    IN `inWrapWrapKb` BINARY(32),
+    IN `inAuthSalt` BINARY(32),
+    IN `inVerifierVersion` TINYINT UNSIGNED,
+    IN `inVerifyHash` BINARY(32),
+    IN `inVerifierSetAt` BIGINT UNSIGNED,
+    IN `inCreatedAt` BIGINT UNSIGNED,
+    IN `inLocale` VARCHAR(255),
+    IN `inEcosystemAnonId` TEXT
+)
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    -- Check to see if the normalizedEmail exists in the emails table before creating a new user
+    -- with this email.
+    SET @emailExists = 0;
+    SELECT COUNT(*) INTO @emailExists FROM emails WHERE normalizedEmail = inNormalizedEmail;
+    IF @emailExists > 0 THEN
+        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1062, MESSAGE_TEXT = 'Unable to create user, email used belongs to another user.';
+    END IF;
+
+    INSERT INTO accounts(
+        uid,
+        normalizedEmail,
+        email,
+        emailCode,
+        emailVerified,
+        kA,
+        wrapWrapKb,
+        authSalt,
+        verifierVersion,
+        verifyHash,
+        verifierSetAt,
+        createdAt,
+        locale,
+        ecosystemAnonId
+    )
+    VALUES(
+        inUid,
+        LOWER(inNormalizedEmail),
+        inEmail,
+        inEmailCode,
+        inEmailVerified,
+        inKA,
+        inWrapWrapKb,
+        inAuthSalt,
+        inVerifierVersion,
+        inVerifyHash,
+        inVerifierSetAt,
+        inCreatedAt,
+        inLocale,
+        inEcosystemAnonId
+    );
+
+    INSERT INTO emails(
+        normalizedEmail,
+        email,
+        uid,
+        emailCode,
+        isVerified,
+        isPrimary,
+        createdAt
+    )
+    VALUES(
+        LOWER(inNormalizedEmail),
+        inEmail,
+        inUid,
+        inEmailCode,
+        inEmailVerified,
+        true,
+        inCreatedAt
+    );
+
+    COMMIT;
+END;
+
+-- Allow the ecosystemAnonId to be set. This does not yet include managing
+-- storing historical ecosystemAnonIds in a separate table (mozilla/fxa
+-- github issue #5539).
+CREATE PROCEDURE `updateEcosystemAnonId_1`(
+    IN `inUid` BINARY(16),
+    IN `inEcosystemAnonId` TEXT
+)
+BEGIN
+  UPDATE accounts SET ecosystemAnonId = inEcosystemAnonId WHERE uid = inUid;
+END;
+
+UPDATE dbMetadata SET value = '111' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-111-110.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-111-110.sql
@@ -1,0 +1,10 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE `account_8`;
+-- DROP PROCEDURE `accountRecord_7`;
+-- DROP PROCEDURE `emailRecord_5`;
+-- DROP PROCEDURE `createAccount_8`;
+
+-- ALTER TABLE accounts DROP COLUMN ecosystemAnonId;
+
+-- UPDATE dbMetadata SET value = '110' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/test/local/metrics_tests.js
+++ b/packages/fxa-auth-db-mysql/test/local/metrics_tests.js
@@ -21,6 +21,8 @@ const zeroBuffer32 = Buffer.from(
   '0000000000000000000000000000000000000000000000000000000000000000',
   'hex'
 );
+const anonId =
+  'eyJhbGciOiJFQ0RILUVTIiwia2lkIjoiMFZFRTdmT0txbFdHVGZrY0taRUJ2WWl3dkpMYTRUUGlJVGxXMGJOcDdqVSIsImVwayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InY3Q1FlRWtVQjMwUGwxV0tPMUZUZ25OQlNQdlFyNlh0UnZxT2kzSWdzNHciLCJ5IjoiNDBKVEpaQlMwOXpWNHpxb0hHZDI5NGFDeHRqcGU5a09reGhELVctUEZsSSJ9LCJlbmMiOiJBMjU2R0NNIn0.A_wzJya943vlHKFH.yq0JhkGZiZd6UiZK6goTcEf6i4gbbBeXxvq8QV5_nC4.Knl_sYSBrrP-aa54z6B6gA';
 
 describe('DB metrics', () => {
   let db;
@@ -583,6 +585,7 @@ describe('DB metrics', () => {
       verifierSetAt: time,
       createdAt: time,
       locale: 'en_US',
+      ecosystemAnonId: anonId,
     });
   }
 

--- a/packages/fxa-auth-db-mysql/test/local/mysql_tests.js
+++ b/packages/fxa-auth-db-mysql/test/local/mysql_tests.js
@@ -18,6 +18,8 @@ const zeroBuffer32 = Buffer.from(
   'hex'
 );
 const now = Date.now();
+const anonId =
+  'eyJhbGciOiJFQ0RILUVTIiwia2lkIjoiMFZFRTdmT0txbFdHVGZrY0taRUJ2WWl3dkpMYTRUUGlJVGxXMGJOcDdqVSIsImVwayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InY3Q1FlRWtVQjMwUGwxV0tPMUZUZ25OQlNQdlFyNlh0UnZxT2kzSWdzNHciLCJ5IjoiNDBKVEpaQlMwOXpWNHpxb0hHZDI5NGFDeHRqcGU5a09reGhELVctUEZsSSJ9LCJlbmMiOiJBMjU2R0NNIn0.A_wzJya943vlHKFH.yq0JhkGZiZd6UiZK6goTcEf6i4gbbBeXxvq8QV5_nC4.Knl_sYSBrrP-aa54z6B6gA';
 
 describe('MySQL', () => {
   let db;
@@ -359,6 +361,7 @@ describe('MySQL', () => {
       verifierSetAt: now,
       createdAt: now,
       locale: 'en_US',
+      ecosystemAnonId: anonId,
     };
     account.normalizedEmail = normalizeEmail(account.email);
 
@@ -390,6 +393,11 @@ describe('MySQL', () => {
           result.verifierVersion,
           account.verifierVersion,
           'verifierVersion set'
+        );
+        assert.equal(
+          result.ecosystemAnonId,
+          account.ecosystemAnonId,
+          'ecosystemAnonId set'
         );
       });
   });

--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -951,7 +951,7 @@ module.exports = (
         },
         response: {
           schema: {
-            ecosystemAnonId: isA.string().optional(),
+            ecosystemAnonId: isA.string().optional().allow(null),
             email: isA.string().optional(),
             locale: isA.string().optional().allow(null),
             authenticationMethods: isA
@@ -978,7 +978,10 @@ module.exports = (
         const res = {};
         const account = await db.account(uid);
 
-        if (scope.contains('profile:ecosystem_anon_id')) {
+        if (
+          scope.contains('profile:ecosystem_anon_id') &&
+          account.ecosystemAnonId
+        ) {
           res.ecosystemAnonId = account.ecosystemAnonId;
         }
         if (scope.contains('profile:email')) {


### PR DESCRIPTION
* Add ecosystemAnonId column to accounts table
* Update stored procedures that create or return an account to include
ecosystemAnonId
* Add stored procedure to update ecosystemAnonId for an account, given
the uid
* Update the authdb API to include ecosystemAnonId in endpoints that
create or return an account
* Add endpoint to authdb API to update ecosystemAnonId
* Add db API tests and update existing tests
* Remove references to deleted memory DB from README

I'm looking forward to ensuring the profile, auth, and auth-db API changes all line up correctly, but that seems like a separate issue from what's in issue #4321, so opening this separately.

This PR also closes part of #4322 (except for the historical anonid tracking)