### PR TITLE
feat(react): introduce useAwait hook

### DIFF
--- a/packages/fxa-react/lib/hooks.stories.tsx
+++ b/packages/fxa-react/lib/hooks.stories.tsx
@@ -1,0 +1,110 @@
+import React, { useCallback } from 'react';
+import { storiesOf } from '@storybook/react';
+import { useAwait, PromiseState } from './hooks';
+import LoadingSpinner from '../components/LoadingSpinner';
+
+const API_URL = '//worldtimeapi.org/api/ip';
+
+storiesOf('hooks|useAwait', module)
+  .add('basic', () => (
+    <>
+      <UseAwaitExample />
+      <UseAwaitExample apiUrl="//worldtimeapi.org/api/timezone/Europe/London" />
+      <UseAwaitExample apiUrl="//worldtimeapi.org/api/timezone/America/Detroit" />
+    </>
+  ))
+  .add('with initial state', () => (
+    <UseAwaitExample
+      initialState={{
+        result: initialResult(),
+        pending: false,
+        error: undefined,
+      }}
+    />
+  ))
+  .add('with immediate execution', () => (
+    <UseAwaitExample
+      executeImmediately={true}
+      fetchApiFn={() => fetchApi(API_URL)}
+    />
+  ))
+  .add('with error', () => (
+    <UseAwaitExample apiUrl="//worldtimeapi.org/badPage" />
+  ));
+
+const UseAwaitExample = ({
+  fetchApiFn = fetchApi,
+  apiUrl = API_URL,
+  style = {},
+  executeImmediately = undefined as boolean | undefined,
+  initialState = undefined as PromiseState<ApiResult, any> | undefined,
+}) => {
+  const [apiState, apiExecute, apiReset] = useAwait(fetchApiFn, {
+    executeImmediately,
+    initialState,
+  });
+  const executeWithApiUrl = useCallback(() => apiExecute(apiUrl), [
+    apiUrl,
+    apiExecute,
+  ]);
+
+  const buttonClassNames = 'mr-1 py-1 px-2 bg-grey-100 border-grey-600';
+  return (
+    <div className="m-4 p-4">
+      <button className={buttonClassNames} onClick={apiReset}>
+        Reset
+      </button>
+      <button className={buttonClassNames} onClick={executeWithApiUrl}>
+        Request
+      </button>
+      {apiUrl}
+      <ApiStateDisplay {...apiState} />
+    </div>
+  );
+};
+
+const ApiStateDisplay = ({
+  pending,
+  error,
+  result,
+}: PromiseState<ApiResult, any>) => {
+  if (!pending && !error && !result) {
+    return <p>Reset state</p>;
+  } else if (pending) {
+    return <LoadingSpinner />;
+  } else if (error) {
+    return <p>Error: {error.message}</p>;
+  } else if (result) {
+    const { datetime, timezone, client_ip, abbreviation } = result;
+    return (
+      <div>
+        <p>Hello, client from {client_ip}</p>
+        <p>
+          It is {datetime} in {timezone} ({abbreviation})
+        </p>
+      </div>
+    );
+  }
+  return <p>Unknown state</p>;
+};
+
+// Partial type of worldtimeapi result
+type ApiResult = {
+  abbreviation: string;
+  client_ip: string;
+  datetime: string;
+  timezone: string;
+};
+
+const fetchApi = async (urlToFetch: string): Promise<ApiResult> => {
+  const resp = await fetch(urlToFetch);
+  const data = await resp.json();
+  return data;
+};
+
+const initialResult = (): ApiResult => ({
+  abbreviation: 'BLA',
+  client_ip: '1.2.3.4',
+  datetime: 'blah blah blah',
+  timezone: 'blah/blah',
+});

--- a/packages/fxa-react/lib/hooks.test.tsx
+++ b/packages/fxa-react/lib/hooks.test.tsx
@@ -2,11 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import React, { useState, useCallback } from 'react';
+import { render, fireEvent, RenderResult } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
-import { useClickOutsideEffect, useBooleanState } from './hooks';
+import {
+  useClickOutsideEffect,
+  useBooleanState,
+  useAwait,
+  PromiseState,
+  PromiseStateResolved,
+} from './hooks';
 
 describe('useBooleanStateResult', () => {
   const Subject = ({ initialState = false }: { initialState?: boolean }) => {
@@ -66,5 +72,204 @@ describe('useClickOutsideEffect', () => {
     const inside = getByTestId('inside');
     fireEvent.click(inside);
     expect(onDismiss).not.toBeCalled();
+  });
+});
+
+describe('useAwait', () => {
+  const Subject = ({
+    fn = async () => 'test',
+    fnArgs,
+    initialState,
+    executeImmediately,
+    rethrowError,
+  }: {
+    fn?: (...args: any) => Promise<string>;
+    fnArgs?: any;
+    initialState?: PromiseState<string, any>;
+    executeImmediately?: boolean;
+    rethrowError?: boolean;
+  }) => {
+    const useDefaults = [initialState, executeImmediately, rethrowError].every(
+      (item) => typeof item === 'undefined'
+    );
+    const options = useDefaults
+      ? undefined
+      : {
+          initialState,
+          executeImmediately,
+          rethrowError,
+        };
+    const [state, execute, reset] = useAwait(fn, options);
+    const [thrownState, setThrownState] = useState('');
+    const executeMaybeThrows = useCallback(async () => {
+      try {
+        await execute(fnArgs);
+      } catch (e) {
+        setThrownState(e);
+      }
+    }, [execute]);
+    return (
+      <div>
+        {state.pending && <div data-testid="pending">pending</div>}
+        {!state.pending && <div data-testid="not-pending">not-pending</div>}
+        <div data-testid="state">{JSON.stringify(state)}</div>
+        <div data-testid="thrown">{JSON.stringify(thrownState)}</div>
+        <button data-testid="execute" onClick={executeMaybeThrows}></button>
+        <button data-testid="reset" onClick={reset}></button>
+      </div>
+    );
+  };
+
+  const parseState = (getByTestId: RenderResult['getByTestId']) =>
+    JSON.parse(getByTestId('state').textContent as string);
+
+  it('accepts initial state', async () => {
+    const initialState: PromiseStateResolved<string> = {
+      result: 'expected',
+      pending: false,
+      error: undefined,
+    };
+    const { getByTestId } = render(<Subject {...{ initialState }} />);
+    expect(parseState(getByTestId)).toEqual(initialState);
+  });
+
+  it('executes immediately when executeImmediately = true', async () => {
+    const expected = 'asdasdasd';
+    const { findByTestId, getByTestId } = render(
+      <Subject {...{ fn: async () => expected, executeImmediately: true }} />
+    );
+    await findByTestId('pending');
+    await findByTestId('not-pending');
+    expect(parseState(getByTestId)).toEqual({
+      result: expected,
+      pending: false,
+      error: undefined,
+    });
+  });
+
+  it('execute passes args to factory function', async () => {
+    const arg = 'hi mom';
+    const fn = async (arg: string) => `result ${arg}`;
+    const { findByTestId, getByTestId } = render(
+      <Subject {...{ fn, fnArgs: [arg] }} />
+    );
+    fireEvent.click(getByTestId('execute'));
+    await findByTestId('pending');
+    await findByTestId('not-pending');
+    expect(parseState(getByTestId)).toEqual({
+      result: `result ${arg}`,
+      pending: false,
+      error: undefined,
+    });
+  });
+
+  it('updates state for a resolved promise', async () => {
+    const expected = 'asdasdasd';
+    const fn = async () => expected;
+    const { findByTestId, getByTestId } = render(<Subject {...{ fn }} />);
+    expect(parseState(getByTestId)).toEqual({
+      pending: undefined,
+      result: undefined,
+      erorr: undefined,
+    });
+    fireEvent.click(getByTestId('execute'));
+    await findByTestId('pending');
+    await findByTestId('not-pending');
+    expect(parseState(getByTestId)).toEqual({
+      result: expected,
+      pending: false,
+      error: undefined,
+    });
+  });
+
+  it('updates state for a rejected promise', async () => {
+    const expectedError = 'oops!';
+    const fn = async () => {
+      throw expectedError;
+    };
+    const { findByTestId, getByTestId, debug } = render(
+      <Subject {...{ fn }} />
+    );
+    expect(parseState(getByTestId)).toEqual({
+      pending: undefined,
+      result: undefined,
+      erorr: undefined,
+    });
+    fireEvent.click(getByTestId('execute'));
+    await findByTestId('pending');
+    await findByTestId('not-pending');
+    expect(parseState(getByTestId)).toEqual({
+      result: undefined,
+      pending: false,
+      error: expectedError,
+    });
+    expect(getByTestId('thrown').textContent).not.toEqual(
+      JSON.stringify(expectedError)
+    );
+  });
+
+  it('optionally re-throws error for rejected promise', async () => {
+    const expectedError = 'oops!';
+    const fn = async () => {
+      throw expectedError;
+    };
+    const { findByTestId, getByTestId, debug } = render(
+      <Subject {...{ fn, rethrowError: true }} />
+    );
+    expect(parseState(getByTestId)).toEqual({
+      pending: undefined,
+      result: undefined,
+      erorr: undefined,
+    });
+    fireEvent.click(getByTestId('execute'));
+    await findByTestId('pending');
+    await findByTestId('not-pending');
+    expect(parseState(getByTestId)).toEqual({
+      result: undefined,
+      pending: false,
+      error: expectedError,
+    });
+    expect(getByTestId('thrown').textContent).toEqual(
+      JSON.stringify(expectedError)
+    );
+  });
+
+  it('allows state to be reset', async () => {
+    const expected = 'asdasdasd';
+    const fn = async () => expected;
+    const { findByTestId, getByTestId } = render(<Subject {...{ fn }} />);
+    expect(parseState(getByTestId)).toEqual({});
+    fireEvent.click(getByTestId('execute'));
+    await findByTestId('pending');
+    await findByTestId('not-pending');
+    expect(parseState(getByTestId)).toEqual({
+      result: expected,
+      pending: false,
+    });
+    fireEvent.click(getByTestId('reset'));
+    expect(parseState(getByTestId)).toEqual({});
+  });
+
+  it('does not re-execute when a promise is already pending', async () => {
+    const expectedError = 'oops!';
+    let count = 0;
+    const fn = async () => `count: ${++count}`;
+    const { findByTestId, getByTestId, debug } = render(
+      <Subject {...{ fn }} />
+    );
+    expect(parseState(getByTestId)).toEqual({
+      pending: undefined,
+      result: undefined,
+      erorr: undefined,
+    });
+    fireEvent.click(getByTestId('execute'));
+    fireEvent.click(getByTestId('execute'));
+    fireEvent.click(getByTestId('execute'));
+    await findByTestId('pending');
+    await findByTestId('not-pending');
+    expect(parseState(getByTestId)).toEqual({
+      result: 'count: 1',
+      pending: false,
+    });
   });
 });

--- a/packages/fxa-react/lib/hooks.tsx
+++ b/packages/fxa-react/lib/hooks.tsx
@@ -48,3 +48,133 @@ export function useClickOutsideEffect<T>(onClickOutside: Function) {
 
   return insideEl;
 }
+
+export type PromiseStateInitial = {
+  pending: undefined;
+  error: undefined;
+  result: undefined;
+};
+
+export type PromiseStatePending = {
+  pending: true;
+  error: undefined;
+  result: undefined;
+};
+
+export type PromiseStateRejected<E> = {
+  pending: false;
+  error: E;
+  result: undefined;
+};
+
+export type PromiseStateResolved<T> = {
+  pending: false;
+  error: undefined;
+  result: T;
+};
+
+export type PromiseState<T = any, E = any> =
+  | PromiseStateInitial
+  | PromiseStatePending
+  | PromiseStateRejected<E>
+  | PromiseStateResolved<T>;
+
+export const resetPromiseState = () => ({
+  pending: undefined,
+  error: undefined,
+  result: undefined,
+});
+
+/**
+ * Hook which helps manage tracking a pending promise through to resolved
+ * success or rejected error states. Supports multiple executions / retries.
+ *
+ * @param factory {Function} function that should return a promise
+ * @param executeImmediately when true, the factory function will be called immediately
+ * @return [ { pending, error, result }, execute, reset ]
+ * @example
+ * const [thingState, thingExecute, thingReset] = useAwait<string, string>(
+ *   async (doError = false) => {
+ *     await wait(1000);
+ *     if (doError) {
+ *       throw 'ERROR';
+ *     }
+ *     return 'SUCCESS';
+ *   },
+ *   true
+ * );
+ */
+export function useAwait<
+  TFactoryArgs extends Array<any>,
+  TResult = any,
+  TError = any
+>(
+  factory: (...args: TFactoryArgs) => Promise<TResult>,
+  {
+    // An initial state can optionally be supplied - e.g. for storybook
+    initialState = undefined as
+      | undefined
+      | PromiseState<TResult | undefined, TError>,
+    // If true, the promise factory will be executed immediately on component mount
+    executeImmediately = false,
+    // Default is to squelch errors because we surface them via UI state change
+    rethrowError = false,
+  } = {}
+): [
+  PromiseState<TResult | undefined, TError>,
+  (...args: TFactoryArgs) => Promise<TResult | undefined>,
+  () => void
+] {
+  const [state, setState] = useState<PromiseState<TResult | undefined, TError>>(
+    initialState || resetPromiseState()
+  );
+
+  const promise = useRef<Promise<TResult | undefined> | undefined>();
+
+  const reset = useCallback(() => {
+    setState(resetPromiseState());
+    promise.current = undefined;
+  }, [setState, promise]);
+
+  const execute = useCallback(
+    async (...args: TFactoryArgs) => {
+      // Avoid re-executing promise if there's already one in flight.
+      if (typeof promise.current !== 'undefined') {
+        return;
+      }
+
+      setState({ pending: true, error: undefined, result: undefined });
+      promise.current = factory(...args);
+
+      try {
+        const result = await promise.current;
+        setState({ pending: false, error: undefined, result });
+        promise.current = undefined;
+        return result;
+      } catch (error) {
+        setState({ pending: false, error, result: undefined });
+        promise.current = undefined;
+        if (rethrowError) {
+          throw error;
+        }
+        return;
+      }
+    },
+    [factory, setState, rethrowError]
+  );
+
+  useEffect(
+    () => {
+      if (executeImmediately) {
+        // HACK: if we're executing immediately, then the factory function
+        // can't take any params. There's probably a better type annotation
+        // to assert this.
+        (execute as () => void)();
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  return [state, execute, reset];
+}

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -27,7 +27,7 @@
     "start": "pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
     "storybook": "npm run build-postcss && start-storybook -p 6007",
-    "test": "yarn clean && jest"
+    "test": "yarn clean && jest --env=jsdom-fourteen"
   },
   "dependencies": {
     "fxa-shared": "workspace:*",
@@ -62,6 +62,7 @@
     "file-loader": "4.2.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.9.0",
+    "jest-environment-jsdom-fourteen": "1.0.1",
     "pm2": "^4.4.0",
     "postcss-cli": "^7.1.1",
     "prettier": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17425,6 +17425,7 @@ fsevents@^1.2.7:
     fxa-shared: "workspace:*"
     identity-obj-proxy: ^3.0.0
     jest: ^24.9.0
+    jest-environment-jsdom-fourteen: 1.0.1
     pm2: ^4.4.0
     postcss-cli: ^7.1.1
     prettier: ^2.0.5


### PR DESCRIPTION
Because:

* I'd like to refactor payments-server to no longer use Redux to orchestrate API calls

This PR:

* Introduces a new useAwait hook for managing promise-based API calls closer to the component using the APIs.

issue #5683