### PR TITLE
chore(pm2): Add ISO timestamp to pm2 log lines

### DIFF
--- a/packages/123done/pm2.config.js
+++ b/packages/123done/pm2.config.js
@@ -21,6 +21,7 @@ module.exports = {
       },
       filter_env: ['npm_'],
       min_uptime: '2m',
+      time: true,
     },
     {
       name: '321done',
@@ -35,6 +36,7 @@ module.exports = {
       },
       filter_env: ['npm_'],
       min_uptime: '2m',
+      time: true,
     },
   ],
 };

--- a/packages/browserid-verifier/pm2.config.js
+++ b/packages/browserid-verifier/pm2.config.js
@@ -21,6 +21,7 @@ module.exports = {
       filter_env: ['npm_'],
       max_restarts: '1',
       min_uptime: '2m',
+      time: true,
     },
   ],
 };

--- a/packages/fortress/pm2.config.js
+++ b/packages/fortress/pm2.config.js
@@ -21,6 +21,7 @@ module.exports = {
       },
       filter_env: ['npm_'],
       min_uptime: '2m',
+      time: true,
     },
   ],
 };

--- a/packages/fxa-admin-panel/pm2.config.js
+++ b/packages/fxa-admin-panel/pm2.config.js
@@ -25,6 +25,7 @@ module.exports = {
         PATH,
       },
       filter_env: ['npm_'],
+      time: true,
     },
     {
       name: 'admin-react',
@@ -41,6 +42,7 @@ module.exports = {
         PATH,
       },
       filter_env: ['npm_', 'BERRY_BIN_FOLDER'],
+      time: true,
     },
     {
       name: 'admin-css',
@@ -59,6 +61,7 @@ module.exports = {
         require.resolve('fxa-react/configs/tailwind.js'),
       ],
       ignore_watch: ['src/styles/tailwind.out.css'],
+      time: true,
     },
   ],
 };

--- a/packages/fxa-admin-server/pm2.config.js
+++ b/packages/fxa-admin-server/pm2.config.js
@@ -24,6 +24,7 @@ module.exports = {
       },
       filter_env: ['npm_'],
       watch: ['src'],
+      time: true,
     },
   ],
 };

--- a/packages/fxa-auth-db-mysql/pm2.config.js
+++ b/packages/fxa-auth-db-mysql/pm2.config.js
@@ -20,6 +20,7 @@ module.exports = {
       filter_env: ['npm_'],
       max_restarts: '2',
       min_uptime: '2m',
+      time: true,
     },
   ],
 };

--- a/packages/fxa-auth-server/pm2.config.js
+++ b/packages/fxa-auth-server/pm2.config.js
@@ -30,6 +30,7 @@ module.exports = {
       watch: ['bin', 'config', 'lib'],
       max_restarts: '1',
       min_uptime: '2m',
+      time: true,
     },
     {
       name: 'inbox',
@@ -43,6 +44,7 @@ module.exports = {
       filter_env: ['npm_'],
       max_restarts: '1',
       min_uptime: '2m',
+      time: true,
     },
   ],
 };

--- a/packages/fxa-content-server/pm2.config.js
+++ b/packages/fxa-content-server/pm2.config.js
@@ -22,6 +22,7 @@ module.exports = {
       watch: ['server'],
       max_restarts: '1',
       min_uptime: '2m',
+      time: true,
     },
   ],
 };

--- a/packages/fxa-customs-server/pm2.config.js
+++ b/packages/fxa-customs-server/pm2.config.js
@@ -21,6 +21,7 @@ module.exports = {
       filter_env: ['npm_'],
       watch: ['bin', 'lib'],
       min_uptime: '2m',
+      time: true,
     },
   ],
 };

--- a/packages/fxa-event-broker/pm2.config.js
+++ b/packages/fxa-event-broker/pm2.config.js
@@ -27,6 +27,7 @@ module.exports = {
       filter_env: ['npm_'],
       watch: ['src', 'config'],
       min_uptime: '2m',
+      time: true,
     },
   ],
 };

--- a/packages/fxa-graphql-api/pm2.config.js
+++ b/packages/fxa-graphql-api/pm2.config.js
@@ -24,6 +24,7 @@ module.exports = {
       },
       filter_env: ['npm_'],
       watch: ['src'],
+      time: true,
     },
   ],
 };

--- a/packages/fxa-payments-server/pm2.config.js
+++ b/packages/fxa-payments-server/pm2.config.js
@@ -24,6 +24,7 @@ module.exports = {
         PATH,
       },
       filter_env: ['npm_'],
+      time: true,
     },
     {
       name: 'payments-react',
@@ -40,6 +41,7 @@ module.exports = {
         PATH,
       },
       filter_env: ['npm_', 'BERRY_BIN_FOLDER'],
+      time: true,
     },
   ],
 };

--- a/packages/fxa-profile-server/pm2.config.js
+++ b/packages/fxa-profile-server/pm2.config.js
@@ -22,6 +22,7 @@ module.exports = {
       },
       filter_env: ['npm_'],
       min_uptime: '2m',
+      time: true,
     },
     {
       name: 'profile-worker',
@@ -36,6 +37,7 @@ module.exports = {
       },
       filter_env: ['npm_'],
       min_uptime: '2m',
+      time: true,
     },
     {
       name: 'profile-static',
@@ -50,6 +52,7 @@ module.exports = {
       },
       filter_env: ['npm_'],
       min_uptime: '2m',
+      time: true,
     },
   ],
 };

--- a/packages/fxa-react/pm2.config.js
+++ b/packages/fxa-react/pm2.config.js
@@ -17,6 +17,7 @@ module.exports = {
         PATH,
       },
       filter_env: ['npm_'],
+      time: true,
     },
     {
       name: 'react-css',
@@ -34,6 +35,7 @@ module.exports = {
         'styles',
       ],
       ignore_watch: ['styles/tailwind.out.css'],
+      time: true,
     },
   ],
 };

--- a/packages/fxa-settings/pm2.config.js
+++ b/packages/fxa-settings/pm2.config.js
@@ -22,6 +22,7 @@ module.exports = {
         PATH,
       },
       filter_env: ['npm_', 'BERRY_BIN_FOLDER'],
+      time: true,
     },
     {
       name: 'settings-css',
@@ -40,6 +41,7 @@ module.exports = {
         require.resolve('fxa-react/configs/tailwind.js'),
       ],
       ignore_watch: ['src/styles/tailwind.out.*'],
+      time: true,
     },
   ],
 };

--- a/packages/fxa-shared/pm2.config.js
+++ b/packages/fxa-shared/pm2.config.js
@@ -17,6 +17,7 @@ module.exports = {
         PATH,
       },
       filter_env: ['npm_'],
+      time: true,
     },
   ],
 };

--- a/packages/fxa-support-panel/pm2.config.js
+++ b/packages/fxa-support-panel/pm2.config.js
@@ -25,6 +25,7 @@ module.exports = {
       },
       filter_env: ['npm_'],
       watch: ['bin', 'config', 'lib'],
+      time: true,
     },
   ],
 };


### PR DESCRIPTION
Sometimes, when I'm debugging a service locally, I can't tell if the error logs are showing recent or older errors. To fix this, it would be handy to have pm2 log the current timestamp with each log line.

This change just adds `time: true` to each of the per-package pm2 server configs to insert the timestamp. It is a _full_ ISO timestamp, which does make the lines about 20 chars longer; this is a bit of an annoyance, but I think having the time is worth it, and everyone but me lives in VSCode anyway, which has very wide terminals by default.

You can try this out locally, but here's a snippet of `./pm2 logs` output that shows pretty clearly where the timestamps start getting inserted:

```
/Users/jh/.pm2/logs/payments-out.log last 15 lines:
32|payment | fxa-payments-server.server.main.INFO: static.proxying {"url":"http://localhost:3032"}
32|payment | fxa-payments-server.server.main.INFO: server.starting {"port":3031}
32|payment | fxa-payments-server.server.main.INFO: server.started {"port":3031}
32|payment | fxa-payments-server.server.main.INFO: source set to: git@github.com:mozilla/fxa
32|payment | fxa-payments-server.server.main.INFO: version set to: 1.175.0
32|payment | fxa-payments-server.server.main.INFO: commit hash set to: 4dbc211bb302f6295e8fb41dc1a8b64197f74ffd
32|payment | fxa-payments-server.server.main.INFO: static.proxying {"url":"http://localhost:3032"}
32|payment | fxa-payments-server.server.main.INFO: server.starting {"port":3031}
32|payment | fxa-payments-server.server.main.INFO: server.started {"port":3031}
32|payment | 2020-06-17T16:57:56: fxa-payments-server.server.main.INFO: source set to: git@github.com:mozilla/fxa
32|payment | 2020-06-17T16:57:56: fxa-payments-server.server.main.INFO: version set to: 1.175.0
32|payment | 2020-06-17T16:57:56: fxa-payments-server.server.main.INFO: commit hash set to: 4dbc211bb302f6295e8fb41dc1a8b64197f74ffd
32|payment | 2020-06-17T16:57:57: fxa-payments-server.server.main.INFO: static.proxying {"url":"http://localhost:3032"}
32|payment | 2020-06-17T16:57:57: fxa-payments-server.server.main.INFO: server.starting {"port":3031}
32|payment | 2020-06-17T16:57:57: fxa-payments-server.server.main.INFO: server.started {"port":3031}

/Users/jh/.pm2/logs/support-error.log last 15 lines:
34|support | For help, see: https://nodejs.org/en/docs/inspector
34|support | Debugger listening on ws://127.0.0.1:9190/7f750342-1be8-4e99-b4f6-07d0647e7412
34|support | For help, see: https://nodejs.org/en/docs/inspector
34|support | Debugger listening on ws://127.0.0.1:9190/72dd698b-be04-4aac-9f89-81a1095b95cd
34|support | For help, see: https://nodejs.org/en/docs/inspector
34|support | Debugger listening on ws://127.0.0.1:9190/cfecd912-eb67-437b-8f1a-55226700764a
34|support | For help, see: https://nodejs.org/en/docs/inspector
34|support | Debugger listening on ws://127.0.0.1:9190/e9091bb1-6b37-48f7-9a4f-87273d228d44
34|support | For help, see: https://nodejs.org/en/docs/inspector
34|support | Debugger listening on ws://127.0.0.1:9190/97bcbc87-4d6f-4cef-b317-6986f5c722a9
34|support | For help, see: https://nodejs.org/en/docs/inspector
34|support | Debugger listening on ws://127.0.0.1:9190/70e78411-89c2-48a4-bc1e-5fbcfec9a634
34|support | For help, see: https://nodejs.org/en/docs/inspector
34|support | 2020-06-17T16:57:59: Debugger listening on ws://127.0.0.1:9190/f5d0100e-0c9f-45cc-892d-f5d25e0a919d
34|support | 2020-06-17T16:57:59: For help, see: https://nodejs.org/en/docs/inspector
```