### PR TITLE
[HOLD] chore(docs): Replace 'master' with 'main' throughout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ workflows:
       - test-many:
           filters:
             branches:
-              ignore: master
+              ignore: main
             tags:
               ignore: /.*/
       - test-package:
@@ -233,43 +233,43 @@ workflows:
           package: fxa-auth-server
           filters:
             branches:
-              ignore: master
+              ignore: main
             tags:
               ignore: /.*/
       - test-content-server-0:
           filters:
             branches:
-              ignore: master
+              ignore: main
             tags:
               ignore: /.*/
       - test-content-server-1:
           filters:
             branches:
-              ignore: master
+              ignore: main
             tags:
               ignore: /.*/
       - test-content-server-2:
           filters:
             branches:
-              ignore: master
+              ignore: main
             tags:
               ignore: /.*/
       - test-content-server-3:
           filters:
             branches:
-              ignore: master
+              ignore: main
             tags:
               ignore: /.*/
       - test-content-server-4:
           filters:
             branches:
-              ignore: master
+              ignore: main
             tags:
               ignore: /.*/
       - test-content-server-5:
           filters:
             branches:
-              ignore: master
+              ignore: main
             tags:
               ignore: /.*/
       - test-email-service:
@@ -286,7 +286,7 @@ workflows:
       - build-and-deploy-storybooks:
           filters:
             branches:
-              ignore: master
+              ignore: main
             tags:
               ignore: /.*/
   deploy_branch:
@@ -295,7 +295,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
                 - /^feature.*/
                 - /^dockerpush.*/
             tags:
@@ -303,7 +303,7 @@ workflows:
       - build-and-deploy-storybooks:
           filters:
             branches:
-              only: master
+              only: main
             tags:
               ignore: /.*/
   test_and_deploy_tag:

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -10,7 +10,7 @@ if [[ "$(docker images -q "$MODULE")" == "" ]]; then
   exit 0
 fi
 
-if [ "${CIRCLE_BRANCH}" == "master" ]; then
+if [ "${CIRCLE_BRANCH}" == "main" ]; then
   DOCKER_TAG="latest"
 fi
 

--- a/.circleci/modules-to-test.js
+++ b/.circleci/modules-to-test.js
@@ -109,10 +109,12 @@ async function main() {
     for (const mod of toRun) {
       console.log(mod);
     }
-  } else if (branch === 'master') {
+  }
+  else if (branch === 'main') {
     console.log('all');
-  } else {
-    //TODO diff master..branch
+  }
+  else {
+    //TODO diff main..branch
     console.log('all');
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,12 +55,12 @@ Before submitting a PR:
 When submitting a PR:
 
 - You agree to and have the legal right to license your code under the project's [license](/LICENSE).
-- Base your branch off the current `master`.
+- Base your branch off the current `main`.
 - Add both your code and new tests if relevant.
 - Run `grunt lint` and `npm test` to make sure your code passes linting and tests.
 - Please do not include merge commits in pull requests; include only commits with the new relevant code.
 - Your commit message must follow the
-  [commit guidelines](https://github.com/mozilla/fxa/blob/master/CONTRIBUTING.md#git-commit-guidelines).
+  [commit guidelines](https://github.com/mozilla/fxa/blob/main/CONTRIBUTING.md#git-commit-guidelines).
 - To skip CI tests add the "🙈 skip ci" github label to the PR.
   - You can skip only specific packages by also adding the corresponding "fxa-" label, for example "fxa-content-server".
 
@@ -72,7 +72,7 @@ This project is production Mozilla code and subject to our [engineering practice
 
 ## Git Commit Guidelines
 
-We loosely follow the [Angular commit guidelines](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#type) of `<type>(<scope>): <subject>` where `type` must be one of:
+We loosely follow the [Angular commit guidelines](https://github.com/angular/angular.js/blob/main/CONTRIBUTING.md#type) of `<type>(<scope>): <subject>` where `type` must be one of:
 
 - **feat**: A new feature
 - **fix**: A bug fix
@@ -139,7 +139,7 @@ if it's a partial fix.
 ### npm
 
 We use [npm](http://npmjs.com/) to manage dependencies. Required components are [automatically
-installed](https://github.com/mozilla/fxa/blob/master/package.json#L6) when you install this project.
+installed](https://github.com/mozilla/fxa/blob/main/package.json#L6) when you install this project.
 
 ### L10N
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The Firefox Accounts (fxa) monorepo
 
 Note: If `yarn install` fails, ensure your `yarn -v` is at least `1.22.0`.
 
-Note this starts up all required services, including Redis, MySQL, and Memcached. It is recommended that you don't run these services yourself, or occupy any of the [server ports](https://github.com/mozilla/fxa/blob/master/mysql_servers.json). Doing so may result in errors.
+Note this starts up all required services, including Redis, MySQL, and Memcached. It is recommended that you don't run these services yourself, or occupy any of the [server ports](https://github.com/mozilla/fxa/blob/main/mysql_servers.json). Doing so may result in errors.
 
 4. Visit [localhost:3030](http://localhost:3030/).
 
@@ -73,7 +73,7 @@ The most common commands are:
 
 ### Contributing
 
-See the separate [CONTRIBUTING.md](https://github.com/mozilla/fxa/blob/master/CONTRIBUTING.md) to learn how to contribute.
+See the separate [CONTRIBUTING.md](https://github.com/mozilla/fxa/blob/main/CONTRIBUTING.md) to learn how to contribute.
 
 ### Workflow
 
@@ -217,8 +217,8 @@ When developing locally you may need to set up some secrets in order to effectiv
 
 Check out the Secrets section in the following READMEs:
 
-- [fxa-auth-server](https://github.com/mozilla/fxa/tree/master/packages/fxa-auth-server#secrets)
-- [fxa-payments-server](https://github.com/mozilla/fxa/tree/master/packages/fxa-payments-server#secrets)
+- [fxa-auth-server](https://github.com/mozilla/fxa/tree/main/packages/fxa-auth-server#secrets)
+- [fxa-payments-server](https://github.com/mozilla/fxa/tree/main/packages/fxa-payments-server#secrets)
 
 ---
 
@@ -245,7 +245,7 @@ Note that this invokes the same test suite that CI uses, and is not necessarily 
 
 #### Emulating CI environment
 
-It is possible to run various test suites (known as Jobs) acting as Circle CI. This is useful if you're encountering CI-specific failures. Please refer to [this documentation](https://github.com/mozilla/fxa/tree/master/.circleci#local-testing).
+It is possible to run various test suites (known as Jobs) acting as Circle CI. This is useful if you're encountering CI-specific failures. Please refer to [this documentation](https://github.com/mozilla/fxa/tree/main/.circleci#local-testing).
 
 ---
 

--- a/_dev/docker/circleci/README.md
+++ b/_dev/docker/circleci/README.md
@@ -13,4 +13,4 @@ curl -u $CIRCLECI_API_TOKEN \
 ```
 
 - `$CIRCLECI_API_TOKEN` is your personal API token from https://app.circleci.com/settings/user/tokens
-- `$GITHUB_BRANCH` is the branch you'd like to build & deploy to docker hub (this may be `master`)
+- `$GITHUB_BRANCH` is the branch you'd like to build & deploy to docker hub (this may be `main`)

--- a/_scripts/gh-pages.sh
+++ b/_scripts/gh-pages.sh
@@ -2,7 +2,7 @@
 
 echo "Branch: $CIRCLE_BRANCH    Pull request: $CIRCLE_PULL_REQUEST"
 
-if [ "$CIRCLE_BRANCH" != "master" ] || [ "$CIRCLE_PULL_REQUEST" != "" ]; then
+if [ "$CIRCLE_BRANCH" != "main" ] || [ "$CIRCLE_PULL_REQUEST" != "" ]; then
   echo "Not building docs."
   exit 0
 fi

--- a/_scripts/upload-assets-to-cdn.sh
+++ b/_scripts/upload-assets-to-cdn.sh
@@ -2,7 +2,7 @@
 
 echo ""
 echo "Usage:"
-echo "  Checkout HEAD of master of https://github.com/mozilla/fxa, and from"
+echo "  Checkout HEAD of main of https://github.com/mozilla/fxa, and from"
 echo "  ./fxa, run ./_scripts/upload-assets-to-cdn.sh."
 echo ""
 echo "Your current branch is $(git branch --show-current)"

--- a/docs/adr/0003-event-broker-for-subscription-platform.md
+++ b/docs/adr/0003-event-broker-for-subscription-platform.md
@@ -1,7 +1,7 @@
 # Event Broker for Subscription Platform
 
-* Deciders: Ben Bangert, Phil Booth, Ryan Kelly, Shane Tomlinson
-* Date: 2019-05-14
+- Deciders: Ben Bangert, Phil Booth, Ryan Kelly, Shane Tomlinson
+- Date: 2019-05-14
 
 ## Context and Problem Statement
 
@@ -28,32 +28,32 @@ query load on existing FxA services.
 
 ## Decision Drivers
 
-* Subscription services deadlines
-* Effort required and experience available for FxA changes
-* Separation of concerns from existing FxA microservices
-* Difficulty of schema migrations in existing FxA microservices
-* Suitability of existing FxA databases for large-scale event storage
-* Architectural desire to treat FxA Auth and OAuth as one (Merging
+- Subscription services deadlines
+- Effort required and experience available for FxA changes
+- Separation of concerns from existing FxA microservices
+- Difficulty of schema migrations in existing FxA microservices
+- Suitability of existing FxA databases for large-scale event storage
+- Architectural desire to treat FxA Auth and OAuth as one (Merging
   in-progress)
 
 ## Considered Options
 
-* Implementing RP notification as a FxA Auth Service feature
-    * A. Storing webhook and login activity in FxA Auth Service
-* Implementing RP notification as a new FxA Event Broker service
-    * B. Storing webhook and login activity in FxA Auth Service
-    * C. Storing webhook and login activity in FxA Event Broker
+- Implementing RP notification as a FxA Auth Service feature
+  - A. Storing webhook and login activity in FxA Auth Service
+- Implementing RP notification as a new FxA Event Broker service
+  - B. Storing webhook and login activity in FxA Auth Service
+  - C. Storing webhook and login activity in FxA Event Broker
 
 ## Decision Outcome
 
 Chosen Option: C. Implementing RP notification as a new FxA Event Broker service
 with webhook and login activity stored in FxA Event Broker, because
 
-* Less subscription platform timeline risk to store new data in new database vs.
+- Less subscription platform timeline risk to store new data in new database vs.
   modify existing FxA OAuth database.
-* Storing events at scale has database requirements that don't fit in well with
+- Storing events at scale has database requirements that don't fit in well with
   the limitations with MySQL encountered in FxA Auth/OAuth.
-* Having FxA Auth be the only store of which RP to notify would require each
+- Having FxA Auth be the only store of which RP to notify would require each
   notification to also include what RPs to notify, increasing the load on the
   FxA Auth database.
 
@@ -61,50 +61,50 @@ with webhook and login activity stored in FxA Event Broker, because
 
 ### A. Implementing RP notification as a FxA Auth Service feature w/webhook & login activity
 
-* Description
-  * FxA Auth Service has additional feature code added to perform webhook
+- Description
+  - FxA Auth Service has additional feature code added to perform webhook
     deliveries to RPs.
-  * FxA Auth Service stores login activity and webhook mapping to OAuth Clients
-* Pros
-  * Auth service has direct access to subscription capability mapping and
+  - FxA Auth Service stores login activity and webhook mapping to OAuth Clients
+- Pros
+  - Auth service has direct access to subscription capability mapping and
     OAuth webhook URLs.
-* Cons
-  * Event logs for each user are not well suited for existing MySQL database.
-  * Additional database schema migrations needed.
-  * Later features needing to query for user events could impact FxA Auth Service
+- Cons
+  - Event logs for each user are not well suited for existing MySQL database.
+  - Additional database schema migrations needed.
+  - Later features needing to query for user events could impact FxA Auth Service
     availability.
 
 ### B. Implementing RP notification as a new FxA Event Broker service w/webhook & login activity in FxA Auth Service
 
-* Description
-  * FxA Event Broker performs webhook deliveries to RPs.
-  * FxA Auth Service stores login activity and webhook mapping to OAuth Clients
-  * FxA Auth Server includes RPs that should be notified in the relevant
+- Description
+  - FxA Event Broker performs webhook deliveries to RPs.
+  - FxA Auth Service stores login activity and webhook mapping to OAuth Clients
+  - FxA Auth Server includes RPs that should be notified in the relevant
     Service Notifications.
-  * FxA Event Broker caches new OAuth /clients request that indicates
+  - FxA Event Broker caches new OAuth /clients request that indicates
     subscription capabilities per RP.
-* Pros
-  * Division of event storing and distribution to a service that can be built
+- Pros
+  - Division of event storing and distribution to a service that can be built
     specifically for that function.
-* Cons
-  * Queries to FxA Auth Service required for each message to determine whether
+- Cons
+  - Queries to FxA Auth Service required for each message to determine whether
     to deliver to an RP could impact FxA Auth Service availability.
-  * FxA OAuth server should still have a record of which RPs a user has logged
+  - FxA OAuth server should still have a record of which RPs a user has logged
     into so a later issue to add this is still needed.
 
 ### C. Implementing RP notification as a new FxA Event Broker service w/webhook & login activity in FxA Event Broker
 
-* Description
-  * FxA Event Broker performs webhook deliveries to RPs.
-  * FxA Event Broker caches new OAuth /clients request that indicates
+- Description
+  - FxA Event Broker performs webhook deliveries to RPs.
+  - FxA Event Broker caches new OAuth /clients request that indicates
     subscription capabilities per RP.
-  * FxA Event Broker logs events and can determine which RPs a user has logged
+  - FxA Event Broker logs events and can determine which RPs a user has logged
     into without any external service queries.
-* Pros
-  * Division of event storing and distribution to a service that can be built
+- Pros
+  - Division of event storing and distribution to a service that can be built
     specifically for that function.
-* Cons
-  * FxA OAuth server should still have a record of which RPs a user has logged
+- Cons
+  - FxA OAuth server should still have a record of which RPs a user has logged
     into so a later issue to add this is still needed.
 
-[Firefox Service Notifications]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/docs/service_notifications.md
+[firefox service notifications]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/service_notifications.md

--- a/docs/adr/0010-transition-fxa-from-backbone-to-react.md
+++ b/docs/adr/0010-transition-fxa-from-backbone-to-react.md
@@ -5,7 +5,7 @@
 
 ## Context and Problem Statement
 
-When Firefox Accounts was created some 6-7 years ago, the front-end Javascript framework and HTML templating options were limited significantly to those available at the time. This ADR details the pros and cons of various FE libraries and frameworks, and why it is desirable for FxA to move to a different technology. It does not cover _how_ we will begin the conversion which can be [read about here](https://github.com/mozilla/fxa/blob/master/docs/adr/0011-create-new-react-app-for-settings-redesign.md).
+When Firefox Accounts was created some 6-7 years ago, the front-end Javascript framework and HTML templating options were limited significantly to those available at the time. This ADR details the pros and cons of various FE libraries and frameworks, and why it is desirable for FxA to move to a different technology. It does not cover _how_ we will begin the conversion which can be [read about here](https://github.com/mozilla/fxa/blob/main/docs/adr/0011-create-new-react-app-for-settings-redesign.md).
 
 While Backbone and Mustache have served their purposes for FxA thus far, other modern libraries and frameworks not only offer more appealing architecture and developer conveniences, but also offer better data predictability, potential performance boosts, and a strong community of online support.
 
@@ -54,7 +54,7 @@ In the end, it is recognized that Vue _may_ have been a good option for FxA, but
   - As Backbone's popularity continues to wane, we will likely be presented with challenges in the future around support, documentation, features, and developer knowledge or experience with the framework.
   - We'd be giving a hard pass on all of the benefits we would gain from another library or framework - i.e. modern approaches, better data clarity and typing, performance optimizations, etc.
 
-Note: also see pros/cons listed on Backbone in general [in this ADR](https://github.com/mozilla/fxa/blob/master/docs/adr/0002-use-react-redux-and-typescript-for-subscription-management-pages.md)
+Note: also see pros/cons listed on Backbone in general [in this ADR](https://github.com/mozilla/fxa/blob/main/docs/adr/0002-use-react-redux-and-typescript-for-subscription-management-pages.md)
 
 ### Options B - E - Common Pros & Cons
 
@@ -149,8 +149,8 @@ Using web components with the [Polymer Project](https://www.polymer-project.org/
 
 ## Links
 
-- [Create a new React app for Settings Redesign](https://github.com/mozilla/fxa/blob/master/docs/adr/0011-create-new-react-app-for-settings-redesign.md)
-- Other Backbone pros/cons: [subscription management stack ADR](https://github.com/mozilla/fxa/blob/master/docs/adr/0002-use-react-redux-and-typescript-for-subscription-management-pages.md)
+- [Create a new React app for Settings Redesign](https://github.com/mozilla/fxa/blob/main/docs/adr/0011-create-new-react-app-for-settings-redesign.md)
+- Other Backbone pros/cons: [subscription management stack ADR](https://github.com/mozilla/fxa/blob/main/docs/adr/0002-use-react-redux-and-typescript-for-subscription-management-pages.md)
 - [Facebook switches licensing](https://www.freecodecamp.org/news/facebook-just-changed-the-license-on-react-heres-a-2-minute-explanation-why-5878478913b2/)
 - [Banana, monkey, jungle problem](http://rcardin.github.io/design/programming/oop/fp/2018/07/27/the-secret-life-of-objects-part-2.html#the-banana-monkey-jungle-problem)
 - [React](https://github.com/facebook/react)

--- a/docs/adr/0011-create-new-react-app-for-settings-redesign.md
+++ b/docs/adr/0011-create-new-react-app-for-settings-redesign.md
@@ -7,7 +7,7 @@
 
 "Settings" refers widely to the `accounts.firefox.com/settings` page where users can manage their Firefox account. The "Settings Redesign Project" refers to a 2019/2020 project centered around giving this page a fresh user interface. The changes are fairly significant and will require a lot of component shuffling and some functionality refactoring. [See the PRD](https://docs.google.com/document/d/18zu7JCYIsUp8tUMJqb2uErNlzL9f6CQvefLy9HFZ4UY/edit?pli=1#heading=h.cf57dt1i8634).
 
-The FxA Engineering team desires to migrate from [Backbone and Mustache to React](https://github.com/mozilla/fxa/blob/master/docs/adr/0010-transition-fxa-from-backbone-to-react.md). This ADR addresses questions around what level of action we should take regarding this desire and the Settings Redesign Project - should a conversion to React be done at a later time, or are the changes significant enough to justify propelling us into React now?
+The FxA Engineering team desires to migrate from [Backbone and Mustache to React](https://github.com/mozilla/fxa/blob/main/docs/adr/0010-transition-fxa-from-backbone-to-react.md). This ADR addresses questions around what level of action we should take regarding this desire and the Settings Redesign Project - should a conversion to React be done at a later time, or are the changes significant enough to justify propelling us into React now?
 
 ## Considered Options
 
@@ -37,7 +37,7 @@ We can mitigate risks by avoiding a "big bang" surprise replacement by implement
 - Cons
   - There are a few significant functionality changes, and all of the functionality we refactor or create for this project will need to be refactored again later with React.
   - On the same note, this does not set us up well for future feature requests that will come later this year. We would be forced into Option B or continue with Option A; either way, the React conversion backlog would continue to grow.
-  - Integration into `master` must be done carefully and A/B testing these changes may be complicated.
+  - Integration into `main` must be done carefully and A/B testing these changes may be complicated.
 
 ##### Option B - Take the "100/0" approach by creating all new components with React, but modify existing Backbone/Mustache files or refactor these components as React components
 
@@ -49,8 +49,8 @@ We can mitigate risks by avoiding a "big bang" surprise replacement by implement
   - Allows us to piecemeal React into Settings, resulting in less future refactoring than option A while avoiding the taboo "ground up remake" approach, and allows for the creation of some React components that could be used elsewhere in the FxA ecosystem.
 - Cons
   - The full benefits of a React application won't be realized until many more pieces are converted.
-  - Many popular Backbone-to-React integration guides use a combination of React and Backbone with approaches like embedding React components in Backbone views, wrapping the Backbone app with React, and/or keeping data synchronized between a Redux store and Backbone. It's preferable to move away from an interlinked dependency of the two and thus would require refactoring later. Packages (like [NestedReact](https://github.com/VoliJS/NestedReact/blob/master/docs/05_Migration_from_Backbone.md)) offer a convergence layer between the two, but is an additional dependency we would want to remove later.
-  - Integration into `master` must be done carefully and A/B testing these changes may be complicated.
+  - Many popular Backbone-to-React integration guides use a combination of React and Backbone with approaches like embedding React components in Backbone views, wrapping the Backbone app with React, and/or keeping data synchronized between a Redux store and Backbone. It's preferable to move away from an interlinked dependency of the two and thus would require refactoring later. Packages (like [NestedReact](https://github.com/VoliJS/NestedReact/blob/main/docs/05_Migration_from_Backbone.md)) offer a convergence layer between the two, but is an additional dependency we would want to remove later.
+  - Integration into `main` must be done carefully and A/B testing these changes may be complicated.
 
 ##### Option C - Take the "ground up" approach and create a new settings React application
 
@@ -64,7 +64,7 @@ We can mitigate risks by avoiding a "big bang" surprise replacement by implement
   - May allow for a fresh take on how we do metrics in Settings.
   - Offers an opportunity to set up and use Storybook in FxA. If we do a view-by-view build up, we can deploy changes somewhere for UX and other folks to see progress and request tweaks as features are built out.
   - We can potentially use this as an opportunity to review and extract model and API code from the existing settings app into shared modules.
-  - Management in GitHub is easy, as changes can go directly into `master` and no feature flagging or branches held in isolation from `master` will be necessary. A/B testing will also likely be easier.
+  - Management in GitHub is easy, as changes can go directly into `main` and no feature flagging or branches held in isolation from `main` will be necessary. A/B testing will also likely be easier.
 - Cons
   - A "ground up remake" is generally viewed as taboo. Changing such a large chunk of the front-end codebase doesn't come without its own set of risks.
   - This approach will take much longer to rollout than previous options.
@@ -72,7 +72,7 @@ We can mitigate risks by avoiding a "big bang" surprise replacement by implement
 ## Links
 
 - [Settings Redesign Project PRD](https://docs.google.com/document/d/18zu7JCYIsUp8tUMJqb2uErNlzL9f6CQvefLy9HFZ4UY/edit?pli=1#heading=h.cf57dt1i8634)
-- [Backbone to React ADR](https://github.com/mozilla/fxa/blob/master/docs/adr/0010-transition-fxa-from-backbone-to-react.md)
+- [Backbone to React ADR](https://github.com/mozilla/fxa/blob/main/docs/adr/0010-transition-fxa-from-backbone-to-react.md)
 - [React](https://github.com/facebook/react)
 - [Backbone](https://backbonejs.org/)
 - [Mustache](https://github.com/mustache/mustache.github.com)

--- a/docs/adr/0013-react-toolchain-for-settings-redesign.md
+++ b/docs/adr/0013-react-toolchain-for-settings-redesign.md
@@ -6,13 +6,13 @@
 
 ## Context and Problem Statement
 
-Firefox Accounts is introducing a new visual design for Settings (the interface that exists at the address `https://accounts.firefox.com/settings`). The changes involved are significant enough such that it [has been decided](https://github.com/mozilla/fxa/blob/master/docs/adr/0011-create-new-react-app-for-settings-redesign.md) that an entirely new React App will be built more or less independent of the existing Settings web app. With this we can beta test and roll out the new design with minimal disruption.
+Firefox Accounts is introducing a new visual design for Settings (the interface that exists at the address `https://accounts.firefox.com/settings`). The changes involved are significant enough such that it [has been decided](https://github.com/mozilla/fxa/blob/main/docs/adr/0011-create-new-react-app-for-settings-redesign.md) that an entirely new React App will be built more or less independent of the existing Settings web app. With this we can beta test and roll out the new design with minimal disruption.
 
 As there are a multitude of ways a React App can be set up and configured, this decision has introduced the question, "What [toolchain](https://en.wikipedia.org/wiki/Toolchain) should we set up a new React App with?". This ADR serves to answer that question by going over the various approaches we can take to set up a new React App and how it might integrate with our existing FxA ecosystem.
 
 It's important to note that we are not deciding the languages, libraries, or other tools that we will use within the React development environment, but rather, the system that will be used to develop the React App with.
 
-Finally, we are not making decisions about the App's production server here. We'll be using [fxa-content-server](https://github.com/mozilla/fxa/tree/master/packages/fxa-content-server/server)'s Express server for the production build.
+Finally, we are not making decisions about the App's production server here. We'll be using [fxa-content-server](https://github.com/mozilla/fxa/tree/main/packages/fxa-content-server/server)'s Express server for the production build.
 
 ## Decision Drivers
 
@@ -112,7 +112,7 @@ There is no shortage of options when it comes to creating a toolchain for your R
 
 ## Additional Links
 
-- [ADR "Create a New React Application for the Settings Redesign Project"](https://github.com/mozilla/fxa/blob/master/docs/adr/0011-create-new-react-app-for-settings-redesign.md)
-- [ADR "Transition FxA from Backbone to React"](https://github.com/mozilla/fxa/blob/master/docs/adr/0010-transition-fxa-from-backbone-to-react.md)
+- [ADR "Create a New React Application for the Settings Redesign Project"](https://github.com/mozilla/fxa/blob/main/docs/adr/0011-create-new-react-app-for-settings-redesign.md)
+- [ADR "Transition FxA from Backbone to React"](https://github.com/mozilla/fxa/blob/main/docs/adr/0010-transition-fxa-from-backbone-to-react.md)
 - [Settings Product Requirement Document](https://docs.google.com/document/d/18zu7JCYIsUp8tUMJqb2uErNlzL9f6CQvefLy9HFZ4UY/edit?pli=1)
 - [Official React toolchain recommendations](https://reactjs.org/docs/create-a-new-react-app.html)

--- a/docs/adr/0016-use-graphql-and-apollo-for-settings-redesign.md
+++ b/docs/adr/0016-use-graphql-and-apollo-for-settings-redesign.md
@@ -5,7 +5,7 @@
 
 ## Context and Problem Statement
 
-The [Settings Redesign project](https://jira.mozilla.com/browse/FXA-840) will be created [as a new React application](https://github.com/mozilla/fxa/blob/master/docs/adr/0011-create-new-react-app-for-settings-redesign.md) and in turn, has opened the door to assess certain pieces of our technology stack.
+The [Settings Redesign project](https://jira.mozilla.com/browse/FXA-840) will be created [as a new React application](https://github.com/mozilla/fxa/blob/main/docs/adr/0011-create-new-react-app-for-settings-redesign.md) and in turn, has opened the door to assess certain pieces of our technology stack.
 
 [GraphQL](https://graphql.org/), or GQL, is not a database query language, but is instead a query language for APIs. It _describes_ data requirements, and is a powerful alternative to REST. Some benefits can be gained by using it on top of existing REST architecture.
 
@@ -133,7 +133,7 @@ While GraphQL will be novel tech to the FxA stack, it's not entirely novel to th
 ## Additional Links
 
 - [Settings Redesign project](https://jira.mozilla.com/browse/FXA-840) (Jira)
-- [ADR for Settings Redesign as a new React App](https://github.com/mozilla/fxa/blob/master/docs/adr/0011-create-new-react-app-for-settings-redesign.md)
+- [ADR for Settings Redesign as a new React App](https://github.com/mozilla/fxa/blob/main/docs/adr/0011-create-new-react-app-for-settings-redesign.md)
 - [GraphQL docs](https://graphql.org/learn/)
 - [Apollo docs](https://www.apollographql.com/docs/intro/platform/)
 - [GraphQL subscriptions](https://www.apollographql.com/docs/react/data/subscriptions/)

--- a/docs/adr/0018-use-tailwind-with-custom-scss.md
+++ b/docs/adr/0018-use-tailwind-with-custom-scss.md
@@ -8,7 +8,7 @@
 
 The [Settings Redesign project](https://github.com/mozilla/fxa/issues/3740) provides us with an opportunity to review how FxA approaches and employs CSS, both while building out new components for this project and for FxA going forward.
 
-Historically, the Firefox Accounts codebase has not adhered to a formal CSS structure. This ADR serves to determine how we'll approach our CSS architecture in the Settings Redesign project, evaluating libraries and frameworks to determine which if any will be the best option for the FxA ecosystem. It is part 2 of two [Settings Redesign CSS ADRs](https://github.com/mozilla/fxa/issues/5087); part 1, detailing how we'll approach build conventions and variables, [can be found here](https://github.com/mozilla/fxa/blob/master/docs/adr/0015-use-css-variables-and-scss.md).
+Historically, the Firefox Accounts codebase has not adhered to a formal CSS structure. This ADR serves to determine how we'll approach our CSS architecture in the Settings Redesign project, evaluating libraries and frameworks to determine which if any will be the best option for the FxA ecosystem. It is part 2 of two [Settings Redesign CSS ADRs](https://github.com/mozilla/fxa/issues/5087); part 1, detailing how we'll approach build conventions and variables, [can be found here](https://github.com/mozilla/fxa/blob/main/docs/adr/0015-use-css-variables-and-scss.md).
 
 Considerations around class naming conventions, color and measurement standards, interoperability across shared components, and custom configuration options offered by each library to meet Settings Redesign design standards are taken into account. Notably, the new design uses space measurements in increments of 8px and [colors](https://protocol.mozilla.org/fundamentals/color.html) are based in Mozilla Protocol's design system, where a hue's brightness scales in increments of 10.
 
@@ -90,7 +90,7 @@ Cons:
 
 Out of the utility library options, the team has reached a consensus that Tailwind would be the best option for FxA, which has several pros over other options:
 
-- While most libraries offer some level of configuration, many require working in SASS to override variables and maps, and the resulting output may not always be predictable. Additionally, SASS-level configuration forces us to use SASS variables, and yet in [CSS ADR part 1](https://github.com/mozilla/fxa/blob/master/docs/adr/0015-use-css-variables-and-scss.md), we determined we would like to avoid SASS variables in favor of CSS variables. Tailwind mitigates these inconveniences by offering a root-level JS configuration file which is a better option for organization, clarity, and ease-of-use. Furthermore, Tailwind's configuration options are vast and allow us to set our own incremental spacing, custom font-sizes, determine class name conventions, set custom breakpoints, etc. as we see fit to align with the Settings Redesign visual designs.
+- While most libraries offer some level of configuration, many require working in SASS to override variables and maps, and the resulting output may not always be predictable. Additionally, SASS-level configuration forces us to use SASS variables, and yet in [CSS ADR part 1](https://github.com/mozilla/fxa/blob/main/docs/adr/0015-use-css-variables-and-scss.md), we determined we would like to avoid SASS variables in favor of CSS variables. Tailwind mitigates these inconveniences by offering a root-level JS configuration file which is a better option for organization, clarity, and ease-of-use. Furthermore, Tailwind's configuration options are vast and allow us to set our own incremental spacing, custom font-sizes, determine class name conventions, set custom breakpoints, etc. as we see fit to align with the Settings Redesign visual designs.
 - We can use CSS variables to share stored values with any additional custom SCSS when applicable and for future theming options.
 - Several engineers on our team have prior experience with Tailwind and like it.
 - As of writing, Tailwind is significantly more popular than our other considered options, with nearly 10x the number of downloads (274k) and more than 2x the number of GitHub stars (22k) than its closest competitor Tachyons. This data was gathered from [npm trends](https://www.npmtrends.com/tachyons-vs-tailwindcss-vs-basscss).
@@ -139,7 +139,7 @@ Cons:
 ## Links
 
 - [Settings Redesign project](https://github.com/mozilla/fxa/issues/3740)
-- [CSS ADR part 1](https://github.com/mozilla/fxa/blob/master/docs/adr/0015-use-css-variables-and-scss.md)
+- [CSS ADR part 1](https://github.com/mozilla/fxa/blob/main/docs/adr/0015-use-css-variables-and-scss.md)
 - [Protocol colors](https://protocol.mozilla.org/fundamentals/color.html)
 - Non-Atomic CSS libraries/frameworks: [Semantic UI](https://semantic-ui.com/), [Tailwind UI](https://tailwindui.com/), [Bootstrap](https://getbootstrap.com/), [Bulma](https://bulma.io/), [Pure.css]- (https://purecss.io/)
 - Atomic CSS libraries: [Tailwind](https://tailwindcss.com/), [Tachyons](http://tachyons.io/), and [Basscss](https://basscss.com/)

--- a/packages/browserid-verifier/README.md
+++ b/packages/browserid-verifier/README.md
@@ -1,5 +1,3 @@
-[![Docker Build Status](https://circleci.com/gh/mozilla/browserid-verifier/tree/master.svg?style=shield&circle-token=da8b9c7c4c778b238eeadb6d8bc695f2be4e22df)](https://circleci.com/gh/mozilla/browserid-verifier/tree/master)
-
 ## A BrowserID verification server
 
 This repository contains a flexible BrowserID verification server authored in

--- a/packages/browserid-verifier/package.json
+++ b/packages/browserid-verifier/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/mozilla/fxa.git"
   },
-  "homepage": "https://github.com/mozilla/fxa/tree/master/packages/browserid-verifier/",
+  "homepage": "https://github.com/mozilla/fxa/tree/main/packages/browserid-verifier/",
   "bugs": "https://github.com/mozilla/fxa/issues/",
   "main": "lib/server.js",
   "engines": {

--- a/packages/fxa-admin-panel/src/components/LinkAbout/index.tsx
+++ b/packages/fxa-admin-panel/src/components/LinkAbout/index.tsx
@@ -9,7 +9,7 @@ import './index.scss';
 export const LinkAbout = () => (
   <LinkExternal
     className="about-link inline-flex align-self-center"
-    href="https://github.com/mozilla/fxa/blob/master/packages/fxa-admin-panel/README.md"
+    href="https://github.com/mozilla/fxa/blob/main/packages/fxa-admin-panel/README.md"
   >
     <span>About</span>{' '}
     <img

--- a/packages/fxa-auth-db-mysql/CONTRIBUTING.md
+++ b/packages/fxa-auth-db-mysql/CONTRIBUTING.md
@@ -28,12 +28,12 @@ Before submitting a PR:
 When submitting a PR:
 
 - You agree to license your code under the project's open source license ([MPL 2.0](/LICENSE)).
-- Base your branch off the current `master` (see below for an example workflow).
+- Base your branch off the current `main` (see below for an example workflow).
 - Add both your code and new tests if relevant.
 - Run `grunt eslint` and `npm test` to make sure your code passes linting and tests.
 - Please do not include merge commits in pull requests; include only commits with the new relevant code.
 - Your commit message must follow the
-  [commit guidelines](https://github.com/mozilla/fxa/blob/master/CONTRIBUTING.md#git-commit-guidelines).
+  [commit guidelines](https://github.com/mozilla/fxa/blob/main/CONTRIBUTING.md#git-commit-guidelines).
 
 After your PR is merged:
 
@@ -79,11 +79,11 @@ This is an example workflow to make it easier to submit Pull Requests. Imagine y
 
 ### Keeping up to Date
 
-The main reason for creating a new branch for each feature or fix is so that you can track master correctly. If you need
+The main reason for creating a new branch for each feature or fix is so that you can track main correctly. If you need
 to fetch the latest code for a new fix, try the following:
 
 ```sh
-$ git checkout master
+$ git checkout main
 $ git pull
 ```
 

--- a/packages/fxa-auth-db-mysql/package.json
+++ b/packages/fxa-auth-db-mysql/package.json
@@ -22,7 +22,7 @@
     "format": "prettier --write --config ../../_dev/.prettierrc '**'"
   },
   "author": "Mozilla (https://mozilla.org/)",
-  "homepage": "https://github.com/mozilla/fxa/tree/master/packages/fxa-auth-db-mysql",
+  "homepage": "https://github.com/mozilla/fxa/tree/main/packages/fxa-auth-db-mysql",
   "bugs": {
     "url": "https://github.com/mozilla/fxa/issues"
   },

--- a/packages/fxa-auth-server/CONTRIBUTING.md
+++ b/packages/fxa-auth-server/CONTRIBUTING.md
@@ -28,12 +28,12 @@ Before submitting a PR:
 When submitting a PR:
 
 - You agree to license your code under the project's open source license ([MPL 2.0](/LICENSE)).
-- Base your branch off the current `master` (see below for an example workflow).
+- Base your branch off the current `main` (see below for an example workflow).
 - Add both your code and new tests if relevant.
 - Run `grunt eslint` and `npm test` to make sure your code passes linting and tests.
 - Please do not include merge commits in pull requests; include only commits with the new relevant code.
 - Your commit message must follow the
-  [commit guidelines](https://github.com/mozilla/fxa/blob/master/CONTRIBUTING.md#git-commit-guidelines).
+  [commit guidelines](https://github.com/mozilla/fxa/blob/main/CONTRIBUTING.md#git-commit-guidelines).
 
 After your PR is merged:
 
@@ -79,11 +79,11 @@ This is an example workflow to make it easier to submit Pull Requests. Imagine y
 
 ### Keeping up to Date
 
-The main reason for creating a new branch for each feature or fix is so that you can track master correctly. If you need
+The main reason for creating a new branch for each feature or fix is so that you can track main correctly. If you need
 to fetch the latest code for a new fix, try the following:
 
 ```sh
-$ git checkout master
+$ git checkout main
 $ git pull
 ```
 

--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -1,6 +1,5 @@
 # Firefox Accounts Server
 
-[![Coverage Status](https://coveralls.io/repos/github/mozilla/fxa-auth-server/badge.svg?branch=master)](https://coveralls.io/github/mozilla/fxa-auth-server?branch=master)
 [![Code Quality: Javascript](https://img.shields.io/lgtm/grade/javascript/g/mozilla/fxa-auth-server.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/mozilla/fxa-auth-server/context:javascript)
 [![Total Alerts](https://img.shields.io/lgtm/alerts/g/mozilla/fxa-auth-server.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/mozilla/fxa-auth-server/alerts)
 

--- a/packages/fxa-auth-server/config/supportedLanguages.js
+++ b/packages/fxa-auth-server/config/supportedLanguages.js
@@ -5,6 +5,6 @@
 'use strict';
 
 // The list below should be kept in sync with:
-// https://raw.githubusercontent.com/mozilla/fxa-content-server/master/server/config/production-locales.json
+// https://github.com/mozilla/fxa/blob/main/packages/fxa-shared/l10n/supportedLanguages.json
 
 module.exports = require('fxa-shared').l10n.supportedLanguages;

--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -2358,7 +2358,7 @@ rather than with a BrowserID assertion.
   forbidden for public clients.
 - `ppid_seed`: _integer.min(0).max(1024), optional_ Seed used in `sub` claim generation of
   JWT access tokens/ID tokens for clients with [Pseudonymous Pairwise
-  Identifiers (PPID)](https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/pairwise-pseudonymous-identifiers.md)
+  Identifiers (PPID)](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/pairwise-pseudonymous-identifiers.md)
   enabled. Used to forcibly rotate the `sub` claim. If not specified, it will default to `0`.
 - `resource`: _url, optional_ Indicates the target service or resource at which access is being
   requested. Its value must be an absolute URI, and may include a query component but
@@ -3809,7 +3809,7 @@ Content-Type: application/json
   "errno": 201,
   "error": "Service Unavailable",
   "message": "Service unavailable",
-  "info": "https://github.com/mozilla/fxa-auth-server/blob/master/docs/api.md#response-format",
+  "info": "https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#response-format",
   "retryAfter": 30,
   "retryAfterLocalized": "in a few seconds"
 }

--- a/packages/fxa-auth-server/docs/bulk-mail.md
+++ b/packages/fxa-auth-server/docs/bulk-mail.md
@@ -7,7 +7,7 @@ the user database.
 ## Steps
 
 1. Know which users you want to send emails to.
-2. Use the [dump-users.js](https://github.com/mozilla/fxa-auth-server/blob/master/scripts/dump-users.js) script to
+2. Use the [dump-users.js](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/scripts/dump-users.js) script to
    write the necessary user information to disk. Users can be dumped by `uid` or `email`
 
 - uid, listing uids on the command line

--- a/packages/fxa-auth-server/docs/metrics-events.md
+++ b/packages/fxa-auth-server/docs/metrics-events.md
@@ -404,7 +404,7 @@ contains the following fields:
 #### Domain names
 
 Possible values for `${domain}` include this
-list of top 20 FxA [email domains](https://github.com/mozilla/fxa-auth-server/blob/master/config/popular-email-domains.js). If an email is not on the list, then the
+list of top 20 FxA [email domains](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/config/popular-email-domains.js). If an email is not on the list, then the
 value `other` is stored.
 
 #### Template names
@@ -438,7 +438,7 @@ Possible values for `${type}` include
 
 Possible values for `${locale}` include
 any valid parsed locale via auth-server
-[translator](https://github.com/mozilla/fxa-auth-server/blob/master/lib/senders/translator.js).
+[translator](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/lib/senders/translator.js).
 
 ## Sampled data sets
 

--- a/packages/fxa-auth-server/docs/oauth/api.md
+++ b/packages/fxa-auth-server/docs/oauth/api.md
@@ -401,7 +401,7 @@ The following types of grant are possible:
 
 - `ppid_seed`: (optional) Seed used in `sub` claim generation of
   JWT access tokens/ID tokens for clients with [Pseudonymous Pairwise
-  Identifiers (PPID)](https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/pairwise-pseudonymous-identifiers.md)
+  Identifiers (PPID)](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/pairwise-pseudonymous-identifiers.md)
   enabled. Used to forcibly rotate the `sub` claim. Must be an integer in the range 0-1024.
   Defaults to 0.
 - `resource`: (optional) Indicates the target service or resource at which access is being
@@ -850,4 +850,4 @@ A valid 200 response will return an empty JSON object.
 [introspect]: #post-v1introspect
 [client-tokens]: #get-v1client-tokens
 [client-tokens-delete]: #delete-v1client-tokensid
-[prompt-none]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/prompt-none.md
+[prompt-none]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/prompt-none.md

--- a/packages/fxa-auth-server/docs/oauth/jwt-access-tokens.md
+++ b/packages/fxa-auth-server/docs/oauth/jwt-access-tokens.md
@@ -129,10 +129,10 @@ tokens when their OAuth credentials are being provisioned.
 [#ietf-jws-spec]: https://tools.ietf.org/html/rfc7515
 [#ietf-jwt-spec]: https://tools.ietf.org/html/rfc7519
 [#ietf-resource-indicator-draft-spec]: https://tools.ietf.org/html/draft-ietf-oauth-resource-indicators-08
-[#ppid-doc]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/pairwise-pseudonymous-identifiers.md
-[#why-fxa-subscriptions-claim]: https://github.com/mozilla/fxa/blob/master/docs/adr/0007-subscription-claim-jwt-access-token.md
-[#fxa-introspect-endpoint-api-docs]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/api.md#post-v1introspect
-[#fxa-verify-endpoint-api-docs]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/api.md#post-v1verify
+[#ppid-doc]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/pairwise-pseudonymous-identifiers.md
+[#why-fxa-subscriptions-claim]: https://github.com/mozilla/fxa/blob/main/docs/adr/0007-subscription-claim-jwt-access-token.md
+[#fxa-introspect-endpoint-api-docs]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/api.md#post-v1introspect
+[#fxa-verify-endpoint-api-docs]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/api.md#post-v1verify
 [#node-jsonwebtoken]: https://github.com/auth0/node-jsonwebtoken/
 [#notify-sp-on-token-revocation]: https://github.com/mozilla/fxa/issues/2246
 [#github-jwt-token-size]: https://github.com/mozilla/fxa/issues/1797

--- a/packages/fxa-auth-server/docs/oauth/prompt-none.md
+++ b/packages/fxa-auth-server/docs/oauth/prompt-none.md
@@ -103,9 +103,9 @@ Now that FxA accepts the id_token_hint query parameter, support for `prompt=none
 
 Support for [OIDC RP Initiated Logout][#oidc-rp-initiated-logout-github-issue] may go some way to reducing user confusion on what it means to sign out of an RP and whether they should have to enter their password again. Upon signing out of the RP, RPs that support the OIDC RP Initiated Logout protocol will redirect the user to FxA where they are given the option to destroy their FxA session as well.
 
-[#authorization-api-doc]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/api.md#get-v1authorization
+[#authorization-api-doc]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/fxa-oauth-server/docs/api.md#get-v1authorization
 [#fxa-devices-and-apps]: https://accounts.firefox.com/settings/clients
-[#oauth-server-api-destroy]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/api.md#post-v1destroy
+[#oauth-server-api-destroy]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/fxa-oauth-server/docs/api.md#post-v1destroy
 [#oidc-error-codes]: https://openid.net/specs/openid-connect-core-1_0.html#AuthError
 [#oidc-id-token-hint-discussion-issue]: https://github.com/mozilla/fxa/issues/4963
 [#oidc-id-token]: https://openid.net/specs/openid-connect-core-1_0.html#IDToken

--- a/packages/fxa-auth-server/lib/email/utils/helpers.js
+++ b/packages/fxa-auth-server/lib/email/utils/helpers.js
@@ -206,7 +206,7 @@ function logFlowEventFromMessage(log, message, type) {
     const eventName = `email.${templateName}.${type}`;
 
     // Flow events have a specific event and structure that must be emitted.
-    // Ref `gather` in https://github.com/mozilla/fxa-auth-server/blob/master/lib/metrics/context.js
+    // Ref `gather` in https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/lib/metrics/context.js
     const flowEventInfo = {
       event: eventName,
       time: currentTime,

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -118,7 +118,7 @@ const DEFAULTS = {
   errno: ERRNO.UNEXPECTED_ERROR,
   message: 'Unspecified error',
   info:
-    'https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/docs/api.md#response-format',
+    'https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#response-format',
 };
 
 const TOO_LARGE = /^Payload (?:content length|size) greater than maximum allowed/;

--- a/packages/fxa-auth-server/lib/oauth/assertion.js
+++ b/packages/fxa-auth-server/lib/oauth/assertion.js
@@ -34,7 +34,7 @@ const { verifyJWT } = require('../../lib/serverJWT');
 const HEX_STRING = /^[0-9a-f]+$/;
 
 // FxA sends several custom claims, ref
-// https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/docs/api.md#post-certificatesign
+// https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#post-certificatesign
 const CLAIMS_SCHEMA = Joi.object({
   uid: Joi.string().length(32).regex(HEX_STRING).required(),
   'fxa-generation': Joi.number().integer().min(0).required(),

--- a/packages/fxa-auth-server/lib/oauth/error.js
+++ b/packages/fxa-auth-server/lib/oauth/error.js
@@ -10,7 +10,7 @@ const DEFAULTS = {
   error: 'Internal Server Error',
   errno: 999,
   info:
-    'https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#errors',
+    'https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/api.md#errors',
   message: 'Unspecified error',
 };
 

--- a/packages/fxa-auth-server/lib/tokens/session_token.js
+++ b/packages/fxa-auth-server/lib/tokens/session_token.js
@@ -12,7 +12,7 @@ module.exports = (log, Token, config) => {
     config.tokenLifetimes.sessionTokenWithoutDevice;
 
   // Convert verificationMethod to a more readable format. Maps to
-  // https://github.com/mozilla/fxa-auth-db-mysql/blob/master/lib/db/util.js#L34
+  // https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-db-mysql/lib/db/util.js#L55
   const VERIFICATION_METHODS = new Map([
     [0, 'email'],
     [1, 'email-2fa'],

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -35,7 +35,7 @@
     "node": ">=12"
   },
   "bugs": "https://github.com/mozilla/fxa/issues/",
-  "homepage": "https://github.com/mozilla/fxa/tree/master/packages/fxa-auth-server",
+  "homepage": "https://github.com/mozilla/fxa/tree/main/packages/fxa-auth-server",
   "license": "MPL-2.0",
   "author": "Mozilla (https://mozilla.org/)",
   "readmeFilename": "README.md",

--- a/packages/fxa-auth-server/test/local/server.js
+++ b/packages/fxa-auth-server/test/local/server.js
@@ -455,7 +455,7 @@ describe('lib/server', () => {
             errno: 125,
             error: 'Request blocked',
             info:
-              'https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/docs/api.md#response-format',
+              'https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#response-format',
             message: 'The request was blocked for security reasons',
           };
           beforeEach(() => {

--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -624,7 +624,7 @@ export default _.extend({}, Errors, {
    */
   toInterpolationContext(err) {
     // For data returned by backend, see
-    // https://github.com/mozilla/fxa-auth-server/blob/master/error.js
+    // https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/lib/error.js
     try {
       if (this.is(err, 'INVALID_PARAMETER')) {
         return {

--- a/packages/fxa-content-server/app/scripts/lib/crypto/recovery-keys.js
+++ b/packages/fxa-content-server/app/scripts/lib/crypto/recovery-keys.js
@@ -7,7 +7,7 @@
  * recovery key data.
  *
  * For more encryption details, check out
- + https://github.com/mozilla/fxa-auth-server/blob/master/docs/recovery_keys.md
+ * https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/recovery_keys.md
  */
 import a256gcm from './a256gcm';
 import Base32 from './base32';

--- a/packages/fxa-content-server/app/scripts/lib/oauth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/oauth-errors.js
@@ -195,7 +195,7 @@ export default _.extend({}, Errors, {
    */
   toInterpolationContext(err) {
     // For data returned by backend, see
-    // https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#errors
+    // https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/api.md#errors
     try {
       if (this.is(err, 'MISSING_PARAMETER')) {
         return {

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -169,7 +169,7 @@ const Account = Backbone.Model.extend(
       return this.createOAuthToken(this._oAuthClientId, {
         scope: CONTENT_SERVER_OAUTH_SCOPE,
         // set authorization TTL to 5 minutes.
-        // Docs: github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#post-v1authorization
+        // Docs: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/api.md#post-v1authorization
         // Issue: https://github.com/mozilla/fxa-content-server/issues/3982
         ttl: 300,
       }).then((accessToken) => {

--- a/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/oauth.js
@@ -195,7 +195,7 @@ var OAuthRelier = Relier.extend({
 
   _setupSignInSignUpFlow() {
     // params listed in:
-    // https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md#post-v1authorization
+    // https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/api.md
     this.importSearchParamsUsingSchema(
       SIGNIN_SIGNUP_QUERY_PARAM_SCHEMA,
       OAuthErrors

--- a/packages/fxa-content-server/app/scripts/views/reset_password.js
+++ b/packages/fxa-content-server/app/scripts/views/reset_password.js
@@ -59,8 +59,7 @@ const ResetPasswordView = FormView.extend({
     // address should be propagated back to the signin page. If
     // the user enters no email and instead clicks "Remember password?"
     // immediately, the /signin page should have the original email.
-    // See https://github.com/mozilla/fxa/tree/master/features/FxA-72-reset-password
-    // and #5293
+    // See https://github.com/mozilla/fxa-content-server/issues/5293.
     if (email) {
       this._formPrefill.set({ email });
     }

--- a/packages/fxa-content-server/app/scripts/views/tooltip.js
+++ b/packages/fxa-content-server/app/scripts/views/tooltip.js
@@ -16,7 +16,8 @@ const PADDING_BELOW_TOOLTIP_PX = 2;
 const PADDING_ABOVE_TOOLTIP_PX = 4;
 
 // These values should be the same as
-// https://github.com/mozilla/fxa/blob/master/packages/fxa-content-server/app/styles/_breakpoints.scss#L8
+// https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/app/styles/_breakpoints.scss
+
 const MIN_HEIGHT_TO_SHOW_TOOLTIP_BELOW = 480;
 const MIN_WIDTH_TO_SHOW_TOOLTIP_BELOW = 960;
 

--- a/packages/fxa-content-server/docs/architecture.md
+++ b/packages/fxa-content-server/docs/architecture.md
@@ -58,35 +58,35 @@ Firefox Sync is a one-off integration that is documented for completeness. Like 
 
 ### High Level Web Client Components
 
-#### [Brokers](https://github.com/mozilla/fxa-content-server/tree/master/app/scripts/models/auth_brokers)
+#### [Brokers](https://github.com/mozilla/fxa/tree/main/packages/fxa-content-server/app/scripts/models/auth_brokers)
 
 Brokers mediate communication between Firefox Accounts and the relier. A single broker is created per Firefox Accounts window. A broker communicates with the relier via the URL or a Channel.
 
-#### [Channels](https://github.com/mozilla/fxa-content-server/tree/master/app/scripts/lib/channels)
+#### [Channels](https://github.com/mozilla/fxa/tree/main/packages/fxa-content-server/app/scripts/lib/channels)
 
 A channel is a two way communication mechanism between the relier and Firefox Accounts. The method of communication is channel specific.
 
-#### [Reliers](https://github.com/mozilla/fxa-content-server/tree/master/app/scripts/models/reliers)
+#### [Reliers](https://github.com/mozilla/fxa/tree/main/packages/fxa-content-server/app/scripts/models/reliers)
 
 The relier model holds and fetches data about the current relier.
 
-#### [User](https://github.com/mozilla/fxa-content-server/blob/master/app/scripts/models/user.js)
+#### [User](https://github.com/mozilla/fxa/tree/main/packages/fxa-content-server/app/scripts/models/user.js)
 
 A User holds and persists data about the current user interacting with Firefox Accounts. A user can have one or more Accounts.
 
-#### [Account](https://github.com/mozilla/fxa-content-server/blob/master/app/scripts/models/account.js)
+#### [Account](https://github.com/mozilla/fxa/tree/main/packages/fxa-content-server/app/scripts/models/account.js)
 
 An Account abstracts interaction between the user's account and the profile server.
 
-#### [Router](https://github.com/mozilla/fxa-content-server/blob/master/app/scripts/router.js)
+#### [Router](https://github.com/mozilla/fxa/tree/main/packages/fxa-content-server/app/scripts/router.js)
 
 The Router is responsible for reacting to URL changes and displaying the Views.
 
-#### [Views](https://github.com/mozilla/fxa-content-server/tree/master/app/scripts/views)
+#### [Views](https://github.com/mozilla/fxa/tree/main/packages/fxa-content-server/app/scripts/views)
 
 Views represent either an entire screen or a portion of a screen. Users enter data into Views.
 
-#### [Templates](https://github.com/mozilla/fxa-content-server/tree/master/app/scripts/templates)
+#### [Templates](https://github.com/mozilla/fxa/tree/main/packages/fxa-content-server/app/scripts/templates)
 
 A templates is a serialized HTML representation of a View. A view renders a template using data available to it and writes the rendered template to the DOM. Templates use the [mustache](http://mustache.github.io/) templating library.
 
@@ -96,21 +96,21 @@ Communication with external servers are done via client libraries.
 
 ##### [fxa-js-client](https://github.com/mozilla/fxa-js-client)
 
-The fxa-js-client communicates with the Firefox Accounts [Auth Server](https://github.com/mozilla/fxa-auth-server/). The fxa-js-client is used for all aspects of authenticating a user - sign up, sign in, password reset, etc.
+The fxa-js-client communicates with the Firefox Accounts [Auth Server](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/). The fxa-js-client is used for all aspects of authenticating a user - sign up, sign in, password reset, etc.
 
-##### [oauth-client](https://github.com/mozilla/fxa-content-server/blob/master/app/scripts/lib/oauth-client.js)
+##### [oauth-client](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/app/scripts/lib/oauth-client.js)
 
-The oauth-client communicates with the Firefox Accounts [OAuth Server](https://github.com/mozilla/fxa-oauth-server/). The OAuth client is used to fetch OAuth codes and tokens to send to the RP.
+The oauth-client communicates with the Firefox Accounts [OAuth Server](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/README.md). The OAuth client is used to fetch OAuth codes and tokens to send to the RP.
 
-##### [profile-client](https://github.com/mozilla/fxa-content-server/blob/master/app/scripts/lib/profile-client.js)
+##### [profile-client](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/app/scripts/lib/profile-client.js)
 
-The profile-client communicates with the Firefox Accounts [Profile Server](https://github.com/mozilla/fxa-profile-server/). This client allows a user to interact with their profile data.
+The profile-client communicates with the Firefox Accounts [Profile Server](https://github.com/mozilla/fxa/blob/main/packages/fxa-profile-server/). This client allows a user to interact with their profile data.
 
 ### Layers/Tiers
 
 The content server web client is made up of many layers. An item is only allowed to interact with a layer below it, but not with ancestors or siblings.
 
-[app-start.js](https://github.com/mozilla/fxa-content-server/blob/master/app/scripts/lib/app-start.js) is where the fun begins. It creates several models and a router. The router is passed a reference to several models. The router creates views. Only views are allowed to interact with templates. Models and Views use functionality provided by lib modules. vendor are external components and should be fully self contained. The full application lifecycle is described in the section `Application lifecycle`.
+[app-start.js](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/app/scripts/lib/app-start.js) is where the fun begins. It creates several models and a router. The router is passed a reference to several models. The router creates views. Only views are allowed to interact with templates. Models and Views use functionality provided by lib modules. vendor are external components and should be fully self contained. The full application lifecycle is described in the section `Application lifecycle`.
 
 ```
    app-start            |
@@ -123,7 +123,7 @@ The content server web client is made up of many layers. An item is only allowed
 
 ### Application lifecycle
 
-When the application starts, [app-start.js](https://github.com/mozilla/fxa-content-server/blob/master/app/scripts/lib/app-start.js) takes care of setting up system-wide dependencies. app-start immediately determines the integration type and creates the appropriate [Broker](https://github.com/mozilla/fxa-content-server/blob/8561ec3c1d06763f454f4ac7cb8ef142eb0c01b0/app/scripts/lib/app-start.js#L234) and [Relier](https://github.com/mozilla/fxa-content-server/blob/8561ec3c1d06763f454f4ac7cb8ef142eb0c01b0/app/scripts/lib/app-start.js#L199). The broker is queried to check support of the current integration. If the integration is supported, other models and the [router](https://github.com/mozilla/fxa-content-server/blob/8561ec3c1d06763f454f4ac7cb8ef142eb0c01b0/app/scripts/lib/app-start.js#L315) are created. The router takes over and determines the initial View to display, based upon the browser's URL. The View writes a Template to the DOM. The user interacts with the View, either by filling out a form or clicking on links and buttons. A view can communicate with external servers using clients. A view that communicates with an external server determines the appropriate next step based on the server's response. A view can redirect to another view, display a status message, or send a command to the broker. Upon successful authentication with Firefox Accounts, the broker is notified, which in turn notifies the relier. The relier is responsible for the final fate of the Firefox Accounts window. It can either close the window or leave the window to be closed by the user.
+When the application starts, [app-start.js](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/app/scripts/lib/app-start.js) takes care of setting up system-wide dependencies. app-start immediately determines the integration type and creates the appropriate [Broker](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/app/scripts/lib/app-start.js#L3024) and [Relier](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/app/scripts/lib/app-start.js#L224). The broker is queried to check support of the current integration. If the integration is supported, other models and the [router](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/app/scripts/lib/app-start.js#L504) are created. The router takes over and determines the initial View to display, based upon the browser's URL. The View writes a Template to the DOM. The user interacts with the View, either by filling out a form or clicking on links and buttons. A view can communicate with external servers using clients. A view that communicates with an external server determines the appropriate next step based on the server's response. A view can redirect to another view, display a status message, or send a command to the broker. Upon successful authentication with Firefox Accounts, the broker is notified, which in turn notifies the relier. The relier is responsible for the final fate of the Firefox Accounts window. It can either close the window or leave the window to be closed by the user.
 
 ### Deeper View of Components
 
@@ -230,11 +230,11 @@ Communication between the FxA and the RP is done via [postMessage](https://devel
 
 #### Application
 
-The content server is a simple [NodeJS](http://nodejs.org/)/[Express](http://expressjs.com/) based application. The content server's primary responsibility is to deliver the web client, [Terms Of Service](https://github.com/mozilla/fxa-content-server/blob/master/server/templates/pages/src/terms.html), and [Privacy Policy](https://github.com/mozilla/fxa-content-server/blob/master/server/templates/pages/src/privacy.html) to users in their preferred locale. The content server's entry point is in [./server/bin/fxa-content-server.js](https://github.com/mozilla/fxa-content-server/blob/master/server/bin/fxa-content-server.js).
+The content server is a simple [NodeJS](http://nodejs.org/)/[Express](http://expressjs.com/) based application. The content server's primary responsibility is to deliver the web client, [Terms Of Service](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/server/templates/pages/src/terms.html), and [Privacy Policy](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/server/templates/pages/src/privacy.html) to users in their preferred locale. The content server's entry point is in [./server/bin/fxa-content-server.js](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/server/bin/fxa-content-server.js).
 
 ##### Additional Templates
 
-Additional [handlebars](http://handlebarsjs.com/) templates are rendered by the server to serve [static pages](https://github.com/mozilla/fxa-content-server/tree/master/server/templates/pages/src) and [send email](https://github.com/mozilla/fxa-content-server/tree/master/server/templates/email). While the content server holds the templates for the emails, emails are delivered by the [fxa-auth-mailer](https://github.com/mozilla/fxa-auth-mailer/). The content server contains the email templates to make L10n simpler.
+Additional [handlebars](http://handlebarsjs.com/) templates are rendered by the server to serve [static pages](https://github.com/mozilla/fxa/tree/main/packages/fxa-content-server/server/templates/pages/src) and send email. While the content server holds the templates for the emails, emails are delivered by the [fxa-auth-mailer](https://github.com/mozilla/fxa-auth-mailer/). The content server contains the email templates to make L10n simpler.
 
 ## UX/User flows
 
@@ -242,7 +242,7 @@ An up to date [flow diagram](http://is.gd/Sync_FxA_Latest_Desktop_UX_PDF) flow d
 
 ## L10n/I18n
 
-Mozilla's L10n community has done an incredible job of translating Firefox Accounts into over 20 languages. More information on how L10n works can be found in this [README](https://github.com/mozilla/fxa-content-server-l10n/blob/master/locale/README.md) in the [fxa-content-server-l10n](https://github.com/mozilla/fxa-content-server-l10n) repo.
+Mozilla's L10n community has done an incredible job of translating Firefox Accounts into over 20 languages. More information on how L10n works can be found in this [README](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/locale/README.md) and in the [fxa-content-server-l10n](https://github.com/mozilla/fxa-content-server-l10n) repo.
 
 ## Contact
 
@@ -254,11 +254,11 @@ UPDATE: On March 2020, Mozilla moved from IRC to Matrix. For more information on
 ## Additional Resources
 
 - [APIs attached to Firefox Accounts](https://developer.mozilla.org/docs/Mozilla/APIs_attached_to_Firefox_Accounts)
-- [Firefox Accounts Auth Server API](https://github.com/mozilla/fxa-auth-server/blob/master/docs/api.md)
-- [Firefox Acocunts Auth Server Codebase](https://github.com/mozilla/fxa-auth-server/)
-- [Firefox Accounts OAuth Server API](https://github.com/mozilla/fxa-oauth-server/blob/master/docs/api.md)
-- [Firefox Accounts OAuth Server Codebase](https://github.com/mozilla/fxa-oauth-server/)
-- [Firefox Accounts Profile Server API](https://github.com/mozilla/fxa-profile-server/blob/master/docs/API.md)
-- [Firefox Accounts Profile Server Codebase](https://github.com/mozilla/fxa-profile-server/)
+- [Firefox Accounts Auth Server API](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md)
+- [Firefox Acocunts Auth Server Codebase](https://github.com/mozilla/fxa/tree/main/packages/fxa-auth-server/)
+- [Firefox Accounts OAuth Server API](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/api.md)
+- [Firefox Accounts OAuth Server Codebase](https://github.com/mozilla/fxa/tree/main/packages/fxa-auth-server/lib/oauth)
+- [Firefox Accounts Profile Server API](https://github.com/mozilla/fxa/blob/main/packages/fxa-profile-server/docs/API.md)
+- [Firefox Accounts Profile Server Codebase](https://github.com/mozilla/fxa/tree/main/packages/fxa-profile-server)
 - [OAuth 2.0 RFC 6749](http://tools.ietf.org/html/rfc6749)
 - [Firefox Accounts Pairing Flow](pairing-architecture.md)

--- a/packages/fxa-content-server/docs/query-params.md
+++ b/packages/fxa-content-server/docs/query-params.md
@@ -339,4 +339,4 @@ if they perform a reset password.
 
 - /settings/emails
 
-[#prompt-none]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/fxa-oauth-server/docs/prompt-none.md
+[#prompt-none]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/prompt-none.md

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -26,7 +26,7 @@
     "type": "git",
     "url": "https://github.com/mozilla/fxa.git"
   },
-  "homepage": "https://github.com/mozilla/fxa/tree/master/packages/fxa-content-server",
+  "homepage": "https://github.com/mozilla/fxa/tree/main/packages/fxa-content-server",
   "bugs": "https://github.com/mozilla/fxa/issues",
   "author": "Mozilla (https://mozilla.org/)",
   "license": "MPL-2.0",

--- a/packages/fxa-content-server/server/lib/flow-event.js
+++ b/packages/fxa-content-server/server/lib/flow-event.js
@@ -206,7 +206,7 @@ function logFlowEvent(event, data, request) {
 }
 
 function logStatsdPerfEvent(eventData) {
-  // See https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/docs/metrics-events.md#success-event-names
+  // See https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/metrics-events.md#success-event-names
   if (eventData.event.startsWith('flow.performance.')) {
     const navTimingMetricNames = PERFORMANCE_TIMINGS.map((x) => x.event);
     const perfMetricNameParts = eventData.event.split('.');

--- a/packages/fxa-content-server/tests/teamcity/run-server.sh
+++ b/packages/fxa-content-server/tests/teamcity/run-server.sh
@@ -62,7 +62,7 @@ echo "GIT_COMMIT          $GIT_COMMIT"
 
 WORKDIR=fxa-"$FXA_TEST_NAME"-server
 rm -rf "$WORKDIR"
-git clone https://github.com/mozilla/fxa.git -b master "$WORKDIR"
+git clone https://github.com/mozilla/fxa.git -b main "$WORKDIR"
 cd "$WORKDIR"/packages/fxa-content-server
 git checkout $GIT_COMMIT
 git show --summary

--- a/packages/fxa-content-server/tests/teamcity/run.sh
+++ b/packages/fxa-content-server/tests/teamcity/run.sh
@@ -78,7 +78,7 @@ echo "GREP                $GREP"
 
 WORKDIR=fxa-"$FXA_TEST_NAME"
 rm -rf "$WORKDIR"
-git clone https://github.com/mozilla/fxa.git -b master "$WORKDIR"
+git clone https://github.com/mozilla/fxa.git -b main "$WORKDIR"
 cd "$WORKDIR"/packages/fxa-content-server
 git checkout $GIT_COMMIT
 git show --summary

--- a/packages/fxa-customs-server/CONTRIBUTING.md
+++ b/packages/fxa-customs-server/CONTRIBUTING.md
@@ -19,12 +19,12 @@ you saw the issue.
 Patches should be submitted as pull requests. When submitting patches as PRs:
 
 - You agree to license your code under the project's open source license ([MPL 2.0](/LICENSE)).
-- Base your branch off the current `master` (see below for an example workflow).
+- Base your branch off the current `main` (see below for an example workflow).
 - Add both your code and new tests if relevant.
 - Run `npm test` to make sure all tests still pass.
 - Please do not include merge commits in pull requests; include only commits with the new relevant code.
 - Your commit message must follow the
-  [commit guidelines](https://github.com/mozilla/fxa/blob/master/CONTRIBUTING.md#git-commit-guidelines).
+  [commit guidelines](https://github.com/mozilla/fxa/blob/main/CONTRIBUTING.md#git-commit-guidelines).
 
 See the main [README.md](/README.md) for information on prerequisites, installing, running and testing.
 
@@ -62,11 +62,11 @@ This is an example workflow to make it easier to submit Pull Requests. Imagine y
 
 ### Keeping up to Date
 
-The main reason for creating a new branch for each feature or fix is so that you can track master correctly. If you need
+The main reason for creating a new branch for each feature or fix is so that you can track main correctly. If you need
 to fetch the latest code for a new fix, try the following:
 
 ```sh
-$ git checkout master
+$ git checkout main
 $ git pull
 ```
 

--- a/packages/fxa-customs-server/README.md
+++ b/packages/fxa-customs-server/README.md
@@ -42,7 +42,7 @@ Here are the main components of this project:
 
 ### API
 
-See our [detailed API spec](https://github.com/mozilla/fxa/blob/master/packages/fxa-customs-server/docs/api.md).
+See our [detailed API spec](https://github.com/mozilla/fxa/blob/main/packages/fxa-customs-server/docs/api.md).
 
 ### Policies
 

--- a/packages/fxa-customs-server/docs/api.md
+++ b/packages/fxa-customs-server/docs/api.md
@@ -102,7 +102,7 @@ Failing requests may be due to the following errors:
 Called by the auth server before performing an action on its end to
 check whether or not the action should be blocked. The endpoint is
 capable of rate-limiting and blocking requests that involve a variety
-of [actions](https://github.com/mozilla/fxa-customs-server/blob/master/lib/actions.js).
+of [actions](https://github.com/mozilla/fxa/blob/main/packages/fxa-customs-server/lib/actions.js).
 
 **_Parameters_**
 

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/mozilla/fxa.git"
   },
-  "homepage": "https://github.com/mozilla/fxa/tree/master/packages/fxa-customs-server",
+  "homepage": "https://github.com/mozilla/fxa/tree/main/packages/fxa-customs-server",
   "bugs": "https://github.com/mozilla/fxa/issues/",
   "scripts": {
     "outdated": "npm outdated --depth 0 || exit 0",

--- a/packages/fxa-email-event-proxy/package.json
+++ b/packages/fxa-email-event-proxy/package.json
@@ -25,7 +25,7 @@
   "bugs": {
     "url": "https://github.com/mozilla/fxa/issues"
   },
-  "homepage": "https://github.com/mozilla/fxa/tree/master/packages/fxa-email-event-proxy#readme",
+  "homepage": "https://github.com/mozilla/fxa/tree/main/packages/fxa-email-event-proxy#readme",
   "dependencies": {
     "aws-sdk": "^2.698.0",
     "bluebird": "^3.7.2",

--- a/packages/fxa-email-service/src/lib.rs
+++ b/packages/fxa-email-service/src/lib.rs
@@ -20,7 +20,7 @@
 //!   polling SQS queues for
 //!   SES bounce, complaint and delivery notifications.
 //!
-//! [readme]: https://github.com/mozilla/fxa-email-service/blob/master/README.md#fxa_email_service
+//! [readme]: https://github.com/mozilla/fxa/blob/main/packages/fxa-email-service/README.md
 //! [send]: ../fxa_email_send/index.html
 //! [queues]: ../fxa_email_queues/index.html
 

--- a/packages/fxa-event-broker/README.md
+++ b/packages/fxa-event-broker/README.md
@@ -210,7 +210,7 @@ of the diagrams.
 - `test` - Unit tests, organized in matching heirarchy with the root event-broker directory.
 - `types` - Additional TypeScript definitions for dependencies missing type information.
 
-[fxasp]: https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/docs/service_notifications.md
+[fxasp]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/service_notifications.md
 [mermaid live editor]: https://mermaid-js.github.io/mermaid-live-editor/
 [mermaid]: mermaidjs.github.io/
 [set]: https://tools.ietf.org/html/rfc8417

--- a/packages/fxa-geodb/README.md
+++ b/packages/fxa-geodb/README.md
@@ -119,7 +119,7 @@ By default, the cron job runs every week on Wednesday at 01:30:30 (UTC -7) and u
 
 Interested in contributing to the development of Firefox Accounts GeoDB repo? Great! Head over to the [#fxa:mozilla.org](https://chat.mozilla.org/#/room/#fxa:mozilla.org) room on Matrix with questions, or jump ahead and fix any of the issues we have.
 
-Please review and understand the [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/) before contributing to this project. Also, following the [commit guidelines](https://github.com/mozilla/fxa/blob/master/CONTRIBUTING.md#git-commit-guidelines) is greatly appreciated.
+Please review and understand the [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/) before contributing to this project. Also, following the [commit guidelines](https://github.com/mozilla/fxa/blob/main/CONTRIBUTING.md#git-commit-guidelines) is greatly appreciated.
 
 UPDATE: On March 2020, Mozilla moved from IRC to Matrix. For more information on Matrix, check out the following wiki article: <https://wiki.mozilla.org/Matrix>.
 

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -26,7 +26,7 @@
   "bugs": {
     "url": "https://github.com/mozilla/fxa/issues"
   },
-  "homepage": "https://github.com/mozilla/fxa/tree/master/packages/fxa-geodb",
+  "homepage": "https://github.com/mozilla/fxa/tree/main/packages/fxa-geodb",
   "dependencies": {
     "bluebird": "^3.7.2",
     "cron": "1.5.0",

--- a/packages/fxa-graphql-api/src/lib/error.ts
+++ b/packages/fxa-graphql-api/src/lib/error.ts
@@ -4,7 +4,7 @@
 import { ApolloError } from 'apollo-server';
 
 export const PROFILE_INFO_URL =
-  'https://github.com/mozilla/fxa/blob/master/packages/fxa-profile-server/docs/API.md#errors';
+  'https://github.com/mozilla/fxa/blob/main/packages/fxa-profile-server/docs/API.md#errors';
 
 export function CatchGatewayError(
   target: any,

--- a/packages/fxa-js-client/CONTRIBUTING.md
+++ b/packages/fxa-js-client/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Before submitting a PR:
 When submitting a PR:
 
 - You agree to license your code under the project's open source license ([MPL 2.0](/LICENSE)).
-- Base your branch off the current `master` (see below for an example workflow).
+- Base your branch off the current `main` (see below for an example workflow).
 - Add both your code and new tests if relevant.
 - Run `grunt lint` and `npm test` to make sure your code passes linting and tests.
 - Please do not include merge commits in pull requests; include only commits with the new relevant code.

--- a/packages/fxa-js-client/package.json
+++ b/packages/fxa-js-client/package.json
@@ -19,7 +19,7 @@
     "LICENSE"
   ],
   "readmeFilename": "README.md",
-  "homepage": "https://github.com/mozilla/fxa/tree/master/packages/fxa-js-client",
+  "homepage": "https://github.com/mozilla/fxa/tree/main/packages/fxa-js-client",
   "engines": {
     "node": ">=12"
   },

--- a/packages/fxa-payments-server/README.md
+++ b/packages/fxa-payments-server/README.md
@@ -6,7 +6,7 @@ This is the server that handles payments.
 
 This project uses [Storybook](https://storybook.js.org/) to show each screen without requiring a full stack.
 
-You can view the Storybook built from the most recent master at http://mozilla.github.io/fxa/fxa-payments-server/
+You can view the Storybook built from the most recent main at http://mozilla.github.io/fxa/fxa-payments-server/
 
 In local development, `npm run storybook` should start a Storybook server at <http://localhost:6006> with hot module replacement to reflect live changes.
 

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -33,7 +33,7 @@
   "bugs": {
     "url": "https://github.com/mozilla/fxa/issues"
   },
-  "homepage": "https://github.com/mozilla/fxa/tree/master/packages/fxa-payments-server#README.md",
+  "homepage": "https://github.com/mozilla/fxa/tree/main/packages/fxa-payments-server#README.md",
   "devDependencies": {
     "@babel/core": "^7.10.3",
     "@babel/register": "^7.7.0",

--- a/packages/fxa-payments-server/src/components/Tooltip/index.tsx
+++ b/packages/fxa-payments-server/src/components/Tooltip/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // This is a React version of this Bootstrap view:
-// https://github.com/mozilla/fxa/blob/master/packages/fxa-content-server/app/scripts/views/tooltip.js
+// https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/app/scripts/views/tooltip.js
 
 import React, { useEffect, useRef, useContext } from 'react';
 import classNames from 'classnames';
@@ -13,8 +13,8 @@ import { AppContext } from '../../lib/AppContext';
 export const PADDING_BELOW_TOOLTIP_PX = 2;
 export const PADDING_ABOVE_TOOLTIP_PX = 4;
 
-// These values should be the same as
-// https://github.com/mozilla/fxa-content-server/blob/0eab619612897dcda43e8074dafdf55e8cbe11ee/app/styles/_breakpoints.scss#L6
+// These values should be the same as the breakpoints in
+// https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/app/styles/_breakpoints.scss
 export const MIN_HEIGHT_TO_SHOW_TOOLTIP_BELOW = 480;
 export const MIN_WIDTH_TO_SHOW_TOOLTIP_BELOW = 520;
 

--- a/packages/fxa-payments-server/src/lib/screen-info.ts
+++ b/packages/fxa-payments-server/src/lib/screen-info.ts
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // This is a port to TypeScript of this fxa-content-server library:
-// https://github.com/mozilla/fxa/blob/master/packages/fxa-content-server/app/scripts/lib/screen-info.js
+// https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/app/scripts/lib/screen-info.js
 
 // module to calculate screen dimentions given a window.
 

--- a/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
@@ -131,7 +131,7 @@ function init() {
               errno: 181,
               error: 'Bad Request',
               info:
-                'https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/docs/api.md#response-format',
+                'https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#response-format',
               statusCode: 402,
             },
           },

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -155,7 +155,7 @@ function init() {
               errno: 181,
               error: 'Bad Request',
               info:
-                'https://github.com/mozilla/fxa/blob/master/packages/fxa-auth-server/docs/api.md#response-format',
+                'https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#response-format',
             }),
           },
         }}

--- a/packages/fxa-profile-server/CONTRIBUTING.md
+++ b/packages/fxa-profile-server/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Before submitting a PR:
 When submitting a PR:
 
 - You agree to license your code under the project's open source license ([MPL 2.0](/LICENSE)).
-- Base your branch off the current `master` (see below for an example workflow).
+- Base your branch off the current `main` (see below for an example workflow).
 - Add both your code and new tests if relevant.
 - Run `npm lint` and `npm test` to make sure your code passes linting and tests.
 - Please do not include merge commits in pull requests; include only commits with the new relevant code.
@@ -72,11 +72,11 @@ $ git push user1 add-new-feature
 
 ### Keeping up to Date
 
-The main reason for creating a new branch for each feature or fix is so that you can track master correctly. If you need
+The main reason for creating a new branch for each feature or fix is so that you can track main correctly. If you need
 to fetch the latest code for a new fix, try the following:
 
 ```sh
-$ git checkout master
+$ git checkout main
 $ git pull
 ```
 

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -64,7 +64,7 @@
     "url": "https://github.com/mozilla/fxa.git"
   },
   "bugs": "https://github.com/mozilla/fxa/issues",
-  "homepage": "https://github.com/mozilla/fxa/tree/master/packages/fxa-profile-server",
+  "homepage": "https://github.com/mozilla/fxa/tree/main/packages/fxa-profile-server",
   "author": "Sean McArthur <sean.monstar@gmail.com>",
   "engines": {
     "node": ">=12"

--- a/packages/fxa-shared/README.md
+++ b/packages/fxa-shared/README.md
@@ -11,7 +11,7 @@
 `oauth.scopes` provides shared logic for validating and checking OAuth scopes.
 
 Detailed documentation on the details of FxA OAuth scope values
-is available from the [fxa-oauth-server](https://github.com/mozilla/fxa-oauth-server/tree/master/docs/scopes.md).
+is available from the [fxa-oauth-server](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/scopes.md).
 This library provides some convenient APIs for working with them
 according to the rules described there.
 

--- a/packages/fxa-shared/feature-flags/README.md
+++ b/packages/fxa-shared/feature-flags/README.md
@@ -15,7 +15,7 @@
 Historically,
 the FxA team has carried out development work
 on feature branches,
-only merging to `master`
+only merging to `main`
 after a given feature has been completed
 and code-reviewed.
 Then,
@@ -44,10 +44,10 @@ that can be used to control rollout
 (or rollback).
 This approach also facilitates
 mainline development,
-where engineers merge their work directly to `master`
+where engineers merge their work directly to `main`
 in regular, smaller chunks
 and releases are cut from
-dedicated branches off `master`.
+dedicated branches off `main`.
 There's a much longer discussion
 to be had around mainline development,
 which is out of scope for this readme.
@@ -174,17 +174,17 @@ you can just make local changes to this file
 but if your changes are meant for production,
 you'll need to open a pull request
 to get the changes reviewed
-and merged back to `master`.
+and merged back to `main`.
 
 ## How do I use a feature flag in the content server?
 
 If you're writing client-side code,
 the feature flags are all available
 via the `config.featureFlags` property
-set in [`app/scripts/lib/config-loader.js`](https://github.com/mozilla/fxa/blob/master/packages/fxa-content-server/app/scripts/lib/config-loader.js).
+set in [`app/scripts/lib/config-loader.js`](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/app/scripts/lib/config-loader.js).
 Typically,
 you'd be expected to access them
-from code in the [`app/scripts/lib/experiments/grouping-rules`](https://github.com/mozilla/fxa/tree/master/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules) directory
+from code in the [`app/scripts/lib/experiments/grouping-rules`](https://github.com/mozilla/fxa/tree/main/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules) directory
 and there are many examples there
 of experiments that use feature flags.
 
@@ -216,7 +216,7 @@ try {
 
 You can find an example of this
 in the route handler
-in [`server/lib/routes/get-index.js`](https://github.com/mozilla/fxa/blob/master/packages/fxa-content-server/server/lib/routes/get-index.js).
+in [`server/lib/routes/get-index.js`](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/server/lib/routes/get-index.js).
 
 ## How do I use a feature flag in the auth server?
 

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -28,7 +28,7 @@
   "engines": {
     "node": ">=12"
   },
-  "homepage": "https://github.com/mozilla/fxa/tree/master/packages/fxa-shared#readme",
+  "homepage": "https://github.com/mozilla/fxa/tree/main/packages/fxa-shared#readme",
   "devDependencies": {
     "@types/chai": "^4.2.11",
     "@types/generic-pool": "^3.1.9",

--- a/release-feature-branch.sh
+++ b/release-feature-branch.sh
@@ -27,8 +27,8 @@ abort() {
   exit 1
 }
 
-if [ "$FEATURE_BRANCH" = "master" ]; then
-  abort "master is not a feature branch";
+if [ "$FEATURE_BRANCH" = "main" ]; then
+  abort "main is not a feature branch";
 fi
 
 LAST_TAG=`git tag -l --sort=version:refname | grep -v '-' | tail -1`
@@ -104,7 +104,7 @@ fi
 
 echo "If there's no deploy bug for $TRAIN_BRANCH_WITH_FEATURE yet, you should create one using this URL (you'll need to update the title of the bug in Bugzilla):"
 echo
-echo "  https://github.com/mozilla/fxa-private/blob/master/_scripts/create-deploy-bug.url"
+echo "  https://github.com/mozilla/fxa-private/blob/main/_scripts/create-deploy-bug.url"
 echo
 echo "Make sure you copy notes from the deploy doc:"
 echo

--- a/release.sh
+++ b/release.sh
@@ -31,7 +31,7 @@ IFS=$'\n'
 #   4. Check there have been some commits since the last tag.
 #   5. Generate the bumped version string.
 #   6. If current branch is train branch, pull from origin.
-#   7. Otherwise checkout existing train branch or create fresh one from master.
+#   7. Otherwise checkout existing train branch or create fresh one from main.
 #   8. For each of the "main" packages...
 #      8.1. List commits since the last tag.
 #      8.2. For each commit...
@@ -117,7 +117,7 @@ TRAIN_BRANCH="train-$TRAIN"
 if [ "$CURRENT_BRANCH" = "$TRAIN_BRANCH" ]; then
   git pull origin "$TRAIN_BRANCH" > /dev/null 2>&1 || true
 else
-  # 7. Otherwise checkout existing train branch or create fresh one from master.
+  # 7. Otherwise checkout existing train branch or create fresh one from main.
   TRAIN_BRANCH_EXISTS=`git branch --no-color | awk '{$1=$1};1' | grep "^$TRAIN_BRANCH\$"` || true
 
   if [ "$TRAIN_BRANCH_EXISTS" = "" ]; then
@@ -127,9 +127,9 @@ else
     REMOTE_BRANCH_EXISTS=`git branch --no-color -r | awk '{$1=$1};1' | grep "^$REMOTE_BRANCH\$"` || true
 
     if [ "$REMOTE_BRANCH_EXISTS" = "" ]; then
-      echo "Warning: $TRAIN_BRANCH branch not found on local or remote, creating one from master."
-      git checkout master > /dev/null 2>&1
-      git pull origin master > /dev/null 2>&1
+      echo "Warning: $TRAIN_BRANCH branch not found on local or remote, creating one from main."
+      git checkout main > /dev/null 2>&1
+      git pull origin main > /dev/null 2>&1
       git checkout -b "$TRAIN_BRANCH" > /dev/null 2>&1
     else
       git checkout --track -b "$TRAIN_BRANCH" "$REMOTE_BRANCH" > /dev/null 2>&1
@@ -352,7 +352,7 @@ echo
 echo "git push origin $TRAIN_BRANCH"
 echo "git push origin $NEW_TAG"
 echo
-echo "After that, you must open pull a request to merge the changes back to master:"
+echo "After that, you must open pull a request to merge the changes back to main:"
 echo
 echo "  https://github.com/mozilla/fxa/compare/$TRAIN_BRANCH?expand=1"
 echo
@@ -369,7 +369,7 @@ if [ "$BUILD_TYPE" = "Train" ]; then
 
   echo "If there's no deploy bug for $TRAIN_BRANCH yet, you should create one using this URL (you'll need to update the title of the bug in Bugzilla):"
   echo
-  echo "  https://github.com/mozilla/fxa-private/blob/master/_scripts/create-deploy-bug.url"
+  echo "  https://github.com/mozilla/fxa-private/blob/main/_scripts/create-deploy-bug.url"
   echo
   echo "Make sure you copy notes from the deploy doc:"
   echo


### PR DESCRIPTION
@dannycoates brought this up on Slack last week, and it seemed like a good smallish "innovation sprint" change to make this afternoon.

The actual work to change FxA’s default remote branch is really just a matter of clicking around the github website UI, but I thought I’d help move things along by updating existing references to an fxa ‘master’ branch throughout our docs and code docs. I also updated some stale links from the pre-monorepo days, since I was in there anyhow.

I’ve also pushed a `main` branch to fxa-private, since `release.sh` refers to it as well. I figure we can move both repos at the same time.

(Unrelated: I think the content-server docs that claim the templates for emails live in content-server are out of date; is that right? In `fxa-content-server/docs/architecture`, the 'Additional Templates' section.)

As of this commit, remaining `master` references are:

1. #5698: mysql or database config-related (I don't know how to proceed here, but seems like something we could handle in a followup)
2. #5699: references to “master key material” and/or “sync master key” in various contexts. I think we should be OK to change those to “primary” or “main” key, but that’ll also require updating sync docs and finally updating our onepw protocol doc, seems like a self-contained bit of work to split off.
3. references to the ‘master’ branch of other repos we don’t control 🤷 
4. #5700: I don’t know if we can change the fxa-l10n repo from ‘master’ to ‘main’ without breaking pontoon integration, so I’ve retained references to ‘master’ in the l10n section of CONTRIBUTING.md.

@fxa-devs R?