### PR TITLE
feat(cad): Add remind me later CAD redis lib

### DIFF
--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -4,7 +4,7 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: "0...100"
 
 parsers:
   gcov:

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1628,6 +1628,46 @@ const conf = convict({
       },
     },
   },
+  cadReminders: {
+    rolloutRate: {
+      doc: 'Rollout rate in the range 0 .. 1',
+      default: 1,
+      env: 'CAD_REMINDERS_ROLLOUT_RATE',
+      format: Number,
+    },
+    firstInterval: {
+      doc: 'Time which the first reminder is sent',
+      default: '8 hours',
+      env: 'CAD_REMINDERS_FIRST_INTERVAL',
+      format: 'duration',
+    },
+    secondInterval: {
+      doc: 'Time which the second reminder is sent',
+      default: '3 days',
+      env: 'CAD_REMINDERS_SECOND_INTERVAL',
+      format: 'duration',
+    },
+    redis: {
+      prefix: {
+        default: 'cadReminders:',
+        doc: 'Key prefix for the cad reminders Redis pool',
+        env: 'CAD_REMINDERS_REDIS_PREFIX',
+        format: String,
+      },
+      maxConnections: {
+        default: 10,
+        doc: 'Maximum connection count for the cad reminders Redis pool',
+        env: 'CAD_REMINDERS_REDIS_MAX_CONNECTIONS',
+        format: 'nat',
+      },
+      minConnections: {
+        default: 1,
+        doc: 'Minimum connection count for the cad reminders Redis pool',
+        env: 'CAD_REMINDERS_REDIS_MIN_CONNECTIONS',
+        format: 'nat',
+      },
+    },
+  },
   zendesk: {
     username: {
       doc: 'Zendesk Username for support interaction',

--- a/packages/fxa-auth-server/lib/cad-reminders.js
+++ b/packages/fxa-auth-server/lib/cad-reminders.js
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// This module implements logic for managing account cad (connect another device) reminders.
+//
+// Similar to account verification reminders, Connect another device (CAD) reminders are
+// stored in sorted sets in redis.
+//
+// More detail on sorted sets:
+//
+// * https://redis.io/topics/data-types#sorted-sets
+// * https://redis.io/topics/data-types-intro#redis-sorted-sets
+'use strict';
+
+const redis = require('./redis');
+const P = require('./promise');
+
+// The config file determines the number of intervals. Ex `firstInterval` is stored
+// in set called `first`.
+const INTERVAL_PATTERN = /^([a-z]+)Interval$/;
+
+class CadReminders {
+  constructor(config, log) {
+    this.redis = redis(
+      {
+        ...config.redis,
+        ...config.cadReminders.redis,
+        enabled: true,
+      },
+      log
+    );
+    this.log = log;
+    this.rolloutRate = config.cadReminders.rolloutRate;
+    const { keys, intervals } = this.parseIntervals(config);
+    this.keys = keys;
+    this.intervals = intervals;
+  }
+
+  parseIntervals(config) {
+    return Object.entries(config.cadReminders).reduce(
+      ({ keys, intervals }, [key, value]) => {
+        const matches = INTERVAL_PATTERN.exec(key);
+        if (matches && matches.length === 2) {
+          const key = matches[1];
+          keys.push(key);
+          intervals[key] = value;
+        }
+        return { keys, intervals };
+      },
+      { keys: [], intervals: {} }
+    );
+  }
+
+  /**
+   * Create cad reminder records for an account.
+   *
+   * @param {String} uid
+   * @returns {Promise} - Each property on the resolved object will be the number
+   *                      of elements added to that sorted set, i.e. the result of
+   *                      [`redis.zadd`](https://redis.io/commands/zadd).
+   */
+  async create(uid) {
+    try {
+      if (this.rolloutRate <= 1 && Math.random() < this.rolloutRate) {
+        const now = Date.now();
+        const result = await P.props(
+          this.keys.reduce((result, key) => {
+            result[key] = this.redis.zadd(key, now, uid);
+            return result;
+          }, {})
+        );
+        this.log.info('cadReminders.create', {
+          uid,
+        });
+        return result;
+      }
+    } catch (err) {
+      this.log.error('cadReminders.create.error', {
+        err,
+        uid,
+      });
+      throw err;
+    }
+  }
+
+  /**
+   * Deletes cad reminder records for an account.
+   *
+   * @param {String} uid
+   * @returns {Promise} - Each property on the resolved object will be the number
+   *                      of elements added to that sorted set, i.e. the result of
+   *                      [`redis.zadd`](https://redis.io/commands/zrem).
+   */
+  async delete(uid) {
+    try {
+      const result = await P.props(
+        this.keys.reduce((result, key) => {
+          result[key] = this.redis.zrem(key, uid);
+          return result;
+        }, {})
+      );
+      this.log.info('cadReminders.delete', {
+        uid,
+      });
+      return result;
+    } catch (err) {
+      this.log.error('cadReminders.delete.error', {
+        err,
+        uid,
+      });
+      throw err;
+    }
+  }
+
+  /**
+   * Gets cad reminder records for an account.
+   *
+   * @param {String} uid
+   * @returns {Promise} - Each property on the resolved object will be the number
+   *                      of elements added to that sorted set, i.e. the result of
+   *                      [`redis.zadd`](https://redis.io/commands/zrank).
+   */
+  async get(uid) {
+    try {
+      this.log.info('cadReminders.get', {
+        uid,
+      });
+      return await P.props(
+        this.keys.reduce((result, key) => {
+          result[key] = this.redis.zrank(key, uid);
+          return result;
+        }, {})
+      );
+    } catch (err) {
+      this.log.error('cadReminders.get.error', {
+        err,
+        uid,
+      });
+      throw err;
+    }
+  }
+
+  /**
+   * Read and remove all reminders that have
+   * ticked past the expiry intervals set in config.
+   *
+   * @returns {Promise} - Each property on the resolved object will be an array of
+   *                      { timestamp, uid } reminder records
+   *                      that have ticked past the relevant expiry interval.
+   */
+  async process() {
+    try {
+      const now = Date.now();
+      return await P.props(
+        this.keys.reduce((result, key) => {
+          const cutoff = now - this.intervals[key];
+          result[key] = this.redis
+            .zpoprangebyscore(key, 0, cutoff, 'WITHSCORES')
+            .then(async (items) => {
+              const reminders = [];
+              let index = 0;
+              for (const item of items) {
+                if (index % 2 === 0) {
+                  const uid = item;
+                  reminders.push({ uid });
+                } else {
+                  reminders[(index - 1) / 2].timestamp = item;
+                }
+                index++;
+              }
+              return reminders;
+            });
+          this.log.info('cadReminders.process', { key, now, cutoff });
+          return result;
+        }, {})
+      );
+    } catch (err) {
+      this.log.error('cadReminders.process.error', { err });
+      throw err;
+    }
+  }
+
+  /**
+   * Close the underlying redis connections.
+   *
+   * @returns {Promise}
+   */
+  close() {
+    return this.redis.close();
+  }
+}
+
+module.exports = (config, log) => {
+  return new CadReminders(config, log);
+};

--- a/packages/fxa-auth-server/lib/redis.js
+++ b/packages/fxa-auth-server/lib/redis.js
@@ -206,6 +206,9 @@ class FxaRedis {
   zrevrangebyscore(key, min, max) {
     return this.redis.zrevrangebyscore(key, min, max);
   }
+  zrank(key, member) {
+    return this.redis.zrank(key, member);
+  }
 
   async zpoprangebyscore(key, min, max) {
     const args = Array.from(arguments);

--- a/packages/fxa-auth-server/test/local/cad-reminders.js
+++ b/packages/fxa-auth-server/test/local/cad-reminders.js
@@ -1,0 +1,212 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const ROOT_DIR = '../..';
+const REMINDERS = ['first', 'second', 'third'];
+const EXPECTED_CREATE_DELETE_RESULT = REMINDERS.reduce((expected, reminder) => {
+  expected[reminder] = 1;
+  return expected;
+}, {});
+
+const { assert } = require('chai');
+const config = require(`${ROOT_DIR}/config`).getProperties();
+const mocks = require('../mocks');
+
+describe('lib/cad-reminders', () => {
+  let log, mockConfig, redis, cadReminders;
+
+  beforeEach(() => {
+    log = mocks.mockLog();
+    mockConfig = {
+      redis: config.redis,
+      cadReminders: {
+        rolloutRate: 1,
+        firstInterval: 1,
+        secondInterval: 2,
+        thirdInterval: 60000,
+        redis: {
+          maxConnections: 1,
+          minConnections: 1,
+          prefix: 'test-cad-reminders:',
+        },
+      },
+    };
+    redis = require('../../lib/redis')(
+      {
+        ...config.redis,
+        ...mockConfig.cadReminders.redis,
+        enabled: true,
+      },
+      mocks.mockLog()
+    );
+    cadReminders = require(`${ROOT_DIR}/lib/cad-reminders`)(mockConfig, log);
+  });
+
+  afterEach(async () => {
+    await redis.close();
+    await cadReminders.close();
+  });
+
+  it('returned the expected interface', () => {
+    assert.isObject(cadReminders);
+    assert.lengthOf(Object.keys(cadReminders), 5);
+
+    assert.deepEqual(cadReminders.keys, ['first', 'second', 'third']);
+
+    assert.isFunction(cadReminders.create);
+    assert.lengthOf(cadReminders.create, 1);
+
+    assert.isFunction(cadReminders.delete);
+    assert.lengthOf(cadReminders.delete, 1);
+
+    assert.isFunction(cadReminders.process);
+    assert.lengthOf(cadReminders.process, 0);
+
+    assert.isFunction(cadReminders.get);
+    assert.lengthOf(cadReminders.get, 1);
+
+    assert.isFunction(cadReminders.close);
+    assert.lengthOf(cadReminders.close, 0);
+  });
+
+  describe('create', () => {
+    let createResult;
+
+    beforeEach(async () => {
+      createResult = await cadReminders.create('wibble');
+    });
+
+    afterEach(async () => {
+      await cadReminders.delete('wibble');
+    });
+
+    it('returned the correct result', async () => {
+      assert.deepEqual(createResult, EXPECTED_CREATE_DELETE_RESULT);
+    });
+
+    REMINDERS.forEach((reminder) => {
+      it(`wrote ${reminder} reminder to redis`, async () => {
+        const reminders = await redis.zrange(reminder, 0, -1);
+        assert.deepEqual(reminders, ['wibble']);
+      });
+    });
+
+    describe('delete', () => {
+      let deleteResult;
+
+      beforeEach(async () => {
+        deleteResult = await cadReminders.delete('wibble');
+      });
+
+      it('returned the correct result', async () => {
+        assert.deepEqual(deleteResult, EXPECTED_CREATE_DELETE_RESULT);
+      });
+
+      REMINDERS.forEach((reminder) => {
+        it(`removed ${reminder} reminder from redis`, async () => {
+          const reminders = await redis.zrange(reminder, 0, -1);
+          assert.lengthOf(reminders, 0);
+        });
+      });
+
+      it('did not call log.error', () => {
+        assert.equal(log.error.callCount, 0);
+      });
+    });
+
+    describe('get', () => {
+      let result;
+
+      beforeEach(async () => {
+        result = await cadReminders.get('wibble');
+      });
+
+      it('returned the correct result', async () => {
+        assert.deepEqual(result, {
+          first: 0,
+          second: 0,
+          third: 0,
+        });
+      });
+
+      it('did not call log.error', () => {
+        assert.equal(log.error.callCount, 0);
+      });
+    });
+
+    describe('process', () => {
+      let before, processResult;
+
+      beforeEach((done) => {
+        before = Date.now();
+        cadReminders.create('blee').then(() => {
+          setTimeout(async () => {
+            processResult = await cadReminders.process();
+            done();
+          }, 2);
+        });
+      });
+
+      afterEach(async () => {
+        await cadReminders.delete('blee');
+      });
+
+      it('returned the correct result', async () => {
+        assert.isObject(processResult);
+
+        assert.isArray(processResult.first);
+        assert.lengthOf(processResult.first, 2);
+        assert.isObject(processResult.first[0]);
+        assert.equal(processResult.first[0].uid, 'wibble');
+
+        assert.isAbove(
+          parseInt(processResult.first[0].timestamp),
+          before - 1000
+        );
+        assert.isBelow(parseInt(processResult.first[0].timestamp), before);
+        assert.equal(processResult.first[1].uid, 'blee');
+        assert.isAtLeast(parseInt(processResult.first[1].timestamp), before);
+        assert.isBelow(
+          parseInt(processResult.first[1].timestamp),
+          before + 1000
+        );
+
+        assert.isArray(processResult.second);
+        assert.lengthOf(processResult.second, 2);
+        assert.equal(processResult.second[0].uid, 'wibble');
+        assert.equal(
+          processResult.second[0].timestamp,
+          processResult.first[0].timestamp
+        );
+
+        assert.equal(processResult.second[1].uid, 'blee');
+        assert.equal(
+          processResult.second[1].timestamp,
+          processResult.first[1].timestamp
+        );
+        assert.deepEqual(processResult.third, []);
+      });
+
+      REMINDERS.forEach((reminder) => {
+        if (reminder !== 'third') {
+          it(`removed ${reminder} reminder from redis correctly`, async () => {
+            const reminders = await redis.zrange(reminder, 0, -1);
+            assert.lengthOf(reminders, 0);
+          });
+        } else {
+          it('left the third reminders in redis', async () => {
+            const reminders = await redis.zrange(reminder, 0, -1);
+            assert.deepEqual(reminders, ['wibble', 'blee']);
+          });
+        }
+      });
+
+      it('did not call log.error', () => {
+        assert.equal(log.error.callCount, 0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Because

- We need to be able to create, remove and process entries in redis this will allow us to know if a user has requested to be reminded later to connect another device

### This commit

- Adds a library to do create, remove and processing of these reminders (based on account verification reminders)

## Issue that this pull request solves

Closes: #5702

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
