### PR TITLE
chore(l10n): copy .ftl files from fxa-content-server-l10n into payments

### DIFF
--- a/packages/fxa-payments-server/.gitignore
+++ b/packages/fxa-payments-server/.gitignore
@@ -1,0 +1,9 @@
+# copied l10n files
+/public/fxa-content-server-l10n
+/public/locales/git-head.txt
+/public/locales/**/*.ftl
+
+# must exclude the original that's copied _into_ fxa-content-server-l10n
+!/public/locales/en-US/*.ftl
+
+/server/lib/fxa-content-server-l10n

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -3,6 +3,7 @@
   "version": "1.176.0",
   "description": "Firefox Accounts Payments Service",
   "scripts": {
+    "postinstall": "scripts/download_l10n.sh",
     "lint": "npm-run-all --parallel lint:eslint lint:sass",
     "lint:eslint": "eslint .",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",

--- a/packages/fxa-payments-server/scripts/download_l10n.sh
+++ b/packages/fxa-payments-server/scripts/download_l10n.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+
+set -e
+
+if [ -n "$FXA_L10N_SKIP" ]; then
+    echo "Skipping fxa-content-server-l10n update..."
+    exit 0
+fi
+
+if [ -z "$FXA_L10N_SHA" ]; then
+    FXA_L10N_SHA="master"
+fi
+
+DOWNLOAD_PATH="https://github.com/mozilla/fxa-content-server-l10n.git"
+
+cd public
+
+# Download L10N using git
+if [ ! -d "fxa-content-server-l10n" ]; then
+	echo "Downloading L10N files from $DOWNLOAD_PATH..."
+	git clone --depth 1 $DOWNLOAD_PATH
+fi
+
+cd fxa-content-server-l10n
+echo "Updating L10N files"
+git checkout -- .
+git checkout $FXA_L10N_SHA
+git pull
+git rev-parse $FXA_L10N_SHA > git-head.txt
+
+cd locale
+cp --parent **/*.ftl ../../locales/
+
+cd ../../../server/lib
+
+if [ ! -d "fxa-content-server-l10n" ]; then
+  mkdir fxa-content-server-l10n
+fi
+
+# L10n version for the payments server version endpoint
+cp ../../public/fxa-content-server-l10n/git-head.txt fxa-content-server-l10n/
+
+cd ../../
+
+# remove the checkout so it won't be included in the build output
+if [ -d "public/fxa-content-server-l10n" ]; then
+  rm -rf public/fxa-content-server-l10n
+fi

--- a/packages/fxa-payments-server/server/lib/server.test.js
+++ b/packages/fxa-payments-server/server/lib/server.test.js
@@ -22,11 +22,13 @@ describe('Test simple server routes', () => {
           const body = response.body;
           expect(Object.keys(body).sort()).toStrictEqual([
             'commit',
+            'l10n',
             'source',
             'version',
           ]);
 
           expectValueNotToBeUnknown(body.commit);
+          expectValueNotToBeUnknown(body.l10n);
           expectValueNotToBeUnknown(body.source);
           expectValueNotToBeUnknown(body.version);
 

--- a/packages/fxa-payments-server/server/lib/version.js
+++ b/packages/fxa-payments-server/server/lib/version.js
@@ -23,6 +23,7 @@
 // TODO - Make this shared code
 
 const cp = require('child_process');
+const fs = require('fs');
 const path = require('path');
 
 const UNKNOWN = 'unknown';
@@ -74,6 +75,19 @@ function getSourceRepo() {
   return stdout && stdout.toString().trim();
 }
 
+function getL10nVersion() {
+  try {
+    const gitShaPath = path.join(
+      __dirname,
+      'fxa-content-server-l10n',
+      'git-head.txt'
+    );
+    return fs.readFileSync(gitShaPath, 'utf8').trim();
+  } catch (e) {
+    /* ignore */
+  }
+}
+
 let version = null;
 function getVersionInfo() {
   if (!version) {
@@ -81,6 +95,7 @@ function getVersionInfo() {
     version = {
       commit: getCommitHash(),
       version: require('../../package.json').version,
+      l10n: getL10nVersion(),
       source: getSourceRepo(),
     };
   }


### PR DESCRIPTION
Because:
 - Payments need to serve the translated strings in .ftl files

This commit:
 - add a postinstall script to copy the .ftl files from fxa-content-server-l10n
 - update Payments' \_\_version__ to show the git hash of the l10n checkout
 - git ignore the copied files

closes #5663 (FXA-2114)
closes #5664 (FXA-2115)

