### PR TITLE
feat(payments): Use Stripe metadata for terms & privacy URLs in payments-server

### DIFF
--- a/packages/fxa-payments-server/src/components/AppLayout/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.test.tsx
@@ -6,24 +6,16 @@ import { AppContext, defaultAppContext } from '../../lib/AppContext';
 
 import AppLayout, { SignInLayout, SettingsLayout } from './index';
 import TermsAndPrivacy from '../TermsAndPrivacy';
+import { DEFAULT_PRODUCT_DETAILS } from '../../store/utils';
 
 afterEach(cleanup);
 
+const { termsOfServiceURL, privacyNoticeURL } = DEFAULT_PRODUCT_DETAILS;
+
 describe('AppLayout', () => {
   const subject = () => {
-    const appContextValue = {
-      ...defaultAppContext,
-      config: {
-        ...config,
-        legalDocLinks: {
-          privacyNotice: 'https://example.me/privacy',
-          termsOfService: 'https://example.me/terms',
-        },
-      },
-    };
-
     return render(
-      <AppContext.Provider value={appContextValue}>
+      <AppContext.Provider value={defaultAppContext}>
         <AppLayout>
           <div data-testid="children">
             <TermsAndPrivacy />
@@ -41,9 +33,9 @@ describe('AppLayout', () => {
     }
 
     const tosLink = getByText('Terms of Service');
-    expect(tosLink).toHaveAttribute('href', 'https://example.me/terms');
+    expect(tosLink).toHaveAttribute('href', termsOfServiceURL);
     const privacyLink = getByText('Privacy Notice');
-    expect(privacyLink).toHaveAttribute('href', 'https://example.me/privacy');
+    expect(privacyLink).toHaveAttribute('href', privacyNoticeURL);
   });
 });
 

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -114,7 +114,7 @@ export const PaymentConfirmation = ({
             Continue to download
           </a>
         </Localized>
-        <TermsAndPrivacy />
+        <TermsAndPrivacy plan={selectedPlan} />
       </div>
     </section>
   );

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -285,7 +285,7 @@ export const PaymentForm = ({
       )}
 
       <PaymentLegalBlurb />
-      <TermsAndPrivacy />
+      <TermsAndPrivacy plan={plan} />
     </Form>
   );
 };

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.stories.tsx
@@ -1,5 +1,15 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { TermsAndPrivacy } from './index';
+import { defaultAppContext, AppContext } from '../../lib/AppContext';
+import { SELECTED_PLAN } from '../../lib/mock-data';
 
-storiesOf('TermsAndPrivacy', module).add('default', () => <TermsAndPrivacy />);
+storiesOf('TermsAndPrivacy', module)
+  .add('default locale', () => <TermsAndPrivacy plan={SELECTED_PLAN} />)
+  .add('with fr locale', () => (
+    <AppContext.Provider
+      value={{ ...defaultAppContext, navigatorLanguages: ['fr'] }}
+    >
+      <TermsAndPrivacy plan={SELECTED_PLAN} />
+    </AppContext.Provider>
+  ));

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.test.tsx
@@ -2,12 +2,68 @@ import React from 'react';
 import { render, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
+import { MOCK_PLANS } from '../../lib/test-utils';
 import { TermsAndPrivacy } from './index';
+import { defaultAppContext, AppContext } from '../../lib/AppContext';
+import { DEFAULT_PRODUCT_DETAILS } from '../../store/utils';
+
+const enTermsOfServiceURL =
+  'https://www.mozilla.org/en-US/about/legal/terms/services/';
+const enPrivacyNoticeURL = 'https://www.mozilla.org/en-US/privacy/websites/';
+const frTermsOfServiceURL =
+  'https://www.mozilla.org/fr/about/legal/terms/services/';
+const frPrivacyNoticeURL = 'https://www.mozilla.org/fr/privacy/websites/';
+
+const plan = {
+  ...MOCK_PLANS[0],
+  plan_metadata: {
+    'product:termsOfServiceURL': enTermsOfServiceURL,
+    'product:termsOfServiceURL:fr': frTermsOfServiceURL,
+    'product:privacyNoticeURL': enPrivacyNoticeURL,
+    'product:privacyNoticeURL:fr': frPrivacyNoticeURL,
+  },
+};
 
 afterEach(cleanup);
 
-it('renders as expected', () => {
+it('renders as expected with no plan', () => {
   const { queryByTestId } = render(<TermsAndPrivacy />);
-  expect(queryByTestId('terms')).toBeInTheDocument();
-  expect(queryByTestId('privacy')).toBeInTheDocument();
+  const termsLink = queryByTestId('terms');
+  expect(termsLink).toBeInTheDocument();
+  expect(termsLink).toHaveAttribute(
+    'href',
+    DEFAULT_PRODUCT_DETAILS.termsOfServiceURL
+  );
+  const privacyLink = queryByTestId('privacy');
+  expect(privacyLink).toBeInTheDocument();
+  expect(privacyLink).toHaveAttribute(
+    'href',
+    DEFAULT_PRODUCT_DETAILS.privacyNoticeURL
+  );
+});
+
+it('renders as expected with default locale', () => {
+  const { queryByTestId } = render(<TermsAndPrivacy plan={plan} />);
+  const termsLink = queryByTestId('terms');
+  expect(termsLink).toBeInTheDocument();
+  expect(termsLink).toHaveAttribute('href', enTermsOfServiceURL);
+  const privacyLink = queryByTestId('privacy');
+  expect(privacyLink).toBeInTheDocument();
+  expect(privacyLink).toHaveAttribute('href', enPrivacyNoticeURL);
+});
+
+it('renders as expected with fr locale', () => {
+  const { queryByTestId } = render(
+    <AppContext.Provider
+      value={{ ...defaultAppContext, navigatorLanguages: ['fr'] }}
+    >
+      <TermsAndPrivacy plan={plan} />
+    </AppContext.Provider>
+  );
+  const termsLink = queryByTestId('terms');
+  expect(termsLink).toBeInTheDocument();
+  expect(termsLink).toHaveAttribute('href', frTermsOfServiceURL);
+  const privacyLink = queryByTestId('privacy');
+  expect(privacyLink).toBeInTheDocument();
+  expect(privacyLink).toHaveAttribute('href', frPrivacyNoticeURL);
 });

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
@@ -1,11 +1,25 @@
 import React, { useContext } from 'react';
 import { Localized } from '@fluent/react';
 import { AppContext } from '../../lib/AppContext';
+import { productDetailsFromPlan } from '../../store/utils';
+import { Plan } from '../../store/types';
+import { DEFAULT_PRODUCT_DETAILS } from '../../store/utils';
 
 import './index.scss';
 
-export const TermsAndPrivacy = () => {
-  const { config } = useContext(AppContext);
+export type TermsAndPrivacyProps = {
+  plan?: Plan;
+};
+
+export const TermsAndPrivacy = ({ plan }: TermsAndPrivacyProps) => {
+  const { navigatorLanguages } = useContext(AppContext);
+
+  // TODO: if a plan is not supplied, fall back to default details
+  // This mainly happens in ProductUpdateForm where we're updating payment
+  // details across *all* plans - are there better URLs to pick in that case?
+  const { termsOfServiceURL, privacyNoticeURL } = plan
+    ? productDetailsFromPlan(plan, navigatorLanguages)
+    : DEFAULT_PRODUCT_DETAILS;
 
   return (
     <div>
@@ -15,7 +29,7 @@ export const TermsAndPrivacy = () => {
             rel="noopener noreferrer"
             target="_blank"
             data-testid="terms"
-            href={config.legalDocLinks.termsOfService}
+            href={termsOfServiceURL}
           >
             Terms of Service
           </a>
@@ -27,7 +41,7 @@ export const TermsAndPrivacy = () => {
             rel="noopener noreferrer"
             target="_blank"
             data-testid="privacy"
-            href={config.legalDocLinks.privacyNotice}
+            href={privacyNoticeURL}
           >
             Privacy Notice
           </a>

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -1,4 +1,4 @@
-import { Profile, Plan, Customer } from '../../../store/types';
+import { Profile, Plan, Customer } from '../store/types';
 
 export const PROFILE: Profile = {
   amrValues: [],
@@ -54,6 +54,14 @@ export const SELECTED_PLAN: Plan = {
     'product:details:1:xx-pirate': 'Device-level encryption arr',
     'product:details:2:xx-pirate': 'Servers is 30+ countries matey',
     'product:details:3:xx-pirate': "Connects 5 devices wit' one subscription",
+    'product:termsOfServiceURL':
+      'https://www.mozilla.org/en-US/about/legal/terms/services/',
+    'product:termsOfServiceURL:fr':
+      'https://www.mozilla.org/fr/about/legal/terms/services/',
+    'product:privacyNoticeURL':
+      'https://www.mozilla.org/en-US/privacy/websites/',
+    'product:privacyNoticeURL:fr':
+      'https://www.mozilla.org/fr/privacy/websites/',
   },
 };
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.stories.tsx
@@ -8,7 +8,12 @@ import { defaultAppContext, AppContextType } from '../../../lib/AppContext';
 
 import { SignInLayout } from '../../../components/AppLayout';
 
-import { CUSTOMER, SELECTED_PLAN, UPGRADE_FROM_PLAN, PROFILE } from './mocks';
+import {
+  CUSTOMER,
+  SELECTED_PLAN,
+  UPGRADE_FROM_PLAN,
+  PROFILE,
+} from '../../../lib/mock-data';
 
 import SubscriptionUpgrade, { SubscriptionUpgradeProps } from './index';
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -22,7 +22,12 @@ import {
   getLocalizedMessage,
 } from '../../../lib/test-utils';
 
-import { CUSTOMER, SELECTED_PLAN, UPGRADE_FROM_PLAN, PROFILE } from './mocks';
+import {
+  CUSTOMER,
+  SELECTED_PLAN,
+  UPGRADE_FROM_PLAN,
+  PROFILE,
+} from '../../../lib/mock-data';
 
 import { SignInLayout } from '../../../components/AppLayout';
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -8,7 +8,6 @@ import {
   Profile,
 } from '../../../store/types';
 import { SelectorReturns } from '../../../store/selectors';
-import { metadataFromPlan } from '../../../store/utils';
 
 import * as Amplitude from '../../../lib/amplitude';
 
@@ -220,7 +219,7 @@ export const SubscriptionUpgrade = ({
             </div>
 
             <PaymentLegalBlurb />
-            <TermsAndPrivacy />
+            <TermsAndPrivacy plan={selectedPlan} />
           </Form>
         </div>
         <PlanUpgradeDetails

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -68,10 +68,22 @@ export interface ProductMetadata {
   // capabilities:{clientID}: string // filtered out or ignored for now
 }
 
-export interface ProductDetails {
-  subtitle?: string;
-  details?: string[];
+// The ProductDetails type is exploded out into enums describing keys to
+// make Stripe metadata parsing & validation easier.
+export enum ProductDetailsStringProperties {
+  'subtitle',
+  'termsOfServiceURL',
+  'privacyNoticeURL',
 }
+export enum ProductDetailsListProperties {
+  'details',
+}
+export type ProductDetailsStringProperty = keyof typeof ProductDetailsStringProperties;
+export type ProductDetailsListProperty = keyof typeof ProductDetailsListProperties;
+export type ProductDetails = {
+  [key in ProductDetailsStringProperty]?: string;
+} &
+  { [key in ProductDetailsListProperty]?: string[] };
 
 export interface Subscription {
   subscriptionId: string;

--- a/packages/fxa-payments-server/src/store/utils.test.tsx
+++ b/packages/fxa-payments-server/src/store/utils.test.tsx
@@ -78,14 +78,22 @@ describe('productDetailsFromPlan', () => {
       'product:details:1': 'Foo Device-level encryption',
       'product:details:2': 'Bar Servers in 30+ countries',
       'product:details:4': 'Quux Available for Windows, iOS and Android',
+      'product:termsOfServiceURL': 'https://example.org/en-US/terms',
+      'product:privacyNoticeURL': 'https://example.org/en-US/privacy',
       'product:subtitle:xx-pirate': 'VPN fer yer full-device',
       'product:foobar:9:xx-pirate': 'what even is this',
       'product:details:4:xx-pirate': "Available fer Windows, iOS an' Android",
       'product:details:1:xx-pirate': 'Device-level encryption arr',
       'product:details:3:xx-pirate': "Connects 5 devices wit' one subscription",
       'product:details:2:xx-pirate': 'Servers is 30+ countries matey',
+      'product:termsOfServiceURL:xx-pirate':
+        'https://example.org/xx-pirate/terms',
+      'product:privacyNoticeURL:xx-pirate':
+        'https://example.org/xx-pirate/privacy',
       'product:subtitle:xx-partial': 'Partial localization',
       'product:details:1:xx-partial': true,
+      'product:termsOfServiceURL:xx-partial':
+        'https://example.org/xx-partial/terms',
     },
   };
 
@@ -98,6 +106,10 @@ describe('productDetailsFromPlan', () => {
         'Connect 5 devices with one subscription',
         'Available for Windows, iOS and Android',
       ],
+      termsOfServiceURL:
+        'https://www.mozilla.org/about/legal/terms/firefox-private-network',
+      privacyNoticeURL:
+        'https://www.mozilla.org/privacy/firefox-private-network',
     });
   });
 
@@ -110,6 +122,8 @@ describe('productDetailsFromPlan', () => {
         'Baz Connects 5 devices with one subscription',
         'Quux Available for Windows, iOS and Android',
       ],
+      termsOfServiceURL: 'https://example.org/en-US/terms',
+      privacyNoticeURL: 'https://example.org/en-US/privacy',
     });
   });
 
@@ -122,6 +136,8 @@ describe('productDetailsFromPlan', () => {
         "Connects 5 devices wit' one subscription",
         "Available fer Windows, iOS an' Android",
       ],
+      termsOfServiceURL: 'https://example.org/xx-pirate/terms',
+      privacyNoticeURL: 'https://example.org/xx-pirate/privacy',
     });
   });
 
@@ -134,6 +150,8 @@ describe('productDetailsFromPlan', () => {
         'Baz Connects 5 devices with one subscription',
         'Quux Available for Windows, iOS and Android',
       ],
+      termsOfServiceURL: 'https://example.org/xx-partial/terms',
+      privacyNoticeURL: 'https://example.org/en-US/privacy',
     });
   });
 
@@ -146,6 +164,8 @@ describe('productDetailsFromPlan', () => {
         'Baz Connects 5 devices with one subscription',
         'Quux Available for Windows, iOS and Android',
       ],
+      termsOfServiceURL: 'https://example.org/en-US/terms',
+      privacyNoticeURL: 'https://example.org/en-US/privacy',
     });
   });
 });


### PR DESCRIPTION
- add support for new product metadata properties
  - product:termsOfServiceURL
  - product:termsOfServiceURL:{locale}
  - product:privacyNoticeURL
  - product:privacyNoticeURL:{locale}

- rework TermsAndPrivacy compoment to use localized product details as
  source of terms & privacy link URLs

- refactor product details parsing to simplify & DRY up types

- updates to tests & stories

https://jira.mozilla.com/browse/FXA-2150
fixes #5711 