### PR TITLE
feat(payments): Add legal doc links to payment confirmation checkbox label

### DIFF
--- a/packages/fxa-payments-server/.storybook/components/MockApp.tsx
+++ b/packages/fxa-payments-server/.storybook/components/MockApp.tsx
@@ -18,6 +18,7 @@ type MockAppProps = {
   appContextValue?: AppContextType;
   stripeApiKey?: string;
   applyStubsToStripe?: (orig: stripe.Stripe) => stripe.Stripe;
+  languages?: readonly string[];
 };
 
 export const defaultAppContextValue: AppContextType = {
@@ -62,6 +63,7 @@ export const MockApp = ({
   stripeApiKey = '8675309',
   applyStubsToStripe = defaultStripeStubs,
   appContextValue = defaultAppContextValue,
+  languages = navigator.languages,
 }: MockAppProps) => {
   const mockStripe = useMemo<stripe.Stripe>(
     () => applyStubsToStripe(window.Stripe(stripeApiKey)),
@@ -78,10 +80,12 @@ export const MockApp = ({
   }, []);
 
   return (
-    <AppContext.Provider value={appContextValue}>
+    <AppContext.Provider
+      value={{ ...appContextValue, navigatorLanguages: languages }}
+    >
       <AppLocalizationProvider
         baseDir="./locales"
-        userLocales={navigator.languages}
+        userLocales={languages}
         bundles={['main']}
       >
         <StripeProvider stripe={mockStripe}>

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -93,27 +93,27 @@ payment-zip =
   .label = ZIP code
 ##  $amount (Number) - The amount billed. It will be formatted as currency.
 # $intervalCount (Number) - The interval between payments, in days.
-payment-confirm-day = { $intervalCount ->
-  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } daily</strong>, according to payment terms, until I cancel my subscription.
-  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } days</strong>, according to payment terms, until I cancel my subscription.
+payment-confirm-with-legal-links-day = { $intervalCount ->
+  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
+  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } days</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
 #  $intervalCount (Number) - The interval between payments, in weeks.
-payment-confirm-week = { $intervalCount ->
-  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } weekly</strong>, according to payment terms, until I cancel my subscription.
-  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } weeks</strong>, according to payment terms, until I cancel my subscription.
+payment-confirm-with-legal-links-week = { $intervalCount ->
+  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } weekly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
+  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } weeks</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
 #  $intervalCount (Number) - The interval between payments, in months.
-payment-confirm-month = { $intervalCount ->
-  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } monthly</strong>, according to payment terms, until I cancel my subscription.
-  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } months</strong>, according to payment terms, until I cancel my subscription.
+payment-confirm-with-legal-links-month = { $intervalCount ->
+  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } monthly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
+  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } months</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
 #  $intervalCount (Number) - The interval between payments, in years.
-payment-confirm-year = { $intervalCount ->
-  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } yearly</strong>, according to payment terms, until I cancel my subscription.
-  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } years</strong>, according to payment terms, until I cancel my subscription.
+payment-confirm-with-legal-links-year = { $intervalCount ->
+  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } yearly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
+  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } years</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
 
-payment-confirm = I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${ $amount } per { $interval }</strong>, according to payment terms, until I cancel my subscription.
+payment-confirm = I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${ $amount } per { $interval }</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 
 ##
 payment-cancel-btn = Cancel
@@ -145,23 +145,23 @@ sub-update-copy =
 ##  $amount (Number) - The amount billed. It will be formatted as currency.
 #  $intervalCount (Number) - The interval between payments, in days.
 sub-update-confirm-day = { $intervalCount ->
-  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } daily</strong>, according to payment terms, until I cancel my subscription.
-  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } days</strong>, according to payment terms, until I cancel my subscription.
+  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
+  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } days</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
 #  $intervalCount (Number) - The interval between payments, in weeks.
 sub-update-confirm-week = { $intervalCount ->
-  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } weekly</strong>, according to payment terms, until I cancel my subscription.
-  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } weeks</strong>, according to payment terms, until I cancel my subscription.
+  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } weekly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
+  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } weeks</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
 #  $intervalCount (Number) - The interval between payments, in months.
 sub-update-confirm-month = { $intervalCount ->
-  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } monthly</strong>, according to payment terms, until I cancel my subscription.
-  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } months</strong>, according to payment terms, until I cancel my subscription.
+  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } monthly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
+  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } months</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
 #  $intervalCount (Number) - The interval between payments, in years.
 sub-update-confirm-year = { $intervalCount ->
-  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } yearly</strong>, according to payment terms, until I cancel my subscription.
-  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } years</strong>, according to payment terms, until I cancel my subscription.
+  [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } yearly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
+  *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } years</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
 
 ##

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
@@ -14,6 +14,7 @@ import { useNonce } from '../../lib/hooks';
 function init() {
   storiesOf('components/PaymentForm', module)
     .add('default', () => <Subject />)
+    .add('fr locale (for legal links)', () => <Subject locale="fr" />)
     .add('in progress', () => <Subject inProgress={true} />)
     .add('all invalid', () => {
       const state = mockValidatorState();
@@ -44,6 +45,16 @@ const PLAN = {
   amount: 1099,
   interval: 'month' as const,
   interval_count: 1,
+  product_metadata: {
+    'product:termsOfServiceURL':
+      'https://www.mozilla.org/en-US/about/legal/terms/services/',
+    'product:termsOfServiceURL:fr':
+      'https://www.mozilla.org/fr/about/legal/terms/services/',
+    'product:privacyNoticeURL':
+      'https://www.mozilla.org/en-US/privacy/websites/',
+    'product:privacyNoticeURL:fr':
+      'https://www.mozilla.org/fr/privacy/websites/',
+  },
 };
 
 type SubjectProps = {
@@ -55,6 +66,7 @@ type SubjectProps = {
   onChange?: Function;
   validatorInitialState?: ValidatorState;
   validatorMiddlewareReducer?: ValidatorMiddlewareReducer;
+  locale?: string;
 };
 
 const Subject = ({
@@ -66,6 +78,7 @@ const Subject = ({
   validatorInitialState,
   validatorMiddlewareReducer,
   onChange = () => {},
+  locale = 'en-US',
 }: SubjectProps) => {
   const [submitNonce, refreshSubmitNonce] = useNonce();
 
@@ -84,7 +97,7 @@ const Subject = ({
     getString: () => {},
   };
   return (
-    <MockPage>
+    <MockPage locale={locale}>
       <div className="product-payment">
         <button onClick={refreshSubmitNonce}>Refresh submit nonce</button>
         <p>Current nonce: {submitNonce}</p>
@@ -95,12 +108,13 @@ const Subject = ({
 };
 
 type MockPageProps = {
+  locale: string;
   children: React.ReactNode;
 };
 
-const MockPage = ({ children }: MockPageProps) => {
+const MockPage = ({ locale, children }: MockPageProps) => {
   return (
-    <MockApp>
+    <MockApp languages={[locale]}>
       <SignInLayout>{children}</SignInLayout>
     </MockApp>
   );

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
@@ -227,9 +227,9 @@ describe('Legal', () => {
     it('renders Localized for daily plan with correct props and displays correct default string', async () => {
       const plan_id = 'plan_daily';
       const plan = findMockPlan(plan_id);
-      const expectedMsgId = 'payment-confirm-day';
+      const expectedMsgId = 'payment-confirm-with-legal-links-day';
       const expectedMsg =
-        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to payment terms, until I cancel my subscription.';
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
       runTests(plan, expectedMsgId, expectedMsg);
     });
@@ -237,9 +237,9 @@ describe('Legal', () => {
     it('renders Localized for 6 days plan with correct props and displays correct default string', async () => {
       const plan_id = 'plan_6days';
       const plan = findMockPlan(plan_id);
-      const expectedMsgId = 'payment-confirm-day';
+      const expectedMsgId = 'payment-confirm-with-legal-links-day';
       const expectedMsg =
-        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to payment terms, until I cancel my subscription.';
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
       runTests(plan, expectedMsgId, expectedMsg);
     });
@@ -247,9 +247,9 @@ describe('Legal', () => {
     it('renders Localized for weekly plan with correct props and displays correct default string', async () => {
       const plan_id = 'plan_weekly';
       const plan = findMockPlan(plan_id);
-      const expectedMsgId = 'payment-confirm-week';
+      const expectedMsgId = 'payment-confirm-with-legal-links-week';
       const expectedMsg =
-        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to payment terms, until I cancel my subscription.';
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
       runTests(plan, expectedMsgId, expectedMsg);
     });
@@ -257,9 +257,9 @@ describe('Legal', () => {
     it('renders Localized for 6 weeks plan with correct props and displays correct default string', async () => {
       const plan_id = 'plan_6weeks';
       const plan = findMockPlan(plan_id);
-      const expectedMsgId = 'payment-confirm-week';
+      const expectedMsgId = 'payment-confirm-with-legal-links-week';
       const expectedMsg =
-        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to payment terms, until I cancel my subscription.';
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
       runTests(plan, expectedMsgId, expectedMsg);
     });
@@ -267,9 +267,9 @@ describe('Legal', () => {
     it('renders Localized for monthly plan with correct props and displays correct default string', async () => {
       const plan_id = 'plan_monthly';
       const plan = findMockPlan(plan_id);
-      const expectedMsgId = 'payment-confirm-month';
+      const expectedMsgId = 'payment-confirm-with-legal-links-month';
       const expectedMsg =
-        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to payment terms, until I cancel my subscription.';
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
       runTests(plan, expectedMsgId, expectedMsg);
     });
@@ -277,9 +277,9 @@ describe('Legal', () => {
     it('renders Localized for 6 months plan with correct props and displays correct default string', async () => {
       const plan_id = 'plan_6months';
       const plan = findMockPlan(plan_id);
-      const expectedMsgId = 'payment-confirm-month';
+      const expectedMsgId = 'payment-confirm-with-legal-links-month';
       const expectedMsg =
-        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to payment terms, until I cancel my subscription.';
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
       runTests(plan, expectedMsgId, expectedMsg);
     });
@@ -287,9 +287,9 @@ describe('Legal', () => {
     it('renders Localized for yearly plan with correct props and displays correct default string', async () => {
       const plan_id = 'plan_yearly';
       const plan = findMockPlan(plan_id);
-      const expectedMsgId = 'payment-confirm-year';
+      const expectedMsgId = 'payment-confirm-with-legal-links-year';
       const expectedMsg =
-        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to payment terms, until I cancel my subscription.';
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
       runTests(plan, expectedMsgId, expectedMsg);
     });
@@ -297,9 +297,9 @@ describe('Legal', () => {
     it('renders Localized for years plan with correct props and displays correct default string', async () => {
       const plan_id = 'plan_6years';
       const plan = findMockPlan(plan_id);
-      const expectedMsgId = 'payment-confirm-year';
+      const expectedMsgId = 'payment-confirm-with-legal-links-year';
       const expectedMsg =
-        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to payment terms, until I cancel my subscription.';
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
       runTests(plan, expectedMsgId, expectedMsg);
     });
@@ -312,12 +312,12 @@ describe('Legal', () => {
       amount,
     };
 
-    describe('when the localized id is payment-confirm-day', () => {
-      const msgId = 'payment-confirm-day';
+    describe('when the localized id is payment-confirm-with-legal-links-day', () => {
+      const msgId = 'payment-confirm-with-legal-links-day';
 
       it('returns the correct string for an interval count of 1', () => {
         const expected =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         const actual = getLocalizedMessage(bundle, msgId, {
           ...args,
@@ -328,7 +328,7 @@ describe('Legal', () => {
 
       it('returns the correct string for an interval count greater than 1', () => {
         const expected =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         const actual = getLocalizedMessage(bundle, msgId, {
           ...args,
@@ -338,12 +338,12 @@ describe('Legal', () => {
       });
     });
 
-    describe('when the localized id is payment-confirm-week', () => {
-      const msgId = 'payment-confirm-week';
+    describe('when the localized id is payment-confirm-with-legal-links-week', () => {
+      const msgId = 'payment-confirm-with-legal-links-week';
 
       it('returns the correct string for an interval count of 1', () => {
         const expected =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         const actual = getLocalizedMessage(bundle, msgId, {
           ...args,
@@ -354,7 +354,7 @@ describe('Legal', () => {
 
       it('returns the correct string for an interval count greater than 1', () => {
         const expected =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         const actual = getLocalizedMessage(bundle, msgId, {
           ...args,
@@ -364,12 +364,12 @@ describe('Legal', () => {
       });
     });
 
-    describe('when the localized id is payment-confirm-month', () => {
-      const msgId = 'payment-confirm-month';
+    describe('when the localized id is payment-confirm-with-legal-links-month', () => {
+      const msgId = 'payment-confirm-with-legal-links-month';
 
       it('returns the correct string for an interval count of 1', () => {
         const expected =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         const actual = getLocalizedMessage(bundle, msgId, {
           ...args,
@@ -380,7 +380,7 @@ describe('Legal', () => {
 
       it('returns the correct string for an interval count greater than 1', async () => {
         const expected =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         const actual = getLocalizedMessage(bundle, msgId, {
           ...args,
@@ -390,12 +390,12 @@ describe('Legal', () => {
       });
     });
 
-    describe('when the localized id is payment-confirm-year', () => {
-      const msgId = 'payment-confirm-year';
+    describe('when the localized id is payment-confirm-with-legal-links-year', () => {
+      const msgId = 'payment-confirm-with-legal-links-year';
 
       it('returns the correct string for an interval count of 1', () => {
         const expected =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         const actual = getLocalizedMessage(bundle, msgId, {
           ...args,
@@ -406,7 +406,7 @@ describe('Legal', () => {
 
       it('returns the correct string for an interval count greater than 1', () => {
         const expected =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         const actual = getLocalizedMessage(bundle, msgId, {
           ...args,

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -34,6 +34,10 @@ import { AppContext } from '../../lib/AppContext';
 
 import './index.scss';
 import { Plan, PlanInterval } from '../../store/types';
+import {
+  DEFAULT_PRODUCT_DETAILS,
+  productDetailsFromPlan,
+} from '../../store/utils';
 import { TermsAndPrivacy } from '../TermsAndPrivacy';
 
 // Define a minimal type for what we use from the Stripe API, which makes
@@ -133,10 +137,16 @@ export const PaymentForm = ({
     ]
   );
 
-  const { matchMedia } = useContext(AppContext);
+  const { matchMedia, navigatorLanguages } = useContext(AppContext);
   const stripeElementStyles = mkStripeElementStyles(
     matchMedia(SMALL_DEVICE_RULE)
   );
+  // TODO: if a plan is not supplied, fall back to default details
+  // This mainly happens in ProductUpdateForm where we're updating payment
+  // details across *all* plans - are there better URLs to pick in that case?
+  const { termsOfServiceURL, privacyNoticeURL } = plan
+    ? productDetailsFromPlan(plan, navigatorLanguages)
+    : DEFAULT_PRODUCT_DETAILS;
 
   return (
     <Form
@@ -215,10 +225,12 @@ export const PaymentForm = ({
 
       {confirm && plan && (
         <Localized
-          id={`payment-confirm-${plan.interval}`}
+          id={`payment-confirm-with-legal-links-${plan.interval}`}
           $intervalCount={plan.interval_count}
           $amount={getLocalizedCurrency(plan.amount, plan.currency)}
           strong={<strong></strong>}
+          termsOfServiceLink={<a href={termsOfServiceURL}></a>}
+          privacyNoticeLink={<a href={privacyNoticeURL}></a>}
         >
           <Checkbox data-testid="confirm" name="confirm" required>
             {getDefaultPaymentConfirmText(

--- a/packages/fxa-payments-server/src/lib/formats.ts
+++ b/packages/fxa-payments-server/src/lib/formats.ts
@@ -160,5 +160,5 @@ export function getDefaultPaymentConfirmText(
     intervalCount
   );
 
-  return `I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${planPricing}</strong>, according to payment terms, until I cancel my subscription.`;
+  return `I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${planPricing}</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.`;
 }

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -189,7 +189,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'sub-update-confirm-day';
         const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         runTests(plan, expectedMsgId, expectedMsg);
       });
@@ -199,7 +199,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'sub-update-confirm-day';
         const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         runTests(plan, expectedMsgId, expectedMsg);
       });
@@ -209,7 +209,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'sub-update-confirm-week';
         const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         runTests(plan, expectedMsgId, expectedMsg);
       });
@@ -219,7 +219,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'sub-update-confirm-week';
         const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         runTests(plan, expectedMsgId, expectedMsg);
       });
@@ -229,7 +229,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'sub-update-confirm-month';
         const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         runTests(plan, expectedMsgId, expectedMsg);
       });
@@ -239,7 +239,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'sub-update-confirm-month';
         const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         runTests(plan, expectedMsgId, expectedMsg);
       });
@@ -249,7 +249,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'sub-update-confirm-year';
         const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         runTests(plan, expectedMsgId, expectedMsg);
       });
@@ -259,7 +259,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
         const plan = findMockPlan(plan_id);
         const expectedMsgId = 'sub-update-confirm-year';
         const expectedMsg =
-          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to payment terms, until I cancel my subscription.';
+          'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
         runTests(plan, expectedMsgId, expectedMsg);
       });
@@ -277,7 +277,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
 
         it('returns the correct string for an interval count of 1', () => {
           const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to payment terms, until I cancel my subscription.';
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
           const actual = getLocalizedMessage(bundle, msgId, {
             ...args,
@@ -288,7 +288,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
 
         it('returns the correct string for an interval count greater than 1', () => {
           const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to payment terms, until I cancel my subscription.';
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
           const actual = getLocalizedMessage(bundle, msgId, {
             ...args,
             intervalCount: 6,
@@ -302,7 +302,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
 
         it('returns the correct string for an interval count of 1', () => {
           const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to payment terms, until I cancel my subscription.';
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
           const actual = getLocalizedMessage(bundle, msgId, {
             ...args,
@@ -313,7 +313,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
 
         it('returns the correct string for an interval count greater than 1', () => {
           const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to payment terms, until I cancel my subscription.';
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
           const actual = getLocalizedMessage(bundle, msgId, {
             ...args,
@@ -328,7 +328,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
 
         it('returns the correct string for an interval count of 1', () => {
           const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to payment terms, until I cancel my subscription.';
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
           const actual = getLocalizedMessage(bundle, msgId, {
             ...args,
@@ -339,7 +339,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
 
         it('returns the correct string for an interval count greater than 1', () => {
           const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to payment terms, until I cancel my subscription.';
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
           const actual = getLocalizedMessage(bundle, msgId, {
             ...args,
@@ -354,7 +354,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
 
         it('returns the correct string for an interval count of 1', () => {
           const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to payment terms, until I cancel my subscription.';
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
           const actual = getLocalizedMessage(bundle, msgId, {
             ...args,
@@ -365,7 +365,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
 
         it('returns the correct string for an interval count greater than 1', () => {
           const expected =
-            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to payment terms, until I cancel my subscription.';
+            'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
           const actual = getLocalizedMessage(bundle, msgId, {
             ...args,

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useContext } from 'react';
 import { Localized } from '@fluent/react';
 
 import {
@@ -29,6 +29,8 @@ import { TermsAndPrivacy } from '../../../components/TermsAndPrivacy';
 
 import PlanUpgradeDetails from './PlanUpgradeDetails';
 import Header from '../../../components/Header';
+import { AppContext } from '../../../lib/AppContext';
+import { productDetailsFromPlan } from '../../../store/utils';
 
 import './index.scss';
 
@@ -57,6 +59,12 @@ export const SubscriptionUpgrade = ({
   resetUpdateSubscriptionPlan,
   updateSubscriptionPlanStatus,
 }: SubscriptionUpgradeProps) => {
+  const { navigatorLanguages } = useContext(AppContext);
+  const { termsOfServiceURL, privacyNoticeURL } = productDetailsFromPlan(
+    selectedPlan,
+    navigatorLanguages
+  );
+
   const validator = useValidatorState();
 
   const inProgress = updateSubscriptionPlanStatus.loading;
@@ -182,6 +190,8 @@ export const SubscriptionUpgrade = ({
                 selectedPlan.currency
               )}
               $intervalCount={selectedPlan.interval_count}
+              termsOfServiceLink={<a href={termsOfServiceURL}></a>}
+              privacyNoticeLink={<a href={privacyNoticeURL}></a>}
             >
               <Checkbox
                 data-testid="confirm"


### PR DESCRIPTION
~Depends on first merging https://github.com/mozilla/fxa/pull/5723~ Merged

- replace `according to payment term` in all FTL strings with `according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>`

- update message IDs from `payment-confirm-*` to `payment-confirm-with-legal-links-*`

- supply legal doc URLs to localized rendering of confirmation checkbox label from Stripe metadata product details

- enable storybook MockApp to accept a locale to exercise localized content

fixes #5584
