### PR TITLE
feat(auth + content): add endpoint and hook up CAD QR flow to trigger reminder

### DIFF
--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -84,6 +84,7 @@ module.exports = (
   customs,
   push,
   verificationReminders,
+  cadReminders,
   signupUtils,
   zendeskClient,
   /** @type import('../payments/stripe').StripeHelper */
@@ -1035,6 +1036,39 @@ module.exports = (
           secondaryEmail: matchedEmail.email,
           uid,
         });
+
+        return {};
+      },
+    },
+    {
+      method: 'POST',
+      path: '/emails/reminders/cad',
+      options: {
+        auth: {
+          strategy: 'sessionToken',
+        },
+      },
+      handler: async function (request) {
+        log.begin('Account.CadReminderEmail', request);
+
+        const sessionToken = request.auth.credentials;
+        const uid = sessionToken.uid;
+
+        const reminders = await cadReminders.get(uid);
+        const exists = cadReminders.keys.some((key) => {
+          return reminders[key] !== null;
+        });
+
+        if (!exists) {
+          await cadReminders.create(uid);
+          log.info('cad.reminder.created', {
+            uid,
+          });
+        } else {
+          log.info('cad.reminder.exists', {
+            uid,
+          });
+        }
 
         return {};
       },

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -39,6 +39,7 @@ module.exports = function (
     log,
     config
   );
+  const cadReminders = require('../cad-reminders')(config, log);
   const signupUtils = require('./utils/signup')(
     log,
     db,
@@ -101,6 +102,7 @@ module.exports = function (
     customs,
     push,
     verificationReminders,
+    cadReminders,
     signupUtils,
     zendeskClient,
     stripeHelper

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -215,6 +215,7 @@ module.exports = {
   mockSubHub,
   mockProfile,
   mockVerificationReminders,
+  mockCadReminders,
   mockStripeHelper,
 };
 
@@ -789,6 +790,20 @@ function mockVerificationReminders(data = {}) {
     keys: ['first', 'second', 'third'],
     create: sinon.spy(() => data.create || { first: 1, second: 1, third: 1 }),
     delete: sinon.spy(() => data.delete || { first: 1, second: 1, third: 1 }),
+    process: sinon.spy(
+      () => data.process || { first: [], second: [], third: [] }
+    ),
+  };
+}
+
+function mockCadReminders(data = {}) {
+  return {
+    keys: ['first', 'second', 'third'],
+    create: sinon.spy(() => data.create || { first: 1, second: 1, third: 1 }),
+    delete: sinon.spy(() => data.delete || { first: 1, second: 1, third: 1 }),
+    get: sinon.spy(
+      () => data.get || { first: null, second: null, third: null }
+    ),
     process: sinon.spy(
       () => data.process || { first: [], second: [], third: [] }
     ),

--- a/packages/fxa-content-server/app/scripts/lib/auth/client.ts
+++ b/packages/fxa-content-server/app/scripts/lib/auth/client.ts
@@ -845,6 +845,10 @@ export default class AuthClient {
     return this.sessionPost('/signinCodes', sessionToken, {});
   }
 
+  async createCadReminder(sessionToken: string) {
+    return this.sessionPost('/emails/reminders/cad', sessionToken, {});
+  }
+
   async recoveryEmails(sessionToken: string) {
     return this.sessionGet('/recovery_emails', sessionToken);
   }

--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -1386,6 +1386,13 @@ FxaClientWrapper.prototype = {
    * @returns {Promise} resolves with response when complete.
    */
   createSigninCode: createClientDelegate('createSigninCode'),
+
+  /**
+   * Queues up a reminder to CAD to be delivered at a later time.
+   *
+   * @returns {Promise} resolves with response when complete.
+   */
+  createCadReminder: createClientDelegate('createCadReminder'),
 };
 
 export default FxaClientWrapper;

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -1682,6 +1682,15 @@ const Account = Backbone.Model.extend(
     createSigninCode() {
       return this._fxaClient.createSigninCode(this.get('sessionToken'));
     },
+
+    /**
+     * Queues up a reminder to CAD to be delivered at a later time.
+     *
+     * @returns {Promise} resolves with response when complete.
+     */
+    createCadReminder() {
+      return this._fxaClient.createCadReminder(this.get('sessionToken'));
+    },
   },
   {
     ALLOWED_KEYS: ALLOWED_KEYS,

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/cad_qr/get_started.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/cad_qr/get_started.mustache
@@ -16,7 +16,7 @@
                 <button id="submit-btn" type="submit">{{#t}}Get started{{/t}}</button>
             </div>
             <div class="links">
-                <a id="maybe-later-btn" data-flow-event="link.maybe-later">{{#t}}I'll do this later, send me a reminder{{/t}}</a>
+                <a id="maybe-later-link" data-flow-event="link.maybe-later">{{#t}}I'll do this later, send me a reminder{{/t}}</a>
             </div>
         </form>
     </section>

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/cad_qr/ready_to_scan.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/cad_qr/ready_to_scan.mustache
@@ -17,7 +17,7 @@
             </div>
             <div class="links centered">
                 <a id="use-sms-link" data-flow-event="link.use-sms">{{#t}}Use SMS instead{{/t}}</a>
-                <a id="maybe-later-link" data-flow-event="link.maybe-later" href="{{maybeLaterLink}}">{{#t}}I'll do this later, send me a reminder{{/t}}</a>
+                <a id="maybe-later-link" data-flow-event="link.maybe-later">{{#t}}I'll do this later, send me a reminder{{/t}}</a>
             </div>
         </form>
     </section>

--- a/packages/fxa-content-server/app/scripts/views/post_verify/cad_qr/get_started.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/cad_qr/get_started.js
@@ -8,13 +8,15 @@ import FlowEventsMixin from './../../mixins/flow-events-mixin';
 import FormView from '../../form';
 import Template from 'templates/post_verify/cad_qr/get_started.mustache';
 import preventDefaultThen from '../../decorators/prevent_default_then';
+import { MOZ_ORG_SYNC_GET_STARTED_LINK } from '../../../lib/constants';
 
 class GetStarted extends FormView {
   template = Template;
   viewName = 'get-started';
+  settingReminder = false;
 
   events = assign(this.events, {
-    'click #maybe-later-btn': preventDefaultThen('clickMaybeLater'),
+    'click #maybe-later-link': preventDefaultThen('clickMaybeLater'),
   });
 
   submit() {
@@ -22,7 +24,20 @@ class GetStarted extends FormView {
   }
 
   clickMaybeLater() {
-    return this.navigate('/sms');
+    if (this.settingReminder) {
+      return;
+    }
+
+    this.settingReminder = true;
+    const account = this.getSignedInAccount();
+    return account
+      .createCadReminder()
+      .then(() => {
+        this.navigateAway(MOZ_ORG_SYNC_GET_STARTED_LINK);
+      })
+      .catch(() => {
+        this.settingReminder = false;
+      });
   }
 }
 

--- a/packages/fxa-content-server/app/scripts/views/post_verify/cad_qr/ready_to_scan.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/cad_qr/ready_to_scan.js
@@ -13,9 +13,11 @@ import { MOZ_ORG_SYNC_GET_STARTED_LINK } from '../../../lib/constants';
 class ReadyToScan extends FormView {
   template = Template;
   viewName = 'ready-to-scan';
+  settingReminder = false;
 
   events = assign(this.events, {
     'click #use-sms-link': preventDefaultThen('clickUseSms'),
+    'click #maybe-later-link': preventDefaultThen('clickMaybeLater'),
   });
 
   setInitialContext(context) {
@@ -30,6 +32,23 @@ class ReadyToScan extends FormView {
 
   clickUseSms() {
     return this.navigate('/sms');
+  }
+
+  clickMaybeLater() {
+    if (this.settingReminder) {
+      return;
+    }
+
+    this.settingReminder = true;
+    const account = this.getSignedInAccount();
+    return account
+      .createCadReminder()
+      .then(() => {
+        this.navigateAway(MOZ_ORG_SYNC_GET_STARTED_LINK);
+      })
+      .catch(() => {
+        this.settingReminder = false;
+      });
   }
 }
 

--- a/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
@@ -1871,4 +1871,17 @@ describe('lib/fxa-client', function () {
       });
     });
   });
+
+  describe('createCadReminder', () => {
+    it('delegates to the fxa-js-client', () => {
+      const sessionToken = 'cool token bro';
+      sinon.stub(realClient, 'createCadReminder').resolves();
+
+      return client.createCadReminder(sessionToken).then((res) => {
+        assert.isTrue(
+          realClient.createCadReminder.calledOnceWith(sessionToken)
+        );
+      });
+    });
+  });
 });

--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/get_started.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/get_started.js
@@ -15,6 +15,7 @@ import User from 'models/user';
 import View from 'views/post_verify/cad_qr/get_started';
 import WindowMock from '../../../../mocks/window';
 import $ from 'jquery';
+import { MOZ_ORG_SYNC_GET_STARTED_LINK } from '../../../../../../app/scripts/lib/constants';
 
 describe('views/post_verify/cad_qr/get_started', () => {
   let account;
@@ -57,6 +58,8 @@ describe('views/post_verify/cad_qr/get_started', () => {
       user,
     });
 
+    sinon.stub(account, 'createCadReminder').callsFake(() => Promise.resolve());
+
     return view.render().then(() => $('#container').html(view.$el));
   });
 
@@ -72,7 +75,7 @@ describe('views/post_verify/cad_qr/get_started', () => {
       assert.lengthOf(view.$('#fxa-cad-qr-get-started-header'), 1);
       assert.lengthOf(view.$('.graphic-laptop-mobile'), 1);
       assert.lengthOf(view.$('#submit-btn'), 1);
-      assert.lengthOf(view.$('#maybe-later-btn'), 1);
+      assert.lengthOf(view.$('#maybe-later-link'), 1);
     });
   });
 
@@ -94,12 +97,16 @@ describe('views/post_verify/cad_qr/get_started', () => {
   describe('click maybe later', () => {
     describe('success', () => {
       beforeEach(() => {
-        sinon.spy(view, 'navigate');
+        sinon.spy(view, 'navigateAway');
+        sinon.stub(view, 'getSignedInAccount').callsFake(() => account);
         return view.clickMaybeLater();
       });
 
-      it('calls correct broker methods', () => {
-        assert.isTrue(view.navigate.calledWith('/sms'));
+      it('calls correct methods', () => {
+        assert.isTrue(account.createCadReminder.calledOnce);
+        assert.isTrue(
+          view.navigateAway.calledOnceWith(MOZ_ORG_SYNC_GET_STARTED_LINK)
+        );
       });
     });
   });

--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/ready_to_scan.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/ready_to_scan.js
@@ -15,6 +15,7 @@ import User from 'models/user';
 import View from 'views/post_verify/cad_qr/ready_to_scan';
 import WindowMock from '../../../../mocks/window';
 import $ from 'jquery';
+import { MOZ_ORG_SYNC_GET_STARTED_LINK } from '../../../../../../app/scripts/lib/constants';
 
 describe('views/post_verify/cad_qr/ready_to_scan', () => {
   let account;
@@ -56,6 +57,8 @@ describe('views/post_verify/cad_qr/ready_to_scan', () => {
       relier,
       user,
     });
+
+    sinon.stub(account, 'createCadReminder').callsFake(() => Promise.resolve());
 
     return view.render().then(() => $('#container').html(view.$el));
   });
@@ -101,6 +104,23 @@ describe('views/post_verify/cad_qr/ready_to_scan', () => {
 
       it('calls correct broker methods', () => {
         assert.isTrue(view.navigate.calledWith('/sms'));
+      });
+    });
+  });
+
+  describe('click maybe later', () => {
+    describe('success', () => {
+      beforeEach(() => {
+        sinon.spy(view, 'navigateAway');
+        sinon.stub(view, 'getSignedInAccount').callsFake(() => account);
+        return view.clickMaybeLater();
+      });
+
+      it('calls correct methods', () => {
+        assert.isTrue(account.createCadReminder.calledOnce);
+        assert.isTrue(
+          view.navigateAway.calledOnceWith(MOZ_ORG_SYNC_GET_STARTED_LINK)
+        );
       });
     });
   });

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -326,12 +326,12 @@ module.exports = {
   POST_VERIFY_CAD_QR_GET_STARTED: {
     HEADER: '#fxa-cad-qr-get-started-header',
     SUBMIT: 'button[type="submit"]',
-    LATER: '#maybe-later-btn',
+    LATER: '#maybe-later-link',
   },
   POST_VERIFY_CAD_QR_READY_TO_SCAN: {
     HEADER: '#fxa-cad-qr-ready-to-scan-header',
     SUBMIT: 'button[type="submit"]',
-    LATER: '#maybe-later-btn',
+    LATER: '#maybe-later-link',
     USE_SMS: '#use-sms-link',
   },
   POST_VERIFY_CAD_QR_SCAN_CODE: {

--- a/packages/fxa-content-server/tests/functional/post_verify/cad_qr.js
+++ b/packages/fxa-content-server/tests/functional/post_verify/cad_qr.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const { registerSuite } = intern.getInterface('object');
+const { assert } = intern.getPlugin('chai');
 const FunctionalHelpers = require('./../lib/helpers');
 const selectors = require('./../lib/selectors');
 const uaStrings = require('../lib/ua-strings');
@@ -72,8 +73,20 @@ registerSuite('cad_qr_signin', {
           .then(
             testElementExists(selectors.POST_VERIFY_CAD_QR_GET_STARTED.HEADER)
           )
+          .then(click(selectors.POST_VERIFY_CAD_QR_GET_STARTED.LATER))
+          .getCurrentUrl()
+          .then(function (url) {
+            assert.isTrue(url.includes('mozilla.org'));
+          })
+          .goBack()
           .then(click(selectors.POST_VERIFY_CAD_QR_GET_STARTED.SUBMIT))
 
+          .then(click(selectors.POST_VERIFY_CAD_QR_READY_TO_SCAN.LATER))
+          .getCurrentUrl()
+          .then(function (url) {
+            assert.isTrue(url.includes('mozilla.org'));
+          })
+          .goBack()
           .then(
             testElementExists(selectors.POST_VERIFY_CAD_QR_READY_TO_SCAN.HEADER)
           )
@@ -171,8 +184,8 @@ registerSuite('cad_qr_signup', {
           .then(
             testElementExists(selectors.POST_VERIFY_CAD_QR_GET_STARTED.HEADER)
           )
-          .then(click(selectors.POST_VERIFY_CAD_QR_GET_STARTED.SUBMIT))
 
+          .then(click(selectors.POST_VERIFY_CAD_QR_GET_STARTED.SUBMIT))
           .then(
             testElementExists(selectors.POST_VERIFY_CAD_QR_READY_TO_SCAN.HEADER)
           )


### PR DESCRIPTION
## Because:

* The CAD QR flow has two spots to "reminder me later" that need to actually do that
* We need an auth server endpoint to facilitate creating new CAD reminders for a user

## This PR:

* Sets up the auth server endpoint to talk to the CAD Reminders mechanism for creating new reminders
* Updates the content server JS client to talk to the auth server and create reminders
* Updates the template and view for the CAD QR flow to invoke the JS client that talks to the auth server

## Issue that this pull request solves

Closes: #5703 
Closes: #5704 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
