### PR TITLE
feat(auth-server): update stripe api version

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.js
+++ b/packages/fxa-auth-server/lib/payments/stripe.js
@@ -122,9 +122,8 @@ class StripeHelper {
     this.plansCacheIsEnabled = this.cacheTtlSeconds && redis;
 
     this.stripe = new stripe(config.subscriptions.stripeApiKey, {
-      apiVersion: '2019-12-03',
+      apiVersion: '2020-03-02',
       maxNetworkRetries: 3,
-      typescript: undefined,
     });
     this.redis = redis;
 

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -92,7 +92,7 @@
     "safe-regex": "^1.1.0",
     "safe-url-assembler": "1.3.5",
     "sandboxed-regexp": "^0.3.0",
-    "stripe": "^8.1.0",
+    "stripe": "^8.64.0",
     "typedi": "^0.8.0",
     "urijs": "1.19.1",
     "uuid": "1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16729,7 +16729,7 @@ fsevents@^1.2.7:
     sandboxed-regexp: ^0.3.0
     simplesmtp: 0.3.35
     sinon: ^9.0.2
-    stripe: ^8.1.0
+    stripe: ^8.64.0
     through: 2.3.8
     ts-node: ^8.10.1
     typedi: ^0.8.0
@@ -32922,13 +32922,13 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"stripe@npm:^8.1.0":
-  version: 8.51.0
-  resolution: "stripe@npm:8.51.0"
+"stripe@npm:^8.64.0":
+  version: 8.64.0
+  resolution: "stripe@npm:8.64.0"
   dependencies:
     "@types/node": ">=8.1.0"
     qs: ^6.6.0
-  checksum: 3/d07b8a035537327a58db951d335a98d80d765dad54ef36d7dd8d2de5907bd3e047f21322fb8b7ca78cba1f80e11536f220168bc84e74e028227ce7333a1b16f6
+  checksum: 3/56591b9672f37ebb0741c96796cabff6f662cafd943bbea13bd949494580325f537ca804737c893906ae64f37f800923ff19b9659c9f58e17ac1cffc71b9cf40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:

* Our SCA and 3D Secure implementation will benefit from using the
  latest Stripe API version.
* Keeping up on the API version reduces large breaking changes.

This commit:

* Updates our Stripe API version to 2020-03-02, which includes no
  breaking changes.

Closes #5737