### PR TITLE
chore(subs): add plan to 123done

### DIFF
--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -22,11 +22,11 @@ $(document).ready(function () {
       break;
     case '123done-stage.dev.lcip.org':
       paymentURL =
-        'https://accounts.stage.mozaws.net/subscriptions/products/prod_FfiuDs9u11ESbD';
+        'https://accounts.stage.mozaws.net/subscriptions/products/prod_FfiuDs9u11ESbD?plan=plan_FfiupsKXZ3mMZ6';
       break;
     case '123done-prod.dev.lcip.org':
       paymentURL =
-        'https://accounts.firefox.com/subscriptions/products/prod_FfiuDs9u11ESbD';
+        'https://accounts.firefox.com/subscriptions/products/prod_FfiuDs9u11ESbD?plan=plan_FfiupsKXZ3mMZ6';
       break;
     default:
       paymentURL =


### PR DESCRIPTION
## Because

123Done in staging goes to the wrong plan

## This commit

Adds an explicit plan parameter to the staging subscription URL

## Issue that this pull request solves

Closes: #5726

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
