### PR TITLE
fix(security-events):fix delete security events test by adding refresh function

### DIFF
--- a/packages/fxa-content-server/tests/functional/security_events.js
+++ b/packages/fxa-content-server/tests/functional/security_events.js
@@ -168,26 +168,33 @@ registerSuite('security_events', {
     },
 
     'delete security events': function () {
-      return this.remote
-        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-        .then(fillOutEmailFirstSignIn(email, PASSWORD, true))
-        .then(testElementExists(selectors.SETTINGS.HEADER))
+      return (
+        this.remote
+          .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD, true))
+          .then(testElementExists(selectors.SETTINGS.HEADER))
 
-        .then(
-          openPage(
-            SECURITY_EVENTS_URL,
-            selectors.SECURITY_EVENTS.RECENT_ACTIVITY_HEADER
+          .then(
+            openPage(
+              SECURITY_EVENTS_URL,
+              selectors.SECURITY_EVENTS.RECENT_ACTIVITY_HEADER
+            )
           )
-        )
-        .then(
-          testElementTextInclude(
-            selectors.SECURITY_EVENTS.FIRST_EVENT_NAME,
-            'account.login'
+          .then(
+            testElementTextInclude(
+              selectors.SECURITY_EVENTS.FIRST_EVENT_NAME,
+              'account.login'
+            )
           )
-        )
-        .then(testElementExists(selectors.SECURITY_EVENTS.DELETE_EVENTS_BUTTON))
-        .then(click(selectors.SECURITY_EVENTS.DELETE_EVENTS_BUTTON))
-        .then(noSuchElement(selectors.SECURITY_EVENTS.SECURITY_EVENT));
+          .then(
+            testElementExists(selectors.SECURITY_EVENTS.DELETE_EVENTS_BUTTON)
+          )
+          .then(click(selectors.SECURITY_EVENTS.DELETE_EVENTS_BUTTON))
+
+          // reload the page to verify that all the security events have been deleted
+          .refresh()
+          .then(noSuchElement(selectors.SECURITY_EVENTS.SECURITY_EVENT))
+      );
     },
   },
 });


### PR DESCRIPTION
## Because

\*

This commit is to fix the Security_events.js file and 'delete security events' test. The test was failing at the assertion point as it wasn't able to validate the presence/absence of the selector. So I added the refresh() to reload the page and now the assertion passes and so does the test.

\*

## Issue that this pull request solves

Closes: #5443

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

@vbudhram  please review this PR.
