### PR TITLE
feat(emails): Add CAD reminder templates

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -58,6 +58,8 @@ const EMAIL_TYPES = {
   verifySecondary: 'secondary_email',
   verificationReminderFirst: 'registration',
   verificationReminderSecond: 'registration',
+  cadReminderFirst: 'connect_another_device',
+  cadReminderSecond: 'connect_another_device',
 };
 
 const EVENTS = {

--- a/packages/fxa-auth-server/lib/senders/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/templates/_versions.json
@@ -37,5 +37,7 @@
   "postNewRecoveryCodes": 4,
   "passwordResetAccountRecovery": 5,
   "postAddAccountRecovery": 5,
-  "postRemoveAccountRecovery": 5
+  "postRemoveAccountRecovery": 5,
+  "cadReminderFirst": 1,
+  "cadReminderSecond": 1
 }

--- a/packages/fxa-auth-server/lib/senders/templates/cadReminderFirst.html
+++ b/packages/fxa-auth-server/lib/senders/templates/cadReminderFirst.html
@@ -1,0 +1,1 @@
+{{> cadReminder }}

--- a/packages/fxa-auth-server/lib/senders/templates/cadReminderFirst.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/cadReminderFirst.txt
@@ -1,0 +1,7 @@
+{{{t "Here's your reminder to sync devices." }}}
+
+{{t "It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox." }}
+
+{{{ link }}}
+
+{{> automatedEmailNoAction}}

--- a/packages/fxa-auth-server/lib/senders/templates/cadReminderSecond.html
+++ b/packages/fxa-auth-server/lib/senders/templates/cadReminderSecond.html
@@ -1,0 +1,1 @@
+{{> cadReminder }}

--- a/packages/fxa-auth-server/lib/senders/templates/cadReminderSecond.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/cadReminderSecond.txt
@@ -1,0 +1,7 @@
+{{{t "Last reminder to sync devices!" }}}
+
+{{t "Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox." }}
+
+{{{ link }}}
+
+{{> automatedEmailNoAction}}

--- a/packages/fxa-auth-server/lib/senders/templates/partials/cadReminder.html
+++ b/packages/fxa-auth-server/lib/senders/templates/partials/cadReminder.html
@@ -1,0 +1,23 @@
+<tr style="page-break-before: always">
+  <td valign="top">
+
+    <h1 class="primary" style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{ headerText }}</h1>
+
+    <div style="text-align: center; margin-bottom: 20px;">
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/5/f9463f08-8831-49fb-bbc4-7b5072cb63be.png"
+           height="175"
+           width="238"
+           alt="Devices"
+           style="-ms-interpolation-mode: bicubic;"
+      />
+    </div>
+
+    <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{ bodyText }}</p>
+  </td>
+</tr>
+
+{{> button}}
+
+{{> appBadges}}
+
+{{> automatedEmailNoAction}}

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -24,7 +24,7 @@
     "test-remote": "MAILER_HOST=restmail.net MAILER_PORT=80 CORS_ORIGIN=http://baz mocha -r ts-node/register --timeout=300000 test/remote",
     "format": "prettier --write --config ../../_dev/.prettierrc '**'",
     "gen-keys": "ts-node ./scripts/gen_keys.js; ts-node ./scripts/oauth_gen_keys.js; ts-node ./scripts/gen_vapid_keys.js",
-    "write-emails": "node ./scripts/write-emails-to-disk.js",
+    "write-emails": "node -r ts-node/register ./scripts/write-emails-to-disk.js",
     "clean-up-old-ci-stripe-customers": "ts-node ./scripts/clean-up-old-ci-stripe-customers.js"
   },
   "repository": {

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -1115,6 +1115,60 @@ const TESTS = new Map([
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+  ['cadReminderFirstEmail', new Map([
+    ['subject', { test: 'equal', expected: 'Your Friendly Reminder: How-To Complete Your Sync Setup' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('syncUrl', 'cad-reminder-first', 'connect-device') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('cadReminderFirst') }],
+      ['X-Template-Name', { test: 'equal', expected: 'cadReminderFirst' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.cadReminderFirst }],
+    ])],
+    ['html', [
+      { test: 'include', expected: "Here&#x27;s your reminder to sync devices." },
+      { test: 'include', expected: 'It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.' },
+      { test: 'include', expected: configHref('syncUrl', 'cad-reminder-first', 'connect-device') },
+      { test: 'include', expected: config.smtp.androidUrl },
+      { test: 'include', expected: config.smtp.iosUrl },
+      { test: 'include', expected: configHref('privacyUrl', 'cad-reminder-first', 'privacy') },
+      { test: 'include', expected: configHref('supportUrl', 'cad-reminder-first', 'support') },
+    ]],
+    ['text', [
+      { test: 'include', expected: "Here's your reminder to sync devices." },
+      { test: 'include', expected: 'It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.' },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'cad-reminder-first', 'privacy')}` },
+      { test: 'include', expected: config.smtp.syncUrl },
+      { test: 'notInclude', expected: config.smtp.androidUrl },
+      { test: 'notInclude', expected: config.smtp.iosUrl },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
+  ['cadReminderSecondEmail', new Map([
+    ['subject', { test: 'equal', expected: 'Final Reminder: Complete Sync Setup' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('syncUrl', 'cad-reminder-second', 'connect-device') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('cadReminderSecond') }],
+      ['X-Template-Name', { test: 'equal', expected: 'cadReminderSecond' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.cadReminderSecond }],
+    ])],
+    ['html', [
+      { test: 'include', expected: "Last reminder to sync devices!" },
+      { test: 'include', expected: 'Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.' },
+      { test: 'include', expected: configHref('syncUrl', 'cad-reminder-second', 'connect-device') },
+      { test: 'include', expected: config.smtp.androidUrl },
+      { test: 'include', expected: config.smtp.iosUrl },
+      { test: 'include', expected: configHref('privacyUrl', 'cad-reminder-second', 'privacy') },
+      { test: 'include', expected: configHref('supportUrl', 'cad-reminder-second', 'support') },
+    ]],
+    ['text', [
+      { test: 'include', expected: "Last reminder to sync devices!" },
+      { test: 'include', expected: 'Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.' },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'cad-reminder-second', 'privacy')}` },
+      { test: 'include', expected: config.smtp.syncUrl },
+      { test: 'notInclude', expected: config.smtp.androidUrl },
+      { test: 'notInclude', expected: config.smtp.iosUrl },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ]);
 
 describe('lib/senders/email:', () => {


### PR DESCRIPTION
This commit:
* Adds cadReminders and templates in email.js to create cadReminderFirstEmail and cadReminderSecondEmail for 'remind me later' functionality
* Fixes write-emails command

Because:
* Users should receive an email to remind them to connect a device later if they opt-in.

fixes #5705

--

<img width="658" alt="image" src="https://user-images.githubusercontent.com/13018240/85626947-6efec880-b633-11ea-8c44-aa403365afa7.png">
<img width="795" alt="image" src="https://user-images.githubusercontent.com/13018240/85626984-7625d680-b633-11ea-86a1-1365bdf4bd31.png">
