### PR TITLE
fix(payments): handle "charges" missing from the subscription object graph

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -278,7 +278,10 @@ module.exports.subscriptionsPlanId = isA.string().max(255);
 module.exports.subscriptionsProductId = isA.string().max(255);
 module.exports.subscriptionsProductName = isA.string().max(255);
 module.exports.subscriptionsPaymentToken = isA.string().max(255);
-module.exports.subscriptionPaymentCountryCode = isA.string().length(2);
+module.exports.subscriptionPaymentCountryCode = isA
+  .string()
+  .length(2)
+  .allow(null);
 
 // This is fxa-auth-db-mysql's perspective on an active subscription
 module.exports.activeSubscriptionValidator = isA.object({


### PR DESCRIPTION
We get the payment source country code from "charges" in the payment
intent of the latest invoice of a created subscription to include in an
Amplitude event.  However, it works most but not all of the time.
Occasionally "charges" is not in the object graph, according an error
captured by Sentry.

Because:
 - "charges" is missing from the subscription object graph in the Stripe
   resposne on some rare instances

This commit:
 - check for the existence of "charges"
 - log the subscription id of the subscription with the missing
   "charges" to help with debugging in Stripe

## Issue that this pull request solves

Closes: #5740 (FXA-2169)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

