### PR TITLE
fix(scripts): use mkdir and cp in a loop to copy .ftl files

### DIFF
--- a/packages/fxa-payments-server/scripts/download_l10n.sh
+++ b/packages/fxa-payments-server/scripts/download_l10n.sh
@@ -29,7 +29,13 @@ git pull
 git rev-parse $FXA_L10N_SHA > git-head.txt
 
 cd locale
-cp --parent **/*.ftl ../../locales/
+
+for src in **/*.ftl; do
+  dir=$(dirname "$src")
+  base=$(basename "$src")
+  mkdir -p "../../locales/$dir"
+  cp "$src" "../../locales/$dir/$base"
+done
 
 cd ../../../server/lib
 


### PR DESCRIPTION
Because:
 - `cp` on BSD/macos does not have the --parents option

This commit:
 - loop through the glob results and copy each .ftl file

This PR is not a part of any issue.