### PR TITLE
fix(emails): Swap grammatically incorrect 'How-To' for 'How To'

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -2449,7 +2449,7 @@ module.exports = function (log, config, oauthdb) {
     const isFirstCadReminderEmail = index < cadReminders.keys.length - 1;
 
     const subject = isFirstCadReminderEmail
-      ? gettext('Your Friendly Reminder: How-To Complete Your Sync Setup')
+      ? gettext('Your Friendly Reminder: How To Complete Your Sync Setup')
       : gettext('Final Reminder: Complete Sync Setup');
 
     const headerText = isFirstCadReminderEmail

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -1116,7 +1116,7 @@ const TESTS = new Map([
     ]],
   ])],
   ['cadReminderFirstEmail', new Map([
-    ['subject', { test: 'equal', expected: 'Your Friendly Reminder: How-To Complete Your Sync Setup' }],
+    ['subject', { test: 'equal', expected: 'Your Friendly Reminder: How To Complete Your Sync Setup' }],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('syncUrl', 'cad-reminder-first', 'connect-device') }],
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('cadReminderFirst') }],


### PR DESCRIPTION
It was pointed out [in this comment](https://github.com/mozilla/fxa/pull/5743#discussion_r445581368) that this is the incorrect usage of "how-to". Alex approved the copy change request.