### PR TITLE
fix(cov): code cov will display coverage but always pass

### DIFF
--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -5,6 +5,17 @@ coverage:
   precision: 2
   round: down
   range: "0...100"
+  status:
+    project:
+      default:
+        if_not_found: success
+        informational: true
+        only_pulls: false
+    patch:
+      default:
+        if_not_found: success
+        informational: true
+        only_pulls: false
 
 parsers:
   gcov:


### PR DESCRIPTION
## Because

* Code coverage shows up as failing on commits

## This commit

* Marks coverage as informational (always pass), devs can still check it out 

## Issue that this pull request solves

Closes: #5754

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate)
