### PR TITLE
chore(payments): remove zip code validation

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
@@ -485,20 +485,6 @@ it('displays an error for empty zip code', () => {
   expect(getByText('Zip code is required')).toBeInTheDocument();
 });
 
-it('filters out non-numbers from zip code field', () => {
-  const { getByText, getByTestId } = render(<Subject />);
-  fireEvent.change(getByTestId('zip'), { target: { value: '!@#123asdf45' } });
-  fireEvent.blur(getByTestId('zip'));
-  expect(getByTestId('zip').getAttribute('value')).toEqual('12345');
-});
-
-it('displays an error for a short zip code', () => {
-  const { getByTestId, getByText } = render(<Subject />);
-  fireEvent.change(getByTestId('zip'), { target: { value: '123' } });
-  fireEvent.blur(getByTestId('zip'));
-  expect(getByText('Zip code is too short')).toBeInTheDocument();
-});
-
 it('fails silently on submit if a stripe API reference has not been supplied', () => {
   let { getByTestId } = renderWithValidFields();
   fireEvent.submit(getByTestId('paymentForm'));

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -209,8 +209,6 @@ export const PaymentForm = ({
             type="text"
             name="zip"
             label="ZIP code"
-            maxLength={5}
-            minLength={5}
             required
             data-testid="zip"
             placeholder="12345"
@@ -353,21 +351,14 @@ const validateName: OnValidateFunction = (
 };
 
 const validateZip: OnValidateFunction = (value, focused, _props, getString) => {
-  let valid = undefined;
+  let valid = true;
   let error = null;
-  value = ('' + value).replace(/[^\d]+/g, '').substr(0, 5);
+  value = ('' + value).trim();
   if (!value) {
     valid = false;
     error = getString
       ? getString('payment-validate-zip-required')
       : 'Zip code is required';
-  } else if (value.length !== 5 && !focused) {
-    valid = false;
-    error = getString
-      ? getString('payment-validate-zip-short')
-      : 'Zip code is too short';
-  } else if (value.length === 5) {
-    valid = true;
   }
   return {
     value,


### PR DESCRIPTION
Because:
 - we want to accept non-US payments
 - Stripe should perform the validation

This commit:
 - remove zip code validation that enforce length and numbers only

## Issue that this pull request solves

Closes: #5732 (FXA-2161)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
