### PR TITLE
feat(account deletion): add checkbox to deletion confirming that your developer extensions and themes will be deleted

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/delete_account.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/delete_account.mustache
@@ -61,6 +61,11 @@
         </li>
 
         <li class='delete-account-checkbox-list-item'>
+          <input id="delete-account-amo" type="checkbox" value="delete-account-amo" class="delete-account-checkbox" required />
+          <label for="delete-account-amo">{{#t}}Any extensions and themes that you published to addons.mozilla.org will be deleted{{/t}}</label>
+        </li>
+
+        <li class='delete-account-checkbox-list-item'>
           <input id="delete-account-saved-info" type="checkbox" value="delete-account-saved-info" class="delete-account-checkbox" required />
           <label for="delete-account-saved-info">{{#t}}You may lose saved information and features within Mozilla products{{/t}}</label>
         </li>


### PR DESCRIPTION
This is [ready](https://github.com/mozilla/fxa/issues/5557#issuecomment-648865631) to be addressed. GitHub wouldn't let me re-open #4532 because I rebased, so here's a new one.

---

Closes #4467

No test changes as it's already covered [here](https://github.com/mozilla/fxa/blob/master/packages/fxa-content-server/app/tests/spec/views/settings/delete_account.js#L531) and [here](https://github.com/mozilla/fxa/blob/master/packages/fxa-content-server/tests/functional/delete_account.js).