### PR TITLE
chore(l10n): match directory names to language codes

### DIFF
--- a/packages/fxa-payments-server/scripts/download_l10n.sh
+++ b/packages/fxa-payments-server/scripts/download_l10n.sh
@@ -30,8 +30,10 @@ git rev-parse $FXA_L10N_SHA > git-head.txt
 
 cd locale
 
+echo "Copying .ftl files"
 for src in **/*.ftl; do
   dir=$(dirname "$src")
+  dir=$(echo "$dir" | sed "s/_/-/")
   base=$(basename "$src")
   mkdir -p "../../locales/$dir"
   cp "$src" "../../locales/$dir/$base"


### PR DESCRIPTION
Because:
 - language codes use hyphens but the directories for Payments' .ftl
   files use underscores (e.g. pt-BR vs pt_BR)

This commit:
 - change the underscore to a hyphen during the .ftl copying

Closes: #5765 (FXA-2182)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

