### PR TITLE
fix(docker): added openssl to fxa-node docker image

### DIFF
--- a/_dev/docker/node/Dockerfile
+++ b/_dev/docker/node/Dockerfile
@@ -11,6 +11,7 @@ RUN set -x \
 RUN apt-get update && apt-get install -y \
     graphicsmagick \
     netcat \
+    openssl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=fxa-builder:latest --chown=app:app /fxa /fxa


### PR DESCRIPTION
## Because

openssl was removed from the base node image

## Issue that this pull request solves

fixes #5669

