### PR TITLE
fix(auth): use stage-specific sync url in post verify emails, when in stage

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -307,11 +307,6 @@ const conf = convict({
         env: 'PREPEND_VERIFICATION_SUBDOMAIN_SUBDOMAIN',
       },
     },
-    syncUrl: {
-      doc: 'url to Sync product page',
-      format: String,
-      default: 'https://accounts.firefox.com/connect_another_device/',
-    },
     androidUrl: {
       doc: 'url to Android product page',
       format: String,
@@ -1801,6 +1796,7 @@ conf.set('smtp.verifyPrimaryEmailUrl', `${baseUri}/verify_primary_email`);
 conf.set('smtp.verifySecondaryEmailUrl', `${baseUri}/verify_secondary_email`);
 conf.set('smtp.subscriptionSettingsUrl', `${baseUri}/subscriptions`);
 conf.set('smtp.subscriptionSupportUrl', `${baseUri}/support`);
+conf.set('smtp.syncUrl', `${baseUri}/connect_another_device`);
 
 conf.set('isProduction', conf.get('env') === 'prod');
 


### PR DESCRIPTION
## Because

- The post-verify Sync URL points to production in emails sent on stage

## This PR

- Sets the Sync URL in post-verify email to stage address when in stage env

## Issue that this pull request solves

Closes: #5614

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
