### PR TITLE
fix(build): added postinstall to fxa-shared

### DIFF
--- a/.circleci/base-install.sh
+++ b/.circleci/base-install.sh
@@ -15,5 +15,4 @@ if ([[ "$MODULE" == "many" ]] && grep -e '.' packages/test.list > /dev/null) ||
   sudo apt-get install -y graphicsmagick
 
   yarn install --immutable
-  yarn workspace fxa-shared run build
 fi

--- a/packages/fxa-profile-server/scripts/test-ci.sh
+++ b/packages/fxa-profile-server/scripts/test-ci.sh
@@ -4,5 +4,4 @@ DIR=$(dirname "$0")
 
 cp "$DIR/../../version.json" "$DIR/../config"
 yarn workspaces focus fxa-profile-server
-yarn workspace fxa-shared run build
 yarn test

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -4,6 +4,7 @@
   "description": "Shared module for FxA repositories",
   "main": "dist/index.js",
   "scripts": {
+    "postinstall": "tsc --build || true",
     "build": "tsc --build",
     "start": "pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",


### PR DESCRIPTION
## Because

In dev we want to be able to go from a `yarn install` to
running code but we also want to keep typescript as a
devDependency for production builds where we have an
explicit build phase then --production install. To keep the
production install from failing on the postinstall we need
it to succeed even if tsc is missing, hence the `|| true`.


