### PR TITLE
fix(l10n): fixed l10n-extract script

### DIFF
--- a/packages/fxa-content-server/grunttasks/l10n-extract.js
+++ b/packages/fxa-content-server/grunttasks/l10n-extract.js
@@ -20,7 +20,7 @@ var messagesOutputPath = path.join(
   'LC_MESSAGES'
 );
 var babelCmd =
-  'npx babel --plugins=@babel/plugin-syntax-dynamic-import,dynamic-import-webpack,@babel/plugin-proposal-class-properties --presets @babel/preset-react,@babel/env,@babel/preset-typescript app/scripts --out-dir .es5';
+  'yarn babel --plugins=@babel/plugin-syntax-dynamic-import,dynamic-import-webpack,@babel/plugin-proposal-class-properties --presets @babel/preset-react,@babel/env,@babel/preset-typescript app/scripts --out-dir .es5';
 var templateCmd = 'cp -r app/scripts/templates .es5/templates/';
 
 module.exports = function (grunt) {


### PR DESCRIPTION
## Because

npx babel tries to install the latest package from npm
which is now deprecated in favor of @babel/cli. By using
`yarn babel` instead we use the correct babel cli command
installed via @babel/cli in package.json
