### PR TITLE
fix(l10n): add en-US to list of available locales

### DIFF
--- a/packages/fxa-payments-server/src/lib/AppLocalizationProvider.tsx
+++ b/packages/fxa-payments-server/src/lib/AppLocalizationProvider.tsx
@@ -9,6 +9,12 @@ import { LocalizationProvider } from '@fluent/react';
 import React, { Component } from 'react';
 
 import availableLocales from 'fxa-shared/l10n/supportedLanguages.json';
+// en-US is always available.  More importantly, if en-US is one of the
+// requested languages, maybe even the first on the list, Fluent will have it
+// as the _last_ fallback language when it's not in the available list.
+if (!availableLocales.includes('en-US')) {
+  availableLocales.push('en-US');
+}
 
 async function fetchMessages(baseDir: string, locale: string, bundle: string) {
   try {


### PR DESCRIPTION
Because:
 - en-US is one of the available locales
 - Fluent will set a requested but not available locale as the last
   fallback locale

This commit:
 - add en-US to the list of available locales

## Issue that this pull request solves

Closes: #5762 (FXA-2181)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

