### PR TITLE
chore(l10n): add en-US to shared list of supported locales

### DIFF
--- a/packages/fxa-shared/l10n/supportedLanguages.json
+++ b/packages/fxa-shared/l10n/supportedLanguages.json
@@ -14,6 +14,7 @@
   "dsb",
   "en",
   "en-GB",
+  "en-US",
   "es",
   "es-AR",
   "es-CL",


### PR DESCRIPTION
Because:
 - `locale/en_US/LC_MESSAGES` exists in the fxa-content-server-l10n repo
   for content-server
 - `public/locales/en-US/main.ftl` exists in fxa-payments-server
 - Fluent will set a requested but not available locale as the last
   fallback locale

This commit:
 - add en-US to the shared list of supported locales


## Issue that this pull request solves

Closes: #5762 (FXA-2181)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
