### PR TITLE
fix(content-server): clean the password input value.

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/base.js
+++ b/packages/fxa-content-server/app/scripts/views/base.js
@@ -1137,6 +1137,25 @@ var BaseView = Backbone.View.extend({
         return result;
       });
   },
+
+  /**
+   * Clear validation tooltips and all visible input values.
+   */
+  clearInput() {
+    const $inputEls = this.$('input');
+
+    $inputEls.each((i, inputEl) => {
+      // Called to clear validation tooltips. issues/5680
+      $(inputEl).change();
+    });
+
+    const formEl = this.$('form input:not(".hidden")');
+    if (formEl) {
+      for (let i = 0; i < formEl.length; i++) {
+        formEl[i].value = '';
+      }
+    }
+  },
 });
 
 Cocktail.mixin(

--- a/packages/fxa-content-server/app/scripts/views/mixins/settings-panel-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/settings-panel-mixin.js
@@ -57,22 +57,6 @@ export default {
     this.closePanel();
   },
 
-  clearInput() {
-    const $inputEls = this.$('input');
-
-    $inputEls.each((i, inputEl) => {
-      // Called to clear validation tooltips. issues/5680
-      $(inputEl).change();
-    });
-
-    const formEl = this.$('form  input:not(".hidden")');
-    if (formEl) {
-      for (let i = 0; i < formEl.length; i++) {
-        formEl[i].value = '';
-      }
-    }
-  },
-
   closePanel() {
     this.$el.closest('#fxa-settings-content').removeClass('animate-shadow');
     this.$('.settings-unit').removeClass('open');

--- a/packages/fxa-content-server/app/scripts/views/settings/account_recovery/confirm_password.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/account_recovery/confirm_password.js
@@ -27,6 +27,7 @@ const View = FormView.extend({
 
   _cancelPasswordConfirm() {
     this.logFlowEvent('cancel', this.viewName);
+    this.clearInput();
     this.navigate('settings/account_recovery', {
       hasRecoveryKey: false,
     });


### PR DESCRIPTION
## Because

* The doorhanger to save the password appeared on "cancel".

* The password input value was not cleaned before navigating.
## This commit

* Clean the input before navigating to account recovery

## Issue that this pull request solves

fixes #606 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
