### PR TITLE
docs(tests): add info about running services before running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Check out the Secrets section in the following READMEs:
 
 #### Test all or some packages
 
-- Run `yarn start infrastructure` before running tests to start services.
+- You might need to run `yarn start infrastructure` before running tests to start services.
 
 From the root directory you may test all or some FxA packages:
 

--- a/README.md
+++ b/README.md
@@ -228,20 +228,22 @@ Check out the Secrets section in the following READMEs:
 
 #### Test all or some packages
 
+- Run `yarn start infrastructure` before running tests to start services.
+
 From the root directory you may test all or some FxA packages:
 
 ```bash
 # Test only `fxa-shared`
-npm test fxa-shared
+yarn test fxa-shared
 
 # Test `fxa-auth-db-mysql` and `fxa-auth-server`
-npm test fxa-auth-db-mysql fxa-auth-server
+yarn test fxa-auth-db-mysql fxa-auth-server
 
 # Test all packages
-npm test all
+yarn test all
 ```
 
-Note that this invokes the same test suite that CI uses, and is not necessarily the same as running `npm test` in any given package.
+- Note that this invokes the same test suite that CI uses, and is not necessarily the same as running `yarn test` in any given package.
 
 #### Emulating CI environment
 


### PR DESCRIPTION
## Because

- Running `yarn test` doesn't run tests. 

## This commit

- Add info about starting services before running tests.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
