### PR TITLE
feat(surveys): add always condition to always show the survey

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/scripts/lib/survey-filter.js
@@ -350,11 +350,13 @@ export const createSurveyFilter = (
   return async (surveyConfig) =>
     !!(
       surveyConfig &&
-      surveyConfig.rate &&
-      withinRate(surveyConfig.rate) &&
+      parseInt(surveyConfig.rate) >= 0 &&
       surveyConfig.conditions &&
+      (surveyConfig.conditions.always === true ||
+        withinRate(surveyConfig.rate)) &&
       Object.keys(surveyConfig.conditions).length > 0 &&
-      !participatedRecently(previousParticipationTime, doNotBotherSpan) &&
+      (surveyConfig.conditions.always === true ||
+        !participatedRecently(previousParticipationTime, doNotBotherSpan)) &&
       languagesCheck(surveyConfig.conditions, fetchLangs) &&
       // User agent related checks
       userAgentChecks(surveyConfig.conditions, fetchUa) &&

--- a/packages/fxa-content-server/app/styles/modules/_survey.scss
+++ b/packages/fxa-content-server/app/styles/modules/_survey.scss
@@ -2,6 +2,11 @@ $shadow: 0 12px 18px 2px rgba(34, 0, 51, 0.04),
   0 6px 22px 4px rgba(7, 48, 114, 0.12), 0 6px 10px -4px rgba(14, 13, 26, 0.12);
 $survey-height: 360px;
 
+.survey-wrapped {
+  position: relative;
+  z-index: 2;
+}
+
 .survey-component {
   align-items: flex-end;
   background: $grey-10;

--- a/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
@@ -1229,5 +1229,77 @@ describe('lib/survey-filter', () => {
       });
       assert.isFalse(actual);
     });
+
+    it('should be true with condition `always: true` when the rate is set to 0', async () => {
+      const filter = SurveyFilter.createSurveyFilter.apply(
+        null,
+        trueDefaultArgs
+      );
+      const actual = await filter({
+        conditions: {
+          ...config.conditions,
+          always: true,
+        },
+        // This rate of 0 would otherwise yield false
+        // if the always condition was not set to true
+        rate: 0,
+      });
+      assert.isTrue(actual);
+    });
+
+    it('should be true with condition `always: true` when the user has recently participated', async () => {
+      const filter = SurveyFilter.createSurveyFilter(
+        mockWindow,
+        mockUser,
+        mockRelier,
+        // This recently participated timestamp would otherwise
+        // yield false if the always condition was not set to true
+        Date.now(),
+        5000000
+      );
+      const actual = await filter({
+        conditions: {
+          ...config.conditions,
+          always: true,
+        },
+        rate: config.rate,
+      });
+      assert.isTrue(actual);
+    });
+
+    it('should be false with condition `always: true` when another condition is not satisfied', async () => {
+      const filter = SurveyFilter.createSurveyFilter.apply(
+        null,
+        trueDefaultArgs
+      );
+      const actual = await filter({
+        conditions: {
+          ...config.conditions,
+          always: true,
+          // This condition will yield false because
+          // it is not considered in the always check
+          subscriptions: ['fpn_id'],
+        },
+        rate: config.rate,
+      });
+      assert.isFalse(actual);
+    });
+
+    it('should be false with condition `always` not set to `true` and rate set to 0', async () => {
+      const filter = SurveyFilter.createSurveyFilter.apply(
+        null,
+        trueDefaultArgs
+      );
+      const actual = await filter({
+        conditions: {
+          ...config.conditions,
+          always: 'blah blah',
+        },
+        // This rate of 0 should yield false because
+        // the always condition was not set to true
+        rate: 0,
+      });
+      assert.isFalse(actual);
+    });
   });
 });


### PR DESCRIPTION
## Because

We wanted an option to always show the survey, regardless of configured rate and the last known time it was shown*.

\* At least, this is what I understood from @johngruen's [comment](https://jira.mozilla.com/browse/FXA-2024?focusedCommentId=86316&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-86316). If I'm off here I can update.

## This change

Allows you to specify `always: true` in survey configuration conditions to have the survey always show, regardless of configured rate and the last known time it was shown

Note this would still yield false if another condition, such as a valid subscription ID or locale, was not satisfied.

## Issue that this pull request solves

Closes: #5529
Closes: #5675 (this is untested, but I have a good feeling about it)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
