### PR TITLE
feat(oauth): Store refresh_token last-used-at timestamp in redis.

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -419,11 +419,47 @@ const conf = convict({
         format: String,
         doc: 'Key prefix for access tokens in Redis',
       },
-      accessTokenLimit: {
+      recordLimit: {
         default: 100,
         env: 'ACCESS_TOKEN_REDIS_LIMIT',
         format: Number,
         doc: 'Maximum number of access tokens per account at any one time',
+      },
+    },
+    refreshTokens: {
+      enabled: {
+        default: true,
+        doc: 'Enable Redis for refresh token metadata',
+        format: Boolean,
+        env: 'REFRESH_TOKEN_REDIS_ENABLED',
+      },
+      host: {
+        default: 'localhost',
+        env: 'REFRESH_TOKEN_REDIS_HOST',
+        format: String,
+      },
+      port: {
+        default: 6379,
+        env: 'REFRESH_TOKEN_REDIS_PORT',
+        format: 'port',
+      },
+      prefix: {
+        default: 'rt:',
+        env: 'REFRESH_TOKEN_REDIS_KEY_PREFIX',
+        format: String,
+        doc: 'Key prefix for refresh tokens in Redis',
+      },
+      maxttl: {
+        default: 86400000,
+        env: 'REFRESH_TOKEN_REDIS_MAX_TTL',
+        format: Number,
+        doc: 'ttl for redis data',
+      },
+      recordLimit: {
+        default: 20,
+        env: 'REFRESH_TOKEN_REDIS_LIMIT',
+        format: Number,
+        doc: 'Maximum number of refresh tokens per account stored in redis',
       },
     },
     sessionTokens: {
@@ -1046,7 +1082,7 @@ const conf = convict({
     },
     refreshToken: {
       updateAfter: {
-        doc: 'lastUsedAt only gets updated after this delay',
+        doc: 'lastUsedAt only gets updated in MySQL after this delay',
         format: 'duration',
         default: '24 hours',
         env: 'FXA_REFRESH_TOKEN_UPDATE_AFTER',

--- a/packages/fxa-auth-server/lib/luaScripts/schema.md
+++ b/packages/fxa-auth-server/lib/luaScripts/schema.md
@@ -1,0 +1,131 @@
+# Schema for data stored in Redis
+
+We currently store three different types of data in redis:
+
+- high-churn sessionToken metadata
+- short-lived OAuth access tokens
+- high-churn refreshToken metadata
+
+Each type of data is stored under a different (and configurable) key prefix
+to avoid collisions.
+
+## Session Token Metadata
+
+Most sessionToken data is stored in MySQL and is updated rarely, but a small
+number of fields may change much more often. Writes to these fields are sent
+to redis because it's better able to cope with the write load, and there are
+no significant consequences to losing the data.
+
+The data is stored as a single record per user, using their `uid` as the key.
+The value is a JSON object whose keys are the ids of session tokens belonging
+to that user, and whose corresponding values are the metadata for that token.
+The metadata is a JSON **_list_** where each item corresponds to a particular
+field of the session token.
+
+For example, if a user has a single session token with the following metadata:
+
+- `id`: "000111222333444555666777888999"
+- `lastAccessTime`: 1583392038878
+- `location`:
+  - city: undefined,
+  - state: undefined
+  - stateCode: undefined,
+  - country: "Australia"
+  - countryCode: "AU"
+- uaBrowser: undefined,
+- uaBrowserVersion: undefined,
+- uaOS: "Windows",
+- uaOSVersion: 10,
+- uaDeviceType: undefined,
+- uaFormFactor: undefined
+
+Then this would be stored in redis as a string value as follows:
+
+- Key: `000111222333444555666777888999`
+- Value: `[1583392038878,[,,,"Australia","AU"],,,"Windows",10,,]`
+
+This scheme is designed to minimize storage space by not encoding field names,
+but leads to some complexity when encoding and decoding.
+
+There is also a legacy format where the value is a straightforward JSON object
+with named fields.
+
+## OAuth Access Tokens
+
+OAuth access tokens are created frequently and are short-lived, making them
+suitable for storage in redis.
+
+The data for each access token is stored as an individual record with a TTL,
+using the `tokenId` as the key and a JSON serialization of the token data
+as the value.
+
+In order to allow easy enumeration of the access tokens belonging to a given
+user, we also maintain a separate record for each user. This record is a redis
+set type whose key is the `uid` and whose members as the `tokenId`s of all
+acesss tokens belonging to that user.
+
+For example, if a user has a single access token with the following metadata:
+
+- `tokenId`: "000111222333444555666777888999"
+- `clientId`: "ABCDEF123456"
+- `clientName`: "Example Client"
+- `clientCanGrant`: false
+- `publicClient`: false
+- `userId`: "AAABBBCCCDDDEEEFFF999888777666"
+- `email`: "user@example.com"
+- `scope`: "profile",
+- `createdAt`: 1583392038878
+- `profileChangedAt`: 0,
+- `expiresAt`: 1583392056878
+
+Then there would be two records in redis as follows:
+
+- Key: `000111222333444555666777888999`
+- Value:
+  ```
+  {
+    "tokenId": "000111222333444555666777888999"
+    "clientId": "ABCDEF123456"
+    "name": "Example Client"
+    "canGrant": false
+    "publicClient": false
+    "userId": "AAABBBCCCDDDEEEFFF999888777666"
+    "email": "user@example.com"
+    "scope": "profile",
+    "createdAt": 1583392038878
+    "profileChangedAt": 0,
+    "expiresAt": 1583392056878
+  }
+  ```
+- Key: `AAABBBCCCDDDEEEFFF999888777666`
+- Set Members: `[000111222333444555666777888999]`
+
+## Refresh Token Metadata
+
+Most refreshToken data is stored in MySQL and is updated rarely, but the `lastUsedAt`
+field may change much more frequently. Writes to this field are sent to redis
+because it's better able to cope with the write load, and there are no significant
+consequences to losing the data.
+
+The data is stored as a single record per user, using their `uid` as the key.
+The record is a redis hash type whose fields are the `tokenId`s of refresh tokens
+held by that user, and whose corresponding values are JSON objects with metadata
+for that token.
+
+These records are short lived and intended for high frequency updates. For longer
+duration data prefer MySQL. For example `lastUsedAt` is written to MySQL once
+per day but updated in redis on every access. This provides high precision
+for active tokens and more efficiency as tokens get older.
+
+For example, if a user has a single refresh token with the following metadata:
+
+- `tokenId`: "000111222333444555666777888999"
+- `userId`: "AAABBBCCCDDDEEEFFF999888777666"
+- `lastUsedAt`: 1583392038878
+
+Then this would be stored in redis as a hash record with one field as follows:
+
+- Key: `AAABBBCCCDDDEEEFFF999888777666`
+- Hash Fields:
+  - Field: `000111222333444555666777888999`
+  - Value: `{"lastUsedAt": 1583392038878}`

--- a/packages/fxa-auth-server/lib/luaScripts/setRefreshToken_1.lua
+++ b/packages/fxa-auth-server/lib/luaScripts/setRefreshToken_1.lua
@@ -1,0 +1,43 @@
+local uid = KEYS[1]
+local tokenId = ARGV[1]
+local token = ARGV[2]
+local recordLimit = tonumber(ARGV[3])
+local expireTimespan = tonumber(ARGV[4])
+
+local function hgetall(key)
+  local kv = redis.call('hgetall', key)
+  local result = {}
+  local k
+  for i, v in ipairs(kv) do
+    if i % 2 == 1 then
+      k = v
+    else
+      result[k] = v
+    end
+  end
+  return result
+end
+
+local len = redis.call('hlen', uid)
+if len >= 2 then
+  -- prune tokens more than 1 day old
+  local newToken = cjson.decode(token)
+  local tokens = hgetall(uid)
+  local toDel = {}
+  for id, value in pairs(tokens) do
+    local t = cjson.decode(value)
+    if newToken["lastUsedAt"] - t["lastUsedAt"] > expireTimespan then
+      table.insert(toDel, id)
+      len = len - 1
+    end
+  end
+  if len >= recordLimit then
+    -- there's still too many tokens
+    -- err on protecting the db from misbehavior
+    redis.call('unlink', uid)
+  elseif #toDel > 0 then
+    redis.call('hdel', uid, unpack(toDel))
+  end
+end
+redis.call('hset', uid, tokenId, token)
+redis.call('pexpire', uid, expireTimespan)

--- a/packages/fxa-auth-server/lib/oauth/db/redis.js
+++ b/packages/fxa-auth-server/lib/oauth/db/redis.js
@@ -1,0 +1,181 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const config = require('../../../config');
+const logger = require('../logging')('db');
+const redis = require('../../redis');
+
+// These are used only in type declarations.
+// eslint-disable-next-line no-unused-vars
+const AccessToken = require('./accessToken');
+// eslint-disable-next-line no-unused-vars
+const RefreshTokenMetadata = require('./refreshTokenMetadata');
+
+// We store both access token and refresh token data in redis, separated
+// into two namespaces by using the "key prefix" feature of our  redis library.
+// Unfortunately, the key prefix is a connection-level setting, meaning that
+// we need to use a separate connection for each type of data.
+//
+// This is a little wrapper class to present the separate access-token and
+// refresh-token connections as a single conceptual "oauth redis db", in order
+// to keep the calling code a bit simpler.
+
+class OauthRedis {
+  constructor() {
+    this.redisAccessTokens = redis(
+      {
+        ...config.get('redis.accessTokens'),
+        enabled: true,
+        maxttl: config.get('oauthServer.expiration.accessToken'),
+      },
+      logger
+    );
+    this.redisRefreshTokens = redis(config.get('redis.refreshTokens'), logger);
+  }
+
+  async close() {
+    await this.redisAccessTokens.close();
+    await this.redisRefreshTokens.close();
+  }
+
+  /**
+   *
+   * @param {Buffer | string} tokenId
+   * @return {Promise<AccessToken>}
+   */
+  async getAccessToken(tokenId) {
+    return this.redisAccessTokens.getAccessToken(tokenId);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   * @return {Promise<AccessToken[]>}
+   */
+  async getAccessTokens(uid) {
+    return this.redisAccessTokens.getAccessTokens(uid);
+  }
+
+  /**
+   *
+   * @param {AccessToken} token
+   */
+  setAccessToken(token) {
+    return this.redisAccessTokens.setAccessToken(token);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} id
+   * @returns {Promise<boolean>} done
+   */
+  async removeAccessToken(id) {
+    return this.redisAccessTokens.removeAccessToken(id);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   */
+  removeAccessTokensForPublicClients(uid) {
+    return this.redisAccessTokens.removeAccessTokensForPublicClients(uid);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   * @param {Buffer | string} clientId
+   */
+  removeAccessTokensForUserAndClient(uid, clientId) {
+    return this.redisAccessTokens.removeAccessTokensForUserAndClient(
+      uid,
+      clientId
+    );
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   */
+  removeAccessTokensForUser(uid) {
+    return this.redisAccessTokens.removeAccessTokensForUser(uid);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   * @param {Buffer | string} tokenId
+   * @return {Promise<RefreshTokenMetadata>}
+   */
+  async getRefreshToken(uid, tokenId) {
+    if (!this.redisRefreshTokens) {
+      return null;
+    }
+    return this.redisRefreshTokens.getRefreshToken(uid, tokenId);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   * @return {Promise<{[key: string]: RefreshTokenMetadata}>}
+   */
+  async getRefreshTokens(uid) {
+    if (!this.redisRefreshTokens) {
+      return {};
+    }
+    return this.redisRefreshTokens.getRefreshTokens(uid);
+  }
+
+  /**
+   * @param {Buffer | string} uid
+   * @param {Buffer | string} tokenId
+   * @param {RefreshTokenMetadata} token
+   */
+  setRefreshToken(uid, tokenId, token) {
+    if (!this.redisRefreshTokens) {
+      return null;
+    }
+    return this.redisRefreshTokens.setRefreshToken(uid, tokenId, token);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   * @param {Buffer | string} token
+   * @returns {Promise<boolean>} done
+   */
+  async removeRefreshToken(uid, token) {
+    if (!this.redisRefreshTokens) {
+      return null;
+    }
+    return this.redisRefreshTokens.removeRefreshToken(uid, token);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   */
+  removeRefreshTokensForUser(uid) {
+    if (!this.redisRefreshTokens) {
+      return null;
+    }
+    return this.redisRefreshTokens.removeRefreshTokensForUser(uid);
+  }
+
+  /**
+   *
+   * @param {Buffer | string} uid
+   * @param {(Buffer | string)[]} tokenIdsToPrune
+   */
+  pruneRefreshTokens(uid, tokenIdsToPrune) {
+    if (!this.redisRefreshTokens) {
+      return null;
+    }
+    return this.redisRefreshTokens.pruneRefreshTokens(uid, tokenIdsToPrune);
+  }
+}
+
+module.exports = () => {
+  return new OauthRedis();
+};

--- a/packages/fxa-auth-server/lib/oauth/db/refreshTokenMetadata.js
+++ b/packages/fxa-auth-server/lib/oauth/db/refreshTokenMetadata.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+class RefreshTokenMetadata {
+  constructor(lastUsedAt) {
+    /** @type {Date} */
+    this.lastUsedAt = lastUsedAt || new Date();
+  }
+
+  /**
+   *
+   * @returns {object}
+   */
+  toJSON() {
+    return {
+      lastUsedAt: this.lastUsedAt.getTime(),
+    };
+  }
+
+  /**
+   *
+   * @param {string} string
+   * @returns {RefreshTokenMetadata}
+   */
+  static parse(string) {
+    const json = JSON.parse(string);
+    return new RefreshTokenMetadata(new Date(json.lastUsedAt));
+  }
+}
+
+module.exports = RefreshTokenMetadata;

--- a/packages/fxa-auth-server/lib/oauth/routes/authorized-clients/list.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/authorized-clients/list.js
@@ -16,9 +16,7 @@ function serialize(clientIdHex, token, acceptLanguage) {
   const lastAccessTime = token.lastUsedAt.getTime();
   return {
     client_id: clientIdHex,
-    refresh_token_id: token.refreshTokenId
-      ? hex(token.refreshTokenId)
-      : undefined,
+    refresh_token_id: token.tokenId ? hex(token.tokenId) : undefined,
     client_name: token.clientName,
     created_time: createdTime,
     last_access_time: lastAccessTime,

--- a/packages/fxa-auth-server/lib/oauth/routes/destroy.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/destroy.js
@@ -73,8 +73,7 @@ module.exports = {
         client_id: hex(tokObj.clientId),
       });
     }
-
-    await db[removeToken](token);
+    await db[removeToken](tokObj);
     return {};
   },
 };

--- a/packages/fxa-auth-server/test/oauth/api.js
+++ b/packages/fxa-auth-server/test/oauth/api.js
@@ -3244,7 +3244,7 @@ describe('/v1', function () {
         email: user.email,
         scope: ScopeSet.fromArray(scope),
       });
-      return encrypt.hash(token.token).toString('hex');
+      return token.tokenId.toString('hex');
     }
 
     async function makeRefreshToken(client, user, scope) {
@@ -3254,7 +3254,7 @@ describe('/v1', function () {
         email: user.email,
         scope: ScopeSet.fromArray(scope),
       });
-      return encrypt.hash(token.token).toString('hex');
+      return token.tokenId.toString('hex');
     }
 
     beforeEach(async () => {


### PR DESCRIPTION
Because:

* The last-used-at timestamp on refresh tokens changes frequently,
  and it's good UX to be able to present an accurate value for this
  field.
* We're expecting a significant increase in the volume of clients
  using refresh tokens.
* Writes to MySQL are expensive at scale.

This commit:

* Stores the last-used-at timestamp in redis, where writes are cheaper.

