### PR TITLE
fix(experiments): fix qr code experiment cohorting rules

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiment.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiment.js
@@ -26,7 +26,6 @@ const MANUAL_EXPERIMENTS = {
   sendSms: BaseExperiment,
   newsletterSync: BaseExperiment,
   qrCodeCad: BaseExperiment,
-  newsletterCadChooser: BaseExperiment,
 };
 
 const ALL_EXPERIMENTS = _.extend({}, STARTUP_EXPERIMENTS, MANUAL_EXPERIMENTS);

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -244,65 +244,13 @@ const EVENTS = {
     group: GROUPS.registration,
     event: 'domain_validation_ignored',
   },
-
-  'screen.get-started': {
-    group: GROUPS.qrConnectDevice,
-    event: 'get_started_view',
-  },
-  'flow.get-started.submit': {
-    group: GROUPS.qrConnectDevice,
-    event: 'get_started_submit',
-  },
-  'flow.get-started.link.maybe-later': {
-    group: GROUPS.qrConnectDevice,
-    event: 'get_started_later',
-  },
-
-  'screen.ready-to-scan': {
-    group: GROUPS.qrConnectDevice,
-    event: 'ready_to_scan_view',
-  },
-  'flow.ready-to-scan.submit': {
-    group: GROUPS.qrConnectDevice,
-    event: 'ready_to_scan_submit',
-  },
-  'flow.ready-to-scan.link.maybe-later': {
-    group: GROUPS.qrConnectDevice,
-    event: 'ready_to_scan_later',
-  },
-  'flow.ready-to-scan.link.use-sms': {
-    group: GROUPS.qrConnectDevice,
-    event: 'ready_to_scan_use_sms',
-  },
-
-  'screen.scan-code': {
-    group: GROUPS.qrConnectDevice,
-    event: 'scan_code_view',
-  },
-  'flow.scan-code.link.use-sms': {
-    group: GROUPS.qrConnectDevice,
-    event: 'scan_code_use_sms',
-  },
   'flow.scan-code.device-connected': {
     group: GROUPS.qrConnectDevice,
     event: 'scan_code_device_connected',
   },
-
-  'screen.connected': {
-    group: GROUPS.qrConnectDevice,
-    event: 'connected_view',
-  },
-  'flow.connected.submit': {
-    group: GROUPS.qrConnectDevice,
-    event: 'connected_connect_another',
-  },
   'flow.connected.link.done': {
     group: GROUPS.qrConnectDevice,
     event: 'connected_done',
-  },
-  'flow.connected.link.use-sms': {
-    group: GROUPS.qrConnectDevice,
-    event: 'connected_use_sms',
   },
 };
 
@@ -323,6 +271,38 @@ const VIEW_ENGAGE_SUBMIT_EVENT_GROUPS = {
 // In the following regular expressions, the first match group is
 // exposed as `eventCategory` and the second as `eventTarget`.
 const FUZZY_EVENTS = new Map([
+  [
+    /^screen(?:\.signin|\.signup)?\.(get-started|ready-to-scan|scan-code|connected)$/,
+    {
+      group: GROUPS.qrConnectDevice,
+      event: (eventCategory, eventTarget) =>
+        `${eventCategory.replace(/-/g, '_')}_view`,
+    },
+  ],
+  [
+    /^flow(?:\.signin|\.signup)?\.(get-started|ready-to-scan|scan-code|connected).submit$/,
+    {
+      group: GROUPS.qrConnectDevice,
+      event: (eventCategory, eventTarget) =>
+        `${eventCategory.replace(/-/g, '_')}_submit`,
+    },
+  ],
+  [
+    /^flow(?:\.signin|\.signup)?\.(get-started|ready-to-scan).link.maybe-later$/,
+    {
+      group: GROUPS.qrConnectDevice,
+      event: (eventCategory, eventTarget) =>
+        `${eventCategory.replace(/-/g, '_')}_later`,
+    },
+  ],
+  [
+    /^flow(?:\.signin|\.signup)?\.(ready-to-scan|scan-code|connected).link.use-sms$/,
+    {
+      group: GROUPS.qrConnectDevice,
+      event: (eventCategory, eventTarget) =>
+        `${eventCategory.replace(/-/g, '_')}_use_sms`,
+    },
+  ],
   [
     /^experiment\.(?:control|designF|designG)\.passwordStrength\.([\w]+)$/,
     {

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -2175,5 +2175,395 @@ registerSuite('amplitude', {
       assert.equal(arg.event_type, 'fxa_connect_device - submit');
       assert.equal(arg.event_properties.connect_device_flow, 'pairing');
     },
+
+    'screen.get-started': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'screen.get-started',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_qr_connect_device - get_started_view');
+    },
+
+    'screen.signin.get-started': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'screen.get-started',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_qr_connect_device - get_started_view');
+    },
+
+    'screen.signup.get-started': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'screen.get-started',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_qr_connect_device - get_started_view');
+    },
+
+    'screen.ready-to-scan': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'screen.ready-to-scan',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(
+        arg.event_type,
+        'fxa_qr_connect_device - ready_to_scan_view'
+      );
+    },
+
+    'screen.scan-code': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'screen.scan-code',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_qr_connect_device - scan_code_view');
+    },
+
+    'screen.connected': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'screen.connected',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_qr_connect_device - connected_view');
+    },
+
+    'flow.get-started.submit': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'flow.get-started.submit',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(
+        arg.event_type,
+        'fxa_qr_connect_device - get_started_submit'
+      );
+    },
+
+    'flow.ready-to-scan.submit': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'flow.ready-to-scan.submit',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(
+        arg.event_type,
+        'fxa_qr_connect_device - ready_to_scan_submit'
+      );
+    },
+
+    'flow.scan-code.submit': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'flow.scan-code.submit',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_qr_connect_device - scan_code_submit');
+    },
+
+    'flow.connected.submit': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'flow.connected.submit',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_qr_connect_device - connected_submit');
+    },
+
+    'flow.get-started.link.maybe-later': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'flow.get-started.link.maybe-later',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_qr_connect_device - get_started_later');
+    },
+
+    'flow.ready-to-scan.link.maybe-later': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'flow.ready-to-scan.link.maybe-later',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(
+        arg.event_type,
+        'fxa_qr_connect_device - ready_to_scan_later'
+      );
+    },
+
+    'flow.ready-to-scan.link.use-sms': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'flow.ready-to-scan.link.use-sms',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(
+        arg.event_type,
+        'fxa_qr_connect_device - ready_to_scan_use_sms'
+      );
+    },
+
+    'flow.scan-code.link.use-sms': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'flow.scan-code.link.use-sms',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_qr_connect_device - scan_code_use_sms');
+    },
+
+    'flow.connected.link.use-sms': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'flow.connected.link.use-sms',
+        },
+        {
+          connection: {},
+          headers: {
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(logger.info.callCount, 1);
+      const arg = logger.info.args[0][1];
+      assert.equal(arg.event_type, 'fxa_qr_connect_device - connected_use_sms');
+    },
   },
 });


### PR DESCRIPTION
## Because

* Our QR code experiment cohorting rules were not grouping users correctly
* QR code experiment had half the volume of users as SMS and non-sms groups
* Targeted against train-177 since this is metrics related

## This commit

* Updates our flow events matching based on https://github.com/mozilla/fxa/issues/5628#issuecomment-649739353
* The previous rules were matching sign-in users only, the New Rules match sign-in/sign-up/direct flows

## Issue that this pull request solves

Closes: #5628

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Other information (Optional)

Raw logs

#### Sign-up amplitude metrics
```
{"op":"amplitudeEvent","event_type":"fxa_email_first - view","time":1593462327561,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
{"op":"amplitudeEvent","event_type":"fxa_email_first - engage","time":1593462328922,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
{"op":"amplitudeEvent","event_type":"fxa_email_first - submit","time":1593462330006,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
{"op":"amplitudeEvent","event_type":"fxa_reg - view","time":1593462331777,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
{"op":"amplitudeEvent","event_type":"fxa_reg - engage","time":1593462332416,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
{"op":"amplitudeEvent","event_type":"fxa_reg - submit","time":1593462338878,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
{"op":"amplitudeEvent","event_type":"fxa_reg - signup_code_view","time":1593462339191,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
{"op":"amplitudeEvent","event_type":"fxa_reg - signup_code_engage","time":1593462352774,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
{"op":"amplitudeEvent","event_type":"fxa_reg - signup_code_submit","time":1593462353189,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
{"op":"amplitudeEvent","event_type":"fxa_qr_connect_device - get_started_view","time":1593462353339,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["qr_code_cad_treatment_a"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
{"op":"amplitudeEvent","event_type":"fxa_qr_connect_device - get_started_submit","time":1593462359144,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["qr_code_cad_treatment_a"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
{"op":"amplitudeEvent","event_type":"fxa_qr_connect_device - ready_to_scan_view","time":1593462359177,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["qr_code_cad_treatment_a"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
{"op":"amplitudeEvent","event_type":"fxa_qr_connect_device - ready_to_scan_submit","time":1593462360375,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["qr_code_cad_treatment_a"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
{"op":"amplitudeEvent","event_type":"fxa_qr_connect_device - scan_code_view","time":1593462360436,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["qr_code_cad_treatment_a"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
{"op":"amplitudeEvent","event_type":"fxa_qr_connect_device - connected_view","time":1593462420722,"device_id":"7ccdf8fda46549f49a5137261dd5e305","session_id":1593462323017,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"a280116107c8cf165fe5112ceafdcd789b523a28d968598cca7a1e225f5274b6","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["qr_code_cad_treatment_a"]},"sync_engines":["bookmarks","history","passwords","addons","tabs","prefs"]}}
```


#### Sign-in amplitude metrics
```
{"op":"amplitudeEvent","event_type":"fxa_login - view","time":1593462558930,"device_id":"d6bae707065646659c884c01a31dd720","session_id":1593462558292,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"359542a0716bfa1b653acab401aae20ac9df9b5c68334fe155f170e53ee22fe0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
{"op":"amplitudeEvent","event_type":"fxa_login - engage","time":1593462559884,"device_id":"d6bae707065646659c884c01a31dd720","session_id":1593462558292,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"359542a0716bfa1b653acab401aae20ac9df9b5c68334fe155f170e53ee22fe0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
{"op":"amplitudeEvent","event_type":"fxa_login - submit","time":1593462563670,"device_id":"d6bae707065646659c884c01a31dd720","session_id":1593462558292,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"359542a0716bfa1b653acab401aae20ac9df9b5c68334fe155f170e53ee22fe0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync"}}}
{"op":"amplitudeEvent","event_type":"fxa_qr_connect_device - get_started_view","time":1593462564042,"user_id":"98464ceb6f3b460f88cc88961484478b","device_id":"d6bae707065646659c884c01a31dd720","session_id":1593462558292,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"359542a0716bfa1b653acab401aae20ac9df9b5c68334fe155f170e53ee22fe0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["qr_code_cad_treatment_a"]}}}
{"op":"amplitudeEvent","event_type":"fxa_qr_connect_device - get_started_submit","time":1593462567129,"user_id":"98464ceb6f3b460f88cc88961484478b","device_id":"d6bae707065646659c884c01a31dd720","session_id":1593462558292,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"359542a0716bfa1b653acab401aae20ac9df9b5c68334fe155f170e53ee22fe0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["qr_code_cad_treatment_a"]}}}
{"op":"amplitudeEvent","event_type":"fxa_qr_connect_device - ready_to_scan_view","time":1593462567162,"user_id":"98464ceb6f3b460f88cc88961484478b","device_id":"d6bae707065646659c884c01a31dd720","session_id":1593462558292,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"359542a0716bfa1b653acab401aae20ac9df9b5c68334fe155f170e53ee22fe0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["qr_code_cad_treatment_a"]}}}
{"op":"amplitudeEvent","event_type":"fxa_qr_connect_device - ready_to_scan_submit","time":1593462567965,"user_id":"98464ceb6f3b460f88cc88961484478b","device_id":"d6bae707065646659c884c01a31dd720","session_id":1593462558292,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"359542a0716bfa1b653acab401aae20ac9df9b5c68334fe155f170e53ee22fe0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["qr_code_cad_treatment_a"]}}}
{"op":"amplitudeEvent","event_type":"fxa_qr_connect_device - scan_code_view","time":1593462568024,"user_id":"98464ceb6f3b460f88cc88961484478b","device_id":"d6bae707065646659c884c01a31dd720","session_id":1593462558292,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"359542a0716bfa1b653acab401aae20ac9df9b5c68334fe155f170e53ee22fe0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["qr_code_cad_treatment_a"]}}}
{"op":"amplitudeEvent","event_type":"fxa_qr_connect_device - scan_code_device_connected","time":1593462592130,"user_id":"98464ceb6f3b460f88cc88961484478b","device_id":"d6bae707065646659c884c01a31dd720","session_id":1593462558292,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"359542a0716bfa1b653acab401aae20ac9df9b5c68334fe155f170e53ee22fe0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["qr_code_cad_treatment_a"]}}}
{"op":"amplitudeEvent","event_type":"fxa_qr_connect_device - connected_view","time":1593462592159,"user_id":"98464ceb6f3b460f88cc88961484478b","device_id":"d6bae707065646659c884c01a31dd720","session_id":1593462558292,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"entrypoint":"fxa_discoverability_native","flow_id":"359542a0716bfa1b653acab401aae20ac9df9b5c68334fe155f170e53ee22fe0","ua_browser":"Firefox","ua_version":"72.0","$append":{"fxa_services_used":"sync","experiments":["qr_code_cad_treatment_a"]}}}
```
