### PR TITLE
fix(tests): fix l10n fallback language tests

### DIFF
--- a/packages/fxa-auth-server/test/local/mailer_locales.js
+++ b/packages/fxa-auth-server/test/local/mailer_locales.js
@@ -50,7 +50,6 @@ describe('mailer locales', () => {
     const locales = [
       // [ locale, expected result ]
       ['', 'en'],
-      ['en-US', 'en'],
       ['en-CA', 'en'],
       ['db-LB', 'en'],
       ['el-GR', 'en'],
@@ -69,7 +68,8 @@ describe('mailer locales', () => {
     const locales = [
       // [ accept-language, expected result ]
       ['bogus-value', 'en'],
-      ['en-US,en;q=0.5', 'en'],
+      ['en', 'en'],
+      ['en-US,en;q=0.5', 'en-US'],
       ['es-AR,es;q=0.8,en-US;q=0.5,en;q=0.3', 'es-AR'],
       ['es-ES,es;q=0.8,en-US;q=0.5,en;q=0.3', 'es-ES'],
       ['sv-SE,sv;q=0.8,en-US;q=0.5,en;q=0.3', 'sv-SE'],

--- a/packages/fxa-content-server/tests/server/l10n.js
+++ b/packages/fxa-content-server/tests/server/l10n.js
@@ -251,9 +251,9 @@ suite.tests['#get /i18n/client.json with en,fr should use en'] = function () {
 };
 
 suite.tests[
-  '#get /i18n/client.json with en-US,fr should use en'
+  '#get /i18n/client.json with en-US,fr should use en_US'
 ] = function () {
-  return testClientJson.call(this, 'en-us,fr', 'en');
+  return testClientJson.call(this, 'en-us,fr', 'en_US');
 };
 
 suite.tests['#get /i18n/client.json with lowercase language'] = function () {


### PR DESCRIPTION
Because:
 - adding en-US to the supported languages list cause some test failures

This:
 - update en-US related l10n tests


The problem was introduce in the PR for #5762 (FXA-2181).

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
