### PR TITLE
fix(payments): further l10n updates for payment update form

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -144,22 +144,22 @@ sub-update-copy =
     you’ll be charged the full amount.
 ##  $amount (Number) - The amount billed. It will be formatted as currency.
 #  $intervalCount (Number) - The interval between payments, in days.
-sub-update-confirm-day = { $intervalCount ->
+sub-update-confirm-with-legal-links-day = { $intervalCount ->
   [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
   *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } days</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
 #  $intervalCount (Number) - The interval between payments, in weeks.
-sub-update-confirm-week = { $intervalCount ->
+sub-update-confirm-with-legal-links-week = { $intervalCount ->
   [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } weekly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
   *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } weeks</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
 #  $intervalCount (Number) - The interval between payments, in months.
-sub-update-confirm-month = { $intervalCount ->
+sub-update-confirm-with-legal-links-month = { $intervalCount ->
   [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } monthly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
   *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } months</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }
 #  $intervalCount (Number) - The interval between payments, in years.
-sub-update-confirm-year = { $intervalCount ->
+sub-update-confirm-with-legal-links-year = { $intervalCount ->
   [one] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } yearly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
   *[other] I authorize { -brand-name-mozilla }, maker of { -brand-name-firefox } products, to charge my payment method <strong>{ $amount } every { $intervalCount } years</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.
 }

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
@@ -14,6 +14,8 @@ import { useNonce } from '../../lib/hooks';
 function init() {
   storiesOf('components/PaymentForm', module)
     .add('default', () => <Subject />)
+    .add('without plan', () => <Subject noPlan />)
+    .add('without confirmation', () => <Subject confirm={false} />)
     .add('fr locale (for legal links)', () => <Subject locale="fr" />)
     .add('in progress', () => <Subject inProgress={true} />)
     .add('all invalid', () => {
@@ -60,6 +62,7 @@ const PLAN = {
 type SubjectProps = {
   inProgress?: boolean;
   confirm?: boolean;
+  noPlan?: boolean;
   plan?: Plan;
   onPayment?: (tokenResponse: stripe.TokenResponse) => void;
   onPaymentError?: (error: any) => void;
@@ -72,6 +75,7 @@ type SubjectProps = {
 const Subject = ({
   inProgress = false,
   confirm = true,
+  noPlan = false,
   plan = PLAN,
   onPayment = action('onPayment'),
   onPaymentError = action('onPaymentError'),
@@ -86,7 +90,7 @@ const Subject = ({
     submitNonce,
     inProgress,
     confirm,
-    plan,
+    plan: noPlan ? undefined : plan,
     onPayment,
     onPaymentError,
     onChange,

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
@@ -210,6 +210,26 @@ it('includes the confirmation checkbox when confirm = true and plan supplied', (
 });
 
 describe('Legal', () => {
+  describe('links', () => {
+    const commonLegalLinkTest = (plan?: Plan) => () => {
+      const { queryByText } = render(<Subject {...{ plan }} />);
+      [
+        queryByText('Terms of Service'),
+        queryByText('Privacy Notice'),
+      ].forEach((q) =>
+        plan ? expect(q).toBeInTheDocument() : expect(q).not.toBeInTheDocument()
+      );
+    };
+    it(
+      'omits terms of service and privacy notice links when plan is missing',
+      commonLegalLinkTest()
+    );
+    it(
+      'includes terms of service and privacy notice links when plan is supplied',
+      commonLegalLinkTest(MOCK_PLAN)
+    );
+  });
+
   describe('rendering the legal checkbox Localized component', () => {
     function runTests(plan: Plan, expectedMsgId: string, expectedMsg: string) {
       const testRenderer = TestRenderer.create(

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -34,10 +34,7 @@ import { AppContext } from '../../lib/AppContext';
 
 import './index.scss';
 import { Plan, PlanInterval } from '../../store/types';
-import {
-  DEFAULT_PRODUCT_DETAILS,
-  productDetailsFromPlan,
-} from 'fxa-shared/subscriptions/metadata';
+import { productDetailsFromPlan } from 'fxa-shared/subscriptions/metadata';
 import { TermsAndPrivacy } from '../TermsAndPrivacy';
 
 // Define a minimal type for what we use from the Stripe API, which makes
@@ -141,12 +138,14 @@ export const PaymentForm = ({
   const stripeElementStyles = mkStripeElementStyles(
     matchMedia(SMALL_DEVICE_RULE)
   );
-  // TODO: if a plan is not supplied, fall back to default details
-  // This mainly happens in ProductUpdateForm where we're updating payment
-  // details across *all* plans - are there better URLs to pick in that case?
-  const { termsOfServiceURL, privacyNoticeURL } = plan
-    ? productDetailsFromPlan(plan, navigatorLanguages)
-    : DEFAULT_PRODUCT_DETAILS;
+
+  let termsOfServiceURL, privacyNoticeURL;
+  if (confirm && plan) {
+    ({ termsOfServiceURL, privacyNoticeURL } = productDetailsFromPlan(
+      plan,
+      navigatorLanguages
+    ));
+  }
 
   return (
     <Form
@@ -222,26 +221,27 @@ export const PaymentForm = ({
       <hr />
 
       {confirm && plan && (
-        <Localized
-          id={`payment-confirm-with-legal-links-${plan.interval}`}
-          $intervalCount={plan.interval_count}
-          $amount={getLocalizedCurrency(plan.amount, plan.currency)}
-          strong={<strong></strong>}
-          termsOfServiceLink={<a href={termsOfServiceURL}></a>}
-          privacyNoticeLink={<a href={privacyNoticeURL}></a>}
-        >
-          <Checkbox data-testid="confirm" name="confirm" required>
-            {getDefaultPaymentConfirmText(
-              plan.amount,
-              plan.currency,
-              plan.interval,
-              plan.interval_count
-            )}
-          </Checkbox>
-        </Localized>
+        <>
+          <Localized
+            id={`payment-confirm-with-legal-links-${plan.interval}`}
+            $intervalCount={plan.interval_count}
+            $amount={getLocalizedCurrency(plan.amount, plan.currency)}
+            strong={<strong></strong>}
+            termsOfServiceLink={<a href={termsOfServiceURL}></a>}
+            privacyNoticeLink={<a href={privacyNoticeURL}></a>}
+          >
+            <Checkbox data-testid="confirm" name="confirm" required>
+              {getDefaultPaymentConfirmText(
+                plan.amount,
+                plan.currency,
+                plan.interval,
+                plan.interval_count
+              )}
+            </Checkbox>
+          </Localized>
+          <hr />
+        </>
       )}
-
-      <hr />
 
       {onCancel ? (
         <div className="button-row">
@@ -295,7 +295,7 @@ export const PaymentForm = ({
       )}
 
       <PaymentLegalBlurb />
-      <TermsAndPrivacy plan={plan} />
+      {plan && <TermsAndPrivacy plan={plan} />}
     </Form>
   );
 };

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -187,7 +187,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
       it('renders Localized for daily plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_daily';
         const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'sub-update-confirm-day';
+        const expectedMsgId = 'sub-update-confirm-with-legal-links-day';
         const expectedMsg =
           'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
@@ -197,7 +197,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
       it('renders Localized for 6 days plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_6days';
         const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'sub-update-confirm-day';
+        const expectedMsgId = 'sub-update-confirm-with-legal-links-day';
         const expectedMsg =
           'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 days</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
@@ -207,7 +207,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
       it('renders Localized for weekly plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_weekly';
         const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'sub-update-confirm-week';
+        const expectedMsgId = 'sub-update-confirm-with-legal-links-week';
         const expectedMsg =
           'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 weekly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
@@ -217,7 +217,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
       it('renders Localized for 6 weeks plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_6weeks';
         const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'sub-update-confirm-week';
+        const expectedMsgId = 'sub-update-confirm-with-legal-links-week';
         const expectedMsg =
           'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 weeks</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
@@ -227,7 +227,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
       it('renders Localized for monthly plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_monthly';
         const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'sub-update-confirm-month';
+        const expectedMsgId = 'sub-update-confirm-with-legal-links-month';
         const expectedMsg =
           'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 monthly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
@@ -237,7 +237,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
       it('renders Localized for 6 months plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_6months';
         const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'sub-update-confirm-month';
+        const expectedMsgId = 'sub-update-confirm-with-legal-links-month';
         const expectedMsg =
           'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 months</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
@@ -247,7 +247,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
       it('renders Localized for yearly plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_yearly';
         const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'sub-update-confirm-year';
+        const expectedMsgId = 'sub-update-confirm-with-legal-links-year';
         const expectedMsg =
           'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 yearly</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
@@ -257,7 +257,7 @@ describe('routes/Product/SubscriptionUpgrade', () => {
       it('renders Localized for years plan with correct props and displays correct default string', async () => {
         const plan_id = 'plan_6years';
         const plan = findMockPlan(plan_id);
-        const expectedMsgId = 'sub-update-confirm-year';
+        const expectedMsgId = 'sub-update-confirm-with-legal-links-year';
         const expectedMsg =
           'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 every 6 years</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
@@ -272,8 +272,8 @@ describe('routes/Product/SubscriptionUpgrade', () => {
         amount,
       };
 
-      describe('when the localized id is sub-update-confirm-day', () => {
-        const msgId = 'sub-update-confirm-day';
+      describe('when the localized id is sub-update-confirm-with-legal-links-day', () => {
+        const msgId = 'sub-update-confirm-with-legal-links-day';
 
         it('returns the correct string for an interval count of 1', () => {
           const expected =
@@ -297,8 +297,8 @@ describe('routes/Product/SubscriptionUpgrade', () => {
         });
       });
 
-      describe('when the localized id is sub-update-confirm-week', () => {
-        const msgId = 'sub-update-confirm-week';
+      describe('when the localized id is sub-update-confirm-with-legal-links-week', () => {
+        const msgId = 'sub-update-confirm-with-legal-links-week';
 
         it('returns the correct string for an interval count of 1', () => {
           const expected =
@@ -323,8 +323,8 @@ describe('routes/Product/SubscriptionUpgrade', () => {
         });
       });
 
-      describe('when the localized id is sub-update-confirm-month', () => {
-        const msgId = 'sub-update-confirm-month';
+      describe('when the localized id is sub-update-confirm-with-legal-links-month', () => {
+        const msgId = 'sub-update-confirm-with-legal-links-month';
 
         it('returns the correct string for an interval count of 1', () => {
           const expected =
@@ -349,8 +349,8 @@ describe('routes/Product/SubscriptionUpgrade', () => {
         });
       });
 
-      describe('when the localized id is sub-update-confirm-year', () => {
-        const msgId = 'sub-update-confirm-year';
+      describe('when the localized id is sub-update-confirm-with-legal-links-year', () => {
+        const msgId = 'sub-update-confirm-with-legal-links-year';
 
         it('returns the correct string for an interval count of 1', () => {
           const expected =

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -183,7 +183,7 @@ export const SubscriptionUpgrade = ({
             <hr />
 
             <Localized
-              id={`sub-update-confirm-${selectedPlan.interval}`}
+              id={`sub-update-confirm-with-legal-links-${selectedPlan.interval}`}
               strong={<strong></strong>}
               $amount={getLocalizedCurrency(
                 selectedPlan.amount,


### PR DESCRIPTION
- Remove Terms of Service and Privacy Notice legal links from payment
  update form when no specific plan is provided

- Add stories for PaymentForm to cover cases without confirmation
  checkbox and without plan

- Also update sub-update-confirm-* l10n IDs to
  sub-update-confirm-with-legal-* so changed strings are flagged new

fixes #5733
