### PR TITLE
task(payments-server): l10n msg 4 required fields

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -131,6 +131,7 @@ sub-redirect-skip-survey = No thanks, just take me to my product.
 
 ## fields
 default-input-error = This field is required
+input-error-is-required = { $label } is required
 
 ## subscription upgrade
 product-plan-upgrade-heading = Review your upgrade

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -179,6 +179,7 @@ export const PaymentForm = ({
           label="Card number"
           style={stripeElementStyles}
           className="input-row input-row--xl"
+          getString={getString}
           required
         />
       </Localized>
@@ -190,6 +191,7 @@ export const PaymentForm = ({
             name="expDate"
             label="Exp. date"
             style={stripeElementStyles}
+            getString={getString}
             required
           />
         </Localized>
@@ -200,6 +202,7 @@ export const PaymentForm = ({
             name="cvc"
             label="CVC"
             style={stripeElementStyles}
+            getString={getString}
             required
           />
         </Localized>

--- a/packages/fxa-payments-server/src/components/fields/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/fields/index.test.tsx
@@ -426,6 +426,7 @@ describe('StripeElement', () => {
   it('runs validation for empty value if focused and blurred', () => {
     const MockStripeElement = buildMockStripeElement(undefined);
     const validatorStateRef = mkValidatorStateRef();
+    const translatedIsRequired = 'IS REQUIRED TRANSLATED';
     const { container, getByTestId } = render(
       <TestForm validatorStateRef={validatorStateRef}>
         <StripeElement
@@ -433,6 +434,10 @@ describe('StripeElement', () => {
           label="Frobnitz"
           name="input-1"
           required={true}
+          // Basic mock of getString, real version is more in depth, but has test coverage within the library
+          getString={(msg, value) => {
+            return value.label + ' ' + translatedIsRequired;
+          }}
           component={MockStripeElement}
         />
       </TestForm>
@@ -446,7 +451,7 @@ describe('StripeElement', () => {
     const tooltipEl = container.querySelector('aside.tooltip');
     expect(tooltipEl).not.toBeNull();
     expect((tooltipEl as Element).textContent).toContain(
-      'Frobnitz is required'
+      'Frobnitz IS REQUIRED TRANSLATED'
     );
   });
 

--- a/packages/fxa-payments-server/src/components/fields/index.tsx
+++ b/packages/fxa-payments-server/src/components/fields/index.tsx
@@ -214,19 +214,25 @@ export const Input = withLocalization(UnwrappedInput);
 
 type StripeElementProps = { onValidate?: OnValidateFunction } & FieldProps & {
     component: any;
+    getString: Function | undefined;
   } & ReactStripeElements.ElementProps;
 
 export const defaultStripeElementValidator: OnValidateFunction = (
   value,
   focused,
-  props
+  props,
+  getString
 ) => {
   if (!value || value.empty) {
     if (props.required) {
       return {
         value,
         valid: false,
-        error: focused ? null : `${props.label} is required`,
+        error: focused
+          ? null
+          : getString
+          ? getString('input-error-is-required', { label: props.label })
+          : props.label + ' is required',
       };
     }
   } else if (value.error && value.error.message) {
@@ -255,6 +261,7 @@ export const StripeElement = (props: StripeElementProps) => {
     label,
     className,
     autoFocus,
+    getString,
     ...childProps
   } = props;
   const { validator } = useContext(FormContext) as FormContextValue;
@@ -265,7 +272,7 @@ export const StripeElement = (props: StripeElementProps) => {
       elementValue.current = value;
       validator.updateField({
         name,
-        ...onValidate(value, true, props),
+        ...onValidate(value, true, props, getString),
       });
     },
     [name, props, validator, onValidate, elementValue]
@@ -276,7 +283,7 @@ export const StripeElement = (props: StripeElementProps) => {
       const value = elementValue.current;
       validator.updateField({
         name,
-        ...onValidate(value, false, props),
+        ...onValidate(value, false, props, getString),
       });
     },
     [name, props, validator, onValidate, elementValue]


### PR DESCRIPTION
## Because
Fix an issue with the way we were concatenating error message labels in our payment form. Decided to keep the english fallback in the case that there is no translation in the user's language

## Issue that this pull request solves

Closes: #5719

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

TRANSLATED:
![is-required-correct](https://user-images.githubusercontent.com/1844554/86156916-a3133700-bad4-11ea-8036-bb0b959ca91e.png)

FALLBACK TO ENGLISH TRANSLATION:
![is-required-falback](https://user-images.githubusercontent.com/1844554/86156952-b0302600-bad4-11ea-969d-2d62bc215e20.png)
