### PR TITLE
fix(coverage): only show code coveage for tests that run, not the entire project

### DIFF
--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -7,10 +7,7 @@ coverage:
   range: "0...100"
   status:
     project:
-      default:
-        if_not_found: success
-        informational: true
-        only_pulls: false
+      default: false
     patch:
       default:
         if_not_found: success


### PR DESCRIPTION
## Because

* Commit status for overall project code coverage is non-nonsensical because it could be based on a commit that didn't necessarily run tests
* We still report `patch` which shows the coverage of the current PR on the tests that did run

## This commit

* Disables the `project` commit status.

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
