### PR TITLE
feat(surveys): send matching conditions over to survey gizmo

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/app-start.js
+++ b/packages/fxa-content-server/app/scripts/lib/app-start.js
@@ -87,7 +87,7 @@ Start.prototype = {
       .then(() => this.initializeDeps())
       .then(() => this.testLocalStorage())
       .then(() => this.allResourcesReady())
-      .catch(err => this.fatalError(err));
+      .catch((err) => this.fatalError(err));
   },
 
   initializeInterTabChannel() {
@@ -410,7 +410,7 @@ Start.prototype = {
           return user.mergeBrowserAccount(browserAccountData);
         }
       })
-      .then(browserAccount => {
+      .then((browserAccount) => {
         const isPairing =
           this.isDevicePairingAsAuthority() || this.isStartingPairing();
 
@@ -531,6 +531,7 @@ Start.prototype = {
         user: this._user,
         surveys: this._config.surveys,
         window: this._window,
+        env: this._config.env,
       });
     }
   },
@@ -568,7 +569,7 @@ Start.prototype = {
           this._storage.testLocalStorage(this._window);
         }
       })
-      .catch(err => this.captureError(err));
+      .catch((err) => this.captureError(err));
   },
 
   /**

--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -168,4 +168,7 @@ module.exports = {
   // Allow ID Tokens used as the id_token_hint argument in a prompt=none
   // request to be this many seconds past their expiration.
   ID_TOKEN_HINT_GRACE_PERIOD: 60 * 60 * 24 * 7,
+
+  ENV_DEVELOPMENT: 'development',
+  ENV_PRODUCTION: 'production',
 };

--- a/packages/fxa-content-server/app/scripts/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/scripts/lib/survey-filter.js
@@ -257,46 +257,53 @@ export const languagesCheck = createConditionCheckFn(fetchAndApplySourceVal)(
 const createUaConditionCheckFn = createConditionCheckFn(fetchAndApplySourceVal);
 
 // Comparator
-export const checkUaDeviceType = (ua) => (val) => {
-  if (
-    ua &&
-    ua.genericDeviceType &&
-    ua.genericDeviceType().toLowerCase() === val.toLowerCase()
-  ) {
-    return val;
+export const checkUaDeviceTypes = (ua) => (vals) => {
+  vals = Array.isArray(vals) ? vals : [vals];
+  if (!(ua && ua.genericDeviceType)) {
+    return;
   }
+  const deviceType = ua.genericDeviceType().toLowerCase();
+  // If one of any eligible device type matches, return
+  // it, otherwise return undefined, which is a failure
+  return vals.filter((v) => {
+    return deviceType === v.toLowerCase();
+  })[0];
 };
 
 // Comparator
-export const checkUaOsName = (ua) => (val) => {
-  if (
-    ua &&
-    ua.os &&
-    ua.os.name &&
-    ua.os.name.toLowerCase() === val.toLowerCase()
-  ) {
-    return val;
+export const checkUaOsNames = (ua) => (vals) => {
+  vals = Array.isArray(vals) ? vals : [vals];
+  if (!(ua && ua.os && ua.os.name)) {
+    return;
   }
+  const osName = ua.os.name.toLowerCase();
+  // If one of any eligible OS value matches, return it,
+  // otherwise return undefined, which is a failure
+  return vals.filter((v) => {
+    return osName === v.toLowerCase();
+  })[0];
 };
 
 // Comparator
-export const checkUaBrowser = (ua) => (val) => {
-  if (
-    ua &&
-    ua.browser &&
-    ua.browser.name &&
-    ua.browser.name.toLowerCase() === val.toLowerCase()
-  ) {
-    return val;
+export const checkUaBrowsers = (ua) => (vals) => {
+  vals = Array.isArray(vals) ? vals : [vals];
+  if (!(ua && ua.browser && ua.browser.name)) {
+    return;
   }
+  const browserName = ua.browser.name.toLowerCase();
+  // If one of any eligible browser value matches, return
+  // it, otherwise return undefined, which is a failure
+  return vals.filter((v) => {
+    return browserName === v.toLowerCase();
+  })[0];
 };
 
 // Ref: https://github.com/mozilla/fxa/blob/9b2d9d1/packages/fxa-content-server/app/scripts/lib/user-agent.js#L182
-export const hasDesiredDeviceType = createUaConditionCheckFn(checkUaDeviceType)(
-  'deviceType'
-);
-export const hasDesiredOs = createUaConditionCheckFn(checkUaOsName)('os');
-export const hasDesiredBrowser = createUaConditionCheckFn(checkUaBrowser)(
+export const hasDesiredDeviceType = createUaConditionCheckFn(
+  checkUaDeviceTypes
+)('deviceType');
+export const hasDesiredOs = createUaConditionCheckFn(checkUaOsNames)('os');
+export const hasDesiredBrowser = createUaConditionCheckFn(checkUaBrowsers)(
   'browser'
 );
 

--- a/packages/fxa-content-server/app/scripts/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/scripts/lib/survey-filter.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import UserAgent from './user-agent';
+import { ENV_DEVELOPMENT } from './constants';
 
 // All but the default export here is to make testing easier.
 
@@ -30,7 +31,7 @@ export const participatedRecently = (
 };
 
 export const withinRate = (rate) => {
-  if (rate === 0) {
+  if (isNaN(rate) || rate === 0) {
     return false;
   }
 
@@ -389,7 +390,8 @@ export const createSurveyFilter = (
   user,
   relier,
   previousParticipationTime,
-  doNotBotherSpan
+  doNotBotherSpan,
+  env
 ) => {
   const fetchUa = createFetchUaFn(window);
   const fetchLangs = createFetchLanguagesFn(window);
@@ -402,11 +404,11 @@ export const createSurveyFilter = (
     if (
       !(
         surveyConfig &&
-        surveyConfig.rate &&
         surveyConfig.conditions &&
-        withinRate(surveyConfig.rate) &&
+        (env === ENV_DEVELOPMENT || withinRate(surveyConfig.rate)) &&
         Object.keys(surveyConfig.conditions).length > 0 &&
-        !participatedRecently(previousParticipationTime, doNotBotherSpan)
+        (env === ENV_DEVELOPMENT ||
+          !participatedRecently(previousParticipationTime, doNotBotherSpan))
       )
     ) {
       return failureRes;

--- a/packages/fxa-content-server/app/scripts/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/scripts/lib/survey-filter.js
@@ -308,14 +308,18 @@ export const hasDesiredBrowser = createUaConditionCheckFn(checkUaBrowsers)(
 );
 
 // Comparator
-export const checkRelierClientId = (relier) => (val) => {
-  if (relier.get('clientId') === val) {
-    return val;
-  }
+export const checkRelierClientIds = (relier) => (vals) => {
+  vals = Array.isArray(vals) ? vals : [vals];
+  const userRP = relier.get('clientId');
+  // If one of any eligible RP IDs matche, return
+  // it, otherwise return undefined, which is a failure
+  return vals.filter((v) => {
+    return userRP === v;
+  })[0];
 };
 
 export const relierClientIdCheck = createConditionCheckFn(applySourceVal)(
-  checkRelierClientId
+  checkRelierClientIds
 )('relier');
 
 // Comparator

--- a/packages/fxa-content-server/app/styles/modules/_survey.scss
+++ b/packages/fxa-content-server/app/styles/modules/_survey.scss
@@ -119,3 +119,18 @@ $survey-height: 360px;
 .button-inner-enter-active {
   transform: rotate(0deg);
 }
+
+@media (prefers-reduced-motion) {
+  .survey-inner-exit-active,
+  .survey-inner-enter-active {
+    transition-duration: 0s;
+  }
+
+  .survey-component {
+    visibility: hidden;
+
+    &.survey-inner-enter-done {
+      visibility: visible;
+    }
+  }
+}

--- a/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
@@ -127,7 +127,7 @@ describe('lib/survey-filter', () => {
         falsyComparator
       )('quuz');
       const actual = condCheck({ fizz: 'buzz' }, {});
-      assert.isTrue(actual);
+      assertConditionResult(actual, true);
       assert.isFalse(valSourceCheck.called);
       assert.isFalse(falsyComparator.called);
       assert.isFalse(falseFn.called);
@@ -139,7 +139,7 @@ describe('lib/survey-filter', () => {
         falsyComparator
       )('quuz');
       const actual = condCheck({ quuz: 'buzz' }, { fxa: 'surveys' });
-      assert.isFalse(actual);
+      assertConditionResult(actual, true, false);
       assert.isTrue(valSoureCheck.calledOnce);
       assert.deepEqual(valSoureCheck.args[0], [{ fxa: 'surveys' }]);
       assert.isTrue(falsyComparator.calledOnce);
@@ -156,7 +156,7 @@ describe('lib/survey-filter', () => {
         falsyComparator
       )('quuz');
       const actual = await condCheck({ fizz: 'buzz' }, {});
-      assert.isTrue(actual);
+      assertConditionResult(actual, true);
       assert.isFalse(valSoureCheck.called);
       assert.isFalse(falsyComparator.called);
       assert.isFalse(falseFn.called);
@@ -177,7 +177,7 @@ describe('lib/survey-filter', () => {
         valSourceCheck
       )(comparator)('quuz');
       const actual = await condCheck({ quuz: 'TESTO' }, { fxa: 'surveys' });
-      assert.isTrue(actual);
+      assertConditionResult(actual, true, true);
       assert.isTrue(valSourceCheck.calledOnce);
       assert.deepEqual(valSourceCheck.args[0], [{ fxa: 'surveys' }]);
       assert.isTrue(comparator.calledOnce);
@@ -365,11 +365,11 @@ describe('lib/survey-filter', () => {
   describe('applySourceVal', () => {
     const comparator = sandbox.stub().returns(() => {});
 
-    it('should return () => false when an undefined is fetched', () => {
+    it('should return () => undefined when an undefined is fetched', () => {
       const fetchFn = sinon.stub().returns(undefined);
       const f = SurveyFilter.fetchAndApplySourceVal(fetchFn)(comparator);
       const actual = f();
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
       assert.isTrue(fetchFn.calledOnce);
       assert.isFalse(comparator.called);
     });
@@ -386,13 +386,13 @@ describe('lib/survey-filter', () => {
   describe('fetchAndApplySourceVal', () => {
     const comparator = sandbox.stub().returns(() => {});
 
-    it('should return () => false when an undefined is fetched', async () => {
+    it('should return () => undefined when an undefined is fetched', async () => {
       const fetchFn = sinon.stub().resolves(undefined);
       const f = await SurveyFilter.asyncFetchAndApplySourceVal(fetchFn)(
         comparator
       );
       const actual = f();
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
       assert.isTrue(fetchFn.calledOnce);
       assert.isFalse(comparator.called);
     });
@@ -411,13 +411,13 @@ describe('lib/survey-filter', () => {
   describe('asyncFetchAndApplySourceVal', () => {
     const comparator = sandbox.stub().returns(() => true);
 
-    it('should return () => false when an undefined is fetched', async () => {
+    it('should return () => undefined when an undefined is fetched', async () => {
       const fetchFn = sinon.stub().returns(undefined);
       const f = await SurveyFilter.asyncFetchAndApplySourceVal(fetchFn)(
         comparator
       );
       const actual = f();
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
       assert.isTrue(fetchFn.calledOnce);
       assert.isFalse(comparator.called);
     });
@@ -434,317 +434,290 @@ describe('lib/survey-filter', () => {
   });
 
   describe('checkLanguages', () => {
-    it('should be case insensitive', () => {
-      const actual = SurveyFilter.checkLanguages(['en'])(['EN']);
-      assert.isTrue(actual);
+    it('should be case insensitive, returning all user locales', () => {
+      const actual = SurveyFilter.checkLanguages(['en-CA'])(['EN']);
+      assert.deepEqual(actual, ['en-CA']);
     });
 
-    it('should be false when there is no match', () => {
+    it('should be undefined when there is no match', () => {
       const actual = SurveyFilter.checkLanguages(['en', 'zh-CN', 'gd'])([
         'es-MX',
       ]);
-      assert.isFalse(actual);
+      assert.notExists(actual);
     });
 
-    it('should be true when a language condition matches the language portion of a tag', () => {
+    it('should return all user locales when a language condition matches the language portion of a tag', () => {
       const actual = SurveyFilter.checkLanguages(['en', 'zh-CN', 'gd'])(['zh']);
-      assert.isTrue(actual);
+      assert.deepEqual(actual, ['en', 'zh-CN', 'gd']);
     });
 
-    it('should be true when an exact match is found', () => {
+    it('should return all user locales when an exact match is found', () => {
       const actual = SurveyFilter.checkLanguages(['en', 'zh-CN', 'gd'])([
         'es',
         'zh-CN',
       ]);
-      assert.isTrue(actual);
+      assert.deepEqual(actual, ['en', 'zh-CN', 'gd']);
     });
   });
 
   describe('languagesCheck', () => {
     const fetchLangs = sandbox.stub().returns(['en', 'es-MX', 'gd']);
 
-    it('should be true when any language tag is matched', () => {
+    it('should be passing and have all user locales value when any language tag is matched', () => {
       const actual = SurveyFilter.languagesCheck(
         { languages: ['zh', 'es'] },
         fetchLangs
       );
-      assert.isTrue(actual);
+      assertConditionResult(actual, true, ['en', 'es-MX', 'gd']);
       assert.isTrue(fetchLangs.calledOnce);
     });
 
-    it('should be false when there is no match', () => {
+    it('should be failing and have no value when there is no match', () => {
       const actual = SurveyFilter.languagesCheck(
         { languages: ['zh', 'de'] },
         fetchLangs
       );
-      assert.isFalse(actual);
+      assertConditionResult(actual, false);
       assert.isTrue(fetchLangs.calledOnce);
     });
   });
 
   describe('checkUaDeviceType', () => {
-    it('should be case insensitive', () => {
+    it('should be case insensitive, returning the passed in value when matching', () => {
       const actual = SurveyFilter.checkUaDeviceType(mockUa)('mObile');
-      assert.isTrue(actual);
+      assert.equal(actual, 'mObile');
       assert.isTrue(mockUa.genericDeviceType.calledOnce);
     });
 
-    it('should be false when the values do not match', () => {
+    it('should not return anything when the values do not match', () => {
       const actual = SurveyFilter.checkUaDeviceType(mockUa)('DESKTOP');
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
       assert.isTrue(mockUa.genericDeviceType.calledOnce);
     });
   });
 
   describe('checkUaOsName', () => {
-    it('should be case insensitive', () => {
+    it('should be case insensitive, returning the passed in value when matching', () => {
       const actual = SurveyFilter.checkUaOsName(mockUa)('Winning');
-      assert.isTrue(actual);
+      assert.equal(actual, 'Winning');
     });
 
-    it('should be false when the values do not match', () => {
+    it('should not return anything when the values do not match', () => {
       const actual = SurveyFilter.checkUaOsName(mockUa)('Windows');
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
     });
   });
 
   describe('checkUaBrowser', () => {
-    it('should be case insensitive', () => {
+    it('should be case insensitive, returning the passed in value when matching', () => {
       const actual = SurveyFilter.checkUaBrowser(mockUa)('spacetuna');
-      assert.isTrue(actual);
+      assert.equal(actual, 'spacetuna');
     });
 
-    it('should be false when the values do not match', () => {
+    it('should not return anything when the values do not match', () => {
       const actual = SurveyFilter.checkUaBrowser(mockUa)('Firefox');
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
     });
   });
 
   describe('hasDesiredDeviceType', () => {
-    it('should be true when the values match', () => {
+    it('should be passing and have the matched value when the values match', () => {
       const actual = SurveyFilter.hasDesiredDeviceType(
         { deviceType: 'deskTOP' },
         fetchGoodUaStub
       );
-      assert.isTrue(actual);
+      assertConditionResult(actual, true, 'deskTOP');
       assert.isTrue(fetchGoodUaStub.calledOnce);
     });
 
-    it('should be false when the values do not match', () => {
+    it('should not be passing and have an undefined value when the values do not match', () => {
       const actual = SurveyFilter.hasDesiredDeviceType(
         { deviceType: 'tablet' },
         fetchBadUaStub
       );
-      assert.isFalse(actual);
+      assertConditionResult(actual, false);
       assert.isTrue(fetchBadUaStub.calledOnce);
     });
   });
 
   describe('hasDesiredOs', () => {
-    it('should be true when the values match', () => {
+    it('should be passing and have the matched value when the values match', () => {
       const actual = SurveyFilter.hasDesiredOs(
         { os: 'Windows' },
         fetchGoodUaStub
       );
-      assert.isTrue(actual);
+      assertConditionResult(actual, true, 'Windows');
       assert.isTrue(fetchGoodUaStub.calledOnce);
     });
 
-    it('should be false when the values do not match', () => {
+    it('should not be passing and have an undefined value when the values do not match', () => {
       const actual = SurveyFilter.hasDesiredOs({ os: 'macOS' }, fetchBadUaStub);
-      assert.isFalse(actual);
+      assertConditionResult(actual, false);
       assert.isTrue(fetchBadUaStub.calledOnce);
     });
   });
 
   describe('hasDesiredBrowser', () => {
-    it('should be true when the values match', () => {
+    it('should be passing and have the matched value when the values match', () => {
       const actual = SurveyFilter.hasDesiredBrowser(
         { browser: 'Firefox' },
         fetchGoodUaStub
       );
-      assert.isTrue(actual);
+      assertConditionResult(actual, true, 'Firefox');
       assert.isTrue(fetchGoodUaStub.calledOnce);
     });
 
-    it('should be false when the values do not match', () => {
+    it('should not be passing and have an undefined value when the values do not match', () => {
       const actual = SurveyFilter.hasDesiredBrowser(
         { browser: 'Brave' },
         fetchBadUaStub
       );
-      assert.isFalse(actual);
+      assertConditionResult(actual, false);
       assert.isTrue(fetchBadUaStub.calledOnce);
-    });
-  });
-
-  describe('userAgentChecks', () => {
-    it('should be true when all three conditions are met', () => {
-      const actual = SurveyFilter.userAgentChecks(
-        { deviceType: 'desktop', os: 'windows', browser: 'firefox' },
-        fetchGoodUaStub
-      );
-      assert.isTrue(actual);
-      assert.isTrue(fetchGoodUaStub.calledThrice);
-    });
-
-    it('should be false when any condition is false', () => {
-      [
-        { deviceType: 'mobile', os: 'windows', browser: 'firefox' },
-        { deviceType: 'desktop', os: 'ios', browser: 'firefox' },
-        { deviceType: 'desktop', os: 'windows', browser: 'waterweasel' },
-        { deviceType: 'desktop', os: 'mac', browser: 'webkit' },
-        { deviceType: 'webos', os: 'windows', browser: 'spacetuna' },
-        { deviceType: 'desktop', os: 'beOS', browser: 'navigator' },
-      ].forEach((conds) => {
-        const actual = SurveyFilter.userAgentChecks(conds, fetchBadUaStub);
-        assert.isFalse(actual);
-        assert.isTrue(fetchBadUaStub.calledOnce);
-        fetchBadUaStub.resetHistory();
-      });
     });
   });
 
   describe('checkRelierClientId', () => {
     const mockRelier = { get: sandbox.stub().returns('galaxy quest') };
 
-    it('should be true when matched exactly', () => {
+    it('should be the matched value when matched exactly', () => {
       const actual = SurveyFilter.checkRelierClientId(mockRelier)(
         'galaxy quest'
       );
-      assert.isTrue(actual);
+      assert.equal(actual, 'galaxy quest');
     });
 
     it('should be false when the values do not match', () => {
       const actual = SurveyFilter.checkRelierClientId(mockRelier)(
         'Galaxy Quest'
       );
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
     });
   });
 
   describe('relierClientIdCheck', () => {
     const mockRelier = { get: sandbox.stub().returns('Relying Party!!!') };
 
-    it('should be true when relier is not in the conditions', () => {
+    it('should be passing and have an undefined value when relier is not in the conditions', () => {
       const actual = SurveyFilter.relierClientIdCheck(
         { noRelierForUs: 'No Parties' },
         mockRelier
       );
-      assert.isTrue(actual);
+      assertConditionResult(actual, true);
       assert.isFalse(mockRelier.get.called);
     });
 
-    it('should be true when client id matches configured condition', () => {
+    it('should be passing and have the matched value when client id matches configured condition', () => {
       const actual = SurveyFilter.relierClientIdCheck(
         { relier: 'Relying Party!!!' },
         mockRelier
       );
-      assert.isTrue(actual);
+      assertConditionResult(actual, true, 'Relying Party!!!');
       assert.isTrue(mockRelier.get.calledOnce);
     });
 
-    it('should be false when client id does not match configured condition', () => {
+    it('should not be passing and have an undefined value when client id does not match configured condition', () => {
       const actual = SurveyFilter.relierClientIdCheck(
         { relier: 'Relier...?' },
         mockRelier
       );
-      assert.isFalse(actual);
+      assertConditionResult(actual, false);
       assert.isTrue(mockRelier.get.calledOnce);
     });
   });
 
   describe('checkSubscriptions', () => {
-    it('should be false when given an empty account subscriptions list', () => {
+    it('should be undefined when given an empty account subscriptions list', () => {
       const actual = SurveyFilter.checkSubscriptions([])(['hello']);
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
     });
 
-    it('should be false when the subscription is not found', () => {
+    it('should be undefined when the subscription is not found', () => {
       const actual = SurveyFilter.checkSubscriptions([{ plan_id: 'HI' }])([
         'hello',
       ]);
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
     });
 
-    it('should be false when the only some of the subscriptions are found', () => {
+    it('should be undefined when the only some of the subscriptions are found', () => {
       const actual = SurveyFilter.checkSubscriptions([{ plan_id: 'HI' }])([
         'hello',
         'HI',
       ]);
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
     });
 
-    it('should be true when all the subscriptions are found', () => {
+    it('should return all user subscriptions when all the subscriptions are found', () => {
       const actual = SurveyFilter.checkSubscriptions([
         { plan_id: 'HI' },
         { plan_id: 'hello' },
         { plan_id: 'How are you?' },
       ])(['hello', 'HI']);
-      assert.isTrue(actual);
+      assert.deepEqual(actual, ['HI', 'hello', 'How are you?']);
     });
   });
 
   describe('subscriptionsCheck', () => {
     const fetchSubscriptionsStub = sandbox.stub().returns(mockSubscriptions);
 
-    it('should be true when "subscriptions" is not in the conditions', async () => {
+    it('should be passing and have an undefined value when "subscriptions" is not in the conditions', async () => {
       const actual = await SurveyFilter.subscriptionsCheck(
         { NOSUB: 'yes' },
         fetchSubscriptionsStub
       );
-      assert.isTrue(actual);
+      assertConditionResult(actual, true);
       assert.isFalse(fetchSubscriptionsStub.called);
     });
 
-    it('should be false when subscription not found', async () => {
+    it('should not be passing and have an undefined value when subscription not found', async () => {
       const actual = await SurveyFilter.subscriptionsCheck(
         {
           subscriptions: ['nope'],
         },
         fetchSubscriptionsStub
       );
-      assert.isFalse(actual);
+      assertConditionResult(actual, false);
       assert.isTrue(fetchSubscriptionsStub.calledOnce);
     });
 
-    it('should be false when only some of the subscriptions are found', async () => {
+    it('should not be passing and have an undefined value when only some of the subscriptions are found', async () => {
       const actual = await SurveyFilter.subscriptionsCheck(
         {
           subscriptions: ['nope', 'level9001'],
         },
         fetchSubscriptionsStub
       );
-      assert.isFalse(actual);
+      assertConditionResult(actual, false);
       assert.isTrue(fetchSubscriptionsStub.calledOnce);
     });
 
-    it('should be true when subscriptions are found', async () => {
+    it('should be passing and have all user subscriptions value when subscriptions are found', async () => {
       const actual = await SurveyFilter.subscriptionsCheck(
         {
           subscriptions: ['quuz', 'level9001'],
         },
         fetchSubscriptionsStub
       );
-      assert.isTrue(actual);
+      assertConditionResult(actual, true, ['level9001', 'quuz']);
       assert.isTrue(fetchSubscriptionsStub.calledOnce);
     });
   });
 
   describe('checkLocation', () => {
-    it('should be false when device of the current session is not found', () => {
+    it('should be undefined when device of the current session is not found', () => {
       const actual = SurveyFilter.checkLocation([])({ city: 'Heapolandia' });
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
     });
 
-    it('should be false when the device does not have a location', () => {
+    it('should be undefined when the device does not have a location', () => {
       const mockDevices = [{ isCurrentSession: true, nolocation: true }];
       const actual = SurveyFilter.checkLocation(mockDevices)({
         city: 'Heapolandia',
       });
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
     });
 
-    it('should be false when the location properties do not match', () => {
+    it('should be undefined when the location properties do not match', () => {
       const mockDevices = [
         {
           isCurrentSession: true,
@@ -754,10 +727,10 @@ describe('lib/survey-filter', () => {
       const actual = SurveyFilter.checkLocation(mockDevices)({
         city: 'Heapolandia',
       });
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
     });
 
-    it('should be true when the location properties are found, case insensitively', () => {
+    it('should return the matched values when the location properties are found, case insensitively', () => {
       const mockDevices = [
         {
           isCurrentSession: true,
@@ -768,44 +741,45 @@ describe('lib/survey-filter', () => {
         city: 'thebes',
         wibble: 'quuz',
       });
-      assert.isTrue(actual);
+      assert.deepEqual(actual, 'thebes, quuz');
     });
   });
 
   describe('geoLocationCheck', () => {
     const getDevicesStub = sandbox.stub().returns(mockDeviceList);
 
-    it('should be true when the condition is not in the config', async () => {
+    it('should be passing and have an undefined value when the condition is not in the config', async () => {
       const actual = await SurveyFilter.geoLocationCheck(
         { bleep: 'bloop' },
         getDevicesStub
       );
-      assert.isTrue(actual);
+      assertConditionResult(actual, true);
       assert.isFalse(getDevicesStub.called);
     });
 
-    it('should be false when location property is not found', async () => {
+    it('should not be passing and have an undefined value when location property is not found', async () => {
       const actual = await SurveyFilter.geoLocationCheck(
         {
           location: { city: 'Babylon' },
         },
         getDevicesStub
       );
-      assert.isFalse(actual);
+      assertConditionResult(actual, false);
       assert.isTrue(getDevicesStub.calledOnce);
     });
 
-    it('should be false when only some location properties are found', async () => {
+    it('should not be passing and have an undefined value when only some location properties are found', async () => {
       const actual = await SurveyFilter.geoLocationCheck(
         {
           location: { city: 'Heapolandia', countryCode: 'UVN' },
         },
         getDevicesStub
       );
-      assert.isFalse(actual);
+      assertConditionResult(actual, false);
       assert.isTrue(getDevicesStub.calledOnce);
     });
-    it('should be true when all location properties are found', async () => {
+
+    it('should be passing and have matching value when all location properties are found', async () => {
       const actual = await SurveyFilter.geoLocationCheck(
         {
           location: {
@@ -815,114 +789,124 @@ describe('lib/survey-filter', () => {
         },
         getDevicesStub
       );
-      assert.isTrue(actual);
+      assertConditionResult(
+        actual,
+        true,
+        'Heapolandia, United Devices of von Neumann'
+      );
       assert.isTrue(getDevicesStub.calledOnce);
     });
   });
 
   describe('checkSignedInReliers', () => {
-    it('should be false when the device list is empty', () => {
+    it('should be undefined when the device list is empty', () => {
       const actual = SurveyFilter.checkSignedInReliers([])(['rprprp']);
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
     });
 
-    it('should be false when the client id is not found', () => {
+    it('should be undefined when the client id is not found', () => {
       const actual = SurveyFilter.checkSignedInReliers([{ clientId: '9001' }])([
         'rprprp',
       ]);
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
     });
 
-    it('should be false when only some of the the client ids are found', () => {
+    it('should be undefined when only some of the the client ids are found', () => {
       const actual = SurveyFilter.checkSignedInReliers([{ clientId: '9001' }])([
         'rprprp',
         '9001',
       ]);
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
     });
 
-    it('should be true when all the client ids are found', () => {
+    it('should return all user relier IDs when all the client ids are found', () => {
       const actual = SurveyFilter.checkSignedInReliers([
         { clientId: '9001' },
         { clientId: 'noop' },
         { clientId: null },
       ])([null, '9001']);
-      assert.isTrue(actual);
+      assert.deepEqual(actual, ['9001', 'noop', null]);
     });
   });
 
   describe('signedInReliersCheck', () => {
     const getDevicesStub = sandbox.stub().returns(mockDeviceList);
 
-    it('should be true when the condition is not in the config', async () => {
+    it('should be passing and have an undefined value when the condition is not in the config', async () => {
       const actual = await SurveyFilter.signedInReliersCheck(
         { noReliersForMe: true },
         getDevicesStub
       );
-      assert.isTrue(actual);
+      assertConditionResult(actual, true);
       assert.isFalse(getDevicesStub.called);
     });
 
-    it('should be false when the client id is not in the list', async () => {
+    it('should not be passing and have an undefined value when the client id is not in the list', async () => {
       const actual = await SurveyFilter.signedInReliersCheck(
         {
           reliersList: ['wibble'],
         },
         getDevicesStub
       );
-      assert.isFalse(actual);
+      assertConditionResult(actual, false);
       assert.isTrue(getDevicesStub.calledOnce);
     });
 
-    it('should be false when only some client ids are in the list', async () => {
+    it('should not be passing and have an undefined value when only some client ids are in the list', async () => {
       const actual = await SurveyFilter.signedInReliersCheck(
         {
           reliersList: [null, 'BMO'],
         },
         getDevicesStub
       );
-      assert.isFalse(actual);
+      assertConditionResult(actual, false);
       assert.isTrue(getDevicesStub.calledOnce);
     });
 
-    it('should be true when all client ids are in the list', async () => {
+    it('should be passing and have all user reliers value when all client ids are in the list', async () => {
       const actual = await SurveyFilter.signedInReliersCheck(
         {
           reliersList: ['level9001', null],
         },
         getDevicesStub
       );
-      assert.isTrue(actual);
+      assertConditionResult(actual, true, ['level9001', null, 'quuz']);
       assert.isTrue(getDevicesStub.calledOnce);
     });
   });
 
   describe('checkNonDefaultAvatar', () => {
-    it('should be false when config is true but avatar is default', () => {
+    // NOTE: checkNonDefaultAvatar will return supplied condition's value if the condition is satisifed.
+    // If the condition is NOT, it will not return (undefined). Therefor, `false` should not be confused
+    // with a non-satisfying result, but instead as a value to pass to Survey Gizmo.
+    // e.g. if the value is true, and the avatar is not the default, true will be returned
+    // e.g. if the value is false, and the avatar is the default, false will be returned
+
+    it('should be undefined when config is true and avatar is default', () => {
       const mockProfileImage = createMockProfileImage(true);
       const actual = SurveyFilter.checkNonDefaultAvatar(mockProfileImage)(true);
-      assert.isFalse(actual);
+      assert.isUndefined(actual);
       assert.isTrue(mockProfileImage.isDefault.calledOnce);
     });
 
-    it('should be true when config is true but avatar is non-default', () => {
+    it('should be true when config is true and avatar is non-default', () => {
       const mockProfileImage = createMockProfileImage(false);
       const actual = SurveyFilter.checkNonDefaultAvatar(mockProfileImage)(true);
       assert.isTrue(actual);
       assert.isTrue(mockProfileImage.isDefault.calledOnce);
     });
 
-    it('should be false when config is false but avatar is non-default', () => {
-      const mockProfileImage = createMockProfileImage(true);
+    it('should be undefined when config is false and avatar is non-default', () => {
+      const mockProfileImage = createMockProfileImage(false);
       const actual = SurveyFilter.checkNonDefaultAvatar(mockProfileImage)(
         false
       );
-      assert.isTrue(actual);
+      assert.isUndefined(actual);
       assert.isTrue(mockProfileImage.isDefault.calledOnce);
     });
 
-    it('should be false when config is false but avatar is default', () => {
-      const mockProfileImage = createMockProfileImage(false);
+    it('should be false when config is false and avatar is default', () => {
+      const mockProfileImage = createMockProfileImage(true);
       const actual = SurveyFilter.checkNonDefaultAvatar(mockProfileImage)(
         false
       );
@@ -932,54 +916,77 @@ describe('lib/survey-filter', () => {
   });
 
   describe('nonDefaultAvatarCheck', () => {
-    it('should be true when hasNonDefaultAvatar is not in the config', async () => {
+    it('should be passing and have an undefined value hasNonDefaultAvatar is not in the config', async () => {
       const mockProfileImage = createMockProfileImage(true);
       const actual = await SurveyFilter.nonDefaultAvatarCheck(
         { bleepBloop: true },
         () => mockProfileImage
       );
-      assert.isTrue(actual);
+      assertConditionResult(actual, true);
       assert.isFalse(mockProfileImage.isDefault.called);
     });
 
-    it('should be true when condition is true and the avatar is non-default', async () => {
+    it('should be passing and have an true value when condition is true and the avatar is non-default', async () => {
       const mockProfileImage = createMockProfileImage(false);
       const actual = await SurveyFilter.nonDefaultAvatarCheck(
         { hasNonDefaultAvatar: true },
         () => mockProfileImage
       );
-      assert.isTrue(actual);
+      assertConditionResult(actual, true, true);
       assert.isTrue(mockProfileImage.isDefault.calledOnce);
     });
 
-    it('should be false when condition is false and the avatar is non default', async () => {
+    it('should not be passing and have an undefined value when condition is false and the avatar is non default', async () => {
       const mockProfileImage = createMockProfileImage(false);
       const actual = await SurveyFilter.nonDefaultAvatarCheck(
         { hasNonDefaultAvatar: false },
         () => mockProfileImage
       );
-      assert.isFalse(actual);
+      assertConditionResult(actual, false);
       assert.isTrue(mockProfileImage.isDefault.calledOnce);
     });
 
-    it('should be false when condition is true and the avatar is the default', async () => {
+    it('should not be passing and have an undefined value when condition is true and the avatar is the default', async () => {
       const mockProfileImage = createMockProfileImage(true);
       const actual = await SurveyFilter.nonDefaultAvatarCheck(
         { hasNonDefaultAvatar: true },
         () => mockProfileImage
       );
-      assert.isFalse(actual);
+      assertConditionResult(actual, false);
       assert.isTrue(mockProfileImage.isDefault.calledOnce);
     });
 
-    it('should be true when condition is false and the avatar is the default', async () => {
+    it('should be passing and have a false value when condition is false and the avatar is the default', async () => {
       const mockProfileImage = createMockProfileImage(true);
       const actual = await SurveyFilter.nonDefaultAvatarCheck(
         { hasNonDefaultAvatar: false },
         () => mockProfileImage
       );
-      assert.isTrue(actual);
+      assertConditionResult(actual, true, false);
       assert.isTrue(mockProfileImage.isDefault.calledOnce);
+    });
+  });
+
+  describe('surveyGizmoSafe', () => {
+    it('returns the stringified version of a string, number, or boolean', () => {
+      assert.equal(
+        SurveyFilter.surveyGizmoSafe('chocolate cake'),
+        'chocolate cake'
+      );
+      assert.equal(SurveyFilter.surveyGizmoSafe(90210), '90210');
+      assert.equal(SurveyFilter.surveyGizmoSafe(true), 'true');
+    });
+    it('returns a string of joined values, excluding null, when given an array', () => {
+      assert.equal(
+        SurveyFilter.surveyGizmoSafe(['Lead', 'SD', null]),
+        'Lead,SD'
+      );
+    });
+    it('throws when given something not covered', () => {
+      assert.throws(
+        SurveyFilter.surveyGizmoSafe.bind(null, { lastName: 'mine' }),
+        /cannot be passed/
+      );
     });
   });
 
@@ -1001,79 +1008,70 @@ describe('lib/survey-filter', () => {
 
     const trueDefaultArgs = [mockWindow, mockUser, mockRelier, null, 5000000];
 
-    it('should be false when the config is missing', async () => {
+    it('should not be passing and have no conditions when the config is missing', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
       );
       const actual = await filter();
-      assert.isFalse(actual);
+      assertFilterResult(actual, false, {});
     });
 
-    it('should be false when the conditions are missing', async () => {
+    it('should not be passing when the conditions are missing', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
       );
       const actual = await filter({ noConds: 'yes' });
-      assert.isFalse(actual);
+      assertFilterResult(actual, false, {});
     });
 
-    it('should be false when the conditions is an empty object', async () => {
+    it('should not be passing when the conditions is an empty object', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
       );
       const actual = await filter({ conditions: {} });
-      assert.isFalse(actual);
+      assertFilterResult(actual, false, {});
     });
 
-    it('should be false when rate is not defined', async () => {
+    it('should not be passing when rate is not defined', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
       );
       const actual = await filter({ ...config, rate: undefined });
-      assert.isFalse(actual);
+      assertFilterResult(actual, false, {});
     });
 
-    it('should be false when rate is 0', async () => {
-      const filter = SurveyFilter.createSurveyFilter.apply(
-        null,
-        trueDefaultArgs
-      );
-      const actual = await filter({ ...config, rate: 0 });
-      assert.isFalse(actual);
-    });
-
-    it('should be true when rate is 1', async () => {
+    it('should be passing when rate is 1', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
       );
       const actual = await filter(config);
-      assert.isTrue(actual);
+      assertFilterResult(actual, true);
     });
 
-    it('should be false when rate is not between 0 and a pseudorandom number', async () => {
+    it('should not be passing when rate is not between 0 and a pseudorandom number', async () => {
       sinon.stub(Math, 'random').returns(0.3);
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
       );
       const actual = await filter({ ...config, rate: 0.2 });
-      assert.isFalse(actual);
+      assertFilterResult(actual, false);
       Math.random.restore();
     });
 
-    it('should be true when rate is between 0 and a pseudorandom number', async () => {
+    it('should be passing when rate is between 0 and a pseudorandom number', async () => {
       sinon.stub(Math, 'random').returns(0.1);
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
       );
       const actual = await filter({ ...config, rate: 0.2 });
-      assert.isTrue(actual);
+      assertFilterResult(actual, true);
       Math.random.restore();
     });
 
@@ -1083,10 +1081,10 @@ describe('lib/survey-filter', () => {
         trueDefaultArgs
       );
       const actual = await filter(config);
-      assert.isTrue(actual);
+      assertFilterResult(actual, true);
     });
 
-    it('should be true when the conditions are met', async () => {
+    it('should be passing when the conditions are met', async () => {
       const filter = SurveyFilter.createSurveyFilter(
         mockWindow,
         mockUser,
@@ -1095,10 +1093,10 @@ describe('lib/survey-filter', () => {
         5
       );
       const actual = await filter(config);
-      assert.isTrue(actual);
+      assertFilterResult(actual, true);
     });
 
-    it('should be false when the user took a survey recently', async () => {
+    it('should not be passing when the user took a survey recently', async () => {
       const filter = SurveyFilter.createSurveyFilter(
         mockWindow,
         mockUser,
@@ -1107,10 +1105,10 @@ describe('lib/survey-filter', () => {
         5000000
       );
       const actual = await filter(config);
-      assert.isFalse(actual);
+      assertFilterResult(actual, false);
     });
 
-    it('should be false when the language is not found', async () => {
+    it('should not be passing when the language is not found', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
@@ -1119,10 +1117,10 @@ describe('lib/survey-filter', () => {
         conditions: { ...config.conditions, languages: ['zh'] },
         rate: config.rate,
       });
-      assert.isFalse(actual);
+      assertFilterResult(actual, false);
     });
 
-    it.skip('should be true when the language is found', async () => {
+    it.skip('should be passing when the language is found', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
@@ -1131,10 +1129,10 @@ describe('lib/survey-filter', () => {
         conditions: { ...config.conditions, languages: ['es'] },
         rate: config.rate,
       });
-      assert.isTrue(actual);
+      assertFilterResult(actual, true);
     });
 
-    it('should be false when the browser does not match', async () => {
+    it('should not be passing when the browser does not match', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
@@ -1143,10 +1141,10 @@ describe('lib/survey-filter', () => {
         conditions: { ...config.conditions, browser: 'elinks' },
         rate: config.rate,
       });
-      assert.isFalse(actual);
+      assertFilterResult(actual, false);
     });
 
-    it('should be false when the device type does not match', async () => {
+    it('should not be passing when the device type does not match', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
@@ -1155,10 +1153,10 @@ describe('lib/survey-filter', () => {
         conditions: { ...config.conditions, deviceType: 'XR' },
         rate: config.rate,
       });
-      assert.isFalse(actual);
+      assertFilterResult(actual, false);
     });
 
-    it('should be false when the OS does not match', async () => {
+    it('should not be passing when the OS does not match', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
@@ -1167,10 +1165,10 @@ describe('lib/survey-filter', () => {
         conditions: { ...config.conditions, os: 'TempleOS' },
         rate: config.rate,
       });
-      assert.isFalse(actual);
+      assertFilterResult(actual, false);
     });
 
-    it('should be false when the relier client id does not match', async () => {
+    it('should not be passing when the relier client id does not match', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
@@ -1179,10 +1177,10 @@ describe('lib/survey-filter', () => {
         conditions: { ...config.conditions, relier: 'FPN' },
         rate: config.rate,
       });
-      assert.isFalse(actual);
+      assertFilterResult(actual, false);
     });
 
-    it('should be false when a subscription is not found', async () => {
+    it('should not be passing when a subscription is not found', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
@@ -1191,10 +1189,10 @@ describe('lib/survey-filter', () => {
         conditions: { ...config.conditions, subscriptions: ['fpn_id'] },
         rate: config.rate,
       });
-      assert.isFalse(actual);
+      assertFilterResult(actual, false);
     });
 
-    it('should be false when the location does not match', async () => {
+    it('should not be passing when the location does not match', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
@@ -1203,10 +1201,10 @@ describe('lib/survey-filter', () => {
         conditions: { ...config.conditions, location: { city: 'Lisbon' } },
         rate: config.rate,
       });
-      assert.isFalse(actual);
+      assertFilterResult(actual, false);
     });
 
-    it('should be false when the signed in RP client ids are not found', async () => {
+    it('should not be passing when the signed in RP client ids are not found', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
@@ -1215,10 +1213,10 @@ describe('lib/survey-filter', () => {
         conditions: { ...config.conditions, reliersList: ['wibble', 'wubble'] },
         rate: config.rate,
       });
-      assert.isFalse(actual);
+      assertFilterResult(actual, false);
     });
 
-    it('should be false when the avatar is not matching the configured condition', async () => {
+    it('should not be passing when the avatar is not matching the configured condition', async () => {
       const filter = SurveyFilter.createSurveyFilter.apply(
         null,
         trueDefaultArgs
@@ -1227,7 +1225,22 @@ describe('lib/survey-filter', () => {
         conditions: { ...config.conditions, hasNonDefaultAvatar: false },
         rate: config.rate,
       });
-      assert.isFalse(actual);
+      assertFilterResult(actual, false);
     });
   });
 });
+
+function assertConditionResult(actual, expectedPassing, expectedValue) {
+  // can't deepEqual the entire object because expectedValue
+  // is sometimes an array and it gives a false negative
+  assert.equal(actual.passing, expectedPassing);
+  assert.deepEqual(actual.value, expectedValue);
+}
+
+function assertFilterResult(actual, expectedPassing, expectedConditions) {
+  assert.equal(actual.passing, expectedPassing);
+
+  if (expectedConditions) {
+    assert.deepEqual(actual.conditions, expectedConditions);
+  }
+}

--- a/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
@@ -1227,6 +1227,22 @@ describe('lib/survey-filter', () => {
       });
       assertFilterResult(actual, false);
     });
+
+    it('should be passing in development, regardless of rate or last shown timestamp', async () => {
+      const filter = SurveyFilter.createSurveyFilter(
+        mockWindow,
+        mockUser,
+        mockRelier,
+        Date.now(),
+        5000000,
+        'development'
+      );
+      const actual = await filter({
+        conditions: config.conditions,
+        rate: 0,
+      });
+      assertFilterResult(actual, true);
+    });
   });
 });
 

--- a/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
@@ -630,18 +630,26 @@ describe('lib/survey-filter', () => {
     });
   });
 
-  describe('checkRelierClientId', () => {
+  describe('checkRelierClientIds', () => {
     const mockRelier = { get: sandbox.stub().returns('galaxy quest') };
 
     it('should be the matched value when matched exactly', () => {
-      const actual = SurveyFilter.checkRelierClientId(mockRelier)(
+      const actual = SurveyFilter.checkRelierClientIds(mockRelier)(
         'galaxy quest'
       );
       assert.equal(actual, 'galaxy quest');
     });
 
+    it('should accept an array of values and return the matched one', () => {
+      const actual = SurveyFilter.checkRelierClientIds(mockRelier)([
+        'galaxy quest',
+        'manchester orchestra',
+      ]);
+      assert.equal(actual, 'galaxy quest');
+    });
+
     it('should be false when the values do not match', () => {
-      const actual = SurveyFilter.checkRelierClientId(mockRelier)(
+      const actual = SurveyFilter.checkRelierClientIds(mockRelier)(
         'Galaxy Quest'
       );
       assert.isUndefined(actual);
@@ -663,6 +671,15 @@ describe('lib/survey-filter', () => {
     it('should be passing and have the matched value when client id matches configured condition', () => {
       const actual = SurveyFilter.relierClientIdCheck(
         { relier: 'Relying Party!!!' },
+        mockRelier
+      );
+      assertConditionResult(actual, true, 'Relying Party!!!');
+      assert.isTrue(mockRelier.get.calledOnce);
+    });
+
+    it('should be passing and have the matched value when client id matches one of any in an array', () => {
+      const actual = SurveyFilter.relierClientIdCheck(
+        { relier: ['Relying Party!!!', 'Second Market Scenes'] },
         mockRelier
       );
       assertConditionResult(actual, true, 'Relying Party!!!');

--- a/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
@@ -482,40 +482,66 @@ describe('lib/survey-filter', () => {
     });
   });
 
-  describe('checkUaDeviceType', () => {
+  describe('checkUaDeviceTypes', () => {
     it('should be case insensitive, returning the passed in value when matching', () => {
-      const actual = SurveyFilter.checkUaDeviceType(mockUa)('mObile');
+      const actual = SurveyFilter.checkUaDeviceTypes(mockUa)('mObile');
       assert.equal(actual, 'mObile');
       assert.isTrue(mockUa.genericDeviceType.calledOnce);
     });
 
+    it('should accept an array of device types and return the matched one', () => {
+      const actual = SurveyFilter.checkUaDeviceTypes(mockUa)([
+        'mobile',
+        'desktop',
+        'tablet',
+      ]);
+      assert.equal(actual, 'mobile');
+      assert.isTrue(mockUa.genericDeviceType.calledOnce);
+    });
+
     it('should not return anything when the values do not match', () => {
-      const actual = SurveyFilter.checkUaDeviceType(mockUa)('DESKTOP');
+      const actual = SurveyFilter.checkUaDeviceTypes(mockUa)('DESKTOP');
       assert.isUndefined(actual);
       assert.isTrue(mockUa.genericDeviceType.calledOnce);
     });
   });
 
-  describe('checkUaOsName', () => {
+  describe('checkUaOsNames', () => {
     it('should be case insensitive, returning the passed in value when matching', () => {
-      const actual = SurveyFilter.checkUaOsName(mockUa)('Winning');
+      const actual = SurveyFilter.checkUaOsNames(mockUa)('Winning');
+      assert.equal(actual, 'Winning');
+    });
+
+    it('should accept an array of os names and return the matched one', () => {
+      const actual = SurveyFilter.checkUaOsNames(mockUa)([
+        'Winning',
+        'Windows',
+      ]);
       assert.equal(actual, 'Winning');
     });
 
     it('should not return anything when the values do not match', () => {
-      const actual = SurveyFilter.checkUaOsName(mockUa)('Windows');
+      const actual = SurveyFilter.checkUaOsNames(mockUa)('Windows');
       assert.isUndefined(actual);
     });
   });
 
-  describe('checkUaBrowser', () => {
+  describe('checkUaBrowsers', () => {
     it('should be case insensitive, returning the passed in value when matching', () => {
-      const actual = SurveyFilter.checkUaBrowser(mockUa)('spacetuna');
+      const actual = SurveyFilter.checkUaBrowsers(mockUa)('spacetuna');
+      assert.equal(actual, 'spacetuna');
+    });
+
+    it('should accept an array of browser names and return the matched one', () => {
+      const actual = SurveyFilter.checkUaBrowsers(mockUa)([
+        'spacetuna',
+        'brocolli',
+      ]);
       assert.equal(actual, 'spacetuna');
     });
 
     it('should not return anything when the values do not match', () => {
-      const actual = SurveyFilter.checkUaBrowser(mockUa)('Firefox');
+      const actual = SurveyFilter.checkUaBrowsers(mockUa)('Firefox');
       assert.isUndefined(actual);
     });
   });
@@ -524,6 +550,15 @@ describe('lib/survey-filter', () => {
     it('should be passing and have the matched value when the values match', () => {
       const actual = SurveyFilter.hasDesiredDeviceType(
         { deviceType: 'deskTOP' },
+        fetchGoodUaStub
+      );
+      assertConditionResult(actual, true, 'deskTOP');
+      assert.isTrue(fetchGoodUaStub.calledOnce);
+    });
+
+    it('should be passing and have the matched value when the values match in an array', () => {
+      const actual = SurveyFilter.hasDesiredDeviceType(
+        { deviceType: ['deskTOP', 'moBile'] },
         fetchGoodUaStub
       );
       assertConditionResult(actual, true, 'deskTOP');
@@ -550,6 +585,15 @@ describe('lib/survey-filter', () => {
       assert.isTrue(fetchGoodUaStub.calledOnce);
     });
 
+    it('should be passing and have the matched value when the values match in an array', () => {
+      const actual = SurveyFilter.hasDesiredOs(
+        { os: ['Windows', 'Mac OS'] },
+        fetchGoodUaStub
+      );
+      assertConditionResult(actual, true, 'Windows');
+      assert.isTrue(fetchGoodUaStub.calledOnce);
+    });
+
     it('should not be passing and have an undefined value when the values do not match', () => {
       const actual = SurveyFilter.hasDesiredOs({ os: 'macOS' }, fetchBadUaStub);
       assertConditionResult(actual, false);
@@ -561,6 +605,15 @@ describe('lib/survey-filter', () => {
     it('should be passing and have the matched value when the values match', () => {
       const actual = SurveyFilter.hasDesiredBrowser(
         { browser: 'Firefox' },
+        fetchGoodUaStub
+      );
+      assertConditionResult(actual, true, 'Firefox');
+      assert.isTrue(fetchGoodUaStub.calledOnce);
+    });
+
+    it('should be passing and have the matched value when the values match in an array', () => {
+      const actual = SurveyFilter.hasDesiredBrowser(
+        { browser: ['Firefox', 'Chrome', 'Edge'] },
         fetchGoodUaStub
       );
       assertConditionResult(actual, true, 'Firefox');

--- a/packages/fxa-content-server/app/tests/spec/lib/survey-targeter.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/survey-targeter.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import SurveyTargeter from 'lib/survey-targeter';
+import Url from '../../../scripts/lib/url';
 import { assert } from 'chai';
 import sinon from 'sinon';
 
@@ -11,7 +12,7 @@ import NullStorage from 'lib/null-storage';
 const sandbox = sinon.createSandbox();
 const nullFn = sandbox.stub().returns(null);
 
-describe('lib/SurveyTargeter', () => {
+describe('lib/survey-targeter', () => {
   let surveyTargeter;
   const doNotBotherSpan = 2592000000;
   const config = {
@@ -65,12 +66,13 @@ describe('lib/SurveyTargeter', () => {
   });
 
   it('returns a survey if the view matches', async () => {
+    newSurveyTargeter({ ...options, surveys: [surveys[1]] });
     const view = await surveyTargeter.getSurvey('settings');
     view.render();
     assert.equal(view.el.className, 'survey-wrapped');
     assert.equal(
       view.$('iframe').first().attr('src'),
-      'https://www.surveygizmo.com/s3/5541940/pizza'
+      'https://www.surveygizmo.com/s3/5541940/pizza?browser=Firefox'
     );
   });
 
@@ -101,7 +103,7 @@ describe('lib/SurveyTargeter', () => {
     const spy = sandbox.spy(surveyTargeter, '_selectSurvey');
     await surveyTargeter.getSurvey('settings');
     assert.isTrue(spy.calledOnce);
-    assert.isTrue(surveys.includes(spy.firstCall.returnValue));
+    assert.isTrue(surveys.includes(spy.firstCall.returnValue.survey));
   });
 
   it('sets "lastSurvey" in localStorage if view returns', async () => {
@@ -111,5 +113,47 @@ describe('lib/SurveyTargeter', () => {
 
     assert(setItemSpy.calledOnce);
     assert.deepEqual(setItemSpy.args[0], ['lastSurvey', lastSurveyValue]);
+  });
+
+  it('generates the survey URL with matching conditions as query parameters', async () => {
+    const urlStringSpy = sandbox.spy(Url, 'updateSearchString');
+
+    const survey = {
+      conditions: {
+        browser: 'Firefox',
+        os: 'Mac OS',
+        languages: ['en'],
+      },
+      rate: 1,
+      view: 'settings',
+      url: 'https://www.surveygizmo.com/s3/5541940/pizza',
+    };
+
+    newSurveyTargeter({
+      ...options,
+      window: {
+        localStorage: new NullStorage(),
+        navigator: {
+          userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:78.0) Gecko/20100101 Firefox/78.0',
+          languages: ['en-CA', 'fr-CA', null],
+        },
+      },
+      surveys: [survey],
+    });
+
+    const targeter = await surveyTargeter.getSurvey('settings');
+    const expectedUrl =
+      'https://www.surveygizmo.com/s3/5541940/pizza?languages=en-CA%2Cfr-CA&browser=Firefox&os=Mac%20OS';
+
+    assert(
+      urlStringSpy.calledWith(survey.url, {
+        browser: 'Firefox',
+        os: 'Mac OS',
+        languages: 'en-CA,fr-CA',
+      })
+    );
+    assert(urlStringSpy.returned(expectedUrl));
+    assert.equal(targeter.surveyURL, expectedUrl);
   });
 });

--- a/packages/fxa-content-server/app/tests/spec/lib/survey-targeter.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/survey-targeter.js
@@ -72,7 +72,7 @@ describe('lib/survey-targeter', () => {
     assert.equal(view.el.className, 'survey-wrapped');
     assert.equal(
       view.$('iframe').first().attr('src'),
-      'https://www.surveygizmo.com/s3/5541940/pizza?browser=Firefox'
+      'https://www.surveygizmo.com/s3/5541940/pizza?browser=Firefox&server=content&env=production'
     );
   });
 
@@ -115,7 +115,7 @@ describe('lib/survey-targeter', () => {
     assert.deepEqual(setItemSpy.args[0], ['lastSurvey', lastSurveyValue]);
   });
 
-  it('generates the survey URL with matching conditions as query parameters', async () => {
+  it('generates the survey URL with matching conditions, env, and server as query parameters', async () => {
     const urlStringSpy = sandbox.spy(Url, 'updateSearchString');
 
     const survey = {
@@ -144,13 +144,14 @@ describe('lib/survey-targeter', () => {
 
     const targeter = await surveyTargeter.getSurvey('settings');
     const expectedUrl =
-      'https://www.surveygizmo.com/s3/5541940/pizza?languages=en-CA%2Cfr-CA&browser=Firefox&os=Mac%20OS';
-
+      'https://www.surveygizmo.com/s3/5541940/pizza?languages=en-CA%2Cfr-CA&browser=Firefox&os=Mac%20OS&server=content&env=production';
     assert(
       urlStringSpy.calledWith(survey.url, {
         browser: 'Firefox',
         os: 'Mac OS',
         languages: 'en-CA,fr-CA',
+        server: 'content',
+        env: 'production',
       })
     );
     assert(urlStringSpy.returned(expectedUrl));

--- a/packages/fxa-content-server/app/tests/spec/lib/url.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/url.js
@@ -110,6 +110,22 @@ describe('lib/url', () => {
     });
   });
 
+  describe('_getObjPairs', () => {
+    it('returns an array containing an array of parent positioning values, and the current value', () => {
+      assert.deepEqual(Url._getObjPairs(['howdy', 'sup']), [
+        [['0'], 'howdy'],
+        [['1'], 'sup'],
+      ]);
+    });
+
+    it('can receive additional parent values and append them', () => {
+      assert.deepEqual(Url._getObjPairs(['howdy', 'sup'], ['variations']), [
+        [['variations', '0'], 'howdy'],
+        [['variations', '1'], 'sup'],
+      ]);
+    });
+  });
+
   describe('objToUrlString', () => {
     it('includes all keys with values', () => {
       var params = {
@@ -119,6 +135,27 @@ describe('lib/url', () => {
       };
 
       assert.equal(Url.objToUrlString(params, '#'), '#hasValue=value');
+    });
+
+    it('supports nested objects and arrays', () => {
+      var params = {
+        phrase: 'hello',
+        variations: ['howdy', 'sup'],
+        translations: {
+          french: ['bonjour', 'salut'],
+          spanish: 'hola',
+        },
+      };
+
+      assert.equal(
+        Url.objToUrlString(params, '?'),
+        `?phrase=hello&
+          variations[0]=howdy&
+          variations[1]=sup&
+          translations[french][0]=bonjour&
+          translations[french][1]=salut&
+          translations[spanish]=hola`.replace(/\n|\s/g, '')
+      );
     });
 
     it('returns an empty string if no parameters are passed in', () => {


### PR DESCRIPTION
## Because

We currently check the configured conditions during the filtering phase to determine eligibility, but we don't surface the matched values.

## This change

Extract user value based on satisfied conditions and passes them along as query params to Survey Gizmo.

- Originally we only passed along the values that satisfied the conditions, but per [this request](https://github.com/mozilla/fxa/issues/5640#issuecomment-653161604) this has changed to now pass along _all_ items of a given condition category belonging to the user. Some examples of this could be:
	- If the browser locale is `en-CA,fr-CA,zh-TW` and the `language` condition is `['en', 'fr-CA', 'es']`, this would be passing and the returned value would be `en-CA,fr-CA,zh-TW` because either `en-CA` _or_ `fr-CA` could have satisfied the condition.
	- If you have a default avatar and the `hasNonDefaultAvatar` condition is `false`, to indicate that you only want to target users with a default avatar, the returned value would be `false` because you do not have a non-default avatar. This should not be confused as a failing result.
	- This was a funky one, but precedent dictates that `null` is also a valid value, at least when it comes to the `relier` condition. Therefor a `null` value can be used to satisfying a condition, but because of how our URL query params are generated this condition will **not** end up in the URL.
- It is maintained that the absence of a condition during its corresponding check still yields a pass, but in this case a value would not be returned.
- Generated URLs will return the conditions as query params, converting arrays into comma-delimited strings per [this request](https://github.com/mozilla/fxa/pull/5816#discussion_r449193495).

## Issue that this pull request solves

Closes: #5640

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.