### PR TITLE
feat(emails): Add onMobileDevice mailOption for post registration email

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -307,6 +307,12 @@ const conf = convict({
         env: 'PREPEND_VERIFICATION_SUBDOMAIN_SUBDOMAIN',
       },
     },
+    firefoxDesktopUrl: {
+      doc: 'url to download Firefox page',
+      format: String,
+      default:
+        'https://firefox.com?utm_content=registration-confirmation&utm_medium=email&utm_source=fxa',
+    },
     androidUrl: {
       doc: 'url to Android product page',
       format: String,

--- a/packages/fxa-auth-server/lib/routes/utils/signup.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signup.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 'use strict';
+const userAgent = require('../../userAgent');
 
 module.exports = (log, db, mailer, push, verificationReminders) => {
   return {
@@ -64,10 +65,13 @@ module.exports = (log, db, mailer, push, verificationReminders) => {
       // Our post-verification email is very specific to sync,
       // so only send it if we're sure this is for sync.
       if (service === 'sync') {
+        const onMobileDevice =
+          userAgent(request.headers['user-agent']).deviceType === 'mobile';
         const mailOptions = {
           acceptLanguage: request.app.acceptLanguage,
           service,
           uid,
+          onMobileDevice,
         };
 
         if (style) {

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1268,7 +1268,7 @@ module.exports = function (log, config, oauthdb) {
       email: message.email,
       uid: message.uid,
     });
-
+    const onDesktopOrTabletDevice = !message.onMobileDevice;
     const templateName = 'postVerify';
     const subject = gettext(
       'Account verified. Next, sync another device to finish setup'
@@ -1295,9 +1295,11 @@ module.exports = function (log, config, oauthdb) {
       template: templateName,
       templateValues: {
         action,
+        onDesktopOrTabletDevice,
         androidLinkAttributes: linkAttributes(links.androidLink),
         androidUrl: links.androidLink,
         cadLinkAttributes: linkAttributes(links.link),
+        desktopLinkAttributes: linkAttributes(config.smtp.firefoxDesktopUrl),
         iosLinkAttributes: linkAttributes(links.iosLink),
         iosUrl: links.iosLink,
         link: links.link,

--- a/packages/fxa-auth-server/lib/senders/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/templates/_versions.json
@@ -17,7 +17,7 @@
   "passwordResetRequired": 4,
   "postChangePrimary": 4,
   "postRemoveSecondary": 4,
-  "postVerify": 4,
+  "postVerify": 5,
   "postVerifySecondary": 4,
   "recovery": 4,
   "sms.installFirefox": 1,

--- a/packages/fxa-auth-server/lib/senders/templates/partials/appBadges.html
+++ b/packages/fxa-auth-server/lib/senders/templates/partials/appBadges.html
@@ -1,18 +1,18 @@
 <tr style="page-break-before: always">
   <td align="center" style="padding: 40px 0 10px;">
-    <a href="{{{iosUrl}}}">
-      <img src="https://accounts.firefox.com/images/apple_app_store_button/en.svg" width="152" height="45" alt="" style="-ms-interpolation-mode: bicubic;" />
-    </a>
-    <a href="{{{androidUrl}}}">
-      <img src="https://accounts.firefox.com/images/google_play_store_button/en@2x.png" width="152" height="45" alt="" style="-ms-interpolation-mode: bicubic;" />
-    </a>
+    <a href="{{{iosUrl}}}"><img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/5/ebdfb903-4e62-4aeb-9eae-26e1ef495049.png" width="152" height="45" alt="" style="-ms-interpolation-mode: bicubic; margin-right:2px" /></a>
+    <a href="{{{androidUrl}}}"><img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/5/0dda16b4-21bb-4cc1-9042-2ebaaa7a9764.png" width="152" height="45" alt="" style="-ms-interpolation-mode: bicubic;" />
   </td>
 </tr>
 
 <tr style="page-break-before: always">
   <td valign="center">
     <p class="secondary" style="font-family: sans-serif; font-weight: normal; margin: 5px 0 12px 0; text-align: center; color: #737373; font-size: 11px; line-height: 18px; width: 310px !important; word-wrap:break-word">
-      {{{t "Or, install on <a %(cadLinkAttributes)s>another device</a>."}}}
+      {{#if onDesktopOrTabletDevice}}
+        {{{t "Or, install on <a %(desktopLinkAttributes)s>another desktop device</a>."}}}
+      {{else}}
+        {{{t "Or, install on <a %(cadLinkAttributes)s>another device</a>."}}}
+      {{/if}}
     </p>
   </td>
 </tr>

--- a/packages/fxa-auth-server/lib/senders/templates/postVerify.html
+++ b/packages/fxa-auth-server/lib/senders/templates/postVerify.html
@@ -4,11 +4,14 @@
 
     <h1 class="primary" style="font-family: sans-serif; font-size: 21px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{t "Next sync between your devices!"}}</h1>
 
-    <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/4/9f34e2a3-7947-4b5b-9c73-98faf8f49df6.png"
-         height="137"
-         width="270"
-         alt=""
-         style="-ms-interpolation-mode: bicubic;"/>
+    <div style="text-align: center; margin-bottom: 20px;">
+      <img src="https://image.e.mozilla.org/lib/fe9915707361037e75/m/5/f9463f08-8831-49fb-bbc4-7b5072cb63be.png"
+        height="175"
+        width="238"
+        alt=""
+        style="-ms-interpolation-mode: bicubic;"
+      />
+    </div>
 
     <p class="primary" style="font-family: sans-serif; font-size: 14px; line-height: 21px; font-weight: normal; margin: 0 0 21px 0; text-align: center;">{{t "Sync privately keeps your bookmarks, passwords and other Firefox data the same across all your devices."}}</p>
   </td>

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -815,8 +815,10 @@ const TESTS = new Map([
       { test: 'include', expected: configHref('syncUrl', 'account-verified', 'connect-device') },
       { test: 'include', expected: config.smtp.androidUrl },
       { test: 'include', expected: config.smtp.iosUrl },
+      { test: 'include', expected: 'another desktop device' },
       { test: 'include', expected: configHref('privacyUrl', 'account-verified', 'privacy') },
       { test: 'include', expected: configHref('supportUrl', 'account-verified', 'support') },
+      { test: 'include', expected: config.smtp.firefoxDesktopUrl },
     ]],
     ['text', [
       { test: 'include', expected: 'Firefox Account verified. You\'re almost there.' },
@@ -1129,8 +1131,10 @@ const TESTS = new Map([
       { test: 'include', expected: configHref('syncUrl', 'cad-reminder-first', 'connect-device') },
       { test: 'include', expected: config.smtp.androidUrl },
       { test: 'include', expected: config.smtp.iosUrl },
+      { test: 'include', expected: 'another device' },
       { test: 'include', expected: configHref('privacyUrl', 'cad-reminder-first', 'privacy') },
       { test: 'include', expected: configHref('supportUrl', 'cad-reminder-first', 'support') },
+      { test: 'notInclude', expected: config.smtp.firefoxDesktopUrl },
     ]],
     ['text', [
       { test: 'include', expected: "Here's your reminder to sync devices." },


### PR DESCRIPTION
Because:
* We want to include "connect on another desktop device" text with a link to download Firefox when users register with a tablet (which largely send desktop UA) or desktop.

This commit:
* Allows `onMobileDevice` to be passed into `message` as an option for the mailer and displays different copy for the link following the app store links.
* Replaces postVerify and appBadges images with CDN versions.

fixes #5553 