### PR TITLE
fix(l10n): polyfill Intl.NumberFormat for emails

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -22,6 +22,14 @@ const UTM_PREFIX = 'fx-';
 const X_SES_CONFIGURATION_SET = 'X-SES-CONFIGURATION-SET';
 const X_SES_MESSAGE_TAGS = 'X-SES-MESSAGE-TAGS';
 
+// Polyfill Intl.NumberFormat until we are using Node >= 13
+if (parseInt(process.versions.node) > 12) {
+  console.error('Time to remove the intl polyfill module!!1!');
+} else {
+  const IntlPolyfill = require('intl');
+  Intl.NumberFormat = IntlPolyfill.NumberFormat;
+}
+
 module.exports = function (log, config, oauthdb) {
   const oauthClientInfo = require('./oauth_client_info')(log, config, oauthdb);
   const verificationReminders = require('../verification-reminders')(

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -69,6 +69,7 @@
     "hkdf": "0.0.2",
     "hot-shots": "^7.6.0",
     "i18n-abide": "0.0.26",
+    "intl": "1.2.5",
     "ioredis": "^4.14.1",
     "jed": "0.5.4",
     "jsonwebtoken": "^8.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15150,6 +15150,7 @@ fsevents@^1.2.7:
     hkdf: 0.0.2
     hot-shots: ^7.6.0
     i18n-abide: 0.0.26
+    intl: 1.2.5
     ioredis: ^4.14.1
     jed: 0.5.4
     jsonwebtoken: ^8.4.0
@@ -18635,6 +18636,13 @@ fsevents@^1.2.7:
   version: 1.2.0
   resolution: "intl-pluralrules@npm:1.2.0"
   checksum: f0e50b284b277c7a9bbc19b88d96ad7982f72f78d37c3ea0d8633419ac09f02ed9f9cc25960d9f67952a7860562c0d8b4dec466a09dea44d446b7960e6a99c01
+  languageName: node
+  linkType: hard
+
+"intl@npm:1.2.5":
+  version: 1.2.5
+  resolution: "intl@npm:1.2.5"
+  checksum: 8fc0b27ce873d865f90bf2e32428b80345e3d91fb2cef7732cfeb6b10c1a83482e4e73c68af48d1dc4eb407a49fc81f1beef34161db7e284259957d3e4fa1aae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:
 - Node's Intl.NumberFormat doesn't format currencies correctly prior to v13

This commit:
 - polyfill Intl.NumberFormat if Node is < 13

## Issue that this pull request solves

Part of #FXA-2202

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
