### PR TITLE
fix(metrics): Create a new oauth token created event that includes sync device data

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -279,7 +279,8 @@
         "redirectUri": "urn:ietf:wg:oauth:2.0:oob",
         "allowedScopes": "https://identity.mozilla.com/apps/oldsync https://identity.mozilla.com/tokens/session",
         "trusted": true,
-        "canGrant": true
+        "canGrant": true,
+        "publicClient": true
       },
       {
         "name": "Fennec",

--- a/packages/fxa-auth-server/docs/metrics-events.md
+++ b/packages/fxa-auth-server/docs/metrics-events.md
@@ -376,6 +376,7 @@ has the same schema as `daily_multi_device_users`.
 | `device.created`       | A device record has been created for a Sync account.         |
 | `device.updated`       | Device record is updated on a Sync account.                  |
 | `device.deleted`       | Device record has been deleted from a Sync account.          |
+| `oauth.token.created`  | An oauth access token has been issued for an account.        |
 | `sync.sentTabToDevice` | Device sent a push message for send-tab-to-device feature.   |
 
 ## Email events

--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -95,6 +95,10 @@ const EVENTS = {
     group: GROUPS.registration,
     event: 'email_confirmed',
   },
+  'oauth.token.created': {
+    group: GROUPS.activity,
+    event: 'oauth_access_token_created',
+  },
   'sms.installFirefox.sent': {
     group: GROUPS.sms,
     event: 'sent',

--- a/packages/fxa-auth-server/lib/metrics/events.js
+++ b/packages/fxa-auth-server/lib/metrics/events.js
@@ -20,6 +20,7 @@ const ACTIVITY_EVENTS = new Set([
   'device.created',
   'device.deleted',
   'device.updated',
+  'oauth.token.created',
   'sync.sentTabToDevice',
 ]);
 


### PR DESCRIPTION
Apologies in advance—the questions I have here probably will make this borderline incomprehensible to everyone except vladikoff and rfk. I will do my best to summarize.

Probably best to start with [this earlier comment](https://github.com/mozilla/fxa/issues/5143#issuecomment-648510736) for context on this issue other than these metrics-related changes.

This change adds a new amplitude event, `fxa_activity - oauth_access_token_created`, emitted by the auth server for the `oauth/token` API endpoint, which will contain the device info needed to restore sync cross-device metrics. I'm also including the grant type in the event, in case we need to slice that data further.

There is code in auth server (the [`request.app.devices` getter](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/lib/server.js#L226)) that enumerates devices and appends this info on the request object, pulling data from [both the auth and oauth DBs](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/lib/routes/devices-and-sessions.js#L539-L563). There's also code in the auth [amplitude lib](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/lib/metrics/amplitude.js#L175) that appends this device info to auth server amplitude events. Lower layers in the token request handler,  the [oauth server proxy layer](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/lib/oauthdb/index.js) and the oauthdb, don't have convenient spots to call into the auth db (I assume this is a feature), so it seems the auth [v1/oauth/token](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/lib/routes/oauth/index.js#L167) route handler is the simplest place to emit this event. (Did I miss a better spot, though?)

Since the new event might work slightly differently than the old event, whether introducing or resolving bugs, it seemed best to choose a slightly different event name.

I don't think this should require a data-review, since it's fixing existing collection that was broken, but I do still need to add it to the metrics list of events.

There is one open question called out as a TODO in the code: I’m not sure if the fxa-credential grants will always have a `credentials.uid` or not. In particular, the test and code assumes the `sessionToken` is either present and complete or `null`. Is that definitely the case? Could the `sessionToken` be present but not include the `uid`?

## Testing this thing works

I've followed the following steps to try to connect a local Firefox to a local FxA:

- Edit the config for auth-server (fxa-auth-server/config/dev.json) to give the client with client name "Firefox" (client ID is "5882386c6d801776") the extra property `publicClient: true`
- Start the local fxa monorepo
- Create a new account locally
- Tail the auth-server logs (./pm2 logs auth)
- Open firefox using a fresh profile
- Go to about:config, set `identity.fxaccounts.allowHttp` to `true`, set `identity.fxaccounts.autoconfig.uri` to `http://localhost:3030/`
- [Enable the browser toolbox](https://developer.mozilla.org/en-US/docs/Tools/Browser_Toolbox#Enabling_the_Browser_Toolbox), a version of devtools used to debug Firefox internals
- Restart firefox.
- Open up the browser toolbox to the network tab
- Sign in to the browser using the test account.
- Look for an event `fxa_activity - oauth_access_token_created` in the auth server logs. Should look like this:
`16|auth  | 2020-07-01T12:22:33: fxa-auth-server.INFO: amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_activity - oauth_access_token_created","time":1593631353100,"user_id":"d9d0b4051d844fb59d10b985062861ce","device_id":"9f41ae8a8012449687aff327a326b92b","session_id":1593631318617,"app_version":"177.0","language":"en-US","os_name":"Mac OS X","os_version":"10.15","event_properties":{"service":"sync"},"user_properties":{"flow_id":"d014bfbd712f29534692e937736713ba7be4c10ed8e9418d2c799fc9a2ddfa15","ua_browser":"Firefox","ua_version":"80.0","$append":{"fxa_services_used":"sync"},"sync_device_count":1,"sync_active_devices_day":1,"sync_active_devices_week":1,"sync_active_devices_month":1}}`
