### PR TITLE
fix(reminders): only send reminders if the user has not logged into another device

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -845,7 +845,7 @@ module.exports = (
           }
         }
 
-        function createResponse() {
+        async function createResponse() {
           const response = {
             uid: sessionToken.uid,
             sessionToken: sessionToken.data,
@@ -868,6 +868,8 @@ module.exports = (
               )
             );
           }
+
+          await signinUtils.cleanupReminders(response, accountRecord);
 
           return response;
         }

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -27,19 +27,20 @@ module.exports = function (
   const push = require('../push')(log, db, config, statsd);
   const pushbox = require('../pushbox')(log, config, statsd);
   const devicesImpl = require('../devices')(log, db, oauthdb, push);
+  const cadReminders = require('../cad-reminders')(config, log);
   const signinUtils = require('./utils/signin')(
     log,
     config,
     customs,
     db,
-    mailer
+    mailer,
+    cadReminders
   );
   const clientUtils = require('./utils/clients')(log, config);
   const verificationReminders = require('../verification-reminders')(
     log,
     config
   );
-  const cadReminders = require('../cad-reminders')(config, log);
   const signupUtils = require('./utils/signup')(
     log,
     db,

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -371,6 +371,7 @@ module.exports = function (
           await signupUtils.verifyAccount(request, account, options);
         } else {
           request.emitMetricsEvent('account.confirmed', { uid });
+          await signinUtils.cleanupReminders({ verified: true }, account);
           await push.notifyAccountUpdated(uid, devices, 'accountConfirm');
         }
 

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -18,7 +18,7 @@ const BASE_36 = validators.BASE_36;
 // Currently only for metrics purposes, not enforced.
 const MAX_ACTIVE_SESSIONS = 200;
 
-module.exports = (log, config, customs, db, mailer) => {
+module.exports = (log, config, customs, db, mailer, cadReminders) => {
   const unblockCodeLifetime =
     (config.signinUnblock && config.signinUnblock.codeLifetime) || 0;
   const unblockCodeLen =
@@ -497,6 +497,19 @@ module.exports = (log, config, customs, db, mailer) => {
         };
       }
       return { verified: true };
+    },
+
+    /**
+     * Remove verification reminders for the account.
+     */
+    async cleanupReminders(response, account) {
+      // We should only really remove reminders if the session
+      // was marked as verified, ie have met all the requirements
+      // to start syncing
+      if (response.verified) {
+        await cadReminders.delete(account.uid);
+      }
+      return;
     },
   };
 };

--- a/packages/fxa-auth-server/test/local/ip_profiling.js
+++ b/packages/fxa-auth-server/test/local/ip_profiling.js
@@ -29,6 +29,7 @@ function makeRoutes(options = {}, requireMocks) {
     smtp: {},
   };
   const log = mocks.mockLog();
+  const cadReminders = mocks.mockCadReminders();
   const customs = {
     check() {
       return P.resolve(true);
@@ -40,7 +41,8 @@ function makeRoutes(options = {}, requireMocks) {
     config,
     customs,
     db,
-    mailer
+    mailer,
+    cadReminders
   );
   signinUtils.checkPassword = () => P.resolve(true);
   return proxyquire('../../lib/routes/account', requireMocks || {})(

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -44,6 +44,7 @@ const makeRoutes = function (options = {}, requireMocks) {
 
   const log = options.log || mocks.mockLog();
   const mailer = options.mailer || {};
+  const cadReminders = options.cadReminders || mocks.mockCadReminders();
   const Password =
     options.Password || require('../../../lib/crypto/password')(log, config);
   const db = options.db || mocks.mockDB();
@@ -59,7 +60,8 @@ const makeRoutes = function (options = {}, requireMocks) {
       config,
       customs,
       db,
-      mailer
+      mailer,
+      cadReminders
     );
   if (options.checkPassword) {
     signinUtils.checkPassword = options.checkPassword;
@@ -1170,6 +1172,7 @@ describe('/account/login', () => {
     check: () => P.resolve(),
     flag: () => P.resolve(),
   };
+  const mockCadReminders = mocks.mockCadReminders();
   const accountRoutes = makeRoutes({
     checkPassword: function () {
       return P.resolve(true);
@@ -1180,6 +1183,7 @@ describe('/account/login', () => {
     log: mockLog,
     mailer: mockMailer,
     push: mockPush,
+    cadReminders: mockCadReminders,
   });
   let route = getRoute(accountRoutes, '/account/login');
 
@@ -1208,6 +1212,7 @@ describe('/account/login', () => {
     mockDB.getSecondaryEmail.resetHistory();
     mockRequest.payload.email = TEST_EMAIL;
     mockRequest.payload.verificationMethod = undefined;
+    mockCadReminders.delete.resetHistory();
   });
 
   it('emits the correct series of calls and events', () => {
@@ -2033,6 +2038,7 @@ describe('/account/login', () => {
           log: mockLog,
           mailer: mockMailer,
           push: mockPush,
+          cadReminders: mockCadReminders,
         });
 
         route = getRoute(accountRoutes, '/account/login');
@@ -2122,6 +2128,8 @@ describe('/account/login', () => {
             response.verified,
             'response indicates account is verified'
           );
+
+          assert.equal(mockCadReminders.delete.callCount, 1);
         });
       });
 

--- a/packages/fxa-auth-server/test/local/routes/session.js
+++ b/packages/fxa-auth-server/test/local/routes/session.js
@@ -30,6 +30,7 @@ function makeRoutes(options = {}) {
   const db = options.db || mocks.mockDB();
   const log = options.log || mocks.mockLog();
   const mailer = options.mailer || mocks.mockMailer();
+  const cadReminders = options.cadReminders || mocks.mockCadReminders();
   const Password =
     options.Password || require('../../../lib/crypto/password')(log, config);
   const customs = options.customs || {
@@ -44,7 +45,8 @@ function makeRoutes(options = {}) {
       config,
       customs,
       db,
-      mailer
+      mailer,
+      cadReminders
     );
 
   const verificationReminders =
@@ -1127,7 +1129,7 @@ describe('/session/duplicate', () => {
 });
 
 describe('/session/verify_code', () => {
-  let route, request, log, db, mailer, push, customs;
+  let route, request, log, db, mailer, push, customs, cadReminders;
 
   function setup(options = {}) {
     db = mocks.mockDB({ ...signupCodeAccount, ...options });
@@ -1136,8 +1138,17 @@ describe('/session/verify_code', () => {
     push = mocks.mockPush();
     customs = mocks.mockCustoms();
     customs.check = sinon.spy(() => P.resolve(true));
+    cadReminders = mocks.mockCadReminders();
     const config = {};
-    const routes = makeRoutes({ log, config, db, mailer, push, customs });
+    const routes = makeRoutes({
+      log,
+      config,
+      db,
+      mailer,
+      push,
+      customs,
+      cadReminders,
+    });
     route = getRoute(routes, '/session/verify_code');
 
     const expectedCode = getExpectedOtpCode({}, signupCodeAccount.emailCode);


### PR DESCRIPTION
## Because

* Users were getting the reminder emails even though they already logged into another device

## This commit

* Deletes the reminders on a successful login or verifying a session

## Issue that this pull request solves

Closes: #5799

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
