### PR TITLE
fix(auth-server): remove plan_name requirement

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -350,7 +350,7 @@ module.exports.subscriptionsPlanValidator = isA.object({
   plan_metadata: module.exports.subscriptionPlanMetadataValidator.optional(),
   product_id: module.exports.subscriptionsProductId.required(),
   product_name: isA.string().required(),
-  plan_name: isA.string().allow('').required(),
+  plan_name: isA.string().allow('').optional(),
   product_metadata: module.exports.subscriptionProductMetadataValidator.optional(),
   interval: isA.string().required(),
   interval_count: isA.number().required(),


### PR DESCRIPTION
Because:

* Objects from Stripe cached previously may be missing the plan_name
  and the client doesn't use it at this time. It was added purely to
  support e-mail requirements.

This commit:

* Removes plan_name from a required return attribute in the responses
  that include plans.

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
