### PR TITLE
fix(surveys): Remove aria-hidden attribute from survey component

### DIFF
--- a/packages/fxa-react/components/Survey/index.tsx
+++ b/packages/fxa-react/components/Survey/index.tsx
@@ -59,11 +59,7 @@ export const Survey = ({ surveyURL, surveyComplete = false }: SurveyProps) => {
 
   return (
     <CSSTransition in={inProp} timeout={200} classNames="survey-inner">
-      <section
-        className="survey-component"
-        data-testid="survey-component"
-        aria-hidden="true"
-      >
+      <section className="survey-component" data-testid="survey-component">
         <CSSTransition in={inProp} timeout={100} classNames="button-inner">
           <button
             className="survey-control"


### PR DESCRIPTION
Because:
* We want screenreaders to be able to access the survey.

This commit:
* Removes 'aria-hidden="true" from the survey container.

--

Pre-req to all the a11y survey work this sprint. Didn't make an issue for this because eh it'd block everything else and it's a 1 line change.