### PR TITLE
fix(attached-clients): Ignore a device's refreshTokenId if it's not a live token

### DIFF
--- a/packages/fxa-auth-server/lib/routes/attached-clients.js
+++ b/packages/fxa-auth-server/lib/routes/attached-clients.js
@@ -104,7 +104,9 @@ module.exports = (log, db, oauthdb, devices, clientUtils) => {
           const client = {
             ...defaultFields,
             sessionTokenId: device.sessionTokenId || null,
-            refreshTokenId: device.refreshTokenId || null,
+            // The refreshTokenId might be a dangling pointer, don't set it
+            // until we know whether the corresponding token exists in the OAuth db.
+            refreshTokenId: null,
             deviceId: device.id,
             deviceType: device.type,
             name: device.name,
@@ -125,7 +127,9 @@ module.exports = (log, db, oauthdb, devices, clientUtils) => {
           let client = clientsByRefreshTokenId.get(
             oauthClient.refresh_token_id
           );
-          if (!client) {
+          if (client) {
+            client.refreshTokenId = oauthClient.refresh_token_id;
+          } else {
             client = {
               ...defaultFields,
               refreshTokenId: oauthClient.refresh_token_id || null,


### PR DESCRIPTION
## Because

* OAuth refresh tokens live in a separate database from device records,
  for hysterial raisins.
* We've observed at least one instance where the device record appears to
  have a "dangling pointer" to a refresh token that no longer exists.
* We can't really do anything useful with a `refreshTokenId` that doesn't
  correspond to an actual refresh token, apart from "ignore it" or
  "delete it".

## This commit

* Silently ignores dangling refreshTokenId references when listing
  the clients attached to a user's account.
* Opts not to try to repair the device record, mostly because this
  is easier and it seems harmless to ignore.

## Issue that this pull request solves

Closes: https://bugzilla.mozilla.org/show_bug.cgi?id=1647126

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- ~~[ ] I have added necessary documentation (if appropriate).~~

