### PR TITLE
feat(surveys): always show surveys in dev, regardless of rate or last shown timestamp

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/app-start.js
+++ b/packages/fxa-content-server/app/scripts/lib/app-start.js
@@ -87,7 +87,7 @@ Start.prototype = {
       .then(() => this.initializeDeps())
       .then(() => this.testLocalStorage())
       .then(() => this.allResourcesReady())
-      .catch(err => this.fatalError(err));
+      .catch((err) => this.fatalError(err));
   },
 
   initializeInterTabChannel() {
@@ -410,7 +410,7 @@ Start.prototype = {
           return user.mergeBrowserAccount(browserAccountData);
         }
       })
-      .then(browserAccount => {
+      .then((browserAccount) => {
         const isPairing =
           this.isDevicePairingAsAuthority() || this.isStartingPairing();
 
@@ -531,6 +531,7 @@ Start.prototype = {
         user: this._user,
         surveys: this._config.surveys,
         window: this._window,
+        env: this._config.env,
       });
     }
   },
@@ -568,7 +569,7 @@ Start.prototype = {
           this._storage.testLocalStorage(this._window);
         }
       })
-      .catch(err => this.captureError(err));
+      .catch((err) => this.captureError(err));
   },
 
   /**

--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -168,4 +168,6 @@ module.exports = {
   // Allow ID Tokens used as the id_token_hint argument in a prompt=none
   // request to be this many seconds past their expiration.
   ID_TOKEN_HINT_GRACE_PERIOD: 60 * 60 * 24 * 7,
+
+  ENV_DEVELOPMENT: 'development',
 };

--- a/packages/fxa-content-server/app/scripts/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/scripts/lib/survey-filter.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import UserAgent from './user-agent';
+import { ENV_DEVELOPMENT } from './constants';
 
 // All but the default export here is to make testing easier.
 
@@ -30,7 +31,7 @@ export const participatedRecently = (
 };
 
 export const withinRate = (rate) => {
-  if (rate === 0) {
+  if (isNaN(rate) || rate === 0) {
     return false;
   }
 
@@ -389,7 +390,8 @@ export const createSurveyFilter = (
   user,
   relier,
   previousParticipationTime,
-  doNotBotherSpan
+  doNotBotherSpan,
+  env
 ) => {
   const fetchUa = createFetchUaFn(window);
   const fetchLangs = createFetchLanguagesFn(window);
@@ -402,11 +404,11 @@ export const createSurveyFilter = (
     if (
       !(
         surveyConfig &&
-        surveyConfig.rate &&
         surveyConfig.conditions &&
-        withinRate(surveyConfig.rate) &&
+        (env === ENV_DEVELOPMENT || withinRate(surveyConfig.rate)) &&
         Object.keys(surveyConfig.conditions).length > 0 &&
-        !participatedRecently(previousParticipationTime, doNotBotherSpan)
+        (env === ENV_DEVELOPMENT ||
+          !participatedRecently(previousParticipationTime, doNotBotherSpan))
       )
     ) {
       return failureRes;

--- a/packages/fxa-content-server/app/scripts/lib/survey-targeter.js
+++ b/packages/fxa-content-server/app/scripts/lib/survey-targeter.js
@@ -13,6 +13,7 @@ export default class SurveyTargeter {
     this.user = options.user;
     this.window = options.window;
     this.surveys = options.surveys;
+    this.env = options.env;
 
     this._buildSurveysByViewPathMap();
   }
@@ -47,7 +48,8 @@ export default class SurveyTargeter {
       this.user,
       this.relier,
       this._storage.get(lastSurveyKey),
-      this.config.doNotBotherSpan
+      this.config.doNotBotherSpan,
+      this.env
     );
 
     try {
@@ -67,6 +69,12 @@ export default class SurveyTargeter {
       }
 
       const selectedSurvey = this._selectSurvey(qualifiedSurveys);
+
+      if (this.env === 'development') {
+        console.info('Satisfactory user data:');
+        console.table(selectedSurvey.conditions);
+      }
+
       this._storage.set(lastSurveyKey, Date.now());
       const surveyURL = Url.updateSearchString(
         selectedSurvey.survey.url,

--- a/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
@@ -1227,6 +1227,22 @@ describe('lib/survey-filter', () => {
       });
       assertFilterResult(actual, false);
     });
+
+    it('should be passing in development, regardless of rate or last shown timestamp', async () => {
+      const filter = SurveyFilter.createSurveyFilter(
+        mockWindow,
+        mockUser,
+        mockRelier,
+        Date.now(),
+        5000000,
+        'development'
+      );
+      const actual = await filter({
+        conditions: config.conditions,
+        rate: 0,
+      });
+      assertFilterResult(actual, true);
+    });
   });
 });
 


### PR DESCRIPTION
## Because

We want to be able to see surveys in development

## This change

Ensures a survey will always show up in development, regardless of when you last saw it or the rate for which it should be shown (including a rate of 0). Note that all other conditions must still be met. To aid in development the matched conditions will also be console table-logged.

## Issue that this pull request solves

Closes: #5529, though the requirements changed to [this](https://github.com/mozilla/fxa/issues/5529#issuecomment-653156870).

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.