### PR TITLE
feat(surveys): permit strings or arrays to be used in ua property checks

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/scripts/lib/survey-filter.js
@@ -256,46 +256,53 @@ export const languagesCheck = createConditionCheckFn(fetchAndApplySourceVal)(
 const createUaConditionCheckFn = createConditionCheckFn(fetchAndApplySourceVal);
 
 // Comparator
-export const checkUaDeviceType = (ua) => (val) => {
-  if (
-    ua &&
-    ua.genericDeviceType &&
-    ua.genericDeviceType().toLowerCase() === val.toLowerCase()
-  ) {
-    return val;
+export const checkUaDeviceTypes = (ua) => (vals) => {
+  vals = Array.isArray(vals) ? vals : [vals];
+  if (!(ua && ua.genericDeviceType)) {
+    return;
   }
+  const deviceType = ua.genericDeviceType().toLowerCase();
+  // If one of any eligible device type matches, return
+  // it, otherwise return undefined, which is a failure
+  return vals.filter((v) => {
+    return deviceType === v.toLowerCase();
+  })[0];
 };
 
 // Comparator
-export const checkUaOsName = (ua) => (val) => {
-  if (
-    ua &&
-    ua.os &&
-    ua.os.name &&
-    ua.os.name.toLowerCase() === val.toLowerCase()
-  ) {
-    return val;
+export const checkUaOsNames = (ua) => (vals) => {
+  vals = Array.isArray(vals) ? vals : [vals];
+  if (!(ua && ua.os && ua.os.name)) {
+    return;
   }
+  const osName = ua.os.name.toLowerCase();
+  // If one of any eligible OS value matches, return it,
+  // otherwise return undefined, which is a failure
+  return vals.filter((v) => {
+    return osName === v.toLowerCase();
+  })[0];
 };
 
 // Comparator
-export const checkUaBrowser = (ua) => (val) => {
-  if (
-    ua &&
-    ua.browser &&
-    ua.browser.name &&
-    ua.browser.name.toLowerCase() === val.toLowerCase()
-  ) {
-    return val;
+export const checkUaBrowsers = (ua) => (vals) => {
+  vals = Array.isArray(vals) ? vals : [vals];
+  if (!(ua && ua.browser && ua.browser.name)) {
+    return;
   }
+  const browserName = ua.browser.name.toLowerCase();
+  // If one of any eligible browser value matches, return
+  // it, otherwise return undefined, which is a failure
+  return vals.filter((v) => {
+    return browserName === v.toLowerCase();
+  })[0];
 };
 
 // Ref: https://github.com/mozilla/fxa/blob/9b2d9d1/packages/fxa-content-server/app/scripts/lib/user-agent.js#L182
-export const hasDesiredDeviceType = createUaConditionCheckFn(checkUaDeviceType)(
-  'deviceType'
-);
-export const hasDesiredOs = createUaConditionCheckFn(checkUaOsName)('os');
-export const hasDesiredBrowser = createUaConditionCheckFn(checkUaBrowser)(
+export const hasDesiredDeviceType = createUaConditionCheckFn(
+  checkUaDeviceTypes
+)('deviceType');
+export const hasDesiredOs = createUaConditionCheckFn(checkUaOsNames)('os');
+export const hasDesiredBrowser = createUaConditionCheckFn(checkUaBrowsers)(
   'browser'
 );
 

--- a/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
@@ -482,40 +482,66 @@ describe('lib/survey-filter', () => {
     });
   });
 
-  describe('checkUaDeviceType', () => {
+  describe('checkUaDeviceTypes', () => {
     it('should be case insensitive, returning the passed in value when matching', () => {
-      const actual = SurveyFilter.checkUaDeviceType(mockUa)('mObile');
+      const actual = SurveyFilter.checkUaDeviceTypes(mockUa)('mObile');
       assert.equal(actual, 'mObile');
       assert.isTrue(mockUa.genericDeviceType.calledOnce);
     });
 
+    it('should accept an array of device types and return the matched one', () => {
+      const actual = SurveyFilter.checkUaDeviceTypes(mockUa)([
+        'mobile',
+        'desktop',
+        'tablet',
+      ]);
+      assert.equal(actual, 'mobile');
+      assert.isTrue(mockUa.genericDeviceType.calledOnce);
+    });
+
     it('should not return anything when the values do not match', () => {
-      const actual = SurveyFilter.checkUaDeviceType(mockUa)('DESKTOP');
+      const actual = SurveyFilter.checkUaDeviceTypes(mockUa)('DESKTOP');
       assert.isUndefined(actual);
       assert.isTrue(mockUa.genericDeviceType.calledOnce);
     });
   });
 
-  describe('checkUaOsName', () => {
+  describe('checkUaOsNames', () => {
     it('should be case insensitive, returning the passed in value when matching', () => {
-      const actual = SurveyFilter.checkUaOsName(mockUa)('Winning');
+      const actual = SurveyFilter.checkUaOsNames(mockUa)('Winning');
+      assert.equal(actual, 'Winning');
+    });
+
+    it('should accept an array of os names and return the matched one', () => {
+      const actual = SurveyFilter.checkUaOsNames(mockUa)([
+        'Winning',
+        'Windows',
+      ]);
       assert.equal(actual, 'Winning');
     });
 
     it('should not return anything when the values do not match', () => {
-      const actual = SurveyFilter.checkUaOsName(mockUa)('Windows');
+      const actual = SurveyFilter.checkUaOsNames(mockUa)('Windows');
       assert.isUndefined(actual);
     });
   });
 
-  describe('checkUaBrowser', () => {
+  describe('checkUaBrowsers', () => {
     it('should be case insensitive, returning the passed in value when matching', () => {
-      const actual = SurveyFilter.checkUaBrowser(mockUa)('spacetuna');
+      const actual = SurveyFilter.checkUaBrowsers(mockUa)('spacetuna');
+      assert.equal(actual, 'spacetuna');
+    });
+
+    it('should accept an array of browser names and return the matched one', () => {
+      const actual = SurveyFilter.checkUaBrowsers(mockUa)([
+        'spacetuna',
+        'brocolli',
+      ]);
       assert.equal(actual, 'spacetuna');
     });
 
     it('should not return anything when the values do not match', () => {
-      const actual = SurveyFilter.checkUaBrowser(mockUa)('Firefox');
+      const actual = SurveyFilter.checkUaBrowsers(mockUa)('Firefox');
       assert.isUndefined(actual);
     });
   });
@@ -524,6 +550,15 @@ describe('lib/survey-filter', () => {
     it('should be passing and have the matched value when the values match', () => {
       const actual = SurveyFilter.hasDesiredDeviceType(
         { deviceType: 'deskTOP' },
+        fetchGoodUaStub
+      );
+      assertConditionResult(actual, true, 'deskTOP');
+      assert.isTrue(fetchGoodUaStub.calledOnce);
+    });
+
+    it('should be passing and have the matched value when the values match in an array', () => {
+      const actual = SurveyFilter.hasDesiredDeviceType(
+        { deviceType: ['deskTOP', 'moBile'] },
         fetchGoodUaStub
       );
       assertConditionResult(actual, true, 'deskTOP');
@@ -550,6 +585,15 @@ describe('lib/survey-filter', () => {
       assert.isTrue(fetchGoodUaStub.calledOnce);
     });
 
+    it('should be passing and have the matched value when the values match in an array', () => {
+      const actual = SurveyFilter.hasDesiredOs(
+        { os: ['Windows', 'Mac OS'] },
+        fetchGoodUaStub
+      );
+      assertConditionResult(actual, true, 'Windows');
+      assert.isTrue(fetchGoodUaStub.calledOnce);
+    });
+
     it('should not be passing and have an undefined value when the values do not match', () => {
       const actual = SurveyFilter.hasDesiredOs({ os: 'macOS' }, fetchBadUaStub);
       assertConditionResult(actual, false);
@@ -561,6 +605,15 @@ describe('lib/survey-filter', () => {
     it('should be passing and have the matched value when the values match', () => {
       const actual = SurveyFilter.hasDesiredBrowser(
         { browser: 'Firefox' },
+        fetchGoodUaStub
+      );
+      assertConditionResult(actual, true, 'Firefox');
+      assert.isTrue(fetchGoodUaStub.calledOnce);
+    });
+
+    it('should be passing and have the matched value when the values match in an array', () => {
+      const actual = SurveyFilter.hasDesiredBrowser(
+        { browser: ['Firefox', 'Chrome', 'Edge'] },
         fetchGoodUaStub
       );
       assertConditionResult(actual, true, 'Firefox');


### PR DESCRIPTION
## Because

Currently User Agent property checks (OS, browser, device) only accept single strings, and we'd like to be able to test against 1 or more values of a given property.

## This changes

Permits you to use either a string or an array of strings when setting up User Agent property checks. For example:

```json
"conditions": {
  "browser": "Firefox",
  "browser": ["Firefox", "Chrome"],

  "os": "Windows",
  "os": ["Mac OS", "Windows", "Linux"],

  "deviceType": "desktop",
  "deviceType": ["desktop", "mobile"],
},
```

And because a user can only have one device type, OS, and browser, the matching value of a property will still always be returned as a single string.

## Issue that this pull request solves

Closes: #5641

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
