### PR TITLE
feat(surveys): permit strings or arrays to be used in RP checks

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/scripts/lib/survey-filter.js
@@ -300,14 +300,18 @@ export const hasDesiredBrowser = createUaConditionCheckFn(checkUaBrowser)(
 );
 
 // Comparator
-export const checkRelierClientId = (relier) => (val) => {
-  if (relier.get('clientId') === val) {
-    return val;
-  }
+export const checkRelierClientIds = (relier) => (vals) => {
+  vals = Array.isArray(vals) ? vals : [vals];
+  const userRP = relier.get('clientId');
+  // If one of any eligible RP IDs matche, return
+  // it, otherwise return undefined, which is a failure
+  return vals.filter((v) => {
+    return userRP === v;
+  })[0];
 };
 
 export const relierClientIdCheck = createConditionCheckFn(applySourceVal)(
-  checkRelierClientId
+  checkRelierClientIds
 )('relier');
 
 // Comparator

--- a/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/survey-filter.js
@@ -577,18 +577,26 @@ describe('lib/survey-filter', () => {
     });
   });
 
-  describe('checkRelierClientId', () => {
+  describe('checkRelierClientIds', () => {
     const mockRelier = { get: sandbox.stub().returns('galaxy quest') };
 
     it('should be the matched value when matched exactly', () => {
-      const actual = SurveyFilter.checkRelierClientId(mockRelier)(
+      const actual = SurveyFilter.checkRelierClientIds(mockRelier)(
         'galaxy quest'
       );
       assert.equal(actual, 'galaxy quest');
     });
 
+    it('should accept an array of values and return the matched one', () => {
+      const actual = SurveyFilter.checkRelierClientIds(mockRelier)([
+        'galaxy quest',
+        'manchester orchestra',
+      ]);
+      assert.equal(actual, 'galaxy quest');
+    });
+
     it('should be false when the values do not match', () => {
-      const actual = SurveyFilter.checkRelierClientId(mockRelier)(
+      const actual = SurveyFilter.checkRelierClientIds(mockRelier)(
         'Galaxy Quest'
       );
       assert.isUndefined(actual);
@@ -610,6 +618,15 @@ describe('lib/survey-filter', () => {
     it('should be passing and have the matched value when client id matches configured condition', () => {
       const actual = SurveyFilter.relierClientIdCheck(
         { relier: 'Relying Party!!!' },
+        mockRelier
+      );
+      assertConditionResult(actual, true, 'Relying Party!!!');
+      assert.isTrue(mockRelier.get.calledOnce);
+    });
+
+    it('should be passing and have the matched value when client id matches one of any in an array', () => {
+      const actual = SurveyFilter.relierClientIdCheck(
+        { relier: ['Relying Party!!!', 'Second Market Scenes'] },
         mockRelier
       );
       assertConditionResult(actual, true, 'Relying Party!!!');


### PR DESCRIPTION
## Because

Surveys can be configured to check the user's current RP, but just against a single value. We'd like to be able to test against 1 or more RP IDs.

## This changes

Permits you to use either a string or an array of strings when setting up the RP condition. For example:

```json
"conditions": {
  "relier": "booya",
  "relier": ["booya", "bonkers"],
},
```

And because a user can only have one current RP, the matching value will still always be returned as a single string.

## Issue that this pull request solves

Closes: #5642

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
