### PR TITLE
feat(surveys): send env and service name to survey gizmo as query params

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -170,4 +170,5 @@ module.exports = {
   ID_TOKEN_HINT_GRACE_PERIOD: 60 * 60 * 24 * 7,
 
   ENV_DEVELOPMENT: 'development',
+  ENV_PRODUCTION: 'production',
 };

--- a/packages/fxa-content-server/app/scripts/lib/survey-targeter.js
+++ b/packages/fxa-content-server/app/scripts/lib/survey-targeter.js
@@ -2,6 +2,7 @@ import SurveyWrapperView from '../views/survey';
 import Storage from './storage';
 import createSurveyFilter from './survey-filter';
 import Url from './url';
+import { ENV_DEVELOPMENT, ENV_PRODUCTION } from './constants';
 
 const lastSurveyKey = 'lastSurvey';
 
@@ -69,16 +70,20 @@ export default class SurveyTargeter {
       }
 
       const selectedSurvey = this._selectSurvey(qualifiedSurveys);
+      const queryParamData = Object.assign(selectedSurvey.conditions, {
+        server: 'content',
+        env: this.env || ENV_PRODUCTION,
+      });
 
-      if (this.env === 'development') {
-        console.info('Satisfactory user data:');
-        console.table(selectedSurvey.conditions);
+      if (this.env === ENV_DEVELOPMENT) {
+        console.info('Query param data:');
+        console.table(queryParamData);
       }
 
       this._storage.set(lastSurveyKey, Date.now());
       const surveyURL = Url.updateSearchString(
         selectedSurvey.survey.url,
-        selectedSurvey.conditions
+        queryParamData
       );
       return new SurveyWrapperView({ surveyURL });
     } catch {

--- a/packages/fxa-content-server/app/tests/spec/lib/survey-targeter.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/survey-targeter.js
@@ -72,7 +72,7 @@ describe('lib/survey-targeter', () => {
     assert.equal(view.el.className, 'survey-wrapped');
     assert.equal(
       view.$('iframe').first().attr('src'),
-      'https://www.surveygizmo.com/s3/5541940/pizza?browser=Firefox'
+      'https://www.surveygizmo.com/s3/5541940/pizza?browser=Firefox&server=content&env=production'
     );
   });
 
@@ -115,7 +115,7 @@ describe('lib/survey-targeter', () => {
     assert.deepEqual(setItemSpy.args[0], ['lastSurvey', lastSurveyValue]);
   });
 
-  it('generates the survey URL with matching conditions as query parameters', async () => {
+  it('generates the survey URL with matching conditions, env, and server as query parameters', async () => {
     const urlStringSpy = sandbox.spy(Url, 'updateSearchString');
 
     const survey = {
@@ -144,13 +144,14 @@ describe('lib/survey-targeter', () => {
 
     const targeter = await surveyTargeter.getSurvey('settings');
     const expectedUrl =
-      'https://www.surveygizmo.com/s3/5541940/pizza?languages=en-CA%2Cfr-CA&browser=Firefox&os=Mac%20OS';
-
+      'https://www.surveygizmo.com/s3/5541940/pizza?languages=en-CA%2Cfr-CA&browser=Firefox&os=Mac%20OS&server=content&env=production';
     assert(
       urlStringSpy.calledWith(survey.url, {
         browser: 'Firefox',
         os: 'Mac OS',
         languages: 'en-CA,fr-CA',
+        server: 'content',
+        env: 'production',
       })
     );
     assert(urlStringSpy.returned(expectedUrl));


### PR DESCRIPTION
## Because

There is a desire to know which environment and which server is calling the survey.

## This change

Modifies the initial condition query params to also include env and service. Now all surveys created in the Content Server will pass this data along to Survey Gizmo.

Notes:

- _"What about Payments?"_ I don't actually see anything set up beyond survey config in the payments server, so with how this is being implemented today it would be up to a future dev to ensure these params get added down the road.
- I could be convinced that, instead of appending these two params to the URL in the content server, both env and service should be [props](https://github.com/mozilla/fxa/blob/main/packages/fxa-react/components/Survey/index.tsx#L11) on the Survey component. However my current belief is that there is a single `surveyURL` prop on that component, and that is the extent to which the component should be concerned about the URL, leaving it up to the individual service to supply accurately.

## Issue that this pull request solves

Closes: #5686

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
