### PR TITLE
feat(surveys): don't animate survey when prefers-reduced-motion is present

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_survey.scss
+++ b/packages/fxa-content-server/app/styles/modules/_survey.scss
@@ -119,3 +119,18 @@ $survey-height: 360px;
 .button-inner-enter-active {
   transform: rotate(0deg);
 }
+
+@media (prefers-reduced-motion) {
+  .survey-inner-exit-active,
+  .survey-inner-enter-active {
+    transition-duration: 0s;
+  }
+
+  .survey-component {
+    visibility: hidden;
+
+    &.survey-inner-enter-done {
+      visibility: visible;
+    }
+  }
+}


### PR DESCRIPTION
## Because

We want to respect the accessibility system preference to reduce on-screen motion.

## This change

Disables the survey's vertical transition when the media query `prefers-reduced-motion` is present.

**Reviewer**: if you'd like to test this on macOS you can enable the preference under `System Preferences > Accessibility > Display > Reduce motion`; on iOS this is under `Settings > Accessibility > Motion > Reduce Motion`. I don't know about other operating systems. 🤷

## Issue that this pull request solves

Closes: #5843

## Checklist

- [x] My commit is GPG signed.