### PR TITLE
Build docker image with functioning API endpoints for Account Ecosystem Telemetry

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/get-fxa-client-configuration.js
+++ b/packages/fxa-content-server/server/lib/routes/get-fxa-client-configuration.js
@@ -33,6 +33,17 @@ module.exports = function (config) {
     ),
     profile_server_base_url: normalizeUrl(config.get('profile_url')),
     sync_tokenserver_base_url: normalizeUrl(config.get('sync_tokenserver_url')),
+    // For dev purposes, hard-code the stage AET pipeline keys.
+    // This value taken from https://bugzilla.mozilla.org/show_bug.cgi?id=1636102#c7
+    ecosystem_anon_id_keys: [
+      {
+        crv: 'P-256',
+        kid: 'LlU4keOmhTuq9fCNnpIldYGT9vT9dIDwnu_SBtTgeEQ',
+        kty: 'EC',
+        x: 'i3FM3OFSCZEoqu-jtelXwKt6AL4ODQ75NUdHbcLWQSo',
+        y: 'nW-S3QiHDo-9hwfBhKnGKarkt_PVqVyIPUytjutTunY',
+      },
+    ],
   };
 
   // This response will very rarely change, so enable caching by default.

--- a/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/post.js
+++ b/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/post.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const fs = require('fs');
 const Joi = require('@hapi/joi');
 
 const logger = require('../../logging')('routes.ecosystem_anon_id.post');
@@ -17,14 +18,22 @@ module.exports = {
       ecosystemAnonId: Joi.string().required(),
     },
   },
-  handler: async function ecosystemAnonIdPost(req) {
+  handler: async function ecosystemAnonIdPost(req, h) {
     const uid = req.auth.credentials.user;
     logger.info('activityEvent', { event: 'ecosystemAnonId.post', uid: uid });
 
-    await req.server.methods.profileCache.drop(uid);
+    // In production, we plan to store the `ecosystemAnonId` field in the auth-server db
+    // and would need to write it back there in this code.
+    // For initial dev purposes, we instead hackily store it in the local filesystem.
+    // The way we implement `If-None-Match` here is not safe against races, but
+    // should be good enough for development purposes.
+    const filenm = `/tmp/profile.${uid}.json`;
+    if (req.headers['if-none-match'] === '*' && fs.existsSync(filenm)) {
+      return h.response({}).code(412);
+    }
+    fs.writeFileSync(filenm, JSON.stringify(req.payload));
 
-    // When DB is ready, insert/update req.payload.ecosystemAnonId.
-    // For now, just notify and return.
+    await req.server.methods.profileCache.drop(uid);
     notifyProfileUpdated(uid);
     return {};
   },


### PR DESCRIPTION
This PR hacks in storage of `ecosystemAnonId` in fxa-profile-server in a terrible, horrible, no good, very bad way. Don't merge it. Don't even review it. I'm pushing it entirely to get a docker image build so I can make a dev environment to unblock client-side development work.