### PR TITLE
fix(gql-api): use envPrefix correctly

### DIFF
--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -39,19 +39,19 @@ function makeMySQLConfig(envPrefix: string, database: string) {
     password: {
       default: '',
       doc: 'MySQL password',
-      env: '_MYSQL_PASSWORD',
+      env: envPrefix + '_MYSQL_PASSWORD',
       format: String,
     },
     port: {
       default: 3306,
       doc: 'MySQL port',
-      env: '_MYSQL_PORT',
+      env: envPrefix + '_MYSQL_PORT',
       format: Number,
     },
     user: {
       default: 'root',
       doc: 'MySQL username',
-      env: '_MYSQL_USERNAME',
+      env: envPrefix + '_MYSQL_USERNAME',
       format: String,
     },
   };


### PR DESCRIPTION
Because:

* envPrefix wasn't properly specified for each key, different
  db configs couldn't be used.

This commit:

* Uses envPrefix on all config vars that need it.

Closes #5862

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

