### PR TITLE
fix(auth-server): payload validation for payment methods

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -1284,7 +1284,7 @@ const directRoutes = (
           schema: validators.subscriptionsSubscriptionExpandedValidator,
         },
         validate: {
-          query: {
+          payload: {
             priceId: isA.string().required(),
             paymentMethodId: validators.stripePaymentMethodId.required(),
             idempotencyKey: isA.string().required(),
@@ -1306,7 +1306,7 @@ const directRoutes = (
           schema: validators.subscriptionsInvoicePIExpandedValidator,
         },
         validate: {
-          query: {
+          payload: {
             invoiceId: isA.string().required(),
             paymentMethodId: validators.stripePaymentMethodId.required(),
             idempotencyKey: isA.string().required(),


### PR DESCRIPTION
Because:

* Payment Method API POST should use payload for data, not the query.

This commit:

* Switches to payload validation.
## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

