### PR TITLE
feat(auth-server): add setup intent methods

### DIFF
--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -3560,6 +3560,31 @@ Update the user's default payment method using a payment token.
 :lock: authenticated with OAuth bearer token
 Returns customer details, including limited payment information.
 
+#### POST /oauth/subscriptions/customer
+
+:lock: authenticated with OAuth bearer token
+Create a new customer object for use with subscription payments.
+
+#### POST /oauth/subscriptions/active/new
+
+:lock: authenticated with OAuth bearer token
+Subscribe the user to a price using a payment method id.
+
+#### POST /oauth/subscriptions/invoice/retry
+
+:lock: authenticated with OAuth bearer token
+Retry an incomplete subscription invoice with a new payment method id.
+
+#### POST /oauth/subscriptions/setupintent/create
+
+:lock: authenticated with OAuth bearer token
+Create a new setup intent for attaching a new payment method to the user.
+
+#### POST /oauth/subscriptions/paymentmethod/default
+
+:lock: authenticated with OAuth bearer token
+Update a user's default payment method for invoices to the attached payment method id.
+
 ### Totp
 
 #### POST /totp/create

--- a/packages/fxa-auth-server/lib/payments/stripe.js
+++ b/packages/fxa-auth-server/lib/payments/stripe.js
@@ -20,6 +20,7 @@ const stripe = require('stripe').Stripe;
 /** @typedef {import('stripe').Stripe.Source} Source */
 /** @typedef {import('stripe').Stripe.Card} Card */
 /** @typedef {import('stripe').Stripe.PaymentIntent} PaymentIntent */
+/** @typedef {import('stripe').Stripe.SetupIntent} SetupIntent */
 /** @typedef {import('stripe').Stripe.Charge} Charge */
 
 /**
@@ -318,6 +319,29 @@ class StripeHelper {
       },
       { idempotencyKey }
     );
+  }
+
+  /**
+   * Create a SetupIntent for a customer.
+   *
+   * @param {string} customerId
+   *
+   * @returns {Promise<SetupIntent>}
+   */
+  async createSetupIntent(customerId) {
+    return this.stripe.setupIntents.create({ customer: customerId });
+  }
+
+  /**
+   * Updates the default payment method used for invoices for the customer
+   *
+   * @param {string} customerId
+   * @param {string} paymentMethodId
+   */
+  async updateDefaultPaymentMethod(customerId, paymentMethodId) {
+    return this.stripe.customers.update(customerId, {
+      invoice_settings: { default_payment_method: paymentMethodId },
+    });
   }
 
   /** END: NEW FLOW HELPERS FOR PAYMENT METHODS **/

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -293,6 +293,12 @@ module.exports.activeSubscriptionValidator = isA.object({
   cancelledAt: isA.alternatives(isA.number(), isA.any().allow(null)),
 });
 
+module.exports.subscriptionsSetupIntent = isA
+  .object({
+    client_secret: isA.string().required(),
+  })
+  .unknown(true);
+
 // This is a Stripe subscription object with latest_invoice.payment_intent expanded
 module.exports.subscriptionsSubscriptionExpandedValidator = isA
   .object({
@@ -409,6 +415,106 @@ module.exports.subscriptionsCustomerValidator = isA.object({
     .items(module.exports.subscriptionsSubscriptionValidator)
     .optional(),
 });
+
+module.exports.subscriptionsStripeIntentValidator = isA
+  .object({
+    client_secret: isA.string().optional(),
+    created: isA.number().required(),
+    next_action: isA.object({}).unknown(true).optional(),
+    payment_method: isA
+      .alternatives(isA.string(), isA.object({}).unknown(true))
+      .optional(),
+    status: isA.string().required(),
+  })
+  .unknown(true);
+
+module.exports.subscriptionsStripeSourceValidator = isA
+  .object({
+    id: isA.string().required(),
+    object: isA.string().required(),
+    brand: isA.string().optional(),
+    exp_month: isA.string().optional(),
+    exp_year: isA.string().optional(),
+    last4: isA.string().optional(),
+  })
+  .unknown(true);
+
+module.exports.subscriptionsStripeInvoiceValidator = isA
+  .object({
+    id: isA.string().required(),
+    payment_intent: isA
+      .alternatives(
+        isA.string(),
+        module.exports.subscriptionsStripeIntentValidator
+      )
+      .optional(),
+  })
+  .unknown(true);
+
+module.exports.subscriptionsStripePriceValidator = isA
+  .object({
+    id: isA.string().required(),
+  })
+  .unknown(true);
+
+module.exports.subscriptionsStripeSubscriptionItemValidator = isA
+  .object({
+    id: isA.string().required(),
+    created: isA.number().required(),
+    price: module.exports.subscriptionsStripePriceValidator.required(),
+  })
+  .unknown(true);
+
+module.exports.subscriptionsStripeSubscriptionValidator = isA
+  .object({
+    id: isA.string().required(),
+    cancel_at: isA.number().optional(),
+    canceled_at: isA.number().optional(),
+    cancel_at_period_end: isA.bool().required(),
+    created: isA.number().required(),
+    current_period_end: isA.number().required(),
+    current_period_start: isA.number().required(),
+    ended_at: isA.number().optional(),
+    items: isA
+      .array()
+      .items(module.exports.subscriptionsStripeSubscriptionItemValidator)
+      .required(),
+    latest_invoice: isA
+      .alternatives(
+        isA.string(),
+        module.exports.subscriptionsStripeInvoiceValidator
+      )
+      .optional(),
+    status: isA.string().required(),
+  })
+  .unknown(true);
+
+module.exports.subscriptionsStripeCustomerValidator = isA
+  .object({
+    invoices_settings: isA
+      .object({
+        default_payment_method: isA.string().optional(),
+      })
+      .optional(),
+    latest_invoice: module.exports.subscriptionsStripeInvoiceValidator,
+    sources: isA
+      .object({
+        data: isA
+          .array()
+          .items(module.exports.subscriptionsStripeSourceValidator)
+          .required(),
+      })
+      .optional(),
+    subscriptions: isA
+      .object({
+        data: isA
+          .array()
+          .items(module.exports.subscriptionsStripeSubscriptionValidator)
+          .required(),
+      })
+      .optional(),
+  })
+  .unknown(true);
 
 module.exports.ppidSeed = isA.number().integer().min(0).max(1024);
 

--- a/packages/fxa-auth-server/test/local/payments/fixtures/setup_intent_new.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/setup_intent_new.json
@@ -1,0 +1,26 @@
+{
+  "id": "seti_1H1wk82eZvKYlo2CeYL31eaa",
+  "object": "setup_intent",
+  "application": null,
+  "cancellation_reason": null,
+  "client_secret": "seti_1H1wk82eZvKYlo2CeYL31eaa_secret_Hb92moULGom7WbECyWRuOjWjGcPsu2h",
+  "created": 1594051232,
+  "customer": "cust_new",
+  "description": null,
+  "last_setup_error": null,
+  "livemode": false,
+  "mandate": null,
+  "metadata": {},
+  "next_action": null,
+  "on_behalf_of": null,
+  "payment_method": null,
+  "payment_method_options": {
+    "card": {
+      "request_three_d_secure": "automatic"
+    }
+  },
+  "payment_method_types": ["card"],
+  "single_use_mandate": null,
+  "status": "requires_payment_method",
+  "usage": "off_session"
+}


### PR DESCRIPTION
Because:

* We want to use the SetupIntent API to update the default payment
  method used for a customer.

This commit:

* Allows the client to create a SetupIntent API for a given customer
  and set the payment method id (after confirming it) as the customer's
  default payment method.

Closes #5744

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
