### PR TITLE
fix(surveys): Provide context to screenreaders when entering the survey

### DIFF
--- a/packages/fxa-react/components/Survey/index.test.tsx
+++ b/packages/fxa-react/components/Survey/index.test.tsx
@@ -17,6 +17,7 @@ describe('Survey', () => {
     const { queryByTestId } = subject();
 
     const surveyContainer = queryByTestId('survey-component');
+    expect(surveyContainer).toHaveAttribute('aria-label', 'Firefox accounts optional user survey');
     expect(surveyContainer).toBeVisible();
   });
 

--- a/packages/fxa-react/components/Survey/index.tsx
+++ b/packages/fxa-react/components/Survey/index.tsx
@@ -59,7 +59,13 @@ export const Survey = ({ surveyURL, surveyComplete = false }: SurveyProps) => {
 
   return (
     <CSSTransition in={inProp} timeout={200} classNames="survey-inner">
-      <section className="survey-component" data-testid="survey-component">
+      {/*
+        * The header/desc IDs typically provided to the `aria-labelledby` and
+        * `aria-describedby` attributes for screenreader context are dynamic in SurveyGizmo.
+        * The `aria-label` provides generic survey context and the title of the survey in
+        * SG is read when the user hits the iframe which provides more specific context.
+      */}
+      <aside className="survey-component" data-testid="survey-component" aria-label="Firefox accounts optional user survey">
         <CSSTransition in={inProp} timeout={100} classNames="button-inner">
           <button
             className="survey-control"
@@ -67,7 +73,7 @@ export const Survey = ({ surveyURL, surveyComplete = false }: SurveyProps) => {
           ></button>
         </CSSTransition>
         {surveyComplete ? surveyCompleteElement : iframe}
-      </section>
+      </aside>
     </CSSTransition>
   );
 };


### PR DESCRIPTION
## Because

* Without this fix, screenreaders hit the survey control button first without any context on what it is that they've just entered.

## This commit

* Changes the 'section' tag to an 'aside', as a 'complimentary' element to the main content seems more applicable, and adds a generic survey aria-label to provide screenreaders with context because we can't easily use an aria-labelledby and aria-describedby due to SurveyGizmo's dynamic IDs that will change with every survey.

## Issue that this pull request solves

Closes: #5834

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Other information (Optional)

Changing 'section' to 'aside' does not change anything visually. The survey control piece of this issue is taken care of in #5871.
