### PR TITLE
In-progress reworking of product subscription page for new payment flows

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.js
+++ b/packages/fxa-auth-server/lib/payments/stripe.js
@@ -300,7 +300,7 @@ class StripeHelper {
         {
           customer: customerId,
         },
-        { idempotencyKey }
+        { idempotencyKey: `pma-${idempotencyKey}` }
       );
     } catch (err) {
       if (err.type === 'StripeCardError') {
@@ -317,7 +317,7 @@ class StripeHelper {
         items: [{ price: priceId }],
         expand: ['latest_invoice.payment_intent'],
       },
-      { idempotencyKey }
+      { idempotencyKey: `ssc-${idempotencyKey}` }
     );
   }
 

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -571,7 +571,7 @@ class DirectStripeRoutes {
    * @param {*} request
    */
   async createCustomer(request) {
-    this.log.begin('subscriptions.getCustomer', request);
+    this.log.begin('subscriptions.createCustomer', request);
     const { uid, email } = await handleAuth(this.db, request.auth, true);
     await this.customs.check(request, email, 'createCustomer');
 

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -470,17 +470,22 @@ module.exports.subscriptionsStripeSubscriptionItemValidator = isA
 module.exports.subscriptionsStripeSubscriptionValidator = isA
   .object({
     id: isA.string().required(),
-    cancel_at: isA.number().optional(),
-    canceled_at: isA.number().optional(),
+    cancel_at: isA.alternatives(isA.number(), isA.any().valid(null)),
+    canceled_at: isA.alternatives(isA.number(), isA.any().valid(null)),
     cancel_at_period_end: isA.bool().required(),
     created: isA.number().required(),
     current_period_end: isA.number().required(),
     current_period_start: isA.number().required(),
-    ended_at: isA.number().optional(),
+    ended_at: isA.alternatives(isA.number(), isA.any().valid(null)),
     items: isA
-      .array()
-      .items(module.exports.subscriptionsStripeSubscriptionItemValidator)
-      .required(),
+      .object({
+        data: isA
+          .array()
+          .items(module.exports.subscriptionsStripeSubscriptionItemValidator)
+          .required(),
+      })
+      .unknown(true)
+      .optional(),
     latest_invoice: isA
       .alternatives(
         isA.string(),
@@ -497,14 +502,7 @@ module.exports.subscriptionsStripeCustomerValidator = isA
       .object({
         default_payment_method: isA.string().optional(),
       })
-      .optional(),
-    sources: isA
-      .object({
-        data: isA
-          .array()
-          .items(module.exports.subscriptionsStripeSourceValidator)
-          .required(),
-      })
+      .unknown(true)
       .optional(),
     subscriptions: isA
       .object({
@@ -513,6 +511,7 @@ module.exports.subscriptionsStripeCustomerValidator = isA
           .items(module.exports.subscriptionsStripeSubscriptionValidator)
           .required(),
       })
+      .unknown(true)
       .optional(),
   })
   .unknown(true);

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -450,4 +450,131 @@ describe('lib/routes/validators:', () => {
       assert.ok(res.error);
     });
   });
+
+  describe('subscriptionsStripeSubscriptionValidator', () => {
+    const { subscriptionsStripeSubscriptionValidator: subject } = validators;
+
+    it('accepts an example of a real API response', () => {
+      const data = {
+        cancel_at_period_end: false,
+        cancel_at: null,
+        canceled_at: null,
+        created: 1594252774,
+        current_period_end: 1596931174,
+        current_period_start: 1594252774,
+        ended_at: null,
+        id: 'sub_Hc1Db1g9PoNzbO',
+        items: {
+          object: 'list',
+          data: [
+            {
+              id: 'si_Hc1DlRa7cZ8vKi',
+              created: 1594252775,
+              price: {
+                id: 'plan_GqM9N6qyhvxaVk',
+                active: true,
+                currency: 'usd',
+                metadata: {},
+                nickname: '123Done Pro Monthly',
+                product: 'prod_GqM9ToKK62qjkK',
+                recurring: {
+                  aggregate_usage: null,
+                  interval: 'month',
+                  interval_count: 1,
+                  trial_period_days: null,
+                  usage_type: 'licensed',
+                },
+                type: 'recurring',
+                unit_amount: 500,
+              },
+            },
+          ],
+          has_more: false,
+          total_count: 1,
+          url: '/v1/subscription_items?subscription=sub_Hc1Db1g9PoNzbO',
+        },
+        latest_invoice: {
+          id: 'in_1H2nApBVqmGyQTMaxm1us1tb',
+          object: 'invoice',
+          payment_intent: {
+            client_secret:
+              'pi_1H2nApBVqmGyQTMaAcsgHdKO_secret_TgEwGsXmcoUH9N8VKyZtOCJxz',
+            created: 1594252775,
+            next_action: {
+              type: 'use_stripe_sdk',
+              use_stripe_sdk: {
+                type: 'three_d_secure_redirect',
+                stripe_js:
+                  'https://hooks.stripe.com/redirect/authenticate/src_1H2nApBVqmGyQTMa1G8pPh9n?client_secret=src_client_secret_0KDP3B9a31NxRRsvwLGm12FT',
+                source: 'src_1H2nApBVqmGyQTMa1G8pPh9n',
+                known_frame_issues: 'false',
+              },
+            },
+            payment_method: 'pm_1H2nAmBVqmGyQTMaEyrNdTGF',
+            status: 'requires_action',
+          },
+        },
+        status: 'incomplete',
+      };
+      const res = subject.validate(data);
+      assert.ok(!res.error);
+    });
+  });
+
+  describe('subscriptionsStripeCustomerValidator', () => {
+    const { subscriptionsStripeCustomerValidator: subject } = validators;
+
+    it('accepts an example of a real API response', () => {
+      const data = {
+        id: 'cus_Hc0e7ojp2976b1',
+        object: 'customer',
+        address: null,
+        balance: 0,
+        created: 1594250683,
+        currency: null,
+        default_source: null,
+        delinquent: false,
+        description: 'fab69542c8ec48d9b9f0366a8f093208',
+        discount: null,
+        email: 'foo@example.com',
+        invoice_prefix: '3ED99BDD',
+        invoice_settings: {
+          custom_fields: null,
+          default_payment_method: null,
+          footer: null,
+        },
+        livemode: false,
+        metadata: { userid: 'fab69542c8ec48d9b9f0366a8f093208' },
+        name: 'ytfytf',
+        next_invoice_sequence: 1,
+        phone: null,
+        preferred_locales: [],
+        shipping: null,
+        sources: {
+          object: 'list',
+          data: [],
+          has_more: false,
+          total_count: 0,
+          url: '/v1/customers/cus_Hc0e7ojp2976b1/sources',
+        },
+        subscriptions: {
+          object: 'list',
+          data: [],
+          has_more: false,
+          total_count: 0,
+          url: '/v1/customers/cus_Hc0e7ojp2976b1/subscriptions',
+        },
+        tax_exempt: 'none',
+        tax_ids: {
+          object: 'list',
+          data: [],
+          has_more: false,
+          total_count: 0,
+          url: '/v1/customers/cus_Hc0e7ojp2976b1/tax_ids',
+        },
+      };
+      const res = subject.validate(data);
+      assert.ok(!res.error);
+    });
+  });
 });

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -22,6 +22,7 @@ import * as FlowEvents from './lib/flow-event';
 import { observeNavigationTiming } from './lib/navigation-timing';
 
 const Product = React.lazy(() => import('./routes/Product'));
+const ProductV2 = React.lazy(() => import('./routes/ProductV2'));
 const Subscriptions = React.lazy(() => import('./routes/Subscriptions'));
 
 // TODO: Come up with a better fallback component for lazy-loaded routes
@@ -99,6 +100,14 @@ export const App = ({
                         render={(props) => (
                           <SignInLayout>
                             <Product {...props} />
+                          </SignInLayout>
+                        )}
+                      />
+                      <Route
+                        path="/v2/products/:productId"
+                        render={(props) => (
+                          <SignInLayout>
+                            <ProductV2 {...props} />
                           </SignInLayout>
                         )}
                       />

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -51,7 +51,10 @@ export const PaymentConfirmation = ({
   );
 
   return (
-    <section className={`container card payment-confirmation ${className}`}>
+    <section
+      className={`container card payment-confirmation ${className}`}
+      data-testid="payment-confirmation"
+    >
       <header>
         <img src={circledCheckbox} alt="circled checkbox" />
         {heading}
@@ -98,9 +101,11 @@ export const PaymentConfirmation = ({
           >
             <p>{planPrice}</p>
           </Localized>
-          <Localized id="payment-confirmation-cc-preview" $last4={last4}>
-            <p className={`c-card ${brand.toLowerCase()}`}></p>
-          </Localized>
+          {last4 && brand && (
+            <Localized id="payment-confirmation-cc-preview" $last4={last4}>
+              <p className={`c-card ${brand.toLowerCase()}`}></p>
+            </Localized>
+          )}
         </div>
       </div>
 

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.stories.tsx
@@ -4,7 +4,7 @@ import { TermsAndPrivacy } from './index';
 import { defaultAppContext, AppContext } from '../../lib/AppContext';
 import { SELECTED_PLAN } from '../../lib/mock-data';
 
-storiesOf('TermsAndPrivacy', module)
+storiesOf('components/TermsAndPrivacy', module)
   .add('default locale', () => <TermsAndPrivacy plan={SELECTED_PLAN} />)
   .add('with fr locale', () => (
     <AppContext.Provider

--- a/packages/fxa-payments-server/src/components/fields/index.tsx
+++ b/packages/fxa-payments-server/src/components/fields/index.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import { withLocalization } from '@fluent/react';
 import { ReactStripeElements } from 'react-stripe-elements';
+import { CardElementProps } from '@stripe/react-stripe-js';
 import classNames from 'classnames';
 import { Validator, FieldType } from '../../lib/validator';
 import Tooltip from '../Tooltip';
@@ -47,7 +48,6 @@ type FieldProps = {
   maxLength?: number;
   minLength?: number;
   autoFocus?: boolean;
-  options?: object;
 };
 
 type FieldHOCProps = {
@@ -213,11 +213,6 @@ const UnwrappedInput = (props: InputProps) => {
 
 export const Input = withLocalization(UnwrappedInput);
 
-type StripeElementProps = { onValidate?: OnValidateFunction } & FieldProps & {
-    component: any;
-    getString: Function | undefined;
-  } & ReactStripeElements.ElementProps;
-
 export const defaultStripeElementValidator: OnValidateFunction = (
   value,
   focused,
@@ -252,7 +247,21 @@ export const defaultStripeElementValidator: OnValidateFunction = (
   };
 };
 
-export const StripeElement = (props: StripeElementProps) => {
+type StripeElementWrapperProps = FieldProps & {
+  onValidate?: OnValidateFunction;
+  component: any;
+  getString?: Function;
+};
+// TODO: This type can go away once we replace PaymentForm with PaymentFormV2
+// and stop using the old Stripe component library
+type OldReactStripeElementProps = StripeElementWrapperProps &
+  ReactStripeElements.ElementProps;
+type NewReactStripeElementProps = StripeElementWrapperProps & CardElementProps;
+type WrappedStripeElementProps =
+  | OldReactStripeElementProps
+  | NewReactStripeElementProps;
+
+export const StripeElement = (props: WrappedStripeElementProps) => {
   const {
     component: StripeElementComponent,
     name,
@@ -263,7 +272,6 @@ export const StripeElement = (props: StripeElementProps) => {
     className,
     autoFocus,
     getString,
-    options = {},
     ...childProps
   } = props;
   const { validator } = useContext(FormContext) as FormContextValue;
@@ -308,7 +316,6 @@ export const StripeElement = (props: StripeElementProps) => {
         <StripeElementComponent
           {...{
             ...childProps,
-            options,
             onChange,
             onBlur,
           }}

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -257,3 +257,55 @@ export async function apiUpdatePayment(params: {
     throw error;
   }
 }
+
+export async function apiCreateCustomer(params: {
+  displayName: string;
+  idempotencyKey: string;
+}): Promise<Customer> {
+  return apiFetch(
+    'POST',
+    `${config.servers.auth.url}/v1/oauth/subscriptions/customer`,
+    { body: JSON.stringify(params) }
+  );
+}
+
+export async function apiCreateSubscriptionWithPaymentMethod(params: {
+  priceId: string;
+  paymentMethodId: string;
+  idempotencyKey: string;
+}): Promise<{
+  id: string;
+  latest_invoice: {
+    id: string;
+    payment_intent: {
+      id: string;
+      client_secret: string;
+      status: string;
+    };
+  };
+}> {
+  return apiFetch(
+    'POST',
+    `${config.servers.auth.url}/v1/oauth/subscriptions/active/new`,
+    { body: JSON.stringify(params) }
+  );
+}
+
+export async function apiRetryInvoice(params: {
+  invoiceId: string;
+  paymentMethodId: string;
+  idempotencyKey: string;
+}): Promise<{
+  id: string;
+  payment_intent: {
+    id: string;
+    client_secret: string;
+    status: string;
+  };
+}> {
+  return apiFetch(
+    'POST',
+    `${config.servers.auth.url}/v1/oauth/subscriptions/invoice/retry`,
+    { body: JSON.stringify(params) }
+  );
+}

--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -15,6 +15,7 @@ const AuthServerErrno = {
  * - handle Payment token not valid
  */
 
+const CARD_ERROR = 'card-error';
 const BASIC_ERROR = 'basic-error-message';
 const PAYMENT_ERROR_1 = 'payment-error-1';
 const PAYMENT_ERROR_2 = 'payment-error-2';
@@ -30,6 +31,8 @@ let errorMessageIndex: { [key: string]: string } = {
   card_error: 'card-error',
   // todo: handle "parameters_exclusive": "Your already subscribed to _product_"
 };
+
+const cardErrors = ['card_declined', 'incorrect_cvc'];
 
 const basicErrors = [
   'api_key_expired',
@@ -104,6 +107,7 @@ const paymentErrors2 = [
   'transaction_not_allowed',
 ];
 
+cardErrors.forEach((k) => (errorMessageIndex[k] = CARD_ERROR));
 basicErrors.forEach((k) => (errorMessageIndex[k] = BASIC_ERROR));
 paymentErrors1.forEach((k) => (errorMessageIndex[k] = PAYMENT_ERROR_1));
 paymentErrors2.forEach((k) => (errorMessageIndex[k] = PAYMENT_ERROR_2));

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -88,3 +88,25 @@ export const UPGRADE_FROM_PLAN: Plan = {
     'product:details:3:xx-pirate': "Connects 5 devices wit' one subscription",
   },
 };
+
+export const PLAN = {
+  plan_id: 'plan_456',
+  product_id: PRODUCT_ID,
+  product_name: 'Example Product',
+  currency: 'USD',
+  amount: 1050,
+  interval: 'month' as const,
+  interval_count: 1,
+  product_metadata: {
+    webIconURL: 'http://placekitten.com/512/512',
+    'product:subtitle': 'Really keen product',
+    'product:details:1':
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit',
+    'product:details:2': 'Sed ut perspiciatis unde omnis iste natus',
+    'product:details:3': 'Nemo enim ipsam voluptatem',
+    'product:details:4':
+      'Ut enim ad minima veniam, quis nostrum exercitationem',
+  },
+};
+
+export const PLANS: Plan[] = [PLAN, UPGRADE_FROM_PLAN, SELECTED_PLAN];

--- a/packages/fxa-payments-server/src/lib/types.tsx
+++ b/packages/fxa-payments-server/src/lib/types.tsx
@@ -20,3 +20,6 @@ export type FunctionWithIgnoredReturn<T extends (...args: any) => any> = (
 ) => unknown;
 
 export type PromiseResolved<T> = T extends Promise<infer U> ? U : T;
+
+export type PickPartial<T, K extends keyof T> = Omit<T, K> &
+  Partial<Pick<T, K>>;

--- a/packages/fxa-payments-server/src/routes/Product/AcceptedCards/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/AcceptedCards/index.stories.tsx
@@ -2,4 +2,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { AcceptedCards } from './index';
 
-storiesOf('AcceptedCards', module).add('default', () => <AcceptedCards />);
+storiesOf('routes/Product/AcceptedCards', module).add('default', () => (
+  <AcceptedCards />
+));

--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -17,14 +17,10 @@ import waitForExpect from 'wait-for-expect';
 import { getErrorMessage, PAYMENT_ERROR_2 } from '../../lib/errors';
 import {
   STRIPE_FIELDS,
-  PLAN_ID,
-  PRODUCT_NAME,
   PRODUCT_ID,
   PRODUCT_REDIRECT_URLS,
   MOCK_PLANS,
   MOCK_PROFILE,
-  MOCK_ACTIVE_SUBSCRIPTIONS,
-  MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION,
   MOCK_CUSTOMER,
   MOCK_CUSTOMER_AFTER_SUBSCRIPTION,
   expectNockScopesDone,

--- a/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.stories.tsx
@@ -1,0 +1,263 @@
+import React from 'react';
+import {
+  Stripe,
+  StripeCardElement,
+  StripeError,
+  PaymentMethod,
+  PaymentIntent,
+} from '@stripe/stripe-js';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { linkTo } from '@storybook/addon-links';
+import MockApp, {
+  defaultAppContextValue,
+} from '../../../../.storybook/components/MockApp';
+import { CUSTOMER, PROFILE, PLAN } from '../../../lib/mock-data';
+import { APIError } from '../../../lib/apiClient';
+import { PickPartial } from '../../../lib/types';
+import { SignInLayout } from '../../../components/AppLayout';
+import SubscriptionCreate, { SubscriptionCreateProps } from './index';
+
+// TODO: Move to some shared lib?
+const deepCopy = (object: Object) => JSON.parse(JSON.stringify(object));
+
+// TODO: Move to some shared lib?
+const wait = (delay: number) =>
+  new Promise((resolve) => setTimeout(resolve, delay));
+
+function init() {
+  storiesOf('routes/ProductV2/SubscriptionCreate', module)
+    .add('default', () => <Subject />)
+    .add('with retry', () => (
+      <Subject
+        apiClientOverrides={{
+          ...defaultApiClientOverrides,
+          apiCreateSubscriptionWithPaymentMethod: async () => {
+            const result = deepCopy(SUBSCRIPTION_RESULT);
+            result.latest_invoice.payment_intent.status =
+              'requires_payment_method';
+            return result;
+          },
+        }}
+      />
+    ))
+    .add('with confirmation', () => (
+      <Subject
+        apiClientOverrides={{
+          ...defaultApiClientOverrides,
+          apiCreateSubscriptionWithPaymentMethod: async () => {
+            const result = deepCopy(SUBSCRIPTION_RESULT);
+            result.latest_invoice.payment_intent.status = 'requires_action';
+            return result;
+          },
+        }}
+        stripeOverride={{
+          ...defaultStripeOverride,
+          confirmCardPayment: async () => {
+            const didConfirm = window.confirm(
+              'Pretend to authenticate with bank for payment?'
+            );
+            return {
+              paymentIntent: {
+                status: didConfirm ? 'succeeded' : 'requires_payment_method',
+              } as PaymentIntent,
+            };
+          },
+        }}
+      />
+    ));
+
+  storiesOf('routes/ProductV2/SubscriptionCreate/failures', module)
+    .add('createPaymentMethod', () => (
+      <Subject
+        stripeOverride={{
+          ...defaultStripeOverride,
+          createPaymentMethod: async () => {
+            throw 'barf';
+          },
+        }}
+      />
+    ))
+    .add('confirmCardPayment', () => (
+      <Subject
+        apiClientOverrides={{
+          ...defaultApiClientOverrides,
+          apiCreateSubscriptionWithPaymentMethod: async () => {
+            const result = deepCopy(SUBSCRIPTION_RESULT);
+            result.latest_invoice.payment_intent.status = 'requires_action';
+            return result;
+          },
+        }}
+        stripeOverride={{
+          ...defaultStripeOverride,
+          confirmCardPayment: async () => {
+            throw 'barf';
+          },
+        }}
+      />
+    ))
+    .add('apiCreateSubscriptionWithPaymentMethod', () => (
+      <Subject
+        apiClientOverrides={{
+          apiCreateSubscriptionWithPaymentMethod: async () => {
+            throw new APIError({
+              statusCode: 500,
+              message: 'Internal Server Error: Subscription creation failed',
+            });
+          },
+        }}
+      />
+    ))
+    .add('apiCreateCustomer', () => (
+      <Subject
+        customer={null}
+        apiClientOverrides={{
+          apiCreateCustomer: async () => {
+            throw new APIError({
+              statusCode: 500,
+              message: 'Internal Server Error: Customer creation failed',
+            });
+          },
+        }}
+      />
+    ))
+    .add('apiRetryInvoice', () => (
+      <Subject
+        apiClientOverrides={{
+          apiCreateSubscriptionWithPaymentMethod: async () => {
+            const result = deepCopy(SUBSCRIPTION_RESULT);
+            result.latest_invoice.payment_intent.status =
+              'requires_payment_method';
+            return result;
+          },
+          apiRetryInvoice: async () => {
+            throw new APIError({
+              statusCode: 500,
+              message: 'Internal Server Error: Customer creation failed',
+            });
+          },
+        }}
+      />
+    ));
+
+  storiesOf('routes/ProductV2/SubscriptionCreate/errors', module)
+    .add('card declined', () => (
+      <Subject
+        paymentErrorInitialState={{
+          type: 'card_error',
+          code: 'card_declined',
+          message: 'Done goofed!', // should not be displayed
+        }}
+      />
+    ))
+    .add('incorrect cvc', () => (
+      <Subject
+        paymentErrorInitialState={{
+          type: 'card_error',
+          code: 'incorrect_cvc',
+          message: 'Done goofed!', // should not be displayed
+        }}
+      />
+    ))
+    .add('card expired', () => (
+      <Subject
+        paymentErrorInitialState={{
+          type: 'card_error',
+          code: 'expired_card',
+          message: 'Your card has expired.',
+        }}
+      />
+    ))
+    .add('other error', () => (
+      <Subject
+        paymentErrorInitialState={{
+          type: 'api_error',
+        }}
+      />
+    ));
+}
+
+const Subject = ({
+  isMobile = false,
+  customer = CUSTOMER,
+  profile = PROFILE,
+  selectedPlan = PLAN,
+  apiClientOverrides = defaultApiClientOverrides,
+  stripeOverride = defaultStripeOverride,
+  refreshSubscriptions = linkTo('routes/Product', 'success'),
+  ...props
+}: PickPartial<
+  SubscriptionCreateProps,
+  'isMobile' | 'profile' | 'customer' | 'selectedPlan' | 'refreshSubscriptions'
+>) => {
+  return (
+    <MockApp
+      appContextValue={{
+        ...defaultAppContextValue,
+      }}
+    >
+      <SignInLayout>
+        <SubscriptionCreate
+          {...{
+            isMobile,
+            profile,
+            customer,
+            selectedPlan,
+            refreshSubscriptions,
+            apiClientOverrides,
+            stripeOverride,
+            ...props,
+          }}
+        />
+      </SignInLayout>
+    </MockApp>
+  );
+};
+
+const SUBSCRIPTION_RESULT = {
+  id: 'sub_1234',
+  latest_invoice: {
+    id: 'invoice_5678',
+    payment_intent: {
+      id: 'pi_7890',
+      client_secret: 'cs_abcd',
+      status: 'succeeded',
+    },
+  },
+};
+
+const RETRY_INVOICE_RESULT = {
+  id: 'invoice_5678',
+  payment_intent: {
+    id: 'pi_9876',
+    client_secret: 'cs_erty',
+    status: 'succeeded',
+  },
+};
+
+const defaultApiClientOverrides = {
+  apiCreateCustomer: async () => CUSTOMER,
+  apiCreateSubscriptionWithPaymentMethod: async () => SUBSCRIPTION_RESULT,
+  apiRetryInvoice: async () => RETRY_INVOICE_RESULT,
+};
+
+const defaultStripeOverride: Pick<
+  Stripe,
+  'createPaymentMethod' | 'confirmCardPayment'
+> = {
+  createPaymentMethod: async () => {
+    await wait(500);
+    return {
+      paymentMethod: { id: 'pm_4567' } as PaymentMethod,
+      error: undefined,
+    };
+  },
+  confirmCardPayment: async () => {
+    return {
+      paymentIntent: { status: 'succeeded' } as PaymentIntent,
+      error: undefined,
+    };
+  },
+};
+
+init();

--- a/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.test.tsx
@@ -1,0 +1,633 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import {
+  screen,
+  render,
+  cleanup,
+  act,
+  fireEvent,
+  wait,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { PaymentMethod, PaymentIntent } from '@stripe/stripe-js';
+import { SignInLayout } from '../../../components/AppLayout';
+import { CUSTOMER, PROFILE, PLAN } from '../../../lib/mock-data';
+import { PickPartial } from '../../../lib/types';
+
+import {
+  defaultAppContextValue,
+  MockApp,
+  mockStripeElementOnChangeFns,
+  elementChangeResponse,
+} from '../../../lib/test-utils';
+
+import waitForExpect from 'wait-for-expect';
+
+import SubscriptionCreate, { SubscriptionCreateProps } from './index';
+
+// TODO: Move to some shared lib?
+const deepCopy = (object: Object) => JSON.parse(JSON.stringify(object));
+
+type SubjectProps = PickPartial<
+  SubscriptionCreateProps,
+  'isMobile' | 'profile' | 'customer' | 'selectedPlan' | 'refreshSubscriptions'
+>;
+
+const Subject = ({
+  isMobile = false,
+  customer = CUSTOMER,
+  profile = PROFILE,
+  selectedPlan = PLAN,
+  apiClientOverrides = defaultApiClientOverrides(),
+  stripeOverride = defaultStripeOverride(),
+  refreshSubscriptions = jest.fn(),
+  ...props
+}: SubjectProps) => {
+  return (
+    <MockApp
+      appContextValue={{
+        ...defaultAppContextValue(),
+      }}
+    >
+      <SignInLayout>
+        <SubscriptionCreate
+          {...{
+            isMobile,
+            profile,
+            customer,
+            selectedPlan,
+            refreshSubscriptions,
+            apiClientOverrides,
+            stripeOverride,
+            ...props,
+          }}
+        />
+      </SignInLayout>
+    </MockApp>
+  );
+};
+
+const SUBSCRIPTION_RESULT = {
+  id: 'sub_1234',
+  latest_invoice: {
+    id: 'invoice_5678',
+    payment_intent: {
+      id: 'pi_7890',
+      client_secret: 'cs_abcd',
+      status: 'succeeded',
+    },
+  },
+};
+
+const RETRY_INVOICE_RESULT = {
+  id: 'invoice_5678',
+  payment_intent: {
+    id: 'pi_9876',
+    client_secret: 'cs_erty',
+    status: 'succeeded',
+  },
+};
+
+const defaultApiClientOverrides = () => ({
+  apiCreateCustomer: jest.fn().mockResolvedValue(CUSTOMER),
+  apiCreateSubscriptionWithPaymentMethod: jest
+    .fn()
+    .mockResolvedValue(SUBSCRIPTION_RESULT),
+  apiRetryInvoice: jest.fn().mockResolvedValue(RETRY_INVOICE_RESULT),
+});
+
+const PAYMENT_METHOD_RESULT = {
+  paymentMethod: { id: 'pm_4567' } as PaymentMethod,
+  error: undefined,
+};
+
+const CONFIRM_CARD_RESULT = {
+  paymentIntent: { status: 'succeeded' } as PaymentIntent,
+  error: undefined,
+};
+
+const defaultStripeOverride = () => ({
+  createPaymentMethod: jest.fn().mockResolvedValue(PAYMENT_METHOD_RESULT),
+  confirmCardPayment: jest.fn().mockResolvedValue(CONFIRM_CARD_RESULT),
+});
+
+describe('routes/ProductV2/SubscriptionCreate', () => {
+  let consoleSpy: jest.SpyInstance<void, [any?, ...any[]]>;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    if (consoleSpy) consoleSpy.mockRestore();
+    return cleanup();
+  });
+
+  it('renders as expected', async () => {
+    render(<Subject />);
+    const {
+      findAllByText,
+      queryByTestId,
+      queryByText,
+      queryAllByText,
+    } = screen;
+    expect(queryByTestId('subscription-create')).toBeInTheDocument();
+    await findAllByText('Set up your subscription');
+    expect(
+      queryAllByText('30-day money-back guarantee')[0]
+    ).toBeInTheDocument();
+    expect(queryByText('Billing Information')).toBeInTheDocument();
+  });
+
+  it('renders as expected for mobile', async () => {
+    render(<Subject isMobile={true} />);
+    expect(screen.queryByTestId('subscription-create')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('mobile-subscription-create-heading')
+    ).toBeInTheDocument();
+  });
+
+  async function commonSubmitSetup({
+    apiClientOverrides = defaultApiClientOverrides(),
+    stripeOverride = defaultStripeOverride(),
+    refreshSubscriptions = jest.fn(),
+    ...props
+  }) {
+    render(
+      <Subject
+        {...{
+          apiClientOverrides,
+          stripeOverride,
+          refreshSubscriptions,
+          ...props,
+        }}
+      />
+    );
+
+    expect(screen.queryByTestId('subscription-create')).toBeInTheDocument();
+    await screen.findAllByText('Set up your subscription');
+
+    await act(async () => {
+      mockStripeElementOnChangeFns.cardElement(
+        elementChangeResponse({ complete: true, value: 'test' })
+      );
+    });
+
+    fireEvent.change(screen.getByTestId('name'), {
+      target: { value: 'Foo Barson' },
+    });
+    fireEvent.blur(screen.getByTestId('name'));
+    fireEvent.click(screen.getByTestId('confirm'));
+
+    return {
+      apiClientOverrides,
+      stripeOverride,
+      refreshSubscriptions,
+    };
+  }
+
+  const commonPaymentSubmissionTest = (
+    withCustomer: boolean = false
+  ) => async () => {
+    const {
+      apiClientOverrides,
+      stripeOverride,
+      refreshSubscriptions,
+    } = await commonSubmitSetup({
+      customer: withCustomer ? CUSTOMER : null,
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('submit'));
+    });
+    await waitForExpect(() =>
+      expect(refreshSubscriptions).toHaveBeenCalledTimes(1)
+    );
+    expect(stripeOverride.createPaymentMethod).toHaveBeenCalled();
+    expect(apiClientOverrides.apiCreateCustomer).toHaveBeenCalledTimes(
+      withCustomer ? 0 : 1
+    );
+    expect(
+      apiClientOverrides.apiCreateSubscriptionWithPaymentMethod.mock.calls[0][0]
+    ).toMatchObject({
+      // idempotencyKey (ignored)
+      priceId: PLAN.plan_id,
+      paymentMethodId: PAYMENT_METHOD_RESULT.paymentMethod.id,
+    });
+  };
+
+  const commonRetryPaymentTest = ({
+    shouldSucceed = true as boolean,
+    apiRetryInvoice = defaultApiClientOverrides().apiRetryInvoice,
+  } = {}) => async () => {
+    const subscriptionResult = deepCopy(SUBSCRIPTION_RESULT);
+    subscriptionResult.latest_invoice.payment_intent.status =
+      'requires_payment_method';
+    const initialPaymentMethod = {
+      paymentMethod: { id: 'pm_initial' } as PaymentMethod,
+      error: undefined,
+    };
+    const retryPaymentMethod = {
+      paymentMethod: { id: 'pm_retry' } as PaymentMethod,
+      error: undefined,
+    };
+
+    const apiClientOverrides = {
+      ...defaultApiClientOverrides(),
+      apiRetryInvoice,
+      apiCreateSubscriptionWithPaymentMethod: jest
+        .fn()
+        .mockResolvedValue(subscriptionResult),
+    };
+
+    const stripeOverride = {
+      ...defaultStripeOverride(),
+      createPaymentMethod: jest
+        .fn()
+        .mockResolvedValueOnce(initialPaymentMethod)
+        .mockResolvedValueOnce(retryPaymentMethod),
+    };
+    const { refreshSubscriptions } = await commonSubmitSetup({
+      apiClientOverrides,
+      stripeOverride,
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('submit'));
+    });
+
+    await waitForExpect(() =>
+      expect(
+        apiClientOverrides.apiCreateSubscriptionWithPaymentMethod.mock
+          .calls[0][0]
+      ).toMatchObject({
+        // idempotencyKey (ignored)
+        priceId: PLAN.plan_id,
+        paymentMethodId: initialPaymentMethod.paymentMethod.id,
+      })
+    );
+    expect(
+      screen.queryByTestId('error-payment-submission')
+    ).toBeInTheDocument();
+    expect(refreshSubscriptions).toHaveBeenCalledTimes(0);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('submit'));
+    });
+    expect(apiClientOverrides.apiRetryInvoice.mock.calls[0][0]).toMatchObject({
+      // idempotencyKey (ignored)
+      invoiceId: subscriptionResult.latest_invoice.id,
+      paymentMethodId: retryPaymentMethod.paymentMethod.id,
+    });
+
+    if (shouldSucceed) {
+      await waitForExpect(() =>
+        expect(refreshSubscriptions).toHaveBeenCalledTimes(1)
+      );
+    } else {
+      expect(
+        screen.queryByTestId('error-payment-submission')
+      ).toBeInTheDocument();
+      expect(refreshSubscriptions).toHaveBeenCalledTimes(0);
+    }
+  };
+
+  const commonConfirmPaymentTest = ({
+    shouldSucceed = true as boolean,
+    confirmCardPayment = defaultStripeOverride().confirmCardPayment,
+  } = {}) => async () => {
+    const subscriptionResult = deepCopy(SUBSCRIPTION_RESULT);
+    subscriptionResult.latest_invoice.payment_intent.status = 'requires_action';
+
+    const apiClientOverrides = {
+      ...defaultApiClientOverrides(),
+      apiCreateSubscriptionWithPaymentMethod: jest
+        .fn()
+        .mockResolvedValue(subscriptionResult),
+    };
+    const stripeOverride = {
+      ...defaultStripeOverride(),
+      confirmCardPayment,
+    };
+    const { refreshSubscriptions } = await commonSubmitSetup({
+      apiClientOverrides,
+      stripeOverride,
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('submit'));
+    });
+
+    await waitForExpect(() =>
+      expect(
+        apiClientOverrides.apiCreateSubscriptionWithPaymentMethod.mock
+          .calls[0][0]
+      ).toMatchObject({
+        // idempotencyKey (ignored)
+        priceId: PLAN.plan_id,
+        paymentMethodId: PAYMENT_METHOD_RESULT.paymentMethod.id,
+      })
+    );
+
+    await waitForExpect(() =>
+      expect(
+        stripeOverride.confirmCardPayment
+      ).toHaveBeenCalledWith(
+        subscriptionResult.latest_invoice.payment_intent.client_secret,
+        { payment_method: PAYMENT_METHOD_RESULT.paymentMethod.id }
+      )
+    );
+
+    if (shouldSucceed) {
+      await waitForExpect(() =>
+        expect(refreshSubscriptions).toHaveBeenCalledTimes(1)
+      );
+    } else {
+      expect(
+        screen.queryByTestId('error-payment-submission')
+      ).toBeInTheDocument();
+      expect(refreshSubscriptions).toHaveBeenCalledTimes(0);
+    }
+  };
+
+  it(
+    'handles a successful payment submission as new customer',
+    commonPaymentSubmissionTest(false)
+  );
+  it(
+    'handles a successful payment submission as existing customer',
+    commonPaymentSubmissionTest(true)
+  );
+
+  it(
+    'handles a payment submission that requires a retry',
+    commonRetryPaymentTest()
+  );
+
+  it(
+    'handles a payment submission that requires user action (confirmed)',
+    commonConfirmPaymentTest()
+  );
+
+  it(
+    'handles a payment submission that requires user action (rejected)',
+    commonConfirmPaymentTest({
+      shouldSucceed: false,
+      confirmCardPayment: jest.fn().mockResolvedValue({
+        paymentIntent: undefined,
+        error: 'rejected',
+      }),
+    })
+  );
+
+  it(
+    'displays an error of card confirmation is missing payment intent',
+    commonConfirmPaymentTest({
+      shouldSucceed: false,
+      confirmCardPayment: jest.fn().mockResolvedValue({
+        paymentIntent: undefined,
+        error: undefined,
+      }),
+    })
+  );
+
+  const commonCreateSubscriptionFailureTest = (
+    error = 'barf apiCreateSubscriptionWithPaymentMethod' as any
+  ) => async () => {
+    const apiClientOverrides = {
+      ...defaultApiClientOverrides(),
+      apiCreateSubscriptionWithPaymentMethod: jest
+        .fn()
+        .mockRejectedValue(error),
+    };
+    const { stripeOverride, refreshSubscriptions } = await commonSubmitSetup({
+      apiClientOverrides,
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('submit'));
+    });
+    expect(
+      apiClientOverrides.apiCreateSubscriptionWithPaymentMethod
+    ).toHaveBeenCalled();
+    expect(
+      screen.queryByTestId('error-payment-submission')
+    ).toBeInTheDocument();
+    expect(refreshSubscriptions).toHaveBeenCalledTimes(0);
+  };
+
+  it('clears the displayed error if the form changes', async () => {
+    const commonSetup = commonCreateSubscriptionFailureTest();
+    await commonSetup();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('confirm'));
+    });
+    await waitForExpect(() =>
+      expect(
+        screen.queryByTestId('error-payment-submission')
+      ).not.toBeInTheDocument()
+    );
+  });
+
+  describe('failures', () => {
+    it('displays confirmCardPayment failure', async () => {
+      commonConfirmPaymentTest({
+        shouldSucceed: false,
+        confirmCardPayment: jest
+          .fn()
+          .mockRejectedValue('barf confirmCardPayment'),
+      });
+    });
+
+    it(
+      'displays apiRetryInvoice failure',
+      commonRetryPaymentTest({
+        shouldSucceed: false,
+        apiRetryInvoice: jest.fn().mockRejectedValue('barf apiRetryInvoice'),
+      })
+    );
+
+    it(
+      'displays apiCreateSubscriptionWithPaymentMethod failure',
+      commonCreateSubscriptionFailureTest()
+    );
+
+    const commonCreatePaymentMethodFailureTest = ({
+      createPaymentMethod = jest
+        .fn()
+        .mockRejectedValue('barf createPaymentMethod'),
+    } = {}) => async () => {
+      const stripeOverride = {
+        ...defaultStripeOverride(),
+        createPaymentMethod,
+      };
+      const {
+        apiClientOverrides,
+        refreshSubscriptions,
+      } = await commonSubmitSetup({
+        stripeOverride,
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('submit'));
+      });
+      expect(stripeOverride.createPaymentMethod).toHaveBeenCalled();
+      expect(
+        screen.queryByTestId('error-payment-submission')
+      ).toBeInTheDocument();
+      expect(refreshSubscriptions).toHaveBeenCalledTimes(0);
+    };
+
+    it(
+      'displays createPaymentMethod failure (exception)',
+      commonCreatePaymentMethodFailureTest()
+    );
+
+    it(
+      'displays createPaymentMethod failure (error)',
+      commonCreatePaymentMethodFailureTest({
+        createPaymentMethod: jest.fn().mockResolvedValue({ error: 'barf' }),
+      })
+    );
+
+    it(
+      'displays createPaymentMethod failure (missing PaymentMethod)',
+      commonCreatePaymentMethodFailureTest({
+        createPaymentMethod: jest
+          .fn()
+          .mockResolvedValue({ error: false, paymentMethod: null }),
+      })
+    );
+
+    it('displays apiCreateCustomer failure', async () => {
+      const apiClientOverrides = {
+        ...defaultApiClientOverrides(),
+        apiCreateCustomer: jest
+          .fn()
+          .mockRejectedValue('barf apiCreateCustomer'),
+      };
+      const { refreshSubscriptions } = await commonSubmitSetup({
+        customer: null,
+        apiClientOverrides,
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('submit'));
+      });
+      expect(apiClientOverrides.apiCreateCustomer).toHaveBeenCalled();
+      expect(
+        screen.queryByTestId('error-payment-submission')
+      ).toBeInTheDocument();
+      expect(refreshSubscriptions).toHaveBeenCalledTimes(0);
+    });
+
+    it('displays for unexpected payment intent status', async () => {
+      const subscriptionResult = deepCopy(SUBSCRIPTION_RESULT);
+      subscriptionResult.latest_invoice.payment_intent.status =
+        'banana_deck_chair';
+      const apiClientOverrides = {
+        ...defaultApiClientOverrides(),
+        apiCreateSubscriptionWithPaymentMethod: jest
+          .fn()
+          .mockResolvedValue(subscriptionResult),
+      };
+      const { refreshSubscriptions } = await commonSubmitSetup({
+        apiClientOverrides,
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('submit'));
+      });
+      await waitForExpect(() =>
+        expect(
+          apiClientOverrides.apiCreateSubscriptionWithPaymentMethod
+        ).toHaveBeenCalled()
+      );
+      expect(
+        screen.queryByTestId('error-payment-submission')
+      ).toBeInTheDocument();
+      expect(refreshSubscriptions).toHaveBeenCalledTimes(0);
+    });
+
+    it('displays if client secret is missing from payment intent', async () => {
+      const subscriptionResult = deepCopy(SUBSCRIPTION_RESULT);
+      subscriptionResult.latest_invoice.payment_intent.status =
+        'requires_action';
+      subscriptionResult.latest_invoice.payment_intent.client_secret = null;
+
+      const apiClientOverrides = {
+        ...defaultApiClientOverrides(),
+        apiCreateSubscriptionWithPaymentMethod: jest
+          .fn()
+          .mockResolvedValue(subscriptionResult),
+      };
+      const { stripeOverride, refreshSubscriptions } = await commonSubmitSetup({
+        apiClientOverrides,
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('submit'));
+      });
+
+      await waitForExpect(() =>
+        expect(
+          apiClientOverrides.apiCreateSubscriptionWithPaymentMethod.mock
+            .calls[0][0]
+        ).toMatchObject({
+          // idempotencyKey (ignored)
+          priceId: PLAN.plan_id,
+          paymentMethodId: PAYMENT_METHOD_RESULT.paymentMethod.id,
+        })
+      );
+      await waitForExpect(() =>
+        expect(
+          screen.queryByTestId('error-payment-submission')
+        ).toBeInTheDocument()
+      );
+      expect(refreshSubscriptions).toHaveBeenCalledTimes(0);
+      expect(stripeOverride.confirmCardPayment).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('errors', () => {
+    // We map Stripe error codes to less-specific error message string IDs for display.
+    // L10n is disabled for these error messages in testing, so they show up as string IDs.
+    // The codes are mapped to IDs in lib/errors.ts and the strings are in public/locales
+    it('reports declined card', async () => {
+      const commonSetup = commonCreateSubscriptionFailureTest({
+        code: 'card_declined',
+      });
+      await commonSetup();
+      expect(screen.getByText('card-error')).toBeInTheDocument();
+    });
+
+    it('reports incorrect cvc', async () => {
+      const commonSetup = commonCreateSubscriptionFailureTest({
+        code: 'incorrect_cvc',
+      });
+      await commonSetup();
+      expect(screen.getByText('card-error')).toBeInTheDocument();
+    });
+
+    it('reports expired card', async () => {
+      const commonSetup = commonCreateSubscriptionFailureTest({
+        code: 'expired_card',
+      });
+      await commonSetup();
+      expect(screen.getByText('expired-card-error')).toBeInTheDocument();
+    });
+
+    it('reports processing errors', async () => {
+      const commonSetup = commonCreateSubscriptionFailureTest({
+        code: 'processing_error',
+      });
+      await commonSetup();
+      expect(screen.getByText('payment-error-1')).toBeInTheDocument();
+    });
+
+    it('reports stolen card error', async () => {
+      const commonSetup = commonCreateSubscriptionFailureTest({
+        code: 'stolen_card',
+      });
+      await commonSetup();
+      expect(screen.getByText('payment-error-2')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.tsx
@@ -1,0 +1,362 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import { Stripe, StripeCardElement, StripeError } from '@stripe/stripe-js';
+import { Plan, Profile, Customer } from '../../../store/types';
+import { State as ValidatorState } from '../../../lib/validator';
+
+import { useNonce } from '../../../lib/hooks';
+import { getErrorMessage } from '../../../lib/errors';
+
+import PlanDetails from '../../../components/PlanDetails';
+import Header from '../../../components/Header';
+import PaymentForm, {
+  PaymentFormProps,
+} from '../../../components/PaymentFormV2';
+import ErrorMessage from '../../../components/ErrorMessage';
+import AcceptedCards from '../../Product/AcceptedCards';
+
+import * as Amplitude from '../../../lib/amplitude';
+import { Localized } from '@fluent/react';
+import * as apiClient from '../../../lib/apiClient';
+
+import '../../Product/SubscriptionCreate/index.scss';
+
+type PaymentError = undefined | StripeError;
+type RetryStatus = undefined | { invoiceId: string };
+
+export type SubscriptionCreateStripeAPIs = Pick<
+  Stripe,
+  'createPaymentMethod' | 'confirmCardPayment'
+>;
+
+export type SubscriptionCreateAuthServerAPIs = Pick<
+  typeof apiClient,
+  | 'apiCreateCustomer'
+  | 'apiCreateSubscriptionWithPaymentMethod'
+  | 'apiRetryInvoice'
+>;
+
+export type SubscriptionCreateProps = {
+  isMobile: boolean;
+  profile: Profile;
+  customer: Customer | null;
+  selectedPlan: Plan;
+  refreshSubscriptions: () => void;
+  validatorInitialState?: ValidatorState;
+  paymentErrorInitialState?: PaymentError;
+  stripeOverride?: SubscriptionCreateStripeAPIs;
+  apiClientOverrides?: Partial<SubscriptionCreateAuthServerAPIs>;
+};
+
+export const SubscriptionCreate = ({
+  isMobile,
+  profile,
+  customer,
+  selectedPlan,
+  refreshSubscriptions,
+  validatorInitialState,
+  paymentErrorInitialState,
+  stripeOverride,
+  apiClientOverrides = {},
+}: SubscriptionCreateProps) => {
+  const [submitNonce, refreshSubmitNonce] = useNonce();
+
+  const onFormMounted = useCallback(
+    () => Amplitude.createSubscriptionMounted(selectedPlan),
+    [selectedPlan]
+  );
+
+  const onFormEngaged = useCallback(
+    () => Amplitude.createSubscriptionEngaged(selectedPlan),
+    [selectedPlan]
+  );
+
+  const [inProgress, setInProgress] = useState(false);
+
+  const [paymentError, setPaymentError] = useState<PaymentError>(
+    paymentErrorInitialState
+  );
+  const [retryStatus, setRetryStatus] = useState<RetryStatus>();
+
+  // clear any error rendered with `ErrorMessage` on form change
+  const onChange = useCallback(() => {
+    if (paymentError) {
+      setPaymentError(undefined);
+    }
+  }, [paymentError, setPaymentError]);
+
+  const onSubmit: PaymentFormProps['onSubmit'] = useCallback(
+    async ({ stripe: stripeFromParams, ...params }) => {
+      setInProgress(true);
+      try {
+        await handleSubscriptionPayment({
+          ...params,
+          ...apiClient,
+          ...apiClientOverrides,
+          stripe:
+            stripeOverride /* istanbul ignore next - used for testing */ ||
+            stripeFromParams,
+          selectedPlan,
+          customer,
+          retryStatus,
+          onSuccess: refreshSubscriptions,
+          onFailure: setPaymentError,
+          onRetry: (status: RetryStatus) => {
+            setRetryStatus(status);
+            setPaymentError({ type: 'card_error', code: 'card_declined' });
+          },
+        });
+      } catch (error) {
+        console.error('handleSubscriptionPayment failed', error);
+        setPaymentError(error);
+      }
+      setInProgress(false);
+      refreshSubmitNonce();
+    },
+    [
+      selectedPlan,
+      customer,
+      retryStatus,
+      apiClientOverrides,
+      stripeOverride,
+      setInProgress,
+      refreshSubscriptions,
+      refreshSubmitNonce,
+      setPaymentError,
+      setRetryStatus,
+    ]
+  );
+
+  return (
+    <>
+      <Header {...{ profile }} />
+      <div className="main-content">
+        <div className="product-payment" data-testid="subscription-create">
+          <div
+            className="subscription-create-heading"
+            data-testid="subscription-create-heading"
+          >
+            <Localized id="product-plan-details-heading">
+              <h2>Set up your subscription</h2>
+            </Localized>
+            <Localized id="sub-guarantee">
+              <p className="subheading">30-day money-back guarantee</p>
+            </Localized>
+          </div>
+
+          <h3 className="billing-title">
+            <Localized id="sub-update-title">
+              <span className="title">Billing Information</span>
+            </Localized>
+          </h3>
+
+          <AcceptedCards />
+
+          <ErrorMessage isVisible={!!paymentError}>
+            {paymentError && (
+              <Localized id={getErrorMessage(paymentError.code || 'UNKNOWN')}>
+                <p data-testid="error-payment-submission">
+                  {getErrorMessage(paymentError.code || 'UNKNOWN')}
+                </p>
+              </Localized>
+            )}
+          </ErrorMessage>
+
+          <PaymentForm
+            {...{
+              submitNonce,
+              onSubmit,
+              onChange,
+              inProgress,
+              validatorInitialState,
+              confirm: true,
+              plan: selectedPlan,
+              onMounted: onFormMounted,
+              onEngaged: onFormEngaged,
+            }}
+          />
+        </div>
+        <PlanDetails
+          {...{
+            profile,
+            selectedPlan,
+            isMobile,
+            showExpandButton: isMobile,
+          }}
+        />
+        <MobileCreateHeading {...{ isMobile }} />
+      </div>
+    </>
+  );
+};
+
+const MobileCreateHeading = ({ isMobile }: { isMobile: boolean }) =>
+  isMobile ? (
+    <div
+      className="mobile-subscription-create-heading"
+      data-testid="mobile-subscription-create-heading"
+    >
+      <div className="subscription-create-heading">
+        <Localized id="product-plan-details-heading">
+          <h2>Set up your subscription</h2>
+        </Localized>
+        <Localized id="sub-guarantee">
+          <p className="subheading">30-day money-back guarantee</p>
+        </Localized>
+      </div>
+    </div>
+  ) : null;
+
+async function handleSubscriptionPayment({
+  stripe,
+  name,
+  card,
+  idempotencyKey,
+  selectedPlan,
+  customer,
+  retryStatus,
+  apiCreateCustomer,
+  apiCreateSubscriptionWithPaymentMethod,
+  apiRetryInvoice,
+  onFailure,
+  onRetry,
+  onSuccess,
+}: {
+  stripe: Pick<Stripe, 'createPaymentMethod' | 'confirmCardPayment'>;
+  name: string;
+  card: StripeCardElement;
+  idempotencyKey: string;
+  selectedPlan: Plan;
+  customer: Customer | null;
+  retryStatus: RetryStatus;
+  onFailure: (error: PaymentError) => void;
+  onRetry: (status: RetryStatus) => void;
+  onSuccess: () => void;
+} & SubscriptionCreateAuthServerAPIs) {
+  // 1. Create the payment method.
+  const {
+    paymentMethod,
+    error: paymentError,
+  } = await stripe.createPaymentMethod({
+    type: 'card',
+    card,
+  });
+  if (paymentError) {
+    return onFailure(paymentError);
+  }
+  if (!paymentMethod) {
+    return onFailure({ type: 'card_error' });
+  }
+
+  // 2. Create the customer, if necessary.
+  if (!customer) {
+    // We look up the customer by UID & email on the server.
+    // No need to retain the result of this call for later.
+    await apiCreateCustomer({
+      displayName: name,
+      idempotencyKey,
+    });
+  }
+
+  const commonPaymentIntentParams = {
+    paymentMethodId: paymentMethod.id,
+    stripe,
+    onSuccess,
+    onFailure,
+    onRetry,
+  };
+
+  if (!retryStatus) {
+    // 3a. Attempt to create the subscription.
+    const createSubscriptionResult = await apiCreateSubscriptionWithPaymentMethod(
+      {
+        priceId: selectedPlan.plan_id,
+        paymentMethodId: paymentMethod.id,
+        idempotencyKey,
+      }
+    );
+    return handlePaymentIntent({
+      invoiceId: createSubscriptionResult.latest_invoice.id,
+      paymentIntentStatus:
+        createSubscriptionResult.latest_invoice.payment_intent.status,
+      paymentIntentClientSecret:
+        createSubscriptionResult.latest_invoice.payment_intent.client_secret,
+      ...commonPaymentIntentParams,
+    });
+  } else {
+    // 3b. Retry payment for the subscription invoice created earlier.
+    const { invoiceId } = retryStatus;
+    const retryInvoiceResult = await apiRetryInvoice({
+      invoiceId: retryStatus.invoiceId,
+      paymentMethodId: paymentMethod.id,
+      idempotencyKey,
+    });
+    return handlePaymentIntent({
+      invoiceId,
+      paymentIntentStatus: retryInvoiceResult.payment_intent.status,
+      paymentIntentClientSecret:
+        retryInvoiceResult.payment_intent.client_secret,
+      ...commonPaymentIntentParams,
+    });
+  }
+}
+
+async function handlePaymentIntent({
+  invoiceId,
+  paymentIntentStatus,
+  paymentIntentClientSecret,
+  paymentMethodId,
+  stripe,
+  onSuccess,
+  onFailure,
+  onRetry,
+}: {
+  invoiceId: string;
+  paymentIntentStatus: string;
+  paymentIntentClientSecret: string | null;
+  paymentMethodId: string;
+  stripe: Pick<Stripe, 'confirmCardPayment'>;
+  onFailure: (error: PaymentError) => void;
+  onRetry: (status: RetryStatus) => void;
+  onSuccess: () => void;
+}): Promise<void> {
+  switch (paymentIntentStatus) {
+    case 'succeeded': {
+      return onSuccess();
+    }
+    case 'requires_payment_method': {
+      return onRetry({ invoiceId });
+    }
+    case 'requires_action': {
+      if (!paymentIntentClientSecret) {
+        return onFailure({ type: 'api_error' });
+      }
+      const confirmResult = await stripe.confirmCardPayment(
+        paymentIntentClientSecret,
+        { payment_method: paymentMethodId }
+      );
+      if (confirmResult.error) {
+        return onFailure(confirmResult.error);
+      }
+      if (!confirmResult.paymentIntent) {
+        return onFailure({ type: 'api_error' });
+      }
+      return handlePaymentIntent({
+        invoiceId,
+        paymentIntentStatus: confirmResult.paymentIntent.status,
+        paymentIntentClientSecret: confirmResult.paymentIntent.client_secret,
+        paymentMethodId,
+        stripe,
+        onSuccess,
+        onFailure,
+        onRetry,
+      });
+    }
+    // Other payment_intent.status cases?
+    default: {
+      console.error('Unexpected payment intent status', paymentIntentStatus);
+      return onFailure({ type: 'api_error' });
+    }
+  }
+}
+
+export default SubscriptionCreate;

--- a/packages/fxa-payments-server/src/routes/ProductV2/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/ProductV2/index.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import nock from 'nock';
+
+import { AuthServerErrno } from '../../lib/errors';
+
+import {
+  PRODUCT_ID,
+  PRODUCT_REDIRECT_URLS,
+  MOCK_PLANS,
+  MOCK_PROFILE,
+  MOCK_CUSTOMER,
+  MOCK_CUSTOMER_AFTER_SUBSCRIPTION,
+  expectNockScopesDone,
+  defaultAppContextValue,
+  MockApp,
+  setupMockConfig,
+  mockConfig,
+  mockServerUrl,
+  mockOptionsResponses,
+} from '../../lib/test-utils';
+
+jest.mock('../../lib/sentry');
+
+jest.mock('../../lib/flow-event');
+
+import { SignInLayout } from '../../components/AppLayout';
+import Product from './index';
+
+describe('routes/Product', () => {
+  let authServer = '';
+  let profileServer = '';
+
+  beforeEach(() => {
+    setupMockConfig({
+      ...mockConfig,
+      productRedirectURLs: PRODUCT_REDIRECT_URLS,
+    });
+    authServer = mockServerUrl('auth');
+    mockOptionsResponses(authServer);
+    profileServer = mockServerUrl('profile');
+    mockOptionsResponses(profileServer);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    return cleanup();
+  });
+
+  const Subject = ({
+    productId = PRODUCT_ID,
+    planId,
+    accountActivated,
+    matchMedia = jest.fn(() => false),
+    navigateToUrl = jest.fn(),
+  }: {
+    productId?: string;
+    planId?: string;
+    matchMedia?: (query: string) => boolean;
+    navigateToUrl?: (url: string) => void;
+    accountActivated?: string;
+  }) => {
+    const props = {
+      match: {
+        params: {
+          productId,
+        },
+      },
+      createSubscriptionMounted: () => {},
+      createSubscriptionEngaged: () => {},
+    };
+    const appContextValue = {
+      ...defaultAppContextValue(),
+      matchMedia,
+      navigateToUrl: navigateToUrl || jest.fn(),
+      queryParams: {
+        plan: planId,
+        activated: accountActivated,
+      },
+    };
+    return (
+      <MockApp {...{ appContextValue }}>
+        <SignInLayout>
+          <Product {...props} />
+        </SignInLayout>
+      </MockApp>
+    );
+  };
+
+  const initApiMocks = (displayName?: string) => [
+    nock(profileServer)
+      .get('/v1/profile')
+      .reply(200, { ...MOCK_PROFILE, displayName }),
+    nock(authServer)
+      .get('/v1/oauth/subscriptions/plans')
+      .reply(200, MOCK_PLANS),
+    nock(authServer)
+      .get('/v1/oauth/subscriptions/customer')
+      .reply(200, MOCK_CUSTOMER),
+  ];
+
+  const initSubscribedApiMocks = (useDefaultIcon: boolean = false) => [
+    nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE),
+    nock(authServer)
+      .get('/v1/oauth/subscriptions/plans')
+      .reply(200, MOCK_PLANS),
+    nock(authServer)
+      .get('/v1/oauth/subscriptions/customer')
+      .reply(200, MOCK_CUSTOMER_AFTER_SUBSCRIPTION),
+  ];
+
+  it('renders with product ID and display name', async () => {
+    const displayName = 'Foo Barson';
+    const apiMocks = initApiMocks(displayName);
+    const { findAllByText, queryByText, queryAllByText } = render(<Subject />);
+    if (window.onload) {
+      dispatchEvent(new Event('load'));
+    }
+
+    await findAllByText('Set up your subscription');
+    expect(
+      queryAllByText('30-day money-back guarantee')[0]
+    ).toBeInTheDocument();
+    expect(queryByText('Billing Information')).toBeInTheDocument();
+    expectNockScopesDone(apiMocks);
+  });
+
+  it('displays an error with invalid product ID', async () => {
+    const apiMocks = initApiMocks();
+    const { findByTestId, queryByTestId } = render(
+      <Subject productId="bad_product" />
+    );
+    await findByTestId('no-such-plan-error');
+    expect(queryByTestId('dialog-dismiss')).not.toBeInTheDocument();
+    expectNockScopesDone(apiMocks);
+  });
+
+  it('displays an error on failure to load profile', async () => {
+    const apiMocks = [
+      nock(profileServer).get('/v1/profile').reply(400, MOCK_PROFILE),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/plans')
+        .reply(200, MOCK_PLANS),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/customer')
+        .reply(200, MOCK_CUSTOMER),
+    ];
+    const { findByTestId } = render(<Subject />);
+    await findByTestId('error-loading-profile');
+  });
+
+  it('displays an error on failure to load plans', async () => {
+    const apiMocks = [
+      nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/plans')
+        .reply(400, MOCK_PLANS),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/customer')
+        .reply(200, MOCK_CUSTOMER),
+    ];
+    const { findByTestId } = render(<Subject />);
+    await findByTestId('error-loading-plans');
+  });
+
+  it('displays an error on failure to load customer', async () => {
+    const apiMocks = [
+      nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/plans')
+        .reply(200, MOCK_PLANS),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/customer')
+        .reply(400, MOCK_CUSTOMER),
+    ];
+    const { findByTestId } = render(<Subject />);
+    await findByTestId('error-loading-customer');
+  });
+
+  it('does not display an error on missing / new customer', async () => {
+    const apiMocks = [
+      nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/plans')
+        .reply(200, MOCK_PLANS),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/customer')
+        .reply(404, { errno: AuthServerErrno.UNKNOWN_SUBSCRIPTION_CUSTOMER }),
+    ];
+    const { findAllByText } = render(<Subject />);
+    await findAllByText('Set up your subscription');
+  });
+
+  it('does not display an error on customer with no subscriptions', async () => {
+    const apiMocks = [
+      nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/plans')
+        .reply(200, MOCK_PLANS),
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/customer')
+        .reply(200, { ...MOCK_CUSTOMER, subscriptions: null }),
+    ];
+    const { findAllByText } = render(<Subject />);
+    await findAllByText('Set up your subscription');
+  });
+
+  it('offers upgrade if user is already subscribed to another plan in the same product set', async () => {
+    const apiMocks = initSubscribedApiMocks();
+    const { findByTestId } = render(
+      <Subject
+        {...{
+          planId: 'plan_upgrade',
+          productId: 'prod_upgrade',
+        }}
+      />
+    );
+    await findByTestId('subscription-upgrade');
+    expectNockScopesDone(apiMocks);
+  });
+
+  it('displays payment confirmation if user is already subscribed the product', async () => {
+    const apiMocks = initSubscribedApiMocks();
+    const { findByTestId } = render(<Subject />);
+    await findByTestId('payment-confirmation');
+    expectNockScopesDone(apiMocks);
+  });
+});

--- a/packages/fxa-payments-server/src/routes/ProductV2/index.tsx
+++ b/packages/fxa-payments-server/src/routes/ProductV2/index.tsx
@@ -1,0 +1,268 @@
+import React, { useEffect, useContext, useMemo } from 'react';
+import { connect } from 'react-redux';
+import { Localized } from '@fluent/react';
+import { AuthServerErrno } from '../../lib/errors';
+import { AppContext } from '../../lib/AppContext';
+import { LoadingOverlay } from '../../components/LoadingOverlay';
+import { useMatchMedia } from '../../lib/hooks';
+
+import { State } from '../../store/state';
+import { sequences, SequenceFunctions } from '../../store/sequences';
+import { actions, ActionFunctions } from '../../store/actions';
+import { selectors, SelectorReturns } from '../../store/selectors';
+import { CustomerSubscription, Plan, ProductMetadata } from '../../store/types';
+import { metadataFromPlan } from 'fxa-shared/subscriptions/metadata';
+
+import '../Product/index.scss';
+
+import DialogMessage from '../../components/DialogMessage';
+import FetchErrorDialogMessage from '../../components/FetchErrorDialogMessage';
+
+import SubscriptionSuccess from '../Product/SubscriptionSuccess';
+import SubscriptionUpgrade from '../Product/SubscriptionUpgrade';
+import SubscriptionCreate from '../ProductV2/SubscriptionCreate';
+
+export type ProductProps = {
+  match: {
+    params: {
+      productId: string;
+    };
+  };
+  profile: SelectorReturns['profile'];
+  plans: SelectorReturns['plans'];
+  customer: SelectorReturns['customer'];
+  customerSubscriptions: SelectorReturns['customerSubscriptions'];
+  plansByProductId: SelectorReturns['plansByProductId'];
+  updateSubscriptionPlanStatus: SelectorReturns['updateSubscriptionPlanStatus'];
+  updateSubscriptionPlanAndRefresh: SequenceFunctions['updateSubscriptionPlanAndRefresh'];
+  resetUpdateSubscriptionPlan: ActionFunctions['resetUpdateSubscriptionPlan'];
+  fetchProductRouteResources: SequenceFunctions['fetchProductRouteResources'];
+  fetchCustomerAndSubscriptions: SequenceFunctions['fetchCustomerAndSubscriptions'];
+};
+
+export const Product = ({
+  match: {
+    params: { productId },
+  },
+  profile,
+  plans,
+  customer,
+  customerSubscriptions,
+  plansByProductId,
+  fetchProductRouteResources,
+  fetchCustomerAndSubscriptions,
+  updateSubscriptionPlanAndRefresh,
+  resetUpdateSubscriptionPlan,
+  updateSubscriptionPlanStatus,
+}: ProductProps) => {
+  const { locationReload, queryParams, matchMediaDefault } = useContext(
+    AppContext
+  );
+
+  const isMobile = !useMatchMedia('(min-width: 768px)', matchMediaDefault);
+  const planId = queryParams.plan;
+  const accountActivated = !!queryParams.activated;
+
+  // Fetch plans on initial render, change in product ID, or auth change.
+  useEffect(() => {
+    fetchProductRouteResources();
+  }, [fetchProductRouteResources]);
+
+  const plansById = useMemo(() => indexPlansById(plans), [plans]);
+
+  // Figure out a selected plan for product, either from query param or first plan.
+  const productPlans = plansByProductId(productId);
+  let selectedPlan = productPlans.filter((plan) => plan.plan_id === planId)[0];
+  if (!selectedPlan) {
+    selectedPlan = productPlans[0];
+  }
+
+  if (customer.loading || plans.loading || profile.loading) {
+    return <LoadingOverlay isLoading={true} />;
+  }
+
+  if (!plans.result || plans.error !== null) {
+    return (
+      <Localized id="product-plan-error">
+        <FetchErrorDialogMessage
+          testid="error-loading-plans"
+          title="Problem loading plans"
+          fetchState={plans}
+          onDismiss={locationReload}
+        />
+      </Localized>
+    );
+  }
+
+  if (!profile.result || profile.error !== null) {
+    return (
+      <Localized id="product-plan-error">
+        <FetchErrorDialogMessage
+          testid="error-loading-profile"
+          title="Problem loading profile"
+          fetchState={profile}
+          onDismiss={locationReload}
+        />
+      </Localized>
+    );
+  }
+
+  if (
+    customer.error &&
+    // Unknown customer just means the user hasn't subscribed to anything yet
+    customer.error.errno !== AuthServerErrno.UNKNOWN_SUBSCRIPTION_CUSTOMER
+  ) {
+    return (
+      <Localized id="product-customer-error">
+        <FetchErrorDialogMessage
+          testid="error-loading-customer"
+          title="Problem loading customer"
+          fetchState={customer}
+          onDismiss={locationReload}
+        />
+      </Localized>
+    );
+  }
+
+  if (!selectedPlan) {
+    return (
+      <DialogMessage className="dialog-error">
+        <Localized id="product-plan-not-found">
+          <h4>Plan not found</h4>
+        </Localized>
+        <Localized id="product-no-such-plan">
+          <p data-testid="no-such-plan-error">No such plan for this product.</p>
+        </Localized>
+      </DialogMessage>
+    );
+  }
+
+  // Only check for upgrade or existing subscription if we have a customer.
+  if (customer.result) {
+    // Can we upgrade from an existing subscription with selected plan?
+    const upgradeFrom = findUpgradeFromPlan(
+      customerSubscriptions,
+      selectedPlan,
+      plansById
+    );
+    if (upgradeFrom) {
+      return (
+        <SubscriptionUpgrade
+          {...{
+            isMobile,
+            profile: profile.result,
+            customer: customer.result,
+            selectedPlan,
+            upgradeFromPlan: upgradeFrom.plan,
+            upgradeFromSubscription: upgradeFrom.subscription,
+            updateSubscriptionPlanAndRefresh,
+            resetUpdateSubscriptionPlan,
+            updateSubscriptionPlanStatus,
+          }}
+        />
+      );
+    }
+
+    // Do we already have a subscription to the product in the selected plan?
+    if (customerIsSubscribedToProduct(customerSubscriptions, productPlans)) {
+      return (
+        <SubscriptionSuccess
+          {...{
+            plan: selectedPlan,
+            customer: customer.result,
+            profile: profile.result,
+            isMobile,
+          }}
+        />
+      );
+    }
+  }
+
+  return (
+    <SubscriptionCreate
+      {...{
+        isMobile,
+        profile: profile.result,
+        customer: customer.result,
+        accountActivated,
+        selectedPlan,
+        refreshSubscriptions: fetchCustomerAndSubscriptions,
+      }}
+    />
+  );
+};
+
+type PlansByIdType = {
+  [plan_id: string]: { plan: Plan; metadata: ProductMetadata };
+};
+
+const indexPlansById = (plans: State['plans']): PlansByIdType =>
+  (plans.result || []).reduce(
+    (acc, plan) => ({
+      ...acc,
+      [plan.plan_id]: { plan, metadata: metadataFromPlan(plan) },
+    }),
+    {}
+  );
+
+// If the customer has any subscription plan that matches a plan for the
+// selected product, then they are already subscribed.
+const customerIsSubscribedToProduct = (
+  customerSubscriptions: ProductProps['customerSubscriptions'],
+  productPlans: Plan[]
+) =>
+  customerSubscriptions &&
+  customerSubscriptions.some((customerSubscription) =>
+    productPlans.some((plan) => plan.plan_id === customerSubscription.plan_id)
+  );
+
+// If the customer has any subscribed plan that matches the productSet
+// for the selected plan, then that is the plan from which to upgrade.
+const findUpgradeFromPlan = (
+  customerSubscriptions: ProductProps['customerSubscriptions'],
+  selectedPlan: Plan,
+  plansById: PlansByIdType
+): {
+  plan: Plan;
+  subscription: CustomerSubscription;
+} | null => {
+  if (customerSubscriptions) {
+    const selectedPlanInfo = plansById[selectedPlan.plan_id];
+    for (const customerSubscription of customerSubscriptions) {
+      const subscriptionPlanInfo = plansById[customerSubscription.plan_id];
+      if (
+        selectedPlan.plan_id !== customerSubscription.plan_id &&
+        selectedPlanInfo.metadata.productSet &&
+        subscriptionPlanInfo.metadata.productSet &&
+        selectedPlanInfo.metadata.productSet ===
+          subscriptionPlanInfo.metadata.productSet
+      ) {
+        return {
+          plan: subscriptionPlanInfo.plan,
+          subscription: customerSubscription,
+        };
+      }
+    }
+  }
+  return null;
+};
+
+// TODO replace this with Redux hooks in component function body
+// https://github.com/mozilla/fxa/issues/3020
+export default connect(
+  (state: State) => ({
+    customer: selectors.customer(state),
+    customerSubscriptions: selectors.customerSubscriptions(state),
+    profile: selectors.profile(state),
+    plans: selectors.plans(state),
+    updateSubscriptionPlanStatus: selectors.updateSubscriptionPlanStatus(state),
+    plansByProductId: selectors.plansByProductId(state),
+  }),
+  {
+    fetchProductRouteResources: sequences.fetchProductRouteResources,
+    fetchCustomerAndSubscriptions: sequences.fetchCustomerAndSubscriptions,
+    updateSubscriptionPlanAndRefresh:
+      sequences.updateSubscriptionPlanAndRefresh,
+    resetUpdateSubscriptionPlan: actions.resetUpdateSubscriptionPlan,
+  }
+)(Product);

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -173,18 +173,22 @@ export const PaymentUpdateForm = ({
       {!updateRevealed ? (
         <div className="with-settings-button">
           <div className="card-details">
-            {/* TODO: Need to find a way to display a card icon here? */}
-            <Localized id="sub-update-card-ending" $last={last4}>
-              <div className="last-four">Card ending {last4}</div>
-            </Localized>
-            <Localized
-              id="pay-update-card-exp"
-              $expirationDate={expirationDate}
-            >
-              <div data-testid="card-expiration-date" className="expiry">
-                Expires {expirationDate}
-              </div>
-            </Localized>
+            {last4 && expirationDate && (
+              <>
+                {/* TODO: Need to find a way to display a card icon here? */}
+                <Localized id="sub-update-card-ending" $last={last4}>
+                  <div className="last-four">Card ending {last4}</div>
+                </Localized>
+                <Localized
+                  id="pay-update-card-exp"
+                  $expirationDate={expirationDate}
+                >
+                  <div data-testid="card-expiration-date" className="expiry">
+                    Expires {expirationDate}
+                  </div>
+                </Localized>
+              </>
+            )}
           </div>
           <div className="action">
             <button


### PR DESCRIPTION
Starting a draft of this PR for issue #5745. Lots of work left to do, but worth starting to take a look at.

Following along with [Stripe's fixed-price subscription example](https://stripe.com/docs/billing/subscriptions/fixed-price), we need to handle a small flowchart of process here.

It's growing into a significant re-write of the product subscription page. And, some of what's here might end up useful to reuse for using the endpoints from #5744 in updating payment method.
