### PR TITLE
fix(devices): Fix response validation for /invoke_command

### DIFF
--- a/packages/fxa-auth-server/lib/push.js
+++ b/packages/fxa-auth-server/lib/push.js
@@ -473,6 +473,7 @@ module.exports = function (log, db, config, statsd) {
       } else {
         errCode = ERR_PUSH_UNKNOWN;
       }
+      err.errCode = errCode;
       metricsTags = { errCode, err, ...metricsTags };
       this.incrementPushMetric(LOG_OP_PUSH_SEND_FAILURE, metricsTags);
       log.warn(LOG_OP_PUSH_SEND_FAILURE, metricsTags);

--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -270,7 +270,11 @@ module.exports = (
           },
         },
         response: {
-          schema: {},
+          schema: {
+            enqueued: isA.boolean().optional(),
+            notified: isA.boolean().optional(),
+            notifyError: isA.string().optional(),
+          },
         },
       },
       handler: async function (request) {
@@ -351,8 +355,10 @@ module.exports = (
 
         return {
           enqueued: true,
-          notified: !!notifyError,
-          notifyError: notifyError,
+          notified: !notifyError,
+          notifyError: notifyError
+            ? notifyError.errCode || 'unknown'
+            : undefined,
         };
       },
     },

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -639,7 +639,7 @@ function mockDevices(data, errors) {
       return data;
     }),
     synthesizeName: sinon.spy(() => {
-      return data.deviceName || null;
+      return data.deviceName || '';
     }),
   };
 }


### PR DESCRIPTION
## Because

- When I added metrics to the /invoke_command route, I modified it
  to return the metrics info to the client without really thinking
  too hard about the implications.
- When we tried to deploy this in train-178, the result was response
  validation errors in production.


## This commit

- Adjusts the response schema for /invoke_command to accommodate the
  new fields.
- Updates the device route tests to validate the response, in order
  to help avoid similar oversights in future.
- Fixes a bunch of unrelated mock values in the device route tests
  that do not pass validation.

## Issue that this pull request solves

Closes: #5886.


## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- ~~[ ] I have added necessary documentation (if appropriate).~~

## Other information (Optional)

This PR targets the `train-178` release branch, for a point-release.