### PR TITLE
fix(docs): Clarify that JWT `typ` header is case-insensitive.

### DIFF
--- a/packages/fxa-auth-server/docs/oauth/jwt-access-tokens.md
+++ b/packages/fxa-auth-server/docs/oauth/jwt-access-tokens.md
@@ -51,8 +51,8 @@ Firefox Accounts largely follows the IETF JWT access token draft spec's
 
 The following is based on the [section on validation][#ietf-jwt-access-token-draft-spec-validation] JWT Access Token Draft Spec:
 
-1.  The resource server MUST verify that the `typ` header value is
-    `at+jwt` and reject tokens carrying any other value.
+1.  The resource server MUST verify that the `typ` header value case-insensitively
+    matches `at+jwt` or `application/at+jwt` and reject tokens carrying any other value.
 2.  The resource server MUST validate the signature of all incoming
     JWT access token according to [RFC7515][#ietf-jws-spec] using the algorithm
     specified in the JWT `alg` Header Parameter. The SP MUST use the keys provided

--- a/packages/fxa-auth-server/lib/oauth/jwt.js
+++ b/packages/fxa-auth-server/lib/oauth/jwt.js
@@ -36,8 +36,10 @@ exports.sign = function sign(claims, options) {
 
 exports.verify = async function verify(jwt, options = {}) {
   const getKey = (header, callback) => {
-    if (options.typ && header.typ !== options.typ) {
-      return callback(new Error('Invalid typ'));
+    if (options.typ) {
+      if (normalizeTyp(options.typ) !== normalizeTyp(header.typ)) {
+        return callback(new Error('Invalid typ'));
+      }
     }
 
     let signingKey;
@@ -58,3 +60,14 @@ exports.verify = async function verify(jwt, options = {}) {
     ignoreExpiration: options.ignoreExpiration,
   });
 };
+
+function normalizeTyp(typ) {
+  // Ref https://tools.ietf.org/html/rfc7515#section-4.1.9 for the rules.
+  if (typ) {
+    typ = typ.toLowerCase();
+    if (!typ.includes('/')) {
+      typ = 'application/' + typ;
+    }
+  }
+  return typ;
+}

--- a/packages/fxa-auth-server/test/oauth/jwt.js
+++ b/packages/fxa-auth-server/test/oauth/jwt.js
@@ -170,6 +170,24 @@ describe('lib/jwt', () => {
         });
         assert.strictEqual(verifiedPayload.foo, 'bar');
       });
+
+      it('succeeds if valid and typ matches according to comparison rules', async () => {
+        const jwt = await JWT.sign(
+          {
+            foo: 'bar',
+          },
+          {
+            header: {
+              typ: 'cUstOm-JwT',
+            },
+          }
+        );
+
+        const verifiedPayload = await JWT.verify(jwt, {
+          typ: 'application/custom-jwt',
+        });
+        assert.strictEqual(verifiedPayload.foo, 'bar');
+      });
     });
   });
 });


### PR DESCRIPTION
## Because

* The docs for JWT OAuth tokens tell RPs check for for "at+jwt".
* The actual code for JWT OAuth tokens uses a value of "at+JWT".
* The relevant RFC says this value should be compared case-insensitively,
  and should be treated as if it has a magic "application/" prefix
  prepended to it (ref https://tools.ietf.org/html/rfc7515#section-4.1.9).

## This commit

* Rewords the docs on JWT OAuth tokens to clarify these requirements.
* Updates our own JWT-verification logic to implement them.

## Issue that this pull request solves

~~Closes: # (issue number)~~

~~It would have taken me longer to file the issue than to make this one-line PR...~~

OK sorry, turns out this was more than a one-line PR. But still, here we are...

## Checklist

- [x] My commit is GPG signed.
- ~~[ ] If applicable, I have modified or added tests which pass locally.~~
- ~~[ ] I have added necessary documentation (if appropriate).~~
