### PR TITLE
fix(payments): stop fetching unused cached subscription data on payments frontend

### DIFF
--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -139,9 +139,6 @@ describe('routes/Product', () => {
       .get('/v1/oauth/subscriptions/plans')
       .reply(200, varyPlansForDefaultIcon(useDefaultIcon)),
     nock(authServer)
-      .get('/v1/oauth/subscriptions/active')
-      .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS),
-    nock(authServer)
       .get('/v1/oauth/subscriptions/customer')
       .reply(200, MOCK_CUSTOMER),
   ];
@@ -151,9 +148,6 @@ describe('routes/Product', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/plans')
       .reply(200, varyPlansForDefaultIcon(useDefaultIcon)),
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/active')
-      .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION),
     nock(authServer)
       .get('/v1/oauth/subscriptions/customer')
       .reply(200, MOCK_CUSTOMER_AFTER_SUBSCRIPTION),
@@ -196,9 +190,6 @@ describe('routes/Product', () => {
         .get('/v1/oauth/subscriptions/plans')
         .reply(200, MOCK_PLANS),
       nock(authServer)
-        .get('/v1/oauth/subscriptions/active')
-        .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS),
-      nock(authServer)
         .get('/v1/oauth/subscriptions/customer')
         .reply(200, MOCK_CUSTOMER),
     ];
@@ -212,9 +203,6 @@ describe('routes/Product', () => {
       nock(authServer)
         .get('/v1/oauth/subscriptions/plans')
         .reply(400, MOCK_PLANS),
-      nock(authServer)
-        .get('/v1/oauth/subscriptions/active')
-        .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS),
       nock(authServer)
         .get('/v1/oauth/subscriptions/customer')
         .reply(200, MOCK_CUSTOMER),
@@ -230,9 +218,6 @@ describe('routes/Product', () => {
         .get('/v1/oauth/subscriptions/plans')
         .reply(200, MOCK_PLANS),
       nock(authServer)
-        .get('/v1/oauth/subscriptions/active')
-        .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS),
-      nock(authServer)
         .get('/v1/oauth/subscriptions/customer')
         .reply(400, MOCK_CUSTOMER),
     ];
@@ -247,9 +232,6 @@ describe('routes/Product', () => {
     const apiMocks = [
       ...initApiMocks(undefined, useDefaultIcon),
       nock(authServer).post('/v1/oauth/subscriptions/active').reply(200, {}),
-      nock(authServer)
-        .get('/v1/oauth/subscriptions/active')
-        .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS_AFTER_SUBSCRIPTION),
       nock(authServer)
         .get('/v1/oauth/subscriptions/customer')
         .reply(200, MOCK_CUSTOMER_AFTER_SUBSCRIPTION),

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ManagementPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ManagementPanel.tsx
@@ -4,12 +4,7 @@
 
 import React, { useCallback } from 'react';
 import { Localized } from '@fluent/react';
-import {
-  Plan,
-  CustomerSubscription,
-  Subscription,
-  Customer,
-} from '../../../store/types';
+import { Plan, CustomerSubscription, Customer } from '../../../store/types';
 import { useBooleanState } from 'fxa-react/lib/hooks';
 import { getLocalizedDateString, getLocalizedDate } from '../../../lib/formats';
 import { ActionFunctions } from '../../../store/actions';
@@ -18,13 +13,11 @@ import ReactivationConfirmationDialog from './ConfirmationDialog';
 export default ({
   plan,
   customerSubscription,
-  subscription,
   customer,
   reactivateSubscription,
 }: {
   plan: Plan;
   customerSubscription: CustomerSubscription;
-  subscription: Subscription;
   customer: Customer;
   reactivateSubscription: ActionFunctions['reactivateSubscription'];
 }) => {
@@ -45,10 +38,6 @@ export default ({
     hideReactivateConfirmation,
   ]);
 
-  const cancelledAt = subscription.cancelledAt
-    ? (subscription.cancelledAt as number) / 1000
-    : null;
-
   const periodEndTimeStamp = customerSubscription.current_period_end;
 
   return (
@@ -63,17 +52,6 @@ export default ({
       <div className="subscription-cancelled">
         <div className="with-settings-button">
           <div className="subscription-cancelled-details">
-            {cancelledAt && (
-              <Localized
-                id="reactivate-panel-date"
-                $date={getLocalizedDate(cancelledAt)}
-              >
-                <p data-testid="subscription-cancelled-date">
-                  You cancelled your subscription on{' '}
-                  {getLocalizedDateString(cancelledAt)}.
-                </p>
-              </Localized>
-            )}
             <Localized
               id="reactivate-panel-copy"
               $name={plan.product_name}

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -25,7 +25,6 @@ import ReactivateSubscriptionPanel from './Reactivate/ManagementPanel';
 
 type SubscriptionItemProps = {
   customerSubscription: CustomerSubscription;
-  subscription: Subscription | null;
   plan: Plan | null;
   cancelSubscription: SubscriptionsProps['cancelSubscription'];
   reactivateSubscription: SubscriptionsProps['reactivateSubscription'];
@@ -37,7 +36,6 @@ type SubscriptionItemProps = {
 };
 
 export const SubscriptionItem = ({
-  subscription,
   cancelSubscription,
   cancelSubscriptionStatus,
   reactivateSubscription,
@@ -49,24 +47,6 @@ export const SubscriptionItem = ({
   customerSubscription,
 }: SubscriptionItemProps) => {
   const { locationReload } = useContext(AppContext);
-
-  if (!subscription) {
-    // TOOD: Maybe need a better message here? This shouldn't happen. But, if it
-    // does, it's because subhub reports a subscription that we don't have in
-    // the fxa-auth-server database. The two should be kept in eventual sync.
-    return (
-      <DialogMessage className="dialog-error" onDismiss={locationReload}>
-        <Localized id="sub-item-missing">
-          <h4 data-testid="error-fxa-missing-subscription">
-            Problem loading subscriptions
-          </h4>
-        </Localized>
-        <Localized id="sub-item-missing-msg">
-          <p>Please try again later.</p>
-        </Localized>
-      </DialogMessage>
-    );
-  }
 
   if (!plan) {
     // TODO: This really shouldn't happen, would mean the user has a
@@ -118,7 +98,6 @@ export const SubscriptionItem = ({
                 plan,
                 customer,
                 customerSubscription,
-                subscription,
                 reactivateSubscription,
               }}
             />

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -17,11 +17,6 @@ function init() {
       <SubscriptionsRoute
         routeProps={{
           ...baseProps,
-          subscriptions: {
-            loading: true,
-            error: null,
-            result: null,
-          },
         }}
       />
     ))
@@ -81,9 +76,6 @@ function init() {
             error: null,
             result: {
               subscriptionId: 'sub_5551212',
-              productId: 'product_123',
-              createdAt: Date.now() - 86400000,
-              cancelledAt: Date.now(),
             },
           },
         }}
@@ -130,14 +122,6 @@ function init() {
         routeProps={{
           ...baseProps,
           plans: errorFetchState(),
-        }}
-      />
-    ))
-    .add('subscriptions', () => (
-      <SubscriptionsRoute
-        routeProps={{
-          ...baseProps,
-          subscriptions: errorFetchState(),
         }}
       />
     ))
@@ -262,11 +246,6 @@ const baseProps: SubscriptionsProps = {
     loading: false,
     result: null,
   },
-  subscriptions: {
-    error: null,
-    loading: false,
-    result: null,
-  },
   customerSubscriptions: [],
   fetchSubscriptionsRouteResources: action('fetchSubscriptionsRouteResources'),
   cancelSubscription: () => linkTo('routes/Subscriptions', 'cancelled')(),
@@ -321,18 +300,6 @@ const subscribedProps: SubscriptionsProps = {
       subscription_id: 'sub_5551212',
     },
   ],
-  subscriptions: {
-    loading: false,
-    error: null,
-    result: [
-      {
-        subscriptionId: 'sub_5551212',
-        productId: 'product_123',
-        createdAt: Date.now(),
-        cancelledAt: null,
-      },
-    ],
-  },
 };
 
 const cancelledProps: SubscriptionsProps = {
@@ -345,18 +312,6 @@ const cancelledProps: SubscriptionsProps = {
         },
       ]
     : null,
-  subscriptions: {
-    loading: false,
-    error: null,
-    result: [
-      {
-        subscriptionId: 'sub_5551212',
-        productId: 'product_123',
-        createdAt: Date.now() - 400000000,
-        cancelledAt: Date.now() - 200000000,
-      },
-    ],
-  },
 };
 
 const reactivationErrorProps = {

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
@@ -278,19 +278,6 @@ describe('routes/Subscriptions', () => {
     await findByTestId('error-loading-plans');
   });
 
-  it('displays an error if subscriptions fetch fails', async () => {
-    nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/plans')
-      .reply(200, MOCK_PLANS);
-    nock(authServer).get('/v1/oauth/subscriptions/active').reply(500, {});
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/customer')
-      .reply(403, MOCK_CUSTOMER);
-    const { findByTestId } = render(<Subject />);
-    await findByTestId('error-subscriptions-fetch');
-  });
-
   it('displays an error if customer fetch fails', async () => {
     nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE);
     nock(authServer)
@@ -519,15 +506,6 @@ describe('routes/Subscriptions', () => {
     }
   };
 
-  it('hides cancellation date message when date is unavailable', async () => {
-    commonReactivationSetup({ cancelledAtIsUnavailable: true });
-    const { findByTestId, queryByTestId } = render(<Subject />);
-    await findByTestId('subscription-management-loaded');
-    expect(
-      queryByTestId('subscription-cancelled-date')
-    ).not.toBeInTheDocument();
-  });
-
   const reactivationTests = (useDefaultIcon = true) => () => {
     it('supports reactivating a subscription through the confirmation flow', async () => {
       commonReactivationSetup({ useDefaultIcon });
@@ -541,8 +519,6 @@ describe('routes/Subscriptions', () => {
 
       // Wait for the page to load with one subscription
       await findByTestId('subscription-management-loaded');
-
-      expect(queryByTestId('subscription-cancelled-date')).toBeInTheDocument();
 
       const reactivateButton = getByTestId('reactivate-subscription-button');
       fireEvent.click(reactivateButton);
@@ -596,19 +572,6 @@ describe('routes/Subscriptions', () => {
   describe('reactivation with defined webIconURL', reactivationTests(false));
 
   describe('reactivation with default icon', reactivationTests(true));
-
-  it('should display an error message if subhub reports a subscription not found in auth-server', async () => {
-    nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/plans')
-      .reply(200, MOCK_PLANS);
-    nock(authServer).get('/v1/oauth/subscriptions/active').reply(200, []);
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/customer')
-      .reply(200, MOCK_CUSTOMER);
-    const { findByTestId } = render(<Subject />);
-    await findByTestId('error-fxa-missing-subscription');
-  });
 
   it('should display an error message for a plan found in auth-server but not subhub', async () => {
     nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE);

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -17,12 +17,7 @@ import { actions, ActionFunctions } from '../../store/actions';
 import { selectors, SelectorReturns } from '../../store/selectors';
 import { sequences, SequenceFunctions } from '../../store/sequences';
 import { State } from '../../store/state';
-import {
-  CustomerSubscription,
-  Profile,
-  Subscription,
-  Plan,
-} from '../../store/types';
+import { CustomerSubscription, Profile, Plan } from '../../store/types';
 
 import './index.scss';
 import SubscriptionItem from './SubscriptionItem';
@@ -39,7 +34,6 @@ export type SubscriptionsProps = {
   profile: SelectorReturns['profile'];
   plans: SelectorReturns['plans'];
   customer: SelectorReturns['customer'];
-  subscriptions: SelectorReturns['subscriptions'];
   cancelSubscriptionStatus: SelectorReturns['cancelSubscriptionStatus'];
   reactivateSubscriptionStatus: SelectorReturns['reactivateSubscriptionStatus'];
   updatePaymentStatus: SelectorReturns['updatePaymentStatus'];
@@ -57,7 +51,6 @@ export const Subscriptions = ({
   profile,
   customer,
   plans,
-  subscriptions,
   customerSubscriptions,
   fetchSubscriptionsRouteResources,
   cancelSubscription,
@@ -111,12 +104,7 @@ export const Subscriptions = ({
     SUPPORT_FORM_URL,
   ]);
 
-  if (
-    customer.loading ||
-    subscriptions.loading ||
-    profile.loading ||
-    plans.loading
-  ) {
+  if (customer.loading || profile.loading || plans.loading) {
     return <LoadingOverlay isLoading={true} />;
   }
 
@@ -140,19 +128,6 @@ export const Subscriptions = ({
           testid="error-loading-plans"
           title="Problem loading plans"
           fetchState={plans}
-          onDismiss={locationReload}
-        />
-      </Localized>
-    );
-  }
-
-  if (!subscriptions.result || subscriptions.error !== null) {
-    return (
-      <Localized id="sub-subscription-error">
-        <FetchErrorDialogMessage
-          testid="error-subscriptions-fetch"
-          title="Problem loading subscriptions"
-          fetchState={subscriptions}
           onDismiss={locationReload}
         />
       </Localized>
@@ -192,7 +167,7 @@ export const Subscriptions = ({
       {customerSubscriptions && cancelSubscriptionStatus.result !== null && (
         <CancellationDialogMessage
           {...{
-            subscription: cancelSubscriptionStatus.result,
+            subscriptionId: cancelSubscriptionStatus.result.subscriptionId,
             customerSubscriptions,
             plans: plans.result,
             resetCancelSubscription,
@@ -305,10 +280,6 @@ export const Subscriptions = ({
                   customerSubscription,
                   cancelSubscriptionStatus,
                   plan: planForId(customerSubscription.plan_id, plans.result),
-                  subscription: subscriptionForId(
-                    customerSubscription.subscription_id,
-                    subscriptions.result
-                  ),
                 }}
               />
             ))}
@@ -326,19 +297,11 @@ const customerSubscriptionForId = (
     (subscription) => subscription.subscription_id === subscriptionId
   )[0];
 
-const subscriptionForId = (
-  subscriptionId: string,
-  subscriptions: Subscription[]
-): Subscription | null =>
-  subscriptions.filter(
-    (subscription) => subscription.subscriptionId === subscriptionId
-  )[0];
-
 const planForId = (planId: string, plans: Plan[]): Plan | null =>
   plans.filter((plan) => plan.plan_id === planId)[0];
 
 type CancellationDialogMessageProps = {
-  subscription: Subscription;
+  subscriptionId: string;
   customerSubscriptions: CustomerSubscription[];
   plans: Plan[];
   resetCancelSubscription: SubscriptionsProps['resetCancelSubscription'];
@@ -346,14 +309,14 @@ type CancellationDialogMessageProps = {
 };
 
 const CancellationDialogMessage = ({
-  subscription,
+  subscriptionId,
   customerSubscriptions,
   plans,
   resetCancelSubscription,
   supportFormUrl,
 }: CancellationDialogMessageProps) => {
   const customerSubscription = customerSubscriptionForId(
-    subscription.subscriptionId,
+    subscriptionId,
     customerSubscriptions
   ) as CustomerSubscription;
   const plan = planForId(customerSubscription.plan_id, plans) as Plan;
@@ -420,7 +383,6 @@ export default connect(
     profile: selectors.profile(state),
     customer: selectors.customer(state),
     customerSubscriptions: selectors.customerSubscriptions(state),
-    subscriptions: selectors.subscriptions(state),
     updatePaymentStatus: selectors.updatePaymentStatus(state),
     cancelSubscriptionStatus: selectors.cancelSubscriptionStatus(state),
     reactivateSubscriptionStatus: selectors.reactivateSubscriptionStatus(state),

--- a/packages/fxa-payments-server/src/store/sequences.test.ts
+++ b/packages/fxa-payments-server/src/store/sequences.test.ts
@@ -56,9 +56,8 @@ describe('updateSubscriptionPlanAndRefresh', () => {
       plan
     )(dispatch);
 
-    expect(dispatch).toHaveBeenCalledTimes(4);
+    expect(dispatch).toHaveBeenCalledTimes(3);
     expect(actions.updateSubscriptionPlan).toBeCalledWith(subscriptionId, plan);
     expect(actions.fetchCustomer).toBeCalled();
-    expect(actions.fetchSubscriptions).toBeCalled();
   });
 });

--- a/packages/fxa-payments-server/src/store/sequences.ts
+++ b/packages/fxa-payments-server/src/store/sequences.ts
@@ -5,7 +5,6 @@ import { FunctionWithIgnoredReturn } from '../lib/types';
 const {
   fetchProfile,
   fetchPlans,
-  fetchSubscriptions,
   fetchCustomer,
   createSubscription,
   updateSubscriptionPlan,
@@ -35,7 +34,6 @@ export const fetchProductRouteResources = () => async (dispatch: Function) => {
     dispatch(fetchPlans()),
     dispatch(fetchProfile()),
     dispatch(fetchCustomer()),
-    dispatch(fetchSubscriptions()),
   ]).catch(handleThunkError);
 };
 
@@ -46,17 +44,13 @@ export const fetchSubscriptionsRouteResources = () => async (
     dispatch(fetchPlans()),
     dispatch(fetchProfile()),
     dispatch(fetchCustomer()),
-    dispatch(fetchSubscriptions()),
   ]).catch(handleThunkError);
 };
 
 export const fetchCustomerAndSubscriptions = () => async (
   dispatch: Function
 ) => {
-  await Promise.all([
-    dispatch(fetchCustomer()),
-    dispatch(fetchSubscriptions()),
-  ]).catch(handleThunkError);
+  await Promise.all([dispatch(fetchCustomer())]).catch(handleThunkError);
 };
 
 export const createSubscriptionAndRefresh = (

--- a/packages/fxa-payments-server/src/store/state.ts
+++ b/packages/fxa-payments-server/src/store/state.ts
@@ -10,6 +10,7 @@ import {
   CreateSubscriptionResult,
   CreateSubscriptionError,
   UpdateSubscriptionPlanResult,
+  CancelSubscriptionResult,
 } from './types';
 
 import { actions, ActionPayload } from './actions';
@@ -20,7 +21,7 @@ export const defaultState = {
   profile: uninitializedFetch<Profile, APIError>(),
   subscriptions: uninitializedFetch<Array<Subscription>>(),
   token: uninitializedFetch<Token>(),
-  cancelSubscription: uninitializedFetch<Subscription>(),
+  cancelSubscription: uninitializedFetch<CancelSubscriptionResult>(),
   reactivateSubscription: uninitializedFetch<
     ActionPayload<typeof actions['reactivateSubscription']>,
     APIError

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -130,3 +130,7 @@ export type CreateSubscriptionError = {
 export interface UpdateSubscriptionPlanResult {
   subscriptionId: string;
 }
+
+export interface CancelSubscriptionResult {
+  subscriptionId: string;
+}


### PR DESCRIPTION
While working on #5745, I found an error on the subscription management page when the redis cache for customer data hasn't been refreshed.

Chased down that rabbit hole and discovered that we're not actually using that cached data on the subscription management UI. We're just throwing errors when it doesn't match up with fresh subscriptions listed in customer data.

Splitting this commit out of #5745, because a) it removes an HTTP fetch we do on every page load and b) it will solve an error whenever #5745 lands.