### PR TITLE
fix(auth-server): allow customer to not have source on file

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -404,12 +404,14 @@ module.exports.subscriptionsPlanValidator = isA.object({
 });
 
 module.exports.subscriptionsCustomerValidator = isA.object({
-  billing_name: isA.alternatives(isA.string(), isA.any().allow(null)),
-  exp_month: isA.number().required(),
-  exp_year: isA.number().required(),
-  last4: isA.string().required(),
-  payment_type: isA.string().required(),
-  brand: isA.string().required(),
+  billing_name: isA
+    .alternatives(isA.string(), isA.any().allow(null))
+    .optional(),
+  exp_month: isA.number().optional(),
+  exp_year: isA.number().optional(),
+  last4: isA.string().optional(),
+  payment_type: isA.string().optional(),
+  brand: isA.string().optional(),
   subscriptions: isA
     .array()
     .items(module.exports.subscriptionsSubscriptionValidator)


### PR DESCRIPTION
Because:

* We throw errors if we have customers with no payment method on file.

This commit:

* Allows the customer endpoint to validate even without payment
  information on file.

Closes #5898

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
