### PR TITLE
fix(tests): replace returns with resolves on stubs

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -711,7 +711,7 @@ class DirectStripeRoutes {
       paymentMethodId
     );
     // Refetch the customer and force a cache clear
-    customer = this.stripeHelper.customer(uid, email, true);
+    customer = await this.stripeHelper.customer(uid, email, true);
     return filterCustomer(customer);
   }
 

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -161,7 +161,7 @@ describe('StripeHelper', () => {
     let refreshFunction;
 
     beforeEach(() => {
-      refreshFunction = sandbox.stub().returns(expectedResult);
+      refreshFunction = sandbox.stub().resolves(expectedResult);
     });
 
     it('follows read-through caching logic', async () => {
@@ -257,7 +257,7 @@ describe('StripeHelper', () => {
   describe('createPlainCustomer', () => {
     it('creates a customer using stripe api', async () => {
       const expected = deepCopy(newCustomerPM);
-      sandbox.stub(stripeHelper.stripe.customers, 'create').returns(expected);
+      sandbox.stub(stripeHelper.stripe.customers, 'create').resolves(expected);
 
       const actual = await stripeHelper.createPlainCustomer(
         'uid',
@@ -289,7 +289,7 @@ describe('StripeHelper', () => {
       const expected = deepCopy(newSetupIntent);
       sandbox
         .stub(stripeHelper.stripe.setupIntents, 'create')
-        .returns(expected);
+        .resolves(expected);
 
       const actual = await stripeHelper.createSetupIntent('cust_new');
 
@@ -315,7 +315,7 @@ describe('StripeHelper', () => {
   describe('updateDefaultPaymentMethod', () => {
     it('updates the default payment method', async () => {
       const expected = deepCopy(newCustomerPM);
-      sandbox.stub(stripeHelper.stripe.customers, 'update').returns(expected);
+      sandbox.stub(stripeHelper.stripe.customers, 'update').resolves(expected);
 
       const actual = await stripeHelper.updateDefaultPaymentMethod(
         'cust_new',
@@ -347,13 +347,13 @@ describe('StripeHelper', () => {
       const invoiceRetryExpected = deepCopy(invoiceRetry);
       sandbox
         .stub(stripeHelper.stripe.paymentMethods, 'attach')
-        .returns(attachExpected);
+        .resolves(attachExpected);
       sandbox
         .stub(stripeHelper.stripe.customers, 'update')
-        .returns(customerExpected);
+        .resolves(customerExpected);
       sandbox
         .stub(stripeHelper.stripe.invoices, 'retrieve')
-        .returns(invoiceRetryExpected);
+        .resolves(invoiceRetryExpected);
       const actual = await stripeHelper.retryInvoiceWithPaymentId(
         'customerId',
         'invoiceId',
@@ -416,10 +416,10 @@ describe('StripeHelper', () => {
       const customerExpected = deepCopy(newCustomerPM);
       sandbox
         .stub(stripeHelper.stripe.paymentMethods, 'attach')
-        .returns(attachExpected);
+        .resolves(attachExpected);
       sandbox
         .stub(stripeHelper.stripe.customers, 'update')
-        .returns(customerExpected);
+        .resolves(customerExpected);
       sandbox
         .stub(stripeHelper.stripe.subscriptions, 'create')
         .resolves(subscriptionPMIExpanded);
@@ -726,11 +726,11 @@ describe('StripeHelper', () => {
       sandbox.stub(moment, 'unix').returns(unixTimestamp);
       sandbox
         .stub(stripeHelper.stripe.subscriptions, 'retrieve')
-        .returns(subscription);
+        .resolves(subscription);
 
       const update = sandbox
         .stub(stripeHelper.stripe.subscriptions, 'update')
-        .returns(subscription2);
+        .resolves(subscription2);
 
       const actual = await stripeHelper.changeSubscriptionPlan(
         'sub_GAt1vgMqOSr5hT',
@@ -759,10 +759,10 @@ describe('StripeHelper', () => {
     it('throws an error if the user already upgraded', async () => {
       sandbox
         .stub(stripeHelper.stripe.subscriptions, 'retrieve')
-        .returns(subscription2);
+        .resolves(subscription2);
       sandbox
         .stub(stripeHelper.stripe.subscriptions, 'update')
-        .returns(subscription2);
+        .resolves(subscription2);
       let thrown;
       try {
         await stripeHelper.changeSubscriptionPlan(
@@ -949,7 +949,7 @@ describe('StripeHelper', () => {
   describe('createCustomer', () => {
     it('creates a customer using stripe api', async () => {
       const expected = deepCopy(newCustomer);
-      sandbox.stub(stripeHelper.stripe.customers, 'create').returns(expected);
+      sandbox.stub(stripeHelper.stripe.customers, 'create').resolves(expected);
 
       const actual = await stripeHelper.createCustomer(
         'uid',
@@ -1080,7 +1080,7 @@ describe('StripeHelper', () => {
   describe('updateCustomerPaymentMethod', () => {
     it('updates a customer using stripe api', async () => {
       const expected = deepCopy(customer1);
-      sandbox.stub(stripeHelper.stripe.customers, 'update').returns(expected);
+      sandbox.stub(stripeHelper.stripe.customers, 'update').resolves(expected);
 
       const actual = await stripeHelper.updateCustomerPaymentMethod(
         customer1.id,
@@ -1258,7 +1258,7 @@ describe('StripeHelper', () => {
       });
 
       it('returns void if no customer is found', async () => {
-        sandbox.stub(stripeHelper, 'customer').returns(null);
+        sandbox.stub(stripeHelper, 'customer').resolves(null);
 
         assert.isUndefined(
           await stripeHelper.subscriptionForCustomer(
@@ -1286,7 +1286,7 @@ describe('StripeHelper', () => {
       it('calls Stripe with the correct arguments', async () => {
         sandbox
           .stub(stripeHelper.stripe.subscriptions, 'list')
-          .returns({ has_more: false, data: [{ id: 'sub_wibble' }] });
+          .resolves({ has_more: false, data: [{ id: 'sub_wibble' }] });
         await stripeHelper.fetchAllSubscriptionsForCustomer(
           'cus_9001',
           'sub_ixi'
@@ -1302,13 +1302,13 @@ describe('StripeHelper', () => {
         const stub = sandbox.stub(stripeHelper.stripe.subscriptions, 'list');
         stub
           .onFirstCall()
-          .returns({ has_more: true, data: [{ id: 'sub_quux' }] });
+          .resolves({ has_more: true, data: [{ id: 'sub_quux' }] });
         stub
           .onSecondCall()
-          .returns({ has_more: true, data: [{ id: 'sub_foo' }] });
+          .resolves({ has_more: true, data: [{ id: 'sub_foo' }] });
         stub
           .onThirdCall()
-          .returns({ has_more: false, data: [{ id: 'sub_bar' }] });
+          .resolves({ has_more: false, data: [{ id: 'sub_bar' }] });
         const subs = await stripeHelper.fetchAllSubscriptionsForCustomer(
           'cus_9001',
           'sub_ixi'
@@ -1432,7 +1432,7 @@ describe('StripeHelper', () => {
     beforeEach(() => {
       stripeCustomerUpdate = sandbox
         .stub(stripeHelper.stripe.customers, 'update')
-        .returns();
+        .resolves();
 
       sandbox.spy(stripeHelper, 'removeCustomerFromCache');
     });
@@ -1667,7 +1667,7 @@ describe('StripeHelper', () => {
     beforeEach(() => {
       sandbox
         .stub(stripeHelper.stripe.paymentIntents, 'retrieve')
-        .returns(unsuccessfulPaymentIntent);
+        .resolves(unsuccessfulPaymentIntent);
     });
 
     describe('when the payment_intent is loaded', () => {
@@ -1718,7 +1718,7 @@ describe('StripeHelper', () => {
     beforeEach(() => {
       sandbox
         .stub(stripeHelper, 'expandResource')
-        .returns({ id: productId, name: productName });
+        .resolves({ id: productId, name: productName });
     });
 
     describe('when is one subscription', () => {
@@ -1780,7 +1780,7 @@ describe('StripeHelper', () => {
         beforeEach(() => {
           sandbox
             .stub(stripeHelper.stripe.charges, 'retrieve')
-            .returns(failedChargeCopy);
+            .resolves(failedChargeCopy);
         });
 
         describe('when the charge is already expanded', () => {
@@ -1822,7 +1822,7 @@ describe('StripeHelper', () => {
             const input = { data: [subscription1] };
             sandbox
               .stub(stripeHelper.stripe.invoices, 'retrieve')
-              .returns(paidInvoice);
+              .resolves(paidInvoice);
             const expected = [
               {
                 created: subscription1.created,
@@ -1853,7 +1853,7 @@ describe('StripeHelper', () => {
             const input = { data: [subscription] };
             sandbox
               .stub(stripeHelper.stripe.invoices, 'retrieve')
-              .returns(paidInvoice);
+              .resolves(paidInvoice);
             const expected = [
               {
                 created: subscription.created,
@@ -1882,7 +1882,7 @@ describe('StripeHelper', () => {
             const input = { data: [cancelledSubscription] };
             sandbox
               .stub(stripeHelper.stripe.invoices, 'retrieve')
-              .returns(paidInvoice);
+              .resolves(paidInvoice);
             const expected = [
               {
                 created: cancelledSubscription.created,
@@ -1927,7 +1927,7 @@ describe('StripeHelper', () => {
 
         sandbox
           .stub(stripeHelper.stripe.invoices, 'retrieve')
-          .returns(paidInvoice);
+          .resolves(paidInvoice);
 
         const input = {
           data: [subscription1, incompleteSubscription, subscription2],
@@ -1959,7 +1959,7 @@ describe('StripeHelper', () => {
     beforeEach(() => {
       sandbox
         .stub(stripeHelper, 'expandResource')
-        .returns({ id: productId, name: productName });
+        .resolves({ id: productId, name: productName });
     });
 
     describe('when is one subscription', () => {
@@ -2470,19 +2470,19 @@ describe('StripeHelper', () => {
             stripeHelper,
             'extractSubscriptionUpdateCancellationDetailsForEmail'
           )
-          .returns(mockCancellationDetails);
+          .resolves(mockCancellationDetails);
         sandbox
           .stub(
             stripeHelper,
             'extractSubscriptionUpdateReactivationDetailsForEmail'
           )
-          .returns(mockReactivationDetails);
+          .resolves(mockReactivationDetails);
         sandbox
           .stub(
             stripeHelper,
             'extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail'
           )
-          .returns(mockUpgradeDowngradeDetails);
+          .resolves(mockUpgradeDowngradeDetails);
       });
 
       function assertOnlyExpectedHelperCalledWith(expectedHelperName, ...args) {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -345,9 +345,9 @@ describe('subscriptions directRoutes', () => {
       };
 
       stripeHelper = sinon.createStubInstance(StripeHelper);
-      stripeHelper.customer.returns(customer);
-      stripeHelper.expandResource.returns(stripePlan);
-      stripeHelper.findPlanById.returns(PLANS[0]);
+      stripeHelper.customer.resolves(customer);
+      stripeHelper.expandResource.resolves(stripePlan);
+      stripeHelper.findPlanById.resolves(PLANS[0]);
       stripeHelper.formatSubscriptionsForSupport.restore();
     });
 
@@ -559,7 +559,7 @@ describe('DirectStripeRoutes', () => {
 
   describe('getClients', () => {
     it('returns the clients and their capabilities', async () => {
-      directStripeRoutesInstance.stripeHelper.allPlans.returns(PLANS);
+      directStripeRoutesInstance.stripeHelper.allPlans.resolves(PLANS);
 
       const expected = [
         {
@@ -629,7 +629,7 @@ describe('DirectStripeRoutes', () => {
 
       sandbox.stub(directStripeRoutesInstance, 'customerChanged').resolves();
 
-      directStripeRoutesInstance.stripeHelper.findPlanById.returns(plan);
+      directStripeRoutesInstance.stripeHelper.findPlanById.resolves(plan);
     });
 
     describe('when called for a new customer', () => {
@@ -728,7 +728,7 @@ describe('DirectStripeRoutes', () => {
   describe('createCustomer', () => {
     it('creates a stripe customer', async () => {
       const expected = deepCopy(emptyCustomer);
-      directStripeRoutesInstance.stripeHelper.createPlainCustomer.returns(
+      directStripeRoutesInstance.stripeHelper.createPlainCustomer.resolves(
         expected
       );
       VALID_REQUEST.payload = {
@@ -747,9 +747,9 @@ describe('DirectStripeRoutes', () => {
   describe('createSubscriptionWithPMI', () => {
     it('creates a subscription with a payment method', async () => {
       const customer = deepCopy(emptyCustomer);
-      directStripeRoutesInstance.stripeHelper.customer.returns(customer);
+      directStripeRoutesInstance.stripeHelper.customer.resolves(customer);
       const expected = deepCopy(subscription2);
-      directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI.returns(
+      directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI.resolves(
         expected
       );
       VALID_REQUEST.payload = {
@@ -766,7 +766,7 @@ describe('DirectStripeRoutes', () => {
     });
 
     it('errors when a customer has not been created', async () => {
-      directStripeRoutesInstance.stripeHelper.customer.returns(undefined);
+      directStripeRoutesInstance.stripeHelper.customer.resolves(undefined);
       VALID_REQUEST.payload = {
         displayName: 'Jane Doe',
         idempotencyKey: uuidv4(),
@@ -786,9 +786,9 @@ describe('DirectStripeRoutes', () => {
   describe('retryInvoice', () => {
     it('retries the invoice with the payment method', async () => {
       const customer = deepCopy(emptyCustomer);
-      directStripeRoutesInstance.stripeHelper.customer.returns(customer);
+      directStripeRoutesInstance.stripeHelper.customer.resolves(customer);
       const expected = deepCopy(openInvoice);
-      directStripeRoutesInstance.stripeHelper.retryInvoiceWithPaymentId.returns(
+      directStripeRoutesInstance.stripeHelper.retryInvoiceWithPaymentId.resolves(
         expected
       );
       VALID_REQUEST.payload = {
@@ -805,7 +805,7 @@ describe('DirectStripeRoutes', () => {
     });
 
     it('errors when a customer has not been created', async () => {
-      directStripeRoutesInstance.stripeHelper.customer.returns(undefined);
+      directStripeRoutesInstance.stripeHelper.customer.resolves(undefined);
       VALID_REQUEST.payload = {
         displayName: 'Jane Doe',
         idempotencyKey: uuidv4(),
@@ -823,9 +823,9 @@ describe('DirectStripeRoutes', () => {
   describe('createSetupIntent', () => {
     it('creates a new setup intent', async () => {
       const customer = deepCopy(emptyCustomer);
-      directStripeRoutesInstance.stripeHelper.customer.returns(customer);
+      directStripeRoutesInstance.stripeHelper.customer.resolves(customer);
       const expected = deepCopy(newSetupIntent);
-      directStripeRoutesInstance.stripeHelper.createSetupIntent.returns(
+      directStripeRoutesInstance.stripeHelper.createSetupIntent.resolves(
         expected
       );
       VALID_REQUEST.payload = {};
@@ -859,12 +859,12 @@ describe('DirectStripeRoutes', () => {
 
       directStripeRoutesInstance.stripeHelper.customer
         .onCall(0)
-        .returns(customer);
+        .resolves(customer);
       directStripeRoutesInstance.stripeHelper.customer
         .onCall(1)
-        .returns(expected);
+        .resolves(expected);
 
-      directStripeRoutesInstance.stripeHelper.updateDefaultPaymentMethod.returns(
+      directStripeRoutesInstance.stripeHelper.updateDefaultPaymentMethod.resolves(
         customer
       );
       VALID_REQUEST.payload = {
@@ -882,7 +882,7 @@ describe('DirectStripeRoutes', () => {
       const customer = deepCopy(emptyCustomer);
       directStripeRoutesInstance.stripeHelper.customer
         .onCall(0)
-        .returns(customer);
+        .resolves(customer);
 
       VALID_REQUEST.payload = { paymentMethodId: 'pm_asdf' };
       try {
@@ -914,8 +914,8 @@ describe('DirectStripeRoutes', () => {
     it('creates a stripe customer and a new subscription', async () => {
       const expected = subscription2;
       const customer = deepCopy(emptyCustomer);
-      directStripeRoutesInstance.stripeHelper.createCustomer.returns(customer);
-      directStripeRoutesInstance.stripeHelper.createSubscription.returns(
+      directStripeRoutesInstance.stripeHelper.createCustomer.resolves(customer);
+      directStripeRoutesInstance.stripeHelper.createSubscription.resolves(
         subscription2
       );
 
@@ -957,13 +957,13 @@ describe('DirectStripeRoutes', () => {
 
     describe('the optional paymentToken parameter', () => {
       beforeEach(() => {
-        directStripeRoutesInstance.stripeHelper.updateCustomerPaymentMethod.returns();
+        directStripeRoutesInstance.stripeHelper.updateCustomerPaymentMethod.resolves();
       });
 
       describe('when a payment token is provided', () => {
         it('calls updateCustomerPaymentMethod', async () => {
           const expected = deepCopy(subscription2);
-          directStripeRoutesInstance.stripeHelper.createSubscription.returns(
+          directStripeRoutesInstance.stripeHelper.createSubscription.resolves(
             expected
           );
           const actual = await directStripeRoutesInstance.createSubscriptionExistingCustomer(
@@ -985,7 +985,7 @@ describe('DirectStripeRoutes', () => {
       describe('when a payment token is not provided', () => {
         it('does not call updateCustomerPaymentMethod', async () => {
           const expected = deepCopy(subscription2);
-          directStripeRoutesInstance.stripeHelper.createSubscription.returns(
+          directStripeRoutesInstance.stripeHelper.createSubscription.resolves(
             expected
           );
           const actual = await directStripeRoutesInstance.createSubscriptionExistingCustomer(
@@ -1006,7 +1006,7 @@ describe('DirectStripeRoutes', () => {
     describe('user with no subscriptions', () => {
       it('calls createSubscription', async () => {
         const expected = deepCopy(subscription2);
-        directStripeRoutesInstance.stripeHelper.createSubscription.returns(
+        directStripeRoutesInstance.stripeHelper.createSubscription.resolves(
           expected
         );
         const actual = await directStripeRoutesInstance.createSubscriptionExistingCustomer(
@@ -1042,7 +1042,7 @@ describe('DirectStripeRoutes', () => {
           customer.subscriptions.data = [existingSubscription];
 
           const expected = deepCopy(subscription2);
-          directStripeRoutesInstance.stripeHelper.createSubscription.returns(
+          directStripeRoutesInstance.stripeHelper.createSubscription.resolves(
             expected
           );
           const actual = await directStripeRoutesInstance.createSubscriptionExistingCustomer(
@@ -1125,7 +1125,7 @@ describe('DirectStripeRoutes', () => {
           customer.subscriptions.data = [existingSubscription];
 
           const expected = deepCopy(subscription2);
-          directStripeRoutesInstance.stripeHelper.createSubscription.returns(
+          directStripeRoutesInstance.stripeHelper.createSubscription.resolves(
             expected
           );
           const actual = await directStripeRoutesInstance.createSubscriptionExistingCustomer(
@@ -1437,12 +1437,12 @@ describe('DirectStripeRoutes', () => {
     beforeEach(() => {
       request = { ...VALID_REQUEST, payload: { paymentToken } };
 
-      directStripeRoutesInstance.stripeHelper.updateCustomerPaymentMethod.returns();
+      directStripeRoutesInstance.stripeHelper.updateCustomerPaymentMethod.resolves();
     });
 
     describe('when the customer exists', () => {
       it('updates the payment method', async () => {
-        directStripeRoutesInstance.stripeHelper.fetchCustomer.returns(
+        directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(
           customerFixture
         );
 
@@ -1481,7 +1481,7 @@ describe('DirectStripeRoutes', () => {
 
     describe('when the customer does not exist', () => {
       it('throws an error', async () => {
-        directStripeRoutesInstance.stripeHelper.fetchCustomer.returns();
+        directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves();
 
         try {
           await directStripeRoutesInstance.updatePayment(request);
@@ -1591,7 +1591,7 @@ describe('DirectStripeRoutes', () => {
     it('returns the available plans when auth headers are valid', async () => {
       const expected = sanitizePlans(PLANS);
 
-      directStripeRoutesInstance.stripeHelper.allPlans.returns(PLANS);
+      directStripeRoutesInstance.stripeHelper.allPlans.resolves(PLANS);
       const actual = await directStripeRoutesInstance.listPlans(VALID_REQUEST);
 
       assert.deepEqual(actual, expected);
@@ -1620,7 +1620,7 @@ describe('DirectStripeRoutes', () => {
 
   describe('getProductCapabilties', () => {
     it('extracts all capabilities for all products', async () => {
-      directStripeRoutesInstance.stripeHelper.allPlans.returns(PLANS);
+      directStripeRoutesInstance.stripeHelper.allPlans.resolves(PLANS);
       assert.deepEqual(
         await directStripeRoutesInstance.getProductCapabilities(
           'firefox_pro_basic'
@@ -1807,7 +1807,7 @@ describe('DirectStripeRoutes', () => {
       const subscription = deepCopy(subscription2);
       const sub = { id: subscription.id, productId: subscription.plan.product };
 
-      directStripeRoutesInstance.stripeHelper.allPlans.returns([
+      directStripeRoutesInstance.stripeHelper.allPlans.resolves([
         ...PLANS,
         {
           plan_id: subscription2.plan.id,
@@ -1856,7 +1856,7 @@ describe('DirectStripeRoutes', () => {
 
     describe('when the customer is found from the subscription', () => {
       it('calls all the update and notification functions', async () => {
-        directStripeRoutesInstance.stripeHelper.getCustomerUidEmailFromSubscription.returns(
+        directStripeRoutesInstance.stripeHelper.getCustomerUidEmailFromSubscription.resolves(
           { uid: UID, email: TEST_EMAIL }
         );
 
@@ -1879,7 +1879,7 @@ describe('DirectStripeRoutes', () => {
 
     describe('when the customer is not found from the subscription', () => {
       it('returns without calling anything', async () => {
-        directStripeRoutesInstance.stripeHelper.getCustomerUidEmailFromSubscription.returns(
+        directStripeRoutesInstance.stripeHelper.getCustomerUidEmailFromSubscription.resolves(
           { uid: undefined, email: undefined }
         );
 


### PR DESCRIPTION
Because:
 - stubs in tests for async functions should return a promise

This commit:
 - replace `returns` with `resolves` on stubs in StripeHelper and
   subscriptions route tests
 - fix a bug found during the test updates

## Issue that this pull request solves

Closes: #5897 (FXA-2253)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

