### PR TITLE
fix(content-server): clean the password input

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/sign_in_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_password.js
@@ -30,6 +30,7 @@ const SignInPasswordView = FormView.extend({
     // directed directly to /signin will not be able
     // to go back. Send them directly to `/` with the
     // account. The email will be prefilled on that page.
+    this.clearInput();
     this.navigate('/', { account: this.getAccount() });
   },
 


### PR DESCRIPTION
Because:

* The password value is not cleaned before navigating.

This commit:

* Clean the password input before navigating.

fixes #2220 
