### PR TITLE
bug(styles): correctly pass styles into stripe card element

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentFormV2/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentFormV2/index.scss
@@ -35,7 +35,7 @@ form.payment {
     }
 
     input {
-      font-size: 14px;
+      font-size: 16px;
 
       // overrides firefox's default box shadow for invalid els
       // we get this from our class system
@@ -54,7 +54,7 @@ form.payment {
 
     input::placeholder {
       color: #767676 !important;
-      font-size: 14px;
+      font-size: 16px;
       font-weight: 400;
       height: 45px;
       line-height: normal;
@@ -89,11 +89,6 @@ form.payment {
 
   .main-content .payments-card {
     width: 100%;
-
-    .input-row input,
-    .input-row .StripeElement {
-      padding-left: 5px !important;
-    }
 
     .input-row-group {
       padding-bottom: 8px;

--- a/packages/fxa-payments-server/src/components/PaymentFormV2/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentFormV2/index.tsx
@@ -122,10 +122,21 @@ export const PaymentForm = ({
     [validator, onSubmitForParent, stripe, submitNonce, shouldAllowSubmit]
   );
 
-  const { matchMedia, navigatorLanguages } = useContext(AppContext);
-  const stripeElementStyles = mkStripeElementStyles(
-    matchMedia(SMALL_DEVICE_RULE)
-  );
+  const { navigatorLanguages } = useContext(AppContext);
+
+  const STRIPE_ELEMENT_STYLES = {
+    style: {
+      base: {
+        fontFamily:
+          'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
+        fontSize: '16px',
+        fontWeight: '500',
+      },
+      invalid: {
+        color: '#0c0c0d',
+      },
+    },
+  };
 
   let termsOfServiceURL, privacyNoticeURL;
   if (confirm && plan) {
@@ -164,8 +175,8 @@ export const PaymentForm = ({
           component={CardElement}
           name="creditCard"
           label="Your card"
-          style={stripeElementStyles}
           className="input-row input-row--xl"
+          options={STRIPE_ELEMENT_STYLES}
           getString={getString}
           required
         />
@@ -273,22 +284,6 @@ const WrappedPaymentForm = (props: PaymentFormProps) => {
 export const SMALL_DEVICE_RULE = '(max-width: 520px)';
 export const SMALL_DEVICE_LINE_HEIGHT = '40px';
 export const DEFAULT_LINE_HEIGHT = '48px';
-
-export function mkStripeElementStyles(useSmallDeviceStyles: boolean) {
-  // ref: https://stripe.com/docs/stripe-js/reference#the-elements-object
-  return {
-    base: {
-      //TODO: Figure out what this really should be - I just copied it from computed styles because CSS can't apply through the iframe
-      fontFamily:
-        'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif',
-      fontSize: '14px',
-      fontWeight: '500',
-    },
-    invalid: {
-      color: '#0c0c0d',
-    },
-  };
-}
 
 const validateName: OnValidateFunction = (
   value,

--- a/packages/fxa-payments-server/src/components/fields/index.tsx
+++ b/packages/fxa-payments-server/src/components/fields/index.tsx
@@ -47,6 +47,7 @@ type FieldProps = {
   maxLength?: number;
   minLength?: number;
   autoFocus?: boolean;
+  options?: object;
 };
 
 type FieldHOCProps = {
@@ -262,11 +263,11 @@ export const StripeElement = (props: StripeElementProps) => {
     className,
     autoFocus,
     getString,
+    options = {},
     ...childProps
   } = props;
   const { validator } = useContext(FormContext) as FormContextValue;
   const elementValue = useRef<stripe.elements.ElementChangeResponse>();
-
   const onChange = useCallback(
     (value: stripe.elements.ElementChangeResponse) => {
       elementValue.current = value;
@@ -307,6 +308,7 @@ export const StripeElement = (props: StripeElementProps) => {
         <StripeElementComponent
           {...{
             ...childProps,
+            options,
             onChange,
             onBlur,
           }}

--- a/packages/fxa-payments-server/src/index.scss
+++ b/packages/fxa-payments-server/src/index.scss
@@ -79,28 +79,19 @@ hr {
 
   .StripeElement {
     @include input-element();
-    padding-top: 14px;
+    padding: 14px $input-left-right-padding 0;
+
+    @include respond-to('small') {
+      padding: 9px $input-left-right-padding * .75 0;
+    }
 
     &:last-child {
       margin-bottom: 0;
     }
 
-    html[dir='ltr'] & {
-      padding: 14px 0 0 $input-left-right-padding;
-
-      @include respond-to('simpleSmall') {
-        padding-top: 11px;
-      }
-    }
-
     html[dir='rtl'] & {
       direction: ltr;
-      padding: 14px $input-left-right-padding 0 0;
       text-align: right;
-
-      @include respond-to('simpleSmall') {
-        padding-top: 11px;
-      }
     }
   }
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
@@ -171,9 +171,4 @@
   .subscription-management .card-details {
     flex-direction: column;
   }
-
-  .input-row input,
-  .input-row .StripeElement {
-    padding-left: 5px !important;
-  }
 }


### PR DESCRIPTION
## Because

We do not correctly handle adding styles to Stripe's card object

## This commit

Resolves that issue by adding an options property to our StripeElement component. I've also made small adjustments to the layout of the input for the paymentsV2 form.

## Issue that this pull request solves

Closes: #5906

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
![image](https://user-images.githubusercontent.com/3323249/87043309-1b74a900-c1f5-11ea-8688-c8a6f257460f.png)

