### PR TITLE
fix(content-server): disable the "Take picture" button

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/avatar_camera.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/avatar_camera.mustache
@@ -15,7 +15,7 @@
 
     <form novalidate>
       <div class="button-row">
-        <button type="submit" id="submit-btn" class="settings-button primary-button">{{#t}}Take picture{{/t}}</button>
+        <button type="submit" id="submit-btn" class="settings-button primary-button" disabled>{{#t}}Take picture{{/t}}</button>
         <button class="settings-button secondary-button" id="back">{{#t}}Cancel{{/t}}</button>
       </div>
     </form>

--- a/packages/fxa-content-server/app/scripts/views/mixins/disable-form-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/disable-form-mixin.js
@@ -13,7 +13,6 @@
 // to open/close the panel, the second to submit. Only the submit button
 // should be disabled.
 const BUTTON_SELECTOR = 'button[type=submit]';
-const DISABLED_CLASS = 'disabled';
 
 export default {
   afterRender() {
@@ -32,13 +31,13 @@ export default {
    * Disable the form by disabling the primary button
    */
   disableForm() {
-    this.$(BUTTON_SELECTOR).addClass(DISABLED_CLASS);
+    this.$(BUTTON_SELECTOR).attr('disabled', true);
   },
 
   /**
    * Enable the form by enabling the primary button.
    */
   enableForm() {
-    this.$(BUTTON_SELECTOR).removeClass(DISABLED_CLASS);
+    this.$(BUTTON_SELECTOR).attr('disabled', false);
   },
 };

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/disable-form-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/disable-form-mixin.js
@@ -61,13 +61,12 @@ describe('views/mixins/disable-form-mixin', () => {
     });
   });
 
-  it('`disableForm` adds the `disabled` class to the submit button, `enableForm` removes it', () => {
+  it('`disableForm` adds the `disabled` attribute to the submit button, `enableForm` removes it', () => {
     return view.render().then(() => {
-      assert.lengthOf(view.$('button.disabled'), 0);
       view.disableForm();
-      assert.lengthOf(view.$('button.disabled'), 1);
+      assert.isTrue(view.$('button').prop('disabled'));
       view.enableForm();
-      assert.lengthOf(view.$('button.disabled'), 0);
+      assert.isFalse(view.$('button').prop('disabled'));
     });
   });
 });


### PR DESCRIPTION
Because:

* The button was clickable

This commit:

* Make the "Take picture" button disabled when the error appears. And enable it when there's no error.

fixes #1472
