### PR TITLE
feat(profile+auth): pass anon id from profile to auth to db

### DIFF
--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -37,6 +37,7 @@ see [`mozilla/fxa-js-client`](https://github.com/mozilla/fxa-js-client).
     - [POST /account/unlock/verify_code](#post-accountunlockverify_code)
     - [POST /account/reset (:lock: accountResetToken)](#post-accountreset)
     - [POST /account/destroy (:lock::unlock: sessionToken)](#post-accountdestroy)
+    - [PUT /account/ecosystemAnonId (:lock: oauthToken)](#put-accountmetricsecosystemanonId)
   - [Devices and sessions](#devices-and-sessions)
     - [POST /account/device (:lock: sessionToken, refreshToken)](#post-accountdevice)
     - [GET /account/device/commands (:lock: sessionToken, refreshToken)](#get-accountdevicecommands)
@@ -1147,6 +1148,37 @@ by the following errors
 
 - `code: 400, errno: 138`:
   Unverified session
+
+#### POST /account/ecosystemAnonId
+
+:lock: Authenticated with OAuth bearer token
+
+<!--begin-route-put-accountmetricsecosystemanonId-->
+
+Adds new or updates existing user Ecosystem Anonymous ID.
+
+<!--end-route-put-accountmetricsecosystemanonId-->
+
+##### Request body
+
+- `anonId`: _string, required_
+
+  <!--begin-request-body-put-accountmetricsecosystemanonId-anonId-->
+
+  The new Ecosystem Anonymous ID.
+
+  <!--end-request-body-put-accountmetricsecosystemanonId-email-->
+
+##### Error responses
+
+Failing requests may be caused
+by the following errors
+(this is not an exhaustive list):
+
+- `code: 400, errno: 163`:
+  Token does not contain the correct scope.
+- `code: 412, errno: 190`:
+  Attempted to update non-null Ecosystem Anon ID.
 
 ### Devices and sessions
 

--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -1435,6 +1435,19 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     return this.redis.pruneSessionTokens(uid, [id]);
   };
 
+  SAFE_URLS.updateEcosystemAnonId = new SafeUrl(
+    '/account/:id/ecosystemAnonId',
+    'db.updateEcosystemAnonId'
+  );
+  DB.prototype.updateEcosystemAnonId = async function (uid, ecosystemAnonId) {
+    log.trace('DB.updateEcosystemAnonId', { uid, ecosystemAnonId });
+    return this.pool.put(
+      SAFE_URLS.updateEcosystemAnonId,
+      { uid },
+      { ecosystemAnonId }
+    );
+  };
+
   function mergeDeviceInfoFromRedis(
     device,
     redisSessionTokens,

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -102,6 +102,7 @@ const ERRNO = {
   PAYMENT_FAILED: 186,
   SUBSCRIPTION_ALREADY_EXISTS: 187,
   UNKNOWN_SUBSCRIPTION_FOR_SOURCE: 188,
+  ECOSYSTEM_ANON_ID_EXISTS: 190,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -1307,6 +1308,15 @@ AppError.invalidOrExpiredOtpCode = () => {
     error: 'Bad Request',
     errno: ERRNO.INVALID_EXPIRED_OTP_CODE,
     message: 'Invalid or expired verification code',
+  });
+};
+
+AppError.anonIdExists = () => {
+  return new AppError({
+    code: 412,
+    error: 'Precondition Failed',
+    errno: ERRNO.ECOSYSTEM_ANON_ID_EXISTS,
+    message: 'Attempted to update non-null Ecosystem Anon ID',
   });
 };
 

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -80,6 +80,7 @@ const DB_METHOD_NAMES = [
   'touchSessionToken',
   'totpToken',
   'updateDevice',
+  'updateEcosystemAnonId',
   'updateLocale',
   'updateRecoveryKey',
   'updateSessionToken',
@@ -508,6 +509,11 @@ function mockDB(data, errors) {
     updateDevice: sinon.spy((uid, device) => {
       assert.ok(typeof uid === 'string');
       return P.resolve(device);
+    }),
+    updateEcosystemAnonId: sinon.spy((uid, ecosystemAnonId) => {
+      assert.ok(typeof uid === 'string');
+      assert.ok(typeof ecosystemAnonId === 'string');
+      return P.resolve({});
     }),
     sessionToken: sinon.spy(() => {
       const res = {

--- a/packages/fxa-profile-server/docs/API.md
+++ b/packages/fxa-profile-server/docs/API.md
@@ -46,6 +46,7 @@ The currently-defined error responses are:
 - 400, 101: Invalid request parameter
 - 400, 102: Unsupported image provider
 - 400, 125: The request was blocked for security reasons
+- 412, 106: Attempted to update non-null Ecosystem Anon ID
 - 429, 114: Client has sent too many requests
 - 500, 103: Image processing error
 - 503, 104: OAuth service unavailable

--- a/packages/fxa-profile-server/lib/error.js
+++ b/packages/fxa-profile-server/lib/error.js
@@ -203,4 +203,18 @@ AppError.authError = function authError(err) {
   );
 };
 
+AppError.anonIdExists = function anonIdExists(err) {
+  return new AppError(
+    {
+      code: 412,
+      error: 'Precondition Failed',
+      errno: 106,
+      message: 'Attempted to update non-null Ecosystem Anon ID',
+    },
+    {
+      cause: err,
+    }
+  );
+};
+
 module.exports = AppError;

--- a/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/post.js
+++ b/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/post.js
@@ -6,6 +6,74 @@ const Joi = require('@hapi/joi');
 
 const logger = require('../../logging')('routes.ecosystem_anon_id.post');
 const notifyProfileUpdated = require('../../updates-queue');
+const AppError = require('../../error');
+const config = require('../../config');
+const request = require('../../request');
+
+const AUTH_SERVER_URL =
+  config.get('authServer.url') + '/account/ecosystemAnonId';
+
+const updateAuthServer = function (
+  credentials,
+  ecosystemAnonId,
+  noneMatchHeader
+) {
+  const headers = {
+    Authorization: 'Bearer ' + credentials.token,
+  };
+
+  if (noneMatchHeader) {
+    headers['If-None-Match'] = noneMatchHeader;
+  }
+
+  return new Promise((resolve, reject) => {
+    request.get(
+      AUTH_SERVER_URL,
+      {
+        headers,
+        body: {
+          ecosystemAnonId,
+        },
+        json: true,
+      },
+      (err, res, body) => {
+        if (err) {
+          logger.error('request.auth_server.network', err);
+          return reject(new AppError.authError('network error'));
+        }
+
+        if (res.statusCode >= 400) {
+          body = body && body.code ? body : { code: res.statusCode };
+
+          if (res.statusCode >= 500) {
+            logger.error('request.auth_server.fail', body);
+            return reject(new AppError.authError('auth-server server error'));
+          }
+
+          if (body.code === 401 || body.errno === 102) {
+            logger.info('request.auth_server.fail', body);
+            return reject(new AppError.unauthorized(body.message));
+          }
+
+          if (body.code === 412 || body.errno === 190) {
+            logger.info('request.auth_server.precondition_fail', body);
+            return reject(new AppError.unauthorized(body.message));
+          }
+
+          logger.error('request.auth_server.fail', body);
+          return reject(
+            new AppError({
+              code: 500,
+              message: 'error communicating with auth server',
+            })
+          );
+        }
+
+        return resolve();
+      }
+    );
+  });
+};
 
 module.exports = {
   auth: {
@@ -18,14 +86,40 @@ module.exports = {
     },
   },
   handler: async function ecosystemAnonIdPost(req) {
-    const uid = req.auth.credentials.user;
-    logger.info('activityEvent', { event: 'ecosystemAnonId.post', uid: uid });
+    return req.server
+      .inject({
+        allowInternals: true,
+        method: 'get',
+        url: '/v1/_core_profile',
+        headers: req.headers,
+        auth: {
+          credentials: req.auth.credentials,
+          strategy: 'oauth',
+        },
+      })
+      .then(async (res) => {
+        const uid = req.auth.credentials.user;
+        const noneMatchHeader = req.headers['if-none-match'];
+        const existingAnonId = res.result.ecosystemAnonId;
 
-    await req.server.methods.profileCache.drop(uid);
+        logger.info('activityEvent', {
+          event: 'ecosystemAnonId.post',
+          uid: uid,
+        });
 
-    // When DB is ready, insert/update req.payload.ecosystemAnonId.
-    // For now, just notify and return.
-    notifyProfileUpdated(uid);
-    return {};
+        if (noneMatchHeader === '*' && existingAnonId != null) {
+          throw AppError.anonIdExists();
+        }
+
+        await req.server.methods.profileCache.drop(uid);
+        await updateAuthServer(
+          req.auth.credentials,
+          req.payload.ecosystemAnonId,
+          noneMatchHeader
+        );
+
+        notifyProfileUpdated(uid);
+        return {};
+      });
   },
 };

--- a/packages/fxa-profile-server/test/api.js
+++ b/packages/fxa-profile-server/test/api.js
@@ -1603,7 +1603,33 @@ describe('api', function () {
         assertSecurityHeaders(res);
       });
 
-      xit('should fail post with 412 error if the If-Match header does not match the ETag', function () {});
+      it('should fail post with 412 error if the If-None-Match: * header is present and anon ID already exists', async function () {
+        mock.coreProfile({
+          email: 'andy@example.domain',
+          locale: 'en-US',
+          authenticationMethods: ['pwd'],
+          authenticatorAssuranceLevel: 1,
+          ecosystemAnonId: 'who is your humble',
+        });
+        mock.token({
+          user: USERID,
+          scope: ['profile:ecosystem_anon_id:write'],
+        });
+
+        const res = await Server.api.post({
+          url: '/ecosystem_anon_id',
+          payload: {
+            ecosystemAnonId: 'are you the light',
+          },
+          headers: {
+            authorization: 'Bearer ' + tok,
+            'If-None-Match': '*',
+          },
+        });
+
+        assert.equal(res.statusCode, 412);
+        assertSecurityHeaders(res);
+      });
 
       it('should require :write scope', async function () {
         mock.token({


### PR DESCRIPTION
## Because

The Profile server can receive an updated ecosystem anon ID, but doesn't do much with it at the moment.

## This change

Makes the Profile server ping the Auth server when it receives a new anon ID, which in turn shoots it over to the Auth DB server.

## Issue that this pull request solves

Closes: #5909 
Closes: #4322 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
