### PR TITLE
fix(pair): Add marketings links (app badges) to pairing page

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -114,11 +114,11 @@ module.exports = {
   MARKETING_ID_AUTUMN_2016: 'autumn-2016-connect-another-device',
 
   DOWNLOAD_LINK_TEMPLATE_ANDROID:
-    'https://app.adjust.com/2uo1qc?campaign=%(campaign)s&creative=%(creative)s&adgroup=android',
+    'https://app.adjust.com/2uo1qc?campaign=%(campaign)s&creative=%(creative)s&adgroup=android&fallback=https://play.google.com/store/apps/details?id=org.mozilla.firefox',
   DOWNLOAD_LINK_TEMPLATE_IOS:
     'https://app.adjust.com/2uo1qc?campaign=%(campaign)s&creative=%(creative)s&adgroup=ios&fallback=https://itunes.apple.com/app/apple-store/id989804926?pt=373246&ct=adjust_tracker&mt=8', //eslint-disable-line max-len
   DOWNLOAD_LINK_PAIRING_APP:
-    'https://play.google.com/store/apps/details?id=org.mozilla.fenix',
+    'https://app.adjust.com/2uo1qc?campaign=%(campaign)s&creative=%(creative)s&adgroup=android&fallback=https://play.google.com/store/apps/details?id=org.mozilla.firefox_beta',
 
   MOZ_ORG_SYNC_GET_STARTED_LINK:
     'https://www.mozilla.org/firefox/sync?utm_source=fx-website&utm_medium=fx-accounts&utm_campaign=fx-signup&utm_content=fx-sync-get-started', //eslint-disable-line max-len

--- a/packages/fxa-content-server/app/scripts/templates/pair/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/index.mustache
@@ -15,9 +15,7 @@
       </div>
     </form>
 
-    <div class="links">
-      <a href="{{downloadAppLink}}" rel="noopener noreferrer" target="_blank">{{#t}}Get app{{/t}}</a>
-    </div>
+    <div class="marketing-area"></div>
 
   </section>
 </div>

--- a/packages/fxa-content-server/app/scripts/views/marketing_snippet.js
+++ b/packages/fxa-content-server/app/scripts/views/marketing_snippet.js
@@ -77,6 +77,7 @@ const View = BaseView.extend(
         options.marketingId || Constants.MARKETING_ID_SPRING_2015;
       this._service = options.service;
       this._which = options.which;
+      this._useAndroidPairingApp = options.useAndroidPairingApp;
     },
 
     events: {
@@ -89,7 +90,9 @@ const View = BaseView.extend(
       const isAndroid = this._isAndroid();
       const isOther = this._isOther();
       const downloadLinkAndroid = this._storeLink(
-        Constants.DOWNLOAD_LINK_TEMPLATE_ANDROID
+        this._useAndroidPairingApp
+          ? Constants.DOWNLOAD_LINK_PAIRING_APP
+          : Constants.DOWNLOAD_LINK_TEMPLATE_ANDROID
       );
       const playStoreImage = this._storeImage(PLAY_STORE_BUTTON, FORMAT_PNG);
       const downloadLinkIos = this._storeLink(

--- a/packages/fxa-content-server/app/scripts/views/pair/index.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/index.js
@@ -9,8 +9,9 @@ import Template from '../../templates/pair/index.mustache';
 import UserAgentMixin from '../../lib/user-agent-mixin';
 import PairingGraphicsMixin from '../mixins/pairing-graphics-mixin';
 import PairingTotpMixin from './pairing-totp-mixin';
-import { DOWNLOAD_LINK_PAIRING_APP } from '../../lib/constants';
+import { MARKETING_ID_AUTUMN_2016, SYNC_SERVICE } from '../../lib/constants';
 import SyncAuthMixin from '../mixins/sync-auth-mixin';
+import MarketingMixin from '../mixins/marketing-mixin';
 
 class PairIndexView extends FormView {
   template = Template;
@@ -45,7 +46,6 @@ class PairIndexView extends FormView {
     const graphicId = this.getGraphicsId();
 
     context.set({
-      downloadAppLink: DOWNLOAD_LINK_PAIRING_APP,
       graphicId,
     });
   }
@@ -57,7 +57,12 @@ Cocktail.mixin(
   PairingGraphicsMixin,
   PairingTotpMixin(),
   UserAgentMixin,
-  SyncAuthMixin
+  SyncAuthMixin,
+  MarketingMixin({
+    marketingId: MARKETING_ID_AUTUMN_2016,
+    service: SYNC_SERVICE,
+    useAndroidPairingApp: true,
+  })
 );
 
 export default PairIndexView;

--- a/packages/fxa-content-server/app/tests/spec/views/marketing_snippet.js
+++ b/packages/fxa-content-server/app/tests/spec/views/marketing_snippet.js
@@ -177,6 +177,25 @@ describe('views/marketing_snippet', function () {
         testStoreLink('DOWNLOAD_LINK_TEMPLATE_ANDROID');
         testStoreLink('DOWNLOAD_LINK_TEMPLATE_IOS');
       });
+
+      it('use android pairing app', () => {
+        createView({
+          marketingId,
+          which: View.WHICH.BOTH,
+          useAndroidPairingApp: true,
+        });
+
+        return view.render().then(() => {
+          assert.lengthOf(view.$('.marketing-link-ios'), 1);
+          assert.lengthOf(view.$('.marketing-link-android'), 1);
+
+          const link = view.$('.marketing-link-android').attr('href');
+          assert.include(
+            link,
+            'https://play.google.com/store/apps/details?id=org.mozilla.firefox_beta'
+          );
+        });
+      });
     });
   }
 

--- a/packages/fxa-content-server/app/tests/spec/views/pair/index.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/index.js
@@ -165,6 +165,14 @@ describe('views/pair/index', () => {
         assert.isTrue(view.navigateAway.calledOnce);
       });
     });
+
+    it('shows marketing snippet', () => {
+      return view.render().then(() => {
+        assert.lengthOf(view.$('.marketing-area'), 1);
+        assert.lengthOf(view.$('a.marketing-link-ios'), 1);
+        assert.lengthOf(view.$('a.marketing-link-android'), 1);
+      });
+    });
   });
 
   describe('submit', () => {

--- a/packages/fxa-content-server/tests/functional/connect_another_device.js
+++ b/packages/fxa-content-server/tests/functional/connect_another_device.js
@@ -13,7 +13,8 @@ const config = intern._config;
 
 const ADJUST_LINK_ANDROID =
   'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&' +
-  'creative=button-autumn-2016-connect-another-device&adgroup=android';
+  'creative=button-autumn-2016-connect-another-device&adgroup=android&' +
+  'fallback=https://play.google.com/store/apps/details?id=org.mozilla.firefox';
 
 const ADJUST_LINK_IOS =
   'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&' +

--- a/packages/fxa-content-server/tests/functional/send_sms.js
+++ b/packages/fxa-content-server/tests/functional/send_sms.js
@@ -12,7 +12,8 @@ const config = intern._config;
 
 const ADJUST_LINK_ANDROID =
   'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&' +
-  'creative=button-autumn-2016-connect-another-device&adgroup=android';
+  'creative=button-autumn-2016-connect-another-device&adgroup=android&' +
+  'fallback=https://play.google.com/store/apps/details?id=org.mozilla.firefox';
 
 const ADJUST_LINK_IOS =
   'https://app.adjust.com/2uo1qc?campaign=fxa-conf-page&' +


### PR DESCRIPTION
## Because

* The pairing page needs to have more than links to install Android

## This commit

* Adds our marketing mixin which gives us App store badges for android and ios

## Issue that this pull request solves

Closes: #5883 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] ~I have added necessary documentation (if appropriate).~

## Screenshots

<img width="507" alt="Screen Shot 2020-07-12 at 12 25 55 PM" src="https://user-images.githubusercontent.com/1295288/87251998-c677a380-c43d-11ea-9b8a-b922af0b615d.png">

