### PR TITLE
[fxa-profile-server] Add block-/allow-lists for passed-through HTTP headers

### DIFF
--- a/packages/fxa-profile-server/lib/config.js
+++ b/packages/fxa-profile-server/lib/config.js
@@ -240,6 +240,12 @@ const conf = convict({
       default: 'http://localhost:1113',
       env: 'WORKER_URL',
     },
+    headers_exclude: {
+      doc: 'HTTP headers to not pass through to the worker requests (in lower case)',
+      format: Array,
+      env: 'WORKER_HEADERS_EXCLUDE',
+      default: ['host'],
+    },
   },
   authServerMessaging: {
     region: {


### PR DESCRIPTION
## Because

HTTP headers are re-used as is from the original incoming request to the profile server when uploading an avatar to the worker service, it also includes headers that might confuse the environment the services are running in.

Most notably, the `Host` header is re-used and the `request` module does not rewrite that for the worker request.

## This commit

Adds the following configuration keys:
* array `worker.headers_exclude` (env variable `WORKER_HEADERS_EXCLUDE`) for blocking headers from passing through to the worker request
* array `worker.headers_include` (env variable `WORKER_HEADERS_INCLUDE`) for passing only the specified headers to the worker request

## Issue that this pull request solves

Closes: #5874
Refs: #FXA-2240

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Other information (Optional)

The new default configuration removes the `Host` header by default, which is functionally not required but confuses some software routing environments.