### PR TITLE
fix(tests): update redis timeout

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -402,6 +402,12 @@ const conf = convict({
       format: 'port',
       doc: 'Port for Redis server',
     },
+    connectTimeout: {
+      default: '1 minute',
+      env: 'REDIS_CONNECT_TIMEOUT',
+      format: 'duration',
+      doc: 'Connect timeout for Redis server',
+    },
     accessTokens: {
       host: {
         default: 'localhost',

--- a/packages/fxa-auth-server/lib/oauth/db/redis.js
+++ b/packages/fxa-auth-server/lib/oauth/db/redis.js
@@ -28,10 +28,17 @@ class OauthRedis {
         ...config.get('redis.accessTokens'),
         enabled: true,
         maxttl: config.get('oauthServer.expiration.accessToken'),
+        connectTimeout: config.get('redis.connectTimeout'),
       },
       logger
     );
-    this.redisRefreshTokens = redis(config.get('redis.refreshTokens'), logger);
+    this.redisRefreshTokens = redis(
+      {
+        ...config.get('redis.refreshTokens'),
+        connectTimeout: config.get('redis.connectTimeout'),
+      },
+      logger
+    );
   }
 
   async close() {


### PR DESCRIPTION
## Because

* I've seen `[ioredis] Unhandled error event: Error: connect ETIMEDOUT` more frequently in circle and locally. I'm not really sure why it is happening more (or maybe I didn't notice it before?)

## This commit

* Updates default timeout from 10s to 1minute

## Issue that this pull request solves

Closes: NA

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
