### PR TITLE
Fxa 2215 use setup intent api

### DIFF
--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -91,7 +91,20 @@ export const App = ({
                         exact
                         render={(props) => (
                           <SettingsLayout>
-                            <Subscriptions {...props} />
+                            <Subscriptions
+                              {...{ ...props, useSCAPaymentFlow: false }}
+                            />
+                          </SettingsLayout>
+                        )}
+                      />
+                      <Route
+                        path="/v2/subscriptions"
+                        exact
+                        render={(props) => (
+                          <SettingsLayout>
+                            <Subscriptions
+                              {...{ ...props, useSCAPaymentFlow: true }}
+                            />
                           </SettingsLayout>
                         )}
                       />

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -43,7 +43,9 @@ import {
   apiCancelSubscription,
   apiReactivateSubscription,
   apiUpdatePayment,
+  apiCreateSetupIntent,
 } from './apiClient';
+import { FilteredSetupIntent } from '../store/types';
 
 describe('APIError', () => {
   it('can be created without params', () => {
@@ -366,6 +368,27 @@ describe('API requests', () => {
         ...metricsOptions,
         error,
       });
+      requestMock.done();
+    });
+  });
+
+  describe('apiCreateSetupIntent', () => {
+    const path = '/v1/oauth/subscriptions/setupintent/create';
+
+    it(`POST {auth-server}${path}`, async () => {
+      const expectedResponse: FilteredSetupIntent = {
+        client_secret: 'secret_squirrel',
+        created: 123456789,
+        next_action: null,
+        payment_method: null,
+        status: 'requires_payment_method',
+      };
+
+      const requestMock = nock(AUTH_BASE_URL)
+        .post(path)
+        .reply(200, expectedResponse);
+
+      expect(await apiCreateSetupIntent()).toEqual(expectedResponse);
       requestMock.done();
     });
   });

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -1,5 +1,12 @@
 import { Config, defaultConfig } from './config';
-import { Plan, Profile, Customer, Subscription, Token } from '../store/types';
+import {
+  Plan,
+  Profile,
+  Customer,
+  Subscription,
+  Token,
+  FilteredSetupIntent,
+} from '../store/types';
 import * as Amplitude from './amplitude';
 
 // TODO: Use a better type here
@@ -307,5 +314,12 @@ export async function apiRetryInvoice(params: {
     'POST',
     `${config.servers.auth.url}/v1/oauth/subscriptions/invoice/retry`,
     { body: JSON.stringify(params) }
+  );
+}
+
+export async function apiCreateSetupIntent(): Promise<FilteredSetupIntent> {
+  return apiFetch(
+    'POST',
+    `${config.servers.auth.url}/v1/oauth/subscriptions/setupintent/create`
   );
 }

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -1,4 +1,4 @@
-import { Profile, Plan, Customer } from '../store/types';
+import { Profile, Plan, Customer, FilteredSetupIntent } from '../store/types';
 
 export const PROFILE: Profile = {
   amrValues: [],
@@ -110,3 +110,12 @@ export const PLAN = {
 };
 
 export const PLANS: Plan[] = [PLAN, UPGRADE_FROM_PLAN, SELECTED_PLAN];
+
+export const FILTERED_SETUP_INTENT: FilteredSetupIntent = {
+  client_secret:
+    'seti_1GnXR2Kb9q6OnNsLFV0IWItK_secret_HMFwCT3daxuB29hhx4j7eJQ0IFtqEB5',
+  created: 1590617356,
+  next_action: null,
+  payment_method: 'card_1GnXR2Kb9q6OnNsLuymjpC5P',
+  status: 'succeeded',
+};

--- a/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.stories.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import {
   Stripe,
-  StripeCardElement,
-  StripeError,
   PaymentMethod,
   PaymentIntent,
+  SetupIntent,
 } from '@stripe/stripe-js';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
@@ -243,7 +242,7 @@ const defaultApiClientOverrides = {
 
 const defaultStripeOverride: Pick<
   Stripe,
-  'createPaymentMethod' | 'confirmCardPayment'
+  'createPaymentMethod' | 'confirmCardPayment' | 'confirmCardSetup'
 > = {
   createPaymentMethod: async () => {
     await wait(500);
@@ -255,6 +254,13 @@ const defaultStripeOverride: Pick<
   confirmCardPayment: async () => {
     return {
       paymentIntent: { status: 'succeeded' } as PaymentIntent,
+      error: undefined,
+    };
+  },
+  confirmCardSetup: async () => {
+    await wait(500);
+    return {
+      setupIntent: { status: 'succeeded' } as SetupIntent,
       error: undefined,
     };
   },

--- a/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.test.tsx
@@ -11,7 +11,7 @@ import {
   wait,
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { PaymentMethod, PaymentIntent } from '@stripe/stripe-js';
+import { PaymentMethod, PaymentIntent, SetupIntent } from '@stripe/stripe-js';
 import { SignInLayout } from '../../../components/AppLayout';
 import { CUSTOMER, PROFILE, PLAN } from '../../../lib/mock-data';
 import { PickPartial } from '../../../lib/types';
@@ -108,9 +108,15 @@ const CONFIRM_CARD_RESULT = {
   error: undefined,
 };
 
+const CONFIRM_CARD_SETUP_RESULT = {
+  setupIntent: { status: 'succeeded' } as SetupIntent,
+  error: undefined,
+};
+
 const defaultStripeOverride = () => ({
   createPaymentMethod: jest.fn().mockResolvedValue(PAYMENT_METHOD_RESULT),
   confirmCardPayment: jest.fn().mockResolvedValue(CONFIRM_CARD_RESULT),
+  confirmCardSetup: jest.fn().mockResolvedValue(CONFIRM_CARD_SETUP_RESULT),
 });
 
 describe('routes/ProductV2/SubscriptionCreate', () => {

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -33,6 +33,7 @@ type SubscriptionItemProps = {
   resetUpdatePayment: SubscriptionsProps['resetUpdatePayment'];
   updatePayment: SubscriptionsProps['updatePayment'];
   cancelSubscriptionStatus: SelectorReturns['cancelSubscriptionStatus'];
+  useSCAPaymentFlow: boolean;
 };
 
 export const SubscriptionItem = ({
@@ -45,6 +46,7 @@ export const SubscriptionItem = ({
   resetUpdatePayment,
   updatePaymentStatus,
   customerSubscription,
+  useSCAPaymentFlow,
 }: SubscriptionItemProps) => {
   const { locationReload } = useContext(AppContext);
 
@@ -80,6 +82,7 @@ export const SubscriptionItem = ({
                 updatePayment,
                 resetUpdatePayment,
                 updatePaymentStatus,
+                useSCAPaymentFlow,
               }}
             />
             <CancelSubscriptionPanel

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -45,6 +45,7 @@ export type SubscriptionsProps = {
   resetReactivateSubscription: ActionFunctions['resetReactivateSubscription'];
   updatePayment: SequenceFunctions['updatePaymentAndRefresh'];
   resetUpdatePayment: ActionFunctions['resetUpdatePayment'];
+  useSCAPaymentFlow: boolean;
 };
 
 export const Subscriptions = ({
@@ -62,6 +63,7 @@ export const Subscriptions = ({
   resetUpdatePayment,
   resetCancelSubscription,
   updatePaymentStatus,
+  useSCAPaymentFlow,
 }: SubscriptionsProps) => {
   const { config, locationReload, navigateToUrl } = useContext(AppContext);
 
@@ -280,6 +282,7 @@ export const Subscriptions = ({
                   customerSubscription,
                   cancelSubscriptionStatus,
                   plan: planForId(customerSubscription.plan_id, plans.result),
+                  useSCAPaymentFlow,
                 }}
               />
             ))}

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -134,3 +134,11 @@ export interface UpdateSubscriptionPlanResult {
 export interface CancelSubscriptionResult {
   subscriptionId: string;
 }
+
+export type FilteredSetupIntent = {
+  client_secret: string;
+  created: number;
+  next_action: string | null;
+  payment_method: string | null;
+  status: string;
+};


### PR DESCRIPTION
## Because:
* To support SCA we must migrate to using Stripe's SetupIntent API
    
## This commit:
    
* Add call to auth server to create SetupIntent
* Use secret from SetupIntent result to confirm card prior to creating a subscription
    
## Closes #5832

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
