### PR TITLE
fix(test): use ts-node in transpile only mode for script tests

### DIFF
--- a/packages/fxa-auth-server/test/oauth/key-management-scripts.js
+++ b/packages/fxa-auth-server/test/oauth/key-management-scripts.js
@@ -28,9 +28,8 @@ describe('the signing-key management scripts', function () {
       return execFileSync(
         process.execPath,
         [
-          require.resolve('ts-node').replace('index.js', 'bin.js'),
-          '-P',
-          path.join(base, '../tsconfig.json'),
+          '-r',
+          'ts-node/register',
           path.join(base, name),
         ],
         {
@@ -39,6 +38,8 @@ describe('the signing-key management scripts', function () {
             FXA_OPENID_NEWKEYFILE: newKeyFile,
             FXA_OPENID_OLDKEYFILE: oldKeyFile,
             NODE_ENV: 'dev',
+            TS_NODE_TRANSPILE_ONLY: true,
+            TS_NODE_PROJECT: path.join(base, '../tsconfig.json'),
           },
           stdio: [0, 'pipe', 'pipe'],
         }


### PR DESCRIPTION
The tests were exceeding the timeout. Type checking here isn't necessary.
