### PR TITLE
feat(auth-server): add ecosystem anon id to oath.token.created metrics ping

### DIFF
--- a/packages/fxa-auth-server/docs/metrics-events.md
+++ b/packages/fxa-auth-server/docs/metrics-events.md
@@ -390,8 +390,10 @@ has the same schema as `daily_multi_device_users`.
 | `device.created`       | A device record has been created for a Sync account.         |
 | `device.updated`       | Device record is updated on a Sync account.                  |
 | `device.deleted`       | Device record has been deleted from a Sync account.          |
-| `oauth.token.created`  | An oauth access token has been issued for an account.        |
+| `oauth.token.created`  | An oauth access token has been issued for an account. **      |
 | `sync.sentTabToDevice` | Device sent a push message for send-tab-to-device feature.   |
+
+** We emit the ecosystem_anonymous_id along with this event into the AET pipeline, this is so that we can calulate Daily Active Users in a safe, non-identifiable way.
 
 ## Email events
 

--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -291,9 +291,13 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
             uid = tokenVerify.user;
           }
 
+          const account = await db.account(uid);
+          const ecosystemAnonId = account.ecosystemAnonId;
+
           await request.emitMetricsEvent('oauth.token.created', {
             grantType: request.payload.grant_type,
             uid,
+            ecosystemAnonId,
           });
         } catch (ex) {}
 

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -257,6 +257,7 @@ function mockDB(data, errors) {
           isPrimary: true,
           emailCode: data.emailCode,
         },
+        ecosystemAnonId: data.ecosystemAnonId,
         emails: [
           {
             normalizedEmail: normalizeEmail(data.email),


### PR DESCRIPTION
## Because

- We want to add a unique anonymous identifier so we can get a correct count of Daily Active Users. More info https://jira.mozilla.com/browse/FXA-1885

## This pull request

- add the `ecosystemAnonId` to the `oauth.token.created` metrics ping.

## Issue that this pull request solves

Closes: #5313

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

