### PR TITLE
feat(AET): Add 'ecosystem_anon_id' field to content server config and expose keys in fxa-client-configuration

### DIFF
--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -748,6 +748,18 @@ const conf = (module.exports = convict({
     env: 'SYNC_TOKENSERVER_URL',
     format: 'url',
   },
+  ecosystem_anon_id: {
+    keys_file: {
+      default: '',
+      doc: 'Path to a file containing an array of Account Ecosystem Telemetry pipeline JWK public key objects for encrypting the ecosystem user ID to the ecosystem anon ID',
+      env: 'ECOSYSTEM_ANON_ID_KEYS_FILE',
+      format: String,
+    },
+    keys: {
+      doc: 'Array of Account Ecosystem Telemetry pipeline JWK public key objects for encrypting the ecosystem user ID to the ecosystem anon ID',
+      default: [],
+    }
+  },
   template_path: {
     default: path.resolve(__dirname, '..', 'templates'),
     doc: 'The location of server-rendered templates',
@@ -866,6 +878,24 @@ if (missingLangs.length) {
 
 const areDistResources = conf.get('static_directory') === 'dist';
 conf.set('are_dist_resources', areDistResources);
+
+if (conf.get('ecosystem_anon_id.keys_file')) {
+  const keysFile = path.resolve(
+    __dirname,
+    '..',
+    'config',
+    conf.get('ecosystem_anon_id.keys_file')
+  );
+  // Alter `ecosystem_anon_id.keys` if the keys file exists.
+  if (fs.existsSync(keysFile)) {
+    const keys = JSON.parse(fs.readFileSync(keysFile));
+    if (keys && Object.keys(keys).length > 0) {
+      conf.set('ecosystem_anon_id.keys', keys);
+    }
+  } else {
+    throw new Error('ECOSYSTEM_ANON_ID_KEYS_FILE path was specified but file does not exist');
+  }
+}
 
 // TODO: convict 6+ doesn't like the schema definition we've got
 // for `scopedKeys.validation`. It doesn't cause runtime problems

--- a/packages/fxa-content-server/server/lib/routes/get-fxa-client-configuration.js
+++ b/packages/fxa-content-server/server/lib/routes/get-fxa-client-configuration.js
@@ -33,6 +33,7 @@ module.exports = function (config) {
     ),
     profile_server_base_url: normalizeUrl(config.get('profile_url')),
     sync_tokenserver_base_url: normalizeUrl(config.get('sync_tokenserver_url')),
+    ecosystem_anon_id_keys: config.get('ecosystem_anon_id.keys'),
   };
 
   // This response will very rarely change, so enable caching by default.

--- a/packages/fxa-content-server/tests/server/routes/get-fxa-client-configuration.js
+++ b/packages/fxa-content-server/tests/server/routes/get-fxa-client-configuration.js
@@ -37,6 +37,7 @@ suite.tests['get-fxa-client-configuration route function'] = {
     mocks.config['pairing.server_base_uri'] = config.get(
       'pairing.server_base_uri'
     );
+    mocks.config.ecosystem_anon_id_keys = config.get('ecosystem_anon_id_keys');
     /*eslint-enable camelcase*/
   },
   tests: {
@@ -47,7 +48,7 @@ suite.tests['get-fxa-client-configuration route function'] = {
 
     'route interface is correct': function () {
       route = getFxAClientConfig(mocks.config);
-      assert.equal(mocks.config.get.callCount, 6);
+      assert.equal(mocks.config.get.callCount, 7);
       assert.isObject(route);
       assert.lengthOf(Object.keys(route), 3);
       assert.equal(route.method, 'get');
@@ -66,7 +67,7 @@ suite.tests['get-fxa-client-configuration route function'] = {
       route = getFxAClientConfig(mocks.config);
       route.process(mocks.request, mocks.response);
 
-      assert.equal(mocks.config.get.callCount, 6);
+      assert.equal(mocks.config.get.callCount, 7);
       assert.equal(mocks.response.json.callCount, 1);
       var args = mocks.response.json.args[0];
       assert.lengthOf(args, 1);
@@ -88,7 +89,7 @@ suite.tests['get-fxa-client-configuration route function'] = {
       route = getFxAClientConfig(mocks.config);
       route.process(mocks.request, mocks.response);
 
-      assert.equal(mocks.config.get.callCount, 6);
+      assert.equal(mocks.config.get.callCount, 7);
       assert.equal(mocks.response.json.callCount, 1);
       assert.equal(mocks.response.header.callCount, 1);
       var args = mocks.response.header.args[0];
@@ -103,7 +104,7 @@ suite.tests['get-fxa-client-configuration route function'] = {
       route = getFxAClientConfig(mocks.config);
       route.process(mocks.request, mocks.response);
 
-      assert.equal(mocks.config.get.callCount, 6);
+      assert.equal(mocks.config.get.callCount, 7);
       assert.equal(mocks.response.json.callCount, 1);
       assert.equal(mocks.response.header.callCount, 1);
       var args = mocks.response.header.args[0];
@@ -118,7 +119,7 @@ suite.tests['get-fxa-client-configuration route function'] = {
       route = getFxAClientConfig(mocks.config);
       route.process(mocks.request, mocks.response);
 
-      assert.equal(mocks.config.get.callCount, 6);
+      assert.equal(mocks.config.get.callCount, 7);
       assert.equal(mocks.response.json.callCount, 1);
       assert.equal(mocks.response.header.callCount, 0);
     },
@@ -142,7 +143,7 @@ suite.tests[
       assert.equal(res.headers['cache-control'], 'public, max-age=' + maxAge);
 
       var result = JSON.parse(res.body);
-      assert.equal(Object.keys(result).length, 5);
+      assert.equal(Object.keys(result).length, 6);
 
       var conf = intern._config;
       var expectAuthRoot = conf.fxaAuthRoot;


### PR DESCRIPTION
## Because

* We need the public key from the profile server exposed to the content-server so that desktop clients can encrypt the ecosystem user ID to the ecosystem anon ID.

## This pull request

* Adds 'ecosystem_anon_id.keys_file' and 'ecosystem_anon_id.keys' to the content server config, checking for a path set in a new env var ECOSYSTEM_ANON_ID_KEYS_FILE and setting it to the .keys value, then exposes it in the .well-known/fxa-client-configuration bundle.

## Issue that this pull request solves

Closes: #5520 (oopsy on my branch name here)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

### Other information
* Defaults to an empty array when `ECOSYSTEM_ANON_ID_KEYS_FILE` env var isn't set
* Expects `ECOSYSTEM_ANON_ID_KEYS_FILE=file` to equal `config/[file]`. I had the thrown error in a check for `conf.get('env') !== 'development'` as well but removed it in case we want to set the env var/file and pull it in locally.