### PR TITLE
feat(payments): Support new download URLs for legal links in emails

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -2563,8 +2563,8 @@ module.exports = function (log, config, oauthdb) {
 
     const translator = this.translator(message.acceptLanguage);
     const {
-      termsOfServiceURL = this.subscriptionTermsUrl,
-      privacyNoticeURL = this.privacyUrl,
+      termsOfServiceDownloadURL = this.subscriptionTermsUrl,
+      privacyNoticeDownloadURL = this.privacyUrl,
     } = productDetailsFromPlan(
       {
         product_metadata: message.productMetadata,
@@ -2691,13 +2691,13 @@ module.exports = function (log, config, oauthdb) {
     links.cancellationSurveyLinkAttributes = `href="${links.cancellationSurveyUrl}" style="text-decoration: none; color: #0060DF;"`;
 
     links.subscriptionTermsUrl = this._generateUTMLink(
-      termsOfServiceURL,
+      termsOfServiceDownloadURL,
       {},
       templateName,
       'subscription-terms'
     );
     links.subscriptionPrivacyUrl = this._generateUTMLink(
-      privacyNoticeURL,
+      privacyNoticeDownloadURL,
       {},
       templateName,
       'subscription-privacy'

--- a/packages/fxa-auth-server/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/scripts/write-emails-to-disk.js
@@ -88,10 +88,10 @@ function sendMail(mailer, messageToSend) {
   const messageSubType = parts[1];
 
   const productMetadata = {
-    'product:termsOfServiceURL':
-      'https://example.com/subscription-product/terms',
-    'product:privacyNoticeURL':
-      'https://example.com/subscription-product/privacy',
+    'product:termsOfServiceDownloadURL':
+      'https://example.com/subscription-product/terms/download',
+    'product:privacyNoticeDownloadURL':
+      'https://example.com/subscription-product/privacy/download',
   };
 
   const message = {

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -31,8 +31,8 @@ const SUBSCRIPTION_TERMS_URL = 'https://example.com/subscription-product/terms';
 const SUBSCRIPTION_PRIVACY_URL =
   'https://example.com/subscription-product/privacy';
 const productMetadata = {
-  'product:termsOfServiceURL': SUBSCRIPTION_TERMS_URL,
-  'product:privacyNoticeURL': SUBSCRIPTION_PRIVACY_URL,
+  'product:termsOfServiceDownloadURL': SUBSCRIPTION_TERMS_URL,
+  'product:privacyNoticeDownloadURL': SUBSCRIPTION_PRIVACY_URL,
 };
 
 const MESSAGE = {

--- a/packages/fxa-shared/subscriptions/metadata.ts
+++ b/packages/fxa-shared/subscriptions/metadata.ts
@@ -24,7 +24,11 @@ export const DEFAULT_PRODUCT_DETAILS: ProductDetails = {
   ],
   termsOfServiceURL:
     'https://www.mozilla.org/about/legal/terms/firefox-private-network',
+  termsOfServiceDownloadURL:
+    'https://accounts-static.cdn.mozilla.net/legal/Mozilla_VPN_ToS/en-US.pdf',
   privacyNoticeURL: 'https://www.mozilla.org/privacy/firefox-private-network',
+  privacyNoticeDownloadURL:
+    'https://accounts-static.cdn.mozilla.net/legal/mozilla_vpn_privacy_notice/en-US.pdf',
 };
 
 // Support some default null values for product / plan metadata and

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -37,7 +37,9 @@ export interface ProductMetadata {
 export enum ProductDetailsStringProperties {
   'subtitle',
   'termsOfServiceURL',
+  'termsOfServiceDownloadURL',
   'privacyNoticeURL',
+  'privacyNoticeDownloadURL',
 }
 export enum ProductDetailsListProperties {
   'details',

--- a/packages/fxa-shared/test/subscriptions/metadata.ts
+++ b/packages/fxa-shared/test/subscriptions/metadata.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import { Plan, ProductMetadata } from '../../subscriptions/types';
 import {
+  DEFAULT_PRODUCT_DETAILS,
   metadataFromPlan,
   productDetailsFromPlan,
 } from '../../subscriptions/metadata';
@@ -85,6 +86,10 @@ describe('subscriptions/metadata', () => {
         'product:details:4': 'Quux Available for Windows, iOS and Android',
         'product:termsOfServiceURL': 'https://example.org/en-US/terms',
         'product:privacyNoticeURL': 'https://example.org/en-US/privacy',
+        'product:termsOfServiceDownloadURL':
+          'https://example.org/en-US/terms/download',
+        'product:privacyNoticeDownloadURL':
+          'https://example.org/en-US/privacy/download',
         'product:subtitle:xx-pirate': 'VPN fer yer full-device',
         'product:foobar:9:xx-pirate': 'what even is this',
         'product:details:4:xx-pirate': "Available fer Windows, iOS an' Android",
@@ -96,6 +101,10 @@ describe('subscriptions/metadata', () => {
           'https://example.org/xx-pirate/terms',
         'product:privacyNoticeURL:xx-pirate':
           'https://example.org/xx-pirate/privacy',
+        'product:termsOfServiceDownloadURL:xx-pirate':
+          'https://example.org/xx-pirate/terms/download',
+        'product:privacyNoticeDownloadURL:xx-pirate':
+          'https://example.org/xx-pirate/privacy/download',
         'product:subtitle:xx-partial': 'Partial localization',
         'product:details:1:xx-partial': true,
         'product:termsOfServiceURL:xx-partial':
@@ -104,19 +113,9 @@ describe('subscriptions/metadata', () => {
     };
 
     it('extracts base details when metadata does not supply product details', () => {
-      expect(productDetailsFromPlan(PLAN)).to.deep.equal({
-        subtitle: 'Full-device VPN',
-        details: [
-          'Device-level encryption',
-          'Servers in 30+ countries',
-          'Connect 5 devices with one subscription',
-          'Available for Windows, iOS and Android',
-        ],
-        termsOfServiceURL:
-          'https://www.mozilla.org/about/legal/terms/firefox-private-network',
-        privacyNoticeURL:
-          'https://www.mozilla.org/privacy/firefox-private-network',
-      });
+      expect(productDetailsFromPlan(PLAN)).to.deep.equal(
+        DEFAULT_PRODUCT_DETAILS
+      );
     });
 
     it('extracts product details for default locale', () => {
@@ -130,6 +129,8 @@ describe('subscriptions/metadata', () => {
         ],
         termsOfServiceURL: 'https://example.org/en-US/terms',
         privacyNoticeURL: 'https://example.org/en-US/privacy',
+        termsOfServiceDownloadURL: 'https://example.org/en-US/terms/download',
+        privacyNoticeDownloadURL: 'https://example.org/en-US/privacy/download',
       });
     });
 
@@ -144,6 +145,10 @@ describe('subscriptions/metadata', () => {
         ],
         termsOfServiceURL: 'https://example.org/xx-pirate/terms',
         privacyNoticeURL: 'https://example.org/xx-pirate/privacy',
+        termsOfServiceDownloadURL:
+          'https://example.org/xx-pirate/terms/download',
+        privacyNoticeDownloadURL:
+          'https://example.org/xx-pirate/privacy/download',
       });
     });
 
@@ -158,6 +163,8 @@ describe('subscriptions/metadata', () => {
         ],
         termsOfServiceURL: 'https://example.org/xx-partial/terms',
         privacyNoticeURL: 'https://example.org/en-US/privacy',
+        termsOfServiceDownloadURL: 'https://example.org/en-US/terms/download',
+        privacyNoticeDownloadURL: 'https://example.org/en-US/privacy/download',
       });
     });
 
@@ -172,6 +179,8 @@ describe('subscriptions/metadata', () => {
         ],
         termsOfServiceURL: 'https://example.org/en-US/terms',
         privacyNoticeURL: 'https://example.org/en-US/privacy',
+        termsOfServiceDownloadURL: 'https://example.org/en-US/terms/download',
+        privacyNoticeDownloadURL: 'https://example.org/en-US/privacy/download',
       });
     });
   });


### PR DESCRIPTION
- add support for two new product metadata properties for legal PDF downloads

  - product:termsOfServiceDownloadURL

  - product:privacyNoticeDownloadURL

- switch emails to link to these download URLs rather than web pages

fixes #5875
