### PR TITLE
fix(payments): remove legal links from footer of payment update form

### DIFF
--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -223,7 +223,6 @@ export const PaymentUpdateForm = ({
           <PaymentForm
             {...{
               submitNonce,
-              plan,
               onPayment,
               onPaymentError,
               inProgress,


### PR DESCRIPTION
fixes #5873

Legal links are not included when `plan` is not supplied to `PaymentForm`. Only really needs to be passed in when we want a confirmation checkbox mentioning plan & price, which we don't do here.

Also turns out we weren't testing for the presence of these links in this context anyway.