### PR TITLE
Support SIGTERM for auth/customs server

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -134,7 +134,7 @@ async function run(config) {
     server,
     log: log,
     async close() {
-      log.info('shutdown');
+      log.info('shutdown', 'gracefully');
       await server.stop();
       await customs.close();
       oauthdb.close();
@@ -166,6 +166,7 @@ async function main() {
       process.exit(); //XXX: because of openid dep ಠ_ಠ
     };
     process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
     server.log.on('error', shutdown);
 
     if (config.get('env') !== 'prod') {

--- a/packages/fxa-customs-server/bin/customs_server.js
+++ b/packages/fxa-customs-server/bin/customs_server.js
@@ -23,6 +23,21 @@ const init = async () => {
       host: config.listen.host,
       port: config.listen.port,
     });
+
+    const server_shutdown = async () => {
+      await api.stop().then(function (err) {
+        if (err) {
+          log.warn({ op: 'shutdown', err: err}, 'graceful shutdown failed');
+          shutdown(1);
+        } else {
+          log.info({ op: 'shutdown' }, 'graceful shutdown complete');
+          shutdown(0);
+        }
+      });
+    };
+    process.on('SIGINT', server_shutdown);
+    process.on('SIGTERM', server_shutdown);
+
     return api;
   } catch (err) {
     log.error({ op: 'customs.bin.error', err: err });


### PR DESCRIPTION
## Because

I want to run the services in standard Docker/Kubernetes environment.

## This pull request

Adds support for handling `SIGTERM` for services which currently do not react to such a signal.

## Issue that this pull request solves

Refs: #5921

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
