### PR TITLE
fix(style): add margin to the 'account recovery' button

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings-account-recovery.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings-account-recovery.scss
@@ -147,3 +147,7 @@ button.button-link {
   background: transparent;
   color: $color-blue;
 }
+
+button.generate-key-link{
+  margin-bottom: 16px;
+}


### PR DESCRIPTION
Because:

* The buttons were overlapping.

This commit:

* Add a margin to the button.

Closes: #5659 


