### PR TITLE
feat(admin): support secondary emails and query highlighting

### DIFF
--- a/packages/fxa-admin-panel/src/components/EmailBlocks/Account/index.scss
+++ b/packages/fxa-admin-panel/src/components/EmailBlocks/Account/index.scss
@@ -18,6 +18,15 @@
     margin-bottom: 10px;
   }
 
+  .highlight {
+    background-color: #ffffba;
+  }
+
+  .verification {
+    margin-left: 10px;
+    font-size: 16px;
+  }
+
   .email-bounce {
     border-image: linear-gradient(to bottom, var(--ff-brand-gradient)) 0 100%;
     border-left: 1px solid;
@@ -38,5 +47,9 @@
   .result {
     color: var(--color-primary);
     font-weight: var(--font-weight-regular);
+  }
+
+  .secondary-emails {
+    margin-bottom: 20px;
   }
 }

--- a/packages/fxa-admin-panel/src/components/EmailBlocks/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/EmailBlocks/Account/index.test.tsx
@@ -9,11 +9,18 @@ import { Account } from './index';
 
 let accountResponse = {
   uid: 'ca1c61239f2448b2af618f0b50226cde',
-  email: 'hey@happy.com',
+  emails: [
+    {
+      email: 'hey@happy.com',
+      isVerified: true,
+      isPrimary: true,
+      createdAt: 1589467100316,
+    },
+  ],
   createdAt: 1589467100316,
-  emailVerified: true,
   emailBounces: [],
   onCleared() {},
+  query: 'hey@happy.com',
 };
 
 it('renders without imploding', () => {
@@ -27,7 +34,9 @@ it('displays the account', async () => {
 
   expect(getByTestId('account-section')).toBeInTheDocument();
   expect(getByTestId('verified-status')).toHaveTextContent('verified');
-  expect(getByTestId('email-label')).toHaveTextContent(accountResponse.email);
+  expect(getByTestId('email-label')).toHaveTextContent(
+    accountResponse.emails[0].email
+  );
   expect(getByTestId('uid-label')).toHaveTextContent(accountResponse.uid);
   expect(getByTestId('createdat-label')).toHaveTextContent(
     accountResponse.createdAt.toString()
@@ -35,7 +44,24 @@ it('displays the account', async () => {
 });
 
 it('displays the unverified account', async () => {
-  accountResponse.emailVerified = false;
+  accountResponse.emails[0].isVerified = false;
   const { getByTestId } = render(<Account {...accountResponse} />);
   expect(getByTestId('verified-status')).toHaveTextContent('not verified');
+});
+
+it('displays secondary emails', async () => {
+  accountResponse.emails.push({
+    email: 'ohdeceiver@gmail.com',
+    isVerified: false,
+    isPrimary: false,
+    createdAt: 1589467100316,
+  });
+
+  const { getByTestId } = render(<Account {...accountResponse} />);
+
+  expect(getByTestId('secondary-section')).toBeInTheDocument();
+  expect(getByTestId('secondary-email')).toHaveTextContent(
+    'ohdeceiver@gmail.com'
+  );
+  expect(getByTestId('secondary-verified')).toHaveTextContent('not verified');
 });

--- a/packages/fxa-admin-panel/src/components/EmailBlocks/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/EmailBlocks/index.test.tsx
@@ -35,9 +35,15 @@ function exampleAccountResponse(email: string): MockedResponse {
       data: {
         accountByEmail: {
           uid: 'a1b2c3',
-          email,
+          emails: [
+            {
+              email,
+              isPrimary: true,
+              isVerified: true,
+              createdAt: chance.timestamp(),
+            },
+          ],
           createdAt: chance.timestamp(),
-          emailVerified: true,
           emailBounces: [exampleBounce(email), exampleBounce(email)],
         },
       },

--- a/packages/fxa-admin-panel/src/components/EmailBlocks/index.tsx
+++ b/packages/fxa-admin-panel/src/components/EmailBlocks/index.tsx
@@ -10,9 +10,15 @@ import './index.scss';
 
 interface AccountType {
   uid: any;
-  email: string;
   createdAt: number;
-  emailVerified: boolean;
+  emails: [
+    {
+      email: string;
+      isVerified: boolean;
+      isPrimary: boolean;
+      createdAt: number;
+    }
+  ];
   emailBounces: [
     {
       email: string;
@@ -27,9 +33,13 @@ export const GET_ACCOUNT_BY_EMAIL = gql`
   query getAccountByEmail($email: String!) {
     accountByEmail(email: $email) {
       uid
-      email
       createdAt
-      emailVerified
+      emails {
+        email
+        isVerified
+        isPrimary
+        createdAt
+      }
       emailBounces {
         email
         createdAt
@@ -97,6 +107,7 @@ export const EmailBlocks = () => {
               loading,
               error,
               data,
+              query: inputValue,
             }}
           />
         </>
@@ -110,6 +121,7 @@ const AccountSearchResult = ({
   loading,
   error,
   data,
+  query,
 }: {
   onCleared: Function;
   loading: boolean;
@@ -117,12 +129,13 @@ const AccountSearchResult = ({
   data?: {
     accountByEmail: AccountType;
   };
+  query: string;
 }) => {
   if (loading) return <p data-testid="loading-message">Loading...</p>;
   if (error) return <p data-testid="error-message">An error occured.</p>;
 
   if (data?.accountByEmail) {
-    return <Account onCleared={onCleared} {...data.accountByEmail} />;
+    return <Account {...{ query, onCleared }} {...data.accountByEmail} />;
   }
   return <p data-testid="no-account-message">Account not found.</p>;
 };

--- a/packages/fxa-admin-server/src/lib/resolvers/account-resolver.ts
+++ b/packages/fxa-admin-server/src/lib/resolvers/account-resolver.ts
@@ -4,7 +4,7 @@
 
 import { Arg, Ctx, FieldResolver, Query, Resolver, Root } from 'type-graphql';
 
-import { Account, EmailBounces } from '../db/models';
+import { Account, EmailBounces, Emails } from '../db/models';
 import { uuidTransformer } from '../db/transformers';
 import { Context } from '../server';
 import { Account as AccountType } from './types/account';
@@ -48,5 +48,11 @@ export class AccountResolver {
       .innerJoin('emails', 'emailBounces.email', 'emails.normalizedEmail')
       .where('emails.uid', uidBuffer);
     return result;
+  }
+
+  @FieldResolver()
+  public async emails(@Root() account: Account) {
+    const uidBuffer = uuidTransformer.to(account.uid);
+    return await Emails.query().where('uid', uidBuffer);
   }
 }

--- a/packages/fxa-admin-server/src/lib/resolvers/types/account.ts
+++ b/packages/fxa-admin-server/src/lib/resolvers/types/account.ts
@@ -5,10 +5,11 @@
 import { Field, ID, ObjectType } from 'type-graphql';
 
 import { EmailBounce } from './email-bounces';
+import { Email } from './emails';
 
 @ObjectType()
 export class Account {
-  @Field(type => ID)
+  @Field((type) => ID)
   public uid!: string;
 
   @Field()
@@ -20,6 +21,9 @@ export class Account {
   @Field()
   public createdAt!: number;
 
-  @Field(type => [EmailBounce], { nullable: true })
+  @Field((type) => [Email], { nullable: true })
+  public emails!: Email[];
+
+  @Field((type) => [EmailBounce], { nullable: true })
   public emailBounces!: EmailBounce[];
 }

--- a/packages/fxa-admin-server/src/lib/resolvers/types/emails.ts
+++ b/packages/fxa-admin-server/src/lib/resolvers/types/emails.ts
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Field, ObjectType } from 'type-graphql';
+
+@ObjectType()
+export class Email {
+  @Field()
+  public email!: string;
+
+  @Field()
+  public isVerified!: boolean;
+
+  @Field()
+  public isPrimary!: boolean;
+
+  @Field()
+  public createdAt!: number;
+}

--- a/packages/fxa-admin-server/src/test/lib/db/models/helpers.ts
+++ b/packages/fxa-admin-server/src/test/lib/db/models/helpers.ts
@@ -12,15 +12,30 @@ import { setupDatabase } from '../../../../lib/db';
 import { Account } from '../../../../lib/db/models/account';
 import { EmailBounces } from '../../../../lib/db/models/email-bounces';
 
-export type AccountIsh = Pick<Account, 'uid' | 'email' | 'emails' | 'normalizedEmail'>;
-export type BounceIsh = Pick<EmailBounces, 'bounceSubType' | 'bounceType' | 'createdAt' | 'email'>;
+export type AccountIsh = Pick<
+  Account,
+  'uid' | 'email' | 'emails' | 'normalizedEmail'
+>;
+export type BounceIsh = Pick<
+  EmailBounces,
+  'bounceSubType' | 'bounceType' | 'createdAt' | 'email'
+>;
 
 export const chance = new Chance();
 
 const thisDir = path.dirname(__filename);
-export const accountTable = fs.readFileSync(path.join(thisDir, './accounts.sql'), 'utf8');
-export const emailsTable = fs.readFileSync(path.join(thisDir, './emails.sql'), 'utf8');
-export const emailBouncesTable = fs.readFileSync(path.join(thisDir, './email-bounces.sql'), 'utf8');
+export const accountTable = fs.readFileSync(
+  path.join(thisDir, './accounts.sql'),
+  'utf8'
+);
+export const emailsTable = fs.readFileSync(
+  path.join(thisDir, './emails.sql'),
+  'utf8'
+);
+export const emailBouncesTable = fs.readFileSync(
+  path.join(thisDir, './email-bounces.sql'),
+  'utf8'
+);
 
 export function randomAccount() {
   const email = chance.email();
@@ -36,7 +51,7 @@ export function randomAccount() {
     verifierSetAt: chance.timestamp(),
     verifierVersion: 0,
     verifyHash: Buffer.from('0', 'hex'),
-    wrapWrapKb: Buffer.from('0', 'hex')
+    wrapWrapKb: Buffer.from('0', 'hex'),
   };
 }
 
@@ -45,19 +60,23 @@ export function randomEmailBounce(email: string): BounceIsh {
     bounceSubType: chance.integer({ min: 0, max: 14 }),
     bounceType: chance.integer({ min: 0, max: 3 }),
     createdAt: chance.timestamp(),
-    email
+    email,
   };
 }
 
-export function randomEmail(account: AccountIsh, primary = true) {
+export function randomEmail(account: AccountIsh, createSecondaryEmail = false) {
+  const email = createSecondaryEmail ? chance.email() : account.email;
+  const normalizedEmail = createSecondaryEmail
+    ? email
+    : account.normalizedEmail;
   return {
     createdAt: chance.timestamp(),
-    email: account.email,
+    email,
+    normalizedEmail,
     emailCode: '',
-    isPrimary: primary,
+    isPrimary: !createSecondaryEmail,
     isVerified: true,
-    normalizedEmail: account.normalizedEmail,
-    uid: account.uid
+    uid: account.uid,
   };
 }
 
@@ -70,8 +89,8 @@ export async function testDatabaseSetup(): Promise<Knex> {
       host: 'localhost',
       password: '',
       port: 3306,
-      user: 'root'
-    }
+      user: 'root',
+    },
   });
 
   await knex.raw('DROP DATABASE IF EXISTS testAdmin');
@@ -83,7 +102,7 @@ export async function testDatabaseSetup(): Promise<Knex> {
     host: 'localhost',
     password: '',
     port: 3306,
-    user: 'root'
+    user: 'root',
   });
 
   await knex.raw(accountTable);

--- a/packages/fxa-admin-server/src/test/lib/schema.spec.ts
+++ b/packages/fxa-admin-server/src/test/lib/schema.spec.ts
@@ -11,7 +11,7 @@ import {
   IntrospectionEnumType,
   IntrospectionObjectType,
   IntrospectionSchema,
-  TypeKind
+  TypeKind,
 } from 'graphql';
 import 'mocha';
 import { buildSchema } from 'type-graphql';
@@ -26,74 +26,86 @@ describe('Schema', () => {
   let mutationType: IntrospectionObjectType;
 
   beforeEach(async () => {
-    const schema = await buildSchema({ resolvers: [AccountResolver, EmailBounceResolver] });
+    const schema = await buildSchema({
+      resolvers: [AccountResolver, EmailBounceResolver],
+    });
     builtSchema = await graphql(schema, getIntrospectionQuery());
     schemaIntrospection = builtSchema.data!.__schema as IntrospectionSchema;
     assert.isDefined(schemaIntrospection);
     queryType = schemaIntrospection.types.find(
-      type => type.name === (schemaIntrospection as IntrospectionSchema).queryType.name
+      (type) =>
+        type.name ===
+        (schemaIntrospection as IntrospectionSchema).queryType.name
     ) as IntrospectionObjectType;
 
     const mutationTypeNameRef = schemaIntrospection.mutationType;
     if (mutationTypeNameRef) {
       mutationType = schemaIntrospection.types.find(
-        type => type.name === mutationTypeNameRef.name
+        (type) => type.name === mutationTypeNameRef.name
       ) as IntrospectionObjectType;
     }
   });
 
   function findTypeByName(name: string) {
     return schemaIntrospection.types.find(
-      type => type.kind === TypeKind.OBJECT && type.name === name
+      (type) => type.kind === TypeKind.OBJECT && type.name === name
     ) as IntrospectionObjectType;
   }
 
   function findEnumByName(name: string) {
     return schemaIntrospection.types.find(
-      type => type.kind === TypeKind.ENUM && type.name === name
+      (type) => type.kind === TypeKind.ENUM && type.name === name
     ) as IntrospectionEnumType;
   }
 
   it('is created with expected types', async () => {
-    const queryNames = queryType.fields.map(it => it.name);
+    const queryNames = queryType.fields.map((it) => it.name);
     assert.sameMembers(queryNames, ['accountByUid', 'accountByEmail']);
 
-    const mutationNames = mutationType.fields.map(it => it.name);
+    const mutationNames = mutationType.fields.map((it) => it.name);
     assert.sameMembers(mutationNames, ['clearEmailBounce']);
 
     const accountType = findTypeByName('Account');
     assert.isDefined(accountType);
-    assert.lengthOf(accountType.fields, 5);
-    const accountTypeNames = accountType.fields.map(it => it.name);
+    assert.lengthOf(accountType.fields, 6);
+    const accountTypeNames = accountType.fields.map((it) => it.name);
     assert.sameMembers(accountTypeNames, [
       'uid',
       'email',
+      'emails',
       'emailVerified',
       'createdAt',
-      'emailBounces'
+      'emailBounces',
     ]);
 
     const emailBounceType = findTypeByName('EmailBounce');
     assert.isDefined(emailBounceType);
     assert.lengthOf(emailBounceType.fields, 4);
-    const emailBounceTypeNames = emailBounceType.fields.map(it => it.name);
-    assert.sameMembers(emailBounceTypeNames, ['email', 'bounceType', 'bounceSubType', 'createdAt']);
+    const emailBounceTypeNames = emailBounceType.fields.map((it) => it.name);
+    assert.sameMembers(emailBounceTypeNames, [
+      'email',
+      'bounceType',
+      'bounceSubType',
+      'createdAt',
+    ]);
 
     const bounceTypeEnum = findEnumByName('BounceType');
     assert.isDefined(bounceTypeEnum);
     assert.lengthOf(bounceTypeEnum.enumValues, 4);
-    const bounceTypeValues = bounceTypeEnum.enumValues.map(it => it.name);
+    const bounceTypeValues = bounceTypeEnum.enumValues.map((it) => it.name);
     assert.sameOrderedMembers(bounceTypeValues, [
       'unmapped',
       'Permanent',
       'Transient',
-      'Complaint'
+      'Complaint',
     ]);
 
     const bounceSubTypeEnum = findEnumByName('BounceSubType');
     assert.isDefined(bounceSubTypeEnum);
     assert.lengthOf(bounceSubTypeEnum.enumValues, 15);
-    const bounceSubTypeValues = bounceSubTypeEnum.enumValues.map(it => it.name);
+    const bounceSubTypeValues = bounceSubTypeEnum.enumValues.map(
+      (it) => it.name
+    );
     assert.sameOrderedMembers(bounceSubTypeValues, [
       'unmapped',
       'Undetermined',
@@ -109,7 +121,7 @@ describe('Schema', () => {
       'Fraud',
       'NotSpam',
       'Other',
-      'Virus'
+      'Virus',
     ]);
   });
 });


### PR DESCRIPTION
## Because

Right now in the Admin Panel you can perform an Email Blocks query using an account's secondary email, and it will return the correct account, but only display the primary email. So you have little context as to why this account is being returned.

## This pull request

- Updates the Admin Server GraphQL query to resolve and return `emails`, an array of the account's emails, with `isPrimary` and `isVerified` properties (but keeps `email` and `emailVerified` top-level properties "just in case"). 
- Update the Admin Panel UI to reflect both primary and secondary emails, and highlights the email that matched your query.

**Notes for reviewer:**

- It looks like Prettify got its hands on some of these files, so the diff looks a little larger than it should 😢 
- Some of the markup/style changes are a little... bleh... however, I plan on doing another pass through the Admin Panel to start styling with Tailwind and do a light UI update in the near future.

## Issue that this pull request solves

Closes: #5915

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots

<img width="1114" alt="Screen Shot 2020-07-14 at 11 20 01 AM" src="https://user-images.githubusercontent.com/6392049/87447080-226e3380-c5c8-11ea-9e1e-629c7354d9ee.png">
