### PR TITLE
fix(content-server): create storage size limit to uploaded avatar image.

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -610,6 +610,10 @@ var ERRORS = {
     errno: 1064,
     message: t('Mistyped email? %(domain)s does not offer email.'),
   },
+  IMAGE_TOO_LARGE: {
+    errno: 1065,
+    message: t('The image file size is too large to be uploaded.'),
+  },
 };
 
 export default _.extend({}, Errors, {

--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -86,6 +86,9 @@ module.exports = {
   PROFILE_IMAGE_MIN_WIDTH: 100,
   DEFAULT_PROFILE_IMAGE_MIME_TYPE: 'image/jpeg',
 
+  // Limit to 1.35 megabytes
+  PROFILE_FILE_IMAGE_MAX_UPLOAD_SIZE: 1.35 * 1024 * 1024,
+
   ONERROR_MESSAGE_LIMIT: 100,
 
   ACCOUNT_UPDATES_WEBCHANNEL_ID: 'account_updates',

--- a/packages/fxa-content-server/app/scripts/views/settings/avatar_change.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/avatar_change.js
@@ -6,6 +6,7 @@ import $ from 'jquery';
 import AuthErrors from '../../lib/auth-errors';
 import AvatarMixin from '../mixins/avatar-mixin';
 import Cocktail from 'cocktail';
+import Constants from '../../lib/constants';
 import CropperImage from '../../models/cropper-image';
 import FormView from '../form';
 import ImageLoader from '../../lib/image-loader';
@@ -102,7 +103,11 @@ const View = FormView.extend({
         reject(msg);
       };
 
-      if (file.type.match('image.*')) {
+      if (file.size > Constants.PROFILE_FILE_IMAGE_MAX_UPLOAD_SIZE) {
+        const msg = AuthErrors.toMessage('IMAGE_TOO_LARGE');
+        this.displayError(msg);
+        reject(msg);
+      } else if (file.type.match('image.*')) {
         const reader = new this.FileReader();
 
         reader.onload = (event) => {

--- a/packages/fxa-content-server/app/tests/mocks/file-reader.js
+++ b/packages/fxa-content-server/app/tests/mocks/file-reader.js
@@ -14,10 +14,11 @@ function FileReaderMock() {
   // nothing to do
 }
 
-FileReaderMock._mockFileEvent = function (type, src) {
+FileReaderMock._mockFileEvent = function (type, src, size) {
   var file = {
     _dataURL: src,
     type: type,
+    size: size,
   };
 
   return {
@@ -29,6 +30,10 @@ FileReaderMock._mockFileEvent = function (type, src) {
 
 FileReaderMock._mockPngEvent = function () {
   return this._mockFileEvent('image/png', pngSrc);
+};
+
+FileReaderMock._mockBigStorageSizePngEvent = function () {
+  return this._mockFileEvent('image/png', pngSrc, 30 * 1000000);
 };
 
 FileReaderMock._mockTinyPngEvent = function () {

--- a/packages/fxa-content-server/app/tests/spec/views/settings/avatar_change.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/avatar_change.js
@@ -213,6 +213,27 @@ describe('views/settings/avatar_change', function () {
         });
       });
 
+      it('error when trying to upload big storage sized image', function () {
+        view.FileReader = FileReaderMock;
+
+        return view.afterVisible().then(function () {
+          var ev = FileReaderMock._mockBigStorageSizePngEvent();
+          return view.fileSet(ev).then(
+            function () {
+              assert.catch('unexpected success');
+            },
+            function () {
+              assert.equal(
+                view.$('.error').text(),
+                AuthErrors.toMessage('IMAGE_TOO_LARGE')
+              );
+              assert.isTrue(view.isErrorVisible());
+              assert.equal(view.logFlowEvent.callCount, 0);
+            }
+          );
+        });
+      });
+
       it('loads a supported file', function (done) {
         view.FileReader = FileReaderMock;
 


### PR DESCRIPTION
Because:

* When the user uploaded a big image and an error message appeared, it was not possible to know the cause of the problem.

This commit:

* Create a limit size to uploaded images.

## Issue that this pull request solves

Closes: #5348, #5123

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
