### PR TITLE
fix(cad): don't show CAD SMS if user declines sync in sync optional flow

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/qr-code-cad.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/qr-code-cad.js
@@ -33,7 +33,6 @@ module.exports = class QrCodeCad extends BaseGroupingRule {
    * For this experiment, we are doing a staged rollout.
    *
    * @param {Object} subject data used to decide
-   *  @param {Boolean} isSync is this a sync signup?
    * @returns {Any}
    */
   choose(subject = {}) {

--- a/packages/fxa-content-server/app/scripts/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/scripts/views/connect_another_device.js
@@ -33,6 +33,13 @@ class ConnectAnotherDeviceView extends FormView {
   beforeRender() {
     const account = this.getAccount();
 
+    // If a relier has explicitly set the `syncPreferences=false` property
+    // this means user dont want to sync. Don't offer CAD
+    const syncPreference = this.relier.get('syncPreference');
+    if (syncPreference === false) {
+      return;
+    }
+
     // Check to see if user is enrolled in the CAD QR code experiment. This
     // takes precedence over the "regular" sms experiment.
     return this.getEligibleQrCodeCadGroup(account).then(

--- a/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
@@ -54,7 +54,6 @@ describe('views/connect_another_device', () => {
       .callsFake(() => Promise.resolve(smsCountry));
     sinon.stub(view, 'replaceCurrentPageWithSmsScreen').callsFake(() => {});
 
-    // TODO: PUll this out into own test section
     sinon
       .stub(view, 'getEligibleQrCodeCadGroup')
       .callsFake(() => Promise.resolve({ group: false }));
@@ -388,6 +387,30 @@ describe('views/connect_another_device', () => {
         assert.isTrue(
           view.replaceCurrentPageWithSmsScreen.calledWith(account, 'CA', false)
         );
+      });
+    });
+
+    describe('with a Fx desktop sync declined user', () => {
+      beforeEach(() => {
+        sinon.stub(view, '_isSignedIn').callsFake(() => true);
+        relier.set('syncPreference', false);
+        return view.render().then(() => {
+          view.afterVisible();
+        });
+      });
+
+      it('shows the marketing area, logs appropriately', () => {
+        assert.isTrue(view._isSignedIn.called);
+        assert.lengthOf(view.$('.marketing-area'), 1);
+        testIsFlowEventLogged('signedin.true');
+        testIsFlowEventLogged('signin.ineligible');
+        testIsFlowEventLogged('install_from.fx_desktop');
+
+        assert.isFalse(view.getEligibleQrCodeCadGroup.called);
+      });
+
+      it('shows the success message', () => {
+        assert.lengthOf(view.$('.success'), 1);
       });
     });
   });


### PR DESCRIPTION
## Because

- We were showing users CAD in the sync optional flow even though they declined using sync

## This pull request

- In the sync optional flow, `syncPreference` is false, check this and redirect as needed

## Issue that this pull request solves

Closes: #5881 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally
