### PR TITLE
feat(admin): set referrer-policy header, form-action csp directive

### DIFF
--- a/packages/fxa-admin-panel/server/lib/csp.test.ts
+++ b/packages/fxa-admin-panel/server/lib/csp.test.ts
@@ -45,6 +45,13 @@ describe('CSP blocking rules', () => {
     expect(frameAncestors).toContain(Sources.NONE);
   });
 
+  it('has correct formAction directives', () => {
+    const { formAction } = directives;
+
+    expect(formAction).toHaveLength(1);
+    expect(formAction).toContain(Sources.NONE);
+  });
+
   it('has correct fontSrc directives', () => {
     const { fontSrc } = directives;
 

--- a/packages/fxa-admin-panel/server/lib/csp/blocking.ts
+++ b/packages/fxa-admin-panel/server/lib/csp/blocking.ts
@@ -49,6 +49,11 @@ export default function cspBlocking(config: { [key: string]: any }) {
       defaultSrc: [NONE],
       baseUri: [NONE],
       frameAncestors: [NONE],
+      // React currently handles 100% of form "submissions",
+      // so disable all form-action values. This might need
+      // to be updated to 'self' or another specific value
+      // down the road as the admin panel evolves
+      formAction: [NONE],
       fontSrc: addCdnRuleIfRequired([SELF]),
       imgSrc: addCdnRuleIfRequired([SELF]),
       scriptSrc: addCdnRuleIfRequired([SELF]),

--- a/packages/fxa-admin-panel/server/lib/server.test.ts
+++ b/packages/fxa-admin-panel/server/lib/server.test.ts
@@ -12,39 +12,43 @@ function expectValueNotToBeUnknown(value: string) {
 }
 
 describe('Test simple server routes', () => {
-  test('__version__ should have correct structure', () => {
-    return new Promise(async (done) => {
-      const response = await request(app).get('/__version__');
-      expect(response.status).toStrictEqual(200);
-      expect(response.header['content-type']).toStrictEqual(
-        'application/json; charset=utf-8'
-      );
-      const body = response.body;
-      expect(Object.keys(body).sort()).toStrictEqual([
-        'commit',
-        'source',
-        'version',
-      ]);
-      expectValueNotToBeUnknown(body.commit);
-      expectValueNotToBeUnknown(body.source);
-      expectValueNotToBeUnknown(body.version);
-      expect(body.version).toStrictEqual(pkg.version);
-      // check that the commit value looks like a git SHA
-      expect(body.commit).toMatch(/^[0-9a-f]{40}$/);
-      done();
+  test('routes should have correct headers', async () => {
+    const response = await request(app).get('/__version__');
+    expect(response.header).toMatchObject({
+      'referrer-policy': 'same-origin',
+      'strict-transport-security': 'max-age=31536000; includeSubDomains',
+      'x-frame-options': 'DENY',
+      'x-xss-protection': '1; mode=block',
+      'x-content-type-options': 'nosniff',
     });
   });
 
-  test('__lbheartbeat__ should return as expected', () => {
-    return new Promise(async (done) => {
-      const response = await request(app).get('/__lbheartbeat__');
-      expect(response.status).toStrictEqual(200);
-      expect(response.header['content-type']).toStrictEqual(
-        'text/plain; charset=utf-8'
-      );
-      expect(response.text).toStrictEqual('Ok');
+  test('__version__ should have correct structure', async () => {
+    const response = await request(app).get('/__version__');
+    expect(response.status).toStrictEqual(200);
+    expect(response.header['content-type']).toStrictEqual(
+      'application/json; charset=utf-8'
+    );
+    const body = response.body;
+    expect(Object.keys(body).sort()).toStrictEqual([
+      'commit',
+      'source',
+      'version',
+    ]);
+    expectValueNotToBeUnknown(body.commit);
+    expectValueNotToBeUnknown(body.source);
+    expectValueNotToBeUnknown(body.version);
+    expect(body.version).toStrictEqual(pkg.version);
+    // check that the commit value looks like a git SHA
+    expect(body.commit).toMatch(/^[0-9a-f]{40}$/);
+  });
 
-      done();
-    });
+  test('__lbheartbeat__ should return as expected', async () => {
+    const response = await request(app).get('/__lbheartbeat__');
+    expect(response.status).toStrictEqual(200);
+    expect(response.header['content-type']).toStrictEqual(
+      'text/plain; charset=utf-8'
+    );
+    expect(response.text).toStrictEqual('Ok');
   });
 });

--- a/packages/fxa-admin-panel/server/lib/server.ts
+++ b/packages/fxa-admin-panel/server/lib/server.ts
@@ -41,6 +41,7 @@ app.use(
   }),
   helmet.xssFilter(),
   helmet.noSniff(),
+  helmet.referrerPolicy({ policy: 'same-origin' }),
   noRobots as express.RequestHandler,
   bodyParser.text({
     type: 'text/plain',


### PR DESCRIPTION
## Because

[Mozilla Observatory](https://observatory.mozilla.org/) identified two areas where security could be improved with the Admin Panel:

1. We don't set the [`form-action` CSP directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action), which dictates which addresses can be used in `<form>` submissions.
2. We don't set the [`Referrer-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) header, which means it defaults to `no-referrer-when-downgrade`. 

## This pull request

1. Sets the `form-action` CSP directive to `'none'`. This could also be `'self'`, but because currently our only form's submission is handled by React there is no need for an `action`. In the future we may want to relax this. I left a note in the code.
2. Sets the `Referrer-Policy` header to `same-origin`. I could be persuaded to use `no-referrer`, too.

Also, updated some tests to remove unnecessary use of Promises and assert all expected headers set by middleware.

## Issue that this pull request solves

Closes: #5944

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.