### PR TITLE
fix(l10n): fixed currency localization for "other than US" locales

### DIFF
--- a/packages/fxa-payments-server/src/lib/AppLocalizationProvider.tsx
+++ b/packages/fxa-payments-server/src/lib/AppLocalizationProvider.tsx
@@ -10,6 +10,8 @@ import React, { Component } from 'react';
 
 import availableLocales from 'fxa-shared/l10n/supportedLanguages.json';
 
+const OTHER_EN_LOCALES = ['en-NZ', 'en-CA', 'en-SG', 'en-MY']
+
 async function fetchMessages(baseDir: string, locale: string, bundle: string) {
   try {
     const response = await fetch(`${baseDir}/${locale}/${bundle}.ftl`);
@@ -48,8 +50,9 @@ async function createMessagesGenerator(
 
   return function* generateMessages() {
     for (const locale of currentLocales) {
+      const sourceLocale = OTHER_EN_LOCALES.includes(locale) ? 'en-GB' : locale;
       const cx = new FluentBundle(locale);
-      for (const i of mergedBundle[locale]) {
+      for (const i of mergedBundle[sourceLocale]) {
         const resource = new FluentResource(i);
         cx.addResource(resource);
       }
@@ -96,7 +99,7 @@ export default class AppLocalizationProvider extends Component<Props, State> {
 
     const currentLocales = negotiateLanguages(
       [...userLocales],
-      availableLocales,
+      [...OTHER_EN_LOCALES, ...availableLocales],
       {
         defaultLocale: 'en-US',
       }


### PR DESCRIPTION
For en locales that don't have their own ftl file this change
sets their FluentResource to be that of en-GB, which does have
an ftl file in order for the currency to be rendered as 'US$x.xx'
instead of the US fallback of '$x.xx' which is ambiguous in which
currency is meant.

These locales are currently hard coded in AppLocalizationProvider
because other services fail when they can't load l10n files that
are present in supportedLanguages.json but not in the l10n repo.