### PR TITLE
feat(auth-server): use payment method on file for card

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.js
+++ b/packages/fxa-auth-server/lib/payments/stripe.js
@@ -10,6 +10,7 @@ const stripe = require('stripe').Stripe;
 
 /** @typedef {import('stripe').Stripe.Customer} Customer */
 /** @typedef {import('stripe').Stripe.Event} StripeEvent */
+/** @typedef {import('stripe').Stripe.PaymentMethod} PaymentMethod */
 /** @typedef {import('stripe').Stripe.Plan} Plan */
 /** @typedef {import('stripe').Stripe.Product} Product */
 /** @typedef {import('stripe').Stripe.DeletedProduct} DeletedProduct */
@@ -508,6 +509,7 @@ class StripeHelper {
       result = await this.fetchCustomer(uid, email, [
         'data.sources',
         'data.subscriptions',
+        'data.invoice_settings.default_payment_method',
       ]);
       if (this.redis) {
         try {

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -422,7 +422,6 @@ module.exports.subscriptionsStripeIntentValidator = isA
   .object({
     client_secret: isA.string().optional(),
     created: isA.number().required(),
-    next_action: isA.object({}).unknown(true).optional(),
     payment_method: isA
       .alternatives(isA.string(), isA.object({}).unknown(true))
       .optional(),

--- a/packages/fxa-auth-server/test/local/payments/fixtures/customer_new_pmi_default_invoice_expanded.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/customer_new_pmi_default_invoice_expanded.json
@@ -1,0 +1,93 @@
+{
+  "id": "cust_new",
+  "object": "customer",
+  "address": null,
+  "balance": 0,
+  "created": 1581078596,
+  "currency": null,
+  "default_source": "card_1G9Vy3Kb9q6OnNsLYw9Zw0Du",
+  "delinquent": false,
+  "description": "testuid",
+  "discount": null,
+  "email": "jane@example.com",
+  "invoice_prefix": "6A11CA66",
+  "invoice_settings": {
+    "custom_fields": null,
+    "default_payment_method": {
+      "id": "pm_1H0FRp2eZvKYlo2CeIZoc0wj",
+      "object": "payment_method",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": null,
+          "line1": null,
+          "line2": null,
+          "postal_code": "95014",
+          "state": null
+        },
+        "email": null,
+        "name": "Jane Doe",
+        "phone": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": "pass",
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "exp_month": 12,
+        "exp_year": 2022,
+        "fingerprint": "PXj5xzTtGdBo1fVl",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "networks": {
+          "available": ["visa"],
+          "preferred": null
+        },
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1593658838,
+      "customer": "cust_new",
+      "livemode": false,
+      "metadata": {},
+      "type": "card"
+    },
+    "footer": null
+  },
+  "livemode": false,
+  "metadata": {
+    "userid": "testuid"
+  },
+  "name": "Jane Doe",
+  "phone": null,
+  "preferred_locales": [],
+  "shipping": null,
+  "sources": {
+    "object": "list",
+    "data": [],
+    "has_more": false,
+    "total_count": 0,
+    "url": "/v1/customers/cust_new/sources"
+  },
+  "subscriptions": {
+    "object": "list",
+    "data": [],
+    "has_more": false,
+    "total_count": 0,
+    "url": "/v1/customers/cust_new/subscriptions"
+  },
+  "tax_exempt": "none",
+  "tax_ids": {
+    "object": "list",
+    "data": [],
+    "has_more": false,
+    "total_count": 0,
+    "url": "/v1/customers/cust_new/tax_ids"
+  }
+}


### PR DESCRIPTION
Because:

* We only looked at sources to return payment method before and
  now we also handle payent methods as a default invoice option.

This commit:

* Looks to see if a payment method was attached as a default invoice
  option and uses it for returned card data.

Closes #5902

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Other information (Optional)

I've also added expansion of this object to the cached customer object, even though its not needed at the moment so that they will match up as desired later.