### PR TITLE
chore(cad): disable qr code experiment

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/qr-code-cad.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/qr-code-cad.js
@@ -17,7 +17,7 @@ const GROUPS = [
   'treatment-b', // Screen displayed in non-sms markets
 ];
 
-const ROLLOUT_RATE = 1.0;
+const ROLLOUT_RATE = 0.0;
 
 module.exports = class QrCodeCad extends BaseGroupingRule {
   constructor() {


### PR DESCRIPTION
## Because

- We have gathered enough experiment data and don't need to keep running while we do the analysis

## This pull request

- Stops the qr code experiment