### PR TITLE
Graceful shutdown support

### DIFF
--- a/packages/fxa-admin-panel/server/lib/server.ts
+++ b/packages/fxa-admin-panel/server/lib/server.ts
@@ -164,12 +164,25 @@ export async function createServer() {
   const port = config.get('listen.port');
   const host = config.get('listen.host');
   logger.info('server.starting', { port });
-  app.listen(port, host, (error) => {
+  const server = app.listen(port, host, (error) => {
     if (error) {
       logger.error('server.start.error', { error });
       return;
     }
 
     logger.info('server.started', { port });
+  });
+
+  const shutdown = (signal: NodeJS.Signals) => {
+    logger.info('server.shutdown', {message: `Graceful shutdown requested (${signal})`});
+    server.close();
+    logger.info('server.shutdown', {message: `Graceful shutdown completed`});
+  }
+
+  Object.values<NodeJS.Signals>(['SIGINT', 'SIGTERM'])
+  .forEach(signal => {
+    process.on(signal, () => {
+      shutdown(signal);
+    });
   });
 }

--- a/packages/fxa-auth-db-mysql/bin/server.js
+++ b/packages/fxa-auth-db-mysql/bin/server.js
@@ -81,4 +81,21 @@ DB.connect(config).done(function (db) {
   // Log connection config and charset info
   logCharsetInfo(db, 'MASTER');
   logCharsetInfo(db, 'SLAVE');
+
+  function shutdown(signal) {
+    return function () {
+      logger.info('Graceful shutdown received', { signal });
+      try {
+        server.close();
+      } catch (err) {
+        logger.warn('Shutdown of API server failed', { error: err });
+      }
+      db.close();
+      logger.info('Graceful shutdown completed');
+    };
+  }
+
+  ['SIGINT', 'SIGTERM'].forEach(function (signal) {
+    process.on(signal, shutdown(signal.substr(3)));
+  });
 });

--- a/packages/fxa-content-server/server/bin/fxa-content-server.js
+++ b/packages/fxa-content-server/server/bin/fxa-content-server.js
@@ -78,6 +78,8 @@ const PAGE_TEMPLATE_DIRECTORY = path.join(
 
 logger.info('page_template_directory: %s', PAGE_TEMPLATE_DIRECTORY);
 
+const shutdownHooks = []
+
 function makeApp() {
   const app = express();
   const betaSettingsPath = '/beta/settings';
@@ -179,7 +181,12 @@ function makeApp() {
   const routes = require('../lib/routes')(config, i18n);
   const routeLogger = loggerFactory('server.routes');
   const routeHelpers = routing(app, routeLogger);
-  routes.forEach(routeHelpers.addRoute);
+  routes.forEach(function(route) {
+    routeHelpers.addRoute(route);
+    if (route.terminate) {
+      shutdownHooks.push(route.terminate);
+    }
+  });
 
   if (!config.get('settings.enableBeta')) {
     app.use('/beta/*', function (req, res) {
@@ -227,6 +234,8 @@ function makeApp() {
 
 let app;
 let port;
+let mainServer;
+let httpServer;
 
 function catchStartUpErrors(e) {
   if ('EACCES' === e.code) {
@@ -242,21 +251,22 @@ function catchStartUpErrors(e) {
 
 function listen(theApp) {
   app = theApp || app;
+  port = config.get('port');
+  let server;
   if (config.get('use_https')) {
     // Development only... Ops runs this behind nginx
-    port = config.get('port');
     const tlsoptions = {
       cert: fs.readFileSync(config.get('cert_path')),
       key: fs.readFileSync(config.get('key_path')),
     };
 
-    https.createServer(tlsoptions, app).listen(port);
-    app.on('error', catchStartUpErrors);
+    server = https.createServer(tlsoptions, app).listen(port);
   } else {
-    port = config.get('port');
-    app.listen(port, '0.0.0.0').on('error', catchStartUpErrors);
+    server = app.listen(port, '0.0.0.0')
   }
+  app.on('error', catchStartUpErrors);
   if (isMain) {
+    mainServer = server;
     logger.info('Firefox Account Content server listening on port', port);
     logger.info(
       `Config scopedKeys.validation: ${JSON.stringify(
@@ -286,8 +296,9 @@ function listenHttpRedirectApp(httpApp) {
     ? config.get('redirect_port')
     : config.get('http_port');
 
-  httpApp.listen(httpPort, '0.0.0.0');
+  const server = httpApp.listen(httpPort, '0.0.0.0');
   if (isMain) {
+    httpServer = server;
     logger.info(
       'Firefox Account HTTP redirect server listening on port',
       httpPort
@@ -299,12 +310,41 @@ function isCorsRequired() {
   return config.get('static_resource_url') !== config.get('public_url');
 }
 
+// handle shutdown
+function shutdown(signal) {
+  return function () {
+    logger.info('Graceful shutdown received', { signal });
+    shutdownHooks.forEach(function(hook) {
+      try {
+        hook();
+      } catch (err) {
+        logger.warn('Shutdown hook failed', {
+          error: err
+        });
+      }
+    })
+    try {
+      httpServer.close();
+    } catch (err) {
+      logger.warn('Shutdown redirect app failed', {
+        error: err
+      });
+    }
+    mainServer.close();
+    logger.info('Graceful shutdown completed');
+  };
+}
+
 if (isMain) {
   app = makeApp();
   listen(app);
 
   const httpApp = makeHttpRedirectApp();
   listenHttpRedirectApp(httpApp);
+
+  ['SIGINT', 'SIGTERM'].forEach(function (signal) {
+    process.on(signal, shutdown(signal.substr(3)));
+  });
 } else {
   module.exports = {
     listen: listen,

--- a/packages/fxa-event-broker/src/bin/worker.ts
+++ b/packages/fxa-event-broker/src/bin/worker.ts
@@ -108,6 +108,7 @@ async function main() {
     process.exit(8);
   });
   process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 
   function shutdown() {
     server.stop({ timeout: 10_000 }).then(() => {

--- a/packages/fxa-support-panel/bin/worker.ts
+++ b/packages/fxa-support-panel/bin/worker.ts
@@ -37,6 +37,7 @@ async function main() {
     process.exit();
   });
   process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
 
   function shutdown() {
     server.stop({ timeout: 10_000 }).then(() => {


### PR DESCRIPTION
## Because

I want to run the services in standard Docker/Kubernetes environment.

## This pull request

Adds support for handling `SIGTERM` (and `SIGINT` where missing) for the following services which currently do not react to such a signals (all in individual commits):
* fxa-admin-panel
* fxa-admin-server
* fxa-auth-db-mysql
* fxa-content-server
* fxa-event-broker
* fxa-graphql-api
* fxa-payments-server
* fxa-support-panel

## Issue that this pull request solves

closes: #5921

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
