### PR TITLE
fix(delete account): Filter active subscriptions for unique product names

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/delete_account.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/delete_account.mustache
@@ -23,11 +23,9 @@
 
       <ul class="delete-account-product-list {{#hasTwoColumnProductList}}two-col{{/hasTwoColumnProductList}}">
         {{#subscriptions}}
-          {{#product_name}}
-            <li class="delete-account-product-subscription" title="{{product_name}}">
-              {{product_name}}
-            </li>
-          {{/product_name}}
+          <li class="delete-account-product-subscription" title="{{.}}">
+            {{.}}
+          </li>
         {{/subscriptions}}
 
         {{#uniqueBrowserNames}}

--- a/packages/fxa-content-server/app/scripts/views/settings/delete_account.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/delete_account.js
@@ -33,6 +33,7 @@ var View = FormView.extend({
       });
     }
     this._activeSubscriptions = [] || options.activeSubscriptions;
+    this._uniqueActiveSubscriptionNames = [];
     this._uniqueBrowserNames = [];
     this._hasTwoColumnProductList = false;
     this._hideProductContainer = false;
@@ -43,7 +44,7 @@ var View = FormView.extend({
       email: this.getSignedInAccount().get('email'),
       clients: this._attachedClients.toJSON(),
       isPanelOpen: this.isPanelOpen(),
-      subscriptions: this._activeSubscriptions,
+      subscriptions: this._uniqueActiveSubscriptionNames,
       uniqueBrowserNames: this._uniqueBrowserNames,
       hasTwoColumnProductList: this._hasTwoColumnProductList,
       hideProductContainer: this._hideProductContainer,
@@ -65,6 +66,7 @@ var View = FormView.extend({
     ])
       .then(() => {
         this._uniqueBrowserNames = this._setuniqueBrowserNames();
+        this._uniqueActiveSubscriptionNames = this._setUniqueActiveSubscriptionNames();
 
         const numberOfProducts = this._getNumberOfProducts();
         if (numberOfProducts === 0) {
@@ -99,6 +101,10 @@ var View = FormView.extend({
     });
   },
 
+  _setUniqueActiveSubscriptionNames() {
+    return [...new Set((this._activeSubscriptions).map(activeSub => activeSub.product_name))];
+  },
+
   _setuniqueBrowserNames() {
     // filter clients for `webSession` clientTypes with unique
     // `userAgent`, replace numeric versioning with 'browser'.
@@ -122,7 +128,7 @@ var View = FormView.extend({
 
   _getNumberOfProducts() {
     let numberOfProducts =
-      this._uniqueBrowserNames.length + this._activeSubscriptions.length;
+      this._uniqueBrowserNames.length + this._uniqueActiveSubscriptionNames.length;
     // eslint-disable-next-line no-unused-vars
     for (const client of this._attachedClients.toJSON()) {
       if (client.isOAuthApp === true) {

--- a/packages/fxa-content-server/app/tests/spec/views/settings/delete_account.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/delete_account.js
@@ -120,6 +120,12 @@ describe('views/settings/delete_account', function () {
         status: 'active',
       },
       {
+        plan_id: 'plan_1',
+        product_id: 'prod_123',
+        product_name: '321Done Pro',
+        status: 'active',
+      },
+      {
         plan_id: 'plan_2',
         product_id: 'prod_123',
         product_name: '321Done Pro',
@@ -128,13 +134,13 @@ describe('views/settings/delete_account', function () {
       {
         plan_id: 'plan_3',
         product_id: 'prod_123',
-        product_name: '321Done Pro',
+        product_name: '321Done Pro II',
         status: 'trialing',
       },
       {
         plan_id: 'plan_4',
         product_id: 'prod_123',
-        product_name: '321Done Pro',
+        product_name: '321Done Pro III',
         status: 'past_due',
       },
     ];
@@ -318,7 +324,7 @@ describe('views/settings/delete_account', function () {
           },
           {
             plan_id: '321doneProYearly',
-            product_name: '321done Pro',
+            product_name: '321done Pro II',
             status: 'cancelled',
           },
         ];
@@ -371,7 +377,7 @@ describe('views/settings/delete_account', function () {
         assert.isTrue(view._fetchActiveSubscriptions.calledOnce);
       });
 
-      it('renders only subscriptions with a status of "active", "trialing", or "past_due"', () => {
+      it('renders only subscriptions with a status of "active", "trialing", or "past_due" and a unique "product_name"', () => {
         assert.lengthOf(view.$('.delete-account-product-subscription'), 3);
       });
 


### PR DESCRIPTION
## Because
* If users have multiple subscriptions of the same name they show multiple times.

## This pull request
* Creates a new Set of active subscription product names and displays this list rather than display all active subscriptions.

## Issue that this pull request solves

Closes: #5884

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
