### PR TITLE
fix(tests): Fix broken get-fxa-client content-server test

### DIFF
--- a/packages/fxa-content-server/tests/server/routes/get-fxa-client-configuration.js
+++ b/packages/fxa-content-server/tests/server/routes/get-fxa-client-configuration.js
@@ -37,7 +37,7 @@ suite.tests['get-fxa-client-configuration route function'] = {
     mocks.config['pairing.server_base_uri'] = config.get(
       'pairing.server_base_uri'
     );
-    mocks.config.ecosystem_anon_id_keys = config.get('ecosystem_anon_id_keys');
+    mocks.config.ecosystem_anon_id_keys = config.get('ecosystem_anon_id.keys');
     /*eslint-enable camelcase*/
   },
   tests: {


### PR DESCRIPTION
## Because

* This test slipped through CI and is causing test failures on main.

## This pull request

* Updates a mock ecosystem_anon_id_keys from ecosystem_anon_id_keys to ecosystem_anon_id.keys

## Issue that this pull request solves

Closes: none

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate)