### PR TITLE
chore(build): build fxa-email-service less often

### DIFF
--- a/packages/fxa-email-service/scripts/build-ci.sh
+++ b/packages/fxa-email-service/scripts/build-ci.sh
@@ -15,6 +15,8 @@ docker cp "$ID":/app/.sourcehash /tmp
 
 if diff .sourcehash /tmp/.sourcehash ; then
   echo "The source is unchanged. Skipping build"
+  # tag latest as build so that deploy.sh will be able to push it as a tagged release, i.e. v1.451.9
+  docker image tag mozilla/fxa-email-service:latest fxa-email-service:build
 else
   cp ../version.json .
   docker build --progress=plain -t fxa-email-service:build . > ../../artifacts/fxa-email-service.log

--- a/packages/fxa-email-service/scripts/hash-source.sh
+++ b/packages/fxa-email-service/scripts/hash-source.sh
@@ -4,10 +4,13 @@ DIR=$(dirname "$0")
 cd $DIR/..
 
 git ls-files | \
-# exclude version.json because it changes on every build.
-# Cargo.toml serves as a signal for new releases
-grep -v -e 'version\.json$' | \
+# exclude these files because they change more often than we want to build.
+grep -v -e '^version\.json$' -e '^CHANGELOG\.md$' -e '^Cargo\.toml$' -e '^Cargo\.lock$' | \
 sort | \
 xargs cat | \
+# This is kind of a silly way to let dependency updates trigger a new hash without
+# including the package version line, but a better way involves more parsing than
+# I'd like to do at the moment. It skips the first 4 lines of Cargo.toml
+cat <(tail -n +4 Cargo.toml) - | \
 shasum -a 256 | \
 cut -d " " -f 1


### PR DESCRIPTION
We're building email-service on train tags more often
than we need to and doing so adds a good chunk of time to the
build process.

We've already got some logic in hash-source.sh to determine
when a build should happen. This change adjusts the criteria
to exclude the files that change when a tag is done even when
there's no meaningful changes.
