### PR TITLE
refactor(admin-server): use subquery for index use

### DIFF
--- a/packages/fxa-admin-server/src/lib/resolvers/account-resolver.ts
+++ b/packages/fxa-admin-server/src/lib/resolvers/account-resolver.ts
@@ -44,9 +44,14 @@ export class AccountResolver {
   @FieldResolver()
   public async emailBounces(@Root() account: Account) {
     const uidBuffer = uuidTransformer.to(account.uid);
-    const result = await EmailBounces.query()
-      .innerJoin('emails', 'emailBounces.email', 'emails.normalizedEmail')
+    const subquery = Emails.query()
+      .select('emails.normalizedEmail')
       .where('emails.uid', uidBuffer);
+    const result = await EmailBounces.query().where(
+      'emailBounces.email',
+      'in',
+      subquery
+    );
     return result;
   }
 


### PR DESCRIPTION
Because:

* MySQL decided to not use its index on email even though
  that was where the join was taking place.

This commit:

* Uses a sub-query to retrieve the keys the hope that MySQL will manage
  to use the index as desired.

Closes #5943

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
