### PR TITLE
fix(payments): hide mention of card in reactivate dialog when unavailable

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -237,6 +237,13 @@ reactivate-confirm-copy =
     Your access to { $name } will continue, and your billing cycle
     and payment will stay the same. Your next charge will be
     { $amount } to the card ending in { $last } on { $endDate }.
+# Alternate copy used when a payment method is not available, e.g. for free trials
+# $amount (Number) - The amount billed. It will be formatted as currency.
+# $endDate (Date) - Last day of product access
+reactivate-confirm-without-payment-method-copy =
+    Your access to { $name } will continue, and your billing cycle
+    and payment will stay the same. Your next charge will be
+    { $amount } on { $endDate }.
 reactivate-confirm-button = Resubscribe
 ##  $date (Date) - Last day of product access
 reactivate-panel-date = You cancelled your subscription on { $date }.

--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -388,7 +388,7 @@ describe('routes/Product', () => {
   });
 
   it('displays an error if subscription creation fails for some other reason', async () => {
-    const message = 'We done goofed';
+    const message = 'Something went wrong';
     const {
       getByTestId,
       queryByText,

--- a/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.stories.tsx
@@ -146,7 +146,7 @@ function init() {
         paymentErrorInitialState={{
           type: 'card_error',
           code: 'card_declined',
-          message: 'Done goofed!', // should not be displayed
+          message: 'Should not be displayed',
         }}
       />
     ))
@@ -155,7 +155,7 @@ function init() {
         paymentErrorInitialState={{
           type: 'card_error',
           code: 'incorrect_cvc',
-          message: 'Done goofed!', // should not be displayed
+          message: 'Should not be displayed',
         }}
       />
     ))

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ConfirmationDialog.tsx
@@ -43,20 +43,37 @@ export default ({
         <h4>Want to keep using {plan.product_name}?</h4>
       </Localized>
       {/* TO DO: display card type, IE 'to the Visa card ending...' */}
-      <Localized
-        id="reactivate-confirm-copy"
-        $name={plan.product_name}
-        $amount={getLocalizedCurrency(plan.amount, plan.currency)}
-        $last={last4}
-        $endDate={getLocalizedDate(periodEndDate)}
-      >
-        <p>
-          Your access to {plan.product_name} will continue, and your billing
-          cycle and payment will stay the same. Your next charge will be
-          {getLocalizedCurrencyString(plan.amount, plan.currency)} to the card
-          ending in {last4} on {getLocalizedDateString(periodEndDate)}.
-        </p>
-      </Localized>
+      {last4 && (
+        <Localized
+          id="reactivate-confirm-copy"
+          $name={plan.product_name}
+          $amount={getLocalizedCurrency(plan.amount, plan.currency)}
+          $last={last4}
+          $endDate={getLocalizedDate(periodEndDate)}
+        >
+          <p>
+            Your access to {plan.product_name} will continue, and your billing
+            cycle and payment will stay the same. Your next charge will be
+            {getLocalizedCurrencyString(plan.amount, plan.currency)} to the card
+            ending in {last4} on {getLocalizedDateString(periodEndDate)}.
+          </p>
+        </Localized>
+      )}
+      {!last4 && (
+        <Localized
+          id="reactivate-confirm-without-payment-method-copy"
+          $name={plan.product_name}
+          $amount={getLocalizedCurrency(plan.amount, plan.currency)}
+          $endDate={getLocalizedDate(periodEndDate)}
+        >
+          <p>
+            Your access to {plan.product_name} will continue, and your billing
+            cycle and payment will stay the same. Your next charge will be{' '}
+            {getLocalizedCurrencyString(plan.amount, plan.currency)} on{' '}
+            {getLocalizedDateString(periodEndDate)}.
+          </p>
+        </Localized>
+      )}
       <div className="action">
         <button
           className="settings-button"


### PR DESCRIPTION
One more spot where the credit card is mentioned. Not an error, but the
message looks broken when the card is unavailable.

fixes #5901
