### PR TITLE
feat(auth-js + content): add updateEcosystemAnonId to auth clients

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -178,6 +178,23 @@ export default class AuthClient {
     );
   }
 
+  private async sessionPut(
+    path: string,
+    sessionToken: string,
+    payload: object,
+    headers?: Headers
+  ) {
+    console.log('hey');
+    return this.hawkRequest(
+      'PUT',
+      path,
+      sessionToken,
+      tokenType.sessionToken,
+      payload,
+      headers
+    );
+  }
+
   async signUp(
     email: string,
     password: string,
@@ -1133,5 +1150,40 @@ export default class AuthClient {
       payload.expiry_grace_period = expiryGracePeriod;
     }
     return this.request('POST', '/oauth/id-token-verify', payload);
+  }
+
+  async updateEcosystemAnonId(
+    sessionToken: string,
+    ecosystemAnonId: string,
+    options: {
+      ifNoneMatch?: string;
+      ifMatch?: string;
+    } = {}
+  ) {
+    if (options.ifNoneMatch && options.ifMatch) {
+      throw 'Options ifMatch and ifNoneMatch cannot both be set';
+    }
+
+    const headers: { [header: string]: string } = {};
+
+    if (options.ifNoneMatch) {
+      headers['If-None-Match'] = options.ifNoneMatch;
+    }
+
+    // Not yet supported in the auth server; will be
+    // updated shortly in another PR.
+    //
+    // if (options.ifMatch) {
+    //   headers['If-Match'] = options.ifMatch
+    // }
+
+    return this.sessionPut(
+      '/account/ecosystemAnonId',
+      sessionToken,
+      {
+        ecosystemAnonId,
+      },
+      new Headers(headers)
+    );
   }
 }

--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -1499,7 +1499,7 @@ module.exports = (
       options: {
         auth: {
           payload: false,
-          strategy: 'oauthToken',
+          strategies: ['sessionToken', 'oauthToken'],
         },
         validate: {
           payload: {

--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -1393,6 +1393,24 @@ FxaClientWrapper.prototype = {
    * @returns {Promise} resolves with response when complete.
    */
   createCadReminder: createClientDelegate('createCadReminder'),
+
+  /**
+   * Update a user's ecosystem anon ID
+   *
+   * @method updateEcosystemAnonId
+   * @param {String} sessionToken sessionToken obtained from signIn
+   * @param {String} ecosystemAnonId the new Ecosystem Anonymous ID
+   * @return {Promise} A promise that will be fulfilled with an empty response object
+   */
+  updateEcosystemAnonId: withClient(
+    (client, sessionToken, ecosystemAnonId, options = {}) => {
+      return client.updateEcosystemAnonId(
+        sessionToken,
+        ecosystemAnonId,
+        options
+      );
+    }
+  ),
 };
 
 export default FxaClientWrapper;

--- a/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
@@ -1884,4 +1884,61 @@ describe('lib/fxa-client', function () {
       });
     });
   });
+
+  describe('updateEcosystemAnonId', () => {
+    const sessionToken = 'the silence';
+    const ecosystemAnonId = 'the gold';
+
+    it('calls the client method', () => {
+      const clientMethod = sinon
+        .stub(realClient, 'updateEcosystemAnonId')
+        .resolves();
+
+      return client
+        .updateEcosystemAnonId(sessionToken, ecosystemAnonId)
+        .then((res) => {
+          sinon.assert.calledWith(clientMethod, sessionToken, ecosystemAnonId);
+        });
+    });
+
+    it('calls the request method', () => {
+      sinon.spy(realClient, 'updateEcosystemAnonId');
+      const requestMethod = sinon.stub(realClient, 'sessionPut').resolves();
+
+      return client
+        .updateEcosystemAnonId(sessionToken, ecosystemAnonId)
+        .then((res) => {
+          requestMethod.calledWith(
+            '/account/ecosystemAnonId',
+            sessionToken,
+            {
+              ecosystemAnonId,
+            },
+            new Headers({})
+          );
+        });
+    });
+
+    it('supports ifNoneMatch option', () => {
+      sinon.spy(realClient, 'updateEcosystemAnonId');
+      const requestMethod = sinon.stub(realClient, 'sessionPut').resolves();
+
+      return client
+        .updateEcosystemAnonId(sessionToken, ecosystemAnonId, {
+          ifNoneMatch: '*',
+        })
+        .then((res) => {
+          requestMethod.calledWith(
+            '/account/ecosystemAnonId',
+            sessionToken,
+            {
+              ecosystemAnonId,
+            },
+            new Headers({
+              'If-None-Match': '*',
+            })
+          );
+        });
+    });
+  });
 });


### PR DESCRIPTION
## Because

- We need to be able to send an updated EAI to the auth server

## This pull request

- Updates the fxa-js-client to also support this
- Updates the content server auth client to support this
  - It delegates to the fxa-js-client
- Allows the EAI endpoint on the auth server to authenticate with a sessionToken

## Issue that this pull request references

Reference: #5954 - which turned into this PR after discussion.

I'm not sure if we can close that issue from this. It sounded like we might not want to implement it just yet.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
