### PR TITLE
feat(auth-server): enhance must-reset script to accept a plain text list

### DIFF
--- a/packages/fxa-auth-server/scripts/must-reset/index.js
+++ b/packages/fxa-auth-server/scripts/must-reset/index.js
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+module.exports = async function main(keys, dbFunction) {
+  const butil = require('../../lib/crypto/butil');
+  const config = require('../../config').getProperties();
+  const crypto = require('crypto');
+  const log = require('../../lib/log')({});
+  const P = require('../../lib/promise');
+  const Token = require('../../lib/tokens')(log, config);
+  const AuthDB = require('../../lib/db')(config, log, Token);
+  const oauth = require('../../lib/oauth/db');
+  const db = await AuthDB.connect(config[config.db.backend]);
+
+  let users = '';
+  await P.mapSeries(keys, (item) =>
+    db[dbFunction](item).catch((err) => {
+      console.error(`${String(err)} - ${item}`);
+      process.exit(1);
+    })
+  ).then((result) => {
+    users = result;
+  });
+
+  await P.all(
+    users.map(async (result) => {
+      try {
+        // Removes all session tokens,
+        const uid = result.uid;
+        await db.resetAccount(
+          { uid },
+          {
+            authSalt: butil.ONES.toString('hex'),
+            verifyHash: butil.ONES.toString('hex'),
+            wrapWrapKb: crypto.randomBytes(32).toString('hex'),
+            verifierVersion: 1,
+          }
+        );
+
+        // Removes oauth related tokens
+        await oauth.removeUser(result.uid);
+        console.info('account reset');
+        console.info('  email: ', result.email);
+        console.info('    uid: ', result.uid);
+      } catch (err) {
+        console.error('failed', result.uid, err);
+        process.exit(1);
+      }
+    })
+  );
+
+  console.info('%s accounts reset', users.length);
+  await db.close();
+  process.exit();
+};

--- a/packages/fxa-auth-server/test/scripts/fixtures/accounts.json
+++ b/packages/fxa-auth-server/test/scripts/fixtures/accounts.json
@@ -1,5 +1,0 @@
-[
-  {
-    "uid": "acab38ecffeb4a27a8835016dbf1292c"
-  }
-]

--- a/packages/fxa-auth-server/test/scripts/fixtures/invalid_email.txt
+++ b/packages/fxa-auth-server/test/scripts/fixtures/invalid_email.txt
@@ -1,0 +1,1 @@
+invalid@email.com

--- a/packages/fxa-auth-server/test/scripts/fixtures/invalid_uid.txt
+++ b/packages/fxa-auth-server/test/scripts/fixtures/invalid_uid.txt
@@ -1,0 +1,1 @@
+invalidUid

--- a/packages/fxa-auth-server/test/scripts/must-reset.js
+++ b/packages/fxa-auth-server/test/scripts/must-reset.js
@@ -49,13 +49,17 @@ function createAccount(email, uid) {
 
 const account1Mock = createAccount(
   'user1@test.com',
-  'acab38ecffeb4a27a8835016dbf1292c'
+  'f9916686c226415abd06ae550f073cec'
+);
+const account2Mock = createAccount(
+  'user2@test.com',
+  'f9916686c226415abd06ae550f073ced'
 );
 
 const DB = require('../../lib/db')(config, log, Token, UnblockCode);
 
 describe('scripts/must-reset', async function () {
-  this.timeout(20000);
+  this.timeout(30000);
 
   let db, server;
 
@@ -63,41 +67,234 @@ describe('scripts/must-reset', async function () {
     server = await TestServer.start(config);
     db = await DB.connect(config[config.db.backend]);
     await db.deleteAccount(account1Mock);
+    await db.deleteAccount(account2Mock);
   });
 
   after(async () => {
     await db.deleteAccount(account1Mock);
+    await db.deleteAccount(account2Mock);
     return await TestServer.stop(server);
   });
 
   beforeEach(async () => {
     await db.createAccount(account1Mock);
+    await db.createAccount(account2Mock);
   });
 
   afterEach(async () => {
     await db.deleteAccount(account1Mock);
+    await db.deleteAccount(account2Mock);
   });
 
   it('fails if -i is not specified', async () => {
     try {
-      await cp.execAsync('node --require ts-node/register scripts/must-reset', {
-        cwd,
-      });
+      await cp.execAsync(
+        'node --require ts-node/register scripts/must-reset ./test/scripts/fixtures/one_email.txt',
+        {
+          cwd,
+        }
+      );
       assert(false, 'script should have failed');
     } catch (err) {
       assert.include(err.message, 'Command failed');
     }
   });
 
-  it('succeeds', async () => {
-    await cp.execAsync(
-      `node --require ts-node/register scripts/must-reset -i ./test/scripts/fixtures/accounts.json`,
-      { cwd }
-    );
-    const account = await db.account(account1Mock.uid);
-    assert.equal(
-      account.authSalt,
-      'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
-    );
+  it('fails if neither --emails nor --uids is specified', async () => {
+    try {
+      await cp.execAsync(
+        'node --require ts-node/register scripts/must-reset -i ./test/scripts/fixtures/one_email.txt',
+        {
+          cwd,
+        }
+      );
+      assert(false, 'script should have failed');
+    } catch (err) {
+      assert.include(err.message, 'Command failed');
+    }
+  });
+
+  it('fails if both --emails and --uids are specified', async () => {
+    try {
+      await cp.execAsync(
+        'node --require ts-node/register scripts/must-reset --emails --uids -i ./test/scripts/fixtures/one_email.txt',
+        {
+          cwd,
+        }
+      );
+      assert(false, 'script should have failed');
+    } catch (err) {
+      assert.include(err.message, 'Command failed');
+    }
+  });
+
+  it('fails if --emails specified w/o --input', async () => {
+    try {
+      await cp.execAsync(
+        'node --require ts-node/register scripts/must-reset --emails',
+        {
+          cwd,
+        }
+      );
+      assert(false, 'script should have failed');
+    } catch (err) {
+      assert.include(err.message, 'Command failed');
+    }
+  });
+
+  it('fails if --uids specified w/o --input', async () => {
+    try {
+      await cp.execAsync(
+        'node --require ts-node/register scripts/must-reset --uids',
+        {
+          cwd,
+        }
+      );
+      assert(false, 'script should have failed');
+    } catch (err) {
+      assert.include(err.message, 'Command failed');
+    }
+  });
+
+  it('fails if --uids and --input specified w/ file missing', async () => {
+    try {
+      await cp.execAsync(
+        'node --require ts-node/register scripts/must-reset --uids -input does_not_exist',
+        {
+          cwd,
+        }
+      );
+      assert(false, 'script should have failed');
+    } catch (err) {
+      assert.include(err.message, 'Command failed');
+    }
+  });
+
+  it('fails if --emails and --input specified w/ file missing', async () => {
+    try {
+      await cp.execAsync(
+        'node --require ts-node/register scripts/must-reset --emails --input does_not_exist',
+        {
+          cwd,
+        }
+      );
+      assert(false, 'script should have failed');
+    } catch (err) {
+      assert.include(err.message, 'Command failed');
+    }
+  });
+
+  it('fails if --uids and -i specified w/ invalid uid', async () => {
+    try {
+      await cp.execAsync(
+        'node --require ts-node/register scripts/must-reset --uids -i ./test/scripts/fixtures/invalid_uid.txt',
+        {
+          cwd,
+        }
+      );
+      assert(false, 'script should have failed');
+    } catch (err) {
+      assert.include(err.message, 'Command failed');
+    }
+  });
+
+  it('fails if --emails and -i specified w/ invalid email', async () => {
+    try {
+      await cp.execAsync(
+        'node --require ts-node/register scripts/must-reset --emails -i ./test/scripts/fixtures/invalid_email.txt',
+        {
+          cwd,
+        }
+      );
+      assert(false, 'script should have failed');
+    } catch (err) {
+      assert.include(err.message, 'Command failed');
+    }
+  });
+
+  it('succeeds with --uids and --input containing 1 uid', async () => {
+    try {
+      await cp.execAsync(
+        'node --require ts-node/register scripts/must-reset --uids --input ./test/scripts/fixtures/one_uid.txt',
+        {
+          cwd,
+        }
+      );
+      const account = await db.account(account1Mock.uid);
+      assert.equal(
+        account.authSalt,
+        'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+      );
+    } catch (err) {
+      assert(false, 'script should have succeeded');
+    }
+  });
+
+  it('succeeds with --emails and --input containing 1 email', async () => {
+    try {
+      await cp.execAsync(
+        'node --require ts-node/register scripts/must-reset --emails --input ./test/scripts/fixtures/one_email.txt',
+        {
+          cwd,
+        }
+      );
+      const account = await db.account(account1Mock.uid);
+      assert.equal(
+        account.authSalt,
+        'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+      );
+    } catch (err) {
+      assert(false, 'script should have succeeded');
+    }
+  });
+
+  it('succeeds with --uids and --input containing 2 uids', async () => {
+    try {
+      await cp.execAsync(
+        'node --require ts-node/register scripts/must-reset --uids --input ./test/scripts/fixtures/two_uids.txt',
+        {
+          cwd,
+        }
+      );
+
+      const account1 = await db.account(account1Mock.uid);
+      const account2 = await db.account(account2Mock.uid);
+
+      assert.equal(
+        account1.authSalt,
+        'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+      );
+      assert.equal(
+        account2.authSalt,
+        'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+      );
+    } catch (err) {
+      assert(false, 'script should have succeeded');
+    }
+  });
+
+  it('succeeds with --emails and --input containing 2 emails', async () => {
+    try {
+      await cp.execAsync(
+        'node --require ts-node/register scripts/must-reset --emails --input ./test/scripts/fixtures/two_emails.txt',
+        {
+          cwd,
+        }
+      );
+
+      const account1 = await db.account(account1Mock.uid);
+      const account2 = await db.account(account2Mock.uid);
+
+      assert.equal(
+        account1.authSalt,
+        'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+      );
+      assert.equal(
+        account2.authSalt,
+        'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+      );
+    } catch (err) {
+      assert(false, 'script should have succeeded');
+    }
   });
 });


### PR DESCRIPTION
## Because

* With a plain list of emails/uids it's easier to use the script.

## This pull request

* Add the option of running the script must-reset from a plain text
 list of uids or emails.
* Remove the option to read from a json.

## Issue that this pull request solves

fixes #5894

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Other information

This script from a secondary email can reset an account, even if the secondary email is not yet verified.

I've had to change `setTimeOut` value to make the tests pass locally, maybe this only happens with me.

When I run 'npm run test', why is the "script part" being skipped?