### PR TITLE
fix(payments): use upcoming invoice for subscription reactivation price

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -2121,6 +2121,7 @@ describe('StripeHelper', () => {
       ...mockInvoice,
       id: 'inv_upcoming',
       amount_due: 299000,
+      next_payment_attempt: 1590018018,
     };
 
     const mockCharge = {
@@ -2702,6 +2703,13 @@ describe('StripeHelper', () => {
           expectedBaseUpdateDetails,
           mockInvoice
         );
+        assert.deepEqual(mockStripe.invoices.retrieveUpcoming.args, [
+          [
+            {
+              subscription: event.data.object.id,
+            },
+          ],
+        ]);
         assert.deepEqual(result, defaultExpected);
       });
 


### PR DESCRIPTION
Using the last invoice for the next amount due on reactivating a
cancelled subscription is incorrect. The upcoming invoice has the
correct prorated price. This switches to that.

fixes #5914
