### PR TITLE
feat(auth-server): create a subs w/out a payment method in req

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -668,13 +668,15 @@ class DirectStripeRoutes {
     }
 
     const { priceId, paymentMethodId, idempotencyKey } = request.payload;
+
     const subIdempotencyKey = `${idempotencyKey}-createSub`;
-    const subscription = await this.stripeHelper.createSubscriptionWithPMI(
-      customer.id,
+    const subscription = await this.stripeHelper.createSubscriptionWithPMI({
+      customerId: customer.id,
       priceId,
       paymentMethodId,
-      subIdempotencyKey
-    );
+      subIdempotencyKey,
+    });
+
     return filterSubscription(subscription);
   }
 
@@ -1366,7 +1368,7 @@ const directRoutes = (
         validate: {
           payload: {
             priceId: isA.string().required(),
-            paymentMethodId: validators.stripePaymentMethodId.required(),
+            paymentMethodId: validators.stripePaymentMethodId.optional(),
             idempotencyKey: isA.string().required(),
           },
         },

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -424,7 +424,14 @@ module.exports.subscriptionsStripeIntentValidator = isA
     created: isA.number().required(),
     payment_method: isA
       .alternatives(isA.string(), isA.object({}).unknown(true))
-      .optional(),
+      .optional()
+      .allow(null),
+    source: isA.alternatives().when('payment_method', {
+      // cannot be that strict here since this validator is used in two routes
+      is: null,
+      then: isA.string().optional(),
+      otherwise: isA.any().optional().allow(null),
+    }),
     status: isA.string().required(),
   })
   .unknown(true);

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -440,12 +440,12 @@ describe('StripeHelper', () => {
         .rejects(apiError);
 
       return stripeHelper
-        .createSubscriptionWithPMI(
-          'customerId',
-          'priceId',
-          'pm_1H0FRp2eZvKYlo2CeIZoc0wj',
-          uuidv4()
-        )
+        .createSubscriptionWithPMI({
+          customerId: 'customerId',
+          priceId: 'priceId',
+          paymentMethodId: 'pm_1H0FRp2eZvKYlo2CeIZoc0wj',
+          subIdempotencyKey: uuidv4(),
+        })
         .then(
           () => Promise.reject(new Error('Method expected to reject')),
           (err) => {
@@ -464,12 +464,12 @@ describe('StripeHelper', () => {
         .rejects(apiError);
 
       return stripeHelper
-        .createSubscriptionWithPMI(
-          'customerId',
-          'invoiceId',
-          'pm_1H0FRp2eZvKYlo2CeIZoc0wj',
-          uuidv4()
-        )
+        .createSubscriptionWithPMI({
+          customerId: 'customerId',
+          priceId: 'invoiceId',
+          paymentMethodId: 'pm_1H0FRp2eZvKYlo2CeIZoc0wj',
+          subIdempotencyKey: uuidv4(),
+        })
         .then(
           () => Promise.reject(new Error('Method expected to reject')),
           (err) => {


### PR DESCRIPTION
Because:
 - the API should allow subscription creation with a payment method
   already on record for the customer

This commit:
 - make the payment method id in the create subscription route optional


## Issue that this pull request solves

Closes: FXA-2288

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

