### PR TITLE
fix(content-server): clean the input values before navigating to '/confirm_signup_code'

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/signup-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signup-mixin.js
@@ -79,6 +79,7 @@ export default {
     this.logViewEvent('signup.success');
 
     if (account.get('verificationMethod') === 'email-otp') {
+      this.clearInput();
       this.navigate('/confirm_signup_code', { account });
     } else {
       // do NOT propagate the returned promise. The broker

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/signup-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/signup-mixin.js
@@ -56,6 +56,7 @@ describe('views/mixins/signup-mixin', function () {
         },
         getSignupCodeExperimentGroup: sinon.spy(),
         onSignUpSuccess: SignUpMixin.onSignUpSuccess,
+        clearInput: sinon.spy(),
         relier,
         signUp: SignUpMixin.signUp,
         user,
@@ -231,6 +232,7 @@ describe('views/mixins/signup-mixin', function () {
       });
 
       it('navigates to `confirm_signup_code`', () => {
+        assert.equal(view.clearInput.callCount, 1);
         assert.equal(view.navigate.callCount, 1);
         const args = view.navigate.args[0];
         assert.lengthOf(args, 2);


### PR DESCRIPTION

Because:
* The values were still present after confirming the signup.

This commit:
* Clean the inputs after confirming the signup.

fixes #643
