### PR TITLE
fix(style): add margin between buttons from account recovery.

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_settings-account-recovery.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings-account-recovery.scss
@@ -141,6 +141,10 @@
     font-size: 14px;
     line-height: 1.5;
   }
+
+  button.lost-recovery-key, button.remember-password{
+    margin-top: 16px;
+  }
 }
 
 button.button-link {
@@ -148,6 +152,6 @@ button.button-link {
   color: $color-blue;
 }
 
-button.generate-key-link{
+button.generate-key-link, button.btn-create-recovery-key{
   margin-bottom: 16px;
 }


### PR DESCRIPTION
Because:

* When highlighted the buttons were overlapping.

This commit:

* Add margin between the buttons from account recovery.

fixes #5986 