### PR TITLE
feat(aet): Add account model methods to generate and store anon id

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/verification-reasons.ts
+++ b/packages/fxa-content-server/app/scripts/lib/verification-reasons.ts
@@ -8,6 +8,7 @@
 
 enum VerificationReasons {
   CHANGE_PASSWORD = 'change_password',
+  ECOSYSTEM_ANON_ID = 'ecosystem_anon_id',
   FORCE_AUTH = 'force_auth',
   PASSWORD_RESET = 'reset_password',
   PASSWORD_RESET_WITH_RECOVERY_KEY = 'reset_password_with_recovery_key',

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -751,14 +751,16 @@ const conf = (module.exports = convict({
   ecosystem_anon_id: {
     keys_file: {
       default: '',
-      doc: 'Path to a file containing an array of Account Ecosystem Telemetry pipeline JWK public key objects for encrypting the ecosystem user ID to the ecosystem anon ID',
+      doc:
+        'Path to a file containing an array of Account Ecosystem Telemetry pipeline JWK public key objects for encrypting the ecosystem user ID to the ecosystem anon ID',
       env: 'ECOSYSTEM_ANON_ID_KEYS_FILE',
       format: String,
     },
     keys: {
-      doc: 'Array of Account Ecosystem Telemetry pipeline JWK public key objects for encrypting the ecosystem user ID to the ecosystem anon ID',
+      doc:
+        'Array of Account Ecosystem Telemetry pipeline JWK public key objects for encrypting the ecosystem user ID to the ecosystem anon ID',
       default: [],
-    }
+    },
   },
   template_path: {
     default: path.resolve(__dirname, '..', 'templates'),
@@ -893,7 +895,9 @@ if (conf.get('ecosystem_anon_id.keys_file')) {
       conf.set('ecosystem_anon_id.keys', keys);
     }
   } else {
-    throw new Error('ECOSYSTEM_ANON_ID_KEYS_FILE path was specified but file does not exist');
+    throw new Error(
+      'ECOSYSTEM_ANON_ID_KEYS_FILE path was specified but file does not exist'
+    );
   }
 }
 


### PR DESCRIPTION
Paired on this with @LZoog 

## Because

- We need to have methods that can update and store the ecosystem anon id for a user

## This pull request

- On loading the settings page, fetches and stores the anon id from the auth-server
- Adds account model methods to generate and store ecosystemAnonId to localstorage and auth-server
- Can generate `ecosystemAnonId` either from kB, using authentication token that can retrieve keys, or using password and sessionReauth

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/4320

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
