### PR TITLE
feat(AET): Pass ecosystem anon ID public keys through account model and expose to client

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/app-start.js
+++ b/packages/fxa-content-server/app/scripts/lib/app-start.js
@@ -371,6 +371,7 @@ Start.prototype = {
         profileClient: this._profileClient,
         sentryMetrics: this._sentryMetrics,
         subscriptionsConfig: this._config.subscriptions,
+        ecosystemAnonIdPublicKeys: this._config.ecosystemAnonIdPublicKeys,
         storage: this._getUserStorageInstance(),
         uniqueUserId: this._getUniqueUserId(),
       });

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -99,6 +99,7 @@ const Account = Backbone.Model.extend(
       this._notifier = options.notifier;
       this._sentryMetrics = options.sentryMetrics;
       this._subscriptionsConfig = options.subscriptionsConfig;
+      this._ecosystemAnonIdPublicKeys = options.ecosystemAnonIdPublicKeys;
 
       // upgrade old `grantedPermissions` to the new `permissions`.
       this._upgradeGrantedPermissions();

--- a/packages/fxa-content-server/app/scripts/models/user.js
+++ b/packages/fxa-content-server/app/scripts/models/user.js
@@ -32,6 +32,7 @@ var User = Backbone.Model.extend({
     this._metrics = options.metrics;
     this._notifier = options.notifier;
     this._subscriptionsConfig = options.subscriptionsConfig;
+    this._ecosystemAnonIdPublicKeys = options.ecosystemAnonIdPublicKeys;
     this._storage = options.storage || Storage.factory();
 
     this.sentryMetrics = options.sentryMetrics;
@@ -142,6 +143,7 @@ var User = Backbone.Model.extend({
       profileClient: this._profileClient,
       sentryMetrics: this.sentryMetrics,
       subscriptionsConfig: this._subscriptionsConfig,
+      ecosystemAnonIdPublicKeys: this._ecosystemAnonIdPublicKeys,
     });
 
     // automatically persist changes to valid accounts.

--- a/packages/fxa-content-server/app/tests/spec/models/account.js
+++ b/packages/fxa-content-server/app/tests/spec/models/account.js
@@ -30,6 +30,7 @@ describe('models/account', function () {
   var profileClient;
   var relier;
   var subscriptionsConfig;
+  var ecosystemAnonIdPublicKeys;
 
   var CLIENT_ID = 'client_id';
   var EMAIL = 'user@example.domain';
@@ -69,6 +70,14 @@ describe('models/account', function () {
       managementClientId: 'foxkeh',
       managementScopes: 'quux',
     };
+    ecosystemAnonIdPublicKeys = [
+      {
+        'kty': 'EC',
+      },
+      {
+        'kty': 'RSA',
+      },
+    ]
 
     account = new Account(
       {
@@ -84,6 +93,7 @@ describe('models/account', function () {
         profileClient: profileClient,
         sentryMetrics: sentryMetrics,
         subscriptionsConfig,
+        ecosystemAnonIdPublicKeys
       }
     );
   });
@@ -2937,6 +2947,13 @@ describe('models/account', function () {
       assert.isFalse(account.get('totpVerified'));
     });
   });
+
+  describe('generateEcosystemAnonIdIfRequired', () => {
+    it('receives ecosystemAnonIdPublicKeys', () => {
+      // kind of a moot test at this point, will be updated with FXA-1225 completion
+      assert.equal(account._ecosystemAnonIdPublicKeys, ecosystemAnonIdPublicKeys);
+    });
+  })
 
   describe('_fetchShortLivedSubscriptionsOAuthToken', () => {
     it('calls createOAuthToken with the correct arguments', () => {

--- a/packages/fxa-content-server/server/lib/routes/get-index.js
+++ b/packages/fxa-content-server/server/lib/routes/get-index.js
@@ -44,6 +44,7 @@ module.exports = function (config) {
   const PROMPT_NONE_ENABLED_CLIENT_IDS = new Set(
     config.get('oauth.prompt_none.enabled_client_ids')
   );
+  const ECOSYSTEM_ANON_ID_PUBLIC_KEYS = config.get('ecosystem_anon_id.keys');
 
   // add version from package.json to config
   const RELEASE = require('../../../package.json').version;
@@ -54,6 +55,7 @@ module.exports = function (config) {
   const configForFrontEnd = {
     authServerUrl: AUTH_SERVER_URL,
     env: ENV,
+    ecosystemAnonIdPublicKeys: ECOSYSTEM_ANON_ID_PUBLIC_KEYS,
     isCoppaEnabled: COPPA_ENABLED,
     isPromptNoneEnabled: PROMPT_NONE_ENABLED,
     marketingEmailEnabled: MARKETING_EMAIL_ENABLED,

--- a/packages/fxa-content-server/tests/server/routes/get-index.js
+++ b/packages/fxa-content-server/tests/server/routes/get-index.js
@@ -109,6 +109,10 @@ registerSuite('routes/get-index', {
                 sentConfig.subscriptions,
                 config.get('subscriptions')
               );
+              assert.deepEqual(
+                sentConfig.ecosystemAnonIdPublicKeys,
+                config.get('ecosystem_anon_id.keys')
+              );
               assert.deepEqual(sentConfig.surveyFeature, config.get('surveyFeature'));
               assert.deepEqual(sentConfig.surveys, surveysFromFile);
               assert.equal(


### PR DESCRIPTION
## Because
* In the account model, we need to generate the ecosystem_anon_id with one of these keys plus the user's kB.

## This pull request

* Adds 'ecosystemAnonIdPublicKeys' to 'configForFrontEnd'
* Passes this value into the user model and then account model

## Issue that this pull request solves

Partial fix for #4320 but does not close.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Other information (Optional)

Looks like we test for this value in the FE config in `get-index` but not in `app-start`, and also only testing values in `user.js` we're actually using there so I replicated those tests. The one in `models/account` doesn't show much but the assertion can happen when we work on tests for `generateEcosystemAnonIdIfRequired` in #5989.
