### PR TITLE
feat(fxa-content-server): AET adding calls to check and generate

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -989,7 +989,12 @@ const Account = Backbone.Model.extend(
             relier
           );
         })
-        .then(this.set.bind(this));
+        .then(this.set.bind(this))
+        .then(async () => {
+          if (relier.hasCapability('ecosystemAnonId')) {
+            await this.generateEcosystemAnonId({password: newPassword});
+          }
+        });
     },
 
     /**
@@ -1045,7 +1050,12 @@ const Account = Backbone.Model.extend(
             metricsContext: this._metrics.getFlowEventMetadata(),
           }
         )
-        .then(this.set.bind(this));
+        .then(this.set.bind(this))
+        .then(async() => {
+          if (relier.hasCapability('ecosystemAnonId')) {
+            await this.generateEcosystemAnonId({password});
+          }
+        });
     },
 
     /**
@@ -1653,7 +1663,13 @@ const Account = Backbone.Model.extend(
             metricsContext: this._metrics.getFlowEventMetadata(),
           }
         )
-        .then(this.set.bind(this));
+        .then(this.set.bind(this))
+        .then(async () => {
+          if (relier.hasCapability('ecosystemAnonId')) {
+            await this.generateEcosystemAnonId({kB});
+          }
+        });
+
     },
 
     /**


### PR DESCRIPTION
ecosystem anon id inside the cached credentials mixin.

- fixes #4318

## Because

-

## This pull request

-

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
