### PR TITLE
feat(payments): feature flag support to select SCA or legacy payment UI as default

### DIFF
--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -12,6 +12,15 @@ convict.addFormats(require('convict-format-with-moment'));
 convict.addFormats(require('convict-format-with-validator'));
 
 const conf = convict({
+  featureFlags: {
+    useSCAPaymentUIByDefault: {
+      default: false,
+      doc:
+        'Whether to use newer SCA payment UI components by default rather than at the /v2 sub-path',
+      env: 'FEATURE_USE_SCA_PAYMENT_UI_BY_DEFAULT',
+      format: Boolean,
+    },
+  },
   amplitude: {
     enabled: {
       default: true,

--- a/packages/fxa-payments-server/src/App.test.tsx
+++ b/packages/fxa-payments-server/src/App.test.tsx
@@ -1,15 +1,199 @@
-import React from 'react';
-import { render } from '@testing-library/react';
+import React, { ReactNode } from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-
 import { defaultAppContextValue } from './lib/test-utils';
-import { AppErrorBoundary, AppErrorDialog } from './App';
 import { AppContext } from './lib/AppContext';
+import { State } from './store/state';
+import { createAppStore } from './store';
+import waitForExpect from 'wait-for-expect';
+import { Config } from './lib/config';
+
+import { MemoryRouter } from 'react-router-dom';
 
 jest.mock('./lib/sentry');
 
-// TODO: backfill general App component tests
-// describe('App', () => {});
+// Mock most of the components used by App in order to isolate routing logic
+// and avoid mocking external network requests.
+jest.mock('./lib/AppLocalizationProvider', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => (
+    <section data-testid="AppLocalizationProvider">{children}</section>
+  ),
+}));
+
+jest.mock('@fluent/react', () => ({
+  __esModule: true,
+  withLocalization: (arg: any) => arg,
+  Localized: ({ children }: { children: ReactNode }) => (
+    <span data-testid="Localized">{children}</span>
+  ),
+}));
+
+jest.mock('./routes/Product', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => (
+    <section data-testid="Product">{children}</section>
+  ),
+}));
+
+jest.mock('./routes/ProductV2', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => (
+    <section data-testid="ProductV2">{children}</section>
+  ),
+}));
+
+jest.mock('./routes/Subscriptions', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => (
+    <section data-testid="Subscriptions">{children}</section>
+  ),
+}));
+
+import { App, AppProps, AppErrorBoundary, AppErrorDialog } from './App';
+
+describe('App', () => {
+  afterEach(() => {
+    return cleanup();
+  });
+
+  // TODO: backfill tests for asserting expected props supplied to mock
+  // components, add tests for AppContext usage
+
+  it('renders with expected content for default path', async () => {
+    render(<Subject />);
+    await waitForExpect(() =>
+      expect(screen.queryByTestId('loading-overlay')).not.toBeInTheDocument()
+    );
+    [
+      'AppLocalizationProvider',
+      'StripeProvider',
+      'Subscriptions',
+    ].forEach((testid) =>
+      expect(screen.queryByTestId(testid)).toBeInTheDocument()
+    );
+    [
+      'Firefox Accounts',
+      'Account Home',
+      'Subscriptions & Payments',
+    ].forEach((text) => expect(screen.queryByText(text)).toBeInTheDocument());
+  });
+
+  const commonRoutePathTest = (
+    testid: string,
+    appPath?: string,
+    config?: Partial<Config>
+  ) => async () => {
+    render(<Subject appPath={appPath} config={config} />);
+    await waitForExpect(() =>
+      expect(screen.queryByTestId('loading-overlay')).not.toBeInTheDocument()
+    );
+    await waitForExpect(() =>
+      expect(screen.queryByTestId(testid)).toBeInTheDocument()
+    );
+  };
+
+  it(
+    'renders Subscriptions route for /subscriptions',
+    commonRoutePathTest('Subscriptions', '/subscriptions')
+  );
+
+  it(
+    'renders Product route for /products/prod_fpn',
+    commonRoutePathTest('Product', '/products/prod_fpn')
+  );
+
+  it(
+    'renders Subscriptions route for /v1/subscriptions',
+    commonRoutePathTest('Subscriptions', '/v1/subscriptions')
+  );
+
+  it(
+    'renders Product route for /v1/products/prod_fpn',
+    commonRoutePathTest('Product', '/v1/products/prod_fpn')
+  );
+
+  // TODO: check for props of V2 Subscription route
+  it(
+    'renders Subscriptions route for /v2/subscriptions',
+    commonRoutePathTest('Subscriptions', '/v2/subscriptions')
+  );
+
+  it(
+    'renders ProductV2 route for /v2/products/prod_fpn',
+    commonRoutePathTest('ProductV2', '/v2/products/prod_fpn')
+  );
+
+  // TODO: check for props of V2 Subscription route
+  it(
+    'renders Subscriptions route at default path when feature flag is set',
+    commonRoutePathTest('Subscriptions', undefined, {
+      featureFlags: { useSCAPaymentUIByDefault: true },
+    })
+  );
+
+  // TODO: check for props of V2 Subscription route
+  it(
+    'renders Subscriptions route at /subscriptions when feature flag is set',
+    commonRoutePathTest('Subscriptions', '/subscriptions', {
+      featureFlags: { useSCAPaymentUIByDefault: true },
+    })
+  );
+
+  it(
+    'renders ProductV2 route at /products/prod_fpn when feature flag is set',
+    commonRoutePathTest('ProductV2', '/products/prod_fpn', {
+      featureFlags: { useSCAPaymentUIByDefault: true },
+    })
+  );
+
+  const Subject = ({
+    config,
+    initialState,
+    storeEnhancers,
+    appPath = '/',
+    navigatorLanguages = ['en', 'en-US'],
+  }: {
+    config?: Partial<Config>;
+    initialState?: State;
+    storeEnhancers?: Array<any>;
+    appPath?: string;
+    navigatorLanguages?: string[];
+  }) => {
+    const {
+      config: defaultConfig,
+      queryParams,
+      matchMedia,
+      matchMediaDefault,
+      navigateToUrl,
+      getScreenInfo,
+      stripePromise,
+      locationReload,
+    } = defaultAppContextValue();
+    return (
+      <App
+        {...{
+          store: createAppStore(initialState, storeEnhancers),
+          config: { ...defaultConfig, ...(config || {}) },
+          queryParams,
+          matchMedia,
+          matchMediaDefault,
+          navigateToUrl,
+          getScreenInfo,
+          locationReload,
+          stripePromise,
+          navigatorLanguages,
+          // HACK: Override BrowserRouter dynamically, because mocking
+          // window.location.href changes seems not currently
+          // supported in the JSDOM environment we're using
+          routerOverride: () => ({ children }: { children: ReactNode }) => (
+            <MemoryRouter initialEntries={[appPath]}>{children}</MemoryRouter>
+          ),
+        }}
+      />
+    );
+  };
+});
 
 describe('App/AppErrorBoundary', () => {
   beforeEach(() => {

--- a/packages/fxa-payments-server/src/lib/AppContext.tsx
+++ b/packages/fxa-payments-server/src/lib/AppContext.tsx
@@ -11,7 +11,7 @@ export type AppContextType = {
   matchMediaDefault: (query: string) => MediaQueryList;
   navigateToUrl: (url: string) => void;
   getScreenInfo: () => ScreenInfo;
-  locationReload: (url: string) => void;
+  locationReload: () => void;
   navigatorLanguages?: readonly string[];
   stripePromise: ReturnType<typeof loadStripe>;
 };

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -167,6 +167,9 @@ jest.setMock(
   'react-stripe-elements',
   Object.assign(require.requireActual('react-stripe-elements'), {
     injectStripe,
+    StripeProvider: ({ children }: { children: ReactNode }) => (
+      <section data-testid="StripeProvider">{children}</section>
+    ),
     Elements: ({ children }: { children: ReactNode }) => children,
     CardNumberElement: MockStripeElement({ testid: 'cardNumberElement' }),
     CardExpiryElement: MockStripeElement({ testid: 'cardExpiryElement' }),


### PR DESCRIPTION
- support for FEATURE_USE_SCA_PAYMENT_UI_BY_DEFAULT=1 env var to select
  SCA as default

- also adds support for /v1 and /v2 URL paths to select legacy or SCA
  payment UI, respectively

- tests to exercise App router against paths with mock routes

fixes #5970
