### PR TITLE
refactor(avatars): move file size validation to post-crop

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/settings/avatar_change.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/avatar_change.js
@@ -6,7 +6,6 @@ import $ from 'jquery';
 import AuthErrors from '../../lib/auth-errors';
 import AvatarMixin from '../mixins/avatar-mixin';
 import Cocktail from 'cocktail';
-import Constants from '../../lib/constants';
 import CropperImage from '../../models/cropper-image';
 import FormView from '../form';
 import ImageLoader from '../../lib/image-loader';
@@ -103,11 +102,7 @@ const View = FormView.extend({
         reject(msg);
       };
 
-      if (file.size > Constants.PROFILE_FILE_IMAGE_MAX_UPLOAD_SIZE) {
-        const msg = AuthErrors.toMessage('IMAGE_TOO_LARGE');
-        this.displayError(msg);
-        reject(msg);
-      } else if (file.type.match('image.*')) {
+      if (file.type.match('image.*')) {
         const reader = new this.FileReader();
 
         reader.onload = (event) => {

--- a/packages/fxa-content-server/app/tests/spec/views/settings/avatar_change.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/avatar_change.js
@@ -213,27 +213,6 @@ describe('views/settings/avatar_change', function () {
         });
       });
 
-      it('error when trying to upload big storage sized image', function () {
-        view.FileReader = FileReaderMock;
-
-        return view.afterVisible().then(function () {
-          var ev = FileReaderMock._mockBigStorageSizePngEvent();
-          return view.fileSet(ev).then(
-            function () {
-              assert.catch('unexpected success');
-            },
-            function () {
-              assert.equal(
-                view.$('.error').text(),
-                AuthErrors.toMessage('IMAGE_TOO_LARGE')
-              );
-              assert.isTrue(view.isErrorVisible());
-              assert.equal(view.logFlowEvent.callCount, 0);
-            }
-          );
-        });
-      });
-
       it('loads a supported file', function (done) {
         view.FileReader = FileReaderMock;
 

--- a/packages/fxa-content-server/app/tests/spec/views/settings/avatar_crop.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/avatar_crop.js
@@ -5,6 +5,7 @@
 import $ from 'jquery';
 import AuthBroker from 'models/auth_brokers/base';
 import AuthErrors from 'lib/auth-errors';
+import Constants from 'lib/constants';
 import Backbone from 'backbone';
 import chai from 'chai';
 import CropperImage from 'models/cropper-image';
@@ -180,6 +181,28 @@ describe('views/settings/avatar/crop', function () {
             assert.equal(eventParts[1], 'avatar');
             assert.equal(eventParts[2], 'upload');
             assert.match(eventParts[3], /^[0-9]+$/);
+          });
+      });
+
+      it('shows an error when the output image is too large', function () {
+        sinon.stub(view, 'toBlob').resolves({
+          size: Constants.PROFILE_FILE_IMAGE_MAX_UPLOAD_SIZE + 1,
+        });
+
+        return view
+          .render()
+          .then(function () {
+            return view.afterVisible();
+          })
+          .then(async function () {
+            try {
+              await view.submit();
+            } catch (error) {
+              assert.equal(
+                error.message,
+                AuthErrors.ERRORS.IMAGE_TOO_LARGE.message
+              );
+            }
           });
       });
 


### PR DESCRIPTION
## Because

- #5941 introduced a bug where certain device photo uploads triggered a too-large error, when the file size is out of the user's control
- The cropper does a lot of work to reduce the size of the file that gets uploaded to the server

## This pull request

- Instead of validating the file size on photo selection, validate the output image generated by the cropper

## Issue that this pull request solves

Closes: #5976

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Other information (Optional)

**Why is this approach better?**

When you select an image for upload, or take an photo on your device camera, the image may be larger than the maximum-allowable file size set by the server. However, this is _not_ the image being submitted to the server. When you select the image and resize/crop it, it is processed in the client by our cropper and typically always yields a file size _much_ smaller than the original image. It is still possible to generate a file too large to be uploaded, but the likelihood is much less.

**How can you test this?**

So far I've only been able to get one image to trigger the error (this is good, because that means the cropper is effectively creating a smaller file most of the time).

- Note: locally the max server file size is 1MB, but in production it's slightly higher at 1.35MB. This means it'll be even harder to trigger when deployed (this is good!)
- Download [this image](https://user-images.githubusercontent.com/6392049/88199289-a355ac80-cc12-11ea-9011-6938b2a071f7.png)
- Upload it to the cropper
- Zoom all the way in and pan into the top cake. The goal is to get as much detail into the cropper frame as possible.
- This should yield an image slightly over 1MB, triggering the error.
- Importantly, I have not been able to trigger this error with any iOS image.
