### PR TITLE
fix(db): Set collation on stored procedure email fields

### DIFF
--- a/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
@@ -16,8 +16,6 @@ const zeroBuffer32 = Buffer.from(
   'hex'
 );
 const now = Date.now();
-const anonId =
-  'eyJhbGciOiJFQ0RILUVTIiwia2lkIjoiMFZFRTdmT0txbFdHVGZrY0taRUJ2WWl3dkpMYTRUUGlJVGxXMGJOcDdqVSIsImVwayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InY3Q1FlRWtVQjMwUGwxV0tPMUZUZ25OQlNQdlFyNlh0UnZxT2kzSWdzNHciLCJ5IjoiNDBKVEpaQlMwOXpWNHpxb0hHZDI5NGFDeHRqcGU5a09reGhELVctUEZsSSJ9LCJlbmMiOiJBMjU2R0NNIn0.A_wzJya943vlHKFH.yq0JhkGZiZd6UiZK6goTcEf6i4gbbBeXxvq8QV5_nC4.Knl_sYSBrrP-aa54z6B6gA';
 
 function newUuid() {
   return crypto.randomBytes(16);
@@ -41,7 +39,6 @@ function createAccount() {
     verifierSetAt: now,
     createdAt: now,
     locale: 'en_US',
-    ecosystemAnonId: anonId,
   };
   account.normalizedEmail = normalizeEmail(account.email);
   account.emailBuffer = Buffer.from(account.email);
@@ -342,11 +339,6 @@ module.exports = function (config, DB) {
             account.hasOwnProperty('locale'),
             false,
             'locale not returned'
-          );
-          assert.equal(
-            account.ecosystemAnonId,
-            accountData.ecosystemAnonId,
-            'ecosystemAnonId'
           );
         });
       });

--- a/packages/fxa-auth-db-mysql/db-server/test/backend/remote.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/remote.js
@@ -2995,12 +2995,6 @@ module.exports = function (cfg, makeServer) {
         respOkEmpty(r);
       });
 
-      it('should create user with ecosystem anon id', async () => {
-        const r = await client.getThen('/account/' + user.accountId);
-        const account = r.obj;
-        assert.equal(account.ecosystemAnonId, 'initialEcosystemAnonId');
-      });
-
       it('should update ecosystem anon id', async () => {
         let r = await client.putThen(
           '/account/' + user.accountId + '/ecosystemAnonId',

--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -198,9 +198,9 @@ module.exports = function (log, error) {
   // CREATE
 
   // Insert : accounts
-  // Values : uid = $1, normalizedEmail = $2, email = $3, emailCode = $4, emailVerified = $5, kA = $6, wrapWrapKb = $7, authSalt = $8, verifierVersion = $9, verifyHash = $10, verifierSetAt = $11, createdAt = $12, locale = $13, ecosystemAnonId = $14
+  // Values : uid = $1, normalizedEmail = $2, email = $3, emailCode = $4, emailVerified = $5, kA = $6, wrapWrapKb = $7, authSalt = $8, verifierVersion = $9, verifyHash = $10, verifierSetAt = $11, createdAt = $12, locale = $13
   var CREATE_ACCOUNT =
-    'CALL createAccount_8(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
+    'CALL createAccount_9(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
 
   MySql.prototype.createAccount = function (uid, data) {
     return this.write(CREATE_ACCOUNT, [
@@ -217,7 +217,6 @@ module.exports = function (log, error) {
       data.verifierSetAt,
       data.createdAt,
       data.locale,
-      data.ecosystemAnonId,
     ]);
   };
 
@@ -601,7 +600,7 @@ module.exports = function (log, error) {
   // Select : accounts
   // Fields : uid, email, normalizedEmail, emailVerified, emailCode, kA, wrapWrapKb, verifierVersion, authSalt, verifierSetAt, createdAt, lockedAt, ecosystemAnonId
   // Where  : accounts.normalizedEmail = LOWER($1)
-  var EMAIL_RECORD = 'CALL emailRecord_5(?)';
+  var EMAIL_RECORD = 'CALL emailRecord_6(?)';
 
   MySql.prototype.emailRecord = function (emailBuffer) {
     return this.readFirstResult(EMAIL_RECORD, [emailBuffer.toString('utf8')]);

--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 111;
+module.exports.level = 112;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-111-112.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-111-112.sql
@@ -1,0 +1,121 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('111');
+
+-- Explicitly set the collation on the email field, so that mysql will use
+-- the email table index and not do a full table scan.
+-- See https://github.com/mozilla/fxa/issues/6006.
+CREATE PROCEDURE `emailRecord_6` (
+    IN `inEmail` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin
+)
+BEGIN
+    SELECT
+        a.uid,
+        a.email,
+        a.normalizedEmail,
+        a.emailVerified,
+        a.emailCode,
+        a.kA,
+        a.wrapWrapKb,
+        a.verifierVersion,
+        a.authSalt,
+        a.verifierSetAt,
+        a.lockedAt,
+        a.createdAt
+    FROM
+        accounts a
+    WHERE
+        a.normalizedEmail = LOWER(inEmail)
+    ;
+END;
+
+-- Remove the eco_anon_id field from createAccount, which we really don't ever
+-- plan to use in practice. Also explicitly set collation on the normalized
+-- email field, so that mysql will use the index and not do a full table read.
+-- See https://github.com/mozilla/fxa/issues/6006.
+CREATE PROCEDURE `createAccount_9`(
+    IN `inUid` BINARY(16) ,
+    IN `inNormalizedEmail` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin,
+    IN `inEmail` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin,
+    IN `inEmailCode` BINARY(16),
+    IN `inEmailVerified` TINYINT(1),
+    IN `inKA` BINARY(32),
+    IN `inWrapWrapKb` BINARY(32),
+    IN `inAuthSalt` BINARY(32),
+    IN `inVerifierVersion` TINYINT UNSIGNED,
+    IN `inVerifyHash` BINARY(32),
+    IN `inVerifierSetAt` BIGINT UNSIGNED,
+    IN `inCreatedAt` BIGINT UNSIGNED,
+    IN `inLocale` VARCHAR(255)
+)
+BEGIN
+    DECLARE EXIT HANDLER FOR SQLEXCEPTION
+    BEGIN
+        ROLLBACK;
+        RESIGNAL;
+    END;
+
+    START TRANSACTION;
+
+    -- Check to see if the normalizedEmail exists in the emails table before creating a new user
+    -- with this email.
+    SET @emailExists = 0;
+    SELECT COUNT(*) INTO @emailExists FROM emails WHERE normalizedEmail = inNormalizedEmail;
+    IF @emailExists > 0 THEN
+        SIGNAL SQLSTATE '45000' SET MYSQL_ERRNO = 1062, MESSAGE_TEXT = 'Unable to create user, email used belongs to another user.';
+    END IF;
+
+    INSERT INTO accounts(
+        uid,
+        normalizedEmail,
+        email,
+        emailCode,
+        emailVerified,
+        kA,
+        wrapWrapKb,
+        authSalt,
+        verifierVersion,
+        verifyHash,
+        verifierSetAt,
+        createdAt,
+        locale
+    )
+    VALUES(
+        inUid,
+        LOWER(inNormalizedEmail),
+        inEmail,
+        inEmailCode,
+        inEmailVerified,
+        inKA,
+        inWrapWrapKb,
+        inAuthSalt,
+        inVerifierVersion,
+        inVerifyHash,
+        inVerifierSetAt,
+        inCreatedAt,
+        inLocale
+    );
+
+    INSERT INTO emails(
+        normalizedEmail,
+        email,
+        uid,
+        emailCode,
+        isVerified,
+        isPrimary,
+        createdAt
+    )
+    VALUES(
+        LOWER(inNormalizedEmail),
+        inEmail,
+        inUid,
+        inEmailCode,
+        inEmailVerified,
+        true,
+        inCreatedAt
+    );
+
+    COMMIT;
+END;
+
+UPDATE dbMetadata SET value = '112' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-112-111.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-112-111.sql
@@ -1,0 +1,7 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE `emailRecord_6`;
+-- DROP PROCEDURE `createAccount_9`;
+
+-- UPDATE dbMetadata SET value = '111' WHERE name = 'schema-patch-level';
+

--- a/packages/fxa-auth-db-mysql/test/local/mysql_tests.js
+++ b/packages/fxa-auth-db-mysql/test/local/mysql_tests.js
@@ -18,8 +18,6 @@ const zeroBuffer32 = Buffer.from(
   'hex'
 );
 const now = Date.now();
-const anonId =
-  'eyJhbGciOiJFQ0RILUVTIiwia2lkIjoiMFZFRTdmT0txbFdHVGZrY0taRUJ2WWl3dkpMYTRUUGlJVGxXMGJOcDdqVSIsImVwayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6InY3Q1FlRWtVQjMwUGwxV0tPMUZUZ25OQlNQdlFyNlh0UnZxT2kzSWdzNHciLCJ5IjoiNDBKVEpaQlMwOXpWNHpxb0hHZDI5NGFDeHRqcGU5a09reGhELVctUEZsSSJ9LCJlbmMiOiJBMjU2R0NNIn0.A_wzJya943vlHKFH.yq0JhkGZiZd6UiZK6goTcEf6i4gbbBeXxvq8QV5_nC4.Knl_sYSBrrP-aa54z6B6gA';
 
 describe('MySQL', () => {
   let db;
@@ -361,7 +359,6 @@ describe('MySQL', () => {
       verifierSetAt: now,
       createdAt: now,
       locale: 'en_US',
-      ecosystemAnonId: anonId,
     };
     account.normalizedEmail = normalizeEmail(account.email);
 
@@ -393,11 +390,6 @@ describe('MySQL', () => {
           result.verifierVersion,
           account.verifierVersion,
           'verifierVersion set'
-        );
-        assert.equal(
-          result.ecosystemAnonId,
-          account.ecosystemAnonId,
-          'ecosystemAnonId set'
         );
       });
   });


### PR DESCRIPTION


## Because

- MySQL doesn't use indexes on stored procedure queries if the collation of the field doesn't explicitly match that of the table.

## This pull request

- explicitly sets collation on email fields used to search the email table

- also removes the ecosystem_anon_id from the create account stored procedure, because in general we will never have that data at account creation time

## Issue that this pull request solves

Closes: #6006

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
