### PR TITLE
feat(aet): support for if-match and if-none-match across the board

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -184,7 +184,6 @@ export default class AuthClient {
     payload: object,
     headers?: Headers
   ) {
-    console.log('hey');
     return this.hawkRequest(
       'PUT',
       path,
@@ -1152,30 +1151,36 @@ export default class AuthClient {
     return this.request('POST', '/oauth/id-token-verify', payload);
   }
 
+  /** Update a user's ecosystem anon ID */
   async updateEcosystemAnonId(
+    /** Session token obtained from signIn */
     sessionToken: string,
+    /** The new Ecosystem Anonymous ID */
     ecosystemAnonId: string,
+    /** Additional options to be passed to the method */
     options: {
+      /**
+       * Sets the If-None-Match header to the specified value.
+       * Use '*' to only update ID if one is not already set.
+       */
       ifNoneMatch?: string;
+      /**
+       * Sets the If-Match header to the specified value.
+       * Use the first part of an existing ID to only update
+       * the ID if the values do not fuzzy match.
+       */
       ifMatch?: string;
     } = {}
   ) {
-    if (options.ifNoneMatch && options.ifMatch) {
-      throw 'Options ifMatch and ifNoneMatch cannot both be set';
-    }
-
     const headers: { [header: string]: string } = {};
 
     if (options.ifNoneMatch) {
       headers['If-None-Match'] = options.ifNoneMatch;
     }
 
-    // Not yet supported in the auth server; will be
-    // updated shortly in another PR.
-    //
-    // if (options.ifMatch) {
-    //   headers['If-Match'] = options.ifMatch
-    // }
+    if (options.ifMatch) {
+      headers['If-Match'] = options.ifMatch;
+    }
 
     return this.sessionPut(
       '/account/ecosystemAnonId',

--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -1178,7 +1178,8 @@ by the following errors
 - `code: 400, errno: 163`:
   Token does not contain the correct scope.
 - `code: 412, errno: 190`:
-  Attempted to update non-null Ecosystem Anon ID.
+  Could not update because criteria set by a header,
+  either If-None-Match or If-Match, was not met
 
 ### Devices and sessions
 

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -102,7 +102,7 @@ const ERRNO = {
   PAYMENT_FAILED: 186,
   SUBSCRIPTION_ALREADY_EXISTS: 187,
   UNKNOWN_SUBSCRIPTION_FOR_SOURCE: 188,
-  ECOSYSTEM_ANON_ID_EXISTS: 190,
+  ECOSYSTEM_ANON_ID_UPDATE_CONFLICT: 190,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -1311,12 +1311,12 @@ AppError.invalidOrExpiredOtpCode = () => {
   });
 };
 
-AppError.anonIdExists = () => {
+AppError.anonIdUpdateConflict = (headerName) => {
   return new AppError({
     code: 412,
     error: 'Precondition Failed',
-    errno: ERRNO.ECOSYSTEM_ANON_ID_EXISTS,
-    message: 'Attempted to update non-null Ecosystem Anon ID',
+    errno: ERRNO.ECOSYSTEM_ANON_ID_UPDATE_CONFLICT,
+    message: `Could not update Ecosystem Anon ID because criteria set by ${headerName} was not met`,
   });
 };
 

--- a/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
@@ -1940,5 +1940,28 @@ describe('lib/fxa-client', function () {
           );
         });
     });
+
+    it('supports ifMatch option', () => {
+      sinon.spy(realClient, 'updateEcosystemAnonId');
+      const requestMethod = sinon.stub(realClient, 'sessionPut').resolves();
+      const ifMatchValue = '2507464399';
+
+      return client
+        .updateEcosystemAnonId(sessionToken, ecosystemAnonId, {
+          ifMatch: ifMatchValue,
+        })
+        .then((res) => {
+          requestMethod.calledWith(
+            '/account/ecosystemAnonId',
+            sessionToken,
+            {
+              ecosystemAnonId,
+            },
+            new Headers({
+              'If-Match': ifMatchValue,
+            })
+          );
+        });
+    });
   });
 });

--- a/packages/fxa-profile-server/docs/API.md
+++ b/packages/fxa-profile-server/docs/API.md
@@ -46,7 +46,7 @@ The currently-defined error responses are:
 - 400, 101: Invalid request parameter
 - 400, 102: Unsupported image provider
 - 400, 125: The request was blocked for security reasons
-- 412, 106: Attempted to update non-null Ecosystem Anon ID
+- 412, 106: Criteria set by a header, either If-None-Match or If-Match, was not met
 - 429, 114: Client has sent too many requests
 - 500, 103: Image processing error
 - 503, 104: OAuth service unavailable

--- a/packages/fxa-profile-server/lib/config.js
+++ b/packages/fxa-profile-server/lib/config.js
@@ -241,7 +241,8 @@ const conf = convict({
       env: 'WORKER_URL',
     },
     headers_exclude: {
-      doc: 'HTTP headers to not pass through to the worker requests (in lower case)',
+      doc:
+        'HTTP headers to not pass through to the worker requests (in lower case)',
       format: Array,
       env: 'WORKER_HEADERS_EXCLUDE',
       default: ['host'],

--- a/packages/fxa-profile-server/lib/error.js
+++ b/packages/fxa-profile-server/lib/error.js
@@ -203,16 +203,19 @@ AppError.authError = function authError(err) {
   );
 };
 
-AppError.anonIdExists = function anonIdExists(err) {
+AppError.anonIdUpdateConflict = function anonIdExists(headerName, message) {
+  message =
+    message ||
+    `Could not update Ecosystem Anon ID because criteria set by ${headerName} was not met`;
   return new AppError(
     {
       code: 412,
       error: 'Precondition Failed',
       errno: 106,
-      message: 'Attempted to update non-null Ecosystem Anon ID',
+      message,
     },
     {
-      cause: err,
+      cause: message,
     }
   );
 };


### PR DESCRIPTION
## Because

- Services internal and external to FxA need to be able to set an the Ecosystem Anon ID under various circumstances, such as only if one isn't set, or if it matches a specific existing value

## This pull request

- Improves [`If-None-Match`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match) and adds [`If-Match`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match) header support across the Profile server, Auth Server, and Auth Client

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Other information (Optional)

For both implementations I tried to follow as close to spec as possible, which includes support for one or more specific values (comma-delimited), and `*` (If-None-Match only). Comparisons are made using an MD5 hashed version of the existing anon ID.