### PR TITLE
fix(profile): set `forever: true` in request

### DIFF
--- a/packages/fxa-profile-server/lib/request.js
+++ b/packages/fxa-profile-server/lib/request.js
@@ -11,4 +11,6 @@ var https = require('https');
 https.globalAgent.maxSockets = Infinity;
 
 // in case we want rip `request` out, it can happen in here
-module.exports = require('request');
+module.exports = require('request').defaults({
+  forever: true
+});


### PR DESCRIPTION
fixes #5691

We've got a lot of connection churn on profile-server. This is the minimal patch to attempt to fix it. Since 'request' is deprecated we should consider swapping it for something else in a future release.
