### PR TITLE
feat(fxa-content-server): AET adding calls to check and generate

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -1079,7 +1079,10 @@ const Account = Backbone.Model.extend(
             relier
           );
         })
-        .then(this.set.bind(this));
+        .then(this.set.bind(this))
+        .then(async () => {
+          await this.generateEcosystemAnonId({ password: newPassword });
+        });
     },
 
     /**
@@ -1135,7 +1138,10 @@ const Account = Backbone.Model.extend(
             metricsContext: this._metrics.getFlowEventMetadata(),
           }
         )
-        .then(this.set.bind(this));
+        .then(this.set.bind(this))
+        .then(async () => {
+          await this.generateEcosystemAnonId({ password });
+        });
     },
 
     /**
@@ -1743,7 +1749,10 @@ const Account = Backbone.Model.extend(
             metricsContext: this._metrics.getFlowEventMetadata(),
           }
         )
-        .then(this.set.bind(this));
+        .then(this.set.bind(this))
+        .then(async () => {
+          await this.generateEcosystemAnonId({ kB });
+        });
     },
 
     /**

--- a/packages/fxa-content-server/app/tests/spec/models/account.js
+++ b/packages/fxa-content-server/app/tests/spec/models/account.js
@@ -2057,6 +2057,11 @@ describe('models/account', function () {
   });
 
   describe('changePassword', function () {
+    beforeEach(() => {
+      sinon.stub(account, 'generateEcosystemAnonId')
+        .callsFake(() => {});
+    });
+
     it('returns `INCORRECT_PASSWORD` error if old password is incorrect (event if passwords are the same)', function () {
       sinon.stub(fxaClient, 'checkPassword').callsFake(function () {
         return Promise.reject(AuthErrors.toError('INCORRECT_PASSWORD'));
@@ -2124,6 +2129,9 @@ describe('models/account', function () {
             )
           );
 
+          assert.isTrue(
+            account.generateEcosystemAnonId.calledWith({password: newPassword})
+          );
           assert.equal(account.get('keyFetchToken'), 'new keyFetchToken');
           assert.equal(account.get('sessionToken'), 'new sessionToken');
           assert.equal(account.get('sessionTokenContext'), 'foo');
@@ -2134,6 +2142,11 @@ describe('models/account', function () {
   });
 
   describe('completePasswordReset', function () {
+    beforeEach(() => {
+      sinon.stub(account, 'generateEcosystemAnonId')
+        .callsFake(() => {});
+    });
+
     it('completes the password reset', function () {
       account.set('email', EMAIL);
       var token = 'token';
@@ -2161,6 +2174,9 @@ describe('models/account', function () {
             )
           );
 
+          assert.isTrue(
+            account.generateEcosystemAnonId.calledWith({password: PASSWORD})
+          );
           assert.ok(account.get('keyFetchToken'), 'new keyFetchToken');
           assert.equal(account.get('sessionToken'), 'new sessionToken');
           assert.equal(account.get('uid'), 'uid');


### PR DESCRIPTION
#6004 without the capability check on reliers 

fixes #4318 

cc/ @vbudhram 

Should be merged after #5989 (for `account.generateEcosystemId` method)