### PR TITLE
fix(content-server): change the buttons from account-recovery to links.

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/account_recovery_confirm_key.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/account_recovery_confirm_key.mustache
@@ -42,7 +42,9 @@
 
                 <div class="button-row">
                     <button id="submit-btn" type="submit" class="primary-button">{{#t}}Confirm recovery key{{/t}}</button>
-                    <button class="button-link lost-recovery-key">{{#t}}Don't have a recovery key?{{/t}}</button>
+                </div>
+                <div class="links">
+                  <a href="#" class="lost-recovery-key">{{#t}}Don't have a recovery key?{{/t}}</a>
                 </div>
             </form>
         </section>

--- a/packages/fxa-content-server/app/scripts/templates/choose_what_to_sync.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/choose_what_to_sync.mustache
@@ -20,8 +20,8 @@
         <button id="submit-btn" type="submit" tabindex="1" autofocus>{{#t}}Sync selections{{/t}}</button>
       </div>
       {{#showDoNotSyncButton}}
-        <div class="links centered">
-          <a id="do-not-sync-device" href="#" class="button-link">{{#t}}Don’t sync this device{{/t}}</a>
+        <div class="links">
+          <a id="do-not-sync-device" href="#">{{#t}}Don’t sync this device{{/t}}</a>
         </div>
       {{/showDoNotSyncButton}}
     </form>

--- a/packages/fxa-content-server/app/scripts/templates/complete_reset_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/complete_reset_password.mustache
@@ -69,7 +69,9 @@
 
       <div class="button-row ">
           <button type="submit">{{#t}}Reset password{{/t}}</button>
-          <button class="button-link remember-password">{{#t}}Remember password? Sign in{{/t}}</button>
+      </div>
+      <div class="links">
+        <a href="#" class="remember-password">{{#t}}Remember password? Sign in{{/t}}</a>
       </div>
     </form>
   </section>

--- a/packages/fxa-content-server/app/scripts/templates/ready.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/ready.mustache
@@ -27,7 +27,9 @@
       {{^isFromRelyingParty}}
         {{#emailVerified}}
           <p class="account-ready-service">{{{escapedEmailReadyText}}}</p>
-          <button class="button-link btn-goto-account">{{#t}}Continue to my account{{/t}}</button>
+          <div class="links">
+            <a href="#" class="btn-goto-account">{{#t}}Continue to my account{{/t}}</a>
+          </div>
         {{/emailVerified}}
         {{^emailVerified}}
           {{#isSignedIn}}
@@ -43,7 +45,9 @@
       {{#isPasswordReset}}
           <div class="button-row">
               <button class="primary-button btn-create-recovery-key">{{#t}}Generate a new recovery key{{/t}}</button>
-              <button class="button-link btn-goto-account">{{#t}}Continue to my account{{/t}}</button>
+          </div>
+          <div class="links">
+            <a href="#" class="btn-goto-account">{{#t}}Continue to my account{{/t}}</a>
           </div>
       {{/isPasswordReset}}
 

--- a/packages/fxa-content-server/app/scripts/templates/settings/account_recovery/confirm_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/account_recovery/confirm_password.mustache
@@ -17,7 +17,7 @@
 
             <div class="button-row">
                 <button class="primary-button generate-key-link">{{#t}}Continue{{/t}}</button>
-                <button class="button-link cancel-link">{{#t}}Cancel{{/t}}</button>
+                <button class="tertiary-button cancel-link">{{#t}}Cancel{{/t}}</button>
             </div>
         </form>
     </section>

--- a/packages/fxa-content-server/app/scripts/templates/would-you-like-to-sync.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/would-you-like-to-sync.mustache
@@ -13,7 +13,7 @@
         <button id="submit-btn" type="submit" tabindex="1" autofocus>{{#t}}Sync this device{{/t}}</button>
       </div>
       <div class="links centered">
-        <a id="do-not-sync-device" href="#" class="button-link">{{#t}}Don’t sync this device{{/t}}</a>
+        <a id="do-not-sync-device" href="#">{{#t}}Don’t sync this device{{/t}}</a>
       </div>
     </form>
   </section>

--- a/packages/fxa-content-server/app/styles/modules/_button-row.scss
+++ b/packages/fxa-content-server/app/styles/modules/_button-row.scss
@@ -57,6 +57,18 @@ button {
     }
   }
 
+  &.tertiary-button {
+    background: transparent;
+    color: $blue-60;
+
+    &:hover {
+      color: $blue-70;
+    }
+    &:active {
+      color: $blue-80;
+    }
+  }
+
   &.warning-button {
     background: $error-background-color;
     border: 0;

--- a/packages/fxa-content-server/app/styles/modules/_settings-account-recovery.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings-account-recovery.scss
@@ -142,16 +142,7 @@
     line-height: 1.5;
   }
 
-  button.lost-recovery-key, button.remember-password{
-    margin-top: 16px;
+  button.generate-key-link {
+    margin-bottom: 16px;
   }
-}
-
-button.button-link {
-  background: transparent;
-  color: $color-blue;
-}
-
-button.generate-key-link, button.btn-create-recovery-key{
-  margin-bottom: 16px;
 }


### PR DESCRIPTION
## Because

* All the `.button-link` should be links and not buttons.

## This pull request

* Change the buttons with `.button-link` to links, and place it outside of `.button-row`.

* Remove the class `.button-link`.

## Issue that this pull request solves

fixes #3951

## Other information
I think the class `.centered` should have another name.