### PR TITLE
fix(aet): Add support for updating ecosystemAnonId using sessionToken

### DIFF
--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -1436,7 +1436,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   };
 
   SAFE_URLS.updateEcosystemAnonId = new SafeUrl(
-    '/account/:id/ecosystemAnonId',
+    '/account/:uid/ecosystemAnonId',
     'db.updateEcosystemAnonId'
   );
   DB.prototype.updateEcosystemAnonId = async function (uid, ecosystemAnonId) {

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -3124,7 +3124,7 @@ describe('/account/ecosystemAnonId', () => {
       log: mockLog,
       credentials: {
         scope: ['profile:ecosystem_anon_id:write'],
-        uid,
+        user: uid,
       },
       payload: {
         ecosystemAnonId,


### PR DESCRIPTION
## Because

- We need to support updating ecosystemAnonId with sessionToken
- sessionTokens are considered to contain all scopes
- Tested this against https://github.com/mozilla/fxa/pull/6020 and the ecosystemAnonId gets correctly set when user changes password

## This pull request

- Adds this support
- Some minor cleanup

## Issue that this pull request solves

Closes: #

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
