### PR TITLE
refactor(auth-server): use type-cacheable for caching

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1,13 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import convict from 'convict';
+import fs from 'fs';
+import path from 'path';
+import url from 'url';
 
-'use strict';
-
-const fs = require('fs');
-const path = require('path');
-const url = require('url');
-const convict = require('convict');
 const DEFAULT_SUPPORTED_LANGUAGES = require('./supportedLanguages');
 
 convict.addFormats(require('convict-format-with-moment'));
@@ -1866,7 +1864,7 @@ if (conf.get('oauthServer.openid.keyFile')) {
   // If the file doesnt exist, or contains an empty object, then there's no active key.
   conf.set('oauthServer.openid.key', null);
   if (fs.existsSync(keyFile)) {
-    const key = JSON.parse(fs.readFileSync(keyFile));
+    const key = JSON.parse(fs.readFileSync(keyFile, 'utf-8'));
     if (key && Object.keys(key).length > 0) {
       conf.set('oauthServer.openid.key', key);
     }
@@ -1885,7 +1883,7 @@ if (conf.get('oauthServer.openid.newKeyFile')) {
   // If the file doesnt exist, or contains an empty object, then there's no new key.
   conf.set('oauthServer.openid.newKey', null);
   if (fs.existsSync(newKeyFile)) {
-    const newKey = JSON.parse(fs.readFileSync(newKeyFile));
+    const newKey = JSON.parse(fs.readFileSync(newKeyFile, 'utf-8'));
     if (newKey && Object.keys(newKey).length > 0) {
       conf.set('oauthServer.openid.newKey', newKey);
     }
@@ -1904,7 +1902,7 @@ if (conf.get('oauthServer.openid.oldKeyFile')) {
   // If the file doesnt exist, or contains an empty object, then there's no old key.
   conf.set('oauthServer.openid.oldKey', null);
   if (fs.existsSync(oldKeyFile)) {
-    const oldKey = JSON.parse(fs.readFileSync(oldKeyFile));
+    const oldKey = JSON.parse(fs.readFileSync(oldKeyFile, 'utf-8'));
     if (oldKey && Object.keys(oldKey).length > 0) {
       conf.set('oauthServer.openid.oldKey', oldKey);
     }
@@ -1931,5 +1929,6 @@ if (conf.get('isProduction')) {
 }
 
 export type conf = typeof conf;
+export type ConfigType = ReturnType<conf['getProperties']>;
 
 module.exports = conf;

--- a/packages/fxa-auth-server/lib/oauth/logging/index.ts
+++ b/packages/fxa-auth-server/lib/oauth/logging/index.ts
@@ -1,13 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Logger } from 'mozlog';
 
-const { Logger } = require('mozlog');
-
-type MozLog = { logger: typeof Logger };
+type MozLog = { logger: Logger };
 let mozlog: null | MozLog;
 
-module.exports = function (nameOrLog: string | MozLog): typeof Logger | void {
+module.exports = function (nameOrLog: string | MozLog): Logger | void {
   if (typeof nameOrLog === 'string') {
     // ignore logger labels for now. auth and oauth used
     // different logging strategies eventually these should

--- a/packages/fxa-auth-server/lib/oauth/metrics/amplitude.ts
+++ b/packages/fxa-auth-server/lib/oauth/metrics/amplitude.ts
@@ -15,7 +15,7 @@ const { version: VERSION } = require('../../../package.json');
 import { GROUPS, initialize, validate } from 'fxa-shared/metrics/amplitude';
 import { Logger } from 'mozlog';
 import { Scope } from '@sentry/node';
-import { conf } from '../../../config';
+import { ConfigType } from '../../../config';
 
 const EVENTS = {
   'token.created': {
@@ -30,7 +30,7 @@ const EVENTS = {
 
 const FUZZY_EVENTS = new Map([]);
 
-module.exports = (log: Logger, config: conf) => {
+module.exports = (log: Logger, config: ConfigType) => {
   if (!log || !config.oauthServer.clientIdToServiceNames) {
     throw new TypeError('Missing argument');
   }

--- a/packages/fxa-auth-server/lib/redis.js
+++ b/packages/fxa-auth-server/lib/redis.js
@@ -321,3 +321,4 @@ module.exports = (config, log) => {
   }
   return new FxaRedis(config, log);
 };
+module.exports.FxARedis = FxaRedis;

--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -1468,12 +1468,11 @@ module.exports = (
         if (config.subscriptions.enabled) {
           try {
             if (stripeHelper) {
-              const customer = await stripeHelper.customer(
+              const customer = await stripeHelper.customer({
                 uid,
                 email,
-                false,
-                true
-              );
+                cacheOnly: true,
+              });
               if (!customer) {
                 throw error.unknownCustomer(uid);
               }

--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -504,7 +504,11 @@ class DirectStripeRoutes {
   async listActive(request) {
     this.log.begin('subscriptions.listActive', request);
     const { uid, email } = await handleAuth(this.db, request.auth, true);
-    const customer = await this.stripeHelper.customer(uid, email, false, true);
+    const customer = await this.stripeHelper.customer({
+      uid,
+      email,
+      cacheOnly: true,
+    });
     const activeSubscriptions = [];
 
     if (customer && customer.subscriptions) {
@@ -606,7 +610,7 @@ class DirectStripeRoutes {
     const { uid, email } = await handleAuth(this.db, request.auth, true);
     await this.customs.check(request, email, 'createCustomer');
 
-    let customer = await this.stripeHelper.customer(uid, email);
+    let customer = await this.stripeHelper.customer({ uid, email });
     if (customer) {
       return customer;
     }
@@ -634,7 +638,7 @@ class DirectStripeRoutes {
     const { uid, email } = await handleAuth(this.db, request.auth, true);
     await this.customs.check(request, email, 'retryInvoice');
 
-    const customer = await this.stripeHelper.customer(uid, email);
+    const customer = await this.stripeHelper.customer({ uid, email });
     if (!customer) {
       throw error.unknownCustomer(uid);
     }
@@ -662,7 +666,7 @@ class DirectStripeRoutes {
     const { uid, email } = await handleAuth(this.db, request.auth, true);
     await this.customs.check(request, email, 'createSubscriptionWithPMI');
 
-    const customer = await this.stripeHelper.customer(uid, email);
+    const customer = await this.stripeHelper.customer({ uid, email });
     if (!customer) {
       throw error.unknownCustomer(uid);
     }
@@ -691,7 +695,7 @@ class DirectStripeRoutes {
     const { uid, email } = await handleAuth(this.db, request.auth, true);
     await this.customs.check(request, email, 'createSetupIntent');
 
-    const customer = await this.stripeHelper.customer(uid, email);
+    const customer = await this.stripeHelper.customer({ uid, email });
     if (!customer) {
       throw error.unknownCustomer(uid);
     }
@@ -710,7 +714,7 @@ class DirectStripeRoutes {
     const { uid, email } = await handleAuth(this.db, request.auth, true);
     await this.customs.check(request, email, 'updateDefaultPaymentMethod');
 
-    let customer = await this.stripeHelper.customer(uid, email);
+    let customer = await this.stripeHelper.customer({ uid, email });
     if (!customer) {
       throw error.unknownCustomer(uid);
     }
@@ -730,7 +734,11 @@ class DirectStripeRoutes {
       paymentMethodId
     );
     // Refetch the customer and force a cache clear
-    customer = await this.stripeHelper.customer(uid, email, true);
+    customer = await this.stripeHelper.customer({
+      uid,
+      email,
+      forceRefresh: true,
+    });
     return filterCustomer(customer);
   }
 
@@ -1171,7 +1179,11 @@ class DirectStripeRoutes {
     this.log.begin('subscriptions.getSubscriptions', request);
 
     const { uid, email } = await handleAuth(this.db, request.auth, true);
-    const customer = await this.stripeHelper.customer(uid, email, false, true);
+    const customer = await this.stripeHelper.customer({
+      uid,
+      email,
+      cacheOnly: true,
+    });
 
     // A FxA user isn't always a customer.
     if (!customer) {
@@ -1196,7 +1208,7 @@ class DirectStripeRoutes {
     const { uid, email } = request.query;
 
     // We know that a user has to be a customer to create a support ticket
-    const customer = await this.stripeHelper.customer(uid, email);
+    const customer = await this.stripeHelper.customer({ uid, email });
     const response = await this.stripeHelper.formatSubscriptionsForSupport(
       customer.subscriptions
     );

--- a/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/utils/subscriptions.js
@@ -67,7 +67,11 @@ const SubscriptionUtils = (module.exports = {
  * @param {string} email
  */
 async function fetchSubscribedProductsFromStripe(uid, stripeHelper, email) {
-  const customer = await stripeHelper.customer(uid, email, false, true);
+  const customer = await stripeHelper.customer({
+    uid,
+    email,
+    cacheOnly: true,
+  });
   if (!customer || !customer.subscriptions.data) {
     return [];
   }

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -46,6 +46,8 @@
     "@hapi/hoek": "^8.5.1",
     "@hapi/joi": "^15.1.1",
     "@sentry/node": "^5.17.0",
+    "@type-cacheable/core": "^5.2.0",
+    "@type-cacheable/ioredis-adapter": "^5.2.0",
     "ajv": "^6.12.2",
     "aws-sdk": "^2.698.0",
     "base64url": "3.0.0",

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -3049,10 +3049,7 @@ describe('/account', () => {
   it('should return formatted Stripe subscriptions when subscriptions are enabled', () => {
     return runTest(buildRoute(), request, (result) => {
       assert.deepEqual(mockStripeHelper.customer.args[0], [
-        uid,
-        email,
-        false,
-        true,
+        { uid, email, cacheOnly: true },
       ]);
       assert.deepEqual(mockStripeHelper.subscriptionsToResponse.args[0], [
         mockCustomer.subscriptions,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -372,13 +372,10 @@ describe('subscriptions directRoutes', () => {
         reqOpts,
         stripeHelper
       );
-      assert.isTrue(
-        stripeHelper.customer.calledOnceWith(
-          reqOpts.query.uid,
-          reqOpts.query.email
-        ),
-        'customer not called as expected'
-      );
+      sinon.assert.calledOnceWithExactly(stripeHelper.customer, {
+        uid: reqOpts.query.uid,
+        email: reqOpts.query.email,
+      });
       assert.deepEqual(response, expected);
     });
   });

--- a/packages/fxa-auth-server/tsconfig.json
+++ b/packages/fxa-auth-server/tsconfig.json
@@ -1,16 +1,13 @@
 {
   "extends": "../../_dev/tsconfig.node.json",
   "compilerOptions": {
+    "experimentalDecorators": true,
     "outDir": "./dist",
     // Permit, but do not report errors for JS files
     // TODO: Remove after transition to TS is complete
     "checkJs": false,
-    "types": ["accept-language", "mocha", "mozlog", "node"],
+    "types": ["accept-language", "mocha", "mozlog", "node"]
   },
-  "references": [
-    { "path": "../fxa-shared" }
-  ],
-  "include": [
-    "bin/*"
-  ]
+  "references": [{ "path": "../fxa-shared" }],
+  "include": ["bin/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4148,6 +4148,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@type-cacheable/core@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@type-cacheable/core@npm:5.2.0"
+  dependencies:
+    serialize-javascript: ^3.0.0
+  checksum: 70a6b8757911aad2b7346b6b4ba97e1451cfc9191612bc65b1e3b05ce67831dc33b4bcd65c39361a4b01134e8709679f42ed8a8a63804d749f4a10fd1cecac0a
+  languageName: node
+  linkType: hard
+
+"@type-cacheable/ioredis-adapter@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@type-cacheable/ioredis-adapter@npm:5.2.0"
+  dependencies:
+    "@type-cacheable/core": ^5.2.0
+  peerDependencies:
+    ioredis: ^4.14.1
+  checksum: f23f8f2358a490c9222e029439a0d1c5f8b786d9e4ae2738f5dd6cd33e598a3c4af53e7176bf4b25e7408211564b1f1a46a7b7fb5f1c2be21da772f89b964c16
+  languageName: node
+  linkType: hard
+
 "@types/accepts@npm:*, @types/accepts@npm:^1.3.5":
   version: 1.3.5
   resolution: "@types/accepts@npm:1.3.5"
@@ -15322,6 +15342,8 @@ fsevents@^1.2.7:
     "@hapi/hoek": ^8.5.1
     "@hapi/joi": ^15.1.1
     "@sentry/node": ^5.17.0
+    "@type-cacheable/core": ^5.2.0
+    "@type-cacheable/ioredis-adapter": ^5.2.0
     "@types/cbor": 5.0.0
     "@types/chai": ^4.2.4
     "@types/convict": ^5.2.1
@@ -27303,7 +27325,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"randombytes@npm:^2.0.0, randombytes@npm:^2.0.1, randombytes@npm:^2.0.5":
+"randombytes@npm:^2.0.0, randombytes@npm:^2.0.1, randombytes@npm:^2.0.5, randombytes@npm:^2.1.0":
   version: 2.1.0
   resolution: "randombytes@npm:2.1.0"
   dependencies:
@@ -29628,6 +29650,15 @@ resolve@~1.11.1:
   version: 2.1.2
   resolution: "serialize-javascript@npm:2.1.2"
   checksum: 9a4d4da6469e327332203438eed9a408e0618519d18aaba3790c88bf87712df4d577423d8fbd7122753800fa12afe19540cba111178ab0cf1f33c2b5771731bf
+  languageName: node
+  linkType: hard
+
+"serialize-javascript@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "serialize-javascript@npm:3.1.0"
+  dependencies:
+    randombytes: ^2.1.0
+  checksum: e3036658c26b4aa0c74b89c91dc702f1b98c34ffc108e7944e2e227f910896367e98374a1a8c9923385ddfccd1759bfbd133d7857f4e315070594bb8761740e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:

* Using a library for caching provides a nicer UX with additional
  capabilities to rolling our own.
* require() imports always resolve to any.

This commit:

* Uses type-cacheable for decorator based caching and clearing instead
  of our DIY function.
* Switches config.ts to use imports for Config type-safety and updates
  use of config for proper typing.

Closes #6000

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Other information (Optional)

This removes the logging assertions as the default strategy in type-cacheable does not log Redis failures. Our logging was never consulted, so it doesn't seem useful that we were logging before. If we do want to know when a Redis command fails, my recommendation for a future PR/issue would be to supply our own [default CacheStrategy](https://github.com/joshuaslate/type-cacheable/blob/master/packages/core/lib/strategies/DefaultStrategy.ts) that emits metrics of failures so we can graph it on a dashboard or even better, log a Sentry error.