### PR TITLE
fix(tests): Remove flaky recovery key assertion

### DIFF
--- a/packages/fxa-content-server/tests/functional/recovery_key.js
+++ b/packages/fxa-content-server/tests/functional/recovery_key.js
@@ -166,15 +166,6 @@ registerSuite('Recovery key', {
             )
           )
 
-          // continue without entering the recovery key
-          .then(fillOutRecoveryKey(''))
-          .then(
-            testElementTextInclude(
-              selectors.COMPLETE_RESET_PASSWORD_RECOVERY_KEY.TOOLTIP,
-              'recovery key required'
-            )
-          )
-
           .then(fillOutRecoveryKey(recoveryKey))
 
           .then(testElementExists(selectors.COMPLETE_RESET_PASSWORD.HEADER))


### PR DESCRIPTION
## Because

- These assertions are flaky and really don't test anything of value
- We have other supporting tests in https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/app/tests/spec/views/elements/recovery-key-input.js to test input.

## This pull request

- Removes the flake

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).