### PR TITLE
feat(payments): use SetupIntent API for SCA payment update

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.js
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.js
@@ -716,15 +716,6 @@ class DirectStripeRoutes {
     }
 
     const { paymentMethodId } = request.payload;
-
-    // Verify the payment method is already attached to the customer
-    const alreadyAttached = !!customer.sources.data.find(
-      (pm) => pm.id === paymentMethodId
-    );
-    if (!alreadyAttached) {
-      throw error.rejectedCustomerUpdate('Invalid payment method id');
-    }
-
     await this.stripeHelper.updateDefaultPaymentMethod(
       customer.id,
       paymentMethodId
@@ -1407,9 +1398,6 @@ const directRoutes = (
         },
         response: {
           schema: validators.subscriptionsStripeIntentValidator,
-        },
-        validate: {
-          payload: {},
         },
       },
       handler: (request) => directStripeRoutes.createSetupIntent(request),

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -909,24 +909,6 @@ describe('DirectStripeRoutes', () => {
       assert.deepEqual(filterCustomer(expected), actual);
     });
 
-    it('errors when the payment method id is not attached', async () => {
-      const customer = deepCopy(emptyCustomer);
-      directStripeRoutesInstance.stripeHelper.customer
-        .onCall(0)
-        .resolves(customer);
-
-      VALID_REQUEST.payload = { paymentMethodId: 'pm_asdf' };
-      try {
-        await directStripeRoutesInstance.updateDefaultPaymentMethod(
-          VALID_REQUEST
-        );
-        assert.fail('Create customer should fail.');
-      } catch (err) {
-        assert.instanceOf(err, WError);
-        assert.equal(err.errno, error.ERRNO.REJECTED_CUSTOMER_UPDATE);
-      }
-    });
-
     it('errors when a customer has not been created', async () => {
       VALID_REQUEST.payload = { paymentMethodId: 'pm_asdf' };
       try {

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -144,7 +144,7 @@ const AppRoutesV1 = () => {
         exact
         render={(props) => (
           <SettingsLayout>
-            <Subscriptions {...props} />
+            <Subscriptions {...{ ...props, useSCAPaymentFlow: false }} />
           </SettingsLayout>
         )}
       />
@@ -170,7 +170,7 @@ const AppRoutesV2 = () => {
         exact
         render={(props) => (
           <SettingsLayout>
-            <Subscriptions {...props} />
+            <Subscriptions {...{ ...props, useSCAPaymentFlow: true }} />
           </SettingsLayout>
         )}
       />

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -43,6 +43,12 @@ import {
   apiCancelSubscription,
   apiReactivateSubscription,
   apiUpdatePayment,
+  apiCreateCustomer,
+  apiCreateSubscriptionWithPaymentMethod,
+  FilteredSetupIntent,
+  apiCreateSetupIntent,
+  apiUpdateDefaultPaymentMethod,
+  apiRetryInvoice,
 } from './apiClient';
 
 describe('APIError', () => {
@@ -366,6 +372,98 @@ describe('API requests', () => {
         ...metricsOptions,
         error,
       });
+      requestMock.done();
+    });
+  });
+
+  describe('apiCreateCustomer', () => {
+    const path = '/v1/oauth/subscriptions/customer';
+
+    it(`POST {auth-server}${path}`, async () => {
+      const requestMock = nock(AUTH_BASE_URL)
+        .post(path)
+        .reply(200, MOCK_CUSTOMER);
+
+      expect(
+        await apiCreateCustomer({
+          displayName: 'Bar Fooson',
+          idempotencyKey: 'idk-8675309',
+        })
+      ).toEqual(MOCK_CUSTOMER);
+      requestMock.done();
+    });
+  });
+
+  describe('apiCreateSubscriptionWithPaymentMethod', () => {
+    const path = '/v1/oauth/subscriptions/active/new';
+
+    it(`POST {auth-server}${path}`, async () => {
+      const expected = { what: 'ever' };
+      const requestMock = nock(AUTH_BASE_URL).post(path).reply(200, expected);
+
+      expect(
+        await apiCreateSubscriptionWithPaymentMethod({
+          priceId: 'price_12345',
+          paymentMethodId: 'pm_test',
+          idempotencyKey: 'idk-8675309',
+        })
+      ).toEqual(expected);
+      requestMock.done();
+    });
+  });
+
+  describe('apiRetryInvoice', () => {
+    const path = '/v1/oauth/subscriptions/invoice/retry';
+
+    it(`POST {auth-server}${path}`, async () => {
+      const expected = { what: 'ever' };
+      const requestMock = nock(AUTH_BASE_URL).post(path).reply(200, expected);
+
+      expect(
+        await apiRetryInvoice({
+          invoiceId: 'inv_12345',
+          paymentMethodId: 'pm_test',
+          idempotencyKey: 'idk-8675309',
+        })
+      ).toEqual(expected);
+      requestMock.done();
+    });
+  });
+
+  describe('apiCreateSetupIntent', () => {
+    const path = '/v1/oauth/subscriptions/setupintent/create';
+
+    it(`POST {auth-server}${path}`, async () => {
+      const expectedResponse: FilteredSetupIntent = {
+        client_secret: 'secret_squirrel',
+        created: 123456789,
+        next_action: null,
+        payment_method: null,
+        status: 'requires_payment_method',
+      };
+
+      const requestMock = nock(AUTH_BASE_URL)
+        .post(path)
+        .reply(200, expectedResponse);
+
+      expect(await apiCreateSetupIntent()).toEqual(expectedResponse);
+      requestMock.done();
+    });
+  });
+
+  describe('apiUpdateDefaultPaymentMethod', () => {
+    const path = '/v1/oauth/subscriptions/paymentmethod/default';
+
+    it(`POST {auth-server}${path}`, async () => {
+      const requestMock = nock(AUTH_BASE_URL)
+        .post(path)
+        .reply(200, MOCK_CUSTOMER);
+
+      expect(
+        await apiUpdateDefaultPaymentMethod({
+          paymentMethodId: 'pm_test',
+        })
+      ).toEqual(MOCK_CUSTOMER);
       requestMock.done();
     });
   });

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -309,3 +309,28 @@ export async function apiRetryInvoice(params: {
     { body: JSON.stringify(params) }
   );
 }
+
+export type FilteredSetupIntent = {
+  client_secret: string;
+  created: number;
+  next_action: string | null;
+  payment_method: string | null;
+  status: string;
+};
+
+export async function apiCreateSetupIntent(): Promise<FilteredSetupIntent> {
+  return apiFetch(
+    'POST',
+    `${config.servers.auth.url}/v1/oauth/subscriptions/setupintent/create`
+  );
+}
+
+export async function apiUpdateDefaultPaymentMethod(params: {
+  paymentMethodId: string;
+}): Promise<Customer> {
+  return apiFetch(
+    'POST',
+    `${config.servers.auth.url}/v1/oauth/subscriptions/paymentmethod/default`,
+    { body: JSON.stringify(params) }
+  );
+}

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -1,4 +1,5 @@
 import { Profile, Plan, Customer } from '../store/types';
+import { FilteredSetupIntent } from '../lib/apiClient';
 
 export const PROFILE: Profile = {
   amrValues: [],
@@ -113,3 +114,12 @@ export const PLAN = {
 };
 
 export const PLANS: Plan[] = [PLAN, UPGRADE_FROM_PLAN, SELECTED_PLAN];
+
+export const FILTERED_SETUP_INTENT: FilteredSetupIntent = {
+  client_secret:
+    'seti_1GnXR2Kb9q6OnNsLFV0IWItK_secret_HMFwCT3daxuB29hhx4j7eJQ0IFtqEB5',
+  created: 1590617356,
+  next_action: null,
+  payment_method: 'card_1GnXR2Kb9q6OnNsLuymjpC5P',
+  status: 'succeeded',
+};

--- a/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.test.tsx
@@ -8,7 +8,6 @@ import {
   cleanup,
   act,
   fireEvent,
-  wait,
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { PaymentMethod, PaymentIntent } from '@stripe/stripe-js';
@@ -382,7 +381,7 @@ describe('routes/ProductV2/SubscriptionCreate', () => {
   );
 
   it(
-    'displays an error of card confirmation is missing payment intent',
+    'displays an error if card confirmation is missing payment intent',
     commonConfirmPaymentTest({
       shouldSucceed: false,
       confirmCardPayment: jest.fn().mockResolvedValue({

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateFormV2.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateFormV2.test.tsx
@@ -1,0 +1,679 @@
+import React from 'react';
+import {
+  screen,
+  render,
+  cleanup,
+  act,
+  fireEvent,
+} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import TestRenderer from 'react-test-renderer';
+
+import waitForExpect from 'wait-for-expect';
+
+import PaymentUpdateForm, {
+  PaymentUpdateFormProps,
+} from './PaymentUpdateFormV2';
+import { Plan } from '../../store/types';
+import {
+  MOCK_PLANS,
+  MOCK_CUSTOMER,
+  setupFluentLocalizationTest,
+  getLocalizedMessage,
+  mockStripeElementOnChangeFns,
+  elementChangeResponse,
+} from '../../lib/test-utils';
+import { CUSTOMER, FILTERED_SETUP_INTENT } from '../../lib/mock-data';
+import {
+  getLocalizedDateString,
+  getLocalizedDate,
+  getLocalizedCurrency,
+} from '../../lib/formats';
+
+import { PickPartial } from '../../lib/types';
+
+describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
+  const dayBasedId = 'pay-update-billing-description-day';
+  const weekBasedId = 'pay-update-billing-description-week';
+  const monthBasedId = 'pay-update-billing-description-month';
+  const yearBasedId = 'pay-update-billing-description-year';
+  const subscription = MOCK_CUSTOMER.subscriptions[0];
+
+  const findMockPlan = (planId: string): Plan => {
+    const plan = MOCK_PLANS.find((x) => x.plan_id === planId);
+    if (plan) {
+      return plan;
+    }
+    throw new Error('unable to find suitable Plan object for test execution.');
+  };
+
+  const baseProps = {
+    customerSubscription: subscription,
+    customer: MOCK_CUSTOMER,
+    plan: MOCK_PLANS[0],
+    refreshSubscription: jest.fn(),
+  };
+
+  type SubjectProps = PickPartial<
+    PaymentUpdateFormProps,
+    | 'customer'
+    | 'customerSubscription'
+    | 'plan'
+    | 'refreshSubscriptions'
+    | 'setUpdatePaymentIsSuccess'
+    | 'resetUpdatePaymentIsSuccess'
+  >;
+
+  const Subject = ({
+    customer = CUSTOMER,
+    customerSubscription = CUSTOMER.subscriptions[0],
+    plan = MOCK_PLANS[0],
+    paymentErrorInitialState,
+    apiClientOverrides = defaultApiClientOverrides(),
+    stripeOverride = defaultStripeOverride(),
+    refreshSubscriptions = jest.fn(),
+    setUpdatePaymentIsSuccess = jest.fn(),
+    resetUpdatePaymentIsSuccess = jest.fn(),
+  }: SubjectProps) => {
+    return (
+      <PaymentUpdateForm
+        {...{
+          customer,
+          customerSubscription,
+          plan,
+          refreshSubscriptions,
+          setUpdatePaymentIsSuccess,
+          resetUpdatePaymentIsSuccess,
+          paymentErrorInitialState,
+          stripeOverride,
+          apiClientOverrides,
+        }}
+      />
+    );
+  };
+
+  const defaultApiClientOverrides = () => ({
+    apiCreateSetupIntent: jest.fn().mockResolvedValue(FILTERED_SETUP_INTENT),
+    apiUpdateDefaultPaymentMethod: jest.fn().mockResolvedValue(CUSTOMER),
+  });
+
+  const DISPLAY_NAME = 'Foo Barson';
+
+  const CONFIRM_CARD_SETUP_RESULT = {
+    setupIntent: {
+      payment_method: 'pm_test',
+    },
+    error: null,
+  };
+
+  const defaultStripeOverride = () => ({
+    confirmCardSetup: jest.fn().mockResolvedValue(CONFIRM_CARD_SETUP_RESULT),
+  });
+
+  let consoleSpy: jest.SpyInstance<void, [any?, ...any[]]>;
+
+  beforeEach(() => {
+    consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    if (consoleSpy) consoleSpy.mockRestore();
+    return cleanup();
+  });
+
+  it('renders with payment update form hidden initially', async () => {
+    render(<Subject />);
+    expect(screen.queryByTestId('payment-update')).toBeInTheDocument();
+    expect(screen.queryByTestId('paymentForm')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('upgrade-cta')).not.toBeInTheDocument();
+  });
+
+  it('renders with payment update form with upgradeCTA when available', async () => {
+    const upgradeCTA = 'Buy the next best thing!';
+    render(
+      <Subject plan={{ ...MOCK_PLANS[0], product_metadata: { upgradeCTA } }} />
+    );
+    expect(screen.queryByTestId('payment-update')).toBeInTheDocument();
+    expect(screen.queryByTestId('paymentForm')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('upgrade-cta')).toBeInTheDocument();
+    expect(screen.queryByText(upgradeCTA)).toBeInTheDocument();
+  });
+
+  it('reveals the payment update form on clicking Change button', async () => {
+    render(<Subject />);
+    expect(screen.queryByTestId('payment-update')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('change-button'));
+    expect(screen.queryByTestId('paymentForm')).toBeInTheDocument();
+  });
+
+  async function commonSubmitSetup({
+    apiClientOverrides = defaultApiClientOverrides(),
+    stripeOverride = defaultStripeOverride(),
+    refreshSubscriptions = jest.fn(),
+    ...props
+  } = {}) {
+    render(
+      <Subject
+        {...{
+          apiClientOverrides,
+          stripeOverride,
+          refreshSubscriptions,
+          ...props,
+        }}
+      />
+    );
+
+    expect(screen.queryByTestId('payment-update')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('change-button'));
+
+    await act(async () => {
+      mockStripeElementOnChangeFns.cardElement(
+        elementChangeResponse({ complete: true, value: 'test' })
+      );
+    });
+
+    fireEvent.change(screen.getByTestId('name'), {
+      target: { value: DISPLAY_NAME },
+    });
+    fireEvent.blur(screen.getByTestId('name'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('submit'));
+    });
+
+    return {
+      apiClientOverrides,
+      stripeOverride,
+      refreshSubscriptions,
+    };
+  }
+
+  const EXPECTED_CONFIRM_CARD_SETUP_ARGS = [
+    FILTERED_SETUP_INTENT.client_secret,
+    {
+      payment_method: {
+        card: { isMockElement: true, testid: 'cardElement' },
+        billing_details: { name: DISPLAY_NAME },
+      },
+    },
+  ];
+
+  it('updates payment method as expected', async () => {
+    const {
+      apiClientOverrides,
+      stripeOverride,
+      refreshSubscriptions,
+    } = await commonSubmitSetup();
+
+    expect(
+      screen.queryByTestId('error-message-container')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('paymentForm')).not.toBeInTheDocument();
+    expect(apiClientOverrides.apiCreateSetupIntent).toHaveBeenCalledTimes(1);
+    expect(stripeOverride.confirmCardSetup).toHaveBeenCalledWith(
+      ...EXPECTED_CONFIRM_CARD_SETUP_ARGS
+    );
+    expect(
+      apiClientOverrides.apiUpdateDefaultPaymentMethod
+    ).toHaveBeenCalledWith({
+      paymentMethodId: CONFIRM_CARD_SETUP_RESULT.setupIntent.payment_method,
+    });
+    expect(refreshSubscriptions).toBeCalledTimes(1);
+  });
+
+  it('clears the displayed error if the form changes', async () => {
+    await commonSubmitSetup({
+      apiClientOverrides: {
+        ...defaultApiClientOverrides(),
+        apiCreateSetupIntent: jest
+          .fn()
+          .mockRejectedValue('barf apiCreateSetupIntent'),
+      },
+    });
+
+    expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('name'), {
+        target: { value: 'Bar Bar' },
+      });
+    });
+
+    await waitForExpect(() =>
+      expect(
+        screen.queryByTestId('error-message-container')
+      ).not.toBeInTheDocument()
+    );
+  });
+
+  it('displays an error if apiCreateSetupIntent throws', async () => {
+    const {
+      apiClientOverrides,
+      stripeOverride,
+      refreshSubscriptions,
+    } = await commonSubmitSetup({
+      apiClientOverrides: {
+        ...defaultApiClientOverrides(),
+        apiCreateSetupIntent: jest
+          .fn()
+          .mockRejectedValue('barf apiCreateSetupIntent'),
+      },
+    });
+
+    expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
+    expect(screen.getByText('basic-error-message')).toBeInTheDocument();
+    expect(screen.queryByTestId('paymentForm')).toBeInTheDocument();
+    expect(apiClientOverrides.apiCreateSetupIntent).toHaveBeenCalledTimes(1);
+    expect(stripeOverride.confirmCardSetup).not.toHaveBeenCalled();
+    expect(
+      apiClientOverrides.apiUpdateDefaultPaymentMethod
+    ).not.toHaveBeenCalled();
+    expect(refreshSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it('displays an error if confirmCardSetup throws', async () => {
+    const {
+      apiClientOverrides,
+      stripeOverride,
+      refreshSubscriptions,
+    } = await commonSubmitSetup({
+      stripeOverride: {
+        ...defaultStripeOverride(),
+        confirmCardSetup: jest.fn().mockRejectedValue('barf confirmCardSetup'),
+      },
+    });
+
+    expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
+    expect(screen.getByText('basic-error-message')).toBeInTheDocument();
+    expect(screen.queryByTestId('paymentForm')).toBeInTheDocument();
+    expect(apiClientOverrides.apiCreateSetupIntent).toHaveBeenCalledTimes(1);
+    expect(stripeOverride.confirmCardSetup).toHaveBeenCalledWith(
+      ...EXPECTED_CONFIRM_CARD_SETUP_ARGS
+    );
+    expect(
+      apiClientOverrides.apiUpdateDefaultPaymentMethod
+    ).not.toHaveBeenCalled();
+    expect(refreshSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it('displays an error if confirmCardSetup returns an error', async () => {
+    const {
+      apiClientOverrides,
+      stripeOverride,
+      refreshSubscriptions,
+    } = await commonSubmitSetup({
+      stripeOverride: {
+        ...defaultStripeOverride(),
+        confirmCardSetup: jest
+          .fn()
+          .mockResolvedValue({ error: { code: 'expired_card' } }),
+      },
+    });
+
+    expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
+    expect(screen.getByText('expired-card-error')).toBeInTheDocument();
+    expect(screen.queryByTestId('paymentForm')).toBeInTheDocument();
+    expect(apiClientOverrides.apiCreateSetupIntent).toHaveBeenCalledTimes(1);
+    expect(stripeOverride.confirmCardSetup).toHaveBeenCalledWith(
+      ...EXPECTED_CONFIRM_CARD_SETUP_ARGS
+    );
+    expect(
+      apiClientOverrides.apiUpdateDefaultPaymentMethod
+    ).not.toHaveBeenCalled();
+    expect(refreshSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it('displays an error if confirmCardSetup returns an empty setupIntent', async () => {
+    const {
+      apiClientOverrides,
+      stripeOverride,
+      refreshSubscriptions,
+    } = await commonSubmitSetup({
+      stripeOverride: {
+        ...defaultStripeOverride(),
+        confirmCardSetup: jest.fn().mockResolvedValue({ setupIntent: null }),
+      },
+    });
+
+    expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
+    expect(screen.getByText('basic-error-message')).toBeInTheDocument();
+    expect(screen.queryByTestId('paymentForm')).toBeInTheDocument();
+    expect(apiClientOverrides.apiCreateSetupIntent).toHaveBeenCalledTimes(1);
+    expect(stripeOverride.confirmCardSetup).toHaveBeenCalledWith(
+      ...EXPECTED_CONFIRM_CARD_SETUP_ARGS
+    );
+    expect(
+      apiClientOverrides.apiUpdateDefaultPaymentMethod
+    ).not.toHaveBeenCalled();
+    expect(refreshSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it('displays an error if confirmCardSetup returns a setupIntent without a payment method ID', async () => {
+    const {
+      apiClientOverrides,
+      stripeOverride,
+      refreshSubscriptions,
+    } = await commonSubmitSetup({
+      stripeOverride: {
+        ...defaultStripeOverride(),
+        confirmCardSetup: jest
+          .fn()
+          .mockResolvedValue({ setupIntent: { payment_method: false } }),
+      },
+    });
+
+    expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
+    expect(screen.getByText('basic-error-message')).toBeInTheDocument();
+    expect(screen.queryByTestId('paymentForm')).toBeInTheDocument();
+    expect(apiClientOverrides.apiCreateSetupIntent).toHaveBeenCalledTimes(1);
+    expect(stripeOverride.confirmCardSetup).toHaveBeenCalledWith(
+      ...EXPECTED_CONFIRM_CARD_SETUP_ARGS
+    );
+    expect(
+      apiClientOverrides.apiUpdateDefaultPaymentMethod
+    ).not.toHaveBeenCalled();
+    expect(refreshSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it('displays an error if apiUpdateDefaultPaymentMethod throws', async () => {
+    const {
+      apiClientOverrides,
+      stripeOverride,
+      refreshSubscriptions,
+    } = await commonSubmitSetup({
+      apiClientOverrides: {
+        ...defaultApiClientOverrides(),
+        apiUpdateDefaultPaymentMethod: jest
+          .fn()
+          .mockRejectedValue('barf apiUpdateDefaultPaymentMethod'),
+      },
+    });
+
+    expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
+    expect(screen.getByText('basic-error-message')).toBeInTheDocument();
+    expect(screen.queryByTestId('paymentForm')).toBeInTheDocument();
+    expect(apiClientOverrides.apiCreateSetupIntent).toHaveBeenCalledTimes(1);
+    expect(stripeOverride.confirmCardSetup).toHaveBeenCalledWith(
+      ...EXPECTED_CONFIRM_CARD_SETUP_ARGS
+    );
+    expect(
+      apiClientOverrides.apiUpdateDefaultPaymentMethod
+    ).toHaveBeenCalledWith({
+      paymentMethodId: CONFIRM_CARD_SETUP_RESULT.setupIntent.payment_method,
+    });
+    expect(refreshSubscriptions).not.toHaveBeenCalled();
+  });
+
+  describe('Localized Plan Billing Description Component', () => {
+    function runTests(props: any, expectedMsgId: string, expectedMsg: string) {
+      const testRenderer = TestRenderer.create(
+        <PaymentUpdateForm {...props} />
+      );
+      const testInstance = testRenderer.root;
+      const billingDetails = testInstance.findByProps({ id: expectedMsgId });
+      const expectedAmount = getLocalizedCurrency(
+        props.plan.amount,
+        props.plan.currency
+      );
+      const expectedDate = getLocalizedDate(
+        props.customerSubscription.current_period_end,
+        true
+      );
+
+      expect(billingDetails.props.$amount).toStrictEqual(expectedAmount);
+      expect(billingDetails.props.$intervalCount).toBe(
+        props.plan.interval_count
+      );
+      expect(billingDetails.props.$name).toBe(props.plan.product_name);
+      expect(billingDetails.props.$date).toStrictEqual(expectedDate);
+      expect(billingDetails.props.children.props.children).toBe(expectedMsg);
+    }
+
+    describe('When plan has day interval', () => {
+      const expectedMsgId = dayBasedId;
+
+      it('Handles an interval count of 1', () => {
+        const plan_id = 'plan_daily';
+        const plan = findMockPlan(plan_id);
+        const periodEndDate = getLocalizedDateString(
+          subscription.current_period_end,
+          true
+        );
+        const expectedMsg = `You are billed $5.00 daily for FPN. Your next payment occurs on ${periodEndDate}.`;
+
+        const props = {
+          ...baseProps,
+          plan: plan,
+        };
+        runTests(props, expectedMsgId, expectedMsg);
+      });
+
+      it('Handles an interval count that is not 1', () => {
+        const plan_id = 'plan_6days';
+        const plan = findMockPlan(plan_id);
+        const periodEndDate = getLocalizedDateString(
+          subscription.current_period_end,
+          true
+        );
+        const expectedMsg = `You are billed $5.00 every 6 days for FPN. Your next payment occurs on ${periodEndDate}.`;
+
+        const props = {
+          ...baseProps,
+          plan: plan,
+        };
+        runTests(props, expectedMsgId, expectedMsg);
+      });
+    });
+
+    describe('When plan has week interval', () => {
+      const expectedMsgId = weekBasedId;
+
+      it('Handles an interval count of 1', () => {
+        const plan_id = 'plan_weekly';
+        const plan = findMockPlan(plan_id);
+        const periodEndDate = getLocalizedDateString(
+          subscription.current_period_end,
+          true
+        );
+        const expectedMsg = `You are billed $5.00 weekly for FPN. Your next payment occurs on ${periodEndDate}.`;
+
+        const props = {
+          ...baseProps,
+          plan: plan,
+        };
+        runTests(props, expectedMsgId, expectedMsg);
+      });
+
+      it('Handles an interval count that is not 1', () => {
+        const plan_id = 'plan_6weeks';
+        const plan = findMockPlan(plan_id);
+        const periodEndDate = getLocalizedDateString(
+          subscription.current_period_end,
+          true
+        );
+        const expectedMsg = `You are billed $5.00 every 6 weeks for FPN. Your next payment occurs on ${periodEndDate}.`;
+
+        const props = {
+          ...baseProps,
+          plan: plan,
+        };
+        runTests(props, expectedMsgId, expectedMsg);
+      });
+    });
+
+    describe('When plan has month interval', () => {
+      const expectedMsgId = monthBasedId;
+
+      it('Handles an interval count of 1', () => {
+        const plan_id = 'plan_monthly';
+        const plan = findMockPlan(plan_id);
+        const periodEndDate = getLocalizedDateString(
+          subscription.current_period_end,
+          true
+        );
+        const expectedMsg = `You are billed $5.00 monthly for FPN. Your next payment occurs on ${periodEndDate}.`;
+
+        const props = {
+          ...baseProps,
+          plan: plan,
+        };
+        runTests(props, expectedMsgId, expectedMsg);
+      });
+
+      it('Handles an interval count that is not 1', () => {
+        const plan_id = 'plan_6months';
+        const plan = findMockPlan(plan_id);
+        const periodEndDate = getLocalizedDateString(
+          subscription.current_period_end,
+          true
+        );
+        const expectedMsg = `You are billed $5.00 every 6 months for FPN. Your next payment occurs on ${periodEndDate}.`;
+
+        const props = {
+          ...baseProps,
+          plan: plan,
+        };
+        runTests(props, expectedMsgId, expectedMsg);
+      });
+    });
+
+    describe('When plan has year interval', () => {
+      const expectedMsgId = yearBasedId;
+
+      it('Handles an interval count of 1', () => {
+        const plan_id = 'plan_yearly';
+        const plan = findMockPlan(plan_id);
+        const periodEndDate = getLocalizedDateString(
+          subscription.current_period_end,
+          true
+        );
+        const expectedMsg = `You are billed $5.00 yearly for FPN. Your next payment occurs on ${periodEndDate}.`;
+
+        const props = {
+          ...baseProps,
+          plan: plan,
+        };
+        runTests(props, expectedMsgId, expectedMsg);
+      });
+
+      it('Handles an interval count that is not 1', () => {
+        const plan_id = 'plan_6years';
+        const plan = findMockPlan(plan_id);
+        const periodEndDate = getLocalizedDateString(
+          subscription.current_period_end,
+          true
+        );
+        const expectedMsg = `You are billed $5.00 every 6 years for FPN. Your next payment occurs on ${periodEndDate}.`;
+
+        const props = {
+          ...baseProps,
+          plan: plan,
+        };
+        runTests(props, expectedMsgId, expectedMsg);
+      });
+    });
+  });
+
+  describe('Fluent Translations for Plan Billing Description', () => {
+    const bundle = setupFluentLocalizationTest('en-US');
+    const amount = getLocalizedCurrency(500, 'USD');
+    const stringDate = getLocalizedDateString(1585334292, true);
+    const args = {
+      amount,
+      name: 'FPN',
+      date: getLocalizedDate(1585334292, true),
+    };
+
+    describe('When message id is pay-update-billing-description-day', () => {
+      const msgId = dayBasedId;
+      it('Handles an interval count of 1', () => {
+        const expected = `You are billed $5.00 daily for FPN. Your next payment occurs on ${stringDate}.`;
+
+        const actual = getLocalizedMessage(bundle, msgId, {
+          ...args,
+          intervalCount: 1,
+        });
+        expect(actual).toEqual(expected);
+      });
+
+      it('Handles an interval count that is not 1', () => {
+        const expected = `You are billed $5.00 every 6 days for FPN. Your next payment occurs on ${stringDate}.`;
+
+        const actual = getLocalizedMessage(bundle, msgId, {
+          ...args,
+          intervalCount: 6,
+        });
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('When message id is pay-update-billing-description-week', () => {
+      const msgId = weekBasedId;
+      it('Handles an interval count of 1', () => {
+        const expected = `You are billed $5.00 weekly for FPN. Your next payment occurs on ${stringDate}.`;
+
+        const actual = getLocalizedMessage(bundle, msgId, {
+          ...args,
+          intervalCount: 1,
+        });
+        expect(actual).toEqual(expected);
+      });
+
+      it('Handles an interval count that is not 1', () => {
+        const expected = `You are billed $5.00 every 6 weeks for FPN. Your next payment occurs on ${stringDate}.`;
+
+        const actual = getLocalizedMessage(bundle, msgId, {
+          ...args,
+          intervalCount: 6,
+        });
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('When message id is pay-update-billing-description-month', () => {
+      const msgId = monthBasedId;
+      it('Handles an interval count of 1', () => {
+        const expected = `You are billed $5.00 monthly for FPN. Your next payment occurs on ${stringDate}.`;
+
+        const actual = getLocalizedMessage(bundle, msgId, {
+          ...args,
+          intervalCount: 1,
+        });
+        expect(actual).toEqual(expected);
+      });
+
+      it('Handles an interval count that is not 1', () => {
+        const expected = `You are billed $5.00 every 6 months for FPN. Your next payment occurs on ${stringDate}.`;
+
+        const actual = getLocalizedMessage(bundle, msgId, {
+          ...args,
+          intervalCount: 6,
+        });
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('When message id is pay-update-billing-description-year', () => {
+      const msgId = yearBasedId;
+      it('Handles an interval count of 1', () => {
+        const expected = `You are billed $5.00 yearly for FPN. Your next payment occurs on ${stringDate}.`;
+
+        const actual = getLocalizedMessage(bundle, msgId, {
+          ...args,
+          intervalCount: 1,
+        });
+        expect(actual).toEqual(expected);
+      });
+
+      it('Handles an interval count that is not 1', () => {
+        const expected = `You are billed $5.00 every 6 years for FPN. Your next payment occurs on ${stringDate}.`;
+
+        const actual = getLocalizedMessage(bundle, msgId, {
+          ...args,
+          intervalCount: 6,
+        });
+        expect(actual).toEqual(expected);
+      });
+    });
+  });
+});

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateFormV2.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateFormV2.tsx
@@ -1,0 +1,308 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback, useState } from 'react';
+import { Localized } from '@fluent/react';
+import dayjs from 'dayjs';
+import {
+  getLocalizedDateString,
+  getLocalizedDate,
+  getLocalizedCurrency,
+  formatPlanPricing,
+} from '../../lib/formats';
+import { useNonce } from '../../lib/hooks';
+import { useBooleanState } from 'fxa-react/lib/hooks';
+import { getErrorMessage } from '../../lib/errors';
+import { Stripe, StripeCardElement, StripeError } from '@stripe/stripe-js';
+import {
+  Customer,
+  CustomerSubscription,
+  Plan,
+  PlanInterval,
+} from '../../store/types';
+import { metadataFromPlan } from 'fxa-shared/subscriptions/metadata';
+import AlertBar from '../../components/AlertBar';
+import { ReactComponent as CloseIcon } from 'fxa-react/images/close.svg';
+import PaymentForm, { PaymentFormProps } from '../../components/PaymentFormV2';
+import ErrorMessage from '../../components/ErrorMessage';
+import * as Amplitude from '../../lib/amplitude';
+import * as apiClient from 'fxa-payments-server/src/lib/apiClient';
+
+type PaymentUpdateError = undefined | StripeError;
+
+export type PaymentUpdateStripeAPIs = Pick<Stripe, 'confirmCardSetup'>;
+
+export type PaymentUpdateAuthServerAPIs = Pick<
+  typeof apiClient,
+  'apiCreateSetupIntent' | 'apiUpdateDefaultPaymentMethod'
+>;
+
+export type PaymentUpdateFormProps = {
+  customer: Customer;
+  customerSubscription: CustomerSubscription;
+  plan: Plan;
+  refreshSubscriptions: () => void;
+  setUpdatePaymentIsSuccess: () => void;
+  resetUpdatePaymentIsSuccess: () => void;
+  paymentErrorInitialState?: PaymentUpdateError;
+  stripeOverride?: PaymentUpdateStripeAPIs;
+  apiClientOverrides?: Partial<PaymentUpdateAuthServerAPIs>;
+};
+
+export const PaymentUpdateForm = ({
+  customer,
+  customerSubscription,
+  plan,
+  refreshSubscriptions,
+  setUpdatePaymentIsSuccess,
+  resetUpdatePaymentIsSuccess,
+  paymentErrorInitialState,
+  stripeOverride,
+  apiClientOverrides,
+}: PaymentUpdateFormProps) => {
+  const [submitNonce, refreshSubmitNonce] = useNonce();
+  const [updateRevealed, revealUpdate, hideUpdate] = useBooleanState();
+  const [inProgress, setInProgress, resetInProgress] = useBooleanState(false);
+  const [paymentError, setPaymentError] = useState<PaymentUpdateError>(
+    paymentErrorInitialState
+  );
+
+  const onRevealUpdateClick = useCallback(() => {
+    refreshSubmitNonce();
+    revealUpdate();
+    resetInProgress();
+    resetUpdatePaymentIsSuccess();
+  }, [
+    refreshSubmitNonce,
+    revealUpdate,
+    resetInProgress,
+    resetUpdatePaymentIsSuccess,
+  ]);
+
+  const onSubmit: PaymentFormProps['onSubmit'] = useCallback(
+    async ({ stripe: stripeFromParams, ...params }) => {
+      setInProgress();
+      resetUpdatePaymentIsSuccess();
+      try {
+        await handlePaymentUpdate({
+          ...params,
+          ...apiClient,
+          ...apiClientOverrides,
+          stripe:
+            stripeOverride /* istanbul ignore next - used for testing */ ||
+            stripeFromParams,
+          onFailure: setPaymentError,
+          onSuccess: () => {
+            hideUpdate();
+            setUpdatePaymentIsSuccess();
+            refreshSubscriptions();
+          },
+        });
+      } catch (error) {
+        console.error('handleSubscriptionPayment failed', error);
+        setPaymentError(error);
+      }
+      resetInProgress();
+      refreshSubmitNonce();
+    },
+    []
+  );
+
+  // clear any error rendered with `ErrorMessage`
+  const onChange = useCallback(() => {
+    if (paymentError) {
+      setPaymentError(undefined);
+    }
+  }, [paymentError, setPaymentError]);
+
+  const onFormMounted = useCallback(
+    () => Amplitude.updatePaymentMounted(plan),
+    [plan]
+  );
+
+  const onFormEngaged = useCallback(
+    () => Amplitude.updatePaymentEngaged(plan),
+    [plan]
+  );
+
+  const { upgradeCTA } = metadataFromPlan(plan);
+
+  const { last4, exp_month, exp_year } = customer;
+
+  // https://github.com/iamkun/dayjs/issues/639
+  const expirationDate = dayjs()
+    .set('month', Number(exp_month) - 1)
+    .set('year', Number(exp_year))
+    .format('MMMM YYYY');
+
+  const billingDescriptionText = getBillingDescriptionText(
+    plan.product_name,
+    plan.amount,
+    plan.currency,
+    plan.interval,
+    plan.interval_count,
+    customerSubscription.current_period_end
+  );
+
+  return (
+    <div className="payment-update" data-testid="payment-update">
+      {inProgress && (
+        <AlertBar className="alert alertPending">
+          <Localized id="sub-route-idx-updating">
+            <span>Updating billing information...</span>
+          </Localized>
+        </AlertBar>
+      )}
+
+      <h3 className="billing-title">
+        <Localized id="sub-update-title">
+          <span className="title">Billing Information</span>
+        </Localized>
+      </h3>
+      <Localized
+        id={`pay-update-billing-description-${plan.interval}`}
+        $amount={getLocalizedCurrency(plan.amount, plan.currency)}
+        $intervalCount={plan.interval_count}
+        $name={plan.product_name}
+        $date={getLocalizedDate(customerSubscription.current_period_end, true)}
+      >
+        <p className="billing-description">{billingDescriptionText}</p>
+      </Localized>
+      {upgradeCTA && (
+        <p
+          className="upgrade-cta"
+          data-testid="upgrade-cta"
+          dangerouslySetInnerHTML={{ __html: upgradeCTA }}
+        />
+      )}
+      {!updateRevealed ? (
+        <div className="with-settings-button">
+          <div className="card-details">
+            {last4 && expirationDate && (
+              <>
+                {/* TODO: Need to find a way to display a card icon here? */}
+                <Localized id="sub-update-card-ending" $last={last4}>
+                  <div className="last-four">Card ending {last4}</div>
+                </Localized>
+                <Localized
+                  id="pay-update-card-exp"
+                  $expirationDate={expirationDate}
+                >
+                  <div data-testid="card-expiration-date" className="expiry">
+                    Expires {expirationDate}
+                  </div>
+                </Localized>
+              </>
+            )}
+          </div>
+          <div className="action">
+            <button
+              data-testid="reveal-payment-update-button"
+              className="settings-button"
+              onClick={onRevealUpdateClick}
+            >
+              <Localized id="pay-update-change-btn">
+                <span className="change-button" data-testid="change-button">
+                  Change
+                </span>
+              </Localized>
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <ErrorMessage isVisible={!!paymentError}>
+            {paymentError && (
+              <Localized id={getErrorMessage(paymentError.code || 'UNKNOWN')}>
+                <p data-testid="error-payment-submission">
+                  {getErrorMessage(paymentError.code || 'UNKNOWN')}
+                </p>
+              </Localized>
+            )}
+          </ErrorMessage>
+          <PaymentForm
+            {...{
+              submitNonce,
+              onSubmit,
+              inProgress,
+              confirm: false,
+              onCancel: hideUpdate,
+              onChange,
+              onMounted: onFormMounted,
+              onEngaged: onFormEngaged,
+            }}
+          />
+        </>
+      )}
+    </div>
+  );
+};
+
+function getBillingDescriptionText(
+  name: string,
+  amount: number,
+  currency: string,
+  interval: PlanInterval,
+  intervalCount: number,
+  date: number
+): string {
+  const formattedDateString = getLocalizedDateString(date, true);
+  const planPricing = formatPlanPricing(
+    amount,
+    currency,
+    interval,
+    intervalCount
+  );
+
+  return `You are billed ${planPricing} for ${name}. Your next payment occurs on ${formattedDateString}.`;
+}
+
+async function handlePaymentUpdate({
+  stripe,
+  name,
+  card,
+  apiCreateSetupIntent,
+  apiUpdateDefaultPaymentMethod,
+  onFailure,
+  onSuccess,
+}: {
+  stripe: PaymentUpdateStripeAPIs;
+  name: string;
+  card: StripeCardElement;
+  onFailure: (error: PaymentUpdateError) => void;
+  onSuccess: () => void;
+} & PaymentUpdateAuthServerAPIs) {
+  // 1. Create the setup intent
+  const filteredIntent = await apiCreateSetupIntent();
+
+  // 2. Confirm the setup intent with a card from the payment form
+  // Note: This client-side Stripe API also handles SCA auth dialogs
+  const { setupIntent, error: setupError } = await stripe.confirmCardSetup(
+    filteredIntent.client_secret,
+    {
+      payment_method: {
+        card,
+        billing_details: { name },
+      },
+    }
+  );
+  if (setupError) {
+    return onFailure(setupError);
+  }
+  if (!setupIntent) {
+    return onFailure({ type: 'card_error' });
+  }
+
+  // 3. Use the payment method ID from the setup intent to update default payment method.
+  const { payment_method: paymentMethodId } = setupIntent;
+  if (typeof paymentMethodId !== 'string') {
+    return onFailure({ type: 'card_error' });
+  }
+  await apiUpdateDefaultPaymentMethod({ paymentMethodId });
+
+  // Finally, if there are no exceptions, we've succeeded.
+  return onSuccess();
+}
+
+export default PaymentUpdateForm;

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -18,6 +18,10 @@ import { SubscriptionsProps } from './index';
 import * as Amplitude from '../../lib/amplitude';
 
 import PaymentUpdateForm from './PaymentUpdateForm';
+import PaymentUpdateFormV2, {
+  PaymentUpdateStripeAPIs,
+  PaymentUpdateAuthServerAPIs,
+} from './PaymentUpdateFormV2';
 import DialogMessage from '../../components/DialogMessage';
 import AppContext from '../../lib/AppContext';
 
@@ -33,6 +37,12 @@ type SubscriptionItemProps = {
   resetUpdatePayment: SubscriptionsProps['resetUpdatePayment'];
   updatePayment: SubscriptionsProps['updatePayment'];
   cancelSubscriptionStatus: SelectorReturns['cancelSubscriptionStatus'];
+  refreshSubscriptions: () => void;
+  setUpdatePaymentIsSuccess: () => void;
+  resetUpdatePaymentIsSuccess: () => void;
+  useSCAPaymentFlow: boolean;
+  paymentUpdateStripeOverride?: PaymentUpdateStripeAPIs;
+  paymentUpdateApiClientOverrides?: Partial<PaymentUpdateAuthServerAPIs>;
 };
 
 export const SubscriptionItem = ({
@@ -45,6 +55,12 @@ export const SubscriptionItem = ({
   resetUpdatePayment,
   updatePaymentStatus,
   customerSubscription,
+  refreshSubscriptions,
+  setUpdatePaymentIsSuccess,
+  resetUpdatePaymentIsSuccess,
+  useSCAPaymentFlow,
+  paymentUpdateStripeOverride,
+  paymentUpdateApiClientOverrides,
 }: SubscriptionItemProps) => {
   const { locationReload } = useContext(AppContext);
 
@@ -72,16 +88,31 @@ export const SubscriptionItem = ({
 
         {!customerSubscription.cancel_at_period_end ? (
           <>
-            <PaymentUpdateForm
-              {...{
-                plan,
-                customerSubscription,
-                customer,
-                updatePayment,
-                resetUpdatePayment,
-                updatePaymentStatus,
-              }}
-            />
+            {useSCAPaymentFlow ? (
+              <PaymentUpdateFormV2
+                {...{
+                  plan,
+                  customerSubscription,
+                  customer,
+                  refreshSubscriptions,
+                  setUpdatePaymentIsSuccess,
+                  resetUpdatePaymentIsSuccess,
+                  stripeOverride: paymentUpdateStripeOverride,
+                  apiClientOverrides: paymentUpdateApiClientOverrides,
+                }}
+              />
+            ) : (
+              <PaymentUpdateForm
+                {...{
+                  plan,
+                  customerSubscription,
+                  customer,
+                  updatePayment,
+                  resetUpdatePayment,
+                  updatePaymentStatus,
+                }}
+              />
+            )}
             <CancelSubscriptionPanel
               {...{
                 cancelSubscription,


### PR DESCRIPTION
Because:

* To support SCA we must migrate to using Stripe's SetupIntent API

This commit:

* Add call to auth server to create SetupIntent
* Use secret from SetupIntent result to confirm card prior to creating a subscription

Closes #5832

Co-authored-by: Jackie Munroe <jmunroe@mozilla.com>
Co-authored-by: Les Orchard <me@lmorchard.com>
