### PR TITLE
chore(emails): remove ! from sub receipt email

### DIFF
--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionFirstInvoice.html
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionFirstInvoice.html
@@ -1,5 +1,5 @@
 {{#*inline "title"}}
-  {{t "Thank you for subscribing to %(productName)s!" }}
+  {{t "Thank you for subscribing to %(productName)s" }}
 {{/inline}}
 
 {{#*inline "content"}}

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -218,7 +218,7 @@ const TESTS = new Map([
       { test: 'include', expected: configHref('subscriptionSettingsUrl', 'subscription-first-invoice', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email') },
       { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-first-invoice', 'subscription-terms') },
       { test: 'include', expected: configHref('subscriptionSupportUrl', 'subscription-first-invoice', 'subscription-support') },
-      { test: 'include', expected: `Thank you for subscribing to ${MESSAGE.productName}!` },
+      { test: 'include', expected: `Thank you for subscribing to ${MESSAGE.productName}` },
       { test: 'include', expected: `start using ${MESSAGE.productName}` },
       { test: 'include', expected: `Invoice Number: <b>${MESSAGE.invoiceNumber}</b>` },
       { test: 'include', expected: `MasterCard card ending in 5309` },
@@ -1249,9 +1249,9 @@ describe('lib/senders/email:', () => {
       123,
       'USD',
       'en-US;q=0.5,en;q=0.3,en-NZ'
-    )
-    assert.equal(result, 'US$1.23')
-  })
+    );
+    assert.equal(result, 'US$1.23');
+  });
 
   it('formats user-agent strings sanely', () => {
     let result = mailer._formatUserAgentInfo({


### PR DESCRIPTION
Because:
 - !s are bad for deliverability

This commit:
 - remove the ! from the receipt email

## Issue that this pull request solves

Closes: #6001 (FXA-2324)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
