### PR TITLE
chore(oauth): add Firefox Send oauth client to local config

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -186,6 +186,17 @@
     },
     "clients": [
       {
+        "id": "fced6b5e3f4c66b9",
+        "hashedSecret": "289a885946ee316844d9ffd0d725ee714901548a1e6507f1a40fb3c2ae0c99f1",
+        "name": "Firefox Send local-dev",
+        "imageUri": "https://mozorg.cdn.mozilla.net/media/img/firefox/new/header-firefox.png",
+        "redirectUri": "http://localhost:1337/oauth",
+        "trusted": true,
+        "canGrant": false,
+        "publicClient": true,
+        "allowedScopes": "https://identity.mozilla.com/apps/send"
+      },
+      {
         "id": "dcdb5ae7add825d2",
         "hashedSecret": "289a885946ee316844d9ffd0d725ee714901548a1e6507f1a40fb3c2ae0c99f1",
         "name": "123Done",
@@ -390,6 +401,10 @@
       },
       {
         "scope": "https://identity.mozilla.com/apps/oldsync",
+        "hasScopedKeys": true
+      },
+      {
+        "scope": "https://identity.mozilla.com/apps/send",
         "hasScopedKeys": true
       }
     ]

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -27,6 +27,11 @@
          "urn:ietf:wg:oauth:2.0:oob:pair-auth-webchannel",
          "urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel"
         ]
+      },
+      "https://identity.mozilla.com/apps/send": {
+        "redirectUris": [
+          "http://localhost:1337/oauth"
+        ]
       }
     }
   },


### PR DESCRIPTION
## Because

- I'm running Send locally again ;)

## This pull request

- Adds configs for a localhost install of Send
