### PR TITLE
feat(aet): handle generateEcosystemAnonId update failure

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -614,6 +614,12 @@ var ERRORS = {
     errno: 1065,
     message: t('The image file size is too large to be uploaded.'),
   },
+  ECOSYSTEM_ANON_ID_UPDATE_CONFLICT: {
+    errno: 190,
+    message: t(
+      'Could not update Ecosystem Anon ID because precondition failed.'
+    ),
+  },
 };
 
 export default _.extend({}, Errors, {


### PR DESCRIPTION
## Because

- When generateEcosystemAnonId calls updateEcosystemAnonId it can fail with a 412 error, which means we tried to update the anon id but another client beat us to it. We need to handle this scenario.

## This pull request

- When updateEcosystemAnonId fails in this method, check if it's a 412 error, and retrieve the existing anon id from the auth server to store on the account instead
- If it’s not a 412 error, or if the profile query doesn’t yield an existing anon ID, just unset the value to avoid any confusion

## Issue that this pull request solves

Closes: #6017

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
