### PR TITLE
feat(aet): bail out of set with password if session unverified

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -415,10 +415,10 @@ const Account = Backbone.Model.extend(
             keys.kB,
             randomKey
           );
-        } else if (options.password) {
-          // TODO: Using sessionReauth to get keys could potentially pose some issues if the user
-          // is attempting to come from an unverified session. FxA only allows fetching keys from
-          // sessions that are verified (ex. performed some email verification loop).
+        } else if (
+          options.password &&
+          (await this.sessionVerificationStatus()).sessionVerified
+        ) {
           const res = await this._fxaClient.sessionReauth(
             this.get('sessionToken'),
             this.get('email'),


### PR DESCRIPTION
## Because

Per the issue:

> Using `sessionReauth` to get keys could potentially pose some issues if the user is attempting to come from an unverified session. FxA only allows fetching keys from sessions that are verified (ex. performed some email verification loop).


## This pull request

Checks that the flow's session is verified, and doesn't attempt to call `sessionReauth` if it's not, therefor not setting the anon ID at all in this flow

Additional comment from rfk:

> We should make our best effort to generate an anon_id, but not at the expense of RP user experience. Given that we have logic in AET clients to generate placeholder ids when the real one is missing, it doesn't seem too bad to leave the non_id empty in this case and just hope the user does a verified flow some time later to fill it in.

## Issue that this pull request solves

Closes: #6018

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
