### PR TITLE
fix(emails): Send post account verify email when created from sync scope client

### DIFF
--- a/packages/fxa-auth-server/lib/constants.js
+++ b/packages/fxa-auth-server/lib/constants.js
@@ -6,4 +6,5 @@ module.exports = {
   OAUTH_SCOPE_OLD_SYNC: 'https://identity.mozilla.com/apps/oldsync',
   OAUTH_SCOPE_SESSION_TOKEN: 'https://identity.mozilla.com/tokens/session',
   SHORT_ACCESS_TOKEN_TTL_IN_MS: 1000 * 60 * 60 * 6,
+  MAX_NEW_ACCOUNT_AGE: 1000 * 60 * 60 * 24,
 };

--- a/packages/fxa-auth-server/lib/routes/utils/oauth.js
+++ b/packages/fxa-auth-server/lib/routes/utils/oauth.js
@@ -5,7 +5,10 @@
 'use strict';
 
 const encrypt = require('../../../lib/oauth/encrypt');
-const { OAUTH_SCOPE_OLD_SYNC } = require('../../constants');
+const {
+  OAUTH_SCOPE_OLD_SYNC,
+  MAX_NEW_ACCOUNT_AGE,
+} = require('../../constants');
 const ScopeSet = require('fxa-shared').oauth.scopes;
 
 // right now we only care about notifications for the following scopes
@@ -65,8 +68,10 @@ module.exports = {
     });
 
     // Email the user about their new device connection
-    // (but don't send anything if it was an existing device)
+    // (but don't send anything if it was an existing device or new account)
     if (!credentials.deviceId) {
+      const account = await db.account(credentials.uid);
+      const isNewAccount = Date.now() - account.createdAt < MAX_NEW_ACCOUNT_AGE;
       const geoData = request.app.geo;
       const ip = request.app.clientAddress;
       const emailOptions = {
@@ -78,12 +83,13 @@ module.exports = {
         uid: credentials.uid,
       };
 
-      const account = await db.account(credentials.uid);
-      await mailer.sendNewDeviceLoginEmail(
-        account.emails,
-        account,
-        emailOptions
-      );
+      if (!isNewAccount) {
+        await mailer.sendNewDeviceLoginEmail(
+          account.emails,
+          account,
+          emailOptions
+        );
+      }
     }
   },
 };

--- a/packages/fxa-auth-server/lib/routes/utils/signup.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signup.js
@@ -5,6 +5,15 @@
 'use strict';
 const userAgent = require('../../userAgent');
 
+function isSyncBased(service) {
+  return (
+    service === 'sync' ||
+    service === '1b1a3e44c54fbb58' || // Firefox iOS browser
+    service === 'a2270f727f45f648' || // Fenix
+    service === '3c49430b43dfba77'
+  ); // Android Reference browser
+}
+
 module.exports = (log, db, mailer, push, verificationReminders) => {
   return {
     /**
@@ -64,7 +73,7 @@ module.exports = (log, db, mailer, push, verificationReminders) => {
 
       // Our post-verification email is very specific to sync,
       // so only send it if we're sure this is for sync.
-      if (service === 'sync') {
+      if (isSyncBased(service)) {
         const onMobileDevice =
           userAgent(request.headers['user-agent']).deviceType === 'mobile';
         const mailOptions = {

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -1823,7 +1823,10 @@ describe('email translations', () => {
         'ru',
         'language header is correct'
       );
-      assert.include(emailConfig.subject, 'Добавлена альтернативная эл. почта');
+      assert.include(
+        emailConfig.subject,
+        'Добавлена альтернативная электронная почта'
+      );
       // assert.include(emailConfig.html, 'Подсоединить другое устройство');
     });
 


### PR DESCRIPTION
## Because

- Account created using a sync scoped token did not send the post verify account email, instead they sent the "new device login" email

## This pull request

- Checks to see if the client doing the verification is using a clientId that is sync based and send the verification email if so
- Updates oauth token route to see if the account is newish in order to send the "new device login" email

## Issue that this pull request solves

Closes: #5920

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Other information (Optional)

@vladikoff @rfk Marking this as a draft to get your input on the approach here.