### PR TITLE
chore(emails): add CC expiration email for Multiple Products

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -24,6 +24,7 @@ const EMAIL_TYPES = {
   subscriptionUpgrade: 'subscription_upgrade',
   subscriptionDowngrade: 'subscription_downgrade',
   subscriptionPaymentExpired: 'subscription_payment_expired',
+  subscriptionsPaymentExpired: 'subscriptions_payment_expired',
   subscriptionPaymentFailed: 'subscription_payment_failed',
   subscriptionAccountDeletion: 'subscription_account_deletion',
   subscriptionCancellation: 'subscription_cancellation',

--- a/packages/fxa-auth-server/lib/routes/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.ts
@@ -1056,6 +1056,7 @@ class DirectStripeRoutes {
     );
     const { uid } = sourceDetails;
     const account = await this.db.account(uid);
+
     await this.mailer.sendSubscriptionPaymentExpiredEmail(
       account.emails,
       account,
@@ -1064,6 +1065,7 @@ class DirectStripeRoutes {
         ...sourceDetails,
       }
     );
+
     return sourceDetails;
   }
 

--- a/packages/fxa-auth-server/lib/senders/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/templates/_versions.json
@@ -3,6 +3,7 @@
   "subscriptionUpgrade": 1,
   "subscriptionDowngrade": 1,
   "subscriptionPaymentExpired": 1,
+  "subscriptionsPaymentExpired": 1,
   "subscriptionPaymentFailed": 1,
   "subscriptionAccountDeletion": 1,
   "subscriptionCancellation": 1,

--- a/packages/fxa-auth-server/lib/senders/templates/layouts/subscription.html
+++ b/packages/fxa-auth-server/lib/senders/templates/layouts/subscription.html
@@ -260,18 +260,22 @@
                                         style="font-family:Helvetica, Geneva, Tahoma, Verdana, sans-serif; font-size: 14px; line-height: 18px; color: #ffffff; padding: 0 20px 30px;"
                                       >
                                         <br /><br />
+                                        {{#if productName}}
                                         {{t "You're receiving this email because %(email)s has a Firefox account and you signed up for %(productName)s." }}
+                                        {{else}}
+                                        {{t "You're receiving this email because %(email)s has a Firefox account and you have subscribed to multiple products." }}
+                                        {{/if}}
                                         <br /><br />
                                         {{{t "Manage your Firefox account settings by visiting your <a %(accountSettingsLinkAttributes)s>account page</a>." }}}
                                         <br /><br />
-                                        <a
+                                        {{#if productName}}<a
                                           href="{{{subscriptionTermsUrl}}}"
                                           target="_blank"
                                           rel="noopener noreferrer"
                                           style="color:#ffffff;font-weight:500;"
                                           alias="TermsofService"
                                           >{{t "Terms and cancellation policy" }}</a>
-                                          &nbsp;&nbsp;&#8226;&nbsp;&nbsp;{{#if isCancellationEmail}}<a
+                                          &nbsp;&nbsp;&#8226;&nbsp;&nbsp;{{/if}}{{#if isCancellationEmail}}<a
                                           href="{{{reactivateSubscriptionUrl}}}"
                                           target="_blank"
                                           rel="noopener noreferrer"
@@ -284,7 +288,7 @@
                                           rel="noopener noreferrer"
                                           style="color:#ffffff;font-weight:normal;"
                                           alias="CancelSubscription"
-                                          >{{t "Cancel subscription" }}</a
+                                          >{{#if productName}}{{t "Cancel subscription" }}{{else}}{{t "Cancel subscriptions" }}{{/if}}</a
                                         >{{/if}}&nbsp;&nbsp;&#8226;&nbsp;&nbsp;
                                         <a
                                           href="{{{updateBillingUrl}}}"
@@ -329,14 +333,14 @@
                                           style="color:#ffffff;font-weight:500;"
                                           alias="textlink1"
                                           >{{t "Legal" }}</a
-                                        >&nbsp;&nbsp;&#8226;&nbsp;&nbsp;<a
+                                        >{{#if productName}}&nbsp;&nbsp;&#8226;&nbsp;&nbsp;<a
                                           href="{{{subscriptionPrivacyUrl}}}"
                                           target="_blank"
                                           rel="noopener noreferrer"
                                           style="color:#ffffff;font-weight:normal;"
                                           alias="textlink2"
                                           >{{t "Privacy" }}</a
-                                        >
+                                        >{{/if}}
                                       </td>
                                     </tr>
                                   </table>

--- a/packages/fxa-auth-server/lib/senders/templates/layouts/subscription.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/layouts/subscription.txt
@@ -2,13 +2,21 @@
 
 {{{t "This is an automated email; if you received it in error, no action is required."}}}
 
+{{#if productName }}
 {{{t "Terms and cancellation policy:"}}}
 {{{subscriptionTermsUrl}}}
+{{/if}}
 
+{{#if productName }}
 {{{t "Privacy notice:"}}}
 {{{subscriptionPrivacyUrl}}}
+{{/if}}
 
+{{#if productName }}
 {{{t "Cancel subscription:"}}}
+{{else}}
+{{{t "Cancel subscriptions:"}}}
+{{/if}}
 {{{cancelSubscriptionUrl}}}
 
 {{{t "Update billing information:"}}}

--- a/packages/fxa-auth-server/lib/senders/templates/partials/subscriptionEmail.html
+++ b/packages/fxa-auth-server/lib/senders/templates/partials/subscriptionEmail.html
@@ -1,3 +1,4 @@
+{{#if icon}}
 <table
   style="background-color: #FFFFFF; min-width: 100%; "
   class="stylingblock-content-wrapper"
@@ -20,6 +21,7 @@
     </td>
   </tr>
 </table>
+{{/if}}
 
 <table class="featured-story featured-story--top" cellspacing="0" cellpadding="0">
   <tr>

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionsPaymentExpired.html
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionsPaymentExpired.html
@@ -1,0 +1,19 @@
+{{#*inline "title"}}
+  {{t "Your credit card is about to expire" }}
+{{/inline}}
+
+{{#*inline "content"}}
+  {{t "The credit card you're using to make payments for the following subscriptions is about to expire." }}
+  <br><br>
+  <ul>
+    {{#subscriptions}}
+    <li>{{productName }}</li>
+    {{/subscriptions}}
+  </ul>
+  <br><br>
+  {{{t "To prevent any interruption to your service, please <a href=\"%(updateBillingUrl)s\">update your payment information</a> as soon as possible." }}}
+  <br><br>
+  {{{t "Questions about your subscription? Our <a href=\"%(subscriptionSupportUrl)s\">support team</a> is here to help you." }}}
+{{/inline}}
+
+{{> subscriptionEmail}}

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionsPaymentExpired.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionsPaymentExpired.txt
@@ -1,0 +1,17 @@
+{{{subject}}}
+
+{{{t "Your credit card is about to expire" }}}
+
+{{{t "The credit card you're using to make payments for the following subscriptions is about to expire." }}}
+
+{{#subscriptions}}
+  - {{productName}}
+{{/subscriptions}}
+
+{{{t "To prevent any interruption to your service, please update your payment information as soon as possible:" }}}
+
+{{{updateBillingUrl}}}
+
+{{{t "Questions about your subscriptions? Our support team is here to help you:" }}}
+
+{{{subscriptionSupportUrl}}}

--- a/packages/fxa-auth-server/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/scripts/write-emails-to-disk.js
@@ -148,6 +148,16 @@ function sendMail(mailer, messageToSend) {
     tokenCode: 'LIT12345',
     uid: '6510cb04abd742c6b3e4abefc7e39c9f',
     productMetadata,
+    subscriptions: [
+      {
+        planDownloadURL: 'http://getfirefox.com/',
+        planEmailIconURL: 'http://placekitten.com/512/512',
+        planId: 'plan-example',
+        productId: '0123456789abcdef',
+        productMetadata,
+        productName: 'Firefox Fortress',
+      },
+    ],
   };
 
   return mailer[messageType](message);

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -2271,18 +2271,22 @@ describe('StripeHelper', () => {
       const expected = {
         uid,
         email,
-        productId,
-        productName,
-        planId,
-        planName,
-        planEmailIconURL,
-        planDownloadURL,
-        productMetadata: {
-          downloadURL: planDownloadURL,
-          emailIconURL: planEmailIconURL,
-          'product:privacyNoticeURL': privacyNoticeURL,
-          'product:termsOfServiceURL': termsOfServiceURL,
-        },
+        subscriptions: [
+          {
+            productId,
+            productName,
+            planId,
+            planName,
+            planEmailIconURL,
+            planDownloadURL,
+            productMetadata: {
+              downloadURL: planDownloadURL,
+              emailIconURL: planEmailIconURL,
+              'product:privacyNoticeURL': privacyNoticeURL,
+              'product:termsOfServiceURL': termsOfServiceURL,
+            },
+          },
+        ],
       };
 
       it('extracts expected details from a source that requires requests to expand', async () => {


### PR DESCRIPTION
Because:
 - a soon to expire credit card can be used to pay for multiple
   subscriptions

This commit:
 - send a slightly different reminder email to customers with multiple
   subscriptions

## Issue that this pull request solves

Closes: FXA-2319

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
