### PR TITLE
fix(emails): Fix translation test

### DIFF
--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -1823,7 +1823,10 @@ describe('email translations', () => {
         'ru',
         'language header is correct'
       );
-      assert.include(emailConfig.subject, 'Добавлена альтернативная эл. почта');
+      assert.include(
+        emailConfig.subject,
+        'Добавлена альтернативная электронная почта'
+      );
       // assert.include(emailConfig.html, 'Подсоединить другое устройство');
     });
 


### PR DESCRIPTION
## Because

- Translation test broke
- Surprised the text changed because the equivalent English text didn't 🤷🏽‍♂️

## This pull request

- Uses new translation text in test.

## Issue that this pull request solves

Closes: NA

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).