### PR TITLE
fix(aet): On password reset, reauth to get new keyfetch token to set ecosystem id

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/verification-reasons.ts
+++ b/packages/fxa-content-server/app/scripts/lib/verification-reasons.ts
@@ -8,7 +8,7 @@
 
 enum VerificationReasons {
   CHANGE_PASSWORD = 'change_password',
-  ECOSYSTEM_ANON_ID = 'ecosystem_anon_id',
+  ECOSYSTEM_ANON_ID = 'anon_id',
   FORCE_AUTH = 'force_auth',
   PASSWORD_RESET = 'reset_password',
   PASSWORD_RESET_WITH_RECOVERY_KEY = 'reset_password_with_recovery_key',

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -381,8 +381,11 @@ const Account = Backbone.Model.extend(
      * this function attempts to generate the id in the following manner:
      *
      * 1. Use kB if it is specified
-     * 2. Attempt to fetch keys if valid authentication token exists to do so
-     * 3. Attempt to use user's password to fetch keys
+     * 2. Attempt to use user's password to fetch keys
+     * 3. Attempt to fetch keys if valid authentication token exists to do so
+     *
+     * Note that on a password reset we will need to do a reauth since
+     * the browser will attempt to use the keyFetchToken.
      *
      * @param {Object} [options={}]
      *   @param {String} [options.kB] Optional The user's kB, if specified takes priority.
@@ -406,13 +409,6 @@ const Account = Backbone.Model.extend(
           ecosystemAnonId = await aet.generateEcosystemAnonID(
             this.get('uid'),
             options.kB,
-            randomKey
-          );
-        } else if (this.canFetchKeys()) {
-          const keys = await this.accountKeys();
-          ecosystemAnonId = await aet.generateEcosystemAnonID(
-            this.get('uid'),
-            keys.kB,
             randomKey
           );
         } else if (options.password) {
@@ -445,6 +441,13 @@ const Account = Backbone.Model.extend(
               randomKey
             );
           }
+        } else if (this.canFetchKeys()) {
+          const keys = await this.accountKeys();
+          ecosystemAnonId = await aet.generateEcosystemAnonID(
+            this.get('uid'),
+            keys.kB,
+            randomKey
+          );
         }
 
         if (ecosystemAnonId) {
@@ -1081,7 +1084,7 @@ const Account = Backbone.Model.extend(
         })
         .then(this.set.bind(this))
         .then(async () => {
-          await this.generateEcosystemAnonId({ password: newPassword });
+          await this.generateEcosystemAnonId({});
         });
     },
 

--- a/packages/fxa-content-server/app/tests/spec/models/account.js
+++ b/packages/fxa-content-server/app/tests/spec/models/account.js
@@ -2058,8 +2058,7 @@ describe('models/account', function () {
 
   describe('changePassword', function () {
     beforeEach(() => {
-      sinon.stub(account, 'generateEcosystemAnonId')
-        .callsFake(() => {});
+      sinon.stub(account, 'generateEcosystemAnonId').callsFake(() => {});
     });
 
     it('returns `INCORRECT_PASSWORD` error if old password is incorrect (event if passwords are the same)', function () {
@@ -2129,9 +2128,7 @@ describe('models/account', function () {
             )
           );
 
-          assert.isTrue(
-            account.generateEcosystemAnonId.calledWith({password: newPassword})
-          );
+          assert.isTrue(account.generateEcosystemAnonId.calledWith({}));
           assert.equal(account.get('keyFetchToken'), 'new keyFetchToken');
           assert.equal(account.get('sessionToken'), 'new sessionToken');
           assert.equal(account.get('sessionTokenContext'), 'foo');
@@ -2143,8 +2140,7 @@ describe('models/account', function () {
 
   describe('completePasswordReset', function () {
     beforeEach(() => {
-      sinon.stub(account, 'generateEcosystemAnonId')
-        .callsFake(() => {});
+      sinon.stub(account, 'generateEcosystemAnonId').callsFake(() => {});
     });
 
     it('completes the password reset', function () {
@@ -2175,7 +2171,7 @@ describe('models/account', function () {
           );
 
           assert.isTrue(
-            account.generateEcosystemAnonId.calledWith({password: PASSWORD})
+            account.generateEcosystemAnonId.calledWith({ password: PASSWORD })
           );
           assert.ok(account.get('keyFetchToken'), 'new keyFetchToken');
           assert.equal(account.get('sessionToken'), 'new sessionToken');


### PR DESCRIPTION
## Because

- We don't want to use the keyfetch token the browser will use, it will throw a 401 and not start syncing

## This pull request

- If a password is specified in `generateEcosystemAnonID` use the password to reauth and attempt to get a new keyfetch token
- Updated change password to not pass a password, this will make it use the `this.canFetchKeys()` if branch if possible

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/6047

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Other information (Optional)

Targets train-181