### PR TITLE
fix(emails): Account for formatting chars in max email header length.

### DIFF
--- a/packages/fxa-email-service/src/types/headers/mod.rs
+++ b/packages/fxa-email-service/src/types/headers/mod.rs
@@ -28,9 +28,11 @@ use hyperx::{
     header::{parsing::from_one_raw_str, Formatter, Raw as RawHeader},
 };
 
-// No header's total length should be greater than 998 characters
+// The total length of a header line should be limited to 998 characters.
 // See: https://tools.ietf.org/html/rfc5322#section-2.1.1
-const HEADER_MAX_LENGTH: usize = 998;
+// That includes the header name, the value, and the two characters ": "
+// used to separate them (which is what the "minus 2" below is for).
+const HEADER_MAX_LENGTH: usize = 998 - 2;
 
 macro_rules! custom_header {
     ($struct_name:ident, $header_name:expr) => {

--- a/packages/fxa-email-service/src/types/headers/test.rs
+++ b/packages/fxa-email-service/src/types/headers/test.rs
@@ -141,11 +141,11 @@ fn verify_code() {
 
 #[test]
 fn any_header_length() {
-    // No header value should be longer than 998 characters, minus the length of the header name
-    let header = Link::new(std::iter::repeat("X").take(999).collect::<String>().to_owned());
+    // No header value should be longer than 996 characters, minus the length of the header name.
+    let header = Link::new(std::iter::repeat("X").take(997).collect::<String>().to_owned());
     assert!(header.to_string().chars().count() <= HEADER_MAX_LENGTH - Link::header_name().len());
 
-    let header = DeviceId::new(std::iter::repeat("X").take(999).collect::<String>().to_owned());
+    let header = DeviceId::new(std::iter::repeat("X").take(998).collect::<String>().to_owned());
     assert!(header.to_string().chars().count() <= HEADER_MAX_LENGTH - DeviceId::header_name().len());
 
     let header = ReportSigninLink::new(std::iter::repeat("X").take(999).collect::<String>().to_owned());


### PR DESCRIPTION
## Because

* Our email headers always contain ": " separating the name and value.
* We weren't accounting for these two extra characters when enforcing
  the maximum length of a header line.

## This pull request

* Ensures that the header line length calculation includes the formatting
  characters.

## Issue that this pull request solves

Closes: https://bugzilla.mozilla.org/show_bug.cgi?id=1655259

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] ~~I have added necessary documentation (if appropriate).~~
