### PR TITLE
fix(style): add active and hover effect to the warning buttons from settings

### DIFF
--- a/packages/fxa-content-server/app/styles/_variables.scss
+++ b/packages/fxa-content-server/app/styles/_variables.scss
@@ -147,6 +147,8 @@ $warning-background-color: $yellow-50;
 $warning-text-color: $yellow-90;
 
 $error-background-color: $red-60;
+$error-background-color-hover: #a4000f;
+$error-background-color-active: #5a0002;
 $error-text-color: $color-white;
 
 $text-color: rgb(32, 18, 59);

--- a/packages/fxa-content-server/app/styles/modules/_button-row.scss
+++ b/packages/fxa-content-server/app/styles/modules/_button-row.scss
@@ -67,15 +67,25 @@ button {
       background: $error-background-color;
     }
 
-    // 'type' is needed for selector specificity
-    &[type='submit'] {
-      &:active:enabled,
-      &:active:enabled:hover {
-        background: darken($error-background-color, 10);
+    &:enabled {
+      &:hover {
+        background: $error-background-color-hover;
       }
 
-      &:hover:enabled {
-        background: darken($error-background-color, 5);
+      &:active {
+        background: $error-background-color-active;
+      }
+
+      // 'type' is needed for selector specificity
+      &[type='submit'] {
+        &:active,
+        &:active:hover {
+          background: darken($error-background-color, 10);
+        }
+
+        &:hover {
+          background: darken($error-background-color, 5);
+        }
       }
     }
   }


### PR DESCRIPTION
Closes #5658

## Because

* The warning buttons did not have an effect.

## This pull request

* Change the background color from the warning buttons, when the button receives hover or active.
## Issue that this pull request solves

fixes #5658 
