### PR TITLE
chore(subscriptions): use just "Subscriptions"

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings/delete_account.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/delete_account.mustache
@@ -14,7 +14,7 @@
     <div class="error"></div>
     {{#subscriptions.0}}
       <p class="subscription-link">
-        {{#unsafeTranslate}}Looking to cancel a paid subscription? Go to <a href="/subscriptions">Subscriptions &amp; Payments</a>.{{/unsafeTranslate}}
+        {{#unsafeTranslate}}Looking to cancel a paid subscription? Go to <a href="/subscriptions">Subscriptions</a>.{{/unsafeTranslate}}
       </p>
     {{/subscriptions.0}}
 

--- a/packages/fxa-content-server/app/scripts/templates/settings/subscription.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings/subscription.mustache
@@ -1,7 +1,7 @@
 <div id="manage-subscription" class="settings-unit">
   <div class="settings-unit-stub">
     <header class="settings-unit-summary">
-      <h2 class="settings-unit-title">{{#t}}Subscriptions & Payments{{/t}}</h2>
+      <h2 class="settings-unit-title">{{#t}}Subscriptions{{/t}}</h2>
     </header>
     <button class="settings-button primary-button settings-unit-toggle">
       <span class="change-button">{{#t}}Manage…{{/t}}</span>

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -32,7 +32,7 @@ card-error = Your transaction could not be processed. Please verify your credit 
 
 ## settings
 settings-home = Account Home
-settings-subscriptions = Subscriptions & Payments
+settings-subscriptions-title = Subscriptions
 
 ## legal footer
 terms = Terms of Service

--- a/packages/fxa-payments-server/src/App.test.tsx
+++ b/packages/fxa-payments-server/src/App.test.tsx
@@ -72,11 +72,9 @@ describe('App', () => {
     ].forEach((testid) =>
       expect(screen.queryByTestId(testid)).toBeInTheDocument()
     );
-    [
-      'Firefox Accounts',
-      'Account Home',
-      'Subscriptions & Payments',
-    ].forEach((text) => expect(screen.queryByText(text)).toBeInTheDocument());
+    ['Firefox Accounts', 'Account Home', 'Subscriptions'].forEach((text) =>
+      expect(screen.queryByText(text)).toBeInTheDocument()
+    );
   });
 
   const commonRoutePathTest = (

--- a/packages/fxa-payments-server/src/components/AppLayout/index.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.tsx
@@ -68,8 +68,8 @@ export const SettingsLayout = ({ children }: SettingsLayout) => {
         </Localized>
       </li>
       <li>
-        <Localized id="settings-subscriptions">
-          <a href="/subscriptions">Subscriptions & Payments</a>
+        <Localized id="settings-subscriptions-title">
+          <a href="/subscriptions">Subscriptions</a>
         </Localized>
       </li>
     </ol>

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -277,10 +277,8 @@ export const Subscriptions = ({
           <div className="settings-unit">
             <div className="settings-unit-stub">
               <header className="settings-unit-summary">
-                <Localized id="settings-subscriptions">
-                  <h2 className="settings-unit-title">
-                    Subscriptions & Payments
-                  </h2>
+                <Localized id="settings-subscriptions-title">
+                  <h2 className="settings-unit-title">Subscriptions</h2>
                 </Localized>
               </header>
               <button


### PR DESCRIPTION
Because:
 - these mocks https://zpl.io/bAWMO9B

This commit:
 - change "Subscriptions & Payments" to just "Subscriptions"


Closes: FXA-2318

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

