### PR TITLE
fix(profile): aet call to auth server should be put, not get

### DIFF
--- a/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/post.js
+++ b/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/post.js
@@ -33,7 +33,7 @@ const updateAuthServer = function (
   }
 
   return new Promise((resolve, reject) => {
-    request.get(
+    request.put(
       AUTH_SERVER_URL,
       {
         headers,

--- a/packages/fxa-profile-server/test/api.js
+++ b/packages/fxa-profile-server/test/api.js
@@ -1685,7 +1685,29 @@ describe('api', function () {
         return hash.update(anonId).digest('hex');
       }
 
-      xit('should post a new ecosystem_anon_id', function () {});
+      it('should put a new ecosystem_anon_id', async function () {
+        const payload = {
+          ecosystemAnonId: 'beans on pizza',
+        };
+        const headers = {
+          authorization: `Bearer ${tok}`,
+        };
+
+        mock.anonIdUpdated(payload, headers);
+        mock.token({
+          user: USERID,
+          scope: ['profile:ecosystem_anon_id:write'],
+        });
+
+        const res = await Server.api.post({
+          url: '/ecosystem_anon_id',
+          payload,
+          headers,
+        });
+
+        assert.equal(res.statusCode, 200);
+        assertSecurityHeaders(res);
+      });
 
       it('should fail post if the ecosystem_anon_id is not a string', async function () {
         mock.token({
@@ -1784,6 +1806,15 @@ describe('api', function () {
       });
 
       it('should post with `If-None-Match: ontario` (hashed) header, anon ID is `quebec`', async function () {
+        const payload = {
+          ecosystemAnonId: 'bitin the bullet',
+        };
+        const headers = {
+          authorization: `Bearer ${tok}`,
+          'If-None-Match': hashAnonId('ontario'),
+        };
+
+        mock.anonIdUpdated(payload, headers);
         mock.coreProfile({
           email: 'andy@example.domain',
           locale: 'en-US',
@@ -1798,16 +1829,11 @@ describe('api', function () {
 
         const res = await Server.api.post({
           url: '/ecosystem_anon_id',
-          payload: {
-            ecosystemAnonId: 'blah',
-          },
-          headers: {
-            authorization: 'Bearer ' + tok,
-            'If-None-Match': hashAnonId('ontario'),
-          },
+          payload,
+          headers,
         });
 
-        assert.equal(res.statusCode, 503);
+        assert.equal(res.statusCode, 200);
         assertSecurityHeaders(res);
       });
 
@@ -1840,6 +1866,15 @@ describe('api', function () {
       });
 
       it('should post with `If-Match: pandemic` (hashed) header, anon ID is `pandemic`', async function () {
+        const payload = {
+          ecosystemAnonId: 'shark attack',
+        };
+        const headers = {
+          authorization: `Bearer ${tok}`,
+          'If-Match': hashAnonId('pandemic'),
+        };
+
+        mock.anonIdUpdated(payload, headers);
         mock.coreProfile({
           email: 'andy@example.domain',
           locale: 'en-US',
@@ -1854,16 +1889,11 @@ describe('api', function () {
 
         const res = await Server.api.post({
           url: '/ecosystem_anon_id',
-          payload: {
-            ecosystemAnonId: 'blah',
-          },
-          headers: {
-            authorization: 'Bearer ' + tok,
-            'If-Match': hashAnonId('pandemic'),
-          },
+          payload,
+          headers,
         });
 
-        assert.equal(res.statusCode, 503);
+        assert.equal(res.statusCode, 200);
         assertSecurityHeaders(res);
       });
 

--- a/packages/fxa-profile-server/test/lib/mock.js
+++ b/packages/fxa-profile-server/test/lib/mock.js
@@ -146,6 +146,21 @@ module.exports = async function mock(options) {
         });
     },
 
+    // This will fail the containing test if the auth server route
+    // `/account/ecosystemAnonId` is not called with the exact
+    // supplied body and header arguments
+    anonIdUpdated: function anonIdUpdated(body = {}, headers = {}) {
+      const parts = url.parse(config.get('authServer.url'));
+      const req = nock(parts.protocol + '//' + parts.host);
+
+      Object.keys(headers).forEach((header) => {
+        req.matchHeader(header, headers[header]);
+      });
+
+      req.put(parts.path + '/account/ecosystemAnonId', body).reply(200);
+      return req;
+    },
+
     subscriptions: function mockSubscriptions(subscriptions) {
       var parts = url.parse(config.get('authServer.url'));
       return nock(parts.protocol + '//' + parts.host)


### PR DESCRIPTION
## Because

- We were GETing to the auth server '/account/ecosystemAnonId' endpoint, when it should be [PUTing](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/lib/routes/account.js#L1494)

## This pull request

- Fixes that, adds test to assert call happens

## Issue that this pull request solves

Closes: #6031

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.