### PR TITLE
fix(payments): add fxa-shared and fxa-react as CI dependencies for fxa-payments-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,14 @@
       "fxa-profile-server": [
         "fxa-auth-server",
         "fxa-shared"
+      ],
+      "fxa-payments-server": [
+        "fxa-shared",
+        "fxa-react"
+      ],
+      "fxa-settings": [
+        "fxa-shared",
+        "fxa-react"
       ]
     }
   },


### PR DESCRIPTION
Looks like we're not running payments-server tests when fxa-shared or fxa-react change, but payments-server uses those. This hopefully fixes that