### PR TITLE
bug(aet): Add logging to profile-server get anon_id route

### DIFF
--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -37,7 +37,7 @@ see [`fxa-auth-client`](https://github.com/mozilla/fxa/tree/main/packages/fxa-au
     - [POST /account/unlock/verify_code](#post-accountunlockverify_code)
     - [POST /account/reset (:lock: accountResetToken)](#post-accountreset)
     - [POST /account/destroy (:lock::unlock: sessionToken)](#post-accountdestroy)
-    - [PUT /account/ecosystemAnonId (:lock: oauthToken)](#put-accountmetricsecosystemanonId)
+    - [PUT /account/ecosystemAnonId (:lock: sessionToken, oauthToken)](#put-accountmetricsecosystemanonId)
   - [Devices and sessions](#devices-and-sessions)
     - [POST /account/device (:lock: sessionToken, refreshToken)](#post-accountdevice)
     - [GET /account/device/commands (:lock: sessionToken, refreshToken)](#get-accountdevicecommands)
@@ -1149,9 +1149,9 @@ by the following errors
 - `code: 400, errno: 138`:
   Unverified session
 
-#### POST /account/ecosystemAnonId
+#### PUT /account/ecosystemAnonId
 
-:lock: Authenticated with OAuth bearer token
+:lock: Authenticated with OAuth bearer token or HAWK-authenticated with session token
 
 <!--begin-route-put-accountmetricsecosystemanonId-->
 

--- a/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/get.js
+++ b/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/get.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const Joi = require('@hapi/joi');
+const logger = require('../../logging')('routes.ecosystem_anon_id.get');
 
 module.exports = {
   auth: {
@@ -15,6 +16,7 @@ module.exports = {
     },
   },
   handler: async function ecosystemAnonIdGet(req, h) {
+    const uid = req.auth.credentials.user;
     return req.server
       .inject({
         allowInternals: true,
@@ -30,7 +32,11 @@ module.exports = {
           strategy: 'oauth',
         },
       })
-      .then(res => {
+      .then((res) => {
+        logger.info('activityEvent', {
+          event: 'ecosystemAnonId.get',
+          uid: uid,
+        });
         if (res.statusCode !== 200) {
           return res;
         }


### PR DESCRIPTION
Fixes #5351

## Because

- We want to be sure we're logging eco_anon_id related behavior at each layer of the FxA service stack, to help understand usage and identify bugs.

## This pull request

- Adds a missing logger to the profile server `GET eco_anon_id` route
- Updates the auth-server API docs to be clear that `PUT /account/ecosystemAnonId` accepts a session token or an oauth token

## Issue that this pull request solves

Closes: #5351

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
