### PR TITLE
feat(auth-client): add abort-controller support to server env

### DIFF
--- a/packages/fxa-auth-client/package.json
+++ b/packages/fxa-auth-client/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@peculiar/webcrypto": "^1.1.2",
     "abab": "^2.0.0",
+    "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {

--- a/packages/fxa-auth-client/server.ts
+++ b/packages/fxa-auth-client/server.ts
@@ -3,12 +3,14 @@ import https from 'https'
 import { Crypto } from '@peculiar/webcrypto';
 import fetch, { Headers } from 'node-fetch';
 import { btoa } from 'abab';
+import AbortController from 'abort-controller';
 import AuthClient from './lib/client';
 
 declare global {
   namespace NodeJS {
     interface Global {
         fetch: typeof fetch,
+        AbortController: typeof AbortController,
         Headers: typeof Headers,
         crypto: Crypto,
         btoa: typeof btoa
@@ -25,6 +27,7 @@ https.globalAgent = new https.Agent({
 
 global.crypto = new Crypto();
 global.fetch = fetch;
+global.AbortController = AbortController;
 global.Headers = Headers;
 global.btoa = btoa;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15287,6 +15287,7 @@ fsevents@^1.2.7:
     "@types/mocha": ^7
     "@types/node-fetch": ^2
     abab: ^2.0.0
+    abort-controller: ^3.0.0
     asmcrypto.js: ^0.22.0
     fast-text-encoding: ^1.0.0
     mocha: ^7.1.2


### PR DESCRIPTION
because we want to be able to timeout requests on the server side as well

feat(auth-client): make auth-client request timeout configurable

because server timeouts should be lower than client ones
