### PR TITLE
feat(auth-server): send email on upgrade from cancelled

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1384,7 +1384,7 @@ export class StripeHelper {
         baseDetails,
         invoice
       );
-    } else if (!cancelAtPeriodEndOld && !cancelAtPeriodEndNew && planOld) {
+    } else if (!cancelAtPeriodEndNew && planOld) {
       return this.extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail(
         subscription,
         baseDetails,

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -2461,6 +2461,25 @@ describe('StripeHelper', () => {
           event.data.previous_attributes.plan
         );
       });
+
+      it('calls the expected helper method for upgrade or downgrade if previously cancelled', async () => {
+        const event = deepCopy(eventCustomerSubscriptionUpdated);
+        event.data.object.cancel_at_period_end = false;
+        event.data.previous_attributes.cancel_at_period_end = true;
+        const result = await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
+          event
+        );
+        assert.equal(result, mockUpgradeDowngradeDetails);
+        assertOnlyExpectedHelperCalledWith(
+          'extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail',
+          event.data.object,
+          expectedBaseUpdateDetails,
+          mockInvoice,
+          mockCustomer,
+          event.data.object.plan.metadata.productOrder,
+          event.data.previous_attributes.plan
+        );
+      });
     });
 
     const productNameOld = '123 Done Pro Plus Monthly';


### PR DESCRIPTION
Because:

* We previously did not send an upgrade email if the prior subscription
  had been cancelled.

This commit:

* Sends the upgrade email if the subscription is not cancelled and was
  upgraded even if it was previously cancelled.

Closes #5987

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
