### PR TITLE
fix(admin-server): restrict selected email columns

### DIFF
--- a/packages/fxa-admin-server/src/lib/resolvers/account-resolver.ts
+++ b/packages/fxa-admin-server/src/lib/resolvers/account-resolver.ts
@@ -10,6 +10,16 @@ import { Context } from '../server';
 import { Account as AccountType } from './types/account';
 
 const ACCOUNT_COLUMNS = ['uid', 'email', 'emailVerified', 'createdAt'];
+const EMAIL_COLUMNS = [
+  'createdAt',
+  'email',
+  'id',
+  'isPrimary',
+  'isVerified',
+  'normalizedEmail',
+  'uid',
+  'verifiedAt',
+];
 
 @Resolver((of) => AccountType)
 export class AccountResolver {
@@ -58,6 +68,6 @@ export class AccountResolver {
   @FieldResolver()
   public async emails(@Root() account: Account) {
     const uidBuffer = uuidTransformer.to(account.uid);
-    return await Emails.query().where('uid', uidBuffer);
+    return await Emails.query().select(EMAIL_COLUMNS).where('uid', uidBuffer);
   }
 }


### PR DESCRIPTION
Because:

* We don't want to give the admin server access to the emailCode field.

This commit:

* Restricts the select on emails to everything except the emailCode
  field.

Closes #6064

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

