### PR TITLE
fix(metrics): Add fxa_login - complete for pairing login

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
@@ -99,6 +99,10 @@ export default BaseAuthenticationBroker.extend({
    * @returns {Promise}
    */
   sendOAuthResultToRelier(result) {
+    if (this.hasCapability('supportsPairing')) {
+      this._metrics.logEvent('pairing.signin.success');
+    }
+
     return this._metrics.flush().then(() => {
       const extraParams = {};
       if (result.error) {

--- a/packages/fxa-content-server/app/scripts/views/pair/supp_allow.js
+++ b/packages/fxa-content-server/app/scripts/views/pair/supp_allow.js
@@ -4,6 +4,7 @@
 
 import { assign } from 'underscore';
 import Cocktail from 'cocktail';
+import FlowEventsMixin from '../mixins/flow-events-mixin';
 import FormView from '../form';
 import DeviceBeingPairedMixin from './device-being-paired-mixin';
 import preventDefaultThen from '../decorators/prevent_default_then';
@@ -29,6 +30,6 @@ class PairSuppAllowView extends FormView {
   }
 }
 
-Cocktail.mixin(PairSuppAllowView, DeviceBeingPairedMixin());
+Cocktail.mixin(PairSuppAllowView, FlowEventsMixin, DeviceBeingPairedMixin());
 
 export default PairSuppAllowView;

--- a/packages/fxa-content-server/app/tests/spec/views/pair/supp_allow.js
+++ b/packages/fxa-content-server/app/tests/spec/views/pair/supp_allow.js
@@ -65,6 +65,7 @@ describe('views/pair/supp_allow', () => {
     view = new View({
       broker,
       viewName: 'pairSuppAllow',
+      notifier,
     });
   }
 

--- a/packages/fxa-content-server/server/lib/amplitude.js
+++ b/packages/fxa-content-server/server/lib/amplitude.js
@@ -90,6 +90,10 @@ const EVENTS = {
     group: GROUPS.login,
     event: 'complete',
   },
+  'pairing.signin.success': {
+    group: GROUPS.login,
+    event: 'complete',
+  },
 
   // Signup code based metrics
   'screen.confirm-signup-code': {

--- a/packages/fxa-content-server/tests/server/amplitude.js
+++ b/packages/fxa-content-server/tests/server/amplitude.js
@@ -1984,6 +1984,61 @@ registerSuite('amplitude', {
       });
     },
 
+    'pairing.signin.success': () => {
+      amplitude(
+        {
+          time: '1585321743',
+          type: 'pairing.signin.success',
+        },
+        {
+          connection: {},
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:58.0) Gecko/20100101 Firefox/65.0',
+            'x-forwarded-for': '63.245.221.32',
+          },
+        },
+        {
+          flowBeginTime: '1585261624219',
+          flowId:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          lang: 'gd',
+          service: '1',
+          uid: '44794bdf0be84d4e8c7a8026b8580fa3',
+        }
+      );
+
+      assert.equal(process.stderr.write.callCount, 0);
+      assert.equal(logger.info.callCount, 1);
+      const args = logger.info.args[0];
+      assert.lengthOf(args, 2);
+      assert.equal(args[0], 'amplitudeEvent');
+      assert.deepEqual(args[1], {
+        app_version: APP_VERSION,
+        event_properties: {
+          oauth_client_id: '1',
+          service: 'pocket',
+        },
+        event_type: 'fxa_login - complete',
+        language: 'gd',
+        op: 'amplitudeEvent',
+        os_name: 'Mac OS X',
+        os_version: '10.11',
+        session_id: '1585261624219',
+        time: '1585321743',
+        user_id: '44794bdf0be84d4e8c7a8026b8580fa3',
+        user_properties: {
+          flow_id:
+            '11750082326622a61b155a58a54442dd3702fa899b18d62868562ef9a3bc8484',
+          ua_browser: 'Firefox',
+          ua_version: '65.0',
+          $append: {
+            fxa_services_used: 'pocket',
+          },
+        },
+      });
+    },
+
     'screen.confirm-signup-code': () => {
       amplitude(
         {


### PR DESCRIPTION
## Because

- We currently don't log any complete events when a user completes a login via pairing

## This pull request

- Adds the `fxa_login - complete` event when the user finishes the pairing flow
- Note that I was not able to add the `login_type` property to these events. I can do that part in a follow up.

## Issue that this pull request solves

Closes: #5990

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Other information (Optional)

The flow itself is a little hard to test. I ran `node tests/intern.js --suites=pairing` and made sure that content-server emitted the correct metrics

Output:

```
31|content  | 2020-07-29T23:39:03: fxa-content-server.INFO: amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_connect_device - view","time":1596080343378,"device_id":"9af7ee53c9a8496a9809909822adcdf8","session_id":1596080342818,"app_version":"181.2","language":"en-US","os_name":"Mac OS X","os_version":"10.14","event_properties":{"connect_device_flow":"pairing"},"user_properties":{"flow_id":"a5baceb8f858bdb56fe535426d9118d3df2579feaa8e0ef5e7fdf63ee83d7e57","ua_browser":"Firefox","ua_version":"67.0"}}
31|content  | 2020-07-29T23:39:03: fxa-content-server.INFO: amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_connect_device - submit","time":1596080343502,"device_id":"9af7ee53c9a8496a9809909822adcdf8","session_id":1596080342818,"app_version":"181.2","language":"en-US","os_name":"Mac OS X","os_version":"10.14","event_properties":{"connect_device_flow":"pairing"},"user_properties":{"flow_id":"a5baceb8f858bdb56fe535426d9118d3df2579feaa8e0ef5e7fdf63ee83d7e57","ua_browser":"Firefox","ua_version":"67.0"}}
31|content  | 2020-07-29T23:39:08: fxa-content-server.INFO: amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_login - complete","time":1596080348909,"device_id":"72761d8e0ac2400a81522a57f292a375","session_id":1596080346527,"app_version":"181.2","language":"en-US","os_name":"Mac OS X","os_version":"10.14","event_properties":{},"user_properties":{"flow_id":"5528e5e5e7f3825d42f6d24f46a4fa0c5f2b57ff4a8548ee710cb61723c5c3f9","ua_browser":"Firefox","ua_version":"67.0"}}
```
