### PR TITLE
feat(aet): make either precondition header mandatory when updating anon id

### DIFF
--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -1157,6 +1157,11 @@ by the following errors
 
 Adds new or updates existing user Ecosystem Anonymous ID.
 
+Note that _either_ request header `If-Match` or `If-None-Match` is required to perform this request.
+
+- `If-Match` with a value of your known Ecosystem Anonymous ID, SHA-256 hashed, to set a new ID if it matches the passed in ID.
+- `If-None-Match` with a value of `*` to set a new ID if one does not already exist, or your known Ecosystem Anonymous ID, SHA-256 hashed, to set a new ID if it does not match the passed in ID.
+
 <!--end-route-put-accountmetricsecosystemanonId-->
 
 ##### Request body
@@ -1180,6 +1185,9 @@ by the following errors
 - `code: 412, errno: 190`:
   Could not update because criteria set by a header,
   either If-None-Match or If-Match, was not met
+- `code: 400, errno: 191`:
+  Header If-None-Match or If-Match is required to
+  perform the request
 
 ### Devices and sessions
 

--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -103,6 +103,7 @@ const ERRNO = {
   SUBSCRIPTION_ALREADY_EXISTS: 187,
   UNKNOWN_SUBSCRIPTION_FOR_SOURCE: 188,
   ECOSYSTEM_ANON_ID_UPDATE_CONFLICT: 190,
+  ECOSYSTEM_ANON_ID_NO_CONDITION: 191,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -1317,6 +1318,16 @@ AppError.anonIdUpdateConflict = (headerName) => {
     error: 'Precondition Failed',
     errno: ERRNO.ECOSYSTEM_ANON_ID_UPDATE_CONFLICT,
     message: `Could not update Ecosystem Anon ID because criteria set by ${headerName} was not met`,
+  });
+};
+
+AppError.anonIdNoCondition = (headerName) => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.ECOSYSTEM_ANON_ID_NO_CONDITION,
+    message:
+      'Header If-None-Match or If-Match is required to perform the request',
   });
 };
 

--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -1494,7 +1494,11 @@ module.exports = (
       method: 'PUT',
       path: '/account/ecosystemAnonId',
       apidoc: {
-        errors: [error.invalidScopes, error.anonIdUpdateConflict],
+        errors: [
+          error.invalidScopes,
+          error.anonIdUpdateConflict,
+          error.anonIdNoCondition,
+        ],
       },
       options: {
         auth: {
@@ -1536,9 +1540,13 @@ module.exports = (
 
         await customs.check(request, uid, 'updateEcosystemAnonId');
 
+        if (!ifNoneMatch && !ifMatch) {
+          throw error.anonIdNoCondition()
+        }
+
         const { ecosystemAnonId: existingAnonId } = await db.account();
 
-        if ((ifNoneMatch || ifMatch) && existingAnonId) {
+        if (existingAnonId) {
           const hashedAnonId = hashAnonId(existingAnonId);
 
           if (ifMatch && ifMatch !== hashedAnonId) {

--- a/packages/fxa-profile-server/docs/API.md
+++ b/packages/fxa-profile-server/docs/API.md
@@ -46,6 +46,7 @@ The currently-defined error responses are:
 - 400, 101: Invalid request parameter
 - 400, 102: Unsupported image provider
 - 400, 125: The request was blocked for security reasons
+- 400, 107: Header If-None-Match or If-Match is required to perform the request
 - 412, 106: Criteria set by a header, either If-None-Match or If-Match, was not met
 - 429, 114: Client has sent too many requests
 - 500, 103: Image processing error

--- a/packages/fxa-profile-server/lib/error.js
+++ b/packages/fxa-profile-server/lib/error.js
@@ -220,4 +220,19 @@ AppError.anonIdUpdateConflict = function anonIdExists(headerName, message) {
   );
 };
 
+AppError.anonIdNoCondition = function anonIdNoCondition(err) {
+  return new AppError(
+    {
+      code: 400,
+      error: 'Bad Request',
+      errno: 107,
+      message:
+        'Header If-None-Match or If-Match is required to perform the request',
+    },
+    {
+      cause: err,
+    }
+  );
+};
+
 module.exports = AppError;

--- a/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/post.js
+++ b/packages/fxa-profile-server/lib/routes/ecosystem_anon_id/post.js
@@ -61,6 +61,11 @@ const updateAuthServer = function (
             return reject(new AppError.unauthorized(body.message));
           }
 
+          if (body.errno === 191) {
+            logger.info('request.auth_server.no_condition', body);
+            return reject(new AppError.anonIdNoCondition());
+          }
+
           if (body.code === 412 || body.errno === 190) {
             logger.info('request.auth_server.precondition_fail', body);
             return reject(
@@ -121,7 +126,11 @@ module.exports = {
           uid: uid,
         });
 
-        if (existingAnonId && (ifNoneMatch || ifMatch)) {
+        if (!ifNoneMatch && !ifMatch) {
+          throw AppError.anonIdNoCondition();
+        }
+
+        if (existingAnonId) {
           const hashedAnonId = hashAnonId(existingAnonId);
 
           if (ifMatch && ifMatch !== hashedAnonId) {

--- a/packages/fxa-profile-server/test/api.js
+++ b/packages/fxa-profile-server/test/api.js
@@ -1706,6 +1706,7 @@ describe('api', function () {
         };
         const headers = {
           authorization: `Bearer ${tok}`,
+          'If-None-Match': '*',
         };
 
         mock.anonIdUpdated(payload, headers);
@@ -1721,6 +1722,30 @@ describe('api', function () {
         });
 
         assert.equal(res.statusCode, 200);
+        assertSecurityHeaders(res);
+      });
+
+      it('should fail post if neither if-none-match nor if-match headers are present', async function () {
+        const payload = {
+          ecosystemAnonId: 'beans on pizza',
+        };
+        const headers = {
+          authorization: `Bearer ${tok}`,
+        };
+
+        mock.token({
+          user: USERID,
+          scope: ['profile:ecosystem_anon_id:write'],
+        });
+
+        const res = await Server.api.post({
+          url: '/ecosystem_anon_id',
+          payload,
+          headers,
+        });
+
+        assert.equal(res.statusCode, 400);
+        assert.equal(res.result.errno, 107);
         assertSecurityHeaders(res);
       });
 


### PR DESCRIPTION
## Because

- There's no valid reason to be performing an eco id change without either asserting one does not exist, or that an existing one matches

## This pull request

- Makes either If-Match or If-None-Match mandatory when performing the ID update

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Other information

This is going to conflict with #6081 - I'm happy to wait until it's merged and then resolve conflicts on my end.