### PR TITLE
fix(auth): added exports to fxa-shared package.json

### DIFF
--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -3,6 +3,10 @@
   "version": "1.181.2",
   "description": "Shared module for FxA repositories",
   "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./": "./dist/"
+  },
   "scripts": {
     "postinstall": "tsc --build || true",
     "build": "tsc --build",


### PR DESCRIPTION
Because auth-server doesn't use ts-node/register in production and fxa-shared compiles typescript, requiring a subpath like 'fxa-shared/subscriptions/metadata' finds no js to load. The "exports" field of package.json allows us to map required paths to other locations, in this case ./dist.

see https://nodejs.org/dist/latest-v12.x/docs/api/esm.html#esm_package_entry_points