### PR TITLE
chore(coverage): disable codecov comments

### DIFF
--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -22,7 +22,4 @@ parsers:
       method: no
       macro: no
 
-comment:
-  layout: "reach,diff,flags,tree"
-  behavior: default
-  require_changes: no
+comment: false


### PR DESCRIPTION
Because, well the code cov comments are providing no real value and are noisy. Once we implement https://docs.codecov.io/docs/carryforward-flags, the code coverage will actually be more accurate.