### PR TITLE
fix(headers): allow X-Verify-Short-Code header to pass through

### DIFF
--- a/packages/fxa-email-service/src/providers/mod.rs
+++ b/packages/fxa-email-service/src/providers/mod.rs
@@ -107,6 +107,7 @@ fn set_custom_header(message: MessageBuilder, name: &str, value: &str) -> Messag
         "x-uid" => message.header(Uid::new(value.to_owned())),
         "x-unblock-code" => message.header(UnblockCode::new(value.to_owned())),
         "x-verify-code" => message.header(VerifyCode::new(value.to_owned())),
+        "x-verify-short-code" => message.header(VerifyShortCode::new(value.to_owned())),
         _ => message,
     }
 }

--- a/packages/fxa-email-service/src/types/headers/mod.rs
+++ b/packages/fxa-email-service/src/types/headers/mod.rs
@@ -98,3 +98,4 @@ custom_header!(TemplateVersion, "X-Template-Version");
 custom_header!(Uid, "X-Uid");
 custom_header!(UnblockCode, "X-Unblock-Code");
 custom_header!(VerifyCode, "X-Verify-Code");
+custom_header!(VerifyShortCode, "X-Verify-Short-Code");

--- a/packages/fxa-email-service/src/types/headers/test.rs
+++ b/packages/fxa-email-service/src/types/headers/test.rs
@@ -140,6 +140,13 @@ fn verify_code() {
 }
 
 #[test]
+fn verify_short_code() {
+    let header = VerifyShortCode::new("wobble".to_owned());
+    assert_eq!(header.to_string(), "wobble");
+    assert_eq!(VerifyShortCode::header_name(), "X-Verify-Short-Code");
+}
+
+#[test]
 fn any_header_length() {
     // No header value should be longer than 996 characters, minus the length of the header name.
     let header = Link::new(std::iter::repeat("X").take(997).collect::<String>().to_owned());


### PR DESCRIPTION
## Because

- we send X-Verify-Short-Code in [tests](https://github.com/mozilla/fxa/search?q=%22x-verify-short-code%22&unscoped_q=%22x-verify-short-code%22) and in [Mailer.prototype.verifyShortCodeEmail](https://github.com/mozilla/fxa/blob/b0c80f64452e0b1228b2ca0ab265e22b555a96d8/packages/fxa-auth-server/lib/senders/email.js#L600-L620)

## This pull request

- allows X-Verify-Short-Code to pass through the email-service

## Issue that this pull request solves

Closes: #5186 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional) N/A
## Other information (Optional)

Test changes pass when run locally with ./scripts/test-ci.sh but I don't see where we actually run the tests under circle-ci, which isn't optimal (unless they are run and I'm just not seeing where).