### PR TITLE
fix(headers): allow X-Verify-Short-Code header to pass through

### DIFF
--- a/packages/fxa-email-service/src/providers/mod.rs
+++ b/packages/fxa-email-service/src/providers/mod.rs
@@ -107,6 +107,7 @@ fn set_custom_header(message: MessageBuilder, name: &str, value: &str) -> Messag
         "x-uid" => message.header(Uid::new(value.to_owned())),
         "x-unblock-code" => message.header(UnblockCode::new(value.to_owned())),
         "x-verify-code" => message.header(VerifyCode::new(value.to_owned())),
+        "x-verify-short-code" => message.header(VerifyShortCode::new(value.to_owned())),
         _ => message,
     }
 }

--- a/packages/fxa-email-service/src/types/headers/mod.rs
+++ b/packages/fxa-email-service/src/types/headers/mod.rs
@@ -98,3 +98,4 @@ custom_header!(TemplateVersion, "X-Template-Version");
 custom_header!(Uid, "X-Uid");
 custom_header!(UnblockCode, "X-Unblock-Code");
 custom_header!(VerifyCode, "X-Verify-Code");
+custom_header!(VerifyShortCode, "X-Verify-Short-Code");

--- a/packages/fxa-email-service/src/types/headers/test.rs
+++ b/packages/fxa-email-service/src/types/headers/test.rs
@@ -140,6 +140,13 @@ fn verify_code() {
 }
 
 #[test]
+fn verify_short_code() {
+    let header = VerifyShortCode::new("wobble".to_owned());
+    assert_eq!(header.to_string(), "wobble");
+    assert_eq!(VerifyShortCode::header_name(), "X-Verify-Short-Code");
+}
+
+#[test]
 fn any_header_length() {
     // No header value should be longer than 996 characters, minus the length of the header name.
     let header = Link::new(std::iter::repeat("X").take(997).collect::<String>().to_owned());


### PR DESCRIPTION
ignore this. Just triggering circleci test for email-service.