### PR TITLE
refactor(avatars): increase max file size to 2mb

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -86,8 +86,8 @@ module.exports = {
   PROFILE_IMAGE_MIN_WIDTH: 100,
   DEFAULT_PROFILE_IMAGE_MIME_TYPE: 'image/jpeg',
 
-  // Limit to 1.35 megabytes
-  PROFILE_FILE_IMAGE_MAX_UPLOAD_SIZE: 1.35 * 1024 * 1024,
+  // Limit to 2 megabytes
+  PROFILE_FILE_IMAGE_MAX_UPLOAD_SIZE: 2 * 1024 * 1024,
 
   ONERROR_MESSAGE_LIMIT: 100,
 

--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -134,7 +134,7 @@ const conf = convict({
   image: {
     maxSize: {
       doc: 'Maximum bytes allow for uploads',
-      default: 1024 * 1024 * 1, // 1MB
+      default: 1024 * 1024 * 2, // 2MB
       env: 'IMG_UPLOADS_DEST_MAX_SIZE',
     },
     types: {

--- a/packages/fxa-profile-server/lib/config.js
+++ b/packages/fxa-profile-server/lib/config.js
@@ -99,7 +99,7 @@ const conf = convict({
       },
       maxSize: {
         doc: 'Maximum bytes allow for uploads',
-        default: 1024 * 1024 * 1, // 1MB
+        default: 1024 * 1024 * 2, // 2MB
         env: 'IMG_UPLOADS_DEST_MAX_SIZE',
       },
       types: {


### PR DESCRIPTION
## Because

- The current max file size for avatar upload is 1mb locally, 1.35mb in prod.

## This pull request

- Bumps frontend and [default] server validation to 2mb across the board. Ops will still need to set the server env var to 2mb.

## Issue that this pull request solves

Closes: #6075

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Other information

**Hold merge**. We need to wait until this change is set in prod first (cc @jrgm).