### PR TITLE
Changed the 404 page Text to be Match with Other Styles

### DIFF
--- a/packages/fxa-content-server/app/styles/_layout.scss
+++ b/packages/fxa-content-server/app/styles/_layout.scss
@@ -89,6 +89,11 @@
   margin-top: 24px;
 }
 
+.fxa-404-p {
+  line-height: 1.5em;
+  margin: 0;
+}
+
 #static-footer {
   align-items: center;
   display: flex;

--- a/packages/fxa-content-server/server/templates/pages/src/404.html
+++ b/packages/fxa-content-server/server/templates/pages/src/404.html
@@ -23,10 +23,10 @@
           <h1 id="fxa-404-header">{{#t}}Page not found{{/t}}</h1>
         </header>
 
-        <section>
+        <p class="fxa-404-p" >
           {{#t}}The page you requested is not found. We've been notified and
           will fix any links that may be broken.{{/t}}
-        </section>
+        </p>
 
         <div class="button-row">
           <a href="/signup" class="button primary-button" id="fxa-404-home"

--- a/packages/fxa-payments-server/public/404.html
+++ b/packages/fxa-payments-server/public/404.html
@@ -19,10 +19,10 @@
     <div id="stage">
       <div id="main-content" class="card">
         <header><h1 id="fxa-404-header">Page not found</h1></header>
-        <section>
+        <p class="fxa-404-p">
           The page you requested is not found. We've been notified and will fix
           any links that may be broken.
-        </section>
+        </p>
         <div class="button-row">
           <a href="/signup" class="button primary-button" id="fxa-404-home"
             >Home</a


### PR DESCRIPTION
Put the 404 page message in a "p" tag and Corrected the Line-heigth to 1.5em

## Because

-Current one doesn't go with other Styles according to the ISSUE this is fixing.

## This pull request

- Fixed the issue by simply changing the tag and adding the necessary styles.

## Issue that this pull request solves

Closes: #6102 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

