### PR TITLE
refactor(rescripts): include all of fxa as valid paths in rescripts

### DIFF
--- a/packages/fxa-admin-panel/.rescriptsrc.js
+++ b/packages/fxa-admin-panel/.rescriptsrc.js
@@ -4,12 +4,8 @@
 
 const {
   permitAdditionalJSImports,
-  setupAliasedPaths,
-  componentsJestMapper,
 } = require('fxa-react/configs/rescripts');
 
 module.exports = [
   permitAdditionalJSImports,
-  setupAliasedPaths,
-  componentsJestMapper,
 ];

--- a/packages/fxa-auth-client/lib/crypto.ts
+++ b/packages/fxa-auth-client/lib/crypto.ts
@@ -175,7 +175,7 @@ export async function checkWebCrypto() {
       window.asmCrypto = await import(/* webpackChunkName: "asmcrypto.js" */ 'asmcrypto.js');
       // prettier-ignore
       // @ts-ignore
-      await import(/* webpackChunkName: "webcrypto-liner" */ 'webcrypto-liner');
+      await import(/* webpackChunkName: "webcrypto-liner" */ 'webcrypto-liner/build/shim');
       return true;
     } catch (e) {
       return false;

--- a/packages/fxa-content-server/webpack.config.js
+++ b/packages/fxa-content-server/webpack.config.js
@@ -75,7 +75,6 @@ const webpackConfig = {
       'ua-parser-js': require.resolve('ua-parser-js/src/ua-parser'),
       uuid: require.resolve('node-uuid/uuid'),
       vat: require.resolve('node-vat/vat'),
-      'webcrypto-liner': require.resolve('webcrypto-liner/build/shim'),
       // Webpack 4 doesn't support the "exports" property of package.json
       // so unfortunately we need to remap it here as well.
       'fxa-react/components/Survey': require.resolve('fxa-react/components/Survey'),

--- a/packages/fxa-payments-server/.rescriptsrc.js
+++ b/packages/fxa-payments-server/.rescriptsrc.js
@@ -4,12 +4,8 @@
 
 const {
   permitAdditionalJSImports,
-  setupAliasedPaths,
-  componentsJestMapper,
 } = require('fxa-react/configs/rescripts');
 
 module.exports = [
   permitAdditionalJSImports,
-  setupAliasedPaths,
-  componentsJestMapper,
 ];

--- a/packages/fxa-react/configs/rescripts.js
+++ b/packages/fxa-react/configs/rescripts.js
@@ -4,14 +4,10 @@
 
 const { resolve } = require('path');
 
-const additionalJSImports = {
-  'fxa-react': resolve(__dirname, '../'),
-  'fxa-shared': resolve(__dirname, '../../fxa-shared'),
-};
-
 const permitAdditionalJSImports = (config) => {
-  const importPaths = Object.values(additionalJSImports);
-
+  // We're just gonna call all of fxa fair game ;)
+  const allFxa = resolve(__dirname, '../../')
+  const importPaths = [allFxa, resolve(__dirname, '../../../node_modules')]
   // Update ModuleScopePlugin's appSrcs to allow our new directory
   config.resolve.plugins.forEach((plugin) => {
     if (plugin.constructor && plugin.constructor.name === 'ModuleScopePlugin') {
@@ -53,7 +49,7 @@ const permitAdditionalJSImports = (config) => {
   ) {
     config.module.rules[2].oneOf[1].include = [
       config.module.rules[2].oneOf[1].include,
-      ...importPaths,
+      allFxa
     ];
   } else {
     throw new Error(
@@ -65,38 +61,6 @@ const permitAdditionalJSImports = (config) => {
   return config;
 };
 
-const setupAliasedPaths = (config) => {
-  // Add the list of additional imports to Webpack's alias resolver
-  config.resolve.alias = Object.assign(
-    config.resolve.alias,
-    additionalJSImports
-  );
-
-  // IMPORTANT - While this will work, in order for Typescript to also resolve
-  // these custom aliases we need to set them in TSConfig's "paths". Please refer
-  // to tsconfig.json and tsconfig.paths.json for details around that setup.
-
-  return config;
-};
-
-const componentsJestMapper = {
-  jest: (config) => {
-    return {
-      ...config,
-      moduleNameMapper: Object.keys(additionalJSImports).reduce(
-        (previous, key) => {
-          return Object.assign(previous, {
-            [`^${key}/(.*)$`]: resolve(additionalJSImports[key], '$1'),
-          });
-        },
-        {}
-      ),
-    };
-  },
-};
-
 module.exports = {
   permitAdditionalJSImports,
-  setupAliasedPaths,
-  componentsJestMapper,
 };

--- a/packages/fxa-settings/.rescriptsrc.js
+++ b/packages/fxa-settings/.rescriptsrc.js
@@ -4,12 +4,8 @@
 
 const {
   permitAdditionalJSImports,
-  setupAliasedPaths,
-  componentsJestMapper,
 } = require('fxa-react/configs/rescripts');
 
 module.exports = [
   permitAdditionalJSImports,
-  setupAliasedPaths,
-  componentsJestMapper,
 ];


### PR DESCRIPTION
Because I was about to add fxa-auth-client to the additionalJSIpmorts but ran into problems. Instead of trying to include the minimum set of paths to add to the webpack rule this just lets all of fxa in.

Also, since we started using `workspace:*` in package.json we no longer need the aliases or jest module mappings!