### PR TITLE
bug(aet): Don't translate anon_id update errors

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -616,9 +616,7 @@ var ERRORS = {
   },
   ECOSYSTEM_ANON_ID_UPDATE_CONFLICT: {
     errno: 190,
-    message: t(
-      'Could not update Ecosystem Anon ID because precondition failed.'
-    ),
+    message: 'Could not update Ecosystem Anon ID because precondition failed.', // only used for logging, no need for translation
   },
 };
 


### PR DESCRIPTION
## Because

- We don't intend for AET update errors to ever be displayed to users (who won't understand or be able to fix those errors)

## This pull request

- Removes the AET update precondition failed error from the list of translated error strings

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
