### PR TITLE
chore(docs): Add documentation for connecting to the GQL playground

### DIFF
--- a/packages/fxa-graphql-api/README.md
+++ b/packages/fxa-graphql-api/README.md
@@ -3,6 +3,24 @@
 This is the GraphQL server for the Firefox Accounts API, its current primary consume is the new
 settings page.
 
+## Connecting to the Playground
+
+The [GraphQL playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/) for this package is available at [localhost:8290/graphql](http://localhost:8290/graphql), providing a GUI for an up-to-date schema and API docs, as well as a way to test queries and mutations.
+
+The playground requires a `sessionToken` for authorization from the `login` response. [Verify an account](https://github.com/mozilla/fxa#verifying-email-and-viewing-logs) locally, sign out, and with the Network tab open, login. Under the "Response" tab for the `account/login` POST request, copy the `sessionToken`.
+
+![](https://user-images.githubusercontent.com/13018240/89205157-e00f9500-d57c-11ea-9829-5638cf00958b.png)
+
+Add this as a property of a JSON object with an `authorization` key in the bottom left-hand corner of the GQL playground labeled "HTTP Headers":
+
+```
+{
+  "authorization": "d4a62a0f58efb0e9c7d17b579434f2a56cad10503033874002ddd507a503cea5"
+}
+```
+
+Hit the "play" button and the schema and docs will populate.
+
 ## Testing
 
 This package uses [Mocha](https://mochajs.org/) to test its code. By default `npm test` will test all files ending in `.spec.ts` under `src/test/` and uses `ts-node` so it can process TypeScript files.

--- a/packages/fxa-settings/README.md
+++ b/packages/fxa-settings/README.md
@@ -1,6 +1,6 @@
 # Firefox Accounts Settings
 
-This documentation is up to date as of 2020-07-31.
+This documentation is up to date as of 2020-08-03.
 
 ## Development
 
@@ -229,6 +229,10 @@ Refer to Jest's [CLI documentation](https://jestjs.io/docs/en/cli) for more adva
 This project uses [Storybook](https://storybook.js.org/) to show each screen without requiring a full stack.
 
 In local development, `yarn storybook` will start a Storybook server at <http://localhost:6008> with hot module replacement to reflect live changes. Storybook provides a way to document and visually show various component states and application routes. Storybook builds from pull requests and commits can be found at https://mozilla-fxa.github.io/storybooks/.
+
+## GQL
+
+This package consumes the [FxA GraphQL API](https://github.com/mozilla/fxa/tree/main/packages/fxa-graphql-api). See the documentation to connect to the playground to view the API docs and schema.
 
 ## License
 


### PR DESCRIPTION
## Because

- We didn't have instructions on connecting to the playground documented.

## This pull request

- Adds docs for the GQL playground

## Issue that this pull request solves

Closes: # none