### PR TITLE
fix(params): Gracefully handle invalid utm params

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/validate.js
+++ b/packages/fxa-content-server/app/scripts/lib/validate.js
@@ -49,6 +49,8 @@ const TOTP_CODE = /^[0-9]{6}$/;
 // Recovery codes can be 8-10 alpha numeric characters
 const RECOVERY_CODE = /^([a-zA-Z0-9]{8,10})$/;
 
+const utmRegex = /^[\w\/.%-]{1,128}$/;
+
 var Validate = {
   /**
    * Check if an email address is valid
@@ -272,6 +274,16 @@ var Validate = {
     }, true);
 
     return areAllValid;
+  },
+
+  /**
+   * Check if the utm param is valid.
+   *
+   * @param {String} value
+   * @returns {Boolean}
+   */
+  isUtmValid(value) {
+    return utmRegex.test(value);
   },
 };
 

--- a/packages/fxa-content-server/app/tests/spec/lib/validate.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/validate.js
@@ -359,4 +359,22 @@ describe('lib/validate', function () {
       );
     });
   });
+
+  describe('isUtmValid', () => {
+    it('returns false if more than 128 chars', () => {
+      assert.isFalse(Validate.isUtmValid(createRandomHexString(129)));
+    });
+
+    it('returns false for empty string', () => {
+      assert.isFalse(Validate.isUtmValid(''));
+    });
+
+    it('returns false for invalid chars', () => {
+      assert.isFalse(Validate.isUtmValid('(not valid)'));
+    });
+
+    it('returns true for valid chars', () => {
+      assert.isTrue(Validate.isUtmValid('marketing-snippet'));
+    });
+  });
 });


### PR DESCRIPTION
## Because

- We shouldn't stop a user from logging in if we detect invalid utm params

## This pull request

- Replaces the invalid utm param with `invalid` and logs a Sentry error. Hopefully we can see how often this happens and what RPs are sending
- By replacing the utm param, it allows us to still submit the metrics

## Issue that this pull request solves

Closes: #3673 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Testing

Try to login with an invalid utm param set. Ex [http://localhost:3030/signin_token_code?context=fx_desktop_v3&entrypoint=fxa_discoverability_native&action=email&service=sync&utm_term=(not%20ready)](http://localhost:3030/signin_token_code?context=fx_desktop_v3&entrypoint=fxa_discoverability_native&action=email&service=sync&utm_term=(not%20ready))

## Screenshots

### Before
<img width="1185" alt="Screen Shot 2020-08-03 at 1 23 18 PM" src="https://user-images.githubusercontent.com/1295288/89210285-da6e7b00-d58d-11ea-832c-e26ec7c002e2.png">

### After
<img width="1394" alt="Screen Shot 2020-08-03 at 1 23 59 PM" src="https://user-images.githubusercontent.com/1295288/89210251-c7f44180-d58d-11ea-8376-8c69189219dc.png">