### PR TITLE
feat(settings): added fxa-auth-client to fxa-settings

### DIFF
--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -32,15 +32,16 @@
     ]
   },
   "dependencies": {
-    "@apollo/client": "^3.0.0-beta.50",
+    "@apollo/client": "^3.1.2",
     "classnames": "^2.2.6",
+    "fxa-auth-client": "workspace:*",
     "fxa-react": "workspace:*",
     "graphql": "^14.6.0",
-    "graphql-tag": "^2.10.3",
     "postcss-import": "^12.0.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.1",
+    "subscriptions-transport-ws": "^0.9.11",
     "typescript": "3.8.3"
   },
   "devDependencies": {

--- a/packages/fxa-settings/src/components/AccountDataHOC/gql.ts
+++ b/packages/fxa-settings/src/components/AccountDataHOC/gql.ts
@@ -1,7 +1,7 @@
-import gql from 'graphql-tag';
+import {gql} from '@apollo/client';
 
 export const GET_ACCOUNT = gql`
-  query {
+  query GetAccount {
     account {
       uid
       displayName

--- a/packages/fxa-settings/src/components/AccountDataHOC/index.test.tsx
+++ b/packages/fxa-settings/src/components/AccountDataHOC/index.test.tsx
@@ -5,13 +5,19 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render, act, wait, screen } from '@testing-library/react';
-import { MockedProvider } from '@apollo/client/testing';
+import { MockedProvider, MockLink } from '@apollo/client/testing';
 import { AccountDataHOC } from '../AccountDataHOC';
 import { MOCK_GET_ACCOUNT } from './mocks';
 
+// workaround for https://github.com/apollographql/apollo-client/issues/6559
+const mockLink = new MockLink([MOCK_GET_ACCOUNT], false);
+mockLink.setOnError((error) => {
+  return;
+});
+
 it('renders without imploding', async () => {
   render(
-    <MockedProvider mocks={[MOCK_GET_ACCOUNT]}>
+    <MockedProvider mocks={[MOCK_GET_ACCOUNT]} addTypename={false}>
       <AccountDataHOC>
         {() => <div data-testid="children">Content</div>}
       </AccountDataHOC>
@@ -26,7 +32,7 @@ it('renders without imploding', async () => {
 it('renders the loading spinner on initial load', async () => {
   await act(async () => {
     render(
-      <MockedProvider mocks={[]}>
+      <MockedProvider mocks={[]} addTypename={false} link={mockLink}>
         <AccountDataHOC>{() => <div>Content</div>}</AccountDataHOC>
       </MockedProvider>
     );
@@ -42,7 +48,7 @@ it('renders the error when loading fails', async () => {
   };
 
   render(
-    <MockedProvider mocks={[exampleErrorAccountMock]}>
+    <MockedProvider mocks={[exampleErrorAccountMock]} addTypename={false}>
       <AccountDataHOC>{() => <div>Content</div>}</AccountDataHOC>
     </MockedProvider>
   );

--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -4,10 +4,16 @@
 
 import React from 'react';
 import { render, act } from '@testing-library/react';
-import { MockedProvider } from '@apollo/client/testing';
+import { MockedProvider, MockLink } from '@apollo/client/testing';
 import '@testing-library/jest-dom/extend-expect';
 import App from '.';
 import FlowEvent from '../../lib/flow-event';
+
+// workaround for https://github.com/apollographql/apollo-client/issues/6559
+const mockLink = new MockLink([], false);
+mockLink.setOnError((error) => {
+  return;
+});
 
 const appProps = {
   queryParams: {},
@@ -20,7 +26,7 @@ beforeEach(() => {
 it('renders', async () => {
   await act(async () => {
     render(
-      <MockedProvider mocks={[]}>
+      <MockedProvider mocks={[]} addTypename={false} link={mockLink}>
         <App {...appProps} />
       </MockedProvider>
     );
@@ -30,7 +36,7 @@ it('renders', async () => {
 it('redirects to /get_flow when flow data is not present', async () => {
   await act(async () => {
     render(
-      <MockedProvider mocks={[]}>
+      <MockedProvider mocks={[]} addTypename={false} link={mockLink}>
         <App {...appProps} />
       </MockedProvider>
     );
@@ -58,7 +64,7 @@ it('redirects to /get_flow when flow data is not present', async () => {
 
   await act(async () => {
     render(
-      <MockedProvider mocks={[]}>
+      <MockedProvider mocks={[]} addTypename={false} link={mockLink}>
         <App {...updatedAppProps} />
       </MockedProvider>
     );

--- a/packages/fxa-settings/src/lib/auth.test.tsx
+++ b/packages/fxa-settings/src/lib/auth.test.tsx
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+
+import { AuthClient, AuthContext, useAuth } from './auth';
+
+describe('useAuth', () => {
+  const client = new AuthClient('none');
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('throws when the context is not set', () => {
+    function App() {
+      expect(() => useAuth()).toThrow(
+        'Are you forgetting an AuthContext.Provider?'
+      );
+      return null;
+    }
+
+    render(<App />);
+  });
+
+  it('returns the auth-client', () => {
+    function App() {
+      expect(useAuth()).toEqual(client);
+      return null;
+    }
+
+    render(
+      <AuthContext.Provider value={{ auth: client }}>
+        <App />
+      </AuthContext.Provider>
+    );
+  });
+});

--- a/packages/fxa-settings/src/lib/auth.ts
+++ b/packages/fxa-settings/src/lib/auth.ts
@@ -1,0 +1,17 @@
+import React, { useContext } from 'react';
+import AuthClient from 'fxa-auth-client/browser';
+
+export interface AuthContextValue {
+  auth?: AuthClient;
+}
+
+export const AuthContext = React.createContext<AuthContextValue>({});
+export { AuthClient };
+
+export function useAuth() {
+  const { auth } = useContext(AuthContext);
+  if (!auth) {
+    throw new Error('Are you forgetting an AuthContext.Provider?');
+  }
+  return auth!;
+}

--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -1,0 +1,39 @@
+import { InMemoryCache, gql } from '@apollo/client';
+import Storage from './storage';
+
+const storage = Storage.factory('localStorage');
+
+export function sessionToken(newToken?: string) {
+  try {
+    const storedAccounts = storage.get('accounts');
+    const currentAccountUid = storage.get('currentAccountUid');
+    if (newToken) {
+      storedAccounts[currentAccountUid].sessionToken = newToken;
+      storage.set('accounts', storedAccounts);
+    }
+    return storedAccounts[currentAccountUid].sessionToken as string;
+  } catch (e) {
+    return null;
+  }
+}
+
+// sessionToken is added as a local field in the cache as an example.
+export const typeDefs = gql`
+  extend type Query {
+    sessionToken: String!
+  }
+`;
+
+export const cache = new InMemoryCache({
+  typePolicies: {
+    Query: {
+      fields: {
+        sessionToken: {
+          read() {
+            return sessionToken();
+          },
+        },
+      },
+    },
+  },
+});

--- a/packages/fxa-settings/tsconfig.json
+++ b/packages/fxa-settings/tsconfig.json
@@ -20,6 +20,9 @@
     },
     {
       "path": "../fxa-shared"
+    },
+    {
+      "path": "../fxa-auth-client/tsconfig.browser.json"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,26 +25,30 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@apollo/client@npm:^3.0.0-beta.50":
-  version: 3.0.0-james.33.0
-  resolution: "@apollo/client@npm:3.0.0-james.33.0"
+"@apollo/client@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@apollo/client@npm:3.1.2"
   dependencies:
     "@types/zen-observable": ^0.8.0
-    "@wry/equality": ^0.1.9
+    "@wry/context": ^0.5.2
+    "@wry/equality": ^0.2.0
     fast-json-stable-stringify: ^2.0.0
-    graphql-tag: ^2.10.1
-    optimism: ^0.11.5
+    graphql-tag: ^2.11.0
+    hoist-non-react-statics: ^3.3.2
+    optimism: ^0.12.1
+    prop-types: ^15.7.2
     symbol-observable: ^1.2.0
     ts-invariant: ^0.4.4
     tslib: ^1.10.0
     zen-observable: ^0.8.14
   peerDependencies:
-    graphql: ^14.5.4
+    graphql: ^14.0.0 || ^15.0.0
     react: ^16.8.0
+    subscriptions-transport-ws: ^0.9.0
   peerDependenciesMeta:
     react:
       optional: true
-  checksum: 7bc3cab7575e1daab8bae3301b6f2cb0915afad6281482e2c11012acd8db05b984834526cd04577b58d0181e9b3682eaef3e9d9aae50808e547faa0ef35e0c7d
+  checksum: acda72746d4d9db9b32d38c5c7032adeec486b88b6a5bb25c2792d32ba2eb61007453a7f628919e50680234e043c9a8aa6f18c72fa2c5d93bbc800c65f887e4e
   languageName: node
   linkType: hard
 
@@ -6013,7 +6017,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wry/context@npm:^0.5.0":
+"@wry/context@npm:^0.5.2":
   version: 0.5.2
   resolution: "@wry/context@npm:0.5.2"
   dependencies:
@@ -6028,6 +6032,15 @@ __metadata:
   dependencies:
     tslib: ^1.9.3
   checksum: 3d1da5799967fc272ae53f698514c169c85a04c11c1db3e4641a21edc82af75bfb4db9221c4f87aa333f14c7b43b72311fa66dae1ae981fa6f24c2bc5863d92b
+  languageName: node
+  linkType: hard
+
+"@wry/equality@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@wry/equality@npm:0.2.0"
+  dependencies:
+    tslib: ^1.9.3
+  checksum: ddd217fbefd8f105174abe099450e0ac1b813e19451b8525d2143098b23c42b30dd5042f38c5c92ba55017f9efab2ae4ce18d66a83d0e329de8523691a8bf60e
   languageName: node
   linkType: hard
 
@@ -16140,7 +16153,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "fxa-settings@workspace:packages/fxa-settings"
   dependencies:
-    "@apollo/client": ^3.0.0-beta.50
+    "@apollo/client": ^3.1.2
     "@babel/core": ^7.10.3
     "@rescripts/cli": 0.0.14
     "@sentry/browser": ^5.17.0
@@ -16166,10 +16179,10 @@ fsevents@^1.2.7:
     eslint-plugin-fxa: ^2.0.2
     eslint-plugin-jest: ^23.13.2
     eslint-plugin-react: 7.19.0
+    fxa-auth-client: "workspace:*"
     fxa-react: "workspace:*"
     fxa-shared: "workspace:*"
     graphql: ^14.6.0
-    graphql-tag: ^2.10.3
     node-sass: ^4.14.0
     npm-run-all: ^4.1.5
     pm2: ^4.4.0
@@ -16178,6 +16191,7 @@ fsevents@^1.2.7:
     react: ^16.13.1
     react-dom: ^16.13.1
     react-scripts: ^3.4.1
+    subscriptions-transport-ws: ^0.9.11
     tailwindcss: ^1.4.6
     typescript: 3.8.3
     webpack: ^4.43.0
@@ -16977,7 +16991,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graphql-tag@npm:^2.10.1, graphql-tag@npm:^2.10.3, graphql-tag@npm:^2.4.2, graphql-tag@npm:^2.9.2":
+"graphql-tag@npm:^2.11.0":
+  version: 2.11.0
+  resolution: "graphql-tag@npm:2.11.0"
+  peerDependencies:
+    graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+  checksum: 400355590180cce2f39df5c599cad20ee982bb7e4a63ad70857aa0fe2e82e3ef6233a4db2b80a03e6dfa84bf3ecb13dc2947936eaf31753c94876e22be45ea78
+  languageName: node
+  linkType: hard
+
+"graphql-tag@npm:^2.4.2, graphql-tag@npm:^2.9.2":
   version: 2.10.3
   resolution: "graphql-tag@npm:2.10.3"
   peerDependencies:
@@ -17795,7 +17818,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.3.0":
+"hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -24395,12 +24418,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"optimism@npm:^0.11.5":
-  version: 0.11.5
-  resolution: "optimism@npm:0.11.5"
+"optimism@npm:^0.12.1":
+  version: 0.12.1
+  resolution: "optimism@npm:0.12.1"
   dependencies:
-    "@wry/context": ^0.5.0
-  checksum: f8d746eb1e6a0cc27588cd84debb1dc3dd3c9cfce7b1e85c60f462c73d0756d03dcb61fd444419073c02f0722e8af19408c9208a3418247cf8c1a922faed66f3
+    "@wry/context": ^0.5.2
+  checksum: 3e2a62ca68bd766087b814782ec174f49863b8419af1db5ac6325803041799bd9c04e288ec1ec37f05d82072f5ae0194d0df095fb169eb639fee03f3986be868
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This provides the base functionality needed for fxa-settings to make api calls to the auth-server. There's an `AuthContext.Provider` initialized in index.tsx and the `useAuth` hook to retrieve the client from components.

This is a pared down version of #6109 which is more of a POC. That one has a functional example of change password.