### PR TITLE
fix(payments): ensure SCA flow sends download email and triggers customer update

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.ts
@@ -698,6 +698,29 @@ class DirectStripeRoutes {
       subIdempotencyKey,
     });
 
+    await this.customerChanged(request, uid, email);
+
+    const account = await this.db.account(uid);
+    const selectedPlan = await this.stripeHelper.findPlanById(priceId);
+    const productId = selectedPlan.product_id;
+    const productMetadata = metadataFromPlan(selectedPlan);
+    await this.mailer.sendDownloadSubscriptionEmail(account.emails, account, {
+      acceptLanguage: account.locale,
+      productId,
+      planId: priceId,
+      planName: selectedPlan.plan_name,
+      productName: selectedPlan.product_name,
+      planEmailIconURL: productMetadata.emailIconURL,
+      planDownloadURL: productMetadata.downloadURL,
+      appStoreLink: productMetadata.appStoreLink,
+      playStoreLink: productMetadata.playStoreLink,
+      productMetadata,
+    });
+    this.log.info('subscriptions.createSubscriptionWithPMI.success', {
+      uid,
+      subscriptionId: subscription.id,
+    });
+
     return filterSubscription(subscription);
   }
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -743,6 +743,13 @@ describe('DirectStripeRoutes', () => {
   });
 
   describe('createSubscriptionWithPMI', () => {
+    const plan = PLANS[2];
+
+    beforeEach(() => {
+      directStripeRoutesInstance.stripeHelper.findPlanById.resolves(plan);
+      sandbox.stub(directStripeRoutesInstance, 'customerChanged').resolves();
+    });
+
     it('creates a subscription with a payment method', async () => {
       const customer = deepCopy(emptyCustomer);
       directStripeRoutesInstance.stripeHelper.customer.resolves(customer);
@@ -759,6 +766,14 @@ describe('DirectStripeRoutes', () => {
       const actual = await directStripeRoutesInstance.createSubscriptionWithPMI(
         VALID_REQUEST
       );
+
+      sinon.assert.calledWith(
+        directStripeRoutesInstance.customerChanged,
+        VALID_REQUEST,
+        UID,
+        TEST_EMAIL
+      );
+      assert.isTrue(mailer.sendDownloadSubscriptionEmail.calledOnce);
 
       assert.deepEqual(filterSubscription(expected), actual);
     });
@@ -808,6 +823,13 @@ describe('DirectStripeRoutes', () => {
           subIdempotencyKey: `${idempotencyKey}-createSub`,
         }
       );
+      sinon.assert.calledWith(
+        directStripeRoutesInstance.customerChanged,
+        VALID_REQUEST,
+        UID,
+        TEST_EMAIL
+      );
+      assert.isTrue(mailer.sendDownloadSubscriptionEmail.calledOnce);
     });
   });
 


### PR DESCRIPTION
I noticed that I didn't get a download email after going through the new SCA subscription flow. Also, we didn't trigger `customerChanged`, which invalidates the profile cache and forces a customer cache update along with some other messaging.