### PR TITLE
Release 182.2

### DIFF
--- a/packages/fxa-auth-db-mysql/CHANGELOG.md
+++ b/packages/fxa-auth-db-mysql/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.182.2
+
+No changes.
+
 ## 1.182.1
 
 No changes.

--- a/packages/fxa-auth-db-mysql/package.json
+++ b/packages/fxa-auth-db-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-db-mysql",
-  "version": "1.182.1",
+  "version": "1.182.2",
   "description": "MySQL backend for Firefox Accounts",
   "main": "index.js",
   "repository": {

--- a/packages/fxa-auth-server/CHANGELOG.md
+++ b/packages/fxa-auth-server/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.182.2
+
+### Bug fixes
+
+- payments: ensure Customer data is not cached with an expiration TTL ([0dced12c6](https://github.com/mozilla/fxa/commit/0dced12c6))
+
 ## 1.182.1
 
 ### Bug fixes

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.182.1",
+  "version": "1.182.2",
   "description": "Firefox Accounts, an identity provider for Mozilla cloud services",
   "bin": {
     "fxa-auth": "./bin/key_server.js"

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -439,6 +439,13 @@ describe('StripeHelper', () => {
       assert.lengthOf(await stripeHelper.allPlans(), 3);
       assert(mockRedis.get.calledTwice);
       assert(mockRedis.set.calledOnce);
+
+      // Assert that a TTL was set for this cache entry
+      assert.deepEqual(mockRedis.set.args[0][2], [
+        'EX',
+        mockConfig.subhub.plansCacheTtlSeconds,
+      ]);
+
       assert(stripeHelper.stripe.plans.list.calledOnce);
 
       assert.deepEqual(
@@ -532,6 +539,13 @@ describe('StripeHelper', () => {
       assert.lengthOf(await stripeHelper.allProducts(), 3);
       assert(mockRedis.get.calledTwice);
       assert(mockRedis.set.calledOnce);
+
+      // Assert that a TTL was set for this cache entry
+      assert.deepEqual(mockRedis.set.args[0][2], [
+        'EX',
+        mockConfig.subhub.plansCacheTtlSeconds,
+      ]);
+
       assert(stripeHelper.stripe.products.list.calledOnce);
 
       assert.deepEqual(
@@ -1130,6 +1144,9 @@ describe('StripeHelper', () => {
         );
         assert(mockRedis.get.calledOnce);
         assert(mockRedis.set.calledOnce);
+
+        // Assert that no TTL was set for this cache entry - i.e. [ 'EX', 600 ] should not appear.
+        assert.deepEqual(mockRedis.set.args[0][2], []);
 
         assert.deepEqual(
           await stripeHelper.customer({ uid, email }),

--- a/packages/fxa-content-server/CHANGELOG.md
+++ b/packages/fxa-content-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.182.2
+
+No changes.
+
 ## 1.182.1
 
 No changes.

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "1.182.1",
+  "version": "1.182.2",
   "description": "Firefox Accounts Content Server",
   "scripts": {
     "build": "tsc --build ../fxa-react && NODE_ENV=production grunt build",

--- a/packages/fxa-customs-server/CHANGELOG.md
+++ b/packages/fxa-customs-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.182.2
+
+No changes.
+
 ## 1.182.1
 
 No changes.

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-customs-server",
-  "version": "1.182.1",
+  "version": "1.182.2",
   "description": "Firefox Accounts Customs Server",
   "author": "Mozilla (https://mozilla.org/)",
   "license": "MPL-2.0",

--- a/packages/fxa-email-event-proxy/package.json
+++ b/packages/fxa-email-event-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-email-event-proxy",
-  "version": "1.182.1",
+  "version": "1.182.2",
   "description": "Proxies events from Sendgrid to FxA SQS queues",
   "main": "index.js",
   "scripts": {

--- a/packages/fxa-email-service/CHANGELOG.md
+++ b/packages/fxa-email-service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.182.2
+
+No changes.
+
 ## 1.182.1
 
 No changes.

--- a/packages/fxa-email-service/Cargo.lock
+++ b/packages/fxa-email-service/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "fxa_email_service"
-version = "1.182.1"
+version = "1.182.2"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/packages/fxa-email-service/Cargo.toml
+++ b/packages/fxa-email-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fxa_email_service"
-version = "1.182.1"
+version = "1.182.2"
 publish = false
 edition = "2018"
 

--- a/packages/fxa-event-broker/CHANGELOG.md
+++ b/packages/fxa-event-broker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.182.2
+
+No changes.
+
 ## 1.182.1
 
 No changes.

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-event-broker",
-  "version": "1.182.1",
+  "version": "1.182.2",
   "description": "Firefox Accounts Event Broker",
   "scripts": {
     "build": "tsc",

--- a/packages/fxa-geodb/CHANGELOG.md
+++ b/packages/fxa-geodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.182.2
+
+No changes.
+
 ## 1.182.1
 
 No changes.

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-geodb",
-  "version": "1.182.1",
+  "version": "1.182.2",
   "description": "Firefox Accounts GeoDB Repo for Geolocation based services",
   "main": "lib/fxa-geodb.js",
   "directories": {

--- a/packages/fxa-payments-server/CHANGELOG.md
+++ b/packages/fxa-payments-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.182.2
+
+No changes.
+
 ## 1.182.1
 
 No changes.

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-payments-server",
-  "version": "1.182.1",
+  "version": "1.182.2",
   "description": "Firefox Accounts Payments Service",
   "scripts": {
     "postinstall": "scripts/download_l10n.sh",

--- a/packages/fxa-profile-server/CHANGELOG.md
+++ b/packages/fxa-profile-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.182.2
+
+No changes.
+
 ## 1.182.1
 
 No changes.

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-profile-server",
-  "version": "1.182.1",
+  "version": "1.182.2",
   "private": true,
   "description": "Firefox Accounts Profile service.",
   "scripts": {

--- a/packages/fxa-shared/CHANGELOG.md
+++ b/packages/fxa-shared/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.182.2
+
+No changes.
+
 ## 1.182.1
 
 No changes.

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.182.1",
+  "version": "1.182.2",
   "description": "Shared module for FxA repositories",
   "main": "dist/index.js",
   "exports": {

--- a/packages/fxa-support-panel/CHANGELOG.md
+++ b/packages/fxa-support-panel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.182.2
+
+No changes.
+
 ## 1.182.1
 
 No changes.

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-support-panel",
-  "version": "1.182.1",
+  "version": "1.182.2",
   "description": "Small app to help customer support access FxA details",
   "directories": {
     "test": "test"


### PR DESCRIPTION
Just in case anyone else is fuzzy on how this "point release" or "dot release" thing works, I'm following the 'cherry-pick from main into train branch' approach documented in the release docs [as "another option for a patch release"](https://mozilla.github.io/ecosystem-platform/docs/fxa-engineering/release-process#another-option-for-a-patch-release):

1. revive the train-182 branch that had been deleted the last time we did a dot release, nbd
2. cherry-pick the required commit into the branch locally
3. run `./release.sh patch` to generate the tags and changelogs locally (see below for the raw script output just FYI)
4. push the branch and tag to the `origin` remote
5. per instructions from the `release.sh` script output, update the ops deploy [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1656387#c8) for the 182 release
6. open this pull request to land the cherry-picked changes and updated changelogs into the train-182 branch

Here's the script output for further edification:
 
```
[09:43:09 fxa.tagging (train-182) ]$ ./release.sh patch
husky > pre-commit (node v12.18.2)
✔ Preparing...
✔ Running tasks...
✔ Applying modifications...
✔ Cleaning up... 
[train-182 d2676cea6] Release 1.182.2
 24 files changed, 59 insertions(+), 13 deletions(-)

Success! The release has been tagged locally but it hasn't been pushed.
Before pushing, you should check that the changes appear to be sane.
At the very least, eyeball the diffs and git log.
If you're feeling particularly vigilant, you may want to run some of the tests and linters too.

Branch:

  train-182

Tag:

  v1.182.2

When you're ready to push, paste the following lines into your terminal:

git push origin train-182
git push origin v1.182.2

After that, you must open pull a request to merge the changes back to main:

  https://github.com/mozilla/fxa/compare/train-182?expand=1

Ask for review on the pull requests from @fxa-devs

Don't forget to leave a comment in the deploy bug.

### Tags

* https://github.com/mozilla/fxa/releases/tag/v1.182.2

### Pertinent changelogs

* https://github.com/mozilla/fxa/blob/v1.182.2/packages/fxa-auth-server/CHANGELOG.md
```



## Because

- we haz a boog

## This pull request

- return FxA to zarro boogs!

## Issue that this pull request solves

Refs: #6097