### PR TITLE
feat(totp): remove session verification requirement from /totp/exists

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -933,7 +933,7 @@ export default class AuthClient {
     return this.sessionPost('/totp/destroy', sessionToken, {});
   }
 
-  async checkTotpTokenExists(sessionToken: string) {
+  async checkTotpTokenExists(sessionToken: string): Promise<{ exists: boolean, verified: boolean }> {
     return this.sessionGet('/totp/exists', sessionToken);
   }
 

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -197,10 +197,6 @@ module.exports = (log, db, mailer, customs, config) => {
 
         const sessionToken = request.auth.credentials;
 
-        if (sessionToken.tokenVerificationId) {
-          throw errors.unverifiedSession();
-        }
-
         try {
           const token = await db.totpToken(sessionToken.uid);
           return {

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -157,18 +157,6 @@ describe('totp', () => {
         assert.equal(db.totpToken.callCount, 1, 'called get TOTP token');
       });
     });
-
-    it('should be disabled in unverified session', () => {
-      requestOptions.credentials.tokenVerificationId = 'notverified';
-      return setup(
-        { db: { email: TEST_EMAIL } },
-        {},
-        '/totp/exists',
-        requestOptions
-      ).then(assert.fail, (err) => {
-        assert.deepEqual(err.errno, 138, 'unverified session error');
-      });
-    });
   });
 
   describe('/session/verify/totp', () => {

--- a/packages/fxa-auth-server/test/remote/totp_tests.js
+++ b/packages/fxa-auth-server/test/remote/totp_tests.js
@@ -94,20 +94,6 @@ describe('remote totp', function () {
     });
   });
 
-  it('should fail check for totp token if in unverified session', () => {
-    email = server.uniqueEmail();
-    return client
-      .login()
-      .then(() => client.sessionStatus())
-      .then((result) => {
-        assert.equal(result.state, 'unverified', 'session is unverified');
-        return client.checkTotpTokenExists();
-      })
-      .then(assert.fail, (err) => {
-        assert.equal(err.errno, 138, 'correct unverified session errno');
-      });
-  });
-
   it('should fail to create second totp token for same user', () => {
     return client.createTotpToken().then(assert.fail, (err) => {
       assert.equal(err.code, 400, 'correct error code');


### PR DESCRIPTION
Because the new settings page shows the enabled state more prominently and the data returned by this call isn't sensitive it makes more sense to lower the restriction than to burden the frontend with a more complicated design.