### PR TITLE
feat(payments): implement metrics for SCA flows

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -751,6 +751,10 @@ describe('DirectStripeRoutes', () => {
     });
 
     it('creates a subscription with a payment method', async () => {
+      const sourceCountry = 'us';
+      directStripeRoutesInstance.stripeHelper.extractSourceCountryFromSubscription.returns(
+        sourceCountry
+      );
       const customer = deepCopy(emptyCustomer);
       directStripeRoutesInstance.stripeHelper.customer.resolves(customer);
       const expected = deepCopy(subscription2);
@@ -775,7 +779,13 @@ describe('DirectStripeRoutes', () => {
       );
       assert.isTrue(mailer.sendDownloadSubscriptionEmail.calledOnce);
 
-      assert.deepEqual(filterSubscription(expected), actual);
+      assert.deepEqual(
+        {
+          sourceCountry,
+          subscription: filterSubscription(expected),
+        },
+        actual
+      );
     });
 
     it('errors when a customer has not been created', async () => {
@@ -796,6 +806,10 @@ describe('DirectStripeRoutes', () => {
     });
 
     it('creates a subscription without an payment id in the request', async () => {
+      const sourceCountry = 'us';
+      directStripeRoutesInstance.stripeHelper.extractSourceCountryFromSubscription.returns(
+        sourceCountry
+      );
       const customer = deepCopy(emptyCustomer);
       directStripeRoutesInstance.stripeHelper.customer.resolves(customer);
       const expected = deepCopy(subscription2);
@@ -813,7 +827,13 @@ describe('DirectStripeRoutes', () => {
         VALID_REQUEST
       );
 
-      assert.deepEqual(filterSubscription(expected), actual);
+      assert.deepEqual(
+        {
+          sourceCountry,
+          subscription: filterSubscription(expected),
+        },
+        actual
+      );
       sinon.assert.calledWith(
         directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI,
         {

--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -10,6 +10,8 @@ const eventGroupNames = {
   updatePayment: 'subPayManage',
   cancelSubscription: 'subCancel',
   manageSubscriptions: 'subManage',
+  createSubscriptionWithPaymentMethod: 'subPaySetup',
+  updateDefaultPaymentMethod: 'subPayManage',
 } as const;
 
 const eventTypeNames = {
@@ -19,6 +21,11 @@ const eventTypeNames = {
   success: 'success',
   fail: 'fail',
   complete: 'complete',
+
+  submit3DS: '3ds-submit',
+  success3DS: '3ds-success',
+  fail3DS: '3ds-fail',
+  complete3DS: '3ds-complete',
 } as const;
 
 type GlobalEventProperties = {
@@ -201,6 +208,76 @@ export function updatePayment_REJECTED(eventProperties: EventProperties) {
   safeLogAmplitudeEvent(
     eventGroupNames.updatePayment,
     eventTypeNames.fail,
+    eventProperties
+  );
+}
+
+export function createSubscriptionWithPaymentMethod_PENDING(
+  eventProperties: EventProperties
+) {
+  safeLogAmplitudeEvent(
+    eventGroupNames.createSubscriptionWithPaymentMethod,
+    eventTypeNames.submit,
+    eventProperties
+  );
+}
+
+export function createSubscriptionWithPaymentMethod_FULFILLED(
+  eventProperties: SuccessfulSubscriptionEventProperties
+) {
+  safeLogAmplitudeEvent(
+    eventGroupNames.createSubscriptionWithPaymentMethod,
+    eventTypeNames.success3DS,
+    eventProperties
+  );
+  safeLogAmplitudeEvent(
+    eventGroupNames.createSubscriptionWithPaymentMethod,
+    eventTypeNames.complete3DS,
+    eventProperties
+  );
+}
+
+export function createSubscriptionWithPaymentMethod_REJECTED(
+  eventProperties: EventProperties
+) {
+  safeLogAmplitudeEvent(
+    eventGroupNames.createSubscriptionWithPaymentMethod,
+    eventTypeNames.fail3DS,
+    eventProperties
+  );
+}
+
+export function updateDefaultPaymentMethod_PENDING(
+  eventProperties: EventProperties
+) {
+  safeLogAmplitudeEvent(
+    eventGroupNames.updateDefaultPaymentMethod,
+    eventTypeNames.submit3DS,
+    eventProperties
+  );
+}
+
+export function updateDefaultPaymentMethod_FULFILLED(
+  eventProperties: EventProperties
+) {
+  safeLogAmplitudeEvent(
+    eventGroupNames.updateDefaultPaymentMethod,
+    eventTypeNames.success3DS,
+    eventProperties
+  );
+  safeLogAmplitudeEvent(
+    eventGroupNames.updateDefaultPaymentMethod,
+    eventTypeNames.complete3DS,
+    eventProperties
+  );
+}
+
+export function updateDefaultPaymentMethod_REJECTED(
+  eventProperties: EventProperties
+) {
+  safeLogAmplitudeEvent(
+    eventGroupNames.updateDefaultPaymentMethod,
+    eventTypeNames.fail3DS,
     eventProperties
   );
 }

--- a/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.test.tsx
@@ -212,6 +212,7 @@ describe('routes/ProductV2/SubscriptionCreate', () => {
     ).toMatchObject({
       // idempotencyKey (ignored)
       priceId: PLAN.plan_id,
+      productId: PLAN.product_id,
       paymentMethodId: PAYMENT_METHOD_RESULT.paymentMethod.id,
     });
   };
@@ -263,6 +264,7 @@ describe('routes/ProductV2/SubscriptionCreate', () => {
       ).toMatchObject({
         // idempotencyKey (ignored)
         priceId: PLAN.plan_id,
+        productId: PLAN.product_id,
         paymentMethodId: initialPaymentMethod.paymentMethod.id,
       })
     );
@@ -325,6 +327,7 @@ describe('routes/ProductV2/SubscriptionCreate', () => {
       ).toMatchObject({
         // idempotencyKey (ignored)
         priceId: PLAN.plan_id,
+        productId: PLAN.product_id,
         paymentMethodId: PAYMENT_METHOD_RESULT.paymentMethod.id,
       })
     );
@@ -572,6 +575,7 @@ describe('routes/ProductV2/SubscriptionCreate', () => {
         ).toMatchObject({
           // idempotencyKey (ignored)
           priceId: PLAN.plan_id,
+          productId: PLAN.product_id,
           paymentMethodId: PAYMENT_METHOD_RESULT.paymentMethod.id,
         })
       );

--- a/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.tsx
@@ -270,6 +270,7 @@ async function handleSubscriptionPayment({
     const createSubscriptionResult = await apiCreateSubscriptionWithPaymentMethod(
       {
         priceId: selectedPlan.plan_id,
+        productId: selectedPlan.product_id,
         paymentMethodId: paymentMethod.id,
         idempotencyKey,
       }


### PR DESCRIPTION
- expand response from SCA subscription create to add sourceCountry

- add amplitude lifecycle events for SCA subscription create and payment
  update APIs

- wrap SCA API client methods in Amplitude lifecycle event pings

fixes #6136
