### PR TITLE
refactor(subscriptions): use a single payment update form

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -198,30 +198,31 @@ plan-price-year = { $intervalCount ->
   *[other] { $amount } every { $intervalCount } years
 }
 
-## payment update
-##  $name (String) - The name of the subscribed product.
-##  $amount (Number) - The amount billed. It will be formatted as currency.
-##  $date (Date) - The date for the next time a charge will occur.
+
+## subscription billing details
+## $amount (Number) - The amount billed. It will be formatted as currency.
 #  $intervalCount (Number) - The interval between payments, in days.
-pay-update-billing-description-day = { $intervalCount ->
-  [one] You are billed { $amount } daily for { $name }. Your next payment occurs on { $date }.
-  *[other] You are billed { $amount } every { $intervalCount } days for { $name }. Your next payment occurs on { $date }.
+sub-plan-price-day = { $intervalCount ->
+  [one] { $amount } daily
+  *[other] { $amount } every { $intervalCount } days
 }
 #  $intervalCount (Number) - The interval between payments, in weeks.
-pay-update-billing-description-week = { $intervalCount ->
-  [one] You are billed { $amount } weekly for { $name }. Your next payment occurs on { $date }.
-  *[other] You are billed { $amount } every { $intervalCount } weeks for { $name }. Your next payment occurs on { $date }.
+sub-plan-price-week = { $intervalCount ->
+  [one] { $amount } weekly
+  *[other] { $amount } every { $intervalCount } weeks
 }
 #  $intervalCount (Number) - The interval between payments, in months.
-pay-update-billing-description-month = { $intervalCount ->
-  [one] You are billed { $amount } monthly for { $name }. Your next payment occurs on { $date }.
-  *[other] You are billed { $amount } every { $intervalCount } months for { $name }. Your next payment occurs on { $date }.
+sub-plan-price-month = { $intervalCount ->
+  [one] { $amount } monthly
+  *[other] { $amount } every { $intervalCount } months
 }
 #  $intervalCount (Number) - The interval between payments, in years.
-pay-update-billing-description-year = { $intervalCount ->
-  [one] You are billed { $amount } yearly for { $name }. Your next payment occurs on { $date }.
-  *[other] You are billed { $amount } every { $intervalCount } years for { $name }. Your next payment occurs on { $date }.
+sub-plan-price-year = { $intervalCount ->
+  [one] { $amount } yearly
+  *[other] { $amount } every { $intervalCount } years
 }
+## $date (Date) - The date for the next time a charge will occur.
+sub-next-bill = Next billed on { $date }
 
 ##
 pay-update-card-exp = Expires { $expirationDate }

--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -167,40 +167,36 @@ export function createSubscription_REJECTED(eventProperties: EventProperties) {
   );
 }
 
-export function updatePaymentMounted(eventProperties: EventProperties) {
-  safeLogAmplitudeEvent(
-    eventGroupNames.updatePayment,
-    eventTypeNames.view,
-    eventProperties
-  );
+export function updatePaymentMounted() {
+  safeLogAmplitudeEvent(eventGroupNames.updatePayment, eventTypeNames.view, {});
 }
 
-export function updatePaymentEngaged(eventProperties: EventProperties) {
+export function updatePaymentEngaged() {
   safeLogAmplitudeEvent(
     eventGroupNames.updatePayment,
     eventTypeNames.engage,
-    eventProperties
+    {}
   );
 }
 
-export function updatePayment_PENDING(eventProperties: EventProperties) {
+export function updatePayment_PENDING() {
   safeLogAmplitudeEvent(
     eventGroupNames.updatePayment,
     eventTypeNames.submit,
-    eventProperties
+    {}
   );
 }
 
-export function updatePayment_FULFILLED(eventProperties: EventProperties) {
+export function updatePayment_FULFILLED() {
   safeLogAmplitudeEvent(
     eventGroupNames.updatePayment,
     eventTypeNames.success,
-    eventProperties
+    {}
   );
   safeLogAmplitudeEvent(
     eventGroupNames.updatePayment,
     eventTypeNames.complete,
-    eventProperties
+    {}
   );
 }
 
@@ -247,28 +243,24 @@ export function createSubscriptionWithPaymentMethod_REJECTED(
   );
 }
 
-export function updateDefaultPaymentMethod_PENDING(
-  eventProperties: EventProperties
-) {
+export function updateDefaultPaymentMethod_PENDING() {
   safeLogAmplitudeEvent(
     eventGroupNames.updateDefaultPaymentMethod,
     eventTypeNames.submit3DS,
-    eventProperties
+    {}
   );
 }
 
-export function updateDefaultPaymentMethod_FULFILLED(
-  eventProperties: EventProperties
-) {
+export function updateDefaultPaymentMethod_FULFILLED() {
   safeLogAmplitudeEvent(
     eventGroupNames.updateDefaultPaymentMethod,
     eventTypeNames.success3DS,
-    eventProperties
+    {}
   );
   safeLogAmplitudeEvent(
     eventGroupNames.updateDefaultPaymentMethod,
     eventTypeNames.complete3DS,
-    eventProperties
+    {}
   );
 }
 

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -347,18 +347,14 @@ describe('API requests', () => {
       productId: 'prod_4567',
       paymentToken: 'pmt_234234',
     };
-    const metricsOptions = {
-      planId: params.planId,
-      productId: params.productId,
-    };
 
     it('POST {auth-server}/v1/oauth/subscriptions/updatePayment', async () => {
       const requestMock = nock(AUTH_BASE_URL)
         .post(path, { paymentToken: params.paymentToken })
         .reply(200, {});
       expect(await apiUpdatePayment(params)).toEqual({});
-      expect(<jest.Mock>updatePayment_PENDING).toBeCalledWith(metricsOptions);
-      expect(<jest.Mock>updatePayment_FULFILLED).toBeCalledWith(metricsOptions);
+      expect(<jest.Mock>updatePayment_PENDING).toBeCalledWith();
+      expect(<jest.Mock>updatePayment_FULFILLED).toBeCalledWith();
       requestMock.done();
     });
 
@@ -373,9 +369,8 @@ describe('API requests', () => {
         error = e;
       }
       expect(error).not.toBeNull();
-      expect(<jest.Mock>updatePayment_PENDING).toBeCalledWith(metricsOptions);
+      expect(<jest.Mock>updatePayment_PENDING).toBeCalledWith();
       expect(<jest.Mock>updatePayment_REJECTED).toBeCalledWith({
-        ...metricsOptions,
         error,
       });
       requestMock.done();
@@ -513,12 +508,8 @@ describe('API requests', () => {
         MOCK_CUSTOMER
       );
 
-      expect(<jest.Mock>updateDefaultPaymentMethod_PENDING).toBeCalledWith(
-        metricsOptions
-      );
-      expect(<jest.Mock>updateDefaultPaymentMethod_FULFILLED).toBeCalledWith({
-        ...metricsOptions,
-      });
+      expect(<jest.Mock>updateDefaultPaymentMethod_PENDING).toBeCalledWith();
+      expect(<jest.Mock>updateDefaultPaymentMethod_FULFILLED).toBeCalledWith();
       requestMock.done();
     });
 
@@ -534,11 +525,8 @@ describe('API requests', () => {
         error = e;
       }
       expect(error).not.toBeNull();
-      expect(<jest.Mock>updateDefaultPaymentMethod_PENDING).toBeCalledWith(
-        metricsOptions
-      );
+      expect(<jest.Mock>updateDefaultPaymentMethod_PENDING).toBeCalledWith();
       expect(<jest.Mock>updateDefaultPaymentMethod_REJECTED).toBeCalledWith({
-        ...metricsOptions,
         error,
       });
       requestMock.done();

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -231,27 +231,18 @@ export async function apiReactivateSubscription({
   };
 }
 
-export async function apiUpdatePayment(params: {
-  planId: string;
-  productId: string;
-  paymentToken: string;
-}) {
-  const metricsOptions = {
-    planId: params.planId,
-    productId: params.productId,
-  };
+export async function apiUpdatePayment(params: { paymentToken: string }) {
   try {
-    Amplitude.updatePayment_PENDING(metricsOptions);
+    Amplitude.updatePayment_PENDING();
     const result = await apiFetch(
       'POST',
       `${config.servers.auth.url}/v1/oauth/subscriptions/updatePayment`,
       { body: JSON.stringify({ paymentToken: params.paymentToken }) }
     );
-    Amplitude.updatePayment_FULFILLED(metricsOptions);
+    Amplitude.updatePayment_FULFILLED();
     return result;
   } catch (error) {
     Amplitude.updatePayment_REJECTED({
-      ...metricsOptions,
       error,
     });
     throw error;
@@ -349,19 +340,17 @@ export async function apiUpdateDefaultPaymentMethod(params: {
   paymentMethodId: string;
 }): Promise<Customer> {
   const { paymentMethodId } = params;
-  const metricsOptions = {};
   try {
-    Amplitude.updateDefaultPaymentMethod_PENDING(metricsOptions);
+    Amplitude.updateDefaultPaymentMethod_PENDING();
     const result = await apiFetch(
       'POST',
       `${config.servers.auth.url}/v1/oauth/subscriptions/paymentmethod/default`,
       { body: JSON.stringify({ paymentMethodId }) }
     );
-    Amplitude.updateDefaultPaymentMethod_FULFILLED(metricsOptions);
+    Amplitude.updateDefaultPaymentMethod_FULFILLED();
     return result;
   } catch (error) {
     Amplitude.updateDefaultPaymentMethod_REJECTED({
-      ...metricsOptions,
       error,
     });
     throw error;

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -509,6 +509,7 @@ export const MOCK_CUSTOMER = {
       cancel_at_period_end: false,
       current_period_start: 1565816388.815,
       current_period_end: 1568408388.815,
+      end_at: null,
     },
   ],
 };

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.test.tsx
@@ -1,0 +1,227 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen, render, act, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import waitForExpect from 'wait-for-expect';
+import * as Amplitude from '../../../lib/amplitude';
+jest.mock('../../../lib/amplitude');
+import CancelSubscriptionPanel, {
+  CancelSubscriptionPanelProps,
+} from './CancelSubscriptionPanel';
+
+import { MOCK_PLANS, MOCK_CUSTOMER } from '../../../lib/test-utils';
+import { Plan } from 'fxa-payments-server/src/store/types';
+import {
+  formatPlanPricing,
+  getLocalizedDateString,
+} from 'fxa-payments-server/src/lib/formats';
+import { defaultState } from 'fxa-payments-server/src/store/state';
+import { FluentBundle, FluentResource } from '@fluent/bundle';
+import { LocalizationProvider } from '@fluent/react';
+
+const { queryByTestId, queryByText, queryAllByText, getByTestId } = screen;
+
+const findMockPlan = (planId: string): Plan => {
+  const plan = MOCK_PLANS.find((x) => x.plan_id === planId);
+  if (plan) {
+    return plan;
+  }
+  throw new Error('unable to find suitable Plan object for test execution.');
+};
+
+describe('CancelSubscriptionPanel', () => {
+  const subscription = MOCK_CUSTOMER.subscriptions[0];
+  const baseProps = {
+    customerSubscription: subscription,
+    cancelSubscription: jest.fn().mockResolvedValue(null),
+    cancelSubscriptionStatus: defaultState.cancelSubscription,
+  };
+
+  afterEach(() => {
+    baseProps.cancelSubscription.mockClear();
+  });
+
+  describe('renders', () => {
+    for (const [k, v] of Object.entries({
+      day: 'daily',
+      week: 'weekly',
+      month: 'monthly',
+      year: 'yearly',
+    })) {
+      describe(`when plan has ${k} interval`, () => {
+        const runTests = (props: CancelSubscriptionPanelProps) => {
+          render(<CancelSubscriptionPanel {...props} />);
+
+          const planPrice = formatPlanPricing(
+            props.plan.amount,
+            props.plan.currency,
+            props.plan.interval,
+            props.plan.interval_count
+          );
+          const nextBillDate = getLocalizedDateString(
+            subscription.current_period_end,
+            true
+          );
+          const nextBill = `Next billed on ${nextBillDate}`;
+
+          expect(queryByTestId('price-details')).toBeInTheDocument();
+          expect(queryByText(planPrice)).toBeInTheDocument();
+          expect(queryByText(nextBill)).toBeInTheDocument();
+          expect(
+            queryByTestId('reveal-cancel-subscription-button')
+          ).toBeInTheDocument();
+        };
+
+        it('handles an interval count of 1', () => {
+          const plan_id = `plan_${v}`;
+          const plan = findMockPlan(plan_id);
+          runTests({ plan, ...baseProps });
+        });
+
+        it('handles an interval count that is not 1', () => {
+          const plan_id = `plan_6${k}s`;
+          const plan = findMockPlan(plan_id);
+          runTests({ plan, ...baseProps });
+        });
+      });
+    }
+
+    describe('upgrade CTA', () => {
+      it('should not be displayed when upgradeCTA is not in the plan', () => {
+        const plan = findMockPlan('plan_daily');
+        render(<CancelSubscriptionPanel {...baseProps} plan={plan} />);
+        expect(queryByTestId('upgrade-cta')).not.toBeInTheDocument();
+      });
+
+      it('should be displayed when upgradeCTA is in the plan', () => {
+        const plan = findMockPlan('plan_daily');
+        const upgradeablePlan = {
+          ...plan,
+          plan_metadata: {
+            upgradeCTA: 'Upgrade to the ultra super premium plus plan!',
+          },
+        };
+        render(
+          <CancelSubscriptionPanel {...baseProps} plan={upgradeablePlan} />
+        );
+        expect(queryByTestId('upgrade-cta')).toBeInTheDocument();
+        expect(
+          queryByText(upgradeablePlan.plan_metadata.upgradeCTA)
+        ).toBeInTheDocument();
+      });
+    });
+
+    describe('with l10n', () => {
+      it('displays the correct pricing info with interval of 1', () => {
+        const bundle = new FluentBundle('gd', { useIsolating: false });
+        [
+          `sub-plan-price-day = { $intervalCount ->
+            [one] { $amount } fooly
+            *[other] { $amount } barly { $intervalCount } 24hrs
+          }`,
+          'sub-next-bill = quuz { $date }',
+          'payment-cancel-btn = blee',
+        ].forEach((x) => bundle.addResource(new FluentResource(x)));
+        const plan = findMockPlan('plan_daily');
+        render(
+          <LocalizationProvider bundles={[bundle]}>
+            <CancelSubscriptionPanel {...baseProps} plan={plan} />
+          </LocalizationProvider>
+        );
+        expect(queryByText('$5.00 fooly')).toBeInTheDocument();
+        expect(queryByText('quuz 09/13/2019')).toBeInTheDocument();
+        expect(queryByText('blee')).toBeInTheDocument();
+      });
+
+      it('displays the correct pricing info with interval > 1', () => {
+        const bundle = new FluentBundle('gd', { useIsolating: false });
+        [
+          `sub-plan-price-day = { $intervalCount ->
+            [one] { $amount } fooly
+            *[other] { $amount } barly { $intervalCount } 24hrs
+          }`,
+        ].forEach((x) => bundle.addResource(new FluentResource(x)));
+        const plan = { ...findMockPlan('plan_daily'), interval_count: 8 };
+
+        render(
+          <LocalizationProvider bundles={[bundle]}>
+            <CancelSubscriptionPanel {...baseProps} plan={plan} />
+          </LocalizationProvider>
+        );
+        expect(queryByText('$5.00 barly 8 24hrs')).toBeInTheDocument();
+      });
+
+      it('displays the correct cancellation info', () => {
+        const bundle = new FluentBundle('gd', { useIsolating: false });
+        [
+          'sub-item-cancel-sub = no more',
+          `sub-item-cancel-msg =
+            Fromage pecorino blue castello { $name } after { $period }, sorry dude.`,
+          `sub-item-cancel-confirm =
+            Stilton when everybody's { $name } on { $period }.`,
+          'sub-item-stay-sub = haha never mind',
+        ].forEach((x) => bundle.addResource(new FluentResource(x)));
+        const plan = findMockPlan('plan_daily');
+        render(
+          <LocalizationProvider bundles={[bundle]}>
+            <CancelSubscriptionPanel {...baseProps} plan={plan} />
+          </LocalizationProvider>
+        );
+        fireEvent.click(getByTestId('reveal-cancel-subscription-button'));
+        expect(queryAllByText('no more').length).toBe(2);
+        expect(
+          queryByText(
+            'Fromage pecorino blue castello FPN after September 13, 2019, sorry dude.'
+          )
+        ).toBeInTheDocument();
+        expect(
+          queryByText("Stilton when everybody's FPN on September 13, 2019.")
+        ).toBeInTheDocument();
+        expect(queryByText('haha never mind')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('event handling', () => {
+    beforeEach(() => {
+      const plan = findMockPlan('plan_daily');
+      render(<CancelSubscriptionPanel {...baseProps} plan={plan} />);
+    });
+
+    it('closes the cancellation confirmation on Stay Subscribed', () => {
+      fireEvent.click(getByTestId('reveal-cancel-subscription-button'));
+      expect(getByTestId('stay-subscribed-button')).toBeVisible();
+      fireEvent.click(getByTestId('stay-subscribed-button'));
+      expect(getByTestId('reveal-cancel-subscription-button')).toBeVisible();
+    });
+
+    it('enables Cancel Subscription button and confirms cancellation on click', async () => {
+      fireEvent.click(getByTestId('reveal-cancel-subscription-button'));
+      fireEvent.click(getByTestId('confirm-cancel-subscription-checkbox'));
+      expect(getByTestId('cancel-subscription-button')).toBeVisible();
+      expect(getByTestId('cancel-subscription-button')).toBeEnabled();
+      await act(async () => {
+        fireEvent.click(getByTestId('cancel-subscription-button'));
+      });
+      await waitForExpect(() => {
+        expect(baseProps.cancelSubscription).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('Amplitude', () => {
+    it('logs metric events', async () => {
+      (Amplitude.cancelSubscriptionMounted as jest.Mock).mockClear();
+      (Amplitude.cancelSubscriptionEngaged as jest.Mock).mockClear();
+      const plan = findMockPlan('plan_daily');
+      render(<CancelSubscriptionPanel {...baseProps} plan={plan} />);
+      fireEvent.click(getByTestId('reveal-cancel-subscription-button'));
+      expect(Amplitude.cancelSubscriptionMounted).toHaveBeenCalledTimes(1);
+      fireEvent.click(getByTestId('confirm-cancel-subscription-checkbox'));
+      expect(Amplitude.cancelSubscriptionEngaged).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback, useEffect, useRef } from 'react';
+import { Localized } from '@fluent/react';
+import {
+  getLocalizedDate,
+  getLocalizedDateString,
+  formatPlanPricing,
+  getLocalizedCurrency,
+} from '../../../lib/formats';
+import { useCheckboxState } from '../../../lib/hooks';
+import { useBooleanState } from 'fxa-react/lib/hooks';
+import { CustomerSubscription, Plan, Customer } from '../../../store/types';
+import { SelectorReturns } from '../../../store/selectors';
+import { SubscriptionsProps } from '../index';
+import { metadataFromPlan } from 'fxa-shared/subscriptions/metadata';
+import * as Amplitude from '../../../lib/amplitude';
+
+export type CancelSubscriptionPanelProps = {
+  plan: Plan;
+  cancelSubscription: SubscriptionsProps['cancelSubscription'];
+  customerSubscription: CustomerSubscription;
+  cancelSubscriptionStatus: SelectorReturns['cancelSubscriptionStatus'];
+};
+
+const CancelSubscriptionPanel = ({
+  plan,
+  cancelSubscription,
+  customerSubscription: { subscription_id, current_period_end },
+  cancelSubscriptionStatus,
+}: CancelSubscriptionPanelProps) => {
+  const [cancelRevealed, revealCancel, hideCancel] = useBooleanState();
+  const [confirmationChecked, onConfirmationChanged] = useCheckboxState();
+
+  const confirmCancellation = useCallback(() => {
+    cancelSubscription(subscription_id, plan);
+  }, [cancelSubscription, subscription_id, plan]);
+
+  const viewed = useRef(false);
+  const engaged = useRef(false);
+
+  useEffect(() => {
+    if (!viewed.current && cancelRevealed) {
+      Amplitude.cancelSubscriptionMounted(plan);
+      viewed.current = true;
+    }
+  }, [cancelRevealed, viewed, plan]);
+
+  const engage = useCallback(() => {
+    if (!engaged.current) {
+      Amplitude.cancelSubscriptionEngaged(plan);
+      engaged.current = true;
+    }
+  }, [engaged, plan]);
+
+  const engagedOnHideCancel = useCallback(
+    (evt) => {
+      engage();
+      onConfirmationChanged(evt);
+      hideCancel();
+    },
+    [hideCancel, engage]
+  );
+
+  const engagedOnConfirmationChanged = useCallback(
+    (evt) => {
+      engage();
+      onConfirmationChanged(evt);
+    },
+    [onConfirmationChanged, engage]
+  );
+
+  const planPricing = formatPlanPricing(
+    plan.amount,
+    plan.currency,
+    plan.interval,
+    plan.interval_count
+  );
+  const nextBillDate = getLocalizedDateString(current_period_end, true);
+  const nextBill = `Next billed on ${nextBillDate}`;
+  const { upgradeCTA } = metadataFromPlan(plan);
+
+  return (
+    <>
+      <div className="cancel-subscription">
+        {!cancelRevealed ? (
+          <>
+            <div className="with-settings-button">
+              <div className="price-details" data-testid="price-details">
+                <Localized
+                  id={`sub-plan-price-${plan.interval}`}
+                  $amount={getLocalizedCurrency(plan.amount, plan.currency)}
+                  $intervalCount={plan.interval_count}
+                >
+                  <div className="plan-pricing">{planPricing}</div>
+                </Localized>
+                <Localized id="sub-next-bill" $date={nextBillDate}>
+                  <div>{nextBill}</div>
+                </Localized>
+              </div>
+              <div className="action">
+                <button
+                  className="settings-button"
+                  onClick={revealCancel}
+                  data-testid="reveal-cancel-subscription-button"
+                >
+                  <Localized id="payment-cancel-btn">
+                    <span className="change-button">Cancel</span>
+                  </Localized>
+                </button>
+              </div>
+            </div>
+            {upgradeCTA && (
+              <p
+                className="upgrade-cta"
+                data-testid="upgrade-cta"
+                dangerouslySetInnerHTML={{ __html: upgradeCTA }}
+              />
+            )}
+          </>
+        ) : (
+          <>
+            <Localized id="sub-item-cancel-sub">
+              <h3>Cancel Subscription</h3>
+            </Localized>
+            <Localized
+              id="sub-item-cancel-msg"
+              $name={plan.product_name}
+              $period={getLocalizedDate(current_period_end)}
+            >
+              <p>
+                You will no longer be able to use {plan.product_name} after{' '}
+                {getLocalizedDateString(current_period_end)}, the last day of
+                your billing cycle.
+              </p>
+            </Localized>
+            <p>
+              <label>
+                <input
+                  data-testid="confirm-cancel-subscription-checkbox"
+                  type="checkbox"
+                  defaultChecked={confirmationChecked}
+                  onChange={engagedOnConfirmationChanged}
+                />
+                <Localized
+                  id="sub-item-cancel-confirm"
+                  $name={plan.product_name}
+                  $period={getLocalizedDate(current_period_end)}
+                >
+                  <span>
+                    Cancel my access and my saved information within{' '}
+                    {plan.product_name} on{' '}
+                    {getLocalizedDateString(current_period_end, false)}
+                  </span>
+                </Localized>
+              </label>
+            </p>
+            <div className="button-row">
+              <Localized id="sub-item-stay-sub">
+                <button
+                  className="settings-button primary-button"
+                  data-testid="stay-subscribed-button"
+                  onClick={engagedOnHideCancel}
+                >
+                  Stay Subscribed
+                </button>
+              </Localized>
+              <button
+                data-testid="cancel-subscription-button"
+                className="settings-button secondary-button"
+                onClick={confirmCancellation}
+                disabled={
+                  cancelSubscriptionStatus.loading || !confirmationChecked
+                }
+              >
+                {cancelSubscriptionStatus.loading ? (
+                  <span data-testid="spinner-update" className="spinner">
+                    &nbsp;
+                  </span>
+                ) : (
+                  <Localized id="sub-item-cancel-sub">
+                    <span>Cancel Subscription</span>
+                  </Localized>
+                )}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default CancelSubscriptionPanel;

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
@@ -1,318 +1,56 @@
 import React from 'react';
+import { screen, render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import TestRenderer from 'react-test-renderer';
+import { FluentBundle, FluentResource } from '@fluent/bundle';
+import { LocalizationProvider } from '@fluent/react';
 
-import { PaymentUpdateForm } from './PaymentUpdateForm';
-import { Plan } from '../../store/types';
-import {
-  MOCK_PLANS,
-  MOCK_CUSTOMER,
-  setupFluentLocalizationTest,
-  getLocalizedMessage,
-} from '../../lib/test-utils';
-import {
-  getLocalizedDateString,
-  getLocalizedDate,
-  getLocalizedCurrency,
-} from '../../lib/formats';
+import PaymentForm from '../../components/PaymentForm';
+jest.mock('../../components/PaymentForm', () => {
+  return jest.fn().mockImplementation(() => <div></div>);
+});
+import { PaymentUpdateForm, PaymentUpdateFormProps } from './PaymentUpdateForm';
+import { CUSTOMER } from '../../lib/mock-data';
+import defaultState from 'fxa-payments-server/src/store/state';
 
-describe('PaymentUpdateForm', () => {
-  const dayBasedId = 'pay-update-billing-description-day';
-  const weekBasedId = 'pay-update-billing-description-week';
-  const monthBasedId = 'pay-update-billing-description-month';
-  const yearBasedId = 'pay-update-billing-description-year';
-  const subscription = MOCK_CUSTOMER.subscriptions[0];
+const { queryByTestId, queryByText, getByTestId } = screen;
 
-  const findMockPlan = (planId: string): Plan => {
-    const plan = MOCK_PLANS.find((x) => x.plan_id === planId);
-    if (plan) {
-      return plan;
-    }
-    throw new Error('unable to find suitable Plan object for test execution.');
-  };
+const baseProps: PaymentUpdateFormProps = {
+  customer: CUSTOMER,
+  resetUpdatePayment: jest.fn(),
+  updatePayment: jest.fn().mockResolvedValue(null),
+  updatePaymentStatus: defaultState.updatePayment,
+};
 
-  const baseProps = {
-    customerSubscription: subscription,
-    customer: MOCK_CUSTOMER,
-    updatePayment: jest.fn(),
-    resetUpdatePayment: jest.fn(),
-    updatePaymentStatus: {
-      error: null,
-      loading: false,
-      result: null,
-    },
-  };
-
-  describe('Localized Plan Billing Description Component', () => {
-    function runTests(props: any, expectedMsgId: string, expectedMsg: string) {
-      const testRenderer = TestRenderer.create(
-        <PaymentUpdateForm {...props} />
-      );
-      const testInstance = testRenderer.root;
-      const billingDetails = testInstance.findByProps({ id: expectedMsgId });
-      const expectedAmount = getLocalizedCurrency(
-        props.plan.amount,
-        props.plan.currency
-      );
-      const expectedDate = getLocalizedDate(
-        props.customerSubscription.current_period_end,
-        true
-      );
-
-      expect(billingDetails.props.$amount).toStrictEqual(expectedAmount);
-      expect(billingDetails.props.$intervalCount).toBe(
-        props.plan.interval_count
-      );
-      expect(billingDetails.props.$name).toBe(props.plan.product_name);
-      expect(billingDetails.props.$date).toStrictEqual(expectedDate);
-      expect(billingDetails.props.children.props.children).toBe(expectedMsg);
-    }
-
-    describe('When plan has day interval', () => {
-      const expectedMsgId = dayBasedId;
-
-      it('Handles an interval count of 1', () => {
-        const plan_id = 'plan_daily';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 daily for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const plan_id = 'plan_6days';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 every 6 days for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-    });
-
-    describe('When plan has week interval', () => {
-      const expectedMsgId = weekBasedId;
-
-      it('Handles an interval count of 1', () => {
-        const plan_id = 'plan_weekly';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 weekly for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const plan_id = 'plan_6weeks';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 every 6 weeks for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-    });
-
-    describe('When plan has month interval', () => {
-      const expectedMsgId = monthBasedId;
-
-      it('Handles an interval count of 1', () => {
-        const plan_id = 'plan_monthly';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 monthly for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const plan_id = 'plan_6months';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 every 6 months for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-    });
-
-    describe('When plan has year interval', () => {
-      const expectedMsgId = yearBasedId;
-
-      it('Handles an interval count of 1', () => {
-        const plan_id = 'plan_yearly';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 yearly for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const plan_id = 'plan_6years';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 every 6 years for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-    });
+describe('PaymentUpdateFormV1', () => {
+  it('renders with payment update form hidden initially', () => {
+    render(<PaymentUpdateForm {...baseProps} />);
+    expect(queryByTestId('card-details')).toBeInTheDocument();
+    expect(queryByTestId('paymentForm')).not.toBeInTheDocument();
   });
 
-  describe('Fluent Translations for Plan Billing Description', () => {
-    const bundle = setupFluentLocalizationTest('en-US');
-    const amount = getLocalizedCurrency(500, 'USD');
-    const stringDate = getLocalizedDateString(1585334292, true);
-    const args = {
-      amount,
-      name: 'FPN',
-      date: getLocalizedDate(1585334292, true),
-    };
+  it('reveals the payment update form on clicking Change button', () => {
+    render(<PaymentUpdateForm {...baseProps} />);
+    expect(queryByTestId('card-details')).toBeInTheDocument();
+    fireEvent.click(getByTestId('reveal-payment-update-button'));
+    expect(PaymentForm).toHaveBeenCalledTimes(1);
+  });
 
-    describe('When message id is pay-update-billing-description-day', () => {
-      const msgId = dayBasedId;
-      it('Handles an interval count of 1', () => {
-        const expected = `You are billed $5.00 daily for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 1,
-        });
-        expect(actual).toEqual(expected);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const expected = `You are billed $5.00 every 6 days for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 6,
-        });
-        expect(actual).toEqual(expected);
-      });
-    });
-
-    describe('When message id is pay-update-billing-description-week', () => {
-      const msgId = weekBasedId;
-      it('Handles an interval count of 1', () => {
-        const expected = `You are billed $5.00 weekly for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 1,
-        });
-        expect(actual).toEqual(expected);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const expected = `You are billed $5.00 every 6 weeks for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 6,
-        });
-        expect(actual).toEqual(expected);
-      });
-    });
-
-    describe('When message id is pay-update-billing-description-month', () => {
-      const msgId = monthBasedId;
-      it('Handles an interval count of 1', () => {
-        const expected = `You are billed $5.00 monthly for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 1,
-        });
-        expect(actual).toEqual(expected);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const expected = `You are billed $5.00 every 6 months for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 6,
-        });
-        expect(actual).toEqual(expected);
-      });
-    });
-
-    describe('When message id is pay-update-billing-description-year', () => {
-      const msgId = yearBasedId;
-      it('Handles an interval count of 1', () => {
-        const expected = `You are billed $5.00 yearly for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 1,
-        });
-        expect(actual).toEqual(expected);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const expected = `You are billed $5.00 every 6 years for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 6,
-        });
-        expect(actual).toEqual(expected);
-      });
-    });
+  it('renders with l10n', () => {
+    const bundle = new FluentBundle('gd', { useIsolating: false });
+    [
+      'sub-update-title = CC Info',
+      'sub-update-card-ending = last four { $last }',
+      'pay-update-card-exp = all over on { $expirationDate }',
+      'pay-update-change-btn = gogo',
+    ].forEach((x) => bundle.addResource(new FluentResource(x)));
+    render(
+      <LocalizationProvider bundles={[bundle]}>
+        <PaymentUpdateForm {...baseProps} />
+      </LocalizationProvider>
+    );
+    expect(queryByText('CC Info')).toBeInTheDocument();
+    expect(queryByText('last four 5309')).toBeInTheDocument();
+    expect(queryByText('all over on February 2099')).toBeInTheDocument();
+    expect(queryByText('gogo')).toBeInTheDocument();
   });
 });

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -5,63 +5,28 @@
 import React, { useCallback, useState } from 'react';
 import { Localized } from '@fluent/react';
 import dayjs from 'dayjs';
-import {
-  getLocalizedDateString,
-  getLocalizedDate,
-  getLocalizedCurrency,
-  formatPlanPricing,
-} from '../../lib/formats';
 import { useNonce } from '../../lib/hooks';
 import { useBooleanState } from 'fxa-react/lib/hooks';
 import { getErrorMessage } from '../../lib/errors';
 import { SelectorReturns } from '../../store/selectors';
-import {
-  Customer,
-  CustomerSubscription,
-  Plan,
-  PlanInterval,
-} from '../../store/types';
-import { metadataFromPlan } from 'fxa-shared/subscriptions/metadata';
+import { Customer } from '../../store/types';
 import PaymentForm from '../../components/PaymentForm';
 import ErrorMessage from '../../components/ErrorMessage';
 import { SubscriptionsProps } from './index';
 import * as Amplitude from '../../lib/amplitude';
 
-type PaymentUpdateFormProps = {
+export type PaymentUpdateFormProps = {
   customer: Customer;
-  customerSubscription: CustomerSubscription;
-  plan: Plan;
   resetUpdatePayment: SubscriptionsProps['resetUpdatePayment'];
   updatePayment: SubscriptionsProps['updatePayment'];
   updatePaymentStatus: SelectorReturns['updatePaymentStatus'];
 };
-
-function getBillingDescriptionText(
-  name: string,
-  amount: number | null,
-  currency: string,
-  interval: PlanInterval,
-  intervalCount: number,
-  date: number
-): string {
-  const formattedDateString = getLocalizedDateString(date, true);
-  const planPricing = formatPlanPricing(
-    amount,
-    currency,
-    interval,
-    intervalCount
-  );
-
-  return `You are billed ${planPricing} for ${name}. Your next payment occurs on ${formattedDateString}.`;
-}
 
 export const PaymentUpdateForm = ({
   updatePayment: updatePaymentBase,
   updatePaymentStatus,
   resetUpdatePayment: resetUpdatePaymentBase,
   customer,
-  customerSubscription,
-  plan,
 }: PaymentUpdateFormProps) => {
   const [submitNonce, refreshSubmitNonce] = useNonce();
   const [updateRevealed, revealUpdate, hideUpdate] = useBooleanState();
@@ -91,7 +56,7 @@ export const PaymentUpdateForm = ({
   const onPayment = useCallback(
     (tokenResponse: stripe.TokenResponse) => {
       if (tokenResponse && tokenResponse.token) {
-        updatePayment(tokenResponse.token.id, plan);
+        updatePayment(tokenResponse.token.id);
       } else {
         // This shouldn't happen with a successful createToken() call, but let's
         // display an error in case it does.
@@ -99,7 +64,7 @@ export const PaymentUpdateForm = ({
         setCreateTokenError(error);
       }
     },
-    [updatePayment, setCreateTokenError, plan]
+    [updatePayment, setCreateTokenError]
   );
 
   const onPaymentError = useCallback(
@@ -116,19 +81,11 @@ export const PaymentUpdateForm = ({
     resetUpdatePayment();
   }, [setCreateTokenError, resetUpdatePayment]);
 
-  const onFormMounted = useCallback(
-    () => Amplitude.updatePaymentMounted(plan),
-    [plan]
-  );
+  const onFormMounted = useCallback(() => Amplitude.updatePaymentMounted(), []);
 
-  const onFormEngaged = useCallback(
-    () => Amplitude.updatePaymentEngaged(plan),
-    [plan]
-  );
+  const onFormEngaged = useCallback(() => Amplitude.updatePaymentEngaged(), []);
 
   const inProgress = updatePaymentStatus.loading;
-
-  const { upgradeCTA } = metadataFromPlan(plan);
 
   const { last4, exp_month, exp_year } = customer;
 
@@ -138,103 +95,82 @@ export const PaymentUpdateForm = ({
     .set('year', Number(exp_year))
     .format('MMMM YYYY');
 
-  const billingDescriptionText = getBillingDescriptionText(
-    plan.product_name,
-    plan.amount,
-    plan.currency,
-    plan.interval,
-    plan.interval_count,
-    customerSubscription.current_period_end
-  );
-
   return (
-    <div className="payment-update">
-      <h3 className="billing-title">
-        <Localized id="sub-update-title">
-          <span className="title">Billing Information</span>
-        </Localized>
-      </h3>
-      <Localized
-        id={`pay-update-billing-description-${plan.interval}`}
-        $amount={getLocalizedCurrency(plan.amount, plan.currency)}
-        $intervalCount={plan.interval_count}
-        $name={plan.product_name}
-        $date={getLocalizedDate(customerSubscription.current_period_end, true)}
-      >
-        <p className="billing-description">{billingDescriptionText}</p>
-      </Localized>
-      {upgradeCTA && (
-        <p
-          className="upgrade-cta"
-          data-testid="upgrade-cta"
-          dangerouslySetInnerHTML={{ __html: upgradeCTA }}
-        />
-      )}
-      {!updateRevealed ? (
-        <div className="with-settings-button">
-          <div className="card-details">
-            {last4 && expirationDate && (
-              <>
-                {/* TODO: Need to find a way to display a card icon here? */}
-                <Localized id="sub-update-card-ending" $last={last4}>
-                  <div className="last-four">Card ending {last4}</div>
+    <div className="settings-unit">
+      <div className="payment-update">
+        <header>
+          <h2 className="billing-title">
+            <Localized id="sub-update-title">
+              <span className="title">Billing Information</span>
+            </Localized>
+          </h2>
+        </header>
+        {!updateRevealed ? (
+          <div className="with-settings-button">
+            <div className="card-details" data-testid="card-details">
+              {last4 && expirationDate && (
+                <>
+                  {/* TODO: Need to find a way to display a card icon here? */}
+                  <Localized id="sub-update-card-ending" $last={last4}>
+                    <div className="last-four">Card ending {last4}</div>
+                  </Localized>
+                  <Localized
+                    id="pay-update-card-exp"
+                    $expirationDate={expirationDate}
+                  >
+                    <div data-testid="card-expiration-date" className="expiry">
+                      Expires {expirationDate}
+                    </div>
+                  </Localized>
+                </>
+              )}
+            </div>
+            <div className="action">
+              <button
+                data-testid="reveal-payment-update-button"
+                className="settings-button"
+                onClick={onRevealUpdateClick}
+              >
+                <Localized id="pay-update-change-btn">
+                  <span className="change-button">Change</span>
                 </Localized>
-                <Localized
-                  id="pay-update-card-exp"
-                  $expirationDate={expirationDate}
-                >
-                  <div data-testid="card-expiration-date" className="expiry">
-                    Expires {expirationDate}
-                  </div>
-                </Localized>
-              </>
-            )}
+              </button>
+            </div>
           </div>
-          <div className="action">
-            <button
-              data-testid="reveal-payment-update-button"
-              className="settings-button"
-              onClick={onRevealUpdateClick}
-            >
-              <Localized id="pay-update-change-btn">
-                <span className="change-button">Change</span>
-              </Localized>
-            </button>
-          </div>
-        </div>
-      ) : (
-        <>
-          <ErrorMessage isVisible={!!createTokenError.error}>
-            {createTokenError.error && (
-              <p data-testid="error-payment-submission">
-                {getErrorMessage(createTokenError.type)}
-              </p>
-            )}
-          </ErrorMessage>
+        ) : (
+          <>
+            <ErrorMessage isVisible={!!createTokenError.error}>
+              {createTokenError.error && (
+                <p data-testid="error-payment-submission">
+                  {getErrorMessage(createTokenError.type)}
+                </p>
+              )}
+            </ErrorMessage>
 
-          <ErrorMessage isVisible={!!updatePaymentStatus.error}>
-            {updatePaymentStatus.error && (
-              <p data-testid="error-billing-update">
-                {updatePaymentStatus.error.message}
-              </p>
-            )}
-          </ErrorMessage>
+            <ErrorMessage isVisible={!!updatePaymentStatus.error}>
+              {updatePaymentStatus.error && (
+                <p data-testid="error-billing-update">
+                  {updatePaymentStatus.error.message}
+                </p>
+              )}
+            </ErrorMessage>
 
-          <PaymentForm
-            {...{
-              submitNonce,
-              onPayment,
-              onPaymentError,
-              inProgress,
-              confirm: false,
-              onCancel: hideUpdate,
-              onChange,
-              onMounted: onFormMounted,
-              onEngaged: onFormEngaged,
-            }}
-          />
-        </>
-      )}
+            <PaymentForm
+              {...{
+                submitNonce,
+                onPayment,
+                onPaymentError,
+                inProgress,
+                confirm: false,
+                onCancel: hideUpdate,
+                onChange,
+                onMounted: onFormMounted,
+                onEngaged: onFormEngaged,
+              }}
+            />
+          </>
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateFormV2.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateFormV2.test.tsx
@@ -7,58 +7,24 @@ import {
   fireEvent,
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import TestRenderer from 'react-test-renderer';
 
 import waitForExpect from 'wait-for-expect';
 
 import PaymentUpdateForm, {
   PaymentUpdateFormProps,
 } from './PaymentUpdateFormV2';
-import { Plan } from '../../store/types';
 import {
-  MOCK_PLANS,
-  MOCK_CUSTOMER,
-  setupFluentLocalizationTest,
-  getLocalizedMessage,
   mockStripeElementOnChangeFns,
   elementChangeResponse,
 } from '../../lib/test-utils';
 import { CUSTOMER, FILTERED_SETUP_INTENT } from '../../lib/mock-data';
-import {
-  getLocalizedDateString,
-  getLocalizedDate,
-  getLocalizedCurrency,
-} from '../../lib/formats';
 
 import { PickPartial } from '../../lib/types';
 
 describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
-  const dayBasedId = 'pay-update-billing-description-day';
-  const weekBasedId = 'pay-update-billing-description-week';
-  const monthBasedId = 'pay-update-billing-description-month';
-  const yearBasedId = 'pay-update-billing-description-year';
-  const subscription = MOCK_CUSTOMER.subscriptions[0];
-
-  const findMockPlan = (planId: string): Plan => {
-    const plan = MOCK_PLANS.find((x) => x.plan_id === planId);
-    if (plan) {
-      return plan;
-    }
-    throw new Error('unable to find suitable Plan object for test execution.');
-  };
-
-  const baseProps = {
-    customerSubscription: subscription,
-    customer: MOCK_CUSTOMER,
-    plan: MOCK_PLANS[0],
-    refreshSubscription: jest.fn(),
-  };
-
   type SubjectProps = PickPartial<
     PaymentUpdateFormProps,
     | 'customer'
-    | 'customerSubscription'
-    | 'plan'
     | 'refreshSubscriptions'
     | 'setUpdatePaymentIsSuccess'
     | 'resetUpdatePaymentIsSuccess'
@@ -66,8 +32,6 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
 
   const Subject = ({
     customer = CUSTOMER,
-    customerSubscription = CUSTOMER.subscriptions[0],
-    plan = MOCK_PLANS[0],
     paymentErrorInitialState,
     apiClientOverrides = defaultApiClientOverrides(),
     stripeOverride = defaultStripeOverride(),
@@ -79,8 +43,6 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
       <PaymentUpdateForm
         {...{
           customer,
-          customerSubscription,
-          plan,
           refreshSubscriptions,
           setUpdatePaymentIsSuccess,
           resetUpdatePaymentIsSuccess,
@@ -125,18 +87,6 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
     render(<Subject />);
     expect(screen.queryByTestId('payment-update')).toBeInTheDocument();
     expect(screen.queryByTestId('paymentForm')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('upgrade-cta')).not.toBeInTheDocument();
-  });
-
-  it('renders with payment update form with upgradeCTA when available', async () => {
-    const upgradeCTA = 'Buy the next best thing!';
-    render(
-      <Subject plan={{ ...MOCK_PLANS[0], product_metadata: { upgradeCTA } }} />
-    );
-    expect(screen.queryByTestId('payment-update')).toBeInTheDocument();
-    expect(screen.queryByTestId('paymentForm')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('upgrade-cta')).toBeInTheDocument();
-    expect(screen.queryByText(upgradeCTA)).toBeInTheDocument();
   });
 
   it('reveals the payment update form on clicking Change button', async () => {
@@ -402,278 +352,5 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
       paymentMethodId: CONFIRM_CARD_SETUP_RESULT.setupIntent.payment_method,
     });
     expect(refreshSubscriptions).not.toHaveBeenCalled();
-  });
-
-  describe('Localized Plan Billing Description Component', () => {
-    function runTests(props: any, expectedMsgId: string, expectedMsg: string) {
-      const testRenderer = TestRenderer.create(
-        <PaymentUpdateForm {...props} />
-      );
-      const testInstance = testRenderer.root;
-      const billingDetails = testInstance.findByProps({ id: expectedMsgId });
-      const expectedAmount = getLocalizedCurrency(
-        props.plan.amount,
-        props.plan.currency
-      );
-      const expectedDate = getLocalizedDate(
-        props.customerSubscription.current_period_end,
-        true
-      );
-
-      expect(billingDetails.props.$amount).toStrictEqual(expectedAmount);
-      expect(billingDetails.props.$intervalCount).toBe(
-        props.plan.interval_count
-      );
-      expect(billingDetails.props.$name).toBe(props.plan.product_name);
-      expect(billingDetails.props.$date).toStrictEqual(expectedDate);
-      expect(billingDetails.props.children.props.children).toBe(expectedMsg);
-    }
-
-    describe('When plan has day interval', () => {
-      const expectedMsgId = dayBasedId;
-
-      it('Handles an interval count of 1', () => {
-        const plan_id = 'plan_daily';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 daily for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const plan_id = 'plan_6days';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 every 6 days for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-    });
-
-    describe('When plan has week interval', () => {
-      const expectedMsgId = weekBasedId;
-
-      it('Handles an interval count of 1', () => {
-        const plan_id = 'plan_weekly';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 weekly for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const plan_id = 'plan_6weeks';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 every 6 weeks for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-    });
-
-    describe('When plan has month interval', () => {
-      const expectedMsgId = monthBasedId;
-
-      it('Handles an interval count of 1', () => {
-        const plan_id = 'plan_monthly';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 monthly for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const plan_id = 'plan_6months';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 every 6 months for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-    });
-
-    describe('When plan has year interval', () => {
-      const expectedMsgId = yearBasedId;
-
-      it('Handles an interval count of 1', () => {
-        const plan_id = 'plan_yearly';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 yearly for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const plan_id = 'plan_6years';
-        const plan = findMockPlan(plan_id);
-        const periodEndDate = getLocalizedDateString(
-          subscription.current_period_end,
-          true
-        );
-        const expectedMsg = `You are billed $5.00 every 6 years for FPN. Your next payment occurs on ${periodEndDate}.`;
-
-        const props = {
-          ...baseProps,
-          plan: plan,
-        };
-        runTests(props, expectedMsgId, expectedMsg);
-      });
-    });
-  });
-
-  describe('Fluent Translations for Plan Billing Description', () => {
-    const bundle = setupFluentLocalizationTest('en-US');
-    const amount = getLocalizedCurrency(500, 'USD');
-    const stringDate = getLocalizedDateString(1585334292, true);
-    const args = {
-      amount,
-      name: 'FPN',
-      date: getLocalizedDate(1585334292, true),
-    };
-
-    describe('When message id is pay-update-billing-description-day', () => {
-      const msgId = dayBasedId;
-      it('Handles an interval count of 1', () => {
-        const expected = `You are billed $5.00 daily for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 1,
-        });
-        expect(actual).toEqual(expected);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const expected = `You are billed $5.00 every 6 days for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 6,
-        });
-        expect(actual).toEqual(expected);
-      });
-    });
-
-    describe('When message id is pay-update-billing-description-week', () => {
-      const msgId = weekBasedId;
-      it('Handles an interval count of 1', () => {
-        const expected = `You are billed $5.00 weekly for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 1,
-        });
-        expect(actual).toEqual(expected);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const expected = `You are billed $5.00 every 6 weeks for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 6,
-        });
-        expect(actual).toEqual(expected);
-      });
-    });
-
-    describe('When message id is pay-update-billing-description-month', () => {
-      const msgId = monthBasedId;
-      it('Handles an interval count of 1', () => {
-        const expected = `You are billed $5.00 monthly for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 1,
-        });
-        expect(actual).toEqual(expected);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const expected = `You are billed $5.00 every 6 months for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 6,
-        });
-        expect(actual).toEqual(expected);
-      });
-    });
-
-    describe('When message id is pay-update-billing-description-year', () => {
-      const msgId = yearBasedId;
-      it('Handles an interval count of 1', () => {
-        const expected = `You are billed $5.00 yearly for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 1,
-        });
-        expect(actual).toEqual(expected);
-      });
-
-      it('Handles an interval count that is not 1', () => {
-        const expected = `You are billed $5.00 every 6 years for FPN. Your next payment occurs on ${stringDate}.`;
-
-        const actual = getLocalizedMessage(bundle, msgId, {
-          ...args,
-          intervalCount: 6,
-        });
-        expect(actual).toEqual(expected);
-      });
-    });
   });
 });

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -2,47 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useContext, useEffect, useRef } from 'react';
+import React, { useContext } from 'react';
 import { Localized } from '@fluent/react';
-import { getLocalizedDate, getLocalizedDateString } from '../../lib/formats';
-import { useCheckboxState } from '../../lib/hooks';
-import { useBooleanState } from 'fxa-react/lib/hooks';
-import {
-  CustomerSubscription,
-  Subscription,
-  Plan,
-  Customer,
-} from '../../store/types';
+import { CustomerSubscription, Plan, Customer } from '../../store/types';
 import { SelectorReturns } from '../../store/selectors';
 import { SubscriptionsProps } from './index';
-import * as Amplitude from '../../lib/amplitude';
 
-import PaymentUpdateForm from './PaymentUpdateForm';
-import PaymentUpdateFormV2, {
-  PaymentUpdateStripeAPIs,
-  PaymentUpdateAuthServerAPIs,
-} from './PaymentUpdateFormV2';
 import DialogMessage from '../../components/DialogMessage';
 import AppContext from '../../lib/AppContext';
 
+import CancelSubscriptionPanel from './Cancel/CancelSubscriptionPanel';
 import ReactivateSubscriptionPanel from './Reactivate/ManagementPanel';
 
-type SubscriptionItemProps = {
+export type SubscriptionItemProps = {
   customerSubscription: CustomerSubscription;
   plan: Plan | null;
   cancelSubscription: SubscriptionsProps['cancelSubscription'];
   reactivateSubscription: SubscriptionsProps['reactivateSubscription'];
   customer: Customer;
-  updatePaymentStatus: SelectorReturns['updatePaymentStatus'];
-  resetUpdatePayment: SubscriptionsProps['resetUpdatePayment'];
-  updatePayment: SubscriptionsProps['updatePayment'];
   cancelSubscriptionStatus: SelectorReturns['cancelSubscriptionStatus'];
-  refreshSubscriptions: () => void;
-  setUpdatePaymentIsSuccess: () => void;
-  resetUpdatePaymentIsSuccess: () => void;
-  useSCAPaymentFlow: boolean;
-  paymentUpdateStripeOverride?: PaymentUpdateStripeAPIs;
-  paymentUpdateApiClientOverrides?: Partial<PaymentUpdateAuthServerAPIs>;
 };
 
 export const SubscriptionItem = ({
@@ -51,16 +29,7 @@ export const SubscriptionItem = ({
   reactivateSubscription,
   customer,
   plan,
-  updatePayment,
-  resetUpdatePayment,
-  updatePaymentStatus,
   customerSubscription,
-  refreshSubscriptions,
-  setUpdatePaymentIsSuccess,
-  resetUpdatePaymentIsSuccess,
-  useSCAPaymentFlow,
-  paymentUpdateStripeOverride,
-  paymentUpdateApiClientOverrides,
 }: SubscriptionItemProps) => {
   const { locationReload } = useContext(AppContext);
 
@@ -87,41 +56,14 @@ export const SubscriptionItem = ({
         </header>
 
         {!customerSubscription.cancel_at_period_end ? (
-          <>
-            {useSCAPaymentFlow ? (
-              <PaymentUpdateFormV2
-                {...{
-                  plan,
-                  customerSubscription,
-                  customer,
-                  refreshSubscriptions,
-                  setUpdatePaymentIsSuccess,
-                  resetUpdatePaymentIsSuccess,
-                  stripeOverride: paymentUpdateStripeOverride,
-                  apiClientOverrides: paymentUpdateApiClientOverrides,
-                }}
-              />
-            ) : (
-              <PaymentUpdateForm
-                {...{
-                  plan,
-                  customerSubscription,
-                  customer,
-                  updatePayment,
-                  resetUpdatePayment,
-                  updatePaymentStatus,
-                }}
-              />
-            )}
-            <CancelSubscriptionPanel
-              {...{
-                cancelSubscription,
-                cancelSubscriptionStatus,
-                customerSubscription,
-                plan,
-              }}
-            />
-          </>
+          <CancelSubscriptionPanel
+            {...{
+              cancelSubscription,
+              cancelSubscriptionStatus,
+              customerSubscription,
+              plan,
+            }}
+          />
         ) : (
           <>
             <ReactivateSubscriptionPanel
@@ -136,156 +78,6 @@ export const SubscriptionItem = ({
         )}
       </div>
     </div>
-  );
-};
-
-type CancelSubscriptionPanelProps = {
-  plan: Plan;
-  cancelSubscription: SubscriptionsProps['cancelSubscription'];
-  customerSubscription: CustomerSubscription;
-  cancelSubscriptionStatus: SelectorReturns['cancelSubscriptionStatus'];
-};
-
-const CancelSubscriptionPanel = ({
-  plan,
-  cancelSubscription,
-  customerSubscription: { subscription_id, current_period_end },
-  cancelSubscriptionStatus,
-}: CancelSubscriptionPanelProps) => {
-  const [cancelRevealed, revealCancel, hideCancel] = useBooleanState();
-  const [confirmationChecked, onConfirmationChanged] = useCheckboxState();
-
-  const confirmCancellation = useCallback(() => {
-    cancelSubscription(subscription_id, plan);
-  }, [cancelSubscription, subscription_id, plan]);
-
-  const viewed = useRef(false);
-  const engaged = useRef(false);
-
-  useEffect(() => {
-    if (!viewed.current && cancelRevealed) {
-      Amplitude.cancelSubscriptionMounted(plan);
-      viewed.current = true;
-    }
-  }, [cancelRevealed, viewed, plan]);
-
-  const engage = useCallback(() => {
-    if (!engaged.current) {
-      Amplitude.cancelSubscriptionEngaged(plan);
-      engaged.current = true;
-    }
-  }, [engaged, plan]);
-
-  const engagedOnHideCancel = useCallback(
-    (evt) => {
-      engage();
-      onConfirmationChanged(evt);
-      hideCancel();
-    },
-    [hideCancel, engage]
-  );
-
-  const engagedOnConfirmationChanged = useCallback(
-    (evt) => {
-      engage();
-      onConfirmationChanged(evt);
-    },
-    [onConfirmationChanged, engage]
-  );
-
-  return (
-    <>
-      <div className="cancel-subscription">
-        {!cancelRevealed ? (
-          <>
-            <div className="with-settings-button">
-              <div className="card-details">
-                <Localized id="sub-item-cancel-sub">
-                  <h3>Cancel Subscription</h3>
-                </Localized>
-              </div>
-              <div className="action">
-                <button
-                  className="settings-button"
-                  onClick={revealCancel}
-                  data-testid="reveal-cancel-subscription-button"
-                >
-                  <Localized id="payment-cancel-btn">
-                    <span className="change-button">Cancel</span>
-                  </Localized>
-                </button>
-              </div>
-            </div>
-          </>
-        ) : (
-          <>
-            <Localized id="sub-item-cancel-sub">
-              <h3>Cancel Subscription</h3>
-            </Localized>
-            <Localized
-              id="sub-item-cancel-msg"
-              $name={plan.product_name}
-              $period={getLocalizedDate(current_period_end)}
-            >
-              <p>
-                You will no longer be able to use {plan.product_name} after{' '}
-                {getLocalizedDateString(current_period_end)}, the last day of
-                your billing cycle.
-              </p>
-            </Localized>
-            <p>
-              <label>
-                <input
-                  data-testid="confirm-cancel-subscription-checkbox"
-                  type="checkbox"
-                  defaultChecked={confirmationChecked}
-                  onChange={engagedOnConfirmationChanged}
-                />
-                <Localized
-                  id="sub-item-cancel-confirm"
-                  $name={plan.product_name}
-                  $period={getLocalizedDate(current_period_end)}
-                >
-                  <span>
-                    Cancel my access and my saved information within{' '}
-                    {plan.product_name} on{' '}
-                    {getLocalizedDateString(current_period_end, false)}
-                  </span>
-                </Localized>
-              </label>
-            </p>
-            <div className="button-row">
-              <Localized id="sub-item-stay-sub">
-                <button
-                  className="settings-button primary-button"
-                  onClick={engagedOnHideCancel}
-                >
-                  Stay Subscribed
-                </button>
-              </Localized>
-              <button
-                data-testid="cancel-subscription-button"
-                className="settings-button secondary-button"
-                onClick={confirmCancellation}
-                disabled={
-                  cancelSubscriptionStatus.loading || !confirmationChecked
-                }
-              >
-                {cancelSubscriptionStatus.loading ? (
-                  <span data-testid="spinner-update" className="spinner">
-                    &nbsp;
-                  </span>
-                ) : (
-                  <Localized id="sub-item-cancel-sub">
-                    <span>Cancel Subscription</span>
-                  </Localized>
-                )}
-              </button>
-            </div>
-          </>
-        )}
-      </div>
-    </>
   );
 };
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
@@ -1,3 +1,4 @@
+@import '../../../../fxa-content-server/app/styles/variables';
 @import '../../../../fxa-content-server/app/styles/breakpoints';
 
 .subscription-management {
@@ -26,7 +27,8 @@
     border: 0;
   }
 
-  .subscription {
+  .subscription,
+  .payment-update {
     margin: 25px 32px;
 
     @include respond-to('simpleSmall') {
@@ -44,12 +46,18 @@
     }
   }
 
-  .cancel-subscription {
-    border-top: 1px solid #e0e0e6;
-    padding-top: 16px;
+  .payment-update {
+    header {
+      h2 {
+        font-weight: 600;
+      }
+    }
+  }
 
+
+  .cancel-subscription {
     p {
-      color: #737373;
+      color: $faint-text-color;
       line-height: 1.5;
     }
 
@@ -76,19 +84,28 @@
     }
   }
 
-  .card-details {
+  .card-details,
+  .price-details {
+    color: $faint-text-color;
     display: flex;
     flex: 4;
 
+    > div {
+      padding-right: 32px;
+    }
+  }
+  .card-details {
     .last-four,
     .expiry {
       align-items: center;
       display: flex;
-      font-weight: 700;
     }
+  }
+  .price-details {
+    flex-direction: column;
 
-    > div {
-      padding-right: 32px;
+    .plan-pricing {
+      font-weight: 600;
     }
   }
 
@@ -124,11 +141,9 @@
   }
 
   .payment-update {
-    padding-bottom: 18px;
-
     .upgrade-cta,
     .billing-description {
-      color: #737373;
+      color: $faint-text-color;
       line-height: 1.5;
     }
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -31,7 +31,8 @@ import { LoadingOverlay } from '../../components/LoadingOverlay';
 import { ReactComponent as CloseIcon } from 'fxa-react/images/close.svg';
 import { getLocalizedDate, getLocalizedDateString } from '../../lib/formats';
 
-import {
+import PaymentUpdateForm from './PaymentUpdateForm';
+import PaymentUpdateFormV2, {
   PaymentUpdateStripeAPIs,
   PaymentUpdateAuthServerAPIs,
 } from './PaymentUpdateFormV2';
@@ -192,6 +193,12 @@ export const Subscriptions = ({
     return <LoadingOverlay isLoading={true} />;
   }
 
+  const hasActiveSubscription =
+    customerSubscriptions &&
+    customerSubscriptions.some((s) => !s.cancel_at_period_end);
+  const showPaymentUpdateForm =
+    customer && customer.result && hasActiveSubscription;
+
   return (
     <div className="subscription-management" onClick={onAnyClick}>
       {customerSubscriptions && cancelSubscriptionStatus.result !== null && (
@@ -292,6 +299,32 @@ export const Subscriptions = ({
               </button>
             </div>
           </div>
+
+          {customer.result && showPaymentUpdateForm && (
+            <>
+              {useSCAPaymentFlow ? (
+                <PaymentUpdateFormV2
+                  {...{
+                    customer: customer.result,
+                    refreshSubscriptions: fetchSubscriptionsRouteResources,
+                    setUpdatePaymentIsSuccess,
+                    resetUpdatePaymentIsSuccess: resetUpdatePaymentIsSuccessAndAlert,
+                    stripeOverride: paymentUpdateStripeOverride,
+                    apiClientOverrides: paymentUpdateApiClientOverrides,
+                  }}
+                />
+              ) : (
+                <PaymentUpdateForm
+                  {...{
+                    customer: customer.result,
+                    updatePayment,
+                    resetUpdatePayment,
+                    updatePaymentStatus,
+                  }}
+                />
+              )}
+            </>
+          )}
 
           {customer.result &&
             customerSubscriptions &&

--- a/packages/fxa-payments-server/src/store/actions/api.ts
+++ b/packages/fxa-payments-server/src/store/actions/api.ts
@@ -83,14 +83,11 @@ export default {
         };
       },
     } as const),
-  updatePayment: (paymentToken: string, plan: Plan) =>
+  updatePayment: (paymentToken: string) =>
     ({
       type: 'updatePayment',
-      meta: { plan },
       payload: apiUpdatePayment({
         paymentToken,
-        planId: plan.plan_id,
-        productId: plan.product_id,
       }),
     } as const),
 } as const;

--- a/packages/fxa-payments-server/src/store/sequences.ts
+++ b/packages/fxa-payments-server/src/store/sequences.ts
@@ -103,12 +103,11 @@ export const reactivateSubscriptionAndRefresh = (
   }
 };
 
-export const updatePaymentAndRefresh = (
-  paymentToken: string,
-  plan: Plan
-) => async (dispatch: Function) => {
+export const updatePaymentAndRefresh = (paymentToken: string) => async (
+  dispatch: Function
+) => {
   try {
-    await dispatch(updatePayment(paymentToken, plan));
+    await dispatch(updatePayment(paymentToken));
     await dispatch(fetchCustomerAndSubscriptions());
     setTimeout(() => dispatch(resetUpdatePayment()), RESET_PAYMENT_DELAY);
   } catch (err) {


### PR DESCRIPTION
Because:
 - payment method for subscriptions should be updated in one place

This commit:
 - move the payment method info and update form into their own section
 - move CancelSubscriptionPanel into its own file
 - replace 'react-test-renderer' tests with 'Testing-Library/react' ones
 - make minor style and layout changes
 - remove product and plan ids from payment update Amplitude events as
   they are no longer associated with a subscription


## Issue that this pull request solves

Closes: FXA-2316

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots 
![image](https://user-images.githubusercontent.com/198055/89428211-c055a980-d701-11ea-9984-692711dda3f4.png)
