### PR TITLE
fix(oidc): Allow prompt=none with id_token_hint for all RPs

### DIFF
--- a/packages/fxa-auth-server/docs/oauth/prompt-none.md
+++ b/packages/fxa-auth-server/docs/oauth/prompt-none.md
@@ -8,8 +8,13 @@ More formally, `prompt=none` is a flow described by the [OpenID Connect spec][#o
 
 ## prompt=none usage is controlled
 
-Usage of `prompt=none` is controlled to an authorized list of RPs since
+Usage of `prompt=none` with `login_hint` / `email` is controlled to an authorized list of RPs, since
 it bypasses the normal authorization flow and use could easily fall afoul of user expectations.
+
+However, _all_ RPs can check the user's FxA login state using `id_token_hint`: since RPs not on the
+[authorized list](#prompt=none-usage-is-controlled) can only obtain an [id_token][#oidc-id-token] by
+going through the normal authorization flow, it is safe to assume an RP presenting the `id_token`
+as part of a `prompt=none` flow has already been granted authorization.
 
 ## Requesting `prompt=none` during authorization
 
@@ -99,15 +104,12 @@ For users that are already authenticated to Firefox Accounts, `prompt=none` bypa
 
 ## Future directions
 
-Now that FxA accepts the id_token_hint query parameter, support for `prompt=none` [could be expanded][#oidc-id-token-hint-discussion-issue] to allow any RP to check the user's FxA login state. Since RPs not on the [authorized list](#prompt=none-usage-is-controlled) can only obtain an [id_token][#oidc-id-token] by going through the normal authorization flow, it is safe to assume an RP presenting the `id_token` as part of a `prompt=none` flow has already been granted authorization.
-
 Support for [OIDC RP Initiated Logout][#oidc-rp-initiated-logout-github-issue] may go some way to reducing user confusion on what it means to sign out of an RP and whether they should have to enter their password again. Upon signing out of the RP, RPs that support the OIDC RP Initiated Logout protocol will redirect the user to FxA where they are given the option to destroy their FxA session as well.
 
 [#authorization-api-doc]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/fxa-oauth-server/docs/api.md#get-v1authorization
 [#fxa-devices-and-apps]: https://accounts.firefox.com/settings/clients
 [#oauth-server-api-destroy]: https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/fxa-oauth-server/docs/api.md#post-v1destroy
 [#oidc-error-codes]: https://openid.net/specs/openid-connect-core-1_0.html#AuthError
-[#oidc-id-token-hint-discussion-issue]: https://github.com/mozilla/fxa/issues/4963
 [#oidc-id-token]: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 [#oidc-logout-flows]: https://medium.com/@robert.broeckelmann/openid-connect-logout-eccc73df758f
 [#oidc-rp-initiated-logout-github-issue]: https://github.com/mozilla/fxa/issues/1979

--- a/packages/fxa-content-server/server/lib/routes/get-index.js
+++ b/packages/fxa-content-server/server/lib/routes/get-index.js
@@ -41,6 +41,8 @@ module.exports = function (config) {
   const SUBSCRIPTIONS = config.get('subscriptions');
   const SURVEY_FEATURE = config.get('surveyFeature');
   const PROMPT_NONE_ENABLED = config.get('oauth.prompt_none.enabled');
+  // Note that this list is only enforced for clients that use login_hint/email
+  // with prompt=none. id_token_hint clients are not subject to this check.
   const PROMPT_NONE_ENABLED_CLIENT_IDS = new Set(
     config.get('oauth.prompt_none.enabled_client_ids')
   );


### PR DESCRIPTION
* If an RP uses prompt=none with an id_token_hint, don't check against the allowed client list. This is because the user must have signed in to the RP before, otherwise the RP could not provide us a valid id_token.

* We still require an RP to be on the allowlist if they want to use prompt=none with the user email (via either the login_hint or email parameters).

Closes #4963, closes #6028.

## Because

- AMO has run into an error using `id_token_hint` due to the `prompt=none` allowlist

- And because we have long planned (see #4963) to allow any RP with an ID Token to use `prompt=none` without being on the allowlist (see also discussion in the docs updated in this PR)

## This pull request

- modifies the `prompt=none` validation flow to only check against the RP allowlist if the RP uses the `login_hint` aka `email` query parameter, but not if the RP uses `id_token_hint`

- adds front-end tests for this new case

- updates the `prompt=none` docs accordingly 

## Issue that this pull request solves

Closes #4963, closes #6028.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
