### PR TITLE
feat(settings): Add AlertBar root el with Context, UnitRowSecondaryEmail

### DIFF
--- a/packages/fxa-react/components/Portal/index.tsx
+++ b/packages/fxa-react/components/Portal/index.tsx
@@ -39,8 +39,11 @@ const Portal = ({
     el = document.createElement('div');
     el.setAttribute('class', 'portal');
     el.setAttribute('id', id);
-    el.setAttribute('role', 'dialog');
     document.body.appendChild(el);
+
+    if (id !== 'alert-bar-portal') {
+      el.setAttribute('role', 'dialog');
+    }
 
     if (id === 'modal') {
       el.setAttribute('aria-labelledby', headerId);

--- a/packages/fxa-settings/src/components/AlertBar/index.test.tsx
+++ b/packages/fxa-settings/src/components/AlertBar/index.test.tsx
@@ -2,21 +2,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { useRef, ReactNode } from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-
 import AlertBar from './index';
+import { AlertBarRootAndContextProvider } from '../../lib/AlertBarContext';
 
 describe('AlertBar', () => {
   const onDismiss = jest.fn();
 
   it('renders as expected', () => {
-    render(
-      <AlertBar {...{ onDismiss }}>
-        <div data-testid="children">Message</div>
-      </AlertBar>
+    const { rerender } = render(<AlertBarRootAndContextProvider />);
+    rerender(
+      <AlertBarRootAndContextProvider>
+        <AlertBar {...{ onDismiss }}>
+          <div data-testid="children">Message</div>
+        </AlertBar>
+      </AlertBarRootAndContextProvider>
     );
+    expect(screen.getByTestId('alert-bar-root')).toContainElement(screen.getByTestId('alert-bar'));
     expect(screen.queryByTestId('children')).toBeInTheDocument();
     expect(screen.queryByTestId('alert-bar')).toHaveAttribute('role', 'alert');
     expect(screen.getByTestId('alert-bar-dismiss')).toHaveAttribute(
@@ -25,31 +29,50 @@ describe('AlertBar', () => {
     );
   });
 
-  it('calls onDismiss on button click', () => {
+  it('uses Portal as a backup if alert-bar-root is not present', () => {
     render(
       <AlertBar {...{ onDismiss }}>
         <div>Message</div>
       </AlertBar>
+    );
+
+    expect(screen.getByTestId('alert-bar-portal')).toBeInTheDocument;
+  })
+
+  it('calls onDismiss on button click', () => {
+    const { rerender } = render(<AlertBarRootAndContextProvider />);
+    rerender(
+      <AlertBarRootAndContextProvider>
+        <AlertBar {...{ onDismiss }}>
+          <div data-testid="children">Message</div>
+        </AlertBar>
+      </AlertBarRootAndContextProvider>
     );
     fireEvent.click(screen.getByTestId('alert-bar-dismiss'));
     expect(onDismiss).toHaveBeenCalled();
   });
 
   it('calls onDismiss on esc key press', () => {
-    render(
-      <AlertBar {...{ onDismiss }}>
-        <p>Message</p>
-      </AlertBar>
+    const { rerender } = render(<AlertBarRootAndContextProvider />);
+    rerender(
+      <AlertBarRootAndContextProvider>
+        <AlertBar {...{ onDismiss }}>
+          <div data-testid="children">Message</div>
+        </AlertBar>
+      </AlertBarRootAndContextProvider>
     );
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(onDismiss).toHaveBeenCalled();
   });
 
   it('shifts focus to the tab fence when rendered', () => {
-    render(
-      <AlertBar {...{ onDismiss }}>
-        <p>Message</p>
-      </AlertBar>
+    const { rerender } = render(<AlertBarRootAndContextProvider />);
+    rerender(
+      <AlertBarRootAndContextProvider>
+        <AlertBar {...{ onDismiss }}>
+          <div data-testid="children">Message</div>
+        </AlertBar>
+      </AlertBarRootAndContextProvider>
     );
     expect(document.activeElement).toBe(
       screen.getByTestId('alert-bar-tab-fence')

--- a/packages/fxa-settings/src/components/AlertBar/index.tsx
+++ b/packages/fxa-settings/src/components/AlertBar/index.tsx
@@ -2,47 +2,70 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useContext } from 'react';
+import { createPortal } from 'react-dom';
+import AlertBarContext from '../../lib/AlertBarContext';
 import { useEscKeydownEffect, useChangeFocusEffect } from '../../lib/hooks';
 import { ReactComponent as CloseIcon } from 'fxa-react/images/close.svg';
+import Portal from 'fxa-react/components/Portal';
 
 type AlertBarProps = {
-  children: ReactNode | string;
+  children: ReactNode;
   onDismiss: Function;
 };
 
 export const AlertBar = ({ children, onDismiss }: AlertBarProps) => {
+  const { alertBarRootRef } = useContext(AlertBarContext);
+
+  // Although `role="alert" is usually sufficient to trigger a screenreader
+  // without having to reset focus, if this component is rerendered before
+  // it's removed from the DOM, the message won't be read. Setting focus
+  // ensures screenreaders receive feedback and makes the "close" button
+  // the next tabbable element after reveal.
   const tabFenceRef = useChangeFocusEffect();
   useEscKeydownEffect(onDismiss);
 
-  return (
-    <div
-      className="flex fixed justify-center mt-2 mx-2 right-0 left-0"
-      role="alert"
-      data-testid="alert-bar"
-    >
-      <div className="max-w-2xl w-full desktop:min-w-sm flex shadow-md bg-green-500 rounded font-bold text-sm">
-        <div
-          tabIndex={0}
-          ref={tabFenceRef}
-          data-testid="alert-bar-tab-fence"
-          className="outline-none"
-        />
-        <div className="flex-1 py-2 px-8 text-center">{children}</div>
-
-        <div className="flex pr-1">
-          <button
-            data-testid="alert-bar-dismiss"
-            className="self-center"
-            onClick={onDismiss as () => void}
-            title="Close message"
-          >
-            <CloseIcon className="w-3 h-3 m-2" role="img" />
-          </button>
-        </div>
+  const alertBar = <div
+    className="flex fixed justify-center mt-2 mx-2 right-0 left-0"
+    role="alert"
+    data-testid="alert-bar"
+  >
+    <div className="max-w-2xl w-full desktop:min-w-sm flex shadow-md bg-green-500 rounded font-bold text-sm">
+      <div
+        tabIndex={0}
+        ref={tabFenceRef}
+        data-testid="alert-bar-tab-fence"
+        className="outline-none"
+      />
+      <div className="flex-1 py-2 px-8 text-center">
+        {children}
+      </div>
+      <div className="flex pr-1">
+        <button
+          data-testid="alert-bar-dismiss"
+          className="self-center"
+          onClick={onDismiss as () => void}
+          title="Close message"
+        >
+          <CloseIcon className="w-3 h-3 m-2" role="img" />
+        </button>
       </div>
     </div>
-  );
+  </div>;
+
+  if (alertBarRootRef.current) {
+    return createPortal(alertBar, alertBarRootRef.current);
+  } else {
+    // this should never happen, but log an error and use Portal as a backup
+    console.error('Attempted to mount AlertBar on element ID "alert-bar-root" but it was not found in the document.');
+    return(
+      <Portal id="alert-bar-portal">
+        <div className="fixed mt-16 top-0" data-testid="alert-bar-portal">
+          {alertBar}
+        </div>
+      </Portal>
+    );
+  }
 };
 
 export default AlertBar;

--- a/packages/fxa-settings/src/components/AppLayout/index.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.tsx
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
+import React, { useRef } from 'react';
 import HeaderLockup from '../HeaderLockup';
 import ContentSkip from '../ContentSkip';
 import Nav from '../Nav';
 import Footer from 'fxa-react/components/Footer';
+import AlertBarContext from '../../lib/AlertBarContext';
 
 type AppLayoutProps = {
   avatarUrl: string | null;
@@ -20,25 +21,31 @@ export const AppLayout = ({
   primaryEmail,
   hasSubscription,
   children,
-}: AppLayoutProps) => (
-  <div className="flex flex-col min-h-screen" data-testid="app">
-    <ContentSkip />
-    <HeaderLockup
-      {...{
-        avatarUrl,
-        primaryEmail,
-      }}
-    />
-    <div className="max-w-screen-desktopXl w-full mx-auto flex flex-1 tablet:px-20 desktop:px-12">
-      <div className="hidden desktop:block desktop:flex-2">
-        <Nav {...{ hasSubscription, primaryEmail }} />
+}: AppLayoutProps) => {
+  const alertBarRootRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div className="flex flex-col min-h-screen" data-testid="app">
+      <ContentSkip />
+      <HeaderLockup
+        {...{
+          avatarUrl,
+          primaryEmail,
+        }}
+      />
+      <div className="max-w-screen-desktopXl w-full mx-auto flex flex-1 tablet:px-20 desktop:px-12">
+        <div className="hidden desktop:block desktop:flex-2">
+          <Nav {...{ hasSubscription, primaryEmail }} />
+        </div>
+        <main id="main" data-testid="main" className="desktop:flex-7">
+          <div id="alert-bar-root" data-testid="alert-bar-root" ref={alertBarRootRef} />
+          <AlertBarContext.Provider value={{ alertBarRootRef }}>
+            {children}
+          </AlertBarContext.Provider>
+        </main>
       </div>
-      <main id="main" data-testid="main" className="desktop:flex-7">
-        {children}
-      </main>
+      <Footer />
     </div>
-    <Footer />
-  </div>
-);
+  )};
 
 export default AppLayout;

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -2,47 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback } from 'react';
-import { useBooleanState } from 'fxa-react/lib/hooks';
+import React from 'react';
 import UnitRow from '../UnitRow';
 import UnitRowWithAvatar from '../UnitRowWithAvatar';
-import Modal from '../Modal';
-import AlertBar from '../AlertBar';
 import Security from '../Security';
+import UnitRowSecondaryEmail from '../UnitRowSecondaryEmail';
 import { AccountData } from '../AccountDataHOC/gql';
 
 export const Settings = ({ account }: { account: AccountData }) => {
-  const [modalRevealed, revealModal, hideModal] = useBooleanState();
-  const [alertBarRevealed, revealAlertBar, hideAlertBar] = useBooleanState();
-
-  const onSecondaryEmailConfirm = useCallback(() => {
-    console.log('confirmed - resend verification code');
-    hideModal();
-    revealAlertBar();
-  }, [hideModal, revealAlertBar]);
-
-  const modalHeaderId = 'modal-header-verify-email';
-  const modalDescId = 'modal-desc-verify-email';
-
   const primaryEmail = account.emails.find((email) => email.isPrimary)!;
 
   return (
     <>
-      {/*
-       * While this is where the AlertBar needs to be in the DOM, it won't be composed here
-       * like this. We likely need some sort of alert bar root element and then AlertBar
-       * can return a React.Portal hooking into this element via a ref so that we can freely
-       * use <AlertBar> with content where needed while its placement in the DOM remains
-       * here. Details will be worked out in FXA-1628.
-       */}
-      {alertBarRevealed && (
-        <AlertBar onDismiss={hideAlertBar}>
-          <p>
-            Check the inbox for {primaryEmail.email} to verify your primary
-            email.
-          </p>
-        </AlertBar>
-      )}
       <section className="mt-11" id="profile" data-testid="settings-profile">
         <h2 className="font-header font-bold ml-4 mb-4">Profile</h2>
 
@@ -72,56 +43,11 @@ export const Settings = ({ account }: { account: AccountData }) => {
 
           <hr className="unit-row-hr" />
 
-          {/*
-          /* TO DO: primary/secondary email section with
-          /* verified status and number of secondary emails
-          /* taken into account
-          */}
           <UnitRow header="Primary email" headerValue={primaryEmail.email} />
 
           <hr className="unit-row-hr" />
 
-          <UnitRow
-            header="Secondary email"
-            headerValue={null}
-            {...{
-              revealModal,
-              modalRevealed,
-            }}
-          >
-            <p className="text-sm mt-3">
-              Access your account if you can't log in to your primary email.
-            </p>
-            <p className="text-grey-400 text-xs mt-2">
-              Note: a secondary email won't restore your information—you'll need
-              a{' '}
-              <a className="link-blue" href="#recovery-key">
-                recovery key
-              </a>{' '}
-              for that.
-            </p>
-
-            {modalRevealed && (
-              <Modal
-                onDismiss={hideModal}
-                onConfirm={onSecondaryEmailConfirm}
-                headerId={modalHeaderId}
-                descId={modalDescId}
-              >
-                <h2
-                  id={modalHeaderId}
-                  className="font-bold text-xl text-center mb-2"
-                >
-                  Verify primary email first
-                </h2>
-                <p className="text-center" id={modalDescId}>
-                  Before you can add a secondary email, you must verify your
-                  primary email. To do this, you'll need access to{' '}
-                  {primaryEmail.email}
-                </p>
-              </Modal>
-            )}
-          </UnitRow>
+          <UnitRowSecondaryEmail primaryEmail={primaryEmail.email} />
         </div>
       </section>
 

--- a/packages/fxa-settings/src/components/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRow/index.tsx
@@ -16,6 +16,7 @@ type UnitRowProps = {
   route?: string;
   revealModal?: () => void;
   modalRevealed?: boolean;
+  alertBarRevealed?: boolean;
 };
 
 // TO DO: accept a refresh button prop to use in for secondary email
@@ -32,11 +33,15 @@ export const UnitRow = ({
   noHeaderValueCtaText = 'Add',
   revealModal,
   modalRevealed,
+  alertBarRevealed,
 }: UnitRowProps) => {
   const ctaText = headerValue ? 'Change' : noHeaderValueCtaText;
 
   const modalTriggerElement = useRef<HTMLButtonElement>(null);
-  useFocusOnTriggeringElementOnClose(modalRevealed, modalTriggerElement);
+  // If the UnitRow children contains an AlertBar that is revealed,
+  // don't redirect focus back to the element that opened the modal
+  // because focus will be set in the AlertBar.
+  useFocusOnTriggeringElementOnClose(modalRevealed, modalTriggerElement, alertBarRevealed);
 
   return (
     <div className="unit-row">

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.stories.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.stories.tsx
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useRef, ReactNode } from 'react';
+import { storiesOf } from '@storybook/react';
+import { UnitRowSecondaryEmail } from '.';
+import { AlertBarRootAndContextProvider } from '../../lib/AlertBarContext';
+
+storiesOf('Components|UnitRowSecondaryEmail', module)
+  .add('basic', () =>
+    <AlertBarRootAndContextProvider>
+      <UnitRowSecondaryEmail primaryEmail="user@example.com" />
+    </AlertBarRootAndContextProvider>
+  );

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback } from 'react';
+import { useBooleanState } from 'fxa-react/lib/hooks';
+import UnitRow from '../UnitRow';
+import Modal from '../Modal';
+import AlertBar from '../AlertBar';
+
+type UnitRowSecondaryEmailProps = {
+  primaryEmail: string;
+};
+
+export const UnitRowSecondaryEmail = ({ primaryEmail }: UnitRowSecondaryEmailProps) => {
+  const [alertBarRevealed, revealAlertBar, hideAlertBar] = useBooleanState();
+  const [modalRevealed, revealModal, hideModal] = useBooleanState();
+
+  const modalHeaderId = 'modal-header-verify-email';
+  const modalDescId = 'modal-desc-verify-email';
+
+  const onSecondaryEmailConfirm = useCallback(() => {
+    console.log('confirmed - resend verification code');
+    hideModal();
+    revealAlertBar();
+  }, [hideModal, revealAlertBar]);
+
+  return (
+      <UnitRow
+        header="Secondary email"
+        headerValue={null}
+        {...{
+          revealModal,
+          modalRevealed,
+          alertBarRevealed
+        }}
+      >
+        <p className="text-sm mt-3">
+          Access your account if you can't log in to your primary email.
+        </p>
+        <p className="text-grey-400 text-xs mt-2">
+          Note: a secondary email won't restore your information—you'll need
+          a{' '}
+          <a className="link-blue" href="#recovery-key">
+            recovery key
+          </a>{' '}
+          for that.
+        </p>
+
+        {modalRevealed && (
+          <Modal
+            onDismiss={hideModal}
+            onConfirm={onSecondaryEmailConfirm}
+            headerId={modalHeaderId}
+            descId={modalDescId}
+          >
+            <h2
+              id={modalHeaderId}
+              className="font-bold text-xl text-center mb-2"
+            >
+              Verify primary email first
+            </h2>
+            <p className="text-center" id={modalDescId}>
+              Before you can add a secondary email, you must verify your
+              primary email. To do this, you'll need access to{' '}
+              {primaryEmail}
+            </p>
+          </Modal>
+        )}
+
+        {alertBarRevealed && (
+          <AlertBar onDismiss={hideAlertBar}>
+            <p>Check the inbox for {primaryEmail} to verify your primary email.</p>
+          </AlertBar>
+        )}
+      </UnitRow>
+  );
+};
+
+export default UnitRowSecondaryEmail;

--- a/packages/fxa-settings/src/lib/AlertBarContext.tsx
+++ b/packages/fxa-settings/src/lib/AlertBarContext.tsx
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ // Test coverage for this file exists in AlertBar tests.
+
+import React, { useRef, ReactNode } from 'react';
+
+type AlertBarContextType = {
+  alertBarRootRef: React.RefObject<HTMLDivElement>;
+};
+
+const defaultAlertBarContext = {
+  alertBarRootRef: {
+    current: null
+  }
+};
+
+const AlertBarContext = React.createContext<AlertBarContextType>(
+  defaultAlertBarContext
+);
+
+// Only used in tests and Storybook.
+export const AlertBarRootAndContextProvider = ({children}: {children?: ReactNode}) => {
+  const alertBarRootRef = useRef<HTMLDivElement>(null);
+  return (
+    <>
+      <div id="alert-bar-root" data-testid="alert-bar-root" ref={alertBarRootRef} />
+      <AlertBarContext.Provider value={{ alertBarRootRef }}>
+        {children}
+      </AlertBarContext.Provider>
+    </>
+  )
+}
+
+export default AlertBarContext;

--- a/packages/fxa-settings/src/lib/hooks.test.tsx
+++ b/packages/fxa-settings/src/lib/hooks.test.tsx
@@ -13,9 +13,9 @@ import {
 } from './hooks';
 
 describe('useFocusOnTriggeringElementOnClose', () => {
-  const Subject = ({ revealed }: { revealed?: boolean }) => {
+  const Subject = ({ revealed, triggerException }: { revealed?: boolean, triggerException?: boolean | undefined }) => {
     const triggerElement = useRef<HTMLButtonElement>(null);
-    useFocusOnTriggeringElementOnClose(revealed, triggerElement);
+    useFocusOnTriggeringElementOnClose(revealed, triggerElement, triggerException);
 
     return (
       <button ref={triggerElement} data-testid="trigger-element">
@@ -33,6 +33,13 @@ describe('useFocusOnTriggeringElementOnClose', () => {
 
   it('does nothing if `revealed` is not passed in', () => {
     const { rerender, getByTestId } = render(<Subject />);
+    rerender(<Subject />);
+
+    expect(document.activeElement).not.toBe(getByTestId('trigger-element'));
+  });
+
+  it('does nothing if `triggerException` is truthy', () => {
+    const { rerender, getByTestId } = render(<Subject triggerException />);
     rerender(<Subject />);
 
     expect(document.activeElement).not.toBe(getByTestId('trigger-element'));

--- a/packages/fxa-settings/src/lib/hooks.tsx
+++ b/packages/fxa-settings/src/lib/hooks.tsx
@@ -5,10 +5,12 @@
 import { useEffect, useRef } from 'react';
 
 // Focus on the element that triggered some action after the first
-// argument changes from `false` to `true`.
+// argument changes from `false` to `true` unless a `triggerException`
+// is also provided.
 export function useFocusOnTriggeringElementOnClose(
   revealed: boolean | undefined,
-  triggerElement: React.RefObject<HTMLButtonElement>
+  triggerElement: React.RefObject<HTMLButtonElement>,
+  triggerException?: boolean
 ) {
   const prevRevealedRef = useRef(revealed);
   const prevRevealed = prevRevealedRef.current;
@@ -17,10 +19,10 @@ export function useFocusOnTriggeringElementOnClose(
     if (revealed !== undefined) {
       prevRevealedRef.current = revealed;
     }
-    if (triggerElement.current && prevRevealed === true && revealed === false) {
+    if (triggerElement.current && prevRevealed === true && revealed === false && !triggerException) {
       triggerElement.current.focus();
     }
-  }, [revealed, triggerElement, prevRevealed]);
+  }, [revealed, triggerElement, prevRevealed, triggerException]);
 }
 
 // Run a function on 'Escape' keydown.


### PR DESCRIPTION
## Because

* We need to use the AlertBar component throughout the project while keeping it as the first DOM element after the main tag.

## This pull request

* Adds 'alert-bar-root' element and uses createPortal in AlertBar to mount
* Adds AlertBarContext for referencing the 'alert-bar-root' element
* Modifies the hook that sets focus on the element opening a modal, allowing for a 'triggerException' to allow AlertBar to take focus
* Pulls the secondary email section into its own component

## Issue that this pull request solves

Closes: #4926 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Other information

This issue had a couple of different parts to it, but part of it was to look into Apollo client cache to ensure that would handle our state needs across our GQL and REST API calls plus anything that would require a global state. Through reading I've done plus Danny's work on #6125, we've determined Apollo client cache is what we want, as we can store any local data there and use it as our single source of truth. We have this initialized already.

The other part of that ticket was allowing us to use the `<AlertBar>` component wherever while rendering it just below `<main>` which is what this PR covers, since it was likely we'd need to use Context or something global to pass around.

I was going to write some docs for this, but I'm afraid the implementation may change later and leave this out of date. I'd gotten this far, I could add this to the README if it seems valuable, but stopped once I got to the example.

```
### React Portals and Using the AlertBar

The `Modal` component uses a [React Portal](https://reactjs.org/docs/portals.html) to render the component in a dynamically created root element adjacent to the `<div id="root"></div>` element, used to mount the React application on load. Similarly, the `AlertBar` uses a portal to render the component inside an `alert-bar-root` element which is the first element inside the `<main>` tag.

[was going to insert AlertBar example use here but you could just reference UnitRowSecondaryEmail ¯\_(ツ)_/¯ ]
```
