### PR TITLE
fix(tests): add job to run tests against remote target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,6 +220,19 @@ jobs:
       - store_artifacts:
           path: artifacts
 
+  # This job is manually triggered for now. see _dev/docker/circleci/README.md
+  test-content-server-remote:
+    executor: content-server-executor
+    steps:
+      - base-install:
+          package: fxa-content-server
+      - run:
+          name: Running test section against a remote target
+          command: ./packages/fxa-content-server/scripts/test-ci-remote.sh
+      - store_artifacts:
+          path: ~/screenshots
+          destination: screenshots
+
   build-and-deploy-storybooks:
     resource_class: small
     docker:

--- a/packages/fxa-content-server/scripts/test-ci-remote.sh
+++ b/packages/fxa-content-server/scripts/test-ci-remote.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -ex
+
+DIR=$(dirname "$0")
+cd "$DIR/.."
+echo -e "\n###################################"
+echo "# testing fxa-content-server"
+echo -e "###################################\n"
+
+env | sort
+
+function test_suite() {
+  local suite=$1
+  node tests/intern.js \
+    --suites="${suite}" \
+    --fxaAuthRoot=https://api-accounts.stage.mozaws.net/v1 \
+    --fxaContentRoot=https://accounts.stage.mozaws.net/ \
+    --fxaOAuthApp=https://123done-stage.dev.lcip.org/ \
+    --fxaUntrustedOauthApp=https://321done-stage.dev.lcip.org/ \
+    --fxaEmailRoot=http://restmail.net \
+    --fxaProduction=true \
+    --output="../../artifacts/tests/${suite}-${numGroups}-${i}-results.xml" \
+    --firefoxBinary=./firefox/firefox \
+    || \
+  node tests/intern.js \
+    --suites="${suite}" \
+    --fxaAuthRoot=https://api-accounts.stage.mozaws.net/v1 \
+    --fxaContentRoot=https://accounts.stage.mozaws.net/ \
+    --fxaOAuthApp=https://123done-stage.dev.lcip.org/ \
+    --fxaUntrustedOauthApp=https://321done-stage.dev.lcip.org/ \
+    --fxaEmailRoot=http://restmail.net \
+    --fxaProduction=true \
+    --output="../../artifacts/tests/${suite}-${numGroups}-${i}-results.xml" \
+    --firefoxBinary=./firefox/firefox \
+    --grep="$(<rerun.txt)"
+}
+
+yarn lint
+
+cd ../../
+mkdir -p artifacts/tests
+
+cd packages/fxa-content-server
+mozinstall /firefox.tar.bz2
+test_suite functional_smoke
+# TODO - restore these
+#test_suite server
+#mozinstall /7f10c7614e9fa46-target.tar.bz2
+#test_suite pairing
+
+

--- a/packages/fxa-content-server/tests/functional_smoke.js
+++ b/packages/fxa-content-server/tests/functional_smoke.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = [
+  //  'tests/functional/fx_browser_relier.js',
+  'tests/functional/reset_password.js',
+  'tests/functional/connect_another_device.js',
+  'tests/functional/delete_account.js',
+  //  'tests/functional/fx_fennec_v1_sign_in.js',
+  //  'tests/functional/fx_fennec_v1_sign_up.js',
+  //  'tests/functional/fx_firstrun_v2.js',
+  //  'tests/functional/fx_ios_v1_sign_in.js',
+  //  'tests/functional/fx_ios_v1_sign_up.js',
+  //  'tests/functional/oauth_reset_password.js',
+  //  'tests/functional/oauth_sign_in_token_code.js',
+  'tests/functional/oauth_sign_up.js',
+  'tests/functional/oauth_sync_sign_in.js',
+  //  'tests/functional/recovery_key.js',
+  'tests/functional/settings_change_email.js',
+  'tests/functional/sign_in_totp.js',
+  //  'tests/functional/subscriptions.js',
+  //  'tests/functional/support.js',
+  //  'tests/functional/sync_v3_email_first.js',
+  //  'tests/functional/sync_v3_sign_in.js',
+  //  'tests/functional/sync_v3_sign_up.js',
+  //  'tests/functional/sync_v3_reset_password.js',
+  //  'tests/functional/pairing.js',
+  'tests/functional/change_password.js',
+];

--- a/packages/fxa-content-server/tests/intern.js
+++ b/packages/fxa-content-server/tests/intern.js
@@ -14,6 +14,7 @@ const testsCircleCi = require('./functional_circle')(
   args.groupsCount,
   args.groupNum
 );
+const testsFunctionalSmoke = require('./functional_smoke');
 const testsPairing = require('./functional_pairing');
 const testsServer = require('./tests_server');
 const testsServerResources = require('./tests_server_resources');
@@ -99,6 +100,9 @@ if (args.suites) {
     case 'pairing':
       config.functionalSuites = testsPairing;
       config.isTestingPairing = true;
+      break;
+    case 'functional_smoke':
+      config.functionalSuites = testsFunctionalSmoke;
       break;
     case 'all':
       config.functionalSuites = testsMain;


### PR DESCRIPTION
## Because

- having a functional test of stage run before further testiing of stage is useful

## This pull request

- adds a job that can be triggered by the api to run tests in stage. (For now; later we can work out a way to automagically trigger test runs)

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

This will run a smaller suite of tests. In the future I may reintroduce parallelism for that suite.

