### PR TITLE
fix(server): register 2FA inline setup routes with server

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/get-frontend.js
+++ b/packages/fxa-content-server/server/lib/routes/get-frontend.js
@@ -23,6 +23,8 @@ module.exports = function () {
     'cookies_disabled',
     'force_auth',
     'get_flow',
+    'inline_totp_setup',
+    'inline_recovery_setup',
     'legal',
     'oauth',
     'oauth/force_auth',

--- a/packages/fxa-content-server/tests/server/routes.js
+++ b/packages/fxa-content-server/tests/server/routes.js
@@ -45,6 +45,8 @@ var routes = {
   '/cookies_disabled': { statusCode: 200 },
   '/force_auth': { statusCode: 200 },
   '/get_flow': { statusCode: 200 },
+  '/inline_totp_setup': { statusCode: 200 },
+  '/inline_recovery_setup': { statusCode: 200 },
   '/legal': { statusCode: 200 },
   '/legal/privacy': { statusCode: 200 },
   '/legal/terms': { statusCode: 200 },


### PR DESCRIPTION
## Because

- Missed a spot in the inline totp routes setup. Now that the OIDC bug is fixed, this route is 404ing on the server.

## This pull request

- Registers the inline totp routes with the server, so the frontend app knows to handle them.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
