### PR TITLE
fix(content-server): validate the sign up input before showing validation error

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/form.js
+++ b/packages/fxa-content-server/app/scripts/views/form.js
@@ -573,6 +573,27 @@ var FormView = BaseView.extend({
     }
     return newValues;
   },
+
+  /**
+   * Checks whether the selected form is valid.
+   * If the elements is invalid, returns false.
+   *
+   * @param {String} selector
+   * @returns {Boolean}
+   */
+  validateFormField(selector) {
+    const $el = this.$(selector);
+
+    try {
+      // calling the jQuery plugin to validate the input elements
+      // and thrown and error if the input fields are not validated.
+      $el.validate();
+    } catch (err) {
+      this.showValidationError(selector, err);
+      return false;
+    }
+    return true;
+  },
 });
 
 export default FormView;

--- a/packages/fxa-content-server/app/scripts/views/settings/change_password.jsx
+++ b/packages/fxa-content-server/app/scripts/views/settings/change_password.jsx
@@ -29,6 +29,7 @@ function ChangePassword(props) {
         displayError={props.displayError}
         isPanelOpen={props.isPanelOpen}
         showValidationError={props.showValidationError}
+        validateFormField={props.validateFormField}
       />
     </div>
   );
@@ -84,7 +85,7 @@ export class ChangePasswordForm extends React.Component {
   showValidationErrors() {
     if (
       this.state.newPass &&
-      this.validateFormField('#new_password') &&
+      this.props.validateFormField('#new_password') &&
       this.state.newVPass &&
       this.state.newPass !== this.state.newVPass
     ) {
@@ -115,24 +116,12 @@ export class ChangePasswordForm extends React.Component {
     );
   };
 
-  validateFormField(selector) {
-    try {
-      // calling the jQuery plugin to validate the input elements
-      // and thrown and error if the input fields are not validated.
-      $(selector).validate();
-    } catch (err) {
-      this.props.showValidationError(selector, err);
-      return false;
-    }
-    return true;
-  }
-
   handleSubmit = (event) => {
     event.preventDefault();
     const areInputsValid =
-      this.validateFormField('#old_password') &&
-      this.validateFormField('#new_password') &&
-      this.validateFormField('#new_vpassword');
+      this.props.validateFormField('#old_password') &&
+      this.props.validateFormField('#new_password') &&
+      this.props.validateFormField('#new_vpassword');
 
     if (!areInputsValid) {
       event.stopPropagation();
@@ -272,6 +261,9 @@ class ChangePasswordView extends FormView {
           isPanelOpen={this.isPanelOpen()}
           showValidationError={(id, err) =>
             this.showValidationError(this.$(id), err)
+          }
+          validateFormField={(selection) =>
+            this.validateFormField(selection)
           }
         />,
         this.$el.get(0)

--- a/packages/fxa-content-server/app/scripts/views/sign_up_password.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_up_password.js
@@ -92,7 +92,10 @@ const SignUpPasswordView = FormView.extend({
   },
 
   showValidationErrorsEnd() {
-    if (!this._doPasswordsMatch()) {
+    if (
+      this.validateFormField(PASSWORD_INPUT_SELECTOR) &&
+      !this._doPasswordsMatch()
+    ) {
       this.showValidationError(
         this.$(VPASSWORD_INPUT_SELECTOR),
         AuthErrors.toError('PASSWORDS_DO_NOT_MATCH'),


### PR DESCRIPTION
## Because

* The "passwords do not match" tooltip is still displayed, even if there is a validation error.

## This pull request

* Check if the input is valid before showing the tooltip.

## Issue that this pull request solves

Closes #3575
