### PR TITLE
feat(settings): redirect to login when session token is invalid

### DIFF
--- a/packages/fxa-settings/src/lib/auth.test.tsx
+++ b/packages/fxa-settings/src/lib/auth.test.tsx
@@ -6,10 +6,10 @@
 import React from 'react';
 import { render, cleanup } from '@testing-library/react';
 
-import { AuthClient, AuthContext, useAuth } from './auth';
+import { AuthContext, createAuthClient, useAuth } from './auth';
 
 describe('useAuth', () => {
-  const client = new AuthClient('none');
+  const client = createAuthClient('none');
 
   afterEach(() => {
     cleanup();

--- a/packages/fxa-settings/src/lib/auth.ts
+++ b/packages/fxa-settings/src/lib/auth.ts
@@ -6,7 +6,10 @@ export interface AuthContextValue {
 }
 
 export const AuthContext = React.createContext<AuthContextValue>({});
-export { AuthClient };
+
+export function createAuthClient(authServerUri: string) {
+  return new AuthClient(authServerUri);
+}
 
 export function useAuth() {
   const { auth } = useContext(AuthContext);

--- a/packages/fxa-settings/src/lib/gql.ts
+++ b/packages/fxa-settings/src/lib/gql.ts
@@ -1,0 +1,52 @@
+import { ApolloClient, createHttpLink, from } from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
+import { onError } from '@apollo/client/link/error';
+import { cache, sessionToken, typeDefs } from './cache';
+
+export function createApolloClient(gqlServerUri: string) {
+  // httpLink makes the actual requests to the server
+  const httpLink = createHttpLink({
+    uri: `${gqlServerUri}/graphql`,
+  });
+
+  // authLink sets the Authentication header on outgoing requests
+  const authLink = setContext((_, { headers }) => {
+    return {
+      headers: {
+        ...headers,
+        Authorization: sessionToken(),
+      },
+    };
+  });
+
+  // errorLink handles error responses from the server
+  const errorLink = onError(({ graphQLErrors, networkError }) => {
+    let reauth = false;
+    if (graphQLErrors) {
+      for (const error of graphQLErrors) {
+        if (error.extensions?.code === 'UNAUTHENTICATED') {
+          reauth = true;
+        }
+      }
+    }
+    if (networkError && 'statusCode' in networkError) {
+      if (networkError.statusCode === 401) {
+        reauth = true;
+      }
+    }
+    if (reauth) {
+      window.location.replace(
+        `/get_flow?redirect_to=${encodeURIComponent(window.location.pathname)}`
+      );
+    } else {
+      console.error(graphQLErrors, networkError);
+    }
+  });
+  const apolloClient = new ApolloClient({
+    cache,
+    link: from([errorLink, authLink, httpLink]),
+    typeDefs,
+  });
+
+  return apolloClient;
+}


### PR DESCRIPTION
When the graphql server fails authentication it means we need to reauthenticate the user. We do this in a slightly roundabout way by redirecting to /get_flow and having it navigate to the login page so that we can redirect_to back to /beta/settings. Once new settings is no longer in beta we ought to be able to redirect straight to /signin.

fixes #6118