### PR TITLE
task(fxa-settings): convert settings component to use cache

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -53,9 +53,7 @@ type AppProps = {
 };
 
 export const App = ({ queryParams }: AppProps) => {
-  const { loading, error, data } = useQuery<{ account: Account }>(
-    GET_INITIAL_STATE
-  );
+  const { loading, error } = useQuery<{ account: Account }>(GET_INITIAL_STATE);
   FlowEvents.init(queryParams);
 
   if (loading) {
@@ -67,11 +65,10 @@ export const App = ({ queryParams }: AppProps) => {
   if (error) {
     return <AppErrorDialog data-testid="error-dialog" {...{ error }} />;
   }
-  const account = data!.account;
 
   return (
     <AppLayout>
-      <Settings {...{ account }} />
+      <Settings />
     </AppLayout>
   );
 };

--- a/packages/fxa-settings/src/components/Settings/index.test.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.test.tsx
@@ -6,9 +6,13 @@ import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render, screen } from '@testing-library/react';
 import Settings from './index';
-import { MOCK_ACCOUNT } from '../../models/_mocks';
+import { MockedCache } from '../../models/_mocks';
 
 it('renders without imploding', async () => {
-  render(<Settings account={MOCK_ACCOUNT} />);
+  render(
+    <MockedCache>
+      <Settings />
+    </MockedCache>
+  );
   expect(screen.getByTestId('settings-profile')).toBeInTheDocument();
 });

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -7,10 +7,17 @@ import UnitRow from '../UnitRow';
 import UnitRowWithAvatar from '../UnitRowWithAvatar';
 import Security from '../Security';
 import UnitRowSecondaryEmail from '../UnitRowSecondaryEmail';
-import { Account } from '../../models';
 
-export const Settings = ({ account }: { account: Account }) => {
-  const primaryEmail = account.emails.find((email) => email.isPrimary)!;
+import { useAccount } from '../../models';
+
+export const Settings = () => {
+  const {
+    primaryEmail,
+    displayName,
+    avatarUrl,
+    passwordCreated,
+    recoveryKey,
+  } = useAccount();
 
   return (
     <>
@@ -18,15 +25,11 @@ export const Settings = ({ account }: { account: Account }) => {
         <h2 className="font-header font-bold ml-4 mb-4">Profile</h2>
 
         <div className="bg-white tablet:rounded-xl shadow">
-          <UnitRowWithAvatar avatarUrl={account.avatarUrl} />
+          <UnitRowWithAvatar avatarUrl={avatarUrl} />
 
           <hr className="unit-row-hr" />
 
-          <UnitRow
-            header="Display name"
-            headerValue={account.displayName}
-            route="#"
-          />
+          <UnitRow header="Display name" headerValue={displayName} route="#" />
 
           <hr className="unit-row-hr" />
 
@@ -37,7 +40,7 @@ export const Settings = ({ account }: { account: Account }) => {
             route="#"
           >
             <p className="text-grey-400 text-xs mobileLandscape:mt-3">
-              Created {account.passwordCreated}
+              Created {passwordCreated}
             </p>
           </UnitRow>
 
@@ -52,7 +55,7 @@ export const Settings = ({ account }: { account: Account }) => {
       </section>
 
       <Security
-        accountRecoveryKeyEnabled={account.recoveryKey}
+        accountRecoveryKeyEnabled={recoveryKey}
         twoFactorAuthEnabled={false}
       />
     </>

--- a/packages/fxa-settings/src/models/_mocks.tsx
+++ b/packages/fxa-settings/src/models/_mocks.tsx
@@ -4,12 +4,11 @@
 
 import React from 'react';
 import { InMemoryCache, ApolloClient, ApolloProvider } from '@apollo/client';
-import { MockedResponse } from '@apollo/client/testing';
 import { Account } from '.';
 import { GET_INITIAL_STATE } from '../components/App';
 import { deepMerge } from '../lib/utilities';
 
-export const MOCK_ACCOUNT: Account = {
+const MOCK_ACCOUNT: Account = {
   uid: 'abc123',
   displayName: 'John Dope',
   avatarUrl: 'http://avatars.com/y2k',
@@ -33,19 +32,6 @@ export const MOCK_ACCOUNT: Account = {
   totp: {
     exists: true,
     verified: true,
-  },
-};
-
-export const MOCK_GET_ACCOUNT: MockedResponse = {
-  request: {
-    query: GET_INITIAL_STATE,
-  },
-  result: {
-    data: {
-      account: {
-        ...MOCK_ACCOUNT,
-      },
-    },
   },
 };
 


### PR DESCRIPTION
## This pull request

- opts for `useAccount` over passing `account` object into components. builds off of @dannycoates pr, https://github.com/mozilla/fxa/pull/6145/files

## Issue that this pull request solves

Closes: #6154 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
