### PR TITLE
fix(email): Lookup account by `originalLoginEmail` if present

### DIFF
--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -178,6 +178,18 @@ module.exports = (log, config, customs, db, mailer, cadReminders) => {
           // If we didn't load it above while checking unblock codes,
           // it's now safe to load the account record from the db.
           if (!accountRecord) {
+            // If `originalLoginEmail` is specified, we need to fetch the account record tied
+            // to that email. In the case where a user has changed their primary email, the `email`
+            // value here is really the value used to hash the password and has no guarantee to
+            // belong to the user.
+            if (request.payload.originalLoginEmail) {
+              return db
+                .accountRecord(request.payload.originalLoginEmail)
+                .then((result) => {
+                  accountRecord = result;
+                });
+            }
+
             return db.accountRecord(email).then((result) => {
               accountRecord = result;
             });


### PR DESCRIPTION
## Because

- When users change their primary email address would could potentially do an account lookup on the wrong email value
- The `originalLoginEmail` is a value that the users password is hashed with

## This pull request

- Uses the `originalLoginEmail` if present

## Issue that this pull request solves

Closes: https://bugzilla.mozilla.org/show_bug.cgi?id=1635027

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
