### PR TITLE
fix(admin): split query for index usage

### DIFF
--- a/packages/fxa-admin-server/src/lib/resolvers/account-resolver.ts
+++ b/packages/fxa-admin-server/src/lib/resolvers/account-resolver.ts
@@ -54,13 +54,14 @@ export class AccountResolver {
   @FieldResolver()
   public async emailBounces(@Root() account: Account) {
     const uidBuffer = uuidTransformer.to(account.uid);
-    const subquery = Emails.query()
+    // MySQL Query optimizer does weird things, use separate queries to force index use
+    const emails = await Emails.query()
       .select('emails.normalizedEmail')
       .where('emails.uid', uidBuffer);
     const result = await EmailBounces.query().where(
       'emailBounces.email',
       'in',
-      subquery
+      emails.map((x) => x.normalizedEmail)
     );
     return result;
   }


### PR DESCRIPTION
Because:

* MySQL optimizer doesn't like using emailBounces index when using a
  sub-query.

This commit:

* Splits the query into two, which then utilizes the indexes of both
  tables as expected.

Closes #6064

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
