### PR TITLE
fix(payments): send subscription download email along with initial invoice

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -47,7 +47,7 @@ const VALID_RESOURCE_TYPES = [
   PLAN_RESOURCE,
   CHARGES_RESOURCE,
   INVOICES_RESOURCE,
-];
+] as const;
 
 export const SUBSCRIPTION_UPDATE_TYPES = {
   UPGRADE: 'upgrade',
@@ -1587,7 +1587,7 @@ export class StripeHelper {
    */
   async expandResource<T>(
     resource: string | T,
-    resourceType: string
+    resourceType: typeof VALID_RESOURCE_TYPES[number]
   ): Promise<T> {
     if (typeof resource !== 'string') {
       return resource;

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -658,7 +658,6 @@ describe('DirectStripeRoutes', () => {
             TEST_EMAIL
           )
         );
-        assert.isTrue(mailer.sendDownloadSubscriptionEmail.calledOnce);
 
         assert.isTrue(log.info.calledOnce);
         assert.deepEqual(actual, expected);
@@ -715,7 +714,6 @@ describe('DirectStripeRoutes', () => {
             TEST_EMAIL
           )
         );
-        assert.isTrue(mailer.sendDownloadSubscriptionEmail.calledOnce);
 
         assert.isTrue(log.info.calledOnce);
         assert.deepEqual(actual, expected);
@@ -777,7 +775,6 @@ describe('DirectStripeRoutes', () => {
         UID,
         TEST_EMAIL
       );
-      assert.isTrue(mailer.sendDownloadSubscriptionEmail.calledOnce);
 
       assert.deepEqual(
         {
@@ -849,7 +846,6 @@ describe('DirectStripeRoutes', () => {
         UID,
         TEST_EMAIL
       );
-      assert.isTrue(mailer.sendDownloadSubscriptionEmail.calledOnce);
     });
   });
 
@@ -861,6 +857,7 @@ describe('DirectStripeRoutes', () => {
       directStripeRoutesInstance.stripeHelper.retryInvoiceWithPaymentId.resolves(
         expected
       );
+      sinon.stub(directStripeRoutesInstance, 'customerChanged').resolves();
       VALID_REQUEST.payload = {
         invoiceId: 'in_testinvoice',
         paymentMethodId: 'pm_asdf',
@@ -869,6 +866,13 @@ describe('DirectStripeRoutes', () => {
 
       const actual = await directStripeRoutesInstance.retryInvoice(
         VALID_REQUEST
+      );
+
+      sinon.assert.calledWith(
+        directStripeRoutesInstance.customerChanged,
+        VALID_REQUEST,
+        UID,
+        TEST_EMAIL
       );
 
       assert.deepEqual(filterInvoice(expected), actual);
@@ -2389,6 +2393,17 @@ describe('DirectStripeRoutes', () => {
           ...mockInvoiceDetails,
         }
       );
+      if (expectedMethodName === 'sendSubscriptionFirstInvoiceEmail') {
+        assert.calledWith(
+          directStripeRoutesInstance.mailer.sendDownloadSubscriptionEmail,
+          mockAccount.emails,
+          mockAccount,
+          {
+            acceptLanguage: mockAccount.locale,
+            ...mockInvoiceDetails,
+          }
+        );
+      }
     };
 
     it(


### PR DESCRIPTION
In the new SCA payment flow, there is at least one case where we'll only
know that the subscription has been successfully paid for when the
webhook event comes in from Stripe. (i.e. client-side 3D Secure
authentication)

But, as far as I can tell, we can't tell the difference between that and any other
case. So, this PR switches all cases over to sending the download email
along with initial invoice in response to the invoice webhook event.

fixes #6175
