### PR TITLE
fix(payments): do not send payment failure emails during subscription creation flow

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.ts
@@ -1027,6 +1027,10 @@ class DirectStripeRoutes {
     event: Stripe.Event
   ) {
     const invoice = event.data.object as Stripe.Invoice;
+    if (invoice.billing_reason !== 'subscription_cycle') {
+      // Send payment failure emails only when processing a subscription renewal.
+      return;
+    }
     const { uid, email } = await this.sendSubscriptionPaymentFailedEmail(
       invoice
     );

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -2265,21 +2265,27 @@ describe('DirectStripeRoutes', () => {
     });
 
     describe('handleInvoicePaymentFailedEvent', () => {
-      it('sends email and emits a notification when an invoice payment fails', async () => {
-        const paymentFailedEvent = deepCopy(eventInvoicePaymentFailed);
-        const sendSubscriptionPaymentFailedEmailStub = sandbox
+      const mockSubscription = {
+        id: 'test1',
+        plan: { product: 'test2' },
+      };
+      let sendSubscriptionPaymentFailedEmailStub;
+
+      beforeEach(() => {
+        sendSubscriptionPaymentFailedEmailStub = sandbox
           .stub(
             directStripeRoutesInstance,
             'sendSubscriptionPaymentFailedEmail'
           )
           .resolves(true);
-        const mockSubscription = {
-          id: 'test1',
-          plan: { product: 'test2' },
-        };
         directStripeRoutesInstance.stripeHelper.expandResource.resolves(
           mockSubscription
         );
+      });
+
+      it('sends email and emits a notification when an invoice payment fails', async () => {
+        const paymentFailedEvent = deepCopy(eventInvoicePaymentFailed);
+        paymentFailedEvent.data.object.billing_reason = 'subscription_cycle';
         await directStripeRoutesInstance.handleInvoicePaymentFailedEvent(
           {},
           paymentFailedEvent
@@ -2289,6 +2295,16 @@ describe('DirectStripeRoutes', () => {
           paymentFailedEvent.data.object
         );
         assert.notCalled(stubSendSubscriptionStatusToSqs);
+      });
+
+      it('does not send email during subscription creation flow', async () => {
+        const paymentFailedEvent = deepCopy(eventInvoicePaymentFailed);
+        paymentFailedEvent.data.object.billing_reason = 'subscription_create';
+        await directStripeRoutesInstance.handleInvoicePaymentFailedEvent(
+          {},
+          paymentFailedEvent
+        );
+        assert.notCalled(sendSubscriptionPaymentFailedEmailStub);
       });
     });
 


### PR DESCRIPTION
fixes #6129
