### PR TITLE
fix(totp): Ensure the user has a verified session before starting inline TOTP setup

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/inline_totp_setup.js
+++ b/packages/fxa-content-server/app/scripts/views/inline_totp_setup.js
@@ -72,15 +72,25 @@ var View = FormView.extend({
 
   beforeRender() {
     const account = this.getAccount();
+
     if (!account.get('sessionToken')) {
       this.navigate(this._getMissingSessionTokenScreen());
     }
-    return account.checkTotpTokenExists().then((result) => {
-      if (result.exists && result.verified) {
-        return this.onSubmitComplete();
+
+    return account.sessionVerificationStatus().then(({ sessionVerified }) => {
+      if (!sessionVerified) {
+        this.relier.set('redirectTo', this.window.location.href);
+        return this.replaceCurrentPage('/signin_token_code');
       }
-      // pre-generate the TOTP token
-      return this.getTotpToken();
+
+      return account.checkTotpTokenExists().then((result) => {
+        if (result.exists && result.verified) {
+          return this.onSubmitComplete();
+        }
+
+        // pre-generate the TOTP token
+        return this.getTotpToken();
+      });
     });
   },
 


### PR DESCRIPTION
Still need to update tests, but want to verify that I'm on the right track here.

## Because

- When a user with an unverified session tries to log in to an RP that wants to force TOTP setup, the user encounters a fatal error

## This pull request

- Explicitly checks the user's session verification status before rendering the inline TOTP setup flow. If the session is unverified, the view now redirects to the verification flow (via `/signin_token_code`), then redirects back.

Note that I had originally thought I could just rely on checking the `verified` status in the `hasTotpToken` auth-db response, but after looking at the authdb code, it seems that just tells us if the TOTP token is verified, not if the user's session is verified. It also seems nicer to rely on regular control flow, rather than exception flow, to check for this edge case.

## Issue that this pull request solves

Closes: #5206

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
