### PR TITLE
fix(content-server): create fake hidden input on change password.

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/settings/change_password.jsx
+++ b/packages/fxa-content-server/app/scripts/views/settings/change_password.jsx
@@ -225,6 +225,12 @@ export class ChangePasswordForm extends React.Component {
             />
           </div>
 
+          {/* The browser wait until all the required inputs is fulfilled to
+         - show the "Save Password" doorhange. This non-fulfilled input tricks
+         - the browser into not showing the doorhanger until the page is changed
+         - with the text on the input. #547*/}
+          <input class="hidden" required />
+
           <div className="button-row">
             <button type="submit" className="settings-button primary-button">
               {t('Change')}


### PR DESCRIPTION
Because:

* When changing password, after all required inputs is completed, the "Save Password" is displayed.

This commit:

* Create a fake input with "required" atribute to trick the browser to not showing the "Save Password" doorhanger until the route is changed.

Closes #547
