### PR TITLE
fix(content-server): create fake hidden input on sign in

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -21,6 +21,11 @@
       </div>
       {{/isPasswordNeeded}}
 
+      <!-- This non-fulfilled input tricks the browser, when 
+         - trying to sign in with the wrong password, into not
+         - showing the doorhanger. -->
+      <input class="hidden" required />
+      
       <div class="button-row">
         <button id="submit-btn" {{^isPasswordNeeded}}class="use-logged-in"{{/isPasswordNeeded}} type="submit">{{#t}}Sign in{{/t}}</button>
       </div>


### PR DESCRIPTION
Because:

* When trying to sign in with wrong password, the "Save Password" is displayed.

This commit:

* Create a fake input with "required" atribute to trick the browser to not showing the "Save Password" doorhanger.
