### PR TITLE
fix(storybook): delete commits and pulls over 3 weeks old on every build

### DIFF
--- a/packages/fxa-payments-server/.storybook/config.js
+++ b/packages/fxa-payments-server/.storybook/config.js
@@ -8,11 +8,12 @@ const reqFromComponents = require.context(
   true,
   /\.stories.tsx?$/
 );
+
 const reqFromRoutes = require.context('../src/routes', true, /\.stories.tsx?$/);
 
 function loadStories() {
-  [reqFromComponents, reqFromRoutes].forEach(req =>
-    req.keys().forEach(filename => req(filename))
+  [reqFromComponents, reqFromRoutes].forEach((req) =>
+    req.keys().forEach((filename) => req(filename))
   );
 }
 


### PR DESCRIPTION
Because I assumed that git retained file creation timestamps, I had a simple find command to delete old commits and pulls after 90 days. Two problems here:

1. 90 days is too long
2. git doesn't retain file creation timestamps anyway - so all files look as if they were created at the beginning of a CircleCI run.

Thus, aging storybook builds have been piling up in [mozilla-fxa/storybooks gh-pages branch](https://github.com/mozilla-fxa/storybooks/tree/gh-pages) and we hit a 10GB limit. 

Still thinking about a cleaner solution, maybe in node.js. But for now, this change should do [what I did manually](https://github.com/mozilla-fxa/storybooks/commit/2f692f3f8cdfa5ba156817db9809bcca4d502aaf).

It's an ugly hack that munges git log output to find `commit/*` and `pull/*` directories to delete old builds.

Not sure if this will run on Mac OS X with the specific Linux shell pipeline.

Trying to think if there might be a cleaner way to do this.

As a follow-up, we could consider moving all of this to an AWS S3 bucket and use object expiration policies there to auto-clean.