### PR TITLE
chore: update typescript

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,35 +1,35 @@
 nodeLinker: node-modules
 
 packageExtensions:
-  "@apollo/react-common@*":
+  '@apollo/react-common@*':
     dependencies:
-      "@types/react": 16.9.35
+      '@types/react': 16.9.35
       apollo-client: 2.6.10
       apollo-utilities: 1.3.4
       graphql: 14.6.0
-  "@apollo/react-components@*":
+  '@apollo/react-components@*':
     dependencies:
       apollo-cache: 1.3.5
       apollo-client: 2.6.10
       apollo-link: 1.2.14
       apollo-utilities: 1.3.4
-  "@apollo/react-ssr@*":
+  '@apollo/react-ssr@*':
     dependencies:
-      "@types/react": 16.9.35
+      '@types/react': 16.9.35
       apollo-client: 2.6.10
       graphql: 14.6.0
-  "@storybook/addon-actions@*":
+  '@storybook/addon-actions@*':
     dependencies:
       react-dom: 16.13.1
       regenerator-runtime: 0.13.5
-  "@storybook/addon-links@*":
+  '@storybook/addon-links@*':
     dependencies:
       react-dom: 16.13.1
       regenerator-runtime: 0.13.5
-  "@storybook/addons@*":
+  '@storybook/addons@*':
     dependencies:
       regenerator-runtime: 0.13.5
-  "@storybook/api@*":
+  '@storybook/api@*':
     dependencies:
       react-dom: 16.13.1
   apollo-link-error@*:
@@ -43,7 +43,7 @@ packageExtensions:
       webpack: 4.43.0
   intern@*:
     dependencies:
-      typescript: 3.8.3
+      typescript: 3.9.7
   react-document-title@*:
     dependencies:
       react: 16.13.1
@@ -53,8 +53,8 @@ packageExtensions:
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs
-    spec: "@yarnpkg/plugin-typescript"
+    spec: '@yarnpkg/plugin-typescript'
   - path: .yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
-    spec: "@yarnpkg/plugin-workspace-tools"
+    spec: '@yarnpkg/plugin-workspace-tools'
 
 yarnPath: .yarn/releases/yarn-2.0.0-rc.36.js

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   ],
   "resolutions": {
     "gobbledygook": "git://github.com/mozilla-fxa/gobbledygook.git#354042684056e57ca77f036989e907707a36cff2",
-    "tap/typescript": "3.8.3",
+    "tap/typescript": "3.9.7",
     "@types/node": "12.12.38",
     "http-proxy": "^1.18.1"
   }

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -106,7 +106,7 @@
     "tailwindcss": "^1.4.6",
     "ts-jest": "^24.3.0",
     "ts-node": "^8.10.2",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "webpack": "^4.43.0"
   }
 }

--- a/packages/fxa-auth-client/package.json
+++ b/packages/fxa-auth-client/package.json
@@ -30,7 +30,7 @@
     "fast-text-encoding": "^1.0.0",
     "mocha": "^7.1.2",
     "ts-node": "^8.10.2",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "webcrypto-liner": "git://github.com/mozilla-fxa/webcrypto-liner.git#6b3ad971b3b1f0d4da3855c6ceee9b3afa9f0eeb"
   }
 }

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -160,7 +160,7 @@
     "sinon": "^9.0.3",
     "through": "2.3.8",
     "ts-node": "^8.10.2",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "ws": "^6.2.1"
   }
 }

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -125,7 +125,7 @@
     "speed-trap": "0.0.10",
     "thread-loader": "^2.1.2",
     "time-grunt": "1.4.0",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "ua-parser-js": "git://github.com/mozilla-fxa/ua-parser-js.git#fxa-version",
     "underscore": "^1.10.2",
     "verror": "1.10.0",

--- a/packages/fxa-metrics-processor/package.json
+++ b/packages/fxa-metrics-processor/package.json
@@ -52,7 +52,7 @@
     "prettier": "^2.0.5",
     "sinon": "^9.0.3",
     "ts-node": "^8.10.2",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "uuid": "^8.3.0"
   }
 }

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -92,7 +92,7 @@
     "supertest": "^4.0.2",
     "ts-jest": "^24.3.0",
     "ts-node": "^8.10.2",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "wait-for-expect": "^1.3.0",
     "webpack": "^4.43.0"
   },

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -166,7 +166,16 @@ function injectStripe<P extends Object>(
 ) {
   return (props: P) => {
     const { mockStripe } = useContext(MockStripeContext);
-    return <WrappedComponent {...{ ...props, stripe: mockStripe }} />;
+    return (
+      <WrappedComponent
+        {...{
+          ...props,
+          stripe: mockStripe as ReactStripeElements.InjectedStripeProps['stripe'],
+        }}
+        as
+        any
+      />
+    );
   };
 }
 

--- a/packages/fxa-payments-server/src/lib/validator.ts
+++ b/packages/fxa-payments-server/src/lib/validator.ts
@@ -127,7 +127,7 @@ export type FieldType = 'input' | 'stripe';
 type FieldStateKeys = 'fieldType' | 'value' | 'required' | 'valid' | 'error';
 type FieldState = {
   fieldType: FieldType;
-  value: any;
+  value?: any;
   required: boolean;
   valid: boolean | undefined | null;
   error: string | null;

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -65,7 +65,7 @@
     "sass-loader": "^8.0.2",
     "tailwindcss": "^1.4.6",
     "ts-jest": "^24.3.0",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "webpack": "^4.43.0"
   },
   "repository": {

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -43,7 +43,7 @@
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.1",
     "subscriptions-transport-ws": "^0.9.11",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "devDependencies": {
     "@babel/core": "^7.10.3",

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -56,7 +56,7 @@
     "proxyquire": "^2.1.3",
     "sinon": "^9.0.3",
     "ts-node": "^8.10.2",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "underscore": "^1.10.2",
     "uuid": "^8.3.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -15764,7 +15764,7 @@ fsevents@^1.2.7:
     tailwindcss: ^1.4.6
     ts-jest: ^24.3.0
     ts-node: ^8.10.2
-    typescript: 3.8.3
+    typescript: 3.9.7
     webpack: ^4.43.0
   languageName: unknown
   linkType: soft
@@ -15834,7 +15834,7 @@ fsevents@^1.2.7:
     mocha: ^7.1.2
     node-fetch: ^2.6.0
     ts-node: ^8.10.2
-    typescript: 3.8.3
+    typescript: 3.9.7
     webcrypto-liner: "git://github.com/mozilla-fxa/webcrypto-liner.git#6b3ad971b3b1f0d4da3855c6ceee9b3afa9f0eeb"
   languageName: unknown
   linkType: soft
@@ -15991,7 +15991,7 @@ fsevents@^1.2.7:
     through: 2.3.8
     ts-node: ^8.10.2
     typedi: ^0.8.0
-    typescript: 3.8.3
+    typescript: 3.9.7
     urijs: 1.19.1
     uuid: 1.4.1
     verror: ^1.10.0
@@ -16145,7 +16145,7 @@ fsevents@^1.2.7:
     time-grunt: 1.4.0
     ts-loader: ^7.0.5
     ts-node: ^8.10.2
-    typescript: 3.8.3
+    typescript: 3.9.7
     ua-parser-js: "git://github.com/mozilla-fxa/ua-parser-js.git#fxa-version"
     underscore: ^1.10.2
     upng-js: 2.1.0
@@ -16433,7 +16433,7 @@ fsevents@^1.2.7:
     sinon: ^9.0.3
     ts-node: ^8.10.2
     typedi: ^0.8.0
-    typescript: 3.8.3
+    typescript: 3.9.7
     uuid: ^8.3.0
   languageName: unknown
   linkType: soft
@@ -16572,7 +16572,7 @@ fsevents@^1.2.7:
     ts-node: ^8.10.2
     type-to-reducer: ^1.2.0
     typedi: ^0.8.0
-    typescript: 3.8.3
+    typescript: 3.9.7
     uuid: ^8.3.0
     wait-for-expect: ^1.3.0
     webpack: ^4.43.0
@@ -16672,7 +16672,7 @@ fsevents@^1.2.7:
     sass-loader: ^8.0.2
     tailwindcss: ^1.4.6
     ts-jest: ^24.3.0
-    typescript: 3.8.3
+    typescript: 3.9.7
     webpack: ^4.43.0
   languageName: unknown
   linkType: soft
@@ -16722,7 +16722,7 @@ fsevents@^1.2.7:
     react-scripts: ^3.4.1
     subscriptions-transport-ws: ^0.9.11
     tailwindcss: ^1.4.6
-    typescript: 3.8.3
+    typescript: 3.9.7
     webpack: ^4.43.0
   languageName: unknown
   linkType: soft
@@ -16768,7 +16768,7 @@ fsevents@^1.2.7:
     sinon: ^9.0.3
     stripe: ^8.69.0
     ts-node: ^8.10.2
-    typescript: 3.8.3
+    typescript: 3.9.7
     underscore: ^1.10.2
     uuid: ^8.3.0
   languageName: unknown
@@ -33715,16 +33715,6 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-typescript@3.8.3:
-  version: 3.8.3
-  resolution: "typescript@npm:3.8.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 519b11576247fe3570d89a2aa757d8f666aafc0cb9465a6cdd4df09c1dc6bf7285f0c6008d2ac7a55ea26457e767aaab819f58439d80af2cce1d9805b2be1034
-  languageName: node
-  linkType: hard
-
 typescript@3.9.7:
   version: 3.9.7
   resolution: "typescript@npm:3.9.7"
@@ -33732,16 +33722,6 @@ typescript@3.9.7:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10848a9c35fd8c70a8792b8bd9485317534bcd58768793d3b7d9c7486e9fd30cf345f83fa2a324e0bf6088bc8a4d8d061d58fda38b18c2ff187cf01fbbff6267
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@3.8.3#builtin<compat/typescript>":
-  version: 3.8.3
-  resolution: "typescript@patch:typescript@npm%3A3.8.3#builtin<compat/typescript>::version=3.8.3&hash=64df9d"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 7b29bcb0576cc81266c5b4e6f84bb5a760483fa80bcd7d9588b0d3e16063c733552acf686c8541b93be2cf29ec5d8360ec927509b11e4e723f0dc91366b9cb1a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:

* Using the latest everywhere helps with consistency and smaller build
  size.

This commit:

* Updates for TypeScript 3.9.7 everywhere in FxA.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
