### PR TITLE
feat(graphql): add new settings mutations

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -547,14 +547,14 @@ export default class AuthClient {
       newsletters?: string[];
       style?: string;
     } = {}
-  ) {
+  ): Promise<{}> {
     return this.sessionPost('/session/verify_code', sessionToken, {
       code,
       ...options,
     });
   }
 
-  async sessionResendVerifyCode(sessionToken: string) {
+  async sessionResendVerifyCode(sessionToken: string): Promise<{}> {
     return this.sessionPost('/session/resend_code', sessionToken, {});
   }
 
@@ -906,7 +906,7 @@ export default class AuthClient {
     sessionToken: string,
     email: string,
     code: string
-  ) {
+  ): Promise<{}> {
     return this.sessionPost(
       '/recovery_email/secondary/verify_code',
       sessionToken,

--- a/packages/fxa-graphql-api/src/lib/datasources/authServer.ts
+++ b/packages/fxa-graphql-api/src/lib/datasources/authServer.ts
@@ -52,7 +52,9 @@ export class AuthServerSource extends DataSource {
   public createTotpToken(
     options: MetricsContext
   ): ReturnType<AuthClient['createTotpToken']> {
-    return this.authClient.createTotpToken(this.token, { metricsContext: options });
+    return this.authClient.createTotpToken(this.token, {
+      metricsContext: options,
+    });
   }
 
   public destroyTotpToken(): Promise<any> {
@@ -90,5 +92,21 @@ export class AuthServerSource extends DataSource {
 
   public verifyTotp(code: string, options?: { service: string }) {
     return this.authClient.verifyTotpCode(this.token, code, options);
+  }
+
+  public recoveryEmailSecondaryVerifyCode(email: string, code: string) {
+    return this.authClient.recoveryEmailSecondaryVerifyCode(
+      this.token,
+      email,
+      code
+    );
+  }
+
+  public sessionResendVerifyCode() {
+    return this.authClient.sessionResendVerifyCode(this.token);
+  }
+
+  public sessionVerifyCode(code: string) {
+    return this.authClient.sessionVerifyCode(this.token, code);
   }
 }

--- a/packages/fxa-graphql-api/src/lib/resolvers/account-resolver.ts
+++ b/packages/fxa-graphql-api/src/lib/resolvers/account-resolver.ts
@@ -29,9 +29,12 @@ import {
   CreateTotpInput,
   DeleteTotpInput,
   EmailInput,
+  SendSessionVerificationInput,
   UpdateAvatarInput,
   UpdateDisplayNameInput,
   VerifyTotpInput,
+  VerifyEmailInput,
+  VerifySessionInput,
 } from './types/input';
 import {
   BasicPayload,
@@ -162,6 +165,35 @@ export class AccountResolver {
   }
 
   @Mutation((returns) => BasicPayload, {
+    description: 'Reset the verification code to a secondary email.',
+  })
+  @CatchGatewayError
+  public async resendSecondaryEmailCode(
+    @Ctx() context: Context,
+    @Arg('input', (type) => EmailInput) input: EmailInput
+  ): Promise<BasicPayload> {
+    await context.dataSources.authAPI.recoveryEmailSecondaryResendCode(
+      input.email
+    );
+    return { clientMutationId: input.clientMutationId };
+  }
+
+  @Mutation((returns) => BasicPayload, {
+    description: 'Verify the email address with a code.',
+  })
+  @CatchGatewayError
+  public async verifySecondaryEmail(
+    @Ctx() context: Context,
+    @Arg('input', (type) => VerifyEmailInput) input: VerifyEmailInput
+  ) {
+    await context.dataSources.authAPI.recoveryEmailSecondaryVerifyCode(
+      input.email,
+      input.code
+    );
+    return { clientMutationId: input.clientMutationId };
+  }
+
+  @Mutation((returns) => BasicPayload, {
     description: 'Remove the secondary email for the signed in account.',
   })
   @CatchGatewayError
@@ -187,20 +219,6 @@ export class AccountResolver {
   }
 
   @Mutation((returns) => BasicPayload, {
-    description: 'Reset the verification code to a secondary email.',
-  })
-  @CatchGatewayError
-  public async resendSecondaryEmailCode(
-    @Ctx() context: Context,
-    @Arg('input', (type) => EmailInput) input: EmailInput
-  ): Promise<BasicPayload> {
-    await context.dataSources.authAPI.recoveryEmailSecondaryResendCode(
-      input.email
-    );
-    return { clientMutationId: input.clientMutationId };
-  }
-
-  @Mutation((returns) => BasicPayload, {
     description:
       "Destroy all tokens held by a connected client, disconnecting it from the user's account.",
   })
@@ -210,6 +228,30 @@ export class AccountResolver {
     input: AttachedClientDisconnectInput
   ) {
     await context.dataSources.authAPI.attachedClientDestroy(input);
+    return { clientMutationId: input.clientMutationId };
+  }
+
+  @Mutation((returns) => BasicPayload, {
+    description: 'Send a session verification email.',
+  })
+  public async sendSessionVerificationCode(
+    @Ctx() context: Context,
+    @Arg('input', (type) => SendSessionVerificationInput)
+    input: SendSessionVerificationInput
+  ) {
+    await context.dataSources.authAPI.sessionResendVerifyCode();
+    return { clientMutationId: input.clientMutationId };
+  }
+
+  @Mutation((returns) => BasicPayload, {
+    description: 'Verify the session via an email code.',
+  })
+  @CatchGatewayError
+  public async verifySession(
+    @Ctx() context: Context,
+    @Arg('input', (type) => VerifySessionInput) input: VerifySessionInput
+  ) {
+    await context.dataSources.authAPI.sessionVerifyCode(input.code);
     return { clientMutationId: input.clientMutationId };
   }
 

--- a/packages/fxa-graphql-api/src/lib/resolvers/types/input/index.ts
+++ b/packages/fxa-graphql-api/src/lib/resolvers/types/input/index.ts
@@ -9,3 +9,6 @@ export { AttachedClientDisconnectInput } from './attached-client-disconnect';
 export { ChangeRecoveryCodesInput } from './change-recovery-codes';
 export { DeleteTotpInput } from './delete-totp';
 export { VerifyTotpInput } from './verify-totp';
+export { VerifyEmailInput } from './verify-email';
+export { SendSessionVerificationInput } from './send-session-verification';
+export { VerifySessionInput } from './verify-session';

--- a/packages/fxa-graphql-api/src/lib/resolvers/types/input/send-session-verification.ts
+++ b/packages/fxa-graphql-api/src/lib/resolvers/types/input/send-session-verification.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType } from 'type-graphql';
+
+@InputType()
+export class SendSessionVerificationInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+}

--- a/packages/fxa-graphql-api/src/lib/resolvers/types/input/verify-email.ts
+++ b/packages/fxa-graphql-api/src/lib/resolvers/types/input/verify-email.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType } from 'type-graphql';
+
+@InputType()
+export class VerifyEmailInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field({ description: 'The email to verify' })
+  public email!: string;
+
+  @Field({ description: 'The code to check' })
+  public code!: string;
+}

--- a/packages/fxa-graphql-api/src/lib/resolvers/types/input/verify-session.ts
+++ b/packages/fxa-graphql-api/src/lib/resolvers/types/input/verify-session.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Field, InputType } from 'type-graphql';
+
+@InputType()
+export class VerifySessionInput {
+  @Field({
+    description: 'A unique identifier for the client performing the mutation.',
+    nullable: true,
+  })
+  public clientMutationId?: string;
+
+  @Field({ description: 'The code to check' })
+  public code!: string;
+}

--- a/packages/fxa-graphql-api/src/test/lib/datasources/authServer.spec.ts
+++ b/packages/fxa-graphql-api/src/test/lib/datasources/authServer.spec.ts
@@ -82,6 +82,9 @@ describe('AuthServerSource', () => {
       recoveryEmailDestroy: sandbox.stub(),
       recoveryEmailSetPrimaryEmail: sandbox.stub(),
       recoveryEmailSecondaryResendCode: sandbox.stub(),
+      recoveryEmailSecondaryVerifyCode: sandbox.stub(),
+      sessionResendVerifyCode: sandbox.stub(),
+      sessionVerifyCode: sandbox.stub(),
     };
     Container.set(fxAccountClientToken, authClient);
     context = mockContext() as Context;
@@ -152,6 +155,9 @@ describe('AuthServerSource', () => {
     'recoveryEmailDestroy',
     'recoveryEmailSetPrimaryEmail',
     'recoveryEmailSecondaryResendCode',
+    'recoveryEmailSecondaryVerifyCode',
+    'sessionResendVerifyCode',
+    'sessionVerifyCode',
   ]) {
     describe(name, () => {
       it('returns', async () => {

--- a/packages/fxa-graphql-api/src/test/lib/resolvers/account-resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/test/lib/resolvers/account-resolver.spec.ts
@@ -353,5 +353,71 @@ describe('accountResolver', () => {
         });
       });
     });
+
+    describe('verifySecondaryEmail', async () => {
+      it('succeeds', async () => {
+        context.dataSources.authAPI.recoveryEmailSecondaryVerifyCode.resolves(
+          true
+        );
+        const query = `mutation {
+          verifySecondaryEmail(input: {clientMutationId: "testid", email: "test@example.com", code: "ABCD1234"}) {
+            clientMutationId
+          }
+        }`;
+        context.session.uid = USER_1.uid;
+        const result = (await graphql(
+          schema,
+          query,
+          undefined,
+          context
+        )) as any;
+        assert.isDefined(result.data);
+        assert.isDefined(result.data.verifySecondaryEmail);
+        assert.deepEqual(result.data.verifySecondaryEmail, {
+          clientMutationId: 'testid',
+        });
+      });
+    });
+
+    describe('sendSessionVerificationCode', async () => {
+      it('succeeds', async () => {
+        context.dataSources.authAPI.sessionResendVerifyCode.resolves(true);
+        const query = `mutation {
+          sendSessionVerificationCode(input: {clientMutationId: "testid"}) {
+            clientMutationId
+          }
+        }`;
+        context.session.uid = USER_1.uid;
+        const result = (await graphql(
+          schema,
+          query,
+          undefined,
+          context
+        )) as any;
+        assert.isDefined(result.data);
+        assert.isDefined(result.data.sendSessionVerificationCode);
+        assert.deepEqual(result.data.sendSessionVerificationCode, {
+          clientMutationId: 'testid',
+        });
+      });
+    });
+  });
+
+  describe('verifySession', async () => {
+    it('succeeds', async () => {
+      context.dataSources.authAPI.sessionVerifyCode.resolves(true);
+      const query = `mutation {
+        verifySession(input: {clientMutationId: "testid", code: "ABCD1234"}) {
+          clientMutationId
+        }
+      }`;
+      context.session.uid = USER_1.uid;
+      const result = (await graphql(schema, query, undefined, context)) as any;
+      assert.isDefined(result.data);
+      assert.isDefined(result.data.verifySession);
+      assert.deepEqual(result.data.verifySession, {
+        clientMutationId: 'testid',
+      });
+    });
   });
 });


### PR DESCRIPTION
This adds the `verifySecondaryEmail` `sendSessionVerificationCode` and `verifySession` mutations to support new settings page.

closes #6204