### PR TITLE
feat(settings): Add basic change password views

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -12,6 +12,7 @@ import * as Metrics from '../../lib/metrics';
 import { Account } from '../../models';
 import { Router } from '@reach/router';
 import FlowContainer from '../FlowContainer';
+import ChangePassword from '../ChangePassword';
 
 export const GET_INITIAL_STATE = gql`
   query GetInitialState {
@@ -75,7 +76,7 @@ export const App = ({ flowQueryParams }: AppProps) => {
         <Settings path="/" />
         <FlowContainer path="/avatar/change" title="Profile picture" />
         <FlowContainer path="/display_name" title="Display name" />
-        <FlowContainer path="/change_password" title="Change password" />
+        <ChangePassword path="/change_password" />
       </Router>
     </AppLayout>
   );

--- a/packages/fxa-settings/src/components/ChangePassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ChangePassword/index.stories.tsx
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { ChangePassword } from '.';
+import { LocationProvider } from '@reach/router';
+
+storiesOf('Components|ChangePassword', module)
+  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
+  .add('default', () => <ChangePassword />);

--- a/packages/fxa-settings/src/components/ChangePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/ChangePassword/index.test.tsx
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render, screen } from '@testing-library/react';
+import ChangePassword from './index';
+import { renderWithRouter } from '../../models/_mocks';
+
+it('renders', async () => {
+  renderWithRouter(<ChangePassword />);
+  expect(screen.getByTestId('flow-container')).toBeInTheDocument();
+  expect(screen.getByTestId('flow-container-back-btn')).toBeInTheDocument();
+  expect(screen.getByTestId('nav-link-common-passwords')).toBeInTheDocument();
+  expect(screen.getByTestId('nav-link-reset-password')).toBeInTheDocument();
+});

--- a/packages/fxa-settings/src/components/ChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/ChangePassword/index.tsx
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { RouteComponentProps } from '@reach/router';
+import FlowContainer from '../FlowContainer';
+import PasswordInput from '../PasswordInput';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+
+export const ChangePassword = ({}: RouteComponentProps) => {
+  const handleSubmit = async (ev: React.FormEvent<HTMLFormElement>) => {
+    ev.preventDefault();
+    // TODO: actually perform the change password
+  };
+
+  return (
+    <FlowContainer title="Change Password">
+      <form onSubmit={handleSubmit}>
+        <h1>Stay safe — don't reuse passwords. Your password:</h1>
+        <ul className="list-disc text-grey-400 text-xs p-3">
+          <li>Must be at least 8 characters</li>
+          <li>Must not be your email address</li>
+          <li>
+            Must not match this{' '}
+            <LinkExternal
+              className="link-blue"
+              data-testid="nav-link-common-passwords"
+              href="https://support.mozilla.org/en-US/kb/password-strength"
+            >
+              list of common passwords
+            </LinkExternal>
+          </li>
+        </ul>
+
+        <PasswordInput label="Enter current password" />
+        <PasswordInput label="Enter new password" />
+        <PasswordInput label="Re-enter new password" />
+
+        <div className="flex justify-center p-2">
+          <button
+            className="cta-neutral-lg w-1/4 m-2"
+            onClick={() => window.history.back()}
+          >
+            Cancel
+          </button>
+          <button className="cta-primary transition-standard w-1/4 m-2">
+            Save
+          </button>
+        </div>
+
+        <LinkExternal
+          className="link-blue text-sm justify-center flex"
+          data-testid="nav-link-reset-password"
+          href="/reset_password"
+        >
+          Forgot password?
+        </LinkExternal>
+      </form>
+    </FlowContainer>
+  );
+};
+
+export default ChangePassword;

--- a/packages/fxa-settings/src/components/TextInput/index.tsx
+++ b/packages/fxa-settings/src/components/TextInput/index.tsx
@@ -44,7 +44,7 @@ export const TextInput = ({
 
   return (
     <label
-      className={`flex items-center rounded transition-all duration-100 ease-in-out border ${
+      className={`flex items-center rounded transition-all duration-100 ease-in-out border mt-3 mb-3 ${
         focussed ? 'border-blue-400 shadow-input-blue-focus' : 'border-grey-200'
       } ${disabled ? 'border-grey-100 bg-grey-10' : 'bg-white'}`}
       data-testid="input-container"


### PR DESCRIPTION
## Because

- We need some basic views for change password

## This pull request

- Implements those views per the design doc
- Does not add any form validation or perform the actual password change

## Issue that this pull request solves

Closes: #5028

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

Mobile:
## Screenshots (Optional)
<img width="452" alt="Screen Shot 2020-08-18 at 12 47 47 PM" src="https://user-images.githubusercontent.com/1295288/90541712-0a527c80-e151-11ea-94c4-8b755e262e6f.png">

Non-mobile:
<img width="599" alt="Screen Shot 2020-08-18 at 12 47 38 PM" src="https://user-images.githubusercontent.com/1295288/90541718-0b83a980-e151-11ea-8026-24c1ff8586e8.png">
