### PR TITLE
fix(metrics): Emit pairing success metric when broker sends `action=pairing`

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
@@ -99,7 +99,7 @@ export default BaseAuthenticationBroker.extend({
    * @returns {Promise}
    */
   sendOAuthResultToRelier(result) {
-    if (this.hasCapability('supportsPairing')) {
+    if (this.hasCapability('supportsPairing') || result.action === 'pairing') {
       this._metrics.logEvent('pairing.signin.success');
     }
 

--- a/packages/fxa-content-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-content-server/server/lib/routes/post-metrics.js
@@ -82,7 +82,7 @@ const BODY_SCHEMA = {
   flowBeginTime: OFFSET_TYPE.optional(),
   flowId: STRING_TYPE.hex().length(64).optional(),
   flushTime: TIME_TYPE.required(),
-  initialView: STRING_TYPE.regex(/^[a-z._-]+$/).optional(),
+  initialView: STRING_TYPE.regex(/^[0-9a-z._-]+$/).optional(),
   isSampledUser: BOOLEAN_TYPE.required(),
   lang: STRING_TYPE.regex(/^[a-z]+(?:-[A-Za-z]+)?$/).required(),
   marketing: joi


### PR DESCRIPTION
## Because

- The pairing success metric was not being emitted when a user signed in via pairing

## This pull request

- Checks for the pairing metrics via `action=pairing`
- Adjusts the `initialView` metric to accept numbers since oauth clients id are numbers and are used in the view name

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Screenshots

I tested this using UA faker (iOS). The logs show that the device was connected via iOS...so it must work right?

Logs:
```
31|content  | 2020-08-18T17:05:15: fxa-content-server.INFO: amplitudeEvent {"op":"amplitudeEvent","event_type":"fxa_login - complete","time":1597784715716,"device_id":"71046070560244a6a6285754e7ddc6d2","session_id":1597784701500,"app_version":"184.0","language":"en-US","os_name":"iOS","os_version":"12.0","device_model":"iPhone","event_properties":{},"user_properties":{"flow_id":"eaa16267bd2204580b2d84427177aac2c951b8a033bc3cf4b81c02edd903a79c","ua_browser":"Mobile Safari","ua_version":"12.0"}}
```