### PR TITLE
fix(content server): make safari save the correct fields in keychain

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -12,13 +12,13 @@
 
     <form novalidate>
       <p class="prefillEmail">{{ email }}</p>
-      <input type="email" class="email hidden" value="{{ email }}" disabled />
+      <input name="email" type="email" class="email hidden" value="{{ email }}" disabled />
       {{#canChangeAccount}}
       <a href="/" class="use-different">{{#t}}Change email{{/t}}</a>
       {{/canChangeAccount}}
 
       <div class="input-row password-row">
-        <input id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autofocus data-form-prefill="password" data-synchronize-show="true" />
+        <input name="password" id="password" type="password" class="password check-password tooltip-below" placeholder="{{#t}}Password{{/t}}" value="{{ password }}" pattern=".{8,}" required autofocus data-form-prefill="password" data-synchronize-show="true" />
         <div class="helper-balloon" tabindex="-1"></div>
       </div>
 


### PR DESCRIPTION
⚠️ **Reviewer**: please check that this works locally for you in Safari desktop. I am unable to get Keychain working in my iOS simulator, so once this is merged and on Latest I will verify on an iPhone as well. It's possible this only fixed the desktop portion of this bug.

## Because

Safari does not effectively save the email you enter with the Keychain login item. It instead grabs the age.

## This pull request

Attempts to direct Safari to store the correct fields.

My current theory is that it has something to do with the email field being `disabled` or set to `display: none`. From my testing, using a `name` appeared to direct Safari to the correct fields, and this still appears to work in other browsers. Also, because we don't submit the form in a traditional way, the `name` on inputs has no impact on the data going in.

## Issue that this pull request solves

Closes: #6217

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots

<img width="646" alt="Screen Shot 2020-08-18 at 6 28 36 PM" src="https://user-images.githubusercontent.com/6392049/90572390-e9564f80-e181-11ea-958e-bd1d8b6694c7.png">