### PR TITLE
feat(auth-server): remove sources on payment update

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -299,6 +299,34 @@ export class StripeHelper {
     });
   }
 
+  /**
+   * Remove all sources from a customer.
+   *
+   * For users that are using payment methods, we no longer wish to store
+   * sources so we remove them all.
+   *
+   * Returns the deleted cards.
+   *
+   * @param customerId
+   */
+  async removeSources(customerId: string): Promise<Stripe.Card[]> {
+    const sources = await this.stripe.customers.listSources(customerId, {
+      object: 'card',
+    });
+    if (sources.data.length === 0) {
+      return [];
+    }
+    return Promise.all(
+      sources.data.map(
+        (s) =>
+          (this.stripe.customers.deleteSource(
+            customerId,
+            s.id
+          ) as unknown) as Promise<Stripe.Card>
+      )
+    );
+  }
+
   /** END: NEW FLOW HELPERS FOR PAYMENT METHODS **/
 
   /**

--- a/packages/fxa-auth-server/lib/routes/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.ts
@@ -742,6 +742,8 @@ class DirectStripeRoutes {
       customer.id,
       paymentMethodId
     );
+    await this.stripeHelper.removeSources(customer.id);
+
     // Refetch the customer and force a cache clear
     customer = await this.stripeHelper.customer({
       uid,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -936,10 +936,15 @@ describe('DirectStripeRoutes', () => {
       directStripeRoutesInstance.stripeHelper.customer
         .onCall(1)
         .resolves(expected);
-
       directStripeRoutesInstance.stripeHelper.updateDefaultPaymentMethod.resolves(
         customer
       );
+      directStripeRoutesInstance.stripeHelper.removeSources.resolves([
+        {},
+        {},
+        {},
+      ]);
+
       VALID_REQUEST.payload = {
         paymentMethodId,
       };
@@ -949,6 +954,9 @@ describe('DirectStripeRoutes', () => {
       );
 
       assert.deepEqual(filterCustomer(expected), actual);
+      sinon.assert.calledOnce(
+        directStripeRoutesInstance.stripeHelper.removeSources
+      );
     });
 
     it('errors when a customer has not been created', async () => {


### PR DESCRIPTION
Because:

* When updating a customer with a payment method, we don't want any
  sources from the Sources API around.

This commit:

* Removes all sources from a customer after updating the default
  payment method with a payment method id.

Closes #2348

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
