### PR TITLE
task(fxa-settings): display errors in tooltip

### DIFF
--- a/packages/fxa-settings/src/components/Profile/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Profile/index.stories.tsx
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { Profile } from '.';
+import { MockedCache } from '../../models/_mocks';
+
+storiesOf('Components|Profile', module).add('default', () => (
+  <MockedCache>
+    <Profile />
+  </MockedCache>
+));

--- a/packages/fxa-settings/src/components/Profile/index.test.tsx
+++ b/packages/fxa-settings/src/components/Profile/index.test.tsx
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { Profile } from '.';
+import {
+  renderWithRouter,
+  MockedCache,
+  MOCK_ACCOUNT,
+} from '../../models/_mocks';
+
+// todo:
+// add test cases for different states, including secondary email
+describe('Profile', () => {
+  it('renders "fresh load" <Profile/> with correct content', async () => {
+    const { findByText } = renderWithRouter(
+      <MockedCache>
+        <Profile />
+      </MockedCache>
+    );
+
+    expect(await findByText(MOCK_ACCOUNT.displayName!)).toBeTruthy;
+    expect(await findByText(MOCK_ACCOUNT.primaryEmail.email)).toBeTruthy;
+  });
+});

--- a/packages/fxa-settings/src/components/Profile/index.tsx
+++ b/packages/fxa-settings/src/components/Profile/index.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { useAccount } from '../../models';
+import { UnitRow } from '../UnitRow';
+import { UnitRowWithAvatar } from '../UnitRowWithAvatar';
+import { UnitRowSecondaryEmail } from '../UnitRowSecondaryEmail';
+
+export const Profile = () => {
+  const {
+    primaryEmail,
+    displayName,
+    avatarUrl,
+    passwordCreated,
+  } = useAccount();
+
+  const pwdDateText = Intl.DateTimeFormat('default', {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+  }).format(new Date(passwordCreated));
+
+  return (
+    <section className="mt-11" id="profile" data-testid="settings-profile">
+      <h2 className="font-header font-bold ml-4 mb-4">Profile</h2>
+
+      <div className="bg-white tablet:rounded-xl shadow">
+        <UnitRowWithAvatar avatarUrl={avatarUrl} />
+
+        <hr className="unit-row-hr" />
+
+        <UnitRow
+          header="Display name"
+          headerValue={displayName}
+          route="/beta/settings/display_name"
+        />
+
+        <hr className="unit-row-hr" />
+
+        <UnitRow
+          header="Password"
+          headerValueClassName="tracking-wider"
+          headerValue="••••••••••••••••••"
+          route="/beta/settings/change_password"
+        >
+          <p className="text-grey-400 text-xs mobileLandscape:mt-3">
+            Created {pwdDateText}
+          </p>
+        </UnitRow>
+
+        <hr className="unit-row-hr" />
+
+        <UnitRow header="Primary email" headerValue={primaryEmail.email} />
+
+        <hr className="unit-row-hr" />
+
+        <UnitRowSecondaryEmail />
+      </div>
+    </section>
+  );
+};

--- a/packages/fxa-settings/src/components/SecondaryEmailInputForm/index.stories.tsx
+++ b/packages/fxa-settings/src/components/SecondaryEmailInputForm/index.stories.tsx
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { InMemoryCache } from '@apollo/client';
+import { MockedProvider } from '@apollo/client/testing';
+import { SecondaryEmailInputForm, CREATE_SECONDARY_EMAIL_MUTATION } from '.';
+import { MockedCache, MOCK_ACCOUNT, mockEmail } from '../../models/_mocks';
+import { GET_INITIAL_STATE } from '../App';
+
+const mockGqlError = (email: string) => ({
+  request: {
+    query: CREATE_SECONDARY_EMAIL_MUTATION,
+    variables: { input: { email } },
+  },
+  error: new Error('Email Address already added'),
+});
+
+storiesOf('Components|SecondaryEmailInputForm', module)
+  .add('Default empty', () => (
+    <MockedCache>
+      <SecondaryEmailInputForm />
+    </MockedCache>
+  ))
+  .add('No secondary email set, primary email verified', () => {
+    const primaryEmail = mockEmail('johndope@example.com');
+    const cache = new InMemoryCache();
+    cache.writeQuery({
+      query: GET_INITIAL_STATE,
+      data: {
+        account: { ...MOCK_ACCOUNT, emails: [primaryEmail] },
+        session: { verified: true },
+      },
+    });
+    const mocks = [mockGqlError('johndope2@example.com')];
+    return (
+      <MockedProvider {...{ mocks, cache }}>
+        <SecondaryEmailInputForm />
+      </MockedProvider>
+    );
+  })
+  .add(
+    'secondary can not match primary error, primary email unverified',
+    () => {
+      const primaryEmail = mockEmail('johndope@example.com');
+      const cache = new InMemoryCache();
+      cache.writeQuery({
+        query: GET_INITIAL_STATE,
+        data: {
+          account: { ...MOCK_ACCOUNT, emails: [primaryEmail] },
+          session: { verified: true },
+        },
+      });
+      const mocks = [mockGqlError('johndope@example.com')];
+      return (
+        <MockedProvider {...{ mocks, cache }}>
+          <SecondaryEmailInputForm />
+        </MockedProvider>
+      );
+    }
+  )
+  .add(
+    'secondary matching secondary already added, primary email verified',
+    () => {
+      const emails = [
+        mockEmail('johndope@example.com'),
+        mockEmail('johndope@example.com', false, true),
+      ];
+      const cache = new InMemoryCache();
+      cache.writeQuery({
+        query: GET_INITIAL_STATE,
+        data: {
+          account: { ...MOCK_ACCOUNT, emails },
+          session: { verified: true },
+        },
+      });
+      const mocks = [mockGqlError('johndope2@example.com')];
+      return (
+        <MockedProvider {...{ mocks, cache }}>
+          <SecondaryEmailInputForm />
+        </MockedProvider>
+      );
+    }
+  );

--- a/packages/fxa-settings/src/components/SecondaryEmailInputForm/index.test.tsx
+++ b/packages/fxa-settings/src/components/SecondaryEmailInputForm/index.test.tsx
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { InMemoryCache } from '@apollo/client';
+import { MockedProvider } from '@apollo/client/testing';
+import {
+  MockedCache,
+  MOCK_ACCOUNT,
+  renderWithRouter,
+  mockEmail,
+} from '../../models/_mocks';
+import { GET_INITIAL_STATE } from '../App';
+import { SecondaryEmailInputForm, CREATE_SECONDARY_EMAIL_MUTATION } from '.';
+
+const mockGqlSuccess = (email: string) => ({
+  request: {
+    query: CREATE_SECONDARY_EMAIL_MUTATION,
+    variables: { input: { email } },
+  },
+  error: new Error('Email Address already added'),
+});
+
+describe('SecondaryEmailInputForm', () => {
+  describe('no secondary email set', () => {
+    it('renders as expected', () => {
+      renderWithRouter(
+        <MockedCache>
+          <SecondaryEmailInputForm />
+        </MockedCache>
+      );
+
+      expect(screen.getByTestId('secondary-email-input').textContent).toContain(
+        'Secondary Email'
+      );
+      expect(screen.getByTestId('cancel-button').textContent).toContain(
+        'Cancel'
+      );
+      expect(screen.getByTestId('save-button').textContent).toContain('Save');
+    });
+
+    it('Enables "save" button once valid email is input', () => {
+      renderWithRouter(
+        <MockedCache>
+          <SecondaryEmailInputForm />
+        </MockedCache>
+      );
+
+      expect(screen.getByTestId('save-button')).toHaveAttribute('disabled');
+
+      const input = screen.getByTestId('input-field');
+      fireEvent.change(input, { target: { value: 'fake@example.com' } });
+
+      expect(screen.getByTestId('save-button')).not.toHaveAttribute('disabled');
+    });
+
+    it('Do not Enable "save" button if invalid email is input', () => {
+      renderWithRouter(
+        <MockedCache>
+          <SecondaryEmailInputForm />
+        </MockedCache>
+      );
+
+      const input = screen.getByTestId('input-field');
+      fireEvent.change(input, { target: { value: 'fake@' } });
+
+      expect(screen.getByTestId('save-button')).toHaveAttribute('disabled');
+    });
+  });
+
+  describe('createSecondaryEmailCode', () => {
+    it('displays an error message in the tooltip', async () => {
+      const emails = [
+        mockEmail('johndope@example.com'),
+        mockEmail('johndope2@example.com', false, false),
+      ];
+      const cache = new InMemoryCache();
+      cache.writeQuery({
+        query: GET_INITIAL_STATE,
+        data: {
+          account: { ...MOCK_ACCOUNT, emails },
+          session: { verified: true },
+        },
+      });
+      const mocks = [mockGqlSuccess('johndope2@example.com')];
+      renderWithRouter(
+        <MockedProvider {...{ mocks, cache }}>
+          <SecondaryEmailInputForm />
+        </MockedProvider>
+      );
+      const input = screen.getByTestId('input-field');
+      fireEvent.change(input, { target: { value: 'johndope2@example.com' } });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('save-button'));
+      });
+
+      expect(screen.queryByTestId('error-tooltip')).toBeInTheDocument();
+
+      expect(
+        screen.queryByText('Email Address already added')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/fxa-settings/src/components/SecondaryEmailInputForm/index.tsx
+++ b/packages/fxa-settings/src/components/SecondaryEmailInputForm/index.tsx
@@ -1,0 +1,78 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { gql, useMutation } from '@apollo/client';
+import sentryMetrics from 'fxa-shared/lib/sentry';
+import TextInput from '../TextInput';
+import { Link } from '@reach/router';
+
+export const CREATE_SECONDARY_EMAIL_MUTATION = gql`
+  mutation createSecondaryEmailMutation($input: EmailInput!) {
+    createSecondaryEmail(input: $input) {
+      clientMutationId
+    }
+  }
+`;
+
+export const SecondaryEmailInputForm = () => {
+  const [saveBtnDisabled, setSaveBtnDisabled] = useState(true);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [createSecondaryEmailCode, { data, error }] = useMutation(
+    CREATE_SECONDARY_EMAIL_MUTATION,
+    {
+      onError: (error) => {
+        sentryMetrics.captureException(error);
+      },
+    }
+  );
+
+  const createSecondaryEmailCodeHandler = () => {
+    if (inputRef.current) {
+      createSecondaryEmailCode({
+        variables: { input: { email: inputRef.current.value } },
+      });
+    }
+  };
+
+  const checkEmail = useCallback(
+    (ev) => {
+      setSaveBtnDisabled(!ev.target.checkValidity());
+    },
+    [saveBtnDisabled, setSaveBtnDisabled]
+  );
+
+  return (
+    <div className="p-10 max-w-md">
+      <div className="mb-3" data-testid="secondary-email-input">
+        <TextInput
+          label="Secondary Email"
+          placeholder="Enter email address"
+          type="email"
+          errorText={error?.message}
+          onChange={checkEmail}
+          {...{ inputRef }}
+        />
+      </div>
+
+      <div className="flex justify-center space-x-6">
+        <Link
+          className="cta-neutral-lg transition-standard mb-3 w-32"
+          data-testid="cancel-button"
+          to="/beta/settings"
+        >
+          Cancel
+        </Link>
+
+        <button
+          className={`cta-primary transition-standard mb-3 w-32 ${
+            saveBtnDisabled ? 'opacity-25' : ''
+          }`}
+          data-testid="save-button"
+          onClick={createSecondaryEmailCodeHandler}
+          disabled={saveBtnDisabled}
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/packages/fxa-settings/src/components/Security/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Security/index.stories.tsx
@@ -5,11 +5,16 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Security } from '.';
+import { MockedCache } from '../../models/_mocks';
 
 storiesOf('Components|Security', module)
   .add('default', () => (
-    <Security accountRecoveryKeyEnabled={false} twoFactorAuthEnabled={false} />
+    <MockedCache>
+      <Security twoFactorAuthEnabled={false} />
+    </MockedCache>
   ))
   .add('account recovery key set and two factor enabled', () => (
-    <Security accountRecoveryKeyEnabled={true} twoFactorAuthEnabled={true} />
+    <MockedCache account={{ recoveryKey: true }}>
+      <Security twoFactorAuthEnabled={true} />
+    </MockedCache>
   ));

--- a/packages/fxa-settings/src/components/Security/index.test.tsx
+++ b/packages/fxa-settings/src/components/Security/index.test.tsx
@@ -5,27 +5,28 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import Security from '.';
-import { renderWithRouter } from '../../models/_mocks';
+import { renderWithRouter, MockedCache } from '../../models/_mocks';
 
 describe('Security', () => {
   it('renders "fresh load" <Security/> with correct content', async () => {
     renderWithRouter(
-      <Security
-        accountRecoveryKeyEnabled={false}
-        twoFactorAuthEnabled={false}
-      />
+      <MockedCache>
+        <Security twoFactorAuthEnabled={false} />
+      </MockedCache>
     );
 
     expect(await screen.findByText('Recovery key')).toBeTruthy;
     expect(await screen.findByText('Two-step authentication')).toBeTruthy;
 
     const result = await screen.findAllByText('Not Set');
-    expect(result).toHaveLength(2);
+    expect(result).toHaveLength(1);
   });
 
   it('renders "enabled two factor" and "recovery key present" <Security/> with correct content', async () => {
     renderWithRouter(
-      <Security accountRecoveryKeyEnabled={true} twoFactorAuthEnabled={true} />
+      <MockedCache account={{ recoveryKey: true }}>
+        <Security twoFactorAuthEnabled={true} />
+      </MockedCache>
     );
 
     const result = await screen.findAllByText('Enabled');

--- a/packages/fxa-settings/src/components/Security/index.tsx
+++ b/packages/fxa-settings/src/components/Security/index.tsx
@@ -3,23 +3,22 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { UnitRow } from '../UnitRow';
 import LinkExternal from 'fxa-react/components/LinkExternal';
+import { UnitRow } from '../UnitRow';
+import { useAccount } from '../../models';
 
 type SecurityProps = {
   twoFactorAuthEnabled: boolean;
-  accountRecoveryKeyEnabled: boolean;
   className?: string;
 };
 
-export const Security = ({
-  twoFactorAuthEnabled,
-  accountRecoveryKeyEnabled,
-}: SecurityProps) => {
+export const Security = ({ twoFactorAuthEnabled }: SecurityProps) => {
   const getValue = (settingOption: boolean) =>
     settingOption ? 'Enabled' : 'Not Set';
   const getClassName = (settingOption: boolean) =>
     settingOption ? 'text-green-800' : '';
+
+  const { recoveryKey } = useAccount();
 
   return (
     <section className="mt-11" id="security" data-testid="settings-security">
@@ -27,8 +26,8 @@ export const Security = ({
       <div className="bg-white tablet:rounded-xl shadow">
         <UnitRow
           header="Recovery key"
-          headerValueClassName={getClassName(accountRecoveryKeyEnabled)}
-          headerValue={getValue(accountRecoveryKeyEnabled)}
+          headerValueClassName={getClassName(recoveryKey)}
+          headerValue={getValue(recoveryKey)}
           route="/beta/settings/account_recovery"
         >
           <p className="text-sm mt-3">

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -3,39 +3,22 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import UnitRow from '../UnitRow';
-import UnitRowWithAvatar from '../UnitRowWithAvatar';
-import Security from '../Security';
-import UnitRowSecondaryEmail from '../UnitRowSecondaryEmail';
 import { RouteComponentProps, Router } from '@reach/router';
 import AlertExternal from '../AlertExternal';
-import * as Metrics from '../../lib/metrics';
-
-import { useAccount } from '../../models';
 import Nav from '../Nav';
+import Security from '../Security';
+import { Profile } from '../Profile';
+
+import * as Metrics from '../../lib/metrics';
+import { useAccount } from '../../models';
 
 export const Settings = (_: RouteComponentProps) => {
-  const {
-    primaryEmail,
-    displayName,
-    avatarUrl,
-    passwordCreated,
-    recoveryKey,
-    uid,
-  } = useAccount();
+  const { uid } = useAccount();
 
   Metrics.setProperties({
     lang: document.querySelector('html')?.getAttribute('lang'),
     uid,
   });
-
-  const pwdDateText = Intl.DateTimeFormat('default', {
-    year: 'numeric',
-    month: 'numeric',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-  }).format(new Date(passwordCreated));
 
   return (
     <div className="flex">
@@ -48,47 +31,8 @@ export const Settings = (_: RouteComponentProps) => {
         <Nav path="/" />
       </Router>
       <div className="flex-7">
-        <section className="mt-11" id="profile" data-testid="settings-profile">
-          <h2 className="font-header font-bold ml-4 mb-4">Profile</h2>
-
-          <div className="bg-white tablet:rounded-xl shadow">
-            <UnitRowWithAvatar avatarUrl={avatarUrl} />
-
-            <hr className="unit-row-hr" />
-
-            <UnitRow
-              header="Display name"
-              headerValue={displayName}
-              route="/beta/settings/display_name"
-            />
-
-            <hr className="unit-row-hr" />
-
-            <UnitRow
-              header="Password"
-              headerValueClassName="tracking-wider"
-              headerValue="••••••••••••••••••"
-              route="/beta/settings/change_password"
-            >
-              <p className="text-grey-400 text-xs mobileLandscape:mt-3">
-                Created {pwdDateText}
-              </p>
-            </UnitRow>
-
-            <hr className="unit-row-hr" />
-
-            <UnitRow header="Primary email" headerValue={primaryEmail.email} />
-
-            <hr className="unit-row-hr" />
-
-            <UnitRowSecondaryEmail />
-          </div>
-        </section>
-
-        <Security
-          accountRecoveryKeyEnabled={recoveryKey}
-          twoFactorAuthEnabled={false}
-        />
+        <Profile />
+        <Security twoFactorAuthEnabled={false} />
       </div>
     </div>
   );

--- a/packages/fxa-settings/src/components/TextInput/index.stories.tsx
+++ b/packages/fxa-settings/src/components/TextInput/index.stories.tsx
@@ -11,27 +11,28 @@ storiesOf('Components|TextInput', module)
     <div className="p-10 max-w-lg">
       <div className="mb-3">
         <TextInput
-          label="Default label"
+          label="Default label (with error tooltip)"
           placeholder="Here's a suggestion"
-          type="text"
+          errorText="This is some error text"
         />
+      </div>
+      <div className="mb-3">
+        <TextInput label="Default label" placeholder="Here's a suggestion" />
       </div>
       <div className="mb-3">
         <TextInput
           label="Label with value"
           placeholder="Here's a suggestion"
           defaultValue="This is the value"
-          type="text"
         />
       </div>
       <div className="mb-3">
-        <TextInput label="This one's disabled" type="text" disabled />
+        <TextInput label="This one's disabled" disabled />
       </div>
       <div className="mb-3">
         <TextInput
           label="This one's disabled"
           defaultValue="But it has a value"
-          type="text"
           disabled
         />
       </div>
@@ -40,7 +41,6 @@ storiesOf('Components|TextInput', module)
           label="Label that is extremely long because you never know what some languages are going to produce with the sentence you give them"
           placeholder="Hope it works!"
           defaultValue="wow"
-          type="text"
         />
       </div>
     </div>

--- a/packages/fxa-settings/src/components/TextInput/index.tsx
+++ b/packages/fxa-settings/src/components/TextInput/index.tsx
@@ -2,7 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { ChangeEvent, useState, useCallback, ReactElement } from 'react';
+import React, {
+  ChangeEvent,
+  useState,
+  useCallback,
+  ReactElement,
+  RefObject,
+} from 'react';
 
 export type TextInputProps = {
   defaultValue?: string | number;
@@ -10,6 +16,9 @@ export type TextInputProps = {
   children?: ReactElement;
   label: string;
   placeholder?: string;
+  errorText?: string;
+  errorTooltipClass?: string;
+  inputRef?: RefObject<HTMLInputElement>;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   type?: 'text' | 'email' | 'tel' | 'number' | 'url' | 'password';
 };
@@ -21,6 +30,9 @@ export const TextInput = ({
   label,
   placeholder,
   onChange,
+  errorText,
+  errorTooltipClass,
+  inputRef,
   type = 'text',
 }: TextInputProps) => {
   const [focussed, setFocussed] = useState<boolean>(false);
@@ -44,9 +56,12 @@ export const TextInput = ({
 
   return (
     <label
-      className={`flex items-center rounded transition-all duration-100 ease-in-out border mt-3 mb-3 ${
+      className={`flex items-center rounded transition-all duration-100 ease-in-out border mt-3 mb-3 tooltip
+      ${errorText ? 'tooltip-showing' : ''}
+      ${
         focussed ? 'border-blue-400 shadow-input-blue-focus' : 'border-grey-200'
-      } ${disabled ? 'border-grey-100 bg-grey-10' : 'bg-white'}`}
+      }
+      ${disabled ? 'border-grey-100 bg-grey-10' : 'bg-white'}`}
       data-testid="input-container"
     >
       <span className="block relative flex-auto">
@@ -64,6 +79,7 @@ export const TextInput = ({
           className="pb-1 pt-5 px-3 w-full font-body text-sm rounded focus:outline-none disabled:bg-grey-10 placeholder-transparent focus:placeholder-grey-500 text-grey-600 disabled:text-grey-300 disabled:cursor-default"
           data-testid="input-field"
           onChange={textFieldChange}
+          ref={inputRef}
           {...{
             defaultValue,
             disabled,
@@ -74,6 +90,19 @@ export const TextInput = ({
           }}
         />
       </span>
+
+      {errorText && (
+        <span
+          data-testid="error-tooltip"
+          className={
+            errorTooltipClass
+              ? errorTooltipClass
+              : 'tooltip-text tooltip-showing bg-red-200 p-3 -mt-20 rounded text-sm'
+          }
+        >
+          {errorText}
+        </span>
+      )}
       {children}
     </label>
   );

--- a/packages/fxa-settings/src/components/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRow/index.tsx
@@ -5,7 +5,7 @@
 import React, { useRef } from 'react';
 import classNames from 'classnames';
 import { useFocusOnTriggeringElementOnClose } from '../../lib/hooks';
-import {Link, RouteComponentProps, useLocation} from '@reach/router';
+import { Link, RouteComponentProps, useLocation } from '@reach/router';
 
 type UnitRowProps = {
   header: string;

--- a/packages/fxa-settings/src/styles/tailwind.scss
+++ b/packages/fxa-settings/src/styles/tailwind.scss
@@ -5,6 +5,7 @@
 @import './animations.css';
 @import './ctas.scss';
 @import './unit-row.scss';
+@import './tooltip.scss';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/packages/fxa-settings/src/styles/tooltip.scss
+++ b/packages/fxa-settings/src/styles/tooltip.scss
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+.tooltip .tooltip-text {
+  visibility: hidden;
+  text-align: center;
+  padding: 2px 6px;
+  position: absolute;
+  z-index: 100;
+}
+
+.tooltip-showing .tooltip-text,
+.tooltip-hover:hover .tooltip-text {
+  visibility: visible;
+}


### PR DESCRIPTION
## Because

- we need to let the user know when they are adding a duplicate email

## This pull request

- Pulls `<Profile/>` into own component
- adds tooltip css
- adds `<SecondaryEmailInputForm/>`

## Issue that this pull request solves

Closes: #4959

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
