### PR TITLE
refactor(settings): Cleanup secondary email tests, catch mutation errors

### DIFF
--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.stories.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.stories.tsx
@@ -8,12 +8,12 @@ import { InMemoryCache } from '@apollo/client';
 import { MockedProvider } from '@apollo/client/testing';
 import { UnitRowSecondaryEmail, RESEND_SECONDARY_EMAIL_CODE_MUTATION } from '.';
 import { AlertBarRootAndContextProvider } from '../../lib/AlertBarContext';
-import { MockedCache, MOCK_ACCOUNT } from '../../models/_mocks';
+import { MockedCache, MOCK_ACCOUNT, mockEmail } from '../../models/_mocks';
 import { GET_INITIAL_STATE } from '../App';
 
 // every unverified email with a functioning "Resend verification"
 // button must have a mock object created per mutation attempt.
-const createMock = (email: string) => ({
+const mockGqlSuccess = (email: string) => ({
   request: {
     query: RESEND_SECONDARY_EMAIL_CODE_MUTATION,
     variables: { input: { email } },
@@ -36,11 +36,7 @@ storiesOf('Components|UnitRowSecondaryEmail', module)
     </MockedCache>
   ))
   .add('No secondary email set, primary email unverified', () => {
-    const primaryEmail = {
-      email: 'johndope@example.com',
-      isPrimary: true,
-      verified: false,
-    };
+    const primaryEmail = mockEmail('johndope@example.com', true, false);
     return (
       <MockedCache account={{ primaryEmail, emails: [primaryEmail] }}>
         <AlertBarRootAndContextProvider>
@@ -51,16 +47,8 @@ storiesOf('Components|UnitRowSecondaryEmail', module)
   })
   .add('One secondary email set, unverified', () => {
     const emails = [
-      {
-        email: 'johndope@example.com',
-        isPrimary: true,
-        verified: true,
-      },
-      {
-        email: 'johndope2@example.com',
-        isPrimary: false,
-        verified: false,
-      },
+      mockEmail('johndope@example.com'),
+      mockEmail('johndope@example.com', false, false),
     ];
     const cache = new InMemoryCache();
     cache.writeQuery({
@@ -70,7 +58,7 @@ storiesOf('Components|UnitRowSecondaryEmail', module)
         session: { verified: true },
       },
     });
-    const mocks = [createMock('johndope2@example.com')];
+    const mocks = [mockGqlSuccess('johndope2@example.com')];
     return (
       <MockedProvider {...{ mocks, cache }}>
         <AlertBarRootAndContextProvider>
@@ -81,16 +69,8 @@ storiesOf('Components|UnitRowSecondaryEmail', module)
   })
   .add('One secondary email set, verified', () => {
     const emails = [
-      {
-        email: 'johndope@example.com',
-        isPrimary: true,
-        verified: true,
-      },
-      {
-        email: 'johndope2@example.com',
-        isPrimary: false,
-        verified: true,
-      },
+      mockEmail('johndope@example.com'),
+      mockEmail('johndope2@example.com', false),
     ];
     return (
       <MockedCache account={{ emails }}>
@@ -102,26 +82,10 @@ storiesOf('Components|UnitRowSecondaryEmail', module)
   })
   .add('Multiple secondary emails set, all verified', () => {
     const emails = [
-      {
-        email: 'johndope@example.com',
-        isPrimary: true,
-        verified: true,
-      },
-      {
-        email: 'johndope2@example.com',
-        isPrimary: false,
-        verified: true,
-      },
-      {
-        email: 'johndope3@example.com',
-        isPrimary: false,
-        verified: true,
-      },
-      {
-        email: 'johndope4@example.com',
-        isPrimary: false,
-        verified: true,
-      },
+      mockEmail('johndope@example.com'),
+      mockEmail('johndope2@example.com', false),
+      mockEmail('johndope3@example.com', false),
+      mockEmail('johndope4@example.com', false),
     ];
     return (
       <MockedCache account={{ emails }}>
@@ -133,26 +97,10 @@ storiesOf('Components|UnitRowSecondaryEmail', module)
   })
   .add('Multiple secondary emails set, one unverified', () => {
     const emails = [
-      {
-        email: 'johndope@example.com',
-        isPrimary: true,
-        verified: true,
-      },
-      {
-        email: 'johndope2@example.com',
-        isPrimary: false,
-        verified: true,
-      },
-      {
-        email: 'johndope3@example.com',
-        isPrimary: false,
-        verified: false,
-      },
-      {
-        email: 'johndope4@example.com',
-        isPrimary: false,
-        verified: true,
-      },
+      mockEmail('johndope@example.com'),
+      mockEmail('johndope2@example.com', false),
+      mockEmail('johndope3@example.com', false, false),
+      mockEmail('johndope4@example.com', false),
     ];
     const cache = new InMemoryCache();
     cache.writeQuery({
@@ -162,7 +110,7 @@ storiesOf('Components|UnitRowSecondaryEmail', module)
         session: { verified: true },
       },
     });
-    const mocks = [createMock('johndope3@example.com')];
+    const mocks = [mockGqlSuccess('johndope3@example.com')];
     return (
       <MockedProvider {...{ mocks, cache }}>
         <AlertBarRootAndContextProvider>
@@ -173,26 +121,10 @@ storiesOf('Components|UnitRowSecondaryEmail', module)
   })
   .add('Multiple secondary emails set, multiple unverified', () => {
     const emails = [
-      {
-        email: 'johndope@example.com',
-        isPrimary: true,
-        verified: true,
-      },
-      {
-        email: 'johndope2@example.com',
-        isPrimary: false,
-        verified: true,
-      },
-      {
-        email: 'johndope3@example.com',
-        isPrimary: false,
-        verified: false,
-      },
-      {
-        email: 'johndope4@example.com',
-        isPrimary: false,
-        verified: false,
-      },
+      mockEmail('johndope@example.com'),
+      mockEmail('johndope2@example.com', false),
+      mockEmail('johndope3@example.com', false, false),
+      mockEmail('johndope4@example.com', false, false),
     ];
     const cache = new InMemoryCache();
     cache.writeQuery({
@@ -203,8 +135,8 @@ storiesOf('Components|UnitRowSecondaryEmail', module)
       },
     });
     const mocks = [
-      createMock('johndope3@example.com'),
-      createMock('johndope4@example.com'),
+      mockGqlSuccess('johndope3@example.com'),
+      mockGqlSuccess('johndope4@example.com'),
     ];
     return (
       <MockedProvider {...{ mocks, cache }}>

--- a/packages/fxa-settings/src/models/_mocks.tsx
+++ b/packages/fxa-settings/src/models/_mocks.tsx
@@ -140,3 +140,13 @@ export function renderWithRouter(
     history,
   };
 }
+
+export const mockEmail = (
+  email: string,
+  isPrimary = true,
+  verified = true
+) => ({
+  email,
+  isPrimary,
+  verified,
+});


### PR DESCRIPTION
Because:
* We setup many 'email' objects and need a helper for DRYer code
* We must have an onError option in mutations to allow tests to pass

This commit:
* Gets tests passing and DRYs them up

fixes #6192

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

### Additional information

I was going to wait to put this PR up because the secondary email section needs a refactor to change the `primaryEmail` verified state check to guard against a _session_ being unverified instead but I'll do that in a follow up since these changes are needed in another PR.
