### PR TITLE
fix(delete): Emit a `delete_account` webchannel message when account deleted by supported client

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
@@ -28,7 +28,7 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
     openWebmailButtonVisible: false,
   }),
 
-  commands: _.pick(WebChannel, 'FXA_STATUS', 'OAUTH_LOGIN'),
+  commands: _.pick(WebChannel, 'FXA_STATUS', 'OAUTH_LOGIN', 'DELETE_ACCOUNT'),
 
   type: Constants.OAUTH_WEBCHANNEL_BROKER,
 
@@ -112,6 +112,13 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
       result.state = state;
     }
     return this.send(this.getCommand('OAUTH_LOGIN'), result);
+  },
+
+  afterDeleteAccount(account) {
+    return this.send(this.getCommand('DELETE_ACCOUNT'), {
+      email: account.get('email'),
+      uid: account.get('uid'),
+    }).then(() => proto.afterDeleteAccount.call(this, account));
   },
 });
 

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
@@ -26,6 +26,7 @@ function generateOAuthCode() {
 
 const OAUTH_STATUS_MESSAGE = 'fxaccounts:fxa_status';
 const OAUTH_LOGIN_MESSAGE = 'fxaccounts:oauth_login';
+const OAUTH_DELETE_ACCOUNT_MESSAGE = 'fxaccounts:delete_account';
 const REDIRECT_URI = 'https://localhost:8080';
 const VALID_OAUTH_CODE = generateOAuthCode();
 
@@ -78,6 +79,8 @@ describe('models/auth_brokers/oauth-webchannel-v1', () => {
 
     account = user.initAccount({
       sessionToken: 'abc123',
+      email: 'test@email.com',
+      uid: 'uid',
     });
     sinon.stub(account, 'createOAuthCode').callsFake(() => {
       return Promise.resolve({
@@ -235,6 +238,19 @@ describe('models/auth_brokers/oauth-webchannel-v1', () => {
         error: 'error',
         redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
         state: 'state',
+      });
+    });
+  });
+
+  describe('delete account', () => {
+    it('calls correct methods', async () => {
+      await broker.afterDeleteAccount(account);
+
+      const msg = broker.send.getCall(0).args;
+      assert.equal(msg[0], OAUTH_DELETE_ACCOUNT_MESSAGE);
+      assert.deepEqual(msg[1], {
+        email: account.get('email'),
+        uid: account.get('uid'),
       });
     });
   });


### PR DESCRIPTION
## Because

- When an account is deleted by an oauth webchannel client, it should be the responsibility of the client to navigate the user to the correct screens (which may or may not be a webview)
- Oauth webchannel clients need to be loaded with specific oauth params in order for an account to be created, in the previous delete account flow. If an account is deleted, and then navigated back to the signup page, it might not have the correct query params to re-create the account.

## This pull request

- Emits the proper `fxaccounts:delete_account` web channel message when an account is deleted in any oauth webchannel broker
- FxiOS currently handles these messages by dismissing the current view and going to the view behind it

## Issue that this pull request solves

Closes: #6164 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

![ios delete](https://user-images.githubusercontent.com/1295288/90685363-ac4c9480-e237-11ea-8f8f-2b9488ceff46.gif)

## Other information (Optional)

It is a bit of a pain to test this locally. But if you dare you will need to modify this https://github.com/mozilla-mobile/firefox-ios/blob/85c8a750184d9a901d5d2bb9317a3ab69791726b/RustFxA/RustFirefoxAccounts.swift#L125

to

```swift
server = isChinaSyncServiceEnabled ? FxAConfig.Server.china : FxAConfig.Server.localdev
```

and build FxiOS. After that create and delete an account.
