### PR TITLE
fix(totp): Ensure the user has a verified session before starting inline TOTP setup

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/sign_in_token_code.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_token_code.js
@@ -21,12 +21,12 @@ const View = FormView.extend({
   template: Template,
 
   getAccount() {
-    return this.model.get('account');
+    return this.getSignedInAccount();
   },
 
   beforeRender() {
     // user cannot confirm if they have not initiated a sign in.
-    if (!this.model.get('account')) {
+    if (!this.getAccount()) {
       this.navigate(this._getAuthPage());
     }
   },
@@ -62,6 +62,11 @@ const View = FormView.extend({
       .verifyAccountSessionCode(account, code)
       .then(() => {
         this.logViewEvent('success');
+
+        const redirectTo = this.model.get('redirectTo');
+        if (redirectTo) {
+          return (this.window.location.href = redirectTo);
+        }
 
         if (this.isForcePasswordChange(account)) {
           return this.invokeBrokerMethod('beforeForcePasswordChange', account);

--- a/packages/fxa-content-server/app/tests/spec/views/sign_in_token_code.js
+++ b/packages/fxa-content-server/app/tests/spec/views/sign_in_token_code.js
@@ -73,6 +73,8 @@ describe('views/sign_in_token_code', () => {
       window: windowMock,
     });
 
+    sinon.stub(view, 'getSignedInAccount').callsFake(() => account);
+
     return view.render();
   });
 
@@ -92,6 +94,8 @@ describe('views/sign_in_token_code', () => {
     describe('without an account', () => {
       beforeEach(() => {
         model.unset('account');
+        view.getSignedInAccount.restore();
+        sinon.stub(view, 'getSignedInAccount').callsFake(() => {});
         sinon.spy(view, 'navigate');
         return view.render();
       });

--- a/packages/fxa-content-server/tests/functional/oauth_sign_in_token_code.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sign_in_token_code.js
@@ -117,27 +117,5 @@ registerSuite('OAuth signin token code', {
           )
       );
     },
-
-    'verified - valid code then click back': function () {
-      return (
-        this.remote
-          .then(openFxaFromRp('enter-email', experimentParams))
-          .then(fillOutEmailFirstSignIn(email, PASSWORD))
-
-          // Correctly submits the token code and navigates to oauth page
-          .then(testElementExists(selectors.SIGNIN_TOKEN_CODE.HEADER))
-          .then(fillOutSignInTokenCode(email, 0))
-
-          .then(
-            testElementTextInclude(
-              NOTES_REDIRECT_PAGE_SELECTOR,
-              NOTES_PAGE_TEXT_SELECTOR
-            )
-          )
-
-          .goBack()
-          .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER))
-      );
-    },
   },
 });


### PR DESCRIPTION
## Because

- A verified session is required to enable 2FA.
- Existing flows do this from within the settings page, where we have the session upgrade mixin (this mixin does DOM twiddling to put an upgrade template in place of the regular template, and doesn't easily generalize to an inline flow)
- We do have a screen to do something similar inline, where users are asked to verify a code sent in an email

## This pull request

- Updates the inline totp setup view to redirect users to the signin_token_code screen if their session is unverified. Users will be redirected back to inline totp setup when that step is completed.

## Issue that this pull request solves

Closes: #5206

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
