### PR TITLE
chore(configs): remove basket proxy configs

### DIFF
--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -60,33 +60,6 @@ const conf = (module.exports = convict({
     doc: 'Check if the resources are under the /dist directory',
     format: Boolean,
   },
-  basket: {
-    api_key: {
-      default: 'test key please change',
-      doc: 'DEPRECATED - Basket API key',
-      format: String,
-    },
-    api_timeout: {
-      default: '5 seconds',
-      doc: 'DEPRECATED - Timeout for talking to the Basket API server, in ms',
-      format: Number,
-    },
-    api_url: {
-      default: 'http://localhost:10140',
-      doc: 'DEPRECATED - Url for the Basket API server',
-      format: String,
-    },
-    email_preferences_url: {
-      default: 'https://basket.allizom.org/fxa/',
-      doc: 'DEPRECATED - Url for the Basket proxy server',
-      format: String,
-    },
-    proxy_url: {
-      default: 'http://localhost:1114',
-      doc: 'DEPRECATED - Url for the Basket proxy server',
-      format: String,
-    },
-  },
   cachify_prefix: {
     default: 'v',
     doc: 'The prefix for cachify hashes in URLs',
@@ -377,12 +350,6 @@ const conf = (module.exports = convict({
     },
   },
   marketing_email: {
-    api_url: {
-      default: 'http://localhost:1114',
-      doc: 'DEPRECATED - User facing URL of the Marketing Email Server',
-      env: 'FXA_MARKETING_EMAIL_API_URL',
-      format: 'url',
-    },
     enabled: {
       default: true,
       doc: 'Feature flag for communication preferences in settings',

--- a/packages/fxa-content-server/server/lib/csp/blocking.js
+++ b/packages/fxa-content-server/server/lib/csp/blocking.js
@@ -19,15 +19,12 @@ function getOrigin(link) {
  * blockingCspMiddleware is where to declare rules that will cause a resource
  * to be blocked if it runs afowl of a rule.
  */
-module.exports = function(config) {
+module.exports = function (config) {
   const AUTH_SERVER = getOrigin(config.get('fxaccount_url'));
   const BLOB = 'blob:';
   const CDN_URL = config.get('static_resource_url');
   const DATA = 'data:';
   const GRAVATAR = 'https://secure.gravatar.com';
-  const MARKETING_EMAIL_SERVER = getOrigin(
-    config.get('marketing_email.api_url')
-  );
   const OAUTH_SERVER = getOrigin(config.get('oauth_url'));
   const PROFILE_SERVER = getOrigin(config.get('profile_url'));
   const PROFILE_IMAGES_SERVER = getOrigin(config.get('profile_images_url'));
@@ -38,10 +35,9 @@ module.exports = function(config) {
   const PAIRING_SERVER_HTTP = PAIRING_SERVER_WEBSOCKET.replace(/^ws/, 'http');
   const SENTRY_SERVER = 'https://sentry.prod.mozaws.net';
   // create a unique array of origins from survey urls
-  const SURVEYS = [
-    ...new Set(surveyList.map(s => getOrigin(s.url))),
-  ];
-  const surveysEnabledAndSet = (config.get('surveyFeature.enabled') && SURVEYS.length);
+  const SURVEYS = [...new Set(surveyList.map((s) => getOrigin(s.url)))];
+  const surveysEnabledAndSet =
+    config.get('surveyFeature.enabled') && SURVEYS.length;
   //
   // Double quoted values
   //
@@ -65,7 +61,6 @@ module.exports = function(config) {
         AUTH_SERVER,
         OAUTH_SERVER,
         PROFILE_SERVER,
-        MARKETING_EMAIL_SERVER,
         PAIRING_SERVER_WEBSOCKET,
         PAIRING_SERVER_HTTP,
         SENTRY_SERVER,
@@ -96,7 +91,6 @@ module.exports = function(config) {
       CDN_URL,
       DATA,
       GRAVATAR,
-      MARKETING_EMAIL_SERVER,
       NONE,
       OAUTH_SERVER,
       PAIRING_SERVER_HTTP,

--- a/packages/fxa-content-server/tests/server/csp.js
+++ b/packages/fxa-content-server/tests/server/csp.js
@@ -42,12 +42,11 @@ suite.tests['blockingRules'] = function () {
   assert.isFalse(reportOnly);
 
   const connectSrc = directives.connectSrc;
-  assert.lengthOf(connectSrc, 8);
+  assert.lengthOf(connectSrc, 7);
   assert.include(connectSrc, Sources.SELF);
   assert.include(connectSrc, Sources.AUTH_SERVER);
   assert.include(connectSrc, Sources.OAUTH_SERVER);
   assert.include(connectSrc, Sources.PROFILE_SERVER);
-  assert.include(connectSrc, Sources.MARKETING_EMAIL_SERVER);
   assert.include(connectSrc, Sources.PAIRING_SERVER_HTTP);
   assert.include(connectSrc, Sources.PAIRING_SERVER_WEBSOCKET);
 
@@ -62,11 +61,11 @@ suite.tests['blockingRules'] = function () {
 
   let frameSrc = directives.frameSrc;
 
-  config.set('surveyFeature', {enabled: false});
+  config.set('surveyFeature', { enabled: false });
   assert.include(frameSrc, "'none'");
   config.set('surveyFeature', {
     enabled: true,
-    doNotBotherSpan: 2592000000
+    doNotBotherSpan: 2592000000,
   });
   frameSrc = blockingRules(config).directives.frameSrc;
   assert.isAbove(frameSrc.length, 1);


### PR DESCRIPTION
Because:
 - the need for basket proxy was removed in f2d2a2d

This commit:
 - delete some configs that are no longer used


## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
