### PR TITLE
fix(portal): remove non-modal portal roots when unloaded

### DIFF
--- a/packages/fxa-react/components/Portal/index.tsx
+++ b/packages/fxa-react/components/Portal/index.tsx
@@ -56,15 +56,17 @@ const Portal = ({
 
   useEffect(() => {
     return () => {
-      // When unloaded, we do not remove the portal element in order to allow
-      // a series of portal dependent components to be rendered.
       let el = document.getElementById(id);
       if (el && el.children.length === 1) {
         // Reset any non-portal properties here
         if (id === 'modal') {
+          // When unloaded, we do not remove the portal element in order to allow
+          // a series of portal dependent components to be rendered.
           resetA11yOnAdjacentElementsAndBody(
             document.querySelectorAll(TOP_LEVEL_NONMODAL_DIVS_SELECTOR)
           );
+        } else {
+          el.remove();
         }
       }
     };


### PR DESCRIPTION
## Because

- train 185 tag is broken https://app.circleci.com/pipelines/github/mozilla/fxa/13110/workflows/8818676d-11a2-41e0-9bc2-30fe9267e666/jobs/189669

this may end up being a temporary fix. there might be a better way to do this

