### PR TITLE
fix(validation): Allow unicode replacement character in display-safe strings

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -40,15 +40,19 @@ exports.IP_ADDRESS = isA.string().ip();
 //   \u2028-\u2029  - unicode line/paragraph separator
 //   \uD800-\uDFFF  - non-BMP surrogate pairs
 //   \uE000-\uF8FF  - BMP private use area
-//   \uFFF9-\uFFFF  - unicode "specials" block
+//   \uFFF9-\uFFFC  - unicode specials prior to the replacement character
+//   \uFFFE-\uFFFF  - unicode this-is-not-a-character specials
+//
+// Note that the unicode replacement character \uFFFD is explicitly allowed,
+// and clients may use it to replace other disallowed characters.
 //
 // We might tweak this list in future.
 
-const DISPLAY_SAFE_UNICODE = /^(?:[^\u0000-\u001F\u007F\u0080-\u009F\u2028-\u2029\uD800-\uDFFF\uE000-\uF8FF\uFFF9-\uFFFF])*$/;
+const DISPLAY_SAFE_UNICODE = /^(?:[^\u0000-\u001F\u007F\u0080-\u009F\u2028-\u2029\uD800-\uDFFF\uE000-\uF8FF\uFFF9-\uFFFC\uFFFE-\uFFFF])*$/;
 module.exports.DISPLAY_SAFE_UNICODE = DISPLAY_SAFE_UNICODE;
 
 // Similar display-safe match but includes non-BMP characters
-const DISPLAY_SAFE_UNICODE_WITH_NON_BMP = /^(?:[^\u0000-\u001F\u007F\u0080-\u009F\u2028-\u2029\uE000-\uF8FF\uFFF9-\uFFFF])*$/;
+const DISPLAY_SAFE_UNICODE_WITH_NON_BMP = /^(?:[^\u0000-\u001F\u007F\u0080-\u009F\u2028-\u2029\uE000-\uF8FF\uFFF9-\uFFFC\uFFFE-\uFFFF])*$/;
 module.exports.DISPLAY_SAFE_UNICODE_WITH_NON_BMP = DISPLAY_SAFE_UNICODE_WITH_NON_BMP;
 
 // Bearer auth header regex

--- a/packages/fxa-auth-server/test/remote/device_tests.js
+++ b/packages/fxa-auth-server/test/remote/device_tests.js
@@ -207,8 +207,9 @@ describe('remote device', function () {
     const password = 'test password';
     return Client.create(config.publicUrl, email, password).then((client) => {
       const deviceInfo = {
-        // That's a beta, and a CJK character from https://bugzilla.mozilla.org/show_bug.cgi?id=1348298
-        name: 'Firefox \u5728 \u03b2 test',
+        // That's a beta, a CJK character from https://bugzilla.mozilla.org/show_bug.cgi?id=1348298,
+        // and the unicode replacement character in case of mojibake.
+        name: 'Firefox \u5728 \u03b2 test\ufffd',
         type: 'desktop',
       };
       return client

--- a/packages/fxa-profile-server/lib/routes/display_name/post.js
+++ b/packages/fxa-profile-server/lib/routes/display_name/post.js
@@ -16,12 +16,16 @@ const EMPTY = Object.create(null);
 //   \u0080-\u009F  - C1 (ansi escape) control characters
 //   \u2028-\u2029  - unicode line/paragraph separator
 //   \uE000-\uF8FF  - BMP private use area
-//   \uFFF9-\uFFFF  - unicode "specials" block
+//   \uFFF9-\uFFFC  - unicode specials prior to the replacement character
+//   \uFFFE-\uFFFF  - unicode this-is-not-a-character specials
+//
+// Note that the unicode replacement character \uFFFD is explicitly allowed,
+// and clients may use it to replace other disallowed characters.
 //
 // We might tweak this list in future.
 
 // eslint-disable-next-line no-control-regex
-const ALLOWED_DISPLAY_NAME_CHARS = /^(?:[^\u0000-\u001F\u007F\u0080-\u009F\u2028-\u2029\uE000-\uF8FF\uFFF9-\uFFFF])*$/;
+const ALLOWED_DISPLAY_NAME_CHARS = /^(?:[^\u0000-\u001F\u007F\u0080-\u009F\u2028-\u2029\uE000-\uF8FF\uFFF9-\uFFFC\uFFFE-\uFFFF])*$/;
 
 module.exports = {
   auth: {

--- a/packages/fxa-profile-server/test/api.js
+++ b/packages/fxa-profile-server/test/api.js
@@ -1521,6 +1521,7 @@ describe('api', function () {
           'André Citroën',
           'the unblinking ಠ_ಠ of ckarlof',
           'abominable ☃',
+          'moji\uFFFDbake',
           // emoji
           '👍',
           '👍🏼',


### PR DESCRIPTION
## Because

* Some clients (notably Firefox Desktop) will attempt to build a default
  device name out of system-provided data, and if they encounter unicode
  encoding issues then they'll insert the unicode replacment character
  rather than failing.
* Such clients cannot complete FxA device registration, because we forbid
  the device name from containing any characters in the unicode specials
  block.
* There is not a concrete risk associated with characters from the specials
  block, we just exclude them because they might have unexpected effects
  (and particularly because some of them are currently unassigned).

## This pull request

* Allows the unicode replacement character U+FFFD (otherwise known as
  "that diamond thingy with a question mark in it") in the display-safe
  string validator.

## Issue that this pull request solves

Closes: #6269 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- ~~[ ] I have added necessary documentation (if appropriate).~~

## Other information (Optional)

If you're interested in the sordid history of how this validator came to be in the first place, I recommend [Bug 1253201](https://bugzilla.mozilla.org/show_bug.cgi?id=1253201); the git history won't help you because these were security bugs, so the fixes were developed in a now-deleted private repo and landed with very prosaic-sounding commit messages.