### PR TITLE
fix(content-server): fix padding in link from legal footer

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_legal.scss
+++ b/packages/fxa-content-server/app/styles/modules/_legal.scss
@@ -22,8 +22,8 @@
     a {
       padding: 0 16px;
 
-      &:last-child {
-        padding: 16px 0 16px 16px;
+      &.privacy {
+        margin-right: -16px;
       }
     }
   }


### PR DESCRIPTION
Because:

* Links from `#legal-footer` have different focus borders shapes.

This commit:

* FIx the padding in the last link from `#legal-footer`.

Closes #6235
