### PR TITLE
fix(payments): use default payment details in reactivation email

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -215,10 +215,12 @@ module.exports = function (log, config, oauthdb) {
   };
 
   function cardTypeToText(cardType) {
-    if (!cardType) {
+    if (typeof cardType !== 'string') {
       return null;
     }
-    return CARD_TYPE_TO_TEXT[cardType] || CARD_TYPE_TO_TEXT.unknown;
+    return (
+      CARD_TYPE_TO_TEXT[cardType.toLowerCase()] || CARD_TYPE_TO_TEXT.unknown
+    );
   }
 
   function Mailer(translator, templates, mailerConfig, sender) {


### PR DESCRIPTION
This switches from displaying the payment details used in the last
charge to displaying default payment details which will be used in the
next invoice.

fixes #6172
