### PR TITLE
fix(release): fixes versioning and changelogs

### DIFF
--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-panel",
-  "version": "0.1.0",
+  "version": "1.185.1",
   "description": "FxA Admin Panel",
   "scripts": {
     "build-postcss": "postcss src/styles/tailwind.css -o src/styles/tailwind.out.css",

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-server",
-  "version": "1.154.0",
+  "version": "1.185.1",
   "description": "FxA GraphQL Admin Server",
   "scripts": {
     "build": "tsc",

--- a/packages/fxa-auth-client/package.json
+++ b/packages/fxa-auth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-client",
-  "version": "1.180.0",
+  "version": "1.185.1",
   "description": "",
   "main": "dist/server/server.js",
   "exports": {

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-graphql-api",
-  "version": "1.154.0",
+  "version": "1.185.1",
   "description": "FxA GraphQL API",
   "scripts": {
     "build": "tsc",

--- a/packages/fxa-metrics-processor/package.json
+++ b/packages/fxa-metrics-processor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-metrics-processor",
-  "version": "1.0.0",
+  "version": "1.185.1",
   "description": "Firefox Accounts metrics ETL worker code",
   "main": "index.js",
   "scripts": {

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-react",
-  "version": "1.0.0",
+  "version": "1.185.1",
   "description": "Shared components for FxA React Apps",
   "exports": {
     "./components/": "./dist/components/",

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-settings",
-  "version": "0.1.0",
+  "version": "1.185.1",
   "homepage": "https://accounts.firefox.com/beta/settings",
   "private": true,
   "scripts": {

--- a/release.sh
+++ b/release.sh
@@ -245,6 +245,12 @@ bump() {
 
   # 8.3. If CHANGELOG.md exists, write the summary string to CHANGELOG.md.
   if [ -f "$1/CHANGELOG.md" ]; then
+    # If the file is empty, we seed it with the last version so awk can pick up
+    # on it.  This is cheesy, but the newlines embedded in the variables limit
+    # our options here.
+    if [ ! -s "$1/CHANGELOG.md" ]; then
+      echo "## $LAST_VERSION" > "$1/CHANGELOG.md"
+    fi
     awk "{ gsub(/^## $LAST_VERSION/, \"## $NEW_VERSION\n\n$SUMMARY## $LAST_VERSION\") }; { print }" "$1/CHANGELOG.md" > "$1/CHANGELOG.md.release.bak"
     mv "$1/CHANGELOG.md.release.bak" "$1/CHANGELOG.md"
 


### PR DESCRIPTION
Because:

* The release script makes some wrong assumptions about the format of data

This commit:

* Fixes the changelog updates to work with empty/new changelogs
* Updates version numbers to the latest versions

Fixes #6195
