### PR TITLE
feat(settings): introduce hook to handle errors in mutations

### DIFF
--- a/packages/fxa-settings/README.md
+++ b/packages/fxa-settings/README.md
@@ -66,31 +66,30 @@ The `AlertBar` is used to display messages to the user, typically for communicat
 
 A basic example for displaying the component:
 
-```
+```jsx
 const MyComponent = () => {
   /* `alertBarRevealed` will return `false` on first render. `revealAlertBar` and `hideAlertBar`
    * are functions - call `revealAlertBar` when you need `alertBarRevealed` to be `true` and
    * call `hideAlertBar` when it should be `false`. You'll typically pass `hideAlertBar` into
    * `AlertBar` as the `onDismiss` prop.
-  */
+   */
   const [alertBarRevealed, revealAlertBar, hideAlertBar] = useBooleanState();
 
-  return(
+  return (
     <>
-    {alertBarRevealed &&
-      <AlertBar onDismiss={hideAlertBar}>
-        <p>Alert bar text!</p>
-      </AlertBar>
-    }
+      {alertBarRevealed && (
+        <AlertBar onDismiss={hideAlertBar}>
+          <p>Alert bar text!</p>
+        </AlertBar>
+      )}
       <div>
-        <button
-          onClick={revealAlertBar}
-        >Click here to see the AlertBar!
+        <button onClick={revealAlertBar}>
+          Click here to see the AlertBar!
         </button>
       </div>
     </>
   );
-}
+};
 ```
 
 See the "Testing" section for mocking the `AlertBar`.
@@ -288,7 +287,7 @@ Inlining our SVGs will minimize the number of network requests our application n
 
 If the inlined SVG is inside of a button, you can forgo the `role` and `aria-label` by preferring a `title` on a button:
 
-```
+```jsx
 import { ReactComponent as CloseIcon } from 'fxa-react/images/close.svg';
 ...
 <button
@@ -371,7 +370,7 @@ Refer to Jest's [CLI documentation](https://jestjs.io/docs/en/cli) for more adva
 
 Because the `AlertBar` renders children into `<div id="alert-bar-root"></div>` located just below the layout header in the DOM in the real application, this element and the reference to it, located in `AlertBarContext`, must be present when running isolated tests. Wrap the test in `AlertBarRootAndContextProvider` for this purpose.
 
-```
+```jsx
 const { rerender } = render(<AlertBarRootAndContextProvider />);
 rerender(
   <AlertBarRootAndContextProvider>

--- a/packages/fxa-settings/src/lib/hooks.test.tsx
+++ b/packages/fxa-settings/src/lib/hooks.test.tsx
@@ -5,17 +5,29 @@
 import React, { useRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import * as apolloClient from '@apollo/client';
 
 import {
   useFocusOnTriggeringElementOnClose,
   useEscKeydownEffect,
   useChangeFocusEffect,
+  useHandledMutation,
 } from './hooks';
 
 describe('useFocusOnTriggeringElementOnClose', () => {
-  const Subject = ({ revealed, triggerException }: { revealed?: boolean, triggerException?: boolean | undefined }) => {
+  const Subject = ({
+    revealed,
+    triggerException,
+  }: {
+    revealed?: boolean;
+    triggerException?: boolean | undefined;
+  }) => {
     const triggerElement = useRef<HTMLButtonElement>(null);
-    useFocusOnTriggeringElementOnClose(revealed, triggerElement, triggerException);
+    useFocusOnTriggeringElementOnClose(
+      revealed,
+      triggerElement,
+      triggerException
+    );
 
     return (
       <button ref={triggerElement} data-testid="trigger-element">
@@ -74,5 +86,35 @@ describe('useChangeFocusEffect', () => {
   it('changes focus as expected', () => {
     render(<Subject />);
     expect(document.activeElement).toBe(screen.getByTestId('el-to-focus'));
+  });
+});
+
+describe('useHandledMutation', () => {
+  const query = {
+    kind: 'Document',
+    definitions: [],
+  } as apolloClient.DocumentNode;
+
+  beforeEach(() => {
+    Object.defineProperty(apolloClient, 'useMutation', {
+      value: jest.fn(),
+    });
+  });
+
+  it('calls useMutation with the correct default params', () => {
+    useHandledMutation(query);
+
+    expect(apolloClient.useMutation).toHaveBeenCalledWith(query, {
+      onError: expect.any(Function),
+    });
+  });
+
+  it('calls useMutation with additional params', () => {
+    useHandledMutation(query, { fetchPolicy: 'no-cache' });
+
+    expect(apolloClient.useMutation).toHaveBeenCalledWith(query, {
+      onError: expect.any(Function),
+      fetchPolicy: 'no-cache',
+    });
   });
 });

--- a/packages/fxa-settings/src/lib/hooks.tsx
+++ b/packages/fxa-settings/src/lib/hooks.tsx
@@ -3,6 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { useEffect, useRef } from 'react';
+import sentryMetrics from 'fxa-shared/lib/sentry';
+import {
+  useMutation,
+  DocumentNode,
+  MutationHookOptions,
+  ApolloError,
+} from '@apollo/client';
 
 // Focus on the element that triggered some action after the first
 // argument changes from `false` to `true` unless a `triggerException`
@@ -19,7 +26,12 @@ export function useFocusOnTriggeringElementOnClose(
     if (revealed !== undefined) {
       prevRevealedRef.current = revealed;
     }
-    if (triggerElement.current && prevRevealed === true && revealed === false && !triggerException) {
+    if (
+      triggerElement.current &&
+      prevRevealed === true &&
+      revealed === false &&
+      !triggerException
+    ) {
       triggerElement.current.focus();
     }
   }, [revealed, triggerElement, prevRevealed, triggerException]);
@@ -49,4 +61,35 @@ export function useChangeFocusEffect() {
   }, []);
 
   return elToFocus;
+}
+
+// TODO - Iron out how we want to handle mutation errors (FXA-2450)
+// We must have an `onError` option in mutations to allow tests to pass
+// but providing one prevents an error from actually throwing so we need
+// to manually report it to Sentry.
+// See https://github.com/apollographql/react-apollo/issues/2614
+export function useHandledMutation(
+  mutation: DocumentNode,
+  options: MutationHookOptions<any, Record<string, any>> | undefined = {}
+) {
+  return useMutation(
+    mutation,
+    Object.assign(options, {
+      // Pass in options.onError to handle an error and
+      // optionally re-throw so it gets logged to Sentry
+      // By default logs to Sentry
+      onError: (error: ApolloError) => {
+        if (options.onError) {
+          try {
+            options.onError(error);
+          } catch (error) {
+            sentryMetrics.captureException(error);
+          }
+        } else {
+          console.error(error);
+          sentryMetrics.captureException(error);
+        }
+      },
+    })
+  );
 }


### PR DESCRIPTION
## Because

- We want to be able to automatically handle mutation errors without importing error handling libs each time `useMutation` is used.
- Documentation needed some syntax highlighting ;)

## This pull request

- Adds `useHandledMutation`. This wraps `useMutation` with the option to specify an onError handler, which can itself throw and send the error to Sentry. In all other cases onError is just a noop. Per #6249, the idea is that we'd like to do this by default instead of importaing the Sentry lib each time. Note this does not close that issue though, as it does not address conventions for a general error message and GQL vs. other error types.
- Adds doc syntax highlighting in a couple spots

## Issue that this pull request solves

This sets the stage for a few things I'm working on in #6107, and also touches on #6249.

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.