### PR TITLE
refactor(settings): make cta buttons more modular, uniform in size

### DIFF
--- a/packages/fxa-settings/src/components/ChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/ChangePassword/index.tsx
@@ -40,7 +40,7 @@ export const ChangePassword = ({}: RouteComponentProps) => {
 
         <div className="flex justify-center p-2">
           <button
-            className="cta-neutral-lg w-1/4 m-2"
+            className="cta-neutral w-1/4 m-2"
             onClick={() => window.history.back()}
           >
             Cancel

--- a/packages/fxa-settings/src/components/Modal/index.tsx
+++ b/packages/fxa-settings/src/components/Modal/index.tsx
@@ -69,7 +69,7 @@ export const Modal = ({
             {hasButtons && (
               <div className="flex mt-6">
                 <button
-                  className="cta-neutral-lg transition-standard flex-1"
+                  className="cta-neutral transition-standard flex-1"
                   data-testid="modal-cancel"
                   onClick={onDismiss}
                 >

--- a/packages/fxa-settings/src/components/ModalVerifySession/index.tsx
+++ b/packages/fxa-settings/src/components/ModalVerifySession/index.tsx
@@ -109,7 +109,7 @@ export const ModalVerifySession = ({
         <div className="flex mt-6">
           <button
             type="button"
-            className="cta-neutral-lg transition-standard flex-1"
+            className="cta-neutral transition-standard flex-1"
             data-testid="modal-verify-session-cancel"
             onClick={onDismiss}
           >

--- a/packages/fxa-settings/src/components/SecondaryEmailInputForm/index.tsx
+++ b/packages/fxa-settings/src/components/SecondaryEmailInputForm/index.tsx
@@ -55,7 +55,7 @@ export const SecondaryEmailInputForm = () => {
 
       <div className="flex justify-center space-x-6">
         <Link
-          className="cta-neutral-lg transition-standard mb-3 w-32"
+          className="cta-neutral transition-standard mb-3 w-32"
           data-testid="cancel-button"
           to="/beta/settings"
         >

--- a/packages/fxa-settings/src/components/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRow/index.tsx
@@ -65,7 +65,7 @@ export const UnitRow = ({
         <div>
           {route && (
             <Link
-              className="cta-neutral transition-standard"
+              className="cta-neutral cta-base transition-standard"
               data-testid="unit-row-route"
               to={`${route}${location.search}`}
             >
@@ -75,7 +75,7 @@ export const UnitRow = ({
 
           {revealModal && (
             <button
-              className="cta-neutral transition-standard"
+              className="cta-neutral cta-base transition-standard"
               data-testid="unit-row-modal"
               ref={modalTriggerElement}
               onClick={revealModal}

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -185,7 +185,7 @@ export const UnitRowSecondaryEmail = () => {
             {secondaryEmailIsVerified && (
               <div>
                 <button
-                  className="cta-neutral transition-standard"
+                  className="cta-neutral cta-base transition-standard"
                   onClick={() => {
                     // Make secondaryEmail the primary email!
                   }}

--- a/packages/fxa-settings/src/components/UnitRowWithAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowWithAvatar/index.tsx
@@ -10,9 +10,7 @@ type UnitRowWithAvatarProps = {
   avatarUrl: string | null;
 };
 
-export const UnitRowWithAvatar = ({
-  avatarUrl,
-}: UnitRowWithAvatarProps) => {
+export const UnitRowWithAvatar = ({ avatarUrl }: UnitRowWithAvatarProps) => {
   const ctaText = avatarUrl ? 'Change' : 'Add';
   const location = useLocation();
   return (
@@ -29,7 +27,7 @@ export const UnitRowWithAvatar = ({
       <div className="unit-row-actions">
         <div>
           <Link
-            className="cta-neutral transition-standard"
+            className="cta-neutral cta-base transition-standard"
             data-testid="unit-row-with-avatar-route"
             to={`/beta/settings/avatar/change${location.search}`}
           >

--- a/packages/fxa-settings/src/styles/ctas.scss
+++ b/packages/fxa-settings/src/styles/ctas.scss
@@ -2,8 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+.cta-neutral,
+.cta-primary {
+  @apply py-2 px-5 rounded w-full inline-block text-center border font-header box-border;
+}
+
 .cta-neutral {
-  @apply block w-full py-2 text-center mt-6 bg-grey-10 border border-grey-200 rounded;
+  @apply bg-grey-10 border-grey-200;
 
   &:hover {
     @apply border-grey-200 bg-grey-100 text-grey-400;
@@ -12,28 +17,14 @@
   &:active {
     @apply border-grey-400 bg-grey-100 text-grey-400;
   }
-}
 
-@screen mobileLandscape {
-  .cta-neutral {
-    @apply text-xs py-1 px-5 mt-0 rounded-sm;
-  }
-}
-
-.cta-neutral-lg {
-  @apply block w-full text-center bg-grey-10 border border-grey-200 text-base mr-4 rounded mt-0 py-2;
-
-  &:hover {
-    @apply border-grey-200 bg-grey-100 text-grey-400;
-  }
-
-  &:active {
-    @apply border-grey-400 bg-grey-100 text-grey-400;
+  &:focus {
+    @apply bg-white;
   }
 }
 
 .cta-primary {
-  @apply bg-blue-500 py-2 text-white border border-blue-600 rounded;
+  @apply bg-blue-500 border-blue-600 text-white;
 
   &:hover {
     @apply bg-blue-600 border-blue-600;
@@ -41,5 +32,24 @@
 
   &:active {
     @apply bg-blue-800 border-blue-800;
+  }
+
+  &:focus {
+    @apply border-0;
+  }
+}
+
+.cta-base {
+  @apply text-base mt-6;
+}
+
+@screen mobileLandscape {
+  .cta-base {
+    @apply text-xs py-1 px-5 mt-0;
+  }
+
+  .cta-primary,
+  .cta-neutral {
+    @apply w-auto;
   }
 }


### PR DESCRIPTION
Breakout from #6283

## Because

- We should have consistent button styles
  - Note the only visual change here is that I've update the type face to Metropolis, per the Figma doc. Everything else is just how classes are approached. My goal is to provide a consistent base class that can be layered on top of with sizing classes, whereas currently we have a different sized primary/neutral buttons

## This pull request

- Updates our CTA classes to use modular classes that supply the style and sizing.

## Checklist

- [x] My commit is GPG signed.