### PR TITLE
feat(settings): Add avatar drop down component

### DIFF
--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -103,7 +103,7 @@
     "postcss-cli": "^7.1.1",
     "prettier": "^2.0.5",
     "supertest": "^4.0.2",
-    "tailwindcss": "^1.4.6",
+    "tailwindcss": "^1.7.3",
     "ts-jest": "^24.3.0",
     "ts-node": "^8.10.2",
     "typescript": "3.9.7",

--- a/packages/fxa-react/configs/tailwind.js
+++ b/packages/fxa-react/configs/tailwind.js
@@ -55,6 +55,9 @@ module.exports = {
       inset: {
         '1/2': '50%',
         '-px': '-1px',
+        '-3': '-0.75rem',
+        '-52': '-13rem',
+        '55': '13.75rem',
       },
       boxShadow: {
         // Specific-use focus shadows for input elements
@@ -245,11 +248,12 @@ module.exports = {
     width: ['responsive', 'hover', 'focus'],
     height: ['responsive', 'hover', 'focus'],
     textColor: ['responsive', 'hover', 'focus', 'active', 'disabled'],
-    borderColor: ['responsive', 'hover', 'focus', 'disabled'],
+    borderColor: ['responsive', 'hover', 'focus', 'active', 'disabled'],
     backgroundColor: ['responsive', 'hover', 'focus', 'disabled'],
     backgroundOpacity: ['hover', 'focus', 'active'],
     placeholderColor: ['responsive', 'focus', 'disabled'],
     cursor: ['responsive', 'disabled'],
+    textDecoration: ['responsive', 'hover', 'focus', 'active', 'group-hover'],
   },
   plugins: [
     plugin(function ({ addUtilities }) {
@@ -260,6 +264,16 @@ module.exports = {
       };
 
       addUtilities(customUtilities, ['responsive', 'hover', 'focus']);
+    }),
+    plugin(function ({ addComponents }) {
+      const carets = {
+        '.caret-up': {
+          borderLeft: '.75rem solid transparent',
+          borderRight: '.75rem solid transparent',
+          borderBottom: '.75rem solid #fff',
+        },
+      };
+      addComponents(carets);
     }),
   ],
 };

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -63,7 +63,7 @@
     "rimraf": "^3.0.2",
     "sass": "^1.26.5",
     "sass-loader": "^8.0.2",
-    "tailwindcss": "^1.4.6",
+    "tailwindcss": "^1.7.3",
     "ts-jest": "^24.3.0",
     "typescript": "3.9.7",
     "webpack": "^4.43.0"

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -75,7 +75,7 @@
     "npm-run-all": "^4.1.5",
     "pm2": "^4.4.1",
     "postcss-cli": "^7.1.1",
-    "tailwindcss": "^1.4.6",
+    "tailwindcss": "^1.7.3",
     "webpack": "^4.43.0"
   }
 }

--- a/packages/fxa-settings/src/components/Avatar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Avatar/index.stories.tsx
@@ -4,12 +4,17 @@
 
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { Avatar } from '.';
+import { MockedCache } from '../../models/_mocks';
+import Avatar from '.';
 
 storiesOf('Components|Avatar', module)
   .add('default avatar', () => (
-    <Avatar avatarUrl={null} className="w-32 h-32" />
+    <MockedCache account={{ avatarUrl: null }}>
+      <Avatar className="w-32 h-32" />
+    </MockedCache>
   ))
   .add('non-default avatar', () => (
-    <Avatar className="w-32 h-32" avatarUrl="http://placekitten.com/256/256" />
+    <MockedCache>
+      <Avatar className="w-32 h-32" />
+    </MockedCache>
   ));

--- a/packages/fxa-settings/src/components/Avatar/index.test.tsx
+++ b/packages/fxa-settings/src/components/Avatar/index.test.tsx
@@ -4,11 +4,16 @@
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { MockedCache } from '../../models/_mocks';
 import Avatar from '.';
 
 describe('Avatar', () => {
   it('renders default avatar with expected attributes', () => {
-    render(<Avatar avatarUrl={null} />);
+    render(
+      <MockedCache account={{ avatarUrl: null }}>
+        <Avatar />
+      </MockedCache>
+    );
 
     expect(screen.getByTestId('avatar-default')).toHaveAttribute('role', 'img');
     expect(screen.getByTestId('avatar-default')).toHaveAttribute(
@@ -19,17 +24,25 @@ describe('Avatar', () => {
   });
 
   it('renders default avatar with a custom className', () => {
-    render(<Avatar avatarUrl={null} className="my-class" />);
+    render(
+      <MockedCache account={{ avatarUrl: null }}>
+        <Avatar className="my-class" />
+      </MockedCache>
+    );
 
     expect(screen.getByTestId('avatar-default')).toHaveClass('my-class');
   });
 
   it('renders the avatar with expected attributes', () => {
-    render(<Avatar avatarUrl="some-fake-image.png" />);
+    render(
+      <MockedCache>
+        <Avatar />
+      </MockedCache>
+    );
 
     expect(screen.getByTestId('avatar-nondefault')).toHaveAttribute(
       'src',
-      'some-fake-image.png'
+      'http://placekitten.com/512/512'
     );
     expect(screen.getByTestId('avatar-nondefault')).toHaveAttribute(
       'alt',
@@ -39,7 +52,11 @@ describe('Avatar', () => {
   });
 
   it('renders the avatar with a custom className', () => {
-    render(<Avatar avatarUrl="some-fake-image.png" className="my-class" />);
+    render(
+      <MockedCache>
+        <Avatar className="my-class" />
+      </MockedCache>
+    );
 
     expect(screen.getByTestId('avatar-nondefault')).toHaveClass('my-class');
   });

--- a/packages/fxa-settings/src/components/Avatar/index.tsx
+++ b/packages/fxa-settings/src/components/Avatar/index.tsx
@@ -4,14 +4,16 @@
 
 import React from 'react';
 import classNames from 'classnames';
+import { useAccount } from '../../models';
 import { ReactComponent as DefaultAvatar } from './avatar-default.svg';
 
 type AvatarProps = {
-  avatarUrl: string | null;
   className?: string;
 };
 
-export const Avatar = ({ avatarUrl, className }: AvatarProps) => {
+export const Avatar = ({ className }: AvatarProps) => {
+  const { avatarUrl } = useAccount();
+
   if (avatarUrl) {
     return (
       <img

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.stories.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.stories.tsx
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { MockedCache } from '../../models/_mocks';
+import DropDownAvatarMenu from '.';
+
+storiesOf('Components|DropDownAvatarMenu', module)
+  .add('default - no avatar or display name', () => (
+    <MockedCache account={{ avatarUrl: null, displayName: null }}>
+      <div className="w-full flex justify-end">
+        <div className="flex pr-10 pt-4">
+          <DropDownAvatarMenu />
+        </div>
+      </div>
+    </MockedCache>
+  ))
+  .add('with avatar and display name', () => (
+    <MockedCache>
+      <div className="w-full flex justify-end">
+        <div className="flex pr-10 pt-4">
+          <DropDownAvatarMenu />
+        </div>
+      </div>
+    </MockedCache>
+  ));

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
@@ -1,0 +1,148 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { MockedCache } from '../../models/_mocks';
+import { AlertBarRootAndContextProvider } from '../../lib/AlertBarContext';
+import DropDownAvatarMenu, { DESTROY_SESSION_MUTATION } from '.';
+
+const mockGqlSuccess = () => ({
+  request: {
+    query: DESTROY_SESSION_MUTATION,
+    variables: { input: {} },
+  },
+  result: {
+    data: {
+      resendSecondaryEmailCode: {
+        clientMutationId: null,
+      },
+    },
+  },
+});
+
+const mockGqlError = () => ({
+  request: {
+    query: DESTROY_SESSION_MUTATION,
+    variables: { input: {} },
+  },
+  error: new Error('Aw shucks'),
+});
+
+describe('DropDownAvatarMenu', () => {
+  it('renders and toggles as expected with default values', () => {
+    render(
+      <MockedCache account={{ avatarUrl: null, displayName: null }}>
+        <DropDownAvatarMenu />
+      </MockedCache>
+    );
+
+    const toggleButton = screen.getByTestId('drop-down-avatar-menu-toggle');
+    const dropDownId = 'drop-down-avatar-menu';
+    const dropDown = screen.queryByTestId(dropDownId);
+
+    expect(toggleButton).toHaveAttribute('title', 'Firefox Account Menu');
+    expect(toggleButton).toHaveAttribute('aria-controls', dropDownId);
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+    expect(dropDown).not.toBeInTheDocument;
+
+    fireEvent.click(toggleButton);
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+    expect(dropDown).toBeInTheDocument;
+    expect(screen.getByTestId('drop-down-name-or-email').textContent).toContain(
+      'johndope@example.com'
+    );
+
+    fireEvent.click(toggleButton);
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+    expect(dropDown).not.toBeInTheDocument;
+  });
+
+  it('renders as expected with avatarUrl and displayName set', () => {
+    render(
+      <MockedCache>
+        <DropDownAvatarMenu />
+      </MockedCache>
+    );
+    fireEvent.click(screen.getByTestId('drop-down-avatar-menu-toggle'));
+    expect(screen.getByTestId('drop-down-name-or-email').textContent).toContain(
+      'John Dope'
+    );
+  });
+
+  it('closes on esc keypress', () => {
+    render(
+      <MockedCache>
+        <DropDownAvatarMenu />
+      </MockedCache>
+    );
+    const dropDown = screen.queryByTestId('drop-down-avatar-menu');
+
+    fireEvent.click(screen.getByTestId('drop-down-avatar-menu-toggle'));
+    expect(dropDown).toBeInTheDocument;
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(dropDown).not.toBeInTheDocument;
+  });
+
+  it('closes on click outside', () => {
+    const { container } = render(
+      <MockedCache>
+        <div className="w-full flex justify-end">
+          <div className="flex pr-10 pt-4">
+            <DropDownAvatarMenu />
+          </div>
+        </div>
+      </MockedCache>
+    );
+    const dropDown = screen.queryByTestId('drop-down-avatar-menu');
+
+    fireEvent.click(screen.getByTestId('drop-down-avatar-menu-toggle'));
+    expect(dropDown).toBeInTheDocument;
+    fireEvent.click(container);
+    expect(dropDown).not.toBeInTheDocument;
+  });
+
+  describe('destroySession', () => {
+    it('redirects the user on success', async () => {
+      window.location.assign = jest.fn();
+      const mocks = [mockGqlSuccess()];
+
+      render(
+        <MockedCache {...{ mocks }}>
+          <DropDownAvatarMenu />
+        </MockedCache>
+      );
+
+      fireEvent.click(screen.getByTestId('drop-down-avatar-menu-toggle'));
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('sign-out'));
+      });
+      expect(window.location.assign).toHaveBeenCalledWith(
+        `${window.location.origin}/signin`
+      );
+    });
+
+    it('displays an error in the AlertBar', async () => {
+      const mocks = [mockGqlError()];
+
+      const { rerender } = render(<AlertBarRootAndContextProvider />);
+      rerender(
+        <MockedCache {...{ mocks }}>
+          <AlertBarRootAndContextProvider>
+            <DropDownAvatarMenu />
+          </AlertBarRootAndContextProvider>
+        </MockedCache>
+      );
+
+      fireEvent.click(screen.getByTestId('drop-down-avatar-menu-toggle'));
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('sign-out'));
+      });
+
+      expect(screen.getByTestId('sign-out-error').textContent).toContain(
+        'Aw shucks'
+      );
+    });
+  });
+});

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useState } from 'react';
+import { gql, useMutation } from '@apollo/client';
+import Avatar from '../Avatar';
+import AlertBar from '../AlertBar';
+import { useAccount } from '../../models';
+import sentryMetrics from 'fxa-shared/lib/sentry';
+import { clearSignedInAccountUid } from '../../lib/cache';
+import { useClickOutsideEffect, useBooleanState } from 'fxa-react/lib/hooks';
+import { useEscKeydownEffect } from '../../lib/hooks';
+import { ReactComponent as SignOut } from './sign-out.svg';
+
+export const DESTROY_SESSION_MUTATION = gql`
+  mutation destroySession($input: DestroySessionInput!) {
+    destroySession(input: $input) {
+      clientMutationId
+    }
+  }
+`;
+
+export const DropDownAvatarMenu = () => {
+  const { displayName, primaryEmail } = useAccount();
+  const [isRevealed, setRevealed] = useState(false);
+  const toggleRevealed = () => setRevealed(!isRevealed);
+  const avatarMenuInsideRef = useClickOutsideEffect<HTMLDivElement>(
+    setRevealed
+  );
+  useEscKeydownEffect(setRevealed);
+  const [alertBarRevealed, revealAlertBar, hideAlertBar] = useBooleanState();
+  const dropDownId = 'drop-down-avatar-menu';
+
+  // TODO: FXA-2450
+  const [destroySession, { data, error }] = useMutation(
+    DESTROY_SESSION_MUTATION,
+    {
+      onError: (error) => {
+        revealAlertBar();
+        sentryMetrics.captureException(error);
+      },
+    }
+  );
+
+  const signOut = () => {
+    destroySession({
+      variables: { input: {} },
+    });
+  };
+
+  if (data) {
+    clearSignedInAccountUid();
+    window.location.assign(`${window.location.origin}/signin`);
+    return null;
+  }
+
+  return (
+    <>
+      {alertBarRevealed && error && (
+        <AlertBar onDismiss={hideAlertBar} type="error">
+          <p data-testid="sign-out-error">Error text TBD. {error.message}</p>
+        </AlertBar>
+      )}
+      <div className="relative" ref={avatarMenuInsideRef}>
+        <button
+          onClick={toggleRevealed}
+          data-testid="drop-down-avatar-menu-toggle"
+          title="Firefox Account Menu"
+          aria-expanded={isRevealed}
+          aria-controls={dropDownId}
+          className="rounded-full border-2 border-transparent hover:border-purple-500 focus:border-purple-500 focus:outline-none active:border-purple-700 transition-standard"
+        >
+          <Avatar className="w-10 rounded-full" />
+        </button>
+        {isRevealed && (
+          <div
+            id={dropDownId}
+            data-testid={dropDownId}
+            className="drop-down-menu -left-52"
+          >
+            <div className="flex flex-wrap">
+              <div className="flex w-full p-4">
+                <div className="mr-3 flex flex-1">
+                  <Avatar className="w-10" />
+                </div>
+                <div className="flex flex-4 truncate">
+                  <p className="leading-5 max-w-full truncate">
+                    <span className="text-grey-400 text-xs">Signed in as</span>
+                    <span
+                      className="font-bold block truncate"
+                      data-testid="drop-down-name-or-email"
+                    >
+                      {displayName || primaryEmail.email}
+                    </span>
+                  </p>
+                </div>
+              </div>
+              <div className="w-full">
+                <div className="bg-gradient-to-r from-blue-500 via-pink-700 to-yellow-500 h-px" />
+                <div className="px-4 py-5">
+                  <button
+                    className="pl-3 group"
+                    onClick={signOut}
+                    data-testid="sign-out"
+                  >
+                    <SignOut
+                      height="18"
+                      width="18"
+                      className="mr-3 inline-block stroke-current align-middle"
+                    />
+                    <span className="group-hover:underline">Sign out</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default DropDownAvatarMenu;

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/sign-out.svg
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/sign-out.svg
@@ -1,0 +1,1 @@
+<svg fill="none" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg"><path d="M6.333 9.26H17M12.733 4.993L17 9.26l-4.267 4.267M9.533 16.727H2.067A1.067 1.067 0 011 15.66V2.86c0-.589.478-1.067 1.067-1.067h7.466" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>

--- a/packages/fxa-settings/src/components/HeaderLockup/index.stories.tsx
+++ b/packages/fxa-settings/src/components/HeaderLockup/index.stories.tsx
@@ -9,12 +9,12 @@ import { HeaderLockup } from '.';
 
 storiesOf('Components|HeaderLockup', module)
   .add('with default avatar', () => (
-    <MockedCache>
+    <MockedCache account={{ avatarUrl: null }}>
       <HeaderLockup />
     </MockedCache>
   ))
   .add('with non-default avatar', () => (
-    <MockedCache account={{ avatarUrl: 'http://placekitten.com/256/256' }}>
+    <MockedCache>
       <HeaderLockup />
     </MockedCache>
   ));

--- a/packages/fxa-settings/src/components/HeaderLockup/index.tsx
+++ b/packages/fxa-settings/src/components/HeaderLockup/index.tsx
@@ -6,14 +6,12 @@ import React from 'react';
 import LogoLockup from 'fxa-react/components/LogoLockup';
 import Header from 'fxa-react/components/Header';
 import LinkExternal from 'fxa-react/components/LinkExternal';
-import Avatar from '../Avatar';
+import DropDownAvatarMenu from '../DropDownAvatarMenu';
 import { ReactComponent as Help } from './help.svg';
 import { ReactComponent as Bento } from './bento.svg';
 import { ReactComponent as Menu } from './menu.svg';
-import { useAccount } from '../../models';
 
 export const HeaderLockup = () => {
-  const { avatarUrl } = useAccount();
   const left = (
     <>
       <button
@@ -59,8 +57,7 @@ export const HeaderLockup = () => {
         className="w-6 mx-6 desktop:mx-8"
         data-testid="header-bento"
       />
-      {/* TODO display primaryEmail.email in the header in FXA-1575 */}
-      <Avatar {...{ avatarUrl }} className="w-10" />
+      <DropDownAvatarMenu />
     </>
   );
 

--- a/packages/fxa-settings/src/components/Profile/index.tsx
+++ b/packages/fxa-settings/src/components/Profile/index.tsx
@@ -5,12 +5,7 @@ import { UnitRowWithAvatar } from '../UnitRowWithAvatar';
 import { UnitRowSecondaryEmail } from '../UnitRowSecondaryEmail';
 
 export const Profile = () => {
-  const {
-    primaryEmail,
-    displayName,
-    avatarUrl,
-    passwordCreated,
-  } = useAccount();
+  const { primaryEmail, displayName, passwordCreated } = useAccount();
 
   const pwdDateText = Intl.DateTimeFormat('default', {
     year: 'numeric',
@@ -25,13 +20,14 @@ export const Profile = () => {
       <h2 className="font-header font-bold ml-4 mb-4">Profile</h2>
 
       <div className="bg-white tablet:rounded-xl shadow">
-        <UnitRowWithAvatar avatarUrl={avatarUrl} />
+        <UnitRowWithAvatar />
 
         <hr className="unit-row-hr" />
 
         <UnitRow
           header="Display name"
           headerValue={displayName}
+          headerValueClassName="break-all"
           route="/beta/settings/display_name"
         />
 
@@ -50,7 +46,11 @@ export const Profile = () => {
 
         <hr className="unit-row-hr" />
 
-        <UnitRow header="Primary email" headerValue={primaryEmail.email} />
+        <UnitRow
+          header="Primary email"
+          headerValue={primaryEmail.email}
+          headerValueClassName="break-all"
+        />
 
         <hr className="unit-row-hr" />
 

--- a/packages/fxa-settings/src/components/Settings/index.tsx
+++ b/packages/fxa-settings/src/components/Settings/index.tsx
@@ -26,7 +26,7 @@ export const Settings = (_: RouteComponentProps) => {
       <div className="hidden desktop:block desktop:flex-2">
         <Nav />
       </div>
-      <div className="flex-7">
+      <div className="flex-7 max-w-full">
         <Profile />
         <Security twoFactorAuthEnabled={false} />
       </div>

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -208,7 +208,7 @@ export const UnitRowSecondaryEmail = () => {
     return (
       <div className="mobileLandscape:flex unit-row-multi-row">
         <div className="unit-row-content" data-testid="unit-row-content">
-          <p className="font-bold" data-testid="unit-row-header-value">
+          <p className="font-bold break-all" data-testid="unit-row-header-value">
             <span className="flex justify-between items-center">
               {email}
               <DeleteEmailButton

--- a/packages/fxa-settings/src/components/UnitRowWithAvatar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/UnitRowWithAvatar/index.stories.tsx
@@ -5,11 +5,18 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { LocationProvider } from '@reach/router';
+import { MockedCache } from '../../models/_mocks';
 import { UnitRowWithAvatar } from '.';
 
 storiesOf('Components|UnitRowWithAvatar', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
-  .add('with default avatar', () => <UnitRowWithAvatar avatarUrl={null} />)
+  .add('with default avatar', () => (
+    <MockedCache account={{ avatarUrl: null }}>
+      <UnitRowWithAvatar />
+    </MockedCache>
+  ))
   .add('with non-default avatar', () => (
-    <UnitRowWithAvatar avatarUrl="http://placekitten.com/256/256" />
-  ));
+    <MockedCache>
+      <UnitRowWithAvatar />
+    </MockedCache>
+  ))

--- a/packages/fxa-settings/src/components/UnitRowWithAvatar/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowWithAvatar/index.test.tsx
@@ -3,13 +3,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import UnitRowWithAvatar from '.';
+import { MockedCache } from '../../models/_mocks';
 import { renderWithRouter } from '../../models/_mocks';
 
 describe('UnitRowWithAvatar', () => {
   it('renders as expected with the default avatar', () => {
-    renderWithRouter(<UnitRowWithAvatar avatarUrl={null} />);
+    renderWithRouter(
+      <MockedCache account={{ avatarUrl: null }}>
+        <UnitRowWithAvatar />
+      </MockedCache>
+    );
 
     expect(
       screen.getByTestId('unit-row-with-avatar-route').textContent
@@ -19,7 +24,11 @@ describe('UnitRowWithAvatar', () => {
   });
 
   it('renders as expected with the user avatar', () => {
-    renderWithRouter(<UnitRowWithAvatar avatarUrl="some-fake-image.png" />);
+    renderWithRouter(
+      <MockedCache>
+        <UnitRowWithAvatar />
+      </MockedCache>
+    );
 
     expect(
       screen.getByTestId('unit-row-with-avatar-route').textContent

--- a/packages/fxa-settings/src/components/UnitRowWithAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowWithAvatar/index.tsx
@@ -4,13 +4,11 @@
 
 import React from 'react';
 import Avatar from '../Avatar';
+import { useAccount } from '../../models';
 import { Link, useLocation } from '@reach/router';
 
-type UnitRowWithAvatarProps = {
-  avatarUrl: string | null;
-};
-
-export const UnitRowWithAvatar = ({ avatarUrl }: UnitRowWithAvatarProps) => {
+export const UnitRowWithAvatar = () => {
+  const { avatarUrl } = useAccount();
   const ctaText = avatarUrl ? 'Change' : 'Add';
   const location = useLocation();
   return (
@@ -19,10 +17,7 @@ export const UnitRowWithAvatar = ({ avatarUrl }: UnitRowWithAvatarProps) => {
         <h3 data-testid="unit-row-with-avatar-header">Picture</h3>
       </div>
       <div className="unit-row-content">
-        <Avatar
-          {...{ avatarUrl }}
-          className="mx-auto mobileLandscape:mx-0 w-32 mobileLandscape:w-16"
-        />
+        <Avatar className="mx-auto mobileLandscape:mx-0 w-32 mobileLandscape:w-16" />
       </div>
       <div className="unit-row-actions">
         <div>

--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -45,6 +45,14 @@ export function sessionToken(newToken?: hexstring) {
   }
 }
 
+export function clearSignedInAccountUid() {
+  const all = accounts() || {};
+  const uid = storage.get('currentAccountUid') as hexstring;
+  delete all[uid];
+  accounts(all);
+  storage.remove('currentAccountUid');
+}
+
 function consumeAlertTextExternal() {
   const account = currentAccount();
   const text = account?.alertText || null;

--- a/packages/fxa-settings/src/models/_mocks.tsx
+++ b/packages/fxa-settings/src/models/_mocks.tsx
@@ -18,7 +18,7 @@ import { render } from '@testing-library/react';
 export const MOCK_ACCOUNT: Account = {
   uid: 'abc123',
   displayName: 'John Dope',
-  avatarUrl: 'http://avatars.com/y2k',
+  avatarUrl: 'http://placekitten.com/512/512',
   accountCreated: 123456789,
   passwordCreated: 123456789,
   recoveryKey: true,

--- a/packages/fxa-settings/src/styles/drop-down-menu.scss
+++ b/packages/fxa-settings/src/styles/drop-down-menu.scss
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+.drop-down-menu {
+  @apply w-64 bg-white absolute shadow-md rounded;
+
+  &::before {
+    content: '';
+    @apply caret-up absolute -top-3 left-55;
+  }
+}

--- a/packages/fxa-settings/src/styles/tailwind.scss
+++ b/packages/fxa-settings/src/styles/tailwind.scss
@@ -6,6 +6,7 @@
 @import './ctas.scss';
 @import './unit-row.scss';
 @import './tooltip.scss';
+@import './drop-down-menu.scss';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/yarn.lock
+++ b/yarn.lock
@@ -10181,7 +10181,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
+"chalk@npm:^3.0.0 || ^4.0.0, chalk@npm:^4.0.0, chalk@npm:^4.1.0":
   version: 4.1.0
   resolution: "chalk@npm:4.1.0"
   dependencies:
@@ -15741,7 +15741,7 @@ fsevents@^1.2.7:
     react-scripts: ^3.4.1
     serve-static: ^1.14.1
     supertest: ^4.0.2
-    tailwindcss: ^1.4.6
+    tailwindcss: ^1.7.3
     ts-jest: ^24.3.0
     ts-node: ^8.10.2
     typescript: 3.9.7
@@ -16649,7 +16649,7 @@ fsevents@^1.2.7:
     rimraf: ^3.0.2
     sass: ^1.26.5
     sass-loader: ^8.0.2
-    tailwindcss: ^1.4.6
+    tailwindcss: ^1.7.3
     ts-jest: ^24.3.0
     typescript: 3.9.7
     webpack: ^4.43.0
@@ -16700,7 +16700,7 @@ fsevents@^1.2.7:
     react-dom: ^16.13.1
     react-scripts: ^3.4.1
     subscriptions-transport-ws: ^0.9.11
-    tailwindcss: ^1.4.6
+    tailwindcss: ^1.7.3
     typescript: 3.9.7
     webpack: ^4.43.0
   languageName: unknown
@@ -24936,7 +24936,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object-hash@npm:^2.0.1":
+"object-hash@npm:^2.0.1, object-hash@npm:^2.0.3":
   version: 2.0.3
   resolution: "object-hash@npm:2.0.3"
   checksum: e633ae67cd6c5f3cd52af5bef0fe7f25d597b415a6d92a601be0b97a47642908cf333cedfc9e848d25b6c51fd6cf6e64ff6eb3af710eae249a42f6a69ad6b12d
@@ -32564,33 +32564,35 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"tailwindcss@npm:^1.4.6":
-  version: 1.4.6
-  resolution: "tailwindcss@npm:1.4.6"
+"tailwindcss@npm:^1.7.3":
+  version: 1.7.3
+  resolution: "tailwindcss@npm:1.7.3"
   dependencies:
     "@fullhuman/postcss-purgecss": ^2.1.2
     autoprefixer: ^9.4.5
     browserslist: ^4.12.0
     bytes: ^3.0.0
-    chalk: ^4.0.0
+    chalk: ^3.0.0 || ^4.0.0
     color: ^3.1.2
     detective: ^5.2.0
     fs-extra: ^8.0.0
     lodash: ^4.17.15
     node-emoji: ^1.8.1
     normalize.css: ^8.0.1
+    object-hash: ^2.0.3
     postcss: ^7.0.11
     postcss-functions: ^3.0.0
     postcss-js: ^2.0.0
     postcss-nested: ^4.1.1
     postcss-selector-parser: ^6.0.0
+    postcss-value-parser: ^4.1.0
     pretty-hrtime: ^1.0.3
     reduce-css-calc: ^2.1.6
     resolve: ^1.14.2
   bin:
     tailwind: lib/cli.js
     tailwindcss: lib/cli.js
-  checksum: 671553f6dfabe4af66d74c2f3a8cad483d4630b0ab26eba5ff0a4df0b75dd2cc00ae1b7678a1d2830774e3110059f29e0f29def8ae0e33521f648ec48b14f769
+  checksum: 82e54f7cecf5dc9dc42f505681cb386b1ebd4fb2c79dc2a7e234c9080334b7f92ff6bd72ea82c0f083e994be00a56fa1c670a74ae7187b6704f2161ff5212156
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because
* Settings needs an avatar drop-down showing the user's avatar, display name or primary email, and sign out button.

## This pull request
* Adds DropDownAvatarMenu component and .drop-down-menu class for Bento menu reuse
* Adds client-side destroySession mutation
* Uses the useAccount hook in Avatar component instead of drilling the prop down and updates the default to use placekitten URL so the avatar actually loads in an img tag
* Adds truncate class to UnitRow showing the displayName

## Issue that this pull request solves

Closes: #4869

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Other information (Optional)

Tailwindcss needed a package update to work with gradients.
