### PR TITLE
feat(payments): add subscription buttons for 123done while logged in

### DIFF
--- a/packages/123done/static/css/main.css
+++ b/packages/123done/static/css/main.css
@@ -74,13 +74,24 @@ button::-moz-focus-inner {
 }
 
 .banner .btn,
-#header-main .btn {
+#header-main .btn,
+#footer-main .btn {
   background: #eef2f0;
   border-radius: 2px;
   margin-right: 16px;
   padding: 10px;
   color: black;
   font-size: 16px;
+}
+#footer-main .subscription-buttons {
+  display: none;
+}
+.logged-in #footer-main .subscription-buttons {
+  display: block;
+  margin: 20px 0px;
+}
+.logged-in.is-subscribed #footer-main .subscription-buttons {
+  display: none;
 }
 
 .banner .btn:hover {
@@ -192,16 +203,6 @@ button::-moz-focus-inner {
   font-size: 14px;
   margin: 7px 0;
   padding: 5px 10px;
-}
-
-#subscriptionCTA {
-  float: right;
-  margin: 7px 0;
-  padding: 5px 10px;
-}
-
-.is-subscribed #subscriptionCTA {
-  display: none;
 }
 
 #header-main h1 {

--- a/packages/123done/static/index.html
+++ b/packages/123done/static/index.html
@@ -148,24 +148,11 @@
           </h1>
           <button id="logout">logout</button>
           <div id="loggedin"><span></span></div>
-          <div id="subscriptionCTA">
-            <a
-              href="//localhost:3030/subscriptions/products/prod_GqM9ToKK62qjkK"
-              class="btn btn-persona btn-subscribe"
-              >Subscribe for Pro</a
-            >
-          </div>
         </div>
       </header>
       <section class="todo">
         <div class="container">
           <div class="preroll">
-            <div id="subscriptionCTA">
-              <span
-                >Subscribe for pro! LINK TBD!
-                productId=123doneProProduct&amp;</span
-              >
-            </div>
             <ul id="signinhere" style="font-size: 15pt;">
               <p>Sign in to get started making todo lists!</p>
             </ul>
@@ -203,6 +190,25 @@
 
     <footer id="footer-main">
       <div class="container">
+        <div class="subscription-buttons">
+          <a
+          class="btn btn-persona btn-subscribe" data-currency="usd"
+          >Subscribe to Pro (USD)</a
+        >
+          <a
+          class="btn btn-persona btn-subscribe" data-currency="eur"
+          >Subscribe to Pro (EUR)</a
+        >
+        <a
+          class="btn btn-persona btn-subscribe" data-currency="cad"
+          >Subscribe to Pro (CAD)</a
+        >
+        <a
+          class="btn btn-persona btn-subscribe" data-currency="myr"
+          >Subscribe to Pro (MYR)</a
+        >
+        </div>
+
         <div class="logo"></div>
         <p>
           <strong>123done</strong> is a simple todo list application!

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -41,7 +41,8 @@ module.exports = {
     BUTTON_PROMPT_NONE: '.ready .prompt-none',
     BUTTON_SIGNUP: '.sign-in-button.signup',
     LINK_LOGOUT: '#logout',
-    BUTTON_SUBSCRIBE: '#subscriptionCTA .btn-subscribe',
+    BUTTON_SUBSCRIBE:
+      '.subscription-buttons .btn-subscribe[data-currency="usd"]',
     SUBSCRIBED: '.pro-status',
   },
   '400': {


### PR DESCRIPTION
- adds subscription buttons to the footer of 123done while logged in but
  not yet subscribed.

- removes the "Subscribe to pro" button from header because there's not
  room for all the currency buttons in that header

fixes #6216
