### PR TITLE
Fxa 2427

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
@@ -26,6 +26,13 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
   defaultCapabilities: _.extend({}, proto.defaultCapabilities, {
     chooseWhatToSyncWebV1: true,
     openWebmailButtonVisible: false,
+
+    // For oauth webchannel clients, the sessionToken will get exchanged
+    // for a refresh token so we shouldn't really reuse it. For example,
+    // reusing a sessionToken that was verified with 2FA, would not prompt
+    // the user for the 2FA code again because the session already has
+    // the highest verification level.
+    reuseExistingSession: false,
   }),
 
   commands: _.pick(WebChannel, 'FXA_STATUS', 'OAUTH_LOGIN', 'DELETE_ACCOUNT'),

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
@@ -113,6 +113,10 @@ describe('models/auth_brokers/oauth-webchannel-v1', () => {
     assert.isTrue(broker.hasCapability('fxaStatus'));
   });
 
+  it('capability reuseExistingSession false', () => {
+    assert.isFalse(broker.getCapability('reuseExistingSession'));
+  });
+
   it('status capability - choose_what_to_sync: true with engines', (done) => {
     channelMock.request = sinon.spy(() =>
       Promise.resolve({


### PR DESCRIPTION
## Because

- We should always try to prompt the user for 2FA if it is enabled on the account

## This pull request

- For oauth webchannel clients (now FxiOS and Fenix) we shouldn't allow them to reuse a sessionToken which could lead to edge cases like these

## Issue that this pull request solves

Closes: #6208

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
