### PR TITLE
feat(payments) - update subscription flow to allow for use of existing card

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentFormV2/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentFormV2/index.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback, useContext, useEffect, useState } from 'react';
-import { Localized, withLocalization, WithLocalizationProps } from '@fluent/react';
+import {
+  Localized,
+  withLocalization,
+  WithLocalizationProps,
+} from '@fluent/react';
 import {
   Stripe,
   StripeElements,
@@ -45,10 +49,14 @@ export type BasePaymentFormProps = {
   customer?: Customer | null;
   onCancel?: () => void;
   onSubmit: (submitResult: {
-    stripe?: Stripe;
-    elements?: StripeElements;
-    name?: string;
-    card?: StripeCardElement;
+    stripe: Stripe;
+    elements: StripeElements;
+    name: string;
+    card: StripeCardElement;
+    idempotencyKey: string;
+  }) => void;
+  onReuseSubmit: (submitResult: {
+    stripe: Stripe;
     idempotencyKey: string;
   }) => void;
   validatorInitialState?: ValidatorState;

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -263,7 +263,7 @@ export async function apiCreateCustomer(params: {
 export async function apiCreateSubscriptionWithPaymentMethod(params: {
   priceId: string;
   productId: string;
-  paymentMethodId: string;
+  paymentMethodId?: string;
   idempotencyKey: string;
 }): Promise<{
   id: string;

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateFormV2.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateFormV2.test.tsx
@@ -116,17 +116,17 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
     expect(screen.queryByTestId('payment-update')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('change-button'));
 
-    await act(async () => {
-      mockStripeElementOnChangeFns.cardElement(
-        elementChangeResponse({ complete: true, value: 'test' })
-      );
-    });
-
-    fireEvent.change(screen.getByTestId('name'), {
-      target: { value: DISPLAY_NAME },
-    });
-    fireEvent.blur(screen.getByTestId('name'));
-
+    if (screen.queryByTestId('name')) {
+      await act(async () => {
+        mockStripeElementOnChangeFns.cardElement(
+          elementChangeResponse({ complete: true, value: 'test' })
+        );
+      });
+      fireEvent.change(screen.getByTestId('name'), {
+        target: { value: DISPLAY_NAME },
+      });
+      fireEvent.blur(screen.getByTestId('name'));
+    }
     await act(async () => {
       fireEvent.click(screen.getByTestId('submit'));
     });


### PR DESCRIPTION
feat: Multiple Products - Subscribed user can make purchase with card on file - Update Subscription Creation endpoint usage

## Because

- we want to allow for users that are already subscribed to be able to sign up for new services without having to re-enter credit card information

## This pull request

- update the usage of the subscription create endpoint to use existing credit card data for existing customers

## Issue that this pull request solves

Closes: # https://jira.mozilla.com/browse/FXA-2289

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
