### PR TITLE
fix(content server): mark account as verified so recovery code usage can redirect you to cad screen

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -1631,14 +1631,16 @@ const Account = Backbone.Model.extend(
 
      * @returns {Promise}
      */
-    consumeRecoveryCode(code) {
-      return this._fxaClient.consumeRecoveryCode(
+    async consumeRecoveryCode(code) {
+      const response = await this._fxaClient.consumeRecoveryCode(
         this.get('sessionToken'),
         code,
         {
           metricsContext: this._metrics.getFlowEventMetadata(),
         }
       );
+      this.set('verified', true);
+      return response;
     },
 
     /**

--- a/packages/fxa-content-server/app/tests/spec/models/account.js
+++ b/packages/fxa-content-server/app/tests/spec/models/account.js
@@ -2961,6 +2961,20 @@ describe('models/account', function () {
     });
   });
 
+  describe('consumeRecoveryCode', () => {
+    beforeEach(() => {
+      sinon
+        .stub(fxaClient, 'consumeRecoveryCode')
+        .callsFake(() => Promise.resolve());
+      account.set('verified', false);
+    });
+
+    it('sets verified state to true', async () => {
+      await account.consumeRecoveryCode();
+      assert.isTrue(account.get('verified'));
+    });
+  });
+
   describe('_fetchShortLivedSubscriptionsOAuthToken', () => {
     it('calls createOAuthToken with the correct arguments', () => {
       const createOAuthTokenStub = sinon.stub(account, 'createOAuthToken');


### PR DESCRIPTION
## Because

- The account that uses a recovery code is not being recognized as verified when it is redirected to the CAD screen, and the user is thusly prompted to sign in/enter a password after they just entered a recovery code.

## This pull request

- Modifies the `Account` model's `consumeRecoveryCode` to mark the account as verified once the request is complete, allowing the redirection to the CAD screen to be completed.

## Issue that this pull request solves

Closes: #6173

## Checklist

- [x] My commit is GPG signed.