### PR TITLE
fix(totp): Add mixin to verify session if a request is `unverified session` based

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/auth-errors.js
+++ b/packages/fxa-content-server/app/scripts/lib/auth-errors.js
@@ -149,6 +149,10 @@ var ERRORS = {
     errno: 136,
     message: t('This email was already verified by another user'),
   },
+  UNVERIFIED_SESSION: {
+    errno: 138,
+    message: t('Unverified session'),
+  },
   EMAIL_PRIMARY_EXISTS: {
     errno: 139,
     message: t('Secondary email must be different than your account email'),

--- a/packages/fxa-content-server/app/scripts/views/form.js
+++ b/packages/fxa-content-server/app/scripts/views/form.js
@@ -144,6 +144,10 @@ var FormView = BaseView.extend({
   },
 
   onFormSubmit() {
+    if (this.skipBaseOnFormSubmit) {
+      return;
+    }
+
     return (
       this.validateAndSubmit()
         // drop the error on the ground, it'll already be logged.

--- a/packages/fxa-content-server/app/scripts/views/mixins/upgrade-session-redirect-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/upgrade-session-redirect-mixin.js
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import AuthErrors from '../../lib/auth-errors';
+
+/**
+ * View mixin to support a user upgrading their session to
+ * be verified. If a form is submitted and returns with an
+ * `unverified session` error, then the user will be redirected
+ * to either verify the session with either a sign-in code
+ * or a TOTP code.
+ *
+ */
+export default {
+  initialize() {
+    this.skipBaseOnFormSubmit = true;
+  },
+
+  async onFormSubmit() {
+    try {
+      await this.validateAndSubmit();
+    } catch (err) {
+      if (AuthErrors.is(err, 'UNVERIFIED_SESSION')) {
+        const account = this.getSignedInAccount();
+        const profile = await account.accountProfile();
+
+        // Check to see if the account has 2FA and redirect to that
+        // page to verify
+        if (
+          profile.authenticationMethods &&
+          profile.authenticationMethods.includes('otp')
+        ) {
+          return this.replaceCurrentPage('/signin_totp_code', {
+            redirectPathname: this.window.location.pathname,
+          });
+        } else {
+          // otw try to do a verification via an email code
+          return account.verifySessionResendCode().then(() => {
+            return this.replaceCurrentPage('/signin_token_code', {
+              redirectPathname: this.window.location.pathname,
+            });
+          });
+        }
+      }
+    }
+  },
+};

--- a/packages/fxa-content-server/app/scripts/views/settings/delete_account.js
+++ b/packages/fxa-content-server/app/scripts/views/settings/delete_account.js
@@ -9,6 +9,7 @@ import PasswordMixin from '../mixins/password-mixin';
 import ServiceMixin from '../mixins/settings-panel-mixin';
 import Session from '../../lib/session';
 import SettingsPanelMixin from '../mixins/service-mixin';
+import UpgradeSessionRedirectMixin from '../mixins/upgrade-session-redirect-mixin';
 import Template from 'templates/settings/delete_account.mustache';
 import AttachedClients from '../../models/attached-clients';
 import { CLIENT_TYPE_WEB_SESSION } from '../../lib/constants';
@@ -102,7 +103,11 @@ var View = FormView.extend({
   },
 
   _setUniqueActiveSubscriptionNames() {
-    return [...new Set((this._activeSubscriptions).map(activeSub => activeSub.product_name))];
+    return [
+      ...new Set(
+        this._activeSubscriptions.map((activeSub) => activeSub.product_name)
+      ),
+    ];
   },
 
   _setuniqueBrowserNames() {
@@ -128,7 +133,8 @@ var View = FormView.extend({
 
   _getNumberOfProducts() {
     let numberOfProducts =
-      this._uniqueBrowserNames.length + this._uniqueActiveSubscriptionNames.length;
+      this._uniqueBrowserNames.length +
+      this._uniqueActiveSubscriptionNames.length;
     // eslint-disable-next-line no-unused-vars
     for (const client of this._attachedClients.toJSON()) {
       if (client.isOAuthApp === true) {
@@ -192,6 +198,12 @@ var View = FormView.extend({
   },
 });
 
-Cocktail.mixin(View, PasswordMixin, SettingsPanelMixin, ServiceMixin);
+Cocktail.mixin(
+  View,
+  PasswordMixin,
+  SettingsPanelMixin,
+  ServiceMixin,
+  UpgradeSessionRedirectMixin
+);
 
 export default View;

--- a/packages/fxa-content-server/app/scripts/views/sign_in_token_code.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_token_code.js
@@ -63,9 +63,9 @@ const View = FormView.extend({
       .then(() => {
         this.logViewEvent('success');
 
-        const redirectTo = this.model.get('redirectTo');
-        if (redirectTo) {
-          return (this.window.location.href = redirectTo);
+        const redirectPathname = this.model.get('redirectPathname');
+        if (redirectPathname) {
+          return this.navigate(redirectPathname);
         }
 
         if (this.isForcePasswordChange(account)) {

--- a/packages/fxa-content-server/app/scripts/views/sign_in_totp_code.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_totp_code.js
@@ -37,6 +37,11 @@ const View = FormView.extend({
         if (result.success) {
           this.logFlowEvent('success', this.viewName);
 
+          const redirectPathname = this.model.get('redirectPathname');
+          if (redirectPathname) {
+            return this.navigate(redirectPathname);
+          }
+
           if (this.isForcePasswordChange(account)) {
             return this.invokeBrokerMethod(
               'beforeForcePasswordChange',

--- a/packages/fxa-content-server/app/tests/spec/views/settings/delete_account.js
+++ b/packages/fxa-content-server/app/tests/spec/views/settings/delete_account.js
@@ -640,6 +640,30 @@ describe('views/settings/delete_account', function () {
           });
         });
 
+        describe('error - unverified session with 2FA', function () {
+          beforeEach(function () {
+            sinon.stub(view, 'validateAndSubmit').callsFake(function () {
+              return Promise.reject(AuthErrors.toError('UNVERIFIED_SESSION'));
+            });
+            sinon.stub(account, 'accountProfile').callsFake(function () {
+              return Promise.resolve({
+                authenticationMethods: ['pwd', 'email', 'otp'],
+              });
+            });
+            sinon.stub(view, 'replaceCurrentPage');
+            return view.onFormSubmit();
+          });
+
+          it('redirects to signin_totp_code page', function () {
+            assert.isTrue(view.replaceCurrentPage.called);
+            assert.isTrue(
+              view.replaceCurrentPage.calledWith('/signin_totp_code', {
+                redirectPathname: view.window.location.pathname,
+              })
+            );
+          });
+        });
+
         describe('other errors', function () {
           beforeEach(function () {
             sinon.stub(user, 'deleteAccount').callsFake(function () {


### PR DESCRIPTION
## Because

- When an account is paired, the paired session would not have the assurance level to delete the account (ie `unverified session`)

## This pull request

- Adds a mixin to redirect the user to verify the session with TOTP if they have it setup on the account

## Issue that this pull request solves

Closes: #6199 #4257

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Other information (Optional)

### Testing instructions

I wasn't actually able to test the pairing flow locally with 2FA enabled. You would need custom build of FxiOS (pointing to local FxA) and then be able to run it on a physical phone since the iOS simulator does not support a camera. I was able to simulate this by the following though

1. Disable session being verified for new accounts via [skipForNewAccount](https://github.com/mozilla/fxa/blob/db20d69957612ea411c1b89d992d52b20763d927/packages/fxa-auth-server/config/index.ts#L1349)
2. Create account A and sign into non Firefox browser A
  a. The account at this state is considered verified but the session is unverified
3. Sign into non Firefox browser B
4. Enable 2FA on non Firefox browser A
5. Attempt to delete account on non Firefox browser B

You will be prompted to enter the 2FA code before deleting the account.

### Screenshot
![2fa](https://user-images.githubusercontent.com/1295288/91320608-c0d6e280-e78b-11ea-90cf-b5f8806d434a.gif)

