### PR TITLE
task(fxa-settings): rework Two-step auth unit row

### DIFF
--- a/packages/fxa-settings/src/components/Modal/index.tsx
+++ b/packages/fxa-settings/src/components/Modal/index.tsx
@@ -17,6 +17,8 @@ type ModalProps = {
   hasButtons?: boolean;
   headerId: string;
   descId: string;
+  confirmText?: string;
+  confirmBtnClassName?: string;
   'data-testid'?: string;
 };
 
@@ -28,6 +30,8 @@ export const Modal = ({
   hasButtons = true,
   headerId,
   descId,
+  confirmText = 'Confirm',
+  confirmBtnClassName = 'cta-primary',
   'data-testid': testid = 'modal',
 }: ModalProps) => {
   const modalInsideRef = useClickOutsideEffect<HTMLDivElement>(onDismiss);
@@ -43,7 +47,7 @@ export const Modal = ({
         <div
           data-testid="modal-content-container"
           className={classNames(
-            'max-w-lg bg-white mx-auto rounded-xl',
+            'max-w-md bg-white mx-auto rounded-xl',
             className
           )}
           ref={modalInsideRef}
@@ -64,7 +68,7 @@ export const Modal = ({
             </button>
           </div>
 
-          <div className="px-4 tablet:px-12 pb-10">
+          <div className="px-4 tablet:px-10 pb-10">
             <div>{children}</div>
             {hasButtons && (
               <div className="flex justify-center mx-auto mt-6 max-w-64">
@@ -78,11 +82,11 @@ export const Modal = ({
 
                 {onConfirm && (
                   <button
-                    className="mx-2 flex-1 cta-primary"
+                    className={classNames('mx-2 flex-1', confirmBtnClassName)}
                     data-testid="modal-confirm"
                     onClick={onConfirm}
                   >
-                    Confirm
+                    {confirmText}
                   </button>
                 )}
               </div>

--- a/packages/fxa-settings/src/components/PageSettings/index.tsx
+++ b/packages/fxa-settings/src/components/PageSettings/index.tsx
@@ -28,7 +28,7 @@ export const PageSettings = (_: RouteComponentProps) => {
       </div>
       <div className="flex-7 max-w-full">
         <Profile />
-        <Security twoFactorAuthEnabled={false} />
+        <Security />
       </div>
     </div>
   );

--- a/packages/fxa-settings/src/components/Security/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Security/index.stories.tsx
@@ -11,12 +11,12 @@ import { MockedCache } from '../../models/_mocks';
 storiesOf('Components|Security', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => (
-    <MockedCache account={{ recoveryKey: false }}>
-      <Security twoFactorAuthEnabled={false} />
+    <MockedCache account={{ recoveryKey: false, totp: { exists: false } }}>
+      <Security />
     </MockedCache>
   ))
   .add('account recovery key set and two factor enabled', () => (
-    <MockedCache>
-      <Security twoFactorAuthEnabled={true} />
+    <MockedCache account={{ recoveryKey: true, totp: { exists: true } }}>
+      <Security />
     </MockedCache>
   ));

--- a/packages/fxa-settings/src/components/Security/index.test.tsx
+++ b/packages/fxa-settings/src/components/Security/index.test.tsx
@@ -10,8 +10,8 @@ import { renderWithRouter, MockedCache } from '../../models/_mocks';
 describe('Security', () => {
   it('renders "fresh load" <Security/> with correct content', async () => {
     renderWithRouter(
-      <MockedCache account={{ recoveryKey: false }}>
-        <Security twoFactorAuthEnabled={false} />
+      <MockedCache account={{ recoveryKey: false, totp: { exists: false } }}>
+        <Security />
       </MockedCache>
     );
 
@@ -24,8 +24,8 @@ describe('Security', () => {
 
   it('renders "enabled two factor" and "recovery key present" <Security/> with correct content', async () => {
     renderWithRouter(
-      <MockedCache>
-        <Security twoFactorAuthEnabled={true} />
+      <MockedCache account={{ recoveryKey: true, totp: { exists: true } }}>
+        <Security />
       </MockedCache>
     );
 

--- a/packages/fxa-settings/src/components/Security/index.tsx
+++ b/packages/fxa-settings/src/components/Security/index.tsx
@@ -3,36 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import UnitRow from '../UnitRow';
 import UnitRowRecoveryKey from '../UnitRowRecoveryKey';
+import UnitRowTwoStepAuth from '../UnitRowTwoStepAuth';
 
-type SecurityProps = {
-  twoFactorAuthEnabled: boolean;
-  className?: string;
-};
-
-export const Security = ({ twoFactorAuthEnabled }: SecurityProps) => {
-  const getValue = (settingOption: boolean) =>
-    settingOption ? 'Enabled' : 'Not Set';
-  const getClassName = (settingOption: boolean) =>
-    settingOption ? 'text-green-800' : '';
+export const Security = () => {
   return (
     <section className="mt-11" id="security" data-testid="settings-security">
       <h2 className="font-header font-bold ml-4 mb-4">Security</h2>
       <div className="bg-white tablet:rounded-xl shadow">
         <UnitRowRecoveryKey />
         <hr className="unit-row-hr" />
-        <UnitRow
-          header="Two-step authentication"
-          headerValueClassName={getClassName(twoFactorAuthEnabled)}
-          headerValue={getValue(twoFactorAuthEnabled)}
-          route="/beta/settings/two_step_authentication"
-        >
-          <p className="text-sm mt-3">
-            Prevent someone else from logging in by requiring a unique code only
-            you have access to.
-          </p>
-        </UnitRow>
+        <UnitRowTwoStepAuth />
       </div>
     </section>
   );

--- a/packages/fxa-settings/src/components/UnitRow/index.stories.tsx
+++ b/packages/fxa-settings/src/components/UnitRow/index.stories.tsx
@@ -44,7 +44,6 @@ storiesOf('Components|UnitRow', module)
           headerValue={null}
           {...{
             revealModal,
-            modalRevealed,
           }}
         >
           <p className="text-sm mt-3">Content goes here.</p>
@@ -61,4 +60,35 @@ storiesOf('Components|UnitRow', module)
         </UnitRow>
       );
     }
-  );
+  )
+  .add('with modal-triggering secondary CTA', () => {
+    const [
+      secondaryModalRevealed,
+      revealSecondaryModal,
+      hideModal,
+    ] = useBooleanState();
+    return (
+      <UnitRow
+        header="Display name"
+        headerValue={null}
+        {...{
+          secondaryButtonClassName: 'bg-red-500 text-white border-red-600',
+          revealSecondaryModal,
+          ctaText: 'Change',
+          route: '#',
+        }}
+      >
+        <p className="text-sm mt-3">Content goes here.</p>
+        <p className="text-grey-400 text-xs mt-2">More content.</p>
+
+        {secondaryModalRevealed && (
+          <Modal onDismiss={hideModal} headerId="some-id" descId="some-desc">
+            <h2 id="some-id" className="font-bold text-xl text-center mb-2">
+              Modal header
+            </h2>
+            <p id="some-desc">Modal description here.</p>
+          </Modal>
+        )}
+      </UnitRow>
+    );
+  });

--- a/packages/fxa-settings/src/components/UnitRow/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRow/index.test.tsx
@@ -83,4 +83,22 @@ describe('UnitRow', () => {
       'Create'
     );
   });
+
+  it('renders `secondaryCtaText`', () => {
+    renderWithRouter(
+      <UnitRow
+        header="Display name"
+        headerValue="Fred Flinstone"
+        route="/display_name"
+        revealSecondaryModal={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId('unit-row-route').textContent).toContain(
+      'Change'
+    );
+    expect(screen.getByTestId('unit-row-modal').textContent).toContain(
+      'Disable'
+    );
+  });
 });

--- a/packages/fxa-settings/src/components/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRow/index.tsx
@@ -7,16 +7,62 @@ import classNames from 'classnames';
 import { useFocusOnTriggeringElementOnClose } from '../../lib/hooks';
 import { Link, RouteComponentProps, useLocation } from '@reach/router';
 
+type ModalButtonProps = {
+  ctaText: string;
+  className?: string;
+  revealModal: () => void;
+  modalRevealed?: boolean;
+  alertBarRevealed?: boolean;
+  leftSpaced?: boolean;
+};
+
+export const ModalButton = ({
+  ctaText,
+  className,
+  revealModal,
+  modalRevealed,
+  alertBarRevealed,
+  leftSpaced,
+}: ModalButtonProps) => {
+  const modalTriggerElement = useRef<HTMLButtonElement>(null);
+  // If the UnitRow children contains an AlertBar that is revealed,
+  // don't redirect focus back to the element that opened the modal
+  // because focus will be set in the AlertBar.
+  useFocusOnTriggeringElementOnClose(
+    modalRevealed,
+    modalTriggerElement,
+    alertBarRevealed
+  );
+
+  return (
+    <button
+      className={classNames(
+        'cta-base transition-standard',
+        leftSpaced && 'ml-2',
+        className || 'cta-neutral'
+      )}
+      data-testid="unit-row-modal"
+      ref={modalTriggerElement}
+      onClick={revealModal}
+    >
+      {ctaText}
+    </button>
+  );
+};
+
 type UnitRowProps = {
   header: string;
   headerValue: string | null;
   noHeaderValueText?: string;
   ctaText?: string;
+  secondaryCtaText?: string;
+  secondaryCtaRoute?: string;
+  secondaryButtonClassName?: string;
   children?: React.ReactNode;
   headerValueClassName?: string;
   route?: string;
   revealModal?: () => void;
-  modalRevealed?: boolean;
+  revealSecondaryModal?: () => void;
   alertBarRevealed?: boolean;
 };
 
@@ -28,23 +74,17 @@ export const UnitRow = ({
   headerValueClassName,
   noHeaderValueText = 'None',
   ctaText,
+  secondaryCtaText = 'Disable',
+  secondaryCtaRoute,
+  secondaryButtonClassName,
   revealModal,
-  modalRevealed,
+  revealSecondaryModal,
   alertBarRevealed,
 }: UnitRowProps & RouteComponentProps) => {
   ctaText = ctaText || (headerValue ? 'Change' : 'Add');
 
-  const modalTriggerElement = useRef<HTMLButtonElement>(null);
-  // If the UnitRow children contains an AlertBar that is revealed,
-  // don't redirect focus back to the element that opened the modal
-  // because focus will be set in the AlertBar.
-  useFocusOnTriggeringElementOnClose(
-    modalRevealed,
-    modalTriggerElement,
-    alertBarRevealed
-  );
-
   const location = useLocation();
+  const multiButton = !!(route || secondaryCtaRoute);
 
   return (
     <div className="unit-row">
@@ -62,10 +102,10 @@ export const UnitRow = ({
       </div>
 
       <div className="unit-row-actions">
-        <div>
+        <div className="flex items-center">
           {route && (
             <Link
-              className="cta-neutral cta-base"
+              className="cta-neutral cta-base transition-standard mr-2"
               data-testid="unit-row-route"
               to={`${route}${location.search}`}
             >
@@ -74,14 +114,30 @@ export const UnitRow = ({
           )}
 
           {revealModal && (
-            <button
-              className="cta-neutral cta-base"
-              data-testid="unit-row-modal"
-              ref={modalTriggerElement}
-              onClick={revealModal}
+            <ModalButton
+              leftSpaced={multiButton}
+              {...{ revealModal, ctaText, alertBarRevealed }}
+            />
+          )}
+
+          {secondaryCtaRoute && (
+            <Link
+              className="cta-neutral cta-base transition-standard mr-2"
+              data-testid="unit-row-route"
+              to={`${secondaryCtaRoute}${location.search}`}
             >
-              {ctaText}
-            </button>
+              {secondaryCtaText}
+            </Link>
+          )}
+
+          {revealSecondaryModal && (
+            <ModalButton
+              leftSpaced={multiButton}
+              revealModal={revealSecondaryModal}
+              ctaText={secondaryCtaText}
+              className={secondaryButtonClassName}
+              alertBarRevealed={alertBarRevealed}
+            />
           )}
         </div>
       </div>

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
@@ -60,7 +60,6 @@ export const UnitRowRecoveryKey = () => {
           : '/beta/settings/account_recovery/confirm_password'
       }
       revealModal={recoveryKey ? revealModal : undefined}
-      modalRevealed={recoveryKey ? modalRevealed : undefined}
       ctaText={recoveryKey ? 'Remove' : 'Create'}
       alertBarRevealed
     >
@@ -78,10 +77,8 @@ export const UnitRowRecoveryKey = () => {
           <Modal
             onDismiss={hideModal}
             onConfirm={deleteRecoveryKey}
-            // TODO - Uncomment these two
-            // lines once #6302 is merged
-            // confirmBtnClassName="cta-caution"
-            // confirmText="Remove"
+            confirmBtnClassName="cta-caution"
+            confirmText="Remove"
             headerId="recovery-key-header"
             descId="recovery-key-desc"
           >

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.stories.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.stories.tsx
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { LocationProvider } from '@reach/router';
+import { MockedCache } from '../../models/_mocks';
+import UnitRowTwoStepAuth from '.';
+
+storiesOf('Components|UnitRowTwoStepAuth', module)
+  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
+  .add('default unset', () => (
+    <MockedCache account={{ totp: { exists: false, verified: false } }}>
+      <UnitRowTwoStepAuth />
+    </MockedCache>
+  ))
+  .add('enabled, not verified', () => (
+    <MockedCache account={{ totp: { exists: true, verified: false } }}>
+      <UnitRowTwoStepAuth />
+    </MockedCache>
+  ))
+  .add('enabled and unverified session', () => (
+    <MockedCache
+      verified={false}
+      account={{ totp: { exists: true, verified: false } }}
+    >
+      <UnitRowTwoStepAuth />
+    </MockedCache>
+  ));

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.test.tsx
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { screen, act, fireEvent, wait } from '@testing-library/react';
+import { DELETE_TOTP_MUTATION, UnitRowTwoStepAuth } from '.';
+import { renderWithRouter, MockedCache } from '../../models/_mocks';
+
+const mockMutationSuccess = {
+  request: {
+    query: DELETE_TOTP_MUTATION,
+    variables: { input: {} },
+  },
+  result: {
+    data: {
+      deleteTotp: {
+        clientMutationId: null,
+      },
+    },
+  },
+};
+
+describe('UnitRowTwoStepAuth', () => {
+  it('renders when Two-step authentication is enabled', () => {
+    renderWithRouter(
+      <MockedCache account={{ totp: { exists: true } }}>
+        <UnitRowTwoStepAuth />
+      </MockedCache>
+    );
+    expect(screen.getByTestId('unit-row-header').textContent).toContain(
+      'Two-step authentication'
+    );
+    expect(screen.getByTestId('unit-row-header-value').textContent).toContain(
+      'Enabled'
+    );
+    expect(screen.getByTestId('unit-row-modal').textContent).toContain(
+      'Disable'
+    );
+  });
+
+  it('renders when Two-step authentication is not enabled', () => {
+    renderWithRouter(
+      <MockedCache account={{ totp: { exists: false } }}>
+        <UnitRowTwoStepAuth />
+      </MockedCache>
+    );
+    expect(screen.getByTestId('unit-row-header').textContent).toContain(
+      'Two-step authentication'
+    );
+    expect(screen.getByTestId('unit-row-header-value').textContent).toContain(
+      'Not Set'
+    );
+    expect(screen.getByTestId('unit-row-route').textContent).toContain('Add');
+  });
+
+  it('renders view as not enabled after disabling TOTP', async () => {
+    const mocks = [mockMutationSuccess];
+
+    renderWithRouter(
+      <MockedCache {...{ mocks, account: { totp: { exists: true } } }}>
+        <UnitRowTwoStepAuth />
+      </MockedCache>
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('unit-row-modal'));
+    });
+    await wait();
+
+    expect(
+      screen.queryByTestId('disable-totp-modal-header')
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('modal-confirm'));
+    });
+    await wait();
+
+    expect(screen.getByTestId('delete-totp-success')).toBeInTheDocument();
+  });
+});

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
@@ -1,0 +1,129 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useState } from 'react';
+import { gql, useMutation } from '@apollo/client';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import { useBooleanState } from 'fxa-react/lib/hooks';
+import AlertBar from '../AlertBar';
+import Modal from '../Modal';
+import UnitRow from '../UnitRow';
+import VerifiedSessionGuard from '../VerifiedSessionGuard';
+import { useAccount } from '../../models';
+
+export const DELETE_TOTP_MUTATION = gql`
+  mutation deleteTotp($input: DeleteTotpInput!) {
+    deleteTotp(input: $input) {
+      clientMutationId
+    }
+  }
+`;
+
+export const UnitRowTwoStepAuth = () => {
+  const { totp } = useAccount();
+  const { exists, verified } = totp;
+  const [modalRevealed, revealModal, hideModal] = useBooleanState();
+  const [alertBarRevealed, revealAlertBar, hideAlertBar] = useBooleanState();
+  const [errorText, setErrorText] = useState<string>();
+  const onError = (e: Error) => {
+    setErrorText(e.message);
+    hideModal();
+    revealAlertBar();
+  };
+  const [disableTwoStepAuth] = useMutation(DELETE_TOTP_MUTATION, {
+    variables: { input: {} },
+    onCompleted: () => {
+      hideModal();
+      revealAlertBar();
+    },
+    onError,
+    ignoreResults: true,
+    update: (cache) => {
+      cache.modify({
+        fields: {
+          account: (existing) => {
+            return { ...existing, totp: { exists: false, verified: false } };
+          },
+        },
+      });
+    },
+  });
+
+  const conditionalUnitRowProps = exists
+    ? {
+        headerValueClassName: 'text-green-800',
+        headerValue: 'Enabled',
+        ctaText: 'Change',
+        secondaryCtaText: 'Disable',
+        secondaryButtonClassName: 'cta-caution',
+        revealSecondaryModal: revealModal,
+      }
+    : {
+        headerValue: null,
+        noHeaderValueText: 'Not Set',
+        ctaText: 'Add',
+        secondaryCtaText: undefined,
+        revealSecondaryModal: undefined,
+      };
+
+  return (
+    <UnitRow
+      header="Two-step authentication"
+      route="/beta/settings/two_step_authentication"
+      {...conditionalUnitRowProps}
+    >
+      <p className="text-sm mt-3">
+        Prevent someone else from logging in by requiring a unique code only you
+        have access to.
+      </p>
+      {modalRevealed && (
+        <VerifiedSessionGuard onDismiss={hideModal} onError={onError}>
+          <Modal
+            onDismiss={hideModal}
+            onConfirm={disableTwoStepAuth}
+            headerId="two-step-auth-disable-header"
+            descId="two-step-auth-disable-description"
+            confirmText="Disable"
+            confirmBtnClassName="cta-caution"
+          >
+            <h2
+              className="font-bold text-xl text-center mb-2"
+              data-testid="disable-totp-modal-header"
+            >
+              Disable two-step authentication?
+            </h2>
+            {/* "replacing recovery codes" link below will actually drop you into
+            recovery codes flow in the future. */}
+            <p className="text-center">
+              You won't be able to undo this action. You also have the option of{' '}
+              <LinkExternal
+                className="link-blue"
+                href="https://support.mozilla.org/en-US/kb/reset-your-firefox-account-password-recovery-keys"
+              >
+                replacing your recovery codes
+              </LinkExternal>
+              .
+            </p>
+          </Modal>
+        </VerifiedSessionGuard>
+      )}
+      {alertBarRevealed && (
+        <AlertBar
+          onDismiss={hideAlertBar}
+          type={errorText ? 'error' : 'success'}
+        >
+          {errorText ? (
+            <p data-testid="delete-totp-error">Error text TBD. {errorText}</p>
+          ) : (
+            <p data-testid="delete-totp-success">
+              Two-step authentication disabled
+            </p>
+          )}
+        </AlertBar>
+      )}
+    </UnitRow>
+  );
+};
+
+export default UnitRowTwoStepAuth;

--- a/packages/fxa-settings/src/styles/ctas.scss
+++ b/packages/fxa-settings/src/styles/ctas.scss
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 .cta-neutral,
+.cta-caution,
 .cta-primary {
   @apply py-2 px-5 rounded w-full inline-block text-center border font-header box-border transition-standard;
 }
@@ -47,6 +48,22 @@
   }
 }
 
+.cta-caution {
+  @apply bg-red-500 border-red-600 text-white;
+
+  &:hover {
+    @apply bg-red-600 border-red-600;
+  }
+
+  &:active {
+    @apply bg-red-800 border-red-800;
+  }
+
+  &:focus {
+    @apply border-0;
+  }
+}
+
 .cta-base {
   @apply text-base mt-6;
 }
@@ -56,6 +73,7 @@
     @apply text-xs py-1 px-5 mt-0;
   }
 
+  .cta-caution,
   .cta-primary,
   .cta-neutral {
     @apply w-auto;


### PR DESCRIPTION
## Because

- detect Two-step auth and add ability to disable

## This pull request

- created `UnitRowTwoStepAuth` component
- added `SecondaryButtonClassName`,` SecondaryCta`, and `SecondaryModalReveal`
options to UnitRow
- updated Security component, and all tests and stories to reflect
changes
- updated each story touched with `<LocationProvider/>` fix

## Issue that this pull request solves

Closes: #4913 #6327 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

![unset-totp](https://user-images.githubusercontent.com/1844554/91241022-a9f3aa00-e711-11ea-8641-adb326742e23.png)

![set-totp](https://user-images.githubusercontent.com/1844554/91241173-1ec6e400-e712-11ea-883d-ab3a7bafe151.png)

