### PR TITLE
fix(metrics): Emit metrics for pairing part 2

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
@@ -102,6 +102,10 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
    * @returns {Promise}
    */
   sendOAuthResultToRelier(result, account) {
+    if (this.hasCapability('supportsPairing') || result.action === 'pairing') {
+      this._metrics.logEvent('pairing.signin.success');
+    }
+
     result.redirect = Constants.OAUTH_WEBCHANNEL_REDIRECT;
     if (account && account.get('declinedSyncEngines')) {
       result.declinedSyncEngines = account.get('declinedSyncEngines');

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-webchannel-v1.js
@@ -55,7 +55,7 @@ describe('models/auth_brokers/oauth-webchannel-v1', () => {
   beforeEach(() => {
     metrics = {
       flush: sinon.spy(() => Promise.resolve()),
-      logEvent: () => {},
+      logEvent: sinon.spy(),
     };
     relier = new Relier({
       action: 'action',
@@ -192,6 +192,19 @@ describe('models/auth_brokers/oauth-webchannel-v1', () => {
       redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
       state: 'state',
     });
+  });
+
+  it('logs pairing metrics if enabled', async () => {
+    broker.setCapability('supportsPairing', true);
+    await broker.sendOAuthResultToRelier(
+      {
+        redirect: Constants.OAUTH_WEBCHANNEL_REDIRECT,
+      },
+      account
+    );
+
+    assert.isTrue(metrics.flush.calledOnce);
+    assert.isTrue(metrics.logEvent.calledOnceWith('pairing.signin.success'));
   });
 
   describe('login with an error', () => {


### PR DESCRIPTION
## Because

- Pairing authentications were not being properly logged
- While debugging other pairing issues I found that the auth broker used was not the one emitting the metrics 

## This pull request

- Adds logging for pairing in the `oauth-webchannel-v1` broker, this is the broker that pairing uses

## Issue that this pull request solves

Closes: #5990

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
