### PR TITLE
chore(tests): Add settings v2 initial functional testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,20 @@ commands:
           path: ~/screenshots
           destination: screenshots
 
+  test-settings-server:
+    steps:
+      - base-install:
+          package: fxa-settings
+      - run:
+          name: Running test...
+          command: ./.circleci/test-package.sh fxa-settings
+      - store_artifacts:
+          path: ~/.pm2/logs
+          destination: logs
+      - store_artifacts:
+          path: ~/screenshots
+          destination: screenshots
+
 jobs:
   test-package:
     resource_class: medium+
@@ -106,7 +120,6 @@ jobs:
             'fxa-react' \
             'fxa-admin-server' \
             'fxa-graphql-api' \
-            'fxa-settings' \
             'fxa-admin-panel' \
             'fxa-payments-server' \
             'fxa-support-panel' \
@@ -128,6 +141,11 @@ jobs:
       - run:
           name: Reporting code coverage...
           command: bash <(curl -s https://codecov.io/bash) -X gcov
+
+  test-settings-server:
+    executor: content-server-executor
+    steps:
+      - test-settings-server
 
   test-content-server-0:
     executor: content-server-executor
@@ -249,6 +267,12 @@ workflows:
   test_pull_request:
     jobs:
       - test-many:
+          filters:
+            branches:
+              ignore: main
+            tags:
+              ignore: /.*/
+      - test-settings-server:
           filters:
             branches:
               ignore: main

--- a/packages/fxa-content-server/tests/functional/recovery_key.js
+++ b/packages/fxa-content-server/tests/functional/recovery_key.js
@@ -120,6 +120,11 @@ registerSuite('Recovery key', {
           // enter old key
           .then(fillOutRecoveryKey(recoveryKey))
           .then(
+            testElementExists(
+              selectors.COMPLETE_RESET_PASSWORD_RECOVERY_KEY.TOOLTIP
+            )
+          )
+          .then(
             testElementTextInclude(
               selectors.COMPLETE_RESET_PASSWORD_RECOVERY_KEY.TOOLTIP,
               'invalid'
@@ -159,6 +164,11 @@ registerSuite('Recovery key', {
 
           // enter invalid recovery key
           .then(fillOutRecoveryKey('N8TVALID'))
+          .then(
+            testElementExists(
+              selectors.COMPLETE_RESET_PASSWORD_RECOVERY_KEY.TOOLTIP
+            )
+          )
           .then(
             testElementTextInclude(
               selectors.COMPLETE_RESET_PASSWORD_RECOVERY_KEY.TOOLTIP,

--- a/packages/fxa-content-server/tests/functional/settings_v2/settings.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/settings.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const intern = require('intern').default;
+const { describe, it, beforeEach } = intern.getPlugin('interface.bdd');
+const selectors = require('../lib/selectors');
+const FunctionalHelpers = require('../lib/helpers');
+
+const config = intern._config;
+const EMAIL_FIRST = config.fxaContentRoot;
+const SETTINGS_V2_URL = `${config.fxaContentRoot}beta/settings`;
+const password = 'passwordzxcv';
+
+const {
+  createEmail,
+  createUser,
+  fillOutEmailFirstSignIn,
+  openPage,
+  testElementExists,
+} = FunctionalHelpers;
+
+describe('settings', () => {
+  let email;
+  beforeEach(async ({ remote }) => {
+    email = createEmail();
+    await remote.then(createUser(email, password, { preVerified: true }));
+  });
+
+  it('can navigate to settings', async ({ remote }) => {
+    await remote
+      .then(openPage(EMAIL_FIRST, selectors.ENTER_EMAIL.HEADER))
+      .then(fillOutEmailFirstSignIn(email, password))
+      .then(testElementExists(selectors.SETTINGS.HEADER))
+      .then(openPage(SETTINGS_V2_URL, '#profile'));
+  });
+});

--- a/packages/fxa-content-server/tests/functional_settings_v2.js
+++ b/packages/fxa-content-server/tests/functional_settings_v2.js
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = ['tests/functional/settings_v2/settings.js'];

--- a/packages/fxa-content-server/tests/intern.js
+++ b/packages/fxa-content-server/tests/intern.js
@@ -18,6 +18,7 @@ const testsFunctionalSmoke = require('./functional_smoke');
 const testsPairing = require('./functional_pairing');
 const testsServer = require('./tests_server');
 const testsServerResources = require('./tests_server_resources');
+const testsSettingsV2 = require('./functional_settings_v2');
 
 const fxaAuthRoot = args.fxaAuthRoot || 'http://localhost:9000/v1';
 const fxaContentRoot = args.fxaContentRoot || 'http://localhost:3030/';
@@ -103,6 +104,9 @@ if (args.suites) {
       break;
     case 'functional_smoke':
       config.functionalSuites = testsFunctionalSmoke;
+      break;
+    case 'settings_v2':
+      config.functionalSuites = testsSettingsV2;
       break;
     case 'all':
       config.functionalSuites = testsMain;

--- a/packages/fxa-settings/scripts/test-ci.sh
+++ b/packages/fxa-settings/scripts/test-ci.sh
@@ -1,5 +1,31 @@
 #!/bin/bash -ex
 
-yarn workspaces focus fxa-settings
-PUBLIC_URL=/ INLINE_RUNTIME_CHUNK=false CI=false SKIP_PREFLIGHT_CHECK=true yarn build
 CI=yes SKIP_PREFLIGHT_CHECK=true yarn test
+
+mkdir -p config
+
+cd ../../
+mkdir -p ~/.pm2/logs
+mkdir -p artifacts/tests
+yarn workspaces foreach \
+    --verbose \
+    --topological-dev \
+    --include browserid-verifier \
+    --include fxa-auth-db-mysql \
+    --include fxa-auth-server \
+    --include fxa-content-server \
+    --include fxa-profile-server \
+    --include fxa-react \
+    --include fxa-settings \
+    --include fxa-shared \
+    --include fxa-graphql-api \
+    run start > ~/.pm2/logs/startup.log
+npx pm2 ls
+# ensure email-service is ready
+_scripts/check-url.sh localhost:8001/__heartbeat__
+# ensure content-server is ready
+_scripts/check-url.sh localhost:3030/bundle/app.bundle.js
+
+cd packages/fxa-content-server
+mozinstall /firefox.tar.bz2
+node tests/intern.js --suites="settings_v2" --output="../../artifacts/tests/results.xml" --firefoxBinary=./firefox/firefox


### PR DESCRIPTION
## Because

- We need some basic functional tests to ensure the new settings page loads

## This pull request

- Adds a new test functional test suite to test settings v2 views
- I unfortunately couldn't move helpers to fxa-shared because some of them access libs from content-server. Moving helpers would require a bigger refactor of content-server
- I ended up moving settings functional tests to content-server functional test directory. I think this makes sense because fxa-settings already requires content-server to be running to access it. If we wanted to expand our smoke testing, its really easy to add them to that suite of tests.

## Issue that this pull request solves

Closes: #4851 Fixes #6320

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate)
