### PR TITLE
feat(settings): strip flow params from url after they've been stored

### DIFF
--- a/packages/fxa-settings/src/lib/metrics.test.ts
+++ b/packages/fxa-settings/src/lib/metrics.test.ts
@@ -101,6 +101,7 @@ afterEach(() => {
 describe('init', () => {
   beforeEach(() => {
     window.location.replace = jest.fn();
+    window.history.replaceState = jest.fn();
     window.console.error = jest.fn();
   });
 
@@ -127,6 +128,12 @@ describe('init', () => {
     initAndLog();
 
     expect(window.navigator.sendBeacon).toHaveBeenCalled();
+  });
+
+  it('strips excess params from the url', () => {
+    initFlow();
+
+    expect(window.history.replaceState).toHaveBeenCalled();
   });
 });
 

--- a/packages/fxa-settings/src/lib/metrics.ts
+++ b/packages/fxa-settings/src/lib/metrics.ts
@@ -4,9 +4,24 @@
 
 import sentryMetrics from 'fxa-shared/lib/sentry';
 import { useEffect } from 'react';
+import { deleteSearchParams } from './utilities';
 
 const NOT_REPORTED_VALUE = 'none';
 const UNKNOWN_VALUE = 'unknown';
+
+// This list of keys is used to strip excess query
+// params from the URL. If more are added they should
+// be added here, as well as updated in FlowQueryParams
+const flowParamKeys = [
+  'broker',
+  'context',
+  'deviceId',
+  'flowBeginTime',
+  'flowId',
+  'isSampledUser',
+  'service',
+  'uniqueUserId',
+];
 
 type Optional<T> = T | typeof NOT_REPORTED_VALUE;
 
@@ -155,6 +170,18 @@ export function init(flowQueryParams: FlowQueryParams) {
     ) {
       flowEventData = flowQueryParams;
       initialized = true;
+
+      let replacementPath = window.location.pathname;
+      const strippedParams = deleteSearchParams(
+        window.location.search,
+        ...flowParamKeys
+      );
+
+      if (strippedParams.length) {
+        replacementPath += `?${strippedParams}`;
+      }
+
+      window.history.replaceState(null, '', replacementPath);
     } else {
       let redirectPath = window.location.pathname;
       if (window.location.search) {

--- a/packages/fxa-settings/src/lib/utilities.ts
+++ b/packages/fxa-settings/src/lib/utilities.ts
@@ -78,3 +78,12 @@ export function splitEncodedParams(str = '', allowedFields?: string[]) {
     .filter((key) => allowedFields.indexOf(key) >= 0)
     .reduce((newObj, key) => Object.assign(newObj, { [key]: terms[key] }), {});
 }
+
+export function deleteSearchParams(
+  search: Location['search'],
+  ...keys: string[]
+): string {
+  const searchParams = new URLSearchParams(search.slice(1));
+  keys.forEach((k) => searchParams.delete(k));
+  return searchParams.toString();
+}


### PR DESCRIPTION
⚠️ Please don't merge this yet. I would like discussion around it first.

## Because

- We don't really need flow params sticking around after the app stores them

## This pull request

- Use `replaceState` to strip them from the URL, leaving non-flow params intact

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Other information

This does what it says on the tin, and it's nice to not have those noisy params hanging around. But I have noticed it becomes incredibly annoying. Any time you refresh the page it loses the stored params and needs to perform the round-trip again. That means in development, when you hit save in a file, it reloads the page automatically, which triggers the round-trip. I would maybe consider disabling this stripping in development?