### PR TITLE
feat(settings): add useAlertBar hook

### DIFF
--- a/packages/fxa-settings/README.md
+++ b/packages/fxa-settings/README.md
@@ -69,29 +69,66 @@ When an external link needs to be opened in a new tab, use the `LinkExternal` co
 
 The `AlertBar` is used to display messages to the user, typically for communicating success or error messages back to the user. `<div id="alert-bar-root"></div>` is located just below the layout header and serves as the parent for where this component renders in the DOM via a React [Portal](https://reactjs.org/docs/portals.html) and an `AlertBarContext` which holds a reference to `alert-bar-root`.
 
-The `AlertBar` takes in an optional `type` prop, defaulting to `'success'` if not passed in but can be set to `'error'` or `'info'`, altering the text and background color of the bar.
+The `AlertBar` takes in an optional `type` prop, defaulting to `'success'` if not passed in but can be set to `'error'` or `'info'`, altering the text and background color of the bar. Additionally, the `useAlertBar` hook is available to help maintain state and provide convenience methods for showing alerts.
 
 A basic example for displaying the component:
 
 ```jsx
 const MyComponent = () => {
-  /* `alertBarRevealed` will return `false` on first render. `revealAlertBar` and `hideAlertBar`
-   * are functions - call `revealAlertBar` when you need `alertBarRevealed` to be `true` and
-   * call `hideAlertBar` when it should be `false`. You'll typically pass `hideAlertBar` into
-   * `AlertBar` as the `onDismiss` prop.
+  /* `.visible` defaults to `false` unless configured otherwise.
+   * The `.show` and `.hide` methods are used to toggle visibility.
+   * You'll typically pass `.hide` into `AlertBar` as the `onDismiss` prop.
    */
-  const [alertBarRevealed, revealAlertBar, hideAlertBar] = useBooleanState();
+
+  const alertBar = useAlertBar();
 
   return (
     <>
-      {alertBarRevealed && (
-        <AlertBar onDismiss={hideAlertBar}>
+      {alertBar.visible && (
+        <AlertBar onDismiss={alertBar.hide}>
           <p>Alert bar text!</p>
         </AlertBar>
       )}
       <div>
-        <button onClick={revealAlertBar}>
-          Click here to see the AlertBar!
+        <button onClick={alertBar.show}>Click here to see the AlertBar!</button>
+      </div>
+    </>
+  );
+};
+```
+
+A more advanced example, using convenience methods, and variable content and type:
+
+```jsx
+const MyComponent = () => {
+  /* The hook provides `.success`, `.info`, and `.error` convenience methods
+   * to help you set content and display the AlertBar of that type.
+   * Use `.content` and `.type` to set those properties on the AlertBar.
+   */
+
+  const alertBar = useAlertBar();
+
+  return (
+    <>
+      {alertBar.visible && (
+        <AlertBar onDismiss={alertBar.hide} type={alertBar.type}>
+          {alertBar.content}
+        </AlertBar>
+      )}
+      <div>
+        <button
+          onClick={() => {
+            alertBar.success('This is a success message.');
+          }}
+        >
+          Click here to a success AlertBar!
+        </button>
+        <button
+          onClick={() => {
+            alertBar.error('This is an error message.');
+          }}
+        >
+          Click here to an error AlertBar!
         </button>
       </div>
     </>

--- a/packages/fxa-settings/src/components/AlertBar/index.tsx
+++ b/packages/fxa-settings/src/components/AlertBar/index.tsx
@@ -17,7 +17,7 @@ type AlertBarProps = {
   type?: AlertBarType;
 };
 
-const typeClasses = {
+export const typeClasses = {
   success: 'text-grey-600 bg-green-500',
   error: 'text-white bg-red-500',
   info: 'text-white bg-blue-500',
@@ -45,6 +45,7 @@ export const AlertBar = ({
       data-testid="alert-bar"
     >
       <div
+        data-testid="alert-bar-inner"
         className={`max-w-2xl w-full desktop:min-w-sm flex shadow-md rounded font-bold text-sm ${typeClasses[type]}`}
       >
         <div

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
@@ -6,6 +6,7 @@ import React, { useState } from 'react';
 import { gql, useMutation } from '@apollo/client';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { useBooleanState } from 'fxa-react/lib/hooks';
+import { useAlertBar } from '../../lib/hooks';
 import AlertBar from '../AlertBar';
 import Modal from '../Modal';
 import UnitRow from '../UnitRow';
@@ -22,19 +23,19 @@ export const DELETE_RECOVERY_KEY_MUTATION = gql`
 
 export const UnitRowRecoveryKey = () => {
   const { recoveryKey } = useAccount();
+  const alertBar = useAlertBar();
   const [modalRevealed, revealModal, hideModal] = useBooleanState();
-  const [alertBarRevealed, revealAlertBar, hideAlertBar] = useBooleanState();
   const [errorText, setErrorText] = useState<string>();
   const onError = (e: Error) => {
     setErrorText(e.message);
     hideModal();
-    revealAlertBar();
+    alertBar.show();
   };
   const [deleteRecoveryKey] = useMutation(DELETE_RECOVERY_KEY_MUTATION, {
     variables: { input: {} },
     onCompleted: () => {
       hideModal();
-      revealAlertBar();
+      alertBar.show();
     },
     onError,
     ignoreResults: true,
@@ -98,10 +99,9 @@ export const UnitRowRecoveryKey = () => {
           </Modal>
         </VerifiedSessionGuard>
       )}
-      {/* TODO: style AlertBar in the error case */}
-      {alertBarRevealed && (
+      {alertBar.visible && (
         <AlertBar
-          onDismiss={hideAlertBar}
+          onDismiss={alertBar.hide}
           type={errorText ? 'error' : 'success'}
         >
           {errorText ? (
@@ -116,7 +116,7 @@ export const UnitRowRecoveryKey = () => {
         </AlertBar>
       )}
     </UnitRow>
-  );
+  )
 };
 
 export default UnitRowRecoveryKey;

--- a/packages/fxa-settings/src/lib/hooks.test.tsx
+++ b/packages/fxa-settings/src/lib/hooks.test.tsx
@@ -3,15 +3,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useRef } from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import * as apolloClient from '@apollo/client';
 
+import { AlertBarRootAndContextProvider } from './AlertBarContext';
+import AlertBar, { typeClasses } from '../components/AlertBar';
 import {
   useFocusOnTriggeringElementOnClose,
   useEscKeydownEffect,
   useChangeFocusEffect,
   useHandledMutation,
+  useAlertBar,
 } from './hooks';
 
 describe('useFocusOnTriggeringElementOnClose', () => {
@@ -116,5 +119,79 @@ describe('useHandledMutation', () => {
       onError: expect.any(Function),
       fetchPolicy: 'no-cache',
     });
+  });
+});
+
+describe('useAlertBar', () => {
+  let alertBar: any;
+
+  const TestAlertBar = () => {
+    alertBar = useAlertBar();
+
+    return (
+      <AlertBarRootAndContextProvider>
+        {alertBar.visible && (
+          <AlertBar onDismiss={alertBar.hide} type={alertBar.type}>
+            {alertBar.content}
+          </AlertBar>
+        )}
+      </AlertBarRootAndContextProvider>
+    );
+  };
+
+  beforeEach(() => {
+    render(<TestAlertBar />);
+  });
+
+  it('defaults to hidden, can show and hide again', () => {
+    expect(screen.queryByTestId('alert-bar')).not.toBeInTheDocument();
+
+    act(alertBar.show);
+    expect(screen.queryByTestId('alert-bar')).toBeInTheDocument();
+
+    act(alertBar.hide);
+    expect(screen.queryByTestId('alert-bar')).not.toBeInTheDocument();
+
+    act(alertBar.show);
+    act(() => {
+      fireEvent.click(screen.getByTestId('alert-bar-dismiss'));
+    });
+    expect(alertBar.visible).toBeFalsy();
+  });
+
+  test('success method works', () => {
+    const phrase = 'You did it, kid';
+    act(() => {
+      alertBar.success(phrase);
+    });
+
+    const alertBarInner = screen.getByTestId('alert-bar-inner');
+    expect(alertBarInner.getAttribute('class')).toContain(typeClasses.success);
+    expect(alertBarInner).toHaveTextContent(phrase);
+    expect(alertBar.type).toEqual('success');
+  });
+
+  test('error method works', () => {
+    const phrase = 'Better luck next time';
+    act(() => {
+      alertBar.error(phrase);
+    });
+
+    const alertBarInner = screen.getByTestId('alert-bar-inner');
+    expect(alertBarInner.getAttribute('class')).toContain(typeClasses.error);
+    expect(alertBarInner).toHaveTextContent(phrase);
+    expect(alertBar.type).toEqual('error');
+  });
+
+  test('info method works', () => {
+    const phrase = 'Howdy, partner';
+    act(() => {
+      alertBar.info(phrase);
+    });
+
+    const alertBarInner = screen.getByTestId('alert-bar-inner');
+    expect(alertBarInner.getAttribute('class')).toContain(typeClasses.info);
+    expect(alertBarInner).toHaveTextContent(phrase);
+    expect(alertBar.type).toEqual('info');
   });
 });

--- a/packages/fxa-settings/src/lib/hooks.tsx
+++ b/packages/fxa-settings/src/lib/hooks.tsx
@@ -2,9 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState, ReactNode, useCallback } from 'react';
 import sentryMetrics from 'fxa-shared/lib/sentry';
 import { useMutation, DocumentNode, MutationHookOptions } from '@apollo/client';
+import { useBooleanState } from 'fxa-react/lib/hooks';
+import { AlertBarType } from '../components/AlertBar';
 
 // Focus on the element that triggered some action after the first
 // argument changes from `false` to `true` unless a `triggerException`
@@ -82,4 +84,58 @@ export function useHandledMutation(
   };
 
   return useMutation(mutation, options);
+}
+
+export function useAlertBar({
+  defaultVisible = false,
+  defaultType = 'success',
+  defaultContent,
+}: {
+  defaultVisible?: boolean;
+  defaultType?: AlertBarType;
+  defaultContent?: ReactNode;
+} = {}) {
+  const [visible, show, hide] = useBooleanState(defaultVisible);
+  const [type, setType] = useState<AlertBarType>(defaultType);
+  const [content, setContent] = useState<ReactNode | null>(defaultContent);
+
+  const success = useCallback(
+    (message: ReactNode) => {
+      setContent(message);
+      setType('success');
+      show();
+    },
+    [setContent, setType, show]
+  );
+
+  const error = useCallback(
+    (message: ReactNode) => {
+      setContent(message);
+      setType('error');
+      show();
+    },
+    [setContent, setType, show]
+  );
+
+  const info = useCallback(
+    (message: ReactNode) => {
+      setContent(message);
+      setType('info');
+      show();
+    },
+    [setContent, setType, show]
+  );
+
+  return {
+    visible,
+    show,
+    hide,
+    type,
+    setType,
+    content,
+    setContent,
+    success,
+    error,
+    info,
+  };
 }


### PR DESCRIPTION
## Because

We have a handful of hooks and functions that make up AlertBar usage

## This pull request

Consolidates the various hooks and functions we use with AlertBar into a single hook.

Now you can use the `useAlertBar` hook in combination with the `AlertBar` component to...

- Hide, show, and check the visibility of the alert bar
- Set the type and contents of the alert bar
- Use the `success`, `info`, and `error` convenience methods to do the above much quicker

## Issue that this pull request solves

Closes: #6316

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.