### PR TITLE
fix(payments): display only one in-progress spinner during subscription cancellation

### DIFF
--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
@@ -33,9 +33,20 @@ const CancelSubscriptionPanel = ({
 }: CancelSubscriptionPanelProps) => {
   const [cancelRevealed, revealCancel, hideCancel] = useBooleanState();
   const [confirmationChecked, onConfirmationChanged] = useCheckboxState();
+  const [
+    isLocalCancellation,
+    setIsLocalCancellation,
+    resetIsLocalCancellation,
+  ] = useBooleanState();
 
-  const confirmCancellation = useCallback(() => {
-    cancelSubscription(subscription_id, plan);
+  const confirmCancellation = useCallback(async () => {
+    setIsLocalCancellation();
+    try {
+      await cancelSubscription(subscription_id, plan);
+    } catch (err) {
+      // no-op, error is displayed in the Subscriptions route parent
+    }
+    resetIsLocalCancellation();
   }, [cancelSubscription, subscription_id, plan]);
 
   const viewed = useRef(false);
@@ -181,7 +192,7 @@ const CancelSubscriptionPanel = ({
                   cancelSubscriptionStatus.loading || !confirmationChecked
                 }
               >
-                {cancelSubscriptionStatus.loading ? (
+                {cancelSubscriptionStatus.loading && isLocalCancellation ? (
                   <span data-testid="spinner-update" className="spinner">
                     &nbsp;
                   </span>


### PR DESCRIPTION
Each cancellation panel now tracks whether it initiated the current cancellation in flight. If so, it displays the spinner. All other cancellation panels just get disabled buttons.

fixes #6234
