### PR TITLE
fix(newsletter): Various newsletter fixes

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/newsletters.js
+++ b/packages/fxa-content-server/app/scripts/lib/newsletters.js
@@ -30,3 +30,22 @@ export default {
     slug: 'knowledge-is-power',
   },
 };
+
+export const newsletterNewCopy = {
+  CONSUMER_BETA: {
+    label: t('Testing Firefox products'),
+    slug: 'test-pilot',
+  },
+  FIREFOX_ACCOUNTS_JOURNEY: {
+    label: t('Get the latest news about Mozilla and Firefox'),
+    slug: 'firefox-accounts-journey',
+  },
+  HEALTHY_INTERNET: {
+    label: t('Taking action to keep the internet healthy'),
+    slug: 'take-action-for-the-internet',
+  },
+  ONLINE_SAFETY: {
+    label: t('Safety and privacy online with Firefox and Mozilla'),
+    slug: 'knowledge-is-power',
+  },
+};

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/newsletters/add_newsletters.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/newsletters/add_newsletters.mustache
@@ -28,7 +28,7 @@
             {{/newsletters}}
 
             <div class="button-row">
-                <button id="submit-btn" type="submit">{{#t}}Subscribe %(email)s{{/t}}</button>
+                <button id="submit-btn" class="disabled" type="submit">{{#t}}Subscribe %(email)s{{/t}}</button>
             </div>
             <div class="links">
                 <a id="maybe-later-btn" data-flow-event="link.maybe-later">{{#t}}Maybe later{{/t}}</a>

--- a/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
+++ b/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
@@ -86,6 +86,7 @@ class ConfirmSignupCodeView extends FormView {
         }
 
         if (this.isInNewsletterSyncExperimentTreatment()) {
+          account.set('verified', true);
           this.navigate('/post_verify/newsletters/add_newsletters', {
             account,
           });

--- a/packages/fxa-content-server/app/scripts/views/mixins/email-opt-in-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/email-opt-in-mixin.js
@@ -7,6 +7,7 @@
  */
 
 import Newsletters from '../../lib/newsletters';
+import { newsletterNewCopy } from '../../lib/newsletters';
 
 const MARKETING_EMAIL_CHECKBOX_SELECTOR = 'input.marketing-email-optin';
 
@@ -18,6 +19,12 @@ const NEWSLETTERS = [
   Newsletters.ONLINE_SAFETY,
   Newsletters.CONSUMER_BETA,
   Newsletters.HEALTHY_INTERNET,
+];
+
+const NEWSLETTERS_NEWCOPY = [
+  newsletterNewCopy.ONLINE_SAFETY,
+  newsletterNewCopy.CONSUMER_BETA,
+  newsletterNewCopy.HEALTHY_INTERNET,
 ];
 
 export default {
@@ -116,6 +123,11 @@ export default {
    * @returns {String[]}
    */
   _getNewsletters() {
+    if (this.getExperimentGroup) {
+      return this.getExperimentGroup('newsletterSync') === 'new-copy'
+        ? NEWSLETTERS_NEWCOPY
+        : NEWSLETTERS;
+    }
     return NEWSLETTERS;
   },
 };

--- a/packages/fxa-content-server/app/scripts/views/post_verify/newsletters/add_newsletters.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/newsletters/add_newsletters.js
@@ -22,6 +22,7 @@ class AddNewsletters extends FormView {
 
   events = assign(this.events, {
     'click #maybe-later-btn': preventDefaultThen('clickMaybeLater'),
+    'click input.marketing-email-optin': 'toggleSubscribeButton',
   });
 
   beforeRender() {
@@ -32,6 +33,14 @@ class AddNewsletters extends FormView {
     if (account.isDefault()) {
       this.relier.set('redirectTo', this.window.location.href);
       return this.replaceCurrentPage('/');
+    }
+  }
+
+  toggleSubscribeButton() {
+    if (this.getOptedIntoNewsletters().length) {
+      this.$('#submit-btn').removeClass('disabled');
+    } else {
+      this.$('#submit-btn').addClass('disabled');
     }
   }
 

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/email-opt-in-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/email-opt-in-mixin.js
@@ -24,16 +24,19 @@ Cocktail.mixin(View, EmailOptInMixin);
 describe('views/mixins/email-opt-in-mixin', () => {
   let experimentGroupingRules;
   let marketingEmailEnabled;
+  let getExperimentGroup;
   let view;
 
   beforeEach(() => {
     experimentGroupingRules = {
       choose: () => {},
     };
+    getExperimentGroup = () => false;
     marketingEmailEnabled = true;
 
     view = new View({
       experimentGroupingRules,
+      getExperimentGroup,
       marketingEmailEnabled,
     });
   });
@@ -117,6 +120,20 @@ describe('views/mixins/email-opt-in-mixin', () => {
         'test-pilot',
         'knowledge-is-power',
       ]);
+    });
+  });
+
+  describe('returns new copy for newsletter experiment', () => {
+    beforeEach(() => {
+      view.getExperimentGroup = () => true;
+      sinon.spy(view, 'getExperimentGroup');
+      return view.render();
+    });
+
+    it('returns list of newsletters', () => {
+      view
+        .$(view._newsletterTypeToSelector(NEWSLETTERS.CONSUMER_BETA))
+        .attr('label', 'Testing Firefox products');
     });
   });
 });


### PR DESCRIPTION
## Because

- QA found a couple bugs with newsletter flows

## This pull request

- Updates the newsletter labels for the new copy
- Only enabled the subscribe button if a user selects a newsletter
- Set account as verified after verifying session and in the newsletter experiment

## Issue that this pull request solves

Closes: #6254 #6257 #6255 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

<img width="468" alt="Screen Shot 2020-09-01 at 12 03 21 PM" src="https://user-images.githubusercontent.com/1295288/91878285-10665400-ec4d-11ea-9284-a7eca5200049.png">

