### PR TITLE
refactor(settings): various cosmetic changes to better reflect designs

### DIFF
--- a/packages/fxa-react/components/Header/index.tsx
+++ b/packages/fxa-react/components/Header/index.tsx
@@ -15,7 +15,7 @@ export const Header = (props: HeaderProps) => {
     <header
       data-testid="header"
       role="banner"
-      className={props.className || 'sticky top-0 bg-grey-10'}
+      className={props.className || 'sticky top-0 bg-grey-10 z-10'}
     >
       <div className="px-6 tablet:px-8 py-4 flex justify-between">
         <div className="flex">{props.left}</div>

--- a/packages/fxa-react/configs/tailwind.js
+++ b/packages/fxa-react/configs/tailwind.js
@@ -51,6 +51,7 @@ module.exports = {
         desktop: '1024px',
         desktopXl: '1441px',
         48: '12rem',
+        64: '16rem',
       },
       inset: {
         '1/2': '50%',

--- a/packages/fxa-settings/src/components/FlowContainer/index.tsx
+++ b/packages/fxa-settings/src/components/FlowContainer/index.tsx
@@ -17,7 +17,7 @@ export const FlowContainer = ({
 }: FlowContainerProps & RouteComponentProps) => {
   return (
     <div
-      className="max-w-lg mx-auto my-6 py-8 px-6 tablet:my-10 flex flex-col items-start bg-white shadow tablet:rounded-xl"
+      className="max-w-lg mx-auto mt-6 p-6 pb-7 tablet:my-10 flex flex-col items-start bg-white shadow tablet:rounded-xl"
       data-testid="flow-container"
     >
       <div className="flex items-center">
@@ -35,7 +35,7 @@ export const FlowContainer = ({
         </button>
         <h1 className="font-header">{title}</h1>
       </div>
-      <div className="mt-2 w-full">{children}</div>
+      <div className="w-full">{children}</div>
     </div>
   );
 };

--- a/packages/fxa-settings/src/components/InputPassword/index.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/index.tsx
@@ -14,6 +14,7 @@ export const InputPassword = ({
   disabled,
   label,
   placeholder,
+  className,
 }: InputPasswordProps) => {
   const [hasContent, setHasContent] = useState<boolean>(defaultValue != null);
   const [visible, setVisible] = useState<boolean>(false);
@@ -31,6 +32,7 @@ export const InputPassword = ({
         label,
         placeholder,
         onChange,
+        className,
       }}
     >
       <button

--- a/packages/fxa-settings/src/components/InputText/index.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.tsx
@@ -9,6 +9,7 @@ import React, {
   ReactElement,
   RefObject,
 } from 'react';
+import classNames from 'classnames';
 
 export type InputTextProps = {
   defaultValue?: string | number;
@@ -18,6 +19,7 @@ export type InputTextProps = {
   placeholder?: string;
   errorText?: string;
   errorTooltipClass?: string;
+  className?: string;
   inputRef?: RefObject<HTMLInputElement>;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   type?: 'text' | 'email' | 'tel' | 'number' | 'url' | 'password';
@@ -32,6 +34,7 @@ export const InputText = ({
   onChange,
   errorText,
   errorTooltipClass,
+  className = '',
   inputRef,
   type = 'text',
 }: InputTextProps) => {
@@ -56,21 +59,23 @@ export const InputText = ({
 
   return (
     <label
-      className={`flex items-center rounded transition-all duration-100 ease-in-out border mt-3 mb-3 tooltip
+      className={`flex items-center rounded transition-all duration-100 ease-in-out border tooltip
       ${errorText ? 'tooltip-showing' : ''}
       ${
         focussed ? 'border-blue-400 shadow-input-blue-focus' : 'border-grey-200'
       }
-      ${disabled ? 'border-grey-100 bg-grey-10' : 'bg-white'}`}
+      ${disabled ? 'border-grey-100 bg-grey-10' : 'bg-white'} ${className}`}
       data-testid="input-container"
     >
       <span className="block relative flex-auto">
         <span
-          className={`px-3 w-full cursor-text absolute text-sm origin-top-left transition-all duration-100 ease-in-out truncate font-body ${
+          className={classNames(
+            'px-3 w-full cursor-text absolute text-sm origin-top-left transition-all duration-100 ease-in-out truncate font-body',
+            disabled ? 'text-grey-300' : 'text-grey-600',
             hasContent || focussed
               ? 'transform scale-80 mt-1 ml-1 -left-px'
               : 'mt-3 pt-px'
-          } ${disabled ? 'text-grey-300' : 'text-grey-600'}`}
+          )}
           data-testid="input-label"
         >
           {label}

--- a/packages/fxa-settings/src/components/Modal/index.tsx
+++ b/packages/fxa-settings/src/components/Modal/index.tsx
@@ -38,7 +38,7 @@ export const Modal = ({
     <Portal id="modal" {...{ headerId, descId }}>
       <div
         data-testid={testid}
-        className="flex flex-col justify-center fixed inset-0 w-full px-2 h-full bg-black bg-opacity-75"
+        className="flex flex-col justify-center fixed inset-0 z-50 w-full px-2 h-full bg-black bg-opacity-75"
       >
         <div
           data-testid="modal-content-container"
@@ -67,9 +67,9 @@ export const Modal = ({
           <div className="px-4 tablet:px-12 pb-10">
             <div>{children}</div>
             {hasButtons && (
-              <div className="flex mt-6">
+              <div className="flex justify-center mx-auto mt-6 max-w-64">
                 <button
-                  className="cta-neutral transition-standard flex-1"
+                  className="cta-neutral mx-2 flex-1"
                   data-testid="modal-cancel"
                   onClick={onDismiss}
                 >
@@ -78,7 +78,7 @@ export const Modal = ({
 
                 {onConfirm && (
                   <button
-                    className="cta-primary transition-standard flex-1"
+                    className="mx-2 flex-1 cta-primary"
                     data-testid="modal-confirm"
                     onClick={onConfirm}
                   >

--- a/packages/fxa-settings/src/components/ModalVerifySession/index.tsx
+++ b/packages/fxa-settings/src/components/ModalVerifySession/index.tsx
@@ -87,14 +87,14 @@ export const ModalVerifySession = ({
     >
       <form
         onSubmit={(event) => {
-          event.preventDefault();
+          event.preventDefault()
           verifySession({
             variables: {
               input: {
                 code,
               },
             },
-          });
+          })
         }}
       >
         <h2
@@ -106,23 +106,27 @@ export const ModalVerifySession = ({
         <p
           id="modal-verify-session-desc"
           data-testid="modal-desc"
-          className="my-6"
+          className="my-6 text-center"
         >
           Please enter the verification code that was sent to{' '}
           <span className="font-bold">{primaryEmail.email}</span> within 5
           minutes.
         </p>
-        <InputText
-          label="Enter your verification code"
-          onChange={(event) => {
-            setCode(event.target.value);
-          }}
-          {...{ errorText }}
-        ></InputText>
-        <div className="flex mt-6">
+
+        <div className="mt-4 mb-6">
+          <InputText
+            label="Enter your verification code"
+            onChange={(event) => {
+              setCode(event.target.value)
+            }}
+            {...{ errorText }}
+          ></InputText>
+        </div>
+
+        <div className="flex justify-center mx-auto max-w-64">
           <button
             type="button"
-            className="cta-neutral transition-standard flex-1"
+            className="cta-neutral mx-2 flex-1"
             data-testid="modal-verify-session-cancel"
             onClick={onDismiss}
           >
@@ -130,7 +134,7 @@ export const ModalVerifySession = ({
           </button>
           <button
             type="submit"
-            className="cta-primary transition-standard flex-1"
+            className="cta-primary mx-2 flex-1"
             data-testid="modal-verify-session-submit"
           >
             Verify
@@ -138,7 +142,7 @@ export const ModalVerifySession = ({
         </div>
       </form>
     </Modal>
-  );
+  )
 };
 
 export default ModalVerifySession;

--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -19,7 +19,8 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
     <FlowContainer title="Change Password">
       <form onSubmit={handleSubmit}>
         <h1>Stay safe — don't reuse passwords. Your password:</h1>
-        <ul className="list-disc text-grey-400 text-xs p-3">
+
+        <ul className="list-disc text-grey-400 text-xs m-3 list-inside">
           <li>Must be at least 8 characters</li>
           <li>Must not be your email address</li>
           <li>
@@ -34,20 +35,20 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
           </li>
         </ul>
 
-        <InputPassword label="Enter current password" />
-        <InputPassword label="Enter new password" />
-        <InputPassword label="Re-enter new password" />
+        <div className="my-6">
+          <InputPassword label="Enter current password" className="mb-2" />
+          <InputPassword label="Enter new password" className="mb-2" />
+          <InputPassword label="Re-enter new password" />
+        </div>
 
-        <div className="flex justify-center p-2">
+        <div className="flex justify-center mb-4 mx-auto max-w-64">
           <button
-            className="cta-neutral w-1/4 m-2"
+            className="cta-neutral mx-2 flex-1"
             onClick={() => window.history.back()}
           >
             Cancel
           </button>
-          <button className="cta-primary transition-standard w-1/4 m-2">
-            Save
-          </button>
+          <button className="cta-primary mx-2 flex-1">Save</button>
         </div>
 
         <LinkExternal

--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
@@ -74,7 +74,7 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
           }
         }}
       >
-        <div className="mb-3" data-testid="secondary-email-input">
+        <div className="mt-4 mb-6" data-testid="secondary-email-input">
           <InputText
             label="Enter email address"
             type="email"
@@ -83,21 +83,18 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
           />
         </div>
 
-        <div className="flex justify-center">
+        <div className="flex justify-center mx-auto max-w-64">
           <button
             type="button"
-            className="cta-neutral-lg transition-standard mb-3 w-32"
+            className="cta-neutral mx-2 flex-1"
             data-testid="cancel-button"
             onClick={goBack}
           >
             Cancel
           </button>
-
           <button
             type="submit"
-            className={`cta-primary transition-standard mb-3 w-32 ${
-              saveBtnDisabled ? 'opacity-25' : ''
-            }`}
+            className="cta-primary mx-2 flex-1"
             data-testid="save-button"
             disabled={saveBtnDisabled}
           >

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
@@ -71,21 +71,25 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
           });
         }}
       >
-        <p className="my-6">
+        <p>
           Please enter the verification code that was sent to{' '}
           <span className="font-bold">{email}</span> within 5 minutes.
         </p>
-        <InputText
-          label="Enter your verification code"
-          onChange={(event) => {
-            setCode(event.target.value);
-          }}
-          {...{ errorText }}
-        ></InputText>
-        <div className="flex mt-6">
+
+        <div className="my-6">
+          <InputText
+            label="Enter your verification code"
+            onChange={(event) => {
+              setCode(event.target.value);
+            }}
+            {...{ errorText }}
+          ></InputText>
+        </div>
+
+        <div className="flex justify-center mx-auto max-w-64">
           <button
             type="button"
-            className="cta-neutral-lg transition-standard flex-1"
+            className="cta-neutral mx-2 flex-1"
             data-testid="secondary-email-verify-cancel"
             onClick={goBack}
           >
@@ -93,7 +97,7 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
           </button>
           <button
             type="submit"
-            className="cta-primary transition-standard flex-1"
+            className="cta-primary mx-2 flex-1"
             data-testid="secondary-email-verify-submit"
           >
             Verify

--- a/packages/fxa-settings/src/components/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRow/index.tsx
@@ -65,7 +65,7 @@ export const UnitRow = ({
         <div>
           {route && (
             <Link
-              className="cta-neutral cta-base transition-standard"
+              className="cta-neutral cta-base"
               data-testid="unit-row-route"
               to={`${route}${location.search}`}
             >
@@ -75,7 +75,7 @@ export const UnitRow = ({
 
           {revealModal && (
             <button
-              className="cta-neutral cta-base transition-standard"
+              className="cta-neutral cta-base"
               data-testid="unit-row-modal"
               ref={modalTriggerElement}
               onClick={revealModal}

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
@@ -75,17 +75,23 @@ export const UnitRowRecoveryKey = () => {
       </LinkExternal>
       {modalRevealed && (
         <VerifiedSessionGuard onDismiss={hideModal} onError={onError}>
-          {/* TODO customize confirm button text and style */}
           <Modal
             onDismiss={hideModal}
             onConfirm={deleteRecoveryKey}
-            headerId="some-id"
-            descId="some-desc"
+            // TODO - Uncomment these two
+            // lines once #6302 is merged
+            // confirmBtnClassName="cta-caution"
+            // confirmText="Remove"
+            headerId="recovery-key-header"
+            descId="recovery-key-desc"
           >
-            <h2 id="some-id" className="font-bold text-xl text-center mb-2">
+            <h2
+              id="recovery-key-header"
+              className="font-bold text-xl text-center mb-2"
+            >
               Remove recovery key?
             </h2>
-            <p id="some-desc">
+            <p id="recovery-key-desc" className="my-6 text-center">
               In the event you reset your password, you won't be able to use
               your recovery key to access your data. You can't undo this action.
             </p>
@@ -94,7 +100,10 @@ export const UnitRowRecoveryKey = () => {
       )}
       {/* TODO: style AlertBar in the error case */}
       {alertBarRevealed && (
-        <AlertBar onDismiss={hideAlertBar}>
+        <AlertBar
+          onDismiss={hideAlertBar}
+          type={errorText ? 'error' : 'success'}
+        >
           {errorText ? (
             <p data-testid="delete-recovery-key-error">
               Error text TBD. {errorText}

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -258,7 +258,7 @@ export const UnitRowSecondaryEmail = () => {
             {verified && (
               <button
                 disabled={makeEmailPrimaryLoading}
-                className="cta-neutral cta-base disabled:cursor-wait whitespace-no-wrap transition-standard"
+                className="cta-neutral cta-base disabled:cursor-wait whitespace-no-wrap"
                 onClick={() => {
                   queueEmailAction(makeEmailPrimary);
                 }}

--- a/packages/fxa-settings/src/components/UnitRowWithAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowWithAvatar/index.tsx
@@ -22,7 +22,7 @@ export const UnitRowWithAvatar = () => {
       <div className="unit-row-actions">
         <div>
           <Link
-            className="cta-neutral cta-base transition-standard"
+            className="cta-neutral cta-base"
             data-testid="unit-row-with-avatar-route"
             to={`/beta/settings/avatar/change${location.search}`}
           >

--- a/packages/fxa-settings/src/styles/ctas.scss
+++ b/packages/fxa-settings/src/styles/ctas.scss
@@ -4,7 +4,7 @@
 
 .cta-neutral,
 .cta-primary {
-  @apply py-2 px-5 rounded w-full inline-block text-center border font-header box-border;
+  @apply py-2 px-5 rounded w-full inline-block text-center border font-header box-border transition-standard;
 }
 
 .cta-neutral {


### PR DESCRIPTION
## Because

- There are a handful of areas in new Settings that could be improved to be more consistent or to adhere more closely to the Figma design.

## This pull request

- Makes various stylistic changes that add a little more polish to the Settings app. These changes are all pretty subtle and may not be noticeable at first. This includes things like:
  - Consistent form button presentation
  - Small spacing improvements to match Figma
  - Updates to make spacing consistent across the various flows that implemented the same elements (think modals, forms)
  - Add transition to base cta class as it's clearly being used manually everywhere lol
  - Adds z-index to header so relatively positioned elements will appear under it
  - There's a TODO to uncomment two props once Dave's work in #6302 is merged

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.