### PR TITLE
fix(payments): pay invoice on retry

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -230,6 +230,9 @@ export class StripeHelper {
       await this.stripe.customers.update(customerId, {
         invoice_settings: { default_payment_method: paymentMethodId },
       });
+      // Try paying now instead of waiting for Stripe since this could block a
+      // customer from finishing a payment
+      await this.stripe.invoices.pay(invoiceId);
     } catch (err) {
       if (err.type === 'StripeCardError') {
         throw error.rejectedSubscriptionPaymentToken(err.message, err);

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -298,6 +298,9 @@ describe('StripeHelper', () => {
         .stub(stripeHelper.stripe.customers, 'update')
         .resolves(customerExpected);
       sandbox
+        .stub(stripeHelper.stripe.invoices, 'pay')
+        .resolves(invoiceRetryExpected);
+      sandbox
         .stub(stripeHelper.stripe.invoices, 'retrieve')
         .resolves(invoiceRetryExpected);
       const actual = await stripeHelper.retryInvoiceWithPaymentId(

--- a/packages/fxa-payments-server/src/components/PaymentFormV2/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentFormV2/index.test.tsx
@@ -528,6 +528,13 @@ describe('with existing card', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders the payment form for customer without subscriptions', () => {
+    const customer = { ...MOCK_CUSTOMER, subscriptions: [] };
+    const { queryByTestId } = render(<Subject customer={customer} />);
+    expect(queryByTestId('name')).toBeInTheDocument();
+    expect(queryByTestId('card-details')).not.toBeInTheDocument();
+  });
+
   it('calls the submit handler', async () => {
     const onSubmit = jest.fn();
     const { getByTestId } = render(

--- a/packages/fxa-payments-server/src/components/PaymentFormV2/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentFormV2/index.tsx
@@ -84,7 +84,8 @@ export const PaymentForm = ({
   onChange: onChangeProp,
   submitNonce,
 }: BasePaymentFormProps) => {
-  const hasExistingCard = customer && customer.last4;
+  const hasExistingCard =
+    customer && customer.last4 && customer.subscriptions.length > 0;
 
   const stripe = useStripe();
   const elements = useElements();

--- a/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/ProductV2/SubscriptionCreate/index.tsx
@@ -387,6 +387,6 @@ async function handlePaymentIntent({
 }
 
 const hasExistingCard = (customer: Customer | null) =>
-  customer && customer.last4;
+  customer && customer.last4 && customer.subscriptions.length > 0;
 
 export default SubscriptionCreate;

--- a/packages/fxa-payments-server/src/routes/ProductV2/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/ProductV2/index.test.tsx
@@ -203,7 +203,7 @@ describe('routes/Product', () => {
         .reply(200, MOCK_PLANS),
       nock(authServer)
         .get('/v1/oauth/subscriptions/customer')
-        .reply(200, { ...MOCK_CUSTOMER, subscriptions: null }),
+        .reply(200, { ...MOCK_CUSTOMER, subscriptions: [] }),
     ];
     const { findAllByText } = render(<Subject />);
     await findAllByText('Set up your subscription');


### PR DESCRIPTION
Because:
 - an unpaid invoice could block a user from a successful subscription
 - current retry only updates the default payment method, not paying the
   inovice

This commit:
 - use Stripe's API to pay an invoice on a retry


## Issue that this pull request solves

Part of FXA-2494

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

