### PR TITLE
fix(config): disable incremental compilation in base ts config

### DIFF
--- a/_dev/tsconfig.base.json
+++ b/_dev/tsconfig.base.json
@@ -12,7 +12,6 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "baseUrl": "../packages",
-    "incremental": true,
     "typeRoots": [
       "../types",
       "../node_modules/@types",


### PR DESCRIPTION
This should hopefully get main passing...

## Because

- Because it's in the base config shared across all tsconfigs in the repo, the incremental property is clashing with other properties, which is leading to failures in circle ci

## This pull request

- Removes it. Ben said it's okay to disable for now.

## Checklist

- [x] My commit is GPG signed.