### PR TITLE
chore(payments): detach payment method on failed first sub payment

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -423,6 +423,12 @@ export class StripeHelper {
     }
   }
 
+  async detachPaymentMethod(
+    paymentMethodId: string
+  ): Promise<Stripe.PaymentMethod> {
+    return await this.stripe.paymentMethods.detach(paymentMethodId);
+  }
+
   /**
    * Fetch a customer for the record from Stripe based on email.
    */

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -243,6 +243,22 @@ describe('StripeHelper', () => {
     });
   });
 
+  describe('detachPaymentMethod', () => {
+    it('calls the Stripe api', async () => {
+      const paymentMethodId = 'pm_9001';
+      const expected = { id: paymentMethodId };
+      sandbox
+        .stub(stripeHelper.stripe.paymentMethods, 'detach')
+        .resolves(expected);
+      const actual = await stripeHelper.detachPaymentMethod(paymentMethodId);
+      assert.deepEqual(actual, expected);
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripe.paymentMethods.detach,
+        paymentMethodId
+      );
+    });
+  });
+
   describe('removeSources', () => {
     it('removes all the sources', async () => {
       const ids = {

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -53,6 +53,7 @@ import {
   apiCreateSetupIntent,
   apiUpdateDefaultPaymentMethod,
   apiRetryInvoice,
+  apiDetachFailedPaymentMethod,
 } from './apiClient';
 
 describe('APIError', () => {
@@ -434,6 +435,20 @@ describe('API requests', () => {
       expect(<jest.Mock>updateDefaultPaymentMethod_REJECTED).toBeCalledWith({
         error,
       });
+      requestMock.done();
+    });
+  });
+
+  describe('apiDetachFailedPaymentMethod', () => {
+    it('POST correctly', async () => {
+      const resp = { id: 'pm_503541' };
+      const requestMock = nock(AUTH_BASE_URL)
+        .post('/v1/oauth/subscriptions/paymentmethod/failed/detach')
+        .reply(200, resp);
+      const actual = await apiDetachFailedPaymentMethod({
+        paymentMethodId: '???',
+      });
+      expect(actual).toEqual(resp);
       requestMock.done();
     });
   });

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -1,6 +1,7 @@
 import { Config, defaultConfig } from './config';
 import { Plan, Profile, Customer, Subscription, Token } from '../store/types';
 import * as Amplitude from './amplitude';
+import { PaymentMethod } from '@stripe/stripe-js';
 
 // TODO: Use a better type here
 export interface APIFetchOptions {
@@ -303,4 +304,16 @@ export async function apiUpdateDefaultPaymentMethod(params: {
     });
     throw error;
   }
+}
+
+export async function apiDetachFailedPaymentMethod(params: {
+  paymentMethodId: string;
+}): Promise<PaymentMethod> {
+  const { paymentMethodId } = params;
+  const result = await apiFetch(
+    'POST',
+    `${config.servers.auth.url}/v1/oauth/subscriptions/paymentmethod/failed/detach`,
+    { body: JSON.stringify({ paymentMethodId }) }
+  );
+  return result;
 }

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -89,12 +89,20 @@ const RETRY_INVOICE_RESULT = {
   },
 };
 
+const DETACH_PAYMENT_METHOD_RESULT = {
+  id: 'pm_80808',
+  foo: 'quux',
+};
+
 const defaultApiClientOverrides = () => ({
   apiCreateCustomer: jest.fn().mockResolvedValue(NEW_CUSTOMER),
   apiCreateSubscriptionWithPaymentMethod: jest
     .fn()
     .mockResolvedValue(SUBSCRIPTION_RESULT),
   apiRetryInvoice: jest.fn().mockResolvedValue(RETRY_INVOICE_RESULT),
+  apiDetachFailedPaymentMethod: jest
+    .fn()
+    .mockResolvedValue(DETACH_PAYMENT_METHOD_RESULT),
 });
 
 const PAYMENT_METHOD_RESULT = {
@@ -290,6 +298,11 @@ describe('routes/ProductV2/SubscriptionCreate', () => {
         productId: PLAN.product_id,
         paymentMethodId: initialPaymentMethod.paymentMethod.id,
       })
+    );
+    await waitForExpect(() =>
+      expect(
+        apiClientOverrides.apiDetachFailedPaymentMethod.mock.calls[0][0]
+      ).toMatchObject({ paymentMethodId: 'pm_initial' })
     );
     expect(
       screen.queryByTestId('error-payment-submission')

--- a/packages/fxa-payments-server/tsconfig.json
+++ b/packages/fxa-payments-server/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../_dev/tsconfig.browser.json",
   "compilerOptions": {
     "noEmit": true,
+    "incremental": false,
     "types": [
       "jest",
       "@testing-library/jest-dom"


### PR DESCRIPTION
Because:
 - a customer is required to enter a different, working, credit card
   after a failed payment during the subscription to their first product,
   so there's no reason to keep the payment method created by the failed
   payment

This commit:
 - have the Payments frontend call the auth-server to detach the payment
   method

## Issue that this pull request solves

Closes: #6336 (FXA-2494)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
