### PR TITLE
fix(oauth): do not issue JWT access tokens that both use PPIDs and grant access to profile scopes

### DIFF
--- a/packages/fxa-auth-server/docs/oauth/api.md
+++ b/packages/fxa-auth-server/docs/oauth/api.md
@@ -54,6 +54,8 @@ The currently-defined error responses are:
 |     400     |  119  | stale authentication timestamp                |
 |     400     |  120  | mismatch acr value                            |
 |     400     |  121  | invalid grant_type                            |
+|     400     |  122  | unknown token                                 |
+|     400     |  123  | PPID tokens cannot grant profile access       |
 |     500     |  999  | internal server error                         |
 
 ## API Endpoints

--- a/packages/fxa-auth-server/docs/oauth/pairwise-pseudonymous-identifiers.md
+++ b/packages/fxa-auth-server/docs/oauth/pairwise-pseudonymous-identifiers.md
@@ -32,7 +32,7 @@ By default, Firefox accounts does not enforce sub rotation, but for sensitive RP
 
 ## Ensuring 3rd parties are unable to access user information
 
-An OAuth access token is a bearer token that can be presented by anyone to an OAuth service provider to access a protected resource. If a JWT access token contains a PPID `sub` claim that is meant to protect a user's privacy, but is granted the `profile` scope allows the service provider to present the same access token to the FxA profile server and learn the user's true identity. As such, tokens _MUST NOT_ be requested with the `profile` scope or any of its implicants such as `profile:uid` or `profile:email`.
+An OAuth access token is a bearer token that can be presented by anyone to an OAuth service provider to access a protected resource. If a JWT access token contains a PPID `sub` claim that is meant to protect a user's privacy, but is granted the `profile` scope, it will allow the service provider to present the same access token to the FxA profile server, and learn the user's true identity. As such, tokens _MUST NOT_ be requested with the `profile` scope or any of its sub-scopes, such as `profile:uid` or `profile:email`. If an RP requests a JWT access token including both the `ppid_seed` parameter and also a profile-related grant, then that request will be rejected with a 400 error with `errno` 123, and error message "PPID tokens cannot grant profile access".
 
 ## PPIDs and logging
 

--- a/packages/fxa-auth-server/lib/oauth/error.js
+++ b/packages/fxa-auth-server/lib/oauth/error.js
@@ -360,6 +360,15 @@ AppError.unknownToken = function unknownToken() {
   });
 };
 
+AppError.ppidConflict = function ppidConflict() {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: 123,
+    message: 'PPID tokens cannot grant profile access',
+  });
+};
+
 // N.B. `errno: 201` is traditionally our generic "service unavailable" error,
 // so let's reserve it for that purpose here as well.
 

--- a/packages/fxa-auth-server/lib/oauth/jwt_access_token.js
+++ b/packages/fxa-auth-server/lib/oauth/jwt_access_token.js
@@ -8,6 +8,8 @@ const jwt = require('./jwt');
 const sub = require('./jwt_sub');
 const { OAUTH_SCOPE_OLD_SYNC } = require('../constants');
 const config = require('../../config');
+const ScopeSet = require('fxa-shared').oauth.scopes;
+const SCOPE_PROFILE_WRITE = ScopeSet.fromString('profile:write');
 const TOKEN_SERVER_URL = config.get('syncTokenserverUrl');
 
 const HEADER_TYP = 'at+JWT';
@@ -26,6 +28,14 @@ exports.create = async function generateJWTAccessToken(accessToken, grant) {
     : grant.scope.contains(OAUTH_SCOPE_OLD_SYNC)
     ? TOKEN_SERVER_URL
     : clientId;
+
+  if (
+    grant.ppidSeed &&
+    grant.scope &&
+    SCOPE_PROFILE_WRITE.intersects(grant.scope)
+  ) {
+    throw AppError.ppidConflict();
+  }
 
   // Claims list from:
   // https://tools.ietf.org/html/draft-ietf-oauth-access-token-jwt#section-2.2

--- a/packages/fxa-auth-server/test/oauth/jwt_access_token.js
+++ b/packages/fxa-auth-server/test/oauth/jwt_access_token.js
@@ -118,6 +118,63 @@ describe('lib/jwt_access_token', () => {
 
       assert.equal(signedClaims.aud, TOKEN_SERVER_URL);
     });
+
+    describe('PPID / uid scope tests', () => {
+      beforeEach(() => {
+        requestedGrant.ppidSeed = 1000;
+      });
+
+      const scopeTest = async (scopes) => {
+        requestedGrant.scope = ScopeSet.fromArray(scopes);
+        try {
+          await JWTAccessToken.create(mockAccessToken, requestedGrant);
+          assert.fail();
+        } catch (err) {
+          assert.instanceOf(err, AppError);
+          assert.equal(err.errno, 123);
+        }
+      };
+
+      it('should not allow a PPID token to grant access to a profile:uid scope', async () => {
+        await scopeTest(['profile:uid']);
+      });
+
+      it('should not allow a PPID token to grant access to a profile scope', async () => {
+        await scopeTest(['profile']);
+      });
+
+      it('should not allow a PPID token to grant access to a profile:write scope', async () => {
+        await scopeTest(['profile:write']);
+      });
+
+      it('should not allow a PPID token to grant access to a profile:write sub-scope', async () => {
+        await scopeTest(['profile:avatar:write']);
+      });
+
+      it('should not allow a PPID token to grant access to a compound scope including a profile sub-scope', async () => {
+        await scopeTest([
+          'https://identity.mozilla.com/apps/sync',
+          'profile:avatar',
+        ]);
+      });
+
+      it('should allow a PPID token to grant access to a random non-profile scope', async () => {
+        requestedGrant.scope = ScopeSet.fromArray([
+          'foo',
+          'bar',
+          'https://identity.mozilla.com/apps/sync',
+        ]);
+        try {
+          const token = await JWTAccessToken.create(
+            mockAccessToken,
+            requestedGrant
+          );
+          assert.ok(token);
+        } catch (err) {
+          assert.fail(err);
+        }
+      });
+    });
   });
 
   describe('tokenId', () => {


### PR DESCRIPTION
Refs #5826. [Note: please see the review comments below, as this description is not quite accurate. In particular, enforcing ppid_seed not be passed for a profile grant request is a good edge case to handle, but doesn't fix the underlying issues FPN is encountering.]

## Because

- JWT access tokens are intended for use by any RP, not necessarily a trusted RP. PPIDs provide an extra layer of user protection by concealing the user's FxA uid while still enabling untrusted RPs to access resources owned by that user. In particular, PPIDs prevent two evil RPs from comparing user identifiers and correlating a user's behavior across their two services.

- As [mentioned](https://github.com/mozilla/fxa/blob/0ed71f677637ee5f817fa17c265191e952f5500e/packages/fxa-auth-server/fxa-oauth-server/docs/pairwise-pseudonymous-identifiers.md) in our PPID docs, it's nonsensical to issue a JWT access token that both uses a PPID to conceal the user's information, yet also grants access to the user's profile data, since that may reveal the user's FxA `uid` as well as their email and display name (depending on the precise scope of the grant).

- FPN unintentionally mixed PPIDs and the profile grant request. As a result of an unrelated bug (#6367), the user's real uid was returned when the TTL was greater than 6 hours, but when FPN set the TTL to exactly 6 hours, we attempted to look up the PPID in the accounts database (treating it as a uid, which it is not). This caused the profile lookup to fail, which led to the FPN outage around July 1st.

## This pull request

- Enforces that we not mix PPIDs and profile access tokens by throwing a 400 if the token request both includes a `ppid_seed` (signaling the RP would like to have a PPID in the returned token) and would grant access to any profile-related scope.

## Issue that this pull request solves

Closes: #5826 (but not by fixing the bug, only by discovering that this bug is a PPID bug, not a TTL bug that should affect other RPs)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
