### PR TITLE
fix(recovery): Use the existing accountResetToken if account model has it set

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -609,8 +609,13 @@ FxaClientWrapper.prototype = {
         sessionToken: true,
       };
 
-      return client
-        .passwordForgotVerifyCode(code, token, {})
+      return Promise.resolve()
+        .then(() => {
+          if (options.accountResetToken) {
+            return { accountResetToken: options.accountResetToken };
+          }
+          return client.passwordForgotVerifyCode(code, token, {});
+        })
         .then((result) => {
           let emailToHashWith = email;
 

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -1161,6 +1161,7 @@ const Account = Backbone.Model.extend(
           {
             emailToHashWith,
             metricsContext: this._metrics.getFlowEventMetadata(),
+            accountResetToken: this.get('accountResetToken'),
           }
         )
         .then(this.set.bind(this))

--- a/packages/fxa-content-server/app/scripts/views/account_recovery_confirm_key.js
+++ b/packages/fxa-content-server/app/scripts/views/account_recovery_confirm_key.js
@@ -30,6 +30,7 @@ const View = FormView.extend({
     this.logFlowEvent('lost-recovery-key', this.viewName);
     this.navigate('/complete_reset_password', {
       lostRecoveryKey: true,
+      accountResetToken: this.model.get('accountResetToken'),
     });
   },
 
@@ -73,6 +74,7 @@ const View = FormView.extend({
         return accountResetToken;
       })
       .then((accountResetToken) => {
+        this.model.set('accountResetToken', accountResetToken);
         return account.getRecoveryBundle(uid, recoveryKey).then((data) => {
           this.logFlowEvent('success', this.viewName);
           this.navigate('/account_recovery_reset_password', {

--- a/packages/fxa-content-server/app/scripts/views/complete_reset_password.js
+++ b/packages/fxa-content-server/app/scripts/views/complete_reset_password.js
@@ -41,8 +41,11 @@ const View = FormView.extend({
     const model = options.model;
 
     // If this property is set, this will ensure that a regular password reset
-    // is preformed by *not* setting any `recoveryKeyId` data.
+    // is preformed by *not* setting any `recoveryKeyId` data. Additionally,
+    // if we already have a valid accountResetToken, don't attempt to verify it
+    // again.
     this.lostRecoveryKey = model && model.get('lostRecoveryKey');
+    this.accountResetToken = model && model.get('accountResetToken');
     if (this.lostRecoveryKey) {
       return;
     }
@@ -59,8 +62,9 @@ const View = FormView.extend({
 
   getAccount() {
     const email = this._verificationInfo.get('email');
+    const accountResetToken = this.accountResetToken;
 
-    return this.user.initAccount({ email });
+    return this.user.initAccount({ email, accountResetToken });
   },
 
   // beforeRender is asynchronous and returns a promise. Only render

--- a/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/fxa-client.js
@@ -1127,6 +1127,36 @@ describe('lib/fxa-client', function () {
           assert.isTrue(sessionData.verified);
         });
     });
+
+    it('completes the password reset using existing accountResetToken', function () {
+      const options = {
+        accountResetToken: 'accountResetToken',
+      };
+      return client
+        .completePasswordReset(email, password, token, code, relier, options)
+        .then(function (sessionData) {
+          assert.isTrue(
+            realClient.passwordForgotVerifyCode.notCalled,
+            'uses accountResetToken'
+          );
+          assert.isTrue(
+            realClient.accountReset.calledWith(
+              trim(email),
+              password,
+              'accountResetToken',
+              { keys: true, sessionToken: true }
+            )
+          );
+
+          assert.equal(sessionData.email, trim(email));
+          assert.equal(sessionData.keyFetchToken, 'new keyFetchToken');
+          assert.equal(sessionData.sessionToken, 'new sessionToken');
+          assert.equal(sessionData.sessionTokenContext, 'fx_desktop_v1');
+          assert.equal(sessionData.uid, 'uid');
+          assert.equal(sessionData.unwrapBKey, 'unwrap b key');
+          assert.isTrue(sessionData.verified);
+        });
+    });
   });
 
   describe('checkAccountExists', function () {


### PR DESCRIPTION
## Because

- We can only create one `accountResetToken` per password reset. The recovery key flow and password reset flow attempts to create one

## This pull request

- If you start the recovery key flow and generate a `accountResetToken`, store the value in the account model so that it can be reused in the regular password reset flow

## Issue that this pull request solves

Closes: #6343 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
