### PR TITLE
feat(123done): add version route

### DIFF
--- a/packages/123done/server.js
+++ b/packages/123done/server.js
@@ -6,13 +6,14 @@ const sessions = require('client-sessions');
 
 const oauth = require('./oauth');
 const config = require('./config');
+const version = require('./version');
 
 const logger = morgan('short');
 
 // create a connection to the redis datastore
 let db = redis.createClient();
 
-db.on('error', function (err) {
+db.on('error', function () {
   // eslint-disable-line handle-callback-err
   db = null;
   console.log(
@@ -24,6 +25,10 @@ db.on('error', function (err) {
 const app = express();
 
 app.use(logger, express.json());
+
+app.get('/__version__', (_, res) =>
+  res.type('application/json').send(JSON.stringify(version))
+);
 
 app.use(function (req, res, next) {
   if (/^\/api/.test(req.url)) {

--- a/packages/123done/version.js
+++ b/packages/123done/version.js
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Return version info based on package.json, the git sha, and source repo
+ *
+ * Try to statically determine commitHash and sourceRepo at startup.
+ *
+ * If commitHash cannot be found from ./version.json (i.e., this is not
+ * production or stage), then an attempt will be made to determine commitHash
+ * and sourceRepo dynamically from `git`. If it cannot be found with `git`,
+ * just show UNKNOWN for commitHash and sourceRepo.
+ */
+
+'use strict';
+
+const cp = require('child_process');
+const path = require('path');
+const pckg = require('./package.json');
+
+const UNKNOWN = 'unknown';
+const versionJsonPath = './version.json';
+const gitDir = path.resolve(__dirname, '..', '..', '.git');
+
+function getCommitHash() {
+  let stdout = UNKNOWN;
+
+  try {
+    const { version } = require(versionJsonPath);
+    return version.hash;
+  } catch (e) {
+    /* Ignore, shell out to `git` for hash */
+  }
+
+  try {
+    stdout = cp.execSync('git rev-parse HEAD', { cwd: gitDir });
+  } catch (e) {
+    /* Ignore, report UNKNOWN */
+  }
+
+  return stdout && stdout.toString().trim();
+}
+
+function getSourceRepo() {
+  let stdout = UNKNOWN;
+
+  try {
+    const { version } = require(versionJsonPath);
+    return version.source;
+  } catch (e) {
+    /* Ignore, shell out to `git` for repo */
+  }
+
+  const configPath = path.join(gitDir, 'config');
+  const cmd = 'git config --get remote.origin.url';
+
+  try {
+    stdout = cp.execSync(cmd, cmd, { env: { GIT_CONFIG: configPath } });
+  } catch (e) {
+    /* Ignore, shell out to `git` for repo */
+  }
+
+  return stdout && stdout.toString().trim();
+}
+
+let version = null;
+function getVersionInfo() {
+  if (!version) {
+    // Only fetch version info if it
+    // has not already been fetched.
+    version = {
+      version: pckg.version,
+      commit: getCommitHash(),
+      source: getSourceRepo(),
+    };
+  }
+
+  return version;
+}
+
+getVersionInfo();
+
+module.exports = version;


### PR DESCRIPTION
## Because

- We should have version endpoints on the 123done server

## This pull request

- Adds basic versioning library to retrieve package.json version, source, and commit hash to 123done (also updates 321done)

## Issue that this pull request solves

Closes: #6219

## Checklist

- [x] My commit is GPG signed.

<img width="403" alt="Screen Shot 2020-09-08 at 12 01 37 PM" src="https://user-images.githubusercontent.com/6392049/92500398-15864e80-f1cb-11ea-8023-45a8015139f4.png">