### PR TITLE
fix(metrics: Emit the the `flow.complete` event when a user creates an oauth token for sync

### DIFF
--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -299,6 +299,16 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
             uid,
             ecosystemAnonId,
           });
+
+          // This is a bit of a hack, but we emit the `account.signed`
+          // event to signal to the flow it has been completed (see flowCompleteSignal).
+          // Previously, this event would get emitted on the `/certificate/sign`
+          // endpoint however, with the move to sync oauth, this does not happen anymore
+          // and we need to "fake" it.
+          await request.emitMetricsEvent('account.signed', {
+            uid: uid,
+            device_id: sessionToken.deviceId,
+          });
         } catch (ex) {}
 
         return grant;

--- a/packages/fxa-auth-server/test/local/routes/oauth.js
+++ b/packages/fxa-auth-server/test/local/routes/oauth.js
@@ -41,7 +41,7 @@ describe('/oauth/ routes', () => {
       mockLog,
       mockConfig,
       mockOAuthDB,
-      mockDB,
+      mockDB
     );
     const route = await getRoute(routes, path);
     if (route.options.validate.payload) {
@@ -316,7 +316,7 @@ describe('/oauth/ routes', () => {
       mockDB = mocks.mockDB({
         ecosystemAnonId: MOCK_ANON_ID,
         email: 'foo@example.com',
-        uid: MOCK_USER_ID
+        uid: MOCK_USER_ID,
       });
       sessionToken = await mockSessionToken();
       const mockRequest = mocks.mockRequest({
@@ -341,12 +341,24 @@ describe('/oauth/ routes', () => {
       );
       assert.called(mockDB.account);
       assert.calledWithExactly(mockDB.account, MOCK_USER_ID);
-      assert.calledOnce(mockEmitMetricsEvent);
-      assert.calledWithExactly(mockEmitMetricsEvent, 'oauth.token.created', {
-        grantType: 'fxa-credentials',
-        uid: MOCK_USER_ID,
-        ecosystemAnonId: MOCK_ANON_ID,
-      });
+      assert.calledTwice(mockEmitMetricsEvent);
+      assert.calledWithMatch(
+        mockEmitMetricsEvent.firstCall,
+        'oauth.token.created',
+        {
+          grantType: 'fxa-credentials',
+          uid: MOCK_USER_ID,
+          ecosystemAnonId: MOCK_ANON_ID,
+        }
+      );
+      assert.calledWithMatch(
+        mockEmitMetricsEvent.secondCall,
+        'account.signed',
+        {
+          uid: MOCK_USER_ID,
+          device_id: undefined,
+        }
+      );
       assert.deepEqual(resp, MOCK_TOKEN_RESPONSE);
     });
 
@@ -359,7 +371,7 @@ describe('/oauth/ routes', () => {
       mockDB = mocks.mockDB({
         ecosystemAnonId: MOCK_ANON_ID,
         email: 'foo@example.com',
-        uid: MOCK_USER_ID
+        uid: MOCK_USER_ID,
       });
       const mockRequest = mocks.mockRequest({
         credentials: sessionToken,
@@ -380,12 +392,16 @@ describe('/oauth/ routes', () => {
       });
       assert.called(mockDB.account);
       assert.calledWithExactly(mockDB.account, MOCK_USER_ID);
-      assert.calledOnce(mockEmitMetricsEvent);
-      assert.calledWithExactly(mockEmitMetricsEvent, 'oauth.token.created', {
-        grantType: 'authorization_code',
-        uid: MOCK_USER_ID,
-        ecosystemAnonId: MOCK_ANON_ID,
-      });
+      assert.calledTwice(mockEmitMetricsEvent);
+      assert.calledWithMatch(
+        mockEmitMetricsEvent.firstCall,
+        'oauth.token.created',
+        {
+          grantType: 'authorization_code',
+          uid: MOCK_USER_ID,
+          ecosystemAnonId: MOCK_ANON_ID,
+        }
+      );
       assert.deepEqual(resp, MOCK_TOKEN_RESPONSE);
     });
 
@@ -398,7 +414,7 @@ describe('/oauth/ routes', () => {
       mockDB = mocks.mockDB({
         ecosystemAnonId: MOCK_ANON_ID,
         email: 'foo@example.com',
-        uid: MOCK_USER_ID
+        uid: MOCK_USER_ID,
       });
       const mockRequest = mocks.mockRequest({
         credentials: sessionToken,
@@ -421,12 +437,16 @@ describe('/oauth/ routes', () => {
 
       assert.called(mockDB.account);
       assert.calledWithExactly(mockDB.account, MOCK_USER_ID);
-      assert.calledOnce(mockEmitMetricsEvent);
-      assert.calledWithExactly(mockEmitMetricsEvent, 'oauth.token.created', {
-        grantType: 'authorization_code',
-        uid: MOCK_USER_ID,
-        ecosystemAnonId: MOCK_ANON_ID,
-      });
+      assert.calledTwice(mockEmitMetricsEvent);
+      assert.calledWithMatch(
+        mockEmitMetricsEvent.firstCall,
+        'oauth.token.created',
+        {
+          grantType: 'authorization_code',
+          uid: MOCK_USER_ID,
+          ecosystemAnonId: MOCK_ANON_ID,
+        }
+      );
 
       assert.deepEqual(resp, MOCK_TOKEN_RESPONSE);
     });
@@ -440,7 +460,7 @@ describe('/oauth/ routes', () => {
       mockDB = mocks.mockDB({
         ecosystemAnonId: MOCK_ANON_ID,
         email: 'foo@example.com',
-        uid: MOCK_USER_ID
+        uid: MOCK_USER_ID,
       });
       const mockRequest = mocks.mockRequest({
         credentials: sessionToken,
@@ -462,12 +482,16 @@ describe('/oauth/ routes', () => {
       });
       assert.called(mockDB.account);
       assert.calledWithExactly(mockDB.account, MOCK_USER_ID);
-      assert.calledOnce(mockEmitMetricsEvent);
-      assert.calledWithExactly(mockEmitMetricsEvent, 'oauth.token.created', {
-        grantType: 'refresh_token',
-        uid: MOCK_USER_ID,
-        ecosystemAnonId: MOCK_ANON_ID,
-      });
+      assert.calledTwice(mockEmitMetricsEvent);
+      assert.calledWithMatch(
+        mockEmitMetricsEvent.firstCall,
+        'oauth.token.created',
+        {
+          grantType: 'refresh_token',
+          uid: MOCK_USER_ID,
+          ecosystemAnonId: MOCK_ANON_ID,
+        }
+      );
       assert.deepEqual(resp, MOCK_TOKEN_RESPONSE);
     });
 
@@ -480,7 +504,7 @@ describe('/oauth/ routes', () => {
       mockDB = mocks.mockDB({
         ecosystemAnonId: MOCK_ANON_ID,
         email: 'foo@example.com',
-        uid: MOCK_USER_ID
+        uid: MOCK_USER_ID,
       });
       sessionToken = await mockSessionToken();
       const mockRequest = mocks.mockRequest({
@@ -506,12 +530,16 @@ describe('/oauth/ routes', () => {
       );
       assert.called(mockDB.account);
       assert.calledWithExactly(mockDB.account, MOCK_USER_ID);
-      assert.calledOnce(mockEmitMetricsEvent);
-      assert.calledWithExactly(mockEmitMetricsEvent, 'oauth.token.created', {
-        grantType: 'fxa-credentials',
-        uid: MOCK_USER_ID,
-        ecosystemAnonId: MOCK_ANON_ID,
-      });
+      assert.calledTwice(mockEmitMetricsEvent);
+      assert.calledWithMatch(
+        mockEmitMetricsEvent.firstCall,
+        'oauth.token.created',
+        {
+          grantType: 'fxa-credentials',
+          uid: MOCK_USER_ID,
+          ecosystemAnonId: MOCK_ANON_ID,
+        }
+      );
       assert.deepEqual(resp, MOCK_TOKEN_RESPONSE);
     });
 
@@ -539,6 +567,50 @@ describe('/oauth/ routes', () => {
       assert.equal(mockEmitMetricsEvent.callCount, 0);
       assert.equal(mockOAuthDB.grantTokensFromSessionToken.callCount, 0);
     });
+
+    it('emits "flow.complete" event', async () => {
+      mockOAuthDB = mocks.mockOAuthDB({
+        grantTokensFromSessionToken: sinon.spy(async () => {
+          return MOCK_TOKEN_RESPONSE;
+        }),
+      });
+      mockDB = mocks.mockDB({
+        ecosystemAnonId: MOCK_ANON_ID,
+        email: 'foo@example.com',
+        uid: MOCK_USER_ID,
+      });
+      sessionToken = await mockSessionToken();
+      const metricsContext = mocks.mockMetricsContext({
+        gather: sinon.spy(() =>
+          Promise.resolve({
+            device_id: 'foo',
+            flow_id: 'bar',
+            flowBeginTime: 123,
+            flowCompleteSignal: 'account.signed',
+          })
+        ),
+      });
+      const mockLog = mocks.mockLog();
+      const mockRequest = mocks.mockRequest({
+        log: mockLog,
+        credentials: sessionToken,
+        payload: {
+          client_id: MOCK_CLIENT_ID,
+          scope: MOCK_SCOPES,
+        },
+        metricsContext,
+      });
+      const resp = await loadAndCallRoute('/oauth/token', mockRequest);
+
+      assert.calledWithMatch(mockLog.flowEvent.thirdCall, {
+        event: 'flow.complete',
+        device_id: 'foo',
+        flow_id: 'bar',
+        flowBeginTime: 123,
+        flowCompleteSignal: 'account.signed',
+      });
+      assert.deepEqual(resp, MOCK_TOKEN_RESPONSE);
+    });
   });
 
   describe('/oauth/destroy', () => {
@@ -554,7 +626,7 @@ describe('/oauth/ routes', () => {
         revokeAccessToken: sinon.spy(NOTFOUND),
         revokeRefreshToken: sinon.spy(NOTFOUND),
       });
-      mockDB = mocks.mockDB({ecosystemAnonId: MOCK_ANON_ID});
+      mockDB = mocks.mockDB({ ecosystemAnonId: MOCK_ANON_ID });
       const mockRequest = mocks.mockRequest({
         payload: {
           client_id: MOCK_CLIENT_ID,


### PR DESCRIPTION
## Because

- We stopped emitting the `flow.complete` metrics for FF80 which we use in amplitue to signal that the user completed the specific action
- For FF 80 we moved to a sync oauth flow and don't call the `/certificate/signed` anypoint anymore, which would have emitted the `account.signed` event.

## This pull request

- Emits the `account.signed` event when an oauth token is created. If the flow has a `flowCompleteSignal=account.signed`, it will emit the `flow.complete` event.

## Issue that this pull request solves

Closes: #6347 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Other information (Optional)

I will be uplifting this to the current train (186) since its metrics related.