### PR TITLE
fix(logging: trace log geodb failures

### DIFF
--- a/packages/fxa-auth-server/lib/geodb.js
+++ b/packages/fxa-auth-server/lib/geodb.js
@@ -60,7 +60,7 @@ module.exports = (log) => {
         timeZone: location.timeZone,
       };
     } catch (err) {
-      log.error('geodb.1', { err: err.message });
+      log.trace('geodb.1', { err: err.message });
       return {};
     }
   };


### PR DESCRIPTION
These don't need to be logged as error, it clutters up the logs when testing.