### PR TITLE
test(reset-password): add few missing checks for resend email

### DIFF
--- a/packages/fxa-content-server/tests/functional/reset_password.js
+++ b/packages/fxa-content-server/tests/functional/reset_password.js
@@ -186,6 +186,22 @@ registerSuite('reset_password', {
           .then(fillOutResetPassword(email))
 
           .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
+          //Check email resent for reset password
+          .then(click(selectors.CONFIRM_RESET_PASSWORD.LINK_RESEND))
+
+          //Confirm the success message for resend email
+          .then(visibleByQSA(selectors.CONFIRM_RESET_PASSWORD.RESEND_SUCCESS))
+
+          //continue to sign in again
+          .then(click(selectors.CONFIRM_RESET_PASSWORD.LINK_SIGNIN))
+          .then(testElementExists(selectors.ENTER_EMAIL.HEADER))
+          .then(testElementValueEquals(selectors.ENTER_EMAIL.EMAIL, email))
+          .then(
+            click(
+              selectors.ENTER_EMAIL.SUBMIT,
+              selectors.SIGNIN_PASSWORD.HEADER
+            )
+          )
       );
     },
 


### PR DESCRIPTION
## Because
-Added few missing checks from the manual test steps for reset password.

## This pull request
- check if the email is resent
-Then try to sign in again

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
