### PR TITLE
fix(totp): Restore unverified session handling in the force-2FA flow

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/sign_in_token_code.js
+++ b/packages/fxa-content-server/app/scripts/views/sign_in_token_code.js
@@ -63,6 +63,14 @@ const View = FormView.extend({
       .then(() => {
         this.logViewEvent('success');
 
+        // Note: `redirectTo` looks similar to `redirectPathname`, but they
+        // work slightly differently: `redirectTo` redirects automatically,
+        // while `redirectPathname` redirects after a form submission.
+        const redirectTo = this.model.get('redirectTo');
+        if (redirectTo) {
+          return (this.window.location.href = redirectTo);
+        }
+
         const redirectPathname = this.model.get('redirectPathname');
         if (redirectPathname) {
           return this.navigate(redirectPathname);


### PR DESCRIPTION
Fixes #6342.

## Because

- changes in #6295 might have regressed unverified session handling for the force-2FA flow

## This pull request

- restores the redirect behavior by adding the `redirectTo` parameter check back to the `sign_in_token_code` screen

## Issue that this pull request solves

Closes: #6342

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
