### PR TITLE
fix(emails): use default lang tag for sub emails when given invalid tag

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -195,7 +195,17 @@ module.exports = function (log, config, oauthdb) {
     const decimal = amountInCents / 100;
     const options = { ...baseCurrencyOptions, currency };
 
-    return new Intl.NumberFormat(locale, options).format(decimal);
+    try {
+      return new Intl.NumberFormat(locale, options).format(decimal);
+    } catch (e) {
+      // The exception could be a verror wrapped one.
+      const cause = e.cause ? e.cause() : e;
+      // If the language tag is not something Intl can handle, use 'en-US'.
+      if (cause.message.endsWith('is not a structurally valid language tag')) {
+        return getLocalizedCurrencyString(amountInCents, currency, 'en-US');
+      }
+      throw e;
+    }
   }
 
   function sesMessageTagsHeaderValue(templateName, serviceName) {

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -1278,6 +1278,11 @@ describe('lib/senders/email:', () => {
     assert.equal(result, 'US$1.23');
   });
 
+  it('formats currency strings when given an invalid language tag', () => {
+    const result = mailer._getLocalizedCurrencyString(123, 'USD', 'en__us');
+    assert.equal(result, '$1.23');
+  });
+
   it('formats user-agent strings sanely', () => {
     let result = mailer._formatUserAgentInfo({
       uaBrowser: 'Firefox',


### PR DESCRIPTION
Because:
 - the Intl module throws an exception when given a language tag that does
   not conform to BCP 47

This commit:
 - handles the exception and use the default 'en-US' instead

## Issue that this pull request solves

Closes: #6312 (FXA-2480)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
