### PR TITLE
fix(metrics): include the client_id when logging the `oauth.token.created` event

### DIFF
--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -298,6 +298,7 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
             grantType: request.payload.grant_type,
             uid,
             ecosystemAnonId,
+            clientId: request.payload.client_id,
           });
 
           // This is a bit of a hack, but we emit the `account.signed`

--- a/packages/fxa-auth-server/test/local/routes/oauth.js
+++ b/packages/fxa-auth-server/test/local/routes/oauth.js
@@ -349,6 +349,7 @@ describe('/oauth/ routes', () => {
           grantType: 'fxa-credentials',
           uid: MOCK_USER_ID,
           ecosystemAnonId: MOCK_ANON_ID,
+          clientId: MOCK_CLIENT_ID,
         }
       );
       assert.calledWithMatch(
@@ -400,6 +401,7 @@ describe('/oauth/ routes', () => {
           grantType: 'authorization_code',
           uid: MOCK_USER_ID,
           ecosystemAnonId: MOCK_ANON_ID,
+          clientId: MOCK_CLIENT_ID,
         }
       );
       assert.deepEqual(resp, MOCK_TOKEN_RESPONSE);
@@ -445,6 +447,7 @@ describe('/oauth/ routes', () => {
           grantType: 'authorization_code',
           uid: MOCK_USER_ID,
           ecosystemAnonId: MOCK_ANON_ID,
+          clientId: MOCK_CLIENT_ID,
         }
       );
 
@@ -490,6 +493,7 @@ describe('/oauth/ routes', () => {
           grantType: 'refresh_token',
           uid: MOCK_USER_ID,
           ecosystemAnonId: MOCK_ANON_ID,
+          clientId: MOCK_CLIENT_ID,
         }
       );
       assert.deepEqual(resp, MOCK_TOKEN_RESPONSE);
@@ -538,6 +542,7 @@ describe('/oauth/ routes', () => {
           grantType: 'fxa-credentials',
           uid: MOCK_USER_ID,
           ecosystemAnonId: MOCK_ANON_ID,
+          clientId: MOCK_CLIENT_ID,
         }
       );
       assert.deepEqual(resp, MOCK_TOKEN_RESPONSE);


### PR DESCRIPTION
## Because

- Right now, we're not gathering quite enough data with the AET pings to understand if AET is working properly across RPs.

## This pull request

- Adds the client_id to the `oauth.token.created` event.

## Issue that this pull request solves

Closes: #6290

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
