### PR TITLE
fix(tests): Update the post-download page selector

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -162,7 +162,7 @@ module.exports = {
     HEADER: '#fxa-cannot-create-account-header',
   },
   DOWNLOAD_FIREFOX_THANKS: {
-    HEADER: '#download-button-wrapper-desktop',
+    HEADER: '[data-test-fxa-template="firefox-download-thanks"]',
   },
   EMAIL: {
     ADD_BUTTON: '.email-add:not(.disabled)',


### PR DESCRIPTION

## Because

- Recent mozilla.org changes removed the ID on the post-download page that our content-server tests expect to find when exercising various firefox download flows.

## This pull request

- Updates the selector to a new one that the helpful folks on the bedrock team are inserting for us (h/t @craigcook)

## Issue that this pull request solves

Closes: #6411

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
