### PR TITLE
fix(event-broker): include lbheartbeat and dev check

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "python.pythonPath": "usr/bin/python3"
+  "python.pythonPath": "usr/bin/python3",
+  "prettier.configPath": "_dev/.prettierrc"
 }

--- a/packages/fxa-event-broker/src/health/health.controller.spec.ts
+++ b/packages/fxa-event-broker/src/health/health.controller.spec.ts
@@ -21,6 +21,10 @@ describe('Health Controller', () => {
     expect(controller.heartbeat()).toStrictEqual({});
   });
 
+  it('should return lbheartbeat', () => {
+    expect(controller.lbheartbeat()).toStrictEqual({});
+  });
+
   it('should return the version', () => {
     const source = controller.versionData().source;
     expect(source).toBe(version.source);

--- a/packages/fxa-event-broker/src/health/health.controller.ts
+++ b/packages/fxa-event-broker/src/health/health.controller.ts
@@ -4,6 +4,11 @@ import { version } from '../version';
 
 @Controller()
 export class HealthController {
+  @Get('__lbheartbeat__')
+  lbheartbeat(): Record<string, any> {
+    return {};
+  }
+
   @Get('__heartbeat__')
   heartbeat(): Record<string, any> {
     return {};

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
@@ -167,6 +167,8 @@ describe('QueueworkerService', () => {
 
   describe('lifecycle', () => {
     it('starts up with dev checks', async () => {
+      (service as any).queueName =
+        'https://localhost:4100/queue.mozilla/321321321/notifications';
       const mockQueue = jest.fn().mockResolvedValue({});
       const mockCreate = jest.fn().mockResolvedValue({});
       (service as any).sqs = {

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
@@ -49,9 +49,10 @@ export class QueueworkerService
     private clientCapability: ClientCapabilityService
   ) {
     const env = this.configService.get<string>('env');
+    this.queueName = configService.get('serviceNotificationQueueUrl') as string;
     this.disableQueueWorker =
       this.configService.get<boolean>('disableQueueWorker') ?? false;
-    if (env === 'development') {
+    if (env === 'development' && this.queueName.includes('localhost:4100')) {
       AWS.config.update({
         accessKeyId: 'fake',
         ['endpoint' as any]: 'localhost:4100',
@@ -59,7 +60,6 @@ export class QueueworkerService
         sslEnabled: false,
       });
     }
-    this.queueName = configService.get('serviceNotificationQueueUrl') as string;
     this.topicPrefix = configService.get('topicPrefix') as string;
 
     const region = extractRegionFromUrl(this.queueName);
@@ -84,7 +84,7 @@ export class QueueworkerService
 
   async onApplicationBootstrap(): Promise<void> {
     const env = this.configService.get<string>('env');
-    if (env === 'development') {
+    if (env === 'development' && this.queueName.includes('localhost:4100')) {
       // Verify that the queue exists
       const queueParts = this.queueName.split('/');
       const queueName = queueParts[queueParts.length - 1];


### PR DESCRIPTION
Because:

* Development mode is used on a deployed stack that doesn't use a
  local SQS testing instance.
* lbheartbeat was missing from the health routes.

This commit:

* Checks that the SQS URL includes localhost before turning on the
  local SQS dev mode flags.
* Includes a lbheartbeat route.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
