### PR TITLE
Train 187 dot two

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "python.pythonPath": "usr/bin/python3"
+  "python.pythonPath": "usr/bin/python3",
+  "prettier.configPath": "_dev/.prettierrc"
 }

--- a/AUTHORS
+++ b/AUTHORS
@@ -21,21 +21,21 @@ bini11
 Brandon Ebersohl
 Brian Warner
 byrw
-César Carruitero
 championshuttler
 Chris Heilmann
 Chris Karlof
 Christian Murphy
 ckarlof
+César Carruitero
 Dan Callahan
 Danny Amey
 Danny Coates
-dave justice
 Dave Justice
+dave justice
 Deepti
 dependabot[bot]
-divyabiyani
 Divya Biyani
+divyabiyani
 Edouard Oger
 Edwin Wong
 Emin Mastizada
@@ -48,8 +48,8 @@ Francois Marier
 Glen Mailer
 Greg Guthe
 Gurjeet Singh
-hannahqd
 Hannah Quay-de la Vallee
+hannahqd
 Heather Booker
 Hector Zhao
 hritvi
@@ -64,9 +64,9 @@ Jason Strutz
 jbonacci
 Jed Parsons
 Jody Heavener
-johngruen
 John Gruen
 John Morrison
+johngruen
 Jon Buckley
 Jon Petto
 jotes
@@ -78,15 +78,15 @@ Karan Sapolia
 Kit Cambridge
 Kohei Yoshino
 Kurt Bauer
-larissagaulia
 Larissa Gaulia
+larissagaulia
 Lauren Zugai
 Leif Oines
 Les Orchard
 Lloyd Hilaiel
 luke crouch
-markh@babelzilla.org
 Mark Striemer
+markh@babelzilla.org
 Marty Ballard
 matjaz@mozilla.com
 Matt Stavola
@@ -110,8 +110,8 @@ Nicholas Mandel
 Nick Alexander
 Nick Chapman
 Omkar Yadav
-petercpg@mail.moztw.org
 Peter deHaan
+petercpg@mail.moztw.org
 Phil Booth
 Philip Jenvey
 Princi Vershwal
@@ -121,8 +121,8 @@ Ramyashree DG
 rebeccabillings
 Renoir Boulanger
 Renovate Bot
-riadhchtara
 Riadh Chtara
+riadhchtara
 Rishi Baldawa
 Robert Kowalski
 Roger Meier
@@ -161,5 +161,5 @@ vladikoff
 Wil Clouser
 Xavier RENE-CORAIL
 YFdyh000
-Zachary Carter
 Zach Carter
+Zachary Carter

--- a/packages/fxa-admin-panel/CHANGELOG.md
+++ b/packages/fxa-admin-panel/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 ### Bug fixes

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-panel",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "description": "FxA Admin Panel",
   "scripts": {
     "build-postcss": "postcss src/styles/tailwind.css -o src/styles/tailwind.out.css",

--- a/packages/fxa-admin-server/CHANGELOG.md
+++ b/packages/fxa-admin-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 ### New features

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-server",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "description": "FxA GraphQL Admin Server",
   "scripts": {
     "build": "tsc",

--- a/packages/fxa-auth-db-mysql/CHANGELOG.md
+++ b/packages/fxa-auth-db-mysql/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 No changes.

--- a/packages/fxa-auth-db-mysql/package.json
+++ b/packages/fxa-auth-db-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-db-mysql",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "description": "MySQL backend for Firefox Accounts",
   "main": "index.js",
   "repository": {

--- a/packages/fxa-auth-server/CHANGELOG.md
+++ b/packages/fxa-auth-server/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.187.1
+
+### Bug fixes
+
+- docker: Copy version.json into expected path /app/version.json ([9536c64e6](https://github.com/mozilla/fxa/commit/9536c64e6))
+
 ## 1.187.0
 
 ### New features

--- a/packages/fxa-auth-server/Dockerfile
+++ b/packages/fxa-auth-server/Dockerfile
@@ -4,3 +4,4 @@ USER root
 RUN ln -sF /fxa/packages/fxa-auth-server/dist/fxa-auth-server /app
 USER app
 WORKDIR /app
+RUN cp /fxa/packages/version.json /fxa/packages/fxa-auth-server/dist/fxa-auth-server/version.json

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "description": "Firefox Accounts, an identity provider for Mozilla cloud services",
   "bin": {
     "fxa-auth": "./bin/key_server.js"

--- a/packages/fxa-content-server/CHANGELOG.md
+++ b/packages/fxa-content-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 ### New features

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "description": "Firefox Accounts Content Server",
   "scripts": {
     "build": "tsc --build ../fxa-react && NODE_ENV=production grunt build",

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -162,7 +162,7 @@ module.exports = {
     HEADER: '#fxa-cannot-create-account-header',
   },
   DOWNLOAD_FIREFOX_THANKS: {
-    HEADER: '#download-button-wrapper-desktop',
+    HEADER: 'div',
   },
   EMAIL: {
     ADD_BUTTON: '.email-add:not(.disabled)',

--- a/packages/fxa-customs-server/CHANGELOG.md
+++ b/packages/fxa-customs-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 ### New features

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-customs-server",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "description": "Firefox Accounts Customs Server",
   "author": "Mozilla (https://mozilla.org/)",
   "license": "MPL-2.0",

--- a/packages/fxa-email-event-proxy/package.json
+++ b/packages/fxa-email-event-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-email-event-proxy",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "description": "Proxies events from Sendgrid to FxA SQS queues",
   "main": "index.js",
   "scripts": {

--- a/packages/fxa-email-service/CHANGELOG.md
+++ b/packages/fxa-email-service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 No changes.

--- a/packages/fxa-email-service/Cargo.lock
+++ b/packages/fxa-email-service/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "fxa_email_service"
-version = "1.187.0"
+version = "1.187.1"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/packages/fxa-email-service/Cargo.toml
+++ b/packages/fxa-email-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fxa_email_service"
-version = "1.187.0"
+version = "1.187.1"
 publish = false
 edition = "2018"
 

--- a/packages/fxa-event-broker/CHANGELOG.md
+++ b/packages/fxa-event-broker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 ### New features

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-event-broker",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "description": "Firefox Accounts Event Broker",
   "scripts": {
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",

--- a/packages/fxa-event-broker/src/health/health.controller.spec.ts
+++ b/packages/fxa-event-broker/src/health/health.controller.spec.ts
@@ -21,6 +21,10 @@ describe('Health Controller', () => {
     expect(controller.heartbeat()).toStrictEqual({});
   });
 
+  it('should return lbheartbeat', () => {
+    expect(controller.lbheartbeat()).toStrictEqual({});
+  });
+
   it('should return the version', () => {
     const source = controller.versionData().source;
     expect(source).toBe(version.source);

--- a/packages/fxa-event-broker/src/health/health.controller.ts
+++ b/packages/fxa-event-broker/src/health/health.controller.ts
@@ -4,6 +4,11 @@ import { version } from '../version';
 
 @Controller()
 export class HealthController {
+  @Get('__lbheartbeat__')
+  lbheartbeat(): Record<string, any> {
+    return {};
+  }
+
   @Get('__heartbeat__')
   heartbeat(): Record<string, any> {
     return {};

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.spec.ts
@@ -167,6 +167,8 @@ describe('QueueworkerService', () => {
 
   describe('lifecycle', () => {
     it('starts up with dev checks', async () => {
+      (service as any).queueName =
+        'https://localhost:4100/queue.mozilla/321321321/notifications';
       const mockQueue = jest.fn().mockResolvedValue({});
       const mockCreate = jest.fn().mockResolvedValue({});
       (service as any).sqs = {

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
@@ -49,9 +49,10 @@ export class QueueworkerService
     private clientCapability: ClientCapabilityService
   ) {
     const env = this.configService.get<string>('env');
+    this.queueName = configService.get('serviceNotificationQueueUrl') as string;
     this.disableQueueWorker =
       this.configService.get<boolean>('disableQueueWorker') ?? false;
-    if (env === 'development') {
+    if (env === 'development' && this.queueName.includes('localhost:4100')) {
       AWS.config.update({
         accessKeyId: 'fake',
         ['endpoint' as any]: 'localhost:4100',
@@ -59,7 +60,6 @@ export class QueueworkerService
         sslEnabled: false,
       });
     }
-    this.queueName = configService.get('serviceNotificationQueueUrl') as string;
     this.topicPrefix = configService.get('topicPrefix') as string;
 
     const region = extractRegionFromUrl(this.queueName);
@@ -84,7 +84,7 @@ export class QueueworkerService
 
   async onApplicationBootstrap(): Promise<void> {
     const env = this.configService.get<string>('env');
-    if (env === 'development') {
+    if (env === 'development' && this.queueName.includes('localhost:4100')) {
       // Verify that the queue exists
       const queueParts = this.queueName.split('/');
       const queueName = queueParts[queueParts.length - 1];

--- a/packages/fxa-geodb/CHANGELOG.md
+++ b/packages/fxa-geodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 No changes.

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-geodb",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "description": "Firefox Accounts GeoDB Repo for Geolocation based services",
   "main": "lib/fxa-geodb.js",
   "directories": {

--- a/packages/fxa-graphql-api/CHANGELOG.md
+++ b/packages/fxa-graphql-api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 ### New features

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-graphql-api",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "description": "FxA GraphQL API",
   "scripts": {
     "build": "tsc",

--- a/packages/fxa-payments-server/CHANGELOG.md
+++ b/packages/fxa-payments-server/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 ### Bug fixes

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-payments-server",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "description": "Firefox Accounts Payments Service",
   "scripts": {
     "postinstall": "scripts/download_l10n.sh",

--- a/packages/fxa-profile-server/CHANGELOG.md
+++ b/packages/fxa-profile-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 No changes.

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-profile-server",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "private": true,
   "description": "Firefox Accounts Profile service.",
   "scripts": {

--- a/packages/fxa-react/CHANGELOG.md
+++ b/packages/fxa-react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 ### Refactorings

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-react",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "description": "Shared components for FxA React Apps",
   "exports": {
     "./components/": "./dist/components/",

--- a/packages/fxa-settings/CHANGELOG.md
+++ b/packages/fxa-settings/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 ### New features

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-settings",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "homepage": "https://accounts.firefox.com/beta/settings",
   "private": true,
   "scripts": {

--- a/packages/fxa-shared/CHANGELOG.md
+++ b/packages/fxa-shared/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 No changes.

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "description": "Shared module for FxA repositories",
   "main": "dist/index.js",
   "exports": {

--- a/packages/fxa-support-panel/CHANGELOG.md
+++ b/packages/fxa-support-panel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.187.1
+
+No changes.
+
 ## 1.187.0
 
 No changes.

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-support-panel",
-  "version": "1.187.0",
+  "version": "1.187.1",
   "description": "Small app to help customer support access FxA details",
   "directories": {
     "test": "test"


### PR DESCRIPTION
Contains the commit from #6414, as well as a new commit that hacks around the missing post-download page selector by swapping in a 'div' selector that should always pass.