### PR TITLE
fix(event-broker): check for emulator var for firestore

### DIFF
--- a/packages/fxa-event-broker/src/firestore/firestore.service.spec.ts
+++ b/packages/fxa-event-broker/src/firestore/firestore.service.spec.ts
@@ -9,6 +9,9 @@ import { v4 as uuid4 } from 'uuid';
 import { ClientWebhooks } from '../client-webhooks/client-webhooks.interface';
 import { FirestoreService } from './firestore.service';
 
+// Set the env var to use the emulator
+process.env.FIRESTORE_EMULATOR_HOST = 'localhost:9090';
+
 describe('FirestoreService', () => {
   let fs: Firestore;
   let service: FirestoreService;

--- a/packages/fxa-event-broker/src/firestore/firestore.service.ts
+++ b/packages/fxa-event-broker/src/firestore/firestore.service.ts
@@ -40,8 +40,8 @@ export class FirestoreService {
       delete config.credentials;
     }
 
-    // Utilize the local firestore emulator in development mode
-    if (configService.get('env') === 'development') {
+    // Utilize the local firestore emulator in when the env indicates
+    if (!!process.env.FIRESTORE_EMULATOR_HOST) {
       this.db = new Firestore({
         customHeaders: {
           Authorization: 'Bearer owner',


### PR DESCRIPTION
Because:

* We only want to use a local firestore emulator setting when
  the env var is set.

This commit:

* Checks for the env var instead of the NODE_ENV.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
