### PR TITLE
fix(event-broker): dont use env for local checks

### DIFF
--- a/packages/fxa-event-broker/src/firestore/firestore.service.spec.ts
+++ b/packages/fxa-event-broker/src/firestore/firestore.service.spec.ts
@@ -9,6 +9,9 @@ import { v4 as uuid4 } from 'uuid';
 import { ClientWebhooks } from '../client-webhooks/client-webhooks.interface';
 import { FirestoreService } from './firestore.service';
 
+// Set the env var to use the emulator
+process.env.FIRESTORE_EMULATOR_HOST = 'localhost:9090';
+
 describe('FirestoreService', () => {
   let fs: Firestore;
   let service: FirestoreService;

--- a/packages/fxa-event-broker/src/firestore/firestore.service.ts
+++ b/packages/fxa-event-broker/src/firestore/firestore.service.ts
@@ -40,8 +40,8 @@ export class FirestoreService {
       delete config.credentials;
     }
 
-    // Utilize the local firestore emulator in development mode
-    if (configService.get('env') === 'development') {
+    // Utilize the local firestore emulator when the env indicates
+    if (!!process.env.FIRESTORE_EMULATOR_HOST) {
       this.db = new Firestore({
         customHeaders: {
           Authorization: 'Bearer owner',

--- a/packages/fxa-event-broker/src/google-pubsub.service.ts
+++ b/packages/fxa-event-broker/src/google-pubsub.service.ts
@@ -10,7 +10,8 @@ import { AppConfig } from './config';
 export const GooglePubsubFactory: Provider = {
   provide: 'GOOGLEPUBSUB',
   useFactory: async (config: ConfigService<AppConfig>) => {
-    if (config.get<string>('env') === 'development') {
+    const pubsubConfig = config.get('pubsub') as AppConfig['pubsub'];
+    if (pubsubConfig.audience === 'example.com') {
       return new PubSub({ projectId: 'fxa-event-broker' });
     }
     return new PubSub();

--- a/packages/fxa-event-broker/src/metrics.service.ts
+++ b/packages/fxa-event-broker/src/metrics.service.ts
@@ -9,11 +9,12 @@ import { AppConfig } from './config';
 
 export const MetricsFactory: Provider<StatsD> = {
   provide: 'METRICS',
-  useFactory: (config: ConfigService<AppConfig>) => {
-    if (config.get<string>('env') === 'development') {
+  useFactory: (configService: ConfigService<AppConfig>) => {
+    const config = configService.get('metrics') as AppConfig['metrics'];
+    if (config.host === '') {
       return new StatsD({ mock: true });
     }
-    return new StatsD(config.get('metrics'));
+    return new StatsD(config);
   },
   inject: [ConfigService],
 };

--- a/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
+++ b/packages/fxa-event-broker/src/queueworker/queueworker.service.ts
@@ -52,7 +52,7 @@ export class QueueworkerService
     this.queueName = configService.get('serviceNotificationQueueUrl') as string;
     this.disableQueueWorker =
       this.configService.get<boolean>('disableQueueWorker') ?? false;
-    if (env === 'development' && this.queueName.includes('localhost:4100')) {
+    if (this.queueName.includes('localhost:4100')) {
       AWS.config.update({
         accessKeyId: 'fake',
         ['endpoint' as any]: 'localhost:4100',
@@ -84,7 +84,7 @@ export class QueueworkerService
 
   async onApplicationBootstrap(): Promise<void> {
     const env = this.configService.get<string>('env');
-    if (env === 'development' && this.queueName.includes('localhost:4100')) {
+    if (this.queueName.includes('localhost:4100')) {
       // Verify that the queue exists
       const queueParts = this.queueName.split('/');
       const queueName = queueParts[queueParts.length - 1];


### PR DESCRIPTION
Because:

* The env var isn't sufficient to indicate whether local emulators
  should be used. Each service has its own config that more clearly
  reflects whether it is running in a local-dev env vs. deployed
  where remote services are available.

This commit:

* Updates the services to inspect the config such that they can
  determine whether to use mock/local emulators or attempt connecting
  to actual remote services.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
