### PR TITLE
fix(metrics): Emit the service name with pairing login complete

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
@@ -100,6 +100,12 @@ export default BaseAuthenticationBroker.extend({
    */
   sendOAuthResultToRelier(result) {
     if (this.hasCapability('supportsPairing') || result.action === 'pairing') {
+      if (!this.relier.has('service')) {
+        // the service in the query parameter currently overrides the status message
+        // this is due to backwards compatibility
+        this.relier.set('service', this.relier.get('clientId'));
+        this._metrics.setService(this.relier.get('clientId'));
+      }
       this._metrics.logEvent('pairing.signin.success');
     }
 

--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-webchannel-v1.js
@@ -103,6 +103,12 @@ const OAuthWebChannelBroker = OAuthRedirectAuthenticationBroker.extend({
    */
   sendOAuthResultToRelier(result, account) {
     if (this.hasCapability('supportsPairing') || result.action === 'pairing') {
+      if (!this.relier.has('service')) {
+        // the service in the query parameter currently overrides the status message
+        // this is due to backwards compatibility
+        this.relier.set('service', this.relier.get('clientId'));
+        this._metrics.setService(this.relier.get('clientId'));
+      }
       this._metrics.logEvent('pairing.signin.success');
     }
 

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -448,7 +448,7 @@ const conf = (module.exports = convict({
       format: Array,
     },
     server_base_uri: {
-      default: 'wss://dev.channelserver.nonprod.cloudops.mozgcp.net',
+      default: 'wss://channelserver.services.mozilla.com',
       doc: 'The url of the Pairing channel server.',
       env: 'PAIRING_SERVER_BASE_URI',
     },

--- a/packages/fxa-content-server/tests/functional/sign_up_with_code.js
+++ b/packages/fxa-content-server/tests/functional/sign_up_with_code.js
@@ -86,7 +86,12 @@ registerSuite('signup with code', {
             type(selectors.SIGNIN_TOKEN_CODE.INPUT, code)
           );
         })
-        .then(click(selectors.SIGNIN_TOKEN_CODE.SUBMIT))
+        .then(
+          click(
+            selectors.SIGNIN_TOKEN_CODE.SUBMIT,
+            selectors.SIGNIN_TOKEN_CODE.TOOLTIP
+          )
+        )
         .then(
           testElementTextInclude(
             selectors.SIGNIN_TOKEN_CODE.TOOLTIP,


### PR DESCRIPTION
## Because

- We were not emitting the service name with the `fxa_login - complete` amplitude event from pairing

## This pull request

- Sets the service name for oauth-redirect and oauth-webchannel brokers. In local testing the `oauth-redirect` broker is used, but in production its oauth-webchannel.
- Updates the channel server config to point to a valid server

## Issue that this pull request solves

Closes: #5990

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Notes

I wasn't able to verify this 100% with a real device since building to test apps are a bit difficult at the moment. However, using the functional pairing test, I was able to see an amplitude log with the service set to the oauth clientId, which I think is probably good enough.
