### PR TITLE
feat(subscriptions): add product specific app/service support field

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1767,6 +1767,13 @@ const conf = convict({
       env: 'ZENDESK_TOPIC_FIELD_ID',
       format: String,
     },
+    appFieldId: {
+      doc:
+        'Zendesk support ticket custom field for product specific app or service',
+      default: '360030780972',
+      env: 'ZENDESK_APP_FIELD_ID',
+      format: String,
+    },
   },
   otp: {
     step: {

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -4,6 +4,7 @@
 import * as Sentry from '@sentry/node';
 import cacheManager, { Cacheable, CacheClear } from '@type-cacheable/core';
 import { useAdapter } from '@type-cacheable/ioredis-adapter';
+import { AbbrevPlan, AbbrevProduct } from 'fxa-shared/dist/subscriptions/types';
 import { StatsD } from 'hot-shots';
 import ioredis from 'ioredis';
 import moment from 'moment';
@@ -13,25 +14,6 @@ import { Stripe } from 'stripe';
 import { ConfigType } from '../../config';
 import error from '../error';
 import Redis from '../redis';
-
-export type AbbrevProduct = {
-  product_id: string;
-  product_metadata: Stripe.Product['metadata'];
-  product_name: string;
-};
-
-export type AbbrevPlan = {
-  amount: Stripe.Plan['amount'];
-  currency: Stripe.Plan['currency'];
-  interval_count: Stripe.Plan['interval_count'];
-  interval: Stripe.Plan['interval'];
-  plan_id: string;
-  plan_metadata: Stripe.Plan['metadata'];
-  plan_name: string;
-  product_id: string;
-  product_metadata: Stripe.Product['metadata'];
-  product_name: string;
-};
 
 const CUSTOMER_RESOURCE = 'customers';
 const SUBSCRIPTIONS_RESOURCE = 'subscriptions';

--- a/packages/fxa-auth-server/lib/routes/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import isA from '@hapi/joi';
 import * as Sentry from '@sentry/node';
+import { AbbrevPlan } from 'fxa-shared/dist/subscriptions/types';
 import ScopeSet from 'fxa-shared/oauth/scopes';
 import { metadataFromPlan } from 'fxa-shared/subscriptions/metadata';
 import {
@@ -17,11 +18,7 @@ import { Stripe } from 'stripe';
 
 import { ConfigType } from '../../config';
 import error from '../error';
-import {
-  AbbrevPlan,
-  StripeHelper,
-  SUBSCRIPTION_UPDATE_TYPES,
-} from '../payments/stripe';
+import { StripeHelper, SUBSCRIPTION_UPDATE_TYPES } from '../payments/stripe';
 import { AuthLogger, AuthRequest } from '../types';
 import { splitCapabilities } from './utils/subscriptions';
 import validators from './validators';

--- a/packages/fxa-auth-server/lib/routes/support.js
+++ b/packages/fxa-auth-server/lib/routes/support.js
@@ -47,6 +47,7 @@ module.exports = (log, db, config, customs, zendeskClient) => {
           payload: isA.object().keys({
             productName: isA.string().required(),
             topic: isA.string().required(),
+            app: isA.string().allow('').optional(),
             subject: isA.string().allow('').optional(),
             message: isA.string().required(),
           }),
@@ -74,6 +75,7 @@ module.exports = (log, db, config, customs, zendeskClient) => {
           locationStateFieldId,
           locationCountryFieldId,
           topicFieldId,
+          appFieldId,
         } = config.zendesk;
 
         const zendeskReq = {
@@ -86,6 +88,7 @@ module.exports = (log, db, config, customs, zendeskClient) => {
           custom_fields: [
             { id: productNameFieldId, value: request.payload.productName },
             { id: topicFieldId, value: request.payload.topic },
+            { id: appFieldId, value: request.payload.app },
             { id: locationCityFieldId, value: location.city },
             { id: locationStateFieldId, value: location.state },
             { id: locationCountryFieldId, value: location.country },

--- a/packages/fxa-auth-server/test/local/routes/support.js
+++ b/packages/fxa-auth-server/test/local/routes/support.js
@@ -174,6 +174,7 @@ describe('support', () => {
       plan: '123done',
       productName: 'FxA - 123done Pro',
       topic: 'Billing',
+      app: 'FxOS Client',
       subject: 'Change of address',
       message: 'How do I change it?',
     },
@@ -217,6 +218,7 @@ describe('support', () => {
           [
             'FxA - 123done Pro',
             requestOptions.payload.topic,
+            requestOptions.payload.app,
             'Mountain View',
             'California',
             'United States',
@@ -266,6 +268,7 @@ describe('support', () => {
           [
             'FxA - 123done Pro',
             requestOptions.payload.topic,
+            requestOptions.payload.app,
             'Mountain View',
             'California',
             'United States',

--- a/packages/fxa-content-server/app/scripts/templates/support.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/support.mustache
@@ -38,7 +38,6 @@
                 <div class="input-row">
                   <select id="product" name="product" data-placeholder="{{optionPlaceholder}}">
                     <option value=""></option>
-                    <option value="Firefox Account">{{#t}}Firefox Account{{/t}}</option>
                     {{#subscriptions}}
                     <option value="{{product_name}}">{{product_name}}</option>
                     {{/subscriptions}}
@@ -56,6 +55,15 @@
                     {{#topicOptions}}
                     <option value="{{topic}}">{{translated}}</option>
                     {{/topicOptions}}
+                  </select>
+                </div>
+              </div>
+              <div class="support-field">
+                <div class="form-label">
+                  <label for="app">{{#t}}Do you need help with a specific app or service? (optional){{/t}}</label>
+                </div>
+                <div class="input-row">
+                  <select id="app" name="app" data-placeholder="{{optionPlaceholder}}" disabled>
                   </select>
                 </div>
               </div>

--- a/packages/fxa-content-server/app/styles/modules/_chosen.scss
+++ b/packages/fxa-content-server/app/styles/modules/_chosen.scss
@@ -174,3 +174,11 @@
     box-shadow: 0 0 0 3px rgba($blue-50, 0.3);
   }
 }
+
+.chosen-disabled {
+  opacity: 0.4;
+  cursor: default;
+  .chosen-single {
+    cursor: default;
+  }
+}

--- a/packages/fxa-content-server/app/tests/spec/models/support-form.js
+++ b/packages/fxa-content-server/app/tests/spec/models/support-form.js
@@ -13,6 +13,7 @@ describe('models/support-form', function () {
       plan: '123done',
       productName: 'FxA - Best Product Ever',
       topic: '345finished',
+      app: '',
       subject: '',
       message: '678completed',
     });
@@ -33,7 +34,7 @@ describe('models/support-form', function () {
     assert.isFalse(supportForm.isValid());
   });
 
-  it('does not require a subject', function () {
+  it('does not require an app/service or a subject', function () {
     assert.isTrue(supportForm.isValid());
   });
 });

--- a/packages/fxa-content-server/tests/functional/support.js
+++ b/packages/fxa-content-server/tests/functional/support.js
@@ -69,30 +69,40 @@ registerSuite('support form with an active subscription', {
         this.skip('missing Stripe API key in CircleCI run');
       }
       const email = createEmail();
-      return this.remote
-        .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(clearBrowserState())
-        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-        .then(fillOutEmailFirstSignIn(email, PASSWORD))
-        .then(testElementExists(selectors.SETTINGS.HEADER))
-        .then(subscribeToTestProduct())
-        .then(openPage(SUPPORT_URL, 'div.support'))
-        .then(click('#product_chosen a.chosen-single'))
-        .then(
-          click(
-            '#product_chosen ul.chosen-results li[data-option-array-index="1"]'
+      return (
+        this.remote
+          .then(createUser(email, PASSWORD, { preVerified: true }))
+          .then(clearBrowserState())
+          .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+          .then(fillOutEmailFirstSignIn(email, PASSWORD))
+          .then(testElementExists(selectors.SETTINGS.HEADER))
+          .then(subscribeToTestProduct())
+          .then(openPage(SUPPORT_URL, 'div.support'))
+          .then(click('#product_chosen a.chosen-single'))
+          .then(
+            click(
+              '#product_chosen ul.chosen-results li[data-option-array-index="1"]'
+            )
           )
-        )
-        .then(click('#topic_chosen a.chosen-single'))
-        .then(
-          click(
-            '#topic_chosen ul.chosen-results li[data-option-array-index="1"]'
+          .then(click('#topic_chosen a.chosen-single'))
+          .then(
+            click(
+              '#topic_chosen ul.chosen-results li[data-option-array-index="1"]'
+            )
           )
-        )
-        // test hitting enter and making sure we don't leave the form
-        .then(typeNative('input[name="subject"]', 'ENTER'))
-        .then(type('textarea[name=message]', 'please send halp'))
-        .then(click('button[type=submit]'));
+          // This next bit rely on the product having at least one
+          // 'support:app:...' entry in its metadata
+          .then(click('#app_chosen a.chosen-single'))
+          .then(
+            click(
+              '#app_chosen ul.chosen-results li[data-option-array-index="1"]'
+            )
+          )
+          // test hitting enter and making sure we don't leave the form
+          .then(typeNative('input[name="subject"]', 'ENTER'))
+          .then(type('textarea[name=message]', 'please send halp'))
+          .then(click('button[type=submit]'))
+      );
       // Since we don't have proper Zendesk config in CircleCI, the form
       // cannot be successfully submitted.
       // .then(testElementExists('.subscription-management'));

--- a/packages/fxa-shared/subscriptions/metadata.ts
+++ b/packages/fxa-shared/subscriptions/metadata.ts
@@ -7,6 +7,8 @@ import {
   ProductDetailsStringProperty,
   ProductDetailsListProperties,
   ProductDetailsListProperty,
+  AccountSubscription,
+  AbbrevPlan,
 } from './types';
 
 const DEFAULT_LOCALE = 'en-US';
@@ -134,4 +136,32 @@ export const productDetailsFromPlan = (
     ...details.default,
     ...details.selected,
   };
+};
+
+/**
+ * Parse out the 'support:app:' metadata into a dictionary keyed by the product
+ * id.  This is used for the app/service select on the support form.
+ */
+export const getProductSupportApps = (subscriptions: AccountSubscription[]) => (
+  plans: AbbrevPlan[]
+) => {
+  const metadataPrefix = 'support:app:';
+  return plans.reduce((acc: { [keys: string]: string[] }, p) => {
+    if (
+      !acc[p.product_id] &&
+      subscriptions.some((s) => p.product_id === s.product_id) &&
+      Object.keys(p.product_metadata).some((k) => k.startsWith(metadataPrefix))
+    ) {
+      acc[p.product_id] = Object.entries(p.product_metadata).reduce(
+        (apps: string[], [k, v]) => {
+          if (k.startsWith(metadataPrefix)) {
+            apps.push(v);
+          }
+          return apps;
+        },
+        []
+      );
+    }
+    return acc;
+  }, {});
 };

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -57,3 +57,44 @@ export type ProductDetails = {
   [key in ProductDetailsStringProperty]?: string;
 } &
   { [key in ProductDetailsListProperty]?: string[] };
+
+export type AbbrevProduct = {
+  product_id: string;
+  product_metadata: Stripe.Product['metadata'];
+  product_name: string;
+};
+
+export type AbbrevPlan = {
+  amount: Stripe.Plan['amount'];
+  currency: Stripe.Plan['currency'];
+  interval_count: Stripe.Plan['interval_count'];
+  interval: Stripe.Plan['interval'];
+  plan_id: string;
+  plan_metadata: Stripe.Plan['metadata'];
+  plan_name: string;
+  product_id: string;
+  product_metadata: Stripe.Product['metadata'];
+  product_name: string;
+};
+
+// The GET /account endpoint on the auth server includes a list of
+// subscriptions.  This type represents one of those subscriptions.
+export type AccountSubscription = Pick<
+  Stripe.Subscription,
+  | 'created'
+  | 'current_period_end'
+  | 'current_period_start'
+  | 'cancel_at_period_end'
+> &
+  Partial<Pick<Stripe.Charge, 'failure_code' | 'failure_message'>> & {
+    end_at: Stripe.Subscription['ended_at'];
+    latest_invoice: Stripe.Invoice['number'];
+    plan_id: Stripe.Plan['id'];
+    product_name: Stripe.Product['name'];
+    product_id: Stripe.Product['id'];
+    status: Omit<
+      Stripe.Subscription.Status,
+      'incomplete' | 'incomplete_expired'
+    >;
+    subscription_id: Stripe.Subscription['id'];
+  };

--- a/packages/fxa-shared/test/subscriptions/metadata.ts
+++ b/packages/fxa-shared/test/subscriptions/metadata.ts
@@ -1,10 +1,16 @@
 import { expect } from 'chai';
 
-import { Plan, ProductMetadata } from '../../subscriptions/types';
+import {
+  AbbrevPlan,
+  AccountSubscription,
+  Plan,
+  ProductMetadata,
+} from '../../subscriptions/types';
 import {
   DEFAULT_PRODUCT_DETAILS,
   metadataFromPlan,
   productDetailsFromPlan,
+  getProductSupportApps,
 } from '../../subscriptions/metadata';
 
 const NULL_METADATA = {
@@ -184,6 +190,83 @@ describe('subscriptions/metadata', () => {
         termsOfServiceDownloadURL: 'https://example.org/en-US/terms/download',
         privacyNoticeDownloadURL: 'https://example.org/en-US/privacy/download',
       });
+    });
+  });
+
+  describe('getProductSupportApps', () => {
+    const subscriptions: AccountSubscription[] = [
+      {
+        created: 1600208907,
+        current_period_end: 1602800907,
+        current_period_start: 1600208907,
+        cancel_at_period_end: false,
+        end_at: null,
+        latest_invoice: 'DDCB9132-0002',
+        plan_id: 'price_1HJnNbBVqmGyQTMaoduxgunR',
+        product_name: 'Cooking with Foxkeh',
+        product_id: 'prod_GvH2k78kKusAlV',
+        status: 'active',
+        subscription_id: 'sub_I1qKQD2YFCVdFI',
+      },
+      {
+        created: 1600185585,
+        current_period_end: 1600271985,
+        current_period_start: 1600185585,
+        cancel_at_period_end: false,
+        end_at: null,
+        latest_invoice: 'DDCB9132-0001',
+        plan_id: 'plan_GjeF1VyTFSnOkD',
+        product_name: 'Firefox Guardian',
+        product_id: 'prod_GjeBkx6iQFoVgg',
+        status: 'active',
+        subscription_id: 'sub_I1k3kT4hAg0TOV',
+      },
+    ];
+    const plans: AbbrevPlan[] = [
+      {
+        amount: 2000,
+        currency: 'usd',
+        interval_count: 1,
+        interval: 'month',
+        plan_id: 'plan_HzXGkO7lSUw8R1',
+        plan_metadata: {},
+        plan_name: '',
+        product_id: 'prod_HzXGNuO76B5o6g',
+        product_metadata: { 'support:app:1': 'Pop!_OS' },
+        product_name: 'myproduct',
+      },
+    ];
+
+    it('returns an empty dictionary when there are no matching products', () => {
+      const actual = getProductSupportApps(subscriptions)(plans);
+      expect(actual).to.deep.equal({});
+    });
+
+    it('returns an empty dictionary when there are no matching metadata', () => {
+      const matchingPlanNoMetadata = [
+        {
+          ...plans[0],
+          product_id: 'prod_GvH2k78kKusAlV',
+          product_metadata: {},
+        },
+      ];
+      const actual = getProductSupportApps(subscriptions)(
+        matchingPlanNoMetadata
+      );
+      expect(actual).to.deep.equal({});
+    });
+
+    it('returns a dictionary keyed by product ids', () => {
+      const matchingPlanNoMetadata = [
+        {
+          ...plans[0],
+          product_id: 'prod_GjeBkx6iQFoVgg',
+        },
+      ];
+      const actual = getProductSupportApps(subscriptions)(
+        matchingPlanNoMetadata
+      );
+      expect(actual).to.deep.equal({ prod_GjeBkx6iQFoVgg: ['Pop!_OS'] });
     });
   });
 });


### PR DESCRIPTION
Because:
 - subscribers should be able to select a product specific app/service
   on the support form

This commit:
 - present product metadata with keys starting with 'support:app:' as
   options on a new field in the support form


## Issue that this pull request solves

Closes: #6220 (FXA-2434)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
