### PR TITLE
feat(payments): display product name in subscription payment signup / signin flow

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -1176,6 +1176,34 @@ describe('DirectStripeRoutes', () => {
     });
   });
 
+  describe('getProductName', () => {
+    it('should respond with product name for valid id', async () => {
+      directStripeRoutesInstance.stripeHelper.allPlans.resolves(PLANS);
+      const productId = PLANS[1].product_id;
+      const expected = { product_name: PLANS[1].product_name };
+      const result = await directStripeRoutesInstance.getProductName({
+        auth: {},
+        query: { productId },
+      });
+      assert.deepEqual(expected, result);
+    });
+
+    it('should respond with an error for invalid id', async () => {
+      directStripeRoutesInstance.stripeHelper.allPlans.resolves(PLANS);
+      const productId = 'this-is-not-valid';
+      try {
+        await directStripeRoutesInstance.getProductName({
+          auth: {},
+          query: { productId },
+        });
+        assert.fail('Getting a product name should fail.');
+      } catch (err) {
+        assert.instanceOf(err, WError);
+        assert.equal(err.errno, error.ERRNO.UNKNOWN_SUBSCRIPTION_PLAN);
+      }
+    });
+  });
+
   describe('listPlans', () => {
     it('returns the available plans when auth headers are valid', async () => {
       const expected = sanitizePlans(PLANS);

--- a/packages/fxa-content-server/app/scripts/lib/app-start.js
+++ b/packages/fxa-content-server/app/scripts/lib/app-start.js
@@ -277,6 +277,7 @@ Start.prototype = {
         relier = new BrowserRelier(
           { context },
           {
+            config: this._config,
             isVerification: this._isVerification(),
             sentryMetrics: this._sentryMetrics,
             translator: this._translator,
@@ -287,6 +288,7 @@ Start.prototype = {
         relier = new Relier(
           { context },
           {
+            config: this._config,
             isVerification: this._isVerification(),
             sentryMetrics: this._sentryMetrics,
             window: this._window,

--- a/packages/fxa-content-server/app/scripts/views/mixins/service-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/service-mixin.js
@@ -14,7 +14,15 @@ export default {
   },
 
   setInitialContext(context) {
-    context.set(this.relier.pick('service', this.translate('serviceName')));
+    const { service, subscriptionProductName, serviceName } = this.relier.pick(
+      'service',
+      'subscriptionProductName',
+      this.translate('serviceName')
+    );
+    context.set({
+      service,
+      serviceName: subscriptionProductName || serviceName,
+    });
   },
 
   transformLinks() {

--- a/packages/fxa-content-server/app/scripts/views/mixins/sync-suggestion-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/sync-suggestion-mixin.js
@@ -74,7 +74,10 @@ export default function (config) {
      */
     isSyncSuggestionEnabled() {
       return (
-        !this.relier.get('service') && this.relier.get('context') === 'web'
+        !this.relier.get('service') &&
+        this.relier.get('context') === 'web' &&
+        // issue #6121 - skip sync suggestion if headed to subscription product page
+        !this.relier.get('subscriptionProductId')
       );
     },
 

--- a/packages/fxa-content-server/app/scripts/views/subscriptions_product_redirect.js
+++ b/packages/fxa-content-server/app/scripts/views/subscriptions_product_redirect.js
@@ -15,6 +15,9 @@ class SubscriptionsProductRedirectView extends FormView {
 
   initialize(options) {
     this._currentPage = options.currentPage;
+    this._productId = this._currentPage.split('/').pop();
+    this.relier.set('subscriptionProductId', this._productId);
+
     this._subscriptionsConfig = {};
     if (options && options.config && options.config.subscriptions) {
       this._subscriptionsConfig = options.config.subscriptions;
@@ -27,8 +30,7 @@ class SubscriptionsProductRedirectView extends FormView {
 
   afterRender() {
     const queryParams = Url.searchParams(this.window.location.search);
-    const productId = this._currentPage.split('/').pop();
-    const redirectPath = `products/${productId}`;
+    const redirectPath = `products/${this._productId}`;
     return PaymentServer.navigateToPaymentServer(
       this,
       this._subscriptionsConfig,

--- a/packages/fxa-content-server/app/tests/spec/views/confirm.js
+++ b/packages/fxa-content-server/app/tests/spec/views/confirm.js
@@ -147,6 +147,7 @@ describe('views/confirm', function () {
         view = new View({
           broker: broker,
           canGoBack: true,
+          relier: relier,
           model: model,
           notifier: notifier,
           user: user,

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/service-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/service-mixin.js
@@ -73,6 +73,14 @@ describe('views/mixins/service-mixin', () => {
         Constants.RELIER_DEFAULT_SERVICE_NAME
       );
     });
+
+    it('sets `serviceName` from subscriptionProductName from the relier when available', () => {
+      const subscriptionProductName = '123 Done Pro';
+      relier.set({ subscriptionProductName });
+      const context = new Backbone.Model({});
+      view.setInitialContext(context);
+      assert.equal(context.get('serviceName'), subscriptionProductName);
+    });
   });
 
   describe('render', () => {

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/sync-suggestion-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/sync-suggestion-mixin.js
@@ -142,6 +142,16 @@ describe('views/mixins/sync-suggestion-mixin', () => {
       });
     });
 
+    it('does not display sync suggestion message if there is a subscription product ID set', () => {
+      relier.set('service', null);
+      relier.set('context', 'web');
+      relier.set('subscriptionProductId', 'prod_8675309');
+
+      return view.render().then(() => {
+        assert.lengthOf(view.$('#suggest-sync'), 0);
+      });
+    });
+
     it('logs the link.signin event', () => {
       sinon.stub(view, 'isSyncSuggestionEnabled').callsFake(() => true);
       sinon.stub(view, 'logFlowEvent').callsFake(() => {});

--- a/packages/fxa-content-server/app/tests/spec/views/reset_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/reset_password.js
@@ -378,11 +378,13 @@ describe('views/reset_password with `canGoBack: false`', () => {
 
 describe('views/reset_password with reset_password_confirm=false', function () {
   var view;
+  let notifier;
   var relier;
   var broker;
   var formPrefill;
 
   beforeEach(function () {
+    notifier = new Notifier();
     relier = new Relier();
     relier.set('email', 'testuser@testuser.com');
     relier.set('resetPasswordConfirm', false);
@@ -397,6 +399,7 @@ describe('views/reset_password with reset_password_confirm=false', function () {
       broker: broker,
       formPrefill: formPrefill,
       relier: relier,
+      notifier,
     });
 
     sinon.stub(view, 'resetPassword').callsFake(function () {

--- a/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
@@ -7,6 +7,7 @@ import Account from 'models/account';
 import { assert } from 'chai';
 import sinon from 'sinon';
 import User from 'models/user';
+import Relier from 'models/reliers/relier';
 import View from 'views/subscriptions_product_redirect';
 import Notifier from 'lib/channels/notifier';
 import WindowMock from '../../mocks/window';
@@ -17,6 +18,7 @@ const SEARCH_QUERY = '?plan=plk_12345';
 
 describe('views/subscriptions_product_redirect', function () {
   let account;
+  let relier;
   let user;
   let view;
   let windowMock;
@@ -30,6 +32,7 @@ describe('views/subscriptions_product_redirect', function () {
   beforeEach(function () {
     user = new User();
     account = new Account();
+    relier = new Relier();
     notifier = new Notifier();
     windowMock = new WindowMock();
     windowMock.location.href = `http://example.com/products${SEARCH_QUERY}`;
@@ -50,6 +53,7 @@ describe('views/subscriptions_product_redirect', function () {
       config,
       currentPage: `subscriptions/product/${PRODUCT_ID}`,
       notifier,
+      relier,
       user,
       window: windowMock,
     });
@@ -67,6 +71,15 @@ describe('views/subscriptions_product_redirect', function () {
     $(view.el).remove();
     view.destroy();
     view = null;
+  });
+
+  describe('initialize', () => {
+    it('sets subscriptionProductId on relier', () => {
+      view.initialize({
+        currentPage: `/subscriptions/products/${PRODUCT_ID}`,
+      });
+      assert.equal(PRODUCT_ID, relier.get('subscriptionProductId'));
+    });
   });
 
   describe('render', () => {

--- a/packages/fxa-content-server/tests/functional/subscriptions.js
+++ b/packages/fxa-content-server/tests/functional/subscriptions.js
@@ -27,8 +27,33 @@ const {
   visibleByQSA,
 } = FunctionalHelpers;
 
+const TEST_PRODUCT_URL = `${config.fxaContentRoot}subscriptions/products/${config.testProductId}`;
+
 registerSuite('subscriptions', {
   tests: {
+    'visit product page without signing in, expect to see product name displayed in sub-header': function () {
+      if (
+        process.env.CIRCLECI === 'true' &&
+        !process.env.SUBHUB_STRIPE_APIKEY
+      ) {
+        this.skip('missing Stripe API key in CircleCI run');
+      }
+      return this.remote
+        .then(
+          clearBrowserState({
+            '123done': true,
+            force: true,
+          })
+        )
+        .then(openPage(TEST_PRODUCT_URL, selectors.ENTER_EMAIL.HEADER))
+        .then(
+          testElementTextInclude(
+            selectors.ENTER_EMAIL.SUB_HEADER,
+            'Continue to 123Done Pro'
+          )
+        );
+    },
+
     'sign up, subscribe for 123Done Pro, sign into 123Done to verify subscription': function () {
       if (
         process.env.CIRCLECI === 'true' &&


### PR DESCRIPTION
- also hides "Looking for Firefox Sync?" when headed to payment
    
fixes #6121

This issue spans a weird slice of FxA auth views and subscription APIs. Opening a draft early before I get tests together, will maybe request some extra eyes on this to see whether this is a terrible hack.