### PR TITLE
Update web-push lib to latest version.

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -103,7 +103,7 @@
     "urijs": "1.19.1",
     "uuid": "1.4.1",
     "verror": "^1.10.0",
-    "web-push": "3.3.0"
+    "web-push": "3.4.4"
   },
   "devDependencies": {
     "@types/cbor": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8638,7 +8638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"asn1.js@npm:^5.0.0, asn1.js@npm:^5.0.1":
+"asn1.js@npm:^5.0.1":
   version: 5.3.0
   resolution: "asn1.js@npm:5.3.0"
   dependencies:
@@ -8647,6 +8647,18 @@ __metadata:
     minimalistic-assert: ^1.0.0
     safer-buffer: ^2.1.0
   checksum: 5cfb2daa2803fbc5cded76cb381266237e07216ce4ccafe46fff1201b7518051acc8bb26feff8cc3dc15f8c09064359353010424e3b3767d1607ecd8ea4ee170
+  languageName: node
+  linkType: hard
+
+"asn1.js@npm:^5.3.0":
+  version: 5.4.1
+  resolution: "asn1.js@npm:5.4.1"
+  dependencies:
+    bn.js: ^4.0.0
+    inherits: ^2.0.1
+    minimalistic-assert: ^1.0.0
+    safer-buffer: ^2.1.0
+  checksum: 4aa368fce1f2213c41016e4d739da9a65a8462d131146109afa9a5527e9071ec550b1b1d2e5b105044b90dc4bd6b6331bfd7a0a5bb12557604ebdfd330a788d0
   languageName: node
   linkType: hard
 
@@ -8942,6 +8954,7 @@ __metadata:
     postcss-value-parser: ^4.1.0
   bin:
     autoprefixer: bin/autoprefixer
+  checksum: b406d8047a97fcc39c9c6d208fd6f1974e5957800461d9a79457a3ecaca2c0ea090bd06f30c8653f48f751c31115c63a80502ff8c9a6bb7b8a5a5063021827d4
   languageName: node
   linkType: hard
 
@@ -9429,6 +9442,7 @@ __metadata:
 "babel-plugin-dynamic-import-webpack@npm:1.1.0":
   version: 1.1.0
   resolution: "babel-plugin-dynamic-import-webpack@npm:1.1.0"
+  checksum: 7c7b50d85159025b74286d11e05fefc57004fb5f173cf4fcb0dd2fd847e77d133cd14cea24b3bc736ec5780779084bdb4383d39983be667f66aacbf943bc10c4
   languageName: node
   linkType: hard
 
@@ -11625,6 +11639,7 @@ __metadata:
 "caniuse-lite@npm:^1.0.30001109":
   version: 1.0.30001125
   resolution: "caniuse-lite@npm:1.0.30001125"
+  checksum: 1253f4fa1996d51c6fe4ccd659ae36a400476e9edb1427f956296f60265217b27e078f51d8820c40a8a6d7993d9530357f49ebd97be52c68ec44173814ba35fb
   languageName: node
   linkType: hard
 
@@ -17793,7 +17808,7 @@ fsevents@^1.2.7:
     urijs: 1.19.1
     uuid: 1.4.1
     verror: ^1.10.0
-    web-push: 3.3.0
+    web-push: 3.4.4
     ws: ^6.2.1
   bin:
     fxa-auth: ./bin/key_server.js
@@ -20614,12 +20629,12 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"http_ece@npm:1.0.5":
-  version: 1.0.5
-  resolution: "http_ece@npm:1.0.5"
+"http_ece@npm:1.1.0":
+  version: 1.1.0
+  resolution: "http_ece@npm:1.1.0"
   dependencies:
     urlsafe-base64: ~1.0.0
-  checksum: b438a50c973b5ee0272b285525b69fd61bd8669155a0b4c51bdc7454b487ee54474f8071be44d57dd4860ac35cbd242515cbc943224ef945c2c57c6278bc605c
+  checksum: 54ba32313115fb9c0da22205dce4383328732281a2ab6de53ee213fbc23106ec3b9c6be7f8356b1889845d12d71fa9d1ad75fbe8fa68e81025c75881792589a7
   languageName: node
   linkType: hard
 
@@ -21406,6 +21421,7 @@ fsevents@^1.2.7:
     bluebird: 3.5.1
     joi: 13.4.0
     request: 2.87.0
+  checksum: 03f255cd61a90c15719972d41d8d2020309a11ea0de7b2c4df133d9af4e25c05f885d32a075f06ea3eed00dad06bd2cd115be91d9c234eb170c8857a5081d162
   languageName: node
   linkType: hard
 
@@ -24056,7 +24072,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"jws@npm:^3.1.3, jws@npm:^3.2.2":
+"jws@npm:^3.2.2":
   version: 3.2.2
   resolution: "jws@npm:3.2.2"
   dependencies:
@@ -37565,18 +37581,19 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"web-push@npm:3.3.0":
-  version: 3.3.0
-  resolution: "web-push@npm:3.3.0"
+"web-push@npm:3.4.4":
+  version: 3.4.4
+  resolution: "web-push@npm:3.4.4"
   dependencies:
-    asn1.js: ^5.0.0
-    http_ece: 1.0.5
-    jws: ^3.1.3
-    minimist: ^1.2.0
+    asn1.js: ^5.3.0
+    http_ece: 1.1.0
+    https-proxy-agent: ^5.0.0
+    jws: ^4.0.0
+    minimist: ^1.2.5
     urlsafe-base64: ^1.0.0
   bin:
     web-push: src/cli.js
-  checksum: 65533750326dfc3a1720b678eb2dccf8c85e1bbea756821a3dd8f7f06ee254d70490ae084ed93dc10e2cf419abc123558c377453893609cc72f03e523a65c868
+  checksum: 9ce9b643e3d9032a4fa6d9cd32ec7ca4b5921b83a28175f17a1439128c0b738198851d3c61b5789d6ee86aad214bb4a50374400d99bbe2380bb4f5144a914d8d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

* We're using a version of the `web-push` module that defaults to
  a legacy encryption scheme.
* The latest release of `web-push` has switched to using a more
  modern default encryption scheme.
* It's good to keep dependencies up to date.

## This pull request

* Updates the version of our `web-push` dependency to the latest
  release.

## Issue that this pull request solves

Closes: #6434

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- ~[ ] If applicable, I have modified or added tests which pass locally.~
- ~[ ] I have added necessary documentation (if appropriate).~

## Other information (Optional)

As noted in #6434, there's a small but non-zero chance this will uncover bugs in the `aes128gcm` handling in our push client libraries or in their integration with FxA client code. We'll need to keep an eye out for bustage in send-tab push notifications as part of this change, and it seems worth explicitly QA-ing send-tab while this is on stage.

I'm happy to help with that but am a bit out of the loop on the FxA release process these days, so let me know whether/where I should flag ^ for QA attention.