### PR TITLE
fix(tests): disable codecov beta check annotations

### DIFF
--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -1,6 +1,9 @@
 codecov:
   require_ci_to_pass: no
 
+github_checks:
+  annotations: false
+
 coverage:
   precision: 2
   round: down


### PR DESCRIPTION
## Because

- The "Unchanged files with check annotations" is still in beta and the comments clutter reviews

## This pull request

- Disables the check

## Issue that this pull request solves

Closes: NA

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
