### PR TITLE
feat(settings): standardize error/success messages and reporting

### DIFF
--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
@@ -30,6 +30,12 @@ const mockGqlError = () => ({
   error: new Error('Aw shucks'),
 });
 
+window.console.error = jest.fn();
+
+afterAll(() => {
+  (window.console.error as jest.Mock).mockReset();
+});
+
 describe('DropDownAvatarMenu', () => {
   it('renders and toggles as expected with default values', () => {
     render(
@@ -141,7 +147,7 @@ describe('DropDownAvatarMenu', () => {
       });
 
       expect(screen.getByTestId('sign-out-error').textContent).toContain(
-        'Aw shucks'
+        'Sorry, there was a problem signing you out.'
       );
     });
   });

--- a/packages/fxa-settings/src/components/ModalVerifySession/index.test.tsx
+++ b/packages/fxa-settings/src/components/ModalVerifySession/index.test.tsx
@@ -78,6 +78,12 @@ const sadMocks = [
   },
 ];
 
+window.console.error = jest.fn();
+
+afterAll(() => {
+  (window.console.error as jest.Mock).mockReset();
+});
+
 describe('ModalVerifySession', () => {
   it('renders', async () => {
     const onDismiss = jest.fn();

--- a/packages/fxa-settings/src/components/ModalVerifySession/index.tsx
+++ b/packages/fxa-settings/src/components/ModalVerifySession/index.tsx
@@ -5,12 +5,13 @@
 import React, { useEffect, useState } from 'react';
 import Modal from '../Modal';
 import InputText from '../InputText';
-import { gql, useMutation } from '@apollo/client';
+import { ApolloError, gql } from '@apollo/client';
 import { useAccount, useSession } from '../../models';
+import { useMutation } from '../../lib/hooks';
 
 type ModalProps = {
   onDismiss: () => void;
-  onError: (error: Error) => void;
+  onError: (error: ApolloError) => void;
   onCompleted?: () => void;
 };
 
@@ -39,12 +40,15 @@ export const ModalVerifySession = ({
   const [code, setCode] = useState<string>();
   const [errorText, setErrorText] = useState<string>();
   const { primaryEmail } = useAccount();
+
   const [sendCode] = useMutation(SEND_SESSION_VERIFICATION_CODE_MUTATION, {
     variables: { input: {} },
     ignoreResults: true,
     onError,
   });
+
   const [verifySession] = useMutation(VERIFY_SESSION_MUTATION, {
+    ignoreResults: true,
     onError: (error) => {
       if (error.graphQLErrors?.length) {
         setErrorText(error.message);
@@ -53,7 +57,6 @@ export const ModalVerifySession = ({
         onError(error);
       }
     },
-    ignoreResults: true,
     update: (cache) => {
       cache.modify({
         fields: {
@@ -87,14 +90,14 @@ export const ModalVerifySession = ({
     >
       <form
         onSubmit={(event) => {
-          event.preventDefault()
+          event.preventDefault();
           verifySession({
             variables: {
               input: {
                 code,
               },
             },
-          })
+          });
         }}
       >
         <h2
@@ -117,7 +120,7 @@ export const ModalVerifySession = ({
           <InputText
             label="Enter your verification code"
             onChange={(event) => {
-              setCode(event.target.value)
+              setCode(event.target.value);
             }}
             {...{ errorText }}
           ></InputText>
@@ -142,7 +145,7 @@ export const ModalVerifySession = ({
         </div>
       </form>
     </Modal>
-  )
+  );
 };
 
 export default ModalVerifySession;

--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.test.tsx
@@ -19,6 +19,12 @@ const mockGqlSuccess = (email: string) => ({
   },
 });
 
+window.console.error = jest.fn();
+
+afterAll(() => {
+  (window.console.error as jest.Mock).mockReset();
+});
+
 describe('PageSecondaryEmailAdd', () => {
   describe('no secondary email set', () => {
     it('renders as expected', () => {

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.test.tsx
@@ -39,6 +39,12 @@ const mockLocation = ({
   state: { email: 'johndope@example.com' },
 } as unknown) as WindowLocation;
 
+window.console.error = jest.fn();
+
+afterAll(() => {
+  (window.console.error as jest.Mock).mockReset();
+});
+
 describe('PageSecondaryEmailVerify', () => {
   it('renders as expected', () => {
     renderWithRouter(

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useState, useEffect } from 'react';
-import { gql, useMutation } from '@apollo/client';
+import { gql } from '@apollo/client';
 import { cloneDeep } from '@apollo/client/utilities';
-import sentryMetrics from 'fxa-shared/lib/sentry';
-import InputText from '../InputText';
 import { RouteComponentProps, useNavigate } from '@reach/router';
-import FlowContainer from '../FlowContainer';
 import { Account } from '../../models';
+import { useAlertBar, useMutation } from '../../lib/hooks';
+import InputText from '../InputText';
+import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 
 export const VERIFY_SECONDARY_EMAIL_MUTATION = gql`
@@ -21,6 +21,7 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
   const [errorText, setErrorText] = useState<string>();
   const goBack = useCallback(() => window.history.back(), []);
   const navigate = useNavigate();
+  const alertBar = useAlertBar();
   const email = (location?.state as any)?.email as string | undefined;
 
   const [verifySecondaryEmail] = useMutation(VERIFY_SECONDARY_EMAIL_MUTATION, {
@@ -28,8 +29,7 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
       if (error.graphQLErrors?.length) {
         setErrorText(error.message);
       } else {
-        sentryMetrics.captureException(error);
-        // TODO
+        alertBar.error('There was a problem sending the verification code.');
       }
     },
     update: (cache) => {

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.test.tsx
@@ -57,6 +57,12 @@ const mock = {
   ),
 };
 
+window.console.error = jest.fn();
+
+afterAll(() => {
+  (window.console.error as jest.Mock).mockReset();
+});
+
 describe('UnitRowSecondaryEmail', () => {
   describe('no secondary email set', () => {
     it('renders as expected', () => {

--- a/packages/fxa-settings/src/components/VerifiedSessionGuard/index.tsx
+++ b/packages/fxa-settings/src/components/VerifiedSessionGuard/index.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
+import { ApolloError } from '@apollo/client';
 import { useSession } from '../../models';
 import ModalVerifySession from '../ModalVerifySession';
 
@@ -12,7 +13,7 @@ export const VerifiedSessionGuard = ({
   children,
 }: {
   onDismiss: () => void;
-  onError: (error: Error) => void;
+  onError: (error: ApolloError) => void;
   children?: React.ReactNode;
 }) => {
   return useSession().verified ? (

--- a/packages/fxa-settings/src/lib/hooks.test.tsx
+++ b/packages/fxa-settings/src/lib/hooks.test.tsx
@@ -13,7 +13,7 @@ import {
   useFocusOnTriggeringElementOnClose,
   useEscKeydownEffect,
   useChangeFocusEffect,
-  useHandledMutation,
+  useMutation,
   useAlertBar,
 } from './hooks';
 
@@ -105,7 +105,7 @@ describe('useHandledMutation', () => {
   });
 
   it('calls useMutation with the correct default params', () => {
-    useHandledMutation(query);
+    useMutation(query);
 
     expect(apolloClient.useMutation).toHaveBeenCalledWith(query, {
       onError: expect.any(Function),
@@ -113,7 +113,7 @@ describe('useHandledMutation', () => {
   });
 
   it('calls useMutation with additional params', () => {
-    useHandledMutation(query, { fetchPolicy: 'no-cache' });
+    useMutation(query, { fetchPolicy: 'no-cache' });
 
     expect(apolloClient.useMutation).toHaveBeenCalledWith(query, {
       onError: expect.any(Function),


### PR DESCRIPTION
## Because

- We perform many mutations and actions across Settings that require error/success messages. Some of the error instances should be reported to Sentry.

## This pull request

- Tries to standardize how we show messages and report errors.

## Issue that this pull request solves

Closes: #6249

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Other information

Okay, so the goal of this issue was to set a convention for how we handle mutation errors. Here's exactly what I did. I encourage pushback:

- Moved all mutations to our custom `useMutation` hook.
  - This hook can be supplied an `onError` function that supplies an `ApolloError` object for you to check for `graphQLErrors`, which should then be rendered in the UI or AlertBar. You can also throw inside this function to send an error to report the error object or another object to Sentry.
  - Internally, `onError` will always report non-GQL errors to Sentry. As Settings evolves we can potentially start ignoring errors on a case-by-case basis.
  - All errors now report out to `console.error`, whether you supply a custom function or not. This is just the help debugging. I could be convinced to only enable this in development. Also, make sure you stub this in tests.
- One thing you'll notice is that when errors occur I am showing a pre-written error message if not rendering GQL errors. I'm not sure it's helpful to be showing things like network error messages in the alert bar. These error/success messages are not set in stone. I have a chat with @MeridelW coming up where we'll iron them out and make changes where needed (followup PR): https://jira.mozilla.com/browse/FXA-2540
- Consolidated how we use AlertBar by making sure the `useAlertBar` hook is present everywhere. This includes error and success messages. 
- Updated the documentation on how we should handle errors.

The TLDR:

- Use our custom `useMutation` hook.
- Handle errors with a custom `onError` function, and display GQL errors in the UI or an AlertBar, optionally throwing if you think it should be sent to Sentry.
- Use dynamic `AlertBar` rendering along with the `useAlertBar` hook.
- Display pre-written error messages instead of relying on the error message from Apollo.