### PR TITLE
chore(experiments): Enable newsletters experiment on 50% of sync users

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/newsletter-sync.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/newsletter-sync.js
@@ -20,7 +20,7 @@ const GROUPS = [
 // This experiment is disabled by default. If you would like to go through
 // the flow, load email-first screen and append query params
 // `?forceExperiment=newsletterSync&forceExperimentGroup=new-copy`
-const ROLLOUT_RATE = 0.0;
+const ROLLOUT_RATE = 0.5;
 
 module.exports = class NewsletterSync extends BaseGroupingRule {
   constructor() {
@@ -41,13 +41,6 @@ module.exports = class NewsletterSync extends BaseGroupingRule {
    * @returns {Any}
    */
   choose(subject = {}) {
-    if (
-      subject.experimentGroupingRules.choose('newsletterCadChooser') !==
-      this.name
-    ) {
-      return false;
-    }
-
     let choice = false;
     const { isSync, lang } = subject;
 


### PR DESCRIPTION
## Because

- We want to enable this experiment
- After merge I will uplift this to the current train 

## This pull request

- Enables the newsletter sync experiment for 50% of sync users

## Issue that this pull request solves

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).