### PR TITLE
fix(tests): Point to correct metrics doc for validation which caused `browserName` unknown

### DIFF
--- a/packages/fxa-content-server/tests/server/validation.js
+++ b/packages/fxa-content-server/tests/server/validation.js
@@ -10,7 +10,7 @@ const request = require('request-promise');
 const validation = require('../../server/lib/validation');
 
 const METRICS_DOCS_URL =
-  'https://raw.githubusercontent.com/mozilla/application-services/master/docs/product-portal/accounts/metrics.md';
+  'https://raw.githubusercontent.com/mozilla/ecosystem-platform/master/docs/relying-parties/metrics-for-relying-parties.md';
 const UTM_REGEX = validation.TYPES.UTM._tests[1].arg.pattern;
 const REGEXES = new Map([
   ['entrypoint', validation.PATTERNS.ENTRYPOINT],


### PR DESCRIPTION
## Because

- We were pointing to a broken link that was used in tests
- The tests ensure that we have the correct information in the document, honestly not sure how much value this provides
- It is still a mystery to me why this gives error `browserName` undefined

## This pull request

- Point to correct metrics document

## Issue that this pull request solves

Closes: #6317 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
