### PR TITLE
refactor(fxa-shared): cleanup sentry and add exc route

### DIFF
--- a/packages/fxa-shared/nestjs/health/health.controller.spec.ts
+++ b/packages/fxa-shared/nestjs/health/health.controller.spec.ts
@@ -29,6 +29,13 @@ describe('Health Controller', () => {
     expect(await controller.heartbeat()).toStrictEqual({});
   });
 
+  it('should return heartbeat extras', async () => {
+    (controller as any).config.extraHealthData = jest
+      .fn()
+      .mockResolvedValue({ test: 'testing' });
+    expect(await controller.heartbeat()).toStrictEqual({ test: 'testing' });
+  });
+
   it('should return lbheartbeat', () => {
     expect(controller.lbheartbeat()).toStrictEqual({});
   });
@@ -36,5 +43,21 @@ describe('Health Controller', () => {
   it('should return the version', () => {
     const source = controller.versionData().source;
     expect(source).toBe(version.source);
+  });
+
+  it('should throw an exception', () => {
+    expect.assertions(1);
+    try {
+      controller.exc();
+    } catch (err) {
+      expect(err.message).toBe('Test Exception');
+    }
+  });
+
+  it('should skip throwing if too frequent', () => {
+    jest
+      .spyOn(global.Date, 'now')
+      .mockImplementationOnce(() => Date.now() - 60_000);
+    expect(controller.exc()).toBe('Too Frequent');
   });
 });

--- a/packages/fxa-shared/nestjs/health/health.controller.ts
+++ b/packages/fxa-shared/nestjs/health/health.controller.ts
@@ -7,6 +7,8 @@ import { Version } from '../version';
 import { HEALTH_CONFIG } from './health.constants';
 import { HealthControllerConfigParams } from './health.module';
 
+let lastTrigger = Date.now() - 60_000;
+
 @Controller()
 export class HealthController {
   constructor(
@@ -29,5 +31,16 @@ export class HealthController {
   @Get('__version__')
   versionData(): Version {
     return this.config.version;
+  }
+
+  @Get('__exception__')
+  exc() {
+    // Limit how frequently this could be abused.
+    const now = Date.now();
+    if (now - lastTrigger >= 60_000) {
+      lastTrigger = now;
+      throw new Error('Test Exception');
+    }
+    return 'Too Frequent';
   }
 }

--- a/packages/fxa-shared/nestjs/sentry/reporting.ts
+++ b/packages/fxa-shared/nestjs/sentry/reporting.ts
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { ExecutionContext } from '@nestjs/common';
+import { GqlContextType, GqlExecutionContext } from '@nestjs/graphql';
+import * as Sentry from '@sentry/node';
+import { SQS } from 'aws-sdk';
+import { Request } from 'express';
+
+// Matches uid, session, oauth and other common tokens which we would
+// prefer not to include in Sentry reports.
+const TOKENREGEX = /[a-fA-F0-9]{32,}/gi;
+// RFC 5322 generalized email regex, ~ 99.99% accurate.
+const EMAILREGEX = /(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/gi;
+const FILTERED = '[Filtered]';
+const URIENCODEDFILTERED = encodeURIComponent(FILTERED);
+
+export interface ExtraContext {
+  name: string;
+  fieldData: Record<string, string>;
+}
+
+/**
+ * Filters all of an objects string properties to remove tokens.
+ *
+ * @param obj Object to filter values on
+ */
+export function filterObject<T>(obj: T): T {
+  if (typeof obj === 'object' && obj) {
+    for (const [key, value] of Object.entries(obj)) {
+      if (typeof value === 'string') {
+        // Typescript can't quite infer that this is the value that was
+        // at that index, so a cast is needed.
+        (obj as any)[key] = value
+          .replace(TOKENREGEX, FILTERED)
+          .replace(EMAILREGEX, FILTERED);
+      }
+    }
+  }
+  return obj;
+}
+
+/**
+ * Filter a sentry event for PII in addition to the default filters.
+ *
+ * Current replacements:
+ *   - A 32-char hex string that typically is a FxA user-id.
+ *
+ * Data Removed:
+ *   - Request body.
+ *
+ * @param event
+ */
+export function filterSentryEvent(event: Sentry.Event, hint: unknown) {
+  if (event.message) {
+    event.message = event.message.replace(TOKENREGEX, FILTERED);
+  }
+  if (event.breadcrumbs) {
+    for (const bc of event.breadcrumbs) {
+      if (bc.message) {
+        bc.message = bc.message.replace(TOKENREGEX, FILTERED);
+      }
+      if (bc.data) {
+        bc.data = filterObject(bc.data);
+      }
+    }
+  }
+  if (event.request) {
+    if (event.request.url) {
+      event.request.url = event.request.url.replace(TOKENREGEX, FILTERED);
+    }
+    if (event.request.query_string) {
+      event.request.query_string = event.request.query_string.replace(
+        TOKENREGEX,
+        URIENCODEDFILTERED
+      );
+    }
+    if (event.request.headers) {
+      (event as any).request.headers = filterObject(event.request.headers);
+    }
+    if (event.request.data) {
+      // Remove request data entirely
+      delete event.request.data;
+    }
+  }
+  if (event.tags && event.tags.url) {
+    event.tags.url = event.tags.url.replace(TOKENREGEX, FILTERED);
+  }
+  return event;
+}
+
+/**
+ * Capture a SQS Error to Sentry with additional context.
+ *
+ * @param err Error object to capture.
+ * @param message SQS Message to include with error.
+ */
+export function captureSqsError(err: Error, message?: SQS.Message): void {
+  Sentry.withScope((scope) => {
+    if (message?.Body) {
+      if (typeof message.Body === 'string') {
+        message.Body = message.Body.replace(TOKENREGEX, FILTERED).replace(
+          EMAILREGEX,
+          FILTERED
+        );
+      }
+      scope.setContext('SQS Message', message);
+    }
+    Sentry.captureException(err);
+  });
+}
+
+/**
+ * Report an exception with request and additional optional context objects.
+ *
+ * @param exception
+ * @param excContexts List of additional exception context objects to capture.
+ * @param request A request object if available.
+ */
+export function reportRequestException(
+  exception: Error,
+  excContexts: ExtraContext[] = [],
+  request?: Request
+) {
+  Sentry.withScope((scope: Sentry.Scope) => {
+    scope.addEventProcessor((event: Sentry.Event) => {
+      if (request) {
+        const sentryEvent = Sentry.Handlers.parseRequest(event, request);
+        sentryEvent.level = Sentry.Severity.Error;
+        return sentryEvent;
+      }
+      return null;
+    });
+    for (const ctx of excContexts) {
+      scope.setContext(ctx.name, ctx.fieldData);
+    }
+    Sentry.captureException(exception);
+  });
+}
+
+export function processException(context: ExecutionContext, exception: Error) {
+  // First determine what type of a request this is
+  let requestType: 'http' | 'graphql' | undefined;
+  let request: Request | undefined;
+  let gqlExec: GqlExecutionContext | undefined;
+  if (context.getType() === 'http') {
+    requestType = 'http';
+    request = context.switchToHttp().getRequest();
+  } else if (context.getType<GqlContextType>() === 'graphql') {
+    requestType = 'graphql';
+    gqlExec = GqlExecutionContext.create(context);
+    request = gqlExec.getContext().req;
+  }
+  let excContexts: ExtraContext[] = [];
+  if (gqlExec) {
+    const info = gqlExec.getInfo();
+    excContexts.push({
+      name: 'graphql',
+      fieldData: { fieldName: info.fieldName, path: info.path },
+    });
+  }
+
+  reportRequestException(exception, excContexts, request);
+}

--- a/packages/fxa-shared/nestjs/sentry/sentry.service.ts
+++ b/packages/fxa-shared/nestjs/sentry/sentry.service.ts
@@ -4,22 +4,14 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ExtraErrorData } from '@sentry/integrations';
 import * as Sentry from '@sentry/node';
-import { SQS } from 'aws-sdk';
 
+import { filterSentryEvent } from './reporting';
 import { SENTRY_CONFIG } from './sentry.constants';
 import { SentryConfigParams } from './sentry.module';
 
-// Matches uid, session, oauth and other common tokens which we would
-// prefer not to include in Sentry reports.
-const TOKENREGEX = /[a-fA-F0-9]{32,}/gi;
-// RFC 5322 generalized email regex, ~ 99.99% accurate.
-const EMAILREGEX = /(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/gi;
-const FILTERED = '[Filtered]';
-const URIENCODEDFILTERED = encodeURIComponent(FILTERED);
-
 @Injectable()
 export class SentryService {
-  constructor(@Inject(SENTRY_CONFIG) private sentryConfig: SentryConfigParams) {
+  constructor(@Inject(SENTRY_CONFIG) sentryConfig: SentryConfigParams) {
     // Setup Sentry
     Sentry.init({
       ...sentryConfig,
@@ -29,94 +21,4 @@ export class SentryService {
       },
     });
   }
-}
-
-/**
- * Filters all of an objects string properties to remove tokens.
- *
- * @param obj Object to filter values on
- */
-function filterObject<T>(obj: T): T {
-  if (typeof obj === 'object' && obj) {
-    for (const [key, value] of Object.entries(obj)) {
-      if (typeof value === 'string') {
-        // Typescript can't quite infer that this is the value that was
-        // at that index, so a cast is needed.
-        (obj as any)[key] = value
-          .replace(TOKENREGEX, FILTERED)
-          .replace(EMAILREGEX, FILTERED);
-      }
-    }
-  }
-  return obj;
-}
-
-/**
- * Filter a sentry event for PII in addition to the default filters.
- *
- * Current replacements:
- *   - A 32-char hex string that typically is a FxA user-id.
- *
- * Data Removed:
- *   - Request body.
- *
- * @param event
- */
-function filterSentryEvent(event: Sentry.Event, hint: unknown) {
-  if (event.message) {
-    event.message = event.message.replace(TOKENREGEX, FILTERED);
-  }
-  if (event.breadcrumbs) {
-    for (const bc of event.breadcrumbs) {
-      if (bc.message) {
-        bc.message = bc.message.replace(TOKENREGEX, FILTERED);
-      }
-      if (bc.data) {
-        bc.data = filterObject(bc.data);
-      }
-    }
-  }
-  if (event.request) {
-    if (event.request.url) {
-      event.request.url = event.request.url.replace(TOKENREGEX, FILTERED);
-    }
-    if (event.request.query_string) {
-      event.request.query_string = event.request.query_string.replace(
-        TOKENREGEX,
-        URIENCODEDFILTERED
-      );
-    }
-    if (event.request.headers) {
-      (event as any).request.headers = filterObject(event.request.headers);
-    }
-    if (event.request.data) {
-      // Remove request data entirely
-      delete event.request.data;
-    }
-  }
-  if (event.tags && event.tags.url) {
-    event.tags.url = event.tags.url.replace(TOKENREGEX, FILTERED);
-  }
-  return event;
-}
-
-/**
- * Capture a SQS Error to Sentry with additional context.
- *
- * @param err Error object to capture.
- * @param message SQS Message to include with error.
- */
-export function captureSqsError(err: Error, message?: SQS.Message): void {
-  Sentry.withScope((scope) => {
-    if (message?.Body) {
-      if (typeof message.Body === 'string') {
-        message.Body = message.Body.replace(TOKENREGEX, FILTERED).replace(
-          EMAILREGEX,
-          FILTERED
-        );
-      }
-      scope.setContext('SQS Message', message);
-    }
-    Sentry.captureException(err);
-  });
 }


### PR DESCRIPTION
Because:

* Sentry relocation didn't clean up reporting functionality from the
  service using it.
* We had no way to verify exceptions are thrown and captured by Sentry.

This commit:

* Refactors the sentry reporting functionality so it can be used
  directly by other code.
* Adds an __exception__ route with basic trigger protection to avoid
  excessive error reporting.

Closes #6454

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
