### PR TITLE
fix(event-broker): possible guard fix + logging

### DIFF
--- a/packages/fxa-event-broker/src/auth/google-jwt-auth.guard.ts
+++ b/packages/fxa-event-broker/src/auth/google-jwt-auth.guard.ts
@@ -1,3 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { ExecutionContext, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { AuthGuard } from '@nestjs/passport';
@@ -5,22 +8,20 @@ import { Observable } from 'rxjs';
 
 import { AppConfig } from '../config';
 
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 @Injectable()
 export class GoogleJwtAuthGuard extends AuthGuard('googlejwt') {
-  private env: string;
+  private authenticate: boolean;
 
   constructor(configService: ConfigService<AppConfig>) {
     super();
-    this.env = configService.get('env') as string;
+    const authConfig = configService.get('pubsub') as AppConfig['pubsub'];
+    this.authenticate = authConfig.authenticate;
   }
 
   canActivate(
     context: ExecutionContext
   ): boolean | Promise<boolean> | Observable<boolean> {
-    if (this.env === 'development') {
+    if (!this.authenticate) {
       return true;
     } else {
       return super.canActivate(context);

--- a/packages/fxa-event-broker/src/auth/googlejwt.strategy.ts
+++ b/packages/fxa-event-broker/src/auth/googlejwt.strategy.ts
@@ -12,8 +12,7 @@ import { AppConfig } from '../config';
 import { PubSubJWT } from './pubsubclaim.interface';
 
 @Injectable()
-export class GoogleJwtStrategy extends PassportStrategy(Strategy) {
-  public readonly name = 'googlejwt';
+export class GoogleJwtStrategy extends PassportStrategy(Strategy, 'googlejwt') {
   private verificationToken: string;
 
   constructor(configService: ConfigService<AppConfig>) {

--- a/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.spec.ts
+++ b/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.spec.ts
@@ -122,6 +122,9 @@ describe('PubsubProxy Controller', () => {
           load: [
             () => ({
               env: 'development',
+              pubsub: {
+                authenticate: true,
+              },
               serviceNotificationQueueUrl:
                 'https://us-east-1/queue.|api-domain|/321321321/notifications',
               log: { app: 'test' },

--- a/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.ts
+++ b/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.ts
@@ -38,6 +38,10 @@ export class PubsubProxyController {
   ): Promise<void> {
     const webhookData = this.webhookService.webhooks;
     if (!Object.keys(webhookData).includes(clientId)) {
+      this.log.debug('proxyDelivery', {
+        message: 'webhook for clientId not found',
+        clientId,
+      });
       res.status(404).send();
       return;
     }
@@ -92,8 +96,13 @@ export class PubsubProxyController {
           clientId,
           statusCode: (err.response as AxiosResponse).status.toString(),
         });
+        this.log.debug('proxyDeliverFail', {
+          response: err.response,
+          message: 'failed to proxy message',
+        });
         response = err.response;
       } else {
+        this.log.error('proxyDeliverError', { err });
         throw err;
       }
     }


### PR DESCRIPTION
Because:

* It's possible I named the strategy in the incorrect location when
  moving this to NestJS.
* We would like more debug logging to detect details about why a proxy
  request may have failed from an RP.

This commit:

* Moves the strategy name so the guard could pick it up.
* Adds more logging to the pubsub controller for additional debugging.

Issue #6458

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Additional Notes

I spent a bit of time with Lets Encrypt and a Google console to setup the event-broker locally and verify that the auth is working. It is! That means the error is possibly somewhere else in the delivery chain, which we need to verify in our dev environment. So additional logging is included here.