### PR TITLE
chore(deps): fixed yarn dependency warnings

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -18,6 +18,11 @@ packageExtensions:
       "@types/react": 16.9.35
       apollo-client: 2.6.10
       graphql: 14.6.0
+  "@nestjs/graphql@^7.6.0":
+    dependencies:
+      class-transformer: ^0.3.1
+      class-validator: ^0.12.2
+      "@nestjs/mapped-types": ^0.1.0
   "@storybook/addon-actions@*":
     dependencies:
       react-dom: 16.13.1

--- a/packages/fortress/package.json
+++ b/packages/fortress/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "audit-filter": "0.5.0",
-    "browser-sync": "^2.26.7",
     "eslint": "^6.8.0",
     "eslint-plugin-fxa": "^2.0.2",
     "fxa-shared": "workspace:*",
@@ -50,7 +49,6 @@
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
     "test": "npm run lint",
-    "format": "prettier --write --config ../../_dev/.prettierrc '**'",
-    "ui": "browser-sync start --proxy='localhost:9292' --files='**/*.css, **/*.ejs, **/*.js' --ignore=node_modules --port=5000 --no-open --serveStatic='static'"
+    "format": "prettier --write --config ../../_dev/.prettierrc '**'"
   }
 }

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -104,7 +104,7 @@
     "prettier": "^2.0.5",
     "supertest": "^4.0.2",
     "tailwindcss": "^1.7.3",
-    "ts-jest": "^24.3.0",
+    "ts-jest": "^26.3.0",
     "ts-node": "^8.10.2",
     "typescript": "3.9.7",
     "webpack": "^4.43.0"

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -37,7 +37,7 @@
     "@google-cloud/pubsub": "^2.3.0",
     "@grpc/grpc-js": "^1.1.3",
     "@hapi/hoek": "^9.0.4",
-    "@hapi/joi": "^17.1.1",
+    "@hapi/joi": "^15.1.1",
     "@nestjs/common": "^7.4.4",
     "@nestjs/config": "^0.5.0",
     "@nestjs/core": "^7.4.4",
@@ -51,6 +51,7 @@
     "@types/sinon": "9.0.5",
     "aws-sdk": "^2.733.0",
     "axios": "^0.20.0",
+    "class-transformer": "^0.3.1",
     "class-validator": "^0.12.2",
     "convict": "^6.0.0",
     "convict-format-with-moment": "^6.0.0",
@@ -59,6 +60,7 @@
     "fxa-jwtool": "^0.7.2",
     "fxa-shared": "workspace:*",
     "google-auth-library": "^6.0.6",
+    "graphql": "^14.6.0",
     "hot-shots": "^7.8.0",
     "jwks-rsa": "^1.9.0",
     "mozlog": "^3.0.1",
@@ -66,7 +68,7 @@
     "passport-jwt": "^4.0.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
-    "rxjs": "^6.6.3",
+    "rxjs": "^6.5.5",
     "sqs-consumer": "^5.4.0",
     "typesafe-joi": "^2.1.0",
     "uuid": "^8.3.0"
@@ -103,7 +105,7 @@
     "ts-loader": "^6.2.1",
     "ts-node": "^8.6.2",
     "tsconfig-paths": "^3.9.0",
-    "typesafe-node-firestore": "^1.3.0",
+    "typesafe-node-firestore": "^1.4.0",
     "typescript": "3.9.7"
   },
   "jest": {

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -90,7 +90,7 @@
     "redux-devtools-extension": "^2.13.8",
     "sinon": "^9.0.3",
     "supertest": "^4.0.2",
-    "ts-jest": "^24.3.0",
+    "ts-jest": "^26.3.0",
     "ts-node": "^8.10.2",
     "typescript": "3.9.7",
     "wait-for-expect": "^1.3.0",

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -64,7 +64,7 @@
     "sass": "1.26.10",
     "sass-loader": "^8.0.2",
     "tailwindcss": "^1.7.3",
-    "ts-jest": "^24.3.0",
+    "ts-jest": "^26.3.0",
     "typescript": "3.9.7",
     "webpack": "^4.43.0"
   },

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -84,10 +84,12 @@
     "aws-sdk": "^2.752.0",
     "bluebird": "^3.7.2",
     "celebrate": "^10.0.1",
+    "class-transformer": "^0.3.1",
+    "class-validator": "^0.12.2",
     "cors": "^2.8.5",
     "find-up": "^5.0.0",
     "generic-pool": "^3.7.1",
-    "graphql": "^15.3.0",
+    "graphql": "^14.6.0",
     "hot-shots": "^7.8.0",
     "joi": "^14.3.1",
     "js-md5": "^0.7.3",
@@ -98,7 +100,7 @@
     "node-uap": "git://github.com/mozilla-fxa/node-uap.git#96dc1f9f224422ec184395b6408cd1fc40ee452a",
     "redis": "^2.8.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^6.6.3",
+    "rxjs": "^6.5.5",
     "stripe": "^8.69.0"
   },
   "jest": {

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -29,7 +29,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "@hapi/hapi": "^20.0.0",
-    "@hapi/joi": "^17.1.1",
+    "@hapi/joi": "^15.1.1",
     "@hapi/scooter": "^6.0.0",
     "blankie": "^5.0.0",
     "convict": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3476,18 +3476,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/mapped-types@npm:0.0.5":
-  version: 0.0.5
-  resolution: "@nestjs/mapped-types@npm:0.0.5"
-  peerDependencies:
-    "@nestjs/common": ^7.0.8
-    class-transformer: ^0.2.3
-    class-validator: ^0.11.1 || ^0.12.0
-    reflect-metadata: ^0.1.12
-  checksum: bf954e22d129f12a1443d02d25c46fd594eb847d8ad2dca5c98b06cde470b9dab8c077abdf269098008736d1a041b49ceab1c74abff31f493356164976bdf36d
-  languageName: node
-  linkType: hard
-
 "@nestjs/mapped-types@npm:^0.1.0":
   version: 0.1.0
   resolution: "@nestjs/mapped-types@npm:0.1.0"
@@ -5725,7 +5713,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:^26.0.13":
+"@types/jest@npm:26.x, @types/jest@npm:^26.0.13":
   version: 26.0.13
   resolution: "@types/jest@npm:26.0.13"
   dependencies:
@@ -7440,13 +7428,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"after@npm:0.8.2":
-  version: 0.8.2
-  resolution: "after@npm:0.8.2"
-  checksum: ac1e164f625a9715daaef092bdc1ceb11d053d95d343d83315c10eced4fdc4ead499f7c25d433aabc26f32cd736370551998a6ce7ab9ad9c2d978cca41852858
-  languageName: node
-  linkType: hard
-
 "agent-base@npm:4, agent-base@npm:^4.2.0, agent-base@npm:^4.3.0":
   version: 4.3.0
   resolution: "agent-base@npm:4.3.0"
@@ -8467,13 +8448,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"arraybuffer.slice@npm:~0.0.7":
-  version: 0.0.7
-  resolution: "arraybuffer.slice@npm:0.0.7"
-  checksum: d7775846f098c6294029a34fad1dd19e6b90f388eb19d6181ff9265fd9ffae4f5f7b243d3b39275b7ffc7ddc7923ae1df83dff720a0001dc1fb740ea4e3a458c
-  languageName: node
-  linkType: hard
-
 "arrify@npm:^1.0.1":
   version: 1.0.1
   resolution: "arrify@npm:1.0.1"
@@ -8653,13 +8627,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async-each-series@npm:0.1.1":
-  version: 0.1.1
-  resolution: "async-each-series@npm:0.1.1"
-  checksum: 48cda18872a4ec0be68f3c6e594242f74456a2ffa4b979f63981e94ae6df8959fb66acd7ae1cfba39c38720faae6da724051435d72a530a555d6dd30564a5237
-  languageName: node
-  linkType: hard
-
 "async-each@npm:^1.0.1":
   version: 1.0.3
   resolution: "async-each@npm:1.0.3"
@@ -8723,7 +8690,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:1.5, async@npm:1.5.2, async@npm:^1.5.2, async@npm:~1.5.2":
+"async@npm:1.5, async@npm:^1.5.2, async@npm:~1.5.2":
   version: 1.5.2
   resolution: "async@npm:1.5.2"
   checksum: 1a83326544c94e5e18203e548f3abca73af85222017e3db6701a2a188044ec711543ccdd62ecae0afeb76f0efca505d61281404d4cef1a3ca576f7b10333d089
@@ -8935,16 +8902,6 @@ __metadata:
   version: 1.9.1
   resolution: "aws4@npm:1.9.1"
   checksum: d59822631844f9da1caf966cfab90ffafa22cc6c50835f9f5ebff83acdbcffc24eca44fa50d4aa191a6cee81747df38b9880547cc1df8a1380c80dd507b8e6ce
-  languageName: node
-  linkType: hard
-
-"axios@npm:0.19.0":
-  version: 0.19.0
-  resolution: "axios@npm:0.19.0"
-  dependencies:
-    follow-redirects: 1.5.10
-    is-buffer: ^2.0.2
-  checksum: be5f8504a1adcb74e4a0353238a81e129f181c7ad65c13feda589c793fcf148e09afe721df808ac6ed2ffcdb95f9b7143e2c44d1bc90056b3e2523f5ed3e2fbd
   languageName: node
   linkType: hard
 
@@ -10184,7 +10141,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"backo2@npm:1.0.2, backo2@npm:^1.0.2":
+"backo2@npm:^1.0.2":
   version: 1.0.2
   resolution: "backo2@npm:1.0.2"
   checksum: 72f19a0fd2b573f5504adf1f2e74e7658eec000e7732ebd5f622b6b1d520187277a5e8310787906455d02fcf915f35c5c48e54c997bed1a60b95355db8f2ccab
@@ -10221,13 +10178,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-arraybuffer@npm:0.1.5":
-  version: 0.1.5
-  resolution: "base64-arraybuffer@npm:0.1.5"
-  checksum: 9ae66a41b880831fbac1bdb9d1ca79d60fb16209b3da6e176cc1b9336a4d34cd48e05a2b919e443bfd4b03a402b043132dc7d0fa3282c1e74baa2c2daf58fa93
-  languageName: node
-  linkType: hard
-
 "base64-js@npm:0.0.2":
   version: 0.0.2
   resolution: "base64-js@npm:0.0.2"
@@ -10239,13 +10189,6 @@ __metadata:
   version: 1.3.1
   resolution: "base64-js@npm:1.3.1"
   checksum: 8a0cc69d7c7c0ab75c164d3e2eccc3dd65fbaba17bcf440aab54636afd31255287ac3cd16a111e98d741c4a6e0b5631774b0c32818355089e645df3ae96a49bb
-  languageName: node
-  linkType: hard
-
-"base64id@npm:1.0.0":
-  version: 1.0.0
-  resolution: "base64id@npm:1.0.0"
-  checksum: c260117da21982276b43d3dcd00b157942065bfedba7dda4df32e00d85ccce5e9a4724d1a0d6d10cf18a74668fa4ef32f85a75e6ebae08c46bfeda16ef57ebe6
   languageName: node
   linkType: hard
 
@@ -10317,15 +10260,6 @@ __metadata:
     lodash: ^4.17.4
     platform: ^1.3.3
   checksum: 3d3d8f4771b7f9b17f1a967b8f5e70319930fcec2691b35418062342bfbbd1a3221b3129aaf5938fc6a85703837f8cdf2f6875349c158c5aa574b6eb36ab6baa
-  languageName: node
-  linkType: hard
-
-"better-assert@npm:~1.0.0":
-  version: 1.0.2
-  resolution: "better-assert@npm:1.0.2"
-  dependencies:
-    callsite: 1.0.0
-  checksum: bc6a68fcd5da7727878e35961e917132058796b28119dcaf7a6f1d88f6c87d37ffd256d13cd7f0a4e332abac35dd1b4c8a09be43edfcfd1f7939915114fe81f0
   languageName: node
   linkType: hard
 
@@ -10445,13 +10379,6 @@ __metadata:
   bin:
     blessed: ./bin/tput.js
   checksum: 92fcf3965851765aa47e6f7a9fca36a20dda2e104c1d0fe6c85c76eeee3b31e8e24a9fc173ae0e5b71e42c7da43e59bb1646f9b596366972f6768764eeb04698
-  languageName: node
-  linkType: hard
-
-"blob@npm:0.0.5":
-  version: 0.0.5
-  resolution: "blob@npm:0.0.5"
-  checksum: 41fbd9f746890eb809ab232995abac41afeb265ba37a5f35694dee36a906d63ab9626aff3db3868d18ec39e826878c93913cd0a3258cd1c310d451dff369658c
   languageName: node
   linkType: hard
 
@@ -10665,72 +10592,6 @@ __metadata:
   version: 1.3.1
   resolution: "browser-stdout@npm:1.3.1"
   checksum: 2f91b1ad26f3401ae68801d901754331811e257aeed4ee0eb287cc2ff375c8fffadb2d14a16654eeb0729e3b1ae6d84642ba7a3119880843d774ee1db2b898b3
-  languageName: node
-  linkType: hard
-
-"browser-sync-client@npm:^2.26.6":
-  version: 2.26.6
-  resolution: "browser-sync-client@npm:2.26.6"
-  dependencies:
-    etag: 1.8.1
-    fresh: 0.5.2
-    mitt: ^1.1.3
-    rxjs: ^5.5.6
-  checksum: b5f7aba26eedf5895f761762bf95ddc99de2806a034c154985e25580c345fdcdc86b87208d897283eca4dc8d4b7ab1d25ad99c36844313401d157f165645a1b1
-  languageName: node
-  linkType: hard
-
-"browser-sync-ui@npm:^2.26.4":
-  version: 2.26.4
-  resolution: "browser-sync-ui@npm:2.26.4"
-  dependencies:
-    async-each-series: 0.1.1
-    connect-history-api-fallback: ^1
-    immutable: ^3
-    server-destroy: 1.0.1
-    socket.io-client: ^2.0.4
-    stream-throttle: ^0.1.3
-  checksum: 429cfd441ac982395a6ca92137099c77aae0177398e8ac85b03d604abed9283ccf611f2efebc625ae8c1daf75f46cb6241ee2e87bf585301bb59e0ede9b0d48b
-  languageName: node
-  linkType: hard
-
-"browser-sync@npm:^2.26.7":
-  version: 2.26.7
-  resolution: "browser-sync@npm:2.26.7"
-  dependencies:
-    browser-sync-client: ^2.26.6
-    browser-sync-ui: ^2.26.4
-    bs-recipes: 1.3.4
-    bs-snippet-injector: ^2.0.1
-    chokidar: ^2.0.4
-    connect: 3.6.6
-    connect-history-api-fallback: ^1
-    dev-ip: ^1.0.1
-    easy-extender: ^2.3.4
-    eazy-logger: ^3
-    etag: ^1.8.1
-    fresh: ^0.5.2
-    fs-extra: 3.0.1
-    http-proxy: 1.15.2
-    immutable: ^3
-    localtunnel: 1.9.2
-    micromatch: ^3.1.10
-    opn: 5.3.0
-    portscanner: 2.1.1
-    qs: 6.2.3
-    raw-body: ^2.3.2
-    resp-modifier: 6.0.2
-    rx: 4.1.0
-    send: 0.16.2
-    serve-index: 1.9.1
-    serve-static: 1.13.2
-    server-destroy: 1.0.1
-    socket.io: 2.1.1
-    ua-parser-js: 0.7.17
-    yargs: 6.4.0
-  bin:
-    browser-sync: dist/bin.js
-  checksum: b75784e11c63f89396738fa90d07ae8a1cc0cb728df11f67108ce8fd5de9932273dcea2ef747446d06e874772016717cd9e489baf88cd282ededb0333f6c4700
   languageName: node
   linkType: hard
 
@@ -11012,20 +10873,6 @@ __metadata:
   dependencies:
     fast-json-stable-stringify: 2.x
   checksum: f5f2f1315d6ceac655c3945d149086a5f5a90b3c908780757e12e938aad0125a7aa563cae2f7153ccf43443adb1b88a44960a61063903c3973e1dfdda6fc2d8c
-  languageName: node
-  linkType: hard
-
-"bs-recipes@npm:1.3.4":
-  version: 1.3.4
-  resolution: "bs-recipes@npm:1.3.4"
-  checksum: 35a3543c3cd4a281235a556715ff5ba55543df383ad6b205d673e46431b2288d6eb0b5d1fc882db1f68b73a549005fa937f2c3f73de1b2b6cadb54ed7a55219c
-  languageName: node
-  linkType: hard
-
-"bs-snippet-injector@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "bs-snippet-injector@npm:2.0.1"
-  checksum: 262519e821483452b4e373c293391fb3aaea7a3ae7118cf217a24fc33a577e2dc87074e13d0f60731d0c6b9e128a3cdfeb2f62a288527985d83f890d94b68540
   languageName: node
   linkType: hard
 
@@ -11398,13 +11245,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"callsite@npm:1.0.0":
-  version: 1.0.0
-  resolution: "callsite@npm:1.0.0"
-  checksum: 5940b23533433f4886dea106cdb16d8a511b36ebaf2ac0bbe0adae547a4259f142d37074f864e12f424927b50cf364fffd1fd75d45a62a622d22984d2375e859
-  languageName: node
-  linkType: hard
-
 "callsites@npm:^2.0.0":
   version: 2.0.0
   resolution: "callsites@npm:2.0.0"
@@ -11499,20 +11339,6 @@ __metadata:
   version: 2.1.1
   resolution: "camelcase@npm:2.1.1"
   checksum: 311182686b3b87ac07851d6bc8c1327d55ef5fe95403bce97e21696dfe666dec70cf2b008593c00ae69a2b84e0074e4c130157a41db1d237f6fe5686cbf870b3
-  languageName: node
-  linkType: hard
-
-"camelcase@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "camelcase@npm:3.0.0"
-  checksum: 7993433f5bc180928f70399b06a0f11a02840bfe027e51a7e6c1b4f68c5c3119a58ec64e17b3112acab9ba420a97613956a0a2cf65f6fc8247fc9938aee64de6
-  languageName: node
-  linkType: hard
-
-"camelcase@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "camelcase@npm:4.1.0"
-  checksum: 6ca41b5114ef3683013fb51cf9a11c60dcfeef90ceb0075c2d77b7455819e2acdcc7fb5c033314f862212acb23056f1774879dfc580938a9a27ecc345856d1a3
   languageName: node
   linkType: hard
 
@@ -11980,6 +11806,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"class-transformer@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "class-transformer@npm:0.3.1"
+  checksum: 3ae3ef2510d2822766a97d31eb7ca550dabda56cbfe70968f295420531667ca95b4d84cddfe2dc302abc41c8e26d667d43235b0f4759eee09a007741cc307bc8
+  languageName: node
+  linkType: hard
+
 "class-utils@npm:^0.3.5":
   version: 0.3.6
   resolution: "class-utils@npm:0.3.6"
@@ -12179,17 +12012,6 @@ __metadata:
     right-align: ^0.1.1
     wordwrap: 0.0.2
   checksum: ea93f1e985c99196f460e8b8bc6fb5363f6088f94fc036e418f02bbc7f54cc39aabd7134c255ceefd487e1f2484d80ed39456ba5a7e110ca68412ca062e8bd0a
-  languageName: node
-  linkType: hard
-
-"cliui@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "cliui@npm:3.2.0"
-  dependencies:
-    string-width: ^1.0.1
-    strip-ansi: ^3.0.1
-    wrap-ansi: ^2.0.0
-  checksum: 369a15d48058633e21e024c29ad314e082da6da6c9ed322385ac3171bce305bb3b3d61374cbe5444feca445de06ffaa2239cf8edb8307dad6a4b6ef62200a281
   languageName: node
   linkType: hard
 
@@ -12500,7 +12322,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.11.0, commander@npm:^2.19.0, commander@npm:^2.2.0, commander@npm:^2.20.0, commander@npm:^2.20.3, commander@npm:~2.20.3":
+"commander@npm:^2.11.0, commander@npm:^2.19.0, commander@npm:^2.20.0, commander@npm:^2.20.3, commander@npm:~2.20.3":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: b73428e97de7624323f81ba13f8ed9271de487017432d18b4da3f07cfc528ad754bbd199004bd5d14e0ccd67d1fdfe0ec8dbbd4c438b401df3c4cc387bfd1daa
@@ -12568,31 +12390,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"component-bind@npm:1.0.0":
-  version: 1.0.0
-  resolution: "component-bind@npm:1.0.0"
-  checksum: afbea09480c570b50fb86d8b4bee5d8b4809c667d8a7072cab0d48832f2cb9ebd62bf61b28722f1560cf7a2b0c2c171f8ef120229ec88e9cf332833cbf2779e8
-  languageName: node
-  linkType: hard
-
-"component-emitter@npm:1.2.1":
-  version: 1.2.1
-  resolution: "component-emitter@npm:1.2.1"
-  checksum: faa45682ad4f3796803e254793f843b54c4f10f9fd8d23a1ed37a174dd2cc847a48dd2b6d016aa55465192d752ec2dada71391ac502ce61202816973678587bb
-  languageName: node
-  linkType: hard
-
 "component-emitter@npm:^1.2.0, component-emitter@npm:^1.2.1, component-emitter@npm:^1.3.0":
   version: 1.3.0
   resolution: "component-emitter@npm:1.3.0"
   checksum: fc4edbf1014f0aed88dcec33ca02d2938734e428423f640d8a3f94975615b8e8c506c19e29b93949637c5a281353e75fa79e299e0d57732f42a9fe346cb2cad6
-  languageName: node
-  linkType: hard
-
-"component-inherit@npm:0.0.3":
-  version: 0.0.3
-  resolution: "component-inherit@npm:0.0.3"
-  checksum: b0caec57577c475a5111ca0a83ae884001c3b4f16f0ff37cf1f0674a71a5419617a65880a691c6bb8a8a4343c96c2e5ec204e40193cabe890aed85b30ba9513e
   languageName: node
   linkType: hard
 
@@ -12712,22 +12513,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"connect-history-api-fallback@npm:^1, connect-history-api-fallback@npm:^1.6.0":
+"connect-history-api-fallback@npm:^1.6.0":
   version: 1.6.0
   resolution: "connect-history-api-fallback@npm:1.6.0"
   checksum: 298f60415d5f5480b76f98d8bf83737cae9f05921e3d3479452cae34ed3498fab35a1c4c8f19ca5b327bbbe759098f5f6e5fc097d829f607d0d642b075c93e21
-  languageName: node
-  linkType: hard
-
-"connect@npm:3.6.6":
-  version: 3.6.6
-  resolution: "connect@npm:3.6.6"
-  dependencies:
-    debug: 2.6.9
-    finalhandler: 1.1.0
-    parseurl: ~1.3.2
-    utils-merge: 1.0.1
-  checksum: 920ce1914953508a51075f97954619626fee24ed84e65ada2f86ce4f32de4666ec5da6b03bef0a6e49aa6d19172451132dc130546b38cd31a431f8090353d7dd
   languageName: node
   linkType: hard
 
@@ -12873,13 +12662,6 @@ __metadata:
   version: 1.0.6
   resolution: "cookie-signature@npm:1.0.6"
   checksum: 305054e102eebd0a483c63aefdc3abf54a9471bed5eb12be56c0dcf35a94110b8a13139b27751ab07a5ef09e9f4190ee67f71e9d3acf1748e6e2f1aed338c987
-  languageName: node
-  linkType: hard
-
-"cookie@npm:0.3.1":
-  version: 0.3.1
-  resolution: "cookie@npm:0.3.1"
-  checksum: 5fb6caf84d4e1f5684abae2a29d019466166a452539ef43562eaba5bf2f5d40a5cf0d0b4e46614fb8e6b408fd0c718885ba6696ce976e2c53d07216152ec7091
   languageName: node
   linkType: hard
 
@@ -13810,7 +13592,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:3.1.0, debug@npm:=3.1.0, debug@npm:~3.1.0":
+"debug@npm:3.1.0, debug@npm:=3.1.0":
   version: 3.1.0
   resolution: "debug@npm:3.1.0"
   dependencies:
@@ -13828,7 +13610,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:4.1.1, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:~4.1.0, debug@npm:~4.1.1":
+"debug@npm:4, debug@npm:4.1.1, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:~4.1.1":
   version: 4.1.1
   resolution: "debug@npm:4.1.1"
   dependencies:
@@ -13847,7 +13629,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decamelize@npm:^1.0.0, decamelize@npm:^1.1.0, decamelize@npm:^1.1.1, decamelize@npm:^1.1.2, decamelize@npm:^1.2.0":
+"decamelize@npm:^1.0.0, decamelize@npm:^1.1.0, decamelize@npm:^1.1.2, decamelize@npm:^1.2.0":
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: 8ca9d03ea8ac07920f4504e219d18edff2491bdd0a3e05a1e5ca2e9a0bf6333564231de3528b01d5e76c40a38c37bbc1e09cb5a0424714f53dd615ed78ced464
@@ -14325,15 +14107,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dev-ip@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "dev-ip@npm:1.0.1"
-  bin:
-    dev-ip: lib/dev-ip.js
-  checksum: 90dbcc30a3fb105ed0c394d845821dfa90ec38f2c7576431aa6cabf4282983262d00ddb50fac76777c316be152f9851eda520e3b59593bd58de3a3cfebe8ccc3
-  languageName: node
-  linkType: hard
-
 "dicer@npm:0.2.5":
   version: 0.2.5
   resolution: "dicer@npm:0.2.5"
@@ -14762,24 +14535,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"easy-extender@npm:^2.3.4":
-  version: 2.3.4
-  resolution: "easy-extender@npm:2.3.4"
-  dependencies:
-    lodash: ^4.17.10
-  checksum: aa8a31b3f20ff236b7bf8a15ba15979750963a6999e9db8ec30cee9696363a7805b115bd68ce6eaa4ec5b65905043ad019c9c3a92d05200f8a0e2fe514904b36
-  languageName: node
-  linkType: hard
-
-"eazy-logger@npm:^3":
-  version: 3.0.2
-  resolution: "eazy-logger@npm:3.0.2"
-  dependencies:
-    tfunk: ^3.0.1
-  checksum: 7d481f35c0468f5d9d8b8499cc4cdaef831964d96d7bdfc39bb0f41df3802b511e47659a8644e6c5999a5ca2766448044113a266b0fb90197e612deb0cb54be1
-  languageName: node
-  linkType: hard
-
 "ecc-jsbn@npm:~0.1.1":
   version: 0.1.2
   resolution: "ecc-jsbn@npm:0.1.2"
@@ -14920,7 +14675,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"encodeurl@npm:~1.0.1, encodeurl@npm:~1.0.2":
+"encodeurl@npm:~1.0.2":
   version: 1.0.2
   resolution: "encodeurl@npm:1.0.2"
   checksum: 6ee5fcbcd245d2a2b6bd6fe36b80f91e31ab46e29192c50af00e8f860c0c2310ebbdaae40257878fdce90b42abcb3526895c7c3a2e229461ed1f0d0b5a020fc8
@@ -14942,84 +14697,6 @@ __metadata:
   dependencies:
     once: ^1.4.0
   checksum: 7da60e458bdb5e16c006a45e85ef3bc1e3791db5ba275b0913258ccddc8899acb9252c4ddbcce87bd1b46e2a3f97315aafb9f0c0330e8aac44defb504a9d3ccd
-  languageName: node
-  linkType: hard
-
-"engine.io-client@npm:~3.2.0":
-  version: 3.2.1
-  resolution: "engine.io-client@npm:3.2.1"
-  dependencies:
-    component-emitter: 1.2.1
-    component-inherit: 0.0.3
-    debug: ~3.1.0
-    engine.io-parser: ~2.1.1
-    has-cors: 1.1.0
-    indexof: 0.0.1
-    parseqs: 0.0.5
-    parseuri: 0.0.5
-    ws: ~3.3.1
-    xmlhttprequest-ssl: ~1.5.4
-    yeast: 0.1.2
-  checksum: 6a3f375a4505074adb60eedcc20623558c8b93137f6179178322a442d8a5f070eed1c09861cb297b84bf21d1a3be0a12c7a0d319663fc439a4193b4dd4ad44a4
-  languageName: node
-  linkType: hard
-
-"engine.io-client@npm:~3.4.0":
-  version: 3.4.1
-  resolution: "engine.io-client@npm:3.4.1"
-  dependencies:
-    component-emitter: 1.2.1
-    component-inherit: 0.0.3
-    debug: ~4.1.0
-    engine.io-parser: ~2.2.0
-    has-cors: 1.1.0
-    indexof: 0.0.1
-    parseqs: 0.0.5
-    parseuri: 0.0.5
-    ws: ~6.1.0
-    xmlhttprequest-ssl: ~1.5.4
-    yeast: 0.1.2
-  checksum: 2dff09a11123dc4dc30f887de7a9f74f726d005c98ea59ccc08d75b4fb9e4c2e818e6bd8ae1828dc482421ca383e1c380d11cfd91943736219199105848fe1a8
-  languageName: node
-  linkType: hard
-
-"engine.io-parser@npm:~2.1.0, engine.io-parser@npm:~2.1.1":
-  version: 2.1.3
-  resolution: "engine.io-parser@npm:2.1.3"
-  dependencies:
-    after: 0.8.2
-    arraybuffer.slice: ~0.0.7
-    base64-arraybuffer: 0.1.5
-    blob: 0.0.5
-    has-binary2: ~1.0.2
-  checksum: fb310389ae0fd1821bbe22ebcbe631cef0b6f1172611e5d59a32e64e130ce6e7fc7ec87f36198e48817e76198e998b2ec302483326eac31b50979cec73ac883d
-  languageName: node
-  linkType: hard
-
-"engine.io-parser@npm:~2.2.0":
-  version: 2.2.0
-  resolution: "engine.io-parser@npm:2.2.0"
-  dependencies:
-    after: 0.8.2
-    arraybuffer.slice: ~0.0.7
-    base64-arraybuffer: 0.1.5
-    blob: 0.0.5
-    has-binary2: ~1.0.2
-  checksum: cd467b8b12efa9db52ffb6691ef9ce8a67016cef83b61d548a1fb223c5a39c3b3dcee631deebc10d3c20a94a59fc58c63c70cee549ef947e85550ba5e8aee0af
-  languageName: node
-  linkType: hard
-
-"engine.io@npm:~3.2.0":
-  version: 3.2.1
-  resolution: "engine.io@npm:3.2.1"
-  dependencies:
-    accepts: ~1.3.4
-    base64id: 1.0.0
-    cookie: 0.3.1
-    debug: ~3.1.0
-    engine.io-parser: ~2.1.0
-    ws: ~3.3.1
-  checksum: 11c474a31ee49507112be8369c9b516aca4e9b44d4c5cd5dbb4a9c918edeec3953cc344d40c8cf878e47e8a1a070e644b3cf508ad83fcf38d6b055fff8823710
   languageName: node
   linkType: hard
 
@@ -15875,7 +15552,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"etag@npm:1.8.1, etag@npm:^1.8.1, etag@npm:~1.8.1":
+"etag@npm:~1.8.1":
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
   checksum: f18341a3c12a554ec46c0d4756bc9cae177e92f25a4ebd9ceefebf0ee448b675972fc110879f22b1bf514174713921ae5de9ff77af2062d422b1085588465a57
@@ -16648,21 +16325,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"finalhandler@npm:1.1.0":
-  version: 1.1.0
-  resolution: "finalhandler@npm:1.1.0"
-  dependencies:
-    debug: 2.6.9
-    encodeurl: ~1.0.1
-    escape-html: ~1.0.3
-    on-finished: ~2.3.0
-    parseurl: ~1.3.2
-    statuses: ~1.3.1
-    unpipe: ~1.0.0
-  checksum: c31bcafafd9ea8e4516e7123f7f5723645b0493337dc9778c3622d22ecf280d297e798ee539a6c09a245511c3b48ae203c96dfd3e4e295034d9d7bb4b1c811fa
-  languageName: node
-  linkType: hard
-
 "finalhandler@npm:~1.1.2":
   version: 1.1.2
   resolution: "finalhandler@npm:1.1.2"
@@ -17165,7 +16827,6 @@ __metadata:
   resolution: "fortress@workspace:packages/fortress"
   dependencies:
     audit-filter: 0.5.0
-    browser-sync: ^2.26.7
     client-sessions: 0.6.x
     ejs: ^3.1.2
     eslint: ^6.8.0
@@ -17214,7 +16875,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fresh@npm:0.5.2, fresh@npm:^0.5.2":
+"fresh@npm:0.5.2":
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
   checksum: 2f76c8505d1ea5a6d5accea3e7aff0b796bfa43364c84929254f33909fa08640948bd1728220d1ff5f4c2b378a65e97da647f2fe0f2b7ddb44001f6e0dc2e91f
@@ -17270,17 +16931,6 @@ __metadata:
   version: 1.0.0
   resolution: "fs-exists-cached@npm:1.0.0"
   checksum: 81681bfe12e291bf146575f1dfacd2c8eb9f820490582b6275379b1c16352ecb16e46a977418162f517fc3d0c25c3d5b56be25b16a37d0c337815c797b50760d
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:3.0.1":
-  version: 3.0.1
-  resolution: "fs-extra@npm:3.0.1"
-  dependencies:
-    graceful-fs: ^4.1.2
-    jsonfile: ^3.0.0
-    universalify: ^0.1.0
-  checksum: 89d26c54f21d1a6a7ce8054fd97545343a8f78f34961bd0007ae1d50b47d9ce2ed054e138603ca982a83fecbb2bb5194644935b3f79011bcffe489d75acb1073
   languageName: node
   linkType: hard
 
@@ -17582,7 +17232,7 @@ fsevents@^1.2.7:
     serve-static: ^1.14.1
     supertest: ^4.0.2
     tailwindcss: ^1.7.3
-    ts-jest: ^24.3.0
+    ts-jest: ^26.3.0
     ts-node: ^8.10.2
     typescript: 3.9.7
     webpack: ^4.43.0
@@ -18084,7 +17734,7 @@ fsevents@^1.2.7:
     "@google-cloud/pubsub": ^2.3.0
     "@grpc/grpc-js": ^1.1.3
     "@hapi/hoek": ^9.0.4
-    "@hapi/joi": ^17.1.1
+    "@hapi/joi": ^15.1.1
     "@nestjs/cli": ^7.5.1
     "@nestjs/common": ^7.4.4
     "@nestjs/config": ^0.5.0
@@ -18115,6 +17765,7 @@ fsevents@^1.2.7:
     aws-sdk: ^2.733.0
     axios: ^0.20.0
     chance: ^1.1.6
+    class-transformer: ^0.3.1
     class-validator: ^0.12.2
     convict: ^6.0.0
     convict-format-with-moment: ^6.0.0
@@ -18127,6 +17778,7 @@ fsevents@^1.2.7:
     fxa-jwtool: ^0.7.2
     fxa-shared: "workspace:*"
     google-auth-library: ^6.0.6
+    graphql: ^14.6.0
     hot-shots: ^7.8.0
     jest: 26.4.2
     jwks-rsa: ^1.9.0
@@ -18139,7 +17791,7 @@ fsevents@^1.2.7:
     prettier: ^2.0.5
     reflect-metadata: ^0.1.13
     rimraf: ^3.0.2
-    rxjs: ^6.6.3
+    rxjs: ^6.5.5
     sqs-consumer: ^5.4.0
     supertest: ^4.0.2
     ts-jest: 26.1.0
@@ -18147,7 +17799,7 @@ fsevents@^1.2.7:
     ts-node: ^8.6.2
     tsconfig-paths: ^3.9.0
     typesafe-joi: ^2.1.0
-    typesafe-node-firestore: ^1.3.0
+    typesafe-node-firestore: ^1.4.0
     typescript: 3.9.7
     uuid: ^8.3.0
   languageName: unknown
@@ -18411,7 +18063,7 @@ fsevents@^1.2.7:
     serve-static: ^1.13.2
     sinon: ^9.0.3
     supertest: ^4.0.2
-    ts-jest: ^24.3.0
+    ts-jest: ^26.3.0
     ts-node: ^8.10.2
     type-to-reducer: ^1.2.0
     typedi: ^0.8.0
@@ -18515,7 +18167,7 @@ fsevents@^1.2.7:
     sass: 1.26.10
     sass-loader: ^8.0.2
     tailwindcss: ^1.7.3
-    ts-jest: ^24.3.0
+    ts-jest: ^26.3.0
     typescript: 3.9.7
     webpack: ^4.43.0
   languageName: unknown
@@ -18602,12 +18254,14 @@ fsevents@^1.2.7:
     bluebird: ^3.7.2
     celebrate: ^10.0.1
     chai: ^4.2.0
+    class-transformer: ^0.3.1
+    class-validator: ^0.12.2
     cors: ^2.8.5
     eslint: ^6.8.0
     eslint-plugin-fxa: ^2.0.2
     find-up: ^5.0.0
     generic-pool: ^3.7.1
-    graphql: ^15.3.0
+    graphql: ^14.6.0
     hot-shots: ^7.8.0
     jest: 26.4.2
     joi: ^14.3.1
@@ -18626,7 +18280,7 @@ fsevents@^1.2.7:
     proxyquire: ^2.1.3
     redis: ^2.8.0
     reflect-metadata: ^0.1.13
-    rxjs: ^6.6.3
+    rxjs: ^6.5.5
     sinon: ^9.0.3
     stripe: ^8.69.0
     ts-jest: 26.1.0
@@ -18644,7 +18298,7 @@ fsevents@^1.2.7:
   resolution: "fxa-support-panel@workspace:packages/fxa-support-panel"
   dependencies:
     "@hapi/hapi": ^20.0.0
-    "@hapi/joi": ^17.1.1
+    "@hapi/joi": ^15.1.1
     "@hapi/scooter": ^6.0.0
     "@types/bluebird": ^3.5.32
     "@types/convict": ^5.2.1
@@ -19533,13 +19187,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graphql@npm:^15.3.0":
-  version: 15.3.0
-  resolution: "graphql@npm:15.3.0"
-  checksum: f01c05eb9102a88f33b4276b38399f066067d5be03c66c3bfec3e71e1793a91750e408f7abb001831bc2daf09746ab70ac0af16894d0ef1f1c1246fb0c2f4b0e
-  languageName: node
-  linkType: hard
-
 "growl@npm:1.10.5":
   version: 1.10.5
   resolution: "growl@npm:1.10.5"
@@ -20026,26 +19673,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"has-binary2@npm:~1.0.2":
-  version: 1.0.3
-  resolution: "has-binary2@npm:1.0.3"
-  dependencies:
-    isarray: 2.0.1
-  checksum: 1a80bcdcef9336c94c0cdd61b9adff66714a964c956bb6eac6732cdb283dcf507841c56d7d186708c36fe2c6fc3d7b12a63f44fa19dc8ffd61c12e76a2e2f136
-  languageName: node
-  linkType: hard
-
 "has-color@npm:~0.1.0":
   version: 0.1.7
   resolution: "has-color@npm:0.1.7"
   checksum: 56775e5d514ac04c76191e284aff9c7bc7de6b964f6f3d8113458e86418cce05609b9da5e323dca48a24afead32e5cfd21ae9764264928bf3d1fb74847c9592e
-  languageName: node
-  linkType: hard
-
-"has-cors@npm:1.1.0":
-  version: 1.1.0
-  resolution: "has-cors@npm:1.1.0"
-  checksum: c8257cbe3fc1c2f49d293879f0c6873c6fa7ba7be44147f9a9023cc421c7842833c3553f46bdc04459f046c1c74eb9c7a98e63fdd2c7713caaddd26b1b7f9043
   languageName: node
   linkType: hard
 
@@ -20858,13 +20489,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"immutable@npm:^3":
-  version: 3.8.2
-  resolution: "immutable@npm:3.8.2"
-  checksum: 08e65dd0579e7d274e0959872aa3cda7b0da30ed2efebbd23fc2cff26ff7a5416f47e21dbf9b56d337c94b98399a15511df1b7a5db2fadae3e77cd60483c4205
-  languageName: node
-  linkType: hard
-
 "import-cwd@npm:^2.0.0":
   version: 2.1.0
   resolution: "import-cwd@npm:2.1.0"
@@ -21360,13 +20984,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"invert-kv@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "invert-kv@npm:1.0.0"
-  checksum: fccd6ea4ee18d30b00fc21d6679191690f8447f248cbcdf6f74fe81a4048d51a3858d7af17a0318bd7c6fe6c46abee5a10756109787a3ec0e0a02a2c1b4a635d
-  languageName: node
-  linkType: hard
-
 "invert-kv@npm:^2.0.0":
   version: 2.0.0
   resolution: "invert-kv@npm:2.0.0"
@@ -21566,7 +21183,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-buffer@npm:^2.0.0, is-buffer@npm:^2.0.2, is-buffer@npm:~2.0.3":
+"is-buffer@npm:^2.0.0, is-buffer@npm:~2.0.3":
   version: 2.0.4
   resolution: "is-buffer@npm:2.0.4"
   checksum: cd1cbc19e5ad2f33284109210945606494bf1adbe775b157b18ffeeb98571187d5fd1dc3fcd36566f67b90a776e364262f496c8998f8f369694b68ad334f8655
@@ -21833,15 +21450,6 @@ fsevents@^1.2.7:
   version: 1.0.0
   resolution: "is-negated-glob@npm:1.0.0"
   checksum: add3803c20bc80cfc8151eb618fe9ee537d2cf5dfa77080100c3262207943627fc562e671d457f88bcc52b788dc588fdaf2bdbfa753f02d1449912aab5286069
-  languageName: node
-  linkType: hard
-
-"is-number-like@npm:^1.0.3":
-  version: 1.0.8
-  resolution: "is-number-like@npm:1.0.8"
-  dependencies:
-    lodash.isfinite: ^3.3.2
-  checksum: e6ed5aa3297fef983c58cc6b1aa7bee6caa402247db761fdc4b8f065c821b64054f9d0a45732c42c63f31175a62bd6993f701bc816b94f2b446480cf8df553e6
   languageName: node
   linkType: hard
 
@@ -22184,13 +21792,6 @@ fsevents@^1.2.7:
   version: 1.0.0
   resolution: "isarray@npm:1.0.0"
   checksum: b0ff31a290e783f7b3fb73f2951ee7fc2946dc197b05f73577dc77f87dc3be2e0f66007bedf069123d4e5c4b691e7c89a241f6ca06f0c0f4765cdac5aa4b4047
-  languageName: node
-  linkType: hard
-
-"isarray@npm:2.0.1":
-  version: 2.0.1
-  resolution: "isarray@npm:2.0.1"
-  checksum: 1387ed49e8cca6aded4ac16a0e6ecf8f0e607ca1d5d5a8e3ab264e506c07a958174951bd1ab638c1f40bf97a122ab5dd15b191d85c7d9966dfa2b40455528984
   languageName: node
   linkType: hard
 
@@ -22540,6 +22141,7 @@ fsevents@^1.2.7:
     yargs: ^15.3.1
   bin:
     jest: bin/jest.js
+  checksum: 1dc23b584d386f78a8b6d649a4c007ea2f32b4e49162c16e78b1291ea1916380c2a419988f0e9759a502a452992183abf81f6998f175ea3cb58cee6a3ed402c9
   languageName: node
   linkType: hard
 
@@ -22590,6 +22192,7 @@ fsevents@^1.2.7:
     jest-validate: ^26.4.2
     micromatch: ^4.0.2
     pretty-format: ^26.4.2
+  checksum: c7de35ec42698e3343eb002f7a960fde207280856ee5bf299d8f6fa58f4c61a8c682d719ce8aec0a7017f769309aa761a2a24101af2f7f5e8d9a96a40aea385c
   languageName: node
   linkType: hard
 
@@ -22625,6 +22228,7 @@ fsevents@^1.2.7:
     diff-sequences: ^26.3.0
     jest-get-type: ^26.3.0
     pretty-format: ^26.4.2
+  checksum: c7ece95bb1782556cce2d14b36614e115b755793db7faaf29a581f78ff117a2d6d9b6b5d48408465879f864b0b508add0ef62197730f7c73ebc0271564c3f88c
   languageName: node
   linkType: hard
 
@@ -22668,6 +22272,7 @@ fsevents@^1.2.7:
     jest-get-type: ^26.3.0
     jest-util: ^26.3.0
     pretty-format: ^26.4.2
+  checksum: 6eeb23caa17480998e2036bafffd3910a50336291d50eb881c2f90890c705ded686752ce98abfbdd0d5b6be295db4647ea7957b9c8db652b70a3c83861d79705
   languageName: node
   linkType: hard
 
@@ -22856,6 +22461,7 @@ fsevents@^1.2.7:
     jest-util: ^26.3.0
     pretty-format: ^26.4.2
     throat: ^5.0.0
+  checksum: db5cf7b79af65094c29106701fd40346e84c791c6618948ccd3e6982d8f17c48a9b47f7bfd0e372954b1877b7e6b5b6b694f3f22948e81819087525d02cdfaa6
   languageName: node
   linkType: hard
 
@@ -22875,6 +22481,7 @@ fsevents@^1.2.7:
   dependencies:
     jest-get-type: ^26.3.0
     pretty-format: ^26.4.2
+  checksum: fff504ff8e34bb1e5844325d6dac10f34e0f608c374941d0b3088a8f1ec6eaa94139afb2b6981e3d84d5ead7142bdd0f60bfd5c83bf7a0bced8330dfabd88b29
   languageName: node
   linkType: hard
 
@@ -22910,6 +22517,7 @@ fsevents@^1.2.7:
     jest-diff: ^26.4.2
     jest-get-type: ^26.3.0
     pretty-format: ^26.4.2
+  checksum: e368b46a0292088856f2e0b1ce45c2aa9f5ca7eed41a8daf94fb2c5f926bc992903245aa13b2647f87c66f3dd7a97dce9ef299e11e9e70c795e43a42f3466e64
   languageName: node
   linkType: hard
 
@@ -23020,6 +22628,7 @@ fsevents@^1.2.7:
     "@jest/types": ^26.3.0
     jest-regex-util: ^26.0.0
     jest-snapshot: ^26.4.2
+  checksum: 35a62ae01a61f1ef4c27e7df0b7f4a3f9c26331c2208d9998d1209949aeb013e05d71f980f86698ec8b2918826257e5d137c3326de53d59ee8351f4837095d7e
   languageName: node
   linkType: hard
 
@@ -23103,6 +22712,7 @@ fsevents@^1.2.7:
     jest-worker: ^26.3.0
     source-map-support: ^0.5.6
     throat: ^5.0.0
+  checksum: 3c354ab53283755e90da86d79a955783ee29a52cc7adb3586e3dee51d5f96e44398a1dcc85a950862bdc6d72dfa9fbd8c51a27feb96bf914cdb3fe070b9ad3b6
   languageName: node
   linkType: hard
 
@@ -23171,6 +22781,7 @@ fsevents@^1.2.7:
     yargs: ^15.3.1
   bin:
     jest-runtime: bin/jest-runtime.js
+  checksum: 2dd0b6887203c67757d48b8b9e97773a61e98026323d06634161f5cedfd37866413cd68eb92186edf27a9d096e14ec0c525a59b0403e9bc1439e6d33737a57bd
   languageName: node
   linkType: hard
 
@@ -23231,6 +22842,21 @@ fsevents@^1.2.7:
     natural-compare: ^1.4.0
     pretty-format: ^26.4.2
     semver: ^7.3.2
+  checksum: d87dbdfd3278358be48be71897aada0f97c3f222c1808c2c87a672a1774d51c1a0bee523873bfb8eb8f9db9b71c30faab2bbb2c33960a77d166d82ef563e94e3
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:26.x, jest-util@npm:^26.3.0":
+  version: 26.3.0
+  resolution: "jest-util@npm:26.3.0"
+  dependencies:
+    "@jest/types": ^26.3.0
+    "@types/node": "*"
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.4
+    is-ci: ^2.0.0
+    micromatch: ^4.0.2
+  checksum: a3574473c503e44db396403823dc2c1495f31db5ae6a11182d3cfaa08af26a4a70c0efd848f199ce423cc9541b7cd2fe2430d22e5bbce28038352120203a116e
   languageName: node
   linkType: hard
 
@@ -23251,20 +22877,6 @@ fsevents@^1.2.7:
     slash: ^2.0.0
     source-map: ^0.6.0
   checksum: 884ec3a45cc43eb3488784f23dd9f748e11752a1987639e24d093971e192c84568e92791c4b2834e2b1c21cd25010136549cef0b187b2af747ac3b1bd48cf367
-  languageName: node
-  linkType: hard
-
-"jest-util@npm:^26.3.0":
-  version: 26.3.0
-  resolution: "jest-util@npm:26.3.0"
-  dependencies:
-    "@jest/types": ^26.3.0
-    "@types/node": "*"
-    chalk: ^4.0.0
-    graceful-fs: ^4.2.4
-    is-ci: ^2.0.0
-    micromatch: ^4.0.2
-  checksum: a3574473c503e44db396403823dc2c1495f31db5ae6a11182d3cfaa08af26a4a70c0efd848f199ce423cc9541b7cd2fe2430d22e5bbce28038352120203a116e
   languageName: node
   linkType: hard
 
@@ -23292,6 +22904,7 @@ fsevents@^1.2.7:
     jest-get-type: ^26.3.0
     leven: ^3.1.0
     pretty-format: ^26.4.2
+  checksum: 36d76e2c80124621eda0b4422111c850eb5f54323d23cacb073f6663e016fcdf902353714337033afc1f3d66ab06c1a7ffcf1c1bac24192c140a93b42765b6dc
   languageName: node
   linkType: hard
 
@@ -23392,6 +23005,7 @@ fsevents@^1.2.7:
     jest-cli: ^26.4.2
   bin:
     jest: bin/jest.js
+  checksum: e577e4863188a5cba6454c9f3208774d7b38562c276aefae4b2abd8ff1006406026c33390bcea33f29a4d83115b3fafdbb113bfcc6124da6b4136797600855ad
   languageName: node
   linkType: hard
 
@@ -23843,18 +23457,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"jsonfile@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "jsonfile@npm:3.0.1"
-  dependencies:
-    graceful-fs: ^4.1.6
-  dependenciesMeta:
-    graceful-fs:
-      optional: true
-  checksum: 65eab8507d0cc5be465a7a4a2813c12610507aecc31501a608be0272a1f6bbddf66fae0f418e617d901f84fbcabbccbb079afdcb1622151a64b3ef52cdddfb05
-  languageName: node
-  linkType: hard
-
 "jsonfile@npm:^4.0.0":
   version: 4.0.0
   resolution: "jsonfile@npm:4.0.0"
@@ -24282,15 +23884,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"lcid@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "lcid@npm:1.0.0"
-  dependencies:
-    invert-kv: ^1.0.0
-  checksum: 36f50f8be935c90e3f9296d3f7057df950ee27c4f1608549b11b3f88d26d68a19a47cf787b1a6e3eb292e820fcc8c96a67be2fca14f713430adb57b24e06fb96
-  languageName: node
-  linkType: hard
-
 "lcid@npm:^2.0.0":
   version: 2.0.0
   resolution: "lcid@npm:2.0.0"
@@ -24425,7 +24018,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"limiter@npm:^1.0.5, limiter@npm:^1.1.5":
+"limiter@npm:^1.1.5":
   version: 1.1.5
   resolution: "limiter@npm:1.1.5"
   checksum: 83f7aa20fefdcfc72a76f034ce804ad8d0063cd94c3ebd9c9b08157051b3f76b099cb953ccd09a0117ed06b876773c6b3876afd88be8d11ced252a8a85603786
@@ -24589,20 +24182,6 @@ fsevents@^1.2.7:
   dependencies:
     lie: 3.1.1
   checksum: 7530b213d2b4c3e40455bc2b69f241f9e8cd7b643e9fc4c67eb522f3a29f44306fc800a30a5513c0444788606e3c72404d9fe68b0cf20e7bf405efad2de449b1
-  languageName: node
-  linkType: hard
-
-"localtunnel@npm:1.9.2":
-  version: 1.9.2
-  resolution: "localtunnel@npm:1.9.2"
-  dependencies:
-    axios: 0.19.0
-    debug: 4.1.1
-    openurl: 1.1.1
-    yargs: 6.6.0
-  bin:
-    lt: ./bin/client
-  checksum: c0ca9798b7184f62bfe404aa0417952f2fd93ef394e11f9aa819913f293a113e578f0037a33b3cfbef4684774990d5ffb6514aa21428c489a115295ef918cb48
   languageName: node
   linkType: hard
 
@@ -24834,13 +24413,6 @@ fsevents@^1.2.7:
   version: 4.5.0
   resolution: "lodash.isequal@npm:4.5.0"
   checksum: 5b47e094641c18a915497343894c66f7da6aebb9aaa2a3fcc5643455aaf29d19df60ebbed664c8374fb959c8b4ce96810ee6becd8a71ac58c6c2ca8d29762947
-  languageName: node
-  linkType: hard
-
-"lodash.isfinite@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "lodash.isfinite@npm:3.3.2"
-  checksum: 0ae13e9207eb64cf04ceb5b7daa1eddf24cabc12bc03cca25b496be8850eae15a69ca476da82d7662e4c5abcef8613990ea7c1074a04504acfb8b4ff5cab8a11
   languageName: node
   linkType: hard
 
@@ -26109,13 +25681,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mitt@npm:^1.1.3":
-  version: 1.2.0
-  resolution: "mitt@npm:1.2.0"
-  checksum: d6222a9d8bc0e7d6ec3d44220476830dcf545a0488b6ce59a08044c116b0832781bf8d1a2b9e6ac9422e0c11e8e0f997a6c58a86a81f5ef346ab347dbd9ec5da
-  languageName: node
-  linkType: hard
-
 "mixin-deep@npm:^1.2.0":
   version: 1.3.2
   resolution: "mixin-deep@npm:1.3.2"
@@ -26161,7 +25726,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:0.5.5, mkdirp@npm:0.x, mkdirp@npm:>=0.5 0, mkdirp@npm:^0.5.0, mkdirp@npm:^0.5.1, mkdirp@npm:^0.5.3, mkdirp@npm:~0.5.1":
+"mkdirp@npm:0.5.5, mkdirp@npm:>=0.5 0, mkdirp@npm:^0.5.0, mkdirp@npm:^0.5.1, mkdirp@npm:^0.5.3, mkdirp@npm:~0.5.1":
   version: 0.5.5
   resolution: "mkdirp@npm:0.5.5"
   dependencies:
@@ -27485,13 +27050,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object-component@npm:0.0.3":
-  version: 0.0.3
-  resolution: "object-component@npm:0.0.3"
-  checksum: ae3417629f7da6f40dc2e50636f40ee33cd2f317cf8744204c24c505e78f9290e36d3ed2812a38e248b34e43982ae8e6e35ed6602655c736fe37de5e39d6d992
-  languageName: node
-  linkType: hard
-
 "object-copy@npm:^0.1.0":
   version: 0.1.0
   resolution: "object-copy@npm:0.1.0"
@@ -27538,13 +27096,6 @@ fsevents@^1.2.7:
   version: 0.11.4
   resolution: "object-path@npm:0.11.4"
   checksum: 5e3d4690d00cd6febeb19f888858ac0da8dc9f83a0a364401259d9dfaad0fd58c638632a78e63f81710d4e9a59b3f1f9e4aadacf61f31ab9cb1602194fd76d81
-  languageName: node
-  linkType: hard
-
-"object-path@npm:^0.9.0":
-  version: 0.9.2
-  resolution: "object-path@npm:0.9.2"
-  checksum: 414ac8b769f7ff2df99bf600287174d5865aca7ca23e6b99ca275ea45fd33bfe116e8c929e83488dfc94c48820fbff668fd45a8161d32d3878e1c33c71912937
   languageName: node
   linkType: hard
 
@@ -27754,22 +27305,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"openurl@npm:1.1.1":
-  version: 1.1.1
-  resolution: "openurl@npm:1.1.1"
-  checksum: cbe2e03594b9ceee8b1cfccb505d6bcea852417061952ef46a5dfe53c0aac9ce870f89d5142a9882bdf11e8fdb457655c7cdb2e7c2f5560d98322755eaacca06
-  languageName: node
-  linkType: hard
-
-"opn@npm:5.3.0":
-  version: 5.3.0
-  resolution: "opn@npm:5.3.0"
-  dependencies:
-    is-wsl: ^1.1.0
-  checksum: e7554ec388ba22bd6a84d1cf78ce0af69bc3e7359b245818071572ed170d4faa6db1ee8fa2d68328ba4896533bfcd0630709df1fd7798157e3d257404f8413e5
-  languageName: node
-  linkType: hard
-
 "opn@npm:5.4.0":
   version: 5.4.0
   resolution: "opn@npm:5.4.0"
@@ -27947,15 +27482,6 @@ fsevents@^1.2.7:
   version: 1.0.2
   resolution: "os-homedir@npm:1.0.2"
   checksum: 725256246b2cec353250ec46442e3cfa7bc96ef92285d448a90f12f4bbd78c1bf087051b2cef0382da572e1a9ebc8aa24bd0940a3bdc633c3e3012eef1dc6848
-  languageName: node
-  linkType: hard
-
-"os-locale@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "os-locale@npm:1.4.0"
-  dependencies:
-    lcid: ^1.0.0
-  checksum: 19d876790073758c346c8df2ec40a9c28ee1497b185bfb54d3fd082b9b82e61f2ee3a9bd329cdd6ae878c7fce045c0c3b21c1196061af8360aebf2775fa27b2b
   languageName: node
   linkType: hard
 
@@ -28450,24 +27976,6 @@ fsevents@^1.2.7:
   version: 5.1.1
   resolution: "parse5@npm:5.1.1"
   checksum: fad72ff5010ee8a6f0a38b83fc886b71a54d746d5c4ff5aad74d6ba1fe87b9606585bf32aa200b015ce329e0906f50f2851f29876abeacd5c13567c7a0455362
-  languageName: node
-  linkType: hard
-
-"parseqs@npm:0.0.5":
-  version: 0.0.5
-  resolution: "parseqs@npm:0.0.5"
-  dependencies:
-    better-assert: ~1.0.0
-  checksum: 46444c9a5bf2ec301bd61cc6020cac30a4e85e58f6d49176aa8773247940029b2df9cac3eabc498810d0c79aad2dcb9f28820fbf9bfdfd067eb0d16ee0c32d51
-  languageName: node
-  linkType: hard
-
-"parseuri@npm:0.0.5":
-  version: 0.0.5
-  resolution: "parseuri@npm:0.0.5"
-  dependencies:
-    better-assert: ~1.0.0
-  checksum: 5a16cd5292be2c99558efee22e7dca8f35e88612cc9d3be944b1c826c78ecd7bacfa1e18cea9157b6c3ad4bf4c72be08ccba592a19346bf216207a85d181993b
   languageName: node
   linkType: hard
 
@@ -29122,16 +28630,6 @@ fsevents@^1.2.7:
     debug: ^3.1.1
     mkdirp: ^0.5.1
   checksum: a766497a3da0a8661067884828ccfa2089f0105ab6d617978bf9120e472f0610288c14cefcf188dfa94c0eee701c4f92c93a4581e85547b69b6bf2361adc5419
-  languageName: node
-  linkType: hard
-
-"portscanner@npm:2.1.1":
-  version: 2.1.1
-  resolution: "portscanner@npm:2.1.1"
-  dependencies:
-    async: 1.5.2
-    is-number-like: ^1.0.3
-  checksum: 95b8d5089736be074418ed429e6658bf6a596c3bec08c6db260406c5b01556d408d297af5eb8952a2bad052c62b5655738eaad17be82e8aef7816bf1c74903ae
   languageName: node
   linkType: hard
 
@@ -30772,13 +30270,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"qs@npm:6.2.3":
-  version: 6.2.3
-  resolution: "qs@npm:6.2.3"
-  checksum: cde8df4c5a39ffb43305f53ab4e95943b2230fb4df52be269221449e73385fb417273d2e399eb31385a8e8257226caa948f79a49dd13b39560a600df3fe35111
-  languageName: node
-  linkType: hard
-
 "qs@npm:6.7.0":
   version: 6.7.0
   resolution: "qs@npm:6.7.0"
@@ -30930,7 +30421,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"raw-body@npm:^2.2.0, raw-body@npm:^2.3.0, raw-body@npm:^2.3.2":
+"raw-body@npm:^2.2.0, raw-body@npm:^2.3.0":
   version: 2.4.1
   resolution: "raw-body@npm:2.4.1"
   dependencies:
@@ -32522,7 +32013,7 @@ resolve@1.15.0:
   languageName: node
   linkType: hard
 
-"resolve@1.x, resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1":
+"resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1":
   version: 1.17.0
   resolution: "resolve@npm:1.17.0"
   dependencies:
@@ -32547,7 +32038,7 @@ resolve@1.15.0:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@1.x#builtin<compat/resolve>, resolve@patch:resolve@^1.1.3#builtin<compat/resolve>, resolve@patch:resolve@^1.1.4#builtin<compat/resolve>, resolve@patch:resolve@^1.1.6#builtin<compat/resolve>, resolve@patch:resolve@^1.1.7#builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#builtin<compat/resolve>, resolve@patch:resolve@^1.11.0#builtin<compat/resolve>, resolve@patch:resolve@^1.11.1#builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#builtin<compat/resolve>, resolve@patch:resolve@^1.15.1#builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#builtin<compat/resolve>, resolve@patch:resolve@^1.8.1#builtin<compat/resolve>":
+"resolve@patch:resolve@^1.1.3#builtin<compat/resolve>, resolve@patch:resolve@^1.1.4#builtin<compat/resolve>, resolve@patch:resolve@^1.1.6#builtin<compat/resolve>, resolve@patch:resolve@^1.1.7#builtin<compat/resolve>, resolve@patch:resolve@^1.10.0#builtin<compat/resolve>, resolve@patch:resolve@^1.11.0#builtin<compat/resolve>, resolve@patch:resolve@^1.11.1#builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#builtin<compat/resolve>, resolve@patch:resolve@^1.13.1#builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#builtin<compat/resolve>, resolve@patch:resolve@^1.15.1#builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#builtin<compat/resolve>, resolve@patch:resolve@^1.8.1#builtin<compat/resolve>":
   version: 1.17.0
   resolution: "resolve@patch:resolve@npm%3A1.17.0#builtin<compat/resolve>::version=1.17.0&hash=3388aa"
   dependencies:
@@ -32571,16 +32062,6 @@ resolve@~1.11.1:
   dependencies:
     path-parse: ^1.0.6
   checksum: 2a47d5e96d5e0b0cc9b0422147447da5a8ccafc9250558c554851d0307a710dc731ab93c12ea09b52e90e78848bc11d426e5829403c20840d5f7ebc308255ab9
-  languageName: node
-  linkType: hard
-
-"resp-modifier@npm:6.0.2":
-  version: 6.0.2
-  resolution: "resp-modifier@npm:6.0.2"
-  dependencies:
-    debug: ^2.2.0
-    minimatch: ^3.0.2
-  checksum: 33fc726cc4b7a0c647263ca9d1fab58ed87e7ece47fb5753ecbe640a742dabfd795948438670ffd98eb0fa8d80435e951d40f8b9400ae5921ae5e0b8cdc9a2dd
   languageName: node
   linkType: hard
 
@@ -32863,13 +32344,6 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"rx@npm:4.1.0":
-  version: 4.1.0
-  resolution: "rx@npm:4.1.0"
-  checksum: 2f8818608864d0a3fcaf8210f4dcc9a8acef2ad041c6b9478bbf2059d1b1efe289226d436a05dfb9038996b833529c28e69eab0f10f26baf3fadc1e5fb8f24bd
-  languageName: node
-  linkType: hard
-
 "rxjs@npm:6.5.4":
   version: 6.5.4
   resolution: "rxjs@npm:6.5.4"
@@ -32879,7 +32353,7 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"rxjs@npm:6.5.5, rxjs@npm:^6.1.0, rxjs@npm:^6.4.0, rxjs@npm:^6.5.3":
+"rxjs@npm:6.5.5, rxjs@npm:^6.1.0, rxjs@npm:^6.4.0, rxjs@npm:^6.5.3, rxjs@npm:^6.5.5":
   version: 6.5.5
   resolution: "rxjs@npm:6.5.5"
   dependencies:
@@ -32888,30 +32362,12 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^5.5.6":
-  version: 5.5.12
-  resolution: "rxjs@npm:5.5.12"
-  dependencies:
-    symbol-observable: 1.0.1
-  checksum: 0f846015aac6d05e5113c437026414b974e06553e2be6058eda066696d3d407cb57c96777f4186cb3510b06bc41f3a02bb7f85741f47db50811b8ad649b47124
-  languageName: node
-  linkType: hard
-
-"rxjs@npm:^6.6.0, rxjs@npm:^6.6.3":
+"rxjs@npm:^6.6.0, rxjs@npm:^6.6.2":
   version: 6.6.3
   resolution: "rxjs@npm:6.6.3"
   dependencies:
     tslib: ^1.9.0
   checksum: 61a3da6db947f69b7d805df3a619d8f60678b7372c4d571dd63e45ef3532be984a88307ea0aa2cd8d2578b62c3c022186e8da9dca47c9c1b8c9ecba6f5581deb
-  languageName: node
-  linkType: hard
-
-"rxjs@npm:^6.6.2":
-  version: 6.6.2
-  resolution: "rxjs@npm:6.6.2"
-  dependencies:
-    tslib: ^1.9.0
-  checksum: 9b16cd36093b87ce454726f14783e204b80431e6657d36191877e4d9d4b0713c73e5ee8b45be336b081d47b10cd016b3812ea3bd4b27bf87942b1410aa18ee04
   languageName: node
   linkType: hard
 
@@ -33239,7 +32695,7 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.3.0, semver@npm:^5.4.1, semver@npm:^5.5, semver@npm:^5.5.0, semver@npm:^5.5.1, semver@npm:^5.6.0, semver@npm:^5.7.0, semver@npm:^5.7.1":
+"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.3.0, semver@npm:^5.4.1, semver@npm:^5.5.0, semver@npm:^5.5.1, semver@npm:^5.6.0, semver@npm:^5.7.0, semver@npm:^5.7.1":
   version: 5.7.1
   resolution: "semver@npm:5.7.1"
   bin:
@@ -33302,27 +32758,6 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"send@npm:0.16.2, send@npm:^0.16.2":
-  version: 0.16.2
-  resolution: "send@npm:0.16.2"
-  dependencies:
-    debug: 2.6.9
-    depd: ~1.1.2
-    destroy: ~1.0.4
-    encodeurl: ~1.0.2
-    escape-html: ~1.0.3
-    etag: ~1.8.1
-    fresh: 0.5.2
-    http-errors: ~1.6.2
-    mime: 1.4.1
-    ms: 2.0.0
-    on-finished: ~2.3.0
-    range-parser: ~1.2.0
-    statuses: ~1.4.0
-  checksum: 0b3b98fd0d933687bafb45552bb9798aa030475c1c7e8a0da1cc97fd92b2dff7b728b41721405335b23d86d31c73300716d3c803075e3e92117f16e9eca84824
-  languageName: node
-  linkType: hard
-
 "send@npm:0.17.1":
   version: 0.17.1
   resolution: "send@npm:0.17.1"
@@ -33341,6 +32776,27 @@ resolve@~1.11.1:
     range-parser: ~1.2.1
     statuses: ~1.5.0
   checksum: 58e4ab2e07e8dfb206ca954a9b85f4e367aba0e4d59ce4c9c96a82034385b67f25d33ad526fdb69d635744bbe4d8afea06e2c0348d7d32920e3489d86dc3ec6f
+  languageName: node
+  linkType: hard
+
+"send@npm:^0.16.2":
+  version: 0.16.2
+  resolution: "send@npm:0.16.2"
+  dependencies:
+    debug: 2.6.9
+    depd: ~1.1.2
+    destroy: ~1.0.4
+    encodeurl: ~1.0.2
+    escape-html: ~1.0.3
+    etag: ~1.8.1
+    fresh: 0.5.2
+    http-errors: ~1.6.2
+    mime: 1.4.1
+    ms: 2.0.0
+    on-finished: ~2.3.0
+    range-parser: ~1.2.0
+    statuses: ~1.4.0
+  checksum: 0b3b98fd0d933687bafb45552bb9798aa030475c1c7e8a0da1cc97fd92b2dff7b728b41721405335b23d86d31c73300716d3c803075e3e92117f16e9eca84824
   languageName: node
   linkType: hard
 
@@ -33382,7 +32838,7 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"serve-index@npm:1.9.1, serve-index@npm:^1.9.1":
+"serve-index@npm:^1.9.1":
   version: 1.9.1
   resolution: "serve-index@npm:1.9.1"
   dependencies:
@@ -33397,18 +32853,6 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"serve-static@npm:1.13.2":
-  version: 1.13.2
-  resolution: "serve-static@npm:1.13.2"
-  dependencies:
-    encodeurl: ~1.0.2
-    escape-html: ~1.0.3
-    parseurl: ~1.3.2
-    send: 0.16.2
-  checksum: ed2fe928fecd9ca86f1fc01066278a4e0574b1a4fff81f212f0b73aaad15e1dc8b68c7dfca9937edbdedc55bdfb21cec6c20cd8bead27524025105e4fd51a2c6
-  languageName: node
-  linkType: hard
-
 "serve-static@npm:1.14.1, serve-static@npm:^1.13.2, serve-static@npm:^1.14.1":
   version: 1.14.1
   resolution: "serve-static@npm:1.14.1"
@@ -33418,13 +32862,6 @@ resolve@~1.11.1:
     parseurl: ~1.3.3
     send: 0.17.1
   checksum: 97e8c94ec02950d019000ca12a8e0b4fdeaaabb7ae965c1c05557b55b48114716ae92688972a8d9f06a5e2d5957c305253a859ec223bb39a1e0732366d0e2768
-  languageName: node
-  linkType: hard
-
-"server-destroy@npm:1.0.1":
-  version: 1.0.1
-  resolution: "server-destroy@npm:1.0.1"
-  checksum: 8bbbf852cf1c91b6d9d54db1bb4ab310fa3daecc72bae733822bd0048dfe8554cafcdeecbb7c903a6877a45a6fcb1f72ac7b167830acc351c73a7fca8ac68188
   languageName: node
   linkType: hard
 
@@ -33991,93 +33428,6 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"socket.io-adapter@npm:~1.1.0":
-  version: 1.1.2
-  resolution: "socket.io-adapter@npm:1.1.2"
-  checksum: a5cbd66049cb7ca20d24cf0e5f7dd618ff517e6c3ca5f853a6deabfd2f832046e3b7103c4a606ef9e9638bf7802a17e099035812ee59e7c78fed6425bbd000a9
-  languageName: node
-  linkType: hard
-
-"socket.io-client@npm:2.1.1":
-  version: 2.1.1
-  resolution: "socket.io-client@npm:2.1.1"
-  dependencies:
-    backo2: 1.0.2
-    base64-arraybuffer: 0.1.5
-    component-bind: 1.0.0
-    component-emitter: 1.2.1
-    debug: ~3.1.0
-    engine.io-client: ~3.2.0
-    has-binary2: ~1.0.2
-    has-cors: 1.1.0
-    indexof: 0.0.1
-    object-component: 0.0.3
-    parseqs: 0.0.5
-    parseuri: 0.0.5
-    socket.io-parser: ~3.2.0
-    to-array: 0.1.4
-  checksum: ed1d5f86cac59eeb27700f5f257cae5f5d68c1442a2490fa6c0a7461767c4086daf4bc4358cf73a523df0934ba3d56052ab9f61a57358b06abca47b1d0b5d160
-  languageName: node
-  linkType: hard
-
-"socket.io-client@npm:^2.0.4":
-  version: 2.3.0
-  resolution: "socket.io-client@npm:2.3.0"
-  dependencies:
-    backo2: 1.0.2
-    base64-arraybuffer: 0.1.5
-    component-bind: 1.0.0
-    component-emitter: 1.2.1
-    debug: ~4.1.0
-    engine.io-client: ~3.4.0
-    has-binary2: ~1.0.2
-    has-cors: 1.1.0
-    indexof: 0.0.1
-    object-component: 0.0.3
-    parseqs: 0.0.5
-    parseuri: 0.0.5
-    socket.io-parser: ~3.3.0
-    to-array: 0.1.4
-  checksum: e38863a3e26e566cda5459ae83be08dc5036d69ad63dd7ced98bd489e0539281ba683076d380a14e5bcdd939aca5ac1a701219e8e2cedb97459d2245e371b07a
-  languageName: node
-  linkType: hard
-
-"socket.io-parser@npm:~3.2.0":
-  version: 3.2.0
-  resolution: "socket.io-parser@npm:3.2.0"
-  dependencies:
-    component-emitter: 1.2.1
-    debug: ~3.1.0
-    isarray: 2.0.1
-  checksum: 73f83e29906b96c6a8b8d653a639089d831de2b2fb4136583ac20b12e9c71caca1f36d3d64dec4b27c19031471e61ecf79cd27dbedc1f2411ab44b83c9157cb7
-  languageName: node
-  linkType: hard
-
-"socket.io-parser@npm:~3.3.0":
-  version: 3.3.0
-  resolution: "socket.io-parser@npm:3.3.0"
-  dependencies:
-    component-emitter: 1.2.1
-    debug: ~3.1.0
-    isarray: 2.0.1
-  checksum: 9765ec0d6813abc4df20a2073ea60911f3820f08482b3a9f9468214b3ce2b99dc5b37e86f42cae0843640973480e02d03ab1cf48d65a7674ecc2ca4513d8e17a
-  languageName: node
-  linkType: hard
-
-"socket.io@npm:2.1.1":
-  version: 2.1.1
-  resolution: "socket.io@npm:2.1.1"
-  dependencies:
-    debug: ~3.1.0
-    engine.io: ~3.2.0
-    has-binary2: ~1.0.2
-    socket.io-adapter: ~1.1.0
-    socket.io-client: 2.1.1
-    socket.io-parser: ~3.2.0
-  checksum: a4da491556d10e40bf2145aaee92d2303930e315b97a9ef911ac14464bd5e934f566df018cd324efe5d8f564e0407b6134786937f7d8b17eb1d4f4e04160015b
-  languageName: node
-  linkType: hard
-
 "sockjs-client@npm:1.3.0":
   version: 1.3.0
   resolution: "sockjs-client@npm:1.3.0"
@@ -34590,13 +33940,6 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"statuses@npm:~1.3.1":
-  version: 1.3.1
-  resolution: "statuses@npm:1.3.1"
-  checksum: c6729133aef058ac09e4cc2249b372866f6d60ccae5afbf219e68b4ae3549afa7128a9d52db7d829b662af938380853240f522646b46f779d47379578b30fcd2
-  languageName: node
-  linkType: hard
-
 "statuses@npm:~1.4.0":
   version: 1.4.0
   resolution: "statuses@npm:1.4.0"
@@ -34703,18 +34046,6 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"stream-throttle@npm:^0.1.3":
-  version: 0.1.3
-  resolution: "stream-throttle@npm:0.1.3"
-  dependencies:
-    commander: ^2.2.0
-    limiter: ^1.0.5
-  bin:
-    throttleproxy: ./bin/throttleproxy.js
-  checksum: 59aa33bee69a85152798499c023bc1232f5a16f44f37a99fffec332b019bd43b8020aeb097e760578cf68c60ed0d6250db1fdae2ba6c3efd6432d8683334ac9c
-  languageName: node
-  linkType: hard
-
 "stream-to-array@npm:2.3.0":
   version: 2.3.0
   resolution: "stream-to-array@npm:2.3.0"
@@ -34791,7 +34122,7 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.1, string-width@npm:^1.0.2":
+"string-width@npm:^1.0.1":
   version: 1.0.2
   resolution: "string-width@npm:1.0.2"
   dependencies:
@@ -35417,13 +34748,6 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"symbol-observable@npm:1.0.1":
-  version: 1.0.1
-  resolution: "symbol-observable@npm:1.0.1"
-  checksum: 7f44d509d9f6e6692b181af73bb2551015670796918764ad96bc1f6c438b7198fc51a1e77ce70f5873c8ed24856954154945c3eb3f2420df05bce0c1f8cb7e7e
-  languageName: node
-  linkType: hard
-
 "symbol-observable@npm:1.2.0, symbol-observable@npm:^1.0.2, symbol-observable@npm:^1.0.4, symbol-observable@npm:^1.2.0":
   version: 1.2.0
   resolution: "symbol-observable@npm:1.2.0"
@@ -35836,16 +35160,6 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"tfunk@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "tfunk@npm:3.1.0"
-  dependencies:
-    chalk: ^1.1.1
-    object-path: ^0.9.0
-  checksum: 64109dd60531ab7196f3992d14c6545d1b9d55a2c702b161d9b403e39807af90b7b00c4c79748de14673f170b27511d2a7ad26e5f2ff6b75593244ff8a578d8b
-  languageName: node
-  linkType: hard
-
 "thenify-all@npm:^1.0.0":
   version: 1.6.0
   resolution: "thenify-all@npm:1.6.0"
@@ -36057,13 +35371,6 @@ resolve@~1.11.1:
   version: 1.0.4
   resolution: "tmpl@npm:1.0.4"
   checksum: 44de07fb81a7273937f3de4b856d12b981b7a9b05a244e6e514e15b072241304cf108f145d2510783eceb91293e237f7e2562b37c8a6e7e6f3fe40daa44259d2
-  languageName: node
-  linkType: hard
-
-"to-array@npm:0.1.4":
-  version: 0.1.4
-  resolution: "to-array@npm:0.1.4"
-  checksum: c25a6d5e97705b08c8259eb92b31532d22d9be32fbd9f8e9fce9bc4a0e687d55284bfd51b3ef00e5cc06770312bffb675065468bf62630f6813d0e8ef8231df5
   languageName: node
   linkType: hard
 
@@ -36376,25 +35683,27 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:^24.3.0":
-  version: 24.3.0
-  resolution: "ts-jest@npm:24.3.0"
+"ts-jest@npm:^26.3.0":
+  version: 26.3.0
+  resolution: "ts-jest@npm:26.3.0"
   dependencies:
+    "@types/jest": 26.x
     bs-logger: 0.x
     buffer-from: 1.x
     fast-json-stable-stringify: 2.x
+    jest-util: 26.x
     json5: 2.x
     lodash.memoize: 4.x
     make-error: 1.x
-    mkdirp: 0.x
-    resolve: 1.x
-    semver: ^5.5
-    yargs-parser: 10.x
+    mkdirp: 1.x
+    semver: 7.x
+    yargs-parser: 18.x
   peerDependencies:
-    jest: ">=24 <25"
+    jest: ">=26 <27"
+    typescript: ">=3.8 <5.0"
   bin:
     ts-jest: cli.js
-  checksum: 657ced9ab8336c0bf3c2168c891a261d1ecb9812855c23bc3784216b50b34a4c8468c76452bdf6242e955d734f362a755f71aef126ebe89be8e1124390743790
+  checksum: aa20f07590814fe6c587733cc0278da12e0f6ed08828ed2904671cf29d31b6d1fbb67320221ad2ac7396c369df1ee777bcec7c3dfda0e383968423e78b41bfe5
   languageName: node
   linkType: hard
 
@@ -36742,12 +36051,12 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"typesafe-node-firestore@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "typesafe-node-firestore@npm:1.3.0"
+"typesafe-node-firestore@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "typesafe-node-firestore@npm:1.4.0"
   peerDependencies:
-    "@google-cloud/firestore": ^3.7.0
-  checksum: c12cedcc39fd3d2ac9802e41dd0ec1d18c6329b114a1686a7084c4b0851fbb57e3d524f6ab9dd4ea12247148f51efae93661164497687ead000a962bd1142309
+    "@google-cloud/firestore": "*"
+  checksum: 96fcd0828ddbdd49b9a77c4ae9645c8c74763d5de6f1b68bb87f4a17ea1fcfbfc17ebd32ad980d1a79396b740481e40964fe8ed3df96c6fb5a29885b60cc3f96
   languageName: node
   linkType: hard
 
@@ -36775,13 +36084,6 @@ resolve@~1.11.1:
   version: 0.7.10
   resolution: "ua-parser-js@git://github.com/mozilla-fxa/ua-parser-js.git#commit=643d1698aef5bed095e1264ae258902bf346175c"
   checksum: 13d0efd3ecede7c73985c5f9d306b7c523d7f2f621ae753270f55902938ddbcc8627b8671284ad4684fd0e52d26b1c846d2e37f9102967af9dfba54c02462f4c
-  languageName: node
-  linkType: hard
-
-"ua-parser-js@npm:0.7.17":
-  version: 0.7.17
-  resolution: "ua-parser-js@npm:0.7.17"
-  checksum: 9d7aea7a89690a7b921c375e8b7f6d7bb15887e44bc8746bb463918e40664ecdf4f5994655381d3b8f18d817ee15763bf9f730353013be06e8f6cb659d9fd919
   languageName: node
   linkType: hard
 
@@ -36842,13 +36144,6 @@ resolve@~1.11.1:
   version: 1.0.2
   resolution: "uglify-to-browserify@npm:1.0.2"
   checksum: 3555c8f33929f1a866c412c04a84ebb03d87ed1ec07140a7fe7f678facb3b5e5740d4cb2458b2e094ccea87649e1964c84d014dd47aac6057b7d4986a021cfa7
-  languageName: node
-  linkType: hard
-
-"ultron@npm:~1.1.0":
-  version: 1.1.1
-  resolution: "ultron@npm:1.1.1"
-  checksum: d80d01857347babafcf3ec2f972698bb50a436421d9ebccfe4663c264a54c85848b98c84d968b0976652e91983f623da54fc9b7ded39ad83b331ce052e9131c7
   languageName: node
   linkType: hard
 
@@ -38207,13 +37502,6 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"which-module@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "which-module@npm:1.0.0"
-  checksum: 2fbdb5d875d9dd141de049ad14820de43403cb664142df2b16430a6349bbbcc48b30a24491df0794b7f16284a977fd03ce8b797fa668db92272172dcbe21f8b6
-  languageName: node
-  linkType: hard
-
 "which-module@npm:^2.0.0":
   version: 2.0.0
   resolution: "which-module@npm:2.0.0"
@@ -38295,15 +37583,6 @@ resolve@~1.11.1:
   bin:
     window-size: cli.js
   checksum: 4d1a580456a54a585fa5725dc85de5d174380a1e481c14d96a25201958087e2169308dca1c521cef7dd51d5b3dd1b7e564993dd06e1d303cab18b12719f74d23
-  languageName: node
-  linkType: hard
-
-"window-size@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "window-size@npm:0.2.0"
-  bin:
-    window-size: cli.js
-  checksum: 29493c1522f73889c6b2a9ce16889572b7f41b1958416cf6509d169b8a72113cc29dacb594f7883dcd1ec2296a9559f398c1b2b16825605ca17e8d0393e92c18
   languageName: node
   linkType: hard
 
@@ -38664,26 +37943,6 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"ws@npm:~3.3.1":
-  version: 3.3.3
-  resolution: "ws@npm:3.3.3"
-  dependencies:
-    async-limiter: ~1.0.0
-    safe-buffer: ~5.1.0
-    ultron: ~1.1.0
-  checksum: a7a1e5e6f011a45588bb79ddd0ce5c281db4f48c4e89158702372ebab9c9849bb15c4e23d30229b332f66a3a8430a81eb3a7d44f131ade6954add7f9c2b53212
-  languageName: node
-  linkType: hard
-
-"ws@npm:~6.1.0":
-  version: 6.1.4
-  resolution: "ws@npm:6.1.4"
-  dependencies:
-    async-limiter: ~1.0.0
-  checksum: 74c224573621110380d29e4c51b92eaec5f87c2fc779eb48873a60704e2ddebcaaadaa2ded3bc90a9b01bc453594dae7118c3c279c6ce6340334eb92c8ff04c2
-  languageName: node
-  linkType: hard
-
 "ws@npm:~7.0.0":
   version: 7.0.1
   resolution: "ws@npm:7.0.1"
@@ -38770,13 +38029,6 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"xmlhttprequest-ssl@npm:~1.5.4":
-  version: 1.5.5
-  resolution: "xmlhttprequest-ssl@npm:1.5.5"
-  checksum: 8bb71857be6fa5536a12998b5a65c73f6f86d38404a08e373d16cbb96f334148b0afe0041bc91a9cff817552a6a1f855806145a7bf0ac0c4a7beaf40d9f5f282
-  languageName: node
-  linkType: hard
-
 "xmlhttprequest@git://github.com/mozilla-fxa/node-XMLHttpRequest.git#onerror":
   version: 1.5.1
   resolution: "xmlhttprequest@git://github.com/mozilla-fxa/node-XMLHttpRequest.git#commit=3f904613b860b4438e65a31b7b82f09a4d2d64dd"
@@ -38823,13 +38075,6 @@ resolve@~1.11.1:
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: 37ee522a3e9fb9b143a400c30b21dc122aa8c9c9411c6afae1005a4617dc20a21765c114d544e37a6bb60c2733dd8ee0a44ed9e80d884ac78cccd30b5e0ab0da
-  languageName: node
-  linkType: hard
-
-"y18n@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "y18n@npm:3.2.1"
-  checksum: e0f3db233608c026dd1d06dc5805c99fedbeb21c6a73bdac70d8a6ec1bbcf1cc38952e7b8a79b46c9d1bdee022cc40e529c760f04f9c6cd3123e5ba657d19322
   languageName: node
   linkType: hard
 
@@ -38897,15 +38142,6 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:10.x":
-  version: 10.1.0
-  resolution: "yargs-parser@npm:10.1.0"
-  dependencies:
-    camelcase: ^4.1.0
-  checksum: fc775037dc0ba363913440db43f8989a65c580048d0dc5735ba7148d622f4f415e8ce651234bc4dd0fc176a944765051ae4242f8d6b545a875d5247e2ed97849
-  languageName: node
-  linkType: hard
-
 "yargs-parser@npm:13.1.2, yargs-parser@npm:^13.0.0, yargs-parser@npm:^13.1.0, yargs-parser@npm:^13.1.2":
   version: 13.1.2
   resolution: "yargs-parser@npm:13.1.2"
@@ -38943,15 +38179,6 @@ resolve@~1.11.1:
     camelcase: ^5.0.0
     decamelize: ^1.2.0
   checksum: 1969d5cf00b9ff37e4958f2fde76728b6ed0b3be36f25870348f825bc99671665488580179af344209c9e08acf12249a9812c0f426b4062cbf00509ee7815fee
-  languageName: node
-  linkType: hard
-
-"yargs-parser@npm:^4.1.0, yargs-parser@npm:^4.2.0":
-  version: 4.2.1
-  resolution: "yargs-parser@npm:4.2.1"
-  dependencies:
-    camelcase: ^3.0.0
-  checksum: c23c21ca499cef4b7e61b4c57c6c7b2685f68db217cbd2045ef9bf1e2f1e9106ddd9a1a70e42f08d47da97a1b3b99275975e5119046282bea30340c3df33eabd
   languageName: node
   linkType: hard
 
@@ -39055,49 +38282,6 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
-"yargs@npm:6.4.0":
-  version: 6.4.0
-  resolution: "yargs@npm:6.4.0"
-  dependencies:
-    camelcase: ^3.0.0
-    cliui: ^3.2.0
-    decamelize: ^1.1.1
-    get-caller-file: ^1.0.1
-    os-locale: ^1.4.0
-    read-pkg-up: ^1.0.1
-    require-directory: ^2.1.1
-    require-main-filename: ^1.0.1
-    set-blocking: ^2.0.0
-    string-width: ^1.0.2
-    which-module: ^1.0.0
-    window-size: ^0.2.0
-    y18n: ^3.2.1
-    yargs-parser: ^4.1.0
-  checksum: 9a2b8e7b78b09f30e9b88032d363e6667aa171da4cf18f2d14d123a686f44bd5c235473c447c0a868dd52f2088fa4b97c2b9b43939d6c31e5fa57c05d0f11ee8
-  languageName: node
-  linkType: hard
-
-"yargs@npm:6.6.0":
-  version: 6.6.0
-  resolution: "yargs@npm:6.6.0"
-  dependencies:
-    camelcase: ^3.0.0
-    cliui: ^3.2.0
-    decamelize: ^1.1.1
-    get-caller-file: ^1.0.1
-    os-locale: ^1.4.0
-    read-pkg-up: ^1.0.1
-    require-directory: ^2.1.1
-    require-main-filename: ^1.0.1
-    set-blocking: ^2.0.0
-    string-width: ^1.0.2
-    which-module: ^1.0.0
-    y18n: ^3.2.1
-    yargs-parser: ^4.2.0
-  checksum: 9fc241ace2f082428b507172b71fd48e38144b5937bfa1e8576b7e3b7a17c68c31d93be2fdf201f5499e0cb334255a55f7ac10f62cfcd97ae1b0f8b19041d930
-  languageName: node
-  linkType: hard
-
 "yargs@npm:^14.2.3":
   version: 14.2.3
   resolution: "yargs@npm:14.2.3"
@@ -39186,13 +38370,6 @@ resolve@~1.11.1:
     buffer-crc32: ~0.2.3
     fd-slicer: ~1.1.0
   checksum: 6d0c4e72706ec2df6ea842d09c792e7b34badc5db3d8a893e0c70d0e464c9bf82bac4b1690f3515b5e1d96b72fceb6cc4dd96465426077ba6dddc54e7dd4d517
-  languageName: node
-  linkType: hard
-
-"yeast@npm:0.1.2":
-  version: 0.1.2
-  resolution: "yeast@npm:0.1.2"
-  checksum: ce326a71c7f25059ef7581121104c21d2837511a95cb44604f9e1825c5722f5b65324fb0b1d20bcfe3975efe45e418106100aa0d0e9fc502f90f3d07d059e177
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fixes these:
```
➤ YN0002: │ fxa-shared@workspace:packages/fxa-shared doesn't provide class-transformer@^0.3.0 requested by @nestjs/mapped-types@npm:0.1.0
➤ YN0002: │ fxa-shared@workspace:packages/fxa-shared doesn't provide class-validator@^0.11.1 || ^0.12.0 requested by @nestjs/mapped-types@npm:0.1.0
➤ YN0002: │ @nestjs/graphql@npm:7.6.0 [ace81] doesn't provide class-transformer@^0.2.3 requested by @nestjs/mapped-types@npm:0.0.5
➤ YN0002: │ @nestjs/graphql@npm:7.6.0 [ace81] doesn't provide class-validator@^0.11.1 || ^0.12.0 requested by @nestjs/mapped-types@npm:0.0.5
➤ YN0060: │ @apollo/gateway@npm:0.17.0 [ead0f] provides graphql@npm:15.3.0 with version 15.3.0 which doesn't satisfy ^14.2.1 requested by apollo-graphql@npm:0.4.5
➤ YN0060: │ @apollo/federation@npm:0.17.0 [0cab6] provides graphql@npm:15.3.0 with version 15.3.0 which doesn't satisfy ^14.2.1 requested by apollo-graphql@npm:0.4.5
➤ YN0060: │ apollo-server-core@npm:2.16.1 [ead0f] provides graphql@npm:15.3.0 with version 15.3.0 which doesn't satisfy ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 requested by graphql-tag@npm:2.10.3
➤ YN0060: │ apollo-server-core@npm:2.16.1 [ead0f] provides graphql@npm:15.3.0 with version 15.3.0 which doesn't satisfy 0.13.1 - 14 requested by graphql-upload@npm:8.1.0
➤ YN0060: │ apollo-server-core@npm:2.16.1 [ead0f] provides graphql@npm:15.3.0 with version 15.3.0 which doesn't satisfy ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.1 || ^14.0.2 requested by subscriptions-transport-ws@npm:0.9.16
➤ YN0060: │ fxa-react@workspace:packages/fxa-react provides jest@npm:26.4.2 with version 26.4.2 which doesn't satisfy >=24 <25 requested by ts-jest@npm:24.3.0
➤ YN0060: │ fxa-admin-panel@workspace:packages/fxa-admin-panel provides jest@npm:26.4.2 with version 26.4.2 which doesn't satisfy >=24 <25 requested by ts-jest@npm:24.3.0
➤ YN0002: │ fxa-event-broker@workspace:packages/fxa-event-broker doesn't provide graphql@^14.1.1 || ^15.0.0 requested by @nestjs/graphql@npm:7.6.0
➤ YN0002: │ fxa-event-broker@workspace:packages/fxa-event-broker doesn't provide class-transformer@^0.3.0 requested by @nestjs/mapped-types@npm:0.1.0
➤ YN0060: │ fxa-event-broker@workspace:packages/fxa-event-broker provides @hapi/joi@npm:17.1.1 with version 17.1.1 which doesn't satisfy ^15.0.1 requested by typesafe-joi@npm:2.1.0
➤ YN0060: │ fxa-event-broker@workspace:packages/fxa-event-broker provides @google-cloud/firestore@npm:4.2.0 with version 4.2.0 which doesn't satisfy ^3.7.0 requested by typesafe-node-firestore@npm:1.3.0
➤ YN0002: │ @nestjs/graphql@npm:7.6.0 [d4fe2] doesn't provide class-transformer@^0.2.3 requested by @nestjs/mapped-types@npm:0.0.5
➤ YN0002: │ @nestjs/graphql@npm:7.6.0 [d4fe2] doesn't provide class-validator@^0.11.1 || ^0.12.0 requested by @nestjs/mapped-types@npm:0.0.5
➤ YN0060: │ fxa-payments-server@workspace:packages/fxa-payments-server provides jest@npm:26.4.2 with version 26.4.2 which doesn't satisfy >=24 <25 requested by ts-jest@npm:24.3.0
➤ YN0060: │ fxa-support-panel@workspace:packages/fxa-support-panel provides @hapi/joi@npm:17.1.1 with version 17.1.1 which doesn't satisfy ^15.0.1 requested by typesafe-joi@npm:2.1.0
```