### PR TITLE
fix(settings): improve GQL error handling to avoid redirect loop

### DIFF
--- a/packages/fxa-graphql-api/src/lib/auth.ts
+++ b/packages/fxa-graphql-api/src/lib/auth.ts
@@ -4,7 +4,7 @@
 
 import AuthClient from 'fxa-auth-client';
 import { Service, Inject } from 'typedi';
-import { AuthenticationError } from 'apollo-server';
+import { AuthenticationError, ApolloError } from 'apollo-server';
 
 import { fxAccountClientToken } from './constants';
 
@@ -17,7 +17,16 @@ export class SessionTokenAuth {
     try {
       return await this.authClient.sessionStatus(sessionToken);
     } catch (err) {
-      throw new AuthenticationError('Invalid session token');
+      if (err.code === 400 || err.code === 401) {
+        // AuthenticationError doesn't allow us to pass along the error code,
+        // but the error message is unique for most auth-server errors.
+        throw new AuthenticationError(err.message);
+      } else {
+        throw new ApolloError(err.message, '' + err.errno, {
+          errno: err.errno,
+          code: err.code,
+        });
+      }
     }
   }
 }

--- a/packages/fxa-settings/src/lib/gql.test.ts
+++ b/packages/fxa-settings/src/lib/gql.test.ts
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { errorHandler } from './gql';
+import { ErrorResponse } from '@apollo/client/link/error';
+import { Operation, NextLink, ServerError } from '@apollo/client/core';
+import { GraphQLError } from 'graphql';
+
+let errorResponse: ErrorResponse;
+
+describe('errorHandler', () => {
+  let realLocation: Location;
+
+  beforeAll(() => {
+    // Note: it's surprisingly difficult to mock out window.location cleanly.
+    // Messing with globals is gross, but works, and is really simple.
+    realLocation = window.location;
+    delete window.location;
+    window.location = {
+      replace: jest.fn(),
+      search: '',
+      pathname: 'foo',
+    };
+
+    // We don't verify that console.error gets called, but mocking it out
+    // avoids console noise filling up the command line as the tests run.
+    console.error = jest.fn();
+  });
+
+  afterAll(() => {
+    window.location = realLocation;
+    console.error.mockRestore();
+  });
+
+  beforeEach(() => {
+    window.location.replace.mockClear();
+  });
+
+  it('redirects to /get_flow if called with a GQL authentication error', () => {
+    errorResponse = {
+      graphQLErrors: [
+        new GraphQLError(
+          'Incorrect password',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { code: 'UNAUTHENTICATED' }
+        ),
+      ],
+      operation: (null as any) as Operation,
+      forward: (null as any) as NextLink,
+    };
+
+    errorHandler(errorResponse);
+
+    expect(window.location.replace).toHaveBeenCalledWith(
+      '/get_flow?redirect_to=foo'
+    );
+  });
+
+  it('redirects to get_flow if called with a 401 NetworkError', () => {
+    let networkError: any;
+    networkError = new Error('Network error') as ServerError;
+    networkError.statusCode = 401;
+    errorResponse = {
+      networkError,
+      operation: (null as any) as Operation,
+      forward: (null as any) as NextLink,
+    };
+
+    errorHandler(errorResponse);
+
+    expect(window.location.replace).toHaveBeenCalledWith(
+      '/get_flow?redirect_to=foo'
+    );
+  });
+
+  it('does not redirect if called with a 500 NetworkError', () => {
+    let networkError: any = new Error('Inscrutable and mysterious error');
+    networkError.statusCode = 500;
+    errorResponse = {
+      networkError,
+      operation: (null as any) as Operation,
+      forward: (null as any) as NextLink,
+    };
+
+    errorHandler(errorResponse);
+
+    expect(window.location.replace).not.toHaveBeenCalled();
+  });
+});

--- a/packages/fxa-settings/src/lib/gql.ts
+++ b/packages/fxa-settings/src/lib/gql.ts
@@ -1,7 +1,30 @@
 import { ApolloClient, createHttpLink, from } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
-import { onError } from '@apollo/client/link/error';
+import { ErrorHandler, onError } from '@apollo/client/link/error';
 import { cache, sessionToken, typeDefs } from './cache';
+
+export const errorHandler: ErrorHandler = ({ graphQLErrors, networkError }) => {
+  let reauth = false;
+  if (graphQLErrors) {
+    for (const error of graphQLErrors) {
+      if (error.extensions?.code === 'UNAUTHENTICATED') {
+        reauth = true;
+      }
+    }
+  }
+  if (networkError && 'statusCode' in networkError) {
+    if (networkError.statusCode === 401) {
+      reauth = true;
+    }
+  }
+  if (reauth) {
+    window.location.replace(
+      `/get_flow?redirect_to=${encodeURIComponent(window.location.pathname)}`
+    );
+  } else {
+    console.error(graphQLErrors, networkError);
+  }
+};
 
 export function createApolloClient(gqlServerUri: string) {
   // httpLink makes the actual requests to the server
@@ -20,28 +43,8 @@ export function createApolloClient(gqlServerUri: string) {
   });
 
   // errorLink handles error responses from the server
-  const errorLink = onError(({ graphQLErrors, networkError }) => {
-    let reauth = false;
-    if (graphQLErrors) {
-      for (const error of graphQLErrors) {
-        if (error.extensions?.code === 'UNAUTHENTICATED') {
-          reauth = true;
-        }
-      }
-    }
-    if (networkError && 'statusCode' in networkError) {
-      if (networkError.statusCode === 401) {
-        reauth = true;
-      }
-    }
-    if (reauth) {
-      window.location.replace(
-        `/get_flow?redirect_to=${encodeURIComponent(window.location.pathname)}`
-      );
-    } else {
-      console.error(graphQLErrors, networkError);
-    }
-  });
+  const errorLink = onError(errorHandler);
+
   const apolloClient = new ApolloClient({
     cache,
     link: from([errorLink, authLink, httpLink]),


### PR DESCRIPTION
I'm annoyed by the branch name, but whatever. Final changes, from the commit message:

fix(settings): improve GQL error handling to avoid redirect loop

* Update the GQL API server to only return an AuthenticationError if it
    received an auth-related 400 or 401 error from auth-server. Otherwise,
    just return a generic ApolloError.

* Add tests for the front-end GQL library to be sure this works
    correctly.

* Add tests for the front-end GQL lib.

Fixes #6400.

-----

Original description from WIP draft:

The bug is that the gql-api was always returning an auth error, even if the problem was that it couldn't hit auth server. Setting up the (missing) tests for this lib has been a little complex; just looking for some feedback on test harness setup. Mocking out globals vs. wrapping in accessor functions might be a tradeoff that's been worked out elsewhere in new-settings?