### PR TITLE
fix(support form): add empty option for app/service field

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/support.js
+++ b/packages/fxa-content-server/app/scripts/views/support.js
@@ -181,6 +181,7 @@ const SupportView = BaseView.extend({
       if (apps.length) {
         this.appEl
           .empty()
+          .append('<option value="">&nbsp;</option>')
           .append(
             apps
               .map(_.escape)

--- a/packages/fxa-content-server/app/tests/spec/views/support.js
+++ b/packages/fxa-content-server/app/tests/spec/views/support.js
@@ -359,7 +359,7 @@ describe('views/support', function () {
           view.$('#product option:eq(1)').prop('selected', true);
           view.$('#product').trigger('change');
           view.$('#topic option:eq(1)').prop('selected', true);
-          view.$('#app option:eq(0)').prop('selected', true);
+          view.$('#app option:eq(1)').prop('selected', true);
           view.$('#message').val(supportTicket.message).trigger('keyup');
 
           // calling this directly instead of clicking submit so we can have


### PR DESCRIPTION
Because:
 - the app/service Support Form field is optional

This commit:
 - add an empty option to the app/service field

## Issue that this pull request solves

Closes: #6501 (FXA-2552)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

