### PR TITLE
feat(db): Create table to store user-customer relationship

### DIFF
--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 112;
+module.exports.level = 113;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-112-113.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-112-113.sql
@@ -1,0 +1,17 @@
+-- -- create accountCustomers table to store the relationship between fxa users and external payment providers
+-- -- stripeCustomerId is nullable by default with the idea that this table can be added upon in the future
+-- -- By creating additional columns for new payment providers. This table will be able to act as a way
+-- -- to quickly determine: is a user also a customer and which payment provider(s) is/are they using?
+
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('112');
+
+CREATE TABLE IF NOT EXISTS accountCustomers (
+  uid BINARY(16) PRIMARY KEY,
+  stripeCustomerId VARCHAR(32),
+  createdAt BIGINT UNSIGNED NOT NULL,
+  updatedAt BIGINT UNSIGNED NOT NULL
+) ENGINE=InnoDB;
+
+UPDATE dbMetadata SET value = '113' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-113-112.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-113-112.sql
@@ -1,0 +1,5 @@
+-- -- drop accountCustomers table to store the relationship between fxa users and external payment providers
+
+-- DROP TABLE accountCustomers;
+
+-- UPDATE dbMetadata SET value = '112' WHERE name = 'schema-patch-level';

--- a/yarn.lock
+++ b/yarn.lock
@@ -35093,6 +35093,7 @@ resolve@~1.11.1:
     semver: ^6.0.0
   peerDependencies:
     typescript: "*"
+  checksum: 2cfdba8538d076fc851ea2ebf02aa39d859e4e62d509fe2004a06c867f5861d7f9cd43ea3b471a09a03b386da0e94a37727400efa7087f814a8d3c6fde431ed1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because:

* We want to be able to tell if an FxA user has an associate Stripe Customer account without having to query Stripe

## This Commit:

* Creates the userCustomers table that will be used to associate FxA user ids with Stripe Customer ids

## Closes: #6158

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
