### PR TITLE
fix(pairing): Redirect to pairing from fxa desktop preferences entrypoint

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/constants.js
+++ b/packages/fxa-content-server/app/scripts/lib/constants.js
@@ -162,9 +162,11 @@ module.exports = {
 
   SIGNUP_CODE_LENGTH: 6,
 
+  // Some common FxA entrypoints for various browsers
   FIREFOX_IOS_OAUTH_ENTRYPOINT: 'ios_settings_manage',
   FIREFOX_TOOLBAR_ENTRYPOINT: 'fxa_discoverability_native',
   FIREFOX_MENU_ENTRYPOINT: 'fxa_app_menu',
+  FIREFOX_PREFERENCES_ENTRYPOINT: 'preferences',
 
   // This is compared against all secondary email
   // records, both verified and unverified

--- a/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/connect-another-device-mixin.js
@@ -88,7 +88,8 @@ export default {
       this.isDefault() &&
       context === Constants.FX_DESKTOP_V3_CONTEXT &&
       (entrypoint === Constants.FIREFOX_TOOLBAR_ENTRYPOINT ||
-        entrypoint === Constants.FIREFOX_MENU_ENTRYPOINT)
+        entrypoint === Constants.FIREFOX_MENU_ENTRYPOINT ||
+        entrypoint === Constants.FIREFOX_PREFERENCES_ENTRYPOINT)
     ) {
       return true;
     }

--- a/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
@@ -85,26 +85,30 @@ describe('views/connect_another_device', () => {
       });
     });
 
-    describe('with a Fx desktop user that can pair', () => {
-      beforeEach(() => {
-        sinon.stub(view, '_isSignedIn').callsFake(() => true);
-        relier.set('entrypoint', 'fxa_discoverability_native');
-        relier.set('context', 'fx_desktop_v3');
-        sinon.spy(view, 'navigate');
+    ['fxa_discoverability_native', 'fxa_app_menu', 'preferences'].forEach(
+      (entrypoint) => {
+        describe(`with a Fx desktop user that can pair from ${entrypoint}`, () => {
+          beforeEach(() => {
+            sinon.stub(view, '_isSignedIn').callsFake(() => true);
+            relier.set('entrypoint', entrypoint);
+            relier.set('context', 'fx_desktop_v3');
+            sinon.spy(view, 'navigate');
 
-        windowMock.navigator.userAgent =
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0';
+            windowMock.navigator.userAgent =
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0';
 
-        return view.render().then(() => {
-          view.afterVisible();
+            return view.render().then(() => {
+              view.afterVisible();
+            });
+          });
+
+          it('shows pairing', () => {
+            assert.isTrue(view._isSignedIn.called);
+            assert.isTrue(view.navigate.calledWith('/pair'));
+          });
         });
-      });
-
-      it('shows pairing', () => {
-        assert.isTrue(view._isSignedIn.called);
-        assert.isTrue(view.navigate.calledWith('/pair'));
-      });
-    });
+      }
+    );
 
     describe('with a fennec user that is signed in', () => {
       beforeEach(() => {


### PR DESCRIPTION
## Because

- We should redirect to pairing if user is coming from desktop and signed in

## This pull request

- Adds the `preferences` entrypoint to redirect to pairing

## Issue that this pull request solves

Closes: #6422 

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
