### PR TITLE
chore(storybooks): switch to a new shared Storybook publisher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,7 +243,7 @@ jobs:
           package: many
       - run:
           name: Build and deploy Storybooks
-          command: ./_scripts/build-storybooks.sh
+          command: npx github:lmorchard/storybook-gcp-publisher
 
 workflows:
   test_pull_request:


### PR DESCRIPTION
## Because

Both FxA and Experimenter want to publish Storybooks

## This pull request

Aims to switch FxA over to a new Storybook publisher that can be shared between the projects and is written completely in Node rather than a mix of Node and shell scripts.

The change to FxA is one line, because the shared publisher lives here right now and [can be run via npx](https://github.com/npm/npx#invoking-a-command-from-a-github-repository):

https://github.com/lmorchard/storybook-gcp-publisher

## TODO

- [x] Would like to move the publisher somewhere more "official" (e.g. [mozilla-fxa/storybook-gcp-publisher](https://github.com/mozilla-fxa/storybook-gcp-publisher)) before actually merging.
- [x] Need to add environment variable config to FxA CircleCI
- [ ] Need to [reduce bus factor](https://en.wikipedia.org/wiki/Bus_factor) on the infra and credentials for GCP and Github

## Issue that this pull request solves

Not technically an FxA issue, but the work can be shared: https://jira.mozilla.com/browse/EXP-281

## Other information (Optional)

This is currently working with my personal accounts for GitHub, CircleCI, and Google Cloud:

* static site - https://storage.googleapis.com/lorchard-dev-storybook-static-1/index.html
* CI run - https://app.circleci.com/pipelines/github/lmorchard/fxa/18/workflows/08b08f13-c447-40e5-9371-95104d7c1b86/jobs/262
* status check - https://github.com/lmorchard/fxa/commit/b639df81788905a93bde01dc6c6ee7db9edd3d76
