### PR TITLE
feat(auth-server): delete stripe record

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -498,15 +498,13 @@ export class StripeHelper {
 
   /**
    * On FxA deletion, if the user is a Stripe Customer:
-   * - flag the stripe customer to delete
+   * - delete the stripe customer to delete
    * - remove the cache entry
    */
   async removeCustomer(uid: string, email: string) {
     const customer = await this.fetchCustomer(uid, email);
     if (customer) {
-      await this.stripe.customers.update(customer.id, {
-        metadata: { delete: 'true' },
-      });
+      await this.stripe.customers.del(customer.id);
       await this.removeCustomerFromCache(uid, email);
     }
   }

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -1389,13 +1389,13 @@ describe('StripeHelper', () => {
   });
 
   describe('removeCustomer', () => {
-    let stripeCustomerUpdate;
+    let stripeCustomerDel;
     const uid = 'user123';
     const email = 'test@example.com';
 
     beforeEach(() => {
-      stripeCustomerUpdate = sandbox
-        .stub(stripeHelper.stripe.customers, 'update')
+      stripeCustomerDel = sandbox
+        .stub(stripeHelper.stripe.customers, 'del')
         .resolves();
 
       sandbox.spy(stripeHelper, 'removeCustomerFromCache');
@@ -1407,7 +1407,7 @@ describe('StripeHelper', () => {
 
         await stripeHelper.removeCustomer(uid, email);
 
-        assert(stripeCustomerUpdate.calledOnce);
+        assert(stripeCustomerDel.calledOnce);
         assert(stripeHelper.removeCustomerFromCache.calledOnce);
       });
     });
@@ -1418,7 +1418,7 @@ describe('StripeHelper', () => {
 
         await stripeHelper.removeCustomer(uid, email);
 
-        assert(stripeCustomerUpdate.notCalled);
+        assert(stripeCustomerDel.notCalled);
         assert(stripeHelper.removeCustomerFromCache.notCalled);
       });
     });


### PR DESCRIPTION
Because:

* We want to ensure the stripe record is deleted, and subhub has not
  been deleting them.

This commit:

* Deletes the stripe customer record on account deletion.

Closes #6493

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
