### PR TITLE
fix(tests): Store test results in insights

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,8 @@ commands:
       - store_artifacts:
           path: ~/screenshots
           destination: screenshots
+      - store_test_results:
+          path: artifacts/tests
 
   test-settings-server:
     steps:
@@ -76,6 +78,8 @@ commands:
       - store_artifacts:
           path: ~/screenshots
           destination: screenshots
+      - store_test_results:
+          path: artifacts/tests
 
 jobs:
   test-package:

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ tailwind.out.*
 coverage.html
 **/coverage
 **/.nyc_output
+test-results.xml
 
 # System files
 *~

--- a/packages/fxa-content-server/tests/intern.js
+++ b/packages/fxa-content-server/tests/intern.js
@@ -76,7 +76,15 @@ const config = {
   fxaPaymentsRoot,
 
   pageLoadTimeout: 20000,
-  reporters: 'runner',
+  reporters: [
+    {
+      name: 'junit',
+      options: {
+        filename: output,
+      },
+    },
+    'runner',
+  ],
   serverPort: 9091,
   serverUrl: 'http://localhost:9091',
   socketPort: 9077,
@@ -113,15 +121,6 @@ if (args.suites) {
       break;
     case 'circle':
       config.functionalSuites = testsCircleCi;
-      config.reporters = [
-        {
-          name: 'junit',
-          options: {
-            filename: output,
-          },
-        },
-        'runner',
-      ];
       console.log('Running tests:', config.functionalSuites);
       break;
     case 'server':


### PR DESCRIPTION
Looks like this broke a little while back and we were logging the results for content-server.

Fixes https://github.com/mozilla/fxa/issues/5320