### PR TITLE
fix(tests): Add carryflags to codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
           path: artifacts/tests
       - run:
           name: Reporting code coverage...
-          command: bash <(curl -s https://codecov.io/bash) -X gcov
+          command: bash <(curl -s https://codecov.io/bash) -F << parameters.package >> -X gcov
 
   test-many:
     resource_class: medium+
@@ -144,7 +144,7 @@ jobs:
             done
       - run:
           name: Reporting code coverage...
-          command: bash <(curl -s https://codecov.io/bash) -X gcov
+          command: bash <(curl -s https://codecov.io/bash) -F many -X gcov
 
   test-settings-server:
     executor: content-server-executor

--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -16,6 +16,9 @@ coverage:
         if_not_found: success
         informational: true
         only_pulls: false
+        flags:
+          - fxa-auth-server
+          - many
 
 parsers:
   gcov:
@@ -26,3 +29,18 @@ parsers:
       macro: no
 
 comment: false
+
+flags:
+  fxa-auth-server:
+    paths:
+      - packages/fxa-auth-server
+    carryforward: true
+  many:
+    paths:
+      - packages/fxa-admin-panel
+      - packages/fxa-auth-db-mysql
+      - packages/fxa-customs-server
+      - packages/fxa-payments-server
+      - packages/fxa-profile-server
+      - packages/fxa-shared
+    carryforward: true


### PR DESCRIPTION
## Because

- Our code coverage metrics are not always accurate

## This pull request

- Adds support for the [carryflags](https://docs.codecov.io/docs/carryforward-flags) which in theory should help. Not 100% sure I set it up correctly since it needs to be merged to master and get a base commit for coverage reports. Doesn't hurt to try

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/6086 

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
