### PR TITLE
feat(auth): create script to populate accountCustomers table

### DIFF
--- a/packages/fxa-auth-server/.vscode/launch.json
+++ b/packages/fxa-auth-server/.vscode/launch.json
@@ -148,6 +148,28 @@
       },
       "preLaunchTask": "Stop PM2 Auth Server",
       "postDebugTask": "Start PM2 Auth Server"
-    },
+    }, {
+      "type": "node",
+      "request": "launch",
+      "name": "Coverage: Mocha Current File",
+      "program": "${workspaceFolder}/../../node_modules/nyc/bin/nyc.js",
+      "args": [
+        "--reporter=lcov",
+        "${workspaceFolder}/../../node_modules/mocha/bin/_mocha",
+        "--timeout",
+        "999999",
+        "--colors",
+        "${workspaceFolder}/${relativeFile}",
+        "--exit"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "env": {
+        "NODE_ENV": "dev",
+        "VERIFIER_VERSION": "0",
+        "NO_COVERAGE": "1",
+        "CORS_ORIGIN": "http://foo,http://bar"
+      },
+    }
   ]
 }

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -11,6 +11,41 @@ const DEFAULT_SUPPORTED_LANGUAGES = require('./supportedLanguages');
 convict.addFormats(require('convict-format-with-moment'));
 convict.addFormats(require('convict-format-with-validator'));
 
+function makeMySQLConfig(envPrefix: string, database: string) {
+  return {
+    database: {
+      default: database,
+      doc: 'MySQL database',
+      env: envPrefix + '_MYSQL_DATABASE',
+      format: String,
+    },
+    host: {
+      default: 'localhost',
+      doc: 'MySQL host',
+      env: envPrefix + '_MYSQL_HOST',
+      format: String,
+    },
+    password: {
+      default: '',
+      doc: 'MySQL password',
+      env: envPrefix + '_MYSQL_PASSWORD',
+      format: String,
+    },
+    port: {
+      default: 3306,
+      doc: 'MySQL port',
+      env: envPrefix + '_MYSQL_PORT',
+      format: Number,
+    },
+    user: {
+      default: 'root',
+      doc: 'MySQL username',
+      env: envPrefix + '_MYSQL_USERNAME',
+      format: String,
+    },
+  };
+}
+
 const conf = convict({
   env: {
     doc: 'The current node.js environment',
@@ -159,6 +194,11 @@ const conf = convict({
     format: String,
     default: path.resolve(__dirname, '../config/vapid-keys.json'),
     env: 'VAPID_KEYS_FILE',
+  },
+  database: {
+    mysql: {
+      auth: makeMySQLConfig('AUTH', 'fxa'),
+    },
   },
   db: {
     backend: {

--- a/packages/fxa-auth-server/scripts/populate-stripe-customer-db.ts
+++ b/packages/fxa-auth-server/scripts/populate-stripe-customer-db.ts
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import program from 'commander';
+const pckg = require('../package.json');
+import { Stripe } from 'stripe';
+
+import { setupAuthDatabase } from 'fxa-shared/db';
+import {
+  accountExists,
+  createAccountCustomer,
+} from 'fxa-shared/db/models/auth';
+
+export async function init() {
+  const config = require('../config').getProperties();
+
+  program
+    .version(pckg.version)
+    .option('-c, --config [config]', 'Configuration to use. Ex. dev')
+    .option(
+      '-k, --stripe-key [key]',
+      'Stripe secret key to use - alternatively, use SUBHUB_STRIPE_APIKEY env var'
+    )
+    .parse(process.argv);
+
+  process.env.NODE_ENV = program.config || 'dev';
+
+  if (program.stripeKey) {
+    process.env.SUBHUB_STRIPE_APIKEY = program.stripeKey;
+  }
+
+  if (process.env.SUBHUB_STRIPE_APIKEY === undefined) {
+    console.log('Unable to execute script without a Stripe Key defined.');
+    return 1;
+  }
+  const stripe = new Stripe(process.env.SUBHUB_STRIPE_APIKEY, {
+    apiVersion: '2020-03-02',
+    maxNetworkRetries: 3,
+  });
+
+  setupAuthDatabase(config.database.mysql.auth);
+
+  await processCustomers(stripe);
+
+  return 0;
+}
+
+async function processCustomers(stripe: Stripe) {
+  let count = 0;
+
+  for await (const customer of stripe.customers.list()) {
+    const uid = customer.metadata.userid;
+    const stripeCustomerId = customer.id;
+    if (uid === undefined) {
+      continue;
+    }
+    const logPrefix = `${count}: uid ${uid} stripeId ${stripeCustomerId}`;
+
+    const msg = await processStripeCustomer(uid, stripeCustomerId);
+
+    console.log(`${logPrefix} - ${msg}`);
+    count++;
+  }
+}
+
+export async function processStripeCustomer(
+  uid: string,
+  stripeCustomerId: string
+) {
+  try {
+    if (await accountExists(uid)) {
+      await createAccountCustomer(uid, stripeCustomerId);
+      return 'CustomerAccount record successfully created.';
+    } else {
+      return 'Firefox account not found.';
+    }
+  } catch (err) {
+    return `Failed to create record: ${err.message}`;
+  }
+}
+
+if (require.main === module) {
+  init()
+    .catch((err) => {
+      console.error(err.message);
+      process.exit(1);
+    })
+    .then((result) => process.exit(result));
+}

--- a/packages/fxa-auth-server/test/scripts/fixtures/account-customers.sql
+++ b/packages/fxa-auth-server/test/scripts/fixtures/account-customers.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `accountCustomers` (
+  `uid` BINARY(16) PRIMARY KEY,
+  `stripeCustomerId` VARCHAR(32),
+  `createdAt` BIGINT UNSIGNED NOT NULL,
+  `updatedAt` BIGINT UNSIGNED NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/packages/fxa-auth-server/test/scripts/fixtures/accounts.sql
+++ b/packages/fxa-auth-server/test/scripts/fixtures/accounts.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `accounts` (
+  `uid` binary(16) NOT NULL,
+  `normalizedEmail` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `email` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `emailCode` binary(16) NOT NULL,
+  `emailVerified` tinyint(1) NOT NULL DEFAULT '0',
+  `kA` binary(32) NOT NULL,
+  `wrapWrapKb` binary(32) NOT NULL,
+  `authSalt` binary(32) NOT NULL,
+  `verifyHash` binary(32) NOT NULL,
+  `verifierVersion` tinyint(3) unsigned NOT NULL,
+  `verifierSetAt` bigint(20) unsigned NOT NULL,
+  `createdAt` bigint(20) unsigned NOT NULL,
+  `locale` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL,
+  `lockedAt` bigint(20) unsigned DEFAULT NULL,
+  `profileChangedAt` bigint(20) unsigned DEFAULT NULL,
+  `keysChangedAt` bigint(20) unsigned DEFAULT NULL,
+  PRIMARY KEY (`uid`),
+  UNIQUE KEY `normalizedEmail` (`normalizedEmail`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci

--- a/packages/fxa-auth-server/test/scripts/fixtures/emails.sql
+++ b/packages/fxa-auth-server/test/scripts/fixtures/emails.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `emails` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `normalizedEmail` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `email` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  `uid` binary(16) NOT NULL,
+  `emailCode` binary(16) NOT NULL,
+  `isVerified` tinyint(1) NOT NULL DEFAULT '0',
+  `isPrimary` tinyint(1) NOT NULL DEFAULT '0',
+  `verifiedAt` bigint(20) unsigned DEFAULT NULL,
+  `createdAt` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `normalizedEmail` (`normalizedEmail`),
+  KEY `emails_uid` (`uid`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci

--- a/packages/fxa-auth-server/test/scripts/populate-stripe-customer-db.spec.ts
+++ b/packages/fxa-auth-server/test/scripts/populate-stripe-customer-db.spec.ts
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import fs from 'fs';
+import path from 'path';
+import { assert } from 'chai';
+import Chance from 'chance';
+import Knex from 'knex';
+
+import { setupAuthDatabase } from 'fxa-shared/db';
+import { Account } from 'fxa-shared/db/models/auth';
+
+import { processStripeCustomer } from '../../scripts/populate-stripe-customer-db';
+
+type AccountIsh = Pick<Account, 'uid' | 'email' | 'emails' | 'normalizedEmail'>;
+
+export const chance = new Chance();
+
+const thisDir = path.dirname(__filename);
+export const accountTable = fs.readFileSync(
+  path.join(thisDir, './fixtures/accounts.sql'),
+  'utf8'
+);
+export const emailsTable = fs.readFileSync(
+  path.join(thisDir, './fixtures/emails.sql'),
+  'utf8'
+);
+export const accountCustomersTable = fs.readFileSync(
+  path.join(thisDir, './fixtures/account-customers.sql'),
+  'utf8'
+);
+
+export function randomAccount() {
+  const email = chance.email();
+  return {
+    authSalt: Buffer.from('0', 'hex'),
+    createdAt: chance.timestamp(),
+    email,
+    emailCode: Buffer.from('0', 'hex'),
+    emailVerified: true,
+    kA: Buffer.from('0', 'hex'),
+    normalizedEmail: email,
+    uid: chance.guid({ version: 4 }).replace(/-/g, ''),
+    verifierSetAt: chance.timestamp(),
+    verifierVersion: 0,
+    verifyHash: Buffer.from('0', 'hex'),
+    wrapWrapKb: Buffer.from('0', 'hex'),
+  };
+}
+
+export function randomEmail(account: AccountIsh, primary = true) {
+  return {
+    createdAt: chance.timestamp(),
+    email: account.email,
+    emailCode: '00000000000000000000000000000000',
+    isPrimary: primary,
+    isVerified: true,
+    normalizedEmail: account.normalizedEmail,
+    uid: account.uid,
+  };
+}
+
+async function testDatabaseSetup(): Promise<Knex> {
+  // Create the db if it doesn't exist
+  let knex = Knex({
+    client: 'mysql',
+    connection: {
+      charset: 'UTF8MB4_BIN',
+      host: 'localhost',
+      password: '',
+      port: 3306,
+      user: 'root',
+    },
+  });
+
+  await knex.raw('DROP DATABASE IF EXISTS testAdmin');
+  await knex.raw('CREATE DATABASE testAdmin');
+  await knex.destroy();
+
+  knex = setupAuthDatabase({
+    database: 'testAdmin',
+    host: 'localhost',
+    password: '',
+    port: 3306,
+    user: 'root',
+  });
+
+  await knex.raw(accountTable);
+  await knex.raw(emailsTable);
+  await knex.raw(accountCustomersTable);
+  return knex;
+}
+
+const USER_1 = randomAccount();
+const EMAIL_1 = randomEmail(USER_1);
+const customer1Mock = {
+  id: 'cus_1',
+  metadata: {
+    userid: USER_1.uid,
+  },
+};
+
+const customer2Mock_noMatch = {
+  id: 'cus_2',
+  metadata: {
+    userid: '00006686c226415abd06ae550f073ced',
+  },
+};
+
+const customer3Mock_duplicate_fxa = {
+  id: 'cus_3',
+  metadata: {
+    userid: USER_1.uid,
+  },
+};
+describe('scripts/populate-stripe-customer-db', function () {
+  let knex: Knex;
+
+  before(async () => {
+    knex = await testDatabaseSetup();
+    // Load the user in
+    await Account.query().insertGraph({ ...USER_1, emails: [EMAIL_1] });
+  });
+
+  after(async () => {
+    await knex.raw('DROP DATABASE IF EXISTS testAdmin');
+    await knex.destroy();
+  });
+
+  describe('processStripeCustomer', () => {
+    const successMsg = 'CustomerAccount record successfully created.';
+    const notFoundMsg = 'Firefox account not found.';
+    const errMsg = 'Failed to create record:';
+
+    it('logs successful creation', async () => {
+      const actual = await processStripeCustomer(
+        customer1Mock.metadata.userid,
+        customer1Mock.id
+      );
+      assert.equal(actual, successMsg);
+    });
+
+    it('logs when no fxa account is found', async () => {
+      const actual = await processStripeCustomer(
+        customer2Mock_noMatch.metadata.userid,
+        customer1Mock.id
+      );
+      assert.equal(actual, notFoundMsg);
+    });
+
+    it('logs failed creation', async () => {
+      const actual = await processStripeCustomer(
+        customer3Mock_duplicate_fxa.metadata.userid,
+        customer1Mock.id
+      );
+      assert.isTrue(actual.includes(errMsg));
+    });
+  });
+});

--- a/packages/fxa-shared/db/models/auth/index.ts
+++ b/packages/fxa-shared/db/models/auth/index.ts
@@ -11,6 +11,17 @@ export type AccountOptions = {
   include?: 'emails'[];
 };
 
+export async function accountExists(uid: string) {
+  let uidBuffer;
+  try {
+    uidBuffer = uuidTransformer.to(uid);
+  } catch (err) {
+    return false;
+  }
+  const account = await Account.query().findOne({ uid: uidBuffer });
+  return account ? true : false;
+}
+
 export function accountByUid(uid: string, options?: AccountOptions) {
   let uidBuffer;
   try {

--- a/packages/fxa-shared/test/db/models/auth/index.spec.ts
+++ b/packages/fxa-shared/test/db/models/auth/index.spec.ts
@@ -18,6 +18,7 @@ import {
 import {
   Account,
   accountByUid,
+  accountExists,
   AccountCustomers,
   createAccountCustomer,
   deleteAccountCustomer,
@@ -40,6 +41,17 @@ describe('auth', () => {
 
   after(async () => {
     await knex.destroy();
+  });
+
+  describe('accountExists', () => {
+    it('returns true if the account is found', async () => {
+      assert.isTrue(await accountExists(USER_1.uid));
+    });
+
+    it('returns false if the account is not found', async () => {
+      const uid = chance.guid({ version: 4 }).replace(/-/g, '');
+      assert.isFalse(await accountExists(uid));
+    });
   });
 
   describe('accountByUid', () => {
@@ -72,7 +84,7 @@ describe('auth', () => {
 
   describe('accountCustomers CRUD', () => {
     describe('createAccountCustomer', () => {
-      const userId = '27384d1476564252aade14e9c71bec49';
+      const userId = '263e29ad86d245eeabf309e6a125bbfb';
       const customerId = 'cus_I4jZCBRq3aiRKX';
       it('Creates a new customer when the uid and customer id are valid', async () => {
         const testCustomer = (await createAccountCustomer(


### PR DESCRIPTION
## Because

- To use the accountCustomers table effectively, we need to prepopulate it with Stripe data

## This pull request

- Create script to populate accountCustomers table from existing customers in Stripe

## Issue that this pull request solves

Closes: #6160

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
