### PR TITLE
fix(metrics): fix payload validation for payments metrics

### DIFF
--- a/packages/fxa-payments-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-payments-server/server/lib/routes/post-metrics.js
@@ -15,7 +15,14 @@ const EVENT_TYPE_PATTERN = /^[\w\s.:-]+$/; // the space is to allow for error co
 const OFFSET_TYPE = joi.number().integer().min(0);
 const STRING_TYPE = joi.string().max(1024);
 const BODY_SCHEMA = {
-  data: joi.object().required(),
+  data: joi
+    .object()
+    .keys({
+      flowBeginTime: OFFSET_TYPE.optional(),
+      flowId: STRING_TYPE.hex().length(64).optional(),
+    })
+    .unknown(true)
+    .required(),
   events: joi
     .array()
     .items(
@@ -25,8 +32,6 @@ const BODY_SCHEMA = {
       })
     )
     .required(),
-  flowBeginTime: OFFSET_TYPE.optional(),
-  flowId: STRING_TYPE.hex().length(64).optional(),
 };
 
 module.exports = {


### PR DESCRIPTION
Because:
 - the payload validation on Payments metrics endpoint was not
   validating the flow begin time and the flow id

This commit:
 - move the Joi validators into the correct spot

## Issue that this pull request solves

Closes: #6564

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
