### PR TITLE
fix(tests): update functional testing docs and settings tests

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -2890,3 +2890,17 @@ module.exports = {
   visibleByQSA,
   waitForUrl,
 };
+
+// Export helpers methods in a form that can be easily used in
+// async/await. The usage of the helpers are the same except
+// they expect the last argument to be the intern remote object.
+const helpersRemoteWrapped = {};
+const helpers = { ...module.exports };
+Object.keys(helpers).forEach((key) => {
+  helpersRemoteWrapped[key] = async function () {
+    const args = [...arguments];
+    const remote = args.pop();
+    return remote.then(helpers[key](...args));
+  };
+});
+module.exports.helpersRemoteWrapped = helpersRemoteWrapped;

--- a/packages/fxa-content-server/tests/functional/settings_v2/settings.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/settings.js
@@ -14,26 +14,26 @@ const EMAIL_FIRST = config.fxaContentRoot;
 const SETTINGS_V2_URL = `${config.fxaContentRoot}beta/settings`;
 const password = 'passwordzxcv';
 
+const { createEmail } = FunctionalHelpers;
+
 const {
-  createEmail,
   createUser,
-  fillOutEmailFirstSignIn,
   openPage,
+  fillOutEmailFirstSignIn,
   testElementExists,
-} = FunctionalHelpers;
+} = FunctionalHelpers.helpersRemoteWrapped;
 
 describe('settings', () => {
   let email;
   beforeEach(async ({ remote }) => {
     email = createEmail();
-    await remote.then(createUser(email, password, { preVerified: true }));
+    await createUser(email, password, { preVerified: true }, remote);
   });
 
   it('can navigate to settings', async ({ remote }) => {
-    await remote
-      .then(openPage(EMAIL_FIRST, selectors.ENTER_EMAIL.HEADER))
-      .then(fillOutEmailFirstSignIn(email, password))
-      .then(testElementExists(selectors.SETTINGS.HEADER))
-      .then(openPage(SETTINGS_V2_URL, '#profile'));
+    await openPage(EMAIL_FIRST, selectors.ENTER_EMAIL.HEADER, remote);
+    await fillOutEmailFirstSignIn(email, password, remote);
+    await testElementExists(selectors.SETTINGS.HEADER, remote);
+    await openPage(SETTINGS_V2_URL, '#profile', remote);
   });
 });

--- a/packages/fxa-settings/README.md
+++ b/packages/fxa-settings/README.md
@@ -29,6 +29,7 @@ This documentation is up to date as of 2020-09-23.
 — [`useAccount`, `useSession`, or GQL Mocks](#components-that-use-useaccount-usesession-or-need-a-gql-mock)\
 — [Mocking mutation errors](#mocking-mutation-errors)\
 [Storybook](#storybook)\
+[Functional Testing](#functional-testing)\
 [License](#license)
 
 ## Relevant ADRs
@@ -543,6 +544,32 @@ No Apollo Client instance can be found. Please ensure that you have called `Apol
 This project uses [Storybook](https://storybook.js.org/) to show each screen without requiring a full stack.
 
 In local development, `yarn storybook` will start a Storybook server at <http://localhost:6008> with hot module replacement to reflect live changes. Storybook provides a way to document and visually show various component states and application routes. Storybook builds from pull requests and commits can be found at https://mozilla-fxa.github.io/storybooks/.
+
+## Functional Testing
+
+Functional testing for this project requires the entire FxA stack to be running. Check out [Getting Started](https://github.com/mozilla/fxa#getting-started) for more instructions.
+
+Running and adding new functional test for settings is very similar to adding a functional test for the content-server. For an overview of functional testing in content-server check out this [document](https://github.com/mozilla/ecosystem-platform/blob/master/docs/fxa-engineering/functional-testing.md).
+
+### Running tests
+
+```
+cd packages/fxa-content-server
+node tests/intern.js --suites="settings_v2"
+```
+
+#### Single test
+
+```
+cd packages/fxa-content-server
+node tests/intern.js --suites="settings_v2" --grep="name of test here"
+```
+
+### Adding a new test
+
+- Create your test file in [packages/fxa-content-server/tests/functional/settings_v2](https://github.com/mozilla/fxa/tree/main/packages/fxa-content-server/tests/functional/settings_v2)
+  - Existing tests are a good starting point
+- Add your test to the settings [suite](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/tests/functional_settings_v2.js)
 
 ## License
 


### PR DESCRIPTION
## Because

- We should probably document how to create functional tests
- While Internjs does support async/await, our test helpers are not in test most convenient format for them

## This pull request

- Adds docs
- Wrap our functional test helpers so that they can be used in async/await 

## Issue that this pull request solves

Closes: #6530 Closes #6528 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
