### PR TITLE
feat(auth): Add Create/Delete for Account-Customer Relationship

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -6,6 +6,7 @@
 
 const error = require('../lib/error');
 const jwtool = require('fxa-jwtool');
+const { setupAuthDatabase } = require('fxa-shared/db');
 const { StatsD } = require('hot-shots');
 const { Container } = require('typedi');
 
@@ -27,6 +28,9 @@ async function run(config) {
 
   const log = require('../lib/log')({ ...config.log, statsd });
   require('../lib/oauth/logging')(log);
+
+  // Establish database connection and bind instance to Model using Knex
+  setupAuthDatabase(config.database.mysql.auth);
 
   /** @type {undefined | import('../lib/payments/stripe').StripeHelper} */
   let stripeHelper = undefined;

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -5,46 +5,12 @@ import convict from 'convict';
 import fs from 'fs';
 import path from 'path';
 import url from 'url';
+import { makeMySQLConfig } from 'fxa-shared/db/config';
 
 const DEFAULT_SUPPORTED_LANGUAGES = require('./supportedLanguages');
 
 convict.addFormats(require('convict-format-with-moment'));
 convict.addFormats(require('convict-format-with-validator'));
-
-function makeMySQLConfig(envPrefix: string, database: string) {
-  return {
-    database: {
-      default: database,
-      doc: 'MySQL database',
-      env: envPrefix + '_MYSQL_DATABASE',
-      format: String,
-    },
-    host: {
-      default: 'localhost',
-      doc: 'MySQL host',
-      env: envPrefix + '_MYSQL_HOST',
-      format: String,
-    },
-    password: {
-      default: '',
-      doc: 'MySQL password',
-      env: envPrefix + '_MYSQL_PASSWORD',
-      format: String,
-    },
-    port: {
-      default: 3306,
-      doc: 'MySQL port',
-      env: envPrefix + '_MYSQL_PORT',
-      format: Number,
-    },
-    user: {
-      default: 'root',
-      doc: 'MySQL username',
-      env: envPrefix + '_MYSQL_USERNAME',
-      format: String,
-    },
-  };
-}
 
 const conf = convict({
   env: {

--- a/packages/fxa-auth-server/test/local/payments/fixtures/customer_new.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/customer_new.json
@@ -1,5 +1,5 @@
 {
-  "id": "cust_new",
+  "id": "cus_new",
   "object": "customer",
   "address": null,
   "balance": 0,

--- a/packages/fxa-auth-server/test/local/payments/fixtures/customer_new_pmi.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/customer_new_pmi.json
@@ -1,5 +1,5 @@
 {
-  "id": "cust_new",
+  "id": "cus_new",
   "object": "customer",
   "address": null,
   "balance": 0,

--- a/packages/fxa-auth-server/test/local/payments/fixtures/customer_new_pmi_default_invoice_expanded.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/customer_new_pmi_default_invoice_expanded.json
@@ -1,5 +1,5 @@
 {
-  "id": "cust_new",
+  "id": "cus_new",
   "object": "customer",
   "address": null,
   "balance": 0,

--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -4,6 +4,7 @@
 import convict from 'convict';
 import fs from 'fs';
 import path from 'path';
+import { makeMySQLConfig } from 'fxa-shared/db/config';
 
 convict.addFormats(require('convict-format-with-moment'));
 convict.addFormats(require('convict-format-with-validator'));
@@ -12,41 +13,6 @@ export interface RedisConfig {
   host: string;
   keyPrefix: string;
   port: number;
-}
-
-function makeMySQLConfig(envPrefix: string, database: string) {
-  return {
-    database: {
-      default: database,
-      doc: 'MySQL database',
-      env: envPrefix + '_MYSQL_DATABASE',
-      format: String,
-    },
-    host: {
-      default: 'localhost',
-      doc: 'MySQL host',
-      env: envPrefix + '_MYSQL_HOST',
-      format: String,
-    },
-    password: {
-      default: '',
-      doc: 'MySQL password',
-      env: envPrefix + '_MYSQL_PASSWORD',
-      format: String,
-    },
-    port: {
-      default: 3306,
-      doc: 'MySQL port',
-      env: envPrefix + '_MYSQL_PORT',
-      format: Number,
-    },
-    user: {
-      default: 'root',
-      doc: 'MySQL username',
-      env: envPrefix + '_MYSQL_USERNAME',
-      format: String,
-    },
-  };
 }
 
 function makeRedisConfig(envPrefix: string, prefix: string) {

--- a/packages/fxa-shared/db/config.ts
+++ b/packages/fxa-shared/db/config.ts
@@ -9,3 +9,38 @@ export interface MySQLConfig {
   port: number;
   user: string;
 }
+
+export function makeMySQLConfig(envPrefix: string, database: string) {
+  return {
+    database: {
+      default: database,
+      doc: 'MySQL database',
+      env: envPrefix + '_MYSQL_DATABASE',
+      format: String,
+    },
+    host: {
+      default: 'localhost',
+      doc: 'MySQL host',
+      env: envPrefix + '_MYSQL_HOST',
+      format: String,
+    },
+    password: {
+      default: '',
+      doc: 'MySQL password',
+      env: envPrefix + '_MYSQL_PASSWORD',
+      format: String,
+    },
+    port: {
+      default: 3306,
+      doc: 'MySQL port',
+      env: envPrefix + '_MYSQL_PORT',
+      format: Number,
+    },
+    user: {
+      default: 'root',
+      doc: 'MySQL username',
+      env: envPrefix + '_MYSQL_USERNAME',
+      format: String,
+    },
+  };
+}


### PR DESCRIPTION
## Because

- We want to have a persistent record connection account ids to stripe customer ids

## This pull request

- Adds relationship creation and deletion to the Stripe Customer Creation and Deletion flows

## Issue that this pull request solves

closes: #6161

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
