### PR TITLE
fix(metrics): add service name to sync oauth Amplitude events

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -180,6 +180,7 @@
     },
     "clientIdToServiceNames": {
       "dcdb5ae7add825d2": "123done",
+      "5882386c6d801776": "firefox-desktop",
       "98e6508e88680e1a": "fxa-settings",
       "7377719276ad44ee": "pocket-mobile",
       "749818d3f2e7857f": "pocket-web"

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -838,6 +838,12 @@ const conf = convict({
       default: {},
       env: 'OAUTH_CLIENT_IDS',
     },
+    oldSyncClientIds: {
+      doc: 'Client IDs of sync clients that migrated to OAuth.',
+      format: Array,
+      default: ['5882386c6d801776', '1b1a3e44c54fbb58'],
+      env: 'OAUTH_OLD_SYNC_CLIENT_IDS',
+    },
     // A safety switch for disabling new signins/signups from particular clients,
     // as a hedge against unexpected client behaviour.
     disableNewConnectionsForClients: {


### PR DESCRIPTION
Because:
 - the "faked" 'cert_signed' event should have a service name of "sync"
   in its event properties when the oauth client is one of the old sync
   clients
 - the 'account.signed' event should be faked only when sync requests a
   token with the "oldsync" scope

This commit:
 - add `service: sync` to the event properties for the events in the
   /oauth/token handler when "oldsync" is in the scopes and the client
   is one of the old sync clients
 - emit the 'account.signed' event only when "oldsync" is in the scopes
 - set the service to the oauth client in the events except for the
   conditions mention in the first bullet

## Issue that this pull request solves

Closes: #6503 (and maybe #6578)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

