### PR TITLE
Increase test timeout to make time for new migration

### DIFF
--- a/packages/fxa-auth-server/test/remote/account_create_tests.js
+++ b/packages/fxa-auth-server/test/remote/account_create_tests.js
@@ -12,7 +12,7 @@ const config = require('../../config').getProperties();
 const mocks = require('../mocks');
 
 describe('remote account create', function () {
-  this.timeout(15000);
+  this.timeout(30000);
   let server;
   before(async () => {
     server = await TestServer.start(config);


### PR DESCRIPTION
## Because

- Our remote tests start the auth-server, which will now do some additional database connection/migration from https://github.com/mozilla/fxa/pull/6580
- Remote tests are run serially and migrations wont run if they have ran already, therefore probably don't need in other remote tests
- This targets train-190 to unblock it.

## This pull request

- Updates the test timeout to the first functional test to give it a little extra time for these connections

## Issue that this pull request solves

Closes: 

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
