### PR TITLE
fix(admin-panel): Fix connection to admin server in dev, remove unneeded Apollo dependencies, update README

### DIFF
--- a/packages/fxa-admin-panel/README.md
+++ b/packages/fxa-admin-panel/README.md
@@ -1,47 +1,65 @@
 # Firefox Accounts Admin Panel
 
-This is an internal resource for FxA Admins to access a set of convenience tools.
+The FxA Admin Panel is an internal resource for FxA Admins to access a set of convenience tools.
+
+Outside of local development, this application is protected by SSO, a VPN connection, and "guest list" login wall to ensure those without administrator privileges cannot access the service.
 
 ## Development
 
-- `npm run start|stop|restart` to start, stop, and restart the server as a PM2 process
-- `npm run build` to create a production build
+- `yarn start|stop|restart` to start, stop, and restart the server as a PM2 process
+- `yarn build` to create a production build
+- `yarn test` to run unit tests
+- `yarn storybook` to run Storybook
 
-**External imports**
+## Getting Started
 
-You can import React components into this project. This is currently restricted to `fxa-react`:
+This service will automatically spin up when `yarn start` is [ran from the root directory](https://github.com/mozilla/fxa#getting-started). A small Express server serves a React application and exposes the server config file for the client to consume via a meta tag.
+
+The React dev server runs at [localhost:8092](http://localhost:8092/) which can be useful when building components if you'd like an auto page refresh on file changes, however, the Express server that serves the React application and proxies its static resources runs at [localhost:8091](http://localhost:8091/). Develop on `:8091` if you need access to anything set in the server configuration file, including the URI for connecting to the `fxa-admin-server`.
+
+API calls are done through [Apollo Client](https://www.apollographql.com/docs/react/) with [GraphQL](https://graphql.org/learn/) to communicate with the `fxa-admin-server`. See [its documentation](https://github.com/mozilla/fxa/tree/main/packages/fxa-admin-server) to connect to the playground, a place to view the API docs and schema, and to write and test queries and mutations before using them in a component.
+
+## External imports
+
+You can import React components from other packages into this project. This is currently restricted to `fxa-react`:
 
 ```javascript
 // e.g. assuming the component HelloWorld exists
 import HelloWorld from 'fxa-react/components/HelloWorld';
 ```
 
+See the [`fxa-react` section of the `fxa-settings` docs](https://github.com/mozilla/fxa/tree/main/packages/fxa-settings#fxa-react) for more info on sharing or moving components into this package.
+
 ## Testing
 
-This package uses [Jest](https://jestjs.io/) to test both the frontend and server. By default `npm test` will run all NPM test scripts:
+This package uses [Jest](https://jestjs.io/) to test both the frontend and server. By default `yarn test` will run all test scripts:
 
-- `npm run test:frontend` will test the React App frontend under `src/`
-- `npm run test:server` will test the Express server under `server/`
+- `yarn test:frontend` will test the React App frontend under `src/`
+- `yarn test:server` will test the Express server under `server/`
 
 Test specific tests with the following commands:
 
 ```bash
 # Test frontend tests for the component EmailBlocks
-npm run test:frontend -- EmailBlocks
+yarn test:frontend EmailBlocks
 
 # Grep frontend tests for "displays the error"
-npm run test:frontend -- -t "displays the error"
+yarn test:frontend -t "displays the error"
 
 # Test server tests for the file server/lib/csp
-npm run test:server -- server/lib/csp
+yarn test:server server/lib/csp
 
 # Grep server tests for "simple server routes"
-npm run test:server -- -t "simple server routes"
+yarn test:server -t "simple server routes"
 ```
 
-Note that prior to testing you may need to create a build of the React App. You can do this by running `npm run build`.
-
 Refer to Jest's [CLI documentation](https://jestjs.io/docs/en/cli) for more advanced test configuration.
+
+## Storybook
+
+This project uses [Storybook](https://storybook.js.org/) to show each screen without requiring a full stack.
+
+In local development, `yarn storybook` will start a Storybook server at <http://localhost:6009> with hot module replacement to reflect live changes. Storybook provides a way to document and visually show various component states and application routes. Storybook builds from pull requests and commits can be found at https://mozilla-fxa.github.io/storybooks/.
 
 ## License
 

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -35,8 +35,7 @@
     ]
   },
   "dependencies": {
-    "apollo-boost": "^0.4.9",
-    "apollo-client": "^2.6.4",
+    "@apollo/client": "^3.2.2",
     "body-parser": "^1.19.0",
     "convict": "^6.0.0",
     "convict-format-with-moment": "^6.0.0",
@@ -52,7 +51,6 @@
     "npm-run-all": "^4.1.5",
     "on-headers": "^1.0.2",
     "react": "^16.13.0",
-    "react-apollo": "^3.1.3",
     "react-dom": "^16.13.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "^3.4.1",
@@ -88,9 +86,6 @@
     "@types/webpack": "4.41.16",
     "@typescript-eslint/eslint-plugin": "2.33.0",
     "@typescript-eslint/parser": "2.33.0",
-    "apollo-cache-inmemory": "^1.6.2",
-    "apollo-link": "^1.2.12",
-    "apollo-utilities": "^1.3.2",
     "babel-loader": "^8.1.0",
     "chance": "^1.1.4",
     "eslint": "^6.8.0",

--- a/packages/fxa-admin-panel/server/config/index.ts
+++ b/packages/fxa-admin-panel/server/config/index.ts
@@ -107,7 +107,7 @@ const conf = convict({
   servers: {
     admin: {
       url: {
-        default: 'http://localhost:8090',
+        default: 'http://localhost:8095',
         doc: 'The url of the fxa-admin-server instance',
         env: 'ADMIN_SERVER_URL',
         format: 'url',

--- a/packages/fxa-admin-panel/src/components/EmailBlocks/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/EmailBlocks/Account/index.test.tsx
@@ -30,7 +30,7 @@ it('renders without imploding', () => {
 });
 
 it('displays the account', async () => {
-  const { getByTestId, getByText } = render(<Account {...accountResponse} />);
+  const { getByTestId } = render(<Account {...accountResponse} />);
 
   expect(getByTestId('account-section')).toBeInTheDocument();
   expect(getByTestId('verified-status')).toHaveTextContent('verified');

--- a/packages/fxa-admin-panel/src/components/EmailBlocks/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/EmailBlocks/Account/index.tsx
@@ -4,8 +4,7 @@
 
 import React from 'react';
 import dateFormat from 'dateformat';
-import { gql } from 'apollo-boost';
-import { useMutation } from 'react-apollo';
+import { gql, useMutation } from '@apollo/client';
 import './index.scss';
 
 type AccountProps = {

--- a/packages/fxa-admin-panel/src/components/EmailBlocks/index.tsx
+++ b/packages/fxa-admin-panel/src/components/EmailBlocks/index.tsx
@@ -3,8 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { useState } from 'react';
-import gql from 'graphql-tag';
-import { useLazyQuery } from 'react-apollo';
+import { useLazyQuery, gql } from '@apollo/client';
 import Account from './Account';
 import './index.scss';
 
@@ -98,7 +97,7 @@ export const EmailBlocks = () => {
         ></button>
       </form>
 
-      {showResult ? (
+      {showResult && refetch ? (
         <>
           <hr />
           <AccountSearchResult

--- a/packages/fxa-admin-panel/src/index.tsx
+++ b/packages/fxa-admin-panel/src/index.tsx
@@ -4,16 +4,31 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { ApolloProvider } from 'react-apollo';
-import ApolloClient from 'apollo-boost';
+import { ApolloProvider } from '@apollo/client';
+import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
 import { config, readConfigFromMeta } from './lib/config';
 import App from './App';
 import './index.scss';
 
 readConfigFromMeta(headQuerySelector);
 
-const client = new ApolloClient({
+const httpLink = createHttpLink({
   uri: `${config.servers.admin.url}/graphql`,
+});
+
+const authLink = setContext((_, { headers }) => ({
+  headers: {
+    ...headers,
+    ...(process.env.NODE_ENV === 'development' && {
+      'oidc-claim-id-token-email': 'johndope@example.com',
+    }),
+  },
+}));
+
+const client = new ApolloClient({
+  link: authLink.concat(httpLink),
+  cache: new InMemoryCache(),
 });
 
 ReactDOM.render(

--- a/packages/fxa-admin-server/README.md
+++ b/packages/fxa-admin-server/README.md
@@ -2,6 +2,20 @@
 
 This is the GraphQL server for an internal resource for FxA Admins to access a set of convenience tools.
 
+## Connecting to the Playground
+
+The [GraphQL playground](https://www.apollographql.com/docs/apollo-server/testing/graphql-playground/) for this package is available at [localhost:8095/graphql](http://localhost:8095/graphql), providing a GUI for an up-to-date schema and API docs, as well as a way to test queries and mutations.
+
+The playground requires an `oidc-claim-id-token-email` authorization header. In production this is supplied through an nginx header after LDAP credentials have been verified but in development, a dummy email should be supplied in the bottom left-hand corner of the GQL playground labeled "HTTP Headers":
+
+```
+{
+  "oidc-claim-id-token-email": "hello@gmail.com"
+}
+```
+
+Hit the "play" button and the schema and docs will populate.
+
 ## Generate test email bounces
 
 If you need to create a handful of test email bounces in development you can use `yarn email-bounce`.

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@apollo/client": "^3.1.3",
+    "@apollo/client": "^3.2.2",
     "@reach/router": "^1.3.4",
     "classnames": "^2.2.6",
     "fxa-auth-client": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,33 +90,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client@npm:^3.1.3":
-  version: 3.1.3
-  resolution: "@apollo/client@npm:3.1.3"
-  dependencies:
-    "@types/zen-observable": ^0.8.0
-    "@wry/context": ^0.5.2
-    "@wry/equality": ^0.2.0
-    fast-json-stable-stringify: ^2.0.0
-    graphql-tag: ^2.11.0
-    hoist-non-react-statics: ^3.3.2
-    optimism: ^0.12.1
-    prop-types: ^15.7.2
-    symbol-observable: ^1.2.0
-    ts-invariant: ^0.4.4
-    tslib: ^1.10.0
-    zen-observable: ^0.8.14
-  peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0
-    react: ^16.8.0
-    subscriptions-transport-ws: ^0.9.0
-  peerDependenciesMeta:
-    react:
-      optional: true
-  checksum: 525668ad5828d1b01cb9e235c6240e17f4f50a4bf536599261065acca5fbfd067b70b1f333b0e0d082690ee37ff9ddbb04305f00dccda7f8a330f7a89a16d7c6
-  languageName: node
-  linkType: hard
-
 "@apollo/client@npm:^3.1.5":
   version: 3.2.1
   resolution: "@apollo/client@npm:3.2.1"
@@ -145,6 +118,37 @@ __metadata:
     subscriptions-transport-ws:
       optional: true
   checksum: c0032610b9528ae9c0dc3e9aaa0ccb096586469fcf20d572add0f3f10632380a3752b21ee0d9598d812db9cb29f84c27da2d177ceca0b43c3f91920f9a5f6ee8
+  languageName: node
+  linkType: hard
+
+"@apollo/client@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@apollo/client@npm:3.2.2"
+  dependencies:
+    "@graphql-typed-document-node/core": ^3.0.0
+    "@types/zen-observable": ^0.8.0
+    "@wry/context": ^0.5.2
+    "@wry/equality": ^0.2.0
+    fast-json-stable-stringify: ^2.0.0
+    graphql-tag: ^2.11.0
+    hoist-non-react-statics: ^3.3.2
+    optimism: ^0.12.1
+    prop-types: ^15.7.2
+    symbol-observable: ^2.0.0
+    terser: ^5.2.0
+    ts-invariant: ^0.4.4
+    tslib: ^1.10.0
+    zen-observable: ^0.8.14
+  peerDependencies:
+    graphql: ^14.0.0 || ^15.0.0
+    react: ^16.8.0
+    subscriptions-transport-ws: ^0.9.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    subscriptions-transport-ws:
+      optional: true
+  checksum: d3c45228be64b9cf14d8fa2b24b774bf41798c4349b37eb97789c0ce31de9f787894ac9b2d881a3d9712af99c03a4d61990b83c43068fa1b8aeca0a58c6df062
   languageName: node
   linkType: hard
 
@@ -210,7 +214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/react-common@npm:^3.0.0, @apollo/react-common@npm:^3.1.4":
+"@apollo/react-common@npm:^3.0.0":
   version: 3.1.4
   resolution: "@apollo/react-common@npm:3.1.4"
   dependencies:
@@ -223,79 +227,6 @@ __metadata:
     graphql: ^14.3.1
     react: ^16.8.0
   checksum: 59a676e3e7610fba7299d9a5c293b3ede7cbc84d1a8ab5e499496383b03d0720e7642906d07e1fe0003efe2c51089775a277cc63cd57215ef35585711cee40b5
-  languageName: node
-  linkType: hard
-
-"@apollo/react-components@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "@apollo/react-components@npm:3.1.5"
-  dependencies:
-    "@apollo/react-common": ^3.1.4
-    "@apollo/react-hooks": ^3.1.5
-    prop-types: ^15.7.2
-    ts-invariant: ^0.4.4
-    tslib: ^1.10.0
-  peerDependencies:
-    "@types/react": ^16.8.0
-    apollo-cache: ^1.3.2
-    apollo-client: ^2.6.4
-    apollo-link: ^1.2.12
-    apollo-utilities: ^1.3.2
-    graphql: ^14.3.1
-    react: ^16.8.0
-    react-dom: ^16.8.0
-  checksum: 0ecc02954c18fe3dcece07f5d9e89609321dc0bd32f4b3fd70e4600cd7f2add2c1628c550e4815efdc04afeb7a2b88328f2892bb86f0106600e0da4a23395333
-  languageName: node
-  linkType: hard
-
-"@apollo/react-hoc@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "@apollo/react-hoc@npm:3.1.5"
-  dependencies:
-    "@apollo/react-common": ^3.1.4
-    "@apollo/react-components": ^3.1.5
-    hoist-non-react-statics: ^3.3.0
-    ts-invariant: ^0.4.4
-    tslib: ^1.10.0
-  peerDependencies:
-    "@types/react": ^16.8.0
-    apollo-client: ^2.6.4
-    graphql: ^14.3.1
-    react: ^16.8.0
-    react-dom: ^16.8.0
-  checksum: 2cb91765fff8b721a8cd9ad176541f0bc4310142fce10e92808197802a6ae61a1dd97057c56c0092f10a7a8d51621be7feafcfcea82fa6bb2434364e87654a27
-  languageName: node
-  linkType: hard
-
-"@apollo/react-hooks@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "@apollo/react-hooks@npm:3.1.5"
-  dependencies:
-    "@apollo/react-common": ^3.1.4
-    "@wry/equality": ^0.1.9
-    ts-invariant: ^0.4.4
-    tslib: ^1.10.0
-  peerDependencies:
-    "@types/react": ^16.8.0
-    apollo-client: ^2.6.4
-    graphql: ^14.3.1
-    react: ^16.8.0
-    react-dom: ^16.8.0
-  checksum: 9a33e4fe41378a588bcf109b4bc4ff87010c106d91a3f11cc00dc65048464079e5cc129d5978b9ad6357a5490f4c6997369653ed22d16b6d8ca5ab95b3fcb217
-  languageName: node
-  linkType: hard
-
-"@apollo/react-ssr@npm:^3.1.5":
-  version: 3.1.5
-  resolution: "@apollo/react-ssr@npm:3.1.5"
-  dependencies:
-    "@apollo/react-common": ^3.1.4
-    "@apollo/react-hooks": ^3.1.5
-    tslib: ^1.10.0
-  peerDependencies:
-    react: ^16.8.0
-    react-dom: ^16.8.0
-  checksum: 8e9df039d0c4dca5885150d69c4ec4418da97cdb3ad21b1f4038eba07776f2d1fbbd59c79c0bc280795cee83d365ec83d974230fcc5e8364b85a9c9885947fc0
   languageName: node
   linkType: hard
 
@@ -7493,16 +7424,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wry/context@npm:^0.4.0":
-  version: 0.4.4
-  resolution: "@wry/context@npm:0.4.4"
-  dependencies:
-    "@types/node": ">=6"
-    tslib: ^1.9.3
-  checksum: b69f6523269b200990af369e3a585980725c8173ed0063127b14862600e99515fc404cd6e32881e32795048b361e2d58a08becc8f41b598bbe78f4cb2db311a1
-  languageName: node
-  linkType: hard
-
 "@wry/context@npm:^0.5.2":
   version: 0.5.2
   resolution: "@wry/context@npm:0.5.2"
@@ -7512,7 +7433,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wry/equality@npm:^0.1.2, @wry/equality@npm:^0.1.9":
+"@wry/equality@npm:^0.1.2":
   version: 0.1.11
   resolution: "@wry/equality@npm:0.1.11"
   dependencies:
@@ -8090,25 +8011,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-boost@npm:^0.4.9":
-  version: 0.4.9
-  resolution: "apollo-boost@npm:0.4.9"
-  dependencies:
-    apollo-cache: ^1.3.5
-    apollo-cache-inmemory: ^1.6.6
-    apollo-client: ^2.6.10
-    apollo-link: ^1.0.6
-    apollo-link-error: ^1.0.3
-    apollo-link-http: ^1.3.1
-    graphql-tag: ^2.4.2
-    ts-invariant: ^0.4.0
-    tslib: ^1.10.0
-  peerDependencies:
-    graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
-  checksum: 04ef05fb03b7351a2d5772c442e6ba96002709f7cda08c2e34537dae247013e15db986c4ff3530fee55793e078403b6b8105df5ec042b5a4a23be368bb4e146d
-  languageName: node
-  linkType: hard
-
 "apollo-cache-control@npm:^0.11.1":
   version: 0.11.1
   resolution: "apollo-cache-control@npm:0.11.1"
@@ -8121,22 +8023,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-cache-inmemory@npm:^1.6.2, apollo-cache-inmemory@npm:^1.6.6":
-  version: 1.6.6
-  resolution: "apollo-cache-inmemory@npm:1.6.6"
-  dependencies:
-    apollo-cache: ^1.3.5
-    apollo-utilities: ^1.3.4
-    optimism: ^0.10.0
-    ts-invariant: ^0.4.0
-    tslib: ^1.10.0
-  peerDependencies:
-    graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
-  checksum: 7e8c358b93d6e1dbf1c5f497b1a190d326c28473ba2ffefbc8a67aa0a9d92485b16f18710dd3ff11e03fc3a531e80771c508021d2c8100961b3ca0fe566ab5a5
-  languageName: node
-  linkType: hard
-
-"apollo-cache@npm:1.3.5, apollo-cache@npm:^1.3.5":
+"apollo-cache@npm:1.3.5":
   version: 1.3.5
   resolution: "apollo-cache@npm:1.3.5"
   dependencies:
@@ -8148,7 +8035,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-client@npm:2.6.10, apollo-client@npm:^2.6.10, apollo-client@npm:^2.6.4":
+"apollo-client@npm:2.6.10":
   version: 2.6.10
   resolution: "apollo-client@npm:2.6.10"
   dependencies:
@@ -8240,44 +8127,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-link-error@npm:^1.0.3":
-  version: 1.1.13
-  resolution: "apollo-link-error@npm:1.1.13"
-  dependencies:
-    apollo-link: ^1.2.14
-    apollo-link-http-common: ^0.2.16
-    tslib: ^1.9.3
-  checksum: 351c1eb4c70b2356f549bc65dd0c3d63a173b881197f107bb4ecac3a414d3e0b4918a07f68f246d02d0319618e0ccc896ee17fa050bff9aa636bd8ed4a9381f4
-  languageName: node
-  linkType: hard
-
-"apollo-link-http-common@npm:^0.2.16":
-  version: 0.2.16
-  resolution: "apollo-link-http-common@npm:0.2.16"
-  dependencies:
-    apollo-link: ^1.2.14
-    ts-invariant: ^0.4.0
-    tslib: ^1.9.3
-  peerDependencies:
-    graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
-  checksum: 7ab319747bc9c3fbebd57b2df08be5425c0f62316e1a71e76d6041721d21e04962dd7522a0fc2280acbe5ee3aaa5acab79d6b35eee61dd91b8caa1bdbdd6d7b0
-  languageName: node
-  linkType: hard
-
-"apollo-link-http@npm:^1.3.1":
-  version: 1.5.17
-  resolution: "apollo-link-http@npm:1.5.17"
-  dependencies:
-    apollo-link: ^1.2.14
-    apollo-link-http-common: ^0.2.16
-    tslib: ^1.9.3
-  peerDependencies:
-    graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
-  checksum: c16c07aa1131af2fb1b43c323197299bb00c04649a7350250f4306f9b72c66d82945d24aedd6e9c07b3efeb14cf79881b0bcd470e60ef58b41115a43d41dc1e8
-  languageName: node
-  linkType: hard
-
-"apollo-link@npm:1.2.14, apollo-link@npm:^1.0.0, apollo-link@npm:^1.0.6, apollo-link@npm:^1.2.12, apollo-link@npm:^1.2.14":
+"apollo-link@npm:1.2.14, apollo-link@npm:^1.0.0, apollo-link@npm:^1.2.14":
   version: 1.2.14
   resolution: "apollo-link@npm:1.2.14"
   dependencies:
@@ -8442,7 +8292,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"apollo-utilities@npm:1.3.4, apollo-utilities@npm:^1.0.1, apollo-utilities@npm:^1.3.0, apollo-utilities@npm:^1.3.2, apollo-utilities@npm:^1.3.4":
+"apollo-utilities@npm:1.3.4, apollo-utilities@npm:^1.0.1, apollo-utilities@npm:^1.3.0, apollo-utilities@npm:^1.3.4":
   version: 1.3.4
   resolution: "apollo-utilities@npm:1.3.4"
   dependencies:
@@ -17371,6 +17221,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "fxa-admin-panel@workspace:packages/fxa-admin-panel"
   dependencies:
+    "@apollo/client": ^3.2.2
     "@apollo/react-testing": 3.0.0
     "@babel/core": ^7.10.3
     "@rescripts/cli": 0.0.14
@@ -17400,11 +17251,6 @@ fsevents@^1.2.7:
     "@types/webpack": 4.41.16
     "@typescript-eslint/eslint-plugin": 2.33.0
     "@typescript-eslint/parser": 2.33.0
-    apollo-boost: ^0.4.9
-    apollo-cache-inmemory: ^1.6.2
-    apollo-client: ^2.6.4
-    apollo-link: ^1.2.12
-    apollo-utilities: ^1.3.2
     babel-loader: ^8.1.0
     body-parser: ^1.19.0
     chance: ^1.1.4
@@ -17431,7 +17277,6 @@ fsevents@^1.2.7:
     postcss-cli: ^7.1.1
     prettier: ^2.0.5
     react: ^16.13.0
-    react-apollo: ^3.1.3
     react-dom: ^16.13.0
     react-router-dom: ^5.1.2
     react-scripts: ^3.4.1
@@ -18390,7 +18235,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "fxa-settings@workspace:packages/fxa-settings"
   dependencies:
-    "@apollo/client": ^3.1.3
+    "@apollo/client": ^3.2.2
     "@babel/core": ^7.10.3
     "@reach/router": ^1.3.4
     "@rescripts/cli": 0.0.14
@@ -19342,7 +19187,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graphql-tag@npm:^2.11.0, graphql-tag@npm:^2.4.2, graphql-tag@npm:^2.9.2":
+"graphql-tag@npm:^2.11.0, graphql-tag@npm:^2.9.2":
   version: 2.11.0
   resolution: "graphql-tag@npm:2.11.0"
   peerDependencies:
@@ -20742,6 +20587,7 @@ fsevents@^1.2.7:
 "immutable@npm:~3.7.6":
   version: 3.7.6
   resolution: "immutable@npm:3.7.6"
+  checksum: 33fb106a330bae44cea58a2bc51c667850ea198396f329787718ab9ae70f6302734d0beb81e22de06876e38807f813a81bb09628e096ef89d9b5e06185edd16a
   languageName: node
   linkType: hard
 
@@ -20779,6 +20625,7 @@ fsevents@^1.2.7:
   resolution: "import-from@npm:3.0.0"
   dependencies:
     resolve-from: ^5.0.0
+  checksum: ba66d42da541286fe50afe800a506534560c067eac7fa1c5fa83b4ea69eb92952adf6bff4ae6a3ea2e45780a874aa0341e4101e6ebc3f9b8fd6b83ac29fafe1b
   languageName: node
   linkType: hard
 
@@ -21214,6 +21061,7 @@ fsevents@^1.2.7:
 "interpret@npm:^1.4.0":
   version: 1.4.0
   resolution: "interpret@npm:1.4.0"
+  checksum: f15725d76206525546f559030ddc967db025c6db904eb8798a70ec3c07e42c5537c5cbc73a15eafd4ae5cdabad35601abf8878261c03dcc8217747e8037575fe
   languageName: node
   linkType: hard
 
@@ -21250,6 +21098,7 @@ fsevents@^1.2.7:
 "invert-kv@npm:^1.0.0":
   version: 1.0.0
   resolution: "invert-kv@npm:1.0.0"
+  checksum: fccd6ea4ee18d30b00fc21d6679191690f8447f248cbcdf6f74fe81a4048d51a3858d7af17a0318bd7c6fe6c46abee5a10756109787a3ec0e0a02a2c1b4a635d
   languageName: node
   linkType: hard
 
@@ -21816,6 +21665,7 @@ fsevents@^1.2.7:
 "is-promise@npm:4.0.0":
   version: 4.0.0
   resolution: "is-promise@npm:4.0.0"
+  checksum: 7085bdc4eaff389c5730a1d54f014880e90ca1e4b7f0a49de9f3c5f5d2fb9e0c3a878ac226d3aa9190bfe4a78400e66d911427ef4812455756293cdb02fb05cf
   languageName: node
   linkType: hard
 
@@ -22105,6 +21955,7 @@ fsevents@^1.2.7:
   dependencies:
     node-fetch: ^1.0.1
     whatwg-fetch: ">=0.10.0"
+  checksum: a4174e332ae98fc93269162f1d8a3ee1f7255257d4eaeea5145d4068f64ac2dbff7e7f681889097238e1e009f7a74ba1a23ffd8ed967402777a32cca96204508
   languageName: node
   linkType: hard
 
@@ -24134,6 +23985,7 @@ fsevents@^1.2.7:
   resolution: "lcid@npm:1.0.0"
   dependencies:
     invert-kv: ^1.0.0
+  checksum: 36f50f8be935c90e3f9296d3f7057df950ee27c4f1608549b11b3f88d26d68a19a47cf787b1a6e3eb292e820fcc8c96a67be2fca14f713430adb57b24e06fb96
   languageName: node
   linkType: hard
 
@@ -24878,6 +24730,7 @@ fsevents@^1.2.7:
 "lodash@npm:4.17.20":
   version: 4.17.20
   resolution: "lodash@npm:4.17.20"
+  checksum: c62101d2500c383b5f174a7e9e6fe8098149ddd6e9ccfa85f36d4789446195f5c4afd3cfba433026bcaf3da271256566b04a2bf2618e5a39f6e67f8c12030cb6
   languageName: node
   linkType: hard
 
@@ -26131,6 +25984,7 @@ fsevents@^1.2.7:
   resolution: "moment-timezone@npm:0.5.31"
   dependencies:
     moment: ">= 2.9.0"
+  checksum: db8c241301530919ea3091b75c067c1b919973619bed0f3b0c009eb94e44da726452a1382c099d55a876407fd4e22802b45bc51f96c5cbfbb7fbbfa6660079e8
   languageName: node
   linkType: hard
 
@@ -26385,6 +26239,7 @@ fsevents@^1.2.7:
     ini: ^1.3.0
     secure-keys: ^1.0.0
     yargs: ^3.19.0
+  checksum: 2b33d443ad1921d290f74f0e3d8511f625beeef7035813afdbc718da24658a9d67c3f5534723c7d353049320a1ea610a830ad47b459f626bc22d4b5328db8164
   languageName: node
   linkType: hard
 
@@ -26577,6 +26432,7 @@ fsevents@^1.2.7:
 "node-fetch@npm:2.6.1":
   version: 2.6.1
   resolution: "node-fetch@npm:2.6.1"
+  checksum: cbb171635e538162b977eac5dfe7a1e07a9a02e991924377a6435502291e2f823d306b95aabc455caebf4a118ccf836868462bc70ccc3095af02bb9da61fda37
   languageName: node
   linkType: hard
 
@@ -26586,6 +26442,7 @@ fsevents@^1.2.7:
   dependencies:
     encoding: ^0.1.11
     is-stream: ^1.0.1
+  checksum: d04afb2e328ffb974a5ac4800fe5714d7419243d72f089a6a2383d3b93368c61ae88954a4866c476c0d7f95d7af414c1b9a885e051971061efe4054d526e23ed
   languageName: node
   linkType: hard
 
@@ -26624,6 +26481,7 @@ fsevents@^1.2.7:
     node-gyp-build: ./bin.js
     node-gyp-build-optional: ./optional.js
     node-gyp-build-test: ./build-test.js
+  checksum: 61c7f2a9e44c5b23a0dc830e98cb0de3364894091daae0da471797627acedd06fe108107f4c840c2b0ff8bcfbdac8ec0c1767a3e159941eadd4c8fbbdc29a586
   languageName: node
   linkType: hard
 
@@ -26860,6 +26718,7 @@ fsevents@^1.2.7:
     nconf: 0.10.x
     querystring: 0.2.x
     request: 2.88.x
+  checksum: ca9e030c33bc7a3ee790eb803c2ff3b9d25ae27c0def0d33632206d1a17c2e907c439a9ba79c5ce045dfe562d06d1f4b2ba600e037f459294c96913385bc9d5a
   languageName: node
   linkType: hard
 
@@ -27154,6 +27013,7 @@ fsevents@^1.2.7:
 "nullthrows@npm:^1.1.1":
   version: 1.1.1
   resolution: "nullthrows@npm:1.1.1"
+  checksum: 47afb80d9784485fe69facb16207a9b3de09258f5c86d4c21680abb3708eb4d3e8b04c2df288938eb7e1a82be0b73b00b991ca3c20ccb8c00a12a5cdc3a08fb5
   languageName: node
   linkType: hard
 
@@ -27543,15 +27403,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"optimism@npm:^0.10.0":
-  version: 0.10.3
-  resolution: "optimism@npm:0.10.3"
-  dependencies:
-    "@wry/context": ^0.4.0
-  checksum: c3bab19cb94476d0f74370fa13ee2ba3243d7ba1de415b685b09780d94a323d6fd1824274e471b61cd37d4e61f136788b043684ad69831dd4848f6f5427c6bc6
-  languageName: node
-  linkType: hard
-
 "optimism@npm:^0.12.1":
   version: 0.12.1
   resolution: "optimism@npm:0.12.1"
@@ -27710,6 +27561,7 @@ fsevents@^1.2.7:
   resolution: "os-locale@npm:1.4.0"
   dependencies:
     lcid: ^1.0.0
+  checksum: 19d876790073758c346c8df2ec40a9c28ee1497b185bfb54d3fd082b9b82e61f2ee3a9bd329cdd6ae878c7fce045c0c3b21c1196061af8360aebf2775fa27b2b
   languageName: node
   linkType: hard
 
@@ -30186,6 +30038,7 @@ fsevents@^1.2.7:
   resolution: "promise@npm:7.3.1"
   dependencies:
     asap: ~2.0.3
+  checksum: 23267a4b078fcb02c57b06ca1a1d5739109deb0932c0fd79615a2c5636dd0571ac6a161f19c4ea9683a4ab89791da13112678fa410b65334de490e97c33410ae
   languageName: node
   linkType: hard
 
@@ -30692,25 +30545,6 @@ fsevents@^1.2.7:
   bin:
     rc: ./cli.js
   checksum: ea2b7f7cee201a67923a2240de594a5d9b59bd312b814b06536d3d609a416dfd6fb9b85ea2abfd3b8a4eb5ed33eaff946ee75a8f2b7fb10941073c5cfee6b7a5
-  languageName: node
-  linkType: hard
-
-"react-apollo@npm:^3.1.3":
-  version: 3.1.5
-  resolution: "react-apollo@npm:3.1.5"
-  dependencies:
-    "@apollo/react-common": ^3.1.4
-    "@apollo/react-components": ^3.1.5
-    "@apollo/react-hoc": ^3.1.5
-    "@apollo/react-hooks": ^3.1.5
-    "@apollo/react-ssr": ^3.1.5
-  peerDependencies:
-    "@types/react": ^16.8.0
-    apollo-client: ^2.6.4
-    graphql: ^14.3.1
-    react: ^16.8.0
-    react-dom: ^16.8.0
-  checksum: 2e2e764629bc4d1ed4f739eb4e3eeb8570eb3fc8057da3700234a6eb022dbfb9ca7cf854e4e9dd31dff15feae43418e9f4683e6be167149829c0649c0ba818da
   languageName: node
   linkType: hard
 
@@ -31854,6 +31688,7 @@ fsevents@^1.2.7:
     graphql: ^15.0.0
   bin:
     relay-compiler: bin/relay-compiler
+  checksum: f9caf9bd1d72855ad41f38fd69cae17f75141f2f62acaec6ac85d0c4de6a9b4891e372ebb70b24ad646b3c9e79160cbab2e5e07f1f79cf0198b649e8f69220ca
   languageName: node
   linkType: hard
 
@@ -31863,6 +31698,7 @@ fsevents@^1.2.7:
   dependencies:
     "@babel/runtime": ^7.0.0
     fbjs: ^1.0.0
+  checksum: 03249ccbd0d0eb71787bdd8db1e696bd89ce8372095338683f5fd1b166a2cc65ef3bf7f171160bb376adf88ccfd6786198b8ad35aa87efd3c9993af7c0fb8726
   languageName: node
   linkType: hard
 
@@ -32882,6 +32718,7 @@ resolve@~1.11.1:
 "secure-keys@npm:^1.0.0":
   version: 1.0.0
   resolution: "secure-keys@npm:1.0.0"
+  checksum: e42d2252e5d3d6d2e0209dc4a142bb3c11306ec414f488ca4a7f607aa12d9231cb93d19c0644c0b64c97372e059a9e37bbbc859ce2956a49bcb08d8bbca2f4e5
   languageName: node
   linkType: hard
 
@@ -33410,6 +33247,7 @@ resolve@~1.11.1:
 "signedsource@npm:^1.0.0":
   version: 1.0.0
   resolution: "signedsource@npm:1.0.0"
+  checksum: e6fdfce197bf4ad37c79078137ff8da4655da37caee4fa1c170475e12e0c4bb5104163fefaf81280099e284a19e81eded08a84bab1c4a358c710237473e37c96
   languageName: node
   linkType: hard
 
@@ -34979,6 +34817,7 @@ resolve@~1.11.1:
 "symbol-observable@npm:^2.0.0":
   version: 2.0.1
   resolution: "symbol-observable@npm:2.0.1"
+  checksum: 912978e734e61079eb15af1a8f90aa6e414635fd65b0adb122a7467385cb3caef269c26ba70ae69c709d53e9a38faeb3024d3527e2d28db14d8c87a42409019b
   languageName: node
   linkType: hard
 
@@ -35366,6 +35205,7 @@ resolve@~1.11.1:
     source-map-support: ~0.5.12
   bin:
     terser: bin/terser
+  checksum: 4de06e4c6ca0e01199a9beba4a6a1e7b76d3465e2cfcf6a7cb195badfdebace709aa687fa209fb6793fa30d74b935d3d1e68603d3d90774109e0f2037a954ae3
   languageName: node
   linkType: hard
 
@@ -36294,6 +36134,7 @@ resolve@~1.11.1:
 "ua-parser-js@npm:^0.7.18":
   version: 0.7.22
   resolution: "ua-parser-js@npm:0.7.22"
+  checksum: c14272a0261bacd6d9daecc8bd2d48d6e5c68d27d5978e10fb27cbbeb07ee0d427786436e4db8ca7ce92ba4bf0399dda647c1f98fbb77ee2fec8f3b7b8244999
   languageName: node
   linkType: hard
 
@@ -36644,6 +36485,7 @@ resolve@~1.11.1:
   resolution: "unixify@npm:1.0.0"
   dependencies:
     normalize-path: ^2.1.1
+  checksum: 8a939fba417b50b84b4bded80bb26d1dc6aaf56eb292ec09e133e569ab7710e13dbb5210d49ff4153e419f560b4cda58b6dfaa8476df6b23be361552c563a65e
   languageName: node
   linkType: hard
 
@@ -36713,6 +36555,7 @@ resolve@~1.11.1:
 "urijs@npm:1.19.2":
   version: 1.19.2
   resolution: "urijs@npm:1.19.2"
+  checksum: de6b943c354b092be71e10c5c16d9d9b67186d6283031f55382d11507dc8a7748001b5aa8136f515f746f2f4786d7f4e43e17c23ba661abcc7dbbbe254924feb
   languageName: node
   linkType: hard
 
@@ -36865,6 +36708,7 @@ resolve@~1.11.1:
   dependencies:
     node-gyp: latest
     node-gyp-build: ~3.7.0
+  checksum: 1ca86a68ee4565141683cfdbf3c290cb746963be28040029717eb27b31ec305c0e0e99586af85eef060ed495617580fcc974250e15807a30a403d8df2a812984
   languageName: node
   linkType: hard
 
@@ -37027,6 +36871,7 @@ resolve@~1.11.1:
 "valid-url@npm:1.0.9":
   version: 1.0.9
   resolution: "valid-url@npm:1.0.9"
+  checksum: 988964543cb297c1d953dbf665de06cc8c46791eaf5ef3bb32b03b103c53dced7dfaa8f19863255126cbd75049a67f19415d9e647b603b759922284ccc48e776
   languageName: node
   linkType: hard
 
@@ -37187,6 +37032,7 @@ resolve@~1.11.1:
   dependencies:
     de-indent: ^1.0.2
     he: ^1.1.0
+  checksum: 5b05dda398cc1df7ba244316ddfb8f6463dbaafb4d23a4ac7e1cb8914e813a464f4ac055e41ac6e60feeadd4cccdeec1111fac592f2bb4eeb320889846a18912
   languageName: node
   linkType: hard
 
@@ -37400,6 +37246,7 @@ resolve@~1.11.1:
     webpack: 4.x.x
   bin:
     webpack-cli: bin/cli.js
+  checksum: 8a195df0eb7006ce1f7e6e87b74f5b2e533e03faf13c594de99fd7cf239652c2618fa22065556afdb454f45ecfd704ffa3e36bf406fe10ce9691970ed04c2ca7
   languageName: node
   linkType: hard
 
@@ -37664,6 +37511,7 @@ resolve@~1.11.1:
     typedarray-to-buffer: ^3.1.5
     utf-8-validate: ^5.0.2
     yaeti: ^0.0.6
+  checksum: 9b74a8dbc46ff8f0551dc55ee631c2a0be3e0775d0dae6e92b03a406890147729cb9ea6f1ffbc8ce3f91fa459d86c599a3dc3b32ce9f4225b68fc53c084ea8fb
   languageName: node
   linkType: hard
 
@@ -38327,6 +38175,7 @@ resolve@~1.11.1:
 "y18n@npm:^3.2.0":
   version: 3.2.1
   resolution: "y18n@npm:3.2.1"
+  checksum: e0f3db233608c026dd1d06dc5805c99fedbeb21c6a73bdac70d8a6ec1bbcf1cc38952e7b8a79b46c9d1bdee022cc40e529c760f04f9c6cd3123e5ba657d19322
   languageName: node
   linkType: hard
 
@@ -38340,6 +38189,7 @@ resolve@~1.11.1:
 "yaeti@npm:^0.0.6":
   version: 0.0.6
   resolution: "yaeti@npm:0.0.6"
+  checksum: fa9beece5a26aac7a2fa71ced85f660184a936883cc16fdd4f7a6bf2f2ea3454af6ceff77128be76ddeb6578d955a5282670187d439a3ee77733d0c12a18de1c
   languageName: node
   linkType: hard
 
@@ -38570,6 +38420,7 @@ resolve@~1.11.1:
     string-width: ^1.0.1
     window-size: ^0.1.4
     y18n: ^3.2.0
+  checksum: 165018a4853701f493f10b1956b8521de506ea751dcdd2ef3a1db95760676d5bcc5cb7db3c8cf26c41907a81d2c6b58c8f102dfec21f623c61e2b24e37682a2b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because
* The admin panel can't connect to the admin server in development
* We use '@apollo/client' in fxa-settings and should be consistent, preferring one package over a lot of separated dependencies

## This pull request
* Changes the gql server port to 8095
* Adds oidc-claim-id-token-email auth header in development
* Removes react-apollo, apollo-boost, apollo-client etc. in favor of @apollo/client
* Includes doc updates for admin-panel and admin-server
* Upgrades @apollo/client version in fxa-settings to be consistent

## Issue that this pull request solves

Closes: #6579 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).

## Other information

I realize duplicating `exampleAccountResponse` in `exampleNoResultsAccountResponse` isn't as "clean" as `Object.assign`, but I couldn't get the test passing without changing it to this. I tried a couple other things and kept getting test failures too and I didn't intend on spending this much time fixing up a test so it's fine to leave as-is IMO.