### PR TITLE
chore(config): Allow Firefox Desktop to request ecosystem telemetry scope

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -289,7 +289,7 @@
         "hashedSecret": "71b5283536f1f1c331eca2f75c58a5947d7a7ac54164eadb4b33a889afe89fbf",
         "imageUri": "",
         "redirectUri": "urn:ietf:wg:oauth:2.0:oob",
-        "allowedScopes": "https://identity.mozilla.com/apps/oldsync https://identity.mozilla.com/tokens/session",
+        "allowedScopes": "https://identity.mozilla.com/apps/oldsync https://identity.mozilla.com/tokens/session https://identity.mozilla.com/ids/ecosystem_telemetry",
         "trusted": true,
         "canGrant": true,
         "publicClient": true
@@ -402,6 +402,10 @@
       },
       {
         "scope": "https://identity.mozilla.com/apps/oldsync",
+        "hasScopedKeys": true
+      },
+      {
+        "scope": "https://identity.mozilla.com/ids/ecosystem_telemetry",
         "hasScopedKeys": true
       },
       {


### PR DESCRIPTION
## Because

* Firefox Desktop will soon be able to calculate the ecosystem_user_id as part
  of its logn flow (https://bugzilla.mozilla.org/show_bug.cgi?id=1647588)
* Calculating this value the right way means deriving it like a scoped key,
  and the FxA server controls wht scoped-key metadata is available to whic
  clients.

## This pull request

* Allows the ecosystem_telemetry scope for the Firefox Desktop OAuth
  client in dev environments.
* Accompanies the production change requested in
  https://bugzilla.mozilla.org/show_bug.cgi?id=1668972

## Issue that this pull request solves

Closes: https://bugzilla.mozilla.org/show_bug.cgi?id=1668972 (for dev environments)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- ~~[ ] If applicable, I have modified or added tests which pass locally.~~
- ~~[ ] I have added necessary documentation (if appropriate).~~