### PR TITLE
feat(metrics): add more Amplitude events to new settings

### DIFF
--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
@@ -7,6 +7,12 @@ import { render, screen, fireEvent, act } from '@testing-library/react';
 import { MockedCache } from '../../models/_mocks';
 import { AlertBarRootAndContextProvider } from '../../lib/AlertBarContext';
 import DropDownAvatarMenu, { DESTROY_SESSION_MUTATION } from '.';
+import { logViewEvent, settingsViewName } from 'fxa-settings/src/lib/metrics';
+
+jest.mock('fxa-settings/src/lib/metrics', () => ({
+  logViewEvent: jest.fn(),
+  settingsViewName: 'quuz',
+}));
 
 const mockGqlSuccess = () => ({
   request: {
@@ -126,6 +132,10 @@ describe('DropDownAvatarMenu', () => {
       });
       expect(window.location.assign).toHaveBeenCalledWith(
         `${window.location.origin}/signin`
+      );
+      expect(logViewEvent).toHaveBeenCalledWith(
+        settingsViewName,
+        'signout.success'
       );
     });
 

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
@@ -11,6 +11,7 @@ import { clearSignedInAccountUid } from '../../lib/cache';
 import { useClickOutsideEffect } from 'fxa-react/lib/hooks';
 import { useEscKeydownEffect, useMutation, useAlertBar } from '../../lib/hooks';
 import { ReactComponent as SignOut } from './sign-out.svg';
+import { logViewEvent, settingsViewName } from 'fxa-settings/src/lib/metrics';
 
 export const DESTROY_SESSION_MUTATION = gql`
   mutation destroySession($input: DestroySessionInput!) {
@@ -32,6 +33,10 @@ export const DropDownAvatarMenu = () => {
   const dropDownId = 'drop-down-avatar-menu';
 
   const [destroySession, { data }] = useMutation(DESTROY_SESSION_MUTATION, {
+    onCompleted: () => {
+      // cannot use a hook here since this callback is not called in a hook
+      logViewEvent(settingsViewName, 'signout.success');
+    },
     onError: (error) => {
       alertBar.error('Sorry, there was a problem signing you out.', error);
     },

--- a/packages/fxa-settings/src/components/PageChangePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.test.tsx
@@ -4,10 +4,25 @@
 
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import { AuthContext, createAuthClient } from '../../lib/auth';
 import { MockedCache, renderWithRouter } from '../../models/_mocks';
 import PageChangePassword from '.';
+import { logViewEvent, settingsViewName } from 'fxa-settings/src/lib/metrics';
+
+jest.mock('../../lib/auth', () => ({
+  ...jest.requireActual('../../lib/auth'),
+  usePasswordChanger: jest
+    .fn()
+    .mockImplementation(({ onSuccess, onError }) => ({
+      execute: () => onSuccess({ sessionToken: 'FFFF' }),
+      reset: () => {},
+    })),
+}));
+jest.mock('fxa-settings/src/lib/metrics', () => ({
+  logViewEvent: jest.fn(),
+  settingsViewName: 'quuz',
+}));
 
 const client = createAuthClient('none');
 
@@ -23,4 +38,32 @@ it('renders', async () => {
   expect(screen.getByTestId('flow-container-back-btn')).toBeInTheDocument();
   expect(screen.getByTestId('nav-link-common-passwords')).toBeInTheDocument();
   expect(screen.getByTestId('nav-link-reset-password')).toBeInTheDocument();
+});
+
+it('emits an Amplitude event on success', async () => {
+  renderWithRouter(
+    <AuthContext.Provider value={{ auth: client }}>
+      <MockedCache>
+        <PageChangePassword />
+      </MockedCache>
+    </AuthContext.Provider>
+  );
+  await act(async () => {
+    fireEvent.change(screen.getAllByTestId('input-field')[0], {
+      target: { value: 'quuz' },
+    });
+    fireEvent.change(screen.getAllByTestId('input-field')[1], {
+      target: { value: 'testo' },
+    });
+    fireEvent.change(screen.getAllByTestId('input-field')[2], {
+      target: { value: 'testo' },
+    });
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('submit-change-password'));
+  });
+  expect(logViewEvent).toHaveBeenCalledWith(
+    settingsViewName,
+    'change-password.success'
+  );
 });

--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -13,6 +13,7 @@ import { useAccount, Account, Session } from '../../models';
 import AlertBar from '../AlertBar';
 import FlowContainer from '../FlowContainer';
 import InputPassword from '../InputPassword';
+import { logViewEvent, settingsViewName } from 'fxa-settings/src/lib/metrics';
 
 // eslint-disable-next-line no-empty-pattern
 export const PageChangePassword = ({}: RouteComponentProps) => {
@@ -29,6 +30,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
   const navigate = useNavigate();
   const changePassword = usePasswordChanger({
     onSuccess: (response) => {
+      logViewEvent(settingsViewName, 'change-password.success');
       changePassword.reset();
       sessionToken(response.sessionToken);
       cache.modify({
@@ -137,6 +139,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
             Cancel
           </button>
           <button
+            data-testid="submit-change-password"
             className="cta-primary mx-2 flex-1"
             disabled={saveBtnDisabled || changePassword.loading}
           >

--- a/packages/fxa-settings/src/components/PageSettings/index.tsx
+++ b/packages/fxa-settings/src/components/PageSettings/index.tsx
@@ -20,7 +20,7 @@ export const PageSettings = (_: RouteComponentProps) => {
     lang: document.querySelector('html')?.getAttribute('lang'),
     uid,
   });
-  Metrics.usePageViewEvent('settings');
+  Metrics.usePageViewEvent(Metrics.settingsViewName);
 
   return (
     <div className="flex">

--- a/packages/fxa-settings/src/lib/metrics.ts
+++ b/packages/fxa-settings/src/lib/metrics.ts
@@ -12,6 +12,8 @@ import {
 } from '../models';
 import { window } from './window';
 
+export const settingsViewName = 'settings';
+
 const NOT_REPORTED_VALUE = 'none';
 const UNKNOWN_VALUE = 'unknown';
 


### PR DESCRIPTION
Because:
 - some implemented features in new settings do not emit Amplitude
   events like their old settings equivalent

This commit:
 - add "fxa_pref - logout" and "fxa_pref - password"

## Issue that this pull request solves

Closes: #6535 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

