### PR TITLE
chore(logs): lower the log level of some lines

### DIFF
--- a/packages/fxa-auth-server/lib/cad-reminders.js
+++ b/packages/fxa-auth-server/lib/cad-reminders.js
@@ -100,7 +100,7 @@ class CadReminders {
           return result;
         }, {})
       );
-      this.log.info('cadReminders.delete', {
+      this.log.debug('cadReminders.delete', {
         uid,
       });
       return result;

--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -305,7 +305,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
       }
       return mergedToken;
     });
-    log.info('db.sessions.count', {
+    log.debug('db.sessions.count', {
       mysql: mysqlSessionTokens.length,
       redis: redisSessionTokens.length,
     });

--- a/packages/fxa-auth-server/lib/log.js
+++ b/packages/fxa-auth-server/lib/log.js
@@ -41,6 +41,10 @@ Lug.prototype.trace = function (op, data) {
   this.logger.debug(op, data);
 };
 
+Lug.prototype.debug = function (op, data) {
+  this.logger.debug(op, data);
+};
+
 Lug.prototype.error = function (op, data) {
   // If the error object contains an email address,
   // lift it into top-level fields so that our
@@ -161,7 +165,7 @@ Lug.prototype.notifyAttachedServices = async function (name, request, data) {
   };
   e.data.metricsContext = metricsContextData;
 
-  this.info('notify.attached', e);
+  this.debug('notify.attached', e);
   this.notifier.send(e);
 };
 

--- a/packages/fxa-auth-server/lib/metrics/context.js
+++ b/packages/fxa-auth-server/lib/metrics/context.js
@@ -130,7 +130,7 @@ module.exports = function (log, config) {
         return (await cache.get(getKey(token))) || {};
       }
     } catch (err) {
-      log.error('metricsContext.get', {
+      log.debug('metricsContext.get', {
         err,
         hasToken: !!token,
         hasId: !!(token && token.id),
@@ -295,7 +295,7 @@ module.exports = function (log, config) {
       return logInvalidContext(this, 'invalid signature');
     }
 
-    log.info('metrics.context.validate', {
+    log.debug('metrics.context.validate', {
       valid: true,
     });
     return true;
@@ -306,7 +306,7 @@ module.exports = function (log, config) {
       delete request.payload.metricsContext.flowId;
       delete request.payload.metricsContext.flowBeginTime;
     }
-    log.warn('metrics.context.validate', {
+    log.debug('metrics.context.validate', {
       valid: false,
       reason: reason,
     });

--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -156,7 +156,7 @@ module.exports.validateRequestedGrant = async function validateRequestedGrant(
 // This function does *not* perform any authentication or validation, assuming that
 // the specified grant has been sufficiently vetted by calling code.
 module.exports.generateTokens = async function generateTokens(grant) {
-  logger.info('oauth.generateTokens', {
+  logger.debug('oauth.generateTokens', {
     grantType: grant.grantType,
     keys: !!grant.keysJwe,
     scope: grant.scope.getScopeValues(),

--- a/packages/fxa-auth-server/lib/oauth/routes/verify.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/verify.js
@@ -32,7 +32,7 @@ module.exports = {
   handler: async function verify(req) {
     const info = await token.verify(req.payload.token);
     info.scope = info.scope.getScopeValues();
-    logger.info('verify.success', {
+    logger.debug('verify.success', {
       client_id: info.client_id,
       scope: info.scope,
     });

--- a/packages/fxa-auth-server/lib/push.js
+++ b/packages/fxa-auth-server/lib/push.js
@@ -457,7 +457,6 @@ module.exports = function (log, db, config, statsd) {
 
     reportPushAttempt(pushCallback, metricsTags) {
       this.incrementPushMetric(LOG_OP_PUSH_SEND_ATTEMPT, metricsTags);
-      log.info(LOG_OP_PUSH_SEND_ATTEMPT, metricsTags);
       // Log the full callback URL for debugging purposes.
       log.trace(LOG_OP_PUSH_SEND_ATTEMPT, {
         pushCallback,
@@ -476,13 +475,13 @@ module.exports = function (log, db, config, statsd) {
       err.errCode = errCode;
       metricsTags = { errCode, err, ...metricsTags };
       this.incrementPushMetric(LOG_OP_PUSH_SEND_FAILURE, metricsTags);
-      log.warn(LOG_OP_PUSH_SEND_FAILURE, metricsTags);
+      log.debug(LOG_OP_PUSH_SEND_FAILURE, metricsTags);
       return err;
     },
 
     reportPushSuccess(metricsTags) {
       this.incrementPushMetric(LOG_OP_PUSH_SEND_SUCCESS, metricsTags);
-      log.info(LOG_OP_PUSH_SEND_SUCCESS, metricsTags);
+      log.debug(LOG_OP_PUSH_SEND_SUCCESS, metricsTags);
     },
 
     incrementPushMetric(name, tags) {

--- a/packages/fxa-auth-server/lib/pushbox.js
+++ b/packages/fxa-auth-server/lib/pushbox.js
@@ -143,7 +143,7 @@ module.exports = function (log, config, statsd) {
         query.index = index.toString();
       }
       const body = await api.retrieve(uid, deviceId, query);
-      log.info('pushbox.retrieve.response', { body: body });
+      log.debug('pushbox.retrieve.response', { body: body });
       if (body.error) {
         log.error('pushbox.retrieve', {
           status: body.status,

--- a/packages/fxa-auth-server/lib/routes/utils/clients.js
+++ b/packages/fxa-auth-server/lib/routes/utils/clients.js
@@ -51,7 +51,7 @@ module.exports = (log, config) => {
             };
           }
         } catch (err) {
-          log.warn('attached-clients.formatLocation.warning', {
+          log.debug('attached-clients.formatLocation.warning', {
             err: err.message,
             languages: request.app.acceptLanguage,
             language,

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -485,7 +485,7 @@ module.exports = function (log, config, oauthdb) {
             );
           }
 
-          log.info('mailer.send', {
+          log.debug('mailer.send', {
             email: emailAddresses[0],
             template,
             headers: Object.keys(headers).join(','),
@@ -526,7 +526,7 @@ module.exports = function (log, config, oauthdb) {
               return d.reject(err);
             }
 
-            log.info('mailer.send.1', {
+            log.debug('mailer.send.1', {
               status: status && status.message,
               id: status && status.messageId,
               to: emailConfig && emailConfig.to,

--- a/packages/fxa-auth-server/test/local/metrics/context.js
+++ b/packages/fxa-auth-server/test/local/metrics/context.js
@@ -130,8 +130,6 @@ describe('metricsContext', () => {
         );
 
         assert.equal(cache.get.callCount, 0, 'cache.get was not called');
-        assert.equal(log.warn.callCount, 0, 'log.warn was not called');
-        assert.equal(log.error.callCount, 0, 'log.error was not called');
       });
   });
 
@@ -157,8 +155,6 @@ describe('metricsContext', () => {
       .then((result) => {
         assert.strictEqual(result, undefined, 'result is undefined');
         assert.equal(cache.add.callCount, 1, 'cache.add was called once');
-        assert.equal(log.warn.callCount, 1, 'log.warn was called once');
-        assert.equal(log.error.callCount, 0, 'log.error was not called');
       });
   });
 
@@ -189,8 +185,6 @@ describe('metricsContext', () => {
           'qux',
           'service property was correct'
         );
-
-        assert.equal(log.error.callCount, 0, 'log.error was not called');
       });
   });
 
@@ -211,39 +205,6 @@ describe('metricsContext', () => {
       )
       .then((result) => {
         assert.equal(result, undefined, 'result is undefined');
-
-        assert.equal(log.error.callCount, 1, 'log.error was called once');
-        assert.equal(
-          log.error.args[0].length,
-          2,
-          'log.error was passed one argument'
-        );
-        assert.equal(
-          log.error.args[0][0],
-          'metricsContext.stash',
-          'op property was correct'
-        );
-        assert.equal(
-          log.error.args[0][1].err.message,
-          'Invalid token',
-          'err.message property was correct'
-        );
-        assert.strictEqual(
-          log.error.args[0][1].hasToken,
-          true,
-          'hasToken property was correct'
-        );
-        assert.strictEqual(
-          log.error.args[0][1].hasId,
-          true,
-          'hasId property was correct'
-        );
-        assert.strictEqual(
-          log.error.args[0][1].hasUid,
-          false,
-          'hasUid property was correct'
-        );
-
         assert.equal(cache.add.callCount, 0, 'cache.add was not called');
       });
   });
@@ -264,7 +225,6 @@ describe('metricsContext', () => {
         assert.equal(result, undefined, 'result is undefined');
 
         assert.equal(cache.add.callCount, 0, 'cache.add was not called');
-        assert.equal(log.error.callCount, 0, 'log.error was not called');
       });
   });
 
@@ -289,7 +249,6 @@ describe('metricsContext', () => {
     });
 
     assert.equal(cache.get.callCount, 0);
-    assert.equal(log.error.callCount, 0);
   });
 
   it('metricsContext.get with payload', async () => {
@@ -313,7 +272,6 @@ describe('metricsContext', () => {
     });
 
     assert.equal(cache.get.callCount, 0);
-    assert.equal(log.error.callCount, 0);
   });
 
   it('metricsContext.get with token', async () => {
@@ -341,8 +299,6 @@ describe('metricsContext', () => {
     assert.equal(cache.get.callCount, 1);
     assert.lengthOf(cache.get.args[0], 1);
     assert.equal(cache.get.args[0][0], hashToken(token));
-
-    assert.equal(log.error.callCount, 0);
   });
 
   it('metricsContext.get with fake token', async () => {
@@ -372,8 +328,6 @@ describe('metricsContext', () => {
     assert.lengthOf(cache.get.args[0], 1);
     assert.equal(cache.get.args[0][0], hashToken(token));
     assert.deepEqual(cache.get.args[0][0], hashToken({ uid, id }));
-
-    assert.equal(log.error.callCount, 0);
   });
 
   it('metricsContext.get with bad token', async () => {
@@ -386,14 +340,6 @@ describe('metricsContext', () => {
     });
 
     assert.deepEqual(result, {});
-
-    assert.equal(log.error.callCount, 1);
-    assert.lengthOf(log.error.args[0], 2);
-    assert.equal(log.error.args[0][0], 'metricsContext.get');
-    assert.equal(log.error.args[0][1].err.message, 'Invalid token');
-    assert.strictEqual(log.error.args[0][1].hasToken, true);
-    assert.strictEqual(log.error.args[0][1].hasId, false);
-    assert.strictEqual(log.error.args[0][1].hasUid, true);
   });
 
   it('metricsContext.get with no token and no payload', async () => {
@@ -402,8 +348,6 @@ describe('metricsContext', () => {
     });
 
     assert.deepEqual(result, {});
-
-    assert.equal(log.error.callCount, 0);
   });
 
   it('metricsContext.get with token and payload', async () => {
@@ -433,7 +377,6 @@ describe('metricsContext', () => {
     });
 
     assert.equal(cache.get.callCount, 0);
-    assert.equal(log.error.callCount, 0);
   });
 
   it('metricsContext.get with cache.get error', async () => {
@@ -450,14 +393,6 @@ describe('metricsContext', () => {
     assert.deepEqual(result, {});
 
     assert.equal(cache.get.callCount, 1);
-
-    assert.equal(log.error.callCount, 1);
-    assert.lengthOf(log.error.args[0], 2);
-    assert.equal(log.error.args[0][0], 'metricsContext.get');
-    assert.equal(log.error.args[0][1].err, 'foo');
-    assert.strictEqual(log.error.args[0][1].hasToken, true);
-    assert.strictEqual(log.error.args[0][1].hasId, true);
-    assert.strictEqual(log.error.args[0][1].hasUid, true);
   });
 
   it('metricsContext.gather with metadata', () => {
@@ -523,7 +458,6 @@ describe('metricsContext', () => {
         assert.equal(result.utm_term, 'mock utm_term');
 
         assert.equal(cache.get.callCount, 0);
-        assert.equal(log.error.callCount, 0);
       });
   });
 
@@ -568,8 +502,6 @@ describe('metricsContext', () => {
         assert.isUndefined(result.utm_medium);
         assert.isUndefined(result.utm_source);
         assert.isUndefined(result.utm_term);
-
-        assert.equal(log.error.callCount, 0);
       });
   });
 
@@ -589,8 +521,6 @@ describe('metricsContext', () => {
         assert.equal(typeof result, 'object', 'result is object');
         assert.notEqual(result, null, 'result is not null');
         assert.strictEqual(result.flow_time, 0, 'result.time is zero');
-
-        assert.equal(log.error.callCount, 0, 'log.error was not called');
       });
   });
 
@@ -618,8 +548,6 @@ describe('metricsContext', () => {
       assert.equal(args[1], 'wibble');
 
       assert.equal(cache.del.callCount, 0);
-      assert.equal(log.warn.callCount, 0);
-      assert.equal(log.error.callCount, 0);
     });
   });
 
@@ -637,9 +565,7 @@ describe('metricsContext', () => {
     return metricsContext.propagate(oldToken, newToken).then(() => {
       assert.equal(cache.get.callCount, 1);
       assert.equal(cache.add.callCount, 1);
-      assert.equal(log.warn.callCount, 1);
       assert.equal(cache.del.callCount, 0);
-      assert.equal(log.error.callCount, 0);
     });
   });
 
@@ -656,9 +582,7 @@ describe('metricsContext', () => {
     };
     return metricsContext.propagate(oldToken, newToken).then(() => {
       assert.equal(cache.get.callCount, 1);
-      assert.equal(log.error.callCount, 1);
       assert.equal(cache.add.callCount, 0);
-      assert.equal(log.warn.callCount, 0);
       assert.equal(cache.del.callCount, 0);
     });
   });
@@ -719,7 +643,6 @@ describe('metricsContext', () => {
       .call({})
       .then(() => {
         assert.equal(cache.del.callCount, 0, 'cache.del was not called');
-        assert.equal(log.error.callCount, 0, 'log.error was not called');
       })
       .catch((err) => assert.fail(err));
   });
@@ -785,17 +708,6 @@ describe('metricsContext', () => {
       '1234567890abcdef1234567890abcdef06146f1d05e7ae215885a4e45b66ff1f',
       'valid flow data was not removed'
     );
-    assert.equal(mockLog.warn.callCount, 0, 'log.warn was not called');
-    assert.equal(mockLog.info.callCount, 1, 'log.info was called once');
-    assert.lengthOf(mockLog.info.args[0], 2);
-    assert.equal(mockLog.info.args[0][0], 'metrics.context.validate');
-    assert.deepEqual(
-      mockLog.info.args[0][1],
-      {
-        valid: true,
-      },
-      'log.info was passed correct argument'
-    );
 
     Date.now.restore();
   });
@@ -822,15 +734,6 @@ describe('metricsContext', () => {
     const valid = metricsContext.validate.call(mockRequest);
 
     assert(!valid, 'the data is treated as invalid');
-    assert.equal(mockLog.info.callCount, 0, 'log.info was not called');
-    assert.equal(mockLog.warn.callCount, 1, 'log.warn was called once');
-    assert.ok(
-      mockLog.warn.calledWithExactly('metrics.context.validate', {
-        valid: false,
-        reason: 'missing payload',
-      }),
-      'log.warn was called with the expected log data'
-    );
   });
 
   it('metricsContext.validate with missing data bundle', () => {
@@ -856,15 +759,6 @@ describe('metricsContext', () => {
     const valid = metricsContext.validate.call(mockRequest);
 
     assert(!valid, 'the data is treated as invalid');
-    assert.equal(mockLog.info.callCount, 0, 'log.info was not called');
-    assert.equal(mockLog.warn.callCount, 1, 'log.warn was called once');
-    assert.ok(
-      mockLog.warn.calledWithExactly('metrics.context.validate', {
-        valid: false,
-        reason: 'missing context',
-      }),
-      'log.warn was called with the expected log data'
-    );
   });
 
   it('metricsContext.validate with missing flowId', () => {
@@ -894,15 +788,6 @@ describe('metricsContext', () => {
     assert(
       !mockRequest.payload.metricsContext.flowBeginTime,
       'the invalid flow data was removed'
-    );
-    assert.equal(mockLog.info.callCount, 0, 'log.info was not called');
-    assert.equal(mockLog.warn.callCount, 1, 'log.warn was called once');
-    assert.ok(
-      mockLog.warn.calledWithExactly('metrics.context.validate', {
-        valid: false,
-        reason: 'missing flowId',
-      }),
-      'log.warn was called with the expected log data'
     );
   });
 
@@ -934,15 +819,6 @@ describe('metricsContext', () => {
     assert(
       !mockRequest.payload.metricsContext.flowId,
       'the invalid flow data was removed'
-    );
-    assert.equal(mockLog.info.callCount, 0, 'log.info was not called');
-    assert.equal(mockLog.warn.callCount, 1, 'log.warn was called once');
-    assert.ok(
-      mockLog.warn.calledWithExactly('metrics.context.validate', {
-        valid: false,
-        reason: 'missing flowBeginTime',
-      }),
-      'log.warn was called with the expected log data'
     );
   });
 
@@ -976,15 +852,6 @@ describe('metricsContext', () => {
       !mockRequest.payload.metricsContext.flowId,
       'the invalid flow data was removed'
     );
-    assert.equal(mockLog.info.callCount, 0, 'log.info was not called');
-    assert.equal(mockLog.warn.callCount, 1, 'log.warn was called once');
-    assert.ok(
-      mockLog.warn.calledWithExactly('metrics.context.validate', {
-        valid: false,
-        reason: 'expired flowBeginTime',
-      }),
-      'log.warn was called with the expected log data'
-    );
   });
 
   it('metricsContext.validate with an invalid flow signature', () => {
@@ -1016,15 +883,6 @@ describe('metricsContext', () => {
     assert(
       !mockRequest.payload.metricsContext.flowId,
       'the invalid flow data was removed'
-    );
-    assert.equal(mockLog.info.callCount, 0, 'log.info was not called');
-    assert.equal(mockLog.warn.callCount, 1, 'log.warn was called once');
-    assert.ok(
-      mockLog.warn.calledWithExactly('metrics.context.validate', {
-        valid: false,
-        reason: 'invalid signature',
-      }),
-      'log.warn was called with the expected log data'
     );
   });
 
@@ -1068,15 +926,6 @@ describe('metricsContext', () => {
       !mockRequest.payload.metricsContext.flowId,
       'the invalid flow data was removed'
     );
-    assert.equal(mockLog.info.callCount, 0, 'log.info was not called');
-    assert.equal(mockLog.warn.callCount, 1, 'log.warn was called once');
-    assert.ok(
-      mockLog.warn.calledWithExactly('metrics.context.validate', {
-        valid: false,
-        reason: 'invalid signature',
-      }),
-      'log.warn was called with the expected log data'
-    );
   });
 
   it('metricsContext.validate with flow signature from different timestamp', () => {
@@ -1118,15 +967,6 @@ describe('metricsContext', () => {
     assert(
       !mockRequest.payload.metricsContext.flowId,
       'the invalid flow data was removed'
-    );
-    assert.equal(mockLog.info.callCount, 0, 'log.info was not called');
-    assert.equal(mockLog.warn.callCount, 1, 'log.warn was called once');
-    assert.ok(
-      mockLog.warn.calledWithExactly('metrics.context.validate', {
-        valid: false,
-        reason: 'invalid signature',
-      }),
-      'log.warn was called with the expected log data'
     );
   });
 
@@ -1173,15 +1013,6 @@ describe('metricsContext', () => {
       !mockRequest.payload.metricsContext.flowId,
       'the invalid flow data was removed'
     );
-    assert.equal(mockLog.info.callCount, 0, 'log.info was not called');
-    assert.equal(mockLog.warn.callCount, 1, 'log.warn was called once');
-    assert.ok(
-      mockLog.warn.calledWithExactly('metrics.context.validate', {
-        valid: false,
-        reason: 'invalid signature',
-      }),
-      'log.warn was called with the expected log data'
-    );
   });
 
   it('metricsContext.validate with flow signature compared without user agent', () => {
@@ -1218,9 +1049,6 @@ describe('metricsContext', () => {
       '1234567890abcdef1234567890abcdef06146f1d05e7ae215885a4e45b66ff1f',
       'valid flow data was not removed'
     );
-    assert.equal(mockLog.warn.callCount, 0, 'log.warn was not called');
-    assert.equal(mockLog.info.callCount, 1, 'log.info was called once');
-
     Date.now.restore();
   });
 

--- a/packages/fxa-auth-server/test/local/push.js
+++ b/packages/fxa-auth-server/test/local/push.js
@@ -115,7 +115,6 @@ describe('push', () => {
     const push = loadMockedPushModule();
     await push.sendPush(mockUid, [], 'accountVerify');
     assert.callCount(mockSendNotification, 0);
-    assert.callCount(mockLog.info, 0);
     assert.callCount(mockStatsD.increment, 0);
   });
 
@@ -128,48 +127,6 @@ describe('push', () => {
     );
     assert.deepEqual(sendErrors, {});
     assert.callCount(mockSendNotification, 2);
-
-    assert.callCount(mockLog.info, 5);
-    assert.calledWith(
-      mockLog.info.getCall(0),
-      'push.filteredUnsupportedDevice'
-    );
-    assert.calledWithExactly(mockLog.info.getCall(1), 'push.send.attempt', {
-      reason: 'accountVerify',
-      uid: mockUid,
-      deviceId: mockDevices[0].id,
-      uaOS: undefined,
-      uaOSVersion: undefined,
-      uaBrowser: undefined,
-      uaBrowserVersion: undefined,
-    });
-    assert.calledWithExactly(mockLog.info.getCall(2), 'push.send.success', {
-      reason: 'accountVerify',
-      uid: mockUid,
-      deviceId: mockDevices[0].id,
-      uaOS: undefined,
-      uaOSVersion: undefined,
-      uaBrowser: undefined,
-      uaBrowserVersion: undefined,
-    });
-    assert.calledWithExactly(mockLog.info.getCall(3), 'push.send.attempt', {
-      reason: 'accountVerify',
-      uid: mockUid,
-      deviceId: mockDevices[1].id,
-      uaOS: 'Windows',
-      uaOSVersion: '10',
-      uaBrowser: 'Firefox',
-      uaBrowserVersion: '65.4',
-    });
-    assert.calledWithExactly(mockLog.info.getCall(4), 'push.send.success', {
-      reason: 'accountVerify',
-      uid: mockUid,
-      deviceId: mockDevices[1].id,
-      uaOS: 'Windows',
-      uaOSVersion: '10',
-      uaBrowser: 'Firefox',
-      uaBrowserVersion: '65.4',
-    });
 
     assert.callCount(mockStatsD.increment, 4);
     assert.calledWithExactly(
@@ -229,52 +186,6 @@ describe('push', () => {
     );
     sinon.assert.match(sendErrors, match.has(mockDevices[1].id, match.any));
     assert.callCount(mockSendNotification, 2);
-
-    assert.callCount(mockLog.info, 4);
-    assert.calledWith(
-      mockLog.info.getCall(0),
-      'push.filteredUnsupportedDevice'
-    );
-    assert.calledWithExactly(mockLog.info.getCall(1), 'push.send.attempt', {
-      reason: 'accountVerify',
-      uid: mockUid,
-      deviceId: mockDevices[0].id,
-      uaOS: undefined,
-      uaOSVersion: undefined,
-      uaBrowser: undefined,
-      uaBrowserVersion: undefined,
-    });
-    assert.calledWithExactly(mockLog.info.getCall(2), 'push.send.success', {
-      reason: 'accountVerify',
-      uid: mockUid,
-      deviceId: mockDevices[0].id,
-      uaOS: undefined,
-      uaOSVersion: undefined,
-      uaBrowser: undefined,
-      uaBrowserVersion: undefined,
-    });
-    assert.calledWithExactly(mockLog.info.getCall(3), 'push.send.attempt', {
-      reason: 'accountVerify',
-      uid: mockUid,
-      deviceId: mockDevices[1].id,
-      uaOS: 'Windows',
-      uaOSVersion: '10',
-      uaBrowser: 'Firefox',
-      uaBrowserVersion: '65.4',
-    });
-
-    assert.callCount(mockLog.warn, 1);
-    assert.calledWithExactly(mockLog.warn.getCall(0), 'push.send.failure', {
-      reason: 'accountVerify',
-      errCode: 'unknown',
-      err: match.has('message', 'intermittent failure'),
-      uid: mockUid,
-      deviceId: mockDevices[1].id,
-      uaOS: 'Windows',
-      uaOSVersion: '10',
-      uaBrowser: 'Firefox',
-      uaBrowserVersion: '65.4',
-    });
 
     assert.callCount(mockStatsD.increment, 4);
     assert.calledWithExactly(
@@ -440,10 +351,8 @@ describe('push', () => {
     ];
     const options = { data: Buffer.from('foobar') };
     await push.sendPush(mockUid, devices, 'deviceConnected', options);
-    assert.callCount(mockLog.info, 1);
-    assert.calledWithMatch(mockLog.info, 'push.send.attempt');
-    assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, 'push.send.failure', {
+    assert.callCount(mockLog.debug, 1);
+    assert.calledWithMatch(mockLog.debug, 'push.send.failure', {
       reason: 'deviceConnected',
       errCode: 'noKeys',
     });
@@ -458,10 +367,8 @@ describe('push', () => {
       },
     ];
     await push.sendPush(mockUid, devices, 'accountVerify');
-    assert.callCount(mockLog.info, 1);
-    assert.calledWithMatch(mockLog.info, 'push.send.attempt');
-    assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, 'push.send.failure', {
+    assert.callCount(mockLog.debug, 1);
+    assert.calledWithMatch(mockLog.debug, 'push.send.failure', {
       reason: 'accountVerify',
       errCode: 'noCallback',
     });
@@ -479,10 +386,8 @@ describe('push', () => {
       },
     ];
     await push.sendPush(mockUid, devices, 'accountVerify');
-    assert.callCount(mockLog.info, 1);
-    assert.calledWithMatch(mockLog.info, 'push.send.attempt');
-    assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, 'push.send.failure', {
+    assert.callCount(mockLog.debug, 1);
+    assert.calledWithMatch(mockLog.debug, 'push.send.failure', {
       reason: 'accountVerify',
       errCode: 'expiredCallback',
     });
@@ -494,10 +399,8 @@ describe('push', () => {
     });
     const push = loadMockedPushModule();
     await push.sendPush(mockUid, [mockDevices[0]], 'accountVerify');
-    assert.callCount(mockLog.info, 1);
-    assert.calledWithMatch(mockLog.info, 'push.send.attempt');
-    assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, 'push.send.failure', {
+    assert.callCount(mockLog.debug, 1);
+    assert.calledWithMatch(mockLog.debug, 'push.send.failure', {
       reason: 'accountVerify',
       errCode: 'unknown',
       err: match.has('message', 'Failed with a nasty error'),
@@ -532,8 +435,8 @@ describe('push', () => {
     const device = JSON.parse(JSON.stringify(mockDevices[0]));
     await push.sendPush(mockUid, [device], 'accountVerify');
     assert.callCount(mockSendNotification, 1);
-    assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, 'push.send.failure', {
+    assert.callCount(mockLog.debug, 1);
+    assert.calledWithMatch(mockLog.debug, 'push.send.failure', {
       reason: 'accountVerify',
       errCode: 'resetCallback',
     });
@@ -554,8 +457,8 @@ describe('push', () => {
     device.pushPublicKey = `E${device.pushPublicKey.substring(1)}`; // make the key invalid
     await push.sendPush(mockUid, [device], 'accountVerify');
     assert.callCount(mockSendNotification, 1);
-    assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, 'push.send.failure', {
+    assert.callCount(mockLog.debug, 1);
+    assert.calledWithMatch(mockLog.debug, 'push.send.failure', {
       reason: 'accountVerify',
       errCode: 'resetCallback',
     });
@@ -574,8 +477,8 @@ describe('push', () => {
     const device = JSON.parse(JSON.stringify(mockDevices[0]));
     await push.sendPush(mockUid, [device], 'accountVerify');
     assert.callCount(mockSendNotification, 1);
-    assert.callCount(mockLog.warn, 1);
-    assert.calledWithMatch(mockLog.warn, 'push.send.failure', {
+    assert.callCount(mockLog.debug, 1);
+    assert.calledWithMatch(mockLog.debug, 'push.send.failure', {
       reason: 'accountVerify',
       errCode: 'unknown',
     });

--- a/packages/fxa-auth-server/test/local/routes/utils/clients.js
+++ b/packages/fxa-auth-server/test/local/routes/utils/clients.js
@@ -122,8 +122,8 @@ describe('clientUtils.formatLocation', () => {
     clientUtils.formatLocation(client, request);
     assert.deepEqual(client.location, {});
 
-    assert.equal(log.warn.callCount, 1);
-    const args = log.warn.args[0];
+    assert.equal(log.debug.callCount, 1);
+    const args = log.debug.args[0];
     assert.lengthOf(args, 2);
     assert.equal(args[0], 'attached-clients.formatLocation.warning');
   });

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -1431,17 +1431,14 @@ describe('lib/senders/email:', () => {
       };
 
       return mailer.send(message).then(() => {
-        assert.equal(mockLog.info.callCount, 3);
-        const emailEventLog = mockLog.info.getCalls()[2];
+        assert.equal(mockLog.info.callCount, 1);
+        const emailEventLog = mockLog.info.getCalls()[0];
         assert.equal(emailEventLog.args[0], 'emailEvent');
         assert.equal(emailEventLog.args[1].domain, 'other');
         assert.equal(emailEventLog.args[1].flow_id, 'wibble');
         assert.equal(emailEventLog.args[1].template, 'verifyLogin');
         assert.equal(emailEventLog.args[1].type, 'sent');
         assert.equal(emailEventLog.args[1].locale, 'en');
-        const mailerSend1 = mockLog.info.getCalls()[1];
-        assert.equal(mailerSend1.args[0], 'mailer.send.1');
-        assert.equal(mailerSend1.args[1].to, message.email);
       });
     });
   });

--- a/packages/fxa-auth-server/test/local/senders/sms.js
+++ b/packages/fxa-auth-server/test/local/senders/sms.js
@@ -141,29 +141,12 @@ describe('lib/senders/sms:', () => {
         assert.deepEqual(args[0].Statistics, ['Maximum']);
       });
 
-      it('called log.info correctly', () => {
-        assert.equal(log.info.callCount, 1);
-        const args = log.info.args[0];
-        assert.lengthOf(args, 2);
-        assert.equal(args[0], 'sms.budget.ok');
-        assert.deepEqual(args[1], {
-          isBudgetOk: true,
-          current: 0,
-          limit: config.sms.minimumCreditThresholdUSD,
-          threshold: config.sms.minimumCreditThresholdUSD,
-        });
-      });
-
       it('isBudgetOk returns true', () => {
         assert.strictEqual(sms.isBudgetOk(), true);
       });
 
       it('did not call sns.publish', () => {
         assert.equal(sns.publish.callCount, 0);
-      });
-
-      it('did not call log.error', () => {
-        assert.equal(log.error.callCount, 0);
       });
     });
 
@@ -182,10 +165,6 @@ describe('lib/senders/sms:', () => {
         it('isBudgetOk returns false', () => {
           assert.strictEqual(sms.isBudgetOk(), false);
         });
-
-        it('did not call log.error', () => {
-          assert.equal(log.error.callCount, 0);
-        });
       });
     });
 
@@ -200,17 +179,6 @@ describe('lib/senders/sms:', () => {
         it('isBudgetOk returns true', () => {
           assert.strictEqual(sms.isBudgetOk(), true);
         });
-
-        it('called log.error correctly', () => {
-          assert.equal(log.error.callCount, 1);
-          const args = log.error.args[0];
-          assert.lengthOf(args, 2);
-          assert.equal(args[0], 'sms.budget.error');
-          assert.deepEqual(args[1], {
-            err: 'Invalid getMetricStatistics result "wibble"',
-            result: undefined,
-          });
-        });
       });
     });
 
@@ -224,17 +192,6 @@ describe('lib/senders/sms:', () => {
 
         it('isBudgetOk returns true', () => {
           assert.strictEqual(sms.isBudgetOk(), true);
-        });
-
-        it('called log.error correctly', () => {
-          assert.equal(log.error.callCount, 1);
-          const args = log.error.args[0];
-          assert.lengthOf(args, 2);
-          assert.equal(args[0], 'sms.budget.error');
-          assert.deepEqual(args[1], {
-            err: "Cannot read property 'Maximum' of undefined",
-            result: JSON.stringify(results.getMetricStatistics),
-          });
         });
       });
     });
@@ -269,34 +226,7 @@ describe('lib/senders/sms:', () => {
         });
       });
 
-      it('called log.trace correctly', () => {
-        assert.equal(log.trace.callCount, 1);
-        const args = log.trace.args[0];
-        assert.lengthOf(args, 2);
-        assert.equal(args[0], 'sms.send');
-        assert.deepEqual(args[1], {
-          templateName: 'installFirefox',
-          acceptLanguage: 'en',
-        });
-      });
-
-      it('called log.info correctly', () => {
-        assert.equal(log.info.callCount, 2);
-        const args = log.info.args[1];
-        assert.lengthOf(args, 2);
-        assert.equal(args[0], 'sms.send.success');
-        assert.deepEqual(args[1], {
-          templateName: 'installFirefox',
-          acceptLanguage: 'en',
-          messageId: 'foo',
-        });
-      });
-
       it('did not call mockSns.publish', () => {
-        assert.equal(log.error.callCount, 0);
-      });
-
-      it('did not call log.error', () => {
         assert.equal(log.error.callCount, 0);
       });
     });
@@ -318,10 +248,6 @@ describe('lib/senders/sms:', () => {
           'Thanks for choosing Firefox! You can install Firefox for mobile here: https://wibble/--__ff0'
         );
       });
-
-      it('did not call log.error', () => {
-        assert.equal(log.error.callCount, 0);
-      });
     });
 
     describe('attempt to send an sms with an invalid template name:', () => {
@@ -341,16 +267,6 @@ describe('lib/senders/sms:', () => {
       it('failed correctly', () => {
         assert.equal(error.errno, 131);
         assert.equal(error.message, 'Invalid message id');
-      });
-
-      it('called log.error correctly', () => {
-        assert.equal(log.error.callCount, 1);
-        const args = log.error.args[0];
-        assert.lengthOf(args, 2);
-        assert.equal(args[0], 'sms.getMessage.error');
-        assert.deepEqual(args[1], {
-          templateName: 'wibble',
-        });
       });
 
       it('did not call sns.publish', () => {
@@ -457,10 +373,6 @@ describe('lib/senders/sms:', () => {
         assert.equal(sns.getSMSAttributes.callCount, 0);
         assert.equal(cloudwatch.getMetricStatistics.callCount, 0);
       });
-
-      it('did not call log.error', () => {
-        assert.equal(log.error.callCount, 0);
-      });
     });
 
     describe('send an sms:', () => {
@@ -495,10 +407,6 @@ describe('lib/senders/sms:', () => {
 
       it('did not call sns.publish', () => {
         assert.equal(sns.publish.callCount, 0);
-      });
-
-      it('did not call log.error', () => {
-        assert.equal(log.error.callCount, 0);
       });
     });
 

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -124,6 +124,7 @@ const LOG_METHOD_NAMES = [
   'warn',
   'summary',
   'trace',
+  'debug',
 ];
 
 const MAILER_METHOD_NAMES = [

--- a/packages/fxa-auth-server/test/oauth/grant.js
+++ b/packages/fxa-auth-server/test/oauth/grant.js
@@ -266,6 +266,7 @@ describe('generateTokens', () => {
 
     mockLog = {
       info: sinon.spy(),
+      debug: sinon.spy(),
     };
 
     mockAmplitude = sinon.spy();
@@ -421,21 +422,6 @@ describe('generateTokens', () => {
       '0123456789',
       'https://resource.server1.com',
     ]);
-  });
-
-  it('should log information about the grant being processed', async () => {
-    await generateTokens(requestedGrant);
-
-    assert.equal(mockLog.info.callCount, 1);
-    const args = mockLog.info.args[0];
-    assert.strictEqual(args[0], 'oauth.generateTokens');
-    assert.deepEqual(args[1], {
-      grantType: 'fxa-credentials',
-      keys: false,
-      resource: undefined,
-      scope: scope.getScopeValues(),
-      service: '0123456789',
-    });
   });
 
   it('should log an amplitude event', async () => {

--- a/packages/fxa-auth-server/test/oauth/routes/verify.js
+++ b/packages/fxa-auth-server/test/oauth/routes/verify.js
@@ -32,6 +32,7 @@ describe('/verify POST', () => {
         getProperties: sinon.spy(() => ({ key: 'value' })),
       },
       log: {
+        debug: sandbox.spy(),
         info: sandbox.spy(),
         warn: sandbox.spy(),
       },
@@ -110,15 +111,6 @@ describe('/verify POST', () => {
 
     it('verifies the token', () => {
       assert.isTrue(mocks.token.verify.calledOnceWith(TOKEN));
-    });
-
-    it('logs as expected', () => {
-      assert.isTrue(
-        mocks.log.info.calledOnceWith('verify.success', {
-          client_id: 'foo',
-          scope: ['bar:foo', 'clients:write'],
-        })
-      );
     });
 
     it('logs an amplitude event', () => {

--- a/packages/fxa-auth-server/test/remote/db_tests.js
+++ b/packages/fxa-auth-server/test/remote/db_tests.js
@@ -17,7 +17,7 @@ const UnblockCode = require('../../lib/crypto/random').base32(
 const uuid = require('uuid');
 const { normalizeEmail } = require('fxa-shared').email.helpers;
 
-const log = { trace() {}, info() {}, error() {} };
+const log = { debug() {}, trace() {}, info() {}, error() {} };
 
 const lastAccessTimeUpdates = {
   enabled: true,

--- a/packages/fxa-auth-server/test/remote/push_db_tests.js
+++ b/packages/fxa-auth-server/test/remote/push_db_tests.js
@@ -42,6 +42,7 @@ const ACCOUNT = {
   tokenVerificationId: zeroBuffer16,
 };
 const mockLog = {
+  debug: function () {},
   error: function () {},
   warn: function () {},
   increment: function () {},
@@ -157,11 +158,11 @@ describe('remote push db', function () {
           'device.pushEndpointExpired is correct'
         );
 
-        const pushWithKnown400 = proxyquire("../../lib/push", mocksKnown400)(
+        const pushWithKnown400 = proxyquire('../../lib/push', mocksKnown400)(
           mockLog,
           db,
           {},
-          mockStatsD,
+          mockStatsD
         );
         return pushWithKnown400.sendPush(ACCOUNT.uid, devices, 'accountVerify');
       })


### PR DESCRIPTION
Because we don't need this level of verbosity for them in production and which are costing us extra storage space and query time.

This lowers the log level of some lines identified by this query:

```
SELECT
  jsonPayload.type,
  COUNT(*) AS count,
  SUM(COUNT(*)) OVER () AS total,
  ROUND(COUNT(*) / SUM(COUNT(*)) OVER (),4) AS percentage
FROM
  `moz-fx-fxa-prod-0712.fxa_prod_logs.docker_fxa_auth_20200928`
GROUP BY
  1
ORDER BY
  4 DESC;
```
