### PR TITLE
fix(fxa-settings): fix photo mask on RTL

### DIFF
--- a/packages/fxa-content-server/app/styles/modules/_cropper.scss
+++ b/packages/fxa-content-server/app/styles/modules/_cropper.scss
@@ -47,6 +47,11 @@
     &::after {
       right: -100%;
     }
+
+    [dir=rtl] & {
+      left: auto;
+      right: calc((100% - #{$avatar-size}) / 2);
+    }
   }
 
   .drag-overlay {


### PR DESCRIPTION
## Because

The mask on photos uploaded in the settings is not positioned correctly over the photo in RTL languages.

## This pull request

Adds CSS that places the mask on the right location for both LTR and RTL languases.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)
Before:
![rtl-before](https://user-images.githubusercontent.com/633345/95243601-898f3300-0819-11eb-9366-8d30f991f7eb.png)

After:
![rtl-after](https://user-images.githubusercontent.com/633345/95243618-901daa80-0819-11eb-8cfe-77d2fd0461e8.png)

## Other information (Optional)

This pull request is related to #5169 but the fix is actually for the current settings page, not the new one. I have another PR in the works that will address the new settings page
