### PR TITLE
fix(tests): Add change password functional test for beta settings

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -464,8 +464,7 @@ const cleanMemory = thenify(function (selector, attributeName) {
   );
 });
 
-const clearBrowserState = thenify(function (options) {
-  options = options || {};
+const clearBrowserState = thenify(function (options = {}) {
   if (!('contentServer' in options)) {
     options.contentServer = true;
   }
@@ -691,7 +690,7 @@ const getQueryParamValue = thenify(function (paramName) {
  *   to make. Defaults to 10.
  * @returns {promise} resolves with the email if email is found.
  */
-const getEmail = thenify(function (user, index, options) {
+const getEmail = thenify(function (user, index, options = {}) {
   if (/@/.test(user)) {
     user = TestHelpers.emailToUser(user);
   }
@@ -742,7 +741,7 @@ function disableInProd(test) {
  *   to make. Defaults to 10.
  * @returns {Promise} resolves with the SMS, if found.
  */
-const getSms = thenify(function (phoneNumber, index, options) {
+const getSms = thenify(function (phoneNumber, index, options = {}) {
   return this.parent
     .then(getEmail(phoneNumberToEmailAddress(phoneNumber), index, options))
     .then((email) => {
@@ -796,7 +795,7 @@ const SIGNIN_CODE_SMS_FORMAT = /m\/([a-zA-Z0-9_-]{8,8})$/;
  * @param {RegExp} smsFormatRegExp
  * @returns {Promise} resolves with the signinCode when complete
  */
-const getSmsSigninCode = thenify(function (phoneNumber, index, options) {
+const getSmsSigninCode = thenify(function (phoneNumber, index, options = {}) {
   return this.parent
     .then(testSmsFormat(phoneNumber, index, SIGNIN_CODE_SMS_FORMAT))
     .then(getSms(phoneNumber, index, options))

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -628,5 +628,19 @@ module.exports = {
     SUBMIT: 'button[type=submit]',
     DO_NOT_SYNC: '#do-not-sync-device',
   },
+  SETTINGS_V2: {
+    HEADER: '#profile',
+    CHANGE_PASSWORD: {
+      OPEN_BUTTON: '[data-testid=password-unit-row-route]',
+      CURRENT_PASSWORD_LABEL: '[data-testid=current-password-input-label]',
+      CURRENT_PASSWORD_INPUT: '[data-testid=current-password-input-field]',
+      NEW_PASSWORD_LABEL: '[data-testid=new-password-input-label]',
+      NEW_PASSWORD_INPUT: '[data-testid=new-password-input-field]',
+      VERIFY_PASSWORD_LABEL: '[data-testid=verify-password-input-label]',
+      VERIFY_PASSWORD_INPUT: '[data-testid=verify-password-input-field]',
+      SAVE_BUTTON: '[data-testid=save-password-button]',
+      FORGOT_PW_BUTTON: '[data-testid=nav-link-reset-password]',
+    },
+  },
 };
 /*eslint-enable max-len*/

--- a/packages/fxa-content-server/tests/functional/settings_v2/change_password.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/change_password.js
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const intern = require('intern').default;
+const { describe, it, beforeEach } = intern.getPlugin('interface.bdd');
+const selectors = require('../lib/selectors');
+const FunctionalHelpers = require('../lib/helpers');
+
+const config = intern._config;
+const EMAIL_FIRST = config.fxaContentRoot;
+const SETTINGS_V2_URL = `${config.fxaContentRoot}beta/settings`;
+const password = 'passwordzxcv';
+const newPassword = 'passwordzxcvb';
+
+const { createEmail } = FunctionalHelpers;
+
+const {
+  clearBrowserState,
+  click,
+  createUser,
+  openPage,
+  fillOutEmailFirstSignIn,
+  testElementExists,
+  type,
+} = FunctionalHelpers.helpersRemoteWrapped;
+
+describe('change password', () => {
+  let email;
+  beforeEach(async ({ remote }) => {
+    email = createEmail();
+    await clearBrowserState(remote);
+    await createUser(email, password, { preVerified: true }, remote);
+  });
+
+  it('change password and login', async ({ remote }) => {
+    await openPage(EMAIL_FIRST, selectors.ENTER_EMAIL.HEADER, remote);
+    await fillOutEmailFirstSignIn(email, password, remote);
+    await testElementExists(selectors.SETTINGS.HEADER, remote);
+    await openPage(SETTINGS_V2_URL, selectors.SETTINGS_V2.HEADER, remote);
+    await click(
+      selectors.SETTINGS_V2.CHANGE_PASSWORD.OPEN_BUTTON,
+      selectors.SETTINGS_V2.CHANGE_PASSWORD.CURRENT_PASSWORD_LABEL,
+      remote
+    );
+
+    await click(
+      selectors.SETTINGS_V2.CHANGE_PASSWORD.CURRENT_PASSWORD_LABEL,
+      remote
+    );
+    await type(
+      selectors.SETTINGS_V2.CHANGE_PASSWORD.CURRENT_PASSWORD_INPUT,
+      password,
+      {},
+      remote
+    );
+
+    await click(
+      selectors.SETTINGS_V2.CHANGE_PASSWORD.NEW_PASSWORD_LABEL,
+      remote
+    );
+    await type(
+      selectors.SETTINGS_V2.CHANGE_PASSWORD.NEW_PASSWORD_INPUT,
+      newPassword,
+      {},
+      remote
+    );
+
+    await click(
+      selectors.SETTINGS_V2.CHANGE_PASSWORD.VERIFY_PASSWORD_LABEL,
+      remote
+    );
+    await type(
+      selectors.SETTINGS_V2.CHANGE_PASSWORD.VERIFY_PASSWORD_INPUT,
+      newPassword,
+      {},
+      remote
+    );
+
+    await click(
+      selectors.SETTINGS_V2.CHANGE_PASSWORD.SAVE_BUTTON,
+      selectors.SETTINGS_V2.HEADER,
+      remote
+    );
+
+    await clearBrowserState(remote);
+
+    await openPage(EMAIL_FIRST, selectors.ENTER_EMAIL.HEADER, remote);
+    await fillOutEmailFirstSignIn(email, newPassword, remote);
+
+    await testElementExists(selectors.SETTINGS.HEADER, remote);
+  });
+
+  it('click forgot password link', async ({ remote }) => {
+    await openPage(EMAIL_FIRST, selectors.ENTER_EMAIL.HEADER, remote);
+    await fillOutEmailFirstSignIn(email, password, remote);
+    await testElementExists(selectors.SETTINGS.HEADER, remote);
+    await openPage(SETTINGS_V2_URL, selectors.SETTINGS_V2.HEADER, remote);
+    await click(
+      selectors.SETTINGS_V2.CHANGE_PASSWORD.OPEN_BUTTON,
+      selectors.SETTINGS_V2.CHANGE_PASSWORD.CURRENT_PASSWORD_LABEL,
+      remote
+    );
+
+    await click(
+      selectors.SETTINGS_V2.CHANGE_PASSWORD.FORGOT_PW_BUTTON,
+      selectors.RESET_PASSWORD.HEADER,
+      remote
+    );
+  });
+});

--- a/packages/fxa-content-server/tests/functional/settings_v2/settings.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/settings.js
@@ -17,6 +17,7 @@ const password = 'passwordzxcv';
 const { createEmail } = FunctionalHelpers;
 
 const {
+  clearBrowserState,
   createUser,
   openPage,
   fillOutEmailFirstSignIn,
@@ -27,6 +28,7 @@ describe('settings', () => {
   let email;
   beforeEach(async ({ remote }) => {
     email = createEmail();
+    await clearBrowserState(remote);
     await createUser(email, password, { preVerified: true }, remote);
   });
 
@@ -34,6 +36,6 @@ describe('settings', () => {
     await openPage(EMAIL_FIRST, selectors.ENTER_EMAIL.HEADER, remote);
     await fillOutEmailFirstSignIn(email, password, remote);
     await testElementExists(selectors.SETTINGS.HEADER, remote);
-    await openPage(SETTINGS_V2_URL, '#profile', remote);
+    await openPage(SETTINGS_V2_URL, selectors.SETTINGS_V2.HEADER, remote);
   });
 });

--- a/packages/fxa-content-server/tests/functional_settings_v2.js
+++ b/packages/fxa-content-server/tests/functional_settings_v2.js
@@ -2,4 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports = ['tests/functional/settings_v2/settings.js'];
+module.exports = [
+  'tests/functional/settings_v2/settings.js',
+  'tests/functional/settings_v2/change_password.js',
+];

--- a/packages/fxa-settings/src/components/InputPassword/index.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/index.tsx
@@ -19,9 +19,14 @@ export const InputPassword = ({
   inputRef,
   errorText,
   name,
+  prefixDataTestId = '',
 }: InputPasswordProps) => {
   const [hasContent, setHasContent] = useState<boolean>(defaultValue != null);
   const [visible, setVisible] = useState<boolean>(false);
+
+  function formatDataTestId(id: string) {
+    return prefixDataTestId ? `${prefixDataTestId}-${id}` : id;
+  }
 
   const onInputChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -44,11 +49,12 @@ export const InputPassword = ({
         inputRef,
         errorText,
         name,
+        prefixDataTestId,
       }}
     >
       <button
         type="button"
-        data-testid="visibility-toggle"
+        data-testid={formatDataTestId('visibility-toggle')}
         className={`w-5 px-3 py-2 text-grey-600 focus:text-blue-500 box-content ${
           hasContent ? '-ml-3' : 'hidden'
         }`}

--- a/packages/fxa-settings/src/components/InputText/index.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.tsx
@@ -25,6 +25,7 @@ export type InputTextProps = {
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   type?: 'text' | 'email' | 'tel' | 'number' | 'url' | 'password';
   name?: string;
+  prefixDataTestId?: string;
 };
 
 export const InputText = ({
@@ -40,6 +41,7 @@ export const InputText = ({
   inputRef,
   type = 'text',
   name,
+  prefixDataTestId = '',
 }: InputTextProps) => {
   const [focussed, setFocussed] = useState<boolean>(false);
   const [hasContent, setHasContent] = useState<boolean>(defaultValue != null);
@@ -60,6 +62,10 @@ export const InputText = ({
     [onChange]
   );
 
+  function formatDataTestId(id: string) {
+    return prefixDataTestId ? `${prefixDataTestId}-${id}` : id;
+  }
+
   return (
     <label
       className={`flex items-center rounded transition-all duration-100 ease-in-out border relative
@@ -67,7 +73,7 @@ export const InputText = ({
         focussed ? 'border-blue-400 shadow-input-blue-focus' : 'border-grey-200'
       }
       ${disabled ? 'border-grey-100 bg-grey-10' : 'bg-white'} ${className}`}
-      data-testid="input-container"
+      data-testid={formatDataTestId('input-container')}
     >
       <span className="block relative flex-auto">
         <span
@@ -78,13 +84,13 @@ export const InputText = ({
               ? 'transform scale-80 mt-1 ml-1 -left-px'
               : 'mt-3 pt-px'
           )}
-          data-testid="input-label"
+          data-testid={formatDataTestId('input-label')}
         >
           {label}
         </span>
         <input
           className="pb-1 pt-5 px-3 w-full font-body text-sm rounded focus:outline-none disabled:bg-grey-10 placeholder-transparent focus:placeholder-grey-500 text-grey-600 disabled:text-grey-300 disabled:cursor-default"
-          data-testid="input-field"
+          data-testid={formatDataTestId('input-field')}
           onChange={textFieldChange}
           ref={inputRef}
           {...{

--- a/packages/fxa-settings/src/components/PageChangePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.test.tsx
@@ -50,18 +50,18 @@ it('emits an Amplitude event on success', async () => {
     </AuthContext.Provider>
   );
   await act(async () => {
-    fireEvent.input(screen.getAllByTestId('input-field')[0], {
+    fireEvent.input(screen.getByTestId('current-password-input-field'), {
       target: { value: 'quuz' },
     });
-    fireEvent.input(screen.getAllByTestId('input-field')[1], {
+    fireEvent.input(screen.getByTestId('new-password-input-field'), {
       target: { value: 'testotesto' },
     });
-    fireEvent.input(screen.getAllByTestId('input-field')[2], {
+    fireEvent.input(screen.getByTestId('verify-password-input-field'), {
       target: { value: 'testotesto' },
     });
   });
   await act(async () => {
-    fireEvent.click(screen.getByTestId('submit-change-password'));
+    fireEvent.click(screen.getByTestId('save-password-button'));
   });
   expect(logViewEvent).toHaveBeenCalledWith(
     settingsViewName,
@@ -77,25 +77,25 @@ it('disables save until the form is valid', async () => {
       </MockedCache>
     </AuthContext.Provider>
   );
-  expect(screen.getByTestId('submit-change-password')).toBeDisabled();
+  expect(screen.getByTestId('save-password-button')).toBeDisabled();
   await act(async () => {
-    fireEvent.input(screen.getAllByTestId('input-field')[0], {
+    fireEvent.input(screen.getByTestId('current-password-input-field'), {
       target: { value: 'quuz' },
     });
   });
-  expect(screen.getByTestId('submit-change-password')).toBeDisabled();
+  expect(screen.getByTestId('save-password-button')).toBeDisabled();
   await act(async () => {
-    fireEvent.input(screen.getAllByTestId('input-field')[1], {
+    fireEvent.input(screen.getByTestId('new-password-input-field'), {
       target: { value: 'testotesto' },
     });
   });
-  expect(screen.getByTestId('submit-change-password')).toBeDisabled();
+  expect(screen.getByTestId('save-password-button')).toBeDisabled();
   await act(async () => {
-    fireEvent.input(screen.getAllByTestId('input-field')[2], {
+    fireEvent.input(screen.getByTestId('verify-password-input-field'), {
       target: { value: 'testotesto' },
     });
   });
-  expect(screen.getByTestId('submit-change-password')).toBeEnabled();
+  expect(screen.getByTestId('save-password-button')).toBeEnabled();
 });
 
 it('shows validation feedback', async () => {
@@ -107,7 +107,7 @@ it('shows validation feedback', async () => {
     </AuthContext.Provider>
   );
   await act(async () => {
-    fireEvent.input(screen.getAllByTestId('input-field')[1], {
+    fireEvent.input(screen.getByTestId('new-password-input-field'), {
       target: { value: 'password' },
     });
   });

--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -165,6 +165,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
             inputRef={register({
               required: true,
             })}
+            prefixDataTestId="current-password"
           />
           <InputPassword
             name="newPassword"
@@ -193,6 +194,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
                 },
               },
             })}
+            prefixDataTestId="new-password"
           />
           <InputPassword
             name="confirmPassword"
@@ -202,6 +204,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
               required: true,
               validate: (value) => value === getValues().newPassword,
             })}
+            prefixDataTestId="verify-password"
           />
         </div>
 
@@ -210,11 +213,12 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
             type="button"
             className="cta-neutral mx-2 flex-1"
             onClick={() => window.history.back()}
+            data-testid="cancel-password-button"
           >
             Cancel
           </button>
           <button
-            data-testid="submit-change-password"
+            data-testid="save-password-button"
             type="submit"
             className="cta-primary mx-2 flex-1"
             disabled={
@@ -225,13 +229,13 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
           </button>
         </div>
 
-        <LinkExternal
+        <a
           className="link-blue text-sm justify-center flex"
           data-testid="nav-link-reset-password"
           href="/reset_password"
         >
           Forgot password?
-        </LinkExternal>
+        </a>
       </form>
     </FlowContainer>
   );

--- a/packages/fxa-settings/src/components/Profile/index.tsx
+++ b/packages/fxa-settings/src/components/Profile/index.tsx
@@ -29,6 +29,7 @@ export const Profile = () => {
           headerValue={displayName}
           headerValueClassName="break-all"
           route="/beta/settings/display_name"
+          prefixDataTestId="display-name"
         />
 
         <hr className="unit-row-hr" />
@@ -38,6 +39,7 @@ export const Profile = () => {
           headerValueClassName="tracking-wider"
           headerValue="••••••••••••••••••"
           route="/beta/settings/change_password"
+          prefixDataTestId="password"
         >
           <p className="text-grey-400 text-xs mobileLandscape:mt-3">
             Created {pwdDateText}
@@ -50,6 +52,7 @@ export const Profile = () => {
           header="Primary email"
           headerValue={primaryEmail.email}
           headerValueClassName="break-all"
+          prefixDataTestId="primary-email"
         />
 
         <hr className="unit-row-hr" />

--- a/packages/fxa-settings/src/components/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRow/index.tsx
@@ -68,6 +68,7 @@ type UnitRowProps = {
   revealSecondaryModal?: () => void;
   alertBarRevealed?: boolean;
   hideCtaText?: boolean;
+  prefixDataTestId?: string;
 };
 
 export const UnitRow = ({
@@ -88,17 +89,22 @@ export const UnitRow = ({
   revealSecondaryModal,
   alertBarRevealed,
   hideCtaText,
+  prefixDataTestId = '',
 }: UnitRowProps & RouteComponentProps) => {
   ctaText = ctaText || (headerValue ? 'Change' : 'Add');
 
   const location = useLocation();
   const multiButton = !!(route || secondaryCtaRoute);
 
+  function formatDataTestId(id: string) {
+    return prefixDataTestId ? `${prefixDataTestId}-${id}` : id;
+  }
+
   return (
     <div className="unit-row">
       <div className="unit-row-header">
         <span className="flex justify-between items-center">
-          <h3 data-testid="unit-row-header" id={headerId}>
+          <h3 data-testid={formatDataTestId('unit-row-header')} id={headerId}>
             {header}
           </h3>
           <span>{headerContent}</span>
@@ -107,7 +113,7 @@ export const UnitRow = ({
       <div className="unit-row-content">
         <p
           className={classNames('font-bold', headerValueClassName)}
-          data-testid="unit-row-header-value"
+          data-testid={formatDataTestId('unit-row-header-value')}
         >
           {headerValue || noHeaderValueText}
         </p>
@@ -119,7 +125,7 @@ export const UnitRow = ({
           {!hideCtaText && route && (
             <Link
               className="cta-neutral cta-base transition-standard mr-1"
-              data-testid="unit-row-route"
+              data-testid={formatDataTestId('unit-row-route')}
               to={`${route}${location.search}`}
             >
               {ctaText}
@@ -136,7 +142,7 @@ export const UnitRow = ({
           {secondaryCtaRoute && (
             <Link
               className="cta-neutral cta-base transition-standard mr-1"
-              data-testid="unit-row-route"
+              data-testid={formatDataTestId('unit-row-route')}
               to={`${secondaryCtaRoute}${location.search}`}
             >
               {secondaryCtaText}


### PR DESCRIPTION
## Because

- We don't have functional tests in the new beta settings page

## This pull request

- Adds functional tests for change password in beta settings
- Adds a helper method `formatDataTestId` that prepends a value to the `data-testid` field so that it is unique
## Issue that this pull request solves

Closes: #4858 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
