### PR TITLE
feat(payments): set cache ttl on customers in redis

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -774,6 +774,12 @@ const conf = convict({
       default: 'YOU MUST CHANGE ME',
       env: 'SUBHUB_KEY',
     },
+    customerCacheTtlSeconds: {
+      doc: 'The number of seconds to cache a Stripe Customer response',
+      format: 'int',
+      default: 3600,
+      env: 'SUBHUB_CUSTOMER_CACHE_TTL_SECONDS',
+    },
     plansCacheTtlSeconds: {
       doc: 'The number of seconds to cache the list of plans from subhub',
       format: 'int',

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -66,6 +66,7 @@ const mockConfig = {
     enabled: true,
     url: 'https://foo.bar',
     key: 'foo',
+    customerCacheTtlSeconds: 90,
     plansCacheTtlSeconds: 60,
   },
 };
@@ -1221,8 +1222,11 @@ describe('StripeHelper', () => {
         assert(mockRedis.get.calledOnce);
         assert(mockRedis.set.calledOnce);
 
-        // Assert that no TTL was set for this cache entry - i.e. [ 'EX', 600 ] should not appear.
-        assert.deepEqual(mockRedis.set.args[0][2], []);
+        // Assert that a TTL was set for this cache entry
+        assert.deepEqual(mockRedis.set.args[0][2], [
+          'EX',
+          mockConfig.subhub.customerCacheTtlSeconds,
+        ]);
 
         assert.deepEqual(
           await stripeHelper.customer({ uid: existingUid, email }),


### PR DESCRIPTION
## Because

- Now that we store the customer-account relationship, we don't have to have forever cache

## This pull request

- Establishes a ttl for customer records in redis

## Issue that this pull request solves

Closes #6163

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.