### PR TITLE
feat(settings): add display name page

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -15,6 +15,7 @@ import PageSettings from '../PageSettings';
 import PageChangePassword from '../PageChangePassword';
 import PageSecondaryEmailAdd from '../PageSecondaryEmailAdd';
 import PageSecondaryEmailVerify from '../PageSecondaryEmailVerify';
+import { PageDisplayName } from '../PageDisplayName';
 
 export const GET_INITIAL_STATE = gql`
   query GetInitialState {
@@ -90,7 +91,7 @@ export const App = ({ flowQueryParams }: AppProps) => {
       <Router basepath="/beta/settings">
         <PageSettings path="/" />
         <FlowContainer path="/avatar/change" title="Profile picture" />
-        <FlowContainer path="/display_name" title="Display name" />
+        <PageDisplayName path="/display_name" />
         <PageChangePassword path="/change_password" />
         <PageSecondaryEmailAdd path="/emails" />
         <PageSecondaryEmailVerify path="/emails/verify" />

--- a/packages/fxa-settings/src/components/PageDisplayName/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.stories.tsx
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { LocationProvider } from '@reach/router';
+import { storiesOf } from '@storybook/react';
+import { MockedCache } from 'fxa-settings/src/models/_mocks';
+import React from 'react';
+import { PageDisplayName } from '.';
+import AppLayout from '../AppLayout';
+
+storiesOf('Pages|DisplayNmae', module)
+  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
+  .add('default', () => (
+    <MockedCache>
+      <AppLayout>
+        <PageDisplayName />
+      </AppLayout>
+    </MockedCache>
+  ));

--- a/packages/fxa-settings/src/components/PageDisplayName/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.test.tsx
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { screen } from '@testing-library/react';
+import PageDisplayName from '.';
+import { MockedCache, renderWithRouter } from 'fxa-settings/src/models/_mocks';
+import { AuthContext, createAuthClient } from 'fxa-settings/src/lib/auth';
+
+const client = createAuthClient('none');
+
+it('renders', async () => {
+  renderWithRouter(
+    <AuthContext.Provider value={{ auth: client }}>
+      <MockedCache>
+        <PageDisplayName />
+      </MockedCache>
+    </AuthContext.Provider>
+  );
+  expect(screen.getByTestId('flow-container')).toBeInTheDocument();
+  expect(screen.getByTestId('flow-container-back-btn')).toBeInTheDocument();
+  expect(screen.getByTestId('input-field')).toBeInTheDocument();
+  expect(screen.getByTestId('submit-display-name')).toBeInTheDocument();
+});

--- a/packages/fxa-settings/src/components/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.tsx
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { RouteComponentProps } from '@reach/router';
+import React, { useRef } from 'react';
+import FlowContainer from '../FlowContainer';
+import InputText from '../InputText';
+
+export const PageDisplayName = ({}: RouteComponentProps) => {
+  const displayNameRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <FlowContainer title="Display Name">
+      <div className="my-6">
+        <InputText
+          label="Enter display name"
+          className="mb-2"
+          data-testid="display-name-input"
+          inputRef={displayNameRef}
+        />
+      </div>
+      <div className="flex justify-center mb-4 mx-auto max-w-64">
+        <button
+          className="cta-neutral mx-2 flex-1"
+          onClick={() => window.history.back()}
+        >
+          Cancel
+        </button>
+        <button
+          data-testid="submit-display-name"
+          className="cta-primary mx-2 flex-1"
+        >
+          Save
+        </button>
+      </div>
+    </FlowContainer>
+  );
+};
+
+export default PageDisplayName;


### PR DESCRIPTION
Because:
 - new settings need a page for updating the display name

This commit:
 - add a (not-yet-functional) form for the display name

## Issue that this pull request solves

Closes: #4955 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
