### PR TITLE
bug(payments): bad stripe expand fields

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -446,9 +446,9 @@ export class StripeHelper {
     email: string
   ): Promise<Stripe.Customer | void> {
     return this.fetchCustomer(uid, [
-      'data.sources',
-      'data.subscriptions',
-      'data.invoice_settings.default_payment_method',
+      'sources',
+      'subscriptions',
+      'invoice_settings.default_payment_method',
     ]);
   }
 

--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -66,8 +66,8 @@ async function updateStripeEmail(
   currentPrimaryEmail,
   newPrimaryEmail
 ) {
-  const customer = await stripeHelper.fetchCustomer(uid, currentPrimaryEmail);
-  if (!customer) {
+  const customer = await stripeHelper.fetchCustomer(uid);
+  if (!customer || customer.email === newPrimaryEmail) {
     // No customer to update, or already updated.
     return;
   }

--- a/packages/fxa-auth-server/lib/routes/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.ts
@@ -375,8 +375,8 @@ class DirectStripeRoutes {
 
     const { uid, email } = await handleAuth(this.db, request.auth, true);
     const customer = await this.stripeHelper.fetchCustomer(uid, [
-      'data.subscriptions.data.latest_invoice',
-      'data.invoice_settings.default_payment_method',
+      'subscriptions.data.latest_invoice',
+      'invoice_settings.default_payment_method',
     ]);
     if (!customer) {
       throw error.unknownCustomer(uid);


### PR DESCRIPTION
The keys for the fields to expand on a customer call are different from a customer list call. The 'data' prefix for the key needs to be dropped.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
