### PR TITLE
feat(settings): update save btn state on display name input

### DIFF
--- a/packages/fxa-settings/src/components/PageDisplayName/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.test.tsx
@@ -2,11 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import 'mutationobserver-shim';
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import PageDisplayName from '.';
-import { MockedCache, renderWithRouter } from 'fxa-settings/src/models/_mocks';
+import {
+  MockedCache,
+  MOCK_ACCOUNT,
+  renderWithRouter,
+} from 'fxa-settings/src/models/_mocks';
 import { AuthContext, createAuthClient } from 'fxa-settings/src/lib/auth';
 
 const client = createAuthClient('none');
@@ -23,4 +28,41 @@ it('renders', async () => {
   expect(screen.getByTestId('flow-container-back-btn')).toBeInTheDocument();
   expect(screen.getByTestId('input-field')).toBeInTheDocument();
   expect(screen.getByTestId('submit-display-name')).toBeInTheDocument();
+});
+
+it('updates the disabled state of the save button', async () => {
+  renderWithRouter(
+    <AuthContext.Provider value={{ auth: client }}>
+      <MockedCache>
+        <PageDisplayName />
+      </MockedCache>
+    </AuthContext.Provider>
+  );
+
+  // initial value
+  expect(screen.getByTestId('submit-display-name')).toBeDisabled();
+
+  // empty value
+  await act(async () => {
+    fireEvent.input(screen.getAllByTestId('input-field')[0], {
+      target: { value: '' },
+    });
+  });
+  expect(screen.getByTestId('submit-display-name')).toBeDisabled();
+
+  // new value
+  await act(async () => {
+    fireEvent.input(screen.getAllByTestId('input-field')[0], {
+      target: { value: 'testo' },
+    });
+  });
+  expect(screen.getByTestId('submit-display-name')).not.toBeDisabled();
+
+  // original value
+  await act(async () => {
+    fireEvent.input(screen.getAllByTestId('input-field')[0], {
+      target: { value: MOCK_ACCOUNT.displayName },
+    });
+  });
+  expect(screen.getByTestId('submit-display-name')).toBeDisabled();
 });

--- a/packages/fxa-settings/src/components/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.tsx
@@ -3,37 +3,59 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { RouteComponentProps } from '@reach/router';
-import React, { useRef } from 'react';
+import { useAccount } from 'fxa-settings/src/models';
+import { useForm } from 'react-hook-form';
+import React, { ChangeEvent, useRef, useCallback, useState } from 'react';
 import FlowContainer from '../FlowContainer';
 import InputText from '../InputText';
 
+const validateDisplayName = (currentDisplayName: string) => (
+  newDisplayName: string
+) => newDisplayName !== '' && newDisplayName !== currentDisplayName;
+
 export const PageDisplayName = ({}: RouteComponentProps) => {
-  const displayNameRef = useRef<HTMLInputElement>(null);
+  const user = useAccount();
+  const { register, handleSubmit, formState, trigger } = useForm();
+  const isValidDisplayName = validateDisplayName(user.displayName || '');
+
+  const onSubmit = async (ev: React.FormEvent<HTMLFormElement>) => {
+    // TODO FXA-1645
+  };
 
   return (
     <FlowContainer title="Display Name">
-      <div className="my-6">
-        <InputText
-          label="Enter display name"
-          className="mb-2"
-          data-testid="display-name-input"
-          inputRef={displayNameRef}
-        />
-      </div>
-      <div className="flex justify-center mb-4 mx-auto max-w-64">
-        <button
-          className="cta-neutral mx-2 flex-1"
-          onClick={() => window.history.back()}
-        >
-          Cancel
-        </button>
-        <button
-          data-testid="submit-display-name"
-          className="cta-primary mx-2 flex-1"
-        >
-          Save
-        </button>
-      </div>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <div className="my-6">
+          <InputText
+            name="displayName"
+            label="Enter display name"
+            className="mb-2"
+            data-testid="display-name-input"
+            onChange={() => trigger('displayName')}
+            inputRef={register({
+              required: true,
+              validate: isValidDisplayName,
+            })}
+          />
+        </div>
+        <div className="flex justify-center mb-4 mx-auto max-w-64">
+          <button
+            type="button"
+            className="cta-neutral mx-2 flex-1"
+            onClick={() => window.history.back()}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            data-testid="submit-display-name"
+            className="cta-primary mx-2 flex-1"
+            disabled={!formState.isDirty || !formState.isValid}
+          >
+            Save
+          </button>
+        </div>
+      </form>
     </FlowContainer>
   );
 };


### PR DESCRIPTION
Because:
 - the disabled state of the save button should be based on the input
   value of the display name

This commit:
 - update the disabled attr of the save button when the display name
   input value changes

## Issue that this pull request solves

Closes: #4954 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

