### PR TITLE
chore(node): Upgrade to Node.js v14

### DIFF
--- a/_dev/docker/builder/Dockerfile
+++ b/_dev/docker/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-slim
+FROM node:14-slim
 
 RUN set -x \
     && addgroup --gid 10001 app \

--- a/_dev/docker/circleci/Dockerfile
+++ b/_dev/docker/circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/node:12-stretch-browsers
+FROM circleci/node:14-stretch-browsers
 
 USER root
 RUN apt-get update && apt-get install -y \

--- a/_dev/docker/mono/Dockerfile
+++ b/_dev/docker/mono/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-slim
+FROM node:14-slim
 
 RUN set -x \
     && addgroup --gid 10001 app \


### PR DESCRIPTION
## Because

Node.js 12 is entering maintenance LTS on 2020-10-20

## This pull request

Upgrades Docker images to Node.js 14, which is entering active LTS on 2020-10-27

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
