### PR TITLE
fix(log): Update metrics error log to trace

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/events.js
+++ b/packages/fxa-auth-server/lib/metrics/events.js
@@ -189,7 +189,7 @@ module.exports = (log, config) => {
 
   function emitFlowEvent(event, request, optionalData) {
     if (!request || !request.headers) {
-      log.error('metricsEvents.emitFlowEvent', { event, badRequest: true });
+      log.trace('metricsEvents.emitFlowEvent', { event, badRequest: true });
       return P.resolve();
     }
 

--- a/packages/fxa-auth-server/test/local/metrics/events.js
+++ b/packages/fxa-auth-server/test/local/metrics/events.js
@@ -12,6 +12,7 @@ const log = {
   error: sinon.spy(),
   flowEvent: sinon.spy(),
   info: sinon.spy(),
+  trace: sinon.spy(),
 };
 const events = require('../../../lib/metrics/events')(log, {
   amplitude: { rawEvents: false },
@@ -813,8 +814,8 @@ describe('metrics/events', () => {
       },
     };
     return events.emit.call(request, 'email.verification.sent').then(() => {
-      assert.equal(log.error.callCount, 1, 'log.error was called once');
-      const args = log.error.args[0];
+      assert.equal(log.trace.callCount, 1, 'log.error was called once');
+      const args = log.trace.args[0];
       assert.lengthOf(args, 2);
       assert.equal(args[0], 'metricsEvents.emitFlowEvent');
       assert.deepEqual(


### PR DESCRIPTION
Noticed this while creating signin/signup papercut milestone, we really don't need this to be `error` since it really isnt.

Fixes #5306
Fixes #3580