### PR TITLE
chore(test): Remove custom firefox build for pairing tests

### DIFF
--- a/_dev/docker/circleci/Dockerfile
+++ b/_dev/docker/circleci/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && apt-get install -y \
 RUN easy_install pip
 RUN pip install mozdownload mozinstall
 RUN mozdownload --version 68.0 --destination firefox.tar.bz2
-RUN wget https://s3-us-west-2.amazonaws.com/fxa-dev-bucket/fenix-pair/desktop/7f10c7614e9fa46-target.tar.bz2
 
 USER circleci
 

--- a/packages/fxa-content-server/scripts/test-ci.sh
+++ b/packages/fxa-content-server/scripts/test-ci.sh
@@ -55,7 +55,5 @@ test_suite circle 6
 # node 5 currently has the least work to do in the above tests
 if [[ "${CIRCLE_NODE_INDEX}" == "5" ]]; then
   test_suite server 1
-
-  mozinstall /7f10c7614e9fa46-target.tar.bz2
   test_suite pairing 1
 fi


### PR DESCRIPTION
Another small fix I found while making papercut milestone.