### PR TITLE
chore(tests): Add basic signout tests

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -630,6 +630,11 @@ module.exports = {
   },
   SETTINGS_V2: {
     HEADER: '#profile',
+    AVATAR_DROP_DOWN_MENU: {
+      MENU_BUTTON: '[data-testid=drop-down-avatar-menu-toggle]',
+      DISPLAY_NAME_LABEL: '[data-testid=drop-down-name-or-email]',
+      SIGNOUT_BUTTON: '[data-testid=avatar-menu-sign-out]',
+    },
     CHANGE_PASSWORD: {
       OPEN_BUTTON: '[data-testid=password-unit-row-route]',
       CURRENT_PASSWORD_LABEL: '[data-testid=current-password-input-label]',

--- a/packages/fxa-content-server/tests/functional/settings_v2/navigation.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/navigation.js
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const intern = require('intern').default;
+const { describe, it, beforeEach } = intern.getPlugin('interface.bdd');
+const selectors = require('../lib/selectors');
+const FunctionalHelpers = require('../lib/helpers');
+
+const config = intern._config;
+const EMAIL_FIRST = config.fxaContentRoot;
+const SETTINGS_V2_URL = `${config.fxaContentRoot}beta/settings`;
+const password = 'passwordzxcv';
+
+const { createEmail } = FunctionalHelpers;
+
+const {
+  clearBrowserState,
+  click,
+  createUser,
+  openPage,
+  fillOutEmailFirstSignIn,
+  testElementExists,
+} = FunctionalHelpers.helpersRemoteWrapped;
+
+describe('navigation', () => {
+  let email;
+  beforeEach(async ({ remote }) => {
+    email = createEmail();
+    await clearBrowserState(remote);
+    await createUser(email, password, { preVerified: true }, remote);
+
+    await openPage(EMAIL_FIRST, selectors.ENTER_EMAIL.HEADER, remote);
+    await fillOutEmailFirstSignIn(email, password, remote);
+    await testElementExists(selectors.SETTINGS.HEADER, remote);
+
+    // Open new settings
+    await openPage(SETTINGS_V2_URL, selectors.SETTINGS_V2.HEADER, remote);
+  });
+
+  it('can sign out', async ({ remote }) => {
+    await click(
+      selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.MENU_BUTTON,
+      selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.DISPLAY_NAME_LABEL,
+      remote
+    );
+    await click(
+      selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.SIGNOUT_BUTTON,
+      selectors.ENTER_EMAIL.HEADER,
+      remote
+    );
+    await testElementExists(selectors.ENTER_EMAIL.HEADER, remote);
+  });
+});

--- a/packages/fxa-content-server/tests/functional_settings_v2.js
+++ b/packages/fxa-content-server/tests/functional_settings_v2.js
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 module.exports = [
-  'tests/functional/settings_v2/settings.js',
+  // Add flaky tests here...once they are safe, add to stable tests
+  'tests/functional/settings_v2/navigation.js',
+
+  // Stable tests
   'tests/functional/settings_v2/change_password.js',
+  'tests/functional/settings_v2/settings.js',
 ];

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
@@ -128,7 +128,7 @@ describe('DropDownAvatarMenu', () => {
 
       fireEvent.click(screen.getByTestId('drop-down-avatar-menu-toggle'));
       await act(async () => {
-        fireEvent.click(screen.getByTestId('sign-out'));
+        fireEvent.click(screen.getByTestId('avatar-menu-sign-out'));
       });
       expect(window.location.assign).toHaveBeenCalledWith(
         `${window.location.origin}/signin`
@@ -153,7 +153,7 @@ describe('DropDownAvatarMenu', () => {
 
       fireEvent.click(screen.getByTestId('drop-down-avatar-menu-toggle'));
       await act(async () => {
-        fireEvent.click(screen.getByTestId('sign-out'));
+        fireEvent.click(screen.getByTestId('avatar-menu-sign-out'));
       });
 
       expect(screen.getByTestId('sign-out-error').textContent).toContain(

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
@@ -99,7 +99,7 @@ export const DropDownAvatarMenu = () => {
                   <button
                     className="pl-3 group"
                     onClick={signOut}
-                    data-testid="sign-out"
+                    data-testid="avatar-menu-sign-out"
                   >
                     <SignOut
                       height="18"


### PR DESCRIPTION
## Because

- Paired on this with @ashrivastava-qa @rbillings, assigned you issue to take it over the line :)
- Settings V2 doesn't have functional test for sign out

## This pull request

- Adds some basic tests to sign out

## Issue that this pull request solves

Closes: #

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
