### PR TITLE
feat(settings): update display name

### DIFF
--- a/packages/fxa-settings/src/components/AppLayout/index.test.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.test.tsx
@@ -7,6 +7,7 @@ import { screen } from '@testing-library/react';
 import { MockedCache } from '../../models/_mocks';
 import AppLayout from '.';
 import { renderWithRouter } from '../../models/_mocks';
+import { HomePath } from '../../constants';
 
 it('renders the app with children', async () => {
   const {
@@ -18,7 +19,7 @@ it('renders the app with children', async () => {
       </AppLayout>
     </MockedCache>
   );
-  await navigate('/beta/settings');
+  await navigate(HomePath);
   expect(screen.getByTestId('app')).toBeInTheDocument();
   expect(screen.getByTestId('content-skip')).toBeInTheDocument();
   expect(screen.getByTestId('header')).toBeInTheDocument();

--- a/packages/fxa-settings/src/components/InputText/index.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.tsx
@@ -26,6 +26,7 @@ export type InputTextProps = {
   type?: 'text' | 'email' | 'tel' | 'number' | 'url' | 'password';
   name?: string;
   prefixDataTestId?: string;
+  autoFocus?: boolean;
 };
 
 export const InputText = ({
@@ -42,6 +43,7 @@ export const InputText = ({
   type = 'text',
   name,
   prefixDataTestId = '',
+  autoFocus,
 }: InputTextProps) => {
   const [focussed, setFocussed] = useState<boolean>(false);
   const [hasContent, setHasContent] = useState<boolean>(defaultValue != null);
@@ -50,13 +52,17 @@ export const InputText = ({
     setFocussed(true);
   }, []);
 
-  const onBlur = useCallback(() => {
+  const checkHasContent = (event: ChangeEvent<HTMLInputElement>) =>
+    setHasContent(event.target.value.length > 0);
+
+  const onBlur = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    checkHasContent(event);
     setFocussed(false);
   }, []);
 
   const textFieldChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      setHasContent(event.target.value.length > 0);
+      checkHasContent(event);
       onChange && onChange(event);
     },
     [onChange]
@@ -101,6 +107,7 @@ export const InputText = ({
             onBlur,
             placeholder,
             type,
+            autoFocus,
           }}
         />
       </span>

--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -14,10 +14,11 @@ import { useAccount, Account, Session } from '../../models';
 import AlertBar from '../AlertBar';
 import FlowContainer from '../FlowContainer';
 import InputPassword from '../InputPassword';
-import { logViewEvent, settingsViewName } from 'fxa-settings/src/lib/metrics';
+import { logViewEvent, settingsViewName } from '../../lib/metrics';
 import { ReactComponent as ValidIcon } from './valid.svg';
 import { ReactComponent as InvalidIcon } from './invalid.svg';
 import { ReactComponent as UnsetIcon } from './unset.svg';
+import { HomePath } from '../../constants';
 
 type FormData = {
   oldPassword: string;
@@ -87,7 +88,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
           },
         },
       });
-      navigate('/beta/settings');
+      navigate(HomePath);
     },
     onError: (e) => {
       if (e.errno === 103) {

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
@@ -7,6 +7,7 @@ import { useAlertBar, useMutation } from '../../lib/hooks';
 import InputText from '../InputText';
 import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
+import { HomePath } from 'fxa-settings/src/constants';
 
 export const VERIFY_SECONDARY_EMAIL_MUTATION = gql`
   mutation verifySecondaryEmail($input: VerifyEmailInput!) {
@@ -44,13 +45,13 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
       });
     },
     onCompleted: () => {
-      navigate('/beta/settings', { replace: true });
+      navigate(HomePath, { replace: true });
     },
   });
 
   useEffect(() => {
     if (!email) {
-      navigate('/beta/settings', { replace: true });
+      navigate(HomePath, { replace: true });
     }
   }, [email, navigate]);
 

--- a/packages/fxa-settings/src/constants/index.tsx
+++ b/packages/fxa-settings/src/constants/index.tsx
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export const HomePath = '/beta/settings';


### PR DESCRIPTION
Because:
 - new settings should save the account's new display name

This commit:
 - save the new display name with gql-api
 - allow empty display name (delete)


## Issue that this pull request solves

Closes: #4956 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).