### PR TITLE
feat(settings): add two step authentication page

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -17,6 +17,7 @@ import PageRecoveryKeyAdd from '../PageRecoveryKeyAdd';
 import PageSecondaryEmailAdd from '../PageSecondaryEmailAdd';
 import PageSecondaryEmailVerify from '../PageSecondaryEmailVerify';
 import { PageDisplayName } from '../PageDisplayName';
+import PageTwoStepAuthentication from '../PageTwoStepAuthentication';
 
 export const GET_INITIAL_STATE = gql`
   query GetInitialState {
@@ -97,6 +98,7 @@ export const App = ({ flowQueryParams }: AppProps) => {
         <PageRecoveryKeyAdd path="/account_recovery" />
         <PageSecondaryEmailAdd path="/emails" />
         <PageSecondaryEmailVerify path="/emails/verify" />
+        <PageTwoStepAuthentication path="/two_step_authentication" />
       </Router>
     </AppLayout>
   );

--- a/packages/fxa-settings/src/components/InputText/index.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.tsx
@@ -27,6 +27,7 @@ export type InputTextProps = {
   name?: string;
   prefixDataTestId?: string;
   autoFocus?: boolean;
+  maxLength?: number;
 };
 
 export const InputText = ({
@@ -44,6 +45,7 @@ export const InputText = ({
   name,
   prefixDataTestId = '',
   autoFocus,
+  maxLength,
 }: InputTextProps) => {
   const [focussed, setFocussed] = useState<boolean>(false);
   const [hasContent, setHasContent] = useState<boolean>(defaultValue != null);
@@ -108,6 +110,7 @@ export const InputText = ({
             placeholder,
             type,
             autoFocus,
+            maxLength,
           }}
         />
       </span>

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.stories.tsx
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { LocationProvider } from '@reach/router';
+import { storiesOf } from '@storybook/react';
+import { MockedCache } from 'fxa-settings/src/models/_mocks';
+import React from 'react';
+import { PageTwoStepAuthentication } from '.';
+import AppLayout from '../AppLayout';
+
+storiesOf('Pages|TwoStepAuthentication', module)
+  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
+  .add('default', () => (
+    <MockedCache>
+      <AppLayout>
+        <PageTwoStepAuthentication />
+      </AppLayout>
+    </MockedCache>
+  ));

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.test.tsx
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import 'mutationobserver-shim';
+import '@testing-library/jest-dom/extend-expect';
+import { act, fireEvent, screen } from '@testing-library/react';
+import { AuthContext, createAuthClient } from '../../lib/auth';
+import { renderWithRouter, MockedCache } from '../../models/_mocks';
+import React from 'react';
+import PageTwoStepAuthentication from '.';
+
+const client = createAuthClient('none');
+
+const render = () =>
+  renderWithRouter(
+    <AuthContext.Provider value={{ auth: client }}>
+      <MockedCache>
+        <PageTwoStepAuthentication />
+      </MockedCache>
+    </AuthContext.Provider>
+  );
+
+const inputTotp = async (totp: string) => {
+  await act(async () => {
+    fireEvent.input(screen.getByTestId('totp-input-field'), {
+      target: { value: totp },
+    });
+  });
+};
+
+it('renders', () => {
+  render();
+  expect(screen.getByTestId('flow-container')).toBeInTheDocument();
+  expect(screen.getByTestId('flow-container-back-btn')).toBeInTheDocument();
+  expect(screen.getByTestId('totp-input-field')).toBeInTheDocument();
+  expect(screen.getByTestId('submit-totp')).toBeInTheDocument();
+});
+
+it('updates the disabled state of the continue button', async () => {
+  render();
+  const button = screen.getByTestId('submit-totp');
+
+  // default
+  expect(button).toBeDisabled();
+
+  // not all numbers
+  await inputTotp('bigcat');
+  expect(button).toBeDisabled();
+
+  // not enough numbers
+  await inputTotp('90210');
+  expect(button).toBeDisabled();
+
+  // valid code
+  await inputTotp('867530');
+  expect(button).not.toBeDisabled();
+});

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { RouteComponentProps } from '@reach/router';
+import LinkExternal from 'fxa-react/components/LinkExternal';
+import React, { useCallback } from 'react';
+import { useForm } from 'react-hook-form';
+import FlowContainer from '../FlowContainer';
+import InputText from '../InputText';
+import VerifiedSessionGuard from '../VerifiedSessionGuard';
+
+type TotpForm = { totp: number };
+
+export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
+  const goBack = useCallback(() => window.history.back(), []);
+  const { register, handleSubmit, trigger, formState } = useForm<TotpForm>({
+    mode: 'onTouched',
+  });
+
+  const isValidTotpFormat = (totp: string) => /\d{6}/.test(totp);
+  const onSubmit = ({ totp }: TotpForm) => {};
+
+  return (
+    <FlowContainer title="Two Step Authentication" subtitle="Step 1 of 3">
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
+
+        <p className="mt-4 mb-4">
+          Scan this QR code using one of{' '}
+          <LinkExternal href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication">
+            these apps
+          </LinkExternal>
+          .
+        </p>
+
+        <div>{/* QR CODE HERE */}</div>
+
+        <p className="mt-4">
+          Now enter the security code from the authentication app.
+        </p>
+
+        <div className="mt-4 mb-6" data-testid="recovery-key-input">
+          <InputText
+            name="totp"
+            label="Enter security code"
+            prefixDataTestId="totp"
+            maxLength={6}
+            onChange={() => trigger('totp')}
+            inputRef={register({
+              validate: isValidTotpFormat,
+            })}
+          />
+        </div>
+
+        <div className="flex justify-center mb-4 mx-auto max-w-64">
+          <button
+            type="button"
+            className="cta-neutral mx-2 flex-1"
+            onClick={() => window.history.back()}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            data-testid="submit-totp"
+            className="cta-primary mx-2 flex-1"
+            disabled={!formState.isDirty || !formState.isValid}
+          >
+            Continue
+          </button>
+        </div>
+      </form>
+    </FlowContainer>
+  );
+};
+
+export default PageTwoStepAuthentication;

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
@@ -27,7 +27,7 @@ export const DELETE_TOTP_MUTATION = gql`
 export const UnitRowTwoStepAuth = () => {
   const alertBar = useAlertBar();
   const {
-    totp: { exists },
+    totp: { exists, verified },
   } = useAccount();
   const [modalRevealed, revealModal, hideModal] = useBooleanState();
   const [
@@ -65,25 +65,26 @@ export const UnitRowTwoStepAuth = () => {
     },
   });
 
-  const conditionalUnitRowProps = exists
-    ? {
-        headerValueClassName: 'text-green-800',
-        headerValue: 'Enabled',
-        secondaryCtaText: 'Disable',
-        secondaryButtonClassName: 'cta-caution',
-        // The naming of this is a bit confusing, since they are swapped in this
-        // case, we should come up with a better name here. Filed FXA-2539
-        revealModal: revealSecondaryModal,
-        revealSecondaryModal: revealModal,
-        hideCtaText: true,
-      }
-    : {
-        headerValue: null,
-        noHeaderValueText: 'Not Set',
-        ctaText: 'Add',
-        secondaryCtaText: undefined,
-        revealSecondaryModal: undefined,
-      };
+  const conditionalUnitRowProps =
+    exists && verified
+      ? {
+          headerValueClassName: 'text-green-800',
+          headerValue: 'Enabled',
+          secondaryCtaText: 'Disable',
+          secondaryButtonClassName: 'cta-caution',
+          // The naming of this is a bit confusing, since they are swapped in this
+          // case, we should come up with a better name here. Filed FXA-2539
+          revealModal: revealSecondaryModal,
+          revealSecondaryModal: revealModal,
+          hideCtaText: true,
+        }
+      : {
+          headerValue: null,
+          noHeaderValueText: 'Not Set',
+          ctaText: 'Add',
+          secondaryCtaText: undefined,
+          revealSecondaryModal: undefined,
+        };
 
   return (
     <UnitRow


### PR DESCRIPTION
Because:
 - we need to scaffold the two step auth page

This commit:
 - add the two step auth page

## Issue that this pull request solves

Closes: #4968 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

