### PR TITLE
fix(subscriptions): add Stripe customer to local DB on webhook

### DIFF
--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -60,12 +60,7 @@ async function updateZendeskPrimaryEmail(
  * @param {string} newPrimaryEmail
  * @returns {Promise<void | import('stripe').Stripe.Customer>}
  */
-async function updateStripeEmail(
-  stripeHelper,
-  uid,
-  currentPrimaryEmail,
-  newPrimaryEmail
-) {
+async function updateStripeEmail(stripeHelper, uid, newPrimaryEmail) {
   const customer = await stripeHelper.fetchCustomer(uid);
   if (!customer || customer.email === newPrimaryEmail) {
     // No customer to update, or already updated.
@@ -862,12 +857,7 @@ module.exports = (
             // Wait here to update stripe and our local cache to avoid loss of
             // valid subscription status.
             try {
-              await updateStripeEmail(
-                stripeHelper,
-                uid,
-                primaryEmail,
-                secondaryEmail.email
-              );
+              await updateStripeEmail(stripeHelper, uid, secondaryEmail.email);
               await stripeHelper.refreshCachedCustomer(
                 uid,
                 secondaryEmail.email

--- a/packages/fxa-auth-server/lib/routes/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.ts
@@ -374,7 +374,7 @@ class DirectStripeRoutes {
     this.log.begin('subscriptions.getCustomer', request);
 
     const { uid, email } = await handleAuth(this.db, request.auth, true);
-    const customer = await this.stripeHelper.fetchCustomer(uid, [
+    const customer = await this.stripeHelper.fetchCustomer(uid, email, [
       'subscriptions.data.latest_invoice',
       'invoice_settings.default_payment_method',
     ]);

--- a/packages/fxa-auth-server/test/local/payments/fixtures/customer_new.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/customer_new.json
@@ -18,7 +18,7 @@
   },
   "livemode": false,
   "metadata": {
-    "userid": "testuid"
+    "userid": "ac893f80d84647e9504bd9532e9571b5"
   },
   "name": "Jane Doe",
   "phone": null,

--- a/packages/fxa-auth-server/test/local/routes/emails.js
+++ b/packages/fxa-auth-server/test/local/routes/emails.js
@@ -313,7 +313,6 @@ describe('update stripe primary email', () => {
     const result = await updateStripeEmail(
       stripeHelper,
       'test',
-      'test@example.com',
       'updated.email@example.com'
     );
     assert.deepEqual(result, CUSTOMER_1_UPDATED);


### PR DESCRIPTION
Because:
 - people can create customers and subscriptions directly via Stripe
   Dashboard

This commit:
 - insert a customer into the local DB when the Stripe customer is found
   with an email address

## Issue that this pull request solves

Closes: #6689 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
