### PR TITLE
fix(settings): fix mobile safari failing to render new settings

### DIFF
--- a/packages/fxa-settings/src/lib/metrics.ts
+++ b/packages/fxa-settings/src/lib/metrics.ts
@@ -72,16 +72,16 @@ let configurableProperties: ConfigurableProperties = defaultConfigProps();
 
 function defaultConfigProps(): ConfigurableProperties {
   const startTime = () => {
-    if (window.performance && window.performance.getEntriesByType) {
+    try {
       return (
         window.performance.timeOrigin +
         (window.performance.getEntriesByType(
           'navigation'
         )[0] as PerformanceNavigationTiming).fetchStart
       );
+    } catch (e) {
+      return Date.now();
     }
-
-    return Date.now();
   };
 
   return {


### PR DESCRIPTION
fixes #6652

The startTime function of metrics throws an error on mobile safari. Try/catch is better here than trying to sniff for availability.

... the page looks like garbage but it renders. 🤷 