### PR TITLE
feat(subscriptions): handle 'customer.created' Stripe event

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.ts
@@ -718,6 +718,9 @@ class DirectStripeRoutes {
       );
 
       switch (event.type) {
+        case 'customer.created':
+          await this.handleCustomerCreatedEvent(request, event);
+          break;
         case 'customer.subscription.created':
           await this.handleSubscriptionCreatedEvent(request, event);
           break;
@@ -757,6 +760,15 @@ class DirectStripeRoutes {
       this.log.error('subscriptions.handleWebhookEvent.failure', { error });
     }
     return {};
+  }
+
+  /**
+   * Handle `customer.created` Stripe webhook events.
+   */
+  async handleCustomerCreatedEvent(_: AuthRequest, event: Stripe.Event) {
+    const customer = event.data.object as Stripe.Customer;
+    const account = await this.db.accountRecord(customer.email);
+    await this.stripeHelper.createLocalCustomer(account.uid, customer);
   }
 
   /**

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -248,6 +248,30 @@ describe('StripeHelper', () => {
     });
   });
 
+  describe('createLocalCustomer', () => {
+    it('inserts a local customer record', async () => {
+      const uid = '993499bcb0cf4da2bf1b37f1a37f3b88';
+
+      // customer doesn't exist
+      const existingCustomer = await getAccountCustomerByUid(uid);
+      assert.isUndefined(existingCustomer);
+
+      await stripeHelper.createLocalCustomer(uid, newCustomer);
+
+      // customer does exist
+      const insertedCustomer = await getAccountCustomerByUid(uid);
+      assert.isObject(insertedCustomer);
+
+      // inserting again
+      await stripeHelper.createLocalCustomer(uid, {
+        ...newCustomer,
+        id: 'cus_nope',
+      });
+      const sameCustomer = await getAccountCustomerByUid(uid);
+      assert.notEqual(sameCustomer.stripeCustomerId, 'cus_nope');
+    });
+  });
+
   describe('createSetupIntent', () => {
     it('creates a setup intent', async () => {
       const expected = deepCopy(newSetupIntent);

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -1587,6 +1587,7 @@ describe('DirectStripeRoutes', () => {
         },
       };
       const handlerNames = [
+        'handleCustomerCreatedEvent',
         'handleSubscriptionCreatedEvent',
         'handleSubscriptionUpdatedEvent',
         'handleSubscriptionDeletedEvent',
@@ -1670,6 +1671,13 @@ describe('DirectStripeRoutes', () => {
         );
       });
 
+      describe('when the event.type is customer.created', () => {
+        itOnlyCallsThisHandler('handleCustomerCreatedEvent', {
+          data: { object: customerFixture },
+          type: 'customer.created',
+        });
+      });
+
       describe('when the event.type is customer.subscription.created', () => {
         itOnlyCallsThisHandler(
           'handleSubscriptionCreatedEvent',
@@ -1735,6 +1743,28 @@ describe('DirectStripeRoutes', () => {
         { id: event.data.object.id, productId: event.data.object.plan.product },
         isActive
       );
+
+    describe('handleCustomerCreatedEvent', () => {
+      it('creates a local db record with the account uid', async () => {
+        await directStripeRoutesInstance.handleCustomerCreatedEvent(
+          {},
+          {
+            data: { object: customerFixture },
+            type: 'customer.created',
+          }
+        );
+
+        assert.calledOnceWithExactly(
+          directStripeRoutesInstance.db.accountRecord,
+          customerFixture.email
+        );
+        assert.calledOnceWithExactly(
+          directStripeRoutesInstance.stripeHelper.createLocalCustomer,
+          UID,
+          customerFixture
+        );
+      });
+    });
 
     describe('handleSubscriptionUpdatedEvent', () => {
       let sendSubscriptionUpdatedEmailStub;

--- a/packages/fxa-shared/test/db/models/auth/index.spec.ts
+++ b/packages/fxa-shared/test/db/models/auth/index.spec.ts
@@ -98,14 +98,15 @@ describe('auth', () => {
         assert.isNotNull(testCustomer.createdAt);
         assert.equal(testCustomer.createdAt, testCustomer.updatedAt);
 
-        try {
-          await createAccountCustomer(userId, 'cus_o8ghropsigjpser');
-          assert.fail(
-            'An error should have been generated when re-using a uid'
-          );
-        } catch (err) {
-          assert.isTrue(err instanceof UniqueViolationError);
-        }
+        // Insert is only attempted when the record for the given uid does not exist.
+        const secondCustomer = await createAccountCustomer(
+          userId,
+          'cus_o8ghropsigjpser'
+        );
+        assert.equal(
+          secondCustomer.stripeCustomerId,
+          testCustomer.stripeCustomerId
+        );
       });
 
       it('Fails to create when the uid is invalid', async () => {


### PR DESCRIPTION
Because:
 - we should add a Stripe customer to the local DB when a customer is
   created on Stripe

This commit:
 - handle the 'customer.created' webhook event from Stripe by inserting
   into the local DB if that account does not already have a record

## Issue that this pull request solves

Closes: #6689 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
