### PR TITLE
fix(fxa-settings): add refresh button margin

### DIFF
--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
@@ -71,7 +71,7 @@ export const UnitRowRecoveryKey = () => {
       headerContent={
         <ButtonIconReload
           title="Refresh recovery key"
-          classNames="mobileLandscape:hidden"
+          classNames="mobileLandscape:hidden ltr:ml-1 rtl:mr-1"
           disabled={accountLoading}
           onClick={getAccount}
         />
@@ -79,7 +79,7 @@ export const UnitRowRecoveryKey = () => {
       actionContent={
         <ButtonIconReload
           title="Refresh recovery key"
-          classNames="hidden mobileLandscape:inline-block"
+          classNames="hidden mobileLandscape:inline-block ltr:ml-1 rtl:mr-1"
           testId="recovery-key-refresh"
           disabled={accountLoading}
           onClick={getAccount}

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -204,7 +204,7 @@ export const UnitRowSecondaryEmail = () => {
                 <span>
                   <ButtonIconTrash
                     title="Remove email"
-                    classNames="mobileLandscape:hidden"
+                    classNames="mobileLandscape:hidden ltr:ml-1 rtl:mr-1"
                     disabled={deleteEmailLoading}
                     onClick={() => {
                       queueEmailAction(deleteEmail);
@@ -213,7 +213,7 @@ export const UnitRowSecondaryEmail = () => {
                   {!verified && (
                     <ButtonIconReload
                       title="Refresh email"
-                      classNames="mobileLandscape:hidden"
+                      classNames="mobileLandscape:hidden ltr:ml-1 rtl:mr-1"
                       disabled={accountLoading}
                       onClick={getAccount}
                     />
@@ -267,7 +267,7 @@ export const UnitRowSecondaryEmail = () => {
               )}
               <ButtonIconTrash
                 title="Remove email"
-                classNames="hidden mobileLandscape:inline-block"
+                classNames="hidden mobileLandscape:inline-block ltr:ml-1 rtl:mr-1"
                 disabled={deleteEmailLoading}
                 testId="secondary-email-delete"
                 onClick={() => {
@@ -277,7 +277,7 @@ export const UnitRowSecondaryEmail = () => {
               {!verified && (
                 <ButtonIconReload
                   title="Refresh email"
-                  classNames="hidden mobileLandscape:inline-block"
+                  classNames="hidden mobileLandscape:inline-block ltr:ml-1 rtl:mr-1"
                   testId="secondary-email-refresh"
                   disabled={accountLoading}
                   onClick={getAccount}

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
@@ -95,7 +95,7 @@ export const UnitRowTwoStepAuth = () => {
       headerContent={
         <ButtonIconReload
           title="Refresh two-step authentication"
-          classNames="mobileLandscape:hidden"
+          classNames="ltr:ml-1 rtl:mr-1 mobileLandscape:hidden"
           disabled={accountLoading}
           onClick={getAccount}
         />
@@ -103,7 +103,7 @@ export const UnitRowTwoStepAuth = () => {
       actionContent={
         <ButtonIconReload
           title="Refresh two-step authentication"
-          classNames="hidden mobileLandscape:inline-block"
+          classNames="hidden ltr:ml-1 rtl:mr-1 mobileLandscape:inline-block"
           testId="two-step-refresh"
           disabled={accountLoading}
           onClick={getAccount}


### PR DESCRIPTION
## This pull request

- Adds a bit of margin-left to the refresh button(same amount applied between normal buttons `ml-2`) so it doesn't look odd when focused

## Issue that this pull request solves

Closes: #6651 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
