### PR TITLE
fix(fxa-settings): mobile nav toggle visibility

### DIFF
--- a/packages/fxa-settings/src/components/HeaderLockup/index.tsx
+++ b/packages/fxa-settings/src/components/HeaderLockup/index.tsx
@@ -23,11 +23,12 @@ export const HeaderLockup = () => {
         aria-label={navRevealedState ? 'Close menu' : 'Site navigation menu'}
         aria-haspopup={true}
         aria-expanded={navRevealedState}
+        onClick={() => setNavState(!navRevealedState)}
       >
         {navRevealedState ? (
-          <Close onClick={() => setNavState(!navRevealedState)} />
+          <Close />
         ) : (
-          <Menu onClick={() => setNavState(!navRevealedState)} />
+          <Menu />
         )}
         {navRevealedState && <Nav />}
       </button>


### PR DESCRIPTION
## This pull request

- Moves the `onClick` handler up to parent element to solve the issue of menu not closing on mobile when selecting an anchor link.

## Issue that this pull request solves

Closes: #6638 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
