### PR TITLE
fix(oauth): increase `state` size limit for oauth requests

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/routes/authorization.js
+++ b/packages/fxa-auth-server/lib/oauth/routes/authorization.js
@@ -54,7 +54,7 @@ module.exports = {
       response_type: Joi.string()
         .valid(RESPONSE_TYPE_CODE, RESPONSE_TYPE_TOKEN)
         .default(RESPONSE_TYPE_CODE),
-      state: Joi.string().max(256).when('response_type', {
+      state: Joi.string().max(512).when('response_type', {
         is: RESPONSE_TYPE_TOKEN,
         then: Joi.optional(),
         otherwise: Joi.required(),

--- a/packages/fxa-auth-server/lib/oauthdb/create-authorization-code.js
+++ b/packages/fxa-auth-server/lib/oauthdb/create-authorization-code.js
@@ -23,7 +23,7 @@ module.exports = (config) => {
           })
           .optional(),
         scope: validators.scope.optional(),
-        state: Joi.string().max(256).required(),
+        state: Joi.string().max(512).required(),
         access_type: Joi.string().valid('offline', 'online').default('online'),
         code_challenge_method: validators.pkceCodeChallengeMethod.optional(),
         code_challenge: validators.pkceCodeChallenge.optional(),
@@ -33,7 +33,7 @@ module.exports = (config) => {
       response: Joi.object({
         redirect: Joi.string(),
         code: validators.authorizationCode,
-        state: Joi.string().max(256),
+        state: Joi.string().max(512),
       }),
     },
   };


### PR DESCRIPTION
fixes #6703

Depending on the url parameters AMO redirects are exceeding 256 characters for state. There's no harm in extending this limit.