### PR TITLE
Show modal on connected services 'sign out' click

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -648,7 +648,7 @@ module.exports = {
       BACK_BUTTON: '[data-testid=flow-container-back-btn]',
     },
     SECONDARY_EMAIL: {
-      ADD_BUTTON: '[data-testid=unit-row-route][href*="emails"]',
+      ADD_BUTTON: '[data-testid=secondary-email-unit-row-route]',
       CANCEL_BUTTON: '[data-testid=cancel-button]',
       SUBMIT_BUTTON: '[data-testid=save-button]',
       TEXTBOX: '[data-testid=input-label]',
@@ -669,15 +669,14 @@ module.exports = {
       MENU: '[data-testid=nav-link-security]',
       HEADER: '[data-testid=settings-security]',
       RECOVERY_KEY: {
-        CREATE: '[data-testid=unit-row-route][href*="account_recovery"]',
+        CREATE: '[data-testid=recovery-key-unit-row-route]',
         BACK_BUTTON: '[data-testid=flow-container-back-btn]',
         PASSWORD_TEXTBOX: '[data-testid=input-label]',
         CANCEL_BUTTON: '[data-testid=cancel-button]',
         CONTINUE_BUTTON: '[data-testid=continue-button]',
       },
       TFA: {
-        ADD_BUTTON:
-          '[data-testid=unit-row-route][href*="two_step_authentication"]',
+        ADD_BUTTON: '[data-testid=two-step-unit-row-route]',
       },
     },
     CONNECTED_SERVICES: {

--- a/packages/fxa-settings/src/components/Checkbox/index.tsx
+++ b/packages/fxa-settings/src/components/Checkbox/index.tsx
@@ -97,7 +97,7 @@ export const Checkbox = ({
       {label && (
         <span
           data-testid={formatDataTestId('checkbox-label')}
-          className="text-sm ml-3 font-body"
+          className="leading-tight ltr:ml-2 rtl:mr-2 font-body"
         >
           {label}
         </span>

--- a/packages/fxa-settings/src/components/ConnectedServices/Service.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/Service.tsx
@@ -3,9 +3,16 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
+
 import { LinkExternal } from 'fxa-react/components/LinkExternal';
+import { useBooleanState } from 'fxa-react/lib/hooks';
+
+import { Checkbox } from '../Checkbox';
 import { DeviceLocation } from '../../models/Account';
 import { Icon } from './Icon';
+import { Modal } from '../Modal';
+import { useAlertBar } from '../../lib/hooks';
+import { VerifiedSessionGuard } from '../VerifiedSessionGuard';
 
 export function Service({
   name,
@@ -20,9 +27,11 @@ export function Service({
   lastAccessTimeFormatted: string;
   canSignOut: boolean;
 }) {
+  const alertBar = useAlertBar();
   const { city, stateCode, country } = location;
   const locationProvided = Boolean(city && stateCode && country);
   let serviceLink, iconName;
+  const [modalRevealed, revealModal, hideModal] = useBooleanState();
 
   switch (name) {
     case 'Pocket':
@@ -42,7 +51,8 @@ export function Service({
       iconName = 'fpn';
       break;
     case 'Firefox Sync':
-      serviceLink = 'https://support.mozilla.org/en-US/kb/how-do-i-set-sync-my-computer';
+      serviceLink =
+        'https://support.mozilla.org/en-US/kb/how-do-i-set-sync-my-computer';
       iconName = 'sync';
       break;
     default:
@@ -101,11 +111,69 @@ export function Service({
             <button
               className="cta-neutral cta-base disabled:cursor-wait whitespace-no-wrap"
               data-testid="connected-service-sign-out"
+              onClick={revealModal}
             >
               Sign out
             </button>
           )}
         </div>
+        {modalRevealed && (
+          <VerifiedSessionGuard
+            onDismiss={hideModal}
+            onError={(error) => {
+              hideModal();
+              alertBar.error(
+                'Sorry, there was a problem verifying your session',
+                error
+              );
+            }}
+          >
+            <Modal
+              onDismiss={hideModal}
+              onConfirm={hideModal} /* to be implemented in a later issue */
+              confirmBtnClassName="cta-primary"
+              confirmText="Sign Out"
+              headerId="connected-services-sign-out-header"
+              descId="connected-services-sign-out-description"
+            >
+              <h2
+                id="connected-services-sign-out-header"
+                className="font-bold text-xl text-center mb-2"
+                data-testid="connected-services-modal-header"
+              >
+                Disconnect from Sync
+              </h2>
+
+              <p id="sign-out-desc" className="my-4 text-center">
+                Your browsing data will remain on your device ({name}), but it
+                will no longer sync with your account.
+              </p>
+
+              <p className="my-4 text-center">
+                What's the main reason for disconnecting this device?
+              </p>
+
+              <ul className="my-4 ltr:text-left rtl:text-right">
+                The device is:
+                <li className="my-2">
+                  <Checkbox {...{ label: 'Suspicious' }} />
+                </li>
+                <li className="my-2">
+                  <Checkbox {...{ label: 'Lost or Stolen' }} />
+                </li>
+                <li className="my-2">
+                  <Checkbox {...{ label: 'Old or replaced' }} />
+                </li>
+                <li className="my-2">
+                  <Checkbox {...{ label: 'Duplicate' }} />
+                </li>
+                <li className="my-2">
+                  <Checkbox {...{ label: 'Rather not say' }} />
+                </li>
+              </ul>
+            </Modal>
+          </VerifiedSessionGuard>
+        )}
       </div>
     </div>
   );

--- a/packages/fxa-settings/src/components/ConnectedServices/index.test.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/index.test.tsx
@@ -3,13 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { act, fireEvent, screen, wait } from '@testing-library/react';
 import ConnectedServices, { sortAndFilterConnectedClients } from '.';
 import { renderWithRouter, MockedCache } from '../../models/_mocks';
 import { isMobileDevice } from '../../lib/utilities';
 import { MOCK_SERVICES } from './MOCK_SERVICES';
 
-const SERVICES_NON_MOBILE = MOCK_SERVICES.filter(d => !isMobileDevice(d));
+const SERVICES_NON_MOBILE = MOCK_SERVICES.filter((d) => !isMobileDevice(d));
 
 const getIconAndServiceLink = async (name: string, testId: string) => {
   const servicesList = MOCK_SERVICES.filter((item) => item.name === name);
@@ -132,7 +132,8 @@ describe('Connected Services', () => {
       </MockedCache>
     );
 
-    expect(await screen.findByTestId('connect-another-device-promo')).toBeTruthy;
+    expect(await screen.findByTestId('connect-another-device-promo'))
+      .toBeTruthy;
   });
 
   it('does not render <ConnectAnotherDevicePromo/> when mobile devices in list', async () => {
@@ -142,6 +143,28 @@ describe('Connected Services', () => {
       </MockedCache>
     );
 
-    expect(await screen.queryByTestId('connect-another-device-promo')).toBeNull();
+    expect(
+      await screen.queryByTestId('connect-another-device-promo')
+    ).toBeNull();
+  });
+
+  it('renders proper modal when "sign out" is clicked', async () => {
+    renderWithRouter(
+      <MockedCache account={{ attachedClients: MOCK_SERVICES }}>
+        <ConnectedServices />
+      </MockedCache>
+    );
+
+    await act(async () => {
+      const signOutButtons = await screen.findAllByTestId(
+        'connected-service-sign-out'
+      );
+      fireEvent.click(signOutButtons[0]);
+    });
+    await wait();
+
+    expect(
+      screen.queryByTestId('connected-services-modal-header')
+    ).toBeInTheDocument();
   });
 });

--- a/packages/fxa-settings/src/components/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/index.tsx
@@ -68,7 +68,9 @@ export const ConnectedServices = () => {
       id="connected-services"
       data-testid="settings-connected-services"
     >
-      <h2 className="font-header font-bold ltr:ml-4 rtl:mr-4 mb-4">Connected Services</h2>
+      <h2 className="font-header font-bold ltr:ml-4 rtl:mr-4 mb-4">
+        Connected Services
+      </h2>
       <div className="bg-white tablet:rounded-xl shadow px-4 tablet:px-6 pt-7 pb-8">
         <div className="flex justify-between mb-4">
           <p>Everything you are using and signed into.</p>
@@ -105,10 +107,14 @@ export const ConnectedServices = () => {
           </LinkExternal>
         </div>
 
-        {showMobilePromo && <><hr className="unit-row-hr mt-5 mx-0"/>
-          <div className="mt-5">
-          <ConnectAnotherDevicePromo />
-        </div></>}
+        {showMobilePromo && (
+          <>
+            <hr className="unit-row-hr mt-5 mx-0" />
+            <div className="mt-5">
+              <ConnectAnotherDevicePromo />
+            </div>
+          </>
+        )}
 
         {alertBar.visible && (
           <AlertBar


### PR DESCRIPTION
Fixes #5099.

## Because

- We want to show a confirmation modal when the user clicks the 'sign out' button on a sync device in the new-settings connected services list

## This pull request

- Displays a modal when 'sign out' is clicked on a connected service item. 

## Questions for reviewers:

- The issue description mentions pulling the sync disconnect survey from "the relevant content-server files". Where exactly are these files?
- Should I modify the `Checkbox` component to allow me to pass in styling for the checkbox labels, or should I just use extra specificity to override the default label size? What's the right Tailwind-y React-y approach here?
- The specs show device specific info in the modal text. What's the nicest way to pass the specific device info back to the parent component, so that it passes this into the modal? Can I pass device state back using `revealModal`?
- Do we have an issue to ensure we only show the 'Sign Out' button if the connected service is sync? It's currently always set to show the sign out button.

## Issue that this pull request solves

Closes: #5099

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

Here's a screenshot of the modal from the spec, see also the [new settings figma](https://www.figma.com/file/Nj2WjMOXoJBiPoWvyJ946X/FxA---Manage-Settings-(Copy)) for the real thing:

<img width="587" alt="Screen Shot 2020-10-20 at 5 45 42 PM" src="https://user-images.githubusercontent.com/96396/96659589-2cf14500-12fc-11eb-9bd6-8a6627ec4f42.png">

Here's a screenshot of my WIP modal:

<img width="589" alt="Screen Shot 2020-10-20 at 5 28 09 PM" src="https://user-images.githubusercontent.com/96396/96659575-2236b000-12fc-11eb-9a40-5d1f97f3ef62.png">


## Other information (Optional)

Any other information that is important to this pull request.
