### PR TITLE
feat(settings): add step 2 of two step auth

### DIFF
--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@apollo/client": "^3.2.2",
     "@reach/router": "^1.3.4",
+    "base32-decode": "^1.0.0",
     "base32-encode": "^1.1.1",
     "classnames": "^2.2.6",
     "fxa-auth-client": "workspace:*",

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { gql } from '@apollo/client';
-import { RouteComponentProps } from '@reach/router';
+import { RouteComponentProps, useNavigate } from '@reach/router';
 import { useForm } from 'react-hook-form';
 import { useAlertBar, useMutation } from '../../lib/hooks';
 import FlowContainer from '../FlowContainer';
@@ -12,7 +12,11 @@ import LinkExternal from 'fxa-react/components/LinkExternal';
 import React, { useCallback, useEffect, useState } from 'react';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import AlertBar from '../AlertBar';
-import { useSession } from 'fxa-settings/src/models';
+import DataBlock from '../DataBlock';
+import GetDataTrio from '../GetDataTrio';
+import { useSession } from '../../models';
+import { checkCode } from '../../lib/totp';
+import { HomePath } from '../../constants';
 
 export const CREATE_TOTP_MUTATION = gql`
   mutation createTotp($input: CreateTotpInput!) {
@@ -25,21 +29,36 @@ export const CREATE_TOTP_MUTATION = gql`
   }
 `;
 
-type TotpForm = { totp: number };
+type TotpForm = { totp: string };
 
 export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
+  const navigate = useNavigate();
   const goBack = useCallback(() => window.history.back(), []);
+  const goHome = useCallback(() => navigate(HomePath, { replace: true }), [
+    navigate,
+  ]);
   const { register, handleSubmit, trigger, formState } = useForm<TotpForm>({
     mode: 'onTouched',
   });
   const isValidTotpFormat = (totp: string) => /\d{6}/.test(totp);
 
   const alertBar = useAlertBar();
+  const [subtitle, setSubtitle] = useState<string>('Step 1 of 3');
   const [qrCodeUrl, setQrCodeUrl] = useState<string>();
   const [secret, setSecret] = useState<string>();
+  const [totpVerified, setTotpVerified] = useState<boolean>(false);
+  const [invalidCodeError, setInvalidCodeError] = useState<string>('');
   const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
 
-  const onSubmit = ({ totp }: TotpForm) => {};
+  const onTotpSubmit = async ({ totp }: TotpForm) => {
+    const isValidCode = await checkCode(secret!, totp);
+    setTotpVerified(isValidCode);
+    if (isValidCode) {
+      setSubtitle('Step 2 of 3');
+    } else {
+      setInvalidCodeError('Invalid two-step authentication code');
+    }
+  };
 
   const [createTotp] = useMutation(CREATE_TOTP_MUTATION, {
     onCompleted: (x) => {
@@ -56,73 +75,104 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
 
   useEffect(() => {
     session.verified && createTotp({ variables: { input: {} } });
-  }, [session]);
+  }, [session, createTotp]);
 
   return (
-    <FlowContainer title="Two Step Authentication" subtitle="Step 1 of 3">
+    <FlowContainer title="Two Step Authentication" {...{ subtitle }}>
       {alertBar.visible && (
         <AlertBar onDismiss={alertBar.hide} type={alertBar.type}>
           <p data-testid="update-display-name-error">{alertBar.content}</p>
         </AlertBar>
       )}
 
-      <form onSubmit={handleSubmit(onSubmit)}>
-        <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
+      {!totpVerified && (
+        <form onSubmit={handleSubmit(onTotpSubmit)}>
+          <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
 
-        <p className="mt-4 mb-4">
-          Scan this QR code using one of{' '}
-          <LinkExternal href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication">
-            these apps
-          </LinkExternal>
-          .
-        </p>
+          <p className="mt-4 mb-4">
+            Scan this QR code using one of{' '}
+            <LinkExternal href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication">
+              these apps
+            </LinkExternal>
+            .
+          </p>
 
-        <div>
-          {qrCodeUrl && (
-            <img
-              className="mx-auto w-40 h-40 qr-code-border"
-              data-testid="2fa-qr-code"
-              src={qrCodeUrl}
-              alt={`Use the code ${secret} to set up two-step authentication in supported applications.`}
+          <div>
+            {qrCodeUrl && (
+              <img
+                className="mx-auto w-40 h-40 qr-code-border"
+                data-testid="2fa-qr-code"
+                src={qrCodeUrl}
+                alt={`Use the code ${secret} to set up two-step authentication in supported applications.`}
+              />
+            )}
+          </div>
+
+          <p className="mt-4">
+            Now enter the security code from the authentication app.
+          </p>
+
+          <div className="mt-4 mb-6" data-testid="recovery-key-input">
+            <InputText
+              name="totp"
+              label="Enter security code"
+              prefixDataTestId="totp"
+              maxLength={6}
+              autoFocus
+              onChange={() => {
+                setInvalidCodeError('');
+                trigger('totp');
+              }}
+              inputRef={register({
+                validate: isValidTotpFormat,
+              })}
+              {...{ errorText: invalidCodeError }}
             />
-          )}
-        </div>
+          </div>
 
-        <p className="mt-4">
-          Now enter the security code from the authentication app.
-        </p>
-
-        <div className="mt-4 mb-6" data-testid="recovery-key-input">
-          <InputText
-            name="totp"
-            label="Enter security code"
-            prefixDataTestId="totp"
-            maxLength={6}
-            onChange={() => trigger('totp')}
-            inputRef={register({
-              validate: isValidTotpFormat,
-            })}
-          />
-        </div>
-
-        <div className="flex justify-center mb-4 mx-auto max-w-64">
-          <button
-            type="button"
-            className="cta-neutral mx-2 flex-1"
-            onClick={() => window.history.back()}
-          >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            data-testid="submit-totp"
-            className="cta-primary mx-2 flex-1"
-            disabled={!formState.isDirty || !formState.isValid}
-          >
-            Continue
-          </button>
-        </div>
-      </form>
+          <div className="flex justify-center mb-4 mx-auto max-w-64">
+            <button
+              type="button"
+              className="cta-neutral mx-2 flex-1"
+              onClick={goBack}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              data-testid="submit-totp"
+              className="cta-primary mx-2 flex-1"
+              disabled={!formState.isDirty || !formState.isValid}
+            >
+              Continue
+            </button>
+          </div>
+        </form>
+      )}
+      {totpVerified && (
+        <form>
+          <div className="my-2" data-testid="2fa-recovery-codes">
+            Save these one-time use codes in a safe place for when you don’t
+            have your mobile device.
+            <div className="mt-6 flex flex-col items-center h-40 justify-between">
+              <DataBlock value={recoveryCodes}></DataBlock>
+              <GetDataTrio value={recoveryCodes}></GetDataTrio>
+            </div>
+          </div>
+          <div className="flex justify-center mt-6 mb-4 mx-auto max-w-64">
+            <button
+              type="button"
+              className="cta-neutral mx-2 flex-1"
+              onClick={goHome}
+            >
+              Cancel
+            </button>
+            <button type="submit" className="cta-primary mx-2 flex-1">
+              Continue
+            </button>
+          </div>
+        </form>
+      )}
     </FlowContainer>
   );
 };

--- a/packages/fxa-settings/src/lib/totp.ts
+++ b/packages/fxa-settings/src/lib/totp.ts
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import base32Decode from 'base32-decode';
+
+function trimOrPad(num: number, digits: number): string {
+  const str = num.toString().substr(-digits);
+  if (str.length === digits) {
+    return str;
+  }
+  return new Array(digits - str.length + 1).join('0') + str;
+}
+
+export async function getCode(
+  secret: string,
+  digits: number = 6,
+  timestamp: number = Date.now()
+): Promise<string> {
+  const secretKey = base32Decode(secret, 'RFC4648');
+  const counter = new ArrayBuffer(8);
+  const cv = new DataView(counter);
+  cv.setUint32(4, Math.floor(timestamp / 30000), false);
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    secretKey,
+    {
+      name: 'HMAC',
+      hash: { name: 'SHA-1' },
+    },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, counter);
+  const hmac = new DataView(signature);
+  const offset = hmac.getUint8(hmac.byteLength - 1) & 0x0f;
+  return trimOrPad(hmac.getInt32(offset, false) & 0x7fffffff, digits);
+}
+
+export async function checkCode(
+  secret: string,
+  code: string,
+  timestamp: number = Date.now(),
+  tries = 2
+): Promise<boolean> {
+  for (; tries > 0; tries--, timestamp -= 30000) {
+    const x = await getCode(secret, 6, timestamp);
+    if (x === code) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10176,7 +10176,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base32-decode@npm:1.0.0":
+"base32-decode@npm:1.0.0, base32-decode@npm:^1.0.0":
   version: 1.0.0
   resolution: "base32-decode@npm:1.0.0"
   checksum: ed3045d2b8872b7023ecf6d320ca58cd0fcca88c49ef44ecac7d26fc4e407cd911ddbd16685009b1040ce190148984b7f63fa0229c5c43f2741de81aae95f83a
@@ -18056,6 +18056,7 @@ fsevents@^1.2.7:
     "@types/testing-library__react-hooks": ^3
     "@types/webpack": 4.41.16
     babel-loader: ^8.0.0
+    base32-decode: ^1.0.0
     base32-encode: ^1.1.1
     classnames: ^2.2.6
     eslint: ^6.8.0


### PR DESCRIPTION
Because:
 - the user need to enter a valid auth code
 - the user should save recovery codes

This commit:
 - verify the code from the user's authenticator app
 - display the recovery codes

## Issue that this pull request solves

Closes: #4973 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

