### PR TITLE
feat(settings): verify recovery code and enable two step auth

### DIFF
--- a/packages/fxa-settings/src/components/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.tsx
@@ -6,6 +6,7 @@ import { navigate, RouteComponentProps } from '@reach/router';
 import { useAccount } from '../../models';
 import { useForm } from 'react-hook-form';
 import React, { useState } from 'react';
+import { Account } from '../../models/Account';
 import FlowContainer from '../FlowContainer';
 import InputText from '../InputText';
 import { useAlertBar, useMutation } from '../../lib/hooks';

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/_mocks.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/_mocks.tsx
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { CREATE_TOTP_MUTATION } from '.';
+import { GraphQLError } from 'graphql';
+import { CREATE_TOTP_MUTATION, VERIFY_TOTP_MUTATION } from '.';
 
 export const CREATE_TOTP_MOCK = [
   {
@@ -21,6 +22,34 @@ export const CREATE_TOTP_MOCK = [
           __typename: 'CreateTotpPayload',
         },
       },
+    },
+  },
+];
+
+export const VERIFY_TOTP_MOCK = [
+  {
+    request: {
+      query: VERIFY_TOTP_MUTATION,
+      variables: { input: { code: '001980' } },
+    },
+    result: {
+      data: { verifyTotp: { success: true } },
+    },
+  },
+  {
+    request: {
+      query: VERIFY_TOTP_MUTATION,
+      variables: { input: { code: '999911' } },
+    },
+    error: new Error('Oops'),
+  },
+  {
+    request: {
+      query: VERIFY_TOTP_MUTATION,
+      variables: { input: { code: '009001' } },
+    },
+    result: {
+      errors: [new GraphQLError('Some sort of server error!')],
     },
   },
 ];

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.test.tsx
@@ -10,21 +10,36 @@ import {
   renderWithRouter,
   MockedCache,
   MockedProps,
+  createCache,
 } from '../../models/_mocks';
 import React from 'react';
 import PageTwoStepAuthentication from '.';
-import { CREATE_TOTP_MOCK } from './_mocks';
-import { checkCode } from '../../lib/totp';
+import { CREATE_TOTP_MOCK, VERIFY_TOTP_MOCK } from './_mocks';
+import { checkCode, getCode } from '../../lib/totp';
+import { MockedProvider } from '@apollo/client/testing';
+import { Account, GET_ACCOUNT } from '../../models/Account';
+import { HomePath } from '../../constants';
 
 jest.mock('../../lib/totp', () => ({
   ...jest.requireActual('../../lib/totp'),
+  getCode: jest.fn(),
   checkCode: jest.fn().mockResolvedValue(true),
 }));
+
+const mockNavigate = jest.fn();
+jest.mock('@reach/router', () => ({
+  ...jest.requireActual('@reach/router'),
+  useNavigate: () => mockNavigate,
+}));
+
 window.URL.createObjectURL = jest.fn();
 
 const client = createAuthClient('none');
+// `any` to disable the error from type inference on the mis-matching shapes of
+// object from each array
+const mocks = CREATE_TOTP_MOCK.concat(VERIFY_TOTP_MOCK as [any]);
 
-const render = (props: MockedProps = { mocks: CREATE_TOTP_MOCK }) =>
+const render = (props: MockedProps = { mocks }) =>
   renderWithRouter(
     <AuthContext.Provider value={{ auth: client }}>
       <MockedCache {...props}>
@@ -48,76 +63,225 @@ const submitTotp = async (totp: string) => {
   });
 };
 
-it('renders', async () => {
-  await act(async () => {
-    render();
-  });
-  expect(screen.getByTestId('flow-container')).toBeInTheDocument();
-  expect(screen.getByTestId('flow-container-back-btn')).toBeInTheDocument();
-  expect(screen.getByTestId('totp-input-field')).toBeInTheDocument();
-  expect(screen.getByTestId('submit-totp')).toBeInTheDocument();
-});
-
-it('updates the disabled state of the continue button', async () => {
-  await act(async () => {
-    render();
-  });
-  const button = screen.getByTestId('submit-totp');
-
-  // default
-  expect(button).toBeDisabled();
-
-  // not all numbers
-  await inputTotp('bigcat');
-  expect(button).toBeDisabled();
-
-  // not enough numbers
-  await inputTotp('90210');
-  expect(button).toBeDisabled();
-
-  // valid code format
-  await inputTotp('867530');
-  expect(button).not.toBeDisabled();
-});
-
-it('displays the QR code', async () => {
-  await act(async () => {
-    render();
-  });
-  expect(screen.getByTestId('2fa-qr-code')).toBeInTheDocument();
-  expect(screen.getByTestId('2fa-qr-code')).toHaveAttribute(
-    'alt',
-    expect.stringContaining('JFXE6ULUGM4U4WDHOFVFIRDPKZITATSK')
-  );
-});
-
-it('does not display the QR code for the unverified', async () => {
-  await act(async () => {
-    render({ verified: false });
-  });
-  expect(screen.queryByTestId('2fa-qr-code')).toBeNull();
-  expect(screen.queryByTestId('alert-bar')).toBeNull();
-});
-
-it('shows the recovery codes when valid auth code is submitted', async () => {
-  await act(async () => {
-    render();
-  });
-  await submitTotp('867530');
-  expect(checkCode).toHaveBeenCalledTimes(1);
-  expect(screen.getByTestId('2fa-recovery-codes')).toBeInTheDocument();
-  expect(screen.getByTestId('2fa-recovery-codes')).toHaveTextContent(
-    CREATE_TOTP_MOCK[0].result.data.createTotp.recoveryCodes[0]
-  );
-});
-
-it('shows an error when an invalid auth code is entered', async () => {
-  await act(async () => {
-    render();
-  });
+const resetCheckcodeMock = () => {
   (checkCode as jest.Mock).mockReset();
-  (checkCode as jest.Mock).mockResolvedValue(false);
-  await submitTotp('867530');
-  expect(checkCode).toHaveBeenCalledTimes(1);
-  expect(screen.getByTestId('tooltip')).toBeInTheDocument();
+  (checkCode as jest.Mock).mockResolvedValue(true);
+};
+
+describe('step 1', () => {
+  it('renders', async () => {
+    await act(async () => {
+      render();
+    });
+    expect(screen.getByTestId('flow-container')).toBeInTheDocument();
+    expect(screen.getByTestId('flow-container-back-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('totp-input-field')).toBeInTheDocument();
+    expect(screen.getByTestId('submit-totp')).toBeInTheDocument();
+  });
+
+  it('updates the disabled state of the continue button', async () => {
+    await act(async () => {
+      render();
+    });
+    const button = screen.getByTestId('submit-totp');
+
+    // default
+    expect(button).toBeDisabled();
+
+    // not all numbers
+    await inputTotp('bigcat');
+    expect(button).toBeDisabled();
+
+    // not enough numbers
+    await inputTotp('90210');
+    expect(button).toBeDisabled();
+
+    // valid code format
+    await inputTotp('867530');
+    expect(button).not.toBeDisabled();
+  });
+
+  it('displays the QR code', async () => {
+    await act(async () => {
+      render();
+    });
+    expect(screen.getByTestId('2fa-qr-code')).toBeInTheDocument();
+    expect(screen.getByTestId('2fa-qr-code')).toHaveAttribute(
+      'alt',
+      expect.stringContaining('JFXE6ULUGM4U4WDHOFVFIRDPKZITATSK')
+    );
+  });
+
+  it('updates the GraphQL cache', async () => {
+    const cache = createCache({
+      account: { totp: { exists: false, verified: false } },
+    });
+    const spy = jest.spyOn(cache, 'modify');
+
+    await act(async () => {
+      renderWithRouter(
+        <AuthContext.Provider value={{ auth: client }}>
+          <MockedProvider cache={cache} mocks={mocks}>
+            <PageTwoStepAuthentication />
+          </MockedProvider>
+        </AuthContext.Provider>
+      );
+    });
+
+    expect(spy).toBeCalledTimes(1);
+    const { account } = cache.readQuery<{ account: Account }>({
+      query: GET_ACCOUNT,
+    })!;
+    expect(account.totp.exists).toEqual(true);
+  });
+
+  it('does not display the QR code for the unverified', async () => {
+    await act(async () => {
+      render({ verified: false });
+    });
+    expect(screen.queryByTestId('2fa-qr-code')).toBeNull();
+    expect(screen.queryByTestId('alert-bar')).toBeNull();
+  });
+});
+
+describe('step 2', () => {
+  beforeEach(() => {
+    resetCheckcodeMock();
+  });
+
+  it('shows the recovery codes when valid auth code is submitted', async () => {
+    await act(async () => {
+      render();
+    });
+    await submitTotp('867530');
+    expect(checkCode).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('2fa-recovery-codes')).toBeInTheDocument();
+    expect(screen.getByTestId('2fa-recovery-codes')).toHaveTextContent(
+      CREATE_TOTP_MOCK[0].result.data.createTotp.recoveryCodes[0]
+    );
+  });
+
+  it('shows an error when an invalid auth code is entered', async () => {
+    await act(async () => {
+      render();
+    });
+    (checkCode as jest.Mock).mockResolvedValue(false);
+    await submitTotp('867530');
+    expect(checkCode).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('tooltip')).toBeInTheDocument();
+  });
+});
+
+describe('step 3', () => {
+  const getRecoveryCodes = async () => {
+    await act(async () => {
+      render();
+    });
+    await submitTotp('867530');
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('ack-recovery-code'));
+    });
+  };
+
+  beforeEach(async () => {
+    // suppress the console output
+    jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+    resetCheckcodeMock();
+  });
+
+  it('renders the recovery code form', async () => {
+    await getRecoveryCodes();
+    expect(screen.getByTestId('recovery-code-input-field')).toBeInTheDocument();
+  });
+
+  it('shows an error when an incorrect recovery code is entered', async () => {
+    await getRecoveryCodes();
+    await act(async () => {
+      fireEvent.input(screen.getByTestId('recovery-code-input-field'), {
+        target: { value: 'bogus' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('submit-recovery-code'));
+    });
+    expect(screen.getByTestId('tooltip')).toBeInTheDocument();
+    expect(screen.getByTestId('tooltip')).toHaveTextContent(
+      'Invalid recovery code'
+    );
+  });
+
+  it('shows an generic error when the code cannot be verified', async () => {
+    await getRecoveryCodes();
+    (getCode as jest.Mock).mockResolvedValue('999911');
+    await act(async () => {
+      fireEvent.input(screen.getByTestId('recovery-code-input-field'), {
+        target: {
+          value: CREATE_TOTP_MOCK[0].result.data.createTotp.recoveryCodes[0],
+        },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('submit-recovery-code'));
+    });
+    expect(screen.getByTestId('alert-bar')).toBeInTheDocument();
+  });
+
+  it('shows the GraphQL error when the code cannot be verified', async () => {
+    await getRecoveryCodes();
+    (getCode as jest.Mock).mockResolvedValue('009001');
+    await act(async () => {
+      fireEvent.input(screen.getByTestId('recovery-code-input-field'), {
+        target: {
+          value: CREATE_TOTP_MOCK[0].result.data.createTotp.recoveryCodes[0],
+        },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('submit-recovery-code'));
+    });
+    expect(screen.getByTestId('tooltip')).toBeInTheDocument();
+  });
+
+  it('verifies and enable two step auth', async () => {
+    const cache = createCache({
+      account: { totp: { exists: false, verified: false } },
+    });
+    const modifyCacheSpy = jest.spyOn(cache, 'modify');
+
+    await act(async () => {
+      renderWithRouter(
+        <AuthContext.Provider value={{ auth: client }}>
+          <MockedProvider cache={cache} mocks={mocks}>
+            <PageTwoStepAuthentication />
+          </MockedProvider>
+        </AuthContext.Provider>
+      );
+    });
+
+    await submitTotp('867530');
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('ack-recovery-code'));
+    });
+
+    (getCode as jest.Mock).mockClear();
+    (getCode as jest.Mock).mockResolvedValue('001980');
+    await act(async () => {
+      fireEvent.input(screen.getByTestId('recovery-code-input-field'), {
+        target: {
+          value: CREATE_TOTP_MOCK[0].result.data.createTotp.recoveryCodes[0],
+        },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('submit-recovery-code'));
+    });
+
+    expect(getCode).toBeCalledTimes(1);
+    expect(modifyCacheSpy).toBeCalledTimes(2);
+    const { account } = cache.readQuery<{ account: Account }>({
+      query: GET_ACCOUNT,
+    })!;
+    expect(account.totp.verified).toEqual(true);
+    expect(mockNavigate).toHaveBeenCalledWith(HomePath, { replace: true });
+  });
 });


### PR DESCRIPTION
Because:
 - we need to verify a recovery code and enable two step auth as the
   last step in the enabling two step auth

This commit:
 - check the recovery code and then verify the totp with gql-api

## Because
## Issue that this pull request solves

Closes: #4976 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

