### PR TITLE
feat(settings): show 2fa enabled message

### DIFF
--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -19,6 +19,7 @@ import { useSession } from '../../models';
 import { checkCode, getCode } from '../../lib/totp';
 import { HomePath } from '../../constants';
 import { cloneDeep } from '@apollo/client/utilities';
+import { alertTextExternal } from '../../lib/cache';
 
 export const CREATE_TOTP_MUTATION = gql`
   mutation createTotp($input: CreateTotpInput!) {
@@ -125,6 +126,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
 
   const [verifyTotp] = useMutation(VERIFY_TOTP_MUTATION, {
     onCompleted: () => {
+      alertTextExternal('Two-step authentication enabled');
       goHome();
     },
     onError: (err) => {


### PR DESCRIPTION
Because:
 - we should let the user know that 2fa was successfully enabled

This commit:
 - display a message on the main settings page after enabling 2fa

Closes: #4977

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
