### PR TITLE
feat(settings): add replace 2fa recovery codes page

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -18,6 +18,7 @@ import PageSecondaryEmailAdd from '../PageSecondaryEmailAdd';
 import PageSecondaryEmailVerify from '../PageSecondaryEmailVerify';
 import { PageDisplayName } from '../PageDisplayName';
 import PageTwoStepAuthentication from '../PageTwoStepAuthentication';
+import { Page2faReplaceRecoveryCodes } from '../Page2faReplaceRecoveryCodes';
 
 export const GET_INITIAL_STATE = gql`
   query GetInitialState {
@@ -99,6 +100,7 @@ export const App = ({ flowQueryParams }: AppProps) => {
         <PageSecondaryEmailAdd path="/emails" />
         <PageSecondaryEmailVerify path="/emails/verify" />
         <PageTwoStepAuthentication path="/two_step_authentication" />
+        <Page2faReplaceRecoveryCodes path="/two_step_authentication/replace_codes" />
       </Router>
     </AppLayout>
   );

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/_mocks.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/_mocks.tsx
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { CHANGE_RECOVERY_CODES_MUTATION } from '.';
+
+export const CHANGE_RECOVERY_CODE_MOCK = [
+  {
+    request: {
+      query: CHANGE_RECOVERY_CODES_MUTATION,
+      variables: { input: {} },
+    },
+    result: {
+      data: {
+        changeRecoveryCodes: {
+          recoveryCodes: ['06pw3ec276', 'ap0d60q2qn', '8pwzhsmsjm'],
+        },
+      },
+    },
+  },
+];
+
+export const CHANGE_RECOVERY_CODE_ERROR_MOCK = [
+  {
+    request: {
+      query: CHANGE_RECOVERY_CODES_MUTATION,
+      variables: { input: {} },
+    },
+    error: new Error('Borked'),
+  },
+];

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.stories.tsx
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { LocationProvider } from '@reach/router';
+import { storiesOf } from '@storybook/react';
+import { MockedCache } from '../../models/_mocks';
+import React from 'react';
+import { Page2faReplaceRecoveryCodes } from '.';
+import AppLayout from '../AppLayout';
+import { CHANGE_RECOVERY_CODE_MOCK } from './_mocks';
+
+storiesOf('Pages|2faReplaceRecoveryCodes', module)
+  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
+  .add('default', () => (
+    <MockedCache mocks={CHANGE_RECOVERY_CODE_MOCK}>
+      <AppLayout>
+        <Page2faReplaceRecoveryCodes />
+      </AppLayout>
+    </MockedCache>
+  ));

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.test.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.test.tsx
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import 'mutationobserver-shim';
+import '@testing-library/jest-dom/extend-expect';
+import { act, screen, wait } from '@testing-library/react';
+import { AuthContext, createAuthClient } from '../../lib/auth';
+import { renderWithRouter, MockedCache } from '../../models/_mocks';
+import React from 'react';
+import {
+  CHANGE_RECOVERY_CODE_ERROR_MOCK,
+  CHANGE_RECOVERY_CODE_MOCK,
+} from './_mocks';
+import { Page2faReplaceRecoveryCodes } from '.';
+import { AlertBarRootAndContextProvider } from '../../lib/AlertBarContext';
+
+window.URL.createObjectURL = jest.fn();
+const client = createAuthClient('none');
+
+it('renders', async () => {
+  await act(async () => {
+    renderWithRouter(
+      <AuthContext.Provider value={{ auth: client }}>
+        <MockedCache {...{ mocks: CHANGE_RECOVERY_CODE_MOCK }}>
+          <Page2faReplaceRecoveryCodes />
+        </MockedCache>
+      </AuthContext.Provider>
+    );
+  });
+
+  expect(screen.getByTestId('2fa-recovery-codes')).toBeInTheDocument();
+  await wait(() => {
+    expect(screen.getByTestId('2fa-recovery-codes')).toHaveTextContent(
+      CHANGE_RECOVERY_CODE_MOCK[0].result.data.changeRecoveryCodes
+        .recoveryCodes[0]
+    );
+  });
+});
+
+it('displays an error when fails to fetch new recovery codes', async () => {
+  await act(async () => {
+    renderWithRouter(
+      <AuthContext.Provider value={{ auth: client }}>
+        <MockedCache {...{ mocks: CHANGE_RECOVERY_CODE_ERROR_MOCK }}>
+          <AlertBarRootAndContextProvider>
+            <Page2faReplaceRecoveryCodes />
+          </AlertBarRootAndContextProvider>
+        </MockedCache>
+      </AuthContext.Provider>
+    );
+  });
+  await wait(() => expect(screen.getByTestId('alert-bar')).toBeInTheDocument());
+});

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { gql } from '@apollo/client';
+import { RouteComponentProps } from '@reach/router';
+import React, { useEffect, useState } from 'react';
+import FlowContainer from '../FlowContainer';
+import VerifiedSessionGuard from '../VerifiedSessionGuard';
+import DataBlock from '../DataBlock';
+import GetDataTrio from '../GetDataTrio';
+import { useSession } from '../../models';
+import { useAlertBar, useMutation } from '../../lib/hooks';
+import { AlertBar } from '../AlertBar';
+
+export const CHANGE_RECOVERY_CODES_MUTATION = gql`
+  mutation changeRecoveryCodes($input: ChangeRecoveryCodesInput!) {
+    changeRecoveryCodes(input: $input) {
+      clientMutationId
+      recoveryCodes
+    }
+  }
+`;
+
+export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
+  const goBack = () => window.history.back();
+
+  const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
+  const [changeRecoveryCodes] = useMutation(CHANGE_RECOVERY_CODES_MUTATION, {
+    onCompleted: (x) => {
+      setRecoveryCodes(x.changeRecoveryCodes.recoveryCodes);
+    },
+    onError: () => {
+      alertBar.error('There was a problem replacing your recovery codes.');
+    },
+  });
+
+  const alertBar = useAlertBar();
+  const session = useSession();
+
+  useEffect(() => {
+    session.verified && changeRecoveryCodes({ variables: { input: {} } });
+  }, [session, changeRecoveryCodes]);
+
+  return (
+    <FlowContainer title="Two Step Authentication">
+      <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
+
+      {alertBar.visible && (
+        <AlertBar onDismiss={alertBar.hide} type={alertBar.type}>
+          <p data-testid="update-display-name-error">{alertBar.content}</p>
+        </AlertBar>
+      )}
+
+      <div className="my-2" data-testid="2fa-recovery-codes">
+        New codes have been created. Save these one-time use codes in a safe
+        place—you’ll need them to access your account if you don’t have your
+        mobile device.
+        <div className="mt-6 flex flex-col items-center h-40 justify-between">
+          <DataBlock value={recoveryCodes}></DataBlock>
+          <GetDataTrio value={recoveryCodes}></GetDataTrio>
+        </div>
+      </div>
+      <div className="flex justify-center mt-6 mb-4 mx-auto max-w-64">
+        <button type="button" className="cta-neutral mx-2" onClick={goBack}>
+          Close
+        </button>
+      </div>
+    </FlowContainer>
+  );
+};

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.test.tsx
@@ -19,7 +19,7 @@ import { checkCode, getCode } from '../../lib/totp';
 import { MockedProvider } from '@apollo/client/testing';
 import { Account, GET_ACCOUNT } from '../../models/Account';
 import { HomePath } from '../../constants';
-import { alertTextExternal } from 'fxa-settings/src/lib/cache';
+import { alertTextExternal } from '../../lib/cache';
 
 jest.mock('../../lib/totp', () => ({
   ...jest.requireActual('../../lib/totp'),

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
@@ -13,8 +13,9 @@ import UnitRow from '../UnitRow';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import { useAccount, useLazyAccount } from '../../models';
 import { ButtonIconReload } from '../ButtonIcon';
+import { HomePath } from '../../constants';
 
-const route = '/beta/settings/two_step_authentication';
+const replaceCodesRoute = `${HomePath}/two_step_authentication/replace_codes`;
 
 export const DELETE_TOTP_MUTATION = gql`
   mutation deleteTotp($input: DeleteTotpInput!) {
@@ -90,7 +91,7 @@ export const UnitRowTwoStepAuth = () => {
     <UnitRow
       header="Two-step authentication"
       prefixDataTestId="two-step"
-      route={route}
+      route={replaceCodesRoute}
       {...conditionalUnitRowProps}
       headerContent={
         <ButtonIconReload
@@ -168,7 +169,7 @@ export const UnitRowTwoStepAuth = () => {
             descId="two-step-auth-change-codes-description"
             confirmText="Change"
             confirmBtnClassName="cta-primary"
-            route={route}
+            route={replaceCodesRoute}
           >
             <h2
               className="font-bold text-xl text-center mb-2"


### PR DESCRIPTION
Because:
 - users might want to replace their 2fa recovery codes

This commit:
 - add the page to get and display the new recovery codes


## Issue that this pull request solves

Closes: #4978 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
