### PR TITLE
fix(settings): fix two step auth route

### DIFF
--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
@@ -15,7 +15,8 @@ import { useAccount, useLazyAccount } from '../../models';
 import { ButtonIconReload } from '../ButtonIcon';
 import { HomePath } from '../../constants';
 
-const replaceCodesRoute = `${HomePath}/two_step_authentication/replace_codes`;
+const route = `${HomePath}/two_step_authentication`;
+const replaceCodesRoute = `${route}/replace_codes`;
 
 export const DELETE_TOTP_MUTATION = gql`
   mutation deleteTotp($input: DeleteTotpInput!) {
@@ -91,7 +92,7 @@ export const UnitRowTwoStepAuth = () => {
     <UnitRow
       header="Two-step authentication"
       prefixDataTestId="two-step"
-      route={replaceCodesRoute}
+      route={route}
       {...conditionalUnitRowProps}
       headerContent={
         <ButtonIconReload


### PR DESCRIPTION
Because:
 - the two step auth button always go to the replace recovery codes page

This commit:
 - fix the routes

In a previous commit, instead of adding an additional route for the
replace recovery code page, the single existing route was incorrectly
updated.

## Issue that this pull request solves

Fixes a bug introduced in #6767