### PR TITLE
chore(build): stop building docker images for each service by default

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -19,10 +19,6 @@ if grep -e "$MODULE" -e 'all' "$DIR/../packages/test.list" > /dev/null; then
     # send Dockerfile over stdin to exclude local context
     # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#pipe-dockerfile-through-stdin
     time (< Dockerfile docker build --progress=plain -t "${MODULE}:build" - &> "../../artifacts/${MODULE}.log")
-  elif [[ -r pm2.config.js ]]; then
-    # Build a default image with the contents of MODULE at /app
-    time (echo -e "FROM fxa-mono:build\nUSER root\nRUN ln -sF /fxa/packages/${MODULE} /app\nUSER app\nWORKDIR /app" | \
-    docker build --progress=plain -t "${MODULE}:build" - &> "../../artifacts/${MODULE}.log")
   fi
 
   # for debugging:

--- a/packages/fxa-auth-server/Dockerfile
+++ b/packages/fxa-auth-server/Dockerfile
@@ -1,7 +1,0 @@
-FROM fxa-mono:build
-
-USER root
-RUN ln -sF /fxa/packages/fxa-auth-server/dist/fxa-auth-server /app
-USER app
-WORKDIR /app
-RUN cp /fxa/packages/version.json /fxa/packages/fxa-auth-server/dist/fxa-auth-server/version.json


### PR DESCRIPTION
## Because

- We're using `fxa-mono` in production and don't need images for each service anymore.

## This pull request

- Eliminates the build step that generates the default individual images. Custom dockerfiles and build scripts are still run.
