### PR TITLE
First pass at enabling docker login

### DIFF
--- a/.circleci/build-all.sh
+++ b/.circleci/build-all.sh
@@ -5,6 +5,11 @@ cd "$DIR"
 
 if [[ -n "${CIRCLECI}" ]]; then
   echo "Docker logs are located in the CircleCI build artifacts"
+  if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
+      echo "Skipping Login to Dockerhub, credentials not available."
+  else
+      echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
+  fi
 fi
 
 ../_scripts/build-builder.sh

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -13,6 +13,12 @@ if grep -e "$MODULE" -e 'all' "$DIR/../packages/test.list" > /dev/null; then
 
   mkdir -p ../../artifacts
 
+  if [ "${DOCKER_USER}" == "" ] || [ "${DOCKER_PASS}" == "" ]; then
+      echo "Skipping Login to Dockerhub, credentials not available."
+  else
+      echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
+  fi
+
   if [[ -x scripts/build-ci.sh ]]; then
     time ./scripts/build-ci.sh
   elif [[ -r Dockerfile ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ executors:
           FXA_EMAIL_ENV: dev
           FXA_EMAIL_LOG_LEVEL: debug
           RUST_BACKTRACE: 1
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     environment:
       FXA_MX_RECORD_EXCLUSIONS: restmail.dev.lcip.org
 
@@ -90,6 +93,9 @@ jobs:
       - image: memcached
       - image: pafortin/goaws
       - image: circleci/mysql:5.7.27
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     parameters:
       package:
         type: string
@@ -113,6 +119,9 @@ jobs:
       - image: jdlk7/firestore-emulator
       - image: memcached
       - image: redis
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     steps:
       - base-install:
           package: many
@@ -197,6 +206,9 @@ jobs:
           - MYSQL_ALLOW_EMPTY_PASSWORD: yes
           - MYSQL_ROOT_PASSWORD: ''
       - image: redis
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     steps:
       - base-install:
           package: fxa-email-service
@@ -209,6 +221,9 @@ jobs:
     resource_class: small
     docker:
       - image: circleci/node:14
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     environment:
       DOCKER_BUILDKIT: 1
     steps:
@@ -230,6 +245,9 @@ jobs:
     resource_class: small
     docker:
       - image: circleci/node:14
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     environment:
       DOCKER_BUILDKIT: 1
     steps:
@@ -262,6 +280,9 @@ jobs:
     resource_class: small
     docker:
       - image: circleci/node:14
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     steps:
       - base-install:
           package: many


### PR DESCRIPTION
Login using *any* configured docker credentials to avoid rate limiting from dockerhub

## Because

- Dockerhub will be enforcing rate-limiting for non-auth'd logins

## This pull request

- This PR will force a `docker login` to auth prior to any docker operations requiring login (pull/push/etc)

## Checklist

- [x ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This will only affect the build process for docker containers. No application code should be affected.
