### PR TITLE
tests(Settings_V2): add tests for display name, config and helper functions for settings 

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -644,7 +644,9 @@ module.exports = {
       ADD_BUTTON: '[data-testid=display-name-unit-row-route]',
       CANCEL_BUTTON: '[data-testid=cancel-display-name]',
       SUBMIT_BUTTON: '[data-testid=submit-display-name]',
-      TEXTBOX: '[data-testid=input-label]',
+      TEXTBOX_LABEL: '[data-testid=input-label]',
+      TEXTBOX_FIELD: '[data-testid=input-field]',
+      SAVED_DISPLAY_NAME: '[data-testid=display-name-unit-row-header-value]',
       BACK_BUTTON: '[data-testid=flow-container-back-btn]',
     },
     SECONDARY_EMAIL: {

--- a/packages/fxa-content-server/tests/functional/settings_v2/display_name.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/display_name.js
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const intern = require('intern').default;
+const { describe, it, beforeEach } = intern.getPlugin('interface.bdd');
+const selectors = require('../lib/selectors');
+const FunctionalHelpers = require('../lib/helpers');
+const FunctionalSettingsHelpers = require('./lib/helpers');
+
+const { navigateToSettingsV2 } = FunctionalSettingsHelpers;
+const {
+  click,
+  testElementTextEquals,
+  type,
+} = FunctionalHelpers.helpersRemoteWrapped;
+
+describe('display name', () => {
+  let email;
+  beforeEach(async ({ remote }) => {
+    email = await navigateToSettingsV2(remote);
+    await click(
+      selectors.SETTINGS_V2.DISPLAY_NAME.ADD_BUTTON,
+      selectors.SETTINGS_V2.DISPLAY_NAME.TEXTBOX_LABEL,
+      remote
+    );
+    await type(
+      selectors.SETTINGS_V2.DISPLAY_NAME.TEXTBOX_FIELD,
+      'Test User',
+      {},
+      remote
+    );
+  });
+
+  it('can add a display name', async ({ remote }) => {
+    await click(selectors.SETTINGS_V2.DISPLAY_NAME.SUBMIT_BUTTON, remote);
+
+    // Verify the saved name is displayed
+    await testElementTextEquals(
+      selectors.SETTINGS_V2.DISPLAY_NAME.SAVED_DISPLAY_NAME,
+      'Test User',
+      remote
+    );
+
+    // Also check the avatar dropdown displays the saved name
+    await click(
+      selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.MENU_BUTTON,
+      remote
+    );
+    await testElementTextEquals(
+      selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.DISPLAY_NAME_LABEL,
+      'Test User',
+      remote
+    );
+  });
+
+  it('can click cancel and not add a display name', async ({ remote }) => {
+    // Click cancel without providing a display name
+    await click(
+      selectors.SETTINGS_V2.DISPLAY_NAME.CANCEL_BUTTON,
+      selectors.SETTINGS_V2.HEADER,
+      remote
+    );
+
+    // Verify the display name is not saved
+    await testElementTextEquals(
+      selectors.SETTINGS_V2.DISPLAY_NAME.SAVED_DISPLAY_NAME,
+      'None',
+      remote
+    );
+
+    // Also check the avatar dropdown displays the email id
+    await click(
+      selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.MENU_BUTTON,
+      remote
+    );
+    await testElementTextEquals(
+      selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.DISPLAY_NAME_LABEL,
+      email,
+      remote
+    );
+  });
+
+  it('can change a display name', async ({ remote }) => {
+    await click(selectors.SETTINGS_V2.DISPLAY_NAME.SUBMIT_BUTTON, remote);
+
+    // Click change and change the display name
+    await click(selectors.SETTINGS_V2.DISPLAY_NAME.ADD_BUTTON, remote);
+    await type(
+      selectors.SETTINGS_V2.DISPLAY_NAME.TEXTBOX_FIELD,
+      'New User',
+      {},
+      remote
+    );
+    await click(selectors.SETTINGS_V2.DISPLAY_NAME.SUBMIT_BUTTON, remote);
+    // Verify the saved name is displayed
+    await testElementTextEquals(
+      selectors.SETTINGS_V2.DISPLAY_NAME.SAVED_DISPLAY_NAME,
+      'New User',
+      remote
+    );
+
+    // Also check the avatar dropdown displays the saved name
+    await click(
+      selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.MENU_BUTTON,
+      remote
+    );
+    await testElementTextEquals(
+      selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.DISPLAY_NAME_LABEL,
+      'New User',
+      remote
+    );
+  });
+
+  it('can click cancel and not change display name', async ({ remote }) => {
+    await click(selectors.SETTINGS_V2.DISPLAY_NAME.SUBMIT_BUTTON, remote);
+
+    // Click change to change the display name
+    await click(selectors.SETTINGS_V2.DISPLAY_NAME.ADD_BUTTON, remote);
+    await type(
+      selectors.SETTINGS_V2.DISPLAY_NAME.TEXTBOX_FIELD,
+      'New User',
+      {},
+      remote
+    );
+
+    // Click cancel and don't save the new display name
+    await click(selectors.SETTINGS_V2.DISPLAY_NAME.CANCEL_BUTTON, remote);
+    // Verify the previous name is displayed
+    await testElementTextEquals(
+      selectors.SETTINGS_V2.DISPLAY_NAME.SAVED_DISPLAY_NAME,
+      'Test User',
+      remote
+    );
+
+    // Also check the avatar dropdown displays the saved name
+    await click(
+      selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.MENU_BUTTON,
+      remote
+    );
+    await testElementTextEquals(
+      selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.DISPLAY_NAME_LABEL,
+      'Test User',
+      remote
+    );
+  });
+
+  it('can remove a display name', async ({ remote }) => {
+    await click(selectors.SETTINGS_V2.DISPLAY_NAME.SUBMIT_BUTTON, remote);
+
+    // Click change to change the display name
+    await click(selectors.SETTINGS_V2.DISPLAY_NAME.ADD_BUTTON, remote);
+    await type(
+      selectors.SETTINGS_V2.DISPLAY_NAME.TEXTBOX_FIELD,
+      '',
+      {},
+      remote
+    );
+
+    // Click submit without providing a display name
+    await click(selectors.SETTINGS_V2.DISPLAY_NAME.SUBMIT_BUTTON, remote);
+    // Verify there is no display name
+    await testElementTextEquals(
+      selectors.SETTINGS_V2.DISPLAY_NAME.SAVED_DISPLAY_NAME,
+      'None',
+      remote
+    );
+
+    // Also check the avatar dropdown displays email id
+    await click(
+      selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.MENU_BUTTON,
+      remote
+    );
+    await testElementTextEquals(
+      selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.DISPLAY_NAME_LABEL,
+      email,
+      remote
+    );
+  });
+});

--- a/packages/fxa-content-server/tests/functional/settings_v2/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/lib/helpers.js
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const selectors = require('../../lib/selectors');
+const FunctionalHelpers = require('../../lib/helpers');
+
+const { createEmail } = FunctionalHelpers;
+const config = intern._config;
+const EMAIL_FIRST = config.fxaContentRoot;
+const SETTINGS_V2_URL = config.fxaSettingsV2Root;
+const password = 'passwordzxcv';
+
+const {
+  clearBrowserState,
+  createUser,
+  openPage,
+  fillOutEmailFirstSignIn,
+  testElementExists,
+} = FunctionalHelpers.helpersRemoteWrapped;
+
+async function navigateToSettingsV2(remote) {
+  const email = createEmail();
+  await clearBrowserState(remote);
+  await createUser(email, password, { preVerified: true }, remote);
+
+  await openPage(EMAIL_FIRST, selectors.ENTER_EMAIL.HEADER, remote);
+  await fillOutEmailFirstSignIn(email, password, remote);
+  await testElementExists(selectors.SETTINGS.HEADER, remote);
+
+  // Open new settings
+  await openPage(SETTINGS_V2_URL, selectors.SETTINGS_V2.HEADER, remote);
+  return email;
+}
+
+module.exports = {
+  navigateToSettingsV2,
+};

--- a/packages/fxa-content-server/tests/functional/settings_v2/navigation.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/navigation.js
@@ -58,7 +58,7 @@ describe('navigation', () => {
   }) => {
     await click(
       selectors.SETTINGS_V2.DISPLAY_NAME.ADD_BUTTON,
-      selectors.SETTINGS_V2.DISPLAY_NAME.TEXTBOX,
+      selectors.SETTINGS_V2.DISPLAY_NAME.TEXTBOX_LABEL,
       remote
     );
     await click(

--- a/packages/fxa-content-server/tests/functional_settings_v2.js
+++ b/packages/fxa-content-server/tests/functional_settings_v2.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 module.exports = [
+  'tests/functional/settings_v2/display_name.js',
   'tests/functional/settings_v2/navigation.js',
   'tests/functional/settings_v2/settings.js',
   'tests/functional/settings_v2/change_password.js',

--- a/packages/fxa-content-server/tests/intern.js
+++ b/packages/fxa-content-server/tests/intern.js
@@ -31,6 +31,8 @@ const fxaUntrustedOauthApp =
   args.fxaUntrustedOauthApp || 'http://localhost:10139/';
 const fxaPaymentsRoot = args.fxaPaymentsRoot || 'http://localhost:3031/';
 const output = args.output || 'test-results.xml';
+const fxaSettingsV2Root =
+  args.fxaSettingsV2Root || 'http://localhost:3030/beta/settings';
 
 // "fxaProduction" is a little overloaded in how it is used in the tests.
 // Sometimes it means real "stage" or real production configuration, but
@@ -64,6 +66,7 @@ const config = {
 
   fxaAuthRoot: fxaAuthRoot,
   fxaContentRoot: fxaContentRoot,
+  fxaSettingsV2Root: fxaSettingsV2Root,
   fxaDevBox: fxaDevBox,
   fxaEmailRoot: fxaEmailRoot,
   fxaOAuthApp: fxaOAuthApp,


### PR DESCRIPTION
## Because

- `This PR is for ticket FXA-1560 for add/change/remove Display name`
- `Another change is to add the config set up for Settings V2 url`
- `I also added a helper function which have steps to create user, email and login and then redirect to Settings page`

## This pull request

- `This PR closes task FXA-1560`

## Issue that this pull request solves

Closes: # (issue number)

## Checklist
_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

@mozilla/fxa-devs please review. Thanks!
