### PR TITLE
fix(fxa-settings): format 2fa recovery codes for export

### DIFF
--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -13,21 +13,34 @@ export type GetDataTrioProps = {
   onAction?: (type: string) => void;
 };
 
+const recoveryCodesPrintTemplate = (recoveryCodes: string | string[]) => {
+  if (typeof recoveryCodes === 'string') recoveryCodes = [recoveryCodes];
+  return (`
+    <html>
+    <head><title>Recovery Codes</title></head>
+    <body>
+    ${recoveryCodes.map((code: string)=> `<p>${code}</p>`).join('')}
+    </body>
+    </html>
+  `);
+};
+
 export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
   const print = useCallback(() => {
     const printWindow = window.open('', 'Print', 'height=600,width=800')!;
-    printWindow.document.write(Array.isArray(value) ? value.join('\n') : value);
+    printWindow.document.write(recoveryCodesPrintTemplate(value));
     printWindow.document.close();
     printWindow.focus();
     printWindow.print();
     printWindow.close();
   }, [value]);
+
   return (
     <div className="flex justify-between w-4/5 max-w-48">
       <a
         title="Download"
         href={URL.createObjectURL(
-          new Blob(Array.isArray(value) ? value : [value], {
+          new Blob(Array.isArray(value) ? [value.join(' \r\n')] : [value], {
             type: 'text/plain',
           })
         )}
@@ -47,7 +60,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
         title="Copy"
         type="button"
         onClick={async () => {
-          const copyValue = Array.isArray(value) ? value.join(', ') : value;
+          const copyValue = Array.isArray(value) ? value.join(' ') : value;
           await copy(copyValue);
           onAction?.('copy');
         }}

--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -15,14 +15,14 @@ export type GetDataTrioProps = {
 
 const recoveryCodesPrintTemplate = (recoveryCodes: string | string[]) => {
   if (typeof recoveryCodes === 'string') recoveryCodes = [recoveryCodes];
-  return (`
+  return `
     <html>
     <head><title>Recovery Codes</title></head>
     <body>
-    ${recoveryCodes.map((code: string)=> `<p>${code}</p>`).join('')}
+    ${recoveryCodes.map((code: string) => `<p>${code}</p>`).join('')}
     </body>
     </html>
-  `);
+  `;
 };
 
 export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
@@ -40,7 +40,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
       <a
         title="Download"
         href={URL.createObjectURL(
-          new Blob(Array.isArray(value) ? [value.join(' \r\n')] : [value], {
+          new Blob(Array.isArray(value) ? [value.join('\r\n')] : [value], {
             type: 'text/plain',
           })
         )}
@@ -60,7 +60,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
         title="Copy"
         type="button"
         onClick={async () => {
-          const copyValue = Array.isArray(value) ? value.join(' ') : value;
+          const copyValue = Array.isArray(value) ? value.join('\r\n') : value;
           await copy(copyValue);
           onAction?.('copy');
         }}


### PR DESCRIPTION
## This pull request

- finishes up #4975, by correcting the formatting for COPY, PRINT, and DOWNLOAD functionality of the recovery codes.

## Issue that this pull request solves

Closes: #4975

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

The main change here is in that we are now creating a template for the print file in function `recoveryCodesPrintTemplate`.
also we are joining the arrays with ` \r\n`, two things we were doing in the content server. I'm a little unsure of a reliable way to test the template as it is just a string. Also not sure if we need to be testing a template like this, it may be redundant. Happy to take input of the reviewer on whatever we think is correct.
