### PR TITLE
fix(settings): scroll to top on navigation

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -19,6 +19,8 @@ import PageSecondaryEmailVerify from '../PageSecondaryEmailVerify';
 import { PageDisplayName } from '../PageDisplayName';
 import PageTwoStepAuthentication from '../PageTwoStepAuthentication';
 import { Page2faReplaceRecoveryCodes } from '../Page2faReplaceRecoveryCodes';
+import { ScrollToTop } from '../ScrollToTop';
+import { HomePath } from '../../constants';
 
 export const GET_INITIAL_STATE = gql`
   query GetInitialState {
@@ -91,16 +93,18 @@ export const App = ({ flowQueryParams }: AppProps) => {
 
   return (
     <AppLayout>
-      <Router basepath="/beta/settings">
-        <PageSettings path="/" />
-        <FlowContainer path="/avatar/change" title="Profile picture" />
-        <PageDisplayName path="/display_name" />
-        <PageChangePassword path="/change_password" />
-        <PageRecoveryKeyAdd path="/account_recovery" />
-        <PageSecondaryEmailAdd path="/emails" />
-        <PageSecondaryEmailVerify path="/emails/verify" />
-        <PageTwoStepAuthentication path="/two_step_authentication" />
-        <Page2faReplaceRecoveryCodes path="/two_step_authentication/replace_codes" />
+      <Router basepath={HomePath}>
+        <ScrollToTop default>
+          <PageSettings path="/" />
+          <FlowContainer path="/avatar/change" title="Profile picture" />
+          <PageDisplayName path="/display_name" />
+          <PageChangePassword path="/change_password" />
+          <PageRecoveryKeyAdd path="/account_recovery" />
+          <PageSecondaryEmailAdd path="/emails" />
+          <PageSecondaryEmailVerify path="/emails/verify" />
+          <PageTwoStepAuthentication path="/two_step_authentication" />
+          <Page2faReplaceRecoveryCodes path="/two_step_authentication/replace_codes" />
+        </ScrollToTop>
       </Router>
     </AppLayout>
   );

--- a/packages/fxa-settings/src/components/ScrollToTop/index.tsx
+++ b/packages/fxa-settings/src/components/ScrollToTop/index.tsx
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// See https://github.com/reach/router/issues/242 for a dicussion
+
+import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
+import React, { useCallback, useLayoutEffect } from 'react';
+
+export const ScrollToTop = (
+  props: React.PropsWithChildren<RouteComponentProps>
+) => {
+  const navigate = useNavigate();
+  const { href, state } = useLocation();
+
+  const updateState = useCallback(async () => {
+    await navigate(href, {
+      state: { ...state, scrolled: true },
+      replace: true,
+    });
+    window.scrollTo(0, 0);
+  }, [href, state, navigate]);
+
+  useLayoutEffect(() => {
+    if (!(state as typeof state & { scrolled?: boolean })?.scrolled) {
+      updateState();
+    }
+  }, [state, updateState]);
+
+  return <>{props.children}</>;
+};


### PR DESCRIPTION
Because:
 - a new page should start at the top

This commit:
 - scroll to the top when a user navigates to a new page (but not when
   back/forward with browser history)

## Issue that this pull request solves

Closes: #6778

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

