### PR TITLE
task(fxa-settings): add beta and classic settings links

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -337,6 +337,9 @@ const Router = Backbone.Router.extend({
       type: VerificationReasons.SECONDARY_EMAIL_VERIFIED,
     }),
     'would_you_like_to_sync(/)': createViewHandler(WouldYouLikeToSync),
+    'beta/settings(/)': function () {
+      this.navigateAway('/beta/settings');
+    },
   },
 
   initialize(options = {}) {

--- a/packages/fxa-content-server/app/scripts/templates/settings.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings.mustache
@@ -5,7 +5,10 @@
     </div>
   {{/ccExpired}}
   <header id="fxa-settings-header">
-    <h1 id="fxa-manage-account"><span class="fxa-account-title">{{#t}}Firefox Accounts{{/t}}</span></h1>
+    <div class="header-lockup">
+      <h1 id="fxa-manage-account"><span class="fxa-account-title">{{#t}}Firefox Accounts{{/t}}</span></h1>
+      <a href="/beta/settings" class="nu-settings-button">Switch to new design</a>
+    </div>
     {{#showSignOut}}
       <button id="signout" class="settings-button secondary-button">{{#t}}Sign out{{/t}}</button>
     {{/showSignOut}}

--- a/packages/fxa-content-server/app/styles/modules/_settings.scss
+++ b/packages/fxa-content-server/app/styles/modules/_settings.scss
@@ -877,6 +877,38 @@ section.modal-panel {
   }
 }
 
+.header-lockup {
+  display: flex;
+  align-items: center;
+}
+
+a.nu-settings-button {
+  background: #FAFAFB;
+  border: 1px solid #C2C2C2;
+  border-radius: .25rem;
+  color: black;
+  height: 100%;
+  margin: 0 1.25rem;
+  padding: .5rem;
+  text-decoration: none;
+
+  &:hover {
+    background: #E7E7E7;
+    color: #6D6D6E;
+  }
+
+  &:active {
+    background: #E7E7E7;
+    border: 1px solid #6D6D6E;
+    color: #6D6D6E;
+    text-decoration: none;
+  }
+
+  &:focus {
+    background: white;
+  }
+}
+
 .open-email-preferences {
   background-image: image-url('icon-open-in.svg');
   background-repeat: no-repeat;

--- a/packages/fxa-settings/src/components/HeaderLockup/index.tsx
+++ b/packages/fxa-settings/src/components/HeaderLockup/index.tsx
@@ -25,11 +25,7 @@ export const HeaderLockup = () => {
         aria-expanded={navRevealedState}
         onClick={() => setNavState(!navRevealedState)}
       >
-        {navRevealedState ? (
-          <Close />
-        ) : (
-          <Menu />
-        )}
+        {navRevealedState ? <Close /> : <Menu />}
         {navRevealedState && <Nav />}
       </button>
       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
@@ -41,7 +37,16 @@ export const HeaderLockup = () => {
       >
         <LogoLockup>
           <>
-            <span className="font-bold ltr:mr-2 rtl:ml-2">Firefox</span> account
+            <span className="font-bold ltr:mr-2 rtl:ml-2">
+              Firefox accounts
+            </span>
+            <a
+              href="/settings"
+              title="classic design link"
+              className="cta-base cta-neutral transition-standard text-sm ltr:ml-4 rtl:mr-4 p-2"
+            >
+              Switch to classic design
+            </a>
           </>
         </LogoLockup>
       </a>


### PR DESCRIPTION
## This pull request

- Adds links to fxa-content-server settings header and fxa-settings header to link to and from beta settings

## Issue that this pull request solves

Closes: #5072 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![new-version](https://user-images.githubusercontent.com/1844554/97904271-3c19bf00-1d0e-11eb-93aa-d895e3645a33.png)
![beta-version](https://user-images.githubusercontent.com/1844554/97904282-40de7300-1d0e-11eb-9c04-c63c2bdeac42.png)


## Other information (Optional)

Any other information that is important to this pull request.
