### PR TITLE
fix(fxa-settings): fix 2fa unit row alignment

### DIFF
--- a/packages/fxa-settings/src/styles/unit-row.scss
+++ b/packages/fxa-settings/src/styles/unit-row.scss
@@ -34,7 +34,8 @@
     @apply flex-no-wrap px-6;
 
     &-header {
-      @apply flex-1 mb-0 mr-2;
+      @apply flex-none mb-0 mr-2;
+      width: 10rem
     }
 
     &-content {


### PR DESCRIPTION
## This pull request

- Sets a min-width to the unit-row-header so that we don't have misalignment in the 2fa section

## Issue that this pull request solves

Closes: #6795

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

