### PR TITLE
chore(fxa-client): removingparam "style" from /sessions/verify_code from both the frontend and backend 

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -558,7 +558,6 @@ export default class AuthClient {
       scopes?: string[];
       marketingOptIn?: boolean;
       newsletters?: string[];
-      style?: string;
     } = {}
   ): Promise<{}> {
     return this.sessionPost('/session/verify_code', sessionToken, {

--- a/packages/fxa-auth-server/lib/routes/session.js
+++ b/packages/fxa-auth-server/lib/routes/session.js
@@ -329,7 +329,6 @@ module.exports = function (
           payload: {
             code: validators.DIGITS,
             service: validators.service,
-            style: validators.style,
             scopes: validators.scopes,
             // The `marketingOptIn` is safe to remove after train-167+
             marketingOptIn: isA.boolean().optional(),

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -529,8 +529,6 @@ module.exports.subscriptionsStripeCustomerValidator = isA
 
 module.exports.ppidSeed = isA.number().integer().min(0).max(1024);
 
-module.exports.style = isA.string().allow(['trailhead']).optional();
-
 module.exports.scopes = isA.array().items(scope).default([]).optional();
 
 module.exports.newsletters = isA


### PR DESCRIPTION
## Because
This param is a left over from the trailhead experiment. It should be safe to remove in frontend and  backend.
 -

## This pull request

-

## Issue that this pull request solves

Closes: #6058 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
