### PR TITLE
Create test for adding and revoking a recovery key

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -681,6 +681,13 @@ module.exports = {
         RECOVERY_KEY_CONFIRM: '[data-testid=recover-key-confirm]',
         RECOVERY_KEY_TEXT: '[data-testid=datablock-button]',
         CLOSE_BUTTON: '[data-testid=close-button]',
+        RECOVERY_KEY_ENABLED:
+          '[data-testid=recovery-key-unit-row-header-value]',
+        REMOVE_RECOVERY_KEY: '[data-testid=unit-row-modal]',
+        REMOVE_KEY_DESCRIPTION: '[data-testid=modal-content-container]',
+        CANCEL_REMOVE_KEY: '[data-testid=modal-cancel]',
+        CONFIRM_REMOVE_KEY: '[data-testid=modal-confirm]',
+        SUCCESS_MSG_REMOVE: '[data-testid=delete-recovery-key-success]',
       },
       TFA: {
         ADD_BUTTON: '[data-testid=two-step-unit-row-route]',

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -673,9 +673,14 @@ module.exports = {
       RECOVERY_KEY: {
         CREATE: '[data-testid=recovery-key-unit-row-route]',
         BACK_BUTTON: '[data-testid=flow-container-back-btn]',
-        PASSWORD_TEXTBOX: '[data-testid=input-label]',
+        PASSWORD_TEXTBOX_LABEL: '[data-testid=input-label]',
+        PASSWORD_TEXTBOX_INPUT: '[data-testid=input-field]',
         CANCEL_BUTTON: '[data-testid=cancel-button]',
         CONTINUE_BUTTON: '[data-testid=continue-button]',
+        TOOLTIP_INCORRECT_PASSWORD: '[data-testid=tooltip]',
+        RECOVERY_KEY_CONFIRM: '[data-testid=recover-key-confirm]',
+        RECOVERY_KEY_TEXT: '[data-testid=datablock-button]',
+        CLOSE_BUTTON: '[data-testid=close-button]',
       },
       TFA: {
         ADD_BUTTON: '[data-testid=two-step-unit-row-route]',

--- a/packages/fxa-content-server/tests/functional/settings_v2/recovery_key.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/recovery_key.js
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const intern = require('intern').default;
+const { describe, it, beforeEach } = intern.getPlugin('interface.bdd');
+const selectors = require('../lib/selectors');
+const FunctionalHelpers = require('../lib/helpers');
+const FunctionalSettingsHelpers = require('./lib/helpers');
+const password = 'passwordzxcv'
+let recoveryKey;
+
+const { navigateToSettingsV2 } = FunctionalSettingsHelpers;
+const {
+  click,
+  testElementExists,
+  type,
+  visibleByQSA,
+} = FunctionalHelpers.helpersRemoteWrapped;
+
+describe('recovery key', () => {
+   //let email;
+   beforeEach(async ({ remote }) => {
+     await navigateToSettingsV2(remote);
+   });
+
+ it('try to add recovery key with invalid password', async ({ remote }) => {
+    await click(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CREATE,
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.PASSWORD_TEXTBOX_LABEL,
+      remote
+    );
+
+    // Type invalid password
+    await click(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.PASSWORD_TEXTBOX_LABEL,
+      remote
+    )
+    await type(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.PASSWORD_TEXTBOX_INPUT,
+      'invalid password',
+      remote
+    )
+    await click(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CONTINUE_BUTTON,
+      remote
+    )
+
+    // Verify that the 'incorrect password' error message is visible
+    await visibleByQSA(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.TOOLTIP_INCORRECT_PASSWORD,
+      remote
+    )
+   });
+
+   it('try to add recovery key with a valid password', async ({ remote }) => {
+    await click(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CREATE,
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.PASSWORD_TEXTBOX_LABEL,
+      remote
+    );
+
+    // Type invalid password
+    await click(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.PASSWORD_TEXTBOX_LABEL,
+      remote
+    )
+    await type(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.PASSWORD_TEXTBOX_INPUT,
+      password,
+      remote
+    )
+    await click(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CONTINUE_BUTTON,
+      remote
+    )
+    await testElementExists(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.RECOVERY_KEY_CONFIRM,
+      remote
+    )
+
+    // Store the key to be used later
+   // Store the key to be used later
+   .findByCssSelector(selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.RECOVERY_KEY_TEXT)
+   .getVisibleText()
+   .then((key) => {
+     recoveryKey = key;
+     return remote.then(
+       click(selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CLOSE_BUTTON)
+     );
+   })
+   .end()
+
+
+  });
+});

--- a/packages/fxa-content-server/tests/functional/settings_v2/recovery_key.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/recovery_key.js
@@ -9,8 +9,7 @@ const { describe, it, beforeEach } = intern.getPlugin('interface.bdd');
 const selectors = require('../lib/selectors');
 const FunctionalHelpers = require('../lib/helpers');
 const FunctionalSettingsHelpers = require('./lib/helpers');
-const password = 'passwordzxcv'
-let recoveryKey;
+const password = 'passwordzxcv';
 
 const { navigateToSettingsV2 } = FunctionalSettingsHelpers;
 const {
@@ -18,81 +17,120 @@ const {
   testElementExists,
   type,
   visibleByQSA,
+  testElementTextEquals,
 } = FunctionalHelpers.helpersRemoteWrapped;
 
 describe('recovery key', () => {
-   //let email;
-   beforeEach(async ({ remote }) => {
-     await navigateToSettingsV2(remote);
-   });
-
- it('try to add recovery key with invalid password', async ({ remote }) => {
+  beforeEach(async ({ remote }) => {
+    await navigateToSettingsV2(remote);
     await click(
       selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CREATE,
       selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.PASSWORD_TEXTBOX_LABEL,
       remote
     );
+  });
 
+  it('try to add recovery key with invalid password', async ({ remote }) => {
     // Type invalid password
     await click(
       selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.PASSWORD_TEXTBOX_LABEL,
       remote
-    )
+    );
     await type(
       selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.PASSWORD_TEXTBOX_INPUT,
       'invalid password',
       remote
-    )
+    );
     await click(
       selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CONTINUE_BUTTON,
       remote
-    )
+    );
 
     // Verify that the 'incorrect password' error message is visible
     await visibleByQSA(
       selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.TOOLTIP_INCORRECT_PASSWORD,
       remote
-    )
-   });
+    );
+  });
 
-   it('try to add recovery key with a valid password', async ({ remote }) => {
+  it('try to add recovery key with a valid password', async ({ remote }) => {
     await click(
-      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CREATE,
       selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.PASSWORD_TEXTBOX_LABEL,
       remote
     );
 
-    // Type invalid password
-    await click(
-      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.PASSWORD_TEXTBOX_LABEL,
-      remote
-    )
+    // Type valid password
     await type(
       selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.PASSWORD_TEXTBOX_INPUT,
       password,
       remote
-    )
+    );
     await click(
       selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CONTINUE_BUTTON,
       remote
-    )
+    );
     await testElementExists(
       selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.RECOVERY_KEY_CONFIRM,
       remote
-    )
+    );
+    await testElementExists(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.RECOVERY_KEY_CONFIRM,
+      remote
+    );
+    await click(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CLOSE_BUTTON,
+      remote
+    );
 
-    // Store the key to be used later
-   // Store the key to be used later
-   .findByCssSelector(selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.RECOVERY_KEY_TEXT)
-   .getVisibleText()
-   .then((key) => {
-     recoveryKey = key;
-     return remote.then(
-       click(selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CLOSE_BUTTON)
-     );
-   })
-   .end()
+    //Verify the status is Enabled
+    await testElementTextEquals(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.RECOVERY_KEY_ENABLED,
+      'Enabled',
+      remote
+    );
+  });
 
+  it('can revoke recovery key', async ({ remote }) => {
+    await click(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.PASSWORD_TEXTBOX_LABEL,
+      remote
+    );
+    await type(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.PASSWORD_TEXTBOX_INPUT,
+      password,
+      remote
+    );
+    await click(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CONTINUE_BUTTON,
+      remote
+    );
+    await click(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CLOSE_BUTTON,
+      remote
+    );
+    await click(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.REMOVE_RECOVERY_KEY,
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.REMOVE_KEY_DESCRIPTION,
+      remote
+    );
 
+    //Click confirm to remove
+    await click(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CONFIRM_REMOVE_KEY,
+      remote
+    );
+
+    //Verify the success message is visible
+    await testElementExists(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.SUCCESS_MSG_REMOVE,
+      remote
+    );
+
+    //Also verify that the recovery key status is 'Not set'
+    await testElementTextEquals(
+      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.RECOVERY_KEY_ENABLED,
+      'Not Set',
+      remote
+    );
   });
 });

--- a/packages/fxa-content-server/tests/functional/settings_v2/recovery_key.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/recovery_key.js
@@ -73,10 +73,6 @@ describe('recovery key', () => {
       selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.RECOVERY_KEY_CONFIRM,
       remote
     );
-    await testElementExists(
-      selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.RECOVERY_KEY_CONFIRM,
-      remote
-    );
     await click(
       selectors.SETTINGS_V2.SECURITY.RECOVERY_KEY.CLOSE_BUTTON,
       remote

--- a/packages/fxa-content-server/tests/functional_settings_v2.js
+++ b/packages/fxa-content-server/tests/functional_settings_v2.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 module.exports = [
+  'tests/functional/settings_v2/recovery_key.js',
   'tests/functional/settings_v2/display_name.js',
   'tests/functional/settings_v2/navigation.js',
   'tests/functional/settings_v2/settings.js',


### PR DESCRIPTION
## Because

`- added tests for creating recovery key with valid password`
`- verifying error message when entered invalid password`
`- revoking recovery key`

## This pull request

`This PR closes task FXA-1564`

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

@mozilla/fxa-devs @rbillings please review. Thank you!
