### PR TITLE
test(settings): add secondary email functional tests

### DIFF
--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -16,6 +16,7 @@
     "test-circle": "node tests/intern.js --suites=circle --fxaAuthRoot=https://fxaci.dev.lcip.org/auth --fxaEmailRoot=http://restmail.net --fxaOAuthApp=https://oauth-fxaci.dev.lcip.org --fxaUntrustedOauthApp=https://321done-fxaci.dev.lcip.org --fxaProduction=true --bailAfterFirstFailure=true",
     "test-functional": "node tests/intern.js",
     "test-functional-oauth": "node tests/intern.js --grep='oauth'",
+    "test-functional-settings": "node tests/intern.js --suites=settings_v2",
     "test-latest": "SKIP_MOCHA=true node tests/intern.js --fxaAuthRoot=https://latest.dev.lcip.org/auth/v1 --fxaContentRoot=https://latest.dev.lcip.org/ --fxaEmailRoot=http://restmail.net --fxaOAuthApp=https://123done-latest.dev.lcip.org/ --fxaUntrustedOauthApp=https://321done-latest.dev.lcip.org/ --fxaProduction=true --fxaToken=https://token.dev.lcip.org/1.0/sync/1.5",
     "test-pairing": "node tests/intern.js --suites=pairing",
     "test-pairing-circle": "node tests/intern.js --suites=pairing --fxaAuthRoot=https://fxaci.dev.lcip.org/auth --fxaEmailRoot=http://restmail.net --fxaOAuthApp=https://123done-fxaci.dev.lcip.org/ --fxaProduction=true --bailAfterFirstFailure=true",

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -2893,8 +2893,9 @@ module.exports = {
 // Export helpers methods in a form that can be easily used in
 // async/await. The usage of the helpers are the same except
 // they expect the last argument to be the intern remote object.
+const fnNames = Object.keys(module.exports);
 const helpersRemoteWrapped = {};
-Object.keys(module.exports).forEach((key) => {
+fnNames.forEach((key) => {
   helpersRemoteWrapped[key] = async function () {
     const args = [...arguments];
     const remote = args.pop();
@@ -2902,3 +2903,13 @@ Object.keys(module.exports).forEach((key) => {
   };
 });
 module.exports.helpersRemoteWrapped = helpersRemoteWrapped;
+
+const applyRemote = (remote) =>
+  fnNames.reduce((acc, key) => {
+    acc[key] = async function () {
+      return remote.then(module.exports[key](...arguments));
+    };
+    return acc;
+  }, {});
+
+module.exports.applyRemote = applyRemote;

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -630,6 +630,8 @@ module.exports = {
   },
   SETTINGS_V2: {
     HEADER: '#profile',
+    TOOLTIP: '[data-testid=tooltip]',
+    BACK_BUTTON: '[data-testid=flow-container-back-btn]',
     AVATAR_DROP_DOWN_MENU: {
       MENU_BUTTON: '[data-testid=drop-down-avatar-menu-toggle]',
       DISPLAY_NAME_LABEL: '[data-testid=drop-down-name-or-email]',
@@ -649,12 +651,23 @@ module.exports = {
       SAVED_DISPLAY_NAME: '[data-testid=display-name-unit-row-header-value]',
       BACK_BUTTON: '[data-testid=flow-container-back-btn]',
     },
+    PRIMARY_EMAIL: {
+      HEADER_VALUE: '[data-testid=primary-email-unit-row-header-value]',
+    },
     SECONDARY_EMAIL: {
+      HEADER_VALUE: '[data-testid=secondary-email-unit-row-header-value]',
       ADD_BUTTON: '[data-testid=secondary-email-unit-row-route]',
+      DELETE_BUTTON: '[data-testid=secondary-email-delete]',
+      REFRESH_BUTTON: '[data-testid=secondary-email-refresh]',
+      MAKE_PRIMARY: '[data-testid=secondary-email-make-primary]',
+      FORM: '[data-testid=secondary-email-verify-form]',
       CANCEL_BUTTON: '[data-testid=cancel-button]',
       SUBMIT_BUTTON: '[data-testid=save-button]',
-      TEXTBOX: '[data-testid=input-label]',
+      TEXTBOX_FIELD: '[data-testid=input-field]',
+      TEXTBOX_LABEL: '[data-testid=input-label]',
       BACK_BUTTON: '[data-testid=flow-container-back-btn]',
+      VERIFY_FORM_LABEL: '[data-testid=input-container]',
+      VERIFY_FORM_SUBMIT_BUTTON: '[data-testid=secondary-email-verify-submit]',
     },
     CHANGE_PASSWORD: {
       OPEN_BUTTON: '[data-testid=password-unit-row-route]',

--- a/packages/fxa-content-server/tests/functional/settings_v2/secondary_email.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/secondary_email.js
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const intern = require('intern').default;
+const { describe, it, beforeEach } = intern.getPlugin('interface.bdd');
+const selectors = require('../lib/selectors');
+const FunctionalHelpers = require('../lib/helpers');
+const { createEmail } = FunctionalHelpers;
+const FunctionalSettingsHelpers = require('./lib/helpers');
+const { navigateToSettingsV2 } = FunctionalSettingsHelpers;
+
+describe('secondary email', () => {
+  let primaryEmail;
+  const secondaryEmail = createEmail();
+  let click, getEmailCode, testElementExists, testElementTextInclude, type;
+
+  beforeEach(async ({ remote }) => {
+    ({
+      click,
+      getEmailCode,
+      testElementExists,
+      testElementTextInclude,
+      type,
+    } = FunctionalHelpers.applyRemote(remote));
+    primaryEmail = await navigateToSettingsV2(remote);
+  });
+
+  it('can add and verify secondary email', async () => {
+    await click(selectors.SETTINGS_V2.SECONDARY_EMAIL.ADD_BUTTON);
+
+    // try adding the primary as the secondary
+    await click(selectors.SETTINGS_V2.SECONDARY_EMAIL.TEXTBOX_LABEL);
+    await type(
+      selectors.SETTINGS_V2.SECONDARY_EMAIL.TEXTBOX_FIELD,
+      primaryEmail
+    );
+    await click(selectors.SETTINGS_V2.SECONDARY_EMAIL.SUBMIT_BUTTON);
+    await testElementTextInclude(
+      selectors.SETTINGS_V2.TOOLTIP,
+      'Can not add secondary email that is same as your primary'
+    );
+
+    // add secondary email, resend, remove
+    await click(selectors.SETTINGS_V2.SECONDARY_EMAIL.TEXTBOX_LABEL);
+    await type(
+      selectors.SETTINGS_V2.SECONDARY_EMAIL.TEXTBOX_FIELD,
+      secondaryEmail
+    );
+    await click(selectors.SETTINGS_V2.SECONDARY_EMAIL.SUBMIT_BUTTON);
+    await testElementTextInclude(
+      selectors.SETTINGS_V2.SECONDARY_EMAIL.FORM,
+      secondaryEmail
+    );
+    await click(selectors.SETTINGS_V2.BACK_BUTTON);
+    await testElementTextInclude(
+      selectors.SETTINGS_V2.SECONDARY_EMAIL.HEADER_VALUE,
+      secondaryEmail
+    );
+    await testElementTextInclude(
+      selectors.SETTINGS_V2.SECONDARY_EMAIL.HEADER_VALUE,
+      'unverified'
+    );
+    await testElementExists(
+      selectors.SETTINGS_V2.SECONDARY_EMAIL.DELETE_BUTTON
+    );
+    await testElementExists(
+      selectors.SETTINGS_V2.SECONDARY_EMAIL.REFRESH_BUTTON
+    );
+    await click(selectors.SETTINGS_V2.SECONDARY_EMAIL.DELETE_BUTTON);
+
+    // add and verify
+    await click(selectors.SETTINGS_V2.SECONDARY_EMAIL.ADD_BUTTON);
+    await click(selectors.SETTINGS_V2.SECONDARY_EMAIL.TEXTBOX_LABEL);
+    await type(
+      selectors.SETTINGS_V2.SECONDARY_EMAIL.TEXTBOX_FIELD,
+      secondaryEmail
+    );
+    await click(selectors.SETTINGS_V2.SECONDARY_EMAIL.SUBMIT_BUTTON);
+    const verifyCode = await getEmailCode(secondaryEmail, 1);
+    await click(selectors.SETTINGS_V2.SECONDARY_EMAIL.VERIFY_FORM_LABEL);
+    await type(selectors.SETTINGS_V2.SECONDARY_EMAIL.TEXTBOX_FIELD, verifyCode);
+    await click(
+      selectors.SETTINGS_V2.SECONDARY_EMAIL.VERIFY_FORM_SUBMIT_BUTTON
+    );
+    await testElementExists(
+      selectors.SETTINGS_V2.SECONDARY_EMAIL.DELETE_BUTTON
+    );
+    await testElementExists(selectors.SETTINGS_V2.SECONDARY_EMAIL.MAKE_PRIMARY);
+
+    // swap primary and secondary
+    await click(selectors.SETTINGS_V2.SECONDARY_EMAIL.MAKE_PRIMARY);
+    await testElementTextInclude(
+      selectors.SETTINGS_V2.PRIMARY_EMAIL.HEADER_VALUE,
+      secondaryEmail
+    );
+    await testElementTextInclude(
+      selectors.SETTINGS_V2.SECONDARY_EMAIL.HEADER_VALUE,
+      primaryEmail
+    );
+  });
+});

--- a/packages/fxa-content-server/tests/functional_settings_v2.js
+++ b/packages/fxa-content-server/tests/functional_settings_v2.js
@@ -8,4 +8,5 @@ module.exports = [
   'tests/functional/settings_v2/navigation.js',
   'tests/functional/settings_v2/settings.js',
   'tests/functional/settings_v2/change_password.js',
+  'tests/functional/settings_v2/secondary_email.js',
 ];


### PR DESCRIPTION
Because:
 - we should verify that the secondary email feature is working in new
   settings

This commit:
 - add functional test for secondary email feature in new settings


## Issue that this pull request solves

Closes: #4854, #4855 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
