### PR TITLE
feat(event-broker): capture error context

### DIFF
--- a/packages/fxa-event-broker/src/client-capability/client-capability.service.spec.ts
+++ b/packages/fxa-event-broker/src/client-capability/client-capability.service.spec.ts
@@ -88,7 +88,7 @@ describe('ClientCapabilityService', () => {
     });
 
     it('throws on error', async () => {
-      const mockUpdate = jest.fn().mockResolvedValue({ status: 500 });
+      const mockUpdate = jest.fn().mockRejectedValue({});
       (service as any).axiosInstance = { get: mockUpdate };
       expect.assertions(1);
       try {
@@ -99,7 +99,7 @@ describe('ClientCapabilityService', () => {
     });
 
     it('logs on error', async () => {
-      const mockUpdate = jest.fn().mockResolvedValue({ status: 500 });
+      const mockUpdate = jest.fn().mockRejectedValue({});
       (service as any).axiosInstance = { get: mockUpdate };
       await service.updateCapabilities();
       expect((service as any).log.error).toBeCalledTimes(1);

--- a/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.ts
+++ b/packages/fxa-event-broker/src/pubsub-proxy/pubsub-proxy.controller.ts
@@ -16,6 +16,7 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { Request } from 'express';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 import { StatsD } from 'hot-shots';
+import { ExtendedError } from 'fxa-shared/nestjs/error';
 
 import { GoogleJwtAuthGuard } from '../auth/google-jwt-auth.guard';
 import { ClientWebhooksService } from '../client-webhooks/client-webhooks.service';
@@ -137,6 +138,7 @@ export class PubsubProxyController {
         this.metrics.increment(`proxy.fail`, {
           clientId,
           statusCode: (err.response as AxiosResponse).status.toString(),
+          type: message.event,
         });
         this.log.debug('proxyDeliverFail', {
           response: err.response,
@@ -145,7 +147,7 @@ export class PubsubProxyController {
         return err.response;
       } else {
         this.log.error('proxyDeliverError', { err });
-        throw err;
+        throw ExtendedError.withCause('Proxy delivery error', err);
       }
     }
   }

--- a/packages/fxa-shared/nestjs/error.ts
+++ b/packages/fxa-shared/nestjs/error.ts
@@ -1,0 +1,15 @@
+/** Application error helpers */
+
+/**
+ * Extends basic Error with `cause` attribute used by Sentry for
+ * linked error reporting.
+ */
+export class ExtendedError extends Error {
+  public cause?: Error;
+
+  static withCause(message: string, cause: Error) {
+    const err = new ExtendedError(message);
+    err.cause = cause;
+    return err;
+  }
+}


### PR DESCRIPTION
Because:

* We would like to see the originating error in the caught location
  when thrown by axios.

This commit:

* Adds a helper exception that appends an original error context when
  throwing.
* Properly captures and re-throws the error during start-up in the
  event-broker.

Fixes #6872

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
