### PR TITLE
Renamed the page, URL, and text for the 'Email Blocks' page to 'Accou…

### DIFF
--- a/packages/fxa-admin-panel/server/lib/server.ts
+++ b/packages/fxa-admin-panel/server/lib/server.ts
@@ -149,7 +149,7 @@ if (proxyUrl) {
     { encoding: 'utf-8' }
   );
 
-  ['/', '/email-blocks'].forEach((route) => {
+  ['/', '/account-search'].forEach((route) => {
     // FIXME: should set ETag, Not-Modified:
     app.get(route, (req, res) => {
       res.send(injectHtmlConfig(STATIC_INDEX_HTML, CLIENT_CONFIG));

--- a/packages/fxa-admin-panel/src/App.tsx
+++ b/packages/fxa-admin-panel/src/App.tsx
@@ -11,8 +11,8 @@ const App = () => (
   <BrowserRouter>
     <AppLayout>
       <Switch>
-        <Redirect exact from="/" to="/email-blocks" />
-        <Route path="/email-blocks" component={EmailBlocks} />
+        <Redirect exact from="/" to="/account-search" />
+        <Route path="/account-search" component={EmailBlocks} />
       </Switch>
     </AppLayout>
   </BrowserRouter>

--- a/packages/fxa-admin-panel/src/components/EmailBlocks/index.tsx
+++ b/packages/fxa-admin-panel/src/components/EmailBlocks/index.tsx
@@ -65,7 +65,7 @@ export const EmailBlocks = () => {
 
   return (
     <div className="email-blocks" data-testid="email-blocks">
-      <h2>Find and Delete Email Blocks</h2>
+      <h2>Account search</h2>
       <p>
         Email addresses are blocked from the FxA email sender when an email sent
         to the address has bounced.

--- a/packages/fxa-admin-panel/src/components/Nav/index.tsx
+++ b/packages/fxa-admin-panel/src/components/Nav/index.tsx
@@ -12,13 +12,13 @@ export const Nav = () => (
       <h2>Navigation</h2>
       <ul>
         <li>
-          <NavLink exact to="/email-blocks">
+          <NavLink exact to="/account-search">
             <img
               className="inline-flex icon"
               src={require('../../images/icon-mail.svg')}
               alt="external link"
             />
-            Email blocks
+            Account search
           </NavLink>
         </li>
       </ul>


### PR DESCRIPTION
…nt Search' for the admin panel.

## Because

Resolving Issue #6746 in regards to the Admin Panel.

## This pull request

Renames the page, URL, and text for "Email Blocks" to "Account Search"

## Issue that this pull request solves

Closes: #6746 

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![ADMIN PANEL](https://user-images.githubusercontent.com/42894447/99001545-0a240c00-2509-11eb-9c2a-6107e0b098ee.PNG)

