### PR TITLE
chore(surveys): remove reset password survey

### DIFF
--- a/packages/fxa-content-server/server/config/surveys.json
+++ b/packages/fxa-content-server/server/config/surveys.json
@@ -1,11 +1,1 @@
-[
-  {
-    "id": "password-reset",
-    "conditions": {
-      "languages": ["en"]
-    },
-    "rate": 0.05,
-    "view": "reset-password",
-    "url": "https://www.surveygizmo.com/s3/5622367/Password-Reset-1"
-  }
-]
+[]


### PR DESCRIPTION
## Because

- reset password survey has been out there for a long time

## This pull request

- stop showing the survey to selected users
