### PR TITLE
task(fxa-settings): add subscriptions link test

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -2773,6 +2773,54 @@ const fillOutForceChangePassword = thenify(function (oldPassword, newPassword) {
     .then(click(selectors.POST_VERIFY_FORCE_PASSWORD_CHANGE.SUBMIT));
 });
 
+const signInToTestProduct = thenify(function () {
+  return this.parent
+    .then(openRP())
+    .then(click(selectors['123DONE'].BUTTON_SIGNIN))
+    .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER))
+    .then(click(selectors['SIGNIN_PASSWORD'].SUBMIT_USE_SIGNED_IN))
+    .then(testElementExists(selectors['123DONE'].AUTHENTICATED));
+});
+
+const createUserAndLoadSettings = thenify(function (email) {
+  const PASSWORD = 'amazingpassword';
+  const ENTER_EMAIL_URL = config.fxaContentRoot;
+
+  return this.parent
+    .then(createUser(email, PASSWORD, { preVerified: true }))
+    .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
+    .then(fillOutEmailFirstSignIn(email, PASSWORD))
+    .then(testElementExists(selectors.SETTINGS.HEADER));
+});
+
+const subscribeAndSigninToRp = thenify(function (email) {
+  return (
+    this.parent
+      .then(
+        clearBrowserState({
+          '123done': true,
+          force: true,
+        })
+      )
+
+      .then(createUserAndLoadSettings(email))
+
+      // subscribe
+      .then(openRP())
+      .then(click(selectors['123DONE'].BUTTON_SIGNIN))
+      .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER))
+      .then(click(selectors['SIGNIN_PASSWORD'].SUBMIT_USE_SIGNED_IN))
+      .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
+      .then(visibleByQSA(selectors['123DONE'].BUTTON_SUBSCRIBE))
+      .then(click(selectors['123DONE'].LINK_LOGOUT))
+      .then(visibleByQSA(selectors['123DONE'].BUTTON_SIGNIN))
+      .then(subscribeToTestProduct())
+
+      // Signin
+      .then(signInToTestProduct())
+  );
+});
+
 module.exports = {
   ...TestHelpers,
   cleanMemory,
@@ -2783,6 +2831,7 @@ module.exports = {
   closeCurrentWindow,
   confirmTotpCode,
   createUser,
+  createUserAndLoadSettings,
   deleteAllEmails,
   deleteAllSms,
   denormalizeStoredEmail,
@@ -2853,7 +2902,9 @@ module.exports = {
   pollUntilHiddenByQSA,
   respondToWebChannelMessage,
   sendVerificationReminders,
+  signInToTestProduct,
   storeWebChannelMessageData,
+  subscribeAndSigninToRp,
   subscribeToTestProduct,
   subscribeToTestProductWithCardNumber,
   switchToWindow,

--- a/packages/fxa-content-server/tests/functional/settings_v2/change_password.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/change_password.js
@@ -11,7 +11,7 @@ const FunctionalHelpers = require('../lib/helpers');
 
 const config = intern._config;
 const EMAIL_FIRST = config.fxaContentRoot;
-const SETTINGS_V2_URL = `${config.fxaContentRoot}beta/settings`;
+const SETTINGS_V2_URL = config.fxaSettingsV2Root;
 const password = 'passwordzxcv';
 const newPassword = 'passwordzxcvb';
 

--- a/packages/fxa-content-server/tests/functional/settings_v2/navigation.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/navigation.js
@@ -11,7 +11,7 @@ const FunctionalHelpers = require('../lib/helpers');
 
 const config = intern._config;
 const EMAIL_FIRST = config.fxaContentRoot;
-const SETTINGS_V2_URL = `${config.fxaContentRoot}beta/settings`;
+const SETTINGS_V2_URL = config.fxaSettingsV2Root;
 const password = 'passwordzxcv';
 
 const { createEmail } = FunctionalHelpers;

--- a/packages/fxa-content-server/tests/functional/settings_v2/settings.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/settings.js
@@ -11,7 +11,7 @@ const FunctionalHelpers = require('../lib/helpers');
 
 const config = intern._config;
 const EMAIL_FIRST = config.fxaContentRoot;
-const SETTINGS_V2_URL = `${config.fxaContentRoot}beta/settings`;
+const SETTINGS_V2_URL = config.fxaSettingsV2Root;
 const password = 'passwordzxcv';
 
 const { createEmail } = FunctionalHelpers;

--- a/packages/fxa-content-server/tests/functional/subscriptions.js
+++ b/packages/fxa-content-server/tests/functional/subscriptions.js
@@ -9,20 +9,16 @@ const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
 
 const config = intern._config;
-const ENTER_EMAIL_URL = config.fxaContentRoot;
-const PASSWORD = 'amazingpassword';
 
 const {
   clearBrowserState,
   click,
   createEmail,
-  createUser,
-  fillOutEmailFirstSignIn,
+  createUserAndLoadSettings,
   openPage,
-  openRP,
-  subscribeToTestProduct,
+  signInToTestProduct,
+  subscribeAndSigninToRp,
   subscribeToTestProductWithCardNumber,
-  testElementExists,
   testElementTextInclude,
   visibleByQSA,
 } = FunctionalHelpers;
@@ -62,36 +58,7 @@ registerSuite('subscriptions', {
         this.skip('missing Stripe API key in CircleCI run');
       }
       const email = createEmail();
-      return this.remote
-        .then(
-          clearBrowserState({
-            '123done': true,
-            force: true,
-          })
-        )
-        .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-        .then(fillOutEmailFirstSignIn(email, PASSWORD))
-        .then(testElementExists(selectors.SETTINGS.HEADER))
-
-        .then(openRP())
-        .then(click(selectors['123DONE'].BUTTON_SIGNIN))
-        .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER))
-        .then(click(selectors['SIGNIN_PASSWORD'].SUBMIT_USE_SIGNED_IN))
-        .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
-        .then(visibleByQSA(selectors['123DONE'].BUTTON_SUBSCRIBE))
-
-        .then(click(selectors['123DONE'].LINK_LOGOUT))
-        .then(visibleByQSA(selectors['123DONE'].BUTTON_SIGNIN))
-
-        .then(subscribeToTestProduct())
-
-        .then(openRP())
-        .then(click(selectors['123DONE'].BUTTON_SIGNIN))
-        .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER))
-        .then(click(selectors['SIGNIN_PASSWORD'].SUBMIT_USE_SIGNED_IN))
-        .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
-        .then(visibleByQSA(selectors['123DONE'].SUBSCRIBED));
+      return this.remote.then(subscribeAndSigninToRp(email));
     },
     'sign up, failed to subscribe due to expired CC': function () {
       if (
@@ -108,17 +75,8 @@ registerSuite('subscriptions', {
             force: true,
           })
         )
-        .then(createUser(email, PASSWORD, { preVerified: true }))
-        .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
-        .then(fillOutEmailFirstSignIn(email, PASSWORD))
-        .then(testElementExists(selectors.SETTINGS.HEADER))
-
-        .then(openRP())
-        .then(click(selectors['123DONE'].BUTTON_SIGNIN))
-        .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER))
-        .then(click(selectors['SIGNIN_PASSWORD'].SUBMIT_USE_SIGNED_IN))
-        .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
-        .then(visibleByQSA(selectors['123DONE'].BUTTON_SUBSCRIBE))
+        .then(createUserAndLoadSettings(email))
+        .then(signInToTestProduct())
 
         .then(click(selectors['123DONE'].LINK_LOGOUT))
         .then(visibleByQSA(selectors['123DONE'].BUTTON_SIGNIN))

--- a/packages/fxa-settings/scripts/test-ci.sh
+++ b/packages/fxa-settings/scripts/test-ci.sh
@@ -17,6 +17,7 @@ yarn workspaces foreach \
     --include fxa-auth-server \
     --include fxa-content-server \
     --include fxa-profile-server \
+    --include fxa-payments-server \
     --include fxa-react \
     --include fxa-settings \
     --include fxa-shared \


### PR DESCRIPTION
## This pull request

- Adds the subscriptions link test back to functional settings v2 tests
- cleans up some duplication around functional tests for settings v2 and content server tests

## Issue that this pull request solves

Closes: #4856 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
