### PR TITLE
chore(tests): remove string helpers from helpersRemoteWrapped and applyRemote

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -2893,7 +2893,10 @@ module.exports = {
 // Export helpers methods in a form that can be easily used in
 // async/await. The usage of the helpers are the same except
 // they expect the last argument to be the intern remote object.
-const fnNames = Object.keys(module.exports);
+const noRemotes = Object.keys(TestHelpers);
+const fnNames = Object.keys(module.exports).filter(
+  (x) => !noRemotes.includes(x)
+);
 const helpersRemoteWrapped = {};
 fnNames.forEach((key) => {
   helpersRemoteWrapped[key] = async function () {


### PR DESCRIPTION
Because:
 - the error might be less confusing when someone tries to use one of those helpers from those returned by `helpersRemoteWrapped` or `applyRemote`
