### PR TITLE
refactor(settings): allow callback override of FlowContainer's back button

### DIFF
--- a/packages/fxa-settings/src/components/FlowContainer/index.test.tsx
+++ b/packages/fxa-settings/src/components/FlowContainer/index.test.tsx
@@ -4,12 +4,22 @@
 
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import FlowContainer from './index';
 import { renderWithRouter } from '../../models/_mocks';
+import { act } from 'react-dom/test-utils';
 
 it('renders', async () => {
   renderWithRouter(<FlowContainer />);
   expect(screen.getByTestId('flow-container')).toBeInTheDocument();
   expect(screen.getByTestId('flow-container-back-btn')).toBeInTheDocument();
+});
+
+it('calls the given on back button click handler', async () => {
+  const cb = jest.fn();
+  renderWithRouter(<FlowContainer onBackButtonClick={cb} />);
+  await act(async () => {
+    fireEvent.click(screen.getByTestId('flow-container-back-btn'));
+  });
+  expect(cb).toBeCalledTimes(1);
 });

--- a/packages/fxa-settings/src/components/FlowContainer/index.tsx
+++ b/packages/fxa-settings/src/components/FlowContainer/index.tsx
@@ -9,12 +9,16 @@ import { ReactComponent as BackArrow } from './back-arrow.svg';
 type FlowContainerProps = {
   title?: string;
   subtitle?: string;
+  onBackButtonClick?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void;
   children?: React.ReactNode;
 };
 
 export const FlowContainer = ({
   title,
   subtitle,
+  onBackButtonClick = () => window.history.back(),
   children,
 }: FlowContainerProps & RouteComponentProps) => {
   return (
@@ -24,7 +28,7 @@ export const FlowContainer = ({
     >
       <div className="flex items-center">
         <button
-          onClick={() => window.history.back()}
+          onClick={onBackButtonClick}
           data-testid="flow-container-back-btn"
           title="Back"
           className="relative w-8 h-8 ltr:-ml-2 rtl:-mr-2 ltr:mr-2 rtl:ml-2 tablet:ltr:mr-10 tablet:rtl:ml-10 tablet:ltr:-ml-18 tablet:rtl:-mr-18"


### PR DESCRIPTION

Because:
 - sometimes popping the browser's history stack isn't what QA or UX
   expects

This commit:
 - allow a callback function to be passed in to handle the click event

## Issue that this pull request solves

Closes: #6937 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
