### PR TITLE
feat(settings): nav backwards on 2fa form

### DIFF
--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.test.tsx
@@ -374,3 +374,37 @@ describe('metrics', () => {
     );
   });
 });
+
+describe('back button', () => {
+  it('goes back a step with the flow container back button', async () => {
+    await act(async () => {
+      render();
+    });
+    await submitTotp('867530');
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('ack-recovery-code'));
+    });
+    await act(async () => {
+      fireEvent.input(screen.getByTestId('recovery-code-input-field'), {
+        target: {
+          value: CREATE_TOTP_MOCK[0].result.data.createTotp.recoveryCodes[0],
+        },
+      });
+    });
+
+    expect(screen.getByTestId('recovery-code-input-field')).toBeInTheDocument();
+
+    // back to step two
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('flow-container-back-btn'));
+    });
+    expect(screen.getByTestId('2fa-recovery-codes')).toBeInTheDocument();
+
+    // back to step one
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('flow-container-back-btn'));
+    });
+    expect(screen.getByTestId('totp-input-field')).toBeInTheDocument();
+    expect(screen.getByTestId('submit-totp')).toBeInTheDocument();
+  });
+});

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -103,6 +103,11 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
     setSubtitle('Step 3 of 3');
   };
 
+  const showQrCodeStep = () => {
+    setTotpVerified(false);
+    setSubtitle('Step 1 of 3');
+  };
+
   const showRecoveryCodes = () => {
     setRecoveryCodesAcknowledged(false);
     setSubtitle('Step 2 of 3');
@@ -180,8 +185,24 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
       logStep2PageViewEvent(`${metricsPreInPostFix}.recovery-codes`);
   }, [totpVerified, recoveryCodesAcknowledged, logStep2PageViewEvent]);
 
+  const moveBack = () => {
+    if (!totpVerified) {
+      return goHome();
+    }
+    if (totpVerified && !recoveryCodesAcknowledged) {
+      return showQrCodeStep();
+    }
+    if (recoveryCodesAcknowledged) {
+      return showRecoveryCodes();
+    }
+    goBack();
+  };
+
   return (
-    <FlowContainer title="Two Step Authentication" {...{ subtitle }}>
+    <FlowContainer
+      title="Two Step Authentication"
+      {...{ subtitle, onBackButtonClick: moveBack }}
+    >
       {alertBar.visible && (
         <AlertBar onDismiss={alertBar.hide} type={alertBar.type}>
           <p data-testid="update-display-name-error">{alertBar.content}</p>
@@ -329,9 +350,9 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
             <button
               type="button"
               className="cta-neutral mx-2 flex-1"
-              onClick={showRecoveryCodes}
+              onClick={goHome}
             >
-              Back
+              Cancel
             </button>
             <button
               type="submit"


### PR DESCRIPTION
Because:
 - the flow container's back button should move the user back a step on
   the 2fa form

This commit:
 - pass a handler to the flow container for the expected back button
   behavior
 - change the form's Back button on step 3 to a Cancel button

## Issue that this pull request solves

Closes: #6898 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
