### PR TITLE
feat(content-server): add new settings opt-out survey

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -222,6 +222,7 @@ const Router = Backbone.Router.extend({
     }),
     'security_events(/)': createViewHandler(SecurityEvents),
     'settings(/)': createViewHandler(SettingsView),
+    'settings/beta_optout(/)': createViewHandler(SettingsView),
     'settings/account_recovery(/)': createChildViewHandler(
       AccountRecoveryView,
       SettingsView

--- a/packages/fxa-content-server/server/config/surveys.json
+++ b/packages/fxa-content-server/server/config/surveys.json
@@ -1,1 +1,11 @@
-[]
+[
+  {
+    "id": "settings-optout",
+    "conditions": {
+      "languages": ["en"]
+    },
+    "rate": 0.1,
+    "view": "settings.beta-optout",
+    "url": "https://survey.alchemer.com/s3/6025756/Settings-Opt-out"
+  }
+]

--- a/packages/fxa-content-server/server/lib/routes/get-frontend.js
+++ b/packages/fxa-content-server/server/lib/routes/get-frontend.js
@@ -64,6 +64,7 @@ module.exports = function () {
     'settings/avatar/camera',
     'settings/avatar/change',
     'settings/avatar/crop',
+    'settings/beta_optout',
     'settings/change_password',
     'settings/clients',
     'settings/clients/disconnect',

--- a/packages/fxa-settings/src/components/HeaderLockup/index.tsx
+++ b/packages/fxa-settings/src/components/HeaderLockup/index.tsx
@@ -40,13 +40,13 @@ export const HeaderLockup = () => {
             <span className="font-bold ltr:mr-2 rtl:ml-2">
               Firefox accounts
             </span>
-            {/* <a
-              href="/settings"
+            <a
+              href="/settings/beta_optout"
               title="classic design link"
               className="cta-base cta-neutral transition-standard text-sm ltr:ml-4 rtl:mr-4 p-2"
             >
               Switch to classic design
-            </a> */}
+            </a>
           </>
         </LogoLockup>
       </a>


### PR DESCRIPTION
Because:
 - we want to learn why people prefer old settings to new

This commit:
 - configure a new settings opt-out survey
 - add a new route on content-server where the survey will be displayed
   to selected users

## Issue that this pull request solves

Closes: #6880 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
