### PR TITLE
task(fxa-content-server): render beta link for en-US

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/settings.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/settings.mustache
@@ -7,7 +7,9 @@
   <header id="fxa-settings-header">
     <div class="header-lockup">
       <h1 id="fxa-manage-account"><span class="fxa-account-title">{{#t}}Firefox Accounts{{/t}}</span></h1>
-      {{! <a href="/beta/settings" class="nu-settings-button">Switch to new design</a> }}
+      {{#showBetaSettingsLink}}
+        <a href="/beta/settings" class="nu-settings-button">Switch to new design</a>
+      {{/showBetaSettingsLink}}
     </div>
     {{#showSignOut}}
       <button id="signout" class="settings-button secondary-button">{{#t}}Sign out{{/t}}</button>

--- a/packages/fxa-content-server/app/scripts/views/settings.js
+++ b/packages/fxa-content-server/app/scripts/views/settings.js
@@ -39,6 +39,8 @@ import TwoStepAuthenticationView from './settings/two_step_authentication';
 import TotpSecretView from './settings/totp_secret';
 import RecoveryCodesView from './settings/recovery_codes';
 
+const RENDER_BETA_SETTINGS_LINK = false;
+
 var PANEL_VIEWS = [
   AvatarView,
   DisplayNameView,
@@ -91,6 +93,9 @@ const View = BaseView.extend({
 
     context.set({
       ccExpired: !!this._ccExpired,
+      showBetaSettingsLink:
+        RENDER_BETA_SETTINGS_LINK &&
+        (navigator.language === 'en' || navigator.language === 'en-US'),
       escapedCcExpiredLinkAttrs: 'href="/subscriptions" class="alert-link"',
       securityEventsVisible: this.displaySecurityEvents(),
       showSignOut:


### PR DESCRIPTION
## This pull request

- Checks for `en-US` before rendering the beta settings link in fxa-content-server

## Issue that this pull request solves

Closes: #6909

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
