### PR TITLE
fix(fxa-settings): add forgotten work in authenticator flow copy

### DIFF
--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -220,7 +220,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
                   className="link-blue"
                   href="https://support.mozilla.org/kb/secure-firefox-account-two-step-authentication"
                 >
-                  these apps
+                  these authentication apps
                 </LinkExternal>
                 .
               </p>


### PR DESCRIPTION
## This pull request

- adds forgotten word to copy of authenticator flow step

## Issue that this pull request solves

Closes: #6888

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
