### PR TITLE
fix(settings): restore the sign out button for OAuth RPs

### DIFF
--- a/packages/fxa-settings/src/components/ConnectedServices/MOCK_SERVICES.js
+++ b/packages/fxa-settings/src/components/ConnectedServices/MOCK_SERVICES.js
@@ -82,7 +82,7 @@ export const DESKTOP_SYNC_MOCKS = [
 const OAUTH_SERVICE_MOCKS = [
   {
     clientId: 'a8c528140153d1c6',
-    deviceId: 'dsalfjsajflkds',
+    deviceId: null,
     sessionTokenId: null,
     refreshTokenId:
       'f0b7dae0043cb07cdb0f1ff160367a0b3214a91f037621e892060d9a146f2d8e',
@@ -106,7 +106,7 @@ const OAUTH_SERVICE_MOCKS = [
   },
   {
     clientId: '802d56ef2a9af9fa',
-    deviceId: 'djflkajlkfsjd',
+    deviceId: null,
     sessionTokenId: null,
     refreshTokenId:
       'f0b7dae0043cb07cdb0f1ff160367a0b3214a91f037621e892060d9a146f2d8e',

--- a/packages/fxa-settings/src/components/ConnectedServices/Service.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/Service.tsx
@@ -13,14 +13,12 @@ export function Service({
   deviceType,
   location,
   lastAccessTimeFormatted,
-  canSignOut,
   handleSignOut,
 }: {
   name: string;
   deviceType: string | null;
   location: DeviceLocation;
   lastAccessTimeFormatted: string;
-  canSignOut: boolean;
   handleSignOut: () => void;
 }) {
   const { city, stateCode, country } = location;
@@ -101,15 +99,13 @@ export function Service({
         </div>
 
         <div className="flex flex-grow w-full mobileLandscape:justify-end mobileLandscape:flex-1">
-          {canSignOut && (
-            <button
-              className="cta-neutral cta-base disabled:cursor-wait whitespace-no-wrap"
-              data-testid="connected-service-sign-out"
-              onClick={handleSignOut}
-            >
-              Sign out
-            </button>
-          )}
+          <button
+            className="cta-neutral cta-base disabled:cursor-wait whitespace-no-wrap"
+            data-testid="connected-service-sign-out"
+            onClick={handleSignOut}
+          >
+            Sign out
+          </button>
         </div>
       </div>
     </div>

--- a/packages/fxa-settings/src/components/ConnectedServices/index.test.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/index.test.tsx
@@ -208,6 +208,17 @@ describe('Connected Services', () => {
     ).toBeNull();
   });
 
+  it('renders the sign out buttons', async () => {
+    renderWithRouter(
+      <MockedCache account={{ attachedClients: MOCK_SERVICES }}>
+        <ConnectedServices />
+      </MockedCache>
+    );
+    expect(
+      await screen.findAllByTestId('connected-service-sign-out')
+    ).toHaveLength(8);
+  });
+
   it('renders proper modal when "sign out" is clicked', async () => {
     renderWithRouter(
       <MockedCache account={{ attachedClients: MOCK_SERVICES }}>

--- a/packages/fxa-settings/src/components/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/index.tsx
@@ -229,13 +229,6 @@ export const ConnectedServices = () => {
                 deviceType: client.deviceType,
                 location: client.location,
                 lastAccessTimeFormatted: client.lastAccessTimeFormatted,
-                // TODO: move this into the AttachedClient model, following the
-                // approach used by old-settings / content-server?
-                // If the client has a deviceId, we know it's a Sync client.
-                // If the client does not have deviceId or clientId, then we
-                // know it's a web session. The user can sign out of either.
-                canSignOut:
-                  !!client.deviceId || (!client.deviceId && !client.clientId),
                 isCurrentSession: client.isCurrentSession,
                 clientId: client.clientId,
                 handleSignOut: () => {


### PR DESCRIPTION
Because:
 - connected OAuth RPs should be able to sign out

This commit:
 - restore the sign out for OAuth RPs


Closes: #6936 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
