### PR TITLE
Restore mobile sync device counts by firing a flow complete event for mobile browsers

### DIFF
--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -317,10 +317,6 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
           // (ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1632635), where
           // we need the 'service' event property to distinguish between sync
           // and browser.
-          //
-          // The service for this event gets special-cased to 'sync' so that it
-          // matches its pre-oauth `/certificate/sign` event.  ref:
-          // https://github.com/mozilla/fxa/pull/6581#issuecomment-702248031
           if (
             scopeSet.contains(OAUTH_SCOPE_OLD_SYNC) &&
             // Desktop requests a profile scope token before adding the device
@@ -328,13 +324,24 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
             // emit this event if the request is for an oldsync scope, not a
             // profile scope. See #6578 for details on the order of API calls
             // made by both desktop and fenix.
-            !scopeSet.contains('profile') &&
-            config.oauth.oldSyncClientIds.includes(request.payload.client_id)
+            !scopeSet.contains('profile')
           ) {
+            // For desktop, the 'service' parameter for this event gets
+            // special-cased to 'sync' so that it matches its pre-oauth
+            // `/certificate/sign` event.
+            // ref: https://github.com/mozilla/fxa/pull/6581#issuecomment-702248031
+            // Otherwise, for mobile browsers, just use the existing client ID
+            // to service name mapping used in the metrics code (see the
+            // OAUTH_CLIENT_IDS config value). #5143
+            const service = config.oauth.oldSyncClientIds.includes(
+              request.payload.client_id
+            )
+              ? 'sync'
+              : request.payload.client_id;
             await request.emitMetricsEvent('account.signed', {
               uid: uid,
               device_id: sessionToken.deviceId,
-              service: 'sync',
+              service,
             });
           }
         } catch (ex) {}

--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -323,6 +323,12 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
           // https://github.com/mozilla/fxa/pull/6581#issuecomment-702248031
           if (
             scopeSet.contains(OAUTH_SCOPE_OLD_SYNC) &&
+            // Desktop requests a profile scope token before adding the device
+            // to the account. To ensure we record accurate device counts, only
+            // emit this event if the request is for an oldsync scope, not a
+            // profile scope. See #6578 for details on the order of API calls
+            // made by both desktop and fenix.
+            !scopeSet.contains('profile') &&
             config.oauth.oldSyncClientIds.includes(request.payload.client_id)
           ) {
             await request.emitMetricsEvent('account.signed', {


### PR DESCRIPTION
When an oauth-based mobile sync device signs in, we're not seeing the corresponding `fxa_login - complete` metrics event that should mark the login, an event which includes the updated count of active sync devices per day for that user. Building on the changes in #6383 and #6581, I think we need to fire the 'account.signed' event when mobile browsers request the oldsync token, which will trigger the flow complete signal that fires the `fxa_login - complete` event (see #6347).

There's also a change here to avoid firing the 'account.signed' event if a 'profile' scoped token is requested, in a first step towards reducing the number of inaccurate device counts recorded in our metrics (see #6578), but I'm thinking we might want to remove that commit, since it's not strictly needed to address #5143 and introduces an unnecessary additional variable.

Refs #6578, fixes #5143.