### PR TITLE
feat(gql-api): add cors

### DIFF
--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -46,6 +46,12 @@ const conf = convict({
       default: 'http://localhost:9000/v1',
     },
   },
+  corsOrigin: {
+    doc: 'Value for the Access-Control-Allow-Origin response header',
+    format: Array,
+    env: 'CORS_ORIGIN',
+    default: ['http://accounts.firefox.com/'],
+  },
   database: {
     mysql: {
       auth: makeMySQLConfig('AUTH', 'fxa'),

--- a/packages/fxa-graphql-api/src/gql/gql.module.ts
+++ b/packages/fxa-graphql-api/src/gql/gql.module.ts
@@ -32,6 +32,8 @@ export const GraphQLConfigFactory = async (
   playground: configService.get<string>('env') !== 'production',
   autoSchemaFile: join(path.dirname(__dirname), './schema.gql'),
   context: ({ req }) => ({ req }),
+  // Disabling cors here allows the cors middleware from NestJS to be applied
+  cors: false,
   uploads: false,
   validationRules: [
     queryComplexity({

--- a/packages/fxa-graphql-api/src/main.ts
+++ b/packages/fxa-graphql-api/src/main.ts
@@ -24,6 +24,13 @@ async function bootstrap() {
     app.use(helmet.hsts({ includeSubDomains: true, maxAge }));
   }
 
+  app.enableCors({
+    origin:
+      Config.getProperties().env === 'development'
+        ? '*'
+        : config.get<string[]>('corsOrigin'),
+  });
+
   // Add sentry as error reporter
   app.useGlobalInterceptors(new SentryInterceptor());
 


### PR DESCRIPTION
Because:

* We want to enforce CORS origin on requests.

This commit:

* Adds a corsOrigin configuration value used the same as in the auth
  server.

Closes #6875

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
