### PR TITLE
refactor(oauth): move /client/{client_id} route

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -62,14 +62,14 @@ async function run(config) {
     config.i18n.supportedLanguages,
     config.i18n.defaultLanguage
   );
-  const oauthdb = require('../lib/oauthdb')(log, config, statsd);
+  const oauthService = require('../lib/oauthdb')(log, config, statsd);
   const profile = require('../lib/profile/client')(log, config, statsd);
   const senders = await require('../lib/senders')(
     log,
     config,
     error,
     translator,
-    oauthdb,
+    oauthService,
     statsd
   );
 
@@ -97,7 +97,7 @@ async function run(config) {
     serverPublicKeys,
     signer,
     database,
-    oauthdb,
+    oauthService,
     senders.email,
     senders.sms,
     Password,
@@ -117,7 +117,7 @@ async function run(config) {
     config,
     routes,
     database,
-    oauthdb,
+    oauthService,
     translator,
     statsd
   );
@@ -141,7 +141,7 @@ async function run(config) {
       log.info('shutdown', 'gracefully');
       await server.stop();
       await customs.close();
-      oauthdb.close();
+      oauthService.close();
       statsd.close();
       try {
         senders.email.stop();

--- a/packages/fxa-auth-server/lib/routes/oauth/client/get.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/client/get.js
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const hex = require('buf').to.hex;
+const Joi = require('@hapi/joi');
+
+const AppError = require('../../../oauth/error');
+const validators = require('../../../oauth/validators');
+
+module.exports = ({ log, oauthDB }) => ({
+  method: 'GET',
+  path: '/client/{client_id}',
+  config: {
+    validate: {
+      params: {
+        client_id: validators.clientId,
+      },
+    },
+    response: {
+      schema: {
+        id: validators.clientId,
+        name: Joi.string().required(),
+        trusted: Joi.boolean().required(),
+        image_uri: Joi.any(),
+        redirect_uri: Joi.string().required().allow(''),
+      },
+    },
+    handler: async function requestInfoEndpoint(req) {
+      const params = req.params;
+
+      return oauthDB
+        .getClient(Buffer.from(params.client_id, 'hex'))
+        .then(function (client) {
+          if (!client) {
+            log.debug('notFound', { id: params.client_id });
+            throw AppError.unknownClient(params.client_id);
+          } else {
+            return {
+              id: hex(client.id),
+              name: client.name,
+              trusted: client.trusted,
+              image_uri: client.imageUri,
+              redirect_uri: client.redirectUri,
+            };
+          }
+        });
+    },
+  },
+});

--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -1,7 +1,9 @@
+const oauthDB = require('../../oauth/db/');
 const proxied = require('./proxied');
 
-module.exports = (log, config, oauthdb, db, mailer, devices) => {
-  const routes = proxied(log, config, oauthdb, db, mailer, devices);
-  routes.push(require('./verify')(log));
+module.exports = (log, config, oauthService, db, mailer, devices) => {
+  const routes = proxied(log, config, oauthService, db, mailer, devices);
+  routes.push(require('./client/get')({ log, oauthDB }));
+  routes.push(require('./verify')({ log }));
   return routes;
 };

--- a/packages/fxa-auth-server/lib/routes/oauth/verify.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/verify.js
@@ -7,7 +7,7 @@ const Joi = require('@hapi/joi');
 const token = require('../../oauth/token');
 const validators = require('../../oauth/validators');
 
-module.exports = (log) => ({
+module.exports = ({ log }) => ({
   method: 'POST',
   path: '/verify',
   config: {

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -23,8 +23,12 @@ const UTM_PREFIX = 'fx-';
 const X_SES_CONFIGURATION_SET = 'X-SES-CONFIGURATION-SET';
 const X_SES_MESSAGE_TAGS = 'X-SES-MESSAGE-TAGS';
 
-module.exports = function (log, config, oauthdb) {
-  const oauthClientInfo = require('./oauth_client_info')(log, config, oauthdb);
+module.exports = function (log, config, oauthService) {
+  const oauthClientInfo = require('./oauth_client_info')(
+    log,
+    config,
+    oauthService
+  );
   const verificationReminders = require('../verification-reminders')(
     log,
     config

--- a/packages/fxa-auth-server/lib/senders/index.js
+++ b/packages/fxa-auth-server/lib/senders/index.js
@@ -12,12 +12,12 @@ module.exports = async (
   config,
   error,
   translator,
-  oauthdb,
+  oauthService,
   statsd,
   sender // This is only used in tests
 ) => {
   const defaultLanguage = config.i18n.defaultLanguage;
-  const Mailer = createMailer(log, config, oauthdb);
+  const Mailer = createMailer(log, config, oauthService);
 
   async function createSenders() {
     const templates = await require('./templates')(log, translator);

--- a/packages/fxa-auth-server/lib/senders/oauth_client_info.js
+++ b/packages/fxa-auth-server/lib/senders/oauth_client_info.js
@@ -6,7 +6,7 @@
 
 const Keyv = require('keyv');
 
-module.exports = (log, config, oauthdb) => {
+module.exports = (log, config, oauthService) => {
   const OAUTH_CLIENT_INFO_CACHE_TTL = config.oauth.clientInfoCacheTTL;
   const OAUTH_CLIENT_INFO_CACHE_NAMESPACE = 'oauthClientInfo';
   const FIREFOX_CLIENT = {
@@ -41,7 +41,7 @@ module.exports = (log, config, oauthdb) => {
 
     let clientInfo;
     try {
-      clientInfo = await oauthdb.getClientInfo(clientId);
+      clientInfo = await oauthService.getClientInfo(clientId);
     } catch (err) {
       // fallback to the Firefox client if request fails
       if (!err.statusCode) {

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -59,7 +59,7 @@ async function create(
   config,
   routes,
   db,
-  oauthdb,
+  oauthService,
   translator,
   statsd
 ) {
@@ -359,7 +359,7 @@ async function create(
 
   server.auth.scheme(
     'fxa-oauth-refreshToken',
-    schemeRefreshToken(config, db, oauthdb)
+    schemeRefreshToken(config, db, oauthService)
   );
 
   server.auth.strategy('refreshToken', 'fxa-oauth-refreshToken');


### PR DESCRIPTION
Because:
 - we want less indirection with our OAuth routes

This commit:
 - move the /client/{client_id} route


## Issue that this pull request solves

Closes: #7054 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

