### PR TITLE
fix: capture GraphQL errors in field resolvers

### DIFF
--- a/packages/fxa-admin-server/src/app.module.ts
+++ b/packages/fxa-admin-server/src/app.module.ts
@@ -7,6 +7,7 @@ import { GraphQLModule } from '@nestjs/graphql';
 import { HealthModule } from 'fxa-shared/nestjs/health/health.module';
 import { LoggerModule } from 'fxa-shared/nestjs/logger/logger.module';
 import { SentryModule } from 'fxa-shared/nestjs/sentry/sentry.module';
+import { SentryPlugin } from 'fxa-shared/nestjs/sentry/sentry.plugin';
 import { getVersionInfo } from 'fxa-shared/nestjs/version';
 import { join } from 'path';
 
@@ -26,7 +27,7 @@ const version = getVersionInfo(__dirname);
     DatabaseModule,
     GqlModule,
     GraphQLModule.forRootAsync({
-      imports: [ConfigModule],
+      imports: [ConfigModule, SentryModule],
       inject: [ConfigService],
       useFactory: async (configService: ConfigService) => ({
         path: '/graphql',
@@ -35,6 +36,7 @@ const version = getVersionInfo(__dirname);
         playground: configService.get<string>('env') !== 'production',
         autoSchemaFile: join(__dirname, './schema.gql'),
         context: ({ req }) => ({ req }),
+        plugins: [SentryPlugin],
       }),
     }),
     HealthModule.forRootAsync({

--- a/packages/fxa-graphql-api/src/app.module.ts
+++ b/packages/fxa-graphql-api/src/app.module.ts
@@ -30,7 +30,7 @@ const version = getVersionInfo(__dirname);
     DatabaseModule,
     GqlModule,
     GraphQLModule.forRootAsync({
-      imports: [ConfigModule, LoggerModule],
+      imports: [ConfigModule, LoggerModule, SentryModule],
       inject: [ConfigService, MozLoggerService],
       useFactory: GraphQLConfigFactory,
     }),

--- a/packages/fxa-graphql-api/src/gql/gql.module.ts
+++ b/packages/fxa-graphql-api/src/gql/gql.module.ts
@@ -5,6 +5,7 @@ import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GqlModuleOptions } from '@nestjs/graphql';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
+import { SentryPlugin } from 'fxa-shared/nestjs/sentry/sentry.plugin';
 import queryComplexity, { simpleEstimator } from 'graphql-query-complexity';
 import { graphqlUploadExpress } from 'graphql-upload';
 import path, { join } from 'path';
@@ -35,6 +36,7 @@ export const GraphQLConfigFactory = async (
   // Disabling cors here allows the cors middleware from NestJS to be applied
   cors: false,
   uploads: false,
+  plugins: [SentryPlugin],
   validationRules: [
     queryComplexity({
       estimators: [simpleEstimator({ defaultComplexity: 1 })],

--- a/packages/fxa-shared/nestjs/sentry/reporting.ts
+++ b/packages/fxa-shared/nestjs/sentry/reporting.ts
@@ -118,10 +118,14 @@ export function captureSqsError(err: Error, message?: SQS.Message): void {
  * @param request A request object if available.
  */
 export function reportRequestException(
-  exception: Error,
+  exception: Error & { reported?: boolean },
   excContexts: ExtraContext[] = [],
   request?: Request
 ) {
+  // Don't report already reported exceptions
+  if (exception.reported) {
+    return;
+  }
   Sentry.withScope((scope: Sentry.Scope) => {
     scope.addEventProcessor((event: Sentry.Event) => {
       if (request) {
@@ -135,6 +139,7 @@ export function reportRequestException(
       scope.setContext(ctx.name, ctx.fieldData);
     }
     Sentry.captureException(exception);
+    exception.reported = true;
   });
 }
 

--- a/packages/fxa-shared/nestjs/sentry/sentry.plugin.ts
+++ b/packages/fxa-shared/nestjs/sentry/sentry.plugin.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/**
+ * Apollo-Server plugin for Sentry
+ *
+ * Modeled after:
+ *   https://blog.sentry.io/2020/07/22/handling-graphql-errors-using-sentry
+ *
+ * This makes the following assumptions about the Apollo Server setup:
+ *   1. The request object to Apollo's context as `.req`.
+ *   2. `SentryPlugin` is passed in the `plugins` option.
+ */
+import { ApolloError } from 'apollo-server';
+
+import { ExtraContext, reportRequestException } from './reporting';
+
+export const SentryPlugin = {
+  requestDidStart(requestContext: any) {
+    return {
+      didEncounterErrors(ctx: any) {
+        // If we couldn't parse the operation, don't
+        // do anything here
+        if (!ctx.operation) {
+          return;
+        }
+        for (const err of ctx.errors) {
+          // Only report internal server errors,
+          // all errors extending ApolloError should be user-facing
+          if (err instanceof ApolloError) {
+            continue;
+          }
+          // Skip errors with a status already set or already reported
+          if (err.originalError?.status) {
+            continue;
+          }
+          const excContexts: ExtraContext[] = [];
+          excContexts.push({
+            name: 'graphql',
+            fieldData: {
+              path: err.path.join(' > '),
+            },
+          });
+          reportRequestException(
+            err.originalError ?? err,
+            excContexts,
+            ctx.context.req
+          );
+        }
+      },
+    };
+  },
+};

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -82,6 +82,7 @@
     "@types/js-md5": "^0.4.2",
     "accept-language": "^2.0.17",
     "ajv": "^6.12.2",
+    "apollo-server": "^2.19.0",
     "aws-sdk": "^2.752.0",
     "bluebird": "^3.7.2",
     "celebrate": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18808,6 +18808,7 @@ fsevents@^1.2.7:
     "@types/sinon": 9.0.8
     accept-language: ^2.0.17
     ajv: ^6.12.2
+    apollo-server: ^2.19.0
     audit-filter: ^0.5.0
     aws-sdk: ^2.752.0
     bluebird: ^3.7.2


### PR DESCRIPTION
Because:

* Interceptors for NestJS do not capture field resolvers due to how
  apollo-server runs the query/mutation before then running separate
  queries to resolve fields.

This commit:

* Hooks into an apollo-server request lifecycle hook made for error
  reporting to accurately report errors to Sentry that occur when
  resolving fields.

Closes #7059

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
