### PR TITLE
task(fxa-content-server): account for legal-docs new format

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,5 +440,5 @@ _Pre-requisites_: The script requires that you have pandoc and LaTeX installed o
 The script will check that pandoc is installed before asking you for the file or directory on your machine that you would like to be converted. If a directory is provided, then all markdown files within that folder will be convered. If a single file is provided, only that file will be converted.
 The resulting output will be stored within `assets/legal`.
 Example:
-file provided to convert: `/Users/test/github/mozilla/legal-docs/firefox_cloud_services_ToS/en-US.md`
-resulting file: `assets/legal/firefox_cloud_services_ToS/en-US.pdf`
+file provided to convert: `/Users/test/github/mozilla/legal-docs/en/firefox_cloud_services_tos.md`
+resulting file: `assets/legal/en/firefox_cloud_services_tos.pdf`

--- a/_scripts/legal-md-to-pdf.sh
+++ b/_scripts/legal-md-to-pdf.sh
@@ -12,11 +12,11 @@
 # The resulting output will be stored within `assets/legal`.
 #
 # Examples:
-# file provided to convert: `/Users/test/github/mozilla/legal-docs/firefox_cloud_services_ToS/en-US.md`
-# resulting file: `assets/legal/firefox_cloud_services_ToS/en-US.pdf`
+# file provided to convert: `/Users/test/github/mozilla/legal-docs/en/firefox_cloud_services_tos.md`
+# resulting file: `assets/legal/en/firefox_cloud_services_tos/en-US.pdf`
 #
-# directory provided to convert: `/Users/test/github/mozilla/legal-docs/firefox_cloud_services_ToS`
-# resulting files: `assets/legal/firefox_cloud_services_ToS/*.pdf`
+# directory provided to convert: `/Users/test/github/mozilla/legal-docs/en`
+# resulting files: `assets/legal/en/*.pdf`
 
 
 legalpath=

--- a/packages/fxa-content-server/grunttasks/clean.js
+++ b/packages/fxa-content-server/grunttasks/clean.js
@@ -37,7 +37,10 @@ module.exports = function (grunt) {
       files: [
         {
           dot: true,
-          src: ['<%= yeoman.pp_html_dest %>', '<%= yeoman.tos_html_dest %>'],
+          src: [
+            '<%= yeoman.page_template_dist %>/**/privacy.html',
+            '<%= yeoman.page_template_dist %>/**/terms.html',
+          ],
         },
       ],
     },

--- a/packages/fxa-content-server/grunttasks/copy.js
+++ b/packages/fxa-content-server/grunttasks/copy.js
@@ -86,26 +86,10 @@ module.exports = function (grunt) {
       //eslint-disable-line camelcase
       // The legal repo use es-ES but we (in accordance with Verbatim) use es,
       // so copy es-ES templates to es
-      files: [
-        {
-          expand: true,
-          cwd: '<%= yeoman.tos_html_dest %>',
-          dest: '<%= yeoman.tos_html_dest %>',
-          src: 'es_ES.html',
-          rename: function (dest) {
-            return dest + '/es.html';
-          },
-        },
-        {
-          expand: true,
-          cwd: '<%= yeoman.pp_html_dest %>',
-          dest: '<%= yeoman.pp_html_dest %>',
-          src: 'es_ES.html',
-          rename: function (dest) {
-            return dest + '/es.html';
-          },
-        },
-      ],
+      expand: true,
+      cwd: '<%= yeoman.page_template_dist %>/es_ES/',
+      dest: '<%= yeoman.page_template_dist %>/es/',
+      src: ['*', '**'],
     },
   });
 };

--- a/packages/fxa-content-server/grunttasks/remarkable.js
+++ b/packages/fxa-content-server/grunttasks/remarkable.js
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var path = require('path');
-var i18n = require('i18n-abide');
+const path = require('path');
+const i18n = require('i18n-abide');
 
 module.exports = function (grunt) {
   // convert localized TOS/PP agreements from markdown to html partials.
@@ -12,7 +12,15 @@ module.exports = function (grunt) {
     // Normalize the filenames to use the locale name.
     // add the extension here, instead of using grunt-remarkable's
     // extension generator, to get locale names in uppercase
-    return path.join(destPath, i18n.localeFrom(destFile) + '.html');
+    const lang = i18n.localeFrom(destFile.split('/')[0]);
+
+    if (destFile.includes('privacy')) {
+      return path.join(destPath, lang, 'privacy.html');
+    } else if (destFile.includes('tos')) {
+      return path.join(destPath, lang, 'terms.html');
+    } else {
+      return path.join(destPath, i18n.localeFrom(destFile) + '.html');
+    }
   }
 
   grunt.config('remarkable', {
@@ -27,19 +35,19 @@ module.exports = function (grunt) {
       files: [
         {
           cwd: '<%= yeoman.pp_md_src %>',
-          dest: '<%= yeoman.pp_html_dest %>',
+          dest: '<%= yeoman.page_template_dist %>',
           expand: true,
-          ext: '',
+          ext: '.html',
+          src: ['**/firefox_privacy_notice.md'],
           rename: rename,
-          src: ['**/*.md'],
         },
         {
           cwd: '<%= yeoman.tos_md_src %>',
-          dest: '<%= yeoman.tos_html_dest %>',
+          dest: '<%= yeoman.page_template_dist %>',
           expand: true,
-          ext: '',
+          ext: '.html',
+          src: ['**/firefox_cloud_services_tos.md'],
           rename: rename,
-          src: ['**/*.md'],
         },
       ],
     },

--- a/packages/fxa-content-server/grunttasks/replace.js
+++ b/packages/fxa-content-server/grunttasks/replace.js
@@ -21,7 +21,7 @@ module.exports = function (grunt) {
           // such as `    [`, this creates a <code> block when parsed by remarkable
           // to avoid that we remove the indent spaces
 
-          // ref: https://github.com/mozilla/legal-docs/blob/master/firefox_privacy_notice/en-US.md
+          // ref: https://github.com/mozilla/legal-docs/blob/master/en/firefox_privacy_notice.md
           from: /^ {4}/gm,
           to: '',
         },

--- a/packages/fxa-content-server/grunttasks/yeoman.js
+++ b/packages/fxa-content-server/grunttasks/yeoman.js
@@ -2,12 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// const { dirname } = require('path');
+const { dirname } = require('path');
 
 module.exports = function (grunt) {
   const TEMP_DIR = '.tmp';
   const TEMPLATE_ROOT = 'server/templates';
-  const TOS_PP_REPO_ROOT = '../../node_modules/legal-docs'; //dirname(require.resolve('legal-docs'));
+  const LEGAL_DOCS_ROOT = dirname(require.resolve('legal-docs/package.json'));
 
   grunt.config('yeoman', {
     /*eslint-disable camelcase */
@@ -16,16 +16,14 @@ module.exports = function (grunt) {
     es5: '.es5',
     page_template_dist: TEMPLATE_ROOT + '/pages/dist',
     page_template_src: TEMPLATE_ROOT + '/pages/src',
-    pp_html_dest: TEMPLATE_ROOT + '/pages/dist/privacy',
-    pp_md_src: TOS_PP_REPO_ROOT + '/firefox_privacy_notice/',
+    pp_md_src: LEGAL_DOCS_ROOT,
     server: 'server',
     strings_dist: 'locale',
     strings_src: 'fxa-content-server-l10n/locale',
     tests: 'tests',
     tmp: TEMP_DIR,
-    tos_html_dest: TEMPLATE_ROOT + '/pages/dist/terms',
-    tos_md_src: TOS_PP_REPO_ROOT + '/firefox_cloud_services_ToS/',
+    tos_md_src: LEGAL_DOCS_ROOT,
     // Translated TOS/PP agreements.
-    tos_pp_repo_dest: TOS_PP_REPO_ROOT,
+    tos_pp_repo_dest: LEGAL_DOCS_ROOT,
   });
 };

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -100,7 +100,7 @@
     "jquery-ui-touch-punch-amd": "1.0.1",
     "js-md5": "0.6.0",
     "jsxgettext-recursive-next": "1.1.0",
-    "legal-docs": "git://github.com/mozilla/legal-docs.git#192bc493988026c4ebd065132a0796548fb3431e",
+    "legal-docs": "git://github.com/mozilla/legal-docs.git#9769a9f31cd5c32945b37509fb94c01b63e5f5d2",
     "load-grunt-tasks": "^5.1.0",
     "lodash": "^4.17.19",
     "mkdirp": "0.5.1",

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -289,7 +289,7 @@ const conf = (module.exports = convict({
       format: String,
     },
     defaultLegalLang: {
-      default: 'en-US',
+      default: 'en',
       doc: 'The default language to use for legal (tos, pp) templates',
       format: String,
     },

--- a/packages/fxa-content-server/server/lib/legal-templates.js
+++ b/packages/fxa-content-server/server/lib/legal-templates.js
@@ -8,20 +8,13 @@ const path = require('path');
 const logger = require('./logging/log')('legal-templates');
 
 module.exports = function (i18n, root) {
-  const TOS_ROOT_PATH = path.join(root, 'terms');
-  const PP_ROOT_PATH = path.join(root, 'privacy');
-
-  function getRoot(type) {
-    return type === 'terms' ? TOS_ROOT_PATH : PP_ROOT_PATH;
-  }
-
   const templateCache = {};
   function getTemplate(type, lang, defaultLang, defaultLegalLang) {
     const DEFAULT_LOCALE = i18n.localeFrom(defaultLegalLang);
 
     // Filenames are normalized to locale, not language.
     const locale = i18n.localeFrom(lang);
-    const templatePath = path.join(getRoot(type), locale + '.html');
+    const templatePath = path.join(root, locale, type + '.html');
 
     return new Promise(function (resolve, reject) {
       // cache the promises to avoid multiple concurrent checks for
@@ -30,8 +23,8 @@ module.exports = function (i18n, root) {
         return resolve(templateCache[templatePath]);
       }
 
-      fs.exists(templatePath, function (exists) {
-        if (!exists) {
+      fs.stat(templatePath, function (err) {
+        if (err) {
           let bestLang = i18n.bestLanguage(i18n.parseAcceptLanguage(lang));
           // If bestLang resolves to the default lang, replace it with
           // the default legal lang since they may differ. E.g. en-US

--- a/yarn.lock
+++ b/yarn.lock
@@ -17875,7 +17875,7 @@ fsevents@^1.2.7:
     js-md5: 0.6.0
     jsqr: 1.2.0
     jsxgettext-recursive-next: 1.1.0
-    legal-docs: "git://github.com/mozilla/legal-docs.git"
+    legal-docs: "git://github.com/mozilla/legal-docs.git#9769a9f31cd5c32945b37509fb94c01b63e5f5d2"
     load-grunt-tasks: ^5.1.0
     lodash: ^4.17.19
     mkdirp: 0.5.1
@@ -24201,7 +24201,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"legal-docs@git://github.com/mozilla/legal-docs.git":
+"legal-docs@git://github.com/mozilla/legal-docs.git#9769a9f31cd5c32945b37509fb94c01b63e5f5d2":
   version: 1.0.0
   resolution: "legal-docs@git://github.com/mozilla/legal-docs.git#commit=9769a9f31cd5c32945b37509fb94c01b63e5f5d2"
   checksum: 0f2ab3408302a04757592c6fa41f0ec23e3bad8eac25446ef26204eff19ea9183ec658259c59e16925c6b0d76b0c774b80ada8fbc3be594144c45da90123e612

--- a/yarn.lock
+++ b/yarn.lock
@@ -17875,7 +17875,7 @@ fsevents@^1.2.7:
     js-md5: 0.6.0
     jsqr: 1.2.0
     jsxgettext-recursive-next: 1.1.0
-    legal-docs: "git://github.com/mozilla/legal-docs.git#192bc493988026c4ebd065132a0796548fb3431e"
+    legal-docs: "git://github.com/mozilla/legal-docs.git"
     load-grunt-tasks: ^5.1.0
     lodash: ^4.17.19
     mkdirp: 0.5.1
@@ -24201,10 +24201,10 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"legal-docs@git://github.com/mozilla/legal-docs.git#192bc493988026c4ebd065132a0796548fb3431e":
+"legal-docs@git://github.com/mozilla/legal-docs.git":
   version: 1.0.0
-  resolution: "legal-docs@git://github.com/mozilla/legal-docs.git#commit=192bc493988026c4ebd065132a0796548fb3431e"
-  checksum: 6147ac3cdcc21cc2516c7dba2c4bc69ad8015b88645936b8d3b72f19f250d6929121d5ef247eda2f6e04f5b3a1f7388dc213777d35ef726b08fc57fc8f6280e9
+  resolution: "legal-docs@git://github.com/mozilla/legal-docs.git#commit=9769a9f31cd5c32945b37509fb94c01b63e5f5d2"
+  checksum: 0f2ab3408302a04757592c6fa41f0ec23e3bad8eac25446ef26204eff19ea9183ec658259c59e16925c6b0d76b0c774b80ada8fbc3be594144c45da90123e612
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## This pull request

- update scripts to account for legal-docs repo changes coming in https://github.com/mozilla/legal-docs/pull/1502

## Issue that this pull request solves

Closes: #6902 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

For testing you'll need to update the `legal-docs` dependency to point to the restructured commit, linked above.
