### PR TITLE
chore(fxa-content-server): apply the MX record validation feature flag to the validate-email-domain endpoint

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/email-domain-validator.js
+++ b/packages/fxa-content-server/app/scripts/lib/email-domain-validator.js
@@ -120,6 +120,9 @@ const checkEmailDomain = ($element, view) => {
           return reject(REJECTION_CODE);
         }
 
+        if (result === 'skip') {
+          return resolve();
+        }
         showInvalidDomainError(domain);
         view.logFlowEvent('email-domain-validation.block');
         reject(REJECTION_CODE);

--- a/packages/fxa-content-server/app/tests/spec/lib/email-domain-validator.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/email-domain-validator.js
@@ -134,7 +134,17 @@ describe('lib/email-domain-validator', () => {
       xhr.ajax.restore();
     });
   });
-
+  it('should resolve on a sucessful skip record', () => {
+    sinon.stub(xhr, 'ajax').returns(Promise.resolve({ result: 'skip' }));
+    $el.val('quuz@great.skip.co.gd');
+    return checkEmailDomain($el, view)
+      .then(() => {
+        xhr.ajax.restore();
+      })
+      .catch(() => {
+        assert.fail('validation should have been skipped');
+      });
+  });
   it('should reject and show a tooltip on a successful A record lookup', () => {
     sinon.stub(xhr, 'ajax').returns(Promise.resolve({ result: 'A' }));
     const renderSpy = sinon.spy(Tooltip.prototype, 'render');

--- a/packages/fxa-content-server/server/lib/routes.js
+++ b/packages/fxa-content-server/server/lib/routes.js
@@ -31,7 +31,7 @@ module.exports = function (config, i18n) {
     require('./routes/redirect-download-firefox')(config),
     require('./routes/redirect-m-to-adjust')(config),
     require('./routes/get-500')(config),
-    require('./routes/validate-email-domain')(),
+    require('./routes/validate-email-domain')(config),
   ];
 
   if (config.get('csp.enabled')) {

--- a/packages/fxa-content-server/tests/server/routes/validate-email-domain.js
+++ b/packages/fxa-content-server/tests/server/routes/validate-email-domain.js
@@ -50,14 +50,26 @@ registerSuite('routes/validate-email-domain', {
         const validateEmailDomainRoute = proxyquireWithDns(dns);
         const req = { query: { domain: 'abc.xyz' } };
         const res = { json: sinon.stub() };
-        const route = validateEmailDomainRoute();
+        const route = validateEmailDomainRoute({
+          get: sinon.stub().returns(true),
+        });
 
         return route.process(req, res).then(() => {
           assert.isTrue(resolveMxStub.calledOnceWith('abc.xyz'));
           assert.isTrue(res.json.calledOnceWith({ result: 'MX' }));
         });
       },
-
+      'responds with {result: skip} when there is a skip record': () => {
+        const validateEmailDomainRoute = require('../../../server/lib/routes/validate-email-domain');
+        const req = { query: { domain: 'skip.abc.xyz' } };
+        const res = { json: sinon.stub() };
+        const route = validateEmailDomainRoute({
+          get: sinon.stub().returns(false),
+        });
+        return route.process(req, res).then(() => {
+          assert.isTrue(res.json.calledOnceWith({ result: 'skip' }));
+        });
+      },
       'responds with {result: "A"} when there is an A record': () => {
         const resolveMxStub = sinon.stub().resolves([]);
         const resolve4Stub = sinon.stub().resolves(['abc.xyz']);
@@ -74,7 +86,9 @@ registerSuite('routes/validate-email-domain', {
         const validateEmailDomainRoute = proxyquireWithDns(dns);
         const req = { query: { domain: 'abc.xyz' } };
         const res = { json: sinon.stub() };
-        const route = validateEmailDomainRoute();
+        const route = validateEmailDomainRoute({
+          get: sinon.stub().returns(true),
+        });
 
         return route.process(req, res).then(() => {
           assert.isTrue(resolveMxStub.calledOnceWith('abc.xyz'));
@@ -99,7 +113,9 @@ registerSuite('routes/validate-email-domain', {
         const validateEmailDomainRoute = proxyquireWithDns(dns);
         const req = { query: { domain: 'abc.xyz' } };
         const res = { json: sinon.stub() };
-        const route = validateEmailDomainRoute();
+        const route = validateEmailDomainRoute({
+          get: sinon.stub().returns(true),
+        });
 
         return route.process(req, res).then(() => {
           assert.isTrue(resolveMxStub.calledOnceWith('abc.xyz'));
@@ -128,7 +144,9 @@ registerSuite('routes/validate-email-domain', {
         const validateEmailDomainRoute = proxyquireWithDns(dns);
         const req = { query: { domain: 'abc.xyz' } };
         const res = { json: sinon.stub() };
-        const route = validateEmailDomainRoute();
+        const route = validateEmailDomainRoute({
+          get: sinon.stub().returns('true'),
+        });
 
         return route.process(req, res).then(() => {
           assert.isTrue(resolveMxStub.calledOnceWith('abc.xyz'));
@@ -155,7 +173,9 @@ registerSuite('routes/validate-email-domain', {
         const req = { query: { domain: 'abc.xyz' } };
         const res = { json: sinon.stub() };
         const next = sinon.stub();
-        const route = validateEmailDomainRoute();
+        const route = validateEmailDomainRoute({
+          get: sinon.stub().returns(true),
+        });
 
         return route.process(req, res, next).then(() => {
           assert.isTrue(resolveMxStub.calledOnceWith('abc.xyz'));
@@ -182,7 +202,9 @@ registerSuite('routes/validate-email-domain', {
         const req = { query: { domain: 'abc.xyz' } };
         const res = { json: sinon.stub() };
         const next = sinon.stub();
-        const route = validateEmailDomainRoute();
+        const route = validateEmailDomainRoute({
+          get: sinon.stub().returns(true),
+        });
 
         return route.process(req, res, next).then(() => {
           assert.isFalse(next.calledWith(error));


### PR DESCRIPTION


## Because

-

## This pull request

-

## Issue that this pull request solves

Closes: #5896 
## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
@chenba 
Fixxed all the requirements in the fxa-content-server for both the front and backend. As well added the required test cases in both the front and backend . Also one more question that I am unable to add the reviewers  since I am missing the reviewers section. Maybe I don't have the required permissions.
![Screenshot from 2020-12-05 16-52-28](https://user-images.githubusercontent.com/56436023/101241244-51717700-371a-11eb-99b1-71444c5c6cc9.png)
