### PR TITLE
feat(gql-api): add customs check on query/mutations

### DIFF
--- a/packages/fxa-auth-client/server.ts
+++ b/packages/fxa-auth-client/server.ts
@@ -24,3 +24,4 @@ global.btoa = btoa;
 
 export default AuthClient;
 export * from './lib/client';
+export * from './lib/hawk';

--- a/packages/fxa-graphql-api/pm2.config.js
+++ b/packages/fxa-graphql-api/pm2.config.js
@@ -20,6 +20,7 @@ module.exports = {
         TS_NODE_TRANSPILE_ONLY: 'true',
         TS_NODE_FILES: 'true',
         PORT: '8290', // TODO: this needs to get added to src/config.ts
+        CUSTOMS_SERVER_URL: 'none',
       },
       filter_env: ['npm_'],
       watch: ['src'],

--- a/packages/fxa-graphql-api/src/auth/auth.module.ts
+++ b/packages/fxa-graphql-api/src/auth/auth.module.ts
@@ -3,16 +3,26 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Module } from '@nestjs/common';
 import { PassportModule } from '@nestjs/passport';
+import { CustomsModule } from 'fxa-shared/nestjs/customs/customs.module';
+import { CustomsService } from 'fxa-shared/nestjs/customs/customs.service';
 
 import { AuthClientFactory } from '../backend/auth-client.service';
 import { BackendModule } from '../backend/backend.module';
+import { GqlCustomsGuard } from './gql-customs.guard';
 import { SessionTokenStrategy } from './session-token.strategy';
 
 @Module({
   imports: [
     BackendModule,
+    CustomsModule,
     PassportModule.register({ defaultStrategy: 'bearer' }),
   ],
-  providers: [AuthClientFactory, SessionTokenStrategy],
+  providers: [
+    AuthClientFactory,
+    CustomsService,
+    SessionTokenStrategy,
+    GqlCustomsGuard,
+  ],
+  exports: [GqlCustomsGuard],
 })
 export class AuthModule {}

--- a/packages/fxa-graphql-api/src/auth/gql-customs.guard.ts
+++ b/packages/fxa-graphql-api/src/auth/gql-customs.guard.ts
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+import { Request } from 'express';
+import { CustomsService } from 'fxa-shared/nestjs/customs/customs.service';
+
+import { SessionTokenResult } from './session-token.strategy';
+
+@Injectable()
+export class GqlCustomsGuard implements CanActivate {
+  constructor(private customs: CustomsService) {
+    if (!customs) {
+      throw new Error('No customs service provided.');
+    }
+  }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const ctx = GqlExecutionContext.create(context);
+    const req = ctx.getContext().req as Request;
+    const { email } = (req.user as SessionTokenResult).session;
+    const handlerName = context.getHandler().name;
+    const className = (context as any).constructorRef.name;
+    const customsName = [className, handlerName].join('.');
+    await this.customs.check({
+      action: customsName,
+      email,
+      ip: req.ip,
+      headers: req.headers,
+      query: req.query,
+    });
+    return true;
+  }
+}

--- a/packages/fxa-graphql-api/src/auth/session-token.strategy.spec.ts
+++ b/packages/fxa-graphql-api/src/auth/session-token.strategy.spec.ts
@@ -1,17 +1,26 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { SessionTokenStrategy } from './session-token.strategy';
 import { UnauthorizedException } from '@nestjs/common';
 import { ExtendedError } from 'fxa-shared/nestjs/error';
 
+let mockSession = {
+  sessionTokenData: jest.fn(),
+};
+let mockAuthClient = {
+  deriveHawkCredentials: jest.fn(),
+};
+jest.mock('fxa-auth-client', () => mockAuthClient);
+jest.mock('fxa-shared/db/models/auth', () => mockSession);
+
+import { SessionTokenStrategy } from './session-token.strategy';
+
 describe('SessionTokenStrategy', () => {
   let strategy: SessionTokenStrategy;
-  let authClient: any;
 
   beforeEach(async () => {
-    authClient = {};
-    strategy = new SessionTokenStrategy(authClient);
+    jest.clearAllMocks();
+    strategy = new SessionTokenStrategy();
   });
 
   it('should be defined', () => {
@@ -19,24 +28,26 @@ describe('SessionTokenStrategy', () => {
   });
 
   it('returns the session status', async () => {
-    authClient.sessionStatus = jest.fn().mockResolvedValue('sessiondata');
+    mockSession.sessionTokenData.mockResolvedValue({ tokenVerified: true });
+    mockAuthClient.deriveHawkCredentials.mockResolvedValue({ id: 'testid' });
     const result = await strategy.validate('token');
-    expect(result).toStrictEqual({ token: 'token', session: 'sessiondata' });
+    expect(result).toStrictEqual({
+      token: 'token',
+      session: { tokenVerified: true },
+    });
   });
 
   it('throws unauthorized', async () => {
-    authClient.sessionStatus = jest
-      .fn()
-      .mockRejectedValue({ code: 400, message: 'unauthorized' });
+    mockSession.sessionTokenData.mockResolvedValue({ tokenVerified: false });
+    mockAuthClient.deriveHawkCredentials.mockResolvedValue({ id: 'testid' });
     await expect(strategy.validate('token')).rejects.toThrowError(
-      new UnauthorizedException('unauthorized')
+      new UnauthorizedException('Invalid/unverified token')
     );
   });
 
   it('throws unexpected', async () => {
-    authClient.sessionStatus = jest
-      .fn()
-      .mockRejectedValue({ message: 'unauthorized' });
+    mockSession.sessionTokenData.mockResolvedValue({ tokenVerified: false });
+    mockAuthClient.deriveHawkCredentials.mockRejectedValue('unauthorized');
     await expect(strategy.validate('token')).rejects.toThrowError(
       ExtendedError.withCause(
         'Unexpected error during authentication.',

--- a/packages/fxa-graphql-api/src/auth/session-token.strategy.ts
+++ b/packages/fxa-graphql-api/src/auth/session-token.strategy.ts
@@ -1,43 +1,38 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { Inject, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
-import AuthClient from 'fxa-auth-client';
+import { deriveHawkCredentials } from 'fxa-auth-client';
+import { sessionTokenData } from 'fxa-shared/db/models/auth';
+import { SessionToken } from 'fxa-shared/db/models/auth/session-token';
 import { ExtendedError } from 'fxa-shared/nestjs/error';
 import { Strategy } from 'passport-http-bearer';
 
-import { AuthClientService } from '../backend/auth-client.service';
-
-// Unwrap the type from a promise
-type ThenArg<T> = T extends PromiseLike<infer U> ? U : T;
-
 export interface SessionTokenResult {
   token: string;
-  session: ThenArg<ReturnType<AuthClient['sessionStatus']>>;
+  session: SessionToken;
 }
 
 @Injectable()
 export class SessionTokenStrategy extends PassportStrategy(Strategy) {
-  constructor(@Inject(AuthClientService) private authAPI: AuthClient) {
-    super({});
-  }
-
   async validate(token: string): Promise<SessionTokenResult> {
     try {
-      const session = await this.authAPI.sessionStatus(token);
+      const { id } = await deriveHawkCredentials(token, 'sessionToken');
+      const session = await sessionTokenData(id);
+      if (!session || !session.tokenVerified) {
+        throw new UnauthorizedException('Invalid/unverified token');
+      }
       return { token, session };
     } catch (err) {
-      if (err.code === 400 || err.code === 401) {
-        // AuthenticationError doesn't allow us to pass along the error code,
-        // but the error message is unique for most auth-server errors.
-        throw new UnauthorizedException(err.message);
-      } else {
-        throw ExtendedError.withCause(
-          'Unexpected error during authentication.',
-          err
-        );
+      if (err.status) {
+        // Re-throw NestJS errors that include a status.
+        throw err;
       }
+      throw ExtendedError.withCause(
+        'Unexpected error during authentication.',
+        err
+      );
     }
   }
 }

--- a/packages/fxa-graphql-api/src/config.ts
+++ b/packages/fxa-graphql-api/src/config.ts
@@ -52,6 +52,11 @@ const conf = convict({
     env: 'CORS_ORIGIN',
     default: ['http://accounts.firefox.com/'],
   },
+  customsUrl: {
+    doc: "fraud / abuse server url; set to the string 'none' to disable",
+    default: 'http://localhost:7000',
+    env: 'CUSTOMS_SERVER_URL',
+  },
   database: {
     mysql: {
       auth: makeMySQLConfig('AUTH', 'fxa'),

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -4,6 +4,7 @@
 import { Provider } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Account, accountByUid } from 'fxa-shared/db/models/auth';
+import { CustomsService } from 'fxa-shared/nestjs/customs/customs.service';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 import Knex from 'knex';
 
@@ -39,6 +40,7 @@ describe('AccountResolver', () => {
       providers: [
         AccountResolver,
         MockMozLogger,
+        { provide: CustomsService, useValue: {} },
         { provide: AuthClientService, useValue: authClient },
         { provide: ProfileClientService, useValue: profileClient },
       ],

--- a/packages/fxa-graphql-api/src/gql/account.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.ts
@@ -27,6 +27,7 @@ import {
 } from 'graphql-parse-resolve-info';
 
 import { GqlAuthGuard } from '../auth/gql-auth.guard';
+import { GqlCustomsGuard } from '../auth/gql-customs.guard';
 import { AuthClientService } from '../backend/auth-client.service';
 import { ProfileClientService } from '../backend/profile-client.service';
 import { GqlSessionToken, GqlUserId } from '../decorators';
@@ -92,7 +93,7 @@ export class AccountResolver {
     description:
       'Create a new randomly generated TOTP token for a user if they do not currently have one.',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async createTotp(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => CreateTotpInput })
@@ -111,7 +112,7 @@ export class AccountResolver {
     description:
       'Verifies the current session if the passed TOTP code is valid.',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async verifyTotp(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => VerifyTotpInput })
@@ -131,7 +132,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Deletes the current TOTP token for the user.',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async deleteTotp(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => DeleteTotpInput })
@@ -146,7 +147,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Deletes the current TOTP token for the user.',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async deleteRecoveryKey(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => DeleteRecoveryKeyInput })
@@ -161,7 +162,7 @@ export class AccountResolver {
   @Mutation((returns) => ChangeRecoveryCodesPayload, {
     description: 'Return new recovery codes while removing old ones.',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async changeRecoveryCodes(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => ChangeRecoveryCodesInput })
@@ -177,7 +178,7 @@ export class AccountResolver {
   @Mutation((returns) => UpdateDisplayNamePayload, {
     description: 'Update the display name.',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async updateDisplayName(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => UpdateDisplayNameInput })
@@ -196,7 +197,7 @@ export class AccountResolver {
   @Mutation((returns) => UpdateAvatarPayload, {
     description: 'Update the avatar in use.',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async updateAvatar(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => UpdateAvatarInput }) input: UpdateAvatarInput
@@ -214,7 +215,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Create a secondary email for the signed in account.',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async createSecondaryEmail(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => EmailInput }) input: EmailInput
@@ -228,7 +229,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Reset the verification code to a secondary email.',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async resendSecondaryEmailCode(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => EmailInput }) input: EmailInput
@@ -240,7 +241,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Verify the email address with a code.',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async verifySecondaryEmail(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => VerifyEmailInput }) input: VerifyEmailInput
@@ -256,7 +257,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Remove the secondary email for the signed in account.',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async deleteSecondaryEmail(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => EmailInput }) input: EmailInput
@@ -269,7 +270,7 @@ export class AccountResolver {
     description:
       'Change users primary email address, this email address must belong to the user and be verified.',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async updatePrimaryEmail(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => EmailInput }) input: EmailInput
@@ -282,7 +283,7 @@ export class AccountResolver {
     description:
       "Destroy all tokens held by a connected client, disconnecting it from the user's account.",
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async attachedClientDisconnect(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => AttachedClientDisconnectInput })
@@ -295,7 +296,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Send a session verification email.',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async sendSessionVerificationCode(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => SendSessionVerificationInput })
@@ -308,7 +309,7 @@ export class AccountResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Verify the session via an email code.',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async verifySession(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => VerifySessionInput }) input: VerifySessionInput
@@ -318,7 +319,7 @@ export class AccountResolver {
   }
 
   @Query((returns) => AccountType, { nullable: true })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public account(@GqlUserId() uid: string, @Info() info: GraphQLResolveInfo) {
     this.log.info('account', { uid });
 

--- a/packages/fxa-graphql-api/src/gql/gql.module.ts
+++ b/packages/fxa-graphql-api/src/gql/gql.module.ts
@@ -4,6 +4,8 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { GqlModuleOptions } from '@nestjs/graphql';
+import { CustomsModule } from 'fxa-shared/nestjs/customs/customs.module';
+import { CustomsService } from 'fxa-shared/nestjs/customs/customs.service';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 import { SentryPlugin } from 'fxa-shared/nestjs/sentry/sentry.plugin';
 import queryComplexity, { simpleEstimator } from 'graphql-query-complexity';
@@ -52,8 +54,8 @@ export const GraphQLConfigFactory = async (
 });
 
 @Module({
-  imports: [BackendModule],
-  providers: [AccountResolver, SessionResolver],
+  imports: [BackendModule, CustomsModule],
+  providers: [AccountResolver, CustomsService, SessionResolver],
 })
 export class GqlModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Provider } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { CustomsService } from 'fxa-shared/nestjs/customs/customs.service';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 
 import { AuthClientService } from '../backend/auth-client.service';
@@ -24,6 +25,7 @@ describe('AccountResolver', () => {
       providers: [
         SessionResolver,
         MockMozLogger,
+        { provide: CustomsService, useValue: {} },
         { provide: AuthClientService, useValue: authClient },
       ],
     }).compile();

--- a/packages/fxa-graphql-api/src/gql/session.resolver.ts
+++ b/packages/fxa-graphql-api/src/gql/session.resolver.ts
@@ -7,6 +7,7 @@ import AuthClient from 'fxa-auth-client';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 
 import { GqlAuthGuard } from '../auth/gql-auth.guard';
+import { GqlCustomsGuard } from '../auth/gql-customs.guard';
 import { AuthClientService } from '../backend/auth-client.service';
 import { GqlSessionToken, GqlUserId, GqlUserState } from '../decorators';
 import { DestroySessionInput } from './dto/input';
@@ -23,7 +24,7 @@ export class SessionResolver {
   @Mutation((returns) => BasicPayload, {
     description: 'Logs out the current session',
   })
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   public async destroySession(
     @GqlSessionToken() token: string,
     @Args('input', { type: () => DestroySessionInput })
@@ -36,7 +37,7 @@ export class SessionResolver {
   }
 
   @Query((returns) => SessionType)
-  @UseGuards(GqlAuthGuard)
+  @UseGuards(GqlAuthGuard, GqlCustomsGuard)
   session(@GqlUserId() uid: string, @GqlUserState() state: string) {
     this.log.info('session', { uid });
     return {

--- a/packages/fxa-graphql-api/tsconfig.json
+++ b/packages/fxa-graphql-api/tsconfig.json
@@ -5,8 +5,9 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "noEmitHelpers": true,
-    "importHelpers": true
+    "importHelpers": true,
+    "types": ["../fxa-auth-client/lib/types", "mozlog", "jest"]
   },
-  "references": [{ "path": "../fxa-shared" }],
+  "references": [{ "path": "../fxa-shared" }, { "path": "../fxa-auth-client" }],
   "include": ["src"]
 }

--- a/packages/fxa-shared/db/models/auth/session-token.ts
+++ b/packages/fxa-shared/db/models/auth/session-token.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { uuidTransformer } from '../../transformers';
+
+/** Session Token
+ *
+ * Note that this class does not currently implement all the functionality of the
+ * `session_token.js` version from `fxa-auth-server`.
+ */
+export class SessionToken {
+  uid!: string;
+  createdAt!: number;
+  email!: string;
+  emailCode!: string;
+  emailVerified!: boolean;
+  verifierSetAt!: number;
+  keysChangedAt!: number;
+  accountCreatedAt!: number;
+  tokenVerified!: boolean;
+  [key: string]: any;
+
+  constructor(options: SessionToken) {
+    Object.assign(this, options);
+    // Tokens are considered verified if no tokenVerificationId exists
+    this.tokenVerificationId = options.tokenVerificationId || null;
+    this.tokenVerified = this.tokenVerificationId ? false : true;
+  }
+
+  get state(): 'verified' | 'unverified' {
+    return this.tokenVerified ? 'verified' : 'unverified';
+  }
+
+  static fromDatabaseRow(row: any): SessionToken {
+    row.uid = uuidTransformer.from(row.uid);
+    row.emailCode = uuidTransformer.from(row.emailCode);
+    return new SessionToken(row);
+  }
+}

--- a/packages/fxa-shared/nestjs/customs/customs.module.ts
+++ b/packages/fxa-shared/nestjs/customs/customs.module.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Module } from '@nestjs/common';
+
+import { CustomsService } from './customs.service';
+
+@Module({
+  providers: [CustomsService],
+  exports: [CustomsService],
+})
+export class CustomsModule {}

--- a/packages/fxa-shared/nestjs/customs/customs.service.ts
+++ b/packages/fxa-shared/nestjs/customs/customs.service.ts
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  Injectable,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import superagent from 'superagent';
+
+type AnyObject = Record<string, any>;
+
+type CheckOptions = {
+  email: string;
+  ip: string;
+  action: string;
+  headers?: AnyObject;
+  query?: AnyObject;
+  payload?: AnyObject;
+};
+
+type CheckResponse = {
+  block: boolean;
+  blockReason?: string;
+  suspect?: boolean;
+  unblock?: boolean;
+  retryAfter?: number;
+};
+
+@Injectable()
+export class CustomsService {
+  private customsUrl: string;
+
+  constructor(configService: ConfigService) {
+    const customsUrl = configService.get<string>('customsUrl');
+    if (!customsUrl) {
+      throw new Error('No customs URL provided.');
+    }
+    this.customsUrl = customsUrl;
+  }
+
+  async check(options: CheckOptions): Promise<CheckResponse> {
+    if (this.customsUrl === 'none') {
+      return { block: false };
+    }
+    const result = await superagent
+      .post(this.customsUrl + '/check')
+      .send(options)
+      .ok((res) => res.status < 600);
+    if (result.status < 200 || result.status >= 300) {
+      throw new Error('Customs server failed to respond as expected.');
+    }
+    const response = result.body as CheckResponse;
+    if (response.block) {
+      if (response.retryAfter) {
+        // TODO: Create a localized retryAfter value like fxa-auth-server does.
+        throw new HttpException(
+          {
+            code: 429,
+            error: 'Too Many Requests',
+            errno: 114,
+            message: 'Client has sent too many requests',
+          },
+          HttpStatus.TOO_MANY_REQUESTS
+        );
+      }
+
+      const errorStr = 'The request was blocked for security reasons';
+      throw new BadRequestException(
+        { error: 'Request blocked', errno: 125, code: 400, message: errorStr },
+        errorStr
+      );
+    }
+    return result.body;
+  }
+}

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -105,7 +105,8 @@
     "redis": "^2.8.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^6.5.5",
-    "stripe": "^8.69.0"
+    "stripe": "^8.69.0",
+    "superagent": "^6.0.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/packages/fxa-shared/test/db/models/auth/index.spec.ts
+++ b/packages/fxa-shared/test/db/models/auth/index.spec.ts
@@ -1,31 +1,29 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
+import 'mocha';
 import 'reflect-metadata';
 
 import { assert } from 'chai';
 import Knex from 'knex';
-import 'mocha';
+import { ValidationError } from 'objection';
 
+import {
+  Account,
+  accountByUid,
+  AccountCustomers,
+  accountExists,
+  createAccountCustomer,
+  deleteAccountCustomer,
+  getAccountCustomerByUid,
+  updateAccountCustomer,
+} from '../../../../db/models/auth';
 import {
   chance,
   randomAccount,
   randomEmail,
   testDatabaseSetup,
 } from './helpers';
-
-import {
-  Account,
-  accountByUid,
-  accountExists,
-  AccountCustomers,
-  createAccountCustomer,
-  deleteAccountCustomer,
-  getAccountCustomerByUid,
-  updateAccountCustomer,
-} from '../../../../db/models/auth';
-import { UniqueViolationError, ValidationError } from 'objection';
 
 const USER_1 = randomAccount();
 const EMAIL_1 = randomEmail(USER_1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -18860,6 +18860,7 @@ fsevents@^1.2.7:
     rxjs: ^6.5.5
     sinon: ^9.0.3
     stripe: ^8.69.0
+    superagent: ^6.0.0
     ts-jest: 26.4.3
     ts-loader: ^8.0.9
     ts-node: ^8.10.2


### PR DESCRIPTION
Because:

* We want to limit query/mutations by uid/ip using customs.

This commit:

* Alters the session token verification to use a direct db query to load
  the session data from the auth database so the email is available for
  use with customs check.
* Adds a Gql customs check that queries customs for the given
  class/method.

Closes #6876

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

