### PR TITLE
chore(oauth): move oauth destroy route to auth server

### DIFF
--- a/packages/fxa-auth-server/lib/routes/oauth/destroy.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/destroy.js
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const crypto = require('crypto');
+const Joi = require('@hapi/joi');
+const hex = require('buf').to.hex;
+
+const AppError = require('../../oauth/error');
+const encrypt = require('../../oauth/encrypt');
+const validators = require('../../oauth/validators');
+const { getTokenId } = require('../../oauth/token');
+const {
+  authenticateClient,
+  clientAuthValidators,
+} = require('../../oauth/client');
+
+/*jshint camelcase: false*/
+module.exports = ({ log, oauthDB }) => ({
+  method: 'POST',
+  path: '/destroy',
+  config: {
+    validate: {
+      headers: clientAuthValidators.headers,
+      payload: Joi.object()
+        .keys({
+          client_id: clientAuthValidators.clientId.optional(),
+          // For historical reasons, we accept and ignore a client_secret if one
+          // is provided without a corresponding client_id.
+          // https://github.com/mozilla/fxa-oauth-server/pull/198
+          client_secret: clientAuthValidators.clientSecret.allow('').optional(),
+          access_token: validators.accessToken,
+          refresh_token: validators.token,
+          refresh_token_id: validators.token,
+        })
+        .rename('token', 'access_token')
+        .xor('access_token', 'refresh_token', 'refresh_token_id'),
+    },
+    handler: async function destroyToken(req) {
+      let token;
+      let getToken;
+      let removeToken;
+
+      // If client credentials were provided, validate them.
+      // For legacy reasons it is possible to call this endpoint without credentials.
+      let client = null;
+      if (req.headers.authorization || req.payload.client_id) {
+        client = await authenticateClient(req.headers, req.payload);
+      }
+
+      if (req.payload.access_token) {
+        getToken = 'getAccessToken';
+        removeToken = 'removeAccessToken';
+        token = await getTokenId(req.payload.access_token);
+      } else {
+        getToken = 'getRefreshToken';
+        removeToken = 'removeRefreshToken';
+        if (req.payload.refresh_token_id) {
+          token = req.payload.refresh_token_id;
+        } else {
+          token = encrypt.hash(req.payload.refresh_token);
+        }
+      }
+
+      const tokObj = await oauthDB[getToken](token);
+      if (!tokObj) {
+        throw AppError.invalidToken();
+      }
+      if (client && !crypto.timingSafeEqual(tokObj.clientId, client.id)) {
+        throw AppError.invalidToken();
+        // eslint-disable-next-line no-prototype-builtins
+      } else if (!client && req.payload.hasOwnProperty('client_secret')) {
+        // Log a warning if legacy client_secret is provided, so we can
+        // measure whether it's safe to remove this behaviour.
+        log.warn('destroy.unexpectedClientSecret', {
+          client_id: hex(tokObj.clientId),
+        });
+      }
+      await oauthDB[removeToken](tokObj);
+      return {};
+    },
+  },
+});

--- a/packages/fxa-auth-server/lib/routes/oauth/index.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/index.js
@@ -6,6 +6,7 @@ module.exports = (log, config, oauthService, db, mailer, devices) => {
   const directRoutes = [
     require('./authorization')({ log, oauthDB }),
     require('./client/get')({ log, oauthDB }),
+    require('./destroy')({ log, oauthDB }),
     require('./introspect')({ oauthDB }),
     require('./key_data')({ log, oauthDB }),
     require('./redirect')({ log, oauthDB }),


### PR DESCRIPTION
## This pull request

- Moves the oauth destroy route to auth-server

## Issue that this pull request solves

Closes: #7094

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
