### PR TITLE
fix(settings): scroll to element id in url hash

### DIFF
--- a/packages/fxa-settings/src/components/ScrollToTop/index.tsx
+++ b/packages/fxa-settings/src/components/ScrollToTop/index.tsx
@@ -22,10 +22,17 @@ export const ScrollToTop = (
   }, [href, state, navigate]);
 
   useLayoutEffect(() => {
-    if (!(state as typeof state & { scrolled?: boolean })?.scrolled) {
+    // If there's a hash, let the browser scroll to the id.
+    const url = new URL(href);
+    const hasHash = !!url.hash;
+
+    if (
+      !hasHash &&
+      !(state as typeof state & { scrolled?: boolean })?.scrolled
+    ) {
       updateState();
     }
-  }, [state, updateState]);
+  }, [href, state, updateState]);
 
   return <>{props.children}</>;
 };


### PR DESCRIPTION
Because:
 - we have some logic for scrolling to the top of the page when the user
   navigates to a new route

This commit:
 - account for the hrefs with a hash and let the browser does its default
   thing

## Issue that this pull request solves

Closes: #7015
