### PR TITLE
fix(gql-api): disallow query in query string

### DIFF
--- a/packages/fxa-graphql-api/src/auth/gql-auth.guard.ts
+++ b/packages/fxa-graphql-api/src/auth/gql-auth.guard.ts
@@ -12,4 +12,19 @@ export class GqlAuthGuard extends AuthGuard('bearer') {
     const ctx = GqlExecutionContext.create(context);
     return ctx.getContext().req;
   }
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const activate = await super.canActivate(context);
+    if (!activate) {
+      return false;
+    }
+    const ctx = GqlExecutionContext.create(context);
+    const req = ctx.getContext().req as Request;
+
+    // Disallow query bodies in the query string.
+    if (req.query.query) {
+      return false;
+    }
+    return true;
+  }
 }


### PR DESCRIPTION
Because:

* The complexity analysis doesn't seem to notice queries done in the
  query string.

This commit:

* Rejects requests that include a query param in the query string.

Issue #6876

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
