### PR TITLE
Support yarn proxy settings for docker image builds

### DIFF
--- a/_dev/docker/builder/Dockerfile
+++ b/_dev/docker/builder/Dockerfile
@@ -3,6 +3,9 @@ FROM node:14-slim
 ARG yarn_http_proxy=
 ARG yarn_https_proxy=
 ARG yarn_http_timeout=30000
+ARG npm_config_http_proxy=${yarn_http_proxy}
+ARG npm_config_https_proxy=${yarn_https_proxy}
+ARG npm_config_proxy=
 ARG NODE_TLS_REJECT_UNAUTHORIZED=1
 
 RUN set -x \

--- a/_dev/docker/builder/Dockerfile
+++ b/_dev/docker/builder/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:14-slim
 
+ARG yarn_http_proxy=
+ARG yarn_https_proxy=
+ARG yarn_http_timeout=30000
+ARG NODE_TLS_REJECT_UNAUTHORIZED=1
+
 RUN set -x \
     && addgroup --gid 10001 app \
     && adduser --disabled-password \

--- a/_scripts/build-builder.sh
+++ b/_scripts/build-builder.sh
@@ -7,5 +7,16 @@ cd "$DIR"
 
 mkdir -p ../artifacts
 
+build_args=()
+
+if [ -n "${DOCKER_BUILD_NETWORK}" ]; then
+    build_args+=("--network" "${DOCKER_BUILD_NETWORK}")
+fi
+
+while read fxa_arg; do
+    echo "Adding docker build arg: $fxa_arg"
+    build_args+=("--build-arg" "$fxa_arg")
+done < <(env | sed -n -E 's/^(RM_FXA_|(FXA_))([a-zA-Z0-9_]+=.*)/\2\3/p' | sort)
+
 echo "Building fxa-builder image..."
-time (cd .. && docker build -f _dev/docker/builder/Dockerfile -t fxa-builder:latest . &> "artifacts/fxa-builder.log")
+time (cd .. && docker build -f _dev/docker/builder/Dockerfile -t fxa-builder:latest "${build_args[@]}" . &> "artifacts/fxa-builder.log")


### PR DESCRIPTION
## Because

I want to avoid running into NPM rate limiting or I am required to use a proxy for outgoing HTTP(S) connections.

## This pull request

Introduces support for the following environment variables picked up by node itself or YARN specifically inside `docker build`:
* `RM_FXA_NODE_TLS_REJECT_UNAUTHORIZED` - in case we have a proxy with a self-signed certificate - or for testing
* `RM_FXA_yarn_http_proxy`- standard HTTP proxy URL for YARN
* `RM_FXA_yarn_https_proxy`- standard HTTPS proxy URL for YARN
* `RM_FXA_yarn_http_timeout`- HTTP request timeout for YARN
* `RM_FXA_npm_config_http_proxy`- usually supported by for custom downloads in NPM package installs
* `RM_FXA_npm_config_https_proxy`- usually supported by for custom downloads in NPM package installs

Also adds the option to specify a docker network for building using environment variable `DOCKER_BUILD_NETWORK`, which opens up quite some options on CI systems other than CircleCI.

Implements generic support for adding environment variables as docker `--build-args` values:
* `FXA_*` - passed-through as is
* `RM_FXA_*` - prefix `RM_FXA_` is removed from the variable name (which actually is used for the above)

## Issue that this pull request solves

Closes: #7118 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

_n/a_

## Other information (Optional)

With these modifications, I was able to improve rebuilds instead of experiencing slowdown:

```
Building fxa-builder image...

real    7m1,579s
user    0m0,667s
sys     0m0,307s

...
Building fxa-builder image...

real    5m36,361s
user    0m0,553s
sys     0m0,234s

...
Building fxa-builder image...

real    5m35,896s
user    0m0,590s
sys     0m0,198s
```

While verifying this change using https://github.com/runk/npm-proxy-cache, I also noticed that packages `node-sass` and `sharp` get installed and built twice, instead of reusing the repo-global cached installation:
```
[2020-12-10T07:46:36.922] [WARN] default - direct https://github.com/lovell/sharp-libvips/releases/download/v8.10.0/libvips-8.10.0-linux-x64.tar.br
[2020-12-10T07:46:37.158] [INFO] default - cache https://github.com/sass/node-sass/releases/download/v4.14.1/linux-x64-83_binding.node
[2020-12-10T07:47:20.321] [INFO] default - cache https://github.com/lovell/sharp-libvips/releases/download/v8.10.0/libvips-8.10.0-linux-x64.tar.br
[2020-12-10T07:47:21.079] [WARN] default - direct https://github.com/lovell/sharp/releases/download/v0.26.0/sharp-v0.26.0-napi-v3-linux-x64.tar.gz
[2020-12-10T07:47:22.485] [INFO] default - cache https://github.com/lovell/sharp/releases/download/v0.26.0/sharp-v0.26.0-napi-v3-linux-x64.tar.gz
[2020-12-10T07:50:13.035] [INFO] default - cache https://github.com/sass/node-sass/releases/download/v4.14.1/linux-x64-83_binding.node
```
But that is another issue.