### PR TITLE
fix(auth-server): Add ACR claim validation to ID Token verifier

### DIFF
--- a/packages/fxa-auth-server/docs/oauth/api.md
+++ b/packages/fxa-auth-server/docs/oauth/api.md
@@ -54,6 +54,7 @@ The currently-defined error responses are:
 |     400     |  119  | stale authentication timestamp                |
 |     400     |  120  | mismatch acr value                            |
 |     400     |  121  | invalid grant_type                            |
+|     400     |  122  | unknown token                                 |
 |     500     |  999  | internal server error                         |
 
 ## API Endpoints

--- a/packages/fxa-auth-server/lib/constants.js
+++ b/packages/fxa-auth-server/lib/constants.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 module.exports = {
+  ACR_VALUE_AAL2: 'AAL2',
   OAUTH_SCOPE_OLD_SYNC: 'https://identity.mozilla.com/apps/oldsync',
   OAUTH_SCOPE_SESSION_TOKEN: 'https://identity.mozilla.com/tokens/session',
   SHORT_ACCESS_TOKEN_TTL_IN_MS: 1000 * 60 * 60 * 6,

--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -22,11 +22,13 @@ const {
   determineClientVisibleSubscriptionCapabilities,
 } = require('../routes/utils/subscriptions');
 
-const ACR_VALUE_AAL2 = 'AAL2';
 const ACCESS_TYPE_OFFLINE = 'offline';
 
 const SCOPE_OPENID = ScopeSet.fromArray(['openid']);
-const { OAUTH_SCOPE_SESSION_TOKEN } = require('../../lib/constants');
+const {
+  ACR_VALUE_AAL2,
+  OAUTH_SCOPE_SESSION_TOKEN,
+} = require('../../lib/constants');
 
 const ID_TOKEN_EXPIRATION = Math.floor(
   config.get('oauthServer.openid.ttl') / 1000

--- a/packages/fxa-auth-server/lib/routes/oauth/proxied.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/proxied.js
@@ -116,9 +116,13 @@ module.exports = (log, config, oauthdb, db, mailer, devices) => {
         },
       },
       handler: async function (request) {
+        const otpUtils = require('../utils/otp')(log, {}, db);
         const claims = await JWTIdToken.verify(
           request.payload.id_token,
           request.payload.client_id,
+          db,
+          otpUtils,
+          log,
           request.payload.expiry_grace_period
         );
         return claims;

--- a/packages/fxa-auth-server/test/oauth/jwt_id_token.js
+++ b/packages/fxa-auth-server/test/oauth/jwt_id_token.js
@@ -2,12 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { assert } = require('chai');
 const jsonwebtoken = require('jsonwebtoken');
+const sinon = require('sinon');
+const assert = { ...sinon.assert, ...require('chai').assert };
 
 const AppError = require('../../lib/oauth/error');
 const config = require('../../config');
 const JWTIdToken = require('../../lib/oauth/jwt_id_token');
+const P = require('../../lib/promise');
+const mocks = require('../mocks');
+let hasTotp = true;
+const mockOtp = {
+  hasTotpToken: () => P.resolve(hasTotp),
+};
 const {
   SIGNING_PEM,
   SIGNING_KID,
@@ -23,7 +30,7 @@ const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
 const TEN_MINUTES_IN_SECONDS = 60 * 10;
 
 describe('lib/jwt_id_token', () => {
-  let claims;
+  let claims, mockLog;
 
   // Note: in order to verify that invalid issuer claims are caught, we need
   // to sign a claim with the wrong issuer. lib/oauth/jwt.js does not allow
@@ -37,13 +44,22 @@ describe('lib/jwt_id_token', () => {
 
   // Helper function that signs a set of invalid claims, calls the verifier,
   // and expects (asserts) that the token verifier will throw an error.
-  const signAndAssertInvalid = async (claims, algorithm) => {
+  // The `loggedError` is specific to each validation error, and tells us
+  // that the token failed validation for the expected reason.
+  const signAndAssertInvalid = async (claims, loggedError, algorithm) => {
     const invalidToken = sign(claims, algorithm);
     try {
-      await JWTIdToken.verify(invalidToken, CLIENT_ID);
+      await JWTIdToken.verify(
+        invalidToken,
+        CLIENT_ID,
+        mocks.mockDB(),
+        mockOtp,
+        mockLog
+      );
       assert.fail();
     } catch (err) {
       assert.instanceOf(err, AppError);
+      assert.calledWithMatch(mockLog.debug, loggedError);
     }
   };
 
@@ -57,6 +73,7 @@ describe('lib/jwt_id_token', () => {
       sub: USER_ID,
       iat: now,
     };
+    mockLog = mocks.mockLog();
   });
 
   describe('_isValidExp', () => {
@@ -79,46 +96,53 @@ describe('lib/jwt_id_token', () => {
   describe('verify', () => {
     it('fails if the input is not a JWT', async () => {
       try {
-        await JWTIdToken.verify('invalid token', CLIENT_ID);
+        await JWTIdToken.verify(
+          'invalid token',
+          CLIENT_ID,
+          mocks.mockDB(),
+          mockOtp,
+          mockLog
+        );
         assert.fail();
       } catch (err) {
         assert.instanceOf(err, AppError);
+        assert.calledWithMatch(mockLog.debug, 'verify.error.jwtverify');
       }
     });
 
     it(`fails if the Issuer Claim doesn't match the expected issuer`, async () => {
       claims.iss = 'http://example.com';
-      await signAndAssertInvalid(claims);
+      await signAndAssertInvalid(claims, 'verify.error.jwtverify');
     });
 
     it(`fails if the Audience Claim doesn't match the client ID`, async () => {
       claims.aud = 'bad1bad1bad1bad1';
-      await signAndAssertInvalid(claims);
+      await signAndAssertInvalid(claims, 'verify.error.aud');
     });
 
     it(`fails if the Audience Claim is a list that doesn't include the client ID`, async () => {
       claims.aud = ['bad1bad1bad1bad1', 'bad2bad2bad2bad2'];
-      await signAndAssertInvalid(claims);
+      await signAndAssertInvalid(claims, 'verify.error.aud');
     });
 
     it(`fails if the Algorithm used isn't the expected default algorithm (RS256)`, async () => {
       const algorithm = 'HS256';
-      await signAndAssertInvalid(claims, algorithm);
+      await signAndAssertInvalid(claims, 'verify.error.jwtverify', algorithm);
     });
 
     it(`fails if the Expiration Time Claim is missing`, async () => {
       delete claims.exp;
-      await signAndAssertInvalid(claims);
+      await signAndAssertInvalid(claims, 'verify.error.exp');
     });
 
     it(`fails if the Expiration Time Claim is in the past`, async () => {
       claims.exp = NOW_IN_SECONDS - TEN_MINUTES_IN_SECONDS;
-      await signAndAssertInvalid(claims);
+      await signAndAssertInvalid(claims, 'verify.error.exp');
     });
 
     it(`fails if the Expiration Time Claim is too far (more than five minutes) in the future`, async () => {
       claims.exp = NOW_IN_SECONDS + TEN_MINUTES_IN_SECONDS;
-      await signAndAssertInvalid(claims);
+      await signAndAssertInvalid(claims, 'verify.error.exp');
     });
 
     it('succeeds if the token is expired but within the grace period', async () => {
@@ -129,6 +153,9 @@ describe('lib/jwt_id_token', () => {
         await JWTIdToken.verify(
           recentlyExpiredToken,
           CLIENT_ID,
+          mocks.mockDB(),
+          mockOtp,
+          mockLog,
           ONE_DAY_IN_SECONDS
         );
         assert.ok(true);
@@ -137,9 +164,70 @@ describe('lib/jwt_id_token', () => {
       }
     });
 
+    describe('ACR claim tests', () => {
+      let mockDB;
+      beforeEach(() => {
+        claims.acr = 'AAL2';
+        hasTotp = true;
+        mockDB = mocks.mockDB({
+          uid: USER_ID,
+          email: 'email@user.com',
+        });
+      });
+
+      it(`fails if the token ACR value is greater than the ACR value on the account`, async () => {
+        hasTotp = false;
+        const signed = sign(claims);
+        try {
+          await JWTIdToken.verify(signed, CLIENT_ID, mockDB, mockOtp, mockLog);
+        } catch (err) {
+          assert.instanceOf(err, AppError);
+          assert.equal(err.message, 'Invalid token');
+          assert.calledWithMatch(mockLog.debug, 'verify.error.acr');
+        }
+      });
+
+      it(`fails if the ACR claim is present but the account isn't found`, async () => {
+        mockDB.account = sinon.spy(() => P.reject(AppError.unknownAccount()));
+        const signed = sign(claims);
+        try {
+          await JWTIdToken.verify(signed, CLIENT_ID, mockDB, mockOtp, mockLog);
+        } catch (err) {
+          assert.calledOnce(mockDB.account);
+          assert.instanceOf(err, AppError);
+          assert.equal(err.message, 'Invalid token');
+          assert.calledWithMatch(mockLog.debug, 'verify.error.acr.account');
+        }
+      });
+
+      it(`succeeds if the token ACR value matches the ACR value on the account`, async () => {
+        const signed = sign(claims);
+        let verified;
+        try {
+          verified = await JWTIdToken.verify(
+            signed,
+            CLIENT_ID,
+            mockDB,
+            mockOtp,
+            mockLog
+          );
+        } catch (err) {
+          assert.calledWithMatch(mockLog.debug, 'bsdjlfverify.');
+          assert.fail(err);
+        }
+        assert.deepEqual(verified, claims);
+      });
+    });
+
     it('succeeds if valid', async () => {
       const validToken = sign(claims);
-      const parsedClaims = await JWTIdToken.verify(validToken, CLIENT_ID);
+      const parsedClaims = await JWTIdToken.verify(
+        validToken,
+        CLIENT_ID,
+        mocks.mockDB(),
+        mockOtp,
+        mockLog
+      );
       assert.deepEqual(parsedClaims, claims);
     });
   });


### PR DESCRIPTION

## Because

In issue #6762 AMO testing ran into a redirect loop if an addon developer without 2FA enabled does this flow:
* signs in to AMO, goes through the inline force-2FA setup flow to add 2FA to their Firefox Account,
* signs out of AMO,
* goes to FxA settings and disables 2FA without logging out,
* then tries to sign in to AMO again.

## This pull request

The bug here seems to be that the ID token was issued when 2FA was enabled,
and in the token verifier, we don’t check that the account’s 2FA state still reflects
the claims in the token.

This bug goes away if the user logs out and back in, so there may also be something
in content-server about not doing 2FA checks for verified sessions; I’m not sure.

But the token verifier should definitely be checking 2FA state when ACR claims are
present in the ID Token, per the OIDC spec; and the flow that verified sessions take includes the
id-token-verify auth-server endpoint, so that should now error out and resolve the bug.

Along the way, I noticed that we weren’t really asserting specifically what was causing
each Invalid Token error in the unit tests, so I started passing the logger in, and used
a mock to assert that the correct error was getting triggered in each case. (Thankfully,
the logged errors were as expected!)

I'm not quite sure how to test this locally; suggestions welcome. I might try a sequence like:
* sign in to 123done with 2fa enabled,
* fish the ID token out of localstorage / network tab,
* disable 2fa on the account,
* send a `prompt=none` request using the 123done client ID and the old ID token as the `id_token_hint`
* expect id-token-verify endpoint to error out the request

## Issue that this pull request solves

Closes: #6762

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
