### PR TITLE
fix(2fa): Fixed cached creds and 2fa redirecting to verify account page

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
@@ -44,7 +44,8 @@ export default {
         // This is important for the infamous signin-from-signup feature.
         this.logFlowEvent('attempt', 'signin');
 
-        let verificationMethod = VerificationMethods.EMAIL_2FA;
+        let verificationMethod =
+          account.get('verificationMethod') || VerificationMethods.EMAIL_2FA;
 
         // Check to see if this is an oauth client is requesting 2FA.
         // If it is, set/override the corresponding verificationMethod.


### PR DESCRIPTION
## Because

- If a user has 2FA and is using a cached credential to login, they won't be redirected to the enter 2FA code page

## This pull request

- Fixes this issue by checking for 2FA in cached creds mixin and setting the account property that would redirect to the correct page on login

## Issue that this pull request solves

Closes: NA

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
