### PR TITLE
fix(graphql-api): allow unverified sessions

### DIFF
--- a/packages/fxa-graphql-api/src/auth/session-token.strategy.spec.ts
+++ b/packages/fxa-graphql-api/src/auth/session-token.strategy.spec.ts
@@ -38,10 +38,10 @@ describe('SessionTokenStrategy', () => {
   });
 
   it('throws unauthorized', async () => {
-    mockSession.sessionTokenData.mockResolvedValue({ tokenVerified: false });
+    mockSession.sessionTokenData.mockResolvedValue(undefined);
     mockAuthClient.deriveHawkCredentials.mockResolvedValue({ id: 'testid' });
     await expect(strategy.validate('token')).rejects.toThrowError(
-      new UnauthorizedException('Invalid/unverified token')
+      new UnauthorizedException('Invalid token')
     );
   });
 

--- a/packages/fxa-graphql-api/src/auth/session-token.strategy.ts
+++ b/packages/fxa-graphql-api/src/auth/session-token.strategy.ts
@@ -20,8 +20,8 @@ export class SessionTokenStrategy extends PassportStrategy(Strategy) {
     try {
       const { id } = await deriveHawkCredentials(token, 'sessionToken');
       const session = await sessionTokenData(id);
-      if (!session || !session.tokenVerified) {
-        throw new UnauthorizedException('Invalid/unverified token');
+      if (!session) {
+        throw new UnauthorizedException('Invalid token');
       }
       return { token, session };
     } catch (err) {


### PR DESCRIPTION
Because:

* When switching token lookup, verification was accidentally required.

This commit:

* Allows unverified tokens to proceed for lookup to match existing
  settings page behavior.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
