### PR TITLE
fix(settings): use Sentry dsn after config's loaded

### DIFF
--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -15,11 +15,11 @@ import { createApolloClient } from './lib/gql';
 import './index.scss';
 
 try {
-  sentryMetrics.configure(config.sentry.dsn, config.version);
   readConfigMeta((name: string) => {
     return document.head.querySelector(name);
   });
 
+  sentryMetrics.configure(config.sentry.dsn, config.version);
   const authClient = createAuthClient(config.servers.auth.url);
   const apolloClient = createApolloClient(config.servers.gql.url);
   const flowQueryParams = searchParams(


### PR DESCRIPTION
Because:
 - we are not using the Sentry dsn

This commit:
 - init Sentry after the config's ready


## Issue that this pull request solves

Closes: #7140 
