### PR TITLE
feat(db): Create table to store PayPal customer information

### DIFF
--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 113;
+module.exports.level = 114;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-113-114.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-113-114.sql
@@ -1,0 +1,22 @@
+-- -- Create paypalCustomers table to store the relationship between FxA users and PayPal
+-- -- This table can be joined with the existing accountCustomers table on the uid to map
+-- -- a PayPal user to their stripeCustomerId.
+-- -- endedAt is nullable by default, since active billing agreements would not have a value
+-- -- A user can have more than one billing agreement e.g. if the funding becomes invalid
+-- -- for the first one. This means there can be more than one row in the table for a given
+-- -- FxA user, so we make a composite key as the primary key.
+
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('113');
+
+CREATE TABLE IF NOT EXISTS paypalCustomers (
+  uid BINARY(16),
+  billingAgreementId CHAR(19),
+  status VARCHAR(9) NOT NULL,
+  createdAt BIGINT UNSIGNED NOT NULL,
+  endedAt BIGINT UNSIGNED,
+  PRIMARY KEY (uid, billingAgreementId)
+) ENGINE=InnoDB;
+
+UPDATE dbMetadata SET value = '114' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-114-113.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-114-113.sql
@@ -1,0 +1,5 @@
+-- -- Drop paypalCustomers table to store the relationship between FxA users and PayPal
+
+-- DROP TABLE paypalCustomers;
+
+-- UPDATE dbMetadata SET value = '113' WHERE name = 'schema-patch-level';


### PR DESCRIPTION
Because:

* We want to be able to tell if an FxA user has an associated PayPal billing agreement without having to query PayPal

This Commit:

* Creates the paypalCustomers table that will be used to associate FxA user ids with PayPal billing agreements

Closes #7031

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).