### PR TITLE
refactor(oauth): remove oauthdb destroy functions

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/validators.js
+++ b/packages/fxa-auth-server/lib/oauth/validators.js
@@ -84,3 +84,4 @@ exports.ppidSeed = authServerValidators.ppidSeed.default(0);
 exports.resourceUrl = authServerValidators.resourceUrl;
 exports.pkceCodeChallengeMethod = authServerValidators.pkceCodeChallengeMethod;
 exports.pkceCodeChallenge = authServerValidators.pkceCodeChallenge;
+exports.refreshToken = authServerValidators.refreshToken;

--- a/packages/fxa-auth-server/lib/oauthdb/index.js
+++ b/packages/fxa-auth-server/lib/oauthdb/index.js
@@ -40,24 +40,6 @@ module.exports = (log, config) => {
   }
 
   return {
-    async revokeAccessToken(accessToken, clientCredentials = {}) {
-      return callRoute('/destroy', {
-        payload: {
-          access_token: accessToken,
-          ...clientCredentials,
-        },
-      });
-    },
-
-    async revokeRefreshToken(refreshToken, clientCredentials = {}) {
-      return callRoute('/destroy', {
-        payload: {
-          refresh_token: refreshToken,
-          ...clientCredentials,
-        },
-      });
-    },
-
     async revokeRefreshTokenById(refreshTokenId, clientCredentials = {}) {
       return callRoute('/destroy', {
         payload: {

--- a/packages/fxa-auth-server/lib/oauthdb/index.js
+++ b/packages/fxa-auth-server/lib/oauthdb/index.js
@@ -40,15 +40,6 @@ module.exports = (log, config) => {
   }
 
   return {
-    async revokeRefreshTokenById(refreshTokenId, clientCredentials = {}) {
-      return callRoute('/destroy', {
-        payload: {
-          refresh_token_id: refreshTokenId,
-          ...clientCredentials,
-        },
-      });
-    },
-
     async getScopedKeyData(sessionToken, oauthParams) {
       oauthParams.assertion = await makeAssertionJWT(config, sessionToken);
       oauthParams.scope = ScopeSet.fromString(oauthParams.scope || '');

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -26,7 +26,7 @@ module.exports = function (
   // Various extra helpers.
   const push = require('../push')(log, db, config, statsd);
   const pushbox = require('../pushbox')(log, config, statsd);
-  const devicesImpl = require('../devices')(log, db, oauthdb, push);
+  const devicesImpl = require('../devices')(log, db, push);
   const cadReminders = require('../cad-reminders')(config, log);
   const signinUtils = require('./utils/signin')(
     log,

--- a/packages/fxa-auth-server/lib/routes/oauth/destroy.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/destroy.js
@@ -6,7 +6,8 @@ const crypto = require('crypto');
 const Joi = require('@hapi/joi');
 const hex = require('buf').to.hex;
 
-const AppError = require('../../oauth/error');
+const OauthError = require('../../oauth/error');
+const AuthError = require('../../error');
 const encrypt = require('../../oauth/encrypt');
 const validators = require('../../oauth/validators');
 const { getTokenId } = require('../../oauth/token');
@@ -16,68 +17,136 @@ const {
 } = require('../../oauth/client');
 
 /*jshint camelcase: false*/
-module.exports = ({ log, oauthDB }) => ({
-  method: 'POST',
-  path: '/destroy',
-  config: {
-    validate: {
-      headers: clientAuthValidators.headers,
-      payload: Joi.object()
-        .keys({
-          client_id: clientAuthValidators.clientId.optional(),
-          // For historical reasons, we accept and ignore a client_secret if one
-          // is provided without a corresponding client_id.
-          // https://github.com/mozilla/fxa-oauth-server/pull/198
-          client_secret: clientAuthValidators.clientSecret.allow('').optional(),
-          access_token: validators.accessToken,
-          refresh_token: validators.token,
-          refresh_token_id: validators.token,
-        })
-        .rename('token', 'access_token')
-        .xor('access_token', 'refresh_token', 'refresh_token_id'),
-    },
-    handler: async function destroyToken(req) {
-      let token;
-      let getToken;
-      let removeToken;
+module.exports = ({ log, oauthDB }) => {
+  async function destroyHandler(req) {
+    let tokenId;
+    let getToken;
+    let removeToken;
 
-      // If client credentials were provided, validate them.
-      // For legacy reasons it is possible to call this endpoint without credentials.
-      let client = null;
-      if (req.headers.authorization || req.payload.client_id) {
-        client = await authenticateClient(req.headers, req.payload);
-      }
+    // If client credentials were provided, validate them.
+    // For legacy reasons it is possible to call this endpoint without credentials.
+    let client = null;
+    if (req.headers.authorization || req.payload.client_id) {
+      client = await authenticateClient(req.headers, req.payload);
+    }
 
-      if (req.payload.access_token) {
-        getToken = 'getAccessToken';
-        removeToken = 'removeAccessToken';
-        token = await getTokenId(req.payload.access_token);
+    if (req.payload.access_token) {
+      getToken = 'getAccessToken';
+      removeToken = 'removeAccessToken';
+      tokenId = await getTokenId(req.payload.access_token);
+    } else {
+      getToken = 'getRefreshToken';
+      removeToken = 'removeRefreshToken';
+      if (req.payload.refresh_token_id) {
+        tokenId = req.payload.refresh_token_id;
       } else {
-        getToken = 'getRefreshToken';
-        removeToken = 'removeRefreshToken';
-        if (req.payload.refresh_token_id) {
-          token = req.payload.refresh_token_id;
-        } else {
-          token = encrypt.hash(req.payload.refresh_token);
-        }
+        tokenId = encrypt.hash(req.payload.refresh_token);
       }
+    }
 
-      const tokObj = await oauthDB[getToken](token);
-      if (!tokObj) {
-        throw AppError.invalidToken();
-      }
-      if (client && !crypto.timingSafeEqual(tokObj.clientId, client.id)) {
-        throw AppError.invalidToken();
-        // eslint-disable-next-line no-prototype-builtins
-      } else if (!client && req.payload.hasOwnProperty('client_secret')) {
-        // Log a warning if legacy client_secret is provided, so we can
-        // measure whether it's safe to remove this behaviour.
-        log.warn('destroy.unexpectedClientSecret', {
-          client_id: hex(tokObj.clientId),
-        });
-      }
-      await oauthDB[removeToken](tokObj);
-      return {};
+    const token = await oauthDB[getToken](tokenId);
+    if (!token) {
+      throw OauthError.invalidToken();
+    }
+    if (client && !crypto.timingSafeEqual(token.clientId, client.id)) {
+      throw OauthError.invalidToken();
+      // eslint-disable-next-line no-prototype-builtins
+    } else if (!client && req.payload.hasOwnProperty('client_secret')) {
+      // Log a warning if legacy client_secret is provided, so we can
+      // measure whether it's safe to remove this behaviour.
+      log.warn('destroy.unexpectedClientSecret', {
+        client_id: hex(token.clientId),
+      });
+    }
+    await oauthDB[removeToken](token);
+    return {};
+  }
+
+  return [
+    {
+      method: 'POST',
+      path: '/destroy',
+      config: {
+        validate: {
+          headers: clientAuthValidators.headers,
+          payload: Joi.object()
+            .keys({
+              client_id: clientAuthValidators.clientId.optional(),
+              // For historical reasons, we accept and ignore a client_secret if one
+              // is provided without a corresponding client_id.
+              // https://github.com/mozilla/fxa-oauth-server/pull/198
+              client_secret: clientAuthValidators.clientSecret
+                .allow('')
+                .optional(),
+              access_token: validators.accessToken,
+              refresh_token: validators.token,
+              refresh_token_id: validators.token,
+            })
+            .rename('token', 'access_token')
+            .xor('access_token', 'refresh_token', 'refresh_token_id'),
+        },
+        handler: destroyHandler,
+      },
     },
-  },
-});
+    {
+      method: 'POST',
+      path: '/oauth/destroy',
+      config: {
+        validate: {
+          headers: clientAuthValidators.headers,
+          payload: {
+            client_id: clientAuthValidators.clientId,
+            client_secret: clientAuthValidators.clientSecret.optional(),
+            token: Joi.alternatives().try(
+              validators.accessToken,
+              validators.refreshToken
+            ),
+            // The spec says we have to ignore invalid token_type_hint values,
+            // but no way I'm going to accept an arbitrarily-long string here...
+            token_type_hint: Joi.string().max(64).optional(),
+          },
+        },
+        response: {},
+      },
+      handler: async function (req) {
+        // This endpoint implements the API for token revocation from RFC7009,
+        // which says that if we can't find the token using the provided token_type_hint
+        // then we MUST search other possible types of token as well. So really
+        // token_type_hint just tells us what *order* to try different token types in.
+        let tokenTypes = ['access_token', 'refresh_token'];
+        if (req.payload.token_type_hint === 'refresh_token') {
+          tokenTypes = ['refresh_token', 'access_token'];
+        }
+        const methodArgValidators = {
+          access_token: validators.accessToken,
+          refresh_token: validators.refreshToken,
+        };
+
+        const token = req.payload.token;
+        delete req.payload.token;
+        for (const tokenType of tokenTypes) {
+          // Only try this method, if the token is syntactically valid for that token type.
+          if (!methodArgValidators[tokenType].validate(token).error) {
+            try {
+              req.payload[tokenType] = token;
+              return await destroyHandler(req);
+            } catch (err) {
+              // If that was an invalid token, try the next token type.
+              // All other errors are fatal.
+              // TODO: on the error refactor pass, change this
+              if (err.errno === 101) {
+                throw AuthError.unknownClientId();
+              } else if (err.errno !== 108) {
+                throw err;
+              }
+              delete req.payload[tokenType];
+            }
+          }
+        }
+
+        // If we coudn't find the token, the RFC says to silently succeed anyway.
+        return {};
+      },
+    },
+  ];
+};

--- a/packages/fxa-auth-server/lib/routes/oauth/proxied.js
+++ b/packages/fxa-auth-server/lib/routes/oauth/proxied.js
@@ -17,10 +17,6 @@
 
 const Joi = require('@hapi/joi');
 const validators = require('../../routes/validators');
-const {
-  clientAuthValidators,
-  getClientCredentials,
-} = require('../../oauth/client');
 
 const error = require('../../error');
 const token = require('../../oauth/token');
@@ -321,65 +317,6 @@ module.exports = (log, config, oauthService, db, mailer, devices) => {
         } catch (ex) {}
 
         return grant;
-      },
-    },
-    {
-      method: 'POST',
-      path: '/oauth/destroy',
-      config: {
-        validate: {
-          headers: clientAuthValidators.headers,
-          payload: {
-            client_id: clientAuthValidators.clientId,
-            client_secret: clientAuthValidators.clientSecret.optional(),
-            token: Joi.alternatives().try(
-              validators.accessToken,
-              validators.refreshToken
-            ),
-            // The spec says we have to ignore invalid token_type_hint values,
-            // but no way I'm going to accept an arbitrarily-long string here...
-            token_type_hint: Joi.string().max(64).optional(),
-          },
-        },
-        response: {},
-      },
-      handler: async function (request) {
-        // This endpoint implements the API for token revocation from RFC7009,
-        // which says that if we can't find the token using the provided token_type_hint
-        // then we MUST search other possible types of token as well. So really
-        // token_type_hint just tells us what *order* to try different token types in.
-        let methodsToTry = ['revokeAccessToken', 'revokeRefreshToken'];
-        if (request.payload.token_type_hint === 'refresh_token') {
-          methodsToTry = ['revokeRefreshToken', 'revokeAccessToken'];
-        }
-        const methodArgValidators = {
-          revokeAccessToken: validators.accessToken,
-          revokeRefreshToken: validators.refreshToken,
-        };
-
-        const creds = getClientCredentials(request.headers, request.payload);
-
-        const token = request.payload.token;
-        for (const methodName of methodsToTry) {
-          // Only try this method, if the token is syntactically valid for that token type.
-          if (!methodArgValidators[methodName].validate(token).error) {
-            try {
-              return await oauthService[methodName](
-                request.payload.token,
-                creds
-              );
-            } catch (err) {
-              // If that was an invalid token, try the next token type.
-              // All other errors are fatal.
-              if (err.errno !== error.ERRNO.INVALID_TOKEN) {
-                throw err;
-              }
-            }
-          }
-        }
-
-        // If we coudn't find the token, the RFC says to silently succeed anyway.
-        return {};
       },
     },
   ];

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -98,8 +98,6 @@ const DB_METHOD_NAMES = [
 ];
 
 const OAUTHDB_METHOD_NAMES = [
-  'revokeAccessToken',
-  'revokeRefreshToken',
   'revokeRefreshTokenById',
   'getScopedKeyData',
   'grantTokensFromAuthorizationCode',

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -98,7 +98,6 @@ const DB_METHOD_NAMES = [
 ];
 
 const OAUTHDB_METHOD_NAMES = [
-  'revokeRefreshTokenById',
   'getScopedKeyData',
   'grantTokensFromAuthorizationCode',
   'grantTokensFromRefreshToken',

--- a/packages/fxa-auth-server/test/remote/oauth_tests.js
+++ b/packages/fxa-auth-server/test/remote/oauth_tests.js
@@ -11,9 +11,6 @@ const config = require('../../config').getProperties();
 const { OAUTH_SCOPE_OLD_SYNC } = require('../../lib/constants');
 const error = require('../../lib/error');
 const testUtils = require('../lib/util');
-const introspect = require('../../lib/routes/oauth/introspect')({
-  oauthDB: require('../../lib/oauth/db'),
-}).config.handler;
 
 const PUBLIC_CLIENT_ID = '3c49430b43dfba77';
 const OAUTH_CLIENT_NAME = 'Android Components Reference Browser';
@@ -25,15 +22,6 @@ const JWT_ACCESS_TOKEN_SECRET =
   'a084f4c36501ea1eb2de33258421af97b2e67ffbe107d2812f4a14f3579900ef';
 
 const { decodeJWT } = testUtils;
-
-async function introspectToken(token) {
-  const res = await introspect({
-    payload: {
-      token,
-    },
-  });
-  return res;
-}
 
 describe('/oauth/ routes', function () {
   this.timeout(15000);
@@ -325,7 +313,7 @@ describe('/oauth/ routes', function () {
     assert.ok(res.access_token);
     assert.ok(res.refresh_token);
 
-    let tokenStatus = await introspectToken(res.access_token);
+    let tokenStatus = await client.api.introspect(res.access_token);
     assert.equal(tokenStatus.active, true);
 
     await client.revokeOAuthToken({
@@ -333,7 +321,7 @@ describe('/oauth/ routes', function () {
       token: res.access_token,
     });
 
-    tokenStatus = await introspectToken(res.access_token);
+    tokenStatus = await client.api.introspect(res.access_token);
     assert.equal(tokenStatus.active, false);
 
     const res2 = await client.grantOAuthTokens({
@@ -342,9 +330,10 @@ describe('/oauth/ routes', function () {
       refresh_token: res.refresh_token,
     });
     assert.ok(res2.access_token);
+    assert.notExists(res2.refresh_token);
 
-    tokenStatus = await introspectToken(res2.refresh_token);
-    assert.equal(tokenStatus.active, false);
+    tokenStatus = await client.api.introspect(res.refresh_token);
+    assert.equal(tokenStatus.active, true);
 
     await client.revokeOAuthToken({
       client_id: PUBLIC_CLIENT_ID,


### PR DESCRIPTION
## Because

- part of #5167

## This pull request

- pulls out the `oauthdb.revokeAccessToken`, `oauthdb.revokeRefreshToken`, and `oauthdb.revokeRefreshTokenById` threads
- adds `introspect` to the test client api