### PR TITLE
feat(admin-server): record x-forwarded-for correctly

### DIFF
--- a/packages/fxa-admin-server/src/main.ts
+++ b/packages/fxa-admin-server/src/main.ts
@@ -4,6 +4,7 @@
 import { NestApplicationOptions } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { SentryInterceptor } from 'fxa-shared/nestjs/sentry/sentry.interceptor';
 import helmet from 'helmet';
 
@@ -15,13 +16,22 @@ async function bootstrap() {
   if (Config.getProperties().env !== 'development') {
     nestConfig.logger = false;
   }
-  const app = await NestFactory.create(AppModule, nestConfig);
+  const app = await NestFactory.create<NestExpressApplication>(
+    AppModule,
+    nestConfig
+  );
   const config: ConfigService<AppConfig> = app.get(ConfigService);
   const port = config.get('port') as number;
 
   if (config.get<boolean>('hstsEnabled')) {
     const maxAge = config.get<number>('hstsMaxAge');
     app.use(helmet.hsts({ includeSubDomains: true, maxAge }));
+  }
+
+  // We run behind a proxy when deployed, include the express middleware
+  // to extract the X-Forwarded-For header.
+  if (Config.getProperties().env !== 'development') {
+    app.set('trust proxy', true);
   }
 
   // Add sentry as error reporter


### PR DESCRIPTION
Because:

* We want to log the correct IP of the accessing request.

This commit:

* Sets the IP correctly for remote requests.

Closes #5904

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
