### PR TITLE
fix(totp): downgrade session to email-based verification after TOTP is removed

### DIFF
--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -140,6 +140,12 @@ module.exports = (log, db, mailer, customs, config) => {
 
         await db.deleteTotpToken(uid);
 
+        // Downgrade the session to email-based verification when TOTP is
+        // removed. Because we know the session is already verified, there's
+        // no security risk in setting it as verified using a different method.
+        // See #5154.
+        await db.verifyTokensWithMethod(sessionToken.id, 'email-2fa');
+
         await log.notifyAttachedServices('profileDataChanged', request, {
           uid,
         });

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -124,6 +124,19 @@ describe('totp', () => {
           'uid',
           'third argument was event data with a uid'
         );
+
+        assert.equal(
+          db.verifyTokensWithMethod.callCount,
+          1,
+          'called db.verifyTokensWithMethod'
+        );
+        const dbArgs = db.verifyTokensWithMethod.args[0];
+        assert.equal(dbArgs[0], sessionId, 'first argument was sessionId');
+        assert.equal(
+          dbArgs[1],
+          'email-2fa',
+          `second argument was reduced verification level`
+        );
       });
     });
 
@@ -424,6 +437,9 @@ function setup(results, errors, routePath, requestOptions) {
       qrCodeUrl: 'some base64 encoded png',
       sharedSecret: secret,
     });
+  });
+  db.verifyTokensWithMethod = sinon.spy(() => {
+    return P.resolve();
   });
   db.totpToken = sinon.spy(() => {
     return P.resolve({


### PR DESCRIPTION
Retrying the fix for #7111 at the right level: when 2FA is removed from the account, immediately downgrade the session. 

## Because

- AMO requires developers to have 2FA enabled.
- To minimize friction, AMO first logs the user in, then checks their developer state against the user's Firefox Account 2FA state, and if 2FA is not enabled on a developer account, redirects back to the FxA using the [`prompt=none` flow](https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/oauth/prompt-none.md) and the user is prompted to enable 2FA in an inline flow, redirecting back to AMO when done.
- In the edge case where a user sets up 2FA, then logs out of AMO, then disables 2FA, then logs back in to AMO, the user gets trapped in a redirect loop (#6762)
- The redirect occurs because, as outlined in an [amazingly thorough and helpful review comment](https://github.com/mozilla/fxa/pull/7111#issuecomment-742209730), a user's session verification state is upgraded to use 2FA when 2FA is enabled, but not downgraded back to using an email loop when 2FA is disabled

## This pull request

- Downgrades session verification when the 2FA token is destroyed, ensuring users won't fall into the redirect loop. Instead, they will be sent back into the inline 2FA setup flow.

## Issue that this pull request solves

Fixes #6762, fixes #5154, closes #499.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
