### PR TITLE
chore(fxa-content-server): apply the MX record validation feature fla…

### DIFF
--- a/packages/fxa-content-server/server/lib/routes/validate-email-domain.js
+++ b/packages/fxa-content-server/server/lib/routes/validate-email-domain.js
@@ -13,7 +13,8 @@ const joi = require('joi');
 const dns = require('dns');
 const VError = require('verror');
 const resolver = new dns.promises.Resolver();
-const results = ['MX', 'A', 'none'].reduce((accumulator, val) => {
+const config = require('../configuration');
+const results = ['MX', 'A', 'none', 'skip'].reduce((accumulator, val) => {
   accumulator[val] = val;
   return accumulator;
 }, {});
@@ -68,7 +69,10 @@ module.exports = function () {
     },
     process: async function (req, res, next) {
       const { domain } = req.query;
-
+      const shouldValidate = config.get('mxRecordValidation.enabled');
+      if (!shouldValidate) {
+        return res.json({ result: results.skip });
+      }
       try {
         if (await tryResolveWith(resolver.resolveMx.bind(resolver))(domain)) {
           return res.json({ result: results.MX });


### PR DESCRIPTION
…g to the validate-email-domain endpoint

## Because

-

## This pull request

-

## Issue that this pull request solves

Closes: #7078 

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
@chenba  Shall we proceed like this since through such a change can pass all the tests and the record whiich are `proxyquire` would have no harm as well the `skip` record can be added easily 