### PR TITLE
[fxa-auth-server] Upgrade uuid dependency

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -211,7 +211,7 @@ module.exports = (
 
           const hexes = await random.hex(32, 32);
           account = await db.createAccount({
-            uid: uuid.v4('binary').toString('hex'),
+            uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
             createdAt: Date.now(),
             email: email,
             emailCode: emailCode,

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -96,7 +96,7 @@
     "sandboxed-regexp": "^0.3.0",
     "stripe": "^8.64.0",
     "typedi": "^0.8.0",
-    "uuid": "1.4.1",
+    "uuid": "^8.3.0",
     "verror": "^1.10.0",
     "web-push": "3.4.4"
   },

--- a/packages/fxa-auth-server/test/local/devices.js
+++ b/packages/fxa-auth-server/test/local/devices.js
@@ -322,7 +322,7 @@ describe('lib/devices:', () => {
         });
         credentials = {
           id: crypto.randomBytes(16).toString('hex'),
-          uid: uuid.v4('binary').toString('hex'),
+          uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
           tokenVerified: true,
         };
       });
@@ -597,7 +597,7 @@ describe('lib/devices:', () => {
         });
         credentials = {
           refreshTokenId: crypto.randomBytes(16).toString('hex'),
-          uid: uuid.v4('binary').toString('hex'),
+          uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
           tokenVerified: true,
         };
       });
@@ -859,7 +859,7 @@ describe('lib/devices:', () => {
         refreshTokenId = crypto.randomBytes(32).toString('hex');
         credentials = {
           id: crypto.randomBytes(16).toString('hex'),
-          uid: uuid.v4('binary').toString('hex'),
+          uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
           tokenVerified: true,
         };
         request = mocks.mockRequest({

--- a/packages/fxa-auth-server/test/local/ip_profiling.js
+++ b/packages/fxa-auth-server/test/local/ip_profiling.js
@@ -14,7 +14,7 @@ const uuid = require('uuid');
 
 const TEST_EMAIL = 'foo@gmail.com';
 const MS_ONE_DAY = 1000 * 60 * 60 * 24;
-const UID = uuid.v4('binary').toString('hex');
+const UID = uuid.v4({}, Buffer.alloc(16)).toString('hex');
 
 function makeRoutes(options = {}, requireMocks) {
   const { db, mailer } = options;

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -113,7 +113,7 @@ describe('/account/reset', () => {
     mailer;
 
   beforeEach(() => {
-    uid = uuid.v4('binary').toString('hex');
+    uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
     mockLog = mocks.mockLog();
     mockMetricsContext = mocks.mockMetricsContext();
     mockRequest = mocks.mockRequest({
@@ -535,7 +535,7 @@ describe('/account/create', () => {
     const emailCode = hexString(16);
     const keyFetchTokenId = hexString(16);
     const sessionTokenId = hexString(16);
-    const uid = uuid.v4('binary').toString('hex');
+    const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
     const mockDB = mocks.mockDB(
       {
         email: TEST_EMAIL,
@@ -1153,7 +1153,7 @@ describe('/account/login', () => {
   });
   const keyFetchTokenId = hexString(16);
   const sessionTokenId = hexString(16);
-  const uid = uuid.v4('binary').toString('hex');
+  const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
   const mockDB = mocks.mockDB({
     email: TEST_EMAIL,
     emailVerified: true,
@@ -2757,7 +2757,7 @@ describe('/account/login', () => {
 
 describe('/account/keys', () => {
   const keyFetchTokenId = hexString(16);
-  const uid = uuid.v4('binary').toString('hex');
+  const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
   const mockLog = mocks.mockLog();
   const mockRequest = mocks.mockRequest({
     credentials: {
@@ -2854,7 +2854,7 @@ describe('/account/keys', () => {
 
 describe('/account/destroy', () => {
   const email = 'foo@example.com';
-  const uid = uuid.v4('binary').toString('hex');
+  const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
   const expectedSubscriptions = [
     { uid, subscriptionId: '123' },
     { uid, subscriptionId: '456' },
@@ -2995,7 +2995,7 @@ describe('/account/destroy', () => {
 
 describe('/account', () => {
   const email = 'foo@example.com';
-  const uid = uuid.v4('binary').toString('hex');
+  const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
 
   const subscription = {
     current_period_end: Date.now() + 60000,
@@ -3103,7 +3103,7 @@ describe('/account', () => {
 });
 
 describe('/account/ecosystemAnonId', () => {
-  const uid = uuid.v4('binary').toString('hex');
+  const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
   const ecosystemAnonId = 'bowl of oranges';
   const oldAnonId = 'old id';
   let mockLog, mockDB, mockRequest, route;

--- a/packages/fxa-auth-server/test/local/routes/attached-clients.js
+++ b/packages/fxa-auth-server/test/local/routes/attached-clients.js
@@ -76,7 +76,7 @@ describe('/account/attached_clients', () => {
 
   beforeEach(() => {
     config = {};
-    uid = uuid.v4('binary').toString('hex');
+    uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
     log = mocks.mockLog();
     db = mocks.mockDB();
     oauthdb = mocks.mockOAuthDB(log, config);
@@ -374,7 +374,7 @@ describe('/account/attached_client/destroy', () => {
 
   beforeEach(() => {
     config = {};
-    uid = uuid.v4('binary').toString('hex');
+    uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
     log = mocks.mockLog();
     db = mocks.mockDB();
     oauthdb = mocks.mockOAuthDB(log, config);

--- a/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/test/local/routes/devices-and-sessions.js
@@ -97,7 +97,7 @@ function hexString(bytes) {
 }
 
 describe('/account/device', () => {
-  const uid = uuid.v4('binary').toString('hex');
+  const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
   const deviceId = crypto.randomBytes(16).toString('hex');
   const mockDeviceName = 'my awesome device 🍓🔥';
   let config,
@@ -343,7 +343,7 @@ describe('/account/device', () => {
 
 describe('/account/devices/notify', () => {
   const config = {};
-  const uid = uuid.v4('binary').toString('hex');
+  const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
   const deviceId = crypto.randomBytes(16).toString('hex');
   const mockLog = mocks.mockLog();
   const mockRequest = mocks.mockRequest({
@@ -767,7 +767,7 @@ describe('/account/devices/notify', () => {
 });
 
 describe('/account/device/commands', () => {
-  const uid = uuid.v4('binary').toString('hex');
+  const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
   const deviceId = crypto.randomBytes(16).toString('hex');
   let mockLog, mockRequest, mockCustoms;
 
@@ -967,7 +967,7 @@ describe('/account/device/commands', () => {
 });
 
 describe('/account/devices/invoke_command', () => {
-  const uid = uuid.v4('binary').toString('hex');
+  const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
   const command = 'bogusCommandName';
   const mockDevices = [
     {
@@ -1385,7 +1385,7 @@ describe('/account/device/destroy', () => {
   let mockPush;
 
   beforeEach(() => {
-    uid = uuid.v4('binary').toString('hex');
+    uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
     deviceId = crypto.randomBytes(16).toString('hex');
     deviceId2 = crypto.randomBytes(16).toString('hex');
     mockDevices = mocks.mockDevices({ deviceId });

--- a/packages/fxa-auth-server/test/local/routes/emails.js
+++ b/packages/fxa-auth-server/test/local/routes/emails.js
@@ -351,7 +351,7 @@ describe('/recovery_email/status', () => {
 
   const mockRequest = mocks.mockRequest({
     credentials: {
-      uid: uuid.v4('binary').toString('hex'),
+      uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
       email: TEST_EMAIL,
     },
   });
@@ -441,7 +441,7 @@ describe('/recovery_email/status', () => {
     });
 
     it('verified account', () => {
-      mockRequest.auth.credentials.uid = uuid.v4('binary').toString('hex');
+      mockRequest.auth.credentials.uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
       mockRequest.auth.credentials.emailVerified = true;
       mockRequest.auth.credentials.tokenVerified = true;
 
@@ -461,7 +461,7 @@ describe('/recovery_email/status', () => {
     pushCalled = false;
     const mockRequest = mocks.mockRequest({
       credentials: {
-        uid: uuid.v4('binary').toString('hex'),
+        uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
         email: TEST_EMAIL,
         emailVerified: true,
         tokenVerified: true,
@@ -551,7 +551,7 @@ describe('/recovery_email/resend_code', () => {
       log: mockLog,
       metricsContext: mockMetricsContext,
       credentials: {
-        uid: uuid.v4('binary').toString('hex'),
+        uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
         deviceId: 'wibble',
         email: TEST_EMAIL,
         emailVerified: false,
@@ -611,8 +611,8 @@ describe('/recovery_email/resend_code', () => {
       log: mockLog,
       metricsContext: mockMetricsContext,
       credentials: {
-        uid: uuid.v4('binary').toString('hex'),
-        deviceId: uuid.v4('binary').toString('hex'),
+        uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
+        deviceId: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
         email: TEST_EMAIL,
         emailVerified: true,
         tokenVerified: false,
@@ -668,8 +668,8 @@ describe('/recovery_email/resend_code', () => {
       log: mockLog,
       metricsContext: mockMetricsContext,
       credentials: {
-        uid: uuid.v4('binary').toString('hex'),
-        deviceId: uuid.v4('binary').toString('hex'),
+        uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
+        deviceId: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
         email: TEST_EMAIL,
         emailVerified: true,
         tokenVerified: false,
@@ -718,7 +718,7 @@ describe('/recovery_email/resend_code', () => {
 });
 
 describe('/recovery_email/verify_code', () => {
-  const uid = uuid.v4('binary').toString('hex');
+  const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
   const mockLog = mocks.mockLog();
   const mockRequest = mocks.mockRequest({
     log: mockLog,
@@ -1168,7 +1168,7 @@ describe('/recovery_email/verify_code', () => {
 });
 
 describe('/recovery_email', () => {
-  const uid = uuid.v4('binary').toString('hex');
+  const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
   const mockLog = mocks.mockLog();
   let dbData, accountRoutes, mockDB, mockRequest, route, otpUtils, stripeHelper;
   const mockMailer = mocks.mockMailer();
@@ -1178,8 +1178,8 @@ describe('/recovery_email', () => {
   beforeEach(() => {
     mockRequest = mocks.mockRequest({
       credentials: {
-        uid: uuid.v4('binary').toString('hex'),
-        deviceId: uuid.v4('binary').toString('hex'),
+        uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
+        deviceId: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
         email: TEST_EMAIL,
         emailVerified: true,
         normalizedEmail: normalizeEmail(TEST_EMAIL),
@@ -1629,7 +1629,7 @@ describe('/recovery_email', () => {
     it('should fail when setting email to email user does not own', () => {
       mockDB.getSecondaryEmail = sinon.spy(() => {
         return P.resolve({
-          uid: uuid.v4('binary').toString('hex'),
+          uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
           isVerified: true,
           isPrimary: false,
         });
@@ -1749,12 +1749,12 @@ describe('/emails/reminders/cad', () => {
   let accountRoutes, mockRequest, route, uid;
 
   beforeEach(() => {
-    uid = uuid.v4('binary').toString('hex');
+    uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
 
     mockRequest = mocks.mockRequest({
       credentials: {
         uid,
-        deviceId: uuid.v4('binary').toString('hex'),
+        deviceId: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
         email: TEST_EMAIL,
         emailVerified: true,
         normalizedEmail: normalizeEmail(TEST_EMAIL),

--- a/packages/fxa-auth-server/test/local/routes/password.js
+++ b/packages/fxa-auth-server/test/local/routes/password.js
@@ -59,7 +59,7 @@ function runRoute(routes, name, request) {
 describe('/password', () => {
   it('/forgot/send_code', () => {
     const mockCustoms = mocks.mockCustoms();
-    const uid = uuid.v4('binary').toString('hex');
+    const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
     const passwordForgotTokenId = crypto.randomBytes(16).toString('hex');
     const mockDB = mocks.mockDB({
       email: TEST_EMAIL,
@@ -186,7 +186,7 @@ describe('/password', () => {
 
   it('/forgot/resend_code', () => {
     const mockCustoms = mocks.mockCustoms();
-    const uid = uuid.v4('binary').toString('hex');
+    const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
     const mockDB = mocks.mockDB();
     const mockMailer = mocks.mockMailer();
     const mockMetricsContext = mocks.mockMetricsContext();
@@ -268,7 +268,7 @@ describe('/password', () => {
 
   it('/forgot/verify_code', () => {
     const mockCustoms = mocks.mockCustoms();
-    const uid = uuid.v4('binary').toString('hex');
+    const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
     const accountResetToken = {
       data: crypto.randomBytes(16).toString('hex'),
       id: crypto.randomBytes(16).toString('hex'),
@@ -402,7 +402,7 @@ describe('/password', () => {
 
   describe('/change/finish', () => {
     it('smoke', () => {
-      const uid = uuid.v4('binary').toString('hex');
+      const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
       const devices = [
         { uid: uid, id: crypto.randomBytes(16) },
         { uid: uid, id: crypto.randomBytes(16) },
@@ -544,7 +544,7 @@ describe('/password', () => {
     });
 
     it('succeeds even if notification blocked', () => {
-      const uid = uuid.v4('binary').toString('hex');
+      const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
       const mockDB = mocks.mockDB({
         email: TEST_EMAIL,
         uid: uid,

--- a/packages/fxa-auth-server/test/local/routes/security-events.js
+++ b/packages/fxa-auth-server/test/local/routes/security-events.js
@@ -11,7 +11,7 @@ const uuid = require('uuid');
 
 let route, routes, request;
 const TEST_EMAIL = 'foo@gmail.com';
-const UID = uuid.v4('binary').toString('hex');
+const UID = uuid.v4({}, Buffer.alloc(16)).toString('hex');
 
 function makeRoutes(options = {}) {
   const log = options.log || mocks.mockLog();

--- a/packages/fxa-auth-server/test/local/routes/sign.js
+++ b/packages/fxa-auth-server/test/local/routes/sign.js
@@ -35,7 +35,7 @@ describe('/certificate/sign', () => {
       }
     );
     return SessionToken.create({
-      uid: uuid.v4('binary').toString('hex'),
+      uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
       email: 'foo@example.com',
       emailVerified: true,
       locale: 'en',

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -71,7 +71,7 @@ const SUBSCRIPTIONS_MANAGEMENT_SCOPE =
 
 const ACCOUNT_LOCALE = 'en-US';
 const TEST_EMAIL = 'test@email.com';
-const UID = uuid.v4('binary').toString('hex');
+const UID = uuid.v4({}, Buffer.alloc(16)).toString('hex');
 const NOW = Date.now();
 const PLAN_ID_1 = 'plan_G93lTs8hfK7NNG';
 const PLANS = [
@@ -374,7 +374,7 @@ describe('subscriptions directRoutes', () => {
 });
 
 describe('handleAuth', () => {
-  const AUTH_UID = uuid.v4('binary').toString('hex');
+  const AUTH_UID = uuid.v4({}, Buffer.alloc(16)).toString('hex');
   const AUTH_EMAIL = 'auth@example.com';
   const DB_EMAIL = 'db@example.com';
 

--- a/packages/fxa-auth-server/test/local/routes/support.js
+++ b/packages/fxa-auth-server/test/local/routes/support.js
@@ -26,7 +26,7 @@ const SUBSCRIPTIONS_MANAGEMENT_SCOPE =
   'https://identity.mozilla.com/account/subscriptions';
 
 const TEST_EMAIL = 'test@email.com';
-const UID = uuid.v4('binary').toString('hex');
+const UID = uuid.v4({}, Buffer.alloc(16)).toString('hex');
 const REQUESTER_ID = 987654321;
 const SUBDOMAIN = 'test';
 

--- a/packages/fxa-auth-server/test/local/routes/unblock-codes.js
+++ b/packages/fxa-auth-server/test/local/routes/unblock-codes.js
@@ -35,7 +35,7 @@ function runTest(route, request, assertions) {
 }
 
 describe('/account/login/send_unblock_code', () => {
-  const uid = uuid.v4('binary').toString('hex');
+  const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
   const email = 'unblock@example.com';
   const mockLog = mocks.mockLog();
   const mockRequest = mocks.mockRequest({
@@ -135,7 +135,7 @@ describe('/account/login/send_unblock_code', () => {
 
 describe('/account/login/reject_unblock_code', () => {
   it('should consume the unblock code', () => {
-    const uid = uuid.v4('binary').toString('hex');
+    const uid = uuid.v4({}, Buffer.alloc(16)).toString('hex');
     const unblockCode = 'A1B2C3D4';
     const mockRequest = mocks.mockRequest({
       payload: {

--- a/packages/fxa-auth-server/test/mailer_helper.js
+++ b/packages/fxa-auth-server/test/mailer_helper.js
@@ -20,7 +20,7 @@ const zeroBuffer32 = Buffer.from(
 
 function createTestAccount() {
   const account = {
-    uid: uuid.v4('binary').toString('hex'),
+    uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
     email: `foo${Math.random()}@bar.com`,
     emailCode: zeroBuffer16,
     emailVerified: false,

--- a/packages/fxa-auth-server/test/remote/db_tests.js
+++ b/packages/fxa-auth-server/test/remote/db_tests.js
@@ -86,7 +86,7 @@ describe('remote db', function () {
 
   beforeEach(() => {
     account = {
-      uid: uuid.v4('binary').toString('hex'),
+      uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
       email: dbServer.uniqueEmail(),
       emailCode: zeroBuffer16,
       emailVerified: false,

--- a/packages/fxa-auth-server/test/remote/push_db_tests.js
+++ b/packages/fxa-auth-server/test/remote/push_db_tests.js
@@ -30,7 +30,7 @@ const zeroBuffer32 = Buffer.from(
 const SESSION_TOKEN_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0';
 const ACCOUNT = {
-  uid: uuid.v4('binary').toString('hex'),
+  uid: uuid.v4({}, Buffer.alloc(16)).toString('hex'),
   email: `push${Math.random()}@bar.com`,
   emailCode: zeroBuffer16,
   emailVerified: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -17849,7 +17849,7 @@ fsevents@^1.2.7:
     ts-node: ^8.10.2
     typedi: ^0.8.0
     typescript: 3.9.7
-    uuid: 1.4.1
+    uuid: ^8.3.0
     verror: ^1.10.0
     web-push: 3.4.4
     ws: ^7.4.0
@@ -37263,13 +37263,6 @@ typescript@~4.1.2:
     escape-string-regexp: ~1.0.5
     extend: ~3.0.0
   checksum: cc762e067a94a97dc3686a8cc1a8e8dad603e00dbe3b4acd36d31b30c9e288fa0103f412baca1e4d837cd9b1c5d625fd565ef0fec668297d74f991f7ee8cead7
-  languageName: node
-  linkType: hard
-
-"uuid@npm:1.4.1":
-  version: 1.4.1
-  resolution: "uuid@npm:1.4.1"
-  checksum: ff1f86d5c0646c4d3eaa4711073f630c2360f2bb62d6f5b319353cbce6a9fba0556f4eefe5f595aa236b4caf94e82567b4c27f8c1761384ebfc156bc947d60f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

The fxa-auth-server was depending on an ancient version of the `uuid` module.

## This pull request

Upgrades the `uuid` module dependency to benefit from the project-global cache.

## Issue that this pull request solves

Closes: _n/a_

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
