### PR TITLE
fix(test): Fix flaky oauth signin test

### DIFF
--- a/packages/fxa-content-server/tests/functional/oauth_sign_in_token_code.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sign_in_token_code.js
@@ -85,7 +85,12 @@ registerSuite('OAuth signin token code', {
 
           // Displays invalid code errors
           .then(type(selectors.SIGNIN_TOKEN_CODE.INPUT, '000000'))
-          .then(click(selectors.SIGNIN_TOKEN_CODE.SUBMIT))
+          .then(
+            click(
+              selectors.SIGNIN_TOKEN_CODE.SUBMIT,
+              selectors.SIGNIN_TOKEN_CODE.TOOLTIP
+            )
+          )
           .then(
             testElementTextInclude(
               selectors.SIGNIN_TOKEN_CODE.TOOLTIP,


### PR DESCRIPTION
## Because

- Flaky tests

## This pull request

- Checks for the error tooltip to appear before asserting the text in tooltip

## Issue that this pull request solves

Closes: #6513 

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
