### PR TITLE
fix(shared): don't report NestJS HttpExceptions

### DIFF
--- a/packages/fxa-shared/nestjs/sentry/reporting.ts
+++ b/packages/fxa-shared/nestjs/sentry/reporting.ts
@@ -118,10 +118,16 @@ export function captureSqsError(err: Error, message?: SQS.Message): void {
  * @param request A request object if available.
  */
 export function reportRequestException(
-  exception: Error & { reported?: boolean },
+  exception: Error & { reported?: boolean; status?: number; response?: any },
   excContexts: ExtraContext[] = [],
   request?: Request
 ) {
+  // Don't report HttpExceptions, we test for its two attributes as its more reliable
+  // than instance checks of HttpException
+  if (exception.status && exception.response) {
+    return;
+  }
+
   // Don't report already reported exceptions
   if (exception.reported) {
     return;


### PR DESCRIPTION
Because:

* HttpExceptions are for flow control to halt request processing and
  return a result, not actual errors that should be reported to Sentry.

This commit:

* Does not report HttpException type errors.

Closes #7067

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
