### PR TITLE
fix(test): Fix settings v2 external link test

### DIFF
--- a/packages/fxa-content-server/tests/functional/settings_v2/external_links.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/external_links.js
@@ -54,7 +54,7 @@ describe('external links', () => {
     );
   });
 
-  it('renders Subscriptions link in navigation when we are subscribed to a product', async () => {
+  it('renders Subscriptions link in navigation when we are subscribed to a product', async function () {
     if (process.env.CIRCLECI === 'true' && !process.env.SUBHUB_STRIPE_APIKEY) {
       this.skip('missing Stripe API key in CircleCI run');
     }


### PR DESCRIPTION
## Because

- The external links functional tests were broken

## This pull request

- Updates the test to not use `async` because it wouldn't have [access to the scope](https://theintern.io/docs.html#Intern/4/api/lib%2FTest/skip) that contains the `skip` method.

## Issue that this pull request solves

Closes: #7096

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
