### PR TITLE
refactor(auth): use native promises more

### DIFF
--- a/packages/fxa-auth-server/lib/crypto/hkdf.js
+++ b/packages/fxa-auth-server/lib/crypto/hkdf.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const HKDF = require('hkdf');
-const P = require('../promise');
 
 const NAMESPACE = 'identity.mozilla.com/picl/v1/';
 
@@ -18,12 +17,12 @@ function KW(name) {
 }
 
 function hkdf(km, info, salt, len) {
-  const d = P.defer();
-  const df = new HKDF('sha256', salt, km);
-  df.derive(KW(info), len, (key) => {
-    d.resolve(key);
+  return new Promise((resolve) => {
+    const df = new HKDF('sha256', salt, km);
+    df.derive(KW(info), len, (key) => {
+      resolve(key);
+    });
   });
-  return d.promise;
 }
 
 hkdf.KW = KW;

--- a/packages/fxa-auth-server/lib/metrics/events.js
+++ b/packages/fxa-auth-server/lib/metrics/events.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const error = require('../error');
-const P = require('../promise');
 
 const ACTIVITY_EVENTS = new Set([
   'account.changedPassword',
@@ -143,7 +142,7 @@ module.exports = (log, config) => {
         IGNORE_ROUTE_FLOW_EVENTS_FOR_PATHS.has(path) ||
         IGNORE_ROUTE_FLOW_EVENTS_REGEX.test(path)
       ) {
-        return P.resolve();
+        return Promise.resolve();
       }
 
       if (status >= 400) {
@@ -154,7 +153,7 @@ module.exports = (log, config) => {
           !request.validateMetricsContext()
         ) {
           // Don't emit flow events if the metrics context failed validation
-          return P.resolve();
+          return Promise.resolve();
         }
 
         status = `${status}.${errno || 999}`;
@@ -190,7 +189,7 @@ module.exports = (log, config) => {
   function emitFlowEvent(event, request, optionalData) {
     if (!request || !request.headers) {
       log.trace('metricsEvents.emitFlowEvent', { event, badRequest: true });
-      return P.resolve();
+      return Promise.resolve();
     }
 
     const { location } = request.app.geo;

--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -4,8 +4,6 @@
 
 const hex = require('buf').to.hex;
 
-const P = require('../../promise');
-
 const config = require('../../../config');
 const encrypt = require('../encrypt');
 const mysql = require('./mysql');
@@ -231,7 +229,7 @@ function convertClientToConfigFormat(client) {
 function preClients() {
   var clients = config.get('oauthServer.clients');
   if (clients && clients.length) {
-    return P.all(
+    return Promise.all(
       clients.map(function (c) {
         if (c.secret) {
           // eslint-disable-next-line no-console
@@ -243,7 +241,7 @@ function preClients() {
             c.id,
             hex(encrypt.hash(c.secret))
           );
-          return P.reject(
+          return Promise.reject(
             new Error('Do not keep client secrets in the config file.')
           );
         }
@@ -265,7 +263,7 @@ function preClients() {
           }
         });
         if (err) {
-          return P.reject(err);
+          return Promise.reject(err);
         }
 
         // ensure booleans are boolean and not undefined
@@ -276,7 +274,7 @@ function preClients() {
         // Modification of the database at startup in production and stage is
         // not preferred. This option will be set to false on those stacks.
         if (!config.get('oauthServer.db.autoUpdateClients')) {
-          return P.resolve();
+          return Promise.resolve();
         }
 
         return module.exports.getClient(c.id).then(function (client) {
@@ -292,7 +290,7 @@ function preClients() {
       })
     );
   } else {
-    return P.resolve();
+    return Promise.resolve();
   }
 }
 
@@ -302,7 +300,7 @@ function preClients() {
 function scopes() {
   var scopes = config.get('oauthServer.scopes');
   if (scopes && scopes.length) {
-    return P.all(
+    return Promise.all(
       scopes.map(function (s) {
         return module.exports.getScope(s.scope).then(function (existing) {
           if (existing) {

--- a/packages/fxa-auth-server/lib/oauth/jwt.js
+++ b/packages/fxa-auth-server/lib/oauth/jwt.js
@@ -3,13 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const jsonwebtoken = require('jsonwebtoken');
-const P = require('../promise');
 const { publicPEM, SIGNING_PEM, SIGNING_KID, SIGNING_ALG } = require('./keys');
 
 const config = require('../../config');
 const ISSUER = config.get('oauthServer.openid.issuer');
 
-const jwtverify = P.promisify(jsonwebtoken.verify);
+const jwtverify = require('util').promisify(jsonwebtoken.verify);
 
 /**
  * Sign `claims` using SIGNING_PEM from keys.js, returning a JWT.

--- a/packages/fxa-auth-server/lib/routes/account.js
+++ b/packages/fxa-auth-server/lib/routes/account.js
@@ -8,7 +8,6 @@ const emailUtils = require('./utils/email');
 const error = require('../error');
 const isA = require('@hapi/joi');
 const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;
-const P = require('../promise');
 const random = require('../crypto/random');
 const requestHelper = require('./utils/request_helper');
 const uuid = require('uuid');
@@ -1136,7 +1135,7 @@ module.exports = (
             return db.getRecoveryKey(accountResetToken.uid, recoveryKeyId);
           }
 
-          return P.resolve();
+          return Promise.resolve();
         }
 
         async function checkTotpToken() {
@@ -1175,7 +1174,7 @@ module.exports = (
           // Notify various interested parties about this password reset.
           // These can all safely happen in parallel.
           account = await db.account(accountResetToken.uid);
-          await P.all([
+          await Promise.all([
             push.notifyPasswordReset(account.uid, devicesToNotify),
             request.emitMetricsEvent('account.reset', {
               uid: account.uid,
@@ -1428,7 +1427,7 @@ module.exports = (
           // Ignore notification errors since this account no longer exists
         }
 
-        await P.all([
+        await Promise.all([
           log.notifyAttachedServices('delete', request, { uid }),
           request.emitMetricsEvent('account.deleted', { uid }),
         ]);

--- a/packages/fxa-auth-server/lib/routes/password.js
+++ b/packages/fxa-auth-server/lib/routes/password.js
@@ -10,7 +10,6 @@ const HEX_STRING = validators.HEX_STRING;
 const butil = require('../crypto/butil');
 const error = require('../error');
 const isA = require('@hapi/joi');
-const P = require('../promise');
 const random = require('../crypto/random');
 const requestHelper = require('../routes/utils/request_helper');
 const { emailsMatch } = require('fxa-shared').email.helpers;
@@ -200,7 +199,7 @@ module.exports = function (
           } else {
             // Don't create a verified session unless they already had one.
             verifiedStatus = false;
-            return P.resolve();
+            return Promise.resolve();
           }
         }
 
@@ -319,7 +318,7 @@ module.exports = function (
         }
 
         function createSessionToken() {
-          return P.resolve()
+          return Promise.resolve()
             .then(() => {
               if (!verifiedStatus) {
                 return random.hex(16);
@@ -445,7 +444,7 @@ module.exports = function (
 
         let passwordForgotToken;
 
-        return P.all([
+        return Promise.all([
           request.emitMetricsEvent('password.forgot.send_code.start'),
           customs.check(request, email, 'passwordForgotSendCode'),
         ])
@@ -463,7 +462,7 @@ module.exports = function (
           })
           .then((result) => {
             passwordForgotToken = result;
-            return P.all([
+            return Promise.all([
               request.stashMetricsContext(passwordForgotToken),
               db.accountEmails(passwordForgotToken.uid),
             ]);
@@ -547,7 +546,7 @@ module.exports = function (
         const { deviceId, flowId, flowBeginTime } = await request.app
           .metricsContext;
 
-        return P.all([
+        return Promise.all([
           request.emitMetricsEvent('password.forgot.resend_code.start'),
           customs.check(
             request,
@@ -635,7 +634,7 @@ module.exports = function (
 
         let accountResetToken;
 
-        return P.all([
+        return Promise.all([
           request.emitMetricsEvent('password.forgot.verify_code.start'),
           customs.check(
             request,
@@ -660,7 +659,7 @@ module.exports = function (
           })
           .then((result) => {
             accountResetToken = result;
-            return P.all([
+            return Promise.all([
               request.propagateMetricsContext(
                 passwordForgotToken,
                 accountResetToken
@@ -673,7 +672,7 @@ module.exports = function (
               // To prevent multiple password change emails being sent to a user,
               // we check for a flag to see if this is a reset using an account recovery key.
               // If it is, then the notification email will be sent in `/account/reset`
-              return P.resolve();
+              return Promise.resolve();
             }
 
             return mailer.sendPasswordResetEmail(emails, passwordForgotToken, {

--- a/packages/fxa-auth-server/lib/routes/utils/signin.js
+++ b/packages/fxa-auth-server/lib/routes/utils/signin.js
@@ -7,7 +7,6 @@
 const emailUtils = require('./email');
 const isA = require('@hapi/joi');
 const validators = require('../validators');
-const P = require('../../promise');
 const butil = require('../../crypto/butil');
 const error = require('../../error');
 const { emailsMatch } = require('fxa-shared').email.helpers;
@@ -90,7 +89,7 @@ module.exports = (log, config, customs, db, mailer, cadReminders) => {
       ) {
         throw error.cannotLoginWithSecondaryEmail();
       }
-      return P.resolve(true);
+      return Promise.resolve(true);
     },
 
     /**
@@ -110,14 +109,14 @@ module.exports = (log, config, customs, db, mailer, cadReminders) => {
       let accountRecord, originalError;
       let didSigninUnblock = false;
 
-      return P.resolve()
+      return Promise.resolve()
         .then(() => {
           // For testing purposes, some email addresses are forced
           // to go through signin unblock on every login attempt.
           const forced =
             config.signinUnblock && config.signinUnblock.forcedEmailAddresses;
           if (forced && forced.test(email)) {
-            return P.reject(error.requestBlocked(true));
+            return Promise.reject(error.requestBlocked(true));
           }
           return customs.check(request, email, 'accountLogin');
         })

--- a/packages/fxa-auth-server/lib/senders/select_email_services.js
+++ b/packages/fxa-auth-server/lib/senders/select_email_services.js
@@ -4,7 +4,6 @@
 
 'use strict';
 
-const Promise = require('../promise');
 const { SandboxedRegExp } = require('sandboxed-regexp');
 
 const SERVICES = {

--- a/packages/fxa-auth-server/scripts/bulk-mailer/send-email-batch.js
+++ b/packages/fxa-auth-server/scripts/bulk-mailer/send-email-batch.js
@@ -4,13 +4,11 @@
 
 'use strict';
 
-const P = require('../../lib/promise');
-
 module.exports = function sendBatch(batch, sendEmail, log) {
   let successCount = 0;
   let errorCount = 0;
 
-  return P.all(
+  return Promise.all(
     batch.map((userRecord) => {
       return sendEmail(userRecord).then(
         () => {

--- a/packages/fxa-auth-server/test/local/authMethods.js
+++ b/packages/fxa-auth-server/test/local/authMethods.js
@@ -8,7 +8,6 @@ const sinon = require('sinon');
 const assert = { ...sinon.assert, ...require('chai').assert };
 
 const mocks = require('../mocks');
-const P = require('../../lib/promise');
 const error = require('../../lib/error');
 
 const authMethods = require('../../lib/authMethods');
@@ -26,7 +25,7 @@ describe('availableAuthenticationMethods', () => {
 
   it('returns [`pwd`,`email`] for non-TOTP-enabled accounts', () => {
     mockDb.totpToken = sinon.spy(() => {
-      return P.reject(error.totpTokenNotFound());
+      return Promise.reject(error.totpTokenNotFound());
     });
     return authMethods
       .availableAuthenticationMethods(mockDb, MOCK_ACCOUNT)
@@ -38,7 +37,7 @@ describe('availableAuthenticationMethods', () => {
 
   it('returns [`pwd`,`email`,`otp`] for TOTP-enabled accounts', () => {
     mockDb.totpToken = sinon.spy(() => {
-      return P.resolve({
+      return Promise.resolve({
         verified: true,
         enabled: true,
         sharedSecret: 'secret!',
@@ -54,7 +53,7 @@ describe('availableAuthenticationMethods', () => {
 
   it('returns [`pwd`,`email`] when TOTP token is not yet enabled', () => {
     mockDb.totpToken = sinon.spy(() => {
-      return P.resolve({
+      return Promise.resolve({
         verified: true,
         enabled: false,
         sharedSecret: 'secret!',
@@ -70,7 +69,7 @@ describe('availableAuthenticationMethods', () => {
 
   it('rethrows unexpected DB errors', () => {
     mockDb.totpToken = sinon.spy(() => {
-      return P.reject(error.serviceUnavailable());
+      return Promise.reject(error.serviceUnavailable());
     });
     return authMethods
       .availableAuthenticationMethods(mockDb, MOCK_ACCOUNT)

--- a/packages/fxa-auth-server/test/local/error.js
+++ b/packages/fxa-auth-server/test/local/error.js
@@ -8,7 +8,6 @@ const { assert } = require('chai');
 const verror = require('verror');
 const messages = require('@hapi/joi/lib/language');
 const AppError = require('../../lib/error');
-const P = require('../../lib/promise');
 
 describe('AppErrors', () => {
   it('tightly-coupled joi message hack is okay', () => {
@@ -130,8 +129,8 @@ describe('AppErrors', () => {
           os: 'Android',
           osVersion: '9',
         },
-        devices: P.resolve([{ id: 1 }]),
-        metricsContext: P.resolve({
+        devices: Promise.resolve([{ id: 1 }]),
+        metricsContext: Promise.resolve({
           service: 'sync',
         }),
       },

--- a/packages/fxa-auth-server/test/local/ip_profiling.js
+++ b/packages/fxa-auth-server/test/local/ip_profiling.js
@@ -8,7 +8,6 @@ const { assert } = require('chai');
 const crypto = require('crypto');
 const getRoute = require('../routes_helpers').getRoute;
 const mocks = require('../mocks');
-const P = require('../../lib/promise');
 const proxyquire = require('proxyquire');
 const uuid = require('uuid');
 
@@ -32,7 +31,7 @@ function makeRoutes(options = {}, requireMocks) {
   const cadReminders = mocks.mockCadReminders();
   const customs = {
     check() {
-      return P.resolve(true);
+      return Promise.resolve(true);
     },
     flag() {},
   };
@@ -44,7 +43,7 @@ function makeRoutes(options = {}, requireMocks) {
     mailer,
     cadReminders
   );
-  signinUtils.checkPassword = () => P.resolve(true);
+  signinUtils.checkPassword = () => Promise.resolve(true);
   return proxyquire('../../lib/routes/account', requireMocks || {})(
     log,
     db,
@@ -59,7 +58,7 @@ function makeRoutes(options = {}, requireMocks) {
 }
 
 function runTest(route, request, assertions) {
-  return new P((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     try {
       return route.handler(request).then(resolve, reject);
     } catch (err) {
@@ -103,7 +102,7 @@ describe('IP Profiling', () => {
 
   it('no previously verified session', () => {
     mockDB.securityEvents = function () {
-      return P.resolve([
+      return Promise.resolve([
         {
           name: 'account.login',
           createdAt: Date.now(),
@@ -125,7 +124,7 @@ describe('IP Profiling', () => {
 
   it('previously verified session', () => {
     mockDB.securityEvents = function () {
-      return P.resolve([
+      return Promise.resolve([
         {
           name: 'account.login',
           createdAt: Date.now(),
@@ -147,7 +146,7 @@ describe('IP Profiling', () => {
 
   it('previously verified session more than a day', () => {
     mockDB.securityEvents = function () {
-      return P.resolve([
+      return Promise.resolve([
         {
           name: 'account.login',
           createdAt: Date.now() - MS_ONE_DAY * 2, // Created two days ago
@@ -172,7 +171,7 @@ describe('IP Profiling', () => {
     mockRequest.payload.email = forceSigninEmail;
 
     mockDB.accountRecord = function () {
-      return P.resolve({
+      return Promise.resolve({
         authSalt: crypto.randomBytes(32),
         data: crypto.randomBytes(32),
         email: forceSigninEmail,

--- a/packages/fxa-auth-server/test/local/metrics/events.js
+++ b/packages/fxa-auth-server/test/local/metrics/events.js
@@ -22,7 +22,6 @@ const events = require('../../../lib/metrics/events')(log, {
   verificationReminders: {},
 });
 const mocks = require('../../mocks');
-const P = require('../../../lib/promise');
 
 describe('metrics/events', () => {
   afterEach(() => {
@@ -381,7 +380,7 @@ describe('metrics/events', () => {
     const metricsContext = mocks.mockMetricsContext();
     const request = {
       app: {
-        devices: P.resolve(),
+        devices: Promise.resolve(),
         geo: {
           location: {
             country: 'United Kingdom',
@@ -800,7 +799,7 @@ describe('metrics/events', () => {
     const metricsContext = mocks.mockMetricsContext();
     const request = {
       app: {
-        devices: P.resolve(),
+        devices: Promise.resolve(),
         geo: {},
         ua: {},
       },

--- a/packages/fxa-auth-server/test/local/profile/updates.js
+++ b/packages/fxa-auth-server/test/local/profile/updates.js
@@ -10,7 +10,6 @@ const assert = { ...sinon.assert, ...require('chai').assert };
 const EventEmitter = require('events').EventEmitter;
 const { mockDB, mockLog } = require('../../mocks');
 const profileUpdates = require('../../../lib/profile/updates');
-const P = require('../../../lib/promise');
 
 const mockDeliveryQueue = new EventEmitter();
 mockDeliveryQueue.start = function start() {};
@@ -27,7 +26,7 @@ const mockPush = {
     if (pushShouldThrow) {
       throw new Error('oops');
     }
-    return P.resolve();
+    return Promise.resolve();
   }),
 };
 

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -11,7 +11,6 @@ const mocks = require('../../mocks');
 const getRoute = require('../../routes_helpers').getRoute;
 const proxyquire = require('proxyquire');
 
-const P = require('../../../lib/promise');
 const uuid = require('uuid');
 const crypto = require('crypto');
 const error = require('../../../lib/error');
@@ -50,7 +49,7 @@ const makeRoutes = function (options = {}, requireMocks) {
   const db = options.db || mocks.mockDB();
   const customs = options.customs || {
     check: () => {
-      return P.resolve(true);
+      return Promise.resolve(true);
     },
   };
   const signinUtils =
@@ -88,7 +87,7 @@ const makeRoutes = function (options = {}, requireMocks) {
 };
 
 function runTest(route, request, assertions) {
-  return new P((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     try {
       return route.handler(request).then(resolve, reject);
     } catch (err) {
@@ -321,7 +320,7 @@ describe('/account/reset', () => {
     let res;
     beforeEach(() => {
       mockDB.totpToken = sinon.spy(() => {
-        return P.resolve({
+        return Promise.resolve({
           verified: true,
           enabled: true,
         });
@@ -489,10 +488,10 @@ describe('/account/create', () => {
     };
     const mockLog = log('ERROR', 'test');
     mockLog.activityEvent = sinon.spy(() => {
-      return P.resolve();
+      return Promise.resolve();
     });
     mockLog.flowEvent = sinon.spy(() => {
-      return P.resolve();
+      return Promise.resolve();
     });
     mockLog.error = sinon.spy();
     mockLog.notifier.send = sinon.spy();
@@ -566,10 +565,10 @@ describe('/account/create', () => {
       Password: function () {
         return {
           unwrap: function () {
-            return P.resolve('wibble');
+            return Promise.resolve('wibble');
           },
           verifyHash: function () {
-            return P.resolve('wibble');
+            return Promise.resolve('wibble');
           },
         };
       },
@@ -988,7 +987,7 @@ describe('/account/create', () => {
   it('should return an error if email fails to send', () => {
     const { mockMailer, mockRequest, route, verificationReminders } = setup();
 
-    mockMailer.sendVerifyEmail = sinon.spy(() => P.reject());
+    mockMailer.sendVerifyEmail = sinon.spy(() => Promise.reject());
 
     return runTest(route, mockRequest).then(assert.fail, (err) => {
       assert.equal(err.message, 'Failed to send email');
@@ -1004,7 +1003,7 @@ describe('/account/create', () => {
     const { mockMailer, mockRequest, route, verificationReminders } = setup();
 
     mockMailer.sendVerifyEmail = sinon.spy(() =>
-      P.reject(error.emailBouncedHard(42))
+      Promise.reject(error.emailBouncedHard(42))
     );
 
     return runTest(route, mockRequest).then(assert.fail, (err) => {
@@ -1052,10 +1051,10 @@ describe('/account/login', () => {
   };
   const mockLog = log('ERROR', 'test');
   mockLog.activityEvent = sinon.spy(() => {
-    return P.resolve();
+    return Promise.resolve();
   });
   mockLog.flowEvent = sinon.spy(() => {
-    return P.resolve();
+    return Promise.resolve();
   });
   mockLog.notifier.send = sinon.spy();
   const mockMetricsContext = mocks.mockMetricsContext();
@@ -1169,13 +1168,13 @@ describe('/account/login', () => {
   const mockMailer = mocks.mockMailer();
   const mockPush = mocks.mockPush();
   const mockCustoms = {
-    check: () => P.resolve(),
-    flag: () => P.resolve(),
+    check: () => Promise.resolve(),
+    flag: () => Promise.resolve(),
   };
   const mockCadReminders = mocks.mockCadReminders();
   const accountRoutes = makeRoutes({
     checkPassword: function () {
-      return P.resolve(true);
+      return Promise.resolve(true);
     },
     config: config,
     customs: mockCustoms,
@@ -1193,9 +1192,9 @@ describe('/account/login', () => {
   afterEach(() => {
     mockLog.activityEvent.resetHistory();
     mockLog.flowEvent.resetHistory();
-    mockMailer.sendNewDeviceLoginEmail = sinon.spy(() => P.resolve([]));
-    mockMailer.sendVerifyLoginEmail = sinon.spy(() => P.resolve());
-    mockMailer.sendVerifyLoginCodeEmail = sinon.spy(() => P.resolve());
+    mockMailer.sendNewDeviceLoginEmail = sinon.spy(() => Promise.resolve([]));
+    mockMailer.sendVerifyLoginEmail = sinon.spy(() => Promise.resolve());
+    mockMailer.sendVerifyLoginCodeEmail = sinon.spy(() => Promise.resolve());
     mockMailer.sendVerifyEmail.resetHistory();
     mockDB.createSessionToken.resetHistory();
     mockDB.sessions.resetHistory();
@@ -1207,7 +1206,7 @@ describe('/account/login', () => {
     mockDB.accountRecord = defaultEmailAccountRecord;
     mockDB.accountRecord.resetHistory();
     mockDB.getSecondaryEmail = sinon.spy(() =>
-      P.reject(error.unknownSecondaryEmail())
+      Promise.reject(error.unknownSecondaryEmail())
     );
     mockDB.getSecondaryEmail.resetHistory();
     mockRequest.payload.email = TEST_EMAIL;
@@ -1502,7 +1501,7 @@ describe('/account/login', () => {
     it('sends email code', () => {
       const emailCode = hexString(16);
       mockDB.accountRecord = function () {
-        return P.resolve({
+        return Promise.resolve({
           authSalt: hexString(32),
           data: hexString(32),
           email: TEST_EMAIL,
@@ -1582,7 +1581,7 @@ describe('/account/login', () => {
       config.signinConfirmation.forcedEmailAddresses = /.+@mozilla\.com$/;
 
       mockDB.accountRecord = function () {
-        return P.resolve({
+        return Promise.resolve({
           authSalt: hexString(32),
           data: hexString(32),
           email: TEST_EMAIL,
@@ -1663,7 +1662,7 @@ describe('/account/login', () => {
     it('requires verification when the request is suspicious, even with no keys', () => {
       const email = TEST_EMAIL;
       mockDB.accountRecord = function () {
-        return P.resolve({
+        return Promise.resolve({
           authSalt: hexString(32),
           data: hexString(32),
           email: email,
@@ -1733,7 +1732,7 @@ describe('/account/login', () => {
     it('does not require verification when keys are not requested', () => {
       const email = 'test@mozilla.com';
       mockDB.accountRecord = function () {
-        return P.resolve({
+        return Promise.resolve({
           authSalt: hexString(32),
           data: hexString(32),
           email: 'test@mozilla.com',
@@ -1803,7 +1802,7 @@ describe('/account/login', () => {
     it('requires change password verification when the lockedAt field is set', () => {
       const email = 'test@mozilla.com';
       mockDB.accountRecord = function () {
-        return P.resolve({
+        return Promise.resolve({
           authSalt: hexString(32),
           data: hexString(32),
           email: email,
@@ -1878,7 +1877,7 @@ describe('/account/login', () => {
       };
       const email = 'u5osi@forcepwdchange.com';
       mockDB.accountRecord = function () {
-        return P.resolve({
+        return Promise.resolve({
           authSalt: hexString(32),
           data: hexString(32),
           email: email,
@@ -1923,7 +1922,7 @@ describe('/account/login', () => {
       const email = 'test@mozilla.com';
       mockRequest.payload.email = email;
       mockDB.accountRecord = function () {
-        return P.resolve({
+        return Promise.resolve({
           authSalt: hexString(32),
           data: hexString(32),
           email: mockRequest.payload.email,
@@ -1987,7 +1986,7 @@ describe('/account/login', () => {
     });
 
     it('should return an error if email fails to send', () => {
-      mockMailer.sendVerifyLoginEmail = sinon.spy(() => P.reject());
+      mockMailer.sendVerifyLoginEmail = sinon.spy(() => Promise.reject());
 
       return runTest(route, mockRequest).then(assert.fail, (err) => {
         assert.equal(err.message, 'Failed to send email');
@@ -2007,7 +2006,7 @@ describe('/account/login', () => {
         const email = mockRequest.payload.email;
 
         mockDB.accountRecord = function () {
-          return P.resolve({
+          return Promise.resolve({
             authSalt: hexString(32),
             createdAt: Date.now() - accountCreatedSince,
             data: hexString(32),
@@ -2030,7 +2029,7 @@ describe('/account/login', () => {
 
         const accountRoutes = makeRoutes({
           checkPassword: function () {
-            return P.resolve(true);
+            return Promise.resolve(true);
           },
           config: config,
           customs: mockCustoms,
@@ -2137,7 +2136,7 @@ describe('/account/login', () => {
         setup(true, 0);
 
         mockMailer.sendNewDeviceLoginEmail = sinon.spy(() =>
-          P.reject(error.emailBouncedHard())
+          Promise.reject(error.emailBouncedHard())
         );
 
         return runTest(route, mockRequest, (response) => {
@@ -2222,7 +2221,7 @@ describe('/account/login', () => {
         mockRequest.payload.email = email;
 
         mockDB.accountRecord = () => {
-          return P.resolve({
+          return Promise.resolve({
             authSalt: hexString(32),
             data: hexString(32),
             email,
@@ -2241,7 +2240,7 @@ describe('/account/login', () => {
         };
 
         const accountRoutes = makeRoutes({
-          checkPassword: () => P.resolve(true),
+          checkPassword: () => Promise.resolve(true),
           config,
           customs: mockCustoms,
           db: mockDB,
@@ -2312,7 +2311,7 @@ describe('/account/login', () => {
   it('creating too many sessions causes an error to be logged', () => {
     const oldSessions = mockDB.sessions;
     mockDB.sessions = sinon.spy(() => {
-      return P.resolve(new Array(200));
+      return Promise.resolve(new Array(200));
     });
     mockLog.error = sinon.spy();
     mockRequest.app.clientAddress = '63.245.221.32';
@@ -2320,7 +2319,7 @@ describe('/account/login', () => {
       assert.equal(mockLog.error.callCount, 0, 'log.error was not called');
     }).then(() => {
       mockDB.sessions = sinon.spy(() => {
-        return P.resolve(new Array(201));
+        return Promise.resolve(new Array(201));
       });
       mockLog.error.resetHistory();
       return runTest(route, mockRequest, () => {
@@ -2348,7 +2347,7 @@ describe('/account/login', () => {
       let securityQuery;
       mockDB.securityEvents = sinon.spy((arg) => {
         securityQuery = arg;
-        return P.resolve([
+        return Promise.resolve([
           {
             name: 'account.login',
             createdAt: Date.now(),
@@ -2378,7 +2377,7 @@ describe('/account/login', () => {
       let securityQuery;
       mockDB.securityEvents = sinon.spy((arg) => {
         securityQuery = arg;
-        return P.resolve([
+        return Promise.resolve([
           {
             name: 'account.login',
             createdAt: Date.now(),
@@ -2408,7 +2407,7 @@ describe('/account/login', () => {
       let securityQuery;
       mockDB.securityEvents = sinon.spy((arg) => {
         securityQuery = arg;
-        return P.resolve([]);
+        return Promise.resolve([]);
       });
       return runTest(route, mockRequest, (response) => {
         assert.equal(
@@ -2433,7 +2432,7 @@ describe('/account/login', () => {
     let securityQuery;
     mockDB.securityEvent = sinon.spy((arg) => {
       securityQuery = arg;
-      return P.resolve();
+      return Promise.resolve();
     });
     return runTest(route, mockRequest, (response) => {
       assert.equal(
@@ -2452,7 +2451,7 @@ describe('/account/login', () => {
       const oldCheck = mockCustoms.check;
 
       before(() => {
-        mockCustoms.check = () => P.reject(error.requestBlocked(true));
+        mockCustoms.check = () => Promise.reject(error.requestBlocked(true));
       });
 
       beforeEach(() => {
@@ -2506,7 +2505,7 @@ describe('/account/login', () => {
         describe('with unblock code', () => {
           it('invalid code', () => {
             mockDB.consumeUnblockCode = () =>
-              P.reject(error.invalidUnblockCode());
+              Promise.reject(error.invalidUnblockCode());
             return runTest(route, mockRequestWithUnblockCode).then(
               () => assert.ok(false),
               (err) => {
@@ -2539,7 +2538,7 @@ describe('/account/login', () => {
           it('expired code', () => {
             // test 5 seconds old, to reduce flakiness of test
             mockDB.consumeUnblockCode = () =>
-              P.resolve({
+              Promise.resolve({
                 createdAt:
                   Date.now() - (config.signinUnblock.codeLifetime + 5000),
               });
@@ -2575,8 +2574,10 @@ describe('/account/login', () => {
           });
 
           it('unknown account', () => {
-            mockDB.accountRecord = () => P.reject(new error.unknownAccount());
-            mockDB.emailRecord = () => P.reject(new error.unknownAccount());
+            mockDB.accountRecord = () =>
+              Promise.reject(new error.unknownAccount());
+            mockDB.emailRecord = () =>
+              Promise.reject(new error.unknownAccount());
             return runTest(route, mockRequestWithUnblockCode).then(
               () => assert(false),
               (err) => {
@@ -2588,7 +2589,7 @@ describe('/account/login', () => {
 
           it('valid code', () => {
             mockDB.consumeUnblockCode = () =>
-              P.resolve({ createdAt: Date.now() });
+              Promise.resolve({ createdAt: Date.now() });
             return runTest(route, mockRequestWithUnblockCode, (res) => {
               assert.equal(mockLog.flowEvent.callCount, 4);
               assert.equal(
@@ -2620,7 +2621,7 @@ describe('/account/login', () => {
     describe('cannot unblock', () => {
       const oldCheck = mockCustoms.check;
       before(() => {
-        mockCustoms.check = () => P.reject(error.requestBlocked(false));
+        mockCustoms.check = () => Promise.reject(error.requestBlocked(false));
       });
 
       after(() => {
@@ -2688,7 +2689,7 @@ describe('/account/login', () => {
   it('fails login with non primary email', () => {
     const email = 'foo@mail.com';
     mockDB.accountRecord = sinon.spy(() => {
-      return P.resolve({
+      return Promise.resolve({
         primaryEmail: {
           normalizedEmail: normalizeEmail(email),
           email: email,
@@ -2712,7 +2713,7 @@ describe('/account/login', () => {
 
   it('fails login when requesting TOTP verificationMethod and TOTP not setup', () => {
     mockDB.totpToken = sinon.spy(() => {
-      return P.resolve({
+      return Promise.resolve({
         verified: true,
         enabled: false,
       });
@@ -2888,7 +2889,7 @@ describe('/account/destroy', () => {
   function buildRoute(subscriptionsEnabled = true) {
     const accountRoutes = makeRoutes({
       checkPassword: function () {
-        return P.resolve(true);
+        return Promise.resolve(true);
       },
       config: {
         subscriptions: {
@@ -3150,7 +3151,7 @@ describe('/account/ecosystemAnonId', () => {
     mockRequest.headers['if-none-match'] = '*';
     mockDB.account = function (providedUid) {
       assert.equal(providedUid, uid);
-      return P.resolve({
+      return Promise.resolve({
         ecosystemAnonId: null,
       });
     };
@@ -3167,7 +3168,7 @@ describe('/account/ecosystemAnonId', () => {
 
   it('throws anonIdNoCondition when neither if-none-match nor if-match are present', async () => {
     mockDB.account = function () {
-      return P.resolve({
+      return Promise.resolve({
         ecosystemAnonId: 'heheheheheh',
       });
     };
@@ -3200,7 +3201,7 @@ describe('/account/ecosystemAnonId', () => {
   it('throws: if-none-match: *, anon id exists', async () => {
     mockRequest.headers['if-none-match'] = '*';
     mockDB.account = function () {
-      return P.resolve({
+      return Promise.resolve({
         ecosystemAnonId: 'such a simple fool',
       });
     };
@@ -3219,7 +3220,7 @@ describe('/account/ecosystemAnonId', () => {
   it('doesnt throw: if-none-match: *, anon id doesnt exist', async () => {
     mockRequest.headers['if-none-match'] = '*';
     mockDB.account = function () {
-      return P.resolve({
+      return Promise.resolve({
         ecosystemAnonId: null,
       });
     };
@@ -3237,7 +3238,7 @@ describe('/account/ecosystemAnonId', () => {
   it('throws: if-none-match: y (hashed), anon id is y', async () => {
     mockRequest.headers['if-none-match'] = hashAnonId('y');
     mockDB.account = function () {
-      return P.resolve({
+      return Promise.resolve({
         ecosystemAnonId: 'y',
       });
     };
@@ -3256,7 +3257,7 @@ describe('/account/ecosystemAnonId', () => {
   it('doesnt throw: if-none-match: x (hashed), anon id is z', async () => {
     mockRequest.headers['if-none-match'] = hashAnonId('x');
     mockDB.account = function () {
-      return P.resolve({
+      return Promise.resolve({
         ecosystemAnonId: 'z',
       });
     };
@@ -3274,7 +3275,7 @@ describe('/account/ecosystemAnonId', () => {
   it('throws: if-match: x (hashed), anon id is z', async () => {
     mockRequest.headers['if-match'] = hashAnonId('x');
     mockDB.account = function () {
-      return P.resolve({
+      return Promise.resolve({
         ecosystemAnonId: 'z',
       });
     };
@@ -3293,7 +3294,7 @@ describe('/account/ecosystemAnonId', () => {
   it('doesnt throw: if-match: x (hashed), anon id is x', async () => {
     mockRequest.headers['if-match'] = hashAnonId('x');
     mockDB.account = function () {
-      return P.resolve({
+      return Promise.resolve({
         ecosystemAnonId: 'x',
       });
     };
@@ -3311,7 +3312,7 @@ describe('/account/ecosystemAnonId', () => {
   it('logs old and new anon_ids on successful update', async () => {
     mockRequest.headers['if-match'] = hashAnonId(oldAnonId);
     mockDB.account = sinon.spy(() => {
-      return P.resolve({
+      return Promise.resolve({
         ecosystemAnonId: oldAnonId,
       });
     });

--- a/packages/fxa-auth-server/test/local/routes/auth-schemes/auth-oauth.js
+++ b/packages/fxa-auth-server/test/local/routes/auth-schemes/auth-oauth.js
@@ -6,7 +6,6 @@ const { assert } = require('chai');
 const proxyquire = require('proxyquire');
 const AppError = require('../../../../lib/error');
 const OauthAppError = require('../../../../lib/oauth/error');
-const P = require('../../../../lib/promise');
 const ScopeSet = require('fxa-shared').oauth.scopes;
 
 const authOauthPath = '../../../../lib/routes/auth-schemes/auth-oauth';
@@ -60,7 +59,7 @@ describe('lib/routes/auth-schemes/auth-oauth', () => {
     describe('when the Bearer token is invalid', () => {
       before(() => {
         tokenStub.verify = (token) => {
-          return P.reject(OauthAppError.invalidToken());
+          return Promise.reject(OauthAppError.invalidToken());
         };
       });
 
@@ -88,7 +87,7 @@ describe('lib/routes/auth-schemes/auth-oauth', () => {
         };
 
         tokenStub.verify = (token) => {
-          return P.resolve(mockTokenInfo);
+          return Promise.resolve(mockTokenInfo);
         };
       });
 

--- a/packages/fxa-auth-server/test/local/routes/password.js
+++ b/packages/fxa-auth-server/test/local/routes/password.js
@@ -8,7 +8,6 @@ const { assert } = require('chai');
 const mocks = require('../../mocks');
 const getRoute = require('../../routes_helpers').getRoute;
 
-const P = require('../../../lib/promise');
 const uuid = require('uuid');
 const crypto = require('crypto');
 const error = require('../../../lib/error');
@@ -80,7 +79,7 @@ describe('/password', () => {
       },
     });
     mockLog.flowEvent = sinon.spy(() => {
-      return P.resolve();
+      return Promise.resolve();
     });
     const passwordRoutes = makeRoutes({
       customs: mockCustoms,
@@ -201,7 +200,7 @@ describe('/password', () => {
       },
     });
     mockLog.flowEvent = sinon.spy(() => {
-      return P.resolve();
+      return Promise.resolve();
     });
     const passwordRoutes = makeRoutes({
       customs: mockCustoms,
@@ -295,7 +294,7 @@ describe('/password', () => {
       },
     });
     mockLog.flowEvent = sinon.spy(() => {
-      return P.resolve();
+      return Promise.resolve();
     });
     const passwordRoutes = makeRoutes({
       customs: mockCustoms,
@@ -552,7 +551,7 @@ describe('/password', () => {
       const mockPush = mocks.mockPush();
       const mockMailer = {
         sendPasswordChangedEmail: sinon.spy(() => {
-          return P.reject(error.emailBouncedHard());
+          return Promise.reject(error.emailBouncedHard());
         }),
       };
       const mockLog = mocks.mockLog();

--- a/packages/fxa-auth-server/test/local/routes/recovery-codes.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-codes.js
@@ -9,7 +9,6 @@ const assert = { ...sinon.assert, ...require('chai').assert };
 const getRoute = require('../../routes_helpers').getRoute;
 const mocks = require('../../mocks');
 const error = require('../../../lib/error');
-const P = require('../../../lib/promise');
 
 let log, db, customs, routes, route, request, requestOptions, mailer;
 const TEST_EMAIL = 'test@email.com';
@@ -31,7 +30,7 @@ function runTest(routePath, requestOptions) {
   );
   route = getRoute(routes, routePath);
   request = mocks.mockRequest(requestOptions);
-  request.emitMetricsEvent = sinon.spy(() => P.resolve({}));
+  request.emitMetricsEvent = sinon.spy(() => Promise.resolve({}));
 
   return route.handler(request);
 }
@@ -89,7 +88,7 @@ describe('recovery codes', () => {
   describe('/session/verify/recoveryCode', () => {
     it('sends email if recovery codes are low', async () => {
       db.consumeRecoveryCode = sinon.spy((code) => {
-        return P.resolve({ remaining: 1 });
+        return Promise.resolve({ remaining: 1 });
       });
       await runTest('/session/verify/recoveryCode', requestOptions);
       assert.equal(mailer.sendLowRecoveryCodesEmail.callCount, 1);

--- a/packages/fxa-auth-server/test/local/routes/recovery-keys.js
+++ b/packages/fxa-auth-server/test/local/routes/recovery-keys.js
@@ -7,7 +7,6 @@
 const { assert } = require('chai');
 const getRoute = require('../../routes_helpers').getRoute;
 const mocks = require('../../mocks');
-const P = require('../../../lib/promise');
 const sinon = require('sinon');
 const errors = require('../../../lib/error');
 
@@ -428,7 +427,7 @@ function setup(results, errors, path, requestOptions) {
   routes = makeRoutes({ log, db, customs, mailer });
   route = getRoute(routes, path, requestOptions.method);
   request = mocks.mockRequest(requestOptions);
-  request.emitMetricsEvent = sinon.spy(() => P.resolve({}));
+  request.emitMetricsEvent = sinon.spy(() => Promise.resolve({}));
   return runTest(route, request);
 }
 

--- a/packages/fxa-auth-server/test/local/routes/sms.js
+++ b/packages/fxa-auth-server/test/local/routes/sms.js
@@ -8,7 +8,6 @@ const AppError = require('../../../lib/error');
 const { assert } = require('chai');
 const getRoute = require('../../routes_helpers').getRoute;
 const mocks = require('../../mocks');
-const P = require('../../../lib/promise');
 const sinon = require('sinon');
 
 function makeRoutes(options = {}, dependencies) {
@@ -42,7 +41,7 @@ describe('/sms with the signinCodes feature included in the payload', () => {
       },
     };
     sms = {
-      send: sinon.spy(() => P.resolve()),
+      send: sinon.spy(() => Promise.resolve()),
     };
     routes = makeRoutes({ log, db, config, sms });
     route = getRoute(routes, '/sms');
@@ -66,7 +65,7 @@ describe('/sms with the signinCodes feature included in the payload', () => {
 
   describe('sms.send succeeds', () => {
     beforeEach(() => {
-      sms.send = sinon.spy(() => P.resolve());
+      sms.send = sinon.spy(() => Promise.resolve());
     });
 
     describe('USA phone number', () => {
@@ -367,7 +366,7 @@ describe('/sms with the signinCodes feature included in the payload', () => {
 
     beforeEach(() => {
       sms.send = sinon.spy(() =>
-        P.reject(AppError.messageRejected('wibble', 7))
+        Promise.reject(AppError.messageRejected('wibble', 7))
       );
       request.payload.phoneNumber = '+18885083401';
       return runTest(route, request).catch((e) => {
@@ -420,7 +419,7 @@ describe('/sms without the signinCodes feature included in the payload', () => {
       },
     };
     sms = {
-      send: sinon.spy(() => P.resolve()),
+      send: sinon.spy(() => Promise.resolve()),
     };
     routes = makeRoutes({ log, db, config, sms });
     route = getRoute(routes, '/sms');
@@ -440,7 +439,7 @@ describe('/sms without the signinCodes feature included in the payload', () => {
         },
       },
     });
-    sms.send = sinon.spy(() => P.resolve());
+    sms.send = sinon.spy(() => Promise.resolve());
     return runTest(route, request);
   });
 
@@ -729,7 +728,7 @@ describe('/sms/status with query param and enabled geo-ip lookup', () => {
     };
     sms = {
       isBudgetOk: () => true,
-      send: sinon.spy(() => P.resolve()),
+      send: sinon.spy(() => Promise.resolve()),
     };
     routes = makeRoutes({ log, config, sms });
     route = getRoute(routes, '/sms/status');
@@ -777,7 +776,7 @@ describe('/sms/status with query param and disabled geo-ip lookup', () => {
     };
     sms = {
       isBudgetOk: () => true,
-      send: sinon.spy(() => P.resolve()),
+      send: sinon.spy(() => Promise.resolve()),
     };
     routes = makeRoutes({ log, config, sms });
     route = getRoute(routes, '/sms/status');

--- a/packages/fxa-auth-server/test/local/routes/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions.js
@@ -10,7 +10,6 @@ const uuid = require('uuid');
 const { getRoute } = require('../../routes_helpers');
 const mocks = require('../../mocks');
 const error = require('../../../lib/error');
-const P = require('../../../lib/promise');
 const Sentry = require('@sentry/node');
 const {
   StripeHelper,
@@ -145,7 +144,7 @@ function runTest(routePath, requestOptions, payments = null) {
   );
   route = getRoute(routes, routePath, requestOptions.method || 'GET');
   request = mocks.mockRequest(requestOptions);
-  request.emitMetricsEvent = sinon.spy(() => P.resolve({}));
+  request.emitMetricsEvent = sinon.spy(() => Promise.resolve({}));
 
   return route.handler(request);
 }

--- a/packages/fxa-auth-server/test/local/routes/support.js
+++ b/packages/fxa-auth-server/test/local/routes/support.js
@@ -10,7 +10,6 @@ const uuid = require('uuid');
 const getRoute = require('../../routes_helpers').getRoute;
 const mocks = require('../../mocks');
 const nock = require('nock');
-const P = require('../../../lib/promise');
 
 let config,
   log,
@@ -133,7 +132,7 @@ function runTest(routePath, requestOptions) {
   );
   route = getRoute(routes, routePath, requestOptions.method || 'GET');
   request = mocks.mockRequest(requestOptions);
-  request.emitMetricsEvent = sinon.spy(() => P.resolve({}));
+  request.emitMetricsEvent = sinon.spy(() => Promise.resolve({}));
 
   return route.handler(request);
 }

--- a/packages/fxa-auth-server/test/local/routes/totp.js
+++ b/packages/fxa-auth-server/test/local/routes/totp.js
@@ -8,7 +8,6 @@ const { assert } = require('chai');
 const getRoute = require('../../routes_helpers').getRoute;
 const mocks = require('../../mocks');
 const otplib = require('otplib');
-const P = require('../../../lib/promise');
 const sinon = require('sinon');
 
 let log, db, customs, routes, route, request, requestOptions, mailer;
@@ -433,16 +432,16 @@ function setup(results, errors, routePath, requestOptions) {
   mailer = mocks.mockMailer();
   db = mocks.mockDB(results.db, errors.db);
   db.createTotpToken = sinon.spy(() => {
-    return P.resolve({
+    return Promise.resolve({
       qrCodeUrl: 'some base64 encoded png',
       sharedSecret: secret,
     });
   });
   db.verifyTokensWithMethod = sinon.spy(() => {
-    return P.resolve();
+    return Promise.resolve();
   });
   db.totpToken = sinon.spy(() => {
-    return P.resolve({
+    return Promise.resolve({
       verified:
         typeof results.totpTokenVerified === 'undefined'
           ? true
@@ -457,7 +456,7 @@ function setup(results, errors, routePath, requestOptions) {
   routes = makeRoutes({ log, db, customs, mailer });
   route = getRoute(routes, routePath);
   request = mocks.mockRequest(requestOptions);
-  request.emitMetricsEvent = sinon.spy(() => P.resolve({}));
+  request.emitMetricsEvent = sinon.spy(() => Promise.resolve({}));
   return runTest(route, request);
 }
 

--- a/packages/fxa-auth-server/test/local/routes/unblock-codes.js
+++ b/packages/fxa-auth-server/test/local/routes/unblock-codes.js
@@ -7,7 +7,6 @@
 const { assert } = require('chai');
 const getRoute = require('../../routes_helpers').getRoute;
 const mocks = require('../../mocks');
-const P = require('../../../lib/promise');
 const proxyquire = require('proxyquire');
 const uuid = require('uuid');
 
@@ -17,7 +16,7 @@ function makeRoutes(options = {}, requireMocks) {
   const db = options.db || mocks.mockDB();
   const customs = options.customs || {
     check: function () {
-      return P.resolve(true);
+      return Promise.resolve(true);
     },
   };
 

--- a/packages/fxa-auth-server/test/local/tokens/token.js
+++ b/packages/fxa-auth-server/test/local/tokens/token.js
@@ -6,16 +6,7 @@
 
 const { assert } = require('chai');
 const config = require('../../../config').getProperties();
-const random = require('../../../lib/crypto/random');
-const hkdf = require('../../../lib/crypto/hkdf');
 const mocks = require('../../mocks');
-const P = require('../../../lib/promise');
-const sinon = require('sinon');
-
-const Bundle = {
-  bundle: sinon.spy(),
-  unbundle: sinon.spy(),
-};
 const log = mocks.mockLog();
 const modulePath = '../../../lib/tokens/token';
 
@@ -24,7 +15,7 @@ describe('Token', () => {
     let Token;
     before(() => {
       config.isProduction = false;
-      Token = require(modulePath)(log, config, random, P, hkdf, Bundle, null);
+      Token = require(modulePath)(log, config);
     });
 
     it('Token constructor was exported', () => {
@@ -133,7 +124,7 @@ describe('Token', () => {
     let Token;
     before(() => {
       config.isProduction = true;
-      Token = require(modulePath)(log, config, random, P, hkdf, Bundle, null);
+      Token = require(modulePath)(log, config);
     });
 
     it('Token.createNewToken defaults createdAt to the current time', () => {

--- a/packages/fxa-auth-server/test/mail_helper.js
+++ b/packages/fxa-auth-server/test/mail_helper.js
@@ -7,7 +7,6 @@
 'use strict';
 const MailParser = require('mailparser').MailParser;
 const simplesmtp = require('simplesmtp');
-const P = require('../lib/promise');
 
 const config = require('../config').getProperties();
 
@@ -30,7 +29,7 @@ module.exports = (printLogs) => {
         log() {},
         error() {},
       };
-  return new P((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const smtp = simplesmtp.createSimpleServer(
       {
         SMTPBanner: 'FXATEST',
@@ -130,7 +129,7 @@ module.exports = (printLogs) => {
         path: '/mail/{email}',
         handler: async function (request) {
           const emailLoop = function () {
-            return new P((resolve) => {
+            return new Promise((resolve) => {
               loop(decodeURIComponent(request.params.email), (emailData) => {
                 resolve(emailData);
               });
@@ -157,7 +156,7 @@ module.exports = (printLogs) => {
 
       return resolve({
         close() {
-          return new P((resolve, reject) => {
+          return new Promise((resolve, reject) => {
             let smtpClosed = false;
             let apiClosed = false;
             smtp.server.end(() => {

--- a/packages/fxa-auth-server/test/mailbox.js
+++ b/packages/fxa-auth-server/test/mailbox.js
@@ -4,7 +4,6 @@
 
 'use strict';
 
-const P = require('../lib/promise');
 const request = require('request');
 const EventEmitter = require('events').EventEmitter;
 
@@ -68,16 +67,16 @@ module.exports = function (host, port, printLogs) {
   }
 
   function waitForEmail(email) {
-    const d = P.defer();
-    loop(email.split('@')[0], 20, (err, json) => {
-      if (err) {
-        eventEmitter.emit('email:error', email, err);
-        return d.reject(err);
-      }
-      eventEmitter.emit('email:message', email, json);
-      return d.resolve(json);
+    return new Promise((resolve, reject) => {
+      loop(email.split('@')[0], 20, (err, json) => {
+        if (err) {
+          eventEmitter.emit('email:error', email, err);
+          return reject(err);
+        }
+        eventEmitter.emit('email:message', email, json);
+        return resolve(json);
+      });
     });
-    return d.promise;
   }
 
   function waitForSms(phoneNumber) {

--- a/packages/fxa-auth-server/test/mock-sns.js
+++ b/packages/fxa-auth-server/test/mock-sns.js
@@ -4,8 +4,6 @@
 
 'use strict';
 
-const P = require('../lib/promise');
-
 module.exports = MockSNS;
 
 function MockSNS(options, config) {
@@ -27,7 +25,7 @@ function MockSNS(options, config) {
     getSMSAttributes() {
       return {
         promise: () =>
-          P.resolve({
+          Promise.resolve({
             attributes: {
               MonthlySpendLimit: config.sms.minimumCreditThresholdUSD,
             },
@@ -36,7 +34,7 @@ function MockSNS(options, config) {
     },
 
     publish(params) {
-      const promise = new P((resolve) => {
+      const promise = new Promise((resolve) => {
         // HACK: Enable remote tests to see what was sent
         mailer.sendMail(
           {

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -13,7 +13,6 @@ const config = require('../config').getProperties();
 const crypto = require('crypto');
 const error = require('../lib/error');
 const knownIpLocation = require('./known-ip-location');
-const P = require('../lib/promise');
 const sinon = require('sinon');
 const { normalizeEmail } = require('fxa-shared').email.helpers;
 
@@ -216,9 +215,9 @@ function mockCustoms(errors) {
 function optionallyThrow(errors, methodName) {
   return sinon.spy(() => {
     if (errors[methodName]) {
-      return P.reject(errors[methodName]);
+      return Promise.reject(errors[methodName]);
     }
-    return P.resolve();
+    return Promise.resolve();
   });
 }
 
@@ -229,7 +228,7 @@ function mockDB(data, errors) {
   return mockObject(DB_METHOD_NAMES)({
     account: sinon.spy((uid) => {
       assert.ok(typeof uid === 'string');
-      return P.resolve({
+      return Promise.resolve({
         createdAt: data.createdAt,
         email: data.email,
         emailCode: data.emailCode,
@@ -258,7 +257,7 @@ function mockDB(data, errors) {
     }),
     accountEmails: sinon.spy((uid) => {
       assert.ok(typeof uid === 'string');
-      return P.resolve([
+      return Promise.resolve([
         {
           email: data.email || 'primary@email.com',
           normalizedEmail: normalizeEmail(data.email || 'primary@email.com'),
@@ -280,9 +279,9 @@ function mockDB(data, errors) {
     }),
     accountRecord: sinon.spy(() => {
       if (errors.emailRecord) {
-        return P.reject(errors.emailRecord);
+        return Promise.reject(errors.emailRecord);
       }
-      return P.resolve({
+      return Promise.resolve({
         authSalt: crypto.randomBytes(32),
         createdAt: data.createdAt || Date.now(),
         data: crypto.randomBytes(32),
@@ -312,15 +311,15 @@ function mockDB(data, errors) {
     }),
     consumeSigninCode: sinon.spy(() => {
       if (errors.consumeSigninCode) {
-        return P.reject(errors.consumeSigninCode);
+        return Promise.reject(errors.consumeSigninCode);
       }
-      return P.resolve({
+      return Promise.resolve({
         email: data.email,
         flowId: data.flowId,
       });
     }),
     createAccount: sinon.spy(() => {
-      return P.resolve({
+      return Promise.resolve({
         uid: data.uid,
         email: data.email,
         emailCode: data.emailCode,
@@ -331,7 +330,7 @@ function mockDB(data, errors) {
     }),
     createDevice: sinon.spy((uid) => {
       assert.ok(typeof uid === 'string');
-      return P.resolve(
+      return Promise.resolve(
         Object.keys(data.device).reduce(
           (result, key) => {
             result[key] = data.device[key];
@@ -345,14 +344,14 @@ function mockDB(data, errors) {
       );
     }),
     createKeyFetchToken: sinon.spy(() => {
-      return P.resolve({
+      return Promise.resolve({
         data: crypto.randomBytes(32).toString('hex'),
         id: data.keyFetchTokenId,
         uid: data.uid,
       });
     }),
     createPasswordForgotToken: sinon.spy(() => {
-      return P.resolve({
+      return Promise.resolve({
         data: crypto.randomBytes(32).toString('hex'),
         passCode: data.passCode,
         id: data.passwordForgotTokenId,
@@ -363,7 +362,7 @@ function mockDB(data, errors) {
       });
     }),
     createSessionToken: sinon.spy((opts) => {
-      return P.resolve({
+      return Promise.resolve({
         createdAt: opts.createdAt || Date.now(),
         data: crypto.randomBytes(32).toString('hex'),
         email: opts.email || data.email,
@@ -394,31 +393,31 @@ function mockDB(data, errors) {
     createSigninCode: sinon.spy((uid, flowId) => {
       assert.ok(typeof uid === 'string');
       assert.ok(typeof flowId === 'string');
-      return P.resolve(data.signinCode || []);
+      return Promise.resolve(data.signinCode || []);
     }),
     devices: sinon.spy((uid) => {
       assert.ok(typeof uid === 'string');
-      return P.resolve(data.devices || []);
+      return Promise.resolve(data.devices || []);
     }),
     device: sinon.spy((uid, deviceId) => {
       assert.ok(typeof uid === 'string');
       assert.ok(typeof deviceId === 'string');
       const device = data.devices.find((d) => d.id === deviceId);
       assert.ok(device);
-      return P.resolve(device);
+      return Promise.resolve(device);
     }),
     deleteSecurityEvents: sinon.spy(() => {
-      return P.resolve({});
+      return Promise.resolve({});
     }),
     deleteSessionToken: sinon.spy(() => {
-      return P.resolve();
+      return Promise.resolve();
     }),
     deleteAccountSubscription: sinon.spy(async (uid, subscriptionId) => true),
     emailRecord: sinon.spy(() => {
       if (errors.emailRecord) {
-        return P.reject(errors.emailRecord);
+        return Promise.reject(errors.emailRecord);
       }
-      return P.resolve({
+      return Promise.resolve({
         authSalt: crypto.randomBytes(32).toString('hex'),
         createdAt: data.createdAt || Date.now(),
         data: crypto.randomBytes(32).toString('hex'),
@@ -447,30 +446,30 @@ function mockDB(data, errors) {
       });
     }),
     forgotPasswordVerified: sinon.spy(() => {
-      return P.resolve(data.accountResetToken);
+      return Promise.resolve(data.accountResetToken);
     }),
     getSecondaryEmail: sinon.spy(() => {
-      return P.reject(error.unknownSecondaryEmail());
+      return Promise.reject(error.unknownSecondaryEmail());
     }),
     getRecoveryKey: sinon.spy(() => {
       if (data.recoveryKeyIdInvalid) {
-        return P.reject(error.recoveryKeyInvalid());
+        return Promise.reject(error.recoveryKeyInvalid());
       }
 
-      return P.resolve({
+      return Promise.resolve({
         recoveryData: data.recoveryData,
       });
     }),
     recoveryKeyExists: sinon.spy(() => {
-      return P.resolve({
+      return Promise.resolve({
         exists: !!data.recoveryData,
       });
     }),
     securityEvents: sinon.spy(() => {
-      return P.resolve([]);
+      return Promise.resolve([]);
     }),
     securityEventsByUid: sinon.spy(() => {
-      return P.resolve([
+      return Promise.resolve([
         {
           name: 'account.create',
           verified: 1,
@@ -490,16 +489,16 @@ function mockDB(data, errors) {
     }),
     sessions: sinon.spy((uid) => {
       assert.ok(typeof uid === 'string');
-      return P.resolve(data.sessions || []);
+      return Promise.resolve(data.sessions || []);
     }),
     updateDevice: sinon.spy((uid, device) => {
       assert.ok(typeof uid === 'string');
-      return P.resolve(device);
+      return Promise.resolve(device);
     }),
     updateEcosystemAnonId: sinon.spy((uid, ecosystemAnonId) => {
       assert.ok(typeof uid === 'string');
       assert.ok(typeof ecosystemAnonId === 'string');
-      return P.resolve({});
+      return Promise.resolve({});
     }),
     sessionToken: sinon.spy(() => {
       const res = {
@@ -523,17 +522,17 @@ function mockDB(data, errors) {
           res[keyOnSession] = data.devices[0][key];
         });
       }
-      return P.resolve(res);
+      return Promise.resolve(res);
     }),
     verifyTokens: optionallyThrow(errors, 'verifyTokens'),
     verifyTokenCode: sinon.spy(() => {
       if (errors.verifyTokenCode) {
-        return P.reject(errors.verifyTokenCode);
+        return Promise.reject(errors.verifyTokenCode);
       }
-      return P.resolve({});
+      return Promise.resolve({});
     }),
     replaceRecoveryCodes: sinon.spy(() => {
-      return P.resolve(['12312312', '12312312']);
+      return Promise.resolve(['12312312', '12312312']);
     }),
   });
 }
@@ -542,7 +541,7 @@ function mockObject(methodNames, baseObj) {
   return (methods) => {
     methods = methods || {};
     return methodNames.reduce((object, name) => {
-      object[name] = methods[name] || sinon.spy(() => P.resolve());
+      object[name] = methods[name] || sinon.spy(() => Promise.resolve());
       return object;
     }, baseObj || {});
   };
@@ -552,7 +551,7 @@ function mockPush(methods) {
   const push = Object.assign({}, methods);
   PUSH_METHOD_NAMES.forEach((name) => {
     if (!push[name]) {
-      push[name] = sinon.spy(() => P.resolve());
+      push[name] = sinon.spy(() => Promise.resolve());
     }
   });
   return push;
@@ -563,7 +562,7 @@ function mockPushbox(methods) {
   if (!pushbox.retrieve) {
     // Route code expects the `retrieve` method to return a properly-structured object.
     pushbox.retrieve = sinon.spy(() =>
-      P.resolve({
+      Promise.resolve({
         last: true,
         index: 0,
         messages: [],
@@ -572,7 +571,7 @@ function mockPushbox(methods) {
   }
   PUSHBOX_METHOD_NAMES.forEach((name) => {
     if (!pushbox[name]) {
-      pushbox[name] = sinon.spy(() => P.resolve());
+      pushbox[name] = sinon.spy(() => Promise.resolve());
     }
   });
   return pushbox;
@@ -582,7 +581,7 @@ function mockSubHub(methods) {
   const subscriptionsBackend = Object.assign({}, methods);
   SUBHUB_METHOD_NAMES.forEach((name) => {
     if (!subscriptionsBackend[name]) {
-      subscriptionsBackend[name] = sinon.spy(() => P.resolve());
+      subscriptionsBackend[name] = sinon.spy(() => Promise.resolve());
     }
   });
   return subscriptionsBackend;
@@ -592,7 +591,7 @@ function mockProfile(methods) {
   const profileBackend = Object.assign({}, methods);
   PROFILE_METHOD_NAMES.forEach((name) => {
     if (!profileBackend[name]) {
-      profileBackend[name] = sinon.spy(() => P.resolve());
+      profileBackend[name] = sinon.spy(() => Promise.resolve());
     }
   });
   return profileBackend;
@@ -606,9 +605,9 @@ function mockDevices(data, errors) {
     isSpuriousUpdate: sinon.spy(() => data.spurious || false),
     upsert: sinon.spy(() => {
       if (errors.upsert) {
-        return P.reject(errors.upsert);
+        return Promise.reject(errors.upsert);
       }
-      return P.resolve({
+      return Promise.resolve({
         id: data.deviceId || crypto.randomBytes(16).toString('hex'),
         name: data.deviceName || 'mock device name',
         type: data.deviceType || 'desktop',
@@ -630,7 +629,7 @@ function mockMetricsContext(methods) {
       methods.gather ||
       sinon.spy(function (data) {
         const time = Date.now();
-        return P.resolve().then(() => {
+        return Promise.resolve().then(() => {
           if (this.payload && this.payload.metricsContext) {
             return Object.assign(
               data,
@@ -718,9 +717,9 @@ function mockRequest(data, errors) {
 
   let devices;
   if (errors && errors.devices) {
-    devices = P.reject(errors.devices);
+    devices = Promise.reject(errors.devices);
   } else {
-    devices = P.resolve(data.devices || []);
+    devices = Promise.resolve(data.devices || []);
   }
 
   let metricsContextData = data.payload && data.payload.metricsContext;
@@ -736,7 +735,7 @@ function mockRequest(data, errors) {
       features: new Set(data.features),
       geo,
       locale: data.locale || 'en-US',
-      metricsContext: P.resolve(metricsContextData),
+      metricsContext: Promise.resolve(metricsContextData),
       ua: {
         browser: data.uaBrowser || 'Firefox',
         browserVersion: data.uaBrowserVersion || '57.0',

--- a/packages/fxa-auth-server/test/profile_helper.js
+++ b/packages/fxa-auth-server/test/profile_helper.js
@@ -7,10 +7,9 @@
 const config = require('../config').getProperties();
 const hapi = require('@hapi/hapi');
 const url = require('url');
-const P = require('../lib/promise');
 
 module.exports = () => {
-  return new P((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const api = new hapi.Server({
       host: url.parse(config.profileServer.url).hostname,
       port: parseInt(url.parse(config.profileServer.url).port),
@@ -33,7 +32,7 @@ module.exports = () => {
       }
       resolve({
         close() {
-          return new P((resolve, reject) => {
+          return new Promise((resolve, reject) => {
             api.stop().then((err) => {
               if (err) {
                 reject(err);

--- a/packages/fxa-auth-server/test/push_helper.js
+++ b/packages/fxa-auth-server/test/push_helper.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const WebSocket = require('ws');
-const P = require('../lib/promise');
 
 /**
  * PushManager, helps create subscriptions against a push server
@@ -39,62 +38,61 @@ function PushManager(options) {
  */
 PushManager.prototype.getSubscription = function getSubscription() {
   const self = this;
-  const d = P.defer();
-  const ws = new WebSocket(this.server);
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(this.server);
 
-  // Registration is a two-step handshake.
-  // We send and receive a "hello" message, then send and receive a "register" message.
-  // See http://mozilla-push-service.readthedocs.io/en/latest/design/#simplepush-protocol
+    // Registration is a two-step handshake.
+    // We send and receive a "hello" message, then send and receive a "register" message.
+    // See http://mozilla-push-service.readthedocs.io/en/latest/design/#simplepush-protocol
 
-  function send(msg) {
-    ws.send(JSON.stringify(msg), { mask: true }, (err) => {
-      if (err) {
-        onError(err);
-      }
-    });
-  }
-
-  function onError(err) {
-    d.reject(err);
-    ws.close();
-  }
-
-  const handlers = {
-    hello: function () {
-      send({
-        messageType: 'register',
-        channelID: self.channelId,
+    function send(msg) {
+      ws.send(JSON.stringify(msg), { mask: true }, (err) => {
+        if (err) {
+          onError(err);
+        }
       });
-    },
-    register: function (data) {
-      d.resolve({
-        endpoint: data.pushEndpoint,
-      });
+    }
+
+    function onError(err) {
+      reject(err);
       ws.close();
-    },
-    '': function (data) {
-      onError(new Error(`Unexpected ws message: ${JSON.stringify(data)}`));
-    },
-  };
+    }
 
-  ws.on('open', () => {
-    send({
-      messageType: 'hello',
-      use_webpush: true,
-    });
-  })
-    .on('error', (code, description) => {
-      onError(new Error(code + description));
+    const handlers = {
+      hello: function () {
+        send({
+          messageType: 'register',
+          channelID: self.channelId,
+        });
+      },
+      register: function (data) {
+        resolve({
+          endpoint: data.pushEndpoint,
+        });
+        ws.close();
+      },
+      '': function (data) {
+        onError(new Error(`Unexpected ws message: ${JSON.stringify(data)}`));
+      },
+    };
+
+    ws.on('open', () => {
+      send({
+        messageType: 'hello',
+        use_webpush: true,
+      });
     })
-    .on('message', (data, flags) => {
-      data = JSON.parse(data);
-      if (data && data.messageType) {
-        const handler = handlers[data.messageType] || handlers[''];
-        handler(data);
-      }
-    });
-
-  return d.promise;
+      .on('error', (code, description) => {
+        onError(new Error(code + description));
+      })
+      .on('message', (data, flags) => {
+        data = JSON.parse(data);
+        if (data && data.messageType) {
+          const handler = handlers[data.messageType] || handlers[''];
+          handler(data);
+        }
+      });
+  });
 };
 
 module.exports.PushManager = PushManager;

--- a/packages/fxa-auth-server/test/remote/concurrent_tests.js
+++ b/packages/fxa-auth-server/test/remote/concurrent_tests.js
@@ -7,7 +7,6 @@
 const { assert } = require('chai');
 const TestServer = require('../test_server');
 const Client = require('../client')();
-const P = require('../../lib/promise');
 
 const config = require('../../config').getProperties();
 
@@ -27,7 +26,7 @@ describe('remote concurrect', function () {
     // Two shall enter, only one shall survive!
     const r1 = Client.create(config.publicUrl, email, password, server.mailbox);
     const r2 = Client.create(config.publicUrl, email, password, server.mailbox);
-    return P.all([r1, r2])
+    return Promise.all([r1, r2])
       .then(
         () => assert(false, 'created both accounts'),
         (err) => {

--- a/packages/fxa-auth-server/test/remote/device_tests.js
+++ b/packages/fxa-auth-server/test/remote/device_tests.js
@@ -10,7 +10,6 @@ const Client = require('../client')();
 const config = require('../../config').getProperties();
 const crypto = require('crypto');
 const base64url = require('base64url');
-const P = require('../../lib/promise');
 const mocks = require('../mocks');
 
 describe('remote device', function () {
@@ -623,7 +622,7 @@ describe('remote device', function () {
             deviceInfo[1].type,
             'devices returned correct type for second item'
           );
-          return P.all([
+          return Promise.all([
             client.destroyDevice(devices[0].id),
             client.destroyDevice(devices[1].id),
           ]);

--- a/packages/fxa-auth-server/test/remote/email_validity_tests.js
+++ b/packages/fxa-auth-server/test/remote/email_validity_tests.js
@@ -7,7 +7,6 @@
 const { assert } = require('chai');
 const TestServer = require('../test_server');
 const Client = require('../client')();
-const P = require('../../lib/promise');
 
 const config = require('../../config').getProperties();
 
@@ -45,7 +44,7 @@ describe('remote email validity', function () {
       );
     });
 
-    return P.all(emails);
+    return Promise.all(emails);
   });
 
   it('/account/create with a variety of unusual but valid email addresses', () => {
@@ -73,7 +72,7 @@ describe('remote email validity', function () {
       );
     });
 
-    return P.all(emails);
+    return Promise.all(emails);
   });
 
   after(() => {

--- a/packages/fxa-auth-server/test/remote/push_db_tests.js
+++ b/packages/fxa-auth-server/test/remote/push_db_tests.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const { assert } = require('chai');
-const P = require('../../lib/promise');
 const uuid = require('uuid');
 const crypto = require('crypto');
 const base64url = require('base64url');
@@ -86,7 +85,7 @@ describe('remote push db', function () {
         sendNotification: function (endpoint, params) {
           const err = new Error('Failed 400 level');
           err.statusCode = 410;
-          return P.reject(err);
+          return Promise.reject(err);
         },
       },
     };
@@ -95,7 +94,7 @@ describe('remote push db', function () {
         sendNotification: function (endpoint, params) {
           const err = new Error('Failed 429 level');
           err.statusCode = 429;
-          return P.reject(err);
+          return Promise.reject(err);
         },
       },
     };
@@ -181,6 +180,6 @@ describe('remote push db', function () {
   });
 
   after(() => {
-    return P.all([TestServer.stop(dbServer), db.close()]);
+    return Promise.all([TestServer.stop(dbServer), db.close()]);
   });
 });

--- a/packages/fxa-auth-server/test/remote/recovery_email_resend_code_tests.js
+++ b/packages/fxa-auth-server/test/remote/recovery_email_resend_code_tests.js
@@ -7,7 +7,6 @@
 const { assert } = require('chai');
 const Client = require('../client')();
 const TestServer = require('../test_server');
-const P = require('../../lib/promise');
 
 const config = require('../../config').getProperties();
 
@@ -149,7 +148,7 @@ describe('remote recovery email resend code', function () {
     const options = {
       keys: true,
     };
-    return P.all([
+    return Promise.all([
       Client.createAndVerify(
         config.publicUrl,
         email,

--- a/packages/fxa-auth-server/test/test_server.js
+++ b/packages/fxa-auth-server/test/test_server.js
@@ -6,7 +6,6 @@
 
 const crypto = require('crypto');
 const EventEmitter = require('events');
-const P = require('../lib/promise');
 const mailbox = require('./mailbox');
 const proxyquire = require('proxyquire').noPreserveCache();
 const createDBServer = require('../../fxa-auth-db-mysql');
@@ -77,7 +76,7 @@ TestServer.prototype.start = function () {
   if (this.config.profileServer.url && !this.profileServer) {
     promises.push(createProfileHelper());
   }
-  return P.all(promises).spread((auth, mail, profileServer) => {
+  return Promise.all(promises).then(([auth, mail, profileServer]) => {
     this.server = auth;
     this.mail = mail;
     this.profileServer = profileServer;
@@ -100,7 +99,7 @@ TestServer.stop = async function (maybeServer) {
     currentDBServer = undefined;
   }
 
-  return P.resolve();
+  return Promise.resolve();
 };
 
 TestServer.prototype.stop = async function () {
@@ -115,9 +114,9 @@ TestServer.prototype.stop = async function () {
     if (this.profileServer) {
       doomed.push(this.profileServer.close());
     }
-    return P.all(doomed);
+    return Promise.all(doomed);
   } else {
-    return P.resolve();
+    return Promise.resolve();
   }
 };
 


### PR DESCRIPTION
There's still a bunch of places that use bluebird specific apis but this eliminates all the easy ones.