### PR TITLE
WIP downgrading multiple sessions on TOTP removal

### DIFF
--- a/packages/fxa-auth-db-mysql/db-server/index.js
+++ b/packages/fxa-auth-db-mysql/db-server/index.js
@@ -119,6 +119,10 @@ function createServer(db) {
   api.post('/account/:id/reset', withIdAndBody(db.resetAccount));
   api.post('/account/:id/resetTokens', withIdAndBody(db.resetAccountTokens));
   api.post(
+    '/account/:id/downgradeSessions',
+    withIdAndBody(db.downgradeSessionVerificationMethod)
+  );
+  api.post(
     '/account/:id/verifyEmail/:emailCode',
     op(function (req) {
       return db.verifyEmail(req.params.id, req.params.emailCode);

--- a/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
@@ -4069,6 +4069,33 @@ module.exports = function (config, DB) {
       });
     });
 
+    describe('downgrade session', () => {
+      let account, sessionToken, tokenId;
+      before(() => {
+        account = createAccount();
+        account.emailVerified = true;
+        tokenId = hex32();
+        sessionToken = makeMockSessionToken(account.uid, false);
+        return db
+          .createAccount(account.uid, account)
+          .then(() => db.createSessionToken(tokenId, sessionToken))
+          .then(() => db.sessionToken(tokenId))
+          .then((session) => {
+            // Returns unverified session
+            assert.equal(
+              session.tokenVerificationId.toString('hex'),
+              sessionToken.tokenVerificationId.toString('hex'),
+              'tokenVerificationId must match sessionToken'
+            );
+            assert.isNull(session.verificationMethod);
+          });
+      });
+      // create one sessionTokens record with a level 2 session. test that calling the method downgrades from 2 to 1.
+      // create one sessionTokens record with a level 1 session. test that, if there are no sessions with method 2, it doesn't throw.
+      // create two sessionTokens records with level 2 sessions. test that, if there are two sessions with method 2, it downgrades both to 1.
+      // throw appropriate error if a random uid is passed in that's not in the database
+    });
+
     describe('recovery codes', () => {
       let account;
       beforeEach(() => {

--- a/packages/fxa-auth-db-mysql/docs/API.md
+++ b/packages/fxa-auth-db-mysql/docs/API.md
@@ -62,6 +62,7 @@ The following datatypes are used throughout this document:
   - devices : `GET /account/:id/devices`
   - deviceFromTokenVerificationId : `GET /account/:id/tokens/:tokenVerificationId/device`
   - updateEcosystemAnonId : `PUT /account/:id/ecosystemAnonId`
+  - downgradeSessions : `POST /account/:id/downgradeSessions`
 - Devices:
   - createDevice : `PUT /account/:id/device/:deviceId`
   - updateDevice : `POST /account/:id/device/:deviceId/update`
@@ -787,6 +788,43 @@ Content-Type: application/json
   - Conditions: if the `uid` is not found
   - Content-Type : 'application/json'
   - Body : `{"message":"Not Found"}`
+
+## downgradeSessions : `PUT /account/<uid>/downgradeSessions`
+
+When a user disables TOTP, this method downgrades the verification method for all sessions from the TOTP verification method to the email code verification method.
+
+### Example
+
+```
+curl \
+    -v \
+    -X POST \
+    http://localhost:8000/account/6044486dd15b42e08b1fb9167415b9ac/downgradeSessions \
+    -d '{
+      "uid": "6044486dd15b42e08b1fb9167415b9ac",
+    }'
+```
+
+### Request
+
+- Method : POST
+- Path : `/account/<uid>/downgradeSessions`
+  - uid : hex128
+- Params:
+  - uid : hex128
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{}
+```
+
+- Status Code : 200 OK
+  - Content-Type : 'application/json'
+  - Body : {}
 
 ## createDevice : `PUT /account/<uid>/device/<deviceId>`
 

--- a/packages/fxa-auth-db-mysql/docs/DB_API.md
+++ b/packages/fxa-auth-db-mysql/docs/DB_API.md
@@ -17,6 +17,7 @@ There are a number of methods that a DB storage backend should implement:
   - .deleteEmail(uid, email)
   - .resetTokens(uid)
   - .updateEcosystemAnonId(uid, ecosystemAnonId)
+  - .downgradeSessionVerificationMethod(uid)
 - Accounts (using `email`)
   - .emailRecord(emailBuffer)
   - .accountRecord(emailBuffer)
@@ -365,6 +366,22 @@ Returns:
         * an empty object `{}`
     * rejects with:
         * error `{ code: 404, errno: 116 }` if the `uid` was not found in the database
+
+## .downgradeSessionVerificationMethod(uid)
+
+    When a user disables TOTP, this method downgrades the verification method for all sessions from the TOTP
+    verification method to the email code verification method.
+
+    Parameters:
+
+    * `uid` - (Buffer16) the uid of the account with TOTP-verified sessions to downgrade
+
+    Returns:
+
+    * resolves with:
+        * an empty object `{}`
+    * rejects with:
+        * any errors from the underlying storage engine
 
 ## .emailRecord(emailBuffer)
 

--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -1532,6 +1532,12 @@ module.exports = function (log, error) {
     });
   };
 
+  const DOWNGRADE_SESSION_VERIFICATION_METHOD =
+    'CALL downgradeSessionVerificationMethod_1(?)';
+  MySql.prototype.downgradeSessionVerificationMethod = function (uid) {
+    return this.write(DOWNGRADE_SESSION_VERIFICATION_METHOD, [uid]);
+  };
+
   const DELETE_RECOVERY_CODES = 'CALL deleteRecoveryCodes_1(?)';
   const INSERT_RECOVERY_CODE = 'CALL createRecoveryCode_3(?, ?, ?)';
   MySql.prototype.replaceRecoveryCodes = function (uid, count) {

--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 114;
+module.exports.level = 115;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-114-115.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-114-115.sql
@@ -1,0 +1,18 @@
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('114');
+
+
+-- When a user removes 2fa from their account, downgrade the verification
+-- method for any TOTP-verified sessions back down to email code-verified.
+CREATE PROCEDURE `downgradeSessionVerificationMethod_1` (
+  IN `inUid` BINARY(16)
+)
+BEGIN
+  UPDATE sessionTokens
+  SET verificationMethod = 1
+  WHERE uid = inUid
+  AND verificationMethod = 2;
+END;
+
+UPDATE dbMetadata SET value = '115' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-115-114.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-115-114.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE `downgradeSessionVerificationMethod_1`;
+
+-- UPDATE dbMetadata SET value = '114' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-server/lib/db.js
+++ b/packages/fxa-auth-server/lib/db.js
@@ -979,6 +979,22 @@ module.exports = (config, log, Token, UnblockCode = null) => {
     }
   };
 
+  SAFE_URLS.downgradeSessions = new SafeUrl(
+    '/account/:uid/downgradeSessions',
+    'db.downgradeSessions'
+  );
+  DB.prototype.downgradeSessions = async function (uid) {
+    log.trace('DB.downgradeSessions', { uid });
+    try {
+      return await this.pool.post(SAFE_URLS.downgradeSessions, { uid });
+    } catch (err) {
+      if (isNotFoundError(err)) {
+        throw error.unknownAccount();
+      }
+      throw err;
+    }
+  };
+
   SAFE_URLS.forgotPasswordVerified = new SafeUrl(
     '/passwordForgotToken/:id/verified',
     'db.forgotPasswordVerified'

--- a/packages/fxa-auth-server/lib/routes/totp.js
+++ b/packages/fxa-auth-server/lib/routes/totp.js
@@ -144,7 +144,7 @@ module.exports = (log, db, mailer, customs, config) => {
         // removed. Because we know the session is already verified, there's
         // no security risk in setting it as verified using a different method.
         // See #5154.
-        await db.verifyTokensWithMethod(sessionToken.id, 'email-2fa');
+        await db.downgradeSessions(uid);
 
         await log.notifyAttachedServices('profileDataChanged', request, {
           uid,

--- a/packages/fxa-auth-server/test/remote/db_tests.js
+++ b/packages/fxa-auth-server/test/remote/db_tests.js
@@ -163,435 +163,446 @@ describe('remote db', function () {
     let tokenId;
 
     // Fetch all sessions for the account
-    return db
-      .sessions(account.uid)
-      .then((sessions) => {
-        assert.ok(Array.isArray(sessions), 'sessions is array');
-        assert.equal(sessions.length, 0, 'sessions is empty');
+    return (
+      db
+        .sessions(account.uid)
+        .then((sessions) => {
+          assert.ok(Array.isArray(sessions), 'sessions is array');
+          assert.equal(sessions.length, 0, 'sessions is empty');
 
-        // Fetch the email record
-        return db.emailRecord(account.email);
-      })
-      .then((emailRecord) => {
-        emailRecord.createdAt = Date.now() - 1000;
-        emailRecord.tokenVerificationId = account.tokenVerificationId;
-        emailRecord.uaBrowser = 'Firefox';
-        emailRecord.uaBrowserVersion = '41';
-        emailRecord.uaOS = 'Mac OS X';
-        emailRecord.uaOSVersion = '10.10';
-        emailRecord.uaDeviceType = emailRecord.uaFormFactor = null;
+          // Fetch the email record
+          return db.emailRecord(account.email);
+        })
+        .then((emailRecord) => {
+          emailRecord.createdAt = Date.now() - 1000;
+          emailRecord.tokenVerificationId = account.tokenVerificationId;
+          emailRecord.uaBrowser = 'Firefox';
+          emailRecord.uaBrowserVersion = '41';
+          emailRecord.uaOS = 'Mac OS X';
+          emailRecord.uaOSVersion = '10.10';
+          emailRecord.uaDeviceType = emailRecord.uaFormFactor = null;
 
-        // Create a session token
-        return db.createSessionToken(emailRecord);
-      })
-      .then((sessionToken) => {
-        assert.deepEqual(sessionToken.uid, account.uid);
-        tokenId = sessionToken.id;
+          // Create a session token
+          return db.createSessionToken(emailRecord);
+        })
+        .then((sessionToken) => {
+          assert.deepEqual(sessionToken.uid, account.uid);
+          tokenId = sessionToken.id;
 
-        // Fetch all sessions for the account
-        return db.sessions(account.uid);
-      })
-      .then((sessions) => {
-        assert.equal(sessions.length, 1, 'sessions contains one item');
-        assert.equal(
-          Object.keys(sessions[0]).length,
-          20,
-          'session has correct number of properties'
-        );
-        assert.equal(
-          typeof sessions[0].id,
-          'string',
-          'id property is not a buffer'
-        );
-        assert.equal(sessions[0].uid, account.uid, 'uid property is correct');
-        assert.ok(
-          sessions[0].createdAt >= account.createdAt,
-          'createdAt property seems correct'
-        );
-        assert.equal(
-          sessions[0].uaBrowser,
-          'Firefox',
-          'uaBrowser property is correct'
-        );
-        assert.equal(
-          sessions[0].uaBrowserVersion,
-          '41',
-          'uaBrowserVersion property is correct'
-        );
-        assert.equal(sessions[0].uaOS, 'Mac OS X', 'uaOS property is correct');
-        assert.equal(
-          sessions[0].uaOSVersion,
-          '10.10',
-          'uaOSVersion property is correct'
-        );
-        assert.equal(
-          sessions[0].uaDeviceType,
-          null,
-          'uaDeviceType property is correct'
-        );
-        assert.equal(
-          sessions[0].uaFormFactor,
-          null,
-          'uaFormFactor property is correct'
-        );
-        assert.equal(
-          sessions[0].lastAccessTime,
-          sessions[0].createdAt,
-          'lastAccessTime property is correct'
-        );
-        assert.equal(
-          sessions[0].authAt,
-          sessions[0].createdAt,
-          'authAt property is correct'
-        );
-        assert.equal(
-          sessions[0].location,
-          undefined,
-          'location property is correct'
-        );
-        assert.deepEqual(
-          sessions[0].deviceId,
-          null,
-          'deviceId property is correct'
-        );
-        assert.deepEqual(
-          sessions[0].deviceAvailableCommands,
-          null,
-          'deviceAvailableCommands property is correct'
-        );
+          // Fetch all sessions for the account
+          return db.sessions(account.uid);
+        })
+        .then((sessions) => {
+          assert.equal(sessions.length, 1, 'sessions contains one item');
+          assert.equal(
+            Object.keys(sessions[0]).length,
+            20,
+            'session has correct number of properties'
+          );
+          assert.equal(
+            typeof sessions[0].id,
+            'string',
+            'id property is not a buffer'
+          );
+          assert.equal(sessions[0].uid, account.uid, 'uid property is correct');
+          assert.ok(
+            sessions[0].createdAt >= account.createdAt,
+            'createdAt property seems correct'
+          );
+          assert.equal(
+            sessions[0].uaBrowser,
+            'Firefox',
+            'uaBrowser property is correct'
+          );
+          assert.equal(
+            sessions[0].uaBrowserVersion,
+            '41',
+            'uaBrowserVersion property is correct'
+          );
+          assert.equal(
+            sessions[0].uaOS,
+            'Mac OS X',
+            'uaOS property is correct'
+          );
+          assert.equal(
+            sessions[0].uaOSVersion,
+            '10.10',
+            'uaOSVersion property is correct'
+          );
+          assert.equal(
+            sessions[0].uaDeviceType,
+            null,
+            'uaDeviceType property is correct'
+          );
+          assert.equal(
+            sessions[0].uaFormFactor,
+            null,
+            'uaFormFactor property is correct'
+          );
+          assert.equal(
+            sessions[0].lastAccessTime,
+            sessions[0].createdAt,
+            'lastAccessTime property is correct'
+          );
+          assert.equal(
+            sessions[0].authAt,
+            sessions[0].createdAt,
+            'authAt property is correct'
+          );
+          assert.equal(
+            sessions[0].location,
+            undefined,
+            'location property is correct'
+          );
+          assert.deepEqual(
+            sessions[0].deviceId,
+            null,
+            'deviceId property is correct'
+          );
+          assert.deepEqual(
+            sessions[0].deviceAvailableCommands,
+            null,
+            'deviceAvailableCommands property is correct'
+          );
 
-        // Fetch the session token
-        return db.sessionToken(tokenId);
-      })
-      .then((sessionToken) => {
-        assert.equal(sessionToken.id, tokenId, 'token id matches');
-        assert.equal(sessionToken.uaBrowser, 'Firefox');
-        assert.equal(sessionToken.uaBrowserVersion, '41');
-        assert.equal(sessionToken.uaOS, 'Mac OS X');
-        assert.equal(sessionToken.uaOSVersion, '10.10');
-        assert.equal(sessionToken.uaDeviceType, null);
-        assert.equal(sessionToken.lastAccessTime, sessionToken.createdAt);
-        assert.equal(sessionToken.uid, account.uid);
-        assert.equal(sessionToken.email, account.email);
-        assert.equal(sessionToken.emailCode, account.emailCode);
-        assert.equal(sessionToken.emailVerified, account.emailVerified);
-        assert.equal(sessionToken.lifetime < Infinity, true);
+          // Fetch the session token
+          return db.sessionToken(tokenId);
+        })
+        .then((sessionToken) => {
+          assert.equal(sessionToken.id, tokenId, 'token id matches');
+          assert.equal(sessionToken.uaBrowser, 'Firefox');
+          assert.equal(sessionToken.uaBrowserVersion, '41');
+          assert.equal(sessionToken.uaOS, 'Mac OS X');
+          assert.equal(sessionToken.uaOSVersion, '10.10');
+          assert.equal(sessionToken.uaDeviceType, null);
+          assert.equal(sessionToken.lastAccessTime, sessionToken.createdAt);
+          assert.equal(sessionToken.uid, account.uid);
+          assert.equal(sessionToken.email, account.email);
+          assert.equal(sessionToken.emailCode, account.emailCode);
+          assert.equal(sessionToken.emailVerified, account.emailVerified);
+          assert.equal(sessionToken.lifetime < Infinity, true);
 
-        // Disable session token updates
-        lastAccessTimeUpdates.enabled = false;
+          // Disable session token updates
+          lastAccessTimeUpdates.enabled = false;
 
-        // Attempt to update the session token
-        return db.touchSessionToken(sessionToken, {});
-      })
-      .then((result) => {
-        assert.equal(result, undefined);
+          // Attempt to update the session token
+          return db.touchSessionToken(sessionToken, {});
+        })
+        .then((result) => {
+          assert.equal(result, undefined);
 
-        // Fetch all sessions for the account
-        return db.sessions(account.uid);
-      })
-      .then((sessions) => {
-        assert.equal(sessions.length, 1, 'sessions contains one item');
-        assert.equal(
-          Object.keys(sessions[0]).length,
-          20,
-          'session has correct number of properties'
-        );
-        assert.equal(sessions[0].uid, account.uid, 'uid property is correct');
-        assert.equal(
-          sessions[0].lastAccessTime,
-          undefined,
-          'lastAccessTime not reported if disabled'
-        );
-        assert.equal(
-          sessions[0].location,
-          undefined,
-          'location property is correct'
-        );
+          // Fetch all sessions for the account
+          return db.sessions(account.uid);
+        })
+        .then((sessions) => {
+          assert.equal(sessions.length, 1, 'sessions contains one item');
+          assert.equal(
+            Object.keys(sessions[0]).length,
+            20,
+            'session has correct number of properties'
+          );
+          assert.equal(sessions[0].uid, account.uid, 'uid property is correct');
+          assert.equal(
+            sessions[0].lastAccessTime,
+            undefined,
+            'lastAccessTime not reported if disabled'
+          );
+          assert.equal(
+            sessions[0].location,
+            undefined,
+            'location property is correct'
+          );
 
-        // Re-enable session token updates
-        lastAccessTimeUpdates.enabled = true;
+          // Re-enable session token updates
+          lastAccessTimeUpdates.enabled = true;
 
-        // Fetch the session token
-        return db.sessionToken(tokenId);
-      })
-      .then((sessionToken) => {
-        // Update the session token
-        return db.touchSessionToken(
-          Object.assign({}, sessionToken, {
-            lastAccessTime: Date.now(),
-          }),
-          {
-            location: {
-              city: 'Bournemouth',
-              country: 'United Kingdom',
-              countryCode: 'GB',
-              state: 'England',
-              stateCode: 'EN',
+          // Fetch the session token
+          return db.sessionToken(tokenId);
+        })
+        .then((sessionToken) => {
+          // Update the session token
+          return db.touchSessionToken(
+            Object.assign({}, sessionToken, {
+              lastAccessTime: Date.now(),
+            }),
+            {
+              location: {
+                city: 'Bournemouth',
+                country: 'United Kingdom',
+                countryCode: 'GB',
+                state: 'England',
+                stateCode: 'EN',
+              },
+              timeZone: 'Europe/London',
+            }
+          );
+        })
+        .then(() => {
+          // Fetch all sessions for the account
+          return db.sessions(account.uid);
+        })
+        .then((sessions) => {
+          assert.equal(sessions.length, 1, 'sessions contains one item');
+          assert.equal(sessions[0].uid, account.uid, 'uid property is correct');
+          assert.ok(
+            sessions[0].lastAccessTime > sessions[0].createdAt,
+            'lastAccessTime is correct'
+          );
+          assert.equal(
+            sessions[0].location.city,
+            'Bournemouth',
+            'city is correct'
+          );
+          assert.equal(
+            sessions[0].location.country,
+            'United Kingdom',
+            'country is correct'
+          );
+          assert.equal(
+            sessions[0].location.countryCode,
+            'GB',
+            'countryCode is correct'
+          );
+          assert.equal(
+            sessions[0].location.state,
+            'England',
+            'state is correct'
+          );
+          assert.equal(
+            sessions[0].location.stateCode,
+            'EN',
+            'stateCode is correct'
+          );
+          assert.equal(
+            sessions[0].location.timeZone,
+            undefined,
+            'timeZone is not set'
+          );
+
+          // Fetch the session token
+          return db.sessionToken(tokenId);
+        })
+        .then((sessionToken) => {
+          // Update the session token
+          return db.touchSessionToken(
+            Object.assign({}, sessionToken, {
+              uaBrowser: 'Firefox Mobile',
+              uaBrowserVersion: '42',
+              uaOS: 'Android',
+              uaOSVersion: '4.4',
+              uaDeviceType: 'mobile',
+              uaFormFactor: null,
+            }),
+            {}
+          );
+        })
+        .then(() => {
+          // Fetch all sessions for the account
+          return db.sessions(account.uid);
+        })
+        .then((sessions) => {
+          assert.equal(sessions.length, 1, 'sessions still contains one item');
+          assert.equal(
+            sessions[0].uaBrowser,
+            'Firefox Mobile',
+            'uaBrowser property is correct'
+          );
+          assert.equal(
+            sessions[0].uaBrowserVersion,
+            '42',
+            'uaBrowserVersion property is correct'
+          );
+          assert.equal(sessions[0].uaOS, 'Android', 'uaOS property is correct');
+          assert.equal(
+            sessions[0].uaOSVersion,
+            '4.4',
+            'uaOSVersion property is correct'
+          );
+          assert.equal(
+            sessions[0].uaDeviceType,
+            'mobile',
+            'uaDeviceType property is correct'
+          );
+          assert.equal(
+            sessions[0].uaFormFactor,
+            null,
+            'uaFormFactor property is correct'
+          );
+          assert.equal(
+            sessions[0].location,
+            null,
+            'location property is correct'
+          );
+        })
+        .then(() => {
+          // Fetch the session token
+          return db.sessionToken(tokenId);
+        })
+        .then((sessionToken) => {
+          // this returns previously stored data since sessionToken doesnt read from cache
+          assert.equal(sessionToken.uaBrowser, 'Firefox');
+          assert.equal(sessionToken.uaBrowserVersion, '41');
+          assert.equal(sessionToken.uaOS, 'Mac OS X');
+          assert.equal(sessionToken.uaOSVersion, '10.10');
+          assert.equal(sessionToken.lastAccessTime, sessionToken.createdAt);
+
+          // Attempt to prune a session token that is younger than maxAge
+          sessionToken.createdAt = Date.now() - tokenPruning.maxAge + 10000;
+          return db.pruneSessionTokens(account.uid, [sessionToken]);
+        })
+        .then(() => {
+          // Fetch all sessions for the account
+          return db.sessions(account.uid);
+        })
+        .then((sessions) => {
+          assert.equal(sessions.length, 1, 'sessions still contains one item');
+          assert.equal(
+            sessions[0].uaBrowser,
+            'Firefox Mobile',
+            'uaBrowser property is correct'
+          );
+          assert.equal(
+            sessions[0].uaBrowserVersion,
+            '42',
+            'uaBrowserVersion property is correct'
+          );
+          assert.equal(sessions[0].uaOS, 'Android', 'uaOS property is correct');
+          assert.equal(
+            sessions[0].uaOSVersion,
+            '4.4',
+            'uaOSVersion property is correct'
+          );
+          assert.equal(
+            sessions[0].uaDeviceType,
+            'mobile',
+            'uaDeviceType property is correct'
+          );
+          assert.equal(
+            sessions[0].uaFormFactor,
+            null,
+            'uaFormFactor property is correct'
+          );
+
+          // Fetch the session token
+          return db.sessionToken(tokenId);
+        })
+        .then((sessionToken) => {
+          // Prune a session token that is older than maxAge
+          sessionToken.createdAt = Date.now() - tokenPruning.maxAge - 1;
+          return db.pruneSessionTokens(account.uid, [sessionToken]);
+        })
+        // TODO: I guess add tests here?
+        .then(() => {
+          // Fetch all sessions for the account
+          return db.sessions(account.uid);
+        })
+        .then((sessions) => {
+          assert.equal(sessions.length, 1, 'sessions still contains one item');
+          assert.equal(
+            sessions[0].uaBrowser,
+            'Firefox',
+            'uaBrowser property is the original value'
+          );
+          assert.equal(
+            sessions[0].uaBrowserVersion,
+            '41',
+            'uaBrowserVersion property is the original value'
+          );
+          assert.equal(
+            sessions[0].uaOS,
+            'Mac OS X',
+            'uaOS property is the original value'
+          );
+          assert.equal(
+            sessions[0].uaOSVersion,
+            '10.10',
+            'uaOSVersion property is the original value'
+          );
+          assert.equal(
+            sessions[0].uaDeviceType,
+            null,
+            'uaDeviceType property is the original value'
+          );
+          assert.equal(
+            sessions[0].uaFormFactor,
+            null,
+            'uaFormFactor property is the original value'
+          );
+
+          // Fetch the session token
+          return db.sessionToken(tokenId);
+        })
+        .then((sessionToken) => {
+          // Delete the session token
+          return db.deleteSessionToken(sessionToken);
+        })
+        .then(() => {
+          // Fetch all sessions for the account
+          return db.sessions(account.uid);
+        })
+        .then((sessions) => {
+          assert.equal(sessions.length, 0, 'sessions is empty');
+
+          // Attempt to delete the deleted session token
+          return db.sessionToken(tokenId).then(
+            (sessionToken) => {
+              assert(false, 'db.sessionToken should have failed');
             },
-            timeZone: 'Europe/London',
-          }
-        );
-      })
-      .then(() => {
-        // Fetch all sessions for the account
-        return db.sessions(account.uid);
-      })
-      .then((sessions) => {
-        assert.equal(sessions.length, 1, 'sessions contains one item');
-        assert.equal(sessions[0].uid, account.uid, 'uid property is correct');
-        assert.ok(
-          sessions[0].lastAccessTime > sessions[0].createdAt,
-          'lastAccessTime is correct'
-        );
-        assert.equal(
-          sessions[0].location.city,
-          'Bournemouth',
-          'city is correct'
-        );
-        assert.equal(
-          sessions[0].location.country,
-          'United Kingdom',
-          'country is correct'
-        );
-        assert.equal(
-          sessions[0].location.countryCode,
-          'GB',
-          'countryCode is correct'
-        );
-        assert.equal(sessions[0].location.state, 'England', 'state is correct');
-        assert.equal(
-          sessions[0].location.stateCode,
-          'EN',
-          'stateCode is correct'
-        );
-        assert.equal(
-          sessions[0].location.timeZone,
-          undefined,
-          'timeZone is not set'
-        );
+            (err) => {
+              assert.equal(
+                err.errno,
+                110,
+                'sessionToken() fails with the correct error code'
+              );
+              const msg = 'Error: The authentication token could not be found';
+              assert.equal(
+                msg,
+                `${err}`,
+                'sessionToken() fails with the correct message'
+              );
+            }
+          );
+        })
+        .then(() => {
+          // Fetch the email record again
+          return db.emailRecord(account.email);
+        })
+        .then((emailRecord) => {
+          emailRecord.createdAt = Date.now() - 1000;
+          emailRecord.tokenVerificationId = account.tokenVerificationId;
+          emailRecord.uaBrowser = 'Firefox';
+          emailRecord.uaBrowserVersion = '41';
+          emailRecord.uaOS = 'Mac OS X';
+          emailRecord.uaOSVersion = '10.10';
+          emailRecord.uaDeviceType = emailRecord.uaFormFactor = null;
 
-        // Fetch the session token
-        return db.sessionToken(tokenId);
-      })
-      .then((sessionToken) => {
-        // Update the session token
-        return db.touchSessionToken(
-          Object.assign({}, sessionToken, {
-            uaBrowser: 'Firefox Mobile',
-            uaBrowserVersion: '42',
-            uaOS: 'Android',
-            uaOSVersion: '4.4',
-            uaDeviceType: 'mobile',
-            uaFormFactor: null,
-          }),
-          {}
-        );
-      })
-      .then(() => {
-        // Fetch all sessions for the account
-        return db.sessions(account.uid);
-      })
-      .then((sessions) => {
-        assert.equal(sessions.length, 1, 'sessions still contains one item');
-        assert.equal(
-          sessions[0].uaBrowser,
-          'Firefox Mobile',
-          'uaBrowser property is correct'
-        );
-        assert.equal(
-          sessions[0].uaBrowserVersion,
-          '42',
-          'uaBrowserVersion property is correct'
-        );
-        assert.equal(sessions[0].uaOS, 'Android', 'uaOS property is correct');
-        assert.equal(
-          sessions[0].uaOSVersion,
-          '4.4',
-          'uaOSVersion property is correct'
-        );
-        assert.equal(
-          sessions[0].uaDeviceType,
-          'mobile',
-          'uaDeviceType property is correct'
-        );
-        assert.equal(
-          sessions[0].uaFormFactor,
-          null,
-          'uaFormFactor property is correct'
-        );
-        assert.equal(
-          sessions[0].location,
-          null,
-          'location property is correct'
-        );
-      })
-      .then(() => {
-        // Fetch the session token
-        return db.sessionToken(tokenId);
-      })
-      .then((sessionToken) => {
-        // this returns previously stored data since sessionToken doesnt read from cache
-        assert.equal(sessionToken.uaBrowser, 'Firefox');
-        assert.equal(sessionToken.uaBrowserVersion, '41');
-        assert.equal(sessionToken.uaOS, 'Mac OS X');
-        assert.equal(sessionToken.uaOSVersion, '10.10');
-        assert.equal(sessionToken.lastAccessTime, sessionToken.createdAt);
+          // Create a session token with the same data as the deleted token
+          return db.createSessionToken(emailRecord);
+        })
+        .then(() => {
+          // Fetch all sessions for the account
+          return db.sessions(account.uid);
+        })
+        .then((sessions) => {
+          // Make sure that the data got deleted from redis too
+          assert.equal(sessions.length, 1, 'sessions contains one item');
+          assert.equal(
+            sessions[0].lastAccessTime,
+            sessions[0].createdAt,
+            'lastAccessTime property is correct'
+          );
+          assert.equal(
+            sessions[0].location,
+            undefined,
+            'location property is correct'
+          );
 
-        // Attempt to prune a session token that is younger than maxAge
-        sessionToken.createdAt = Date.now() - tokenPruning.maxAge + 10000;
-        return db.pruneSessionTokens(account.uid, [sessionToken]);
-      })
-      .then(() => {
-        // Fetch all sessions for the account
-        return db.sessions(account.uid);
-      })
-      .then((sessions) => {
-        assert.equal(sessions.length, 1, 'sessions still contains one item');
-        assert.equal(
-          sessions[0].uaBrowser,
-          'Firefox Mobile',
-          'uaBrowser property is correct'
-        );
-        assert.equal(
-          sessions[0].uaBrowserVersion,
-          '42',
-          'uaBrowserVersion property is correct'
-        );
-        assert.equal(sessions[0].uaOS, 'Android', 'uaOS property is correct');
-        assert.equal(
-          sessions[0].uaOSVersion,
-          '4.4',
-          'uaOSVersion property is correct'
-        );
-        assert.equal(
-          sessions[0].uaDeviceType,
-          'mobile',
-          'uaDeviceType property is correct'
-        );
-        assert.equal(
-          sessions[0].uaFormFactor,
-          null,
-          'uaFormFactor property is correct'
-        );
-
-        // Fetch the session token
-        return db.sessionToken(tokenId);
-      })
-      .then((sessionToken) => {
-        // Prune a session token that is older than maxAge
-        sessionToken.createdAt = Date.now() - tokenPruning.maxAge - 1;
-        return db.pruneSessionTokens(account.uid, [sessionToken]);
-      })
-      .then(() => {
-        // Fetch all sessions for the account
-        return db.sessions(account.uid);
-      })
-      .then((sessions) => {
-        assert.equal(sessions.length, 1, 'sessions still contains one item');
-        assert.equal(
-          sessions[0].uaBrowser,
-          'Firefox',
-          'uaBrowser property is the original value'
-        );
-        assert.equal(
-          sessions[0].uaBrowserVersion,
-          '41',
-          'uaBrowserVersion property is the original value'
-        );
-        assert.equal(
-          sessions[0].uaOS,
-          'Mac OS X',
-          'uaOS property is the original value'
-        );
-        assert.equal(
-          sessions[0].uaOSVersion,
-          '10.10',
-          'uaOSVersion property is the original value'
-        );
-        assert.equal(
-          sessions[0].uaDeviceType,
-          null,
-          'uaDeviceType property is the original value'
-        );
-        assert.equal(
-          sessions[0].uaFormFactor,
-          null,
-          'uaFormFactor property is the original value'
-        );
-
-        // Fetch the session token
-        return db.sessionToken(tokenId);
-      })
-      .then((sessionToken) => {
-        // Delete the session token
-        return db.deleteSessionToken(sessionToken);
-      })
-      .then(() => {
-        // Fetch all sessions for the account
-        return db.sessions(account.uid);
-      })
-      .then((sessions) => {
-        assert.equal(sessions.length, 0, 'sessions is empty');
-
-        // Attempt to delete the deleted session token
-        return db.sessionToken(tokenId).then(
-          (sessionToken) => {
-            assert(false, 'db.sessionToken should have failed');
-          },
-          (err) => {
-            assert.equal(
-              err.errno,
-              110,
-              'sessionToken() fails with the correct error code'
-            );
-            const msg = 'Error: The authentication token could not be found';
-            assert.equal(
-              msg,
-              `${err}`,
-              'sessionToken() fails with the correct message'
-            );
-          }
-        );
-      })
-      .then(() => {
-        // Fetch the email record again
-        return db.emailRecord(account.email);
-      })
-      .then((emailRecord) => {
-        emailRecord.createdAt = Date.now() - 1000;
-        emailRecord.tokenVerificationId = account.tokenVerificationId;
-        emailRecord.uaBrowser = 'Firefox';
-        emailRecord.uaBrowserVersion = '41';
-        emailRecord.uaOS = 'Mac OS X';
-        emailRecord.uaOSVersion = '10.10';
-        emailRecord.uaDeviceType = emailRecord.uaFormFactor = null;
-
-        // Create a session token with the same data as the deleted token
-        return db.createSessionToken(emailRecord);
-      })
-      .then(() => {
-        // Fetch all sessions for the account
-        return db.sessions(account.uid);
-      })
-      .then((sessions) => {
-        // Make sure that the data got deleted from redis too
-        assert.equal(sessions.length, 1, 'sessions contains one item');
-        assert.equal(
-          sessions[0].lastAccessTime,
-          sessions[0].createdAt,
-          'lastAccessTime property is correct'
-        );
-        assert.equal(
-          sessions[0].location,
-          undefined,
-          'location property is correct'
-        );
-
-        // Delete the session token again
-        return db.deleteSessionToken(sessions[0]);
-      })
-      .then(() => redis.getAsync(account.uid))
-      .then((result) => assert.equal(result, null, 'redis was cleared'));
+          // Delete the session token again
+          return db.deleteSessionToken(sessions[0]);
+        })
+        .then(() => redis.getAsync(account.uid))
+        .then((result) => assert.equal(result, null, 'redis was cleared'))
+    );
   });
 
   it('device registration', () => {


### PR DESCRIPTION
(Switching gears for the afternoon, but wanted to get this out now to be sure I'm going in the right direction.)

This is a followup from #7155 to downgrade _all_ sessions marked TOTP verified when the user disables TOTP. This should close #5154. It's basically a SQL one-liner that shouldn't cause any perf issues (the necessary index already exists on the sessionTokens table), wrapped in a ton of boilerplate changes to the auth and auth-db layers.

API thoughts: I'm adding a very specific `account/:id/downgradeSessions` API endpoint to auth-db to do this, which feels weird because it's such a specific edge case, but it also seems like the most direct path to a fix. The obvious (to me) alternative would be to modify the existing `POST /tokens/:tokenId/verifyWithMethod` endpoint to handle multiple tokens at once, but I didn't see a nice way to turn that single-token-oriented API into a batch-oriented API. I'm open to suggestions on nicer ways to handle this.

I still have to fill in some tests, but I verified locally that this does flip the verification method from 2 to 1 (i.e. from totp-2fa to email-2fa) on multiple sessions if present in the DB.

Unfortunately, looks like prettier did its thing with the remote/db_tests file. There's nothing to see there, feel free to ignore.