### PR TITLE
fix(settings): account for header height on anchor jump

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -724,7 +724,7 @@ module.exports = {
         SUBMIT_RECOVERY_KEY: '[data-testid=submit-recovery-code]',
         SUCCESS_MESSAGE: '[data-testid=alert-external-text]',
         DISABLE_TFA:
-          '#security div:nth-child(2) > div:nth-child(3) div.unit-row-actions button:nth-child(2)',
+          '[data-testid=settings-security] div:nth-child(2) > div:nth-child(3) div.unit-row-actions button:nth-child(2)',
         DISABLE_MODAL: '[data-testid=disable-totp-modal-header]',
         DISABLE_TFA_CONFIRM: '[data-testid=modal-confirm]',
         CANCEL_DISABLE_TFA: '[data-testid=modal-cancel]',

--- a/packages/fxa-content-server/tests/functional/settings_v2/connected_services_oauth_clients.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/connected_services_oauth_clients.js
@@ -90,14 +90,14 @@ describe('connected services: oauth clients', () => {
     // disconnect
     await click(
       // the current lack of unique ids make the positional selector here necessary
-      `#connected-services #service:nth-child(3) ${selectors.SETTINGS_V2.CONNECTED_SERVICES.SIGN_OUT}`
+      `${selectors.SETTINGS_V2.CONNECTED_SERVICES.HEADER} #service:nth-child(3) ${selectors.SETTINGS_V2.CONNECTED_SERVICES.SIGN_OUT}`
     );
     await pollUntilGoneByQSA(
-      `#connected-services #service:nth-child(4) ${selectors.SETTINGS_V2.CONNECTED_SERVICES.SIGN_OUT}`
+      `${selectors.SETTINGS_V2.CONNECTED_SERVICES.HEADER} #service:nth-child(4) ${selectors.SETTINGS_V2.CONNECTED_SERVICES.SIGN_OUT}`
     );
     await click(selectors.SETTINGS_V2.CONNECTED_SERVICES.REFRESH_BUTTON);
     await noSuchElement(
-      `#connected-services #service:nth-child(4) ${selectors.SETTINGS_V2.CONNECTED_SERVICES.SIGN_OUT}`
+      `${selectors.SETTINGS_V2.CONNECTED_SERVICES.HEADER} #service:nth-child(4) ${selectors.SETTINGS_V2.CONNECTED_SERVICES.SIGN_OUT}`
     );
   });
 });

--- a/packages/fxa-settings/src/components/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/index.tsx
@@ -200,13 +200,10 @@ export const ConnectedServices = () => {
   );
 
   return (
-    <section
-      className="mt-11"
-      id="connected-services"
-      data-testid="settings-connected-services"
-    >
-      <h2 className="font-header font-bold ltr:ml-4 rtl:mr-4 mb-4">
-        Connected Services
+    <section className="mt-11" data-testid="settings-connected-services">
+      <h2 className="font-header font-bold ltr:ml-4 rtl:mr-4 mb-4 relative">
+        <span id="connected-services" className="nav-anchor"></span>Connected
+        Services
       </h2>
       <div className="bg-white tablet:rounded-xl shadow px-4 tablet:px-6 pt-7 pb-8">
         <div className="flex justify-between mb-4">

--- a/packages/fxa-settings/src/components/Profile/index.tsx
+++ b/packages/fxa-settings/src/components/Profile/index.tsx
@@ -16,8 +16,10 @@ export const Profile = () => {
   }).format(new Date(passwordCreated));
 
   return (
-    <section className="mt-11" id="profile" data-testid="settings-profile">
-      <h2 className="font-header font-bold ltr:ml-4 rtl:mr-4 mb-4">Profile</h2>
+    <section className="mt-11" data-testid="settings-profile">
+      <h2 className="font-header font-bold ltr:ml-4 rtl:mr-4 mb-4 relative">
+        <span id="profile" className="nav-anchor"></span>Profile
+      </h2>
 
       <div className="bg-white tablet:rounded-xl shadow">
         <UnitRowWithAvatar />

--- a/packages/fxa-settings/src/components/Security/index.tsx
+++ b/packages/fxa-settings/src/components/Security/index.tsx
@@ -8,8 +8,10 @@ import UnitRowTwoStepAuth from '../UnitRowTwoStepAuth';
 
 export const Security = () => {
   return (
-    <section className="mt-11" id="security" data-testid="settings-security">
-      <h2 className="font-header font-bold ltr:ml-4 rtl:mr-4 mb-4">Security</h2>
+    <section className="mt-11" data-testid="settings-security">
+      <h2 className="font-header font-bold ltr:ml-4 rtl:mr-4 mb-4 relative">
+        <span id="security" className="nav-anchor"></span>Security
+      </h2>
       <div className="bg-white tablet:rounded-xl shadow">
         <UnitRowRecoveryKey />
         <hr className="unit-row-hr" />

--- a/packages/fxa-settings/src/styles/tailwind.scss
+++ b/packages/fxa-settings/src/styles/tailwind.scss
@@ -29,6 +29,11 @@ body {
   }
 }
 
+.nav-anchor {
+  position: absolute;
+  top: -5em;
+}
+
 .transition-standard {
   @apply transition duration-150;
 


### PR DESCRIPTION
Because:
 - settings has a fixed heaer that covers up content

This commit:
 - account for the height of the header when navigating to a section
   with an anchor


## Issue that this pull request solves

Closes: #7016 
