### PR TITLE
task(fxa-content-server): add log to track down entrypoint sentry error

### DIFF
--- a/packages/fxa-content-server/server/bin/fxa-content-server.js
+++ b/packages/fxa-content-server/server/bin/fxa-content-server.js
@@ -217,6 +217,14 @@ function makeApp() {
 
   // log and capture any errors
   app.use((err, req, res, next) => {
+    // in order to track down the culprit of sentry issue, https://sentry.prod.mozaws.net/operations/fxa-content-server-prod/issues/6602579/events/latest/
+    if (err.joi && err.joi.isJoi)
+      console.error(
+        'GLOBAL SENTRY JOI ERROR: ',
+        req.path,
+        req.query,
+        req.originalUrl
+      );
     sentry.sentryModule.captureException(err);
     routeHelpers.validationErrorHandler(err, req, res, next);
   });


### PR DESCRIPTION
## This pull request
Adding this to get more info about the request that is causing https://sentry.prod.mozaws.net/operations/fxa-content-server-prod/issues/6602579/events/latest/
- adds a log with query and url info for joi validation errors.

refs #3718 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Need to check with @jbuck to see how we will be able to access this once it is in production. Additionally we may be able to avoid this patch if I can get access to see `fxa-content-server.server.routes.validation.failed` in our logs. Waiting to hear back from @ckolos on that. It's the holidays so we may not get answers until after the break.
