### PR TITLE
refactor(oauth): add /config route back

### DIFF
--- a/packages/fxa-auth-server/lib/routes/defaults.js
+++ b/packages/fxa-auth-server/lib/routes/defaults.js
@@ -8,7 +8,7 @@ const error = require('../error');
 
 const getVersion = require('../version').getVersion;
 
-module.exports = (log, db) => {
+module.exports = (log, config, db) => {
   async function versionHandler(request, h) {
     log.begin('Defaults.root', request);
     const versionData = await getVersion();
@@ -46,6 +46,22 @@ module.exports = (log, db) => {
       handler: async function heartbeat(request) {
         log.begin('Defaults.lbheartbeat', request);
         return {};
+      },
+    },
+    {
+      method: 'GET',
+      path: '/config',
+      handler: async function (request) {
+        // This is a legacy oauth route used by tokenserver.
+        // We should consider it deprecated but removing it isn't a high priority.
+        log.begin('Defaults.config', request);
+        return {
+          browserid: {
+            issuer: config.oauthServer.browserid.issuer,
+            verificationUrl: config.oauthServer.browserid.verificationUrl,
+          },
+          contentUrl: config.oauthServer.contentUrl,
+        };
       },
     },
     {

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -48,7 +48,7 @@ module.exports = function (
     verificationReminders
   );
   // The routing modules themselves.
-  const defaults = require('./defaults')(log, db);
+  const defaults = require('./defaults')(log, config, db);
   const idp = require('./idp')(log, serverPublicKeys);
   const grant = require('../oauth/grant');
   const oauthRawDB = require('../oauth/db');


### PR DESCRIPTION
because token server still uses it

see https://github.com/mozilla/fxa/pull/7113#issuecomment-753505539