### PR TITLE
fix: use proper Sentry arguments

### DIFF
--- a/packages/fxa-admin-server/src/app.module.ts
+++ b/packages/fxa-admin-server/src/app.module.ts
@@ -54,7 +54,7 @@ const version = getVersionInfo(__dirname);
       useFactory: (configService: ConfigService<AppConfig>) => ({
         dsn: configService.get('sentryDsn'),
         environment: configService.get('env'),
-        version: version.version,
+        release: version.version,
       }),
     }),
   ],

--- a/packages/fxa-event-broker/src/app.module.ts
+++ b/packages/fxa-event-broker/src/app.module.ts
@@ -41,7 +41,7 @@ const version = getVersionInfo(__dirname);
       useFactory: (configService: ConfigService<AppConfig>) => ({
         dsn: configService.get('sentryDsn'),
         environment: configService.get('env'),
-        version: version.version,
+        release: version.version,
       }),
     }),
     QueueworkerModule,

--- a/packages/fxa-graphql-api/src/app.module.ts
+++ b/packages/fxa-graphql-api/src/app.module.ts
@@ -49,7 +49,7 @@ const version = getVersionInfo(__dirname);
       useFactory: (configService: ConfigService<AppConfig>) => ({
         dsn: configService.get('sentryDsn'),
         environment: configService.get('env'),
-        version: version.version,
+        release: version.version,
       }),
     }),
   ],

--- a/packages/fxa-support-panel/src/app.module.ts
+++ b/packages/fxa-support-panel/src/app.module.ts
@@ -34,7 +34,7 @@ const version = getVersionInfo(__dirname);
       useFactory: (configService: ConfigService<AppConfig>) => ({
         dsn: configService.get('sentryDsn'),
         environment: configService.get('env'),
-        version: version.version,
+        release: version.version,
       }),
     }),
   ],


### PR DESCRIPTION
Because:

* Version is not a valid Sentry Config parameter, but oddly was not
  caught by the type-checker.

This commit:

* Uses the `release` property to correctly specify the project release.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
