### PR TITLE
task(fxa-content-server): show settings survey for all

### DIFF
--- a/packages/fxa-content-server/server/config/surveys.json
+++ b/packages/fxa-content-server/server/config/surveys.json
@@ -4,7 +4,7 @@
     "conditions": {
       "languages": ["en"]
     },
-    "rate": 0.1,
+    "rate": 1,
     "view": "settings.beta-optout",
     "url": "https://survey.alchemer.com/s3/6025756/Settings-Opt-out"
   }


### PR DESCRIPTION
## This pull request

- sets our rate to 1 for showing the settings survey

## Issue that this pull request solves

Closes: #7171

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
