### PR TITLE
feat(head): Add react-helmet to update page title

### DIFF
--- a/packages/fxa-react/components/Head/index.stories.tsx
+++ b/packages/fxa-react/components/Head/index.stories.tsx
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import Head from './index';
+
+storiesOf('Components|Head', module)
+  .add('basic', () => <Head />)
+  .add('with title', () => <Head title="neat feature" />);

--- a/packages/fxa-react/components/Head/index.tsx
+++ b/packages/fxa-react/components/Head/index.tsx
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { Helmet } from 'react-helmet';
+
+const Head = ({ title }: { title?: string }) => (
+  <Helmet>
+    <title>{title ? `${title} | Firefox Accounts` : 'Firefox Accounts'}</title>
+  </Helmet>
+);
+
+export default Head;

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -26,6 +26,7 @@
     "fxa-shared": "workspace:*",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-helmet": "^6.1.0",
     "react-transition-group": "^4.3.0",
     "tailwindcss-dir": "^4.0.0"
   },
@@ -48,6 +49,7 @@
     "@types/prettier": "2.1.5",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.6",
+    "@types/react-helmet": "^6",
     "@types/react-transition-group": "^4.2.4",
     "@types/rimraf": "3.0.0",
     "babel-eslint": "^10.1.0",

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -11,6 +11,7 @@ import * as Metrics from '../../lib/metrics';
 import { Account } from '../../models';
 import { ACCOUNT_FIELDS } from '../../models/Account';
 import { Router } from '@reach/router';
+import Head from 'fxa-react/components/Head';
 import FlowContainer from '../FlowContainer';
 import PageSettings from '../PageSettings';
 import PageChangePassword from '../PageChangePassword';
@@ -60,6 +61,7 @@ export const App = ({ flowQueryParams, config }: AppProps) => {
 
   return (
     <AppLayout>
+      <Head />
       <Router basepath={HomePath}>
         <ScrollToTop default>
           <PageSettings path="/" />

--- a/packages/fxa-settings/src/components/FlowContainer/index.tsx
+++ b/packages/fxa-settings/src/components/FlowContainer/index.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { RouteComponentProps } from '@reach/router';
 import { ReactComponent as BackArrow } from './back-arrow.svg';
+import Head from 'fxa-react/components/Head';
 
 type FlowContainerProps = {
   title?: string;
@@ -26,6 +27,8 @@ export const FlowContainer = ({
       className="max-w-lg mx-auto mt-6 p-6 pb-7 tablet:my-10 flex flex-col items-start bg-white shadow tablet:rounded-xl"
       data-testid="flow-container"
     >
+      <Head title={title} />
+
       <div className="flex items-center">
         <button
           onClick={onBackButtonClick}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6502,6 +6502,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-helmet@npm:^6":
+  version: 6.1.0
+  resolution: "@types/react-helmet@npm:6.1.0"
+  dependencies:
+    "@types/react": "*"
+  checksum: b7aaa3aa2d81cd3b14a0e77a858de86934a3400f4ec35945117edb3979b8a41130e70b8a27241de295195e365962a9b5bc149a2a029d23795fd0f6c740d1de77
+  languageName: node
+  linkType: hard
+
 "@types/react-redux@npm:^7.1.5":
   version: 7.1.8
   resolution: "@types/react-redux@npm:7.1.8"
@@ -18522,6 +18531,7 @@ fsevents@^1.2.7:
     "@types/prettier": 2.1.5
     "@types/react": ^16.9.53
     "@types/react-dom": ^16.9.6
+    "@types/react-helmet": ^6
     "@types/react-transition-group": ^4.2.4
     "@types/rimraf": 3.0.0
     babel-eslint: ^10.1.0
@@ -18540,6 +18550,7 @@ fsevents@^1.2.7:
     prettier: ^2.0.5
     react: ^16.13.1
     react-dom: ^16.13.1
+    react-helmet: ^6.1.0
     react-transition-group: ^4.3.0
     rimraf: ^3.0.2
     sass: 1.26.10
@@ -30931,6 +30942,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"react-fast-compare@npm:^3.1.1":
+  version: 3.2.0
+  resolution: "react-fast-compare@npm:3.2.0"
+  checksum: 6fe65c889eb4f326e97769135f97b3d63ac68737866f9c37f9625c9de4f5eaa9abed6f748eb3fd6a66808392118842916309cab7cfa99c67991f0c837433d6d2
+  languageName: node
+  linkType: hard
+
 "react-focus-lock@npm:^2.1.0":
   version: 2.3.1
   resolution: "react-focus-lock@npm:2.3.1"
@@ -30960,6 +30978,20 @@ fsevents@^1.2.7:
     react: ^16.6.0
     react-dom: ^16.6.0
   checksum: 7b30fad33a212df5e61734b21c8a816e00d5516172c0e74e481f93c2724f673d08f8c1381a015085fbadaa8f9981aae1d9f8aab11c923bd650e70af90fee595a
+  languageName: node
+  linkType: hard
+
+"react-helmet@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "react-helmet@npm:6.1.0"
+  dependencies:
+    object-assign: ^4.1.1
+    prop-types: ^15.7.2
+    react-fast-compare: ^3.1.1
+    react-side-effect: ^2.1.0
+  peerDependencies:
+    react: ">=16.3.0"
+  checksum: 56fd795b0aecc89bac8d2733268751f0ef463bf6764090f8a801778741d4a6eaf135234cdaa50188bbda29c8e2d3ec43e9a42d1ec06b60092645c8754c7bad81
   languageName: node
   linkType: hard
 
@@ -31210,6 +31242,15 @@ fsevents@^1.2.7:
   peerDependencies:
     react: ^0.13.0 || ^0.14.0 || ^15.0.0 || ^16.0.0
   checksum: 5916b3eeaf599087529fbd3a0f879da4179d1ce39fbc368e669815d831531217c6ef638b54ff2ec569d15398f8eb1ec637b31c8ed1fca21960816b0ae529a034
+  languageName: node
+  linkType: hard
+
+"react-side-effect@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "react-side-effect@npm:2.1.1"
+  peerDependencies:
+    react: ^16.3.0 || ^17.0.0
+  checksum: 5896f7c126b9e7147e3ea6cc967dab8e3a2f6c395bd5327d16483adb91177866eec47770500a92fece866ea551f395484f6e6e078796002293bc1b53b7e65b26
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- In the original settings page the page title is updated when navigating to different subsections
- Based on https://github.com/mozilla/experimenter/pull/4126

## This pull request

- Updates the page title when navigating to a subsection based on the `FlowContainer` title
- Defaults to `Firefox Accounts` if no title is passed

## Issue that this pull request solves

Closes: #7210

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots
<img width="337" alt="Screen Shot 2021-01-05 at 4 00 41 PM" src="https://user-images.githubusercontent.com/1295288/103698345-39865080-4f6f-11eb-9607-ecaf8d01903e.png">

