### PR TITLE
fix(fxa-content-server): pass params to amplitude

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/app-start.js
+++ b/packages/fxa-content-server/app/scripts/lib/app-start.js
@@ -189,6 +189,8 @@ Start.prototype = {
       context: relier.get('context'),
       devicePixelRatio: screenInfo.devicePixelRatio,
       entrypoint: relier.get('entrypoint'),
+      entrypointExperiment: relier.get('entrypointExperiment'),
+      entrypointVariation: relier.get('entrypointVariation'),
       isSampledUser: isSampledUser,
       lang: this._config.lang,
       notifier: this._notifier,


### PR DESCRIPTION
## Because

- entrypoint_experiment and entrypoint_variation weren't being passed
from frontend to amplitude

## Issue that this pull request solves

Closes: #6925

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
