### PR TITLE
refactor(settings): limit queried data for reloads

### DIFF
--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@apollo/client": "^3.2.2",
+    "@apollo/client": "^3.3.6",
     "@reach/router": "^1.3.4",
     "base32-decode": "^1.0.0",
     "base32-encode": "^1.1.1",

--- a/packages/fxa-settings/src/components/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/index.tsx
@@ -11,7 +11,11 @@ import { useBooleanState } from 'fxa-react/lib/hooks';
 import { useAlertBar, useMutation } from '../../lib/hooks';
 import { Modal } from '../Modal';
 import { isMobileDevice } from '../../lib/utilities';
-import { AttachedClient, useAccount, useLazyAccount } from '../../models';
+import {
+  AttachedClient,
+  useAccount,
+  useLazyConnectedClients,
+} from '../../models';
 import { AlertBar } from '../AlertBar';
 import { ButtonIconReload } from '../ButtonIcon';
 import { ConnectAnotherDevicePromo } from '../ConnectAnotherDevicePromo';
@@ -74,7 +78,10 @@ export const ConnectedServices = () => {
   const sortedAndUniqueClients = sortAndFilterConnectedClients([
     ...attachedClients,
   ]);
-  const [getAccount, { accountLoading }] = useLazyAccount((error) => {
+  const [
+    getConnectedClients,
+    { connectedClientsLoading },
+  ] = useLazyConnectedClients((error) => {
     alertBar.error(
       'Sorry, there was a problem refreshing the list of connected services.'
     );
@@ -179,23 +186,21 @@ export const ConnectedServices = () => {
       onError: (error: ApolloError) =>
         clearDisconnectingState(undefined, error),
       ignoreResults: true,
-      update: (cache) => {
+      update: (cache) =>
         cache.modify({
+          id: cache.identify({ __typename: 'Account' }),
           fields: {
-            account: (existing: Account) => {
-              return {
-                ...existing,
-                attachedClients: attachedClients.filter(
-                  // TODO: should this also go into the AttachedClient model?
-                  (client) =>
-                    client.lastAccessTime !== DS.client!.lastAccessTime &&
-                    client.name !== DS.client!.name
-                ),
-              };
+            attachedClients(existingClients: AttachedClient[]) {
+              const updatedList = [...existingClients];
+              return updatedList.filter(
+                // TODO: should this also go into the AttachedClient model?
+                (client) =>
+                  client.lastAccessTime !== DS.client!.lastAccessTime &&
+                  client.name !== DS.client!.name
+              );
             },
           },
-        });
-      },
+        }),
     }
   );
 
@@ -212,8 +217,8 @@ export const ConnectedServices = () => {
             title="Refresh connected services"
             classNames="hidden mobileLandscape:inline-block"
             testId="connected-services-refresh"
-            disabled={accountLoading}
-            onClick={getAccount}
+            disabled={connectedClientsLoading}
+            onClick={getConnectedClients}
           />
         </div>
 

--- a/packages/fxa-settings/src/components/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.tsx
@@ -6,13 +6,11 @@ import { navigate, RouteComponentProps } from '@reach/router';
 import { useAccount } from '../../models';
 import { useForm } from 'react-hook-form';
 import React, { useState } from 'react';
-import { Account } from '../../models/Account';
 import FlowContainer from '../FlowContainer';
 import InputText from '../InputText';
 import { useAlertBar, useMutation } from '../../lib/hooks';
 import { gql } from '@apollo/client';
 import AlertBar from '../AlertBar';
-import { cloneDeep } from '@apollo/client/utilities';
 import { HomePath } from '../../constants';
 
 const validateDisplayName = (currentDisplayName: string) => (
@@ -56,11 +54,10 @@ export const PageDisplayName = (_: RouteComponentProps) => {
     },
     update: (cache) => {
       cache.modify({
+        id: cache.identify({ __typename: 'Account' }),
         fields: {
-          account: (existing: Account) => {
-            const account = cloneDeep(existing);
-            account.displayName = displayName!;
-            return account;
+          displayName() {
+            return displayName;
           },
         },
       });

--- a/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
@@ -5,13 +5,12 @@ import { RouteComponentProps, useNavigate } from '@reach/router';
 import { useRecoveryKeyMaker } from '../../lib/auth';
 import { cache, sessionToken } from '../../lib/cache';
 import { useAlertBar } from '../../lib/hooks';
-import { useAccount, Account } from '../../models';
+import { useAccount } from '../../models';
 import InputPassword from '../InputPassword';
 import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import AlertBar from '../AlertBar';
 import DataBlock from '../DataBlock';
-import { cloneDeep } from '@apollo/client/utilities';
 import { HomePath } from '../../constants';
 import GetDataTrio from '../GetDataTrio';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
@@ -47,11 +46,10 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
       );
       setSubtitleText('Step 2 of 2');
       cache.modify({
+        id: cache.identify({ __typename: 'Account' }),
         fields: {
-          account: (existing: Account) => {
-            const account = cloneDeep(existing);
-            account.recoveryKey = true;
-            return account;
+          recoveryKey() {
+            return true;
           },
         },
       });

--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
@@ -1,10 +1,8 @@
 import React, { ChangeEvent, useCallback, useRef, useState } from 'react';
 import { gql } from '@apollo/client';
-import { cloneDeep } from '@apollo/client/utilities';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import { useAlertBar, useMutation } from '../../lib/hooks';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
-import { Account } from '../../models';
 import InputText from '../InputText';
 import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
@@ -40,15 +38,17 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
     },
     update: (cache) => {
       cache.modify({
+        id: cache.identify({ __typename: 'Account' }),
         fields: {
-          account: (existing: Account) => {
-            const account = cloneDeep(existing);
-            account.emails.push({
-              email: email!,
-              isPrimary: false,
-              verified: false,
-            });
-            return account;
+          emails(existingEmails) {
+            return [
+              ...existingEmails,
+              {
+                email: email!,
+                isPrimary: false,
+                verified: false,
+              },
+            ];
           },
         },
       });

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
@@ -1,11 +1,10 @@
 import React, { useCallback, useState, useEffect } from 'react';
 import { gql } from '@apollo/client';
-import { cloneDeep } from '@apollo/client/utilities';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import { HomePath } from '../../constants';
 import { useAlertBar, useMutation } from '../../lib/hooks';
 import { logViewEvent } from '../../lib/metrics';
-import { Account } from '../../models';
+import { Email } from '../../models';
 import InputText from '../InputText';
 import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
@@ -49,11 +48,12 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
       },
       update: (cache) => {
         cache.modify({
+          id: cache.identify({ __typename: 'Account' }),
           fields: {
-            account: (existing: Account) => {
-              const account = cloneDeep(existing);
-              account.emails.find((m) => m.email === email)!.verified = true;
-              return account;
+            emails(existingEmails) {
+              return existingEmails.map((x: Email) =>
+                x.email === email ? { ...x, verified: true } : { ...x }
+              );
             },
           },
         });

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -6,7 +6,6 @@ import { gql } from '@apollo/client';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import { useForm } from 'react-hook-form';
 import { useAlertBar, useMutation } from '../../lib/hooks';
-import { Account } from '../../models/Account';
 import FlowContainer from '../FlowContainer';
 import InputText from '../InputText';
 import LinkExternal from 'fxa-react/components/LinkExternal';
@@ -18,7 +17,6 @@ import GetDataTrio from '../GetDataTrio';
 import { useSession } from '../../models';
 import { checkCode, getCode } from '../../lib/totp';
 import { HomePath } from '../../constants';
-import { cloneDeep } from '@apollo/client/utilities';
 import { alertTextExternal } from '../../lib/cache';
 import { logViewEvent, useMetrics } from '../../lib/metrics';
 
@@ -133,11 +131,10 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
     },
     update: (cache) => {
       cache.modify({
+        id: cache.identify({ __typename: 'Account' }),
         fields: {
-          account: (existing: Account) => {
-            const account = cloneDeep(existing);
-            account.totp.exists = true;
-            return account;
+          totp(currentTotp) {
+            return { ...currentTotp, exists: true };
           },
         },
       });
@@ -158,11 +155,10 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
     },
     update: (cache) => {
       cache.modify({
+        id: cache.identify({ __typename: 'Account' }),
         fields: {
-          account: (existing: Account) => {
-            const account = cloneDeep(existing);
-            account.totp.verified = true;
-            return account;
+          totp(currentTotp) {
+            return { ...currentTotp, verified: true };
           },
         },
       });

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.test.tsx
@@ -3,12 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { screen, fireEvent, act } from '@testing-library/react';
+import { screen, fireEvent, act, wait } from '@testing-library/react';
 import UnitRowRecoveryKey from '.';
 import {
   renderWithRouter,
   MockedCache,
-  mockAccountQuery,
+  mockRecoveryKeyExistsQuery,
 } from '../../models/_mocks';
 
 describe('UnitRowRecoveryKey', () => {
@@ -47,20 +47,24 @@ describe('UnitRowRecoveryKey', () => {
   });
 
   it('can be refreshed', async () => {
-    renderWithRouter(
-      <MockedCache
-        account={{ recoveryKey: false }}
-        mocks={[mockAccountQuery({ recoveryKey: true })]}
-      >
-        <UnitRowRecoveryKey />
-      </MockedCache>
-    );
+    await act(async () => {
+      renderWithRouter(
+        <MockedCache
+          account={{ recoveryKey: false }}
+          mocks={[mockRecoveryKeyExistsQuery({ recoveryKey: true })]}
+        >
+          <UnitRowRecoveryKey />
+        </MockedCache>
+      );
+    });
     expect(
       screen.getByTestId('recovery-key-unit-row-header-value')
     ).toHaveTextContent('Not Set');
     await act(async () => {
       fireEvent.click(screen.getByTestId('recovery-key-refresh'));
     });
+    // wait a tick to get past the 'loading' state of the query
+    await wait();
     expect(
       screen.getByTestId('recovery-key-unit-row-header-value')
     ).toHaveTextContent('Enabled');

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
@@ -7,7 +7,7 @@ import { gql } from '@apollo/client';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { useBooleanState } from 'fxa-react/lib/hooks';
 import { useAlertBar, useMutation } from '../../lib/hooks';
-import { useAccount, useLazyAccount } from '../../models';
+import { useAccount, useLazyRecoveryKeyExists } from '../../models';
 import { logViewEvent } from '../../lib/metrics';
 import AlertBar from '../AlertBar';
 import Modal from '../Modal';
@@ -28,7 +28,10 @@ export const UnitRowRecoveryKey = () => {
   const alertBar = useAlertBar();
   const [modalRevealed, revealModal, hideModal] = useBooleanState();
 
-  const [getAccount, { accountLoading }] = useLazyAccount((error) => {
+  const [
+    getRecoveryKeyExists,
+    { recoveryKeyExistsLoading },
+  ] = useLazyRecoveryKeyExists((error) => {
     hideModal();
     alertBar.error(
       'Sorry, there was a problem refreshing the recovery key.',
@@ -51,9 +54,10 @@ export const UnitRowRecoveryKey = () => {
     ignoreResults: true,
     update: (cache) => {
       cache.modify({
+        id: cache.identify({ __typename: 'Account' }),
         fields: {
-          account: (existing) => {
-            return { ...existing, recoveryKey: false };
+          recoveryKey() {
+            return false;
           },
         },
       });
@@ -75,8 +79,8 @@ export const UnitRowRecoveryKey = () => {
         <ButtonIconReload
           title="Refresh recovery key"
           classNames="mobileLandscape:hidden ltr:ml-1 rtl:mr-1"
-          disabled={accountLoading}
-          onClick={getAccount}
+          disabled={recoveryKeyExistsLoading}
+          onClick={getRecoveryKeyExists}
         />
       }
       actionContent={
@@ -84,8 +88,8 @@ export const UnitRowRecoveryKey = () => {
           title="Refresh recovery key"
           classNames="hidden mobileLandscape:inline-block ltr:ml-1 rtl:mr-1"
           testId="recovery-key-refresh"
-          disabled={accountLoading}
-          onClick={getAccount}
+          disabled={recoveryKeyExistsLoading}
+          onClick={getRecoveryKeyExists}
         />
       }
     >

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -5,9 +5,8 @@
 import React, { ReactNode, useState } from 'react';
 import { gql } from '@apollo/client';
 import { useNavigate } from '@reach/router';
-import { cloneDeep } from '@apollo/client/utilities';
 import { useAlertBar, useMutation } from '../../lib/hooks';
-import { useAccount, useLazyAccount, Email, Account } from '../../models';
+import { useAccount, useLazyAccount, Email } from '../../models';
 import UnitRow from '../UnitRow';
 import AlertBar from '../AlertBar';
 import ModalVerifySession from '../ModalVerifySession';
@@ -83,14 +82,19 @@ export const UnitRowSecondaryEmail = () => {
       },
       update: (cache) => {
         cache.modify({
+          id: cache.identify({ __typename: 'Account' }),
           fields: {
-            account: (existing: Account) => {
-              const account = cloneDeep(existing);
-              account.emails.find((m) => m.email === email)!.isPrimary = true;
-              account.emails.find(
-                (m) => m.isPrimary && m.email !== email
-              )!.isPrimary = false;
-              return account;
+            emails(existingEmails) {
+              return existingEmails.map((x: Email) => {
+                const e = { ...x };
+                if (e.email === email) {
+                  e.isPrimary = true;
+                } else if (e.isPrimary) {
+                  e.isPrimary = false;
+                }
+
+                return e;
+              });
             },
           },
         });
@@ -109,14 +113,15 @@ export const UnitRowSecondaryEmail = () => {
       },
       update: (cache) => {
         cache.modify({
+          id: cache.identify({ __typename: 'Account' }),
           fields: {
-            account: (existing: Account) => {
-              const account = cloneDeep(existing);
-              account.emails.splice(
-                account.emails.findIndex((m) => m.email === email),
+            emails(existingEmails) {
+              const emails = [...existingEmails];
+              emails.splice(
+                emails.findIndex((x) => x.email === email),
                 1
               );
-              return account;
+              return emails;
             },
           },
         });

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.test.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.test.tsx
@@ -8,7 +8,7 @@ import { DELETE_TOTP_MUTATION, UnitRowTwoStepAuth } from '.';
 import {
   renderWithRouter,
   MockedCache,
-  mockAccountQuery,
+  mockTotpStatusQuery,
 } from '../../models/_mocks';
 
 const mockMutationSuccess = {
@@ -86,7 +86,7 @@ describe('UnitRowTwoStepAuth', () => {
       <MockedCache
         account={{ totp: { exists: false } }}
         mocks={[
-          mockAccountQuery({
+          mockTotpStatusQuery({
             totp: {
               exists: true,
               verified: true,

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
@@ -11,7 +11,7 @@ import AlertBar from '../AlertBar';
 import Modal from '../Modal';
 import UnitRow from '../UnitRow';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
-import { useAccount, useLazyAccount } from '../../models';
+import { useAccount, useLazyTotpStatus } from '../../models';
 import { ButtonIconReload } from '../ButtonIcon';
 import { HomePath } from '../../constants';
 
@@ -38,7 +38,7 @@ export const UnitRowTwoStepAuth = () => {
     hideSecondaryModal,
   ] = useBooleanState();
 
-  const [getAccount, { accountLoading }] = useLazyAccount(() => {
+  const [getTotpStatus, { totpStatusLoading }] = useLazyTotpStatus(() => {
     hideModal();
     alertBar.success(
       'Sorry, there was a problem refreshing two-step authentication.'
@@ -58,9 +58,10 @@ export const UnitRowTwoStepAuth = () => {
     ignoreResults: true,
     update: (cache) => {
       cache.modify({
+        id: cache.identify({ __typename: 'Account' }),
         fields: {
-          account: (existing) => {
-            return { ...existing, totp: { exists: false, verified: false } };
+          totp() {
+            return { exists: false, verified: false };
           },
         },
       });
@@ -98,8 +99,8 @@ export const UnitRowTwoStepAuth = () => {
         <ButtonIconReload
           title="Refresh two-step authentication"
           classNames="ltr:ml-1 rtl:mr-1 mobileLandscape:hidden"
-          disabled={accountLoading}
-          onClick={getAccount}
+          disabled={totpStatusLoading}
+          onClick={getTotpStatus}
         />
       }
       actionContent={
@@ -107,8 +108,8 @@ export const UnitRowTwoStepAuth = () => {
           title="Refresh two-step authentication"
           classNames="hidden ltr:ml-1 rtl:mr-1 mobileLandscape:inline-block"
           testId="two-step-refresh"
-          disabled={accountLoading}
-          onClick={getAccount}
+          disabled={totpStatusLoading}
+          onClick={getTotpStatus}
         />
       }
     >

--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -92,6 +92,7 @@ export const cache = new InMemoryCache({
           },
         },
       },
+      keyFields: [],
     },
     Session: {
       fields: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,6 +121,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@apollo/client@npm:^3.3.6":
+  version: 3.3.6
+  resolution: "@apollo/client@npm:3.3.6"
+  dependencies:
+    "@graphql-typed-document-node/core": ^3.0.0
+    "@types/zen-observable": ^0.8.0
+    "@wry/context": ^0.5.2
+    "@wry/equality": ^0.3.0
+    fast-json-stable-stringify: ^2.0.0
+    graphql-tag: ^2.11.0
+    hoist-non-react-statics: ^3.3.2
+    optimism: ^0.13.1
+    prop-types: ^15.7.2
+    symbol-observable: ^2.0.0
+    ts-invariant: ^0.6.0
+    tslib: ^1.10.0
+    zen-observable: ^0.8.14
+  peerDependencies:
+    graphql: ^14.0.0 || ^15.0.0
+    react: ^16.8.0 || ^17.0.0
+    subscriptions-transport-ws: ^0.9.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    subscriptions-transport-ws:
+      optional: true
+  checksum: cf04e983176addf51b5cd2d25519b56eda0c595c6f4ad566e396ff80c2279f80100ec327301bffb936619438838a554af10ed2bb473fe010df066231d1d040ca
+  languageName: node
+  linkType: hard
+
 "@apollo/federation@npm:^0.17.0":
   version: 0.17.0
   resolution: "@apollo/federation@npm:0.17.0"
@@ -6847,6 +6877,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/ungap__global-this@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@types/ungap__global-this@npm:0.3.1"
+  checksum: c000b1f7792fa96def1e976d54bf23a127c99fa0bb0ee713e9792f9cf8fc97f4dba3313df9f9295e33f6461a54bd41279bb89ba1add1fb86d309b08e3a95f260
+  languageName: node
+  linkType: hard
+
 "@types/unist@npm:^2.0.0, @types/unist@npm:^2.0.2":
   version: 2.0.3
   resolution: "@types/unist@npm:2.0.3"
@@ -7198,6 +7235,13 @@ __metadata:
     "@typescript-eslint/types": 4.10.0
     eslint-visitor-keys: ^2.0.0
   checksum: e8d8057632a4aa5595769da14d41a19cbc4a6c02539e5c882b218b2f347445a397f9ef28ffc8b9eefa4d271bed39aa9e3adb182416840f1c73ecf59a0abac876
+  languageName: node
+  linkType: hard
+
+"@ungap/global-this@npm:^0.4.2":
+  version: 0.4.3
+  resolution: "@ungap/global-this@npm:0.4.3"
+  checksum: fe620031b4bb4ec79ad1c96b53bc00da389325a95169b2f24170919296726b2301a59479f5b3f1f25e52f62d8207596883e5a4d8e49ba4ad03939172dded9d05
   languageName: node
   linkType: hard
 
@@ -7611,6 +7655,15 @@ __metadata:
   dependencies:
     tslib: ^1.9.3
   checksum: ddd217fbefd8f105174abe099450e0ac1b813e19451b8525d2143098b23c42b30dd5042f38c5c92ba55017f9efab2ae4ce18d66a83d0e329de8523691a8bf60e
+  languageName: node
+  linkType: hard
+
+"@wry/equality@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "@wry/equality@npm:0.3.1"
+  dependencies:
+    tslib: ^1.14.1
+  checksum: 50b8ee5376de1fb81470d21080158d9ad6880d76ca9354735337b78ea93df6558bf859f56e9a4d3a2ab7d9f611716da79f50b85e64144e5095eaf78634892cdb
   languageName: node
   linkType: hard
 
@@ -18460,7 +18513,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "fxa-settings@workspace:packages/fxa-settings"
   dependencies:
-    "@apollo/client": ^3.2.2
+    "@apollo/client": ^3.3.6
     "@babel/core": ^7.10.3
     "@reach/router": ^1.3.4
     "@rescripts/cli": 0.0.15
@@ -27391,6 +27444,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"optimism@npm:^0.13.1":
+  version: 0.13.2
+  resolution: "optimism@npm:0.13.2"
+  dependencies:
+    "@wry/context": ^0.5.2
+  checksum: 1a37293983d18998ee9528887e27b177231bec1ec6045e90f744ae5a9abe47d3c71561c10772113f7623750a1fb159e6929e9b1f67496e83857f9100fdb9bbab
+  languageName: node
+  linkType: hard
+
 "optimist@npm:0.6.1, optimist@npm:^0.6.1":
   version: 0.6.1
   resolution: "optimist@npm:0.6.1"
@@ -35831,6 +35893,17 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
+"ts-invariant@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "ts-invariant@npm:0.6.0"
+  dependencies:
+    "@types/ungap__global-this": ^0.3.1
+    "@ungap/global-this": ^0.4.2
+    tslib: ^1.9.3
+  checksum: 5dd4579516d6ae78e8ebb231e0e80c48cd44109a7d5161d99c80a85e678a1920b642b1de8ce22f6fb05d617347fcedf84893159fa23e2b2aa9f364891d4fe5c4
+  languageName: node
+  linkType: hard
+
 "ts-jest@npm:26.4.3, ts-jest@npm:^26.3.0":
   version: 26.4.3
   resolution: "ts-jest@npm:26.4.3"
@@ -35963,6 +36036,13 @@ resolve@~1.11.1:
   version: 1.12.0
   resolution: "tslib@npm:1.12.0"
   checksum: a2f020c1187db465fbfb1c6d7d5dcd1a56aa08153d868b614f36fd59ef1225e938288a7cc8c593562faf5a681c53caccc6b580b06b7618a6670830079117f803
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^1.14.1":
+  version: 1.14.1
+  resolution: "tslib@npm:1.14.1"
+  checksum: f44fe7f216946b17d3e3074df3746372703cf24e9127b4c045511456e8e4bf25515fb0a1bb3937676cc305651c5d4fcb6377b0588a4c6a957e748c4c28905d17
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:
 - querying everything for an account when reloading the state of
   recovery key, two step auth, or connected services incur unnecessary
   costs

This commit:
 - use reload queries that only query gql-api for what they need

The most impactful change is actually the 'keyFields' configuration for
Account in the InMemoryCache's 'typePolicies'.  It allows the query
results from the reloads to be automagically merged into the cache.
(The value of 'keyFields' is set to '[]', making the cached account a
singleton.)

However, setting 'keyFields' affected the `cache.modify` calls to update
the cached account.  The account passed into the field modifier function
is now a Reference, not a plain object, thus breaking the "clone object
then merged in updated properties" pattern.

Setting the proper `__typename` property is now also vital, at least for
Account.  Without it the cache will not able to merge updated propertie
into the cached account.  (gql-api already include `__typename` on its
results.)


## Issue that this pull request solves

Closes: #6532 