### PR TITLE
Support custom environment variables inside Docker builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ coverage.html
 **/.nyc_output
 test-results.xml
 
+# Local configuration
+/_dev/local-build-env.sh
+
 # System files
 *~
 \#*\#

--- a/_dev/README.md
+++ b/_dev/README.md
@@ -1,3 +1,33 @@
 # \_dev
 
 This directory contains files to support local development that aren't needed in production, especially things that would otherwise clutter up the root directory.
+
+## Build-Time Environment Variables (Docker)
+
+By default, only environment variables explicitly declared inside the respective
+`Dockerfile` are visible during the build process of a Docker image. However,
+it is sometimes needed to customize how certain tools do their job within that
+process. For this reason, the developer can opt to provide additional
+environment variables using a Shell file at `_dev/local-build-env.sh`.
+
+This file - if available (ignored by Git, so be careful with `git clean -x`) -
+will be sourced by the actual build script [`_scripts/base-docker.sh`](../_scripts/base-docker.sh)
+and thus allows to use any Shell code to also do other customizations, although
+it is expected to define variables only (and may use functions to generate the
+value).
+
+The following is an example of such a file to set a proxy for downloading
+dependencies by NPM or YARN:
+
+```bash
+npm_config_http_proxy="https://npm-proxy.mycorp.localdomain:9876"
+npm_config_https_proxy="${npm_config_https_proxy}"
+
+yarn_http_proxy="${npm_config_https_proxy}"
+yarn_https_proxy="${npm_config_https_proxy}"
+```
+
+_Please note that the execution context of this script is also inside the
+Docker build environment, so it will be limited to the commands that the Docker
+base image provides or that have been installed before (see
+[`_dev/docker/builder/Dockerfile`](docker/builder/Dockerfile))._

--- a/_scripts/base-docker.sh
+++ b/_scripts/base-docker.sh
@@ -9,6 +9,12 @@ for d in ./packages/*/ ; do
   (cd "$d" && mkdir -p config && cp ../version.json . && cp ../version.json config)
 done
 
+if [ -f _dev/local-build-env.sh ]; then
+    set -a
+    . _dev/local-build-env.sh
+    set +a
+fi
+
 check_build_logs() {
     for log_file in /tmp/xfs-*/build.log; do
         [ -f "$log_file" ] || continue

--- a/_scripts/base-docker.sh
+++ b/_scripts/base-docker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -ex
 
+set -o pipefail
+
 DIR=$(dirname "$0")
 cd "$DIR/.."
 
@@ -7,8 +9,21 @@ for d in ./packages/*/ ; do
   (cd "$d" && mkdir -p config && cp ../version.json . && cp ../version.json config)
 done
 
+check_build_logs() {
+    for log_file in /tmp/xfs-*/build.log; do
+        [ -f "$log_file" ] || continue
+        cat <<EOF
+==========================[ BEGIN: ${log_file} ]==========================
+EOF
+        cat "${log_file}"
+        cat <<EOF
+==========================[ END: ${log_file} ]==========================
+EOF
+    done
+}
+
 # `npx yarn` because `npm i -g yarn` needs sudo
-npx yarn install
+npx yarn install || check_build_logs
 SKIP_PREFLIGHT_CHECK=true npx yarn workspaces foreach --topological-dev --verbose run build
 rm -rf node_modules
 rm -rf packages/*/node_modules


### PR DESCRIPTION
## Because

I want to avoid running into NPM rate limiting or I am required to use a proxy for outgoing HTTP(S) connections.

## This pull request

Introduces generic support to allow adding environment variables inside Docker image builds by sourcing the file `_dev/local-build-env.sh` if available locally (ignored by Git) and exporting all defined variables, so that they become visible to sub-processes of the build process.

One use case is to configure proxy URL's (e.g. standard HTTP or for NPM, YARN, aso.). The following is an example configuration for the newly supported file:

```bash
npm_config_http_proxy="https://npm-proxy.mycorp.localdomain:9876"
npm_config_https_proxy="https://npm-proxy.mycorp.localdomain:9876"

yarn_http_proxy="https://npm-proxy.mycorp.localdomain:9876"
yarn_https_proxy="https://npm-proxy.mycorp.localdomain:9876"
yarn_http_timeout=10000
```

## Issue that this pull request solves

Closes: #7118 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

As an added bonus, this PR dumps logs from NPM builds to the console (ending up in `artifacts/fxa-builder.log`) for troubleshooting in case `npx yarn install` fails.
