### PR TITLE
chore(gql-api): allow fewer CORS HTTP methods

### DIFF
--- a/packages/fxa-graphql-api/src/main.ts
+++ b/packages/fxa-graphql-api/src/main.ts
@@ -63,6 +63,7 @@ async function bootstrap() {
       Config.getProperties().env === 'development'
         ? '*'
         : config.get<string[]>('corsOrigin'),
+    methods: ['OPTIONS', 'POST'],
   });
 
   // Add sentry as error reporter


### PR DESCRIPTION
Because:
 - we want to disable unused HTTP methods on gql-api

This commit:
 - update CORS config to allow only OPTIONS and POST


## Issue that this pull request solves

Closes: #6874
