### PR TITLE
fix(settings): fix email communications link

### DIFF
--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -27,6 +27,7 @@ if (env !== 'development') {
 
 const settingsConfig = {
   env,
+  marketingEmailPreferencesUrl: config.get('marketing_email.preferences_url'),
   metrics: {
     navTiming: {
       enabled: config.get('statsd.enabled'),

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -2270,6 +2270,17 @@ const testHrefEquals = thenify(function (selector, expected) {
 });
 
 /**
+ * Check whether an anchor has a href that contains some text
+ *
+ * @param {string} selector
+ * @param {string} expected
+ * @returns {promise} rejects if test fails.
+ */
+const testHrefIncludes = thenify(function (selector, expected) {
+  return this.parent.then(testAttributeIncludes(selector, 'href', expected));
+});
+
+/**
  * Check whether the current URL matches the expected value
  *
  * @param {string} expected
@@ -2927,6 +2938,7 @@ module.exports = {
   testErrorWasShown,
   testErrorWasNotShown,
   testHrefEquals,
+  testHrefIncludes,
   testIsBrowserNotified,
   testSmsFormat,
   testSuccessWasShown,

--- a/packages/fxa-content-server/tests/functional/settings_v2/external_links.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/external_links.js
@@ -17,6 +17,7 @@ const { navigateToSettingsV2 } = FunctionalSettingsHelpers;
 describe('external links', () => {
   let primaryEmail,
     testHrefEquals,
+    testHrefIncludes,
     testElementExists,
     clearBrowserState,
     openPage,
@@ -26,6 +27,7 @@ describe('external links', () => {
     ({
       clearBrowserState,
       testHrefEquals,
+      testHrefIncludes,
       testElementExists,
       openPage,
       subscribeAndSigninToRp,
@@ -36,9 +38,9 @@ describe('external links', () => {
 
   it('renders external links correctly', async () => {
     await testElementExists(selectors.SETTINGS_V2.NAVIGATION.NEWSLETTERS_LINK);
-    await testHrefEquals(
+    await testHrefIncludes(
       selectors.SETTINGS_V2.NAVIGATION.NEWSLETTERS_LINK,
-      `https://basket.mozilla.org/fxa/?email=${primaryEmail}`
+      encodeURIComponent(primaryEmail)
     );
 
     await testElementExists(selectors.SETTINGS_V2.FOOTER.PRIVACY_LINK);

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -23,7 +23,7 @@ import PageTwoStepAuthentication from '../PageTwoStepAuthentication';
 import { Page2faReplaceRecoveryCodes } from '../Page2faReplaceRecoveryCodes';
 import { ScrollToTop } from '../ScrollToTop';
 import { HomePath } from '../../constants';
-import { Config } from 'fxa-settings/src/lib/config';
+import { useConfig } from 'fxa-settings/src/lib/config';
 import { observeNavigationTiming } from 'fxa-shared/metrics/navigation-timing';
 
 export const GET_INITIAL_STATE = gql`
@@ -37,10 +37,11 @@ export const GET_INITIAL_STATE = gql`
 
 type AppProps = {
   flowQueryParams: FlowQueryParams;
-  config: Config;
 };
 
-export const App = ({ flowQueryParams, config }: AppProps) => {
+export const App = ({ flowQueryParams }: AppProps) => {
+  const config = useConfig();
+
   useEffect(() => {
     config.metrics.navTiming.enabled &&
       observeNavigationTiming(config.metrics.navTiming.endpoint);

--- a/packages/fxa-settings/src/components/Nav/index.test.tsx
+++ b/packages/fxa-settings/src/components/Nav/index.test.tsx
@@ -5,13 +5,17 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { MockedCache } from '../../models/_mocks';
+import { getDefault } from '../../lib/config';
 import Nav from '.';
+import { ConfigContext } from 'fxa-settings/src/lib/config';
 
 describe('Nav', () => {
   it('renders as expected', () => {
     render(
       <MockedCache>
-        <Nav />
+        <ConfigContext.Provider value={getDefault()}>
+          <Nav />
+        </ConfigContext.Provider>
       </MockedCache>
     );
 
@@ -42,7 +46,9 @@ describe('Nav', () => {
     );
     expect(screen.getByTestId('nav-link-newsletters')).toHaveAttribute(
       'href',
-      'https://basket.mozilla.org/fxa/?email=johndope@example.com'
+      `https://basket.mozilla.org/fxa/?email=${encodeURIComponent(
+        'johndope@example.com'
+      )}`
     );
 
     expect(screen.queryByTestId('nav-link-subscriptions')).toBeNull();

--- a/packages/fxa-settings/src/components/Nav/index.tsx
+++ b/packages/fxa-settings/src/components/Nav/index.tsx
@@ -7,11 +7,16 @@ import classNames from 'classnames';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { ReactComponent as OpenExternal } from './open-external.svg';
 import { useAccount } from '../../models';
+import { useConfig } from 'fxa-settings/src/lib/config';
 
 export const Nav = () => {
   const account = useAccount();
+  const config = useConfig();
   const primaryEmail = account.primaryEmail.email;
   const hasSubscription = account.subscriptions.length > 0;
+  const marketingCommPrefLink = `${
+    config.marketingEmailPreferencesUrl
+  }?email=${encodeURIComponent(primaryEmail)}`;
 
   const activeClasses = 'font-bold text-blue-500 rounded-sm';
   return (
@@ -76,7 +81,7 @@ export const Nav = () => {
           <LinkExternal
             className="font-bold"
             data-testid="nav-link-newsletters"
-            href={`https://basket.mozilla.org/fxa/?email=${primaryEmail}`}
+            href={marketingCommPrefLink}
           >
             Email Communications
             <OpenExternal

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -9,7 +9,7 @@ import AppErrorBoundary from 'fxa-react/components/AppErrorBoundary';
 import App from './components/App';
 import { AuthContext, createAuthClient } from './lib/auth';
 import sentryMetrics from 'fxa-shared/lib/sentry';
-import config, { readConfigMeta } from './lib/config';
+import config, { readConfigMeta, ConfigContext } from './lib/config';
 import { searchParams } from './lib/utilities';
 import { createApolloClient } from './lib/gql';
 import './index.scss';
@@ -30,9 +30,11 @@ try {
     <React.StrictMode>
       <ApolloProvider client={apolloClient}>
         <AuthContext.Provider value={{ auth: authClient }}>
-          <AppErrorBoundary>
-            <App {...{ flowQueryParams, config }} />
-          </AppErrorBoundary>
+          <ConfigContext.Provider value={config}>
+            <AppErrorBoundary>
+              <App {...{ flowQueryParams }} />
+            </AppErrorBoundary>
+          </ConfigContext.Provider>
         </AuthContext.Provider>
       </ApolloProvider>
     </React.StrictMode>,

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -2,12 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import React, { useContext } from 'react';
 import { deepMerge } from './utilities';
 
 export const META_CONFIG = 'fxa-config';
 
 export interface Config {
   env: string;
+  marketingEmailPreferencesUrl: string;
   metrics: {
     navTiming: {
       enabled: boolean;
@@ -31,6 +33,7 @@ export interface Config {
 export function getDefault() {
   return {
     env: 'development',
+    marketingEmailPreferencesUrl: 'https://basket.mozilla.org/fxa/',
     metrics: {
       navTiming: { enabled: false, endpoint: '/check-your-metrics-config' },
     },
@@ -104,6 +107,17 @@ export function reset() {
 
 export function update(newData: { [key: string]: any }) {
   deepMerge(config, newData);
+}
+
+export const ConfigContext = React.createContext<Config>(getDefault());
+
+export function useConfig() {
+  const c = useContext(ConfigContext);
+  if (!c) {
+    return getDefault();
+  }
+
+  return c;
 }
 
 const config: Config = getDefault();


### PR DESCRIPTION
Because:
 - the Email Communications link on the nav was not working

This commit:
 - encode the email in the link
 - pass the configured email communication URL to the client
 - add a ConfigContext with a hook for accessing the config

Closes: #6562 
