### PR TITLE
feat(auth-server): add paypal API base client

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal-client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-client.ts
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import querystring from 'querystring';
+import superagent from 'superagent';
+import pRetry from 'p-retry';
+
+export const PAYPAL_SANDBOX_API = 'https://api-3t.sandbox.paypal.com/nvp';
+export const PAYPAL_LIVE_API = 'https://api-3t.paypal.com/nvp';
+const PAYPAL_VERSION = '204';
+const L_LIST = /L_([A-Z]+)(\d+)$/;
+
+type PaypalOptions = {
+  sandbox: boolean;
+  user: string;
+  pwd: string;
+  signature: string;
+  retryOptions?: {
+    retries?: number;
+    minTimeout?: number;
+    factor?: number;
+  };
+};
+
+export type PAYPAL_METHODS =
+  | 'BillAgreementUpdate'
+  | 'CreateBillingAgreement'
+  | 'DoReferenceTransaction'
+  | 'GetTransactionDetails'
+  | 'SetExpressCheckout'
+  | 'TransactionSearch';
+
+export class PayPalClient {
+  private url: string;
+  private user: string;
+  private pwd: string;
+  private signature: string;
+  private retryOptions: {
+    retries: number;
+    minTimeout: number;
+    factor: number;
+  };
+
+  constructor(options: PaypalOptions) {
+    this.url = options.sandbox ? PAYPAL_SANDBOX_API : PAYPAL_LIVE_API;
+    this.user = options.user;
+    this.pwd = options.pwd;
+    this.signature = options.signature;
+    this.retryOptions = {
+      retries: 3,
+      minTimeout: 500,
+      factor: 1.66,
+      ...options.retryOptions,
+    };
+  }
+
+  private objectToNVP(object: Record<string, any>): string {
+    return querystring.stringify(object);
+  }
+
+  private nvpToObject(payload: string): Record<string, any> {
+    const object = querystring.parse(payload, undefined, undefined, {
+      maxKeys: 0,
+    });
+    const result: Record<string, any> = {};
+    const lst: any[] = [];
+    for (const [key, value] of Object.entries(object)) {
+      const match = key.match(L_LIST);
+      if (!match) {
+        result[key] = value;
+        continue;
+      }
+      const [name, indexString] = [match[1], match[2]];
+      const index = parseInt(indexString);
+
+      if (!lst[index]) {
+        lst[index] = {};
+      }
+      lst[index][name] = value;
+    }
+    if (lst.length !== 0) {
+      result['L'] = lst;
+    }
+    return result;
+  }
+
+  private async doRequest(
+    method: PAYPAL_METHODS,
+    data: Record<string, any>
+  ): Promise<Record<string, any>> {
+    const payload = this.objectToNVP({
+      ...data,
+      USER: this.user,
+      METHOD: method,
+      PWD: this.pwd,
+      SIGNATURE: this.signature,
+      VERSION: PAYPAL_VERSION,
+    });
+    const result = await pRetry(
+      () =>
+        superagent
+          .post(this.url)
+          .set('content-type', 'application/x-www-form-urlencoded')
+          .send(payload),
+      this.retryOptions
+    );
+    return this.nvpToObject(result.text);
+  }
+}

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -94,6 +94,7 @@
     "safe-url-assembler": "1.3.5",
     "sandboxed-regexp": "^0.3.0",
     "stripe": "^8.64.0",
+    "superagent": "^6.0.0",
     "typedi": "^0.8.0",
     "uuid": "^8.3.0",
     "verror": "^1.10.0",

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const nock = require('nock');
+
+const {
+  PayPalClient,
+  PAYPAL_SANDBOX_API,
+  PAYPAL_LIVE_API,
+} = require('../../../lib/payments/paypal-client');
+
+const ERROR_RESPONSE =
+  'TIMESTAMP=2011%2d11%2d15T20%3a27%3a02Z&CORRELATIONID=5be53331d9700&ACK=Failure&VERSION=78%2e0&BUILD=000000&L_ERRORCODE0=15005&L_SHORTMESSAGE0=Processor%20Decline&L_LONGMESSAGE0=This%20transaction%20cannot%20be%20processed%2e&L_SEVERITYCODE0=Error&L_ERRORPARAMID0=ProcessorResponse&L_ERRORPARAMVALUE0=0051&AMT=10%2e40&CURRENCYCODE=USD&AVSCODE=X&CVV2MATCH=M';
+
+describe('PayPalClient', () => {
+  const expectedPayload =
+    'NAME=Robert%20Moore&COMPANY=R.%20H.%20Moore%20%26%20Associates&USER=user&METHOD=BillAgreementUpdate&PWD=pwd&SIGNATURE=sig&VERSION=204';
+  let client;
+
+  beforeEach(() => {
+    client = new PayPalClient({
+      user: 'user',
+      sandbox: true,
+      pwd: 'pwd',
+      signature: 'sig',
+    });
+  });
+
+  describe('constructor', () => {
+    it('uses sandbox', () => {
+      assert.equal(client.url, PAYPAL_SANDBOX_API);
+    });
+
+    it('uses live', () => {
+      client = new PayPalClient({
+        user: 'user',
+        sandbox: false,
+        pwd: 'pwd',
+        signature: 'sig',
+      });
+      assert.equal(client.url, PAYPAL_LIVE_API);
+    });
+  });
+
+  it('objectToNVP', () => {
+    const obj = { NAME: 'Robert Moore', COMPANY: 'R. H. Moore & Associates' };
+    const result = client.objectToNVP(obj);
+    assert.equal(
+      result,
+      'NAME=Robert%20Moore&COMPANY=R.%20H.%20Moore%20%26%20Associates'
+    );
+  });
+
+  it('nvpToObject', () => {
+    const result = client.nvpToObject(ERROR_RESPONSE);
+    assert.deepEqual(result, {
+      ACK: 'Failure',
+      AMT: '10.40',
+      AVSCODE: 'X',
+      BUILD: '000000',
+      CORRELATIONID: '5be53331d9700',
+      CURRENCYCODE: 'USD',
+      CVV2MATCH: 'M',
+      L: [
+        {
+          ERRORCODE: '15005',
+          ERRORPARAMID: 'ProcessorResponse',
+          ERRORPARAMVALUE: '0051',
+          LONGMESSAGE: 'This transaction cannot be processed.',
+          SEVERITYCODE: 'Error',
+          SHORTMESSAGE: 'Processor Decline',
+        },
+      ],
+      TIMESTAMP: '2011-11-15T20:27:02Z',
+      VERSION: '78.0',
+    });
+  });
+
+  describe('doRequest', () => {
+    it('succeeds', async () => {
+      nock('https://api-3t.sandbox.paypal.com')
+        .post('/nvp', expectedPayload)
+        .reply(
+          200,
+          'NAME=Robert%20Moore&COMPANY=R.%20H.%20Moore%20%26%20Associates'
+        );
+      const expectedObject = {
+        NAME: 'Robert Moore',
+        COMPANY: 'R. H. Moore & Associates',
+      };
+      const result = await client.doRequest(
+        'BillAgreementUpdate',
+        expectedObject
+      );
+      assert.deepEqual(result, expectedObject);
+    });
+
+    it('fails', async () => {
+      nock('https://api-3t.sandbox.paypal.com')
+        .post('/nvp', expectedPayload)
+        .reply(500, 'ERROR');
+      nock('https://api-3t.sandbox.paypal.com')
+        .post('/nvp', expectedPayload)
+        .reply(
+          200,
+          'NAME=Robert%20Moore&COMPANY=R.%20H.%20Moore%20%26%20Associates'
+        );
+      const expectedObject = {
+        NAME: 'Robert Moore',
+        COMPANY: 'R. H. Moore & Associates',
+      };
+      const result = await client.doRequest(
+        'BillAgreementUpdate',
+        expectedObject
+      );
+      assert.deepEqual(result, expectedObject);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -17908,6 +17908,7 @@ fsevents@^1.2.7:
     simplesmtp: 0.3.35
     sinon: ^9.0.3
     stripe: ^8.64.0
+    superagent: ^6.0.0
     through: 2.3.8
     ts-node: ^8.10.2
     typedi: ^0.8.0


### PR DESCRIPTION
Because:

* We want to use the PayPal NVP API, and there isn't a suitable
  existing library.

This commit:

* Adds a base PayPal NVP API client for extending with additional
  methods.

Closes #7232

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

