### PR TITLE
feat(fxa-settings): add delete account page

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -26,6 +26,8 @@ import checkEmailDomain from '../lib/email-domain-validator';
 
 const EMAIL_SELECTOR = 'input[type=email]';
 
+const t = (msg) => msg;
+
 class IndexView extends FormView {
   template = Template;
 
@@ -99,6 +101,12 @@ class IndexView extends FormView {
     // so a user can only be enrolled in one of them at a time. This
     // select the experiment the user will belong to.
     this.getAndReportExperimentGroup('newsletterCadChooser');
+
+    // This is so we can show the delete success message after redirect
+    // from the settings beta.
+    if (this.getSearchParam('delete_account_success')) {
+      this.displaySuccess(t('Account deleted successfully'));
+    }
   }
 
   chooseEmailActionPage() {

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -21,6 +21,7 @@ import PageSecondaryEmailVerify from '../PageSecondaryEmailVerify';
 import { PageDisplayName } from '../PageDisplayName';
 import PageTwoStepAuthentication from '../PageTwoStepAuthentication';
 import { Page2faReplaceRecoveryCodes } from '../Page2faReplaceRecoveryCodes';
+import { PageDeleteAccount } from '../PageDeleteAccount';
 import { ScrollToTop } from '../ScrollToTop';
 import { HomePath } from '../../constants';
 import { useConfig } from 'fxa-settings/src/lib/config';
@@ -79,6 +80,7 @@ export const App = ({ flowQueryParams }: AppProps) => {
             <PageSecondaryEmailVerify path="/emails/verify" />
             <PageTwoStepAuthentication path="/two_step_authentication" />
             <Page2faReplaceRecoveryCodes path="/two_step_authentication/replace_codes" />
+            <PageDeleteAccount path="/delete_account" />
           </ScrollToTop>
         </Router>
       </AppLayout>

--- a/packages/fxa-settings/src/components/Checkbox/index.test.tsx
+++ b/packages/fxa-settings/src/components/Checkbox/index.test.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import Checkbox from './index';
 
 it('renders as expected', () => {
@@ -32,4 +32,11 @@ it('can have a label', () => {
   render(<Checkbox {...{ label }} />);
   expect(screen.getByTestId('checkbox-label')).toBeInTheDocument();
   expect(screen.getByTestId('checkbox-label')).toHaveTextContent(label);
+});
+
+it('will call onChange argument', () => {
+  const onChange = jest.fn();
+  render(<Checkbox {...{ onChange }} />);
+  fireEvent.click(screen.getByTestId('checkbox-input'));
+  expect(onChange).toBeCalled();
 });

--- a/packages/fxa-settings/src/components/Checkbox/index.tsx
+++ b/packages/fxa-settings/src/components/Checkbox/index.tsx
@@ -2,14 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { MouseEvent, useState, useCallback, ChangeEvent } from 'react';
+import React, { ChangeEvent, useState, useCallback } from 'react';
 import { ReactComponent as Checkmark } from './checkmark.svg';
 
 export type CheckboxProps = {
   defaultChecked?: boolean;
   disabled?: boolean;
   label?: string;
-  onClick?: (event: MouseEvent<HTMLInputElement>) => void;
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   prefixDataTestId?: string;
 };
 
@@ -17,6 +17,7 @@ export const Checkbox = ({
   defaultChecked,
   disabled,
   label,
+  onChange,
   prefixDataTestId,
 }: CheckboxProps) => {
   const [focussed, setFocussed] = useState<boolean>(false);
@@ -34,8 +35,9 @@ export const Checkbox = ({
   const checkboxChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       setChecked(event.target.checked);
+      if (onChange) onChange(event);
     },
-    [setChecked]
+    [setChecked, onChange]
   );
   function formatDataTestId(id: string) {
     return prefixDataTestId ? `${prefixDataTestId}-${id}` : id;

--- a/packages/fxa-settings/src/components/InputText/index.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.tsx
@@ -19,7 +19,6 @@ export type InputTextProps = {
   label: string;
   placeholder?: string;
   errorText?: string;
-  errorTooltipClass?: string;
   className?: string;
   inputRef?: Ref<HTMLInputElement>;
   onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
@@ -39,7 +38,6 @@ export const InputText = ({
   placeholder,
   onChange,
   errorText,
-  errorTooltipClass,
   className = '',
   inputRef,
   type = 'text',

--- a/packages/fxa-settings/src/components/PageChangePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.test.tsx
@@ -10,6 +10,7 @@ import { AuthContext, createAuthClient } from '../../lib/auth';
 import { MockedCache, renderWithRouter } from '../../models/_mocks';
 import PageChangePassword from '.';
 import { logViewEvent, settingsViewName } from '../../lib/metrics';
+import { typeByTestIdFn } from '../../lib/test-utils';
 
 jest.mock('../../lib/auth', () => ({
   ...jest.requireActual('../../lib/auth'),
@@ -35,14 +36,6 @@ const render = () => {
       </MockedCache>
     </AuthContext.Provider>
   );
-};
-
-const typeByTestIdFn = (testId: string) => async (x: string) => {
-  await act(async () => {
-    fireEvent.input(screen.getByTestId(testId), {
-      target: { value: x },
-    });
-  });
 };
 
 const inputCurrentPassword = typeByTestIdFn('current-password-input-field');

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.stories.tsx
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { PageDeleteAccount } from '.';
+import { LocationProvider } from '@reach/router';
+import AppLayout from '../AppLayout';
+import { AuthContext, createAuthClient } from '../../lib/auth';
+import { MockedCache } from '../../models/_mocks';
+
+const client = createAuthClient('none');
+
+storiesOf('Pages|DeleteAccount', module)
+  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
+  .add('default', () => (
+    <AuthContext.Provider value={{ auth: client }}>
+      <MockedCache>
+        <AppLayout>
+          <PageDeleteAccount />
+        </AppLayout>
+      </MockedCache>
+    </AuthContext.Provider>
+  ));

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.test.tsx
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import 'mutationobserver-shim';
+import React from 'react';
+import { screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { AuthContext, createAuthClient } from '../../lib/auth';
+import { MockedCache, renderWithRouter } from '../../models/_mocks';
+import { PageDeleteAccount } from '.';
+import { typeByTestIdFn } from '../../lib/test-utils';
+
+jest.mock('../../lib/auth', () => ({
+  ...jest.requireActual('../../lib/auth'),
+  useAccountDestroyer: jest
+    .fn()
+    .mockImplementation(({ onSuccess, onError }) => ({
+      execute: () => onSuccess(),
+      reset: () => {},
+    })),
+}));
+
+const client = createAuthClient('none');
+window.URL.createObjectURL = jest.fn();
+
+const advanceStep = async () => {
+  await act(async () => {
+    const inputs = screen.getAllByTestId('checkbox-input');
+    inputs.forEach((el) => fireEvent.click(el));
+    const continueBtn = await screen.findByTestId('continue-button');
+    fireEvent.click(continueBtn);
+  });
+};
+
+describe('PageDeleteAccount', () => {
+  it('renders as expected', () => {
+    renderWithRouter(
+      <AuthContext.Provider value={{ auth: client }}>
+        <MockedCache>
+          <PageDeleteAccount />
+        </MockedCache>
+      </AuthContext.Provider>
+    );
+
+    expect(screen.getByTestId('delete-account-confirm').textContent).toContain(
+      'deleting your account'
+    );
+    expect(screen.getByTestId('close-button').textContent).toContain('Close');
+    expect(screen.getByTestId('continue-button').textContent).toContain(
+      'Continue'
+    );
+  });
+
+  it('Enables "continue" button once all 4 inputs are valid', async () => {
+    renderWithRouter(
+      <AuthContext.Provider value={{ auth: client }}>
+        <MockedCache>
+          <PageDeleteAccount />
+        </MockedCache>
+      </AuthContext.Provider>
+    );
+
+    expect(screen.getByTestId('continue-button')).toBeDisabled();
+
+    await act(async () => {
+      const inputs = screen.getAllByTestId('checkbox-input');
+      inputs.forEach((el) => fireEvent.click(el));
+    });
+
+    expect(screen.getByTestId('continue-button')).toBeEnabled();
+  });
+
+  it('Does not Enable "continue" button if all for checks are not confirmed', async () => {
+    renderWithRouter(
+      <AuthContext.Provider value={{ auth: client }}>
+        <MockedCache>
+          <PageDeleteAccount />
+        </MockedCache>
+      </AuthContext.Provider>
+    );
+
+    await act(async () => {
+      const inputs = screen.getAllByTestId('checkbox-input');
+      // drop last checkbox so all will not be selected
+      inputs.pop();
+      inputs.forEach((el) => fireEvent.click(el));
+    });
+
+    expect(screen.getByTestId('continue-button')).toBeDisabled();
+  });
+
+  it('Gets valid response on submit', async () => {
+    renderWithRouter(
+      <AuthContext.Provider value={{ auth: client }}>
+        <MockedCache>
+          <PageDeleteAccount />
+        </MockedCache>
+      </AuthContext.Provider>
+    );
+
+    await advanceStep();
+    await typeByTestIdFn('delete-account-confirm-input-field')('hunter6');
+
+    const deleteAccountButton = screen.getByTestId('delete-account-button');
+    expect(deleteAccountButton).toBeEnabled();
+
+    expect(location.pathname).toContainEqual('/');
+  });
+});

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -1,0 +1,216 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React, { useCallback, useState, ChangeEvent } from 'react';
+import { useForm } from 'react-hook-form';
+import { RouteComponentProps, useNavigate } from '@reach/router';
+import { useAccountDestroyer } from '../../lib/auth';
+import { sessionToken } from '../../lib/cache';
+import { useAlertBar } from '../../lib/hooks';
+import { useAccount } from '../../models';
+import InputPassword from '../InputPassword';
+import FlowContainer from '../FlowContainer';
+import VerifiedSessionGuard from '../VerifiedSessionGuard';
+import AlertBar from '../AlertBar';
+import {
+  HomePath,
+  LockwiseLink,
+  MonitorLink,
+  ROOTPATH,
+  VPNLink,
+} from '../../constants';
+import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
+import { Checkbox } from '../Checkbox';
+
+type FormData = {
+  password: string;
+};
+
+const checkboxLabels = [
+  'Any paid subscriptions you have will be cancelled',
+  'Any may lose saved information and features within Mozilla products',
+  'Reactivating with this email may not restore your saved information',
+  'Any extensions and themes that you published to addons.mozilla.org will be deleted',
+];
+
+export const PageDeleteAccount = (_: RouteComponentProps) => {
+  usePageViewEvent('settings.delete-account');
+  const { handleSubmit, register, formState, setValue } = useForm<FormData>({
+    mode: 'all',
+    defaultValues: {
+      password: '',
+    },
+  });
+  // TODO: the `.errors.password` clause shouldn't be necessary, but `isValid` isn't updating
+  // properly. I think this is a bug in react-hook-form.
+  const disabled =
+    !formState.isDirty || !formState.isValid || !!formState.errors.password;
+  const [errorText, setErrorText] = useState<string>();
+  const [confirmed, setConfirmed] = useState<boolean>(false);
+  const [subtitleText, setSubtitleText] = useState<string>('Step 1 of 2');
+  const [checkedBoxes, setCheckedBoxes] = useState<string[]>([]);
+  const allBoxesChecked = checkboxLabels.every((element) =>
+    checkedBoxes.includes(element)
+  );
+  const navigate = useNavigate();
+  const alertBar = useAlertBar();
+  const goBack = useCallback(() => window.history.back(), []);
+
+  const { primaryEmail } = useAccount();
+
+  const advanceStep = () => {
+    setSubtitleText('Step 2 of 2');
+    setConfirmed(true);
+
+    logViewEvent('flow.settings.account-delete', 'terms-checked.success');
+  };
+
+  const deleteAccount = useAccountDestroyer({
+    onSuccess: () => {
+      // must use location.href over navigate() since this is an exernal link
+      window.location.href = `${ROOTPATH}?delete_account_success=true`;
+      logViewEvent('flow.settings.account-delete', 'confirm-password.success');
+    },
+    onError: (error) => {
+      if (error.errno === 103) {
+        setErrorText(error.message);
+        setValue('password', '');
+      } else {
+        alertBar.setType('error');
+        alertBar.setContent(error.message);
+        alertBar.show();
+        logViewEvent('flow.settings.account-delete', 'confirm-password.fail');
+      }
+    },
+  });
+
+  const handleConfirmChange = (labelText: string) => (
+    event: ChangeEvent<HTMLInputElement>
+  ) => {
+    event.persist();
+    setCheckedBoxes((existing) => {
+      if (event.target.checked) {
+        return [...existing, labelText];
+      } else {
+        return [...existing.filter((text) => text !== labelText)];
+      }
+    });
+  };
+
+  const onFormSubmit = ({ password }: FormData) => {
+    deleteAccount.execute(primaryEmail.email, password, sessionToken()!);
+  };
+
+  return (
+    <FlowContainer title="Delete Account" subtitle={subtitleText}>
+      {alertBar.visible && (
+        <AlertBar onDismiss={alertBar.hide} type={alertBar.type}>
+          <p data-testid="delete-account-error">{alertBar.content}</p>
+        </AlertBar>
+      )}
+      <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
+      {!confirmed && (
+        <div className="my-4 text-sm" data-testid="delete-account-confirm">
+          <p className="mb-4">
+            You've connected your Firefox account to Mozilla products that keep
+            you secure and productive on the web:
+          </p>
+          <div className="p-2">
+            <ul className="list-inside mb-4">
+              <li className="list-disc">
+                <a className="link-blue" href={VPNLink}>
+                  Mozilla VPN
+                </a>
+              </li>
+              <li className="list-disc">
+                <a className="link-blue" href={LockwiseLink}>
+                  Firefox Lockwise
+                </a>
+              </li>
+              <li className="list-disc">
+                <a className="link-blue" href={MonitorLink}>
+                  Firefox Monitor
+                </a>
+              </li>
+            </ul>
+          </div>
+          <p className="mb-4">
+            Please acknowledge that by deleting your account:
+          </p>
+          <form>
+            <ul className="mt-4 text-xs">
+              {checkboxLabels.map((label, i) => (
+                <li className="py-2" key={i}>
+                  <Checkbox
+                    data-testid="required-confirm"
+                    label={label}
+                    onChange={handleConfirmChange(label)}
+                  />
+                </li>
+              ))}
+            </ul>
+          </form>
+          <div className="mt-4 flex items-center justify-center">
+            <button
+              className="cta-neutral mx-2 px-10"
+              onClick={() => navigate(HomePath, { replace: true })}
+              data-testid="close-button"
+            >
+              Close
+            </button>
+            <button
+              className="cta-primary mx-2 px-10"
+              disabled={!allBoxesChecked}
+              onClick={() => advanceStep()}
+              data-testid="continue-button"
+            >
+              Continue
+            </button>
+          </div>
+        </div>
+      )}
+      {confirmed && (
+        <form onSubmit={handleSubmit(onFormSubmit)}>
+          <div className="mt-4 mb-6" data-testid="delete-account-input">
+            <InputPassword
+              name="password"
+              label="Enter password"
+              prefixDataTestId="delete-account-confirm"
+              onChange={() => {
+                if (errorText) {
+                  setErrorText(undefined);
+                }
+              }}
+              inputRef={register({
+                required: true,
+              })}
+              {...{ errorText }}
+            />
+          </div>
+
+          <div className="flex items-center justify-center">
+            <button
+              type="button"
+              className="cta-neutral mx-2 px-4 tablet:px-10"
+              data-testid="cancel-button"
+              onClick={goBack}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="cta-primary mx-2 px-4"
+              data-testid="delete-account-button"
+              disabled={disabled}
+            >
+              Delete Account
+            </button>
+          </div>
+        </form>
+      )}
+    </FlowContainer>
+  );
+};
+
+export default PageDeleteAccount;

--- a/packages/fxa-settings/src/components/PageSettings/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageSettings/index.test.tsx
@@ -20,6 +20,7 @@ it('renders without imploding', async () => {
   expect(screen.getByTestId('settings-profile')).toBeInTheDocument();
   expect(screen.getByTestId('settings-security')).toBeInTheDocument();
   expect(screen.getByTestId('settings-connected-services')).toBeInTheDocument();
+  expect(screen.getByTestId('settings-delete-account')).toBeInTheDocument();
   expect(Metrics.setProperties).toHaveBeenCalledWith({
     uid: 'abc123',
   });

--- a/packages/fxa-settings/src/components/PageSettings/index.tsx
+++ b/packages/fxa-settings/src/components/PageSettings/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { RouteComponentProps } from '@reach/router';
+import { Link, RouteComponentProps } from '@reach/router';
 import AlertExternal from '../AlertExternal';
 import Nav from '../Nav';
 import Security from '../Security';
@@ -12,6 +12,7 @@ import ConnectedServices from '../ConnectedServices';
 
 import * as Metrics from '../../lib/metrics';
 import { useAccount } from '../../models';
+import { DeleteAccountPath } from 'fxa-settings/src/constants';
 
 export const PageSettings = (_: RouteComponentProps) => {
   const { uid } = useAccount();
@@ -32,6 +33,15 @@ export const PageSettings = (_: RouteComponentProps) => {
         <Profile />
         <Security />
         <ConnectedServices />
+        <div className="flex mx-4 tablet:mx-0">
+          <Link
+            data-testid="settings-delete-account"
+            className="cta-caution cta-base text-sm transition-standard mt-12"
+            to={DeleteAccountPath}
+          >
+            Delete Account
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/packages/fxa-settings/src/constants/index.tsx
+++ b/packages/fxa-settings/src/constants/index.tsx
@@ -2,4 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+export const ROOTPATH = '/';
 export const HomePath = '/beta/settings';
+export const DeleteAccountPath = '/beta/settings/delete_account';
+export const VPNLink = 'https://vpn.mozilla.org/';
+export const LockwiseLink = 'https://lockwise.firefox.com/';
+export const MonitorLink = 'https://monitor.firefox.com/';

--- a/packages/fxa-settings/src/lib/auth.ts
+++ b/packages/fxa-settings/src/lib/auth.ts
@@ -27,6 +27,35 @@ type PasswordChangeResponse = Resolved<
   ReturnType<typeof AuthClient.prototype.passwordChange>
 >;
 
+type AccountDestroyResponse = Resolved<
+  ReturnType<typeof AuthClient.prototype.accountDestroy>
+>;
+
+export function useAccountDestroyer({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: (r: AccountDestroyResponse) => void;
+  onError?: (e: AuthServerError) => void;
+} = {}) {
+  const auth = useAuth();
+  return useAsyncCallback(
+    async (email: string, password: string, sessionToken: hexstring) => {
+      const response = await auth.accountDestroy(
+        email,
+        password,
+        {},
+        sessionToken
+      );
+      return response;
+    },
+    {
+      onSuccess,
+      onError,
+    }
+  );
+}
+
 export function usePasswordChanger({
   onSuccess,
   onError,

--- a/packages/fxa-settings/src/lib/test-utils.ts
+++ b/packages/fxa-settings/src/lib/test-utils.ts
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { act, fireEvent, screen } from '@testing-library/react';
+
+export const typeByTestIdFn = (testId: string) => async (x: string) => {
+  await act(async () => {
+    fireEvent.input(screen.getByTestId(testId), {
+      target: { value: x },
+    });
+  });
+};


### PR DESCRIPTION
## This pull request

- Add the delete account page to beta/settings
- small change to remove `errorTooltipClass` from `packages/fxa-settings/src/components/InputText/index.tsx` as it's not being used anywhere

## Issue that this pull request solves

- refs #5180
- fixes #4983
- fixes #4981
- fixes #4980
- fixes #4984

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![settings-page-delete-account-button](https://user-images.githubusercontent.com/1844554/104383345-af556380-54fd-11eb-9843-90cfa7f54924.png)
![settings-page-delete-account-button-mobile](https://user-images.githubusercontent.com/1844554/104383347-afedfa00-54fd-11eb-8043-09ab4a49c3a1.png)
![step-1](https://user-images.githubusercontent.com/1844554/104383362-b7ad9e80-54fd-11eb-8288-e425a8851fb2.png)
![step-1-mobile](https://user-images.githubusercontent.com/1844554/104383363-b7ad9e80-54fd-11eb-95f2-df931beae38b.png)
![step-2-error](https://user-images.githubusercontent.com/1844554/104383382-c1cf9d00-54fd-11eb-8387-b407e8280d3f.png)
![step-2-error-mobile](https://user-images.githubusercontent.com/1844554/104383384-c2683380-54fd-11eb-814d-461fe36f41c9.png)
![step-2-mobile](https://user-images.githubusercontent.com/1844554/104383386-c2683380-54fd-11eb-8e39-fdd21d2093a6.png)
![complete](https://user-images.githubusercontent.com/1844554/104383392-c5632400-54fd-11eb-9001-a53ca75ee017.png)
![complete-mobile](https://user-images.githubusercontent.com/1844554/104383393-c5fbba80-54fd-11eb-953d-b079f596011c.png)


## Other information (Optional)

Opening this up before I finish tests and RTL adjustments so I can maybe get some feedback on spacing and style tweaks
