### PR TITLE
fix(oauth): fixed oauth -> auth error conversion after refactoring

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -213,6 +213,8 @@ AppError.translate = function (request, response) {
   }
   if (OauthError.isOauthRoute(request && request.route.path)) {
     return OauthError.translate(response);
+  } else if (response instanceof OauthError) {
+    return appErrorFromOauthError(response);
   }
   const payload = response.output.payload;
   const reason = response.reason;
@@ -1454,6 +1456,53 @@ function scrubHeaders(headers) {
   const scrubbed = { ...headers };
   delete scrubbed['x-forwarded-for'];
   return scrubbed;
+}
+
+function appErrorFromOauthError(err) {
+  switch (err.errno) {
+    case 101:
+      return AppError.unknownClientId(err.clientId);
+    case 102:
+      return AppError.incorrectClientSecret(err.clientId);
+    case 103:
+      return AppError.incorrectRedirectURI(err.redirectUri);
+    case 104:
+      return AppError.invalidToken();
+    case 105:
+      return AppError.unknownAuthorizationCode(err.code);
+    case 106:
+      return AppError.mismatchAuthorizationCode(err.code, err.clientId);
+    case 107:
+      return AppError.expiredAuthorizationCode(err.code, err.expiredAt);
+    case 108:
+      return AppError.invalidToken();
+    case 109:
+      return AppError.invalidRequestParameter(err.validation);
+    case 110:
+      return AppError.invalidResponseType();
+    case 114:
+      return AppError.invalidScopes(err.invalidScopes);
+    case 116:
+      return AppError.notPublicClient();
+    case 117:
+      return AppError.invalidPkceChallenge(err.pkceHashValue);
+    case 118:
+      return AppError.missingPkceParameters();
+    case 119:
+      return AppError.staleAuthAt(err.authAt);
+    case 120:
+      return AppError.insufficientACRValues(err.foundValue);
+    case 121:
+      return AppError.invalidRequestParameter('grant_type');
+    case 122:
+      return AppError.unknownRefreshToken();
+    case 201:
+      return AppError.serviceUnavailable(err.retryAfter);
+    case 202:
+      return AppError.disabledClientId(err.clientId);
+    default:
+      return err;
+  }
 }
 
 module.exports = AppError;

--- a/packages/fxa-auth-server/lib/oauth/assertion.js
+++ b/packages/fxa-auth-server/lib/oauth/assertion.js
@@ -24,7 +24,7 @@
 const Joi = require('@hapi/joi');
 const validators = require('./validators');
 
-const AppError = require('./error');
+const OauthError = require('./error');
 const config = require('../../config');
 const { verifyJWT } = require('../../lib/serverJWT');
 
@@ -57,7 +57,7 @@ const request = require('request').defaults({
 });
 
 function error(assertion, msg, val) {
-  throw AppError.invalidAssertion();
+  throw OauthError.invalidAssertion();
 }
 
 // Verify a BrowserID assertion,

--- a/packages/fxa-auth-server/lib/oauth/auth_client_management.js
+++ b/packages/fxa-auth-server/lib/oauth/auth_client_management.js
@@ -4,7 +4,7 @@
 
 const ScopeSet = require('fxa-shared').oauth.scopes;
 
-const AppError = require('./error');
+const OauthError = require('./error');
 const token = require('./token');
 const validators = require('./validators');
 
@@ -24,12 +24,12 @@ exports.strategy = function () {
     authenticate: async function dogfoodStrategy(req, h) {
       const auth = req.headers.authorization;
       if (!auth || auth.indexOf('Bearer ') !== 0) {
-        throw AppError.unauthorized('Bearer token not provided');
+        throw OauthError.unauthorized('Bearer token not provided');
       }
       const tok = auth.split(' ')[1];
 
       if (!validators.HEX_STRING.test(tok)) {
-        throw AppError.unauthorized('Illegal Bearer token');
+        throw OauthError.unauthorized('Illegal Bearer token');
       }
       try {
         const details = await token.verify(tok);
@@ -38,14 +38,14 @@ exports.strategy = function () {
             return re.test(details.email);
           });
           if (blocked) {
-            throw AppError.forbidden();
+            throw OauthError.forbidden();
           }
         }
 
         details.scope = details.scope.getScopeValues();
         return h.authenticated({ credentials: details });
       } catch (err) {
-        throw AppError.unauthorized('Bearer token invalid');
+        throw OauthError.unauthorized('Bearer token invalid');
       }
     },
   };

--- a/packages/fxa-auth-server/lib/oauth/authorized_clients.js
+++ b/packages/fxa-auth-server/lib/oauth/authorized_clients.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const error = require('./error');
+const OauthError = require('./error');
 const oauthDB = require('./db');
 const hex = require('buf').to.hex;
 const ScopeSet = require('fxa-shared').oauth.scopes;
@@ -28,7 +28,7 @@ module.exports = {
       if (
         !(await oauthDB.deleteClientRefreshToken(refreshTokenId, clientId, uid))
       ) {
-        throw error.unknownToken();
+        throw OauthError.unknownToken();
       }
     } else {
       await oauthDB.deleteClientAuthorization(clientId, uid);

--- a/packages/fxa-auth-server/lib/oauth/error.js
+++ b/packages/fxa-auth-server/lib/oauth/error.js
@@ -21,13 +21,14 @@ function merge(target, other) {
   }
 }
 
-function AppError(options, extra, headers) {
+// Deprecated. New error types should be defined in lib/error.js
+function OauthError(options, extra, headers) {
   this.message = options.message || DEFAULTS.message;
   this.isBoom = true;
   if (options.stack) {
     this.stack = options.stack;
   } else {
-    Error.captureStackTrace(this, AppError);
+    Error.captureStackTrace(this, OauthError);
   }
   this.errno = options.errno || DEFAULTS.errno;
   this.output = {
@@ -43,17 +44,17 @@ function AppError(options, extra, headers) {
   };
   merge(this.output.payload, extra);
 }
-util.inherits(AppError, Error);
+util.inherits(OauthError, Error);
 
-AppError.prototype.toString = function () {
+OauthError.prototype.toString = function () {
   return 'Error: ' + this.message;
 };
 
-AppError.prototype.header = function (name, value) {
+OauthError.prototype.header = function (name, value) {
   this.output.headers[name] = value;
 };
 
-AppError.isOauthRoute = function isOauthRoute(path) {
+OauthError.isOauthRoute = function isOauthRoute(path) {
   const routes = require('../routes/oauth')();
   // ironically, routes that include "oauth" are considered auth-server routes
   return (
@@ -63,19 +64,19 @@ AppError.isOauthRoute = function isOauthRoute(path) {
   );
 };
 
-AppError.translate = function translate(response) {
-  if (response instanceof AppError) {
+OauthError.translate = function translate(response) {
+  if (response instanceof OauthError) {
     return response;
   }
 
   var error;
   var payload = response.output.payload;
   if (payload.validation) {
-    error = AppError.invalidRequestParameter(payload.validation);
+    error = OauthError.invalidRequestParameter(payload.validation);
   } else if (payload.statusCode === 415) {
-    error = AppError.invalidContentType();
+    error = OauthError.invalidContentType();
   } else {
-    error = new AppError({
+    error = new OauthError({
       message: payload.message,
       code: payload.statusCode,
       error: payload.error,
@@ -87,16 +88,16 @@ AppError.translate = function translate(response) {
   return error;
 };
 
-AppError.prototype.backtrace = function (traced) {
+OauthError.prototype.backtrace = function (traced) {
   this.output.payload.log = traced;
 };
 
-AppError.unexpectedError = function unexpectedError() {
-  return new AppError({});
+OauthError.unexpectedError = function unexpectedError() {
+  return new OauthError({});
 };
 
-AppError.unknownClient = function unknownClient(clientId) {
-  return new AppError(
+OauthError.unknownClient = function unknownClient(clientId) {
+  return new OauthError(
     {
       code: 400,
       error: 'Bad Request',
@@ -109,8 +110,8 @@ AppError.unknownClient = function unknownClient(clientId) {
   );
 };
 
-AppError.incorrectSecret = function incorrectSecret(clientId) {
-  return new AppError(
+OauthError.incorrectSecret = function incorrectSecret(clientId) {
+  return new OauthError(
     {
       code: 400,
       error: 'Bad Request',
@@ -123,8 +124,8 @@ AppError.incorrectSecret = function incorrectSecret(clientId) {
   );
 };
 
-AppError.incorrectRedirect = function incorrectRedirect(uri) {
-  return new AppError(
+OauthError.incorrectRedirect = function incorrectRedirect(uri) {
+  return new OauthError(
     {
       code: 400,
       error: 'Bad Request',
@@ -137,8 +138,8 @@ AppError.incorrectRedirect = function incorrectRedirect(uri) {
   );
 };
 
-AppError.invalidAssertion = function invalidAssertion() {
-  return new AppError({
+OauthError.invalidAssertion = function invalidAssertion() {
+  return new OauthError({
     code: 401,
     error: 'Bad Request',
     errno: 104,
@@ -146,8 +147,8 @@ AppError.invalidAssertion = function invalidAssertion() {
   });
 };
 
-AppError.unknownCode = function unknownCode(code) {
-  return new AppError(
+OauthError.unknownCode = function unknownCode(code) {
+  return new OauthError(
     {
       code: 400,
       error: 'Bad Request',
@@ -160,8 +161,8 @@ AppError.unknownCode = function unknownCode(code) {
   );
 };
 
-AppError.mismatchCode = function mismatchCode(code, clientId) {
-  return new AppError(
+OauthError.mismatchCode = function mismatchCode(code, clientId) {
+  return new OauthError(
     {
       code: 400,
       error: 'Bad Request',
@@ -175,8 +176,8 @@ AppError.mismatchCode = function mismatchCode(code, clientId) {
   );
 };
 
-AppError.expiredCode = function expiredCode(code, expiredAt) {
-  return new AppError(
+OauthError.expiredCode = function expiredCode(code, expiredAt) {
+  return new OauthError(
     {
       code: 400,
       error: 'Bad Request',
@@ -190,8 +191,8 @@ AppError.expiredCode = function expiredCode(code, expiredAt) {
   );
 };
 
-AppError.invalidToken = function invalidToken() {
-  return new AppError({
+OauthError.invalidToken = function invalidToken() {
+  return new OauthError({
     code: 400,
     error: 'Bad Request',
     errno: 108,
@@ -199,8 +200,8 @@ AppError.invalidToken = function invalidToken() {
   });
 };
 
-AppError.invalidRequestParameter = function invalidRequestParameter(val) {
-  return new AppError(
+OauthError.invalidRequestParameter = function invalidRequestParameter(val) {
+  return new OauthError(
     {
       code: 400,
       error: 'Bad Request',
@@ -213,8 +214,8 @@ AppError.invalidRequestParameter = function invalidRequestParameter(val) {
   );
 };
 
-AppError.invalidResponseType = function invalidResponseType() {
-  return new AppError({
+OauthError.invalidResponseType = function invalidResponseType() {
+  return new OauthError({
     code: 400,
     error: 'Bad Request',
     errno: 110,
@@ -222,8 +223,8 @@ AppError.invalidResponseType = function invalidResponseType() {
   });
 };
 
-AppError.unauthorized = function unauthorized(reason) {
-  return new AppError(
+OauthError.unauthorized = function unauthorized(reason) {
+  return new OauthError(
     {
       code: 401,
       error: 'Unauthorized',
@@ -236,8 +237,8 @@ AppError.unauthorized = function unauthorized(reason) {
   );
 };
 
-AppError.forbidden = function forbidden() {
-  return new AppError({
+OauthError.forbidden = function forbidden() {
+  return new OauthError({
     code: 403,
     error: 'Forbidden',
     errno: 112,
@@ -245,8 +246,8 @@ AppError.forbidden = function forbidden() {
   });
 };
 
-AppError.invalidContentType = function invalidContentType() {
-  return new AppError({
+OauthError.invalidContentType = function invalidContentType() {
+  return new OauthError({
     code: 415,
     error: 'Unsupported Media Type',
     errno: 113,
@@ -256,8 +257,8 @@ AppError.invalidContentType = function invalidContentType() {
   });
 };
 
-AppError.invalidScopes = function invalidScopes(scopes) {
-  return new AppError(
+OauthError.invalidScopes = function invalidScopes(scopes) {
+  return new OauthError(
     {
       code: 400,
       error: 'Invalid scopes',
@@ -270,8 +271,8 @@ AppError.invalidScopes = function invalidScopes(scopes) {
   );
 };
 
-AppError.expiredToken = function expiredToken(expiredAt) {
-  return new AppError(
+OauthError.expiredToken = function expiredToken(expiredAt) {
+  return new OauthError(
     {
       code: 400,
       error: 'Bad Request',
@@ -284,8 +285,8 @@ AppError.expiredToken = function expiredToken(expiredAt) {
   );
 };
 
-AppError.notPublicClient = function notPublicClient(clientId) {
-  return new AppError(
+OauthError.notPublicClient = function notPublicClient(clientId) {
+  return new OauthError(
     {
       code: 400,
       error: 'Bad Request',
@@ -298,8 +299,10 @@ AppError.notPublicClient = function notPublicClient(clientId) {
   );
 };
 
-AppError.mismatchCodeChallenge = function mismatchCodeChallenge(pkceHashValue) {
-  return new AppError(
+OauthError.mismatchCodeChallenge = function mismatchCodeChallenge(
+  pkceHashValue
+) {
+  return new OauthError(
     {
       code: 400,
       error: 'Bad Request',
@@ -312,8 +315,8 @@ AppError.mismatchCodeChallenge = function mismatchCodeChallenge(pkceHashValue) {
   );
 };
 
-AppError.missingPkceParameters = function missingPkceParameters() {
-  return new AppError({
+OauthError.missingPkceParameters = function missingPkceParameters() {
+  return new OauthError({
     code: 400,
     error: 'PKCE parameters missing',
     errno: 118,
@@ -321,8 +324,8 @@ AppError.missingPkceParameters = function missingPkceParameters() {
   });
 };
 
-AppError.staleAuthAt = function staleAuthAt(authAt) {
-  return new AppError(
+OauthError.staleAuthAt = function staleAuthAt(authAt) {
+  return new OauthError(
     {
       code: 401,
       error: 'Bad Request',
@@ -335,8 +338,8 @@ AppError.staleAuthAt = function staleAuthAt(authAt) {
   );
 };
 
-AppError.mismatchAcr = function mismatchAcr(foundValue) {
-  return new AppError(
+OauthError.mismatchAcr = function mismatchAcr(foundValue) {
+  return new OauthError(
     {
       code: 400,
       error: 'Bad Request',
@@ -347,8 +350,8 @@ AppError.mismatchAcr = function mismatchAcr(foundValue) {
   );
 };
 
-AppError.invalidGrantType = function invalidGrantType() {
-  return new AppError({
+OauthError.invalidGrantType = function invalidGrantType() {
+  return new OauthError({
     code: 400,
     error: 'Bad Request',
     errno: 121,
@@ -356,8 +359,8 @@ AppError.invalidGrantType = function invalidGrantType() {
   });
 };
 
-AppError.unknownToken = function unknownToken() {
-  return new AppError({
+OauthError.unknownToken = function unknownToken() {
+  return new OauthError({
     code: 400,
     error: 'Bad Request',
     errno: 122,
@@ -368,8 +371,8 @@ AppError.unknownToken = function unknownToken() {
 // N.B. `errno: 201` is traditionally our generic "service unavailable" error,
 // so let's reserve it for that purpose here as well.
 
-AppError.disabledClient = function disabledClient(clientId) {
-  return new AppError(
+OauthError.disabledClient = function disabledClient(clientId) {
+  return new OauthError(
     {
       code: 503,
       error: 'Client Disabled',
@@ -380,4 +383,6 @@ AppError.disabledClient = function disabledClient(clientId) {
   );
 };
 
-module.exports = AppError;
+// Deprecated. New error types should be defined in lib/error.js
+
+module.exports = OauthError;

--- a/packages/fxa-auth-server/lib/oauth/grant.js
+++ b/packages/fxa-auth-server/lib/oauth/grant.js
@@ -6,7 +6,7 @@ const buf = require('buf').hex;
 const hex = require('buf').to.hex;
 
 const config = require('../../config');
-const AppError = require('./error');
+const OauthError = require('./error');
 const db = require('./db');
 const util = require('./util');
 const ScopeSet = require('fxa-shared').oauth.scopes;
@@ -71,7 +71,7 @@ module.exports.validateRequestedGrant = async function validateRequestedGrant(
       acrTokens.includes(ACR_VALUE_AAL2) &&
       !(verifiedClaims['fxa-aal'] >= 2)
     ) {
-      throw AppError.mismatchAcr(verifiedClaims['fxa-aal']);
+      throw OauthError.mismatchAcr(verifiedClaims['fxa-aal']);
     }
   }
 
@@ -81,7 +81,7 @@ module.exports.validateRequestedGrant = async function validateRequestedGrant(
       UNTRUSTED_CLIENT_ALLOWED_SCOPES
     );
     if (!invalidScopes.isEmpty()) {
-      throw AppError.invalidScopes(invalidScopes.getScopeValues());
+      throw OauthError.invalidScopes(invalidScopes.getScopeValues());
     }
   }
 
@@ -104,7 +104,7 @@ module.exports.validateRequestedGrant = async function validateRequestedGrant(
       ScopeSet.fromString(client.allowedScopes || '')
     );
     if (!invalidScopes.isEmpty()) {
-      throw AppError.invalidScopes(invalidScopes.getScopeValues());
+      throw OauthError.invalidScopes(invalidScopes.getScopeValues());
     }
   }
 
@@ -117,7 +117,7 @@ module.exports.validateRequestedGrant = async function validateRequestedGrant(
     // verified by email before 2FA was enabled on the account. Such sessions must
     // be able to access sync even after 2FA is enabled, hence checking `verified`
     // rather than the `aal`-related properties here.
-    throw AppError.invalidAssertion();
+    throw OauthError.invalidAssertion();
   }
 
   // If we grow our per-client config, there are more things we could check here:

--- a/packages/fxa-auth-server/lib/oauth/jwt_access_token.js
+++ b/packages/fxa-auth-server/lib/oauth/jwt_access_token.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const hex = require('buf').to.hex;
-const AppError = require('./error');
+const OauthError = require('./error');
 const jwt = require('./jwt');
 const sub = require('./jwt_sub');
 const { OAUTH_SCOPE_OLD_SYNC } = require('../constants');
@@ -89,7 +89,7 @@ exports.tokenId = async function tokenId(accessToken) {
   // a JWT access token.
   const payload = await exports.verify(accessToken);
   if (!payload.jti) {
-    throw AppError.invalidToken();
+    throw OauthError.invalidToken();
   }
   return payload.jti;
 };
@@ -108,11 +108,11 @@ exports.verify = async function verify(accessToken) {
       typ: HEADER_TYP,
     });
   } catch (err) {
-    throw AppError.invalidToken();
+    throw OauthError.invalidToken();
   }
 
   if (!payload) {
-    throw AppError.invalidToken();
+    throw OauthError.invalidToken();
   }
 
   return payload;

--- a/packages/fxa-auth-server/lib/oauth/jwt_id_token.js
+++ b/packages/fxa-auth-server/lib/oauth/jwt_id_token.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const AppError = require('./error');
+const OauthError = require('./error');
 const jwt = require('./jwt');
 
 /**
@@ -65,7 +65,7 @@ exports.verify = async function verify(
   try {
     claims = await jwt.verify(idToken, { ignoreExpiration: true });
   } catch (err) {
-    throw AppError.invalidToken();
+    throw OauthError.invalidToken();
   }
 
   // For Step 3, we just need to verify the audience claim matches the
@@ -79,9 +79,9 @@ exports.verify = async function verify(
   //    Token does not list the Client as a valid audience, or if it contains
   //    additional audiences not trusted by the Client.
   if (typeof claims.aud === 'string' && claims.aud !== clientId) {
-    throw AppError.invalidToken();
+    throw OauthError.invalidToken();
   } else if (!claims.aud.includes(clientId)) {
-    throw AppError.invalidToken();
+    throw OauthError.invalidToken();
   }
 
   // Steps 4 and 5 are skipped, because FxA doesn't support the Authorized
@@ -126,7 +126,7 @@ exports.verify = async function verify(
   //
   // Note also that this time is specified to be in seconds, not milliseconds.
   if (!exports._isValidExp(claims.exp)) {
-    throw AppError.invalidToken();
+    throw OauthError.invalidToken();
   }
 
   const currentTime = Math.round(Date.now() / 1000);
@@ -135,7 +135,7 @@ exports.verify = async function verify(
     claims.exp > fiveMinutesAhead ||
     claims.exp + expiryGracePeriod < currentTime
   ) {
-    throw AppError.invalidToken();
+    throw OauthError.invalidToken();
   }
 
   // The remaining steps don't apply to our use case, so they are skipped.

--- a/packages/fxa-auth-server/lib/oauth/token.js
+++ b/packages/fxa-auth-server/lib/oauth/token.js
@@ -4,7 +4,7 @@
 
 const ScopeSet = require('fxa-shared').oauth.scopes;
 
-const AppError = require('./error');
+const OauthError = require('./error');
 const config = require('../../config');
 const db = require('./db');
 const encrypt = require('./encrypt');
@@ -52,7 +52,7 @@ exports.verify = async function verify(accessToken) {
   // until we fully migrate to JWTs.
   const token = await db.getAccessToken(await exports.getTokenId(accessToken));
   if (!token) {
-    throw AppError.invalidToken();
+    throw OauthError.invalidToken();
   } else if (+token.expiresAt < Date.now()) {
     // We dug ourselves a bit of a hole with token expiry,
     // and this logic is here to help us climb back out.
@@ -67,7 +67,7 @@ exports.verify = async function verify(accessToken) {
       +token.expiresAt >=
       config.get('oauthServer.expiration.accessTokenExpiryEpoch')
     ) {
-      throw AppError.expiredToken(token.expiresAt);
+      throw OauthError.expiredToken(token.expiresAt);
     }
   }
   var tokenInfo = {


### PR DESCRIPTION
In anticipation of combining the auth/oauth error.js source files I prematurely removed the pre-existing logic to convert oauth errors into auth errors for certain routes. This restores that logic in the `appErrorFromOauthError` function and calls it as part of `AppError.translate` where appropriate.

I also renamed the AppError 'type' in oauth/error.js to OauthError to make them easier to differentiate.

This fixes https://sentry.prod.mozaws.net/operations/fxa-auth-prod/issues/10391764