### PR TITLE
feat(auth-server): add paypal helper

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -36,6 +36,14 @@ async function run(config) {
   if (config.subscriptions && config.subscriptions.stripeApiKey) {
     const createStripeHelper = require('../lib/payments/stripe');
     stripeHelper = createStripeHelper(log, config, statsd);
+    const { PayPalClient } = require('../lib/payments/paypal-client');
+    const { PayPalHelper } = require('../lib/payments/paypal');
+    const paypalClient = new PayPalClient(
+      config.subscriptions.paypalNvpSigCredentials
+    );
+    Container.set(PayPalClient, paypalClient);
+    const paypalHelper = new PayPalHelper({ log });
+    Container.set(PayPalHelper, paypalHelper);
   }
 
   const redis = require('../lib/redis')(

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -794,6 +794,32 @@ const conf = convict({
       env: 'SUBSCRIPTIONS_ENABLED',
       default: false,
     },
+    paypalNvpSigCredentials: {
+      sandbox: {
+        doc: 'PayPal Sandbox mode',
+        format: Boolean,
+        env: 'PAYPAL_SANDBOX',
+        default: true,
+      },
+      user: {
+        doc: 'PayPal NVP API User name',
+        format: String,
+        default: 'user',
+        env: 'PAYPAL_NVP_USER',
+      },
+      pwd: {
+        doc: 'PayPal NVP API password',
+        format: String,
+        default: 'user',
+        env: 'PAYPAL_NVP_PWD',
+      },
+      signature: {
+        doc: 'PayPal NVP API signature',
+        format: String,
+        default: 'user',
+        env: 'PAYPAL_NVP_SIGNATURE',
+      },
+    },
     sharedSecret: {
       doc:
         'Shared secret for authentication between backend subscription services',

--- a/packages/fxa-auth-server/lib/payments/paypal-client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-client.ts
@@ -1,9 +1,9 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import pRetry from 'p-retry';
 import querystring from 'querystring';
 import superagent from 'superagent';
-import pRetry from 'p-retry';
 
 export const PAYPAL_SANDBOX_API = 'https://api-3t.sandbox.paypal.com/nvp';
 export const PAYPAL_LIVE_API = 'https://api-3t.paypal.com/nvp';

--- a/packages/fxa-auth-server/lib/payments/paypal.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { StatsD } from 'hot-shots';
+import { Logger } from 'mozlog';
+import { Container } from 'typedi';
+
+import { PayPalClient } from './paypal-client';
+
+type PaypalHelperOptions = {
+  log: Logger;
+};
+
+export class PayPalHelper {
+  private log: Logger;
+  private client: PayPalClient;
+  private metrics: StatsD;
+
+  constructor(options: PaypalHelperOptions) {
+    this.log = options.log;
+    this.client = Container.get(PayPalClient);
+    this.metrics = Container.get(StatsD);
+  }
+}

--- a/packages/fxa-auth-server/lib/routes/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions.ts
@@ -15,9 +15,11 @@ import {
 } from 'fxa-shared/subscriptions/stripe';
 import omitBy from 'lodash/omitBy';
 import { Stripe } from 'stripe';
+import Container from 'typedi';
 
 import { ConfigType } from '../../config';
 import error from '../error';
+import { PayPalHelper } from '../payments/paypal';
 import { StripeHelper, SUBSCRIPTION_UPDATE_TYPES } from '../payments/stripe';
 import { AuthLogger, AuthRequest } from '../types';
 import { splitCapabilities } from './utils/subscriptions';
@@ -68,6 +70,8 @@ function sanitizePlans(plans: AbbrevPlan[]) {
 }
 
 class DirectStripeRoutes {
+  private paypalHelper: PayPalHelper;
+
   constructor(
     private log: AuthLogger,
     private db: any,
@@ -77,7 +81,9 @@ class DirectStripeRoutes {
     private mailer: any,
     private profile: any,
     private stripeHelper: StripeHelper
-  ) {}
+  ) {
+    this.paypalHelper = Container.get(PayPalHelper);
+  }
 
   /**
    * Reload the customer data to reflect a change.

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -40,6 +40,12 @@ describe('remote subscriptions:', function () {
     before(async () => {
       config.subscriptions.enabled = true;
       config.subscriptions.stripeApiKey = 'sk_34523452345';
+      config.subscriptions.paypalNvpSigCredentials = {
+        sandbox: true,
+        user: 'user',
+        pwd: 'pwd',
+        signature: 'sig',
+      };
       mockStripeHelper.allPlans = async () => [
         {
           plan_id: PLAN_ID,


### PR DESCRIPTION
Because:

* We want to have a helper for PayPal that takes a similar role as the
  StripeHelper.

This commit:

* Add's the PayPalHelper and wires in its configuration, initialization,
  and use in the subscription routes.

Closes #7233

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
