### PR TITLE
feat(l10n): Add initial fluent l10n for settings v2

### DIFF
--- a/packages/fxa-payments-server/.storybook/components/MockApp.tsx
+++ b/packages/fxa-payments-server/.storybook/components/MockApp.tsx
@@ -6,7 +6,7 @@ import { MockLoader } from './MockLoader';
 import { AppContext, AppContextType } from '../../src/lib/AppContext';
 import { config } from '../../src/lib/config';
 import ScreenInfo from '../../src/lib/screen-info';
-import AppLocalizationProvider from '../../src/lib/AppLocalizationProvider';
+import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 
 // Stripe API key used in official doc examples. Used as fallback if missing
 // from config and is necessary for Stripe elements to render at all

--- a/packages/fxa-payments-server/src/App.test.tsx
+++ b/packages/fxa-payments-server/src/App.test.tsx
@@ -14,7 +14,7 @@ jest.mock('./lib/sentry');
 
 // Mock most of the components used by App in order to isolate routing logic
 // and avoid mocking external network requests.
-jest.mock('./lib/AppLocalizationProvider', () => ({
+jest.mock('fxa-react/lib/AppLocalizationProvider', () => ({
   __esModule: true,
   default: ({ children }: { children: ReactNode }) => (
     <section data-testid="AppLocalizationProvider">{children}</section>

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -6,7 +6,7 @@ import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
 import { Localized } from '@fluent/react';
 import DocumentTitle from 'react-document-title';
 
-import AppLocalizationProvider from './lib/AppLocalizationProvider';
+import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 import sentryMetrics from './lib/sentry';
 import { QueryParams } from './lib/types';
 import { Config, config } from './lib/config';

--- a/packages/fxa-react/lib/AppLocalizationProvider.test.tsx
+++ b/packages/fxa-react/lib/AppLocalizationProvider.test.tsx
@@ -2,29 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* eslint jest/valid-expect: 0 */
-
-import IntlPolyfill from 'intl';
-Intl.NumberFormat = IntlPolyfill.NumberFormat;
-
 import React from 'react';
 import { render, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import waitUntil from 'async-wait-until';
-import { Localized } from '@fluent/react';
 import sinon from 'sinon';
+
+import { Localized } from '@fluent/react';
 
 import fetchMock from 'fetch-mock';
 import AppLocalizationProvider from './AppLocalizationProvider';
-import { getLocalizedCurrency } from './formats';
 
 describe('<AppLocalizationProvider/>', () => {
   const locales = ['en-GB', 'en-US', 'es-ES'];
   const bundles = ['greetings', 'farewells'];
   function waitUntilTranslated() {
     return waitUntil(
-      () => AppLocalizationProvider.prototype.render.callCount === 2
+      () => {
+        // @ts-ignore
+        return AppLocalizationProvider.prototype.render.callCount === 2
+      }
     );
   }
 
@@ -32,7 +30,7 @@ describe('<AppLocalizationProvider/>', () => {
     fetchMock.get('/locales/en-US/greetings.ftl', 'hello = Hello\n');
     fetchMock.get('/locales/en-US/farewells.ftl', 'goodbye = Goodbye\n');
     fetchMock.get('/locales/es-ES/greetings.ftl', 'hello = Hola\n');
-    fetchMock.get('/locales/en-GB/greetings.ftl', 'hello = Hello { $amount }')
+    fetchMock.get('/locales/en-GB/greetings.ftl', 'hello = Hello { $amount }');
     fetchMock.get('*', { throws: new Error() });
   });
 
@@ -45,7 +43,8 @@ describe('<AppLocalizationProvider/>', () => {
   });
 
   afterEach(() => {
-    AppLocalizationProvider.prototype.render.restore();
+    // @ts-ignore
+    AppLocalizationProvider.prototype.render.restore()
     cleanup();
   });
 
@@ -120,6 +119,7 @@ describe('<AppLocalizationProvider/>', () => {
 
   test('check code property', () => {
     const err = new Error();
+    // @ts-ignore
     err.code = 404;
 
     return expect(Promise.reject(err)).rejects.toHaveProperty('code', 404);
@@ -129,7 +129,10 @@ describe('<AppLocalizationProvider/>', () => {
     const { getByTestId } = render(
       <AppLocalizationProvider bundles={bundles} userLocales={['en-NZ']}>
         <main data-testid="result">
-          <Localized id="hello" vars={{ amount: getLocalizedCurrency(123, 'USD') }}>
+          <Localized
+            id="hello"
+            vars={{ amount: '$US123.00' }}
+          >
             <div>untranslated</div>
           </Localized>
         </main>
@@ -137,6 +140,6 @@ describe('<AppLocalizationProvider/>', () => {
     );
     await waitUntilTranslated();
 
-    expect(getByTestId('result')).toHaveTextContent('Hello ⁨US$1.23');
+    expect(getByTestId('result')).toHaveTextContent('Hello ⁨$US123.00⁩');
   });
 });

--- a/packages/fxa-react/lib/AppLocalizationProvider.tsx
+++ b/packages/fxa-react/lib/AppLocalizationProvider.tsx
@@ -3,14 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { FluentBundle, FluentResource } from '@fluent/bundle';
-import 'intl-pluralrules';
 import { negotiateLanguages } from '@fluent/langneg';
 import { LocalizationProvider, ReactLocalization } from '@fluent/react';
 import React, { Component } from 'react';
 
 import availableLocales from 'fxa-shared/l10n/supportedLanguages.json';
 
-const OTHER_EN_LOCALES = ['en-NZ', 'en-CA', 'en-SG', 'en-MY']
+const OTHER_EN_LOCALES = ['en-NZ', 'en-CA', 'en-SG', 'en-MY'];
 
 async function fetchMessages(baseDir: string, locale: string, bundle: string) {
   try {
@@ -41,9 +40,11 @@ async function createFluentBundleGenerator(
   bundles: Array<string>
 ) {
   const fetched = await Promise.all(
-    currentLocales.filter(l => !OTHER_EN_LOCALES.includes(l)).map(async (locale) => {
-      return { [locale]: await fetchAllMessages(baseDir, locale, bundles) };
-    })
+    currentLocales
+      .filter((l) => !OTHER_EN_LOCALES.includes(l))
+      .map(async (locale) => {
+        return { [locale]: await fetchAllMessages(baseDir, locale, bundles) };
+      })
   );
 
   const mergedBundle = fetched.reduce((obj, cur) => Object.assign(obj, cur));
@@ -121,8 +122,6 @@ export default class AppLocalizationProvider extends Component<Props, State> {
       return <div />;
     }
 
-    return (
-      <LocalizationProvider l10n={l10n}>{children}</LocalizationProvider>
-    );
+    return <LocalizationProvider l10n={l10n}>{children}</LocalizationProvider>;
   }
 }

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -22,12 +22,18 @@
     "test": "jest --env=jsdom-fourteen"
   },
   "dependencies": {
+    "@fluent/bundle": "^0.16.0",
+    "@fluent/langneg": "^0.5.0",
+    "@fluent/react": "^0.13.0",
+    "async-wait-until": "^1.2.6",
     "classnames": "^2.2.6",
+    "fetch-mock": "^9.11.0",
     "fxa-shared": "workspace:*",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-helmet": "^6.1.0",
     "react-transition-group": "^4.3.0",
+    "sinon": "^9.2.3",
     "tailwindcss-dir": "^4.0.0"
   },
   "devDependencies": {
@@ -52,6 +58,7 @@
     "@types/react-helmet": "^6",
     "@types/react-transition-group": "^4.2.4",
     "@types/rimraf": "3.0.0",
+    "@types/sinon": "^9",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
     "babel-preset-react-app": "^9.1.2",

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.3.6",
+    "@fluent/react": "^0.13.0",
     "@reach/router": "^1.3.4",
     "base32-decode": "^1.0.0",
     "base32-encode": "^1.1.1",

--- a/packages/fxa-settings/public/locales/en-US/settings.ftl
+++ b/packages/fxa-settings/public/locales/en-US/settings.ftl
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+## Display name page
+display-name-input =
+ .label = Enter display name
+submit-display-name = Save
+cancel-display-name = Cancel

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -25,6 +25,7 @@ import { ScrollToTop } from '../ScrollToTop';
 import { HomePath } from '../../constants';
 import { useConfig } from 'fxa-settings/src/lib/config';
 import { observeNavigationTiming } from 'fxa-shared/metrics/navigation-timing';
+import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 
 export const GET_INITIAL_STATE = gql`
   query GetInitialState {
@@ -61,22 +62,27 @@ export const App = ({ flowQueryParams }: AppProps) => {
   }
 
   return (
-    <AppLayout>
-      <Head />
-      <Router basepath={HomePath}>
-        <ScrollToTop default>
-          <PageSettings path="/" />
-          <FlowContainer path="/avatar/change" title="Profile picture" />
-          <PageDisplayName path="/display_name" />
-          <PageChangePassword path="/change_password" />
-          <PageRecoveryKeyAdd path="/account_recovery" />
-          <PageSecondaryEmailAdd path="/emails" />
-          <PageSecondaryEmailVerify path="/emails/verify" />
-          <PageTwoStepAuthentication path="/two_step_authentication" />
-          <Page2faReplaceRecoveryCodes path="/two_step_authentication/replace_codes" />
-        </ScrollToTop>
-      </Router>
-    </AppLayout>
+    <AppLocalizationProvider
+      baseDir="/beta/settings/locales"
+      bundles={['settings']}
+    >
+      <AppLayout>
+        <Head />
+        <Router basepath={HomePath}>
+          <ScrollToTop default>
+            <PageSettings path="/" />
+            <FlowContainer path="/avatar/change" title="Profile picture" />
+            <PageDisplayName path="/display_name" />
+            <PageChangePassword path="/change_password" />
+            <PageRecoveryKeyAdd path="/account_recovery" />
+            <PageSecondaryEmailAdd path="/emails" />
+            <PageSecondaryEmailVerify path="/emails/verify" />
+            <PageTwoStepAuthentication path="/two_step_authentication" />
+            <Page2faReplaceRecoveryCodes path="/two_step_authentication/replace_codes" />
+          </ScrollToTop>
+        </Router>
+      </AppLayout>
+    </AppLocalizationProvider>
   );
 };
 

--- a/packages/fxa-settings/src/components/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.tsx
@@ -12,6 +12,7 @@ import { useAlertBar, useMutation } from '../../lib/hooks';
 import { gql } from '@apollo/client';
 import AlertBar from '../AlertBar';
 import { HomePath } from '../../constants';
+import { Localized } from '@fluent/react';
 
 const validateDisplayName = (currentDisplayName: string) => (
   newDisplayName: string
@@ -79,36 +80,42 @@ export const PageDisplayName = (_: RouteComponentProps) => {
 
       <form onSubmit={handleSubmit(onSubmit)}>
         <div className="my-6">
-          <InputText
-            name="displayName"
-            label="Enter display name"
-            className="mb-2"
-            data-testid="display-name-input"
-            autoFocus
-            onChange={() => trigger('displayName')}
-            inputRef={register({
-              validate: isValidDisplayName,
-            })}
-            {...{ errorText }}
-          />
+          <Localized id="display-name-input" attrs={{ label: true }}>
+            <InputText
+              name="displayName"
+              label="Enter display name"
+              className="mb-2"
+              data-testid="display-name-input"
+              autoFocus
+              onChange={() => trigger('displayName')}
+              inputRef={register({
+                validate: isValidDisplayName,
+              })}
+              {...{ errorText }}
+            />
+          </Localized>
         </div>
         <div className="flex justify-center mb-4 mx-auto max-w-64">
-          <button
-            type="button"
-            data-testid="cancel-display-name"
-            className="cta-neutral mx-2 flex-1"
-            onClick={() => window.history.back()}
-          >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            data-testid="submit-display-name"
-            className="cta-primary mx-2 flex-1"
-            disabled={!formState.isDirty || !formState.isValid}
-          >
-            Save
-          </button>
+          <Localized id="cancel-display-name">
+            <button
+              type="button"
+              data-testid="cancel-display-name"
+              className="cta-neutral mx-2 flex-1"
+              onClick={() => window.history.back()}
+            >
+              Cancel
+            </button>
+          </Localized>
+          <Localized id="submit-display-name">
+            <button
+              type="submit"
+              data-testid="submit-display-name"
+              className="cta-primary mx-2 flex-1"
+              disabled={!formState.isDirty || !formState.isValid}
+            >
+              Save
+            </button>
+          </Localized>
         </div>
       </form>
     </FlowContainer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4288,6 +4288,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sinonjs/commons@npm:^1.8.1":
+  version: 1.8.2
+  resolution: "@sinonjs/commons@npm:1.8.2"
+  dependencies:
+    type-detect: 4.0.8
+  checksum: b7eb499e3537a487160fcc42e65b9ad8c7d70ee4a1bbebacdbe28149e01b2da501912df2fbf06c81eac51de8c0ad10eaae573b31932ee747c9f1949fee30c20d
+  languageName: node
+  linkType: hard
+
 "@sinonjs/fake-timers@npm:^6.0.0, @sinonjs/fake-timers@npm:^6.0.1":
   version: 6.0.1
   resolution: "@sinonjs/fake-timers@npm:6.0.1"
@@ -4345,6 +4354,17 @@ __metadata:
     lodash.get: ^4.4.2
     type-detect: ^4.0.8
   checksum: 666f5da1d766c05c3d6ae88a798c7c5eb2f353af1c05b2caa02570df9f5ee5714238611203917e66ebca928bda4b41a0e1ec14622a86fdc2299c2ab24a362321
+  languageName: node
+  linkType: hard
+
+"@sinonjs/samsam@npm:^5.3.0":
+  version: 5.3.1
+  resolution: "@sinonjs/samsam@npm:5.3.1"
+  dependencies:
+    "@sinonjs/commons": ^1.6.0
+    lodash.get: ^4.4.2
+    type-detect: ^4.0.8
+  checksum: 0277cd0b71146efed3d243edddc98362adcc25c13e0067b91500fd990792194be64b0ace6f4ba9f98cdec60ee46749e24aad44b46193cfa73096c5ef309b00a1
   languageName: node
   linkType: hard
 
@@ -6705,6 +6725,15 @@ __metadata:
   dependencies:
     "@types/sinonjs__fake-timers": "*"
   checksum: b6edb8f2c814bff1af4bbbd2ef60250a682bfe4f55942a6cf80e9350271f15598ea46651aca6badaca46b9a1b1060864105a75b4eba620d9139fb10afc1dfe0e
+  languageName: node
+  linkType: hard
+
+"@types/sinon@npm:^9":
+  version: 9.0.10
+  resolution: "@types/sinon@npm:9.0.10"
+  dependencies:
+    "@types/sinonjs__fake-timers": "*"
+  checksum: dfa431fe83bcaf1c15bf6be9aa6cfa266b3951cffdeb950c0c0a45cddd6f2fa72bd81862d0f4937ac82dbe9d4712d17e33cd629e6f20822324fd713738901d49
   languageName: node
   linkType: hard
 
@@ -16584,6 +16613,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fetch-mock@npm:^9.11.0":
+  version: 9.11.0
+  resolution: "fetch-mock@npm:9.11.0"
+  dependencies:
+    "@babel/core": ^7.0.0
+    "@babel/runtime": ^7.0.0
+    core-js: ^3.0.0
+    debug: ^4.1.1
+    glob-to-regexp: ^0.4.0
+    is-subset: ^0.1.1
+    lodash.isequal: ^4.5.0
+    path-to-regexp: ^2.2.1
+    querystring: ^0.2.0
+    whatwg-url: ^6.5.0
+  peerDependencies:
+    node-fetch: "*"
+  peerDependenciesMeta:
+    node-fetch:
+      optional: true
+  checksum: ba019727c6aeabd8c9109723c5747ff71fc96813c8d52312f239e3d0f6e90612e1ad520895c4919503d05adc79876384050d6b2f947ed16701aafcda441abad3
+  languageName: node
+  linkType: hard
+
 "fetch@npm:0.3.6":
   version: 0.3.6
   resolution: "fetch@npm:0.3.6"
@@ -18565,6 +18617,9 @@ fsevents@^1.2.7:
   resolution: "fxa-react@workspace:packages/fxa-react"
   dependencies:
     "@babel/core": ^7.10.3
+    "@fluent/bundle": ^0.16.0
+    "@fluent/langneg": ^0.5.0
+    "@fluent/react": ^0.13.0
     "@storybook/addon-actions": ^5.3.19
     "@storybook/addon-links": ^6.0.28
     "@storybook/addons": ^5.3.19
@@ -18585,12 +18640,15 @@ fsevents@^1.2.7:
     "@types/react-helmet": ^6
     "@types/react-transition-group": ^4.2.4
     "@types/rimraf": 3.0.0
+    "@types/sinon": ^9
+    async-wait-until: ^1.2.6
     babel-eslint: ^10.1.0
     babel-loader: ^8.1.0
     babel-preset-react-app: ^9.1.2
     camelcase: ^6.0.0
     classnames: ^2.2.6
     eslint: ^7.17.0
+    fetch-mock: ^9.11.0
     file-loader: ^4.3.0
     fxa-shared: "workspace:*"
     identity-obj-proxy: ^3.0.0
@@ -18606,6 +18664,7 @@ fsevents@^1.2.7:
     rimraf: ^3.0.2
     sass: 1.26.10
     sass-loader: ^10.0.3
+    sinon: ^9.2.3
     tailwindcss-dir: ^4.0.0
     ts-jest: ^26.3.0
     typescript: 3.9.7
@@ -18619,6 +18678,7 @@ fsevents@^1.2.7:
   dependencies:
     "@apollo/client": ^3.3.6
     "@babel/core": ^7.10.3
+    "@fluent/react": ^0.13.0
     "@reach/router": ^1.3.4
     "@rescripts/cli": 0.0.15
     "@sentry/browser": ^5.27.6
@@ -33644,6 +33704,20 @@ resolve@~1.11.1:
     nise: ^4.0.4
     supports-color: ^7.1.0
   checksum: 8f8f005d976b85431c391f9fe67b687abb5cf67cd8dd8e2d185d02e0bded02e6fc74a57f9d459d90065fa23d3adca06101ef696aa94547610fc6c8b2e69b65d1
+  languageName: node
+  linkType: hard
+
+"sinon@npm:^9.2.3":
+  version: 9.2.3
+  resolution: "sinon@npm:9.2.3"
+  dependencies:
+    "@sinonjs/commons": ^1.8.1
+    "@sinonjs/fake-timers": ^6.0.1
+    "@sinonjs/samsam": ^5.3.0
+    diff: ^4.0.2
+    nise: ^4.0.4
+    supports-color: ^7.1.0
+  checksum: 7c818e8e3bd257eec8a6c3d0da310ca7331831fcf1742d3f84196979c3df5967636851fe950f9f9987a4da5090962011445df996e2455f8b837fb0938b7bd276
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- Settings v2 needs to be localized

## This pull request

- Moves the [AppLocalizationProvider]() to fxa-react
- Updates payment server and settings server to use the provider
- Adds `settings.ftl` in locales/en-US
- Adds basic support for display name page localization
- Note that we will have to refactor this once we split the ftl files by route/components

## Issue that this pull request solves

Closes: #6036 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
