### PR TITLE
Fix base-docker.sh print out of build error logs

### DIFF
--- a/_scripts/base-docker.sh
+++ b/_scripts/base-docker.sh
@@ -1,7 +1,5 @@
 #!/bin/bash -ex
 
-set -o pipefail
-
 DIR=$(dirname "$0")
 cd "$DIR/.."
 
@@ -16,6 +14,7 @@ if [ -f _dev/local-build-env.sh ]; then
 fi
 
 check_build_logs() {
+    set +x
     for log_file in /tmp/xfs-*/build.log; do
         [ -f "$log_file" ] || continue
         cat <<EOF
@@ -23,13 +22,15 @@ check_build_logs() {
 EOF
         cat "${log_file}"
         cat <<EOF
-==========================[ END: ${log_file} ]==========================
+===========================[ END: ${log_file} ]===========================
 EOF
     done
 }
 
+trap 'check_build_logs' EXIT
+
 # `npx yarn` because `npm i -g yarn` needs sudo
-npx yarn install || check_build_logs
+npx yarn install
 SKIP_PREFLIGHT_CHECK=true npx yarn workspaces foreach --topological-dev --verbose run build
 rm -rf node_modules
 rm -rf packages/*/node_modules


### PR DESCRIPTION
## Because

In case the `npx yarn install` command fails because of a module installation, the actual error output is stored in `/tmp/xfa-XYZ/build.log` files which are not easily accessible afterwards. This makes troubleshooting of the build process unnecessarily complicated and time consuming.

## This pull request

Fixes the already existing code to dump out these build logs whenever they exist and whenever the script `_scripts/base-docker.sh` exits (with whatever exit code).

During Docker image builds using the script `_scripts/build-builder.sh`, the resulting `artifacts/fxa-builder.log` will then also contain this output for further inspection.

## Issue that this pull request solves

Closes: n/a

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
