### PR TITLE
chore(auth-server): add ability to run remote tests with mocha vscode

### DIFF
--- a/packages/fxa-auth-server/.vscode/launch.json
+++ b/packages/fxa-auth-server/.vscode/launch.json
@@ -49,7 +49,32 @@
       "preLaunchTask": "Stop PM2 Auth Server",
       "postDebugTask": "Start PM2 Auth Server"
     },
-        {
+
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha All (remote)",
+      "program": "${workspaceFolder}/../../node_modules/mocha/bin/_mocha",
+      "args": [
+        "--require",
+        "ts-node/register",
+        "--timeout",
+        "999999",
+        "--colors",
+        "${workspaceFolder}/test/remote"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "env": {
+        "NODE_ENV": "dev",
+        "VERIFIER_VERSION": "0",
+        "NO_COVERAGE": "1",
+        "CORS_ORIGIN": "http://foo,http://bar"
+      },
+      "preLaunchTask": "Stop PM2 Auth Server",
+      "postDebugTask": "Start PM2 Auth Server"
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "Mocha Current File",

--- a/packages/fxa-auth-server/.vscode/tasks.json
+++ b/packages/fxa-auth-server/.vscode/tasks.json
@@ -33,12 +33,12 @@
     {
       "label": "Stop PM2 Auth Server",
       "type": "shell",
-      "command": "pm2 stop auth"
+      "command": "pm2 stop auth inbox profile"
     },
     {
       "label": "Start PM2 Auth Server",
       "type": "shell",
-      "command": "pm2 start auth"
+      "command": "pm2 start auth inbox profile"
     }
   ]
 }


### PR DESCRIPTION
These tweaks got the mocha command running for auth-server remote tests for me in vscode.