### PR TITLE
chore(settings): use small .ftl files

### DIFF
--- a/packages/fxa-settings/.license.header
+++ b/packages/fxa-settings/.license.header
@@ -1,0 +1,3 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/packages/fxa-settings/.rescriptsrc.js
+++ b/packages/fxa-settings/.rescriptsrc.js
@@ -2,10 +2,56 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const {
-  permitAdditionalJSImports,
-} = require('fxa-react/configs/rescripts');
+const path = require('path');
+const fs = require('fs');
+const { default: WebpackWatchPlugin } = require('webpack-watch-files-plugin');
+const MergeIntoSingleFilePlugin = require('webpack-merge-and-include-globally');
+const { permitAdditionalJSImports } = require('fxa-react/configs/rescripts');
+
+const watchFtlPlugin = new WebpackWatchPlugin({
+  files: ['src/**/*.ftl'],
+});
+
+const mergeFtlPlugin = new MergeIntoSingleFilePlugin({
+  files: {
+    '../public/locales/en-US/settings.ftl': ['.license.header', 'src/**/*.ftl'],
+  },
+});
 
 module.exports = [
+  {
+    devServer: (config) => {
+      const oldWriteToDisk = config.writeToDisk
+        ? config.writeToDisk
+        : () => false;
+      const newConfig = {
+        ...config,
+        writeToDisk: (path) =>
+          /public\/locales\/\S+.ftl/.test(path) || oldWriteToDisk(path),
+      };
+
+      return newConfig;
+    },
+    webpack: (config) => {
+      let newConfig = { ...config };
+
+      if (!newConfig.output.path) {
+        newConfig = {
+          ...newConfig,
+          output: {
+            ...newConfig.output,
+            path: path.resolve(fs.realpathSync(__dirname), 'build'),
+          },
+        };
+      }
+
+      newConfig = {
+        ...newConfig,
+        plugins: [...newConfig.plugins, watchFtlPlugin, mergeFtlPlugin],
+      };
+
+      return newConfig;
+    },
+  },
   permitAdditionalJSImports,
 ];

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -89,6 +89,8 @@
     "pm2": "^4.4.1",
     "postcss-cli": "^7.1.1",
     "react-test-renderer": "^17.0.1",
-    "webpack": "^4.43.0"
+    "webpack": "^4.43.0",
+    "webpack-merge-and-include-globally": "^2.2.3",
+    "webpack-watch-files-plugin": "^1.1.0"
   }
 }

--- a/packages/fxa-settings/public/locales/en-US/settings.ftl
+++ b/packages/fxa-settings/public/locales/en-US/settings.ftl
@@ -2,8 +2,23 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+## Settings Nav
+
+nav-settings = Settings
+nav-profile = Profile
+nav-security = Security
+nav-connected-services = Connected Services
+nav-paid-subs = Paid Subscriptions
+nav-email-comm = Email Communications
+
 ## Display name page
 display-name-input =
  .label = Enter display name
 submit-display-name = Save
 cancel-display-name = Cancel
+
+## Two Step Authentication
+
+tfa-enter-totp = Now enter the security code from the authentication app.
+tfa-enter-code-to-confirm = Please enter one of your recovery codes now to confirm you've saved it. You'll need a code if you lose your device and want to access your account.
+tfa-save-these-codes = Save these one-time use codes in a safe place for when you don’t have your mobile device.

--- a/packages/fxa-settings/src/components/Nav/en-US.ftl
+++ b/packages/fxa-settings/src/components/Nav/en-US.ftl
@@ -1,0 +1,8 @@
+## Settings Nav
+
+nav-settings = Settings
+nav-profile = Profile
+nav-security = Security
+nav-connected-services = Connected Services
+nav-paid-subs = Paid Subscriptions
+nav-email-comm = Email Communications

--- a/packages/fxa-settings/src/components/Nav/index.tsx
+++ b/packages/fxa-settings/src/components/Nav/index.tsx
@@ -8,6 +8,7 @@ import LinkExternal from 'fxa-react/components/LinkExternal';
 import { ReactComponent as OpenExternal } from './open-external.svg';
 import { useAccount } from '../../models';
 import { useConfig } from 'fxa-settings/src/lib/config';
+import { Localized } from '@fluent/react';
 
 export const Nav = () => {
   const account = useAccount();
@@ -26,37 +27,45 @@ export const Nav = () => {
     >
       <ul className="px-6 py-7 tablet:px-8 desktop:p-0 mobileLandscape:mt-8 ltr:text-left rtl:text-right">
         <li className="mb-5">
-          <h2 className="font-bold">Settings</h2>
+          <Localized id="nav-settings">
+            <h2 className="font-bold">Settings</h2>
+          </Localized>
           <ul className="ltr:ml-4 rtl:mr-4">
             <li className="mt-3">
-              <a
-                data-testid="nav-link-profile"
-                href="#profile"
-                className={classNames(
-                  activeClasses,
-                  'inline-block py-1 px-2 hover:bg-grey-100'
-                )}
-              >
-                Profile
-              </a>
+              <Localized id="nav-profile">
+                <a
+                  data-testid="nav-link-profile"
+                  href="#profile"
+                  className={classNames(
+                    activeClasses,
+                    'inline-block py-1 px-2 hover:bg-grey-100'
+                  )}
+                >
+                  Profile
+                </a>
+              </Localized>
             </li>
             <li className="mt-3">
-              <a
-                href="#security"
-                data-testid="nav-link-security"
-                className="inline-block py-1 px-2 hover:bg-grey-100"
-              >
-                Security
-              </a>
+              <Localized id="nav-security">
+                <a
+                  href="#security"
+                  data-testid="nav-link-security"
+                  className="inline-block py-1 px-2 hover:bg-grey-100"
+                >
+                  Security
+                </a>
+              </Localized>
             </li>
             <li className="mt-3">
-              <a
-                href="#connected-services"
-                data-testid="nav-link-connected-services"
-                className="inline-block py-1 px-2 hover:bg-grey-100"
-              >
-                Connected Services
-              </a>
+              <Localized id="nav-connected-services">
+                <a
+                  href="#connected-services"
+                  data-testid="nav-link-connected-services"
+                  className="inline-block py-1 px-2 hover:bg-grey-100"
+                >
+                  Connected Services
+                </a>
+              </Localized>
             </li>
           </ul>
         </li>
@@ -68,7 +77,7 @@ export const Nav = () => {
               data-testid="nav-link-subscriptions"
               href="/subscriptions"
             >
-              Paid Subscriptions
+              <Localized id="nav-paid-subs">Paid Subscriptions</Localized>
               <OpenExternal
                 className="inline-block w-3 h-3 ml-1"
                 aria-hidden="true"
@@ -83,7 +92,7 @@ export const Nav = () => {
             data-testid="nav-link-newsletters"
             href={marketingCommPrefLink}
           >
-            Email Communications
+            <Localized id="nav-email-comm">Email Communications</Localized>
             <OpenExternal
               className="inline-block w-3 h-3 ltr:ml-1 rtl:mr-1 transform rtl:-scale-x-1"
               aria-hidden="true"

--- a/packages/fxa-settings/src/components/PageDisplayName/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageDisplayName/en-US.ftl
@@ -1,0 +1,5 @@
+## Display name page
+display-name-input =
+ .label = Enter display name
+submit-display-name = Save
+cancel-display-name = Cancel

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/en-US.ftl
@@ -1,0 +1,5 @@
+## Two Step Authentication
+
+tfa-enter-totp = Now enter the security code from the authentication app.
+tfa-enter-code-to-confirm = Please enter one of your recovery codes now to confirm you've saved it. You'll need a code if you lose your device and want to access your account.
+tfa-save-these-codes = Save these one-time use codes in a safe place for when you don’t have your mobile device.

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -19,6 +19,7 @@ import { checkCode, getCode } from '../../lib/totp';
 import { HomePath } from '../../constants';
 import { alertTextExternal } from '../../lib/cache';
 import { logViewEvent, useMetrics } from '../../lib/metrics';
+import { Localized } from '@fluent/react';
 
 export const metricsPreInPostFix = 'settings.two-step-authentication';
 
@@ -247,7 +248,9 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
             </div>
           )}
 
-          <p>Now enter the security code from the authentication app.</p>
+          <Localized id="tfa-enter-totp">
+            <p>Now enter the security code from the authentication app.</p>
+          </Localized>
 
           <div className="mt-4 mb-6" data-testid="recovery-key-input">
             <InputText
@@ -291,8 +294,10 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
       {totpVerified && !recoveryCodesAcknowledged && (
         <>
           <div className="my-2" data-testid="2fa-recovery-codes">
-            Save these one-time use codes in a safe place for when you don’t
-            have your mobile device.
+            <Localized id="tfa-save-these-codes">
+              Save these one-time use codes in a safe place for when you don’t
+              have your mobile device.
+            </Localized>
             <div className="mt-6 flex flex-col items-center h-40 justify-between">
               <DataBlock value={recoveryCodes}></DataBlock>
               <GetDataTrio
@@ -322,11 +327,13 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
       )}
       {totpVerified && recoveryCodesAcknowledged && (
         <form onSubmit={recoveryCodeForm.handleSubmit(onRecoveryCodeSubmit)}>
-          <p className="mt-4 mb-4">
-            Please enter one of your recovery codes now to confirm you've saved
-            it. You'll need a code if you lose your device and want to access
-            your account.
-          </p>
+          <Localized id="tfa-enter-code-to-confirm">
+            <p className="mt-4 mb-4">
+              Please enter one of your recovery codes now to confirm you've
+              saved it. You'll need a code if you lose your device and want to
+              access your account.
+            </p>
+          </Localized>
           <div className="mt-4 mb-6" data-testid="recovery-code-input">
             <InputText
               name="recoveryCode"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15408,6 +15408,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es6-promisify@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "es6-promisify@npm:6.1.1"
+  checksum: 03654617c47d261c7cb97a0477a42999f06c638b8ae8d944ce7232a5c5f3add307abe5a4fe93fd7174725e77131ab1a2f9b534bd09a2fe11993f671b46ad75f0
+  languageName: node
+  linkType: hard
+
 "es6-shim@npm:^0.35.5":
   version: 0.35.5
   resolution: "es6-shim@npm:0.35.5"
@@ -18732,6 +18739,8 @@ fsevents@^1.2.7:
     subscriptions-transport-ws: ^0.9.18
     typescript: 3.9.7
     webpack: ^4.43.0
+    webpack-merge-and-include-globally: ^2.2.3
+    webpack-watch-files-plugin: ^1.1.0
   languageName: unknown
   linkType: soft
 
@@ -32595,6 +32604,13 @@ resolve@~1.11.1:
   languageName: node
   linkType: hard
 
+"rev-hash@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "rev-hash@npm:3.0.0"
+  checksum: cd725ae4e775f747578a49a889419538eac2aaef92e9f1cf53d0d5e0bc61e589635e92b2d14aa1f7c839fd5722d10c7d6d19e5dad51122a4026ca40d6ab2e4d5
+  languageName: node
+  linkType: hard
+
 "rework-visit@npm:1.0.0":
   version: 1.0.0
   resolution: "rework-visit@npm:1.0.0"
@@ -37664,6 +37680,19 @@ typescript@~4.1.2:
   languageName: node
   linkType: hard
 
+"webpack-merge-and-include-globally@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "webpack-merge-and-include-globally@npm:2.2.3"
+  dependencies:
+    es6-promisify: ^6.1.1
+    glob: ^7.1.6
+    rev-hash: ^3.0.0
+  peerDependencies:
+    webpack: ">=1.0.0"
+  checksum: 20c0d0de191564f8bbeaab4d0a2e95b6acee0a6d17d1d225737313c6926ea533e16d077424cb00b749abb80de7c90397e23c1c981e90de6660bbf173c5719de7
+  languageName: node
+  linkType: hard
+
 "webpack-merge@npm:^4.2.2":
   version: 4.2.2
   resolution: "webpack-merge@npm:4.2.2"
@@ -37706,6 +37735,18 @@ typescript@~4.1.2:
   dependencies:
     debug: ^3.0.0
   checksum: f06d8f3e8427dd8231d9102e5f3f765329f49f4e6fe3d274bce9c06e386e633a29bca256dd98dfa836334488518e17dcddc0e8d087988cd17d206f25481ebe3c
+  languageName: node
+  linkType: hard
+
+"webpack-watch-files-plugin@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "webpack-watch-files-plugin@npm:1.1.0"
+  dependencies:
+    glob: ^7.1.6
+    lodash: ^4.17.20
+  peerDependencies:
+    webpack: ^3 || ^4
+  checksum: 9534cfe15d03f0111500ea4441f59a8b0f2366a4b6985bfa6be24bf08a3a55b7e55430b636610d6f181538156af93cb68244db5edf4be3a0e02e20043b065b4a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:
 - we want to use .ftl files that are located alongside the components
   in which they are used for better DX

This commit:
 - use Webpack to watch and merge small .ftl files into a combined file
   that's served to the client
 - add small .ftl files as examples

## Issue that this pull request solves

Closes: #7253

