### PR TITLE
feat(payments): Add feature flag for PayPal UI

### DIFF
--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -20,6 +20,13 @@ const conf = convict({
       env: 'FEATURE_USE_SCA_PAYMENT_UI_BY_DEFAULT',
       format: Boolean,
     },
+    usePaypalUIByDefault: {
+      default: false,
+      doc:
+        'Whether to use PayPal payment UI by default rather than Stripe payment UI alone',
+      env: 'FEATURE_USE_PAYPAL_UI_BY_DEFAULT',
+      format: Boolean,
+    },
   },
   amplitude: {
     enabled: {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -26,6 +26,8 @@ import waitForExpect from 'wait-for-expect';
 
 import SubscriptionCreate, { SubscriptionCreateProps } from './index';
 
+import { updateConfig } from '../../../lib/config';
+
 // TODO: Move to some shared lib?
 const deepCopy = (object: Object) => JSON.parse(JSON.stringify(object));
 
@@ -146,6 +148,21 @@ describe('routes/ProductV2/SubscriptionCreate', () => {
       queryAllByText('30-day money-back guarantee')[0]
     ).toBeInTheDocument();
     expect(queryByText('Billing Information')).toBeInTheDocument();
+    expect(
+      document.getElementById('paypal-button-container')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders as expected with PayPal UI enabled', async () => {
+    updateConfig({
+      featureFlags: {
+        usePaypalUIByDefault: true,
+      },
+    });
+    render(<Subject />);
+    expect(
+      document.getElementById('paypal-button-container')
+    ).toBeInTheDocument();
   });
 
   it('renders as expected for mobile', async () => {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -16,6 +16,8 @@ import * as Amplitude from '../../../lib/amplitude';
 import { Localized } from '@fluent/react';
 import * as apiClient from '../../../lib/apiClient';
 
+import { config } from '../../../lib/config';
+
 import '../../Product/SubscriptionCreate/index.scss';
 
 type PaymentError = undefined | StripeError;
@@ -159,6 +161,11 @@ export const SubscriptionCreate = ({
               </Localized>
             )}
           </ErrorMessage>
+
+          {config.featureFlags.usePaypalUIByDefault ? (
+            // To be updated in issue #7097
+            <div id="paypal-button-container"></div>
+          ) : null}
 
           <PaymentForm
             {...{


### PR DESCRIPTION
## Because

- We want to implement Paypal support without deploying to production until it's ready, and it's a good idea in general to put new features behind a flag in case there are unforeseen problems.

## This pull request

- Adds a PayPal feature flag for the front-end that is disabled by default.
- Currently, an empty `<div>` is rendered in the `SubscriptionCreate` component if the flag is enabled.

## Issue that this pull request solves

Closes: #7271

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
