### PR TITLE
feat(auth-server): add paypal enabled option

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -36,14 +36,17 @@ async function run(config) {
   if (config.subscriptions && config.subscriptions.stripeApiKey) {
     const createStripeHelper = require('../lib/payments/stripe');
     stripeHelper = createStripeHelper(log, config, statsd);
-    const { PayPalClient } = require('../lib/payments/paypal-client');
-    const { PayPalHelper } = require('../lib/payments/paypal');
-    const paypalClient = new PayPalClient(
-      config.subscriptions.paypalNvpSigCredentials
-    );
-    Container.set(PayPalClient, paypalClient);
-    const paypalHelper = new PayPalHelper({ log });
-    Container.set(PayPalHelper, paypalHelper);
+
+    if (config.subscriptions.paypalNvpSigCredentials.enabled) {
+      const { PayPalClient } = require('../lib/payments/paypal-client');
+      const { PayPalHelper } = require('../lib/payments/paypal');
+      const paypalClient = new PayPalClient(
+        config.subscriptions.paypalNvpSigCredentials
+      );
+      Container.set(PayPalClient, paypalClient);
+      const paypalHelper = new PayPalHelper({ log });
+      Container.set(PayPalHelper, paypalHelper);
+    }
   }
 
   const redis = require('../lib/redis')(

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -795,6 +795,12 @@ const conf = convict({
       default: false,
     },
     paypalNvpSigCredentials: {
+      enabled: {
+        doc: 'Indicates whether PayPal APIs are enabled',
+        format: Boolean,
+        env: 'SUBSCRIPTIONS_PAYPAL_ENABLED',
+        default: false,
+      },
       sandbox: {
         doc: 'PayPal Sandbox mode',
         format: Boolean,


### PR DESCRIPTION
Because:

* We want to disable paypal APIs when not configured.

This commit:

* Adds an enabled flag to default paypal to an off state.

Closes #7265

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
