### PR TITLE
fix(auth): copy session verification method on password change

### DIFF
--- a/packages/fxa-auth-server/lib/routes/password.js
+++ b/packages/fxa-auth-server/lib/routes/password.js
@@ -155,6 +155,7 @@ module.exports = function (
         let account,
           verifyHash,
           sessionToken,
+          previousSessionToken,
           keyFetchToken,
           verifiedStatus,
           devicesToNotify,
@@ -167,6 +168,7 @@ module.exports = function (
           .then(changePassword)
           .then(notifyAccount)
           .then(createSessionToken)
+          .then(verifySessionToken)
           .then(createKeyFetchToken)
           .then(createResponse);
 
@@ -187,6 +189,7 @@ module.exports = function (
         function getSessionVerificationStatus() {
           if (sessionTokenId) {
             return db.sessionToken(sessionTokenId).then((tokenData) => {
+              previousSessionToken = tokenData;
               verifiedStatus = tokenData.tokenVerified;
               if (tokenData.deviceId) {
                 originatingDeviceId = tokenData.deviceId;
@@ -356,6 +359,19 @@ module.exports = function (
             .then((result) => {
               sessionToken = result;
             });
+        }
+
+        function verifySessionToken() {
+          if (
+            sessionToken &&
+            previousSessionToken &&
+            previousSessionToken.verificationMethodValue
+          ) {
+            return db.verifyTokensWithMethod(
+              sessionToken.id,
+              previousSessionToken.verificationMethodValue
+            );
+          }
         }
 
         function createKeyFetchToken() {


### PR DESCRIPTION
Because:
 - a 2fa verified session becomes unverified after a successful password
   change, leading to several dead ends on the client side

This commit:
 - copy the previous session's verification method to the new session on
   password change

## Issue that this pull request solves

Closes: #4257, #4753


This is a follow-up to https://github.com/mozilla/fxa-auth-server/issues/2313 (https://github.com/mozilla/fxa-auth-server/pull/2437), and fixes #4257 and #4753.  More specifically, it addresses rfk's comment at https://github.com/mozilla/fxa/issues/4257#issuecomment-590518611: 
> ... it does not correctly copy the 2FA verification status

I interpreted that comment to mean that we should copy the verification status.

https://github.com/mozilla/fxa/issues/7288 is a related issue; its comment https://github.com/mozilla/fxa/issues/7288#issuecomment-763466516 ultimately led to this PR.