### PR TITLE
fix(metrics): fixed 'fxa - activity' metric

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -107,10 +107,12 @@ const EVENTS = {
   'token.created': {
     group: GROUPS.activity,
     event: 'access_token_created',
+    minimal: true,
   },
   'verify.success': {
     group: GROUPS.activity,
     event: 'access_token_checked',
+    minimal: true,
   },
 };
 

--- a/packages/fxa-auth-server/lib/metrics/events.js
+++ b/packages/fxa-auth-server/lib/metrics/events.js
@@ -34,6 +34,8 @@ const NOT_FLOW_EVENTS = new Set([
   'device.deleted',
   'device.updated',
   'sync.sentTabToDevice',
+  'token.created',
+  'verify.success',
 ]);
 
 // It's an error if a flow event doesn't have a flow_id

--- a/packages/fxa-auth-server/test/local/metrics/amplitude.js
+++ b/packages/fxa-auth-server/test/local/metrics/amplitude.js
@@ -693,6 +693,47 @@ describe('metrics/amplitude', () => {
       });
     });
 
+    describe('verify.success', () => {
+      beforeEach(() => {
+        Container.set(StatsD, { increment: sinon.spy() });
+        return amplitude(
+          'verify.success',
+          mocks.mockRequest({
+            uaBrowser: 'foo',
+            credentials: {
+              uid: 'blee',
+            },
+            geo: {
+              location: {
+                country: 'United Kingdom',
+                state: 'England',
+              },
+            },
+            query: {
+              service: '0',
+            },
+          })
+        );
+      });
+      it('only includes minimal data', () => {
+        assert.equal(log.amplitudeEvent.callCount, 1);
+        const args = log.amplitudeEvent.args[0];
+        assert.equal(args.length, 1);
+        assert.equal(args[0].user_id, 'blee');
+        assert.equal(args[0].country, undefined);
+        assert.equal(args[0].region, undefined);
+        assert.deepEqual(args[0].event_properties, {
+          service: 'amo',
+          oauth_client_id: '0',
+        });
+        assert.deepEqual(args[0].user_properties, {
+          $append: {
+            fxa_services_used: 'amo',
+          },
+        });
+      });
+    });
+
     describe('email templates', () => {
       const templates = require('../../../lib/senders/templates/_versions');
       const emailTypes = amplitudeModule.EMAIL_TYPES;

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -182,7 +182,9 @@ module.exports = {
    *
    * @param {Object} events   An object of name:definition event mappings, where
    *                          each definition value is itself an object with `group`
-   *                          and `event` string properties.
+   *                          and `event` string properties, with an optional `minimal`
+   *                          property that can be set to `true` to only report
+   *                          uid, service, and version.
    *
    * @param {Map} fuzzyEvents A map of regex:definition event mappings. Each regex
    *                          key may include up to two capturing groups. The first
@@ -258,6 +260,16 @@ module.exports = {
         try {
           version = /([0-9]+)\.([0-9])$/.exec(data.version)[0];
         } catch (err) {}
+
+        // minimal data should be enabled for routes used by internal
+        // services like profile-server and token-server
+        if (mapping.minimal) {
+          data = {
+            uid: data.uid,
+            service: data.service,
+            version: data.version,
+          };
+        }
 
         return pruneUnsetValues({
           op: 'amplitudeEvent',


### PR DESCRIPTION
The token verify metric began including location data in 196 because it started using the auth-server metrics code path. Although seemingly a benign addition, due to how the location got used further down the ETL pipeline it got integrated into the rollup 'fxa - activity' event unexpectedly. Since a large portion of the verify events originate at the profile server this overwrote the user's actual location with our server's geoip.

This commit adds a `minimal` option to the amplitude metrics code that only logs the data originally submitted before 196 for the two oauth specific metrics.

fixes #7298

