### PR TITLE
feat(settings): localize page title

### DIFF
--- a/packages/fxa-react/components/Head/index.tsx
+++ b/packages/fxa-react/components/Head/index.tsx
@@ -2,13 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { useLocalization } from '@fluent/react';
 import React from 'react';
 import { Helmet } from 'react-helmet';
 
-const Head = ({ title }: { title?: string }) => (
-  <Helmet>
-    <title>{title ? `${title} | Firefox Accounts` : 'Firefox Accounts'}</title>
-  </Helmet>
-);
+const Head = ({ title }: { title?: string }) => {
+  const { l10n } = useLocalization();
+  return (
+    <Helmet>
+      <title>
+        {title
+          ? l10n.getString('app-page-title', { title })
+          : l10n.getString('app-default-title', null, 'Firefox Accounts')}
+      </title>
+    </Helmet>
+  );
+};
 
 export default Head;

--- a/packages/fxa-settings/public/locales/en-US/settings.ftl
+++ b/packages/fxa-settings/public/locales/en-US/settings.ftl
@@ -2,6 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# Application
+
+app-default-title = Firefox Accounts
+app-page-title = { $title } | Firefox Accounts
+
 ## Settings Nav
 
 nav-settings = Settings

--- a/packages/fxa-settings/src/components/App/en-US.ftl
+++ b/packages/fxa-settings/src/components/App/en-US.ftl
@@ -1,0 +1,4 @@
+# Application
+
+app-default-title = Firefox Accounts
+app-page-title = { $title } | Firefox Accounts

--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -21,8 +21,7 @@ import { ReactComponent as InvalidIcon } from './invalid.svg';
 import { ReactComponent as UnsetIcon } from './unset.svg';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 import { gql } from '@apollo/client';
-import { useLocalization } from '@fluent/react';
-import { Localized } from '@fluent/react';
+import { useLocalization, Localized } from '@fluent/react';
 
 type FormData = {
   oldPassword: string;


### PR DESCRIPTION
Because:
 - we should localize the page title

This commit:
 - localize the page title in the Head component
 - add en-US strings

## Issue that this pull request solves

Closes: #5059 
