### PR TITLE
browser comms for new settings on desktop

### DIFF
--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -10,6 +10,7 @@ import { useBooleanState } from 'fxa-react/lib/hooks';
 import { HomePath } from '../../constants';
 import { usePasswordChanger } from '../../lib/auth';
 import { cache, sessionToken } from '../../lib/cache';
+import firefox from '../../lib/firefox';
 import { logViewEvent, settingsViewName } from '../../lib/metrics';
 import { useAccount } from '../../models';
 import AlertBar from '../AlertBar';
@@ -78,6 +79,14 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
     onSuccess: (response) => {
       logViewEvent(settingsViewName, 'change-password.success');
       changePassword.reset();
+      firefox.passwordChanged(
+        primaryEmail.email,
+        response.uid,
+        response.sessionToken,
+        response.verified,
+        response.keyFetchToken,
+        response.unwrapBKey
+      );
       sessionToken(response.sessionToken);
       cache.writeQuery({
         query: gql`

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -7,6 +7,7 @@ import { useForm } from 'react-hook-form';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import { useAccountDestroyer } from '../../lib/auth';
 import { sessionToken } from '../../lib/cache';
+import firefox from '../../lib/firefox';
 import { useAlertBar } from '../../lib/hooks';
 import { useAccount } from '../../models';
 import InputPassword from '../InputPassword';
@@ -62,7 +63,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
   const alertBar = useAlertBar();
   const goBack = useCallback(() => window.history.back(), []);
 
-  const { primaryEmail } = useAccount();
+  const { primaryEmail, uid } = useAccount();
 
   const advanceStep = () => {
     setSubtitleText(l10n.getString('delete-account-step-2-2'));
@@ -73,6 +74,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
 
   const deleteAccount = useAccountDestroyer({
     onSuccess: () => {
+      firefox.accountDeleted(uid);
       // must use location.href over navigate() since this is an external link
       window.location.href = `${ROOTPATH}?delete_account_success=true`;
       logViewEvent('flow.settings.account-delete', 'confirm-password.success');

--- a/packages/fxa-settings/src/components/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.tsx
@@ -8,6 +8,7 @@ import { useForm } from 'react-hook-form';
 import React, { useState } from 'react';
 import FlowContainer from '../FlowContainer';
 import InputText from '../InputText';
+import firefox from '../../lib/firefox';
 import { useAlertBar, useMutation } from '../../lib/hooks';
 import { gql } from '@apollo/client';
 import AlertBar from '../AlertBar';
@@ -44,6 +45,7 @@ export const PageDisplayName = (_: RouteComponentProps) => {
 
   const [updateDisplayName] = useMutation(UPDATE_DISPLAY_NAME_MUTATION, {
     onCompleted: () => {
+      firefox.profileChanged(account.uid);
       navigate(HomePath, { replace: true });
     },
     onError(err) {

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -5,6 +5,7 @@
 import React, { ReactNode, useState } from 'react';
 import { gql } from '@apollo/client';
 import { useNavigate } from '@reach/router';
+import firefox from '../../lib/firefox';
 import { useAlertBar, useMutation } from '../../lib/hooks';
 import { useAccount, useLazyAccount, Email } from '../../models';
 import UnitRow from '../UnitRow';
@@ -86,6 +87,7 @@ export const UnitRowSecondaryEmail = () => {
     MAKE_EMAIL_PRIMARY_MUTATION,
     {
       onCompleted() {
+        firefox.profileChanged(account.uid);
         alertBar.success(
           l10n.getString(
             'se-set-primary-successful',

--- a/packages/fxa-settings/src/lib/auth.test.tsx
+++ b/packages/fxa-settings/src/lib/auth.test.tsx
@@ -99,7 +99,7 @@ describe('usePasswordChanger', () => {
       'email',
       'oldPassword',
       'newPassword',
-      { sessionToken: 'sessionToken' }
+      { keys: true, sessionToken: 'sessionToken' }
     );
     // expect.anything() is the PromiseCallbackOptions of react-async-hook
     expect(onSuccess).toBeCalledWith(response, expect.anything());

--- a/packages/fxa-settings/src/lib/auth.ts
+++ b/packages/fxa-settings/src/lib/auth.ts
@@ -76,6 +76,7 @@ export function usePasswordChanger({
         oldPassword,
         newPassword,
         {
+          keys: true,
           sessionToken,
         }
       );

--- a/packages/fxa-settings/src/lib/firefox.ts
+++ b/packages/fxa-settings/src/lib/firefox.ts
@@ -1,0 +1,148 @@
+export enum FirefoxCommand {
+  AccountDeleted = 'fxaccounts:delete',
+  ProfileChanged = 'profile:change',
+  PasswordChanged = 'fxaccounts:change_password',
+  Error = 'fxError',
+}
+
+export interface FirefoxMessage {
+  id: string;
+  message?: {
+    command: FirefoxCommand;
+    data: Record<string, any> & {
+      error?: {
+        message: string;
+        stack: string;
+      };
+    };
+    messageId: string;
+    error?: string;
+  };
+}
+
+type FirefoxEvent = CustomEvent<FirefoxMessage | string>;
+
+export class Firefox extends EventTarget {
+  private broadcastChannel?: BroadcastChannel;
+  readonly id: string;
+  constructor() {
+    super();
+    this.id = 'account_updates';
+    if (typeof BroadcastChannel !== 'undefined') {
+      this.broadcastChannel = new BroadcastChannel('firefox_accounts');
+      this.broadcastChannel.addEventListener('message', (event) =>
+        this.handleBroadcastEvent(event)
+      );
+    }
+    window.addEventListener('WebChannelMessageToContent', (event) =>
+      this.handleFirefoxEvent(event as FirefoxEvent)
+    );
+  }
+
+  private handleBroadcastEvent(event: MessageEvent) {
+    console.debug('broadcast', event);
+    const envelope = JSON.parse(event.data);
+    this.dispatchEvent(
+      new CustomEvent(envelope.name, { detail: envelope.data })
+    );
+  }
+
+  private handleFirefoxEvent(event: FirefoxEvent) {
+    console.debug('webchannel', event);
+    try {
+      const detail =
+        typeof event.detail === 'string'
+          ? (JSON.parse(event.detail) as FirefoxMessage)
+          : event.detail;
+      if (detail.id !== this.id) {
+        return;
+      }
+      const message = detail.message;
+      if (message) {
+        if (message.error || message.data.error) {
+          const error = {
+            message: message.error || message.data.error?.message,
+            stack: message.data.error?.stack,
+          };
+          this.dispatchEvent(
+            new CustomEvent(FirefoxCommand.Error, { detail: error })
+          );
+        } else {
+          this.dispatchEvent(
+            new CustomEvent(message.command, { detail: message.data })
+          );
+        }
+      }
+    } catch (e) {
+      // TODO: log and ignore
+    }
+  }
+
+  private formatEventDetail(
+    command: FirefoxCommand,
+    data: any,
+    messageId: string = ''
+  ) {
+    const detail = {
+      id: this.id,
+      message: {
+        command,
+        data,
+        messageId,
+      },
+    };
+
+    // Firefox Desktop and Fennec >= 50 expect the detail to be
+    // sent as a string.
+    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1275616 and
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1238128
+    return JSON.stringify(detail);
+  }
+
+  // send a message to the browser chrome
+  send(command: FirefoxCommand, data: any, messageId?: string) {
+    window.dispatchEvent(
+      new CustomEvent('WebChannelMessageToChrome', {
+        detail: this.formatEventDetail(command, data, messageId),
+      })
+    );
+  }
+
+  // broadcast a message to other tabs
+  broadcast(name: FirefoxCommand, data: any) {
+    this.broadcastChannel?.postMessage(JSON.stringify({ name, data }));
+  }
+
+  accountDeleted(uid: hexstring) {
+    this.send(FirefoxCommand.AccountDeleted, { uid });
+    this.broadcast(FirefoxCommand.AccountDeleted, { uid });
+  }
+
+  passwordChanged(
+    email: string,
+    uid: hexstring,
+    sessionToken: hexstring,
+    verified: boolean,
+    keyFetchToken?: hexstring,
+    unwrapBKey?: hexstring
+  ) {
+    this.send(FirefoxCommand.PasswordChanged, {
+      email,
+      uid,
+      sessionToken,
+      verified,
+      keyFetchToken,
+      unwrapBKey,
+    });
+    this.broadcast(FirefoxCommand.PasswordChanged, {
+      uid,
+    });
+  }
+
+  profileChanged(uid: hexstring) {
+    this.send(FirefoxCommand.ProfileChanged, { uid });
+    this.broadcast(FirefoxCommand.ProfileChanged, { uid });
+  }
+}
+
+export default new Firefox();

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -109,6 +109,22 @@ export const ACCOUNT_FIELDS = `
     }
 `;
 
+export const GET_PROFILE_INFO = gql`
+  query GetProfileInfo {
+    account {
+      uid
+      displayName
+      avatarUrl
+      primaryEmail @client
+      emails {
+        email
+        isPrimary
+        verified
+      }
+    }
+  }
+`;
+
 export const GET_ACCOUNT = gql`
   query GetAccount {
     ${ACCOUNT_FIELDS}


### PR DESCRIPTION
This implements the desktop firefox version of browser/page messaging for the new settings. It's loosely based on the content-server [channels](https://github.com/mozilla/fxa/blob/main/packages/fxa-content-server/app/scripts/lib/channels) but only includes aspects required for the settings page. Implementation for the mobile browsers on iOS and Android can be done in future PRs.