### PR TITLE
chore(docs): Add missing package README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,21 +402,29 @@ All emails sent can be viewed from [http://localhost:1080](http://localhost:1080
 
 The [Firefox Ecosystem Platform](https://mozilla.github.io/ecosystem-platform/) serves as a documentation hub for Firefox Accounts, Services, Synced Client Integrations, and Subscription Platform.
 
-In addition to the ecosystem docs, each package has it's own README.md and `docs/` directory with info specific to that project.
+In addition to the ecosystem docs, each package has it's own README.md and some have a `docs/` directory with info specific to that project.
 
 - 123done [README](./packages/123done/README.md)
 - browserid-verifier [README](./packages/browserid-verifier/README.md)
 - fortress [README](./packages/fortress/README.md)
+- fxa-admin-panel [README](./packages/fxa-admin-panel/README.md)
+- fxa-admin-server [README](./packages/fxa-admin-server/README.md)
 - fxa-auth-client [README](./packages/fxa-auth-client/README.md)
 - fxa-auth-db-mysql [README](./packages/fxa-auth-db-mysql/README.md) / [docs/](./packages/fxa-auth-db-mysql/docs)
 - fxa-auth-server [README](./packages/fxa-auth-server/README.md) / [docs/](./packages/fxa-auth-server/docs)
 - fxa-content-server [README](./packages/fxa-content-server/README.md) / [docs/](./packages/fxa-content-server/docs)
+- fxa-customs-server [README](./packages/fxa-content-server/README.md) / [docs/](./packages/fxa-customs-server/docs)
+- fxa-dev-launcher [README](./packages/fxa-dev-launcher/README.md)
 - fxa-email-event-proxy [README](./packages/fxa-email-event-proxy/README.md)
 - fxa-email-service [README](./packages/fxa-email-service/README.md) / [docs/](./packages/fxa-email-service/docs)
 - fxa-event-broker [README](./packages/fxa-event-broker/README.md) / [docs/](./packages/fxa-event-broker/docs)
 - fxa-geodb [README](./packages/fxa-geodb/README.md)
+- fxa-graphql-api [README](./packages/fxa-graphql-api/README.md)
+- fxa-metrics-processor [README](./packages/fxa-metrics-processor/README.md)
 - fxa-payments-server [README](./packages/fxa-payments-server/README.md)
 - fxa-profile-server [README](./packages/fxa-profile-server/README.md) / [docs/](./packages/fxa-profile-server/docs)
+- fxa-react [README](./packages/fxa-react/README.md)
+- fxa-settings [README](./packages/fxa-settings/README.md)
 - fxa-shared [README](./packages/fxa-shared/README.md)
 - fxa-support-panel [README](./packages/fxa-support-panel/README.md)
 


### PR DESCRIPTION
Was passing by and noticed some packages were missing links to their docs.

miss u fxa