### PR TITLE
localize settings header and footer

### DIFF
--- a/packages/fxa-react/components/Footer/index.test.tsx
+++ b/packages/fxa-react/components/Footer/index.test.tsx
@@ -19,7 +19,7 @@ describe('Footer', () => {
     expect(linkMozilla.firstElementChild).toHaveAttribute('role', 'img');
     expect(linkMozilla.firstElementChild).toHaveAttribute(
       'aria-label',
-      'Mozilla logo'
+      'app-footer-mozilla-logo-label'
     );
     expect(screen.getByTestId('link-privacy')).toHaveAttribute(
       'href',

--- a/packages/fxa-react/components/Footer/index.tsx
+++ b/packages/fxa-react/components/Footer/index.tsx
@@ -2,40 +2,48 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { Localized, useLocalization } from '@fluent/react';
 import React from 'react';
 import LinkExternal from '../LinkExternal';
 import { ReactComponent as MozLogo } from './moz-logo.svg';
 
-export const Footer = () => (
-  <footer
-    className="py-4 mt-16 mx-4 flex-wrap mobileLandscape:flex-no-wrap mobileLandscape:mx-8 mobileLandscape:pb-6 flex border-t border-grey-100 text-grey-400"
-    data-testid="footer"
-  >
-    <LinkExternal
-      href="https://www.mozilla.org/about/?utm_source=firefox-accounts&utm_medium=Referral"
-      data-testid="link-mozilla"
+export const Footer = () => {
+  const { l10n } = useLocalization();
+  return (
+    <footer
+      className="py-4 mt-16 mx-4 flex-wrap mobileLandscape:flex-no-wrap mobileLandscape:mx-8 mobileLandscape:pb-6 flex border-t border-grey-100 text-grey-400"
+      data-testid="footer"
     >
-      <MozLogo
-        aria-label="Mozilla logo"
-        role="img"
-        className="transition-standard w-18 h-auto opacity-75 hover:opacity-100"
-      />
-    </LinkExternal>
-    <LinkExternal
-      data-testid="link-privacy"
-      href="https://www.mozilla.org/en-US/privacy/websites/"
-      className="transition-standard w-full text-xs my-3 hover:text-grey-500 hover:underline mobileLandscape:my-0 mobileLandscape:w-auto mobileLandscape:mx-10 mobileLandscape:self-end"
-    >
-      Website Privacy Notice
-    </LinkExternal>
-    <LinkExternal
-      data-testid="link-terms"
-      href="https://www.mozilla.org/en-US/about/legal/terms/services/"
-      className="transition-standard w-full text-xs mobileLandscape:self-end hover:text-grey-500 hover:underline mobileLandscape:w-auto"
-    >
-      Terms of Service
-    </LinkExternal>
-  </footer>
-);
+      <LinkExternal
+        href="https://www.mozilla.org/about/?utm_source=firefox-accounts&utm_medium=Referral"
+        data-testid="link-mozilla"
+      >
+        <MozLogo
+          aria-label={l10n.getString('app-footer-mozilla-logo-label')}
+          role="img"
+          className="transition-standard w-18 h-auto opacity-75 hover:opacity-100"
+        />
+      </LinkExternal>
+      <Localized id="app-footer-privacy-notice">
+        <LinkExternal
+          data-testid="link-privacy"
+          href="https://www.mozilla.org/en-US/privacy/websites/"
+          className="transition-standard w-full text-xs my-3 hover:text-grey-500 hover:underline mobileLandscape:my-0 mobileLandscape:w-auto mobileLandscape:mx-10 mobileLandscape:self-end"
+        >
+          Website Privacy Notice
+        </LinkExternal>
+      </Localized>
+      <Localized id="app-footer-terms-of-service">
+        <LinkExternal
+          data-testid="link-terms"
+          href="https://www.mozilla.org/en-US/about/legal/terms/services/"
+          className="transition-standard w-full text-xs mobileLandscape:self-end hover:text-grey-500 hover:underline mobileLandscape:w-auto"
+        >
+          Terms of Service
+        </LinkExternal>
+      </Localized>
+    </footer>
+  );
+};
 
 export default Footer;

--- a/packages/fxa-settings/public/locales/en-US/settings.ftl
+++ b/packages/fxa-settings/public/locales/en-US/settings.ftl
@@ -7,6 +7,12 @@
 app-default-title = Firefox Accounts
 app-page-title = { $title } | Firefox Accounts
 
+# Application-wide footer
+
+app-footer-mozilla-logo-label = Mozilla logo
+app-footer-privacy-notice = Website Privacy Notice
+app-footer-terms-of-service = Terms of Service
+
 # HeaderLockup component
 
 header-menu-open = Close menu

--- a/packages/fxa-settings/public/locales/en-US/settings.ftl
+++ b/packages/fxa-settings/public/locales/en-US/settings.ftl
@@ -7,6 +7,17 @@
 app-default-title = Firefox Accounts
 app-page-title = { $title } | Firefox Accounts
 
+# HeaderLockup component
+
+header-menu-open = Close menu
+header-menu-closed = Site navigation menu
+header-back-to-top-link =
+  .title = Back to top
+header-title = Firefox account
+header-switch-title = Switch to classic design
+  .title = classic design link
+header-help = Help
+
 ## Settings Nav
 
 nav-settings = Settings

--- a/packages/fxa-settings/src/components/App/en-US.ftl
+++ b/packages/fxa-settings/src/components/App/en-US.ftl
@@ -2,3 +2,9 @@
 
 app-default-title = Firefox Accounts
 app-page-title = { $title } | Firefox Accounts
+
+# Application-wide footer
+
+app-footer-mozilla-logo-label = Mozilla logo
+app-footer-privacy-notice = Website Privacy Notice
+app-footer-terms-of-service = Terms of Service

--- a/packages/fxa-settings/src/components/HeaderLockup/en-US.ftl
+++ b/packages/fxa-settings/src/components/HeaderLockup/en-US.ftl
@@ -1,0 +1,10 @@
+# HeaderLockup component
+
+header-menu-open = Close menu
+header-menu-closed = Site navigation menu
+header-back-to-top-link =
+  .title = Back to top
+header-title = Firefox account
+header-switch-title = Switch to classic design
+  .title = classic design link
+header-help = Help

--- a/packages/fxa-settings/src/components/HeaderLockup/index.tsx
+++ b/packages/fxa-settings/src/components/HeaderLockup/index.tsx
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { Localized, useLocalization } from '@fluent/react';
 import React, { useState } from 'react';
 import LogoLockup from 'fxa-react/components/LogoLockup';
 import Header from 'fxa-react/components/Header';
@@ -15,12 +16,17 @@ import Nav from '../Nav';
 
 export const HeaderLockup = () => {
   const [navRevealedState, setNavState] = useState(false);
+  const { l10n } = useLocalization();
   const left = (
     <>
       <button
         className="desktop:hidden ltr:mr-6 rtl:ml-6 w-8 h-6 self-center"
         data-testid="header-menu"
-        aria-label={navRevealedState ? 'Close menu' : 'Site navigation menu'}
+        aria-label={
+          navRevealedState
+            ? l10n.getString('header-menu-open')
+            : l10n.getString('header-menu-closed')
+        }
         aria-haspopup={true}
         aria-expanded={navRevealedState}
         onClick={() => setNavState(!navRevealedState)}
@@ -28,41 +34,47 @@ export const HeaderLockup = () => {
         {navRevealedState ? <Close /> : <Menu />}
         {navRevealedState && <Nav />}
       </button>
-      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-      <a
-        href="#"
-        title="Back to top"
-        className="flex"
-        data-testid="back-to-top"
-      >
-        <LogoLockup>
-          <>
-            <span className="font-bold ltr:mr-2 rtl:ml-2">
-              Firefox accounts
-            </span>
-            <a
-              href="/settings/beta_optout"
-              title="classic design link"
-              className="cta-base cta-neutral transition-standard text-sm ltr:ml-4 rtl:mr-4 p-2"
-            >
-              Switch to classic design
-            </a>
-          </>
-        </LogoLockup>
-      </a>
+      <Localized id="header-back-to-top-link" attrs={{ title: true }}>
+        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+        <a
+          href="#"
+          title="Back to top"
+          className="flex"
+          data-testid="back-to-top"
+        >
+          <LogoLockup>
+            <>
+              <Localized id="header-title">
+                <span className="font-bold ltr:mr-2 rtl:ml-2">
+                  Firefox accounts
+                </span>
+              </Localized>
+              <Localized id="header-switch-title" attrs={{ title: true }}>
+                <a
+                  href="/settings/beta_optout"
+                  title="classic design link"
+                  className="cta-base cta-neutral transition-standard text-sm ltr:ml-4 rtl:mr-4 p-2"
+                >
+                  Switch to classic design
+                </a>
+              </Localized>
+            </>
+          </LogoLockup>
+        </a>
+      </Localized>
     </>
   );
   const right = (
     <>
       <LinkExternal
         href="https://support.mozilla.org"
-        title="Help"
+        title={l10n.getString('header-help')}
         className="self-center"
         data-testid="header-sumo-link"
       >
         <Help
-          aria-label="Help"
-          title="Help"
+          aria-label={l10n.getString('header-help')}
+          title={l10n.getString('header-help')}
           role="img"
           className="w-6"
           data-testid="header-help"


### PR DESCRIPTION
## Because

- we want to localize the header and footer

## This pull request

- localizes the header and footer :-)

- Note: I feel a little weird about putting the strings for the footer (which lives in fxa-react) over in the fxa-settings App component's ftl file. This is in keeping with the approach from #7327 and I can't think of a better approach, but other suggestions welcome!

- [Update: regular casing restored.] ~~Also note: I've used SpOnGeBoB cAsInG to convince myself that the l10n transforms are actually getting applied. But nobody else is doing that in the other l10n commits, so I can revert to normal casing if that's preferred.~~ 
<img src="https://user-images.githubusercontent.com/96396/105428114-8884e480-5c03-11eb-9190-e7325c389ad3.png" width=100>


## Issue that this pull request solves

Closes: #5058

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
