### PR TITLE
feat(shared): add paypal BA model commands

### DIFF
--- a/packages/fxa-shared/db/models/auth/index.ts
+++ b/packages/fxa-shared/db/models/auth/index.ts
@@ -6,10 +6,18 @@ import { Account } from './account';
 import { AccountCustomers } from './account-customers';
 import { AuthBaseModel } from './auth-base';
 import { SessionToken } from './session-token';
+import { PayPalBillingAgreements } from './paypal-ba';
 
 export type AccountOptions = {
   include?: 'emails'[];
 };
+
+export type PayPalBillingAgreementStatusType =
+  | 'Pending'
+  | 'Active'
+  | 'Suspended'
+  | 'Cancelled'
+  | 'Expired';
 
 export async function sessionTokenData(
   tokenId: string
@@ -128,6 +136,72 @@ export async function deleteAccountCustomer(uid: string) {
   return AccountCustomers.query().delete().where({ uid: uidBuffer });
 }
 
+/**
+ * Get all the PayPal Billing Agreements by uid
+ *
+ * @param uid
+ */
+export async function getAllPayPalBAByUid(
+  uid: string
+): Promise<PayPalBillingAgreements[]> {
+  const uidBuffer = uuidTransformer.to(uid);
+  return PayPalBillingAgreements.query()
+    .where({ uid: uidBuffer })
+    .orderBy('createdAt', 'DESC');
+}
+
+/**
+ * Create a PayPal Billing Agreement record for a user by uid.
+ * @param uid
+ * @param billingAgreementId
+ * @param status
+ */
+export async function createPayPalBA(
+  uid: string,
+  billingAgreementId: string,
+  status: string
+): Promise<PayPalBillingAgreements> {
+  return PayPalBillingAgreements.query().insertAndFetch({
+    uid,
+    billingAgreementId,
+    status,
+  });
+}
+
+/**
+ * Update a PayPal Billing Agreement for a user by uid/billingAgreementId.
+ *
+ * @param uid
+ * @param billingAgreementId
+ * @param status
+ * @param endedAt
+ */
+export async function updatePayPalBA(
+  uid: string,
+  billingAgreementId: string,
+  status: PayPalBillingAgreementStatusType,
+  endedAt?: number
+): Promise<number> {
+  const uidBuffer = uuidTransformer.to(uid);
+  return PayPalBillingAgreements.query()
+    .patch({
+      status,
+      endedAt,
+    })
+    .where({ uid: uidBuffer, billingAgreementId });
+}
+
+/**
+ * Deletes all billing agreements for a user by uid.
+ *
+ * @param uid
+ * @param billingAgreementId
+ */
+export async function deleteAllPayPalBAs(uid: string) {
+  const uidBuffer = uuidTransformer.to(uid);
+  return PayPalBillingAgreements.query().delete().where({ uid: uidBuffer });
+}
+
 // TODO: Find a better home for this.
 /**
  * Type machinery to filter an Objection model class down to its direct
@@ -149,4 +223,4 @@ export function batchAccountUpdate(uids: Buffer[], updateFields: Accountish) {
   return Account.query().whereIn('uid', uids).update(updateFields);
 }
 
-export { Account, AccountCustomers, AuthBaseModel };
+export { Account, AccountCustomers, AuthBaseModel, PayPalBillingAgreements };

--- a/packages/fxa-shared/db/models/auth/paypal-ba.ts
+++ b/packages/fxa-shared/db/models/auth/paypal-ba.ts
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { AuthBaseModel } from './auth-base';
+
+/**
+ * Tracks current and prior PayPal Billing Agreements for a user.
+ */
+export class PayPalBillingAgreements extends AuthBaseModel {
+  public static tableName = 'paypalCustomers';
+  public static idColumn = 'uid';
+
+  protected $uuidFields = ['uid'];
+
+  public uid!: string;
+  public billingAgreementId!: string;
+  public status!: string;
+
+  public createdAt!: number | null;
+  public endedAt?: number;
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['uid', 'billingAgreementId'],
+      properties: {
+        uid: {
+          type: 'string',
+          pattern: '^(?:[a-fA-F0-9]{2})+$',
+        },
+        billingAgreementId: {
+          type: 'string',
+          pattern: '^[A-Z]+-[A-Za-z0-9]+$',
+        },
+        status: {
+          type: 'string',
+          pattern: '^[A-Za-z]+$',
+        },
+      },
+    };
+  }
+
+  $beforeInsert() {
+    this.createdAt = Date.now();
+  }
+}

--- a/packages/fxa-shared/test/db/models/auth/helpers.ts
+++ b/packages/fxa-shared/test/db/models/auth/helpers.ts
@@ -31,6 +31,10 @@ export const accountCustomersTable = fs.readFileSync(
   path.join(thisDir, './account-customers.sql'),
   'utf8'
 );
+export const paypalBATable = fs.readFileSync(
+  path.join(thisDir, './paypal-ba.sql'),
+  'utf8'
+);
 
 export function randomAccount() {
   const email = chance.email();
@@ -90,6 +94,7 @@ export async function testDatabaseSetup(): Promise<Knex> {
   await knex.raw(accountTable);
   await knex.raw(emailsTable);
   await knex.raw(accountCustomersTable);
+  await knex.raw(paypalBATable);
 
   /* Debugging Assistance
   knex.on('query', (data) => {

--- a/packages/fxa-shared/test/db/models/auth/paypal-ba.sql
+++ b/packages/fxa-shared/test/db/models/auth/paypal-ba.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `paypalCustomers` (
+  `uid` BINARY(16),
+  `billingAgreementId` CHAR(19),
+  `status` VARCHAR(9) NOT NULL,
+  `createdAt` BIGINT UNSIGNED NOT NULL,
+  `endedAt` BIGINT UNSIGNED,
+  PRIMARY KEY (uid, billingAgreementId)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;


### PR DESCRIPTION
Because:

* We want to track billing agreement IDs used by customers using PayPal
  over time, and Stripe metadata is only used to track the currently
  active billing agreement ID to use.

This commit:

* Adds model commands and a model to use the existing paypalCustomers
  table that handle basic CRUD operations.

Closes #7032

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
