### PR TITLE
localize the secondary email page

### DIFF
--- a/packages/fxa-settings/public/locales/en-US/settings.ftl
+++ b/packages/fxa-settings/public/locales/en-US/settings.ftl
@@ -74,6 +74,16 @@ display-name-input =
 submit-display-name = Save
 cancel-display-name = Cancel
 
+# Add secondary email page
+
+add-secondary-email-error = There was a problem creating this email.
+add-secondary-email-page-title
+  .title = Secondary email
+add-secondary-email-enter-address =
+  .label = Enter email address
+add-secondary-email-cancel-button = Cancel
+add-secondary-email-save-button = Save
+
 ## Two Step Authentication
 
 tfa-enter-totp = Now enter the security code from the authentication app.

--- a/packages/fxa-settings/public/locales/en-US/settings.ftl
+++ b/packages/fxa-settings/public/locales/en-US/settings.ftl
@@ -84,6 +84,18 @@ add-secondary-email-enter-address =
 add-secondary-email-cancel-button = Cancel
 add-secondary-email-save-button = Save
 
+# Verify secondary email page
+
+verify-secondary-email-error = There was a problem sending the verification code.
+verify-secondary-email-page-title =
+  .title = Secondary email
+verify-secondary-email-verification-code =
+  .label = Enter your verification code
+verify-secondary-email-cancel-button = Cancel
+verify-secondary-email-verify-button = Verify
+# Note: include the placeholder '{email}' without translation. It will be replaced with the user's email address.
+verify-secondary-email-please-enter-code = Please enter the verification code that was sent to {email} within 5 minutes.
+
 ## Two Step Authentication
 
 tfa-enter-totp = Now enter the security code from the authentication app.

--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/en-US.ftl
@@ -1,0 +1,9 @@
+# Add secondary email page
+
+add-secondary-email-error = There was a problem creating this email.
+add-secondary-email-page-title
+  .title = Secondary email
+add-secondary-email-enter-address =
+  .label = Enter email address
+add-secondary-email-cancel-button = Cancel
+add-secondary-email-save-button = Save

--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent, useCallback, useRef, useState } from 'react';
 import { gql } from '@apollo/client';
+import { Localized, useLocalization } from '@fluent/react';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import { useAlertBar, useMutation } from '../../lib/hooks';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
@@ -23,6 +24,7 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   const [errorText, setErrorText] = useState<string>();
   const [email, setEmail] = useState<string>();
   const inputRef = useRef<HTMLInputElement>(null);
+  const { l10n } = useLocalization();
   const navigate = useNavigate();
   const alertBar = useAlertBar();
   const goBack = useCallback(() => window.history.back(), []);
@@ -32,7 +34,7 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
       if (error.graphQLErrors?.length) {
         setErrorText(error.message);
       } else {
-        alertBar.error('There was a problem creating this email.');
+        alertBar.error(l10n.getString('add-secondary-email-error'));
         // TODO: old settings has no equivalent metrics event here
       }
     },
@@ -71,53 +73,64 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   );
 
   return (
-    <FlowContainer title="Secondary email">
-      {alertBar.visible && (
-        <AlertBar onDismiss={alertBar.hide} type={alertBar.type}>
-          <p data-testid="add-email-error">{alertBar.content}</p>
-        </AlertBar>
-      )}
-      <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
-      <form
-        onSubmit={(ev) => {
-          ev.preventDefault();
-          if (inputRef.current) {
-            createSecondaryEmail({
-              variables: { input: { email } },
-            });
-            logViewEvent('settings.emails', 'submit');
-          }
-        }}
-      >
-        <div className="mt-4 mb-6" data-testid="secondary-email-input">
-          <InputText
-            label="Enter email address"
-            type="email"
-            onChange={checkEmail}
-            {...{ inputRef, errorText }}
-          />
-        </div>
+    <Localized id="add-secondary-email-page-title" attrs={{ title: true }}>
+      <FlowContainer title="Secondary email">
+        {alertBar.visible && (
+          <AlertBar onDismiss={alertBar.hide} type={alertBar.type}>
+            <p data-testid="add-email-error">{alertBar.content}</p>
+          </AlertBar>
+        )}
+        <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
+        <form
+          onSubmit={(ev) => {
+            ev.preventDefault();
+            if (inputRef.current) {
+              createSecondaryEmail({
+                variables: { input: { email } },
+              });
+              logViewEvent('settings.emails', 'submit');
+            }
+          }}
+        >
+          <div className="mt-4 mb-6" data-testid="secondary-email-input">
+            <Localized
+              id="add-secondary-email-enter-address"
+              attrs={{ label: true }}
+            >
+              <InputText
+                label="Enter email address"
+                type="email"
+                onChange={checkEmail}
+                {...{ inputRef, errorText }}
+              />
+            </Localized>
+          </div>
 
-        <div className="flex justify-center mx-auto max-w-64">
-          <button
-            type="button"
-            className="cta-neutral mx-2 flex-1"
-            data-testid="cancel-button"
-            onClick={goBack}
-          >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            className="cta-primary mx-2 flex-1"
-            data-testid="save-button"
-            disabled={saveBtnDisabled}
-          >
-            Save
-          </button>
-        </div>
-      </form>
-    </FlowContainer>
+          <div className="flex justify-center mx-auto max-w-64">
+            <Localized id="add-secondary-email-cancel-button">
+              <button
+                type="button"
+                className="cta-neutral mx-2 flex-1"
+                data-testid="cancel-button"
+                onClick={goBack}
+              >
+                Cancel
+              </button>
+            </Localized>
+            <Localized id="add-secondary-email-save-button">
+              <button
+                type="submit"
+                className="cta-primary mx-2 flex-1"
+                data-testid="save-button"
+                disabled={saveBtnDisabled}
+              >
+                Save
+              </button>
+            </Localized>
+          </div>
+        </form>
+      </FlowContainer>
+    </Localized>
   );
 };
 

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/en-US.ftl
@@ -1,0 +1,11 @@
+# Verify secondary email page
+
+verify-secondary-email-error = There was a problem sending the verification code.
+verify-secondary-email-page-title =
+  .title = Secondary email
+verify-secondary-email-verification-code =
+  .label = Enter your verification code
+verify-secondary-email-cancel-button = Cancel
+verify-secondary-email-verify-button = Verify
+# Note: include the placeholder '{email}' without translation. It will be replaced with the user's email address.
+verify-secondary-email-please-enter-code = Please enter the verification code that was sent to {email} within 5 minutes.

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState, useEffect } from 'react';
 import { gql } from '@apollo/client';
+import { Localized, useLocalization } from '@fluent/react';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import { HomePath } from '../../constants';
 import { useAlertBar, useMutation } from '../../lib/hooks';
@@ -31,6 +32,7 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
     },
   });
   const goBack = useCallback(() => window.history.back(), []);
+  const { l10n } = useLocalization();
   const navigate = useNavigate();
   const alertBar = useAlertBar();
   const email = (location?.state as any)?.email as string | undefined;
@@ -42,7 +44,7 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
         if (error.graphQLErrors?.length) {
           setErrorText(error.message);
         } else {
-          alertBar.error('There was a problem sending the verification code.');
+          alertBar.error(l10n.getString('verify-secondary-email-error'));
           logViewEvent('verify-secondary-email.verification', 'fail');
         }
       },
@@ -73,65 +75,81 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
 
   const buttonDisabled = !formState.isDirty || !formState.isValid || loading;
   return (
-    <FlowContainer title="Secondary email">
-      <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
-      <form
-        data-testid="secondary-email-verify-form"
-        onSubmit={handleSubmit(({ verificationCode }) => {
-          verifySecondaryEmail({
-            variables: {
-              input: {
-                code: verificationCode,
-                email,
+    <Localized id="verify-secondary-email-page-title" attrs={{ title: true }}>
+      <FlowContainer title="Secondary email">
+        <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
+        <form
+          data-testid="secondary-email-verify-form"
+          onSubmit={handleSubmit(({ verificationCode }) => {
+            verifySecondaryEmail({
+              variables: {
+                input: {
+                  code: verificationCode,
+                  email,
+                },
               },
-            },
-          });
-          logViewEvent('verify-secondary-email.verification', 'clicked');
-        })}
-      >
-        <p>
-          Please enter the verification code that was sent to{' '}
-          <span className="font-bold">{email}</span> within 5 minutes.
-        </p>
-
-        <div className="my-6">
-          <InputText
-            name="verificationCode"
-            label="Enter your verification code"
-            onChange={() => {
-              if (errorText) {
-                setErrorText(undefined);
-              }
-            }}
-            inputRef={register({
-              required: true,
-              pattern: /^\s*[0-9]{6}\s*$/,
-            })}
-            prefixDataTestId="verification-code"
-            {...{ errorText }}
-          ></InputText>
-        </div>
-
-        <div className="flex justify-center mx-auto max-w-64">
-          <button
-            type="button"
-            className="cta-neutral mx-2 flex-1"
-            data-testid="secondary-email-verify-cancel"
-            onClick={goBack}
+            });
+            logViewEvent('verify-secondary-email.verification', 'clicked');
+          })}
+        >
+          <Localized
+            id="verify-secondary-email-please-enter"
+            elems={{ email: <span className="font-bold">{email}</span> }}
           >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            className="cta-primary mx-2 flex-1"
-            data-testid="secondary-email-verify-submit"
-            disabled={buttonDisabled}
-          >
-            Verify
-          </button>
-        </div>
-      </form>
-    </FlowContainer>
+            <p>
+              Please enter the verification code that was sent to {email} within
+              5 minutes.
+            </p>
+          </Localized>
+
+          <div className="my-6">
+            <Localized
+              id="verify-secondary-email-verification-code"
+              attrs={{ label: true }}
+            >
+              <InputText
+                name="verificationCode"
+                label="Enter your verification code"
+                onChange={() => {
+                  if (errorText) {
+                    setErrorText(undefined);
+                  }
+                }}
+                inputRef={register({
+                  required: true,
+                  pattern: /^\s*[0-9]{6}\s*$/,
+                })}
+                prefixDataTestId="verification-code"
+                {...{ errorText }}
+              ></InputText>
+            </Localized>
+          </div>
+
+          <div className="flex justify-center mx-auto max-w-64">
+            <Localized id="verify-secondary-email-cancel-button">
+              <button
+                type="button"
+                className="cta-neutral mx-2 flex-1"
+                data-testid="secondary-email-verify-cancel"
+                onClick={goBack}
+              >
+                Cancel
+              </button>
+            </Localized>
+            <Localized id="verify-secondary-email-verify-button">
+              <button
+                type="submit"
+                className="cta-primary mx-2 flex-1"
+                data-testid="secondary-email-verify-submit"
+                disabled={buttonDisabled}
+              >
+                Verify
+              </button>
+            </Localized>
+          </div>
+        </form>
+      </FlowContainer>
+    </Localized>
   );
 };
 


### PR DESCRIPTION
## Because

- we want to localize the Add Secondary Email page and Verify Secondary Email page

## This pull request

- localizes both pages
- adds en-US strings

## Issue that this pull request solves

Closes: #5063
## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
