### PR TITLE
feat(payments): Add PayPal button to Subscribe page

### DIFF
--- a/packages/fxa-payments-server/.storybook/preview-head.html
+++ b/packages/fxa-payments-server/.storybook/preview-head.html
@@ -1,1 +1,2 @@
 <script src="https://js.stripe.com/v3/"></script>
+<script src = "https://www.paypal.com/sdk/js?client-id=sb&vault=true&commit=false&intent=authorize&disable-funding=credit,card"></script>

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -325,6 +325,26 @@ const conf = convict({
       env: 'STATSD_PREFIX',
     },
   },
+  paypal: {
+    clientId: {
+      default: 'sb',
+      doc: 'The PayPal client ID',
+      env: 'PAYPAL_CLIENT_ID',
+      format: String,
+    },
+    apiUrl: {
+      default: 'https://www.sandbox.paypal.com',
+      doc: 'The PAYPAL API url',
+      env: 'PAYPAL_API_URL',
+      format: 'url',
+    },
+    scriptUrl: {
+      default: 'https://www.paypal.com',
+      doc: 'The PayPal script url',
+      env: 'PAYPAL_SCRIPT_URL',
+      format: 'url',
+    },
+  },
   stripe: {
     apiKey: {
       default: 'pk_test_VNpCidC0a2TJJB3wqXq7drhN00sF8r9mhs',

--- a/packages/fxa-payments-server/server/lib/csp.test.js
+++ b/packages/fxa-payments-server/server/lib/csp.test.js
@@ -15,10 +15,11 @@ describe('CSP blocking rules', () => {
   it('has correct connectSrc directives', () => {
     const { connectSrc } = directives;
 
-    expect(connectSrc).toHaveLength(6);
+    expect(connectSrc).toHaveLength(7);
     expect(connectSrc).toContain(Sources.SELF);
     expect(connectSrc).toContain(Sources.AUTH_SERVER);
     expect(connectSrc).toContain(Sources.OAUTH_SERVER);
+    expect(connectSrc).toContain(Sources.PAYPAL_API_URL);
     expect(connectSrc).toContain(Sources.PROFILE_SERVER);
     expect(connectSrc).toContain(Sources.STRIPE_API_URL);
   });
@@ -41,7 +42,9 @@ describe('CSP blocking rules', () => {
   it('has correct frameSrc directives', () => {
     const { frameSrc } = directives;
 
-    expect(frameSrc).toHaveLength(3);
+    expect(frameSrc).toHaveLength(5);
+    expect(frameSrc).toContain(Sources.PAYPAL_API_URL);
+    expect(frameSrc).toContain(Sources.PAYPAL_SCRIPT_URL);
     expect(frameSrc).toContain(Sources.STRIPE_SCRIPT_URL);
     expect(frameSrc).toContain(Sources.STRIPE_HOOKS_URL);
     expect(frameSrc).toContain(Sources.SURVEY_GIZMO_IFRAME_EMBED_URL);
@@ -76,7 +79,8 @@ describe('CSP blocking rules', () => {
   it('has correct scriptSrc directives', () => {
     const { scriptSrc } = directives;
 
-    expect(scriptSrc).toHaveLength(3);
+    expect(scriptSrc).toHaveLength(4);
+    expect(scriptSrc).toContain(Sources.PAYPAL_SCRIPT_URL);
     expect(scriptSrc).toContain(Sources.SELF);
     expect(scriptSrc).toContain(Sources.STRIPE_SCRIPT_URL);
     expect(scriptSrc).toContain(CDN_SERVER);

--- a/packages/fxa-payments-server/server/lib/csp/blocking.js
+++ b/packages/fxa-payments-server/server/lib/csp/blocking.js
@@ -31,6 +31,9 @@ module.exports = function (config) {
   const PUBLIC_URL = config.get('listen.publicUrl');
   const HOT_RELOAD_WEBSOCKET = PUBLIC_URL.replace(/^http/, 'ws');
 
+  const PAYPAL_API_URL = getOrigin(config.get('paypal.apiUrl'));
+  const PAYPAL_SCRIPT_URL = getOrigin(config.get('paypal.scriptUrl'));
+
   const STRIPE_API_URL = getOrigin(config.get('stripe.apiUrl'));
   const STRIPE_HOOKS_URL = getOrigin(config.get('stripe.hooksUrl'));
   const STRIPE_SCRIPT_URL = getOrigin(config.get('stripe.scriptUrl'));
@@ -63,6 +66,7 @@ module.exports = function (config) {
         SELF,
         AUTH_SERVER,
         OAUTH_SERVER,
+        PAYPAL_API_URL,
         PROFILE_SERVER,
         SENTRY_SERVER,
         STRIPE_API_URL,
@@ -70,6 +74,8 @@ module.exports = function (config) {
       defaultSrc: [SELF],
       fontSrc: addCdnRuleIfRequired([SELF]),
       frameSrc: [
+        PAYPAL_API_URL,
+        PAYPAL_SCRIPT_URL,
         STRIPE_SCRIPT_URL,
         STRIPE_HOOKS_URL,
         SURVEY_GIZMO_IFRAME_EMBED_URL,
@@ -88,7 +94,11 @@ module.exports = function (config) {
       mediaSrc: [NONE],
       objectSrc: [NONE],
       reportUri: config.get('csp.reportUri'),
-      scriptSrc: addCdnRuleIfRequired([SELF, STRIPE_SCRIPT_URL]),
+      scriptSrc: addCdnRuleIfRequired([
+        SELF,
+        STRIPE_SCRIPT_URL,
+        PAYPAL_SCRIPT_URL,
+      ]),
       styleSrc: addCdnRuleIfRequired([SELF, UNSAFE_INLINE]),
     },
     reportOnly: false,
@@ -104,6 +114,8 @@ module.exports = function (config) {
       PROFILE_IMAGES_SERVER,
       ACCOUNTS_STATIC_CDN,
       SURVEY_GIZMO_IFRAME_EMBED_URL,
+      PAYPAL_API_URL,
+      PAYPAL_SCRIPT_URL,
       PROFILE_SERVER,
       PUBLIC_URL,
       SENTRY_SERVER,

--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -85,6 +85,10 @@ module.exports = () => {
         url: config.get('servers.surveyGizmo.url'),
       },
     },
+    paypal: {
+      clientId: config.get('paypal.clientId'),
+      scriptUrl: config.get('paypal.scriptUrl'),
+    },
     stripe: {
       apiKey: config.get('stripe.apiKey'),
     },

--- a/packages/fxa-payments-server/src/lib/config.test.ts
+++ b/packages/fxa-payments-server/src/lib/config.test.ts
@@ -143,6 +143,10 @@ const expectedMergedConfig = {
       url: '',
     },
   },
+  paypal: {
+    clientId: '',
+    scriptUrl: '',
+  },
   stripe: {
     apiKey: '',
   },

--- a/packages/fxa-payments-server/src/lib/config.ts
+++ b/packages/fxa-payments-server/src/lib/config.ts
@@ -32,6 +32,10 @@ export interface Config {
       url: string;
     };
   };
+  paypal: {
+    clientId: string;
+    scriptUrl: string;
+  };
   stripe: {
     apiKey: string;
   };
@@ -70,6 +74,10 @@ export function defaultConfig(): Config {
       surveyGizmo: {
         url: '',
       },
+    },
+    paypal: {
+      clientId: '',
+      scriptUrl: '',
     },
     stripe: {
       apiKey: '',

--- a/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.stories.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { PaypalButton } from './index';
+
+storiesOf('routes/Product/PaypalButton', module).add('default', () => (
+  <PaypalButton />
+));

--- a/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+declare var paypal: {
+  Buttons: {
+    driver: Function;
+  };
+};
+
+const PaypalButtonBase = paypal.Buttons.driver('react', {
+  React,
+  ReactDOM,
+});
+
+export const PaypalButton = () => {
+  return <PaypalButtonBase data-testid="paypal-button" />;
+};
+
+export default PaypalButton;

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -148,21 +148,33 @@ describe('routes/ProductV2/SubscriptionCreate', () => {
       queryAllByText('30-day money-back guarantee')[0]
     ).toBeInTheDocument();
     expect(queryByText('Billing Information')).toBeInTheDocument();
-    expect(
-      document.getElementById('paypal-button-container')
-    ).not.toBeInTheDocument();
+    expect(queryByTestId('paypal-button')).not.toBeInTheDocument();
   });
 
-  it('renders as expected with PayPal UI enabled', async () => {
+  it('renders as expected with PayPal UI enabled', () => {
+    const { queryByTestId } = screen;
     updateConfig({
       featureFlags: {
         usePaypalUIByDefault: true,
       },
     });
     render(<Subject />);
-    expect(
-      document.getElementById('paypal-button-container')
-    ).toBeInTheDocument();
+    waitForExpect(() =>
+      expect(queryByTestId('paypal-button')).toBeInTheDocument()
+    );
+  });
+
+  it('renders as expected with PayPal UI enabled and an existing customer', () => {
+    const { queryByTestId } = screen;
+    updateConfig({
+      featureFlags: {
+        usePaypalUIByDefault: true,
+      },
+    });
+    render(<Subject customer={CUSTOMER} />);
+    waitForExpect(() =>
+      expect(queryByTestId('paypal-button')).not.toBeInTheDocument()
+    );
   });
 
   it('renders as expected for mobile', async () => {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useCallback } from 'react';
+import React, {
+  useState,
+  useCallback,
+  useContext,
+  useEffect,
+  Suspense,
+} from 'react';
 import { Stripe, StripeCardElement, StripeError } from '@stripe/stripe-js';
 import { Plan, Profile, Customer } from '../../../store/types';
 import { State as ValidatorState } from '../../../lib/validator';
@@ -16,7 +22,7 @@ import * as Amplitude from '../../../lib/amplitude';
 import { Localized } from '@fluent/react';
 import * as apiClient from '../../../lib/apiClient';
 
-import { config } from '../../../lib/config';
+import { AppContext } from '../../../lib/AppContext';
 
 import '../../Product/SubscriptionCreate/index.scss';
 
@@ -48,6 +54,8 @@ export type SubscriptionCreateProps = {
   apiClientOverrides?: Partial<SubscriptionCreateAuthServerAPIs>;
 };
 
+const PaypalButton = React.lazy(() => import('../../Product/PayPalButton'));
+
 export const SubscriptionCreate = ({
   isMobile,
   profile,
@@ -70,6 +78,25 @@ export const SubscriptionCreate = ({
     () => Amplitude.createSubscriptionEngaged(selectedPlan),
     [selectedPlan]
   );
+
+  const { config } = useContext(AppContext);
+
+  const [paypalScriptLoaded, setPaypalScriptLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!config.featureFlags.usePaypalUIByDefault) {
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = `${config.paypal.scriptUrl}/sdk/js?client-id=${config.paypal.clientId}&vault=true&commit=false&intent=authorize&disable-funding=credit,card`;
+    script.onload = () => {
+      setPaypalScriptLoaded(true);
+    };
+    script.onerror = () => {
+      throw new Error('Paypal SDK could not be loaded.');
+    };
+    document.body.appendChild(script);
+  }, []);
 
   const [inProgress, setInProgress] = useState(false);
 
@@ -144,6 +171,12 @@ export const SubscriptionCreate = ({
             </Localized>
           </div>
 
+          {!hasExistingCard(customer) && paypalScriptLoaded && (
+            <Suspense fallback={<div>Loading...</div>}>
+              <PaypalButton />
+            </Suspense>
+          )}
+
           <h3 className="billing-title">
             <Localized id="sub-update-title">
               <span className="title">Billing Information</span>
@@ -161,11 +194,6 @@ export const SubscriptionCreate = ({
               </Localized>
             )}
           </ErrorMessage>
-
-          {config.featureFlags.usePaypalUIByDefault ? (
-            // To be updated in issue #7097
-            <div id="paypal-button-container"></div>
-          ) : null}
 
           <PaymentForm
             {...{


### PR DESCRIPTION
## Because

- We want to provide the option to pay with PayPal on the Subscribe page.

## This pull request

- Adds a `PaypalButton` React component that renders if the PayPal feature is enabled (Issue #7271 ), and the customer is a new customer.

## Issue that this pull request solves

Closes: #7097 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
![Screen Shot 2021-01-25 at 3 08 16 PM](https://user-images.githubusercontent.com/17437436/105760029-2f78c180-5f1f-11eb-96ed-867392d740a4.png)


## Other information (Optional)

- To see the button, the PayPal feature must be enabled, see #7271 .
  - i.e. `FEATURE_USE_PAYPAL_UI_BY_DEFAULT=true pm2 restart payments --update-env`
- There is one CSP error that still needs to be handled by #7350 .
- The button needs to be shown conditionally based on whether there is any saved payment information. Currently, it is shown only if there is no saved Stripe payment information. After #7115 , #7098 will handle checking for saved PayPal payment information. 
- UI for this needs to be finalized with the TBD UX spec, see [FXA-2799](https://jira.mozilla.com/browse/FXA-2799), for example by adding the PayPal privacy policy.
- Button functionality will be handled by #7269 .
