### PR TITLE
feat(settings): Localize the Avatar page

### DIFF
--- a/packages/fxa-settings/public/locales/en-US/settings.ftl
+++ b/packages/fxa-settings/public/locales/en-US/settings.ftl
@@ -37,6 +37,13 @@ get-data-trio-copy =
 get-data-trio-print =
   .title = Print
 
+# Avatar component
+
+avatar-your-avatar =
+  .alt = Your avatar
+avatar-default-avatar =
+  .alt = Default avatar
+
 # HeaderLockup component
 
 header-menu-open = Close menu
@@ -56,6 +63,25 @@ nav-security = Security
 nav-connected-services = Connected Services
 nav-paid-subs = Paid Subscriptions
 nav-email-comm = Email Communications
+
+# Avatar change page
+
+avatar-page-title =
+  .title = Avatar
+avatar-page-add-photo = Add Photo
+avatar-page-add-photo-button =
+  .title = { avatar-page-add-photo }
+avatar-page-take-photo = Take Photo
+avatar-page-take-photo-button =
+  .title = { avatar-page-take-photo }
+avatar-page-remove-photo-button =
+  .title = Remove photo
+avatar-page-retake-photo = Retake Photo
+avatar-page-close-button = Close
+avatar-page-save-button = Save
+avatar-page-camera-error = Could not initialize camera
+avatar-page-new-avatar =
+  .alt = new avatar
 
 ## Password change page
 pw-change-header =

--- a/packages/fxa-settings/src/components/Avatar/en-US.ftl
+++ b/packages/fxa-settings/src/components/Avatar/en-US.ftl
@@ -1,0 +1,6 @@
+# Avatar component
+
+avatar-your-avatar =
+  .alt = Your avatar
+avatar-default-avatar =
+  .alt = Default avatar

--- a/packages/fxa-settings/src/components/Avatar/index.tsx
+++ b/packages/fxa-settings/src/components/Avatar/index.tsx
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
+import { Localized } from '@fluent/react';
 import classNames from 'classnames';
 import { useAccount } from '../../models';
 import defaultAvatar from './avatar-default.svg';
@@ -16,15 +17,17 @@ export const Avatar = ({ className }: AvatarProps) => {
 
   if (avatarUrl) {
     return (
-      <img
-        data-testid="avatar-nondefault"
-        src={avatarUrl}
-        alt="Your avatar"
-        className={classNames(
-          'rounded-full bg-grey-200 text-grey-200',
-          className
-        )}
-      />
+      <Localized id="avatar-your-avatar" attrs={{ alt: true }}>
+        <img
+          data-testid="avatar-nondefault"
+          src={avatarUrl}
+          alt="Your avatar"
+          className={classNames(
+            'rounded-full bg-grey-200 text-grey-200',
+            className
+          )}
+        />
+      </Localized>
     );
   }
 
@@ -33,12 +36,14 @@ export const Avatar = ({ className }: AvatarProps) => {
     // has a bug that makes the image disappear in some case
     // with inline svgs. img elements don't have this problem.
     // see: https://github.com/mozilla/fxa/issues/6359
-    <img
-      data-testid="avatar-default"
-      src={defaultAvatar}
-      alt="Default avatar"
-      className={classNames('rounded-full', className)}
-    />
+    <Localized id="avatar-default-avatar" attrs={{ alt: true }}>
+      <img
+        data-testid="avatar-default"
+        src={defaultAvatar}
+        alt="Default avatar"
+        className={classNames('rounded-full', className)}
+      />
+    </Localized>
   );
 };
 

--- a/packages/fxa-settings/src/components/PageAvatar/Add.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/Add.tsx
@@ -4,6 +4,7 @@
 
 import { useAlertBar } from '../../lib/hooks';
 import React from 'react';
+import { Localized } from '@fluent/react';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 
 import AlertBar from '../AlertBar';
@@ -30,53 +31,77 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
   };
 
   return (
-    <FlowContainer title="Avatar">
-      {alertBar.visible && (
-        <AlertBar onDismiss={alertBar.hide} type={alertBar.type}>
-          <p data-testid="update-avatar-error">{alertBar.content}</p>
-        </AlertBar>
-      )}
+    <Localized id="avatar-page-title" attrs={{ title: true }}>
+      <FlowContainer title="Avatar">
+        {/* TODO - localize the error message once errors are implemented */}
+        {alertBar.visible && (
+          <AlertBar onDismiss={alertBar.hide} type={alertBar.type}>
+            <p data-testid="update-avatar-error">{alertBar.content}</p>
+          </AlertBar>
+        )}
 
-      <form onSubmit={handleSubmit}>
-        <Avatar className="mx-auto w-32" />
+        <form onSubmit={handleSubmit}>
+          <Avatar className="mx-auto w-32" />
 
-        <div className="flex text-center justify-around max-w-xs my-4 mx-24">
-          <div className="cursor-pointer">
-            <ButtonIcon
-              title="Add photo"
-              icon={[AddIcon, 22, 22]}
-              classNames="mx-2 text-grey-500 hover:text-grey-600 hover:text-grey-600 focus:text-grey-400"
-            />
-            <p>Add Photo</p>
+          <div className="flex text-center justify-around max-w-xs my-4 mx-24">
+            <div className="cursor-pointer">
+              <Localized
+                id="avatar-page-add-photo-button"
+                attrs={{ title: true }}
+              >
+                <ButtonIcon
+                  title="Add photo"
+                  icon={[AddIcon, 22, 22]}
+                  classNames="mx-2 text-grey-500 hover:text-grey-600 hover:text-grey-600 focus:text-grey-400"
+                />
+              </Localized>
+              <Localized id="avatar-page-add-photo">
+                <p>Add Photo</p>
+              </Localized>
+            </div>
+            <div
+              onClick={() => navigate(CapturePath)}
+              className="cursor-pointer"
+            >
+              <Localized
+                id="avatar-page-take-photo-button"
+                attrs={{ title: true }}
+              >
+                <ButtonIcon
+                  title="Take photo"
+                  icon={[CameraIcon, 24, 22]}
+                  classNames="mx-2 text-grey-500 hover:text-grey-600 hover:text-grey-600 focus:text-grey-400"
+                />
+              </Localized>
+              <Localized id="avatar-page-take-photo">
+                <p>Take Photo</p>
+              </Localized>
+            </div>
           </div>
-          <div onClick={() => navigate(CapturePath)} className="cursor-pointer">
-            <ButtonIcon
-              title="Take photo"
-              icon={[CameraIcon, 24, 22]}
-              classNames="mx-2 text-grey-500 hover:text-grey-600 hover:text-grey-600 focus:text-grey-400"
-            />
-            <p>Take Photo</p>
+          <div className="mt-4 flex items-center justify-center">
+            <Localized id="avatar-page-close-button">
+              <button
+                className="cta-neutral mx-2 px-10"
+                onClick={() => navigate(HomePath, { replace: true })}
+                data-testid="close-button"
+              >
+                Close
+              </button>
+            </Localized>
+            <Localized id="avatar-page-save-button">
+              <button
+                className="cta-primary mx-2 px-10"
+                onClick={() => save()}
+                disabled={true}
+                data-testid="save-button"
+              >
+                Save
+              </button>
+            </Localized>
           </div>
-        </div>
-        <div className="mt-4 flex items-center justify-center">
-          <button
-            className="cta-neutral mx-2 px-10"
-            onClick={() => navigate(HomePath, { replace: true })}
-            data-testid="close-button"
-          >
-            Close
-          </button>
-          <button
-            className="cta-primary mx-2 px-10"
-            onClick={() => save()}
-            disabled={true}
-            data-testid="save-button"
-          >
-            Save
-          </button>
-        </div>
-      </form>
-    </FlowContainer>
+        </form>
+      </FlowContainer>
+    </Localized>
   );
 };
 

--- a/packages/fxa-settings/src/components/PageAvatar/Capture.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/Capture.tsx
@@ -4,6 +4,7 @@
 
 import { useAlertBar } from '../../lib/hooks';
 import React, { useRef, useState, useCallback } from 'react';
+import { Localized } from '@fluent/react';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import Webcam from 'react-webcam';
 
@@ -61,11 +62,13 @@ export const PageCaptureAvatar = (_: RouteComponentProps) => {
         <div className="p-2">
           {showMediaError && <Avatar className="mx-auto w-32" />}
           {imgSrc ? (
-            <img
-              src={imgSrc}
-              className={`${frameClass} h-32`}
-              alt="new avatar"
-            />
+            <Localized id="avatar-page-new-avatar" attrs={{ alt: true }}>
+              <img
+                src={imgSrc}
+                className={`${frameClass} h-32`}
+                alt="new avatar"
+              />
+            </Localized>
           ) : (
             <>
               <LoadingSpinner
@@ -90,43 +93,64 @@ export const PageCaptureAvatar = (_: RouteComponentProps) => {
           )}
         </div>
         {showMediaError && (
-          <div className="text-white bg-red-500 rounded font-bold text-sm text-center px-8 py-2 mt-8">
-            Could not initialize camera
-          </div>
+          <Localized id="avatar-page-camera-error">
+            <div className="text-white bg-red-500 rounded font-bold text-sm text-center px-8 py-2 mt-8">
+              Could not initialize camera
+            </div>
+          </Localized>
         )}
         <div className="flex text-center justify-center max-w-xs my-4 mx-24">
-          {!showMediaError && <div className="cursor-pointer">
-            <ButtonIcon
-              testId="shutter"
-              title="Take photo"
-              onClick={() => {
-                if (imgSrc) {
-                  setImgSrc(null);
-                  setCamLoaded(false);
-                } else capture();
-              }}
-              icon={[CameraIcon, 24, 22]}
-              classNames={imgSrc ? retakeClass : captureClass}
-            />
-            {imgSrc ? <p>Retake Photo</p> : <p>Take Photo</p>}
-          </div>}
+          {!showMediaError && (
+            <div className="cursor-pointer">
+              <Localized
+                id="avatar-page-take-photo-button"
+                attrs={{ title: true }}
+              >
+                <ButtonIcon
+                  testId="shutter"
+                  title="Take photo"
+                  onClick={() => {
+                    if (imgSrc) {
+                      setImgSrc(null);
+                      setCamLoaded(false);
+                    } else capture();
+                  }}
+                  icon={[CameraIcon, 24, 22]}
+                  classNames={imgSrc ? retakeClass : captureClass}
+                />
+              </Localized>
+              {imgSrc ? (
+                <Localized id="avatar-page-retake-photo">
+                  <p>Retake Photo</p>
+                </Localized>
+              ) : (
+                <Localized id="avatar-page-take-photo">
+                  <p>Take Photo</p>
+                </Localized>
+              )}
+            </div>
+          )}
         </div>
         <div className="mt-4 flex items-center justify-center">
-          <button
-            className="cta-neutral mx-2 px-10"
-            onClick={() => navigate(HomePath, { replace: true })}
-            data-testid="close-button"
-          >
-            Close
-          </button>
-          <button
-            className="cta-primary mx-2 px-10"
-            disabled={!imgSrc}
-            onClick={() => save()}
-            data-testid="save-button"
-          >
-            Save
-          </button>
+          <Localized id="avatar-page-close-button">
+            <button
+              className="cta-neutral mx-2 px-10"
+              onClick={() => navigate(HomePath, { replace: true })}
+              data-testid="close-button"
+            >
+              Close
+            </button>
+          </Localized>
+          <Localized id="avatar-page-save-button">
+            <button
+              className="cta-primary mx-2 px-10"
+              disabled={!imgSrc}
+              onClick={() => save()}
+              data-testid="save-button"
+            >
+              Save
+            </button>
+          </Localized>
         </div>
       </form>
     </FlowContainer>

--- a/packages/fxa-settings/src/components/PageAvatar/Change.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/Change.tsx
@@ -5,6 +5,7 @@
 //import { useAccount } from '../../models';
 import { useAlertBar } from '../../lib/hooks';
 import React /*, { useState } */ from 'react';
+import { Localized } from '@fluent/react';
 import { RouteComponentProps } from '@reach/router';
 
 import AlertBar from '../AlertBar';
@@ -38,26 +39,37 @@ export const PageChangeAvatar = (_: RouteComponentProps) => {
         <AvatarCropper />
 
         <div className="flex justify-center max-w-xs mx-auto my-4">
-          <ButtonIcon
-            title="Add photo"
-            icon={[AddIcon, 22, 22]}
-            classNames="mx-2 text-grey-500 hover:text-grey-600 hover:text-grey-600 focus:text-grey-400"
-          />
-          <ButtonIcon
-            title="Take photo"
-            icon={[CameraIcon, 24, 22]}
-            classNames="mx-2 text-grey-500 hover:text-grey-600 hover:text-grey-600 focus:text-grey-400"
-          />
-          <ButtonIcon
-            title="Remove photo"
-            icon={[RemoveIcon, 22, 22]}
-            classNames="mx-2 text-grey-500 hover:text-grey-600 hover:text-grey-600 focus:text-grey-400"
-          />
-          <ButtonIcon
-            title="Take photo"
-            icon={[CameraIcon, 22, 22]}
-            classNames="mx-2 bg-red-500 text-white rounded-full border border-red-600 hover:bg-red-600 hover:border-red-600 active:border-red-700 focus:border-red-800"
-          />
+          <Localized id="avatar-page-add-photo-button" attrs={{ title: true }}>
+            <ButtonIcon
+              title="Add photo"
+              icon={[AddIcon, 22, 22]}
+              classNames="mx-2 text-grey-500 hover:text-grey-600 hover:text-grey-600 focus:text-grey-400"
+            />
+          </Localized>
+          <Localized id="avatar-page-take-photo-button" attrs={{ title: true }}>
+            <ButtonIcon
+              title="Take photo"
+              icon={[CameraIcon, 24, 22]}
+              classNames="mx-2 text-grey-500 hover:text-grey-600 hover:text-grey-600 focus:text-grey-400"
+            />
+          </Localized>
+          <Localized
+            id="avatar-page-remove-photo-button"
+            attrs={{ title: true }}
+          >
+            <ButtonIcon
+              title="Remove photo"
+              icon={[RemoveIcon, 22, 22]}
+              classNames="mx-2 text-grey-500 hover:text-grey-600 hover:text-grey-600 focus:text-grey-400"
+            />
+          </Localized>
+          <Localized id="avatar-page-take-photo-button" attrs={{ title: true }}>
+            <ButtonIcon
+              title="Take photo"
+              icon={[CameraIcon, 22, 22]}
+              classNames="mx-2 bg-red-500 text-white rounded-full border border-red-600 hover:bg-red-600 hover:border-red-600 active:border-red-700 focus:border-red-800"
+            />
+          </Localized>
         </div>
       </form>
     </FlowContainer>

--- a/packages/fxa-settings/src/components/PageAvatar/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageAvatar/en-US.ftl
@@ -1,0 +1,18 @@
+# Avatar change page
+
+avatar-page-title =
+  .title = Avatar
+avatar-page-add-photo = Add Photo
+avatar-page-add-photo-button =
+  .title = { avatar-page-add-photo }
+avatar-page-take-photo = Take Photo
+avatar-page-take-photo-button =
+  .title = { avatar-page-take-photo }
+avatar-page-remove-photo-button =
+  .title = Remove photo
+avatar-page-retake-photo = Retake Photo
+avatar-page-close-button = Close
+avatar-page-save-button = Save
+avatar-page-camera-error = Could not initialize camera
+avatar-page-new-avatar =
+  .alt = new avatar


### PR DESCRIPTION
I added localization for everything except the error handling on the Add page, which isn't wired up yet.

The strings are namespaced so that there won't be any l10n refactoring needed when merging stuff back into a single parent page for #7334.

## Because

 - we want to localize the Avatar page

## This pull request

 - localizes the Avatar page and Avatar component
 - adds en-US strings

## Issue that this pull request solves

Closes: #5065

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
