### PR TITLE
Up the dependabot limit to 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 4
+    open-pull-requests-limit: 6
+    default_labels:
+      - "code_quality"
+      - "dependencies"
     reviewers:
       - "@mozilla/fxa-devs"


### PR DESCRIPTION
## Because

- We're not keeping up with dependency updates

## This pull request

- Increases the open PR count
