### PR TITLE
feat(auth-server): adds createBillingAgreement method to PayPalHelper

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal-client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-client.ts
@@ -64,6 +64,10 @@ type SetExpressCheckoutData = {
   TOKEN: string;
 };
 
+type CreateBillingAgreementData = {
+  BILLINGAGREEMENTID: string;
+};
+
 type DoReferenceTransactionData = {
   BILLINGAGREEMENTID: string;
   TRANSACTIONID: string;
@@ -85,8 +89,15 @@ type DoReferenceTransactionData = {
 export type NVPSetExpressCheckoutResponse = NVPResponse &
   SetExpressCheckoutData;
 
+export type NVPCreateBillingAgreementResponse = NVPResponse &
+  CreateBillingAgreementData;
+
 export type NVPDoReferenceTransactionResponse = NVPResponse &
   DoReferenceTransactionData;
+
+export type CreateBillingAgreementOptions = {
+  token: string;
+};
 
 export type DoReferenceTransactionOptions = {
   amount: string;
@@ -241,6 +252,21 @@ export class PayPalClient {
     return await this.doRequest<NVPSetExpressCheckoutResponse>(
       'SetExpressCheckout',
       data
+    );
+  }
+
+  /**
+   * Call the Paypal CreateBillingAgreement NVP API
+   *
+   * Using the Paypal CreateBillingAgreement API (https://developer.paypal.com/docs/nvp-soap-api/create-billing-agreement-nvp/)
+   * creates a billing agreement using the time-stamped token returned in the SetExpressCheckout response.
+   */
+  public async createBillingAgreement(
+    options: CreateBillingAgreementOptions
+  ): Promise<NVPCreateBillingAgreementResponse> {
+    return await this.doRequest<NVPCreateBillingAgreementResponse>(
+      'CreateBillingAgreement',
+      options
     );
   }
 

--- a/packages/fxa-auth-server/lib/payments/paypal.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal.ts
@@ -6,6 +6,7 @@ import { Logger } from 'mozlog';
 import { Container } from 'typedi';
 
 import {
+  CreateBillingAgreementOptions,
   DoReferenceTransactionOptions,
   IpnMessage,
   NVPDoReferenceTransactionResponse,
@@ -36,6 +37,19 @@ export class PayPalHelper {
   public async getCheckoutToken(): Promise<string> {
     const response = await this.client.setExpressCheckout();
     return response.TOKEN;
+  }
+
+  /**
+   * Create billing agreement using the ExpressCheckout token.
+   *
+   * If the call to PayPal fails, a PayPalClientError will be thrown.
+   *
+   */
+  public async createBillingAgreement(
+    options: CreateBillingAgreementOptions
+  ): Promise<string> {
+    const response = await this.client.createBillingAgreement(options);
+    return response.BILLINGAGREEMENTID;
   }
 
   /**

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -29,6 +29,8 @@ const unSuccessfulDoReferenceTransactionResponse = require('./fixtures/paypal/do
 const sampleIpnMessage = require('./fixtures/paypal/sample_ipn_message.json')
   .message;
 
+const sandbox = sinon.createSandbox();
+
 describe('PayPalClient', () => {
   /** @type {PayPalClient} */
   let client;
@@ -40,6 +42,10 @@ describe('PayPalClient', () => {
       pwd: 'pwd',
       signature: 'sig',
     });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
   });
 
   describe('constructor', () => {
@@ -181,21 +187,12 @@ describe('PayPalClient', () => {
   });
 
   describe('setExpressCheckout', () => {
-    let sandbox;
     const defaultData = {
       PAYMENTREQUEST_0_AMT: '0',
       RETURNURL: PLACEHOLDER_URL,
       CANCELURL: PLACEHOLDER_URL,
       L_BILLINGTYPE0: 'MerchantInitiatedBilling',
     };
-
-    beforeEach(() => {
-      sandbox = sinon.createSandbox();
-    });
-
-    afterEach(function () {
-      sandbox.restore();
-    });
 
     it('calls api with correct method and data', () => {
       client.doRequest = sandbox.fake.resolves(
@@ -234,22 +231,33 @@ describe('PayPalClient', () => {
     });
   });
 
-  describe('doReferenceTransaction', () => {
-    let sandbox;
+  describe('createBillingAgreement', () => {
+    const defaultData = {
+      token: 'insert_token_value_here',
+    };
 
+    const expectedResponse = {
+      BILLINGAGREEMENTID: 'B-7FB31251F28061234',
+      ACK: 'Success',
+    };
+
+    it('calls API with valid token', async () => {
+      client.doRequest = sandbox.fake.resolves(expectedResponse);
+      await client.createBillingAgreement(defaultData);
+      sinon.assert.calledOnceWithExactly(
+        client.doRequest,
+        'CreateBillingAgreement',
+        defaultData
+      );
+    });
+  });
+
+  describe('doReferenceTransaction', () => {
     const defaultData = {
       AMT: '5.99',
       REFERENCEID: 'B-BILLINGAGREEMENTID',
       PAYMENTACTION: 'Sale',
     };
-
-    beforeEach(() => {
-      sandbox = sinon.createSandbox();
-    });
-
-    afterEach(function () {
-      sandbox.restore();
-    });
 
     it('calls api with correct method and data', async () => {
       client.doRequest = sandbox.fake.resolves(

--- a/packages/fxa-auth-server/test/local/payments/paypal.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal.js
@@ -83,6 +83,29 @@ describe('PayPalHelper', () => {
     });
   });
 
+  describe('createBillingAgreement', () => {
+    const validOptions = {
+      token: 'insert_token_value_here',
+    };
+
+    const expectedResponse = {
+      BILLINGAGREEMENTID: 'B-7FB31251F28061234',
+      ACK: 'Success',
+    };
+
+    it('calls createBillingAgreement with passed options', async () => {
+      paypalHelper.client.createBillingAgreement = sinon.fake.resolves(
+        expectedResponse
+      );
+      const response = await paypalHelper.createBillingAgreement(validOptions);
+      sinon.assert.calledOnceWithExactly(
+        paypalHelper.client.createBillingAgreement,
+        validOptions
+      );
+      assert.equal(response, 'B-7FB31251F28061234');
+    });
+  });
+
   describe('chargeCustomer', () => {
     const validOptions = {
       amount: '10.99',


### PR DESCRIPTION
## Because

- We need Billing Agreement from PayPal before charging customer

## This pull request

- Adds billing agreement method to PayPalHelper

## Issue that this pull request solves

Closes: #7235

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).