### PR TITLE
fix(auth-server): Correct checks in createRoutes

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
@@ -21,8 +21,7 @@ const createRoutes = (
   push: any,
   mailer: any,
   profile: any,
-  stripeHelper: StripeHelper,
-  payPalHelper: PayPalHelper
+  stripeHelper: StripeHelper
 ) => {
   const routes: ServerRoute[] = [];
 
@@ -57,7 +56,7 @@ const createRoutes = (
       )
     );
   }
-  if (stripeHelper && payPalHelper) {
+  if (stripeHelper && config.subscriptions.paypalNvpSigCredentials.enabled) {
     routes.push(
       ...paypalRoutes(
         log,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -20,10 +20,13 @@ const MOCK_SCOPES = ['profile:email', SUBSCRIPTIONS_MANAGEMENT_SCOPE];
 
 let log, customs, request, payPalHelper;
 
-function runTest(routePath, requestOptions, ppHelper = null) {
+function runTest(routePath, requestOptions) {
   const config = {
     subscriptions: {
       enabled: true,
+      paypalNvpSigCredentials: {
+        enabled: true,
+      },
     },
   };
   const db = mocks.mockDB({
@@ -38,8 +41,7 @@ function runTest(routePath, requestOptions, ppHelper = null) {
     {}, // push
     {}, // mailer
     {}, // profile
-    {}, // stripeHelper
-    ppHelper
+    {} // stripeHelper
   );
   const route = getRoute(routes, routePath, requestOptions.method || 'GET');
   request = mocks.mockRequest(requestOptions);

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -199,6 +199,9 @@ describe('subscriptions stripeRoutes', () => {
         managementClientId: MOCK_CLIENT_ID,
         managementTokenTTL: MOCK_TTL,
         stripeApiKey: 'sk_test_1234',
+        paypalNvpSigCredentials: {
+          enabled: true,
+        },
       },
     };
 

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -1851,7 +1851,7 @@ describe('email translations', () => {
       );
       assert.include(
         emailConfig.subject,
-        'Добавлена альтернативная электронная почта'
+        'Добавлена дополнительная электронная почта'
       );
       // assert.include(emailConfig.html, 'Подсоединить другое устройство');
     });


### PR DESCRIPTION
## Because

- Moving to new paradigm of Container means that paypalHelper is not passed into createRoutes.

## This pull request

- Fixes the createRoutes method to check the config, not expect a passed in PayPalHelper

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
