### PR TITLE
chore(settings): localize the common password hint

### DIFF
--- a/packages/fxa-settings/public/locales/en-US/settings.ftl
+++ b/packages/fxa-settings/public/locales/en-US/settings.ftl
@@ -142,6 +142,9 @@ pw-change-stay-safe = Stay safe — don’t reuse passwords. Your password:
 pw-change-least-8-chars = Must be at least 8 characters
 pw-change-not-contain-email = Must not be your email address
 pw-change-must-match = New password matches confirmation
+# linkExternal is a link to a mozilla.org support article on password strength
+pw-change-common-passwords = Must not match this <linkExternal>list of common
+  passwords</linkExternal>
 pw-change-cancel-button = { fxa-cancel-button }
 pw-change-save-button = { fxa-save-button }
 pw-change-forgot-password-link = Forgot password?

--- a/packages/fxa-settings/src/components/PageChangePassword/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageChangePassword/en-US.ftl
@@ -6,6 +6,9 @@ pw-change-stay-safe = Stay safe — don’t reuse passwords. Your password:
 pw-change-least-8-chars = Must be at least 8 characters
 pw-change-not-contain-email = Must not be your email address
 pw-change-must-match = New password matches confirmation
+# linkExternal is a link to a mozilla.org support article on password strength
+pw-change-common-passwords = Must not match this <linkExternal>list of common
+  passwords</linkExternal>
 pw-change-cancel-button = { fxa-cancel-button }
 pw-change-save-button = { fxa-save-button }
 pw-change-forgot-password-link = Forgot password?

--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -174,14 +174,31 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
                 isSet={formState.dirtyFields.newPassword}
                 hasError={errors.newPassword?.types?.uncommon}
               />
-              Must not match this{' '}
-              <LinkExternal
-                className="link-blue"
-                data-testid="nav-link-common-passwords"
-                href="https://support.mozilla.org/en-US/kb/password-strength"
+              <Localized
+                id="pw-change-common-passwords"
+                elems={{
+                  linkExternal: (
+                    <LinkExternal
+                      className="link-blue"
+                      data-testid="nav-link-common-passwords"
+                      href="https://support.mozilla.org/en-US/kb/password-strength"
+                    >
+                      {' '}
+                    </LinkExternal>
+                  ),
+                }}
               >
-                list of common passwords
-              </LinkExternal>
+                <span>
+                  Must not match this{' '}
+                  <LinkExternal
+                    className="link-blue"
+                    data-testid="nav-link-common-passwords"
+                    href="https://support.mozilla.org/en-US/kb/password-strength"
+                  >
+                    list of common passwords
+                  </LinkExternal>
+                </span>
+              </Localized>
             </li>
             <li data-testid="change-password-match">
               <ValidationIcon


### PR DESCRIPTION
Because:
 - something wasn't localized

This commit:
 - localize!

## Issue that this pull request solves

Closes: #7322
