### PR TITLE
feat(settings): support firefox-ios in new settings browser comms

### DIFF
--- a/packages/fxa-settings/src/lib/firefox.ts
+++ b/packages/fxa-settings/src/lib/firefox.ts
@@ -93,9 +93,12 @@ export class Firefox extends EventTarget {
     };
 
     // Firefox Desktop and Fennec >= 50 expect the detail to be
-    // sent as a string.
+    // sent as a string and fxios as an object.
     // See https://bugzilla.mozilla.org/show_bug.cgi?id=1275616 and
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1238128
+    if (navigator.userAgent.toLowerCase().includes('fxios')) {
+      return detail;
+    }
     return JSON.stringify(detail);
   }
 


### PR DESCRIPTION
## Because

- Firefox iOS needs to know about changes to settings

## This pull request

- Accounts for the difference in message format for firefox-ios

### Notes

- Verifying the messages are handled by fx-ios from the new settings page requires a custom build to change the settings url to beta.
- Unlike desktop the browser's message handler is only enable via the built-in account menu UI, loading the new settings page in a tab does not enable the browser end of the channel.
- I manually verified the messages are handled via the xcode debugger.
- The previous `fx_ios_v1` context from content-server is no longer in use.

## Issue that this pull request solves

closes #7378