### PR TITLE
chore(tests): add browser comm assertions to new settings functional tests

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -1186,11 +1186,12 @@ const storeWebChannelMessageData = thenify(function (expectedCommand) {
   return this.parent.executeAsync(
     function (expectedCommand, callback) {
       function listener(e) {
-        var command = e.detail.message.command;
+        const detail = JSON.parse(e.detail);
+        const command = detail.message.command;
         if (command === expectedCommand) {
           const storedEvents =
             JSON.parse(sessionStorage.getItem('webChannelEventData')) || {};
-          storedEvents[command] = e.detail.message;
+          storedEvents[command] = detail.message;
           sessionStorage.setItem(
             'webChannelEventData',
             JSON.stringify(storedEvents)

--- a/packages/fxa-content-server/tests/functional/settings_v2/change_password.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/change_password.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const intern = require('intern').default;
+const assert = intern.getPlugin('chai').assert;
 const { describe, it, beforeEach } = intern.getPlugin('interface.bdd');
 const selectors = require('../lib/selectors');
 const FunctionalHelpers = require('../lib/helpers');
@@ -14,6 +15,7 @@ const EMAIL_FIRST = config.fxaContentRoot;
 const SETTINGS_V2_URL = config.fxaSettingsV2Root;
 const password = 'passwordzxcv';
 const newPassword = 'passwordzxcvb';
+const CHANGE_PASSWORD_COMMAND = 'fxaccounts:change_password';
 
 const { createEmail } = FunctionalHelpers;
 
@@ -23,6 +25,8 @@ const {
   createUser,
   openPage,
   fillOutEmailFirstSignIn,
+  getWebChannelMessageData,
+  storeWebChannelMessageData,
   testElementExists,
   type,
 } = FunctionalHelpers.helpersRemoteWrapped;
@@ -40,6 +44,8 @@ describe('change password', () => {
     await fillOutEmailFirstSignIn(email, password, remote);
     await testElementExists(selectors.SETTINGS.HEADER, remote);
     await openPage(SETTINGS_V2_URL, selectors.SETTINGS_V2.HEADER, remote);
+    await storeWebChannelMessageData(CHANGE_PASSWORD_COMMAND, remote);
+
     await click(
       selectors.SETTINGS_V2.CHANGE_PASSWORD.OPEN_BUTTON,
       selectors.SETTINGS_V2.CHANGE_PASSWORD.CURRENT_PASSWORD_LABEL,
@@ -84,6 +90,10 @@ describe('change password', () => {
       selectors.SETTINGS_V2.HEADER,
       remote
     );
+
+    const msg = await getWebChannelMessageData(CHANGE_PASSWORD_COMMAND, remote);
+    assert.equal(msg.command, CHANGE_PASSWORD_COMMAND);
+    assert.isString(msg.data.sessionToken);
 
     await clearBrowserState(remote);
 

--- a/packages/fxa-content-server/tests/functional/settings_v2/display_name.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/display_name.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const intern = require('intern').default;
+const assert = intern.getPlugin('chai').assert;
 const { describe, it, beforeEach } = intern.getPlugin('interface.bdd');
 const selectors = require('../lib/selectors');
 const FunctionalHelpers = require('../lib/helpers');
@@ -13,9 +14,12 @@ const FunctionalSettingsHelpers = require('./lib/helpers');
 const { navigateToSettingsV2 } = FunctionalSettingsHelpers;
 const {
   click,
+  getWebChannelMessageData,
+  storeWebChannelMessageData,
   testElementTextEquals,
   type,
 } = FunctionalHelpers.helpersRemoteWrapped;
+const CHANGE_PROFILE_COMMAND = 'profile:change';
 
 describe('display name', () => {
   let email;
@@ -84,6 +88,7 @@ describe('display name', () => {
   });
 
   it('can change a display name', async ({ remote }) => {
+    await storeWebChannelMessageData(CHANGE_PROFILE_COMMAND, remote);
     await click(selectors.SETTINGS_V2.DISPLAY_NAME.SUBMIT_BUTTON, remote);
 
     // Click change and change the display name
@@ -95,6 +100,9 @@ describe('display name', () => {
       remote
     );
     await click(selectors.SETTINGS_V2.DISPLAY_NAME.SUBMIT_BUTTON, remote);
+    const msg = await getWebChannelMessageData(CHANGE_PROFILE_COMMAND, remote);
+    assert.equal(msg.command, CHANGE_PROFILE_COMMAND);
+    assert.isString(msg.data.uid);
     // Verify the saved name is displayed
     await testElementTextEquals(
       selectors.SETTINGS_V2.DISPLAY_NAME.SAVED_DISPLAY_NAME,


### PR DESCRIPTION
## Because

- we want to be sure the browser is notified on these state changes

closes #7376


