### PR TITLE
fix(settings): fix startup error on some legacy browsers

### DIFF
--- a/packages/fxa-settings/src/lib/firefox.ts
+++ b/packages/fxa-settings/src/lib/firefox.ts
@@ -148,4 +148,28 @@ export class Firefox extends EventTarget {
   }
 }
 
-export default new Firefox();
+// Some non-firefox legacy browsers can't extend EventTarget.
+// For those we can safely return a mock instance that
+// implements the interface but does nothing because
+// this functionality is only meant for firefox.
+let canUseEventTarget = true;
+try {
+  new EventTarget();
+} catch (e) {
+  canUseEventTarget = false;
+}
+function noop() {}
+const firefox = canUseEventTarget
+  ? new Firefox()
+  : // otherwise a mock
+    ((Object.fromEntries(
+      Object.getOwnPropertyNames(Firefox.prototype)
+        .map((name) => [name, noop])
+        .concat([
+          ['addEventListener', noop],
+          ['removeEventListener', noop],
+          ['dispatchEvent', noop],
+        ])
+    ) as unknown) as Firefox);
+
+export default firefox;


### PR DESCRIPTION
## Because

Apparently oldish ios safari won't let you extend EventTarget

<img width="372" alt="Screen Shot 2021-02-04 at 1 43 42 PM" src="https://user-images.githubusercontent.com/87619/106959853-1aa2e780-66f0-11eb-87ae-cfe470acc97c.png">


## This pull request

- uses a mock for those browsers