### PR TITLE
feat(auth-server): handle stripe invoice open events

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -329,6 +329,23 @@ export class StripeHelper {
     );
   }
 
+  async invoicePayableWithPaypal(invoice: Stripe.Invoice): Promise<boolean> {
+    if (invoice.billing_reason === 'subscription_create') {
+      // We only work with non-creation invoices, initial invoices are resolved by
+      // checkout code.
+      return false;
+    }
+    const subscription = await this.expandResource(
+      invoice.subscription,
+      'subscriptions'
+    );
+    if (subscription?.collection_method !== 'send_invoice') {
+      // Not a PayPal funded subscription.
+      return false;
+    }
+    return true;
+  }
+
   /**
    * Finalizes an invoice and marks auto_advance as false.
    *

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -604,6 +604,57 @@ describe('StripeHelper', () => {
     });
   });
 
+  describe('invoicePayableWithPaypal', () => {
+    it('returns true if its payable via paypal', async () => {
+      const mockInvoice = {
+        billing_reason: 'subscription_cycle',
+        subscription: 'sub-1234',
+      };
+      const mockSub = {
+        collection_method: 'send_invoice',
+      };
+      sandbox.stub(stripeHelper, 'expandResource').resolves(mockSub);
+      const actual = await stripeHelper.invoicePayableWithPaypal(mockInvoice);
+      assert.isTrue(actual);
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.expandResource,
+        'sub-1234',
+        'subscriptions'
+      );
+    });
+
+    it('returns false if invoice is sub create', async () => {
+      const mockInvoice = {
+        billing_reason: 'subscription_create',
+      };
+      const mockSub = {
+        collection_method: 'send_invoice',
+      };
+      sandbox.stub(stripeHelper, 'expandResource').resolves(mockSub);
+      const actual = await stripeHelper.invoicePayableWithPaypal(mockInvoice);
+      assert.isFalse(actual);
+      sinon.assert.notCalled(stripeHelper.expandResource);
+    });
+
+    it('returns false if subscription collection_method isnt invoice', async () => {
+      const mockInvoice = {
+        billing_reason: 'subscription_cycle',
+        subscription: 'sub-1234',
+      };
+      const mockSub = {
+        collection_method: 'charge_automatically',
+      };
+      sandbox.stub(stripeHelper, 'expandResource').resolves(mockSub);
+      const actual = await stripeHelper.invoicePayableWithPaypal(mockInvoice);
+      assert.isFalse(actual);
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.expandResource,
+        'sub-1234',
+        'subscriptions'
+      );
+    });
+  });
+
   describe('finalizeInvoice', () => {
     it('works successfully', async () => {
       sandbox


### PR DESCRIPTION
Because:

* We want to process invoices for Paypal customers when the invoice
  is opened to attempt a first charge.

This commit:

* Will process invoices upon stripe webhook reception.

Closes #7428

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

