### PR TITLE
fix(settings): when gql-api switched to nestjs the auth error changed

### DIFF
--- a/packages/fxa-settings/src/lib/gql.test.ts
+++ b/packages/fxa-settings/src/lib/gql.test.ts
@@ -38,17 +38,7 @@ describe('errorHandler', () => {
 
   it('redirects to /get_flow if called with a GQL authentication error', () => {
     errorResponse = {
-      graphQLErrors: [
-        new GraphQLError(
-          'Incorrect password',
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          { code: 'UNAUTHENTICATED' }
-        ),
-      ],
+      graphQLErrors: [new GraphQLError('Invalid token')],
       operation: (null as any) as Operation,
       forward: (null as any) as NextLink,
     };

--- a/packages/fxa-settings/src/lib/gql.ts
+++ b/packages/fxa-settings/src/lib/gql.ts
@@ -7,7 +7,7 @@ export const errorHandler: ErrorHandler = ({ graphQLErrors, networkError }) => {
   let reauth = false;
   if (graphQLErrors) {
     for (const error of graphQLErrors) {
-      if (error.extensions?.code === 'UNAUTHENTICATED') {
+      if (error.message === 'Invalid token') {
         reauth = true;
       }
     }
@@ -22,7 +22,7 @@ export const errorHandler: ErrorHandler = ({ graphQLErrors, networkError }) => {
       `/get_flow?redirect_to=${encodeURIComponent(window.location.pathname)}`
     );
   } else {
-    console.error(graphQLErrors, networkError);
+    console.error('graphql errors', graphQLErrors, networkError);
   }
 };
 

--- a/packages/fxa-shared/db/models/auth/index.ts
+++ b/packages/fxa-shared/db/models/auth/index.ts
@@ -31,7 +31,7 @@ export async function sessionTokenData(
   const knex = Account.knex();
   const [result] = await knex.raw('Call sessionWithDevice_18(?)', tokenBuffer);
   const rowPacket = result.shift();
-  if (result.length === 0) {
+  if (rowPacket.length === 0) {
     return;
   }
   return SessionToken.fromDatabaseRow(rowPacket[0]);


### PR DESCRIPTION
## Because

- The new settings page started showing the blank "Application Error" page when the sessiontoken was no longer valid.

## This pull request

- fixes it to redirect to signin

