### PR TITLE
fix(settings): only set hover css when supported

### DIFF
--- a/packages/fxa-settings/src/styles/ctas.scss
+++ b/packages/fxa-settings/src/styles/ctas.scss
@@ -11,10 +11,6 @@
 .cta-neutral {
   @apply bg-grey-10 border-grey-200;
 
-  &:hover {
-    @apply border-grey-200 bg-grey-100 text-grey-400;
-  }
-
   &:active {
     @apply border-grey-400 bg-grey-100 text-grey-400;
   }
@@ -30,10 +26,6 @@
 
 .cta-primary {
   @apply bg-blue-500 border-blue-600 text-white;
-
-  &:hover {
-    @apply bg-blue-600 border-blue-600;
-  }
 
   &:active {
     @apply bg-blue-800 border-blue-800;
@@ -51,10 +43,6 @@
 .cta-caution {
   @apply bg-red-500 border-red-600 text-white;
 
-  &:hover {
-    @apply bg-red-600 border-red-600;
-  }
-
   &:active {
     @apply bg-red-800 border-red-800;
   }
@@ -70,6 +58,22 @@
 
 .cta-base {
   @apply text-base mt-6;
+}
+
+@media (hover: hover) {
+
+  .cta-neutral:hover {
+    @apply border-grey-200 bg-grey-100 text-grey-400;
+  }
+
+  .cta-primary:hover {
+    @apply bg-blue-600 border-blue-600;
+  }
+
+  .cta-caution:hover {
+    @apply bg-red-600 border-red-600;
+  }
+
 }
 
 @screen mobileLandscape {

--- a/packages/fxa-settings/src/styles/tailwind.scss
+++ b/packages/fxa-settings/src/styles/tailwind.scss
@@ -22,10 +22,6 @@ body {
 .link-blue {
   @apply underline text-blue-500;
 
-  &:hover {
-    @apply text-blue-600;
-  }
-
   &:active {
     @apply text-blue-800;
   }
@@ -39,11 +35,17 @@ body {
 .transition-standard {
   @apply transition duration-150;
 
-  &:hover {
+  &:active {
     @apply transition duration-150;
   }
+}
 
-  &:active {
+@media (hover: hover) {
+  .link-blue:hover {
+    @apply text-blue-600;
+  }
+
+  .transition-standard:hover {
     @apply transition duration-150;
   }
 }


### PR DESCRIPTION
## Because

- iOS is weird about `hover` effects

## This pull request

- uses a `@media` query to set the hover styles

## Issue that this pull request solves

fixes #6371