### PR TITLE
feat(payments): Add createOrder handler to PayPal button

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -823,7 +823,7 @@ export const stripeRoutes = (
         },
         validate: {
           payload: {
-            displayName: isA.string().required(),
+            displayName: isA.string().optional(),
             idempotencyKey: isA.string().required(),
           },
         },

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -31,6 +31,7 @@ import {
   MOCK_PROFILE,
   MOCK_CUSTOMER,
   MOCK_ACTIVE_SUBSCRIPTIONS,
+  MOCK_CHECKOUT_TOKEN,
   MOCK_TOKEN,
   MOCK_PLANS,
 } from './test-utils';
@@ -54,6 +55,7 @@ import {
   apiUpdateDefaultPaymentMethod,
   apiRetryInvoice,
   apiDetachFailedPaymentMethod,
+  apiGetPaypalCheckoutToken,
 } from './apiClient';
 
 describe('APIError', () => {
@@ -449,6 +451,16 @@ describe('API requests', () => {
         paymentMethodId: '???',
       });
       expect(actual).toEqual(resp);
+      requestMock.done();
+    });
+  });
+
+  describe('apiGetPaypalCheckoutToken', () => {
+    it('POST /v1/oauth/subscriptions/paypal-checkout', async () => {
+      const requestMock = nock(AUTH_BASE_URL)
+        .post('/v1/oauth/subscriptions/paypal-checkout')
+        .reply(200, MOCK_CHECKOUT_TOKEN);
+      expect(await apiGetPaypalCheckoutToken()).toEqual(MOCK_CHECKOUT_TOKEN);
       requestMock.done();
     });
   });

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -197,13 +197,22 @@ export async function apiReactivateSubscription({
 }
 
 export async function apiCreateCustomer(params: {
-  displayName: string;
+  displayName?: string;
   idempotencyKey: string;
 }): Promise<Customer> {
   return apiFetch(
     'POST',
     `${config.servers.auth.url}/v1/oauth/subscriptions/customer`,
     { body: JSON.stringify(params) }
+  );
+}
+
+export async function apiGetPaypalCheckoutToken(): Promise<{
+  token: string;
+}> {
+  return apiFetch(
+    'POST',
+    `${config.servers.auth.url}/v1/oauth/subscriptions/paypal-checkout`
   );
 }
 

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -307,6 +307,10 @@ export const MOCK_TOKEN: Token = {
   jti: '',
 };
 
+export const MOCK_CHECKOUT_TOKEN = {
+  token: 'EC-8NC18566WJ1581100',
+};
+
 export const STRIPE_FIELDS = [
   'cardNumberElement',
   'cardCVCElement',

--- a/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.stories.tsx
@@ -1,7 +1,34 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { PaypalButton } from './index';
+import { PaypalButton, PaypalButtonProps } from './index';
+
+import { PickPartial } from '../../../lib/types';
+
+const Subject = ({
+  customer = null,
+  setPaymentError = () => {},
+  idempotencyKey = '',
+  ...props
+}: PickPartial<
+  PaypalButtonProps,
+  | 'apiClientOverrides'
+  | 'customer'
+  | 'setPaymentError'
+  | 'idempotencyKey'
+  | 'ButtonBase'
+>) => {
+  return (
+    <PaypalButton
+      {...{
+        customer,
+        setPaymentError,
+        idempotencyKey,
+        ...props,
+      }}
+    />
+  );
+};
 
 storiesOf('routes/Product/PaypalButton', module).add('default', () => (
-  <PaypalButton />
+  <Subject></Subject>
 ));

--- a/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.tsx
@@ -1,5 +1,9 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import ReactDOM from 'react-dom';
+
+import * as apiClient from '../../../lib/apiClient';
+import { Customer } from '../../../store/types';
+import { SubscriptionCreateAuthServerAPIs } from '../SubscriptionCreate';
 
 declare var paypal: {
   Buttons: {
@@ -7,13 +11,77 @@ declare var paypal: {
   };
 };
 
-const PaypalButtonBase = paypal.Buttons.driver('react', {
-  React,
-  ReactDOM,
-});
+export type PaypalButtonProps = {
+  apiClientOverrides?: Partial<SubscriptionCreateAuthServerAPIs>;
+  customer: Customer | null;
+  setPaymentError: Function;
+  idempotencyKey: string;
+  ButtonBase?: React.ElementType;
+};
 
-export const PaypalButton = () => {
-  return <PaypalButtonBase data-testid="paypal-button" />;
+export type ButtonBaseProps = {
+  createOrder?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onError?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+};
+
+export const PaypalButtonBase =
+  typeof paypal !== 'undefined'
+    ? paypal.Buttons.driver('react', {
+        React,
+        ReactDOM,
+      })
+    : null;
+
+export const PaypalButton = ({
+  apiClientOverrides,
+  customer,
+  setPaymentError,
+  idempotencyKey,
+  ButtonBase = PaypalButtonBase,
+}: PaypalButtonProps) => {
+  const createOrder = useCallback(async () => {
+    try {
+      const { apiCreateCustomer, apiGetPaypalCheckoutToken } = {
+        ...apiClient,
+        ...apiClientOverrides,
+      };
+      if (!customer) {
+        await apiCreateCustomer({
+          idempotencyKey,
+        });
+      }
+      const { token } = await apiGetPaypalCheckoutToken();
+      return token;
+    } catch (error) {
+      setPaymentError(error);
+    }
+    return null;
+  }, [
+    apiClient.apiCreateCustomer,
+    apiClient.apiGetPaypalCheckoutToken,
+    customer,
+    setPaymentError,
+    idempotencyKey,
+  ]);
+
+  const onError = useCallback(
+    (error) => {
+      setPaymentError(error);
+    },
+    [setPaymentError]
+  );
+
+  return (
+    <>
+      {ButtonBase && (
+        <ButtonBase
+          data-testid="paypal-button"
+          createOrder={createOrder}
+          onError={onError}
+        />
+      )}
+    </>
+  );
 };
 
 export default PaypalButton;

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -26,6 +26,9 @@ import { AppContext } from '../../../lib/AppContext';
 
 import '../../Product/SubscriptionCreate/index.scss';
 
+import { ButtonBaseProps } from '../../Product/PayPalButton';
+const PaypalButton = React.lazy(() => import('../../Product/PayPalButton'));
+
 type PaymentError = undefined | StripeError;
 type RetryStatus = undefined | { invoiceId: string };
 
@@ -52,9 +55,8 @@ export type SubscriptionCreateProps = {
   paymentErrorInitialState?: PaymentError;
   stripeOverride?: SubscriptionCreateStripeAPIs;
   apiClientOverrides?: Partial<SubscriptionCreateAuthServerAPIs>;
+  paypalButtonBase?: React.FC<ButtonBaseProps>;
 };
-
-const PaypalButton = React.lazy(() => import('../../Product/PayPalButton'));
 
 export const SubscriptionCreate = ({
   isMobile,
@@ -66,6 +68,7 @@ export const SubscriptionCreate = ({
   paymentErrorInitialState,
   stripeOverride,
   apiClientOverrides = {},
+  paypalButtonBase,
 }: SubscriptionCreateProps) => {
   const [submitNonce, refreshSubmitNonce] = useNonce();
 
@@ -87,8 +90,14 @@ export const SubscriptionCreate = ({
     if (!config.featureFlags.usePaypalUIByDefault) {
       return;
     }
+
+    if (paypalButtonBase) {
+      setPaypalScriptLoaded(true);
+      return;
+    }
+
     const script = document.createElement('script');
-    script.src = `${config.paypal.scriptUrl}/sdk/js?client-id=${config.paypal.clientId}&vault=true&commit=false&intent=authorize&disable-funding=credit,card`;
+    script.src = `${config.paypal.scriptUrl}/sdk/js?client-id=${config.paypal.clientId}&vault=true&commit=false&intent=capture&disable-funding=credit,card`;
     script.onload = () => {
       setPaypalScriptLoaded(true);
     };
@@ -173,7 +182,13 @@ export const SubscriptionCreate = ({
 
           {!hasExistingCard(customer) && paypalScriptLoaded && (
             <Suspense fallback={<div>Loading...</div>}>
-              <PaypalButton />
+              <PaypalButton
+                apiClientOverrides={apiClientOverrides}
+                customer={customer}
+                setPaymentError={setPaymentError}
+                idempotencyKey={submitNonce}
+                ButtonBase={paypalButtonBase}
+              />
             </Suspense>
           )}
 


### PR DESCRIPTION
## Because

- We want to initialize the PayPal transaction when the user clicks the PayPal button.

## This pull request

- Adds a `createOrder` handler to the `PaypalButton` component, which creates a new customer if one doesn't already exist and posts to a new `fxa-auth-server` route to get a Paypal checkout token.
- Fixes some Paypal feature flag tests that were passing despite the Paypal button not rendering in the tests. For some reason, the below assertion was passing even when `queryByTestId('paypal-button')` was `null`:
```js
waitForExpect(() =>
  expect(queryByTestId('paypal-button')).toBeInTheDocument()
);
```

## Issue that this pull request solves

Closes: #7269 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Screenshot_2021-02-02 Firefox Accounts](https://user-images.githubusercontent.com/17437436/107313766-347e5a80-6a61-11eb-9902-6e6827f8099c.png)

## Other information (Optional)

- The `PaypalButton` is mocked in the tests, since it is ordinarily a third-party React component rendered in a cross-origin iframe.
- This PR adds two negative UI integration tests for when the post to get the checkout token fails, and when the Paypal `createOrder` framework method (or really any Paypal framework method) fails. A corresponding positive test will be covered in #7450 .
- After we update the UI to match the Checkout spec, we will need to move the location of the default error messages; I filed #7461 for that.
