### PR TITLE
feat(auth-server): cleanup paypal data on delete

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal-client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-client.ts
@@ -120,6 +120,7 @@ export type DoReferenceTransactionOptions = {
 
 export type BAUpdateOptions = {
   billingAgreementId: string;
+  cancel?: boolean;
 };
 
 export type IpnMessage = {
@@ -329,9 +330,12 @@ export class PayPalClient {
   public async baUpdate(
     options: BAUpdateOptions
   ): Promise<NVPBAUpdateTransactionResponse> {
-    const data = {
+    const data: Record<string, any> = {
       REFERENCEID: options.billingAgreementId,
     };
+    if (options.cancel) {
+      data.BILLINGAGREEMENTSTATUS = 'Canceled';
+    }
     return await this.doRequest<NVPBAUpdateTransactionResponse>(
       'BillAgreementUpdate',
       data

--- a/packages/fxa-auth-server/test/local/payments/fixtures/paypal/ba_update_success.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/paypal/ba_update_success.json
@@ -1,0 +1,12 @@
+{
+  "ACK": "Success",
+  "BILLINGAGREEMENTID": "B-00R675662S291773P",
+  "BILLINGAGREEMENTSTATUS": "active",
+  "BUILD": "55100925",
+  "CORRELATIONID": "a600174ee8945",
+  "COUNTRYCODE": "US",
+  "EMAIL": "test@example.com",
+  "PAYERSTATUS": "verified",
+  "TIMESTAMP": "2021-01-25T17:02:17Z",
+  "VERSION": "204"
+}

--- a/packages/fxa-auth-server/test/local/payments/paypal.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal.js
@@ -18,6 +18,7 @@ const { mockLog } = require('../../mocks');
 const error = require('../../../lib/error');
 const successfulSetExpressCheckoutResponse = require('./fixtures/paypal/set_express_checkout_success.json');
 const successfulDoReferenceTransactionResponse = require('./fixtures/paypal/do_reference_transaction_success.json');
+const successfulBAUpdateResponse = require('./fixtures/paypal/ba_update_success.json');
 const eventCustomerSourceExpiring = require('./fixtures/stripe/event_customer_source_expiring.json');
 const sampleIpnMessage = require('./fixtures/paypal/sample_ipn_message.json');
 const { StripeHelper } = require('../../../lib/payments/stripe');
@@ -186,6 +187,24 @@ describe('PayPalHelper', () => {
         assert.instanceOf(err, PayPalClientError);
         assert.equal(err.name, 'PayPalClientError');
       }
+    });
+  });
+
+  describe('cancelBillingAgreement', () => {
+    it('cancels an agreement', async () => {
+      paypalHelper.client.doRequest = sinon.fake.resolves(
+        successfulBAUpdateResponse
+      );
+      const response = await paypalHelper.cancelBillingAgreement('test');
+      assert.isNull(response);
+    });
+
+    it('ignores paypal client errors', async () => {
+      paypalHelper.client.doRequest = sinon.fake.throws(
+        new PayPalClientError('Fake', {})
+      );
+      const response = await paypalHelper.cancelBillingAgreement('test');
+      assert.isNull(response);
     });
   });
 

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -201,6 +201,7 @@ module.exports = {
   mockVerificationReminders,
   mockCadReminders,
   mockStripeHelper,
+  mockPayPalHelper,
 };
 
 function mockCustoms(errors) {
@@ -800,4 +801,8 @@ function mockCadReminders(data = {}) {
 
 function mockStripeHelper(methods) {
   return mockObject(methods, require('../lib/payments/stripe').StripeHelper);
+}
+
+function mockPayPalHelper(methods) {
+  return mockObject(methods, require('../lib/payments/paypal').PayPalHelper);
 }


### PR DESCRIPTION
Because:

* We want to ensure any remaining billing agreements and customer
  data for PayPal users is deleted upon account delete.

This commit:

* Cancels all billing agreements that are not already in a terminal
  state.
* Deletes the billing agreement rows from the database.

Closes #7071

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
