### PR TITLE
feat(settings): display success tooltip on datablock action

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -713,8 +713,8 @@ module.exports = {
         SECRET_CODE_TEXT: '[data-testid=manual-code]',
         QR_CODE: '[data-testid=2fa-qr-code]',
         INCORRECT_TOTP_TOOLTIP: '[data-testid=tooltip]',
-        RECOVERY_CODE_BLOCK: '[data-testid=datablock-button]',
-        FIRST_RECOVERY_CODE: '[data-testid=datablock-button] span:nth-child(1)',
+        RECOVERY_CODE_BLOCK: '[data-testid=datablock]',
+        FIRST_RECOVERY_CODE: '[data-testid=datablock] span:nth-child(1)',
         SECOND_RECOVERY_CODE:
           '[data-testid=datablock-button] span:nth-child(2)',
         CLOSE_RECOVERY_KEY_BLOCK: '[data-testid=close-modal]',

--- a/packages/fxa-settings/public/locales/en-US/settings.ftl
+++ b/packages/fxa-settings/public/locales/en-US/settings.ftl
@@ -85,6 +85,15 @@ cs-disconnect-suspicious-advice-content = If the disconnected device is indeed
 
 cs-sign-out-button = Sign out
 
+## Tooltip notifications for actions performed on recovery keys or one-time use codes
+
+datablock-download =
+  .message = Downloaded
+datablock-copy =
+  .message = Copied
+datablock-print =
+  .message = Printed
+
 # GetDataTrio component, part of Recovery Key flow
 
 get-data-trio-title = Recovery Codes

--- a/packages/fxa-settings/src/components/DataBlock/en-US.ftl
+++ b/packages/fxa-settings/src/components/DataBlock/en-US.ftl
@@ -1,0 +1,8 @@
+## Tooltip notifications for actions performed on recovery keys or one-time use codes
+
+datablock-download =
+  .message = Downloaded
+datablock-copy =
+  .message = Copied
+datablock-print =
+  .message = Printed

--- a/packages/fxa-settings/src/components/DataBlock/index.test.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.test.tsx
@@ -3,8 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import DataBlock from './index';
+import { act } from 'react-dom/test-utils';
 
 const singleValue = 'ANMD 1S09 7Y2Y 4EES 02CW BJ6Z PYKP H69F';
 
@@ -22,6 +23,7 @@ const multiValue = [
 Object.defineProperty(window.navigator, 'clipboard', {
   value: { writeText: jest.fn() },
 });
+window.URL.createObjectURL = jest.fn();
 
 it('can render single values', () => {
   render(<DataBlock value={singleValue} />);
@@ -35,18 +37,12 @@ it('can render multiple values', () => {
   });
 });
 
-it('can copy a single value to the clipboard', () => {
-  render(<DataBlock value={singleValue} />);
-  fireEvent.click(screen.getByTestId('datablock-button'));
-  expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
-    singleValue
-  );
-});
-
-it('can copy multiple values to the clipboard', () => {
+it('displays a tooltip on action', async () => {
   render(<DataBlock value={multiValue} />);
-  fireEvent.click(screen.getByTestId('datablock-button'));
-  expect(window.navigator.clipboard.writeText).toHaveBeenCalledWith(
-    multiValue.join(', ')
-  );
+  await act(async () => {
+    fireEvent.click(await screen.findByTestId('databutton-copy'));
+  });
+  expect(
+    await screen.findByTestId('datablock-copy-tooltip')
+  ).toBeInTheDocument();
 });

--- a/packages/fxa-settings/src/components/DataBlock/index.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.tsx
@@ -2,52 +2,77 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React from 'react';
-import { copy } from '../../lib/clipboard';
+import { Localized } from '@fluent/react';
+import React, { useState } from 'react';
+import GetDataTrio from '../GetDataTrio';
+import { Tooltip } from '../Tooltip';
+
+const actionTypeToNotification = {
+  download: 'Downloaded',
+  copy: 'Copied',
+  print: 'Printed',
+} as const;
+
+type actions = keyof typeof actionTypeToNotification;
+type actionFn = (action: actions) => void;
 
 export type DataBlockProps = {
   value: string | string[];
   prefixDataTestId?: string;
-  onCopied?: (copiedValue: string) => void;
+  onAction?: actionFn;
 };
 
 export const DataBlock = ({
   value,
   prefixDataTestId,
-  onCopied,
+  onAction = () => {},
 }: DataBlockProps) => {
   const valueIsArray = Array.isArray(value);
+  const [performedAction, setPerformedAction] = useState<actions>();
+  const dataTestId = prefixDataTestId
+    ? `${prefixDataTestId}-datablock`
+    : 'datablock';
+  const actionCb: actionFn = (action) => {
+    onAction(action);
 
-  async function copyToClipboard() {
-    const copyValue = valueIsArray
-      ? (value as string[]).join(', ')
-      : (value as string);
-
-    await copy(copyValue);
-    onCopied && onCopied(copyValue);
-  }
-  function formatDataTestId(id: string) {
-    return prefixDataTestId ? `${prefixDataTestId}-${id}` : id;
-  }
+    if (actionTypeToNotification[action]) {
+      setPerformedAction(action);
+    }
+  };
 
   return (
-    <button
-      className={`flex rounded-xl px-7 font-mono text-sm text-green-900 bg-green-800 bg-opacity-10 flex-wrap hover:bg-opacity-20 focus:bg-opacity-30 active:bg-opacity-30 ${
-        valueIsArray ? 'py-4' : 'py-5'
-      }`}
-      data-testid={formatDataTestId('datablock-button')}
-      onClick={copyToClipboard}
-    >
-      {valueIsArray ? (
-        (value as string[]).map((item) => (
-          <span key={item} className="flex-50% py-1">
-            {item}
-          </span>
-        ))
-      ) : (
-        <span>{value}</span>
-      )}
-    </button>
+    <>
+      <div
+        className={`flex rounded-xl px-7 font-mono text-center text-sm text-green-900 bg-green-800 bg-opacity-10 flex-wrap relative mb-8 ${
+          valueIsArray ? 'py-4' : 'py-5'
+        }`}
+        data-testid={dataTestId}
+      >
+        {valueIsArray ? (
+          (value as string[]).map((item) => (
+            <span key={item} className="flex-50% py-1">
+              {item}
+            </span>
+          ))
+        ) : (
+          <span>{value}</span>
+        )}
+        {performedAction && (
+          <Localized
+            id={`datablock-${performedAction}`}
+            attrs={{ message: true }}
+          >
+            <Tooltip
+              prefixDataTestId={`datablock-${performedAction}`}
+              message={actionTypeToNotification[performedAction]}
+              position="bottom"
+              className="mt-1"
+            ></Tooltip>
+          </Localized>
+        )}
+      </div>
+      <GetDataTrio {...{ value, onAction: actionCb }} />
+    </>
   );
 };
 

--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -11,7 +11,7 @@ import { ReactComponent as PrintIcon } from './print.svg';
 
 export type GetDataTrioProps = {
   value: string | string[];
-  onAction?: (type: string) => void;
+  onAction?: (type: 'download' | 'copy' | 'print') => void;
 };
 
 const recoveryCodesPrintTemplate = (

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
@@ -8,7 +8,6 @@ import React, { useEffect, useState } from 'react';
 import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import DataBlock from '../DataBlock';
-import GetDataTrio from '../GetDataTrio';
 import { useSession } from '../../models';
 import { useAlertBar, useMutation } from '../../lib/hooks';
 import { AlertBar } from '../AlertBar';
@@ -67,7 +66,6 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
         </Localized>
         <div className="mt-6 flex flex-col items-center h-40 justify-between">
           <DataBlock value={recoveryCodes}></DataBlock>
-          <GetDataTrio value={recoveryCodes}></GetDataTrio>
         </div>
       </div>
       <div className="flex justify-center mt-6 mb-4 mx-auto max-w-64">

--- a/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.test.tsx
@@ -97,7 +97,7 @@ describe('PageRecoveryKeyAdd', () => {
     });
 
     expect(screen.getByTestId('recover-key-confirm')).toBeVisible();
-    expect(screen.getByTestId('datablock-button')).toHaveTextContent(
+    expect(screen.getByTestId('datablock')).toHaveTextContent(
       '0000 0000 0000 0000 0000 0000 0000 0000'
     );
     expect(screen.getByTestId('databutton-copy')).toBeEnabled();

--- a/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
@@ -13,7 +13,6 @@ import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import AlertBar from '../AlertBar';
 import DataBlock from '../DataBlock';
 import { HomePath } from '../../constants';
-import GetDataTrio from '../GetDataTrio';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
 import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 
@@ -105,8 +104,7 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
               </p>
             </Localized>
             <div className="mt-6 flex flex-col items-center h-48 justify-between">
-              <DataBlock value={formattedRecoveryKey}></DataBlock>
-              <GetDataTrio
+              <DataBlock
                 value={formattedRecoveryKey}
                 onAction={(type) => {
                   logViewEvent(
@@ -114,7 +112,7 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
                     `recovery-key.${type}-option`
                   );
                 }}
-              ></GetDataTrio>
+              ></DataBlock>
               <Localized id="recovery-key-close-button">
                 <button
                   className="cta-primary mx-2 px-10"

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -13,7 +13,6 @@ import React, { useEffect, useState } from 'react';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import AlertBar from '../AlertBar';
 import DataBlock from '../DataBlock';
-import GetDataTrio from '../GetDataTrio';
 import { useSession } from '../../models';
 import { checkCode, getCode } from '../../lib/totp';
 import { HomePath } from '../../constants';
@@ -370,11 +369,10 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
               have your mobile device.
             </Localized>
             <div className="mt-6 flex flex-col items-center h-40 justify-between">
-              <DataBlock value={recoveryCodes}></DataBlock>
-              <GetDataTrio
+              <DataBlock
                 value={recoveryCodes}
                 onAction={logDataTrioActionEvent}
-              ></GetDataTrio>
+              ></DataBlock>
             </div>
           </div>
           <div className="flex justify-center mt-6 mb-4 mx-auto max-w-64">


### PR DESCRIPTION
Because:
  - there is no feedback to users when they download/copy/print codes

This commit:
  - display a tooltip when a user download/copy/print
  - remove the copy feature from DataBlock
    - it's confusing? why have that and the copy feature in
      GetDataTrio?
    - it's not obvious that it's a button and there's no feedback so
      users wouldn't know they copied something
    - it uses a different separator for arrays than GetDataTrio
  - update DataBlock to include GetDataTrio by default
    - they are always used together already
    - we need to display the tooltip in DataBlock on an action in
      GetDataTrio


## Issue that this pull request solves

Closes: #7026

## Screenshots (Optional)
![image](https://user-images.githubusercontent.com/198055/107546492-064c6800-6b92-11eb-9eb3-e29bedf462cb.png)
