### PR TITLE
feat(payments): Add onApprove handler to PayPal button

### DIFF
--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -33,6 +33,7 @@ import {
   MOCK_ACTIVE_SUBSCRIPTIONS,
   MOCK_CHECKOUT_TOKEN,
   MOCK_TOKEN,
+  MOCK_PAYPAL_SUBSCRIPTION_RESULT,
   MOCK_PLANS,
 } from './test-utils';
 
@@ -56,6 +57,7 @@ import {
   apiRetryInvoice,
   apiDetachFailedPaymentMethod,
   apiGetPaypalCheckoutToken,
+  apiCapturePaypalPayment,
 } from './apiClient';
 
 describe('APIError', () => {
@@ -463,6 +465,25 @@ describe('API requests', () => {
       const currencyCode = 'USD';
       expect(await apiGetPaypalCheckoutToken({ currencyCode })).toEqual(
         MOCK_CHECKOUT_TOKEN
+      );
+      requestMock.done();
+    });
+  });
+
+  describe('apiCapturePaypalPayment', () => {
+    const path = '/v1/oauth/subscriptions/active/new-paypal';
+    const params = {
+      idempotencyKey: 'idk-8675309',
+      priceId: 'price_12345',
+      ...MOCK_CHECKOUT_TOKEN,
+    };
+
+    it('POST {auth-server}/v1/oauth/subscriptions/active/new-paypal', async () => {
+      const requestMock = nock(AUTH_BASE_URL)
+        .post(path, params)
+        .reply(200, MOCK_PAYPAL_SUBSCRIPTION_RESULT);
+      expect(await apiCapturePaypalPayment(params)).toEqual(
+        MOCK_PAYPAL_SUBSCRIPTION_RESULT
       );
       requestMock.done();
     });

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -220,6 +220,21 @@ export async function apiGetPaypalCheckoutToken(params: {
   );
 }
 
+export async function apiCapturePaypalPayment(params: {
+  idempotencyKey: string;
+  priceId: string;
+  token: string;
+}): Promise<{
+  sourceCountry: string;
+  subscription: Subscription;
+}> {
+  return apiFetch(
+    'POST',
+    `${config.servers.auth.url}/v1/oauth/subscriptions/active/new-paypal`,
+    { body: JSON.stringify(params) }
+  );
+}
+
 export async function apiCreateSubscriptionWithPaymentMethod(params: {
   priceId: string;
   productId: string;

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -311,6 +311,11 @@ export const MOCK_CHECKOUT_TOKEN = {
   token: 'EC-8NC18566WJ1581100',
 };
 
+export const MOCK_PAYPAL_SUBSCRIPTION_RESULT = {
+  sourceCountry: 'FR',
+  subscription: { what: 'ever' },
+};
+
 export const STRIPE_FIELDS = [
   'cardNumberElement',
   'cardCVCElement',

--- a/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.stories.tsx
@@ -1,31 +1,43 @@
 import React from 'react';
-import { storiesOf } from '@storybook/react';
 import { PaypalButton, PaypalButtonProps } from './index';
 
+import { storiesOf } from '@storybook/react';
+import { linkTo } from '@storybook/addon-links';
+import { CUSTOMER, PLAN } from '../../../lib/mock-data';
 import { PickPartial } from '../../../lib/types';
 
+const defaultApiClientOverrides = {
+  apiCreateCustomer: async () => CUSTOMER,
+};
+
 const Subject = ({
-  customer = null,
-  setPaymentError = () => {},
-  idempotencyKey = '',
+  apiClientOverrides = defaultApiClientOverrides,
   currencyCode = 'USD',
+  customer = CUSTOMER,
+  idempotencyKey = '',
+  priceId = PLAN.plan_id,
+  refreshSubscriptions = linkTo('routes/Product', 'success'),
+  setPaymentError = () => {},
   ...props
 }: PickPartial<
   PaypalButtonProps,
-  | 'apiClientOverrides'
-  | 'customer'
-  | 'setPaymentError'
-  | 'idempotencyKey'
-  | 'ButtonBase'
   | 'currencyCode'
+  | 'customer'
+  | 'idempotencyKey'
+  | 'priceId'
+  | 'refreshSubscriptions'
+  | 'setPaymentError'
 >) => {
   return (
     <PaypalButton
       {...{
-        customer,
-        setPaymentError,
-        idempotencyKey,
+        apiClientOverrides,
         currencyCode,
+        customer,
+        idempotencyKey,
+        priceId,
+        refreshSubscriptions,
+        setPaymentError,
         ...props,
       }}
     />
@@ -33,5 +45,5 @@ const Subject = ({
 };
 
 storiesOf('routes/Product/PaypalButton', module).add('default', () => (
-  <Subject></Subject>
+  <Subject />
 ));

--- a/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.tsx
@@ -13,15 +13,18 @@ declare var paypal: {
 
 export type PaypalButtonProps = {
   apiClientOverrides?: Partial<SubscriptionCreateAuthServerAPIs>;
-  customer: Customer | null;
-  setPaymentError: Function;
-  idempotencyKey: string;
-  ButtonBase?: React.ElementType;
   currencyCode: string;
+  customer: Customer | null;
+  idempotencyKey: string;
+  priceId: string;
+  refreshSubscriptions: () => void;
+  setPaymentError: Function;
+  ButtonBase?: React.ElementType;
 };
 
 export type ButtonBaseProps = {
   createOrder?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onApprove?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onError?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
@@ -35,11 +38,13 @@ export const PaypalButtonBase =
 
 export const PaypalButton = ({
   apiClientOverrides,
-  customer,
-  setPaymentError,
-  idempotencyKey,
-  ButtonBase = PaypalButtonBase,
   currencyCode,
+  customer,
+  idempotencyKey,
+  priceId,
+  refreshSubscriptions,
+  setPaymentError,
+  ButtonBase = PaypalButtonBase,
 }: PaypalButtonProps) => {
   const createOrder = useCallback(async () => {
     try {
@@ -62,9 +67,38 @@ export const PaypalButton = ({
     apiClient.apiCreateCustomer,
     apiClient.apiGetPaypalCheckoutToken,
     customer,
-    setPaymentError,
     idempotencyKey,
+    setPaymentError,
   ]);
+
+  const onApprove = useCallback(
+    async (data: { orderID: string }) => {
+      try {
+        const { apiCapturePaypalPayment } = {
+          ...apiClient,
+          ...apiClientOverrides,
+        };
+        // This is the same token as obtained in createOrder
+        const token = data.orderID;
+        await apiCapturePaypalPayment({
+          idempotencyKey,
+          priceId,
+          token,
+        });
+        refreshSubscriptions();
+      } catch (error) {
+        setPaymentError(error);
+      }
+      return null;
+    },
+    [
+      apiClient.apiCreateCustomer,
+      apiClient.apiGetPaypalCheckoutToken,
+      customer,
+      idempotencyKey,
+      setPaymentError,
+    ]
+  );
 
   const onError = useCallback(
     (error) => {
@@ -79,6 +113,7 @@ export const PaypalButton = ({
         <ButtonBase
           data-testid="paypal-button"
           createOrder={createOrder}
+          onApprove={onApprove}
           onError={onError}
         />
       )}

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -184,11 +184,13 @@ export const SubscriptionCreate = ({
             <Suspense fallback={<div>Loading...</div>}>
               <PaypalButton
                 apiClientOverrides={apiClientOverrides}
-                customer={customer}
-                setPaymentError={setPaymentError}
-                idempotencyKey={submitNonce}
-                ButtonBase={paypalButtonBase}
                 currencyCode={selectedPlan.currency}
+                customer={customer}
+                idempotencyKey={submitNonce}
+                priceId={selectedPlan.plan_id}
+                refreshSubscriptions={refreshSubscriptions}
+                setPaymentError={setPaymentError}
+                ButtonBase={paypalButtonBase}
               />
             </Suspense>
           )}


### PR DESCRIPTION
## Because

- We want to process a successful PayPal authorization during Checkout.

## This pull request

- Adds an `onApprove` handler to the `PaypalButton` component, which posts to a new `fxa-auth-server` route to perform a bunch of tasks (see [PayPal Checkout ladder diagram](https://mozilla.github.io/ecosystem-platform/docs/fxa-engineering/fxa-sub-platform#paypal-checkout)), including creating a new subscription and attempting to capture the first payment.

## Issue that this pull request solves

Closes: #7420 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
