### PR TITLE
(feat)auth-server: Add define-able currencies to paypal checkout

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal-client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-client.ts
@@ -133,6 +133,10 @@ export type NVPBAUpdateTransactionResponse = NVPResponse & BAUpdateData;
 
 export type NVPTransactionSearchResponse = NVPResponse & TransactionSearchData;
 
+export type SetExpressCheckoutOptions = {
+  currencyCode: string;
+};
+
 export type CreateBillingAgreementOptions = {
   token: string;
 };
@@ -304,14 +308,16 @@ export class PayPalClient {
    * The API is extensive. Currently this method only supports the situation where you're getting an authorizing
    * token that allows us to perform billing in the future.
    */
-  public async setExpressCheckout(): Promise<NVPSetExpressCheckoutResponse> {
+  public async setExpressCheckout(
+    options: SetExpressCheckoutOptions
+  ): Promise<NVPSetExpressCheckoutResponse> {
     const data = {
       CANCELURL: PLACEHOLDER_URL,
       L_BILLINGAGREEMENTDESCRIPTION0: 'Mozilla',
       L_BILLINGTYPE0: 'MerchantInitiatedBilling',
       NOSHIPPING: 1,
       PAYMENTREQUEST_0_AMT: '0',
-      PAYMENTREQUEST_0_CURRENCYCODE: 'USD',
+      PAYMENTREQUEST_0_CURRENCYCODE: options.currencyCode,
       PAYMENTREQUEST_0_PAYMENTACTION: 'AUTHORIZATION',
       RETURNURL: PLACEHOLDER_URL,
     };

--- a/packages/fxa-auth-server/lib/payments/paypal.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal.ts
@@ -9,6 +9,7 @@ import { Container } from 'typedi';
 import error from '../error';
 import {
   BAUpdateOptions,
+  SetExpressCheckoutOptions,
   CreateBillingAgreementOptions,
   DoReferenceTransactionOptions,
   IpnMessage,
@@ -105,8 +106,10 @@ export class PayPalHelper {
    * If the call to PayPal fails, a PayPalClientError will be thrown.
    *
    */
-  public async getCheckoutToken(): Promise<string> {
-    const response = await this.client.setExpressCheckout();
+  public async getCheckoutToken(
+    options: SetExpressCheckoutOptions
+  ): Promise<string> {
+    const response = await this.client.setExpressCheckout(options);
     return response.TOKEN;
   }
 

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -41,7 +41,9 @@ export class PayPalHandler extends StripeHandler {
     this.log.begin('subscriptions.getCheckoutToken', request);
     const { uid, email } = await handleAuth(this.db, request.auth, true);
     await this.customs.check(request, email, 'getCheckoutToken');
-    const token = await this.paypalHelper.getCheckoutToken();
+
+    const { currencyCode } = request.payload as Record<string, string>;
+    const token = await this.paypalHelper.getCheckoutToken({ currencyCode });
     const responseObject = { token };
     this.log.info('subscriptions.getCheckoutToken.success', responseObject);
     return responseObject;
@@ -157,6 +159,11 @@ export const paypalRoutes = (
           schema: isA.object({
             token: isA.string().required(),
           }),
+        },
+        validate: {
+          payload: {
+            currencyCode: isA.string().required(),
+          },
         },
       },
       handler: (request: AuthRequest) =>

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -199,11 +199,15 @@ describe('PayPalClient', () => {
       RETURNURL: PLACEHOLDER_URL,
     };
 
+    const defaultOptions = {
+      currencyCode: 'USD',
+    };
+
     it('calls api with correct method and data', () => {
       client.doRequest = sandbox.fake.resolves(
         successfulSetExpressCheckoutResponse
       );
-      client.setExpressCheckout();
+      client.setExpressCheckout(defaultOptions);
       sinon.assert.calledOnceWithExactly(
         client.doRequest,
         'SetExpressCheckout',
@@ -224,7 +228,7 @@ describe('PayPalClient', () => {
         .post(PAYPAL_NVP_ROUTE, client.objectToNVP(expectedPayload))
         .reply(200, client.objectToNVP(unSuccessfulSetExpressCheckoutResponse));
       try {
-        await client.setExpressCheckout();
+        await client.setExpressCheckout(defaultOptions);
         assert.fail('Request should have thrown an error.');
       } catch (err) {
         assert.instanceOf(err, PayPalClientError);
@@ -232,6 +236,24 @@ describe('PayPalClient', () => {
         assert.include(err.raw, 'ACK=Failure');
         assert.equal(err.data.ACK, 'Failure');
       }
+    });
+
+    it('calls api with requested currency', async () => {
+      client.doRequest = sandbox.fake.resolves(
+        successfulSetExpressCheckoutResponse
+      );
+      const currency = 'EUR';
+      await client.setExpressCheckout({
+        currencyCode: currency,
+      });
+      sinon.assert.calledOnceWithExactly(
+        client.doRequest,
+        'SetExpressCheckout',
+        {
+          ...defaultData,
+          PAYMENTREQUEST_0_CURRENCYCODE: currency,
+        }
+      );
     });
   });
 

--- a/packages/fxa-auth-server/test/local/payments/paypal.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal.js
@@ -93,11 +93,13 @@ describe('PayPalHelper', () => {
   });
 
   describe('getCheckoutToken', () => {
+    const validOptions = { currencyCode: 'USD' };
+
     it('it returns the token from doRequest', async () => {
       paypalHelper.client.doRequest = sinon.fake.resolves(
         successfulSetExpressCheckoutResponse
       );
-      const token = await paypalHelper.getCheckoutToken();
+      const token = await paypalHelper.getCheckoutToken(validOptions);
       assert.equal(token, successfulSetExpressCheckoutResponse.TOKEN);
     });
 
@@ -106,12 +108,24 @@ describe('PayPalHelper', () => {
         new PayPalClientError('Fake', {})
       );
       try {
-        await paypalHelper.getCheckoutToken();
+        await paypalHelper.getCheckoutToken(validOptions);
         assert.fail('Request should have thrown an error.');
       } catch (err) {
         assert.instanceOf(err, PayPalClientError);
         assert.equal(err.name, 'PayPalClientError');
       }
+    });
+
+    it('calls setExpressCheckout with passed options', async () => {
+      paypalHelper.client.setExpressCheckout = sinon.fake.resolves(
+        successfulSetExpressCheckoutResponse
+      );
+      const currencyCode = 'EUR';
+      await paypalHelper.getCheckoutToken({ currencyCode });
+      sinon.assert.calledOnceWithExactly(
+        paypalHelper.client.setExpressCheckout,
+        { currencyCode }
+      );
     });
   });
 

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -460,7 +460,10 @@ describe('API requests', () => {
       const requestMock = nock(AUTH_BASE_URL)
         .post('/v1/oauth/subscriptions/paypal-checkout')
         .reply(200, MOCK_CHECKOUT_TOKEN);
-      expect(await apiGetPaypalCheckoutToken()).toEqual(MOCK_CHECKOUT_TOKEN);
+      const currencyCode = 'USD';
+      expect(await apiGetPaypalCheckoutToken({ currencyCode })).toEqual(
+        MOCK_CHECKOUT_TOKEN
+      );
       requestMock.done();
     });
   });

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -207,12 +207,16 @@ export async function apiCreateCustomer(params: {
   );
 }
 
-export async function apiGetPaypalCheckoutToken(): Promise<{
+export async function apiGetPaypalCheckoutToken(params: {
+  currencyCode: string;
+}): Promise<{
   token: string;
 }> {
+  const { currencyCode } = params;
   return apiFetch(
     'POST',
-    `${config.servers.auth.url}/v1/oauth/subscriptions/paypal-checkout`
+    `${config.servers.auth.url}/v1/oauth/subscriptions/paypal-checkout`,
+    { body: JSON.stringify({ currencyCode }) }
   );
 }
 

--- a/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.stories.tsx
@@ -8,6 +8,7 @@ const Subject = ({
   customer = null,
   setPaymentError = () => {},
   idempotencyKey = '',
+  currencyCode = 'USD',
   ...props
 }: PickPartial<
   PaypalButtonProps,
@@ -16,6 +17,7 @@ const Subject = ({
   | 'setPaymentError'
   | 'idempotencyKey'
   | 'ButtonBase'
+  | 'currencyCode'
 >) => {
   return (
     <PaypalButton
@@ -23,6 +25,7 @@ const Subject = ({
         customer,
         setPaymentError,
         idempotencyKey,
+        currencyCode,
         ...props,
       }}
     />

--- a/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.tsx
@@ -17,6 +17,7 @@ export type PaypalButtonProps = {
   setPaymentError: Function;
   idempotencyKey: string;
   ButtonBase?: React.ElementType;
+  currencyCode: string;
 };
 
 export type ButtonBaseProps = {
@@ -38,6 +39,7 @@ export const PaypalButton = ({
   setPaymentError,
   idempotencyKey,
   ButtonBase = PaypalButtonBase,
+  currencyCode,
 }: PaypalButtonProps) => {
   const createOrder = useCallback(async () => {
     try {
@@ -50,7 +52,7 @@ export const PaypalButton = ({
           idempotencyKey,
         });
       }
-      const { token } = await apiGetPaypalCheckoutToken();
+      const { token } = await apiGetPaypalCheckoutToken({ currencyCode });
       return token;
     } catch (error) {
       setPaymentError(error);

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -188,6 +188,7 @@ export const SubscriptionCreate = ({
                 setPaymentError={setPaymentError}
                 idempotencyKey={submitNonce}
                 ButtonBase={paypalButtonBase}
+                currencyCode={selectedPlan.currency}
               />
             </Suspense>
           )}


### PR DESCRIPTION
## Because

- We need to pass through the currency from the selected plan to paypal

## This pull request

- Makes the currency code configurable on the paypal-client SetExpressCheckout and follows back down the chain of calls adding the currencyCode as appropriate.

## Issue that this pull request solves

Closes: #7471

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).