### PR TITLE
fix(settings): account for sessionToken.mustVerify in new settings

### DIFF
--- a/packages/fxa-graphql-api/src/auth/session-token.strategy.spec.ts
+++ b/packages/fxa-graphql-api/src/auth/session-token.strategy.spec.ts
@@ -37,11 +37,23 @@ describe('SessionTokenStrategy', () => {
     });
   });
 
-  it('throws unauthorized', async () => {
+  it('throws unauthorized for an invalid token', async () => {
     mockSession.sessionTokenData.mockResolvedValue(undefined);
     mockAuthClient.deriveHawkCredentials.mockResolvedValue({ id: 'testid' });
     await expect(strategy.validate('token')).rejects.toThrowError(
       new UnauthorizedException('Invalid token')
+    );
+  });
+
+  it('throws unauthorized when mustVerify is not met', async () => {
+    mockSession.sessionTokenData.mockResolvedValue({
+      mustVerify: true,
+      tokenVerified: false,
+      emailVerified: true,
+    });
+    mockAuthClient.deriveHawkCredentials.mockResolvedValue({ id: 'testid' });
+    await expect(strategy.validate('token')).rejects.toThrowError(
+      new UnauthorizedException('Must verify')
     );
   });
 

--- a/packages/fxa-graphql-api/src/auth/session-token.strategy.ts
+++ b/packages/fxa-graphql-api/src/auth/session-token.strategy.ts
@@ -23,6 +23,12 @@ export class SessionTokenStrategy extends PassportStrategy(Strategy) {
       if (!session) {
         throw new UnauthorizedException('Invalid token');
       }
+      if (
+        session.mustVerify &&
+        (!session.tokenVerified || !session.emailVerified)
+      ) {
+        throw new UnauthorizedException('Must verify');
+      }
       return { token, session };
     } catch (err) {
       if (err.status) {

--- a/packages/fxa-settings/src/lib/gql.ts
+++ b/packages/fxa-settings/src/lib/gql.ts
@@ -10,6 +10,10 @@ export const errorHandler: ErrorHandler = ({ graphQLErrors, networkError }) => {
     for (const error of graphQLErrors) {
       if (error.message === 'Invalid token') {
         reauth = true;
+      } else if (error.message === 'Must verify') {
+        return window.location.replace(
+          `/signin_token_code?action=email&service=sync`
+        );
       }
     }
   }


### PR DESCRIPTION
There's a special token status of `mustVerify` that requires the session to be verified before it can be used at all. We need to reject any requests from unverified sessions when it is set.

The frontend should redirect to the `signin_token_code` page when this happens.

fixes #6240

ref https://github.com/mozilla/fxa/blob/67c3afa3ea38826d7b4b9f78fa3d706cfa07ecca/packages/fxa-auth-server/lib/routes/emails.js#L175-L181
