### PR TITLE
feat(auth-server): add transaction search to paypal

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal.ts
@@ -14,6 +14,8 @@ import {
   IpnMessage,
   PayPalClient,
   PayPalClientError,
+  TransactionSearchOptions,
+  TransactionStatus,
 } from './paypal-client';
 import { StripeHelper } from './stripe';
 
@@ -69,6 +71,19 @@ export type ChargeResponse = {
     | 'buyer-complaint'
     | 'refund'
     | 'other';
+};
+
+export type TransactionSearchResult = {
+  amount: string;
+  currencyCode: string;
+  email: string;
+  feeAmount: string;
+  name: string;
+  netAmount: string;
+  status: TransactionStatus;
+  timestamp: string;
+  transactionId: string;
+  type: string;
 };
 
 export class PayPalHelper {
@@ -187,6 +202,24 @@ export class PayPalHelper {
    */
   public extractIpnMessage(payload: string): IpnMessage {
     return this.client.nvpToObject(payload) as IpnMessage;
+  }
+
+  public async searchTransactions(
+    options: TransactionSearchOptions
+  ): Promise<TransactionSearchResult[]> {
+    const results = await this.client.transactionSearch(options);
+    return results.L.map((r) => ({
+      amount: r.AMT,
+      currencyCode: r.CURRENCYCODE,
+      email: r.EMAIL,
+      feeAmount: r.FEEAMT,
+      name: r.NAME,
+      netAmount: r.NETAMT,
+      status: r.STATUS,
+      timestamp: r.TIMESTAMP,
+      transactionId: r.TRANSACTIONID,
+      type: r.TYPE,
+    }));
   }
 
   /**

--- a/packages/fxa-auth-server/test/local/payments/fixtures/paypal/transaction_search_success.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/paypal/transaction_search_success.json
@@ -1,0 +1,48 @@
+{
+  "TIMESTAMP": "2021-02-11T18:15:12Z",
+  "CORRELATIONID": "89f9bb2201990",
+  "ACK": "Success",
+  "VERSION": "204",
+  "BUILD": "55101542",
+  "L": [
+    {
+      "TIMESTAMP": "2021-02-11T17:38:28Z",
+      "TIMEZONE": "GMT",
+      "TYPE": "Payment",
+      "EMAIL": "sb-ufoot5037790@personal.example.com",
+      "NAME": "John Doe",
+      "TRANSACTIONID": "2TA09271XC591854A",
+      "STATUS": "Under Review",
+      "AMT": "5.99",
+      "CURRENCYCODE": "USD",
+      "FEEAMT": "-0.47",
+      "NETAMT": "5.52"
+    },
+    {
+      "TIMESTAMP": "2021-02-11T17:38:23Z",
+      "TIMEZONE": "GMT",
+      "TYPE": "Payment",
+      "EMAIL": "sb-ufoot5037790@personal.example.com",
+      "NAME": "John Doe",
+      "TRANSACTIONID": "7WW53923D67853628",
+      "STATUS": "Under Review",
+      "AMT": "5.99",
+      "CURRENCYCODE": "USD",
+      "FEEAMT": "-0.47",
+      "NETAMT": "5.52"
+    },
+    {
+      "TIMESTAMP": "2021-02-11T17:31:05Z",
+      "TIMEZONE": "GMT",
+      "TYPE": "Payment",
+      "EMAIL": "sb-ufoot5037790@personal.example.com",
+      "NAME": "John Doe",
+      "TRANSACTIONID": "22N88933SF2815829",
+      "STATUS": "Under Review",
+      "AMT": "5.99",
+      "CURRENCYCODE": "USD",
+      "FEEAMT": "-0.47",
+      "NETAMT": "5.52"
+    }
+  ]
+}

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -26,6 +26,7 @@ const successfulSetExpressCheckoutResponse = require('./fixtures/paypal/set_expr
 const unSuccessfulSetExpressCheckoutResponse = require('./fixtures/paypal/set_express_checkout_failure.json');
 const successfulDoReferenceTransactionResponse = require('./fixtures/paypal/do_reference_transaction_success.json');
 const unSuccessfulDoReferenceTransactionResponse = require('./fixtures/paypal/do_reference_transaction_failure.json');
+const searchTransactionResponse = require('./fixtures/paypal/transaction_search_success.json');
 const sampleIpnMessage = require('./fixtures/paypal/sample_ipn_message.json')
   .message;
 
@@ -364,6 +365,17 @@ describe('PayPalClient', () => {
         .reply(200, 'VERIFIED');
       const result = await client.ipnVerify(sampleIpnMessage);
       assert.equal(result, 'VERIFIED');
+    });
+  });
+
+  describe('transactionSearch', () => {
+    it('calls API with valid message', async () => {
+      client.doRequest = sandbox.fake.resolves(searchTransactionResponse);
+      const response = await client.transactionSearch({
+        startDate: new Date('2010-09-02'),
+        invoice: 'inv-000',
+      });
+      assert.equal(response, searchTransactionResponse);
     });
   });
 });

--- a/packages/fxa-auth-server/test/local/payments/paypal.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal.js
@@ -19,6 +19,7 @@ const error = require('../../../lib/error');
 const successfulSetExpressCheckoutResponse = require('./fixtures/paypal/set_express_checkout_success.json');
 const successfulDoReferenceTransactionResponse = require('./fixtures/paypal/do_reference_transaction_success.json');
 const successfulBAUpdateResponse = require('./fixtures/paypal/ba_update_success.json');
+const searchTransactionResponse = require('./fixtures/paypal/transaction_search_success.json');
 const eventCustomerSourceExpiring = require('./fixtures/stripe/event_customer_source_expiring.json');
 const sampleIpnMessage = require('./fixtures/paypal/sample_ipn_message.json');
 const { StripeHelper } = require('../../../lib/payments/stripe');
@@ -205,6 +206,57 @@ describe('PayPalHelper', () => {
       );
       const response = await paypalHelper.cancelBillingAgreement('test');
       assert.isNull(response);
+    });
+  });
+
+  describe('searchTransactions', () => {
+    it('returns the data from doRequest', async () => {
+      paypalHelper.client.doRequest = sinon.fake.resolves(
+        searchTransactionResponse
+      );
+      const expectedResponse = [
+        {
+          amount: '5.99',
+          currencyCode: 'USD',
+          email: 'sb-ufoot5037790@personal.example.com',
+          feeAmount: '-0.47',
+          name: 'John Doe',
+          netAmount: '5.52',
+          status: 'Under Review',
+          timestamp: '2021-02-11T17:38:28Z',
+          transactionId: '2TA09271XC591854A',
+          type: 'Payment',
+        },
+        {
+          amount: '5.99',
+          currencyCode: 'USD',
+          email: 'sb-ufoot5037790@personal.example.com',
+          feeAmount: '-0.47',
+          name: 'John Doe',
+          netAmount: '5.52',
+          status: 'Under Review',
+          timestamp: '2021-02-11T17:38:23Z',
+          transactionId: '7WW53923D67853628',
+          type: 'Payment',
+        },
+        {
+          amount: '5.99',
+          currencyCode: 'USD',
+          email: 'sb-ufoot5037790@personal.example.com',
+          feeAmount: '-0.47',
+          name: 'John Doe',
+          netAmount: '5.52',
+          status: 'Under Review',
+          timestamp: '2021-02-11T17:31:05Z',
+          transactionId: '22N88933SF2815829',
+          type: 'Payment',
+        },
+      ];
+      const response = await paypalHelper.searchTransactions({
+        startDate: new Date(),
+        invoice: 'inv-001',
+      });
+      assert.deepEqual(response, expectedResponse);
     });
   });
 


### PR DESCRIPTION
Because:

* We want to search transactions for a given user/invoice.

This commit:

* Adds a paypal transaction search API command.

Closes #7238

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
