### PR TITLE
fix(settings): ensure modal callbacks adhere to the defined type

### DIFF
--- a/packages/fxa-settings/src/components/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/index.tsx
@@ -294,10 +294,8 @@ export const ConnectedServices = () => {
         )}
         {confirmDisconnectModalRevealed && (
           <VerifiedSessionGuard
-            onDismiss={clearDisconnectingState}
-            onError={(error: ApolloError) =>
-              clearDisconnectingState(undefined, error)
-            }
+            onDismiss={hideConfirmDisconnectModal}
+            onError={(error) => clearDisconnectingState(undefined, error)}
           >
             <Modal
               onDismiss={hideConfirmDisconnectModal}

--- a/packages/fxa-settings/src/components/Modal/index.tsx
+++ b/packages/fxa-settings/src/components/Modal/index.tsx
@@ -67,7 +67,7 @@ export const Modal = ({
           <div className="flex justify-end pr-2 pt-2">
             <button
               data-testid="modal-dismiss"
-              onClick={onDismiss}
+              onClick={(event) => onDismiss()}
               title="Close modal"
             >
               <CloseIcon className="w-2 h-2 m-3" role="img" />
@@ -82,7 +82,7 @@ export const Modal = ({
                   <button
                     className="cta-neutral mx-2 flex-1"
                     data-testid="modal-cancel"
-                    onClick={onDismiss}
+                    onClick={(event) => onDismiss()}
                   >
                     Cancel
                   </button>
@@ -102,7 +102,7 @@ export const Modal = ({
                   <button
                     className={classNames('mx-2 flex-1', confirmBtnClassName)}
                     data-testid="modal-confirm"
-                    onClick={onConfirm}
+                    onClick={(event) => onConfirm()}
                   >
                     {confirmText}
                   </button>

--- a/packages/fxa-settings/src/components/ModalVerifySession/index.tsx
+++ b/packages/fxa-settings/src/components/ModalVerifySession/index.tsx
@@ -148,7 +148,7 @@ export const ModalVerifySession = ({
             type="button"
             className="cta-neutral mx-2 flex-1"
             data-testid="modal-verify-session-cancel"
-            onClick={onDismiss}
+            onClick={(event) => onDismiss()}
           >
             Cancel
           </button>


### PR DESCRIPTION
The `Modal` and `ModalVerifySession` components were incidentally calling the `onDismiss` callback with the dom event argument from their originating element. This happened to break the `ConnectedServices` component which was using a fn that accepted optional parameters as the callback.

This commit ensures the callbacks are called with no arguments.

fixes #7509