### PR TITLE
feat(auth-server): add 'payment_provider' property to Customer object

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -416,6 +416,7 @@ module.exports.subscriptionsCustomerValidator = isA.object({
   exp_month: isA.number().optional(),
   exp_year: isA.number().optional(),
   last4: isA.string().optional(),
+  payment_provider: isA.string().optional(),
   payment_type: isA.string().optional(),
   brand: isA.string().optional(),
   subscriptions: isA

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
@@ -27,6 +27,7 @@ const selectedPlan: Plan = {
 
 const customer: Customer = {
   billing_name: 'Jane Doe',
+  payment_provider: 'stripe',
   payment_type: 'credit',
   last4: '5309',
   exp_month: '02',

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.test.tsx
@@ -39,6 +39,7 @@ const selectedPlan = {
 
 const customer: Customer = {
   billing_name: 'Jane Doe',
+  payment_provider: 'stripe',
   payment_type: 'credit',
   last4: '5309',
   exp_month: '02',
@@ -113,7 +114,9 @@ describe('PaymentConfirmation', () => {
         });
         const expectedAmount = getLocalizedCurrency(plan.amount, plan.currency);
 
-        expect(planPriceComponent.props.vars.amount).toStrictEqual(expectedAmount);
+        expect(planPriceComponent.props.vars.amount).toStrictEqual(
+          expectedAmount
+        );
         expect(planPriceComponent.props.vars.intervalCount).toBe(
           plan.interval_count
         );

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
@@ -58,6 +58,7 @@ const PLAN = {
 };
 const CUSTOMER = {
   billing_name: 'Foo Barson',
+  payment_provider: 'stripe',
   payment_type: 'credit',
   last4: '5309',
   exp_month: '02',

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -18,6 +18,7 @@ export const NEW_CUSTOMER: Customer = {
 
 export const CUSTOMER: Customer = {
   billing_name: 'Foo Barson',
+  payment_provider: 'stripe',
   payment_type: 'credit',
   last4: '5309',
   exp_month: '02',

--- a/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
@@ -178,6 +178,7 @@ const PLANS: Plan[] = [
 
 const CUSTOMER: Customer = {
   billing_name: 'Jane Doe',
+  payment_provider: 'stripe',
   payment_type: 'credit',
   last4: '5309',
   exp_month: '02',

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -273,6 +273,7 @@ const subscribedProps: SubscriptionsProps = {
     error: null,
     result: {
       billing_name: 'Jane Doe',
+      payment_provider: 'not_chosen',
       payment_type: 'card',
       last4: '8675',
       exp_month: '12',

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -73,6 +73,7 @@ export type Customer = {
   exp_month?: string;
   exp_year?: string;
   last4?: string;
+  payment_provider?: string;
   payment_type?: string;
   subscriptions: Array<CustomerSubscription>;
 };


### PR DESCRIPTION
## Because

- We want to vary pieces of UI based on the user's payment provider...

## This pull request

- Adds a `payment_provider` to the Customer object

## Issue that this pull request solves

Closes: #7115 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
