### PR TITLE
(feat)payments-server: update create subscription page for paypal designs

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -76,8 +76,8 @@ product-plan-not-found = Plan not found
 product-no-such-plan = No such plan for this product.
 
 ## payment legal blurb
-payment-legal-copy = { -brand-name-mozilla } uses Stripe for secure payment processing.
-payment-legal-link = View the <a>Stripe privacy policy</a>.
+payment-legal-copy-stripe-paypal = { -brand-name-mozilla } uses Stripe and Paypal for secure payment processing.
+payment-legal-link-stripe-paypal = View the <stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> and <paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>.
 
 ## payment form
 payment-name =
@@ -291,6 +291,9 @@ sub-billing-update-success = Your billing information has been updated successfu
 
 ## subscription create
 sub-guarantee = 30-day money-back guarantee
+pay-with-heading-other = Select payment option
+pay-with-heading-card-or = Or pay with card
+pay-with-heading-card-only = Pay with card
 
 ## plan-details
 plan-details-header = Product details

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.test.tsx
@@ -191,26 +191,6 @@ it('includes the confirmation checkbox when confirm = true and plan supplied', (
 });
 
 describe('Legal', () => {
-  describe('links', () => {
-    const commonLegalLinkTest = (plan?: Plan) => () => {
-      const { queryByText } = render(<Subject {...{ plan }} />);
-      [
-        queryByText('Terms of Service'),
-        queryByText('Privacy Notice'),
-      ].forEach((q) =>
-        plan ? expect(q).toBeInTheDocument() : expect(q).not.toBeInTheDocument()
-      );
-    };
-    it(
-      'omits terms of service and privacy notice links when plan is missing',
-      commonLegalLinkTest()
-    );
-    it(
-      'includes terms of service and privacy notice links when plan is supplied',
-      commonLegalLinkTest(MOCK_PLAN)
-    );
-  });
-
   describe('rendering the legal checkbox Localized component', () => {
     function runTests(plan: Plan, expectedMsgId: string, expectedMsg: string) {
       const testRenderer = TestRenderer.create(

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -24,7 +24,6 @@ import {
   Checkbox,
   OnValidateFunction,
 } from '../fields';
-import PaymentLegalBlurb from '../PaymentLegalBlurb';
 import {
   State as ValidatorState,
   MiddlewareReducer as ValidatorMiddlewareReducer,
@@ -40,7 +39,6 @@ import { Plan, Customer } from '../../store/types';
 import { productDetailsFromPlan } from 'fxa-shared/subscriptions/metadata';
 
 import './index.scss';
-import { TermsAndPrivacy } from '../TermsAndPrivacy';
 
 export type PaymentSubmitResult = {
   stripe: Stripe;
@@ -295,9 +293,6 @@ export const PaymentForm = ({
           </Localized>
         </div>
       )}
-
-      <PaymentLegalBlurb />
-      {plan && <TermsAndPrivacy plan={plan} />}
     </Form>
   );
 };

--- a/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
@@ -3,25 +3,36 @@ import { Localized } from '@fluent/react';
 
 import './index.scss';
 
+function getPrivacyLinkText(): string {
+  return 'View the <stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> and <paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>.';
+}
+
 export const PaymentLegalBlurb = () => (
   <div className="payment-legal-blurb">
-    <Localized id="payment-legal-copy">
-      <p>Mozilla uses Stripe for secure payment processing.</p>
+    <Localized id="payment-legal-copy-stripe-paypal">
+      <p>Mozilla uses Stripe and Paypal for secure payment processing.</p>
     </Localized>
 
     <Localized
-      id="payment-legal-link"
+      id="payment-legal-link-stripe-paypal"
       elems={{
-        a: <a
-          href="https://stripe.com/privacy"
-          target="_blank"
-          rel="noopener noreferrer"
-        ></a>
+        stripePrivacyLink: (
+          <a
+            href="https://stripe.com/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+          ></a>
+        ),
+        paypalPrivacyLink: (
+          <a
+            href="https://paypal.com/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+          ></a>
+        ),
       }}
     >
-      <p>
-        View the <a>Stripe privacy policy</a>.
-      </p>
+      <p>{getPrivacyLinkText()}</p>
     </Localized>
   </div>
 );

--- a/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.tsx
@@ -107,10 +107,21 @@ export const PaypalButton = ({
     [setPaymentError]
   );
 
+  // Style docs: https://developer.paypal.com/docs/business/checkout/reference/style-guide/
+  const styleOptions = {
+    layout: 'horizontal',
+    color: 'gold',
+    shape: 'pill',
+    label: 'paypal',
+    height: 48,
+    tagline: 'false',
+  };
+
   return (
     <>
       {ButtonBase && (
         <ButtonBase
+          style={styleOptions}
           data-testid="paypal-button"
           createOrder={createOrder}
           onApprove={onApprove}

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.scss
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.scss
@@ -20,16 +20,38 @@
   @include min-width('desktop') {
     padding: 28px 48px 48px;
   }
+  .pay-with-heading {
+    color: rgb(115, 115, 115);
+    margin: 0 0 24px 0;
+    display: grid;
+    width: 100%;
+    align-items: center;
+    text-align: center;
+    grid-template-columns: minmax(20px, 1fr) auto minmax(20px, 1fr);
+    grid-gap: 20px;
+    &:before,
+    &:after {
+      content: '';
+      border-top: 1px solid #e0e0e6;
+    }
+  }
+
+
+  .subscription-create-pay-with-other .paypal-button {
+    width: 240px;
+    height: 48px + 48;
+    margin: auto; 
+  }
+
+
+  .subscription-create-pay-with-card .accepted-cards {
+    justify-content: center;
+  }
 
   .billing-title {
     font-size: 15px;
     font-weight: 600;
     margin-bottom: 20px;
-
-    @include min-width('tablet') {
-      border-top: 1px solid #e0e0e6;
-      padding-top: 16px;
-    }
   }
 
   .subscription-create-heading {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -159,6 +159,13 @@ describe('routes/ProductV2/SubscriptionCreate', () => {
     ).toBeInTheDocument();
     expect(queryByText('Billing Information')).toBeInTheDocument();
     expect(queryByTestId('paypal-button')).not.toBeInTheDocument();
+    expect(queryByText('Terms of Service')).toBeInTheDocument();
+    expect(queryByText('Privacy Notice')).toBeInTheDocument();
+    expect(
+      queryByText(
+        'Mozilla uses Stripe and Paypal for secure payment processing.'
+      )
+    ).toBeInTheDocument();
   });
 
   it('renders as expected with PayPal UI enabled', async () => {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -17,6 +17,8 @@ import Header from '../../../components/Header';
 import PaymentForm, { PaymentFormProps } from '../../../components/PaymentForm';
 import ErrorMessage from '../../../components/ErrorMessage';
 import AcceptedCards from '../../Product/AcceptedCards';
+import PaymentLegalBlurb from '../../../components/PaymentLegalBlurb';
+import { TermsAndPrivacy } from '../../../components/TermsAndPrivacy';
 
 import * as Amplitude from '../../../lib/amplitude';
 import { Localized } from '@fluent/react';
@@ -180,53 +182,82 @@ export const SubscriptionCreate = ({
             </Localized>
           </div>
 
-          {!hasExistingCard(customer) && paypalScriptLoaded && (
-            <Suspense fallback={<div>Loading...</div>}>
-              <PaypalButton
-                apiClientOverrides={apiClientOverrides}
-                currencyCode={selectedPlan.currency}
-                customer={customer}
-                idempotencyKey={submitNonce}
-                priceId={selectedPlan.plan_id}
-                refreshSubscriptions={refreshSubscriptions}
-                setPaymentError={setPaymentError}
-                ButtonBase={paypalButtonBase}
-              />
-            </Suspense>
-          )}
-
-          <h3 className="billing-title">
-            <Localized id="sub-update-title">
-              <span className="title">Billing Information</span>
-            </Localized>
-          </h3>
-
-          {!hasExistingCard(customer) && <AcceptedCards />}
-
-          <ErrorMessage isVisible={!!paymentError}>
-            {paymentError && (
-              <Localized id={getErrorMessage(paymentError.code || 'UNKNOWN')}>
-                <p data-testid="error-payment-submission">
-                  {getErrorMessage(paymentError.code || 'UNKNOWN')}
-                </p>
-              </Localized>
+          <div className="subscription-create-pay-with-other">
+            {!hasExistingCard(customer) && paypalScriptLoaded && (
+              <Suspense fallback={<div>Loading...</div>}>
+                <Localized id="pay-with-heading-other">
+                  <p className="pay-with-heading">Select payment option</p>
+                </Localized>
+                <div className="paypal-button">
+                  <PaypalButton
+                    apiClientOverrides={apiClientOverrides}
+                    currencyCode={selectedPlan.currency}
+                    customer={customer}
+                    idempotencyKey={submitNonce}
+                    priceId={selectedPlan.plan_id}
+                    refreshSubscriptions={refreshSubscriptions}
+                    setPaymentError={setPaymentError}
+                    ButtonBase={paypalButtonBase}
+                  />
+                </div>
+              </Suspense>
             )}
-          </ErrorMessage>
+          </div>
 
-          <PaymentForm
-            {...{
-              customer,
-              submitNonce,
-              onSubmit,
-              onChange,
-              inProgress,
-              validatorInitialState,
-              confirm: true,
-              plan: selectedPlan,
-              onMounted: onFormMounted,
-              onEngaged: onFormEngaged,
-            }}
-          />
+          <div className="subscription-create-pay-with-card">
+            {!hasExistingCard(customer) && !paypalScriptLoaded && (
+              <div>
+                <Localized id="pay-with-heading-card-only">
+                  <p className="pay-with-heading">Pay with card</p>
+                </Localized>
+                <AcceptedCards />
+              </div>
+            )}
+
+            {!hasExistingCard(customer) && paypalScriptLoaded && (
+              <div>
+                <Localized id="pay-with-heading-card-or">
+                  <p className="pay-with-heading">Or pay with card</p>
+                </Localized>
+                <AcceptedCards />
+              </div>
+            )}
+
+            <h3 className="billing-title">
+              <Localized id="sub-update-title">
+                <span className="title">Billing Information</span>
+              </Localized>
+            </h3>
+
+            <ErrorMessage isVisible={!!paymentError}>
+              {paymentError && (
+                <Localized id={getErrorMessage(paymentError.code || 'UNKNOWN')}>
+                  <p data-testid="error-payment-submission">
+                    {getErrorMessage(paymentError.code || 'UNKNOWN')}
+                  </p>
+                </Localized>
+              )}
+            </ErrorMessage>
+
+            <PaymentForm
+              {...{
+                customer,
+                submitNonce,
+                onSubmit,
+                onChange,
+                inProgress,
+                validatorInitialState,
+                confirm: true,
+                plan: selectedPlan,
+                onMounted: onFormMounted,
+                onEngaged: onFormEngaged,
+              }}
+            />
+          </div>
+          <div className="subscription-create-footer">
+            <PaymentLegalBlurb />
+            {selectedPlan && <TermsAndPrivacy plan={selectedPlan} />}
+          </div>
         </div>
         <PlanDetails
           {...{


### PR DESCRIPTION
## Because

- The create subscription screen did not match the user tested designs

## This pull request

- adds centered headings
- reorganizes form code, now that payment is more complicated
- updates the paypal button
- updates the privacy policy links
- moves the test for legal text to the createSubscription tests

## Issue that this pull request solves

Closes: #7449

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots 

Before:
![Screenshot from 2021-02-11 20-13-12](https://user-images.githubusercontent.com/1796208/107723101-f7ef7080-6ca5-11eb-9b27-ac7be302497f.png)

After:
![Screenshot from 2021-02-11 20-08-48](https://user-images.githubusercontent.com/1796208/107723106-fcb42480-6ca5-11eb-80c5-bd6449818f97.png)

Design should roughly be [panel 288 from here](https://www.figma.com/file/AvdKdmts8KN8HK6d1VCMTH/Paypal_Checkout_Concept(B)?node-id=0%3A1) - jess cook can provide more guidance.

## Other information 

Note that the paypal button is delivered automatically from paypal. despite the docs (https://developer.paypal.com/docs/business/checkout/reference/style-guide/#size) it does not want to give us a button with a P logo in it. My current best guess for this is that the buttons have been updated but the docs haven't (see "update your buttons" here - https://www.paypal.com/us/webapps/mpp/logos-buttons and note we're doing "Checkout")
