### PR TITLE
fix(fxa-settings): add/change avatar button alignment

### DIFF
--- a/packages/fxa-settings/src/components/UnitRowWithAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowWithAvatar/index.tsx
@@ -28,7 +28,7 @@ export const UnitRowWithAvatar = () => {
         <div>
           <Localized id={ctaL10nId}>
             <Link
-              className="cta-neutral cta-base"
+              className="cta-neutral cta-base ltr:ml-1 rtl:mr-1"
               data-testid="unit-row-with-avatar-route"
               to={`${HomePath}/avatar${location.search}`}
             >


### PR DESCRIPTION
## This pull request

- Fixes the alignment of the add/change avatar button on the main settings view

## Issue that this pull request solves

- fixes #7410

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
