### PR TITLE
task(fxa-settings): load styles for react-easy-crop

### DIFF
--- a/packages/fxa-settings/src/components/PageAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/index.tsx
@@ -11,6 +11,8 @@ import Cropper from 'react-easy-crop';
 import { Slider } from '@material-ui/core';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 
+import 'react-easy-crop/react-easy-crop.css';
+
 import { useAccount } from '../../models';
 import { HomePath } from '../../constants';
 import firefox from '../../lib/firefox';
@@ -199,6 +201,7 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
           onCropChange={setCrop}
           onCropComplete={onCropComplete}
           onZoomChange={setZoom}
+          disableAutomaticStylesInjection={true}
           cropSize={{ width: 160, height: 160 }}
           style={{ containerStyle: { borderRadius: '8px' } }}
         />


### PR DESCRIPTION
## Because

- react-easy-crop style injection was being blocked for security

## This pull request

- Loads the styles for react-easy-crop in a more sane way

## Issue that this pull request solves

- fixes #7507

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
