### PR TITLE
fix(auth-server): Paypal requires uppercased currencyCode

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal-client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-client.ts
@@ -317,7 +317,7 @@ export class PayPalClient {
       L_BILLINGTYPE0: 'MerchantInitiatedBilling',
       NOSHIPPING: 1,
       PAYMENTREQUEST_0_AMT: '0',
-      PAYMENTREQUEST_0_CURRENCYCODE: options.currencyCode,
+      PAYMENTREQUEST_0_CURRENCYCODE: options.currencyCode.toUpperCase(),
       PAYMENTREQUEST_0_PAYMENTACTION: 'AUTHORIZATION',
       RETURNURL: PLACEHOLDER_URL,
     };

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -162,7 +162,7 @@ export const paypalRoutes = (
         },
         validate: {
           payload: {
-            currencyCode: isA.string().required(),
+            currencyCode: isA.string().uppercase().required(),
           },
         },
       },

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -255,6 +255,23 @@ describe('PayPalClient', () => {
         }
       );
     });
+
+    it('calls upper cases requested currency', async () => {
+      client.doRequest = sandbox.fake.resolves(
+        successfulSetExpressCheckoutResponse
+      );
+      await client.setExpressCheckout({
+        currencyCode: 'eur',
+      });
+      sinon.assert.calledOnceWithExactly(
+        client.doRequest,
+        'SetExpressCheckout',
+        {
+          ...defaultData,
+          PAYMENTREQUEST_0_CURRENCYCODE: 'EUR',
+        }
+      );
+    });
   });
 
   describe('createBillingAgreement', () => {


### PR DESCRIPTION
## Because

- paypal requires uppercased currencyCode

## This pull request

- adds it at the client level 
- and at the handler validation

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
