### PR TITLE
feat(auth-server): add metrics for paypal client

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal-client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-client.ts
@@ -4,6 +4,7 @@
 import pRetry from 'p-retry';
 import querystring from 'querystring';
 import superagent from 'superagent';
+import { EventEmitter } from 'events';
 
 export const PAYPAL_SANDBOX_BASE = 'https://api-3t.sandbox.paypal.com';
 export const PAYPAL_SANDBOX_IPN_BASE = 'https://ipnpb.sandbox.paypal.com';
@@ -201,6 +202,15 @@ export function isIpnMerchPmt(
   return ['merch_pmt', 'mp_cancel'].includes(ipnMessage.txn_type);
 }
 
+type ResponseEventType = {
+  error?: Error;
+  request_end_time: number;
+  version: string;
+  elapsed: number;
+  method: string;
+  request_start_time: number;
+};
+
 export class PayPalClientError extends Error {
   public raw: string;
   public data: NVPResponse;
@@ -227,6 +237,11 @@ export class PayPalClient {
     minTimeout: number;
     factor: number;
   };
+  private emitter: EventEmitter;
+  public on: (
+    event: 'response',
+    listener: (response: ResponseEventType) => void
+  ) => EventEmitter;
 
   constructor(options: PaypalOptions) {
     this.url = options.sandbox ? PAYPAL_SANDBOX_API : PAYPAL_LIVE_API;
@@ -240,6 +255,8 @@ export class PayPalClient {
       factor: 1.66,
       ...options.retryOptions,
     };
+    this.emitter = new EventEmitter();
+    this.on = this.emitter.on.bind(this.emitter);
   }
 
   private objectToNVP(object: Record<string, any>): string {
@@ -284,15 +301,38 @@ export class PayPalClient {
       SIGNATURE: this.signature,
       VERSION: PAYPAL_VERSION,
     });
-    const result = await pRetry(
-      () =>
-        superagent
-          .post(this.url)
-          .set('content-type', 'application/x-www-form-urlencoded')
-          .send(payload),
-      this.retryOptions
-    );
+    const response = {
+      request_start_time: Date.now(),
+      method,
+      version: PAYPAL_VERSION,
+    };
+    let result;
+    try {
+      result = await pRetry(
+        () =>
+          superagent
+            .post(this.url)
+            .set('content-type', 'application/x-www-form-urlencoded')
+            .send(payload),
+        this.retryOptions
+      );
+    } catch (err) {
+      const request_end_time = Date.now();
+      this.emitter.emit('response', {
+        ...response,
+        elapsed: request_end_time - response.request_start_time,
+        error: err,
+        request_end_time,
+      });
+      throw err;
+    }
+    const request_end_time = Date.now();
     const resultObj = this.nvpToObject(result.text) as T;
+    this.emitter.emit('response', {
+      ...response,
+      elapsed: request_end_time - response.request_start_time,
+      request_end_time,
+    });
     if (resultObj.ACK === 'Success' || resultObj.ACK === 'SuccessWithWarning') {
       return resultObj;
     } else {

--- a/packages/fxa-auth-server/lib/payments/paypal.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal.ts
@@ -98,6 +98,14 @@ export class PayPalHelper {
     this.client = Container.get(PayPalClient);
     this.metrics = Container.get(StatsD);
     this.stripeHelper = Container.get(StripeHelper);
+    if (this.metrics) {
+      this.client.on('response', (response) => {
+        this.metrics.timing('paypal_request', response.elapsed, undefined, {
+          method: response.method,
+          error: response.error ? 'false' : 'true',
+        });
+      });
+    }
   }
 
   /**

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -133,6 +133,52 @@ describe('PayPalClient', () => {
       assert.deepEqual(result, userNameSuccessResponseData);
     });
 
+    it('emits an event on success', async () => {
+      const event = {};
+      client.on('response', (response) => Object.assign(event, response));
+      nock(PAYPAL_SANDBOX_BASE)
+        .post(PAYPAL_NVP_ROUTE, expectedPayload)
+        .reply(200, client.objectToNVP(userNameSuccessResponseData));
+      const result = await client.doRequest(
+        'BillAgreementUpdate',
+        userNameRequestData
+      );
+      assert.deepEqual(result, userNameSuccessResponseData);
+      assert.deepNestedInclude(event, {
+        method: 'BillAgreementUpdate',
+        version: '204',
+      });
+    });
+
+    it('emits an event on error', async () => {
+      const event = {};
+      client.on('response', (response) => Object.assign(event, response));
+      nock(PAYPAL_SANDBOX_BASE)
+        .post(PAYPAL_NVP_ROUTE, expectedPayload)
+        .reply(500, 'ERROR');
+      nock(PAYPAL_SANDBOX_BASE)
+        .post(PAYPAL_NVP_ROUTE, expectedPayload)
+        .reply(500, 'ERROR');
+      nock(PAYPAL_SANDBOX_BASE)
+        .post(PAYPAL_NVP_ROUTE, expectedPayload)
+        .reply(500, 'ERROR');
+      nock(PAYPAL_SANDBOX_BASE)
+        .post(PAYPAL_NVP_ROUTE, expectedPayload)
+        .reply(500, 'ERROR');
+      try {
+        await client.doRequest('BillAgreementUpdate', userNameRequestData);
+        assert.fail('Request should have thrown an error.');
+      } catch (err) {
+        assert.instanceOf(err, Error);
+        assert.equal(err.message, 'Internal Server Error');
+        assert.deepNestedInclude(event, {
+          method: 'BillAgreementUpdate',
+          version: '204',
+        });
+        assert.deepNestedInclude(event.error, { status: 500 });
+      }
+    });
+
     it('retries after a failure', async () => {
       nock(PAYPAL_SANDBOX_BASE)
         .post(PAYPAL_NVP_ROUTE, expectedPayload)


### PR DESCRIPTION
Because:

* We want to gauge response times from PayPal and track client errors.

This commit:

* Adds an event emitter similar to Stripes so that the paypal helper
  can augment it with metric reporting.

Closes #7522

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
