### PR TITLE
fix(settings): Add page view event for PageChangePassword metrics parity

### DIFF
--- a/packages/fxa-settings/src/components/PageChangePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.test.tsx
@@ -9,7 +9,11 @@ import { act, fireEvent, screen, wait } from '@testing-library/react';
 import { AuthContext, createAuthClient } from '../../lib/auth';
 import { MockedCache, renderWithRouter } from '../../models/_mocks';
 import PageChangePassword from '.';
-import { logViewEvent, settingsViewName } from '../../lib/metrics';
+import {
+  logViewEvent,
+  settingsViewName,
+  usePageViewEvent,
+} from '../../lib/metrics';
 import { typeByTestIdFn } from '../../lib/test-utils';
 
 jest.mock('../../lib/auth', () => ({
@@ -22,6 +26,7 @@ jest.mock('../../lib/auth', () => ({
     })),
 }));
 jest.mock('fxa-settings/src/lib/metrics', () => ({
+  usePageViewEvent: jest.fn(),
   logViewEvent: jest.fn(),
   settingsViewName: 'quuz',
 }));
@@ -48,6 +53,11 @@ it('renders', async () => {
   expect(screen.getByTestId('flow-container-back-btn')).toBeInTheDocument();
   expect(screen.getByTestId('nav-link-common-passwords')).toBeInTheDocument();
   expect(screen.getByTestId('nav-link-reset-password')).toBeInTheDocument();
+});
+
+it('emits a metrics event on render', async () => {
+  await render();
+  expect(usePageViewEvent).toHaveBeenCalledWith('settings.change-password');
 });
 
 it('emits an Amplitude event on success', async () => {

--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -11,7 +11,11 @@ import { HomePath } from '../../constants';
 import { usePasswordChanger } from '../../lib/auth';
 import { cache, sessionToken } from '../../lib/cache';
 import firefox from '../../lib/firefox';
-import { logViewEvent, settingsViewName } from '../../lib/metrics';
+import {
+  logViewEvent,
+  settingsViewName,
+  usePageViewEvent,
+} from '../../lib/metrics';
 import { useAccount } from '../../models';
 import AlertBar from '../AlertBar';
 import FlowContainer from '../FlowContainer';
@@ -49,6 +53,7 @@ const ValidationIcon = ({
 
 // eslint-disable-next-line no-empty-pattern
 export const PageChangePassword = ({}: RouteComponentProps) => {
+  usePageViewEvent('settings.change-password');
   const {
     handleSubmit,
     register,


### PR DESCRIPTION
Fixes #5173.

## Because

- we'd like to get metrics parity across old and new settings

## This pull request

- adds a missing event logged when the change password page is viewed

## Issue that this pull request solves

Closes: #5173

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
