### PR TITLE
fix(settings): Shorten 'delete account' button string to fit

### DIFF
--- a/packages/fxa-settings/src/components/PageDeleteAccount/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/en-US.ftl
@@ -26,6 +26,6 @@ delete-account-password-input =
  .label = Enter password
 
 delete-account-cancel-button = Cancel
-delete-account-delete-button = Delete Account
+delete-account-delete-button = Delete
 
 ##

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -240,7 +240,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
                   data-testid="delete-account-button"
                   disabled={disabled}
                 >
-                  Delete Account
+                  Delete
                 </button>
               </Localized>
             </div>


### PR DESCRIPTION
Fixes #7443.

## Because

- it would be nice to close out the 'delete account' epic
- the button text splits across two lines on android

## This pull request

- shortens the text from "delete account" to "delete"

## Issue that this pull request solves

Closes: #7443

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
