### PR TITLE
fix(payments): Use brand name PayPal in localized strings.

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -6,6 +6,7 @@
 project-brand = Firefox Accounts
 -brand-name-mozilla = Mozilla
 -brand-name-firefox = Firefox
+-brand-name-paypal = PayPal
 
 document =
   .title = Firefox Accounts
@@ -76,8 +77,8 @@ product-plan-not-found = Plan not found
 product-no-such-plan = No such plan for this product.
 
 ## payment legal blurb
-payment-legal-copy-stripe-paypal = { -brand-name-mozilla } uses Stripe and Paypal for secure payment processing.
-payment-legal-link-stripe-paypal = View the <stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> and <paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>.
+payment-legal-copy-stripe-paypal = { -brand-name-mozilla } uses Stripe and { -brand-name-paypal } for secure payment processing.
+payment-legal-link-stripe-paypal = View the <stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> and <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
 
 ## payment form
 payment-name =


### PR DESCRIPTION
## Because

- PayPal as a brand has a capital "P" for both Ps. This is a follow-up from #7449 .

## This pull request

- Creates a Fluent [placeable](https://www.projectfluent.org/fluent/guide/placeables.html) for the PayPal brand name, replacing "Paypal" with "PayPal" in main.ftl.

## Issue that this pull request solves

Closes: mozilla/fxa-content-server-l10n#471

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Changes to `SubscriptionCreate` component

Before
![Screen Shot 2021-02-19 at 4 54 17 PM](https://user-images.githubusercontent.com/17437436/108570295-21765080-72d3-11eb-873a-d21b4d47535c.png)

After
![Screen Shot 2021-02-19 at 4 50 14 PM](https://user-images.githubusercontent.com/17437436/108570024-97c68300-72d2-11eb-891e-7a6e8e935c68.png)

