### PR TITLE
chore(auth/payments): Update README for PayPal secrets and feature fl…

### DIFF
--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -56,12 +56,24 @@ Use the following as a template, and fill in your own values:
 ```json
 {
   "subscriptions": {
-    "stripeApiKey": "sk_test_123"
+    "stripeApiKey": "sk_test_123",
+    "paypalNvpSigCredentials": {
+      "enabled": true,
+      "sandbox": true,
+      "user": "business_account_email_ID",
+      "pwd": "business_account_password",
+      "signature": "business_account_signature"
+    }
   }
 }
 ```
 
 - `stripeApiKey` should be a test Stripe Secret Key
+- `user` should be a sandbox PayPal business account username
+- `pwd` should be a sandbox PayPal business account password
+- `signature` should be a sandbox PayPal business account signature
+
+The sandbox PayPal business account API credentials above can be found in the PayPal developer dashboard under "Sandbox" > "Accounts". You may need to create a business account if one doesn't exist.
 
 ## Testing
 

--- a/packages/fxa-payments-server/README.md
+++ b/packages/fxa-payments-server/README.md
@@ -2,6 +2,8 @@
 
 This is the server that handles payments.
 
+To enable PayPal, restart the server with its feature flag enabled: `FEATURE_USE_PAYPAL_UI_BY_DEFAULT=true pm2 restart payments --update-env`
+
 ## Storybook
 
 This project uses [Storybook](https://storybook.js.org/) to show each screen without requiring a full stack.
@@ -24,11 +26,15 @@ Use the following as a template, and fill in your own values:
 {
   "stripe": {
     "apiKey": "pk_test_123"
+  },
+  "paypal": {
+    "clientId": "sandbox_client_id"
   }
 }
 ```
 
 - `apiKey` should be a test Stripe Publishable Key
+- `clientId` should be a sandbox PayPal client ID. For local testing, the default value of "sb" should be sufficient.
 
 ## Testing
 


### PR DESCRIPTION
…ags.

## Because

- PayPal support is disabled by default currently, and similarly to Stripe, it has its own secrets that should not be checked in to version control.

## This pull request

- Updates the READMEs with instructions for adding PayPal secrets to the existing `secrets.json` in `fxa-auth-server` and `fxa-payments-server`.
- Updates the `fxa-payments-server` README with instructions on how to enable PayPal in development.

## Issue that this pull request solves

Closes: no issue on file

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
