### PR TITLE
Show alert bar after completing tasks

### DIFF
--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/en-US.ftl
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/en-US.ftl
@@ -4,3 +4,4 @@ tfa-replace-code-error = There was a problem replacing your recovery codes.
 tfa-replace-code-success = New codes have been created. Save these one-time use
   codes in a safe place — you’ll need them to access your account if you don’t
   have your mobile device.
+tfa-replace-code-success-alert = Account recovery codes updated.

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
@@ -3,12 +3,14 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { gql } from '@apollo/client';
-import { RouteComponentProps } from '@reach/router';
+import { RouteComponentProps, useNavigate } from '@reach/router';
 import React, { useEffect, useState } from 'react';
 import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import DataBlock from '../DataBlock';
+import { HomePath } from '../../constants';
 import { useSession } from '../../models';
+import { alertTextExternal } from '../../lib/cache';
 import { useAlertBar, useMutation } from '../../lib/hooks';
 import { AlertBar } from '../AlertBar';
 import { useLocalization, Localized } from '@fluent/react';
@@ -24,8 +26,19 @@ export const CHANGE_RECOVERY_CODES_MUTATION = gql`
 
 export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
   const alertBar = useAlertBar();
+  const navigate = useNavigate();
   const session = useSession();
   const goBack = () => window.history.back();
+  const goHome = () => {
+    alertTextExternal(
+      l10n.getString(
+        'tfa-replace-code-success-alert',
+        null,
+        'Account recovery codes updated.'
+      )
+    );
+    navigate(HomePath, { replace: true });
+  };
   const { l10n } = useLocalization();
 
   const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
@@ -73,7 +86,7 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
           type="button"
           className="cta-neutral mx-2 px-10"
           data-testid="close-modal"
-          onClick={goBack}
+          onClick={goHome}
         >
           Close
         </button>

--- a/packages/fxa-settings/src/components/PageChangePassword/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageChangePassword/en-US.ftl
@@ -21,4 +21,6 @@ pw-change-new-password =
 pw-change-confirm-password =
   .label = Confirm new password
 
+pw-change-success-alert = Password updated.
+
 ##

--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -9,7 +9,7 @@ import LinkExternal from 'fxa-react/components/LinkExternal';
 import { useBooleanState } from 'fxa-react/lib/hooks';
 import { HomePath } from '../../constants';
 import { usePasswordChanger } from '../../lib/auth';
-import { cache, sessionToken } from '../../lib/cache';
+import { alertTextExternal, cache, sessionToken } from '../../lib/cache';
 import firefox from '../../lib/firefox';
 import {
   logViewEvent,
@@ -79,6 +79,12 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
   const [newPasswordErrorText, setNewPasswordErrorText] = useState<string>();
   const { primaryEmail } = useAccount();
   const navigate = useNavigate();
+  const goHome = () => {
+    alertTextExternal(
+      l10n.getString('pw-change-success-alert', null, 'Password updated.')
+    );
+    navigate(HomePath, { replace: true });
+  };
   const { l10n } = useLocalization();
   const changePassword = usePasswordChanger({
     onSuccess: (response) => {
@@ -112,7 +118,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
           session: { verified: response.verified, __typename: 'Session' },
         },
       });
-      navigate(HomePath);
+      goHome();
     },
     onError: (e) => {
       const localizedError = l10n.getString(

--- a/packages/fxa-settings/src/components/PageDisplayName/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageDisplayName/en-US.ftl
@@ -7,4 +7,6 @@ cancel-display-name = Cancel
 
 display-name-update-error = There was a problem updating your display name.
 
+display-name-success-alert = Display name updated.
+
 ##

--- a/packages/fxa-settings/src/components/PageDisplayName/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.test.tsx
@@ -14,6 +14,7 @@ import {
   renderWithRouter,
 } from '../../models/_mocks';
 import { AuthContext, createAuthClient } from '../../lib/auth';
+import { alertTextExternal } from '../../lib/cache';
 import { HomePath } from '../../constants';
 import { GraphQLError } from 'graphql';
 import { MockedProvider } from '@apollo/client/testing';
@@ -48,6 +49,10 @@ const mocks = [
     },
   },
 ];
+
+jest.mock('../../lib/cache', () => ({
+  alertTextExternal: jest.fn(),
+}));
 
 const inputDisplayName = async (newName: string) => {
   await act(async () => {
@@ -102,7 +107,7 @@ it('updates the disabled state of the save button', async () => {
   expect(screen.getByTestId('submit-display-name')).toBeDisabled();
 });
 
-it('navigates back to settings home on a successful update', async () => {
+it('navigates back to settings home and shows a success message on a successful update', async () => {
   renderWithRouter(
     <AuthContext.Provider value={{ auth: client }}>
       <MockedCache mocks={mocks}>
@@ -112,6 +117,8 @@ it('navigates back to settings home on a successful update', async () => {
   );
   await submitDisplayName('John Hope');
   expect(window.location.pathname).toBe(HomePath);
+  expect(alertTextExternal).toHaveBeenCalledTimes(1);
+  expect(alertTextExternal).toHaveBeenCalledWith('Display name updated.');
 });
 
 it('updates the cache', async () => {

--- a/packages/fxa-settings/src/components/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.tsx
@@ -9,6 +9,7 @@ import React, { useState } from 'react';
 import FlowContainer from '../FlowContainer';
 import InputText from '../InputText';
 import firefox from '../../lib/firefox';
+import { alertTextExternal } from '../../lib/cache';
 import { useAlertBar, useMutation } from '../../lib/hooks';
 import { gql } from '@apollo/client';
 import AlertBar from '../AlertBar';
@@ -31,6 +32,16 @@ export const PageDisplayName = (_: RouteComponentProps) => {
   const account = useAccount();
   const alertBar = useAlertBar();
   const { l10n } = useLocalization();
+  const goHome = () => {
+    alertTextExternal(
+      l10n.getString(
+        'display-name-success-alert',
+        null,
+        'Display name updated.'
+      )
+    );
+    navigate(HomePath, { replace: true });
+  };
   const [errorText, setErrorText] = useState<string>();
   const [displayName, setDisplayName] = useState<string>();
   const initialValue = account.displayName || '';
@@ -47,7 +58,7 @@ export const PageDisplayName = (_: RouteComponentProps) => {
   const [updateDisplayName] = useMutation(UPDATE_DISPLAY_NAME_MUTATION, {
     onCompleted: () => {
       firefox.profileChanged(account.uid);
-      navigate(HomePath, { replace: true });
+      goHome();
     },
     onError(err) {
       if (err.graphQLErrors?.length) {

--- a/packages/fxa-settings/src/components/PageRecoveryKeyAdd/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageRecoveryKeyAdd/en-US.ftl
@@ -10,3 +10,4 @@ recovery-key-page-title =
   .title = Recovery key
 recovery-key-step-1 = Step 1 of 2
 recovery-key-step-2 = Step 2 of 2
+recovery-key-success-alert = Recovery key created.

--- a/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.test.tsx
@@ -89,11 +89,8 @@ describe('PageRecoveryKeyAdd', () => {
 
     await act(async () => {
       const input = screen.getByTestId('input-field');
-      fireEvent.input(input, { target: { value: 'myFavPassword' } });
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('continue-button'));
+      await fireEvent.input(input, { target: { value: 'myFavPassword' } });
+      await fireEvent.click(screen.getByTestId('continue-button'));
     });
 
     expect(screen.getByTestId('recover-key-confirm')).toBeVisible();

--- a/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
@@ -4,7 +4,7 @@ import base32encode from 'base32-encode';
 import { useForm } from 'react-hook-form';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import { useRecoveryKeyMaker } from '../../lib/auth';
-import { cache, sessionToken } from '../../lib/cache';
+import { alertTextExternal, cache, sessionToken } from '../../lib/cache';
 import { useAlertBar } from '../../lib/hooks';
 import { useAccount } from '../../models';
 import InputPassword from '../InputPassword';
@@ -41,7 +41,16 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
   const navigate = useNavigate();
   const alertBar = useAlertBar();
   const goBack = useCallback(() => window.history.back(), []);
-
+  const goHome = () => {
+    alertTextExternal(
+      l10n.getString(
+        'recovery-key-success-alert',
+        null,
+        'Recovery key created.'
+      )
+    );
+    navigate(HomePath, { replace: true });
+  };
   const account = useAccount();
   const createRecoveryKey = useRecoveryKeyMaker({
     onSuccess: (recoveryKey) => {
@@ -116,7 +125,7 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
               <Localized id="recovery-key-close-button">
                 <button
                   className="cta-primary mx-2 px-10"
-                  onClick={() => navigate(HomePath, { replace: true })}
+                  onClick={goHome}
                   data-testid="close-button"
                 >
                   Close

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/en-US.ftl
@@ -11,5 +11,9 @@ verify-secondary-email-verify-button = Verify
 # Variables:
 #   $email (String) - the user's email address, which does not need translation.
 verify-secondary-email-please-enter-code = Please enter the verification code that was sent to <strong>{ $email }</strong> within 5 minutes.
+# This string is a confirmation message shown after verifying an email.
+# Variables:
+#   $email (String) - the user's email address, which does not need translation.
+verify-secondary-email-success-alert = { $email } successfully added.
 
 ##

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.test.tsx
@@ -7,9 +7,14 @@ import React from 'react';
 import { screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { MockedCache, renderWithRouter } from '../../models/_mocks';
+import { alertTextExternal } from '../../lib/cache';
 import { PageSecondaryEmailVerify, VERIFY_SECONDARY_EMAIL_MUTATION } from '.';
 import { GraphQLError } from 'graphql';
 import { WindowLocation } from '@reach/router';
+
+jest.mock('../../lib/cache', () => ({
+  alertTextExternal: jest.fn(),
+}));
 
 const mocks = [
   {
@@ -79,7 +84,7 @@ describe('PageSecondaryEmailVerify', () => {
     expect(screen.getByTestId('tooltip').textContent).toContain('invalid code');
   });
 
-  it('navigates to settings on success', async () => {
+  it('navigates to settings and shows a message on success', async () => {
     const { history } = renderWithRouter(
       <MockedCache mocks={mocks}>
         <PageSecondaryEmailVerify location={mockLocation} />
@@ -97,5 +102,9 @@ describe('PageSecondaryEmailVerify', () => {
     );
 
     expect(history.location.pathname).toEqual('/beta/settings');
+    expect(alertTextExternal).toHaveBeenCalledTimes(1);
+    expect(alertTextExternal).toHaveBeenCalledWith(
+      'johndope@example.com successfully added.'
+    );
   });
 });

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
@@ -3,6 +3,7 @@ import { gql } from '@apollo/client';
 import { Localized, useLocalization } from '@fluent/react';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import { HomePath } from '../../constants';
+import { alertTextExternal } from '../../lib/cache';
 import { useAlertBar, useMutation } from '../../lib/hooks';
 import { logViewEvent } from '../../lib/metrics';
 import { Email } from '../../models';
@@ -31,9 +32,19 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
       verificationCode: '',
     },
   });
-  const goBack = useCallback(() => window.history.back(), []);
-  const { l10n } = useLocalization();
   const navigate = useNavigate();
+  const goBack = useCallback(() => window.history.back(), []);
+  const goHome = (email: string) => {
+    alertTextExternal(
+      l10n.getString(
+        'verify-secondary-email-success-alert',
+        { email },
+        `${email} successfully added.`
+      )
+    );
+    navigate(HomePath, { replace: true });
+  };
+  const { l10n } = useLocalization();
   const alertBar = useAlertBar();
   // Using 'any' here, instead of FluentVariable, to avoid having to import @fluent/bundle.
   const email = (location?.state as any)?.email as string | undefined | any;
@@ -68,7 +79,7 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
         });
       },
       onCompleted: () => {
-        navigate(HomePath, { replace: true });
+        goHome(email);
         logViewEvent('verify-secondary-email.verification', 'success');
       },
     }


### PR DESCRIPTION
## Because

- we're supposed to show an alert bar in the settings page after completing tasks in individual sub-pages
- the sub-pages sometimes try to show an alert, but it isn't displayed before the user navigates away

## This pull request

- updates all sub-pages to use `alertTextExternal` to display a notification in the base settings page
- a couple of tests still need to be updated (this work has been deferred to #7596)

## Issue that this pull request solves

Closes: #7030

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
