### PR TITLE
feat(settings): replace connected service display name for Mac OS X with macOS on retrieval

### DIFF
--- a/packages/fxa-auth-server/lib/routes/attached-clients.js
+++ b/packages/fxa-auth-server/lib/routes/attached-clients.js
@@ -206,6 +206,7 @@ module.exports = (log, db, devices, clientUtils) => {
           if (client.deviceId && !client.deviceType) {
             client.deviceType = 'desktop';
           }
+          client.name = client.name.replace('Mac OS X', 'macOS');
         }
 
         return attachedClients;


### PR DESCRIPTION
closes #7482
