### PR TITLE
feat(fxa-payments-server): add processing view to checkout

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -41,7 +41,6 @@ privacy = Privacy Notice
 
 ## plan details
 product-plan-details-heading = Set up your subscription
-product-plan-details-heading = Let's set up your subscription
 
 ##  $productName (String) - The name of the subscribed product.
 ##  $amount (Number) - The amount billed. It will be formatted as currency.
@@ -300,6 +299,9 @@ plan-details-header = Product details
 plan-details-show-button = Show details
 plan-details-hide-button = Hide details
 plan-details-total-label = Total
+
+## payment-processing
+payment-processing-message = Please wait while we process your payment...
 
 ## payment confirmation
 payment-confirmation-alert = Click here to download

--- a/packages/fxa-payments-server/src/components/PaymentProcessing/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentProcessing/index.scss
@@ -1,0 +1,41 @@
+@import '../../../../fxa-content-server/app/styles/variables';
+@import '../../../../fxa-content-server/app/styles/breakpoints';
+
+.payment-processing {
+  background: $color-white;
+  border: 1px solid #e7e7e7;
+  border-bottom: 0;
+  color: rgba(12, 12, 13, 0.8);
+  min-height: 100%;
+  padding: 20px 16px 0;
+  width: 100%;
+
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+  }
+
+  #loading-spinner {
+    margin: 140px auto 100px;
+    position: relative;
+  }
+
+  p {
+    margin: 0;
+    color: $grey-40;
+  }
+
+  @include min-width('tablet') {
+    border-top: 0;
+  }
+
+  @include min-width('desktop') {
+    padding-top: 12px;
+  }
+
+  @include min-width('desktop') {
+    min-width: 60%;
+    padding: 20px 48px 0;
+  }
+}

--- a/packages/fxa-payments-server/src/components/PaymentProcessing/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentProcessing/index.stories.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { PaymentProcessing } from './index';
+
+storiesOf('components/PaymentProcessing', module).add('default', () => (
+  <PaymentProcessing />
+));

--- a/packages/fxa-payments-server/src/components/PaymentProcessing/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentProcessing/index.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import {
+  setupFluentLocalizationTest,
+  getLocalizedMessage,
+} from '../../lib/test-utils';
+
+import { PaymentProcessing } from './index';
+
+afterEach(cleanup);
+describe('Fluent Localized Text', () => {
+  const bundle = setupFluentLocalizationTest('en-US');
+
+  it('renders as expected', () => {
+    const { queryByTestId } = render(<PaymentProcessing />);
+    const spinner = queryByTestId('loading-spinner');
+    expect(spinner).toBeInTheDocument();
+
+    const mainBlock = queryByTestId('payment-processing');
+    expect(mainBlock).toBeInTheDocument();
+
+    const expected = 'Please wait while we process your payment...';
+    const actual = getLocalizedMessage(
+      bundle,
+      'payment-processing-message',
+      {}
+    );
+    expect(actual).toEqual(expected);
+  });
+});

--- a/packages/fxa-payments-server/src/components/PaymentProcessing/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentProcessing/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Localized } from '@fluent/react';
+
+import { LoadingSpinner } from '../LoadingSpinner';
+
+import './index.scss';
+
+export type PaymentProcessingProps = {
+  className?: string;
+};
+
+export const PaymentProcessing = ({
+  className = '',
+}: PaymentProcessingProps) => {
+  return (
+    <section
+      className={`container card payment-processing ${className}`}
+      data-testid="payment-processing"
+    >
+      <div className="wrapper">
+        <LoadingSpinner />
+        <Localized id="payment-processing-message">
+          <p>Please wait while we process your payment...</p>
+        </Localized>
+      </div>
+    </section>
+  );
+};
+
+export default PaymentProcessing;

--- a/packages/fxa-payments-server/src/index.scss
+++ b/packages/fxa-payments-server/src/index.scss
@@ -213,3 +213,7 @@ hr {
     font-weight: bold;
   }
 }
+
+.hidden {
+  display: none;
+}

--- a/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.stories.tsx
@@ -18,6 +18,7 @@ const Subject = ({
   priceId = PLAN.plan_id,
   refreshSubscriptions = linkTo('routes/Product', 'success'),
   setPaymentError = () => {},
+  setOnClick = () => {},
   ...props
 }: PickPartial<
   PaypalButtonProps,
@@ -27,6 +28,7 @@ const Subject = ({
   | 'priceId'
   | 'refreshSubscriptions'
   | 'setPaymentError'
+  | 'setOnClick'
 >) => {
   return (
     <PaypalButton
@@ -38,6 +40,7 @@ const Subject = ({
         priceId,
         refreshSubscriptions,
         setPaymentError,
+        setOnClick,
         ...props,
       }}
     />

--- a/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.tsx
@@ -19,6 +19,7 @@ export type PaypalButtonProps = {
   priceId: string;
   refreshSubscriptions: () => void;
   setPaymentError: Function;
+  setOnClick: Function;
   ButtonBase?: React.ElementType;
 };
 
@@ -26,6 +27,7 @@ export type ButtonBaseProps = {
   createOrder?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onApprove?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onError?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
 export const PaypalButtonBase =
@@ -44,6 +46,7 @@ export const PaypalButton = ({
   priceId,
   refreshSubscriptions,
   setPaymentError,
+  setOnClick,
   ButtonBase = PaypalButtonBase,
 }: PaypalButtonProps) => {
   const createOrder = useCallback(async () => {
@@ -107,6 +110,13 @@ export const PaypalButton = ({
     [setPaymentError]
   );
 
+  const onClick = useCallback(
+    (event) => {
+      setOnClick(event);
+    },
+    [setOnClick]
+  );
+
   // Style docs: https://developer.paypal.com/docs/business/checkout/reference/style-guide/
   const styleOptions = {
     layout: 'horizontal',
@@ -126,6 +136,7 @@ export const PaypalButton = ({
           createOrder={createOrder}
           onApprove={onApprove}
           onError={onError}
+          onClick={onClick}
         />
       )}
     </>

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.stories.tsx
@@ -7,7 +7,6 @@ import {
   PaymentIntent,
 } from '@stripe/stripe-js';
 import { storiesOf } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 import MockApp, {
   defaultAppContextValue,

--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -160,7 +160,8 @@ describe('routes/Product', () => {
         .reply(200, MOCK_CUSTOMER, { 'Access-Control-Allow-Origin': '*' }),
     ];
     const { findByTestId } = render(<Subject />);
-    await findByTestId('error-loading-profile');
+    const errorEl = await findByTestId('error-loading-profile');
+    expect(errorEl).toBeInTheDocument();
   });
 
   it('displays an error on failure to load plans', async () => {
@@ -174,7 +175,8 @@ describe('routes/Product', () => {
         .reply(200, MOCK_CUSTOMER),
     ];
     const { findByTestId } = render(<Subject />);
-    await findByTestId('error-loading-plans');
+    const errorEl = await findByTestId('error-loading-plans');
+    expect(errorEl).toBeInTheDocument();
   });
 
   it('displays an error on failure to load customer', async () => {
@@ -190,7 +192,8 @@ describe('routes/Product', () => {
         .reply(400, MOCK_CUSTOMER, { 'Access-Control-Allow-Origin': '*' }),
     ];
     const { findByTestId } = render(<Subject />);
-    await findByTestId('error-loading-customer');
+    const errorEl = await findByTestId('error-loading-customer');
+    expect(errorEl).toBeInTheDocument();
   });
 
   it('does not display an error on missing / new customer', async () => {
@@ -210,7 +213,8 @@ describe('routes/Product', () => {
         ),
     ];
     const { findAllByText } = render(<Subject />);
-    await findAllByText('Set up your subscription');
+    const headingEls = await findAllByText('Set up your subscription');
+    expect(headingEls.length).toBeGreaterThan(0);
   });
 
   it('does not display an error on customer with no subscriptions', async () => {
@@ -230,12 +234,13 @@ describe('routes/Product', () => {
         ),
     ];
     const { findAllByText } = render(<Subject />);
-    await findAllByText('Set up your subscription');
+    const headingEls = await findAllByText('Set up your subscription');
+    expect(headingEls.length).toBeGreaterThan(0);
   });
 
   it('offers upgrade if user is already subscribed to another plan in the same product set', async () => {
     const apiMocks = initSubscribedApiMocks();
-    const { findByTestId } = render(
+    const { findByTestId, queryByTestId } = render(
       <Subject
         {...{
           planId: 'plan_upgrade',
@@ -243,14 +248,16 @@ describe('routes/Product', () => {
         }}
       />
     );
-    await findByTestId('subscription-upgrade');
+    const upgradeEl = await findByTestId('subscription-upgrade');
+    expect(upgradeEl).toBeInTheDocument();
     expectNockScopesDone(apiMocks);
   });
 
   it('displays payment confirmation if user is already subscribed the product', async () => {
     const apiMocks = initSubscribedApiMocks();
     const { findByTestId } = render(<Subject />);
-    await findByTestId('payment-confirmation');
+    const confirmEl = await findByTestId('payment-confirmation');
+    expect(confirmEl).toBeInTheDocument();
     expectNockScopesDone(apiMocks);
   });
 });


### PR DESCRIPTION
## Because

- We want to give the user feedback about the status of their paypal payments

## This pull request

- Adds a processing view to the paypal payment flow

## Issue that this pull request solves

- fixes #7450

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
![processing-screen](https://user-images.githubusercontent.com/1844554/108923609-2145c000-7607-11eb-90df-d71e1f106328.png)

![image](https://user-images.githubusercontent.com/1844554/108923694-489c8d00-7607-11eb-8ed6-ba674a5c236f.png)



