### PR TITLE
7020 scroll position

### DIFF
--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
@@ -28,7 +28,8 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
   const alertBar = useAlertBar();
   const navigate = useNavigate();
   const session = useSession();
-  const goBack = () => window.history.back();
+  const goBack = () =>
+    navigate(HomePath + '#two-step-authentication', { replace: true });
   const goHome = () => {
     alertTextExternal(
       l10n.getString(
@@ -37,7 +38,7 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
         'Account recovery codes updated.'
       )
     );
-    navigate(HomePath, { replace: true });
+    navigate(HomePath + '#two-step-authentication', { replace: true });
   };
   const { l10n } = useLocalization();
 

--- a/packages/fxa-settings/src/components/PageAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/index.tsx
@@ -64,7 +64,7 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
           },
         },
       });
-      navigate(HomePath, { replace: true });
+      navigate(HomePath + '#profile-picture', { replace: true });
     },
     onError: onFileError,
   });

--- a/packages/fxa-settings/src/components/PageChangePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.test.tsx
@@ -86,7 +86,9 @@ it('emits an Amplitude event on success', async () => {
 
 it('redirects on success', async () => {
   await changePassword();
-  expect(mockNavigate).toHaveBeenCalledWith(HomePath, { replace: true });
+  expect(mockNavigate).toHaveBeenCalledWith(HomePath + '#password', {
+    replace: true,
+  });
 });
 
 it('disables save until the form is valid', async () => {

--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -79,11 +79,12 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
   const [newPasswordErrorText, setNewPasswordErrorText] = useState<string>();
   const { primaryEmail } = useAccount();
   const navigate = useNavigate();
+  const goBack = () => navigate(HomePath + '#password', { replace: true });
   const goHome = () => {
     alertTextExternal(
       l10n.getString('pw-change-success-alert', null, 'Password updated.')
     );
-    navigate(HomePath, { replace: true });
+    navigate(HomePath + '#password', { replace: true });
   };
   const { l10n } = useLocalization();
   const changePassword = usePasswordChanger({
@@ -300,7 +301,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
               <button
                 type="button"
                 className="cta-neutral mx-2 flex-1"
-                onClick={() => window.history.back()}
+                onClick={goBack}
                 data-testid="cancel-password-button"
               >
                 Cancel

--- a/packages/fxa-settings/src/components/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.tsx
@@ -32,6 +32,7 @@ export const PageDisplayName = (_: RouteComponentProps) => {
   const account = useAccount();
   const alertBar = useAlertBar();
   const { l10n } = useLocalization();
+  const goBack = () => navigate(HomePath + '#display-name', { replace: true });
   const goHome = () => {
     alertTextExternal(
       l10n.getString(
@@ -40,7 +41,7 @@ export const PageDisplayName = (_: RouteComponentProps) => {
         'Display name updated.'
       )
     );
-    navigate(HomePath, { replace: true });
+    navigate(HomePath + '#display-name', { replace: true });
   };
   const [errorText, setErrorText] = useState<string>();
   const [displayName, setDisplayName] = useState<string>();
@@ -122,7 +123,7 @@ export const PageDisplayName = (_: RouteComponentProps) => {
                 type="button"
                 data-testid="cancel-display-name"
                 className="cta-neutral mx-2 flex-1"
-                onClick={() => window.history.back()}
+                onClick={goBack}
               >
                 Cancel
               </button>

--- a/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Localized, useLocalization } from '@fluent/react';
 import base32encode from 'base32-encode';
 import { useForm } from 'react-hook-form';
@@ -40,7 +40,7 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
   const [formattedRecoveryKey, setFormattedRecoveryKey] = useState<string>();
   const navigate = useNavigate();
   const alertBar = useAlertBar();
-  const goBack = useCallback(() => window.history.back(), []);
+  const goBack = () => navigate(HomePath + '#recovery-key', { replace: true });
   const goHome = () => {
     alertTextExternal(
       l10n.getString(
@@ -49,7 +49,7 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
         'Recovery key created.'
       )
     );
-    navigate(HomePath, { replace: true });
+    navigate(HomePath + '#recovery-key', { replace: true });
   };
   const account = useAccount();
   const createRecoveryKey = useRecoveryKeyMaker({

--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
@@ -4,6 +4,7 @@ import { Localized, useLocalization } from '@fluent/react';
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import { useAlertBar, useMutation } from '../../lib/hooks';
 import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
+import { HomePath } from 'fxa-settings/src/constants';
 import InputText from '../InputText';
 import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
@@ -27,7 +28,8 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   const { l10n } = useLocalization();
   const navigate = useNavigate();
   const alertBar = useAlertBar();
-  const goBack = useCallback(() => window.history.back(), []);
+  const goBack = () =>
+    navigate(HomePath + '#secondary-email', { replace: true });
 
   const [createSecondaryEmail] = useMutation(CREATE_SECONDARY_EMAIL_MUTATION, {
     onError: (error) => {

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.test.tsx
@@ -101,7 +101,7 @@ describe('PageSecondaryEmailVerify', () => {
       screen.getByTestId('secondary-email-verify-submit').click()
     );
 
-    expect(history.location.pathname).toEqual('/beta/settings');
+    expect(history.location.pathname).toEqual('/beta/settings#secondary-email');
     expect(alertTextExternal).toHaveBeenCalledTimes(1);
     expect(alertTextExternal).toHaveBeenCalledWith(
       'johndope@example.com successfully added.'

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { gql } from '@apollo/client';
 import { Localized, useLocalization } from '@fluent/react';
 import { RouteComponentProps, useNavigate } from '@reach/router';
@@ -33,7 +33,8 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
     },
   });
   const navigate = useNavigate();
-  const goBack = useCallback(() => window.history.back(), []);
+  const goBack = () =>
+    navigate(HomePath + '#secondary-email', { replace: true });
   const goHome = (email: string) => {
     alertTextExternal(
       l10n.getString(
@@ -42,7 +43,7 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
         `${email} successfully added.`
       )
     );
-    navigate(HomePath, { replace: true });
+    navigate(HomePath + '#secondary-email', { replace: true });
   };
   const { l10n } = useLocalization();
   const alertBar = useAlertBar();

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.test.tsx
@@ -290,7 +290,10 @@ describe('step 3', () => {
       query: GET_ACCOUNT,
     })!;
     expect(account.totp.verified).toEqual(true);
-    expect(mockNavigate).toHaveBeenCalledWith(HomePath, { replace: true });
+    expect(mockNavigate).toHaveBeenCalledWith(
+      HomePath + '#two-step-authentication',
+      { replace: true }
+    );
     expect(alertTextExternal).toHaveBeenCalledTimes(1);
     expect(alertTextExternal).toHaveBeenCalledWith(
       'Two-step authentication enabled'

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -48,8 +48,14 @@ type RecoveryCodeForm = { recoveryCode: string };
 
 export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
   const navigate = useNavigate();
-  const goBack = () => window.history.back();
-  const goHome = () => navigate(HomePath, { replace: true });
+  const goBack = () =>
+    navigate(HomePath + '#two-step-authentication', { replace: true });
+  const goHome = () => {
+    alertTextExternal(
+      l10n.getString('tfa-enabled', null, 'Two-step authentication enabled')
+    );
+    navigate(HomePath + '#two-step-authentication', { replace: true });
+  };
 
   const { l10n } = useLocalization();
 
@@ -164,12 +170,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
   });
 
   const [verifyTotp] = useMutation(VERIFY_TOTP_MUTATION, {
-    onCompleted: () => {
-      alertTextExternal(
-        l10n.getString('tfa-enabled', null, 'Two-step authentication enabled')
-      );
-      goHome();
-    },
+    onCompleted: goHome,
     onError: (err) => {
       if (err.graphQLErrors?.length) {
         if (
@@ -226,7 +227,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
 
   const moveBack = () => {
     if (!totpVerified) {
-      return goHome();
+      return goBack();
     }
     if (totpVerified && !recoveryCodesAcknowledged) {
       return showQrCodeStep();
@@ -381,7 +382,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
               <button
                 type="button"
                 className="cta-neutral mx-2 flex-1"
-                onClick={goHome}
+                onClick={goBack}
               >
                 Cancel
               </button>
@@ -431,7 +432,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
               <button
                 type="button"
                 className="cta-neutral mx-2 flex-1"
-                onClick={goHome}
+                onClick={goBack}
               >
                 Cancel
               </button>

--- a/packages/fxa-settings/src/components/Profile/index.tsx
+++ b/packages/fxa-settings/src/components/Profile/index.tsx
@@ -31,6 +31,7 @@ export const Profile = () => {
         <Localized id="profile-display-name" attrs={{ header: true }}>
           <UnitRow
             header="Display name"
+            headerId="display-name"
             headerValue={displayName}
             headerValueClassName="break-all"
             route="/beta/settings/display_name"
@@ -43,6 +44,7 @@ export const Profile = () => {
         <Localized id="profile-password" attrs={{ header: true }}>
           <UnitRow
             header="Password"
+            headerId="password"
             headerValueClassName="tracking-wider"
             headerValue="••••••••••••••••••"
             route="/beta/settings/change_password"
@@ -64,6 +66,7 @@ export const Profile = () => {
         <Localized id="profile-primary-email" attrs={{ header: true }}>
           <UnitRow
             header="Primary email"
+            headerId="primary-email"
             headerValue={primaryEmail.email}
             headerValueClassName="break-all"
             prefixDataTestId="primary-email"

--- a/packages/fxa-settings/src/components/ScrollToTop/index.tsx
+++ b/packages/fxa-settings/src/components/ScrollToTop/index.tsx
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// See https://github.com/reach/router/issues/242 for a dicussion
+// See https://github.com/reach/router/issues/242 for a discussion
 
 import { RouteComponentProps, useLocation, useNavigate } from '@reach/router';
 import React, { useCallback, useLayoutEffect } from 'react';
@@ -26,7 +26,13 @@ export const ScrollToTop = (
     const url = new URL(href);
     const hasHash = !!url.hash;
 
-    if (
+    // Hack alert: if the URL contains a hash, we have to manually navigate
+    // to it, because reach router can't handle hashes (see reach router
+    // issue 32) 🙄
+    if (hasHash) {
+      const el = document.querySelector(url.hash);
+      if (el) el.scrollIntoView();
+    } else if (
       !hasHash &&
       !(state as typeof state & { scrolled?: boolean })?.scrolled
     ) {

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -210,6 +210,7 @@ export const UnitRowSecondaryEmail = () => {
       <Localized id="se-heading" attrs={{ header: true }}>
         <UnitRow
           header="Secondary email"
+          headerId="secondary-email"
           prefixDataTestId="secondary-email"
           headerValue={null}
           route={`${HomePath}/emails`}

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
@@ -114,6 +114,7 @@ export const UnitRowTwoStepAuth = () => {
   return (
     <UnitRow
       header="Two-step authentication"
+      headerId="two-step-authentication"
       prefixDataTestId="two-step"
       route={route}
       {...conditionalUnitRowProps}

--- a/packages/fxa-settings/src/components/UnitRowWithAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowWithAvatar/index.tsx
@@ -18,7 +18,9 @@ export const UnitRowWithAvatar = () => {
     <div className="unit-row">
       <div className="unit-row-header">
         <Localized id="avatar-heading">
-          <h3 data-testid="unit-row-with-avatar-header">Picture</h3>
+          <h3 id="profile-picture" data-testid="unit-row-with-avatar-header">
+            Picture
+          </h3>
         </Localized>
       </div>
       <div className="unit-row-content">


### PR DESCRIPTION
Ready for review. To ensure we scroll to the right spot in the page, we could do something fancy, complex, and brittle, like storing the scroll distance when navigating to a page, then restoring the scroll location if the user goes back. However, the intent of the bug is to not get thrown to the top of the screen when backing out of a sub-page, and the simplest approach is to add `id`s to each of the rows, then just navigate to that hash instead of using `history.back()`. 

This ran into a little bit of complexity, because reach router doesn't handle hashes, but hacking around that was easy enough and well-contained.

Fixes #7020.