### PR TITLE
feat(auth-server): add paypal invoice processor

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal-client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-client.ts
@@ -59,6 +59,12 @@ type NVPResponse = {
   CORRELATIONID: string;
   TIMESTAMP: string;
   VERSION: string;
+  L?: {
+    ERRORCODE: string;
+    SHORTMESSAGE: string;
+    LONGMESSAGE: string;
+    SEVERITYCODE: string;
+  }[];
 };
 
 type SetExpressCheckoutData = {
@@ -132,7 +138,7 @@ export type NVPDoReferenceTransactionResponse = NVPResponse &
 
 export type NVPBAUpdateTransactionResponse = NVPResponse & BAUpdateData;
 
-export type NVPTransactionSearchResponse = NVPResponse & TransactionSearchData;
+export type NVPTransactionSearchResponse = TransactionSearchData & NVPResponse;
 
 export type SetExpressCheckoutOptions = {
   currencyCode: string;
@@ -214,6 +220,7 @@ type ResponseEventType = {
 export class PayPalClientError extends Error {
   public raw: string;
   public data: NVPResponse;
+  public errorCode: number | undefined;
 
   constructor(raw: string, data: NVPResponse, ...params: any) {
     super(...params);
@@ -224,8 +231,10 @@ export class PayPalClientError extends Error {
     }
     this.raw = raw;
     this.data = data;
+    this.errorCode = data.L?.length ? parseInt(data.L[0].ERRORCODE) : undefined;
   }
 }
+
 export class PayPalClient {
   private url: string;
   private ipnUrl: string;

--- a/packages/fxa-auth-server/lib/payments/paypal-error-codes.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-error-codes.ts
@@ -1,0 +1,85 @@
+/**
+ * Error Codes representing an error that is temporary to PayPal
+ * and should be retried again without changes.
+ */
+export const PAYPAL_RETRY_ERRORS = [10014, 10445, 11453, 11612];
+
+/**
+ * Errors Codes representing an error with the customers funding
+ * source, such as the AVS, CVV2, funding, etc. not being valid.
+ *
+ * The customer should be prompted to login to PayPal and fix their
+ * funding source.
+ */
+export const PAYPAL_SOURCE_ERRORS = [
+  10069,
+  10203,
+  10204,
+  10205,
+  10207,
+  10210,
+  10212,
+  10216,
+  10417,
+  10502,
+  10504,
+  10507,
+  10525,
+  10527,
+  10537,
+  10546,
+  10554,
+  10555,
+  10556,
+  10560,
+  10567,
+  10600,
+  10601,
+  10606,
+  10606,
+  10748,
+  10752,
+  11084,
+  11091,
+  11458,
+  11611,
+  13109,
+  13122,
+  15012,
+  18014,
+];
+
+/**
+ * Error codes representing an error in how we called PayPal and/or
+ * the arguments we passed them. These can only be fixed by fixing our
+ * code.
+ */
+export const PAYPAL_APP_ERRORS = [
+  10004,
+  10009,
+  10211,
+  10213,
+  10214,
+  10402,
+  10406,
+  10412,
+  10414,
+  10443,
+  10538,
+  10539,
+  10613,
+  10747,
+  10755,
+  11302,
+  11452,
+];
+
+/**
+ * Returned when the paypal billing agreement is no longer valid.
+ */
+export const PAYPAL_BILLING_AGREEMENT_INVALID = 10201;
+
+/**
+ * Returned with a transaction if the message sub id was seen before.
+ */
+export const PAYPAL_REPEAT_MESSAGE_SUB_ID = 11607;

--- a/packages/fxa-auth-server/lib/payments/paypal-processor.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-processor.ts
@@ -1,0 +1,334 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Logger } from 'mozlog';
+import Stripe from 'stripe';
+import { Container } from 'typedi';
+
+import { ConfigType } from '../../config';
+import error from '../../lib/error';
+import { reportSentryError } from '../sentry';
+import { PayPalHelper, TransactionSearchResult } from './paypal';
+import { PayPalClientError } from './paypal-client';
+import {
+  PAYPAL_BILLING_AGREEMENT_INVALID,
+  PAYPAL_SOURCE_ERRORS,
+} from './paypal-error-codes';
+import { StripeHelper } from './stripe';
+
+/**
+ * Generest a timestamp in seconds that is `hours` before the current
+ * time.
+ *
+ * @param hours
+ */
+function hoursBeforeInSeconds(hours: number): number {
+  const date = new Date();
+  date.setHours(date.getHours() - hours);
+  return date.getTime() / 1000;
+}
+
+/**
+ * Returns whether two dates are the same month/day/year.
+ *
+ * @param d1
+ * @param d2
+ */
+function sameDay(d1: Date, d2: Date) {
+  return (
+    d1.getUTCFullYear() === d2.getUTCFullYear() &&
+    d1.getUTCMonth() === d2.getUTCMonth() &&
+    d1.getUTCDate() === d2.getUTCDate()
+  );
+}
+
+export class PaypalProcessor {
+  private stripeHelper: StripeHelper;
+  private paypalHelper: PayPalHelper;
+
+  constructor(
+    private log: Logger,
+    config: ConfigType,
+    private graceDays: number,
+    private maxRetryAttempts: number,
+    private invoiceAge = 6
+  ) {
+    this.stripeHelper = Container.get(StripeHelper);
+    this.paypalHelper = Container.get(PayPalHelper);
+  }
+
+  /**
+   * Determine if the given invoice is within its grace period for
+   * additional payment retries or waiting on a pending transaction.
+   *
+   * Calculated by adding the `graceDays` in seconds to the invoice
+   * creation time. A `graceDays` value of 1 allows an invoice to be
+   * open for 24 hours hours (1 day) before not in grace period, etc.
+   *
+   * @param invoice
+   */
+  private inGracePeriod(invoice: Stripe.Invoice): boolean {
+    const graceDaysInSeconds = this.graceDays * 24 * 60 * 60;
+    return Date.now() / 1000 < invoice.created + graceDaysInSeconds;
+  }
+
+  private cancelInvoiceSubscription(invoice: Stripe.Invoice) {
+    // TODO: should send an email about subscription cancelled as overdue
+    return Promise.all([
+      this.stripeHelper.markUncollectible(invoice),
+      this.stripeHelper.cancelSubscription(invoice.subscription as string),
+    ]);
+  }
+
+  /**
+   * Ensures that an invoice matches the payment attempts returned from a PayPal
+   * Transaction Search.
+   *
+   * In general this should be the case, but in the event that an IPN notification
+   * is missed a mismatch could occur.
+   *
+   * @param invoice
+   * @param transactions
+   */
+  private async ensureAccurateAttemptCount(
+    invoice: Stripe.Invoice,
+    transactions: TransactionSearchResult[]
+  ) {
+    const paymentAttempts = this.stripeHelper.getPaymentAttempts(invoice);
+    if (paymentAttempts !== transactions.length) {
+      await this.stripeHelper.updatePaymentAttempts(
+        invoice,
+        transactions.length
+      );
+    }
+  }
+
+  /**
+   * Handles the condition where a transaction for an invoice has been paid.
+   *
+   * This occurrs when a previously pending transaction becomes paid, and the
+   * invoice should now be marked as paid.
+   *
+   * Returns whether the invoice has been paid.
+   *
+   * @param invoice
+   * @param transactions
+   */
+  private async handlePaidTransaction(
+    invoice: Stripe.Invoice,
+    transactions: TransactionSearchResult[]
+  ): Promise<boolean> {
+    const customer = invoice.customer;
+    const successTransactions = transactions.filter((t) =>
+      ['Completed', 'Processed'].includes(t.status)
+    );
+    if (successTransactions.length) {
+      if (successTransactions.length > 1) {
+        this.log.error('multipleCompletedTransactions', {
+          customer,
+          invoiceId: invoice.id,
+          transactionCount: successTransactions.length,
+          excessTransactions: successTransactions
+            .slice(1)
+            .map((t) => t.transactionId),
+        });
+        reportSentryError(
+          new Error('Multiple completed payments for invoice: ' + invoice.id)
+        );
+      }
+      const transaction = successTransactions[0];
+      await this.stripeHelper.updateInvoiceWithPaypalTransactionId(
+        invoice,
+        transaction.transactionId
+      );
+      await this.stripeHelper.payInvoiceOutOfBand(invoice);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Handles the condition where a transaction for an invoice is pending.
+   *
+   * This occurs when a previous payment attempt has not completed. This
+   * method checks to see if there's a pending transaction for the invoice.
+   * Returns `true` if this invoice has valid pending transactions to wait
+   * for, `false` otherwise.
+   *
+   * @param invoice
+   * @param transactions
+   */
+  private async handlePendingTransaction(
+    invoice: Stripe.Invoice,
+    transactions: TransactionSearchResult[]
+  ): Promise<boolean> {
+    const customer = invoice.customer;
+    const inGracePeriod = this.inGracePeriod(invoice);
+    const outstandingTransactions = transactions.filter((t) =>
+      ['Pending', 'In-Progress', 'Under Review'].includes(t.status)
+    );
+    if (outstandingTransactions.length) {
+      if (outstandingTransactions.length > 1) {
+        this.log.error('multiplePendingTransactions', {
+          customer,
+          invoiceId: invoice.id,
+        });
+        reportSentryError(
+          new Error('Multiple pending payments for invoice: ' + invoice.id)
+        );
+      }
+      if (inGracePeriod) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Make a payment attempt on an invoice.
+   *
+   * @param invoice
+   */
+  private async makePaymentAttempt(invoice: Stripe.Invoice) {
+    const customer = invoice.customer as Stripe.Customer;
+    if (invoice.amount_due === 0) {
+      await this.paypalHelper.processZeroInvoice(invoice);
+      return true;
+    }
+
+    try {
+      await this.paypalHelper.processInvoice({
+        customer,
+        invoice,
+        batchProcessing: true,
+      });
+      return true;
+    } catch (err) {
+      if (err instanceof PayPalClientError) {
+        if (err.errorCode === PAYPAL_BILLING_AGREEMENT_INVALID) {
+          const uid = customer.metadata.userid;
+          const billingAgreementId = this.stripeHelper.getCustomerPaypalAgreement(
+            customer
+          ) as string;
+          await this.stripeHelper.removeCustomerPaypalAgreement(
+            uid,
+            customer,
+            billingAgreementId
+          );
+          // TODO: Send email to user that they must go to sub management and re-auth PayPal
+          return false;
+        }
+        if (PAYPAL_SOURCE_ERRORS.includes(err.errorCode ?? 0)) {
+          // TODO: Send email to user that they must go to PayPal and fix their billing agreement funding source
+          return false;
+        }
+      }
+      this.log.error('processInvoice', { err, invoiceId: invoice.id });
+      reportSentryError(err);
+      return false;
+    }
+  }
+
+  private attemptsToday(transactions: TransactionSearchResult[]) {
+    const today = new Date();
+    return transactions.filter((t) => sameDay(today, new Date(t.timestamp)))
+      .length;
+  }
+
+  /**
+   * Attempt to process an invoice that is at least 24 hours after its creation.
+   *
+   * This attempt consists of:
+   *   1. Verifying the customer was expanded on the invoice.
+   *   2. Ensuring we don't process invoices for deleted customers, their invoice will
+   *      be marked as uncollectible.
+   *   3. Search all transactions run for this invoice and:
+   *     a. Ensure the transaction count matches the invoice retry attempts.
+   *     b. If a transaction completed, mark invoice as paid, return.
+   *     c. If a transaction is pending/in-progress:
+   *       - If we're in grace period, skip invoice and wait for completion, return.
+   *   4. If we're past grace period, cancelInvoiceSubscription, return.
+   *   5. If we have no billing agreement, email user to inform them.
+   *   6. If retries for today remain:
+   *       a. Attempt payment on invoice.
+   *   7. Otherwise, return.
+   *
+   * @param invoice
+   */
+  private async attemptInvoiceProcessing(invoice: Stripe.Invoice) {
+    const customer = invoice.customer;
+    // 1
+    if (!customer || typeof customer === 'string') {
+      this.log.error('customerNotLoaded', { customer });
+      throw error.internalValidationError('customerNotLoad', {
+        customer,
+        invoiceId: invoice.id,
+      });
+    }
+
+    // 2, Void the invoice for deleted customers
+    if (customer.deleted) {
+      await this.stripeHelper.markUncollectible(invoice);
+      this.log.info('customerDeletedVoid', { customerId: customer.id });
+      return;
+    }
+
+    // 3, search transactions
+    const transactions = await this.paypalHelper.searchTransactions({
+      startDate: new Date(invoice.created * 1000),
+      invoice: invoice.id,
+    });
+    // 3a
+    await this.ensureAccurateAttemptCount(invoice, transactions);
+
+    // 3b
+    if (await this.handlePaidTransaction(invoice, transactions)) {
+      return;
+    }
+
+    // 3c
+    if (await this.handlePendingTransaction(invoice, transactions)) {
+      return;
+    }
+
+    // 4
+    const inGracePeriod = this.inGracePeriod(invoice);
+    if (!inGracePeriod) {
+      return this.cancelInvoiceSubscription(invoice);
+    }
+
+    // 5
+    const billingAgreementId = this.stripeHelper.getCustomerPaypalAgreement(
+      customer
+    );
+    if (!billingAgreementId) {
+      // TODO: Send email to user that they must go to sub management and re-auth PayPal
+      //       Don't send email if payment attempts today > 1.
+      return;
+    }
+
+    // 6
+    if (this.attemptsToday(transactions) < this.maxRetryAttempts) {
+      await this.makePaymentAttempt(invoice);
+    }
+    return;
+  }
+
+  public async processInvoices() {
+    // Generate a time `invoiceAge` hours prior.
+    const invoiceAgeInSeconds = hoursBeforeInSeconds(this.invoiceAge);
+
+    const invoices = this.stripeHelper.fetchOpenInvoices({
+      lte: invoiceAgeInSeconds,
+    });
+    for await (const invoice of invoices) {
+      this.log.info('processInvoice', { invoiceId: invoice.id });
+      try {
+        await this.attemptInvoiceProcessing(invoice);
+      } catch (err) {
+        this.log.error('processInvoice', { err, invoiceId: invoice.id });
+        reportSentryError(err);
+      }
+    }
+  }
+}

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -8,6 +8,7 @@ import {
   createAccountCustomer,
   deleteAccountCustomer,
   getAccountCustomerByUid,
+  updatePayPalBA,
 } from 'fxa-shared/db/models/auth';
 import { AbbrevPlan, AbbrevProduct } from 'fxa-shared/dist/subscriptions/types';
 import { StatsD } from 'hot-shots';
@@ -352,10 +353,10 @@ export class StripeHelper {
 
   /**
    * Get Invoice object based on invoice Id
-   * 
-   * @param id 
+   *
+   * @param id
    */
-  async getInvoice(id: string) : Promise<Stripe.Invoice> {
+  async getInvoice(id: string): Promise<Stripe.Invoice> {
     return this.stripe.invoices.retrieve(id);
   }
 
@@ -388,6 +389,13 @@ export class StripeHelper {
   /**
    * Retrieve the payment attempts that have been made on this invoice via PayPal.
    *
+   * This variable reflects the amount of payment attempts that have been made. It is
+   * incremented *after* a payment attempt is made by any code that runs a reference
+   * transaction. As such, this number could be incremented multiple times at checkout
+   * or during a payment update on the subscription management page.
+   *
+   * The PayPal idempotencyKey has this number affixed to it in the pre-increment state.
+   *
    * @param invoice
    */
   getPaymentAttempts(invoice: Stripe.Invoice): number {
@@ -397,12 +405,15 @@ export class StripeHelper {
   /**
    * Update the payment attempts on an invoice after attempting via PayPal.
    *
+   * Increments by 1, or sets to the attempts passed in.
+   *
    * @param invoice
+   * @param attempts
    */
-  async updatePaymentAttempts(invoice: Stripe.Invoice) {
-    const currentAttempts = this.getPaymentAttempts(invoice);
+  async updatePaymentAttempts(invoice: Stripe.Invoice, attempts?: number) {
+    const setAttempt = attempts ?? this.getPaymentAttempts(invoice) + 1;
     return this.stripe.invoices.update(invoice.id, {
-      metadata: { paymentAttempts: (currentAttempts + 1).toString() },
+      metadata: { paymentAttempts: setAttempt.toString() },
     });
   }
 
@@ -436,12 +447,66 @@ export class StripeHelper {
   }
 
   /**
+   * Remove the PayPal Billing Agreement ID from a customer.
+   *
+   * @param customer
+   * @param agreementId
+   */
+  async removeCustomerPaypalAgreement(
+    uid: string,
+    customer: Stripe.Customer,
+    billingAgreementId: string
+  ) {
+    return [
+      this.stripe.customers.update(customer.id, {
+        metadata: { [PAYPAL_AGREEMENT_METADATA_KEY]: null },
+      }),
+      updatePayPalBA(uid, billingAgreementId, 'Cancelled', Date.now()),
+    ];
+  }
+
+  /**
    * Get the PayPal billing agreement id to use for this customer if available.
    *
    * @param customer
    */
   getCustomerPaypalAgreement(customer: Stripe.Customer): string | undefined {
     return customer.metadata[PAYPAL_AGREEMENT_METADATA_KEY];
+  }
+
+  /**
+   * Fetch all open invoices for manually invoiced subscriptions.
+   *
+   * @param created
+   */
+  fetchOpenInvoices(created: Stripe.InvoiceListParams['created']) {
+    return this.stripe.invoices.list({
+      limit: 100,
+      collection_method: 'send_invoice',
+      status: 'open',
+      created,
+      expand: ['data.customer'],
+    });
+  }
+
+  /**
+   * Updates the invoice to uncollectible
+   *
+   * @param invoice
+   */
+  markUncollectible(invoice: Stripe.Invoice) {
+    return this.stripe.invoices.markUncollectible(invoice.id);
+  }
+
+  /**
+   * Updates subscription to cancelled status
+   *
+   * @param subscriptionId
+   */
+  async cancelSubscription(
+    subscriptionId: string
+  ): Promise<Stripe.Subscription> {
+    return this.stripe.subscriptions.del(subscriptionId);
   }
 
   /**

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.ts
@@ -31,6 +31,9 @@ export class PayPalNotificationHandler extends PayPalHandler {
       });
     }
 
+    // TODO: If the invoice is void/uncollectible and this is Completed/Processed, issue
+    // a refunded.
+
     if (invoice.status == null || !['draft', 'open'].includes(invoice.status)) {
       // nothing to do since the invoice is already at its final status
       return;
@@ -56,15 +59,7 @@ export class PayPalNotificationHandler extends PayPalHandler {
             message: 'No idempotency key on PayPal transaction',
           });
         }
-        const { paymentAttempt } = this.paypalHelper.parseIdempotencyKey(
-          message.custom
-        );
-        if (paymentAttempt < this.stripeHelper.getPaymentAttempts(invoice)) {
-          // the attempts were already recorded during the transaction and do not need
-          // to be updated here
-          return;
-        }
-        return this.stripeHelper.updatePaymentAttempts(invoice);
+        return;
       default:
         // Unexpected response here, log details and throw validation error.
         this.log.error('handleMerchPayment', {

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -25,7 +25,8 @@
     "format": "prettier --write --config ../../_dev/.prettierrc '**'",
     "gen-keys": "ts-node ./scripts/gen_keys.js; ts-node ./scripts/oauth_gen_keys.js; ts-node ./scripts/gen_vapid_keys.js",
     "write-emails": "node -r ts-node/register ./scripts/write-emails-to-disk.js",
-    "clean-up-old-ci-stripe-customers": "ts-node ./scripts/clean-up-old-ci-stripe-customers.js"
+    "clean-up-old-ci-stripe-customers": "ts-node ./scripts/clean-up-old-ci-stripe-customers.js",
+    "paypal-processor": "CONFIG_FILES='config/secrets.json' ts-node ./scripts/paypal-processor.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/fxa-auth-server/scripts/paypal-processor.ts
+++ b/packages/fxa-auth-server/scripts/paypal-processor.ts
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import program from 'commander';
+import { PayPalHelper } from 'fxa-auth-server/lib/payments/paypal';
+import { setupAuthDatabase } from 'fxa-shared/db';
+import { StatsD } from 'hot-shots';
+import Container from 'typedi';
+
+import { PaypalProcessor } from '../lib/payments/paypal-processor';
+import { StripeHelper } from '../lib/payments/stripe';
+import { configureSentry } from '../lib/sentry';
+
+const pckg = require('../package.json');
+const config = require('../config').getProperties();
+
+export async function init() {
+  configureSentry(undefined, config);
+  // Establish database connection and bind instance to Model using Knex
+  setupAuthDatabase(config.database.mysql.auth);
+
+  const statsd = config.statsd.enabled
+    ? new StatsD({
+        ...config.statsd,
+        errorHandler: (err) => {
+          // eslint-disable-next-line no-use-before-define
+          log.error('statsd.error', err);
+        },
+      })
+    : {
+        increment: () => {},
+        timing: () => {},
+        close: () => {},
+      };
+  Container.set(StatsD, statsd);
+
+  const log = require('../lib/log')({ ...config.log, statsd });
+
+  program
+    .version(pckg.version)
+    .option('-g, --grace [days]', 'Grace days to allow. Defaults to 1.', '1')
+    .option(
+      '-r, --retries [times]',
+      'Retry attempts to per day. Defaults to 1.',
+      '1'
+    )
+    .option(
+      '-i, --invoice-age [hours]',
+      'How old the invoice must be to get processed. Defaults to 6.',
+      '6'
+    )
+    .parse(process.argv);
+
+  const stripeHelper = new StripeHelper(log, config);
+  Container.set(StripeHelper, stripeHelper);
+  const paypalHelper = new PayPalHelper({ log });
+  Container.set(PayPalHelper, paypalHelper);
+
+  const processor = new PaypalProcessor(
+    log,
+    config,
+    parseInt(program.grace),
+    parseInt(program.retries),
+    parseInt(program.invoice_age)
+  );
+  await processor.processInvoices();
+  return 0;
+}
+
+if (require.main === module) {
+  init()
+    .catch((err) => {
+      console.error(err.message);
+      process.exit(1);
+    })
+    .then((result) => process.exit(result));
+}

--- a/packages/fxa-auth-server/test/local/payments/fixtures/paypal/create_billing_agreement_failure.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/paypal/create_billing_agreement_failure.json
@@ -4,12 +4,8 @@
   "ACK": "Failure",
   "VERSION": "204",
   "BUILD": "55251101",
-  "L": [
-    {
-      "ERRORCODE": "11455",
-      "SHORTMESSAGE": "Buyer did not accept billing agreement",
-      "LONGMESSAGE": "Buyer did not accept billing agreement",
-      "SEVERITYCODE": "Error"
-    }
-  ]
+  "L_ERRORCODE0": "11455",
+  "L_SHORTMESSAGE0": "Buyer did not accept billing agreement",
+  "L_LONGMESSAGE0": "Buyer did not accept billing agreement",
+  "L_SEVERITYCODE0": "Error"
 }

--- a/packages/fxa-auth-server/test/local/payments/fixtures/paypal/do_reference_transaction_failure.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/paypal/do_reference_transaction_failure.json
@@ -4,12 +4,8 @@
   "ACK": "Failure",
   "VERSION": "204",
   "BUILD": "55251101",
-  "L": [
-    {
-      "ERRORCODE": "11451",
-      "SHORTMESSAGE": "Billing Agreement Id or transaction Id is not valid",
-      "LONGMESSAGE": "Billing Agreement Id or transaction Id is not valid",
-      "SEVERITYCODE": "Error"
-    }
-  ]
+  "L_ERRORCODE0": "11451",
+  "L_SHORTMESSAGE0": "Billing Agreement Id or transaction Id is not valid",
+  "L_LONGMESSAGE0": "Billing Agreement Id or transaction Id is not valid",
+  "L_SEVERITYCODE0": "Error"
 }

--- a/packages/fxa-auth-server/test/local/payments/fixtures/paypal/set_express_checkout_failure.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/paypal/set_express_checkout_failure.json
@@ -4,12 +4,8 @@
   "ACK": "Failure",
   "VERSION": "204",
   "BUILD": "55251101",
-  "L": [
-    {
-      "ERRORCODE": "81100",
-      "SHORTMESSAGE": "Missing Parameter",
-      "LONGMESSAGE": "OrderTotal (Amt) : Required parameter missing",
-      "SEVERITYCODE": "Error"
-    }
-  ]
+  "L_ERRORCODE0": "81100",
+  "L_SHORTMESSAGE0": "Missing Parameter",
+  "L_LONGMESSAGE0": "OrderTotal (Amt) : Required parameter missing",
+  "L_SEVERITYCODE0": "Error"
 }

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -281,6 +281,7 @@ describe('PayPalClient', () => {
         assert.equal(err.name, 'PayPalClientError');
         assert.include(err.raw, 'ACK=Failure');
         assert.equal(err.data.ACK, 'Failure');
+        assert.equal(err.errorCode, 81100);
       }
     });
 
@@ -439,6 +440,7 @@ describe('PayPalClient', () => {
         assert.equal(err.name, 'PayPalClientError');
         assert.include(err.raw, 'ACK=Failure');
         assert.equal(err.data.ACK, 'Failure');
+        assert.equal(err.errorCode, 11451);
       }
     });
   });

--- a/packages/fxa-auth-server/test/local/payments/paypal-processor.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-processor.js
@@ -1,0 +1,620 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const sinon = require('sinon');
+const { Container } = require('typedi');
+
+const { PayPalHelper } = require('../../../lib/payments/paypal');
+const { mockLog } = require('../../mocks');
+const { PaypalProcessor } = require('../../../lib/payments/paypal-processor');
+const { StripeHelper } = require('../../../lib/payments/stripe');
+const error = require('../../../lib/error');
+const paidInvoice = require('./fixtures/stripe/invoice_paid.json');
+const unpaidInvoice = require('./fixtures/stripe/invoice_open.json');
+const customer1 = require('./fixtures/stripe/customer1.json');
+const failedDoReferenceTransactionResponse = require('./fixtures/paypal/do_reference_transaction_failure.json');
+const { PayPalClientError } = require('../../../lib/payments/paypal-client');
+const {
+  PAYPAL_BILLING_AGREEMENT_INVALID,
+  PAYPAL_SOURCE_ERRORS,
+} = require('../../../lib/payments/paypal-error-codes');
+const { CurrencyHelper } = require('../../../lib/payments/currencies');
+
+const sandbox = sinon.createSandbox();
+
+/**
+ * To prevent the modification of the test objects loaded, which can impact other tests referencing the object,
+ * a deep copy of the object can be created which uses the test object as a template
+ *
+ * @param {Object} object
+ */
+function deepCopy(object) {
+  return JSON.parse(JSON.stringify(object));
+}
+
+describe('PaypalProcessor', () => {
+  /** @type PayPalHelper */
+  let mockPaypalHelper;
+  let mockStripeHelper;
+  let processor;
+  let mockConfig;
+
+  beforeEach(() => {
+    mockConfig = {
+      currenciesToCountries: { ZAR: ['AS', 'CA'] },
+    };
+    mockStripeHelper = {};
+    mockPaypalHelper = {};
+    // Make currencyHelper
+    const currencyHelper = new CurrencyHelper(mockConfig);
+    Container.set(CurrencyHelper, currencyHelper);
+    Container.set(StripeHelper, mockStripeHelper);
+    Container.set(PayPalHelper, mockPaypalHelper);
+    processor = new PaypalProcessor(mockLog, mockConfig, 1, 1);
+  });
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  describe('constructor', () => {
+    it('sets log, graceDays, retryAttemps, stripe and paypalHelpers', () => {
+      const paypalProcessor = new PaypalProcessor(mockLog, mockConfig, 1, 1);
+      assert.strictEqual(paypalProcessor.log, mockLog);
+      assert.equal(paypalProcessor.graceDays, 1);
+      assert.equal(paypalProcessor.maxRetryAttempts, 1);
+      assert.strictEqual(paypalProcessor.stripeHelper, mockStripeHelper);
+      assert.strictEqual(paypalProcessor.paypalHelper, mockPaypalHelper);
+    });
+  });
+
+  describe('inGracePeriod', () => {
+    it('returns true within grace period', () => {
+      const invoice = deepCopy(unpaidInvoice);
+      const hoursAgo = new Date();
+      hoursAgo.setHours(hoursAgo.getHours() - 20);
+      invoice.created = hoursAgo.getTime() / 1000;
+      const result = processor.inGracePeriod(invoice);
+      assert.isTrue(result);
+    });
+
+    it('returns false when outside of grace period', () => {
+      const invoice = deepCopy(unpaidInvoice);
+      const twoDaysAgo = new Date();
+      twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+      invoice.created = twoDaysAgo.getTime() / 1000;
+      const result = processor.inGracePeriod(invoice);
+      assert.isFalse(result);
+    });
+  });
+
+  describe('cancelInvoiceSubscription', () => {
+    it('marks invoice and cancels subscription', async () => {
+      mockStripeHelper.markUncollectible = sandbox.fake.resolves({});
+      mockStripeHelper.cancelSubscription = sandbox.fake.resolves({});
+      const result = await processor.cancelInvoiceSubscription(paidInvoice);
+      assert.deepEqual(result, [{}, {}]);
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.markUncollectible,
+        paidInvoice
+      );
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.cancelSubscription,
+        paidInvoice.subscription
+      );
+    });
+  });
+
+  describe('ensureAccurateAttemptCount', () => {
+    it('does nothing if the attempts match', async () => {
+      mockStripeHelper.getPaymentAttempts = sandbox.fake.returns(1);
+      mockStripeHelper.updatePaymentAttempts = sandbox.fake.resolves({});
+      await processor.ensureAccurateAttemptCount(unpaidInvoice, [{}]);
+      sinon.assert.notCalled(mockStripeHelper.updatePaymentAttempts);
+    });
+
+    it('updates the attempts if they do not match', async () => {
+      const invoice = deepCopy(unpaidInvoice);
+      mockStripeHelper.getPaymentAttempts = sandbox.fake.returns(2);
+      mockStripeHelper.updatePaymentAttempts = sandbox.fake.resolves({});
+      await processor.ensureAccurateAttemptCount(invoice, [{}]);
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.updatePaymentAttempts,
+        invoice,
+        1
+      );
+      sandbox.reset();
+      await processor.ensureAccurateAttemptCount(invoice, [{}, {}, {}]);
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.updatePaymentAttempts,
+        invoice,
+        3
+      );
+    });
+  });
+
+  describe('handlePaidTransaction', () => {
+    it('returns false if no success', async () => {
+      let result = await processor.handlePaidTransaction(unpaidInvoice, []);
+      assert.isFalse(result);
+      result = await processor.handlePaidTransaction(unpaidInvoice, [
+        { status: 'Pending' },
+      ]);
+      assert.isFalse(result);
+    });
+
+    it('returns true if success', async () => {
+      mockStripeHelper.updateInvoiceWithPaypalTransactionId = sandbox.fake.resolves(
+        {}
+      );
+      mockStripeHelper.payInvoiceOutOfBand = sandbox.fake.resolves({});
+      const result = await processor.handlePaidTransaction(unpaidInvoice, [
+        { status: 'Completed', transactionId: 'test1234' },
+      ]);
+      assert.isTrue(result);
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.updateInvoiceWithPaypalTransactionId,
+        unpaidInvoice,
+        'test1234'
+      );
+    });
+
+    it('returns true and logs if > 1 success', async () => {
+      mockStripeHelper.updateInvoiceWithPaypalTransactionId = sandbox.fake.resolves(
+        {}
+      );
+      mockStripeHelper.payInvoiceOutOfBand = sandbox.fake.resolves({});
+      mockLog.error = sandbox.fake.returns({});
+      const result = await processor.handlePaidTransaction(unpaidInvoice, [
+        { status: 'Completed', transactionId: 'test1234' },
+        { status: 'Completed', transactionId: 'test12345' },
+      ]);
+      assert.isTrue(result);
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.updateInvoiceWithPaypalTransactionId,
+        unpaidInvoice,
+        'test1234'
+      );
+      sinon.assert.calledOnceWithExactly(
+        mockLog.error,
+        'multipleCompletedTransactions',
+        {
+          customer: unpaidInvoice.customer,
+          invoiceId: unpaidInvoice.id,
+          transactionCount: 2,
+          excessTransactions: ['test12345'],
+        }
+      );
+    });
+  });
+
+  describe('handlePendingTransaction', () => {
+    it('returns true if a pending within grace period exists', async () => {
+      processor.inGracePeriod = sandbox.fake.returns(true);
+      const result = await processor.handlePendingTransaction(unpaidInvoice, [
+        { status: 'Pending' },
+      ]);
+      assert.isTrue(result);
+      sinon.assert.calledOnceWithExactly(
+        processor.inGracePeriod,
+        unpaidInvoice
+      );
+    });
+
+    it('returns true and logs if multiple pending within grace exist', async () => {
+      processor.inGracePeriod = sandbox.fake.returns(true);
+      mockLog.error = sandbox.fake.returns({});
+      const result = await processor.handlePendingTransaction(unpaidInvoice, [
+        { status: 'Pending' },
+        { status: 'Pending' },
+      ]);
+      assert.isTrue(result);
+      sinon.assert.calledOnceWithExactly(
+        processor.inGracePeriod,
+        unpaidInvoice
+      );
+      sinon.assert.calledOnceWithExactly(
+        mockLog.error,
+        'multiplePendingTransactions',
+        { customer: unpaidInvoice.customer, invoiceId: unpaidInvoice.id }
+      );
+    });
+
+    it('returns false if no pending exist', async () => {
+      processor.inGracePeriod = sandbox.fake.returns(true);
+      const result = await processor.handlePendingTransaction(unpaidInvoice, [
+        { status: 'Completed' },
+      ]);
+      assert.isFalse(result);
+      sinon.assert.calledOnceWithExactly(
+        processor.inGracePeriod,
+        unpaidInvoice
+      );
+    });
+
+    it('returns false if no pending within grace period exist', async () => {
+      processor.inGracePeriod = sandbox.fake.returns(false);
+      const result = await processor.handlePendingTransaction(unpaidInvoice, [
+        { status: 'Pending' },
+      ]);
+      assert.isFalse(result);
+      sinon.assert.calledOnceWithExactly(
+        processor.inGracePeriod,
+        unpaidInvoice
+      );
+    });
+  });
+
+  describe('makePaymentAttempt', () => {
+    it('processes zero invoice if its 0', async () => {
+      const invoice = deepCopy(unpaidInvoice);
+      invoice.amount_due = 0;
+      mockPaypalHelper.processZeroInvoice = sandbox.fake.resolves({});
+      const result = await processor.makePaymentAttempt(invoice);
+      assert.isTrue(result);
+      sinon.assert.calledOnceWithExactly(
+        mockPaypalHelper.processZeroInvoice,
+        invoice
+      );
+    });
+
+    it('processes an invoice successfully', async () => {
+      const invoice = deepCopy(unpaidInvoice);
+      mockPaypalHelper.processInvoice = sandbox.fake.resolves({});
+      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.resolves({});
+      const result = await processor.makePaymentAttempt(invoice);
+      assert.isTrue(result);
+      sinon.assert.notCalled(mockStripeHelper.getCustomerPaypalAgreement);
+    });
+
+    it('handles a paypal source error', async () => {
+      const paypalHelper = new PayPalHelper({ mockLog });
+      const invoice = deepCopy(unpaidInvoice);
+      const testCustomer = { metadata: { userid: 'testuser' } };
+      invoice.customer = testCustomer;
+
+      const failedResponse = deepCopy(failedDoReferenceTransactionResponse);
+      failedResponse.L_ERRORCODE0 = PAYPAL_SOURCE_ERRORS[0];
+      const rawString = paypalHelper.client.objectToNVP(failedResponse);
+      const parsedNvpObject = paypalHelper.client.nvpToObject(rawString);
+      const throwErr = new PayPalClientError(rawString, parsedNvpObject);
+      mockPaypalHelper.processInvoice = sandbox.fake.rejects(throwErr);
+      mockStripeHelper.removeCustomerPaypalAgreement = sandbox.fake.resolves(
+        {}
+      );
+      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.returns(
+        'testba'
+      );
+
+      const result = await processor.makePaymentAttempt(invoice);
+      assert.isFalse(result);
+      sinon.assert.notCalled(mockStripeHelper.getCustomerPaypalAgreement);
+      sinon.assert.notCalled(mockStripeHelper.removeCustomerPaypalAgreement);
+    });
+
+    it('handles an invalid billing agreement', async () => {
+      const paypalHelper = new PayPalHelper({ mockLog });
+      const invoice = deepCopy(unpaidInvoice);
+      const testCustomer = { metadata: { userid: 'testuser' } };
+      invoice.customer = testCustomer;
+
+      const failedResponse = deepCopy(failedDoReferenceTransactionResponse);
+      failedResponse.L_ERRORCODE0 = PAYPAL_BILLING_AGREEMENT_INVALID;
+      const rawString = paypalHelper.client.objectToNVP(failedResponse);
+      const parsedNvpObject = paypalHelper.client.nvpToObject(rawString);
+      const throwErr = new PayPalClientError(rawString, parsedNvpObject);
+      mockPaypalHelper.processInvoice = sandbox.fake.rejects(throwErr);
+      mockStripeHelper.removeCustomerPaypalAgreement = sandbox.fake.resolves(
+        {}
+      );
+      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.returns(
+        'testba'
+      );
+
+      const result = await processor.makePaymentAttempt(invoice);
+      assert.isFalse(result);
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.getCustomerPaypalAgreement,
+        testCustomer
+      );
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.removeCustomerPaypalAgreement,
+        'testuser',
+        testCustomer,
+        'testba'
+      );
+    });
+
+    it('handles an unexpected error', async () => {
+      const invoice = deepCopy(unpaidInvoice);
+      const testCustomer = { metadata: { userid: 'testuser' } };
+      invoice.customer = testCustomer;
+
+      const throwErr = new Error('test');
+      mockLog.error = sandbox.fake.returns({});
+      mockPaypalHelper.processInvoice = sandbox.fake.rejects(throwErr);
+      mockStripeHelper.removeCustomerPaypalAgreement = sandbox.fake.resolves(
+        {}
+      );
+      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.returns(
+        'testba'
+      );
+
+      const result = await processor.makePaymentAttempt(invoice);
+      assert.isFalse(result);
+      sinon.assert.calledOnceWithExactly(mockLog.error, 'processInvoice', {
+        err: throwErr,
+        invoiceId: invoice.id,
+      });
+      sinon.assert.notCalled(mockStripeHelper.getCustomerPaypalAgreement);
+      sinon.assert.notCalled(mockStripeHelper.removeCustomerPaypalAgreement);
+    });
+  });
+
+  describe('attemptsToday', () => {
+    it('locates the transactions for today', () => {
+      let yesterdayTransaction = new Date();
+      yesterdayTransaction.setDate(yesterdayTransaction.getDate() - 1);
+      yesterdayTransaction = yesterdayTransaction.toUTCString();
+      const todayTransaction = new Date().toUTCString();
+      const result = processor.attemptsToday([
+        { timestamp: yesterdayTransaction },
+        { timestamp: todayTransaction },
+      ]);
+      assert.equal(result, 1);
+    });
+  });
+
+  describe('attemptInvoiceProcessing', () => {
+    let invoice;
+    let customer;
+
+    beforeEach(() => {
+      invoice = deepCopy(unpaidInvoice);
+      invoice.customer = customer = deepCopy(customer1);
+    });
+
+    it('makes an attempt', async () => {
+      mockPaypalHelper.searchTransactions = sandbox.fake.resolves([]);
+      processor.ensureAccurateAttemptCount = sandbox.fake.resolves({});
+      processor.handlePaidTransaction = sandbox.fake.resolves(false);
+      processor.handlePendingTransaction = sandbox.fake.resolves(false);
+      processor.inGracePeriod = sandbox.fake.returns(true);
+      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.returns(
+        'b-1234'
+      );
+      processor.attemptsToday = sandbox.fake.returns(0);
+      processor.makePaymentAttempt = sandbox.fake.resolves({});
+
+      const result = await processor.attemptInvoiceProcessing(invoice);
+      assert.isUndefined(result);
+      sinon.assert.callCount(mockPaypalHelper.searchTransactions, 1);
+
+      for (const spy of [
+        processor.ensureAccurateAttemptCount,
+        processor.handlePaidTransaction,
+        processor.handlePendingTransaction,
+      ]) {
+        sinon.assert.calledOnceWithExactly(spy, invoice, []);
+      }
+      sinon.assert.calledOnceWithExactly(processor.inGracePeriod, invoice);
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.getCustomerPaypalAgreement,
+        invoice.customer
+      );
+      sinon.assert.calledOnceWithExactly(processor.attemptsToday, []);
+      sinon.assert.calledOnceWithExactly(processor.makePaymentAttempt, invoice);
+    });
+
+    it('errors with no customer loaded', async () => {
+      invoice.customer = 'cust_1232142';
+      mockLog.error = sandbox.fake.returns({});
+      try {
+        await processor.attemptInvoiceProcessing(invoice);
+        assert.fail('Expected to throw an error without a customer loaded.');
+      } catch (err) {
+        assert.deepEqual(
+          err,
+          error.internalValidationError('customerNotLoad', {
+            customer: 'cust_1232142',
+            invoiceId: invoice.id,
+          })
+        );
+        sinon.assert.calledOnceWithExactly(mockLog.error, 'customerNotLoaded', {
+          customer: 'cust_1232142',
+        });
+      }
+    });
+
+    it('stops with a pending transaction', async () => {
+      mockPaypalHelper.searchTransactions = sandbox.fake.resolves([]);
+      processor.ensureAccurateAttemptCount = sandbox.fake.resolves({});
+      processor.handlePaidTransaction = sandbox.fake.resolves(false);
+      processor.handlePendingTransaction = sandbox.fake.resolves(true);
+      processor.inGracePeriod = sandbox.fake.returns(true);
+
+      const result = await processor.attemptInvoiceProcessing(invoice);
+      assert.isUndefined(result);
+      sinon.assert.callCount(mockPaypalHelper.searchTransactions, 1);
+
+      for (const spy of [
+        processor.ensureAccurateAttemptCount,
+        processor.handlePaidTransaction,
+        processor.handlePendingTransaction,
+      ]) {
+        sinon.assert.calledOnceWithExactly(spy, invoice, []);
+      }
+      sinon.assert.notCalled(processor.inGracePeriod);
+    });
+
+    it('stops with a completed transaction', async () => {
+      mockPaypalHelper.searchTransactions = sandbox.fake.resolves([]);
+      processor.ensureAccurateAttemptCount = sandbox.fake.resolves({});
+      processor.handlePaidTransaction = sandbox.fake.resolves(true);
+      processor.handlePendingTransaction = sandbox.fake.resolves(false);
+
+      const result = await processor.attemptInvoiceProcessing(invoice);
+      assert.isUndefined(result);
+      sinon.assert.callCount(mockPaypalHelper.searchTransactions, 1);
+
+      for (const spy of [
+        processor.ensureAccurateAttemptCount,
+        processor.handlePaidTransaction,
+      ]) {
+        sinon.assert.calledOnceWithExactly(spy, invoice, []);
+      }
+      sinon.assert.notCalled(processor.handlePendingTransaction);
+    });
+
+    it('stops if no billing agreement', async () => {
+      mockPaypalHelper.searchTransactions = sandbox.fake.resolves([]);
+      processor.ensureAccurateAttemptCount = sandbox.fake.resolves({});
+      processor.handlePaidTransaction = sandbox.fake.resolves(false);
+      processor.handlePendingTransaction = sandbox.fake.resolves(false);
+      processor.inGracePeriod = sandbox.fake.returns(true);
+      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.returns(
+        undefined
+      );
+      processor.attemptsToday = sandbox.fake.returns(0);
+
+      const result = await processor.attemptInvoiceProcessing(invoice);
+      assert.isUndefined(result);
+      sinon.assert.callCount(mockPaypalHelper.searchTransactions, 1);
+
+      for (const spy of [
+        processor.ensureAccurateAttemptCount,
+        processor.handlePaidTransaction,
+        processor.handlePendingTransaction,
+      ]) {
+        sinon.assert.calledOnceWithExactly(spy, invoice, []);
+      }
+      sinon.assert.calledOnceWithExactly(processor.inGracePeriod, invoice);
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.getCustomerPaypalAgreement,
+        invoice.customer
+      );
+      sinon.assert.notCalled(processor.attemptsToday);
+    });
+
+    it('voids invoices for deleted customers', async () => {
+      mockStripeHelper.markUncollectible = sandbox.fake.resolves({});
+      mockLog.info = sandbox.fake.returns({});
+      customer.deleted = true;
+      const result = await processor.attemptInvoiceProcessing(invoice);
+      assert.isUndefined(result);
+      sinon.assert.calledOnceWithExactly(mockLog.info, 'customerDeletedVoid', {
+        customerId: customer.id,
+      });
+    });
+
+    it('cancels if outside the grace period', async () => {
+      mockPaypalHelper.searchTransactions = sandbox.fake.resolves([]);
+      processor.ensureAccurateAttemptCount = sandbox.fake.resolves({});
+      processor.handlePaidTransaction = sandbox.fake.resolves(false);
+      processor.handlePendingTransaction = sandbox.fake.resolves(false);
+      processor.inGracePeriod = sandbox.fake.returns(false);
+      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.returns(
+        'b-1234'
+      );
+      processor.cancelInvoiceSubscription = sandbox.fake.resolves({});
+
+      const result = await processor.attemptInvoiceProcessing(invoice);
+      assert.deepEqual(result, {});
+      sinon.assert.callCount(mockPaypalHelper.searchTransactions, 1);
+
+      for (const spy of [
+        processor.ensureAccurateAttemptCount,
+        processor.handlePaidTransaction,
+        processor.handlePendingTransaction,
+      ]) {
+        sinon.assert.calledOnceWithExactly(spy, invoice, []);
+      }
+      sinon.assert.calledOnceWithExactly(processor.inGracePeriod, invoice);
+      sinon.assert.notCalled(mockStripeHelper.getCustomerPaypalAgreement);
+      sinon.assert.calledOnceWithExactly(
+        processor.cancelInvoiceSubscription,
+        invoice
+      );
+    });
+
+    it('does not attempt payment after too many attempts', async () => {
+      mockPaypalHelper.searchTransactions = sandbox.fake.resolves([]);
+      processor.ensureAccurateAttemptCount = sandbox.fake.resolves({});
+      processor.handlePaidTransaction = sandbox.fake.resolves(false);
+      processor.handlePendingTransaction = sandbox.fake.resolves(false);
+      processor.inGracePeriod = sandbox.fake.returns(true);
+      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.returns(
+        'b-1234'
+      );
+      processor.attemptsToday = sandbox.fake.returns(20);
+      processor.makePaymentAttempt = sandbox.fake.resolves({});
+
+      const result = await processor.attemptInvoiceProcessing(invoice);
+      assert.isUndefined(result);
+      sinon.assert.callCount(mockPaypalHelper.searchTransactions, 1);
+
+      for (const spy of [
+        processor.ensureAccurateAttemptCount,
+        processor.handlePaidTransaction,
+        processor.handlePendingTransaction,
+      ]) {
+        sinon.assert.calledOnceWithExactly(spy, invoice, []);
+      }
+      sinon.assert.calledOnceWithExactly(processor.inGracePeriod, invoice);
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.getCustomerPaypalAgreement,
+        invoice.customer
+      );
+      sinon.assert.calledOnceWithExactly(processor.attemptsToday, []);
+      sinon.assert.notCalled(processor.makePaymentAttempt);
+    });
+  });
+
+  describe('processInvoices', () => {
+    it('processes an invoice', async () => {
+      const invoice = deepCopy(unpaidInvoice);
+      mockLog.error = sandbox.fake.returns({});
+      mockLog.info = sandbox.fake.returns({});
+      processor.attemptInvoiceProcessing = sandbox.fake.resolves({});
+      mockStripeHelper.fetchOpenInvoices = sandbox.fake.returns({
+        *[Symbol.asyncIterator]() {
+          yield invoice;
+        },
+      });
+      await processor.processInvoices();
+      sinon.assert.calledOnceWithExactly(mockLog.info, 'processInvoice', {
+        invoiceId: invoice.id,
+      });
+      sinon.assert.notCalled(mockLog.error);
+    });
+
+    it('logs an error on invoice exception', async () => {
+      const invoice = deepCopy(unpaidInvoice);
+      mockLog.error = sandbox.fake.returns({});
+      mockLog.info = sandbox.fake.returns({});
+      const throwErr = new Error('Test');
+      processor.attemptInvoiceProcessing = sandbox.fake.rejects(throwErr);
+      mockStripeHelper.fetchOpenInvoices = sandbox.fake.returns({
+        *[Symbol.asyncIterator]() {
+          yield invoice;
+        },
+      });
+      try {
+        await processor.processInvoices();
+        assert.fail('Process invoicce should fail');
+      } catch (err) {
+        sinon.assert.calledOnceWithExactly(mockLog.info, 'processInvoice', {
+          invoiceId: invoice.id,
+        });
+        sinon.assert.calledOnceWithExactly(mockLog.error, 'processInvoice', {
+          err: throwErr,
+          invoiceId: invoice.id,
+        });
+      }
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -681,18 +681,17 @@ describe('StripeHelper', () => {
   });
 
   describe('getInvoice', () => {
-    it('works successfully',
-      async () => {
-        sandbox
-          .stub(stripeHelper.stripe.invoices, 'retrieve')
-          .resolves(unpaidInvoice);
-        const actual = await stripeHelper.getInvoice(unpaidInvoice.id);
-        assert.deepEqual(actual, unpaidInvoice);
-        sinon.assert.calledOnceWithExactly(
-          stripeHelper.stripe.invoices.retrieve,
-          unpaidInvoice.id
-        );
-      });
+    it('works successfully', async () => {
+      sandbox
+        .stub(stripeHelper.stripe.invoices, 'retrieve')
+        .resolves(unpaidInvoice);
+      const actual = await stripeHelper.getInvoice(unpaidInvoice.id);
+      assert.deepEqual(actual, unpaidInvoice);
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripe.invoices.retrieve,
+        unpaidInvoice.id
+      );
+    });
   });
 
   describe('finalizeInvoice', () => {
@@ -775,6 +774,22 @@ describe('StripeHelper', () => {
         }
       );
     });
+
+    it('returns 3 updating from 1', async () => {
+      const attemptedInvoice = deepCopy(unpaidInvoice);
+      attemptedInvoice.metadata.paymentAttempts = '1';
+      const actual = stripeHelper.getPaymentAttempts(attemptedInvoice);
+      assert.equal(actual, 1);
+      sandbox.stub(stripeHelper.stripe.invoices, 'update').resolves({});
+      await stripeHelper.updatePaymentAttempts(attemptedInvoice, 3);
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripe.invoices.update,
+        attemptedInvoice.id,
+        {
+          metadata: { paymentAttempts: '3' },
+        }
+      );
+    });
   });
 
   describe('payInvoiceOutOfBand', () => {
@@ -816,6 +831,38 @@ describe('StripeHelper', () => {
     });
   });
 
+  describe('removeCustomerPaypalAgreement', () => {
+    it('removes billing agreement id', async () => {
+      const paypalCustomer = deepCopy(customer1);
+      sandbox.stub(stripeHelper.stripe.customers, 'update').resolves({});
+      const now = new Date();
+      const clock = sinon.useFakeTimers(now.getTime());
+
+      const authDbModule = require('fxa-shared/db/models/auth');
+      sandbox.stub(authDbModule, 'updatePayPalBA').returns(0);
+
+      await stripeHelper.removeCustomerPaypalAgreement(
+        'uid',
+        paypalCustomer,
+        'billingAgreementId'
+      );
+
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripe.customers.update,
+        paypalCustomer.id,
+        { metadata: { paypalAgreementId: null } }
+      );
+      sinon.assert.calledOnceWithExactly(
+        authDbModule.updatePayPalBA,
+        'uid',
+        'billingAgreementId',
+        'Cancelled',
+        clock.now
+      );
+      clock.restore();
+    });
+  });
+
   describe('getCustomerPaypalAgreement', () => {
     it('returns undefined with no paypal agreement', () => {
       const actual = stripeHelper.getCustomerPaypalAgreement(customer1);
@@ -827,6 +874,47 @@ describe('StripeHelper', () => {
       paypalCustomer.metadata.paypalAgreementId = 'test-1234';
       const actual = stripeHelper.getCustomerPaypalAgreement(paypalCustomer);
       assert.equal(actual, 'test-1234');
+    });
+  });
+
+  describe('fetchOpenInvoices', () => {
+    it('returns customer paypal agreement id', async () => {
+      sandbox.stub(stripeHelper.stripe.invoices, 'list').resolves({});
+      const actual = await stripeHelper.fetchOpenInvoices(0);
+      assert.deepEqual(actual, {});
+      sinon.assert.calledOnceWithExactly(stripeHelper.stripe.invoices.list, {
+        limit: 100,
+        collection_method: 'send_invoice',
+        status: 'open',
+        created: 0,
+        expand: ['data.customer'],
+      });
+    });
+  });
+
+  describe('markUncollectible', () => {
+    it('returns an invoice marked uncollectible', async () => {
+      sandbox
+        .stub(stripeHelper.stripe.invoices, 'markUncollectible')
+        .resolves({});
+      sandbox.stub(stripeHelper.stripe.invoices, 'list').resolves({});
+      const actual = await stripeHelper.markUncollectible(unpaidInvoice);
+      assert.deepEqual(actual, {});
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripe.invoices.markUncollectible,
+        unpaidInvoice.id
+      );
+    });
+  });
+
+  describe('cancelSubscription', () => {
+    it('sets subscription to cancelled', async () => {
+      sandbox.stub(stripeHelper.stripe.subscriptions, 'del').resolves({});
+      await stripeHelper.cancelSubscription('subscriptionId');
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripe.subscriptions.del,
+        'subscriptionId'
+      );
     });
   });
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
@@ -196,65 +196,6 @@ describe('PayPalNotificationHandler', () => {
       );
     });
 
-    it('receives IPN message with unsuccessful payment status and it increments payment attempts', async () => {
-      const invoice = { status: 'open' };
-      const deniedMessage = {
-        ...message,
-        payment_status: 'Denied',
-        custom: 'inv_000-0',
-      };
-      stripeHelper.getInvoice = sinon.fake.resolves(invoice);
-      paypalHelper.parseIdempotencyKey = sinon.fake.returns({
-        invoiceId: 'inv_000',
-        paymentAttempt: 0,
-      });
-      stripeHelper.getPaymentAttempts = sinon.fake.returns(0);
-      stripeHelper.updatePaymentAttempts = sinon.fake.resolves({});
-      const result = await handler.handleMerchPayment(deniedMessage);
-      assert.deepEqual(result, {});
-      sinon.assert.calledOnceWithExactly(
-        stripeHelper.getInvoice,
-        message.invoice
-      );
-      sinon.assert.calledOnceWithExactly(
-        stripeHelper.getPaymentAttempts,
-        invoice
-      );
-      sinon.assert.calledOnceWithExactly(
-        stripeHelper.updatePaymentAttempts,
-        invoice
-      );
-    });
-
-    it('receives IPN message with unsuccessful payment status and it does not increments payment attempts', async () => {
-      const invoice = { status: 'open' };
-      const deniedMessage = {
-        ...message,
-        payment_status: 'Denied',
-        custom: 'inv_000-0',
-      };
-      stripeHelper.getInvoice = sinon.fake.resolves(invoice);
-      paypalHelper.parseIdempotencyKey = sinon.fake.returns({
-        invoiceId: 'inv_000',
-        paymentAttempt: 0,
-      });
-      stripeHelper.getPaymentAttempts = sinon.fake.returns(1);
-      const result = await handler.handleMerchPayment(deniedMessage);
-      assert.deepEqual(result, undefined);
-      sinon.assert.calledOnceWithExactly(
-        stripeHelper.getInvoice,
-        message.invoice
-      );
-      sinon.assert.calledOnceWithExactly(
-        paypalHelper.parseIdempotencyKey,
-        deniedMessage.custom
-      );
-      sinon.assert.calledOnceWithExactly(
-        stripeHelper.getPaymentAttempts,
-        invoice
-      );
-    });
-
     it('receives IPN message with unsuccessful payment status and no idempotency key', async () => {
       const invoice = { status: 'open' };
       const deniedMessage = {


### PR DESCRIPTION
Because:

* We want to ensure invoices paid via PayPal are processed when their
  initial attempt fails or payments are pending then completed later.

This commit:

* Adds a paypal-processor script intended to be run on an hourly basis
  that queries open invoices paid via paypal to process them as needed.

Closes #7452

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
