### PR TITLE
serve beta settings subroutes the index.html page in production

### DIFF
--- a/packages/fxa-content-server/server/bin/fxa-content-server.js
+++ b/packages/fxa-content-server/server/bin/fxa-content-server.js
@@ -179,6 +179,13 @@ function makeApp() {
   const routeHelpers = routing(app, routeLogger);
   routes.forEach(routeHelpers.addRoute);
 
+  app.get(betaSettingsPath, modifySettingsStatic);
+  app.use(
+    serveStatic(STATIC_DIRECTORY, {
+      maxAge: config.get('static_max_age'),
+    })
+  );
+
   if (!config.get('settings.enableBeta')) {
     app.use('/beta/*', function (req, res) {
       res.status(403);
@@ -187,14 +194,8 @@ function makeApp() {
   } else if (config.get('env') === 'development') {
     app.use(betaSettingsPath, useSettingsProxy);
   } else {
-    app.get(betaSettingsPath, modifySettingsStatic);
+    app.get(betaSettingsPath + '/*', modifySettingsStatic);
   }
-
-  app.use(
-    serveStatic(STATIC_DIRECTORY, {
-      maxAge: config.get('static_max_age'),
-    })
-  );
 
   // it's a four-oh-four not found.
   app.use(fourOhFour);

--- a/packages/fxa-content-server/server/config/production.json
+++ b/packages/fxa-content-server/server/config/production.json
@@ -5,5 +5,6 @@
   "csp": {
     "enabled": true,
     "reportOnly": true
-  }
+  },
+  "settings":{"enableBeta": true}
 }


### PR DESCRIPTION
## Because

- subroutes currently 404 on a hard refresh in stage / prod
- subroutes of /beta/settings should serve the SPA index.html
