### PR TITLE
feat(settings): hide email communications link if set to empty url

### DIFF
--- a/packages/fxa-settings/src/components/Nav/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Nav/index.stories.tsx
@@ -5,7 +5,9 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { MockedCache } from '../../models/_mocks';
+import { getDefault } from '../../lib/config';
 import { Nav } from '.';
+import { ConfigContext } from 'fxa-settings/src/lib/config';
 
 storiesOf('Components|Nav', module)
   .add('basic', () => (
@@ -19,4 +21,17 @@ storiesOf('Components|Nav', module)
     >
       <Nav />
     </MockedCache>
-  ));
+  ))
+  .add('without link to Newsletters', () => {
+    const config = Object.assign({}, getDefault(), {
+      marketingEmailPreferencesUrl: '',
+    });
+
+    return (
+      <MockedCache>
+        <ConfigContext.Provider value={ config }>
+          <Nav />
+        </ConfigContext.Provider>
+      </MockedCache>
+    );
+  });

--- a/packages/fxa-settings/src/components/Nav/index.test.tsx
+++ b/packages/fxa-settings/src/components/Nav/index.test.tsx
@@ -71,4 +71,20 @@ describe('Nav', () => {
       '/subscriptions'
     );
   });
+
+  it('renders as expected without newsletters link', () => {
+    const config = Object.assign({}, getDefault(), {
+      marketingEmailPreferencesUrl: '',
+    });
+
+    render(
+      <MockedCache>
+        <ConfigContext.Provider value={ config }>
+          <Nav />
+        </ConfigContext.Provider>
+      </MockedCache>
+    );
+
+    expect(screen.queryByTestId('nav-link-newsletters')).toBeNull();
+  });
 });

--- a/packages/fxa-settings/src/components/Nav/index.tsx
+++ b/packages/fxa-settings/src/components/Nav/index.tsx
@@ -15,9 +15,11 @@ export const Nav = () => {
   const config = useConfig();
   const primaryEmail = account.primaryEmail.email;
   const hasSubscription = account.subscriptions.length > 0;
-  const marketingCommPrefLink = `${
-    config.marketingEmailPreferencesUrl
-  }?email=${encodeURIComponent(primaryEmail)}`;
+  const marketingCommPrefLink =
+    config.marketingEmailPreferencesUrl &&
+    `${config.marketingEmailPreferencesUrl}?email=${encodeURIComponent(
+      primaryEmail
+    )}`;
 
   const activeClasses = 'font-bold text-blue-500 rounded-sm';
   return (
@@ -86,19 +88,21 @@ export const Nav = () => {
           </li>
         )}
 
-        <li>
-          <LinkExternal
-            className="font-bold"
-            data-testid="nav-link-newsletters"
-            href={marketingCommPrefLink}
-          >
-            <Localized id="nav-email-comm">Email Communications</Localized>
-            <OpenExternal
-              className="inline-block w-3 h-3 ltr:ml-1 rtl:mr-1 transform rtl:-scale-x-1"
-              aria-hidden="true"
-            />
-          </LinkExternal>
-        </li>
+        {marketingCommPrefLink && (
+          <li>
+            <LinkExternal
+              className="font-bold"
+              data-testid="nav-link-newsletters"
+              href={marketingCommPrefLink}
+            >
+              <Localized id="nav-email-comm">Email Communications</Localized>
+              <OpenExternal
+                className="inline-block w-3 h-3 ltr:ml-1 rtl:mr-1 transform rtl:-scale-x-1"
+                aria-hidden="true"
+              />
+            </LinkExternal>
+          </li>
+        )}
       </ul>
     </nav>
   );


### PR DESCRIPTION
## Because

- Similar change was made to current settings in https://github.com/mozilla/fxa-content-server/pull/6882
- I'd like to restart the effort to upstream China specific changes behind feature flags, starting with the newer `fxa-settings`

## This pull request

- Remove the "Email Communications" link if it's set to an empty url in configuration

## Issue that this pull request solves

Closes: not filed

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Settings Nav with "Email Communications" removed](https://user-images.githubusercontent.com/31391/109115801-88d04c80-777a-11eb-98bb-99f40d23559b.png)
