### PR TITLE
fix(auth-server): link invoice handler to webhook

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -71,6 +71,11 @@ export class StripeWebhookHandler extends StripeHandler {
             await this.handleInvoiceCreatedEvent(request, event);
           }
           break;
+        case 'invoice.finalized':
+          if (this.paypalHelper) {
+            await this.handleInvoiceOpenEvent(request, event);
+          }
+          break;
         case 'invoice.payment_succeeded':
           await this.handleInvoicePaymentSucceededEvent(request, event);
           break;


### PR DESCRIPTION
Because:

* The paypal invoice open handler was not linked into the webhook
  routing to actually run.

This commit:

* Adds a case statement for `invoice.finalize` which triggers when
  the invoice becomes open to process the invoice with PayPal if
  needed.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
