### PR TITLE
feat(auth-server): Paypal chargeCustomer must be called with currency…

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal-client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-client.ts
@@ -153,6 +153,7 @@ export type DoReferenceTransactionOptions = {
   billingAgreementId: string;
   invoiceNumber: string;
   idempotencyKey: string;
+  currencyCode: string;
 };
 
 export type BAUpdateOptions = {
@@ -407,6 +408,7 @@ export class PayPalClient {
   ): Promise<NVPDoReferenceTransactionResponse> {
     const data = {
       AMT: options.amount,
+      CURRENCYCODE: options.currencyCode.toUpperCase(),
       CUSTOM: options.idempotencyKey,
       INVNUM: options.invoiceNumber,
       MSGSUBID: options.idempotencyKey,

--- a/packages/fxa-auth-server/lib/payments/paypal.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal.ts
@@ -41,6 +41,7 @@ export type ChargeCustomerOptions = {
   billingAgreementId: string;
   invoiceNumber: string;
   idempotencyKey: string;
+  currencyCode: string;
 };
 
 export type ChargeResponse = {
@@ -252,6 +253,7 @@ export class PayPalHelper {
       billingAgreementId: options.billingAgreementId,
       invoiceNumber: options.invoiceNumber,
       idempotencyKey: options.idempotencyKey,
+      currencyCode: options.currencyCode,
     };
     const response = await this.client.doReferenceTransaction(
       doReferenceTransactionOptions
@@ -396,6 +398,7 @@ export class PayPalHelper {
         amountInCents: invoice.amount_due,
         billingAgreementId: agreementId,
         invoiceNumber: invoice.id,
+        currencyCode: invoice.currency,
         idempotencyKey,
       }),
     ];

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -345,6 +345,7 @@ describe('PayPalClient', () => {
   describe('doReferenceTransaction', () => {
     const defaultData = {
       AMT: '5.99',
+      CURRENCYCODE: 'USD',
       CUSTOM: 'in_asdf-12',
       INVNUM: 'in_asdf',
       MSGSUBID: 'in_asdf-12',
@@ -362,6 +363,7 @@ describe('PayPalClient', () => {
         billingAgreementId: defaultData.REFERENCEID,
         invoiceNumber: defaultData.INVNUM,
         idempotencyKey: defaultData.MSGSUBID,
+        currencyCode: defaultData.CURRENCYCODE,
       });
       sinon.assert.calledOnceWithExactly(
         client.doRequest,
@@ -380,6 +382,7 @@ describe('PayPalClient', () => {
         billingAgreementId: defaultData.REFERENCEID,
         invoiceNumber: defaultData.INVNUM,
         idempotencyKey: defaultData.MSGSUBID,
+        currencyCode: defaultData.CURRENCYCODE,
       });
       sinon.assert.calledOnceWithExactly(
         client.doRequest,
@@ -401,6 +404,7 @@ describe('PayPalClient', () => {
         billingAgreementId: ref,
         invoiceNumber: defaultData.INVNUM,
         idempotencyKey: defaultData.MSGSUBID,
+        currencyCode: defaultData.CURRENCYCODE,
       });
       sinon.assert.calledOnceWithExactly(
         client.doRequest,
@@ -408,6 +412,28 @@ describe('PayPalClient', () => {
         {
           ...defaultData,
           REFERENCEID: ref,
+        }
+      );
+    });
+
+    it('calls api with requested currency', async () => {
+      client.doRequest = sandbox.fake.resolves(
+        successfulDoReferenceTransactionResponse
+      );
+      const currency = 'EUR';
+      await client.doReferenceTransaction({
+        amount: defaultData.AMT,
+        billingAgreementId: defaultData.REFERENCEID,
+        invoiceNumber: defaultData.INVNUM,
+        idempotencyKey: defaultData.MSGSUBID,
+        currencyCode: currency,
+      });
+      sinon.assert.calledOnceWithExactly(
+        client.doRequest,
+        'DoReferenceTransaction',
+        {
+          ...defaultData,
+          CURRENCYCODE: currency,
         }
       );
     });
@@ -433,6 +459,7 @@ describe('PayPalClient', () => {
           billingAgreementId: defaultData.REFERENCEID,
           invoiceNumber: defaultData.INVNUM,
           idempotencyKey: defaultData.MSGSUBID,
+          currencyCode: defaultData.CURRENCYCODE,
         });
         assert.fail('Request should have thrown an error.');
       } catch (err) {

--- a/packages/fxa-auth-server/test/local/payments/paypal.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal.js
@@ -211,6 +211,7 @@ describe('PayPalHelper', () => {
     const validOptions = {
       amountInCents: 1099,
       billingAgreementId: 'B-12345',
+      currencyCode: 'usd',
       invoiceNumber: 'in_asdf',
       idempotencyKey: ' in_asdf-0',
     };
@@ -227,6 +228,7 @@ describe('PayPalHelper', () => {
         billingAgreementId: validOptions.billingAgreementId,
         invoiceNumber: validOptions.invoiceNumber,
         idempotencyKey: validOptions.idempotencyKey,
+        currencyCode: validOptions.currencyCode,
       };
       assert.ok(
         paypalHelper.client.doReferenceTransaction.calledOnceWith(
@@ -437,6 +439,7 @@ describe('PayPalHelper', () => {
         ...mockInvoice,
         status: 'open',
         amount_due: 499,
+        currency: 'eur',
       };
       mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
         agreementId
@@ -467,6 +470,7 @@ describe('PayPalHelper', () => {
       sinon.assert.calledOnceWithExactly(paypalHelper.chargeCustomer, {
         amountInCents: validInvoice.amount_due,
         billingAgreementId: agreementId,
+        currencyCode: validInvoice.currency,
         invoiceNumber: validInvoice.id,
         idempotencyKey: paypalHelper.generateIdempotencyKey(
           validInvoice.id,
@@ -489,7 +493,7 @@ describe('PayPalHelper', () => {
       const validInvoice = {
         ...mockInvoice,
         status: 'draft',
-        amount_due: 4.99,
+        amount_due: 499,
       };
       mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
         agreementId
@@ -521,6 +525,7 @@ describe('PayPalHelper', () => {
       sinon.assert.calledOnceWithExactly(paypalHelper.chargeCustomer, {
         amountInCents: validInvoice.amount_due,
         billingAgreementId: agreementId,
+        currencyCode: validInvoice.currency,
         invoiceNumber: validInvoice.id,
         idempotencyKey: paypalHelper.generateIdempotencyKey(
           validInvoice.id,
@@ -547,7 +552,7 @@ describe('PayPalHelper', () => {
       const validInvoice = {
         ...mockInvoice,
         status: 'open',
-        amount_due: 4.99,
+        amount_due: 499,
       };
       mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
         agreementId
@@ -574,6 +579,7 @@ describe('PayPalHelper', () => {
       sinon.assert.calledOnceWithExactly(paypalHelper.chargeCustomer, {
         amountInCents: validInvoice.amount_due,
         billingAgreementId: agreementId,
+        currencyCode: validInvoice.currency,
         invoiceNumber: validInvoice.id,
         idempotencyKey: paypalHelper.generateIdempotencyKey(
           validInvoice.id,
@@ -587,7 +593,7 @@ describe('PayPalHelper', () => {
       const validInvoice = {
         ...mockInvoice,
         status: 'open',
-        amount_due: 4.99,
+        amount_due: 499,
       };
       mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
         agreementId
@@ -621,6 +627,7 @@ describe('PayPalHelper', () => {
       sinon.assert.calledOnceWithExactly(paypalHelper.chargeCustomer, {
         amountInCents: validInvoice.amount_due,
         billingAgreementId: agreementId,
+        currencyCode: validInvoice.currency,
         invoiceNumber: validInvoice.id,
         idempotencyKey: paypalHelper.generateIdempotencyKey(
           validInvoice.id,
@@ -638,7 +645,7 @@ describe('PayPalHelper', () => {
       const validInvoice = {
         ...mockInvoice,
         status: 'open',
-        amount_due: 4.99,
+        amount_due: 499,
       };
       mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
         agreementId
@@ -679,6 +686,7 @@ describe('PayPalHelper', () => {
       sinon.assert.calledOnceWithExactly(paypalHelper.chargeCustomer, {
         amountInCents: validInvoice.amount_due,
         billingAgreementId: agreementId,
+        currencyCode: validInvoice.currency,
         invoiceNumber: validInvoice.id,
         idempotencyKey: paypalHelper.generateIdempotencyKey(
           validInvoice.id,
@@ -759,7 +767,7 @@ describe('PayPalHelper', () => {
         validInvoice = {
           ...mockInvoice,
           status: 'open',
-          amount_due: 4.99,
+          amount_due: 499,
         };
         mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
           agreementId


### PR DESCRIPTION
## Because

- We need to charge paypal customer in correct currency

## This pull request

- Adds currencyCode to doReferenceTransaction and upstream chargeCustomer method.

## Issue that this pull request solves

Closes: #7470

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information 

I verified that without this a FR customer would be charged in USD (aka Before):
![Screenshot from 2021-02-26 19-14-26](https://user-images.githubusercontent.com/1796208/109370937-1a69b800-7868-11eb-8871-3b807662a36a.png)

And with this, they are charged in EUR (aka After): 
![Screenshot from 2021-02-26 19-14-06](https://user-images.githubusercontent.com/1796208/109370943-20f82f80-7868-11eb-8db5-64972fd937b8.png)
