### PR TITLE
task(fxa-payments-server): add legal snippet to checkout flow

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -81,6 +81,12 @@ product-no-such-plan = No such plan for this product.
 payment-legal-copy-stripe-paypal = { -brand-name-mozilla } uses Stripe and { -brand-name-paypal } for secure payment processing.
 payment-legal-link-stripe-paypal = View the <stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> and <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
 
+payment-legal-copy-paypal = { -brand-name-mozilla } uses { -brand-name-paypal } for secure payment processing.
+payment-legal-link-paypal = View the <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
+
+payment-legal-copy-stripe = { -brand-name-mozilla } uses Stripe for secure payment processing.
+payment-legal-link-stripe = View the <stripePrivacyLink>Stripe privacy policy</stripePrivacyLink>.
+
 ## payment form
 payment-name =
   .placeholder = Full Name

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -6,6 +6,10 @@ import { Plan, Profile, Customer } from '../../store/types';
 import { PaymentProviderDetails } from '../PaymentProviderDetails';
 import SubscriptionTitle from '../SubscriptionTitle';
 import { TermsAndPrivacy } from '../TermsAndPrivacy';
+import {
+  PaypalPaymentLegalBlurb,
+  StripePaymentLegalBlurb,
+} from '../PaymentLegalBlurb';
 
 import circledCheckbox from './images/circled-confirm.svg';
 
@@ -131,6 +135,8 @@ export const PaymentConfirmation = ({
               Continue to download
             </a>
           </Localized>
+          {Provider.isPaypal(payment_provider) && <PaypalPaymentLegalBlurb />}
+          {Provider.isStripe(payment_provider) && <StripePaymentLegalBlurb />}
           <TermsAndPrivacy plan={selectedPlan} />
         </div>
       </section>

--- a/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
@@ -7,6 +7,60 @@ function getPrivacyLinkText(): string {
   return 'View the <stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> and <paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>.';
 }
 
+function getPaypalPrivacyLinkText(): string {
+  return 'View the <paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>.';
+}
+
+function getStripePrivacyLinkText(): string {
+  return 'View the <stripePrivacyLink>Stripe privacy policy</stripePrivacyLink>.';
+}
+
+export const PaypalPaymentLegalBlurb = () => (
+  <div className="payment-legal-blurb">
+    <Localized id="payment-legal-copy-paypal">
+      <p>Mozilla uses Paypal for secure payment processing.</p>
+    </Localized>
+
+    <Localized
+      id="payment-legal-link-paypal"
+      elems={{
+        paypalPrivacyLink: (
+          <a
+            href="https://paypal.com/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+          ></a>
+        ),
+      }}
+    >
+      <p>{getPaypalPrivacyLinkText()}</p>
+    </Localized>
+  </div>
+);
+
+export const StripePaymentLegalBlurb = () => (
+  <div className="payment-legal-blurb">
+    <Localized id="payment-legal-copy-stripe">
+      <p>Mozilla uses Stripe for secure payment processing.</p>
+    </Localized>
+
+    <Localized
+      id="payment-legal-link-stripe"
+      elems={{
+        stripePrivacyLink: (
+          <a
+            href="https://stripe.com/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+          ></a>
+        ),
+      }}
+    >
+      <p>{getStripePrivacyLinkText()}</p>
+    </Localized>
+  </div>
+);
+
 export const PaymentLegalBlurb = () => (
   <div className="payment-legal-blurb">
     <Localized id="payment-legal-copy-stripe-paypal">

--- a/packages/fxa-payments-server/src/components/PaymentProcessing/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentProcessing/index.scss
@@ -8,13 +8,42 @@
 }
 
 .payment-processing {
-  grid-row: 2/3;
   background: $color-white;
   box-shadow: 0px 1px 4px rgba(12, 12, 13, 0.1);
   border-radius: 8px;
-  margin: 0 16px 32px;
   color: rgba(12, 12, 13, 0.8);
+  display: flex;
+  flex-direction: column;
+  grid-row: 2/3;
+  margin: 0;
+  min-height: 100%;
   padding: 16px 16px 60px;
+  width: 100%;
+
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+  }
+
+  #loading-spinner {
+    margin: 60px auto;
+    position: relative;
+  }
+
+  p {
+    margin: 0;
+    color: $grey-40;
+  }
+
+  .footer {
+    border: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin-bottom: 3rem;
+    margin-top: auto;
+  }
 
   @include min-width('tablet') {
     border-top: 0;
@@ -25,21 +54,5 @@
   @include min-width('desktop') {
     min-width: 60%;
     padding: 28px 48px 48px;
-  }
-
-  .wrapper {
-    display: flex;
-    flex-direction: column;
-    text-align: center;
-  }
-
-  #loading-spinner {
-    margin: 140px auto 100px;
-    position: relative;
-  }
-
-  p {
-    margin: 0;
-    color: $grey-40;
   }
 }

--- a/packages/fxa-payments-server/src/components/PaymentProcessing/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentProcessing/index.stories.tsx
@@ -3,5 +3,5 @@ import { storiesOf } from '@storybook/react';
 import { PaymentProcessing } from './index';
 
 storiesOf('components/PaymentProcessing', module).add('default', () => (
-  <PaymentProcessing />
+  <PaymentProcessing provider="paypal" />
 ));

--- a/packages/fxa-payments-server/src/components/PaymentProcessing/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentProcessing/index.test.tsx
@@ -9,11 +9,11 @@ import {
 import { PaymentProcessing } from './index';
 
 afterEach(cleanup);
-describe('Fluent Localized Text', () => {
+describe('PaymentProcessing tests', () => {
   const bundle = setupFluentLocalizationTest('en-US');
 
   it('renders as expected', () => {
-    const { queryByTestId } = render(<PaymentProcessing />);
+    const { queryByTestId } = render(<PaymentProcessing provider="paypal" />);
 
     const subscriptionTitle = queryByTestId('subscription-processing-title');
     expect(subscriptionTitle).toBeInTheDocument();
@@ -24,6 +24,9 @@ describe('Fluent Localized Text', () => {
 
     const mainBlock = queryByTestId('payment-processing');
     expect(mainBlock).toBeInTheDocument();
+
+    const footer = queryByTestId('footer');
+    expect(footer).toBeInTheDocument();
 
     const expected = 'Please wait while we process your payment...';
     const actual = getLocalizedMessage(

--- a/packages/fxa-payments-server/src/components/PaymentProcessing/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentProcessing/index.tsx
@@ -1,16 +1,23 @@
 import React from 'react';
 import { Localized } from '@fluent/react';
 
+import * as Provider from '../../lib/PaymentProvider';
 import { LoadingSpinner } from '../LoadingSpinner';
 import SubscriptionTitle from '../SubscriptionTitle';
+import {
+  PaypalPaymentLegalBlurb,
+  StripePaymentLegalBlurb,
+} from '../PaymentLegalBlurb';
 
 import './index.scss';
 
 export type PaymentProcessingProps = {
+  provider: 'stripe' | 'paypal';
   className?: string;
 };
 
 export const PaymentProcessing = ({
+  provider,
   className = '',
 }: PaymentProcessingProps) => {
   return (
@@ -25,6 +32,11 @@ export const PaymentProcessing = ({
           <Localized id="payment-processing-message">
             <p>Please wait while we process your payment...</p>
           </Localized>
+        </div>
+
+        <div className="footer" data-testid="footer">
+          {Provider.isPaypal(provider) && <PaypalPaymentLegalBlurb />}
+          {Provider.isStripe(provider) && <StripePaymentLegalBlurb />}
         </div>
       </section>
     </>

--- a/packages/fxa-payments-server/src/index.scss
+++ b/packages/fxa-payments-server/src/index.scss
@@ -214,5 +214,5 @@ hr {
 }
 
 .hidden {
-  display: none;
+  display: none !important;
 }

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -186,6 +186,7 @@ export const SubscriptionCreate = ({
       <Header {...{ profile }} />
       <div className="main-content">
         <PaymentProcessing
+          provider="paypal"
           className={classNames({
             hidden: !transactionInProgress,
           })}


### PR DESCRIPTION
## Because

- We need to show the legal terms at every stage of the checkout process

## This pull request

- Adds the legal copy and links for the payment provider to the processing page and confirmation page.

## Issue that this pull request solves

- fixes #7614

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![legal-in-confirmation](https://user-images.githubusercontent.com/1844554/109373003-7f2e0e00-787a-11eb-9045-c930fbfc3f86.png)
![legal-in-confirmation-mobile](https://user-images.githubusercontent.com/1844554/109373004-7f2e0e00-787a-11eb-8779-dfec493f0ca2.png)
![legal-in-processing](https://user-images.githubusercontent.com/1844554/109373005-7fc6a480-787a-11eb-9883-66b933b88895.png)
![legal-in-processing-mobile](https://user-images.githubusercontent.com/1844554/109373007-7fc6a480-787a-11eb-8de7-022e960f57de.png)

