### PR TITLE
feat(auth-server): pass ip through to paypal

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal-client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-client.ts
@@ -154,6 +154,7 @@ export type DoReferenceTransactionOptions = {
   invoiceNumber: string;
   idempotencyKey: string;
   currencyCode: string;
+  ipaddress?: string;
 };
 
 export type BAUpdateOptions = {
@@ -411,6 +412,7 @@ export class PayPalClient {
       CURRENCYCODE: options.currencyCode.toUpperCase(),
       CUSTOM: options.idempotencyKey,
       INVNUM: options.invoiceNumber,
+      ...(options.ipaddress && { IPADDRESS: options.ipaddress }),
       MSGSUBID: options.idempotencyKey,
       PAYMENTACTION: 'Sale',
       PAYMENTTYPE: 'instant',

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -99,6 +99,7 @@ export class PayPalHandler extends StripeHandler {
       await this.paypalHelper.processInvoice({
         customer,
         invoice: latestInvoice,
+        ipaddress: request.info.remoteAddress,
       });
     }
 
@@ -198,7 +199,11 @@ export class PayPalHandler extends StripeHandler {
       if (invoice.amount_due === 0) {
         await this.paypalHelper.processZeroInvoice(invoice);
       } else {
-        await this.paypalHelper.processInvoice({ customer, invoice });
+        await this.paypalHelper.processInvoice({
+          customer,
+          invoice,
+          ipaddress: request.info.remoteAddress,
+        });
       }
     } catch (err) {
       reportSentryError(err, request);

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -348,6 +348,7 @@ describe('PayPalClient', () => {
       CURRENCYCODE: 'USD',
       CUSTOM: 'in_asdf-12',
       INVNUM: 'in_asdf',
+      IPADDRESS: '127.0.0.1',
       MSGSUBID: 'in_asdf-12',
       PAYMENTACTION: 'Sale',
       PAYMENTTYPE: 'instant',
@@ -361,9 +362,10 @@ describe('PayPalClient', () => {
       await client.doReferenceTransaction({
         amount: defaultData.AMT,
         billingAgreementId: defaultData.REFERENCEID,
-        invoiceNumber: defaultData.INVNUM,
-        idempotencyKey: defaultData.MSGSUBID,
         currencyCode: defaultData.CURRENCYCODE,
+        idempotencyKey: defaultData.MSGSUBID,
+        invoiceNumber: defaultData.INVNUM,
+        ipaddress: defaultData.IPADDRESS,
       });
       sinon.assert.calledOnceWithExactly(
         client.doRequest,
@@ -380,9 +382,10 @@ describe('PayPalClient', () => {
       await client.doReferenceTransaction({
         amount: amt,
         billingAgreementId: defaultData.REFERENCEID,
-        invoiceNumber: defaultData.INVNUM,
-        idempotencyKey: defaultData.MSGSUBID,
         currencyCode: defaultData.CURRENCYCODE,
+        idempotencyKey: defaultData.MSGSUBID,
+        invoiceNumber: defaultData.INVNUM,
+        ipaddress: defaultData.IPADDRESS,
       });
       sinon.assert.calledOnceWithExactly(
         client.doRequest,
@@ -402,9 +405,10 @@ describe('PayPalClient', () => {
       await client.doReferenceTransaction({
         amount: defaultData.AMT,
         billingAgreementId: ref,
-        invoiceNumber: defaultData.INVNUM,
-        idempotencyKey: defaultData.MSGSUBID,
         currencyCode: defaultData.CURRENCYCODE,
+        idempotencyKey: defaultData.MSGSUBID,
+        invoiceNumber: defaultData.INVNUM,
+        ipaddress: defaultData.IPADDRESS,
       });
       sinon.assert.calledOnceWithExactly(
         client.doRequest,
@@ -424,9 +428,10 @@ describe('PayPalClient', () => {
       await client.doReferenceTransaction({
         amount: defaultData.AMT,
         billingAgreementId: defaultData.REFERENCEID,
-        invoiceNumber: defaultData.INVNUM,
-        idempotencyKey: defaultData.MSGSUBID,
         currencyCode: currency,
+        idempotencyKey: defaultData.MSGSUBID,
+        invoiceNumber: defaultData.INVNUM,
+        ipaddress: defaultData.IPADDRESS,
       });
       sinon.assert.calledOnceWithExactly(
         client.doRequest,
@@ -457,9 +462,10 @@ describe('PayPalClient', () => {
         await client.doReferenceTransaction({
           amount: defaultData.AMT,
           billingAgreementId: defaultData.REFERENCEID,
-          invoiceNumber: defaultData.INVNUM,
-          idempotencyKey: defaultData.MSGSUBID,
           currencyCode: defaultData.CURRENCYCODE,
+          idempotencyKey: defaultData.MSGSUBID,
+          invoiceNumber: defaultData.INVNUM,
+          ipaddress: defaultData.IPADDRESS,
         });
         assert.fail('Request should have thrown an error.');
       } catch (err) {

--- a/packages/fxa-auth-server/test/local/payments/paypal.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal.js
@@ -458,6 +458,7 @@ describe('PayPalHelper', () => {
       const response = await paypalHelper.processInvoice({
         customer: mockCustomer,
         invoice: validInvoice,
+        ipaddress: '127.0.0.1',
       });
       sinon.assert.calledOnceWithExactly(
         mockStripeHelper.getCustomerPaypalAgreement,
@@ -476,6 +477,7 @@ describe('PayPalHelper', () => {
           validInvoice.id,
           paymentAttempts
         ),
+        ipaddress: '127.0.0.1',
       });
       sinon.assert.calledOnceWithExactly(
         mockStripeHelper.updateInvoiceWithPaypalTransactionId,


### PR DESCRIPTION
## Because:

* PayPal has additional fraud protections requiring ip address pass
  through in a similar manner to Stripe.

## This commit:

* Adds the ip address of the remote user when present to PayPal.

Closes #7590

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

My other PR #7664 should be merged first.