### PR TITLE
feat(auth-server): remove paypal BA and cancel at end

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal.ts
@@ -347,6 +347,36 @@ export class PayPalHelper {
   }
 
   /**
+   * Removes Paypal billing agreements on a customer if they paid with
+   * Paypal but no longer have an active/past_due subscription.
+   */
+  async conditionallyRemoveBillingAgreement(
+    customer: Stripe.Customer
+  ): Promise<boolean> {
+    const billingAgreementId = this.stripeHelper.getCustomerPaypalAgreement(
+      customer
+    );
+    if (!billingAgreementId) {
+      return false;
+    }
+    const paypalSubscription = customer.subscriptions?.data.find(
+      (sub) =>
+        ['active', 'past_due'].includes(sub.status) &&
+        sub.collection_method === 'send_invoice'
+    );
+    if (paypalSubscription) {
+      return false;
+    }
+    await this.cancelBillingAgreement(billingAgreementId);
+    await this.stripeHelper.removeCustomerPaypalAgreement(
+      customer.metadata.userid,
+      customer,
+      billingAgreementId
+    );
+    return true;
+  }
+
+  /**
    * Finalize and process a draft invoice that has no amounted owed.
    *
    * @param invoice

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -32,6 +32,8 @@ const eventInvoicePaymentFailed = require('../../payments/fixtures/stripe/event_
 const eventCustomerSubscriptionUpdated = require('../../payments/fixtures/stripe/event_customer_subscription_updated.json');
 const eventCustomerSourceExpiring = require('../../payments/fixtures/stripe/event_customer_source_expiring.json');
 const { default: Container } = require('typedi');
+const { PayPalHelper } = require('../../../../lib/payments/paypal');
+const { CurrencyHelper } = require('../../../../lib/payments/currencies');
 
 let config, log, db, customs, push, mailer, profile;
 
@@ -195,6 +197,9 @@ describe('StripeWebhookHandler', () => {
       locale: ACCOUNT_LOCALE,
     });
     const stripeHelperMock = sandbox.createStubInstance(StripeHelper);
+    const paypalHelperMock = sandbox.createStubInstance(PayPalHelper);
+    Container.set(CurrencyHelper, {});
+    Container.set(PayPalHelper, paypalHelperMock);
     Container.set(StripeHelper, stripeHelperMock);
 
     StripeWebhookHandlerInstance = new StripeWebhookHandler(
@@ -463,6 +468,9 @@ describe('StripeWebhookHandler', () => {
 
     describe('handleSubscriptionDeletedEvent', () => {
       it('sends email and emits a notification when a subscription is deleted', async () => {
+        StripeWebhookHandlerInstance.stripeHelper.customer.resolves(
+          customerFixture
+        );
         const deletedEvent = deepCopy(subscriptionDeleted);
         const sendSubscriptionDeletedEmailStub = sandbox
           .stub(StripeWebhookHandlerInstance, 'sendSubscriptionDeletedEmail')
@@ -484,8 +492,40 @@ describe('StripeWebhookHandler', () => {
           UID,
           TEST_EMAIL
         );
+        assert.calledOnceWithExactly(
+          StripeWebhookHandlerInstance.stripeHelper.customer,
+          { uid: UID, email: TEST_EMAIL }
+        );
+        assert.calledOnceWithExactly(
+          StripeWebhookHandlerInstance.paypalHelper
+            .conditionallyRemoveBillingAgreement,
+          customerFixture
+        );
         assert.calledWith(profile.deleteCache, UID);
         assertSendSubscriptionStatusToSqsCalledWith(deletedEvent, false);
+      });
+
+      it('does not conditionally delete without customer record', async () => {
+        const deletedEvent = deepCopy(subscriptionDeleted);
+        const sendSubscriptionDeletedEmailStub = sandbox
+          .stub(StripeWebhookHandlerInstance, 'sendSubscriptionDeletedEmail')
+          .resolves({ uid: UID, email: TEST_EMAIL });
+        await StripeWebhookHandlerInstance.handleSubscriptionDeletedEvent(
+          {},
+          deletedEvent
+        );
+        assert.calledWith(
+          sendSubscriptionDeletedEmailStub,
+          deletedEvent.data.object
+        );
+        assert.calledOnceWithExactly(
+          StripeWebhookHandlerInstance.stripeHelper.customer,
+          { uid: UID, email: TEST_EMAIL }
+        );
+        assert.notCalled(
+          StripeWebhookHandlerInstance.paypalHelper
+            .conditionallyRemoveBillingAgreement
+        );
       });
     });
 


### PR DESCRIPTION
Because:

* We want to cancel the paypal billing agreement and remove it from
  the customer when they no longer have active/past_due subscriptions
  being paid for with paypal.

This commit:

* Hooks into the subscription cancellation event to determine if its the
  last one paid by paypal, and cancels/removes the billing agreement if
  that's the case.

Closes #7103

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
