### PR TITLE
Refactor goHome/goBack

### DIFF
--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
@@ -28,9 +28,9 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
   const alertBar = useAlertBar();
   const navigate = useNavigate();
   const session = useSession();
-  const goBack = () =>
+  const goHome = () =>
     navigate(HomePath + '#two-step-authentication', { replace: true });
-  const goHome = () => {
+  const alertSuccessAndGoHome = () => {
     alertTextExternal(
       l10n.getString(
         'tfa-replace-code-success-alert',
@@ -64,7 +64,7 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
 
   return (
     <FlowContainer title="Two Step Authentication">
-      <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
+      <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
 
       {alertBar.visible && (
         <AlertBar onDismiss={alertBar.hide} type={alertBar.type}>
@@ -87,7 +87,7 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
           type="button"
           className="cta-neutral mx-2 px-10"
           data-testid="close-modal"
-          onClick={goHome}
+          onClick={alertSuccessAndGoHome}
         >
           Close
         </button>

--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -79,8 +79,8 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
   const [newPasswordErrorText, setNewPasswordErrorText] = useState<string>();
   const { primaryEmail } = useAccount();
   const navigate = useNavigate();
-  const goBack = () => navigate(HomePath + '#password', { replace: true });
-  const goHome = () => {
+  const goHome= () => navigate(HomePath + '#password', { replace: true });
+  const alertSuccessAndGoHome = () => {
     alertTextExternal(
       l10n.getString('pw-change-success-alert', null, 'Password updated.')
     );
@@ -119,7 +119,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
           session: { verified: response.verified, __typename: 'Session' },
         },
       });
-      goHome();
+      alertSuccessAndGoHome();
     },
     onError: (e) => {
       const localizedError = l10n.getString(
@@ -301,7 +301,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
               <button
                 type="button"
                 className="cta-neutral mx-2 flex-1"
-                onClick={goBack}
+                onClick={goHome}
                 data-testid="cancel-password-button"
               >
                 Cancel

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -62,7 +62,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
   );
   const navigate = useNavigate();
   const alertBar = useAlertBar();
-  const goBack = useCallback(() => window.history.back(), []);
+  const goHome = useCallback(() => window.history.back(), []);
 
   const { primaryEmail, uid } = useAccount();
 
@@ -123,7 +123,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
             <p data-testid="delete-account-error">{alertBar.content}</p>
           </AlertBar>
         )}
-        <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
+        <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
         {!confirmed && (
           <div className="my-4 text-sm" data-testid="delete-account-confirm">
             <Localized id="delete-account-confirm-title-2">
@@ -228,7 +228,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
                   type="button"
                   className="cta-neutral mx-2 px-4 tablet:px-10"
                   data-testid="cancel-button"
-                  onClick={goBack}
+                  onClick={goHome}
                 >
                   Cancel
                 </button>

--- a/packages/fxa-settings/src/components/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.tsx
@@ -32,8 +32,8 @@ export const PageDisplayName = (_: RouteComponentProps) => {
   const account = useAccount();
   const alertBar = useAlertBar();
   const { l10n } = useLocalization();
-  const goBack = () => navigate(HomePath + '#display-name', { replace: true });
-  const goHome = () => {
+  const goHome = () => navigate(HomePath + '#display-name', { replace: true });
+  const alertSuccessAndGoHome = () => {
     alertTextExternal(
       l10n.getString(
         'display-name-success-alert',
@@ -59,7 +59,7 @@ export const PageDisplayName = (_: RouteComponentProps) => {
   const [updateDisplayName] = useMutation(UPDATE_DISPLAY_NAME_MUTATION, {
     onCompleted: () => {
       firefox.profileChanged(account.uid);
-      goHome();
+      alertSuccessAndGoHome();
     },
     onError(err) {
       if (err.graphQLErrors?.length) {
@@ -123,7 +123,7 @@ export const PageDisplayName = (_: RouteComponentProps) => {
                 type="button"
                 data-testid="cancel-display-name"
                 className="cta-neutral mx-2 flex-1"
-                onClick={goBack}
+                onClick={goHome}
               >
                 Cancel
               </button>

--- a/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.tsx
@@ -40,8 +40,8 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
   const [formattedRecoveryKey, setFormattedRecoveryKey] = useState<string>();
   const navigate = useNavigate();
   const alertBar = useAlertBar();
-  const goBack = () => navigate(HomePath + '#recovery-key', { replace: true });
-  const goHome = () => {
+  const goHome = () => navigate(HomePath + '#recovery-key', { replace: true });
+  const alertSuccessAndGoHome = () => {
     alertTextExternal(
       l10n.getString(
         'recovery-key-success-alert',
@@ -102,7 +102,7 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
             <p data-testid="add-recovery-key-error">{alertBar.content}</p>
           </AlertBar>
         )}
-        <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
+        <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
         {formattedRecoveryKey && (
           <div className="my-2" data-testid="recover-key-confirm">
             <Localized id="recovery-key-created">
@@ -125,7 +125,7 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
               <Localized id="recovery-key-close-button">
                 <button
                   className="cta-primary mx-2 px-10"
-                  onClick={goHome}
+                  onClick={alertSuccessAndGoHome}
                   data-testid="close-button"
                 >
                   Close
@@ -177,7 +177,7 @@ export const PageRecoveryKeyAdd = (_: RouteComponentProps) => {
                   type="button"
                   className="cta-neutral mx-2 flex-1"
                   data-testid="cancel-button"
-                  onClick={goBack}
+                  onClick={goHome}
                 >
                   Cancel
                 </button>

--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
@@ -28,7 +28,7 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   const { l10n } = useLocalization();
   const navigate = useNavigate();
   const alertBar = useAlertBar();
-  const goBack = () =>
+  const goHome = () =>
     navigate(HomePath + '#secondary-email', { replace: true });
 
   const [createSecondaryEmail] = useMutation(CREATE_SECONDARY_EMAIL_MUTATION, {
@@ -88,7 +88,7 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
             <p data-testid="add-email-error">{alertBar.content}</p>
           </AlertBar>
         )}
-        <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
+        <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
         <form
           onSubmit={(ev) => {
             ev.preventDefault();
@@ -120,7 +120,7 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
                 type="button"
                 className="cta-neutral mx-2 flex-1"
                 data-testid="cancel-button"
-                onClick={goBack}
+                onClick={goHome}
               >
                 Cancel
               </button>

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
@@ -33,9 +33,9 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
     },
   });
   const navigate = useNavigate();
-  const goBack = () =>
+  const goHome = () =>
     navigate(HomePath + '#secondary-email', { replace: true });
-  const goHome = (email: string) => {
+  const alertSuccessAndGoHome = (email: string) => {
     alertTextExternal(
       l10n.getString(
         'verify-secondary-email-success-alert',
@@ -80,7 +80,7 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
         });
       },
       onCompleted: () => {
-        goHome(email);
+        alertSuccessAndGoHome(email);
         logViewEvent('verify-secondary-email.verification', 'success');
       },
     }
@@ -96,7 +96,7 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
   return (
     <Localized id="verify-secondary-email-page-title" attrs={{ title: true }}>
       <FlowContainer title="Secondary email">
-        <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
+        <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
         <form
           data-testid="secondary-email-verify-form"
           onSubmit={handleSubmit(({ verificationCode }) => {
@@ -151,7 +151,7 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
                 type="button"
                 className="cta-neutral mx-2 flex-1"
                 data-testid="secondary-email-verify-cancel"
-                onClick={goBack}
+                onClick={goHome}
               >
                 Cancel
               </button>

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -48,9 +48,9 @@ type RecoveryCodeForm = { recoveryCode: string };
 
 export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
   const navigate = useNavigate();
-  const goBack = () =>
+  const goHome = () =>
     navigate(HomePath + '#two-step-authentication', { replace: true });
-  const goHome = () => {
+  const alertSuccessAndGoHome = () => {
     alertTextExternal(
       l10n.getString('tfa-enabled', null, 'Two-step authentication enabled')
     );
@@ -170,7 +170,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
   });
 
   const [verifyTotp] = useMutation(VERIFY_TOTP_MUTATION, {
-    onCompleted: goHome,
+    onCompleted: alertSuccessAndGoHome,
     onError: (err) => {
       if (err.graphQLErrors?.length) {
         if (
@@ -227,7 +227,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
 
   const moveBack = () => {
     if (!totpVerified) {
-      return goBack();
+      return goHome();
     }
     if (totpVerified && !recoveryCodesAcknowledged) {
       return showQrCodeStep();
@@ -236,7 +236,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
       setRecoveryCodeError('');
       return showRecoveryCodes();
     }
-    goBack();
+    goHome();
   };
 
   return (
@@ -252,7 +252,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
 
       {!totpVerified && (
         <form onSubmit={totpForm.handleSubmit(onTotpSubmit)}>
-          <VerifiedSessionGuard onDismiss={goBack} onError={goBack} />
+          <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
           {showQrCode && (
             <>
               <Localized
@@ -343,7 +343,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
               <button
                 type="button"
                 className="cta-neutral mx-2 flex-1"
-                onClick={goBack}
+                onClick={goHome}
               >
                 Cancel
               </button>
@@ -382,7 +382,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
               <button
                 type="button"
                 className="cta-neutral mx-2 flex-1"
-                onClick={goBack}
+                onClick={goHome}
               >
                 Cancel
               </button>
@@ -432,7 +432,7 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
               <button
                 type="button"
                 className="cta-neutral mx-2 flex-1"
-                onClick={goBack}
+                onClick={goHome}
               >
                 Cancel
               </button>


### PR DESCRIPTION
## Because

- The goBack and goHome functions need to be searched and replaced with the goHome and alertSuccessAndGoHome function names throughout the Page components in the fxa-settings package.

## This pull request

- Replace `goBack` and `goHome` with `goHome` and `alertSuccessAndGoHome` respectively.

## Issue that this pull request solves

Closes: #7679 7630

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
