### PR TITLE
feat(payments): Show processing screen onApprove for PayPalButton

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -182,7 +182,6 @@ export const PaymentForm = ({
           data-testid="name"
           placeholder="Full Name"
           required
-          autoFocus
           spellCheck={false}
           onValidate={(value, focused, props) =>
             validateName(value, focused, props, getString)

--- a/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.test.tsx
@@ -1,22 +1,17 @@
 import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
 import { PaypalButton, PaypalButtonProps } from './index';
 
-import { storiesOf } from '@storybook/react';
-import { linkTo } from '@storybook/addon-links';
-import { CUSTOMER, PLAN } from '../../../lib/mock-data';
 import { PickPartial } from '../../../lib/types';
-
-const defaultApiClientOverrides = {
-  apiCreateCustomer: async () => CUSTOMER,
-};
+import { CUSTOMER, PLAN } from '../../../lib/mock-data';
 
 const Subject = ({
-  apiClientOverrides = defaultApiClientOverrides,
   currencyCode = 'USD',
   customer = CUSTOMER,
   idempotencyKey = '',
   priceId = PLAN.plan_id,
-  refreshSubscriptions = linkTo('routes/Product', 'success'),
+  refreshSubscriptions = () => {},
   setPaymentError = () => {},
   setTransactionInProgress = () => {},
   ...props
@@ -33,7 +28,6 @@ const Subject = ({
   return (
     <PaypalButton
       {...{
-        apiClientOverrides,
         currencyCode,
         customer,
         idempotencyKey,
@@ -47,6 +41,11 @@ const Subject = ({
   );
 };
 
-storiesOf('routes/Product/PaypalButton', module).add('default', () => (
-  <Subject />
-));
+describe('PaypalButton', () => {
+  it("Doesn't render the PayPal button if the PayPal script fails to load", async () => {
+    // The script is loaded in this button's consumer (e.g. SubscriptionCreate), so we
+    // can guarantee that it won't be loaded for the button in isolation
+    render(<Subject />);
+    expect(screen.queryByTestId('paypal-button')).not.toBeInTheDocument();
+  });
+});

--- a/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/PayPalButton/index.tsx
@@ -19,7 +19,7 @@ export type PaypalButtonProps = {
   priceId: string;
   refreshSubscriptions: () => void;
   setPaymentError: Function;
-  setOnClick: Function;
+  setTransactionInProgress: Function;
   ButtonBase?: React.ElementType;
 };
 
@@ -46,7 +46,7 @@ export const PaypalButton = ({
   priceId,
   refreshSubscriptions,
   setPaymentError,
-  setOnClick,
+  setTransactionInProgress,
   ButtonBase = PaypalButtonBase,
 }: PaypalButtonProps) => {
   const createOrder = useCallback(async () => {
@@ -77,6 +77,7 @@ export const PaypalButton = ({
   const onApprove = useCallback(
     async (data: { orderID: string }) => {
       try {
+        setTransactionInProgress(true);
         const { apiCapturePaypalPayment } = {
           ...apiClient,
           ...apiClientOverrides,
@@ -110,13 +111,6 @@ export const PaypalButton = ({
     [setPaymentError]
   );
 
-  const onClick = useCallback(
-    (event) => {
-      setOnClick(event);
-    },
-    [setOnClick]
-  );
-
   // Style docs: https://developer.paypal.com/docs/business/checkout/reference/style-guide/
   const styleOptions = {
     layout: 'horizontal',
@@ -136,7 +130,6 @@ export const PaypalButton = ({
           createOrder={createOrder}
           onApprove={onApprove}
           onError={onError}
-          onClick={onClick}
         />
       )}
     </>

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -202,8 +202,11 @@ export const SubscriptionCreate = ({
           })}
           data-testid="subscription-create"
         >
-          <div className="subscription-create-pay-with-other">
-            {!hasExistingCard(customer) && paypalScriptLoaded && (
+          {!hasExistingCard(customer) && paypalScriptLoaded && (
+            <div
+              className="subscription-create-pay-with-other"
+              data-testid="pay-with-other"
+            >
               <Suspense fallback={<div>Loading...</div>}>
                 <Localized id="pay-with-heading-other">
                   <p className="pay-with-heading">Select payment option</p>
@@ -218,14 +221,12 @@ export const SubscriptionCreate = ({
                     refreshSubscriptions={refreshSubscriptions}
                     setPaymentError={setPaymentError}
                     ButtonBase={paypalButtonBase}
-                    setOnClick={() => {
-                      setTransactionInProgress(true);
-                    }}
+                    setTransactionInProgress={setTransactionInProgress}
                   />
                 </div>
               </Suspense>
-            )}
-          </div>
+            </div>
+          )}
 
           <div className="subscription-create-pay-with-card">
             {!hasExistingCard(customer) && !paypalScriptLoaded && (


### PR DESCRIPTION
## Because

- We want users to return to the first step of Checkout if they close the PayPal window (see [design spec](https://www.figma.com/file/ejDMYaKpm5bsYL5YvhItur/Payment-Integration?node-id=519%3A5608)). This is a follow-up from #7450 .

## This pull request

- Replaces the `PayPalButton` `onClick` handler with calling `setTransactionInProgress` in its `onApprove` method. This means the `PaymentProcessing` screen is only shown after successul authorization while we are waiting for the `POST /oauth/subscription/active/new-paypal` request to return.

## Issue that this pull request solves

Closes: #7677 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots
Before
![Screen Shot 2021-03-01 at 2 59 14 PM](https://user-images.githubusercontent.com/17437436/109558214-bb41b880-7a9e-11eb-954f-cb3bbb637ca0.png)

After
![Screen Shot 2021-03-01 at 2 56 25 PM](https://user-images.githubusercontent.com/17437436/109558056-87ff2980-7a9e-11eb-8a36-e4387241c88b.png)

## Notes
* Also remove autofocus from the Name field on the Stripe widget, since it's no longer the only interactive element on the screen.