### PR TITLE
feat(auth-server): refund paypal transaction

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -158,7 +158,14 @@
   },
   "subscriptions": {
     "enabled": true,
-    "sharedSecret": "devsecret"
+    "sharedSecret": "devsecret",
+    "paypalNvpSigCredentials": {
+      "enabled": true,
+      "sandbox": true,
+      "user": "sb-i11ty5077364_api1.business.example.com",
+      "pwd": "Q43EHXXYVFTF8KPH",
+      "signature": "ATq0Lw3ury0wjGtXkF30nozpLja-ASxng61sj1bMjEhIJJj3HAF02QB2"
+    }
   },
   "totp": {
     "recoveryCodes": {

--- a/packages/fxa-auth-server/lib/payments/paypal-client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-client.ts
@@ -39,6 +39,7 @@ export type PAYPAL_METHODS =
   | 'CreateBillingAgreement'
   | 'DoReferenceTransaction'
   | 'GetTransactionDetails'
+  | 'RefundTransaction'
   | 'SetExpressCheckout'
   | 'TransactionSearch';
 
@@ -95,6 +96,18 @@ type DoReferenceTransactionData = {
   TRANSACTIONTYPE: string;
 };
 
+type RefundTransactionData = {
+  REFUNDTRANSACTIONID: string;
+  FEEREFUNDAMT: string;
+  GROSSREFUNDAMT: string;
+  NETREFUNDAMT: string;
+  CURRENCYCODE: string;
+  TOTALREFUNDEDAMOUNT: string;
+  MSGSUBID: string;
+  REFUNDSTATUS: string;
+  PENDINGREASON: string;
+};
+
 type BAUpdateData = {
   BILLINGAGREEMENTID: string;
   BILLINGAGREEMENTSTATUS: string;
@@ -136,6 +149,8 @@ export type NVPCreateBillingAgreementResponse = NVPResponse &
 export type NVPDoReferenceTransactionResponse = NVPResponse &
   DoReferenceTransactionData;
 
+export type NVPRefundTransactionResponse = NVPResponse & RefundTransactionData;
+
 export type NVPBAUpdateTransactionResponse = NVPResponse & BAUpdateData;
 
 export type NVPTransactionSearchResponse = TransactionSearchData & NVPResponse;
@@ -153,6 +168,11 @@ export type DoReferenceTransactionOptions = {
   billingAgreementId: string;
   invoiceNumber: string;
   idempotencyKey: string;
+};
+
+export type RefundTransactionOptions = {
+  idempotencyKey: string;
+  transactionId: string;
 };
 
 export type BAUpdateOptions = {
@@ -416,6 +436,27 @@ export class PayPalClient {
     };
     return this.doRequest<NVPDoReferenceTransactionResponse>(
       'DoReferenceTransaction',
+      data
+    );
+  }
+
+  /**
+   * Call the PayPal RefundTransaction NVP API
+   *
+   * Using the PayPal RefundTransaction API (https://developer.paypal.com/docs/nvp-soap-api/refund-transaction-nvp/)
+   * we fund the entire transaction to the user.
+   *
+   * @param options
+   */
+  public async refundTransaction(
+    options: RefundTransactionOptions
+  ): Promise<NVPRefundTransactionResponse> {
+    const data = {
+      TRANSACTIONID: options.transactionId,
+      MSGSUBID: options.idempotencyKey,
+    };
+    return this.doRequest<NVPRefundTransactionResponse>(
+      'RefundTransaction',
       data
     );
   }

--- a/packages/fxa-auth-server/lib/payments/paypal.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal.ts
@@ -14,6 +14,7 @@ import {
   IpnMessage,
   PayPalClient,
   PayPalClientError,
+  RefundTransactionOptions,
   SetExpressCheckoutOptions,
   TransactionSearchOptions,
   TransactionStatus,
@@ -446,5 +447,45 @@ export class PayPalHelper {
           transactionResponse: transactionResponse.paymentStatus,
         });
     }
+  }
+
+  /**
+   * Given the transaction ID, refund the transaction in full.
+   * Use the Stripe Invoice ID as the idempotency key since we
+   * expect one refund per invoice.
+   *
+   * @param options
+   */
+  public async refundTransaction(options: RefundTransactionOptions) {
+    const response = await this.client.refundTransaction(options);
+    return {
+      pendingReason: response.PENDINGREASON,
+      refundStatus: response.REFUNDSTATUS,
+      refundTransactionId: response.REFUNDTRANSACTIONID,
+    };
+  }
+
+  public async issueRefund(invoice: Stripe.Invoice, transactionId: string) {
+    const refundResponse = await this.refundTransaction({
+      idempotencyKey: invoice.id,
+      transactionId: transactionId,
+    });
+    const success = ['instant', 'delayed'];
+    if (success.includes(refundResponse.refundStatus.toLowerCase())) {
+      this.stripeHelper.updateInvoiceWithPaypalRefundTransactionId(
+        invoice,
+        refundResponse.refundTransactionId
+      );
+      return;
+    }
+    this.log.error('issueRefund', {
+      message: 'PayPal refund transaction unsuccessful',
+      invoiceId: invoice.id,
+      transactionId,
+      refundResponse,
+    });
+    throw error.internalValidationError('issueRefund', {
+      message: 'PayPal refund transaction unsuccessful',
+    });
   }
 }

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -387,6 +387,21 @@ export class StripeHelper {
   }
 
   /**
+   * Updates invoice metadata with the PayPal Refund Transaction ID.
+   *
+   * @param invoice
+   * @param transactionId
+   */
+  async updateInvoiceWithPaypalRefundTransactionId(
+    invoice: Stripe.Invoice,
+    transactionId: string
+  ) {
+    return this.stripe.invoices.update(invoice.id, {
+      metadata: { paypalRefundTransactionId: transactionId },
+    });
+  }
+
+  /**
    * Retrieve the payment attempts that have been made on this invoice via PayPal.
    *
    * This variable reflects the amount of payment attempts that have been made. It is

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.ts
@@ -31,10 +31,15 @@ export class PayPalNotificationHandler extends PayPalHandler {
       });
     }
 
-    // TODO: If the invoice is void/uncollectible and this is Completed/Processed, issue
-    // a refunded.
-
     if (invoice.status == null || !['draft', 'open'].includes(invoice.status)) {
+      if (
+        invoice.status == 'uncollectible' &&
+        ['Completed', 'Processed'].includes(message.payment_status)
+      ) {
+        // we need to refund the user since the invoice was cancelled
+        // but payment was processed
+        this.paypalHelper.issueRefund(invoice, message.txn_id);
+      }
       // nothing to do since the invoice is already at its final status
       return;
     }

--- a/packages/fxa-auth-server/test/local/payments/fixtures/paypal/refund_transaction_success.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/paypal/refund_transaction_success.json
@@ -1,0 +1,16 @@
+{
+    "REFUNDTRANSACTIONID": "1ND716707U579832F",
+    "FEEREFUNDAMT": "0.00",
+    "GROSSREFUNDAMT": "5.99",
+    "NETREFUNDAMT": "5.99",
+    "CURRENCYCODE": "USD",
+    "TOTALREFUNDEDAMOUNT": "5.99",
+    "MSGSUBID": "inv_025-abc-3",
+    "TIMESTAMP": "2021-03-01T16:06:31Z",
+    "CORRELATIONID": "7fc25bc325e0c",
+    "ACK": "Success",
+    "VERSION": "204",
+    "BUILD": "55374957",
+    "REFUNDSTATUS": "Instant",
+    "PENDINGREASON": "None"
+}

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -26,6 +26,7 @@ const successfulSetExpressCheckoutResponse = require('./fixtures/paypal/set_expr
 const unSuccessfulSetExpressCheckoutResponse = require('./fixtures/paypal/set_express_checkout_failure.json');
 const successfulDoReferenceTransactionResponse = require('./fixtures/paypal/do_reference_transaction_success.json');
 const unSuccessfulDoReferenceTransactionResponse = require('./fixtures/paypal/do_reference_transaction_failure.json');
+const successfulRefundTransactionResponse = require('./fixtures/paypal/refund_transaction_success.json');
 const searchTransactionResponse = require('./fixtures/paypal/transaction_search_success.json');
 const sampleIpnMessage = require('./fixtures/paypal/sample_ipn_message.json')
   .message;
@@ -442,6 +443,28 @@ describe('PayPalClient', () => {
         assert.equal(err.data.ACK, 'Failure');
         assert.equal(err.errorCode, 11451);
       }
+    });
+  });
+
+  describe('refundTransaction', () => {
+    const defaultData = {
+      MSGSUBID: 'in_asdf',
+      TRANSACTIONID: '9EG80664Y1384290G',
+    };
+
+    it('calls api with correct method and data', async () => {
+      client.doRequest = sandbox.fake.resolves(
+        successfulRefundTransactionResponse
+      );
+      await client.refundTransaction({
+        idempotencyKey: defaultData.MSGSUBID,
+        transactionId: defaultData.TRANSACTIONID,
+      });
+      sinon.assert.calledOnceWithExactly(
+        client.doRequest,
+        'RefundTransaction',
+        defaultData
+      );
     });
   });
 

--- a/packages/fxa-auth-server/test/local/payments/paypal.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal.js
@@ -18,6 +18,7 @@ const { mockLog } = require('../../mocks');
 const error = require('../../../lib/error');
 const successfulSetExpressCheckoutResponse = require('./fixtures/paypal/set_express_checkout_success.json');
 const successfulDoReferenceTransactionResponse = require('./fixtures/paypal/do_reference_transaction_success.json');
+const successfulRefundTransactionResponse = require('./fixtures/paypal/refund_transaction_success.json');
 const failedDoReferenceTransactionResponse = require('./fixtures/paypal/do_reference_transaction_failure.json');
 const successfulBAUpdateResponse = require('./fixtures/paypal/ba_update_success.json');
 const searchTransactionResponse = require('./fixtures/paypal/transaction_search_success.json');
@@ -267,6 +268,94 @@ describe('PayPalHelper', () => {
         assert.instanceOf(err, PayPalClientError);
         assert.equal(err.name, 'PayPalClientError');
       }
+    });
+  });
+
+  describe('refundTransaction', () => {
+    const defaultData = {
+      MSGSUBID: 'in_asdf',
+      TRANSACTIONID: '9EG80664Y1384290G',
+    };
+
+    it('refunds entire transaction', async () => {
+      paypalHelper.client.doRequest = sinon.fake.resolves(
+        successfulRefundTransactionResponse
+      );
+      const response = await paypalHelper.refundTransaction({
+        idempotencyKey: defaultData.MSGSUBID,
+        transactionId: defaultData.TRANSACTIONID,
+      });
+      assert.deepEqual(response, {
+        pendingReason: successfulRefundTransactionResponse.PENDINGREASON,
+        refundStatus: successfulRefundTransactionResponse.REFUNDSTATUS,
+        refundTransactionId:
+          successfulRefundTransactionResponse.REFUNDTRANSACTIONID,
+      });
+      sinon.assert.calledOnceWithExactly(
+        paypalHelper.client.doRequest,
+        'RefundTransaction',
+        defaultData
+      );
+    });
+  });
+
+  describe('issueRefund', () => {
+    const invoice = { id: 'inv_025-abc-3' };
+    const transactionId = '9EG80664Y1384290G';
+
+    it('successfully refunds completed transaction', async () => {
+      mockStripeHelper.updateInvoiceWithPaypalRefundTransactionId = sinon.fake.resolves(
+        {}
+      );
+      paypalHelper.refundTransaction = sinon.fake.resolves({
+        pendingReason: successfulRefundTransactionResponse.PENDINGREASON,
+        refundStatus: successfulRefundTransactionResponse.REFUNDSTATUS,
+        refundTransactionId:
+          successfulRefundTransactionResponse.REFUNDTRANSACTIONID,
+      });
+      const result = await paypalHelper.issueRefund(invoice, transactionId);
+
+      assert.deepEqual(result, undefined);
+      sinon.assert.calledOnceWithExactly(paypalHelper.refundTransaction, {
+        idempotencyKey: invoice.id,
+        transactionId: transactionId,
+      });
+      sinon.assert.calledOnceWithExactly(
+        mockStripeHelper.updateInvoiceWithPaypalRefundTransactionId,
+        invoice,
+        successfulRefundTransactionResponse.REFUNDTRANSACTIONID
+      );
+    });
+
+    it('unsuccessfully refunds completed transaction', async () => {
+      mockStripeHelper.updateInvoiceWithPaypalRefundTransactionId = sinon.fake.resolves(
+        {}
+      );
+      paypalHelper.refundTransaction = sinon.fake.resolves({
+        pendingReason: successfulRefundTransactionResponse.PENDINGREASON,
+        refundStatus: 'None',
+        refundTransactionId:
+          successfulRefundTransactionResponse.REFUNDTRANSACTIONID,
+      });
+      paypalHelper.log = { error: sinon.fake.returns({}) };
+
+      try {
+        await paypalHelper.issueRefund(invoice, transactionId);
+        assert.fail(
+          'Error should throw PayPal refund transaction unsuccessful.'
+        );
+      } catch (err) {
+        assert.deepEqual(
+          err,
+          error.internalValidationError('issueRefund', {
+            message: 'PayPal refund transaction unsuccessful',
+          })
+        );
+      }
+      sinon.assert.calledOnceWithExactly(paypalHelper.refundTransaction, {
+        idempotencyKey: invoice.id,
+        transactionId: transactionId,
+      });
     });
   });
 

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -729,6 +729,24 @@ describe('StripeHelper', () => {
     });
   });
 
+  describe('updateInvoiceWithPaypalRefundTransactionId', () => {
+    it('works successfully', async () => {
+      sandbox.stub(stripeHelper.stripe.invoices, 'update').resolves({});
+      const actual = await stripeHelper.updateInvoiceWithPaypalRefundTransactionId(
+        unpaidInvoice,
+        'tid'
+      );
+      assert.deepEqual(actual, {});
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripe.invoices.update,
+        unpaidInvoice.id,
+        {
+          metadata: { paypalRefundTransactionId: 'tid' },
+        }
+      );
+    });
+  });
+
   describe('getPaymentAttempts', () => {
     it('returns 0 with no attempts', () => {
       const actual = stripeHelper.getPaymentAttempts(unpaidInvoice);


### PR DESCRIPTION
## Because

- There is no way to cancel the pending transaction, we want to listen for the successful transaction IPN and refund the transaction for invoice with uncollectible status.

## This pull request

- Adds refund transaction method in PayPal client and helper to refund successful merchant payment with uncollectible invoice found in IPN.

## Issue that this pull request solves

Closes: #7615

## Checklist
- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).