### PR TITLE
feat(payments): Fix alignment of resubscribe <p> in sub. management

### DIFF
--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
@@ -85,6 +85,7 @@
   }
 
   .card-details,
+  .subscription-cancelled-details,
   .price-details {
     color: $faint-text-color;
     display: flex;
@@ -122,7 +123,7 @@
     p {
       margin-top: 0;
       &:last-child {
-        margin: 0;
+        margin: auto 0;
       }
     }
 
@@ -138,10 +139,6 @@
         font-weight: 600;
         padding: 0 16px;
       }
-    }
-
-    .subscription-cancelled-details {
-      flex: 4;
     }
   }
 


### PR DESCRIPTION
## Because

- We want vertical positioning to be consistent.

## This pull request

- Vertically centers the resubscribe blurb in relation to the resubscribe button.

## Issue that this pull request solves

Closes: #7692 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="692" alt="Screen Shot 2021-03-02 at 3 16 26 PM" src="https://user-images.githubusercontent.com/22355127/109722571-7b4c0580-7b72-11eb-87b6-a4ecc50f215c.png">
<img width="680" alt="Screen Shot 2021-03-02 at 3 17 01 PM" src="https://user-images.githubusercontent.com/22355127/109722583-7edf8c80-7b72-11eb-8c62-ec9b5d305d88.png">

<img width="317" alt="Screen Shot 2021-03-02 at 4 02 12 PM" src="https://user-images.githubusercontent.com/22355127/109722494-61aabe00-7b72-11eb-887d-9bf935657eda.png">
<img width="326" alt="Screen Shot 2021-03-02 at 4 02 20 PM" src="https://user-images.githubusercontent.com/22355127/109722497-640d1800-7b72-11eb-8df3-ae42b7cc3281.png">


## Other information (Optional)

Any other information that is important to this pull request.
