### PR TITLE
fix(l10n): Add 'hi' locale support

### DIFF
--- a/packages/fxa-shared/l10n/supportedLanguages.json
+++ b/packages/fxa-shared/l10n/supportedLanguages.json
@@ -28,6 +28,7 @@
   "fy",
   "fy-NL",
   "he",
+  "hi",
   "hi-IN",
   "hsb",
   "hu",


### PR DESCRIPTION
Fixes #7455.

## Because

- we actually do have translations for Hindi: our l10n code copies 'hi-HI' to 'hi', and firefox offers 'hi', but our supportedLanguages only included 'hi-HI'

## This pull request

- adds 'hi' locale to the list of supported languages

## Issue that this pull request solves

Closes: #7455

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

<img width="563" alt="Screen Shot 2021-03-02 at 2 17 50 PM" src="https://user-images.githubusercontent.com/96396/109723093-7c753680-7b62-11eb-922e-6ba0e4a6f19a.png">


## Other information (Optional)

You can verify the fix by adding Hindi as the primary language in about:preferences, then try loading this branch in localhost:3030 and you'll see the form in Hindi. Compare to staging, where you'll see English, not Hindi.
