### PR TITLE
feature: Add a new event property to Checkout related Amplitude events

### DIFF
--- a/packages/fxa-payments-server/src/lib/amplitude.test.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.test.ts
@@ -68,23 +68,31 @@ it('should capture error during logAmplitudeEvent', () => {
 });
 
 it('should call logAmplitudeEvent with subscription plan info', () => {
-  const plan = { plan_id: '123xyz_hourly', product_id: '123xyz' };
-  Amplitude.createSubscription_PENDING(plan);
+  const metricsData: Amplitude.EventProperties = {
+    plan_id: '123xyz_hourly',
+    product_id: '123xyz',
+    paymentProvider: 'Stripe',
+  };
+  Amplitude.createSubscription_PENDING(metricsData);
   const eventProps = (<jest.Mock>(
     FlowEvent.logAmplitudeEvent
   )).mock.calls[0].pop();
 
   expect(eventProps).toMatchObject({
-    planId: plan.plan_id,
-    productId: plan.product_id,
+    planId: metricsData.plan_id,
+    productId: metricsData.product_id,
+    paymentProvider: metricsData.paymentProvider,
   });
 });
 
 it('should call logAmplitudeEvent with reason for failure on fail event', () => {
-  const plan = { plan_id: '123xyz_hourly', product_id: '123xyz' };
+  const metricsData: Amplitude.EventProperties = {
+    plan_id: '123xyz_hourly',
+    product_id: '123xyz',
+  };
   const payload = { message: 'oopsie daisies' };
   Amplitude.createSubscription_REJECTED({
-    ...plan,
+    ...metricsData,
     error: payload,
   });
   const eventProps = (<jest.Mock>(
@@ -92,8 +100,8 @@ it('should call logAmplitudeEvent with reason for failure on fail event', () => 
   )).mock.calls[0].pop();
 
   expect(eventProps).toMatchObject({
-    planId: plan.plan_id,
-    productId: plan.product_id,
+    planId: metricsData.plan_id,
+    productId: metricsData.product_id,
     reason: payload.message,
   });
 });

--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -32,11 +32,12 @@ type GlobalEventProperties = {
   uid?: string;
 };
 
-type EventProperties = GlobalEventProperties & {
+export type EventProperties = GlobalEventProperties & {
   planId?: string;
   plan_id?: string;
   productId?: string;
   product_id?: string;
+  paymentProvider?: 'Stripe' | 'PayPal';
   error?: Error;
 };
 
@@ -93,12 +94,14 @@ const normalizeEventProperties = (eventProperties: EventProperties) => {
     plan_id = undefined,
     productId = undefined,
     product_id = undefined,
+    paymentProvider = undefined,
     ...otherEventProperties
   } = eventProperties;
 
   return {
     planId: planId || plan_id,
     productId: productId || product_id,
+    paymentProvider,
     reason: error && error.message ? error.message : undefined,
     ...otherEventProperties,
   };

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -314,6 +314,7 @@ module.exports = {
           //       equivalents have been in place for at least one train.
           plan_id: data.planId || data.plan_id,
           product_id: data.productId || data.product_id,
+          payment_provider: data.paymentProvider,
         }),
         EVENT_PROPERTIES[eventGroup](
           eventType,


### PR DESCRIPTION
## Because

We should have metrics parity between Stripe and PayPal checkout events and we should be able to distinguish between them.

## This pull request

Adds pings to the `apiCapturePaypalPayment` call.

## Issue that this pull request solves

Closes: #7073

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
