### PR TITLE
fix: remove sandbox credentials

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -158,14 +158,7 @@
   },
   "subscriptions": {
     "enabled": true,
-    "sharedSecret": "devsecret",
-    "paypalNvpSigCredentials": {
-      "enabled": true,
-      "sandbox": true,
-      "user": "sb-i11ty5077364_api1.business.example.com",
-      "pwd": "Q43EHXXYVFTF8KPH",
-      "signature": "ATq0Lw3ury0wjGtXkF30nozpLja-ASxng61sj1bMjEhIJJj3HAF02QB2"
-    }
+    "sharedSecret": "devsecret"
   },
   "totp": {
     "recoveryCodes": {


### PR DESCRIPTION
Because:

* Sandbox credentials for paypal were accidentally comitted.

This commit:

* Removes them.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
