### PR TITLE
feat(auth-server): add credit note listener

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -402,6 +402,15 @@ export class StripeHelper {
   }
 
   /**
+   * Returns the Paypal transaction id for the invoice if one exists.
+   *
+   * @param invoice
+   */
+  getInvoicePaypalTransactionId(invoice: Stripe.Invoice) {
+    return invoice.metadata?.paypalTransactionId;
+  }
+
+  /**
    * Retrieve the payment attempts that have been made on this invoice via PayPal.
    *
    * This variable reflects the amount of payment attempts that have been made. It is

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_credit_note_created.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_credit_note_created.json
@@ -1,0 +1,62 @@
+{
+  "created": 1326853478,
+  "livemode": false,
+  "id": "evt_00000000000000",
+  "type": "credit_note.created",
+  "object": "event",
+  "request": null,
+  "pending_webhooks": 1,
+  "api_version": "2019-12-03",
+  "data": {
+    "object": {
+      "id": "cn_1IQydqBVqmGyQTMaJSemYePQ",
+      "object": "credit_note",
+      "amount": 500,
+      "created": 1614793066,
+      "currency": "usd",
+      "customer": "cus_J341KaY0qUnMPU",
+      "customer_balance_transaction": null,
+      "discount_amount": 0,
+      "discount_amounts": [],
+      "invoice": "in_1IQxtXBVqmGyQTMaKvd8H6jT",
+      "lines": {
+        "object": "list",
+        "data": [
+          {
+            "id": "cnli_1IQydqBVqmGyQTMaSQAMDZeA",
+            "object": "credit_note_line_item",
+            "amount": 500,
+            "description": "1 × 123Done Pro (at $5.00 / month)",
+            "discount_amount": 0,
+            "discount_amounts": [],
+            "invoice_line_item": "il_1IQxtXBVqmGyQTMaAcxPUae9",
+            "livemode": false,
+            "quantity": 1,
+            "tax_amounts": [],
+            "tax_rates": [],
+            "type": "invoice_line_item",
+            "unit_amount": 500,
+            "unit_amount_decimal": "500"
+          }
+        ],
+        "has_more": false,
+        "url": "/v1/credit_notes/cn_1IQydqBVqmGyQTMaJSemYePQ/lines"
+      },
+      "livemode": false,
+      "memo": null,
+      "metadata": {},
+      "number": "AB5AE528-0001-CN-01",
+      "out_of_band_amount": 500,
+      "pdf": "https://pay.stripe.com/credit_notes/acct_1GCAr3BVqmGyQTMa/cnst_J34n5cCwHjDrAyeTKaEYIcMxff2Hxij/pdf",
+      "reason": "product_unsatisfactory",
+      "refund": null,
+      "status": "issued",
+      "subtotal": 500,
+      "tax_amounts": [],
+      "total": 500,
+      "type": "post_payment",
+      "voided_at": null
+    },
+    "previous_attributes": {}
+  }
+}


### PR DESCRIPTION
Because:

* We want to allow support to refund paypal users.

This commit:

* Listens for credit note events on invoices and refunds a paypal
  transaction on the invoice if one has completed with the same
  amount.

Closes #7324

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
