### PR TITLE
feat(auth-server): handle IPN for billing agreement cancelled

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/fixtures/mp_cancel_successful.json
+++ b/packages/fxa-auth-server/test/local/routes/fixtures/mp_cancel_successful.json
@@ -1,0 +1,20 @@
+{
+    "charset": "UTF-8",
+    "first_name": "John",
+    "ipn_track_id": "aa4335d8c3e27",
+    "last_name": "Doe",
+    "mp_currency": "USD",
+    "mp_custom": "",
+    "mp_desc": "Mozilla",
+    "mp_id": "B-75F71268HU787010S",
+    "mp_status": "1",
+    "notify_version": "3.9",
+    "payer_email": "syk3@personal.example.com",
+    "payer_id": "YRA75ZXLP83G8",
+    "payer_status": "verified",
+    "reason_code": "mp_2002",
+    "residence_country": "US",
+    "test_ipn": "1",
+    "txn_type": "mp_cancel",
+    "verify_sign": "AnneGm6iAtogaFpJq4cobwW29Mu4Ais1x8fLJdTdZDzGF8.oWAuk3SIY"
+}

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
@@ -14,10 +14,10 @@ const mocks = require('../../../mocks');
 const error = require('../../../../lib/error');
 const completedMerchantPaymentNotification = require('../fixtures/merch_pmt_completed.json');
 const pendingMerchantPaymentNotification = require('../fixtures/merch_pmt_pending.json');
+const billingAgreementCancelNotification = require('../fixtures/mp_cancel_successful.json');
 const {
   PayPalNotificationHandler,
 } = require('../../../../lib/routes/subscriptions/paypal-notifications');
-const successfulRefundTransactionResponse = require('../../payments/fixtures/paypal/refund_transaction_success.json');
 const { PayPalHelper } = require('../../../../lib/payments/paypal');
 
 const ACCOUNT_LOCALE = 'en-US';
@@ -36,6 +36,8 @@ describe('PayPalNotificationHandler', () => {
   let profile;
   let push;
   let stripeHelper;
+  /** @type sinon.SinonSandbox */
+  let sandbox;
 
   beforeEach(() => {
     config = {
@@ -324,6 +326,72 @@ describe('PayPalNotificationHandler', () => {
         invoice,
         completedMerchantPaymentNotification.txn_id
       );
+    });
+  });
+
+  describe('handleMpCancel', () => {
+    const billingAgreement = {
+      billingAgreementId: 'abc',
+      status: 'Active',
+      uid: '123',
+    };
+    const accountCustomer = {
+      stripeCustomerId: '321',
+      uid: '123',
+    };
+
+    it('receives IPN message with successful billing agreement cancelled', async () => {
+      sandbox = sinon.createSandbox();
+
+      const authDbModule = require('fxa-shared/db/models/auth');
+      sandbox.stub(authDbModule, 'getPayPalBAByBAId').returns(billingAgreement);
+      sandbox
+        .stub(authDbModule, 'getAccountCustomerByUid')
+        .returns(accountCustomer);
+      stripeHelper.removeCustomerPaypalAgreement = sinon.fake.resolves({});
+
+      const result = await handler.handleMpCancel(
+        billingAgreementCancelNotification
+      );
+
+      assert.isUndefined(result);
+      sinon.assert.calledOnceWithExactly(
+        authDbModule.getPayPalBAByBAId,
+        billingAgreementCancelNotification.mp_id
+      );
+      sinon.assert.calledOnceWithExactly(
+        authDbModule.getAccountCustomerByUid,
+        billingAgreement.uid
+      );
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.removeCustomerPaypalAgreement,
+        accountCustomer.uid,
+        { id: accountCustomer.stripeCustomerId },
+        billingAgreement.billingAgreementId
+      );
+
+      sandbox.restore();
+    });
+
+    it('receives IPN message for billing agreement already cancelled', async () => {
+      sandbox = sinon.createSandbox();
+
+      const authDbModule = require('fxa-shared/db/models/auth');
+      sandbox
+        .stub(authDbModule, 'getPayPalBAByBAId')
+        .returns({ ...billingAgreement, status: 'Cancelled' });
+
+      const result = await handler.handleMpCancel(
+        billingAgreementCancelNotification
+      );
+
+      assert.isUndefined(result);
+      sinon.assert.calledOnceWithExactly(
+        authDbModule.getPayPalBAByBAId,
+        billingAgreementCancelNotification.mp_id
+      );
+
+      sandbox.restore();
     });
   });
 });

--- a/packages/fxa-shared/db/models/auth/index.ts
+++ b/packages/fxa-shared/db/models/auth/index.ts
@@ -150,6 +150,12 @@ export async function getAllPayPalBAByUid(
     .orderBy('createdAt', 'DESC');
 }
 
+export async function getPayPalBAByBAId(
+  billingAgreementId: string
+): Promise<PayPalBillingAgreements> {
+  return PayPalBillingAgreements.query().findOne({ billingAgreementId });
+}
+
 /**
  * Create a PayPal Billing Agreement record for a user by uid.
  * @param uid

--- a/packages/fxa-shared/test/db/models/auth/index.spec.ts
+++ b/packages/fxa-shared/test/db/models/auth/index.spec.ts
@@ -22,6 +22,7 @@ import {
   getAllPayPalBAByUid,
   updatePayPalBA,
   deleteAllPayPalBAs,
+  getPayPalBAByBAId,
 } from '../../../../db/models/auth';
 import {
   chance,
@@ -356,6 +357,28 @@ describe('auth', () => {
         } catch (err) {
           assert.isTrue(err.message.includes('Invalid hex data'));
         }
+      });
+    });
+
+    describe('getPayPalBAByBAId', () => {
+      const uid = '10000927384d147aade1656425200000';
+      const billingAgreementId = 'B-1234XXXXX';
+      const status = 'Active';
+
+      before(async () => {
+        await createPayPalBA(uid, billingAgreementId, status);
+      });
+
+      it('finds an existing PayPalBillingAgreements', async () => {
+        const result = await getPayPalBAByBAId(billingAgreementId);
+        assert.isDefined(result);
+        assert.equal(result.uid, uid);
+        assert.equal(result.billingAgreementId, billingAgreementId);
+      });
+
+      it('does not find a non-existent PayPalBillingAgreements', async () => {
+        const result = await getPayPalBAByBAId('B-1234');
+        assert.isUndefined(result, 'no result defined');
       });
     });
 


### PR DESCRIPTION
## Because

- When we receive a cancelled billing agreement notification we want to update the PayPalBillingAgreements and Stripe Customer

## This pull request

- Adds IPN message handler for billing agreement cancelled and respectively updates the PayPalBillingAgreements and Stripe Customer

## Issue that this pull request solves

Closes: #7278

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
