### PR TITLE
feat(payments-server): Display currency restrictions errors on front-end.

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -678,7 +678,7 @@ AppError.currencyCurrencyMismatch = (currencyA, currencyB) => {
       code: 400,
       error: 'Bad Request',
       errno: ERRNO.INVALID_REGION,
-      message: `Change from ${currencyA} to ${currencyB} is not permitted.`,
+      message: `Changing currencies is not permitted.`,
     },
     {
       currencyA,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -1162,7 +1162,7 @@ describe('DirectStripeRoutes', () => {
       } catch (err) {
         assert.instanceOf(err, WError);
         assert.equal(err.errno, error.ERRNO.INVALID_REGION);
-        assert.equal(err.message, 'Change from USD to EUR is not permitted.');
+        assert.equal(err.message, 'Changing currencies is not permitted.');
       }
     });
 

--- a/packages/fxa-content-server/tests/functional/subscriptions.js
+++ b/packages/fxa-content-server/tests/functional/subscriptions.js
@@ -114,7 +114,7 @@ registerSuite('subscriptions', {
           .then(
             testElementTextInclude(
               '.payment-error',
-              'something went wrong. please try again later.'
+              'The currency of this subscription is not valid for the country associated with your payment.'
             )
           )
       );

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -23,6 +23,9 @@ payment-error-1 = Hmm. There was a problem authorizing your payment. Try again o
 payment-error-2 = Hmm. There was a problem authorizing your payment. Get in touch with your card issuer.
 payment-error-3 = An unexpected error has occured while processing your payment, please try again.
 
+country-currency-mismatch = The currency of this subscription is not valid for the country associated with your payment.
+currency-currency-mismatch = Sorry. You can't switch between currencies.
+
 expired-card-error = It looks like your credit card has expired. Try another card.
 insufficient-funds-error = It looks like your card has insufficient funds. Try another card.
 withdrawal-count-limit-exceeded-error = It looks like this transaction will put you over your credit limit. Try another card.

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -153,7 +153,7 @@ export const AppErrorDialog = ({ error: { message } }: { error: Error }) => {
         <Localized id="general-error-heading">
           <h4 data-testid="error-loading-app">General application error</h4>
         </Localized>
-        <Localized id={getErrorMessage('api_connection_error')}>
+        <Localized id={getErrorMessage({ code: 'api_connection_error' })}>
           <p>Something went wrong. Please try again later.</p>
         </Localized>
       </DialogMessage>

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
@@ -2,15 +2,11 @@ import React from 'react';
 import { Localized } from '@fluent/react';
 import { StripeError } from '@stripe/stripe-js';
 
-import { getErrorMessage } from '../../lib/errors';
+import { getErrorMessage, GeneralError } from '../../lib/errors';
 import errorIcon from './error.svg';
 import SubscriptionTitle from '../SubscriptionTitle';
 
 import './index.scss';
-
-type GeneralError = {
-  code: string;
-};
 
 export type PaymentErrorViewProps = {
   onRetry: Function;
@@ -33,9 +29,9 @@ export const PaymentErrorView = ({
         <div className="wrapper">
           <img id="error-icon" src={errorIcon} alt="error icon" />
           <div>
-            <Localized id={getErrorMessage(error.code || 'UNKNOWN')}>
+            <Localized id={getErrorMessage(error)}>
               <p data-testid="error-payment-submission">
-                {getErrorMessage(error.code || 'UNKNOWN')}
+                {getErrorMessage(error)}
               </p>
             </Localized>
           </div>

--- a/packages/fxa-payments-server/src/lib/errors.test.tsx
+++ b/packages/fxa-payments-server/src/lib/errors.test.tsx
@@ -1,16 +1,28 @@
 import '@testing-library/jest-dom/extend-expect';
 import { getErrorMessage, BASIC_ERROR, PAYMENT_ERROR_1 } from './errors';
 
+it('returns the basic error text if undefined error type', () => {
+  expect(getErrorMessage(undefined)).toEqual(BASIC_ERROR);
+});
+
 it('returns the basic error text if not predefined error type', () => {
-  expect(getErrorMessage('NON_PREDEFINED_ERROR')).toEqual(BASIC_ERROR);
+  expect(getErrorMessage({ code: 'NON_PREDEFINED_ERROR' })).toEqual(
+    BASIC_ERROR
+  );
 });
 
 it('returns the payment error text for the correct error type', () => {
-  expect(getErrorMessage('approve_with_id')).toEqual(PAYMENT_ERROR_1);
+  expect(getErrorMessage({ code: 'approve_with_id' })).toEqual(PAYMENT_ERROR_1);
 });
 
 it('returns the payment error text for setup intent authentication failure', () => {
-  expect(getErrorMessage('setup_intent_authentication_failure')).toEqual(
+  expect(
+    getErrorMessage({ code: 'setup_intent_authentication_failure' })
+  ).toEqual(PAYMENT_ERROR_1);
+});
+
+it('returns payment error based on message if that is what is available in error map', () => {
+  expect(getErrorMessage({ code: 'test', message: 'approve_with_id' })).toEqual(
     PAYMENT_ERROR_1
   );
 });

--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -1,3 +1,11 @@
+import { StripeError } from '@stripe/stripe-js';
+
+export type GeneralError = {
+  code: string;
+  errno?: number;
+  message?: string;
+};
+
 // ref: fxa-auth-server/lib/error.js
 const AuthServerErrno = {
   UNKNOWN_SUBSCRIPTION_CUSTOMER: 176,
@@ -21,7 +29,12 @@ const PAYMENT_ERROR_1 = 'payment-error-1';
 const PAYMENT_ERROR_2 = 'payment-error-2';
 const PAYMENT_ERROR_3 = 'payment-error-3';
 
-let errorMessageIndex: { [key: string]: string } = {
+/*
+ * errorToErrorMessageMap - the keys are lookups, that
+ * are assembled in getErrorMessage. The values are strings
+ * that correspond to ftl strings.
+ */
+const errorToErrorMessageMap: { [key: string]: string } = {
   expired_card: 'expired-card-error',
   insufficient_funds: 'insufficient-funds-error',
   withdrawal_count_limit_exceeded: 'withdrawal-count-limit-error',
@@ -31,6 +44,10 @@ let errorMessageIndex: { [key: string]: string } = {
   coupon_expired: 'coupon-expired-error',
   card_error: 'card-error',
   // todo: handle "parameters_exclusive": "Your already subscribed to _product_"
+  // Currency errors
+  'Funding source country does not match plan currency.':
+    'country-currency-mismatch',
+  'Changing currencies is not permitted.': 'currency-currency-mismatch',
 };
 
 const cardErrors = ['card_declined', 'incorrect_cvc'];
@@ -111,14 +128,24 @@ const paymentErrors2 = [
 
 const paymentErrors3 = ['general-paypal-error'];
 
-cardErrors.forEach((k) => (errorMessageIndex[k] = CARD_ERROR));
-basicErrors.forEach((k) => (errorMessageIndex[k] = BASIC_ERROR));
-paymentErrors1.forEach((k) => (errorMessageIndex[k] = PAYMENT_ERROR_1));
-paymentErrors2.forEach((k) => (errorMessageIndex[k] = PAYMENT_ERROR_2));
-paymentErrors3.forEach((k) => (errorMessageIndex[k] = PAYMENT_ERROR_3));
+cardErrors.forEach((k) => (errorToErrorMessageMap[k] = CARD_ERROR));
+basicErrors.forEach((k) => (errorToErrorMessageMap[k] = BASIC_ERROR));
+paymentErrors1.forEach((k) => (errorToErrorMessageMap[k] = PAYMENT_ERROR_1));
+paymentErrors2.forEach((k) => (errorToErrorMessageMap[k] = PAYMENT_ERROR_2));
+paymentErrors3.forEach((k) => (errorToErrorMessageMap[k] = PAYMENT_ERROR_3));
 
-function getErrorMessage(type: string) {
-  return errorMessageIndex[type] ? errorMessageIndex[type] : BASIC_ERROR;
+function getErrorMessage(error: undefined | StripeError | GeneralError) {
+  if (!error) {
+    return BASIC_ERROR;
+  }
+  let lookup = 'UNKNOWN';
+  // Handle case where we need to lookup by message (e.g. currency error)
+  if (error.message && errorToErrorMessageMap[error.message]) {
+    lookup = error.message;
+  } else if (error.code && errorToErrorMessageMap[error.code]) {
+    lookup = error.code;
+  }
+  return errorToErrorMessageMap[lookup];
 }
 
 // BASIC_ERROR and PAYMENT_ERROR_1 are exported for errors.test.tsx

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -161,9 +161,9 @@ export const PaymentUpdateForm = ({
           <>
             <ErrorMessage isVisible={!!paymentError}>
               {paymentError && (
-                <Localized id={getErrorMessage(paymentError.code || 'UNKNOWN')}>
+                <Localized id={getErrorMessage(paymentError)}>
                   <p data-testid="error-payment-submission">
-                    {getErrorMessage(paymentError.code || 'UNKNOWN')}
+                    {getErrorMessage(paymentError)}
                   </p>
                 </Localized>
               )}


### PR DESCRIPTION
## Because

- We need to display multi-currency errors to users

## This pull request

- Updates the getErrorMessage function to handle a variety of error message

## Issue that this pull request solves

Closes: #7467 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

To test:

#### Pre req:
Make sure your server's running with:
a) paypal enabled and 
b) update auth-server config so that currenciesToCountries is:
```
    default: {
      USD: ['US', 'GB', 'NZ', 'MY', 'SG', 'CA', 'AS', 'GU', 'MP', 'PR', 'VI'],
      EUR: ['FR', 'DE'],
    },
```

#### Test 1 - When trying to subscribe a US PayPal account to a Euro plan.
Steps:
* Go to localhost:8080, subscribe to Euro plan
* Use a paypal account that's configured for the US as it's country

![Screenshot from 2021-03-04 20-20-19](https://user-images.githubusercontent.com/1796208/110058192-8b591600-7d27-11eb-9bca-5260c7016864.png)

#### Test 2: When trying to subscribe a US credit card to a Euro Plan

Steps:
* Go to localhost:8080, subscribe to Euro plan
* Use normal stripe card 4242 4242 4242 4242 etc.

Alternatively, subscribe to a USD plan and use a, for example, french credit card (https://stripe.com/docs/testing#international-cards) 

![Screenshot from 2021-03-04 20-19-28](https://user-images.githubusercontent.com/1796208/110058162-7da39080-7d27-11eb-9c7a-8d4ebf3f96a8.png)

#### Test 3: When trying to change a euro subscribed plan user who signed up with a french credit card to a USD credit card

Steps:
* Go to localhost:8080, subscribe to Euro plan
* Use a french stripe card to subscribe (https://stripe.com/docs/testing#international-cards) 
* Go to subscription management and try to change your card to standard US card 4242 ....

![Screenshot from 2021-03-04 20-18-04](https://user-images.githubusercontent.com/1796208/110058262-a88de480-7d27-11eb-902f-8ecb8a4d922a.png)

## Other information
I could not get the front-end into a state where I was returned the currency-currency-mismatch error that we throw in the back-end. Can you help me think through if I've actually got everything? cc @bbangert