### PR TITLE
Enhance L10N handling

### DIFF
--- a/_scripts/clone-l10n.sh
+++ b/_scripts/clone-l10n.sh
@@ -1,64 +1,142 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
+# ensure the script errors out when a command fails
 set -e
 
-MODULE=$1
+MODULE="$1"
 
-if [ -z "$MODULE" ]; then
-  echo "\nYou need specify a module.\n"
-  exit 0
-fi
+log() {
+    echo "[clone-l10n] $1"
+}
+
+error() {
+    log "$1" >&2
+    exit 1
+}
+
+[ -n "$MODULE" ] || error "You need to specify a module."
 
 if [ -n "$FXA_L10N_SKIP" ]; then
-    echo "Skipping fxa-content-server-l10n update..."
+    log "Skipping fxa-content-server-l10n update..."
     exit 0
 fi
 
-DOWNLOAD_PATH="https://github.com/mozilla/fxa-content-server-l10n.git"
-SCRIPT_DIR=$(dirname "$0")
-MODULE_PATH="$SCRIPT_DIR/../packages/$MODULE"
 
-if [ ! -d "$MODULE_PATH" ]; then
-  echo "\nThe module/package does not appear to exist.\n"
-fi
+# BEGIN: workaround for missing GNU realpath in BSD/MacOS-X
+backup_ifs="$IFS"
 
-if [ -z "$FXA_L10N_SHA" ]; then
-    FXA_L10N_SHA="master"
-fi
+get_realpath_missing() {
+    if hash -- realpath 2>/dev/null; then
+        realpath -m "$1"
+        return
+    fi
+
+    local final_path is_first
+    final_path="$(pwd -P)"
+
+    IFS=/
+    is_first=true
+    for path_part in $1; do
+        if [ -z "${path_part}" ]; then
+            if $is_first; then
+                # absolute path
+                final_path=""
+            fi # otherwise, just ignore (e.g. "//")
+            continue
+        fi
+        is_first=false
+
+        if [ "${path_part}" = ".." ]; then
+            # one up
+            final_path="$(dirname "${final_path}")"
+        elif [ "${path_part}" != "." ]; then
+            final_path="${final_path}/${path_part}"
+        fi # otherwise ignore - current directory
+    done
+    IFS="${backup_ifs}"
+
+    echo "${final_path}"
+}
+# END: workaround for missing GNU realpath in BSD/MacOS-X
+
+DOWNLOAD_PATH="${FXA_L10N_DOWNLOAD_PATH:-fxa-content-server-l10n}"
+SCRIPT_DIR="$(dirname "$0")"
+MODULE_PATH="$(get_realpath_missing "$SCRIPT_DIR/../packages/$MODULE")"
+
+[ -d "$MODULE_PATH" ] || error "The module/package does not exist at: $MODULE_PATH"
 
 # Clone and pull
 cd "$MODULE_PATH"
-if [ ! -d "fxa-content-server-l10n" ]; then
-	echo "Downloading L10N files from $DOWNLOAD_PATH..."
-	git clone --depth 1 $DOWNLOAD_PATH
+
+if [ -n "${FXA_L10N_COPY_FROM}" ]; then
+    echo "Using L10N files from: ${FXA_L10N_COPY_FROM}"
+    [ ! -d "${DOWNLOAD_PATH}" ] || rm -rf "${DOWNLOAD_PATH}"
+    ln -sf "${FXA_L10N_COPY_FROM}" "${DOWNLOAD_PATH}"
+else
+    # Git repository to clone
+    FXA_L10N_REPO="${FXA_L10N_REPO:-https://github.com/mozilla/fxa-content-server-l10n.git}"
+
+    # branch name
+    FXA_L10N_BRANCH="${FXA_L10N_BRANCH:-master}"
+
+    # number of commits to truncate the history for specific commit checkout
+    FXA_L10N_DEPTH="${FXA_L10N_DEPTH:-1000}"
+
+    clone_opts=(--depth 1)
+
+    # fetch some history when required
+    [ -z "${FXA_L10N_SHA}" ] || clone_opts=(--depth "${FXA_L10N_DEPTH}")
+
+    # directly checkout to the desired branch and don't fetch others
+    [ -z "${FXA_L10N_BRANCH}" ] || clone_opts+=(--branch "${FXA_L10N_BRANCH}" --single-branch)
+
+    # Download L10N using git
+    if [ ! -d "${DOWNLOAD_PATH}" ]; then
+        log "Downloading L10N files from: ${FXA_L10N_REPO}"
+        git clone "${clone_opts[@]}" "${FXA_L10N_REPO}" "${DOWNLOAD_PATH}"
+    fi
+
+    log "Updating L10N files in: $(get_realpath_missing "${DOWNLOAD_PATH}")"
+
+    cd "${DOWNLOAD_PATH}"
+
+    # handle branch updates
+    if [ -n "${FXA_L10N_BRANCH}" ]; then
+        git checkout --quiet -- .
+        git checkout --quiet --force "${FXA_L10N_BRANCH}"
+        git pull --quiet origin "${FXA_L10N_BRANCH}"
+    fi
+
+    # checkout to a specific commit
+    if [ -n "${FXA_L10N_SHA}" ]; then
+        # ensure we have enough history
+        git fetch --quiet --depth "${FXA_L10N_DEPTH}"
+        git checkout --quiet --force "${FXA_L10N_SHA}"
+    fi
+    git rev-parse HEAD > git-head.txt
 fi
-cd fxa-content-server-l10n
-echo "Updating L10N files"
-git checkout -- .
-git checkout $FXA_L10N_SHA
-git pull
-git rev-parse $FXA_L10N_SHA > git-head.txt
+
+copy_ftl() {
+    local ftl_name locale_dir
+    ftl_name="$1"
+
+    for src in locale/**"/${ftl_name}.ftl"; do
+        [ -f "$src" ] || continue
+        locale_dir="$MODULE_PATH/public/locales/$(echo "$src" | sed -E 's/^.*\/([a-zA-Z_]+)\/.+/\1/; s/_/-/g')"
+        [ -d "$locale_dir" ] || mkdir -p "$locale_dir"
+        cp "$src" "$locale_dir/"
+    done
+}
 
 PAYMENTS="fxa-payments-server"
 SETTINGS="fxa-settings"
 
 # Copy .ftl files for payments or settings
-if [ "$MODULE" = "$PAYMENTS" ] || [ "$MODULE" = "$SETTINGS" ]; then
-  case "$MODULE" in
-    "$PAYMENT") FTL_FILENAME="main" ;;
-    "$SETTINGS") FTL_FILENAME="settings" ;;
-    *) FTL_FILENAME="*" ;;
-  esac
-
-  for src in locale/**/$FTL_FILENAME.ftl; do
-    [ -f "$src" ] || continue
-    dir=$(dirname "$src")
-    dir=$(echo "$dir" | sed "s/_/-/")
-    dir=$(basename "$dir")
-    base=$(basename "$src")
-    mkdir -p "../public/locales/$dir"
-    cp "$src" "../public/locales/$dir/$base"
-  done
-fi
-
-cd "$INIT_CWD"
+case "$MODULE" in
+    "$PAYMENTS")
+        copy_ftl "main"
+        ;;
+    "$SETTINGS")
+        copy_ftl "settings"
+        ;;
+esac


### PR DESCRIPTION
## Because

The current script has quite some functional errors and shortcomings.

## This pull request

...fixes some functional issues, introduces new functionality useful for testing/debugging.

More specifically:
* fix checkout to a specific commit - with existing environment variable `FXA_L10N_SHA`
* fix script errors/warnings as reported by `shellcheck` and unify code style

New features:
* specify a different branch - env var `FXA_L10N_BRANCH`
* override Git repository URL (e.g. a fork for testing) - env var `FXA_L10N_REPO`
* support to just use a local directory as-is (existing clone) - env var `FXA_L10N_COPY_FROM`
* override directory into which the content is cloned/linked into - env var `FXA_L10N_DOWNLOAD_PATH`

## Issue that this pull request solves

Closes: #7767 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Output of `shellcheck -ax` of the existing script:
```

In _scripts/clone-l10n.sh line 9:
  echo "\nYou need specify a module.\n"
       ^-- SC2028: echo may not expand escape sequences. Use printf.


In _scripts/clone-l10n.sh line 23:
  echo "\nThe module/package does not appear to exist.\n"
       ^-- SC2028: echo may not expand escape sequences. Use printf.


In _scripts/clone-l10n.sh line 49:
    "$PAYMENT") FTL_FILENAME="main" ;;
     ^------^ SC2153: Possible misspelling: PAYMENT may not be assigned, but PAYMENTS is.


In _scripts/clone-l10n.sh line 54:
  for src in locale/**/$FTL_FILENAME.ftl; do
                       ^-----------^ SC2231: Quote expansions in this for loop glob to prevent wordsplitting, e.g. "$dir"/*.txt .

For more information:
  https://www.shellcheck.net/wiki/SC2153 -- Possible misspelling: PAYMENT may...
  https://www.shellcheck.net/wiki/SC2028 -- echo may not expand escape sequen...
  https://www.shellcheck.net/wiki/SC2231 -- Quote expansions in this for loop...
```

New output using a specific commit:

```bash
$ FXA_L10N_SHA=fa77dc93fba361f201ba16d4d7072f8e778b63c2 bash _scripts/clone-l10n.sh fxa-payments-server
[clone-l10n] Downloading L10N files from: https://github.com/mozilla/fxa-content-server-l10n.git
Cloning into 'fxa-content-server-l10n'...
remote: Enumerating objects: 16149, done.
remote: Counting objects: 100% (16149/16149), done.
remote: Compressing objects: 100% (6037/6037), done.
remote: Total 16149 (delta 9498), reused 15599 (delta 9004), pack-reused 0
Receiving objects: 100% (16149/16149), 47.59 MiB | 6.64 MiB/s, done.
Resolving deltas: 100% (9498/9498), done.
[clone-l10n] Updating L10N files in: /srv/dev/mozilla/fxa/packages/fxa-payments-server/fxa-content-server-l10n
```

...or when using an existing local clone instead (fastest, of course):
```bash
$ FXA_L10N_COPY_FROM=/srv/dev/mozilla/fxa-l10n/ bash _scripts/clone-l10n.sh fxa-auth-server
Using L10N files from: /srv/dev/mozilla/fxa-l10n/

$ ls -l packages/fxa-auth-server/fxa-content-server-l10n
lrwxrwxrwx 1 kane kane 28 Mar  9 22:30 packages/fxa-auth-server/fxa-content-server-l10n -> /srv/dev/mozilla/fxa-l10n/
```
