### PR TITLE
feat(payments): Add Checkout error screen for returning PayPal customers

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -22,9 +22,13 @@ basic-error-message = Something went wrong. Please try again later.
 payment-error-1 = Hmm. There was a problem authorizing your payment. Try again or get in touch with your card issuer.
 payment-error-2 = Hmm. There was a problem authorizing your payment. Get in touch with your card issuer.
 payment-error-3 = An unexpected error has occured while processing your payment, please try again.
+payment-error-retry-button = Try again
+payment-error-manage-subscription-button = Manage my subscription
 
 country-currency-mismatch = The currency of this subscription is not valid for the country associated with your payment.
 currency-currency-mismatch = Sorry. You can't switch between currencies.
+
+returning-paypal-customer-error = Sorry. Currently, you can only sign up for one subscription at a time. Please check back soon.
 
 expired-card-error = It looks like your credit card has expired. Try another card.
 insufficient-funds-error = It looks like your card has insufficient funds. Try another card.

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.test.tsx
@@ -8,6 +8,13 @@ import {
 
 import { PaymentErrorView } from './index';
 
+const mockHistoryPush = jest.fn();
+jest.mock('react-router-dom', () => ({
+  useHistory: () => ({
+    push: mockHistoryPush,
+  }),
+}));
+
 afterEach(cleanup);
 describe('PaymentErrorView test with l10n', () => {
   const bundle = setupFluentLocalizationTest('en-US');
@@ -29,6 +36,12 @@ describe('PaymentErrorView test with l10n', () => {
       'An unexpected error has occured while processing your payment, please try again.';
     const actual = getLocalizedMessage(bundle, 'payment-error-3', {});
     expect(actual).toEqual(expected);
+
+    const retryButton = queryByTestId('retry-link');
+    expect(retryButton).toBeInTheDocument();
+
+    const termsAndPrivacy = queryByTestId('terms');
+    expect(termsAndPrivacy).toBeInTheDocument();
   });
 
   it('calls passed onRetry function when retry button clicked', async () => {
@@ -45,5 +58,49 @@ describe('PaymentErrorView test with l10n', () => {
     });
 
     expect(onRetry).toHaveBeenCalled();
+  });
+
+  it('renders as expected for a returning PayPal customer', () => {
+    const { queryByTestId, queryByAltText } = render(
+      <PaymentErrorView
+        onRetry={() => {}}
+        error={{ code: 'returning_paypal_customer_error' }}
+      />
+    );
+    const spinner = queryByAltText('error icon');
+    expect(spinner).toBeInTheDocument();
+
+    const mainBlock = queryByTestId('payment-error');
+    expect(mainBlock).toBeInTheDocument();
+
+    const expected =
+      'Sorry. Currently, you can only sign up for one subscription at a time. Please check back soon.';
+    const actual = getLocalizedMessage(
+      bundle,
+      'returning-paypal-customer-error',
+      {}
+    );
+    expect(actual).toEqual(expected);
+
+    const manageSubscriptionButton = queryByTestId('manage-subscription-link');
+    expect(manageSubscriptionButton).toBeInTheDocument();
+
+    const termsAndPrivacy = queryByTestId('terms');
+    expect(termsAndPrivacy).toBeInTheDocument();
+  });
+
+  it('navigates to the correct relative URL when the "Manage my subscription" button is clicked', async () => {
+    const { getByTestId } = render(
+      <PaymentErrorView
+        onRetry={() => {}}
+        error={{ code: 'returning_paypal_customer_error' }}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(getByTestId('manage-subscription-link'));
+    });
+
+    expect(mockHistoryPush).toHaveBeenCalledWith('/subscriptions');
   });
 });

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 import { Localized } from '@fluent/react';
 import { StripeError } from '@stripe/stripe-js';
 
 import { getErrorMessage, GeneralError } from '../../lib/errors';
 import errorIcon from './error.svg';
 import SubscriptionTitle from '../SubscriptionTitle';
+import TermsAndPrivacy from '../TermsAndPrivacy';
 
 import './index.scss';
 
@@ -19,6 +21,34 @@ export const PaymentErrorView = ({
   error,
   className = '',
 }: PaymentErrorViewProps) => {
+  const history = useHistory();
+
+  // We want the button label and onClick handler to be different depending
+  // on the type of error
+  const ActionButton = () => {
+    return error?.code === 'returning_paypal_customer_error' ? (
+      <Localized id="payment-error-manage-subscription-button">
+        <button
+          data-testid="manage-subscription-link"
+          className="button"
+          onClick={() => history.push('/subscriptions')}
+        >
+          Manage my subscription
+        </button>
+      </Localized>
+    ) : (
+      <Localized id="payment-error-retry-button">
+        <button
+          data-testid="retry-link"
+          className="button retry-link"
+          onClick={() => onRetry()}
+        >
+          Try again
+        </button>
+      </Localized>
+    );
+  };
+
   return error ? (
     <>
       <SubscriptionTitle screenType="error" className={className} />
@@ -38,15 +68,8 @@ export const PaymentErrorView = ({
         </div>
 
         <div className="footer" data-testid="footer">
-          <Localized id="payment-error-retry-button">
-            <button
-              data-testid="retry-link"
-              className="button retry-link"
-              onClick={() => onRetry()}
-            >
-              Try Again
-            </button>
-          </Localized>
+          <ActionButton />
+          <TermsAndPrivacy />
         </div>
       </section>
     </>

--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -48,6 +48,7 @@ const errorToErrorMessageMap: { [key: string]: string } = {
   'Funding source country does not match plan currency.':
     'country-currency-mismatch',
   'Changing currencies is not permitted.': 'currency-currency-mismatch',
+  returning_paypal_customer_error: 'returning-paypal-customer-error',
 };
 
 const cardErrors = ['card_declined', 'incorrect_cvc'];

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -34,7 +34,10 @@ import '../../Product/SubscriptionCreate/index.scss';
 import { ButtonBaseProps } from '../../Product/PayPalButton';
 const PaypalButton = React.lazy(() => import('../../Product/PayPalButton'));
 
-type PaymentError = undefined | StripeError;
+type PaymentError =
+  | undefined
+  | StripeError
+  | { code: string; message?: string };
 type RetryStatus = undefined | { invoiceId: string };
 
 export type SubscriptionCreateStripeAPIs = Pick<
@@ -135,6 +138,16 @@ export const SubscriptionCreate = ({
     paymentErrorInitialState
   );
   const [retryStatus, setRetryStatus] = useState<RetryStatus>();
+
+  useEffect(() => {
+    // Avoid infinite loop by ignoring changes to paymentError from this hook
+    if (
+      isExistingPaypalCustomer(customer) &&
+      paymentError?.code !== 'returning_paypal_customer_error'
+    ) {
+      setPaymentError({ code: 'returning_paypal_customer_error' });
+    }
+  }, [paymentError]);
 
   // clear any error rendered with `ErrorMessage` on form change
   const onChange = useCallback(() => {


### PR DESCRIPTION
## Because

- We descoped the [Returning Checkout story](https://jira.mozilla.com/browse/FXA-3078) for PayPal customers for the initial launch, and we want a descriptive placeholder screen for the small number of users who may be affected in the meantime.

## This pull request

- Shows `PaymentErrorView` in Checkout for returning PayPal customers with a descriptive message.
- Updates `PaymentErrorView` to show a different button for this error with the label "Manage my subscription" instead of "Try again" that takes the user to Subscription Management instead of SubscriptionCreate on click (the latter would have effectively been a noop).
- Localizes `PaymentErrorView` default "Try again" button label.
- Adds `TermsAndPrivacy` to `PaymentErrorView` for consistency with the rest of our Checkout screens.

## Issue that this pull request solves

Closes: #7726 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
![Screenshot_2021-03-09 Firefox Accounts(2)](https://user-images.githubusercontent.com/17437436/110574585-fa1ce180-8122-11eb-88dc-59854d640c3b.png)


