### PR TITLE
chore(payments): Replace localization ids for 'payment-legal-copy-str…

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -83,8 +83,8 @@ product-plan-not-found = Plan not found
 product-no-such-plan = No such plan for this product.
 
 ## payment legal blurb
-payment-legal-copy-stripe-paypal = { -brand-name-mozilla } uses Stripe and { -brand-name-paypal } for secure payment processing.
-payment-legal-link-stripe-paypal = View the <stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> and <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
+payment-legal-copy-stripe-and-paypal = { -brand-name-mozilla } uses Stripe and { -brand-name-paypal } for secure payment processing.
+payment-legal-link-stripe-and-paypal = View the <stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> and <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
 
 payment-legal-copy-paypal = { -brand-name-mozilla } uses { -brand-name-paypal } for secure payment processing.
 payment-legal-link-paypal = View the <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.

--- a/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
@@ -65,12 +65,12 @@ const StripePaymentLegalBlurb = () => (
 
 const DefaultPaymentLegalBlurb = () => (
   <div className="payment-legal-blurb">
-    <Localized id="payment-legal-copy-stripe-paypal">
+    <Localized id="payment-legal-copy-stripe-and-paypal">
       <p>Mozilla uses Stripe and Paypal for secure payment processing.</p>
     </Localized>
 
     <Localized
-      id="payment-legal-link-stripe-paypal"
+      id="payment-legal-copy-stripe-and-paypal"
       elems={{
         stripePrivacyLink: (
           <a


### PR DESCRIPTION
…ipe-paypal' and 'payment-legal-link-stripe-paypal'

## Because

- When we modify the content of a localized string, we must also create a new localization id. Otherwise, the localizers will not know about the change. This is a follow-up from PR #7581.

## This pull request
- Changes `'payment-legal-copy-stripe-paypal'` to `'payment-legal-copy-stripe-and-paypal'`
- Changes `'payment-legal-link-stripe-paypal'` to `'payment-legal-link-stripe-and-paypal'`

## Issue that this pull request solves

Closes: #7744 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

@chenba , I changed to RTL to see what this looks like, and it looks wrong for the footer and also the checkbox label -- do you know why that is? Should that be a follow-up bug?
![Screen Shot 2021-03-10 at 2 57 02 PM](https://user-images.githubusercontent.com/17437436/110696740-10717e80-81b1-11eb-8032-e0bb3fb06a98.png)
