### PR TITLE
fix(l10n): Pass navigator.languages into the new settings page

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -39,9 +39,10 @@ export const GET_INITIAL_STATE = gql`
 
 type AppProps = {
   flowQueryParams: FlowQueryParams;
+  navigatorLanguages: readonly string[];
 };
 
-export const App = ({ flowQueryParams }: AppProps) => {
+export const App = ({ flowQueryParams, navigatorLanguages }: AppProps) => {
   const config = useConfig();
 
   useEffect(() => {
@@ -68,6 +69,7 @@ export const App = ({ flowQueryParams }: AppProps) => {
     <AppLocalizationProvider
       baseDir="/beta/settings/locales"
       bundles={['settings']}
+      userLocales={navigatorLanguages}
     >
       <AppLayout>
         <Head />

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -81,7 +81,12 @@ try {
         <AuthContext.Provider value={{ auth: authClient }}>
           <ConfigContext.Provider value={config}>
             <AppErrorBoundary>
-              <App {...{ flowQueryParams }} />
+              <App
+                {...{
+                  flowQueryParams,
+                  navigatorLanguages: navigator.languages,
+                }}
+              />
             </AppErrorBoundary>
           </ConfigContext.Provider>
         </AuthContext.Provider>


### PR DESCRIPTION
Fixes #7740.

## Because

- The new settings page is always getting shown in English

## This pull request

- Actually passes in navigator.languages so that our translations can be displayed

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
