### PR TITLE
feat(auth-server): send emails for invoicing

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -20,9 +20,10 @@ import { msToSec } from '../../time';
 import { AuthLogger, AuthRequest } from '../../types';
 import validators from '../validators';
 import { StripeHandler } from './stripe';
+import { StripeWebhookHandler } from './stripe-webhook';
 import { handleAuth } from './utils';
 
-export class PayPalHandler extends StripeHandler {
+export class PayPalHandler extends StripeWebhookHandler {
   protected paypalHelper: PayPalHelper;
 
   constructor(

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -371,6 +371,7 @@ export class StripeWebhookHandler extends StripeHandler {
         ...invoiceDetails,
       }
     );
+    await this.stripeHelper.updateEmailSent(invoice, 'paymentFailed');
     return invoiceDetails;
   }
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
@@ -44,6 +44,9 @@ describe('PayPalNotificationHandler', () => {
       subscriptions: {
         enabled: true,
         stripeApiKey: 'sk_test_1234',
+        paypalNvpSigCredentials: {
+          enabled: false,
+        },
       },
     };
 


### PR DESCRIPTION
Because:

* We want to alert users when processing invoices
  if the payment failed.

This commit:

* Adds email sending of payment failed messages
  when invoice processing fails.

Closes #7594

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
