### PR TITLE
fix(auth-server): use proper relative import

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -3,8 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { ServerRoute } from '@hapi/hapi';
 import isA from '@hapi/joi';
-import { reportSentryError } from 'fxa-auth-server/lib/sentry';
-import { msToSec } from 'fxa-auth-server/lib/time';
 import { createPayPalBA } from 'fxa-shared/db/models/auth';
 import {
   filterCustomer,
@@ -17,6 +15,8 @@ import { ConfigType } from '../../../config';
 import error from '../../error';
 import { PayPalHelper } from '../../payments/paypal';
 import { StripeHelper } from '../../payments/stripe';
+import { reportSentryError } from '../../sentry';
+import { msToSec } from '../../time';
 import { AuthLogger, AuthRequest } from '../../types';
 import validators from '../validators';
 import { StripeHandler } from './stripe';

--- a/packages/fxa-auth-server/scripts/paypal-processor.ts
+++ b/packages/fxa-auth-server/scripts/paypal-processor.ts
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import program from 'commander';
-import { PayPalHelper } from 'fxa-auth-server/lib/payments/paypal';
 import { setupAuthDatabase } from 'fxa-shared/db';
 import { StatsD } from 'hot-shots';
 import Container from 'typedi';
 
+import { PayPalHelper } from '../lib/payments/paypal';
 import { PaypalProcessor } from '../lib/payments/paypal-processor';
 import { StripeHelper } from '../lib/payments/stripe';
 import { configureSentry } from '../lib/sentry';


### PR DESCRIPTION
Because:

* fxa-auth-server only works as import path during tests and in some dev
  conditions.

This commit:

* Uses a proper relative import.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
