### PR TITLE
fix(auth-server): allow payment error out

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -418,6 +418,7 @@ module.exports.subscriptionsCustomerValidator = isA.object({
   last4: isA.string().optional(),
   payment_provider: isA.string().optional(),
   payment_type: isA.string().optional(),
+  paypal_payment_error: isA.string().optional(),
   brand: isA.string().optional(),
   subscriptions: isA
     .array()


### PR DESCRIPTION
Because:

* We validate responses, and the optional property for paypal error
  messages wasn't added to the validator.

This commit:

* Adds the optional property to the validator so an internal error
  will not be thrown.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
