### PR TITLE
fix(settings): buttons are correctly  aligned to right

### DIFF
--- a/packages/fxa-settings/src/components/UnitRow/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRow/index.tsx
@@ -142,7 +142,7 @@ export const UnitRow = ({
         <div className="flex items-center">
           {!hideCtaText && route && (
             <Link
-              className="cta-neutral cta-base transition-standard ltr:mr-1 rtl:ml-1"
+              className="cta-neutral cta-base transition-standard rtl:ml-1"
               data-testid={formatDataTestId('unit-row-route')}
               to={`${route}${location.search}`}
             >


### PR DESCRIPTION
## Because

-

## This pull request

- removes the right margin class from the Link inside the UnitRow Component 

## Issue that this pull request solves

Closes: #7687 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

before            |  after
:-------------------------:|:-------------------------:
![fxa-before-2](https://user-images.githubusercontent.com/44236566/111022247-a0086e80-83f7-11eb-9568-29c94cbbb839.png) |  ![fxa-after-2](https://user-images.githubusercontent.com/44236566/111022256-ad255d80-83f7-11eb-967a-2f9ae3a5fbc7.png)

before            |  after
:-------------------------:|:-------------------------:
![fxa-before-1](https://user-images.githubusercontent.com/44236566/111022227-7ea78280-83f7-11eb-8dd5-8e9167afe5a3.png)  |  ![fxa-after-1](https://user-images.githubusercontent.com/44236566/111022251-a72f7c80-83f7-11eb-8489-508c1fec3b01.png)

## Other information (Optional)

Any other information that is important to this pull request.
