### PR TITLE
feat(auth-server): copy billing address info to Stripe customer

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal-client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-client.ts
@@ -111,10 +111,18 @@ type RefundTransactionData = {
 type BAUpdateData = {
   BILLINGAGREEMENTID: string;
   BILLINGAGREEMENTSTATUS: string;
-  COUNTRYCODE: string;
   EMAIL: string;
   PAYERSTATUS: string;
 };
+
+type BillToAddressData = {
+  CITY: string;
+  COUNTRYCODE: string;
+  STATE: string;
+  STREET: string;
+  STREET2: string;
+  ZIP: string;
+}
 
 export type TransactionStatus =
   | 'Pending'
@@ -151,7 +159,7 @@ export type NVPDoReferenceTransactionResponse = NVPResponse &
 
 export type NVPRefundTransactionResponse = NVPResponse & RefundTransactionData;
 
-export type NVPBAUpdateTransactionResponse = NVPResponse & BAUpdateData;
+export type NVPBAUpdateTransactionResponse = NVPResponse & BAUpdateData & BillToAddressData;
 
 export type NVPTransactionSearchResponse = TransactionSearchData & NVPResponse;
 

--- a/packages/fxa-auth-server/lib/payments/paypal.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal.ts
@@ -34,7 +34,12 @@ type PaypalHelperOptions = {
 
 type AgreementDetails = {
   status: 'active' | 'cancelled';
+  city: string;
   countryCode: string;
+  state: string;
+  street: string;
+  street2: string;
+  zip: string;
 };
 
 export type ChargeCustomerOptions = {
@@ -286,7 +291,12 @@ export class PayPalHelper {
     const response = await this.client.baUpdate(options);
     return {
       status: response.BILLINGAGREEMENTSTATUS.toLowerCase() as AgreementDetails['status'],
+      city: response.CITY,
       countryCode: response.COUNTRYCODE,
+      state: response.STATE,
+      street: response.STREET,
+      street2: response.STREET2,
+      zip: response.ZIP
     };
   }
 

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -66,6 +66,14 @@ export const SUBSCRIPTION_UPDATE_TYPES = {
   CANCELLATION: 'cancellation',
 };
 
+type BillingAddressOptions = {
+  city: string,
+  country: string,
+  line1: string,
+  line2: string,
+  postalCode: string,
+  state: string,
+}
 /**
  * Determine for two product metadata object's whether the new one
  * is a valid upgrade for the old one.
@@ -505,6 +513,32 @@ export class StripeHelper {
    */
   async payInvoiceOutOfBand(invoice: Stripe.Invoice) {
     return this.stripe.invoices.pay(invoice.id, { paid_out_of_band: true });
+  }
+
+  /**
+   * Update the customer object to add customer's PayPal billing address.
+   * 
+   * @param customer_id 
+   * @param city 
+   * @param country 
+   * @param line1 
+   * @param line2 
+   * @param postal_code 
+   * @param state 
+   */
+  async updateCustomerBillingAddress(
+    customer_id: string,
+    options: BillingAddressOptions
+  ): Promise<Stripe.Customer> {
+    const address = {
+      city: options.city,
+      country: options.country,
+      line1: options.line1,
+      line2: options.line2,
+      postal_code: options.postalCode,
+      state: options.state
+    }
+    return this.stripe.customers.update(customer_id, {address});
   }
 
   /**

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -999,6 +999,38 @@ describe('StripeHelper', () => {
     });
   });
 
+  describe('updateCustomerBillingAddress', () => {
+    it('updates Customer with empty PayPal billing address', async () => {
+      sandbox.stub(stripeHelper.stripe.customers, 'update').resolves({});
+      const result = await stripeHelper.updateCustomerBillingAddress(
+        customer1.id,
+        {
+          city: 'city',
+          country: 'US',
+          line1: 'street address',
+          line2: undefined,
+          postalCode: '12345',
+          state: 'CA',
+        }
+      );
+      assert.deepEqual(result, {});
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripe.customers.update,
+        customer1.id,
+        {
+          address: {
+            city: 'city',
+            country: 'US',
+            line1: 'street address',
+            line2: undefined,
+            postal_code: '12345',
+            state: 'CA',
+          },
+        }
+      );
+    });
+  });
+
   describe('updateCustomerPaypalAgreement', () => {
     it('skips if the agreement id is already set', async () => {
       const paypalCustomer = deepCopy(customer1);


### PR DESCRIPTION
## Because

- when creating a new billing agreement we want to make sure the billing address information is copied to the Stripe Customer

## This pull request

- expands existing PayPal handler to retrieve billing address from Billing Agreement

## Issue that this pull request solves

Closes: #7693

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
