### PR TITLE
fix(avatar): Avatar upload tweaks for new settings

### DIFF
--- a/packages/fxa-settings/src/components/PageAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/index.tsx
@@ -143,16 +143,10 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
   const capture = useCallback(async () => {
     const webcam: any = webcamRef?.current;
     const screenshot = await webcam.getScreenshot();
-    const cropped = await getCroppedImg(screenshot, {
-      width: 720,
-      height: 720,
-      x: 290,
-      y: 0,
-    });
-    setCroppedImgSrc(cropped);
+    setCapturedImgSrc(screenshot);
     setCapturing(false);
-    setSaveEnabled(true);
-  }, [webcamRef, setCroppedImgSrc, setCapturing]);
+    setSaveEnabled(false);
+  }, [webcamRef, setCapturing]);
 
   const onMediaLoad = useCallback(() => {
     setTimeout(() => {

--- a/packages/fxa-settings/src/lib/file-utils.tsx
+++ b/packages/fxa-settings/src/lib/file-utils.tsx
@@ -1,15 +1,9 @@
 import { ChangeEvent } from 'react';
-import { getOrientation } from 'get-orientation/browser';
 
-import { getRotatedImage } from './canvas-utils';
-
-const ORIENTATION_TO_ANGLE = {
-  '3': 180,
-  '6': 90,
-  '8': -90,
-};
-
-function readFile(file: Blob, onError: Function): Promise<string | ArrayBuffer | null> {
+function readFile(
+  file: Blob,
+  onError: Function
+): Promise<string | ArrayBuffer | null> {
   return new Promise((resolve) => {
     const reader = new FileReader();
     reader.addEventListener('load', () => resolve(reader.result), false);
@@ -21,20 +15,11 @@ function readFile(file: Blob, onError: Function): Promise<string | ArrayBuffer |
 export const onFileChange = async (
   evt: ChangeEvent<HTMLInputElement>,
   onSuccess: Function,
-  onError: Function,
+  onError: Function
 ) => {
   if (evt.target.files && evt.target.files.length > 0) {
     const file = evt.target.files[0];
     let imageDataUrl = await readFile(file, onError);
-
-    // apply rotation if needed
-    const orientation = await getOrientation(file);
-    // @ts-ignore
-    const rotation = ORIENTATION_TO_ANGLE[orientation];
-    if (rotation) {
-      imageDataUrl = await getRotatedImage(imageDataUrl, rotation);
-    }
-
     onSuccess(imageDataUrl);
   }
 };


### PR DESCRIPTION
## Because

- Avatar uploading from iOS doesn't always work as expected
- Taking a picture via camera on Firefox and Safari creates an image with different offsets (290px), so they will look different

## This pull request

- Removes auto rotation when uploading an image, `react-easy-cropper` allows the user the ability to rotate the image as needed
- When taking a photo from the camera, the user is taken to the cropper page to finalize the picture before saving

## Issue that this pull request solves

Closes: #7703

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
