### PR TITLE
fix(auth-server): skip currency check without pmi

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -494,18 +494,21 @@ export class StripeHandler {
       idempotencyKey,
     } = request.payload as Record<string, string>;
 
-    const planCurrency = (await this.stripeHelper.findPlanById(priceId))
-      .currency;
-    const paymentMethodCountry = (
-      await this.stripeHelper.getPaymentMethod(paymentMethodId)
-    ).card?.country;
-    if (
-      !this.stripeHelper.currencyHelper.isCurrencyCompatibleWithCountry(
-        planCurrency,
-        paymentMethodCountry
-      )
-    ) {
-      throw error.currencyCountryMismatch(planCurrency, paymentMethodCountry);
+    // Skip the payment source check if there's no payment method id.
+    if (paymentMethodId) {
+      const planCurrency = (await this.stripeHelper.findPlanById(priceId))
+        .currency;
+      const paymentMethodCountry = (
+        await this.stripeHelper.getPaymentMethod(paymentMethodId)
+      ).card?.country;
+      if (
+        !this.stripeHelper.currencyHelper.isCurrencyCompatibleWithCountry(
+          planCurrency,
+          paymentMethodCountry
+        )
+      ) {
+        throw error.currencyCountryMismatch(planCurrency, paymentMethodCountry);
+      }
     }
 
     const subIdempotencyKey = `${idempotencyKey}-createSub`;

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -665,6 +665,11 @@ describe('DirectStripeRoutes', () => {
     it('errors if the planCurrency does not match the paymentMethod country', async () => {
       plan.currency = 'EUR';
       directStripeRoutesInstance.stripeHelper.findPlanById.resolves(plan);
+      VALID_REQUEST.payload = {
+        priceId: 'Jane Doe',
+        paymentMethodId: 'pm_asdf',
+        idempotencyKey: uuidv4(),
+      };
       try {
         await directStripeRoutesInstance.createSubscriptionWithPMI(
           VALID_REQUEST
@@ -685,6 +690,11 @@ describe('DirectStripeRoutes', () => {
       directStripeRoutesInstance.stripeHelper.getPaymentMethod.resolves(
         paymentMethod
       );
+      VALID_REQUEST.payload = {
+        priceId: 'Jane Doe',
+        paymentMethodId: 'pm_asdf',
+        idempotencyKey: uuidv4(),
+      };
       try {
         await directStripeRoutesInstance.createSubscriptionWithPMI(
           VALID_REQUEST


### PR DESCRIPTION
Because:

* We can only do the currency check when a payment method id is
  provided. The Stripe createSubscriptionWithPMI intentionally
  allows no paymentMethodId to be provided to handle SCA which the
  check did not account for.

This commit:

* Only verifies currency matches when a payment method id is provided.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
