### PR TITLE
chore(subscriptions): update ToS link to use redirect URL

### DIFF
--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.test.tsx
@@ -46,7 +46,7 @@ it('renders as expected with no plan', () => {
   expect(termsDownloadLink).toBeInTheDocument();
   expect(termsDownloadLink).toHaveAttribute(
     'href',
-    DEFAULT_PRODUCT_DETAILS.termsOfServiceDownloadURL
+    `/legal-docs?url=${DEFAULT_PRODUCT_DETAILS.termsOfServiceDownloadURL}`
   );
 
   const privacyLink = queryByTestId('privacy');

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
@@ -8,6 +8,7 @@ import {
 import { Plan } from '../../store/types';
 
 import './index.scss';
+import { legalDocsRedirectUrl } from 'fxa-payments-server/src/lib/formats';
 
 export type TermsAndPrivacyProps = {
   plan?: Plan;
@@ -26,6 +27,10 @@ export const TermsAndPrivacy = ({ plan }: TermsAndPrivacyProps) => {
   } = plan
     ? productDetailsFromPlan(plan, navigatorLanguages)
     : DEFAULT_PRODUCT_DETAILS;
+
+  const tosUrl = termsOfServiceDownloadURL
+    ? legalDocsRedirectUrl(termsOfServiceDownloadURL)
+    : termsOfServiceDownloadURL;
 
   return (
     <div>
@@ -46,7 +51,7 @@ export const TermsAndPrivacy = ({ plan }: TermsAndPrivacyProps) => {
             rel="noopener noreferrer"
             target="_blank"
             data-testid="terms-download"
-            href={termsOfServiceDownloadURL}
+            href={tosUrl}
           >
             Download Terms
           </a>

--- a/packages/fxa-payments-server/src/lib/formats.ts
+++ b/packages/fxa-payments-server/src/lib/formats.ts
@@ -162,3 +162,6 @@ export function getDefaultPaymentConfirmText(
 
   return `I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>${planPricing}</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.`;
 }
+
+export const legalDocsRedirectUrl = (docUrl: string): string =>
+  `/legal-docs?url=${encodeURI(docUrl)}`;


### PR DESCRIPTION
Because:
 - the frontend should use the new legal docs redirect endpoint so that
   future metadata values of "localizeable" urls would work

This commit:
 - update the ToS link to use the redirect endpoint

## Issue that this pull request solves

Closes: #7850 
