### PR TITLE
bug(l10n): Minor fixes to payments l10n

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -7,6 +7,7 @@ project-brand = Firefox Accounts
 -brand-name-mozilla = Mozilla
 -brand-name-firefox = Firefox
 -brand-name-paypal = PayPal
+-brand-name-stripe = Stripe
 
 document =
   .title = Firefox Accounts
@@ -21,7 +22,7 @@ general-error-heading = General application error
 basic-error-message = Something went wrong. Please try again later.
 payment-error-1 = Hmm. There was a problem authorizing your payment. Try again or get in touch with your card issuer.
 payment-error-2 = Hmm. There was a problem authorizing your payment. Get in touch with your card issuer.
-payment-error-3 = An unexpected error has occured while processing your payment, please try again.
+payment-error-3b = An unexpected error has occurred while processing your payment, please try again.
 payment-error-retry-button = Try again
 payment-error-manage-subscription-button = Manage my subscription
 
@@ -50,8 +51,8 @@ privacy = Privacy Notice
 ## Subscription titles
 subscription-create-title = Set up your subscription
 subscription-success-title = Subscription confirmation
-subscription-processing-title = Confirming subscription...
-subscription-error-title = Error confirming subscription...
+subscription-processing-title = Confirming subscription…
+subscription-error-title = Error confirming subscription…
 
 ##  $productName (String) - The name of the subscribed product.
 ##  $amount (Number) - The amount billed. It will be formatted as currency.
@@ -87,14 +88,14 @@ product-plan-not-found = Plan not found
 product-no-such-plan = No such plan for this product.
 
 ## payment legal blurb
-payment-legal-copy-stripe-and-paypal = { -brand-name-mozilla } uses Stripe and { -brand-name-paypal } for secure payment processing.
-payment-legal-link-stripe-and-paypal = View the <stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> and <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
+payment-legal-copy-stripe-and-paypal-2 = { -brand-name-mozilla } uses { -brand-name-stripe } and { -brand-name-paypal } for secure payment processing.
+payment-legal-link-stripe-and-paypal-2 = View the <stripePrivacyLink>{ -brand-name-stripe } privacy policy</stripePrivacyLink> and <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
 
 payment-legal-copy-paypal = { -brand-name-mozilla } uses { -brand-name-paypal } for secure payment processing.
 payment-legal-link-paypal = View the <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
 
-payment-legal-copy-stripe = { -brand-name-mozilla } uses Stripe for secure payment processing.
-payment-legal-link-stripe = View the <stripePrivacyLink>Stripe privacy policy</stripePrivacyLink>.
+payment-legal-copy-stripe-2 = { -brand-name-mozilla } uses { -brand-name-stripe } for secure payment processing.
+payment-legal-link-stripe-2 = View the <stripePrivacyLink>{ -brand-name-stripe } privacy policy</stripePrivacyLink>.
 
 ## payment form
 payment-name =
@@ -286,7 +287,7 @@ sub-item-cancel-confirm =
 account-activated = Your account is activated, <userEl/>
 
 ## subscription route index
-sub-route-idx-updating = Updating billing information...
+sub-route-idx-updating = Updating billing information…
 sub-route-idx-reactivating = Reactivating subscription failed
 sub-route-idx-cancel-failed = Cancelling subscription failed
 sub-route-idx-contact = Contact Support
@@ -318,7 +319,7 @@ plan-details-hide-button = Hide details
 plan-details-total-label = Total
 
 ## payment-processing
-payment-processing-message = Please wait while we process your payment...
+payment-processing-message = Please wait while we process your payment…
 
 ## payment confirmation
 payment-confirmation-alert = Click here to download

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.test.tsx
@@ -33,8 +33,8 @@ describe('PaymentErrorView test with l10n', () => {
     expect(mainBlock).toBeInTheDocument();
 
     const expected =
-      'An unexpected error has occured while processing your payment, please try again.';
-    const actual = getLocalizedMessage(bundle, 'payment-error-3', {});
+      'An unexpected error has occurred while processing your payment, please try again.';
+    const actual = getLocalizedMessage(bundle, 'payment-error-3b', {});
     expect(actual).toEqual(expected);
 
     const retryButton = queryByTestId('retry-link');

--- a/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
@@ -42,12 +42,12 @@ const PaypalPaymentLegalBlurb = () => (
 
 const StripePaymentLegalBlurb = () => (
   <div className="payment-legal-blurb">
-    <Localized id="payment-legal-copy-stripe">
+    <Localized id="payment-legal-copy-stripe-2">
       <p>Mozilla uses Stripe for secure payment processing.</p>
     </Localized>
 
     <Localized
-      id="payment-legal-link-stripe"
+      id="payment-legal-link-stripe-2"
       elems={{
         stripePrivacyLink: (
           <a
@@ -65,12 +65,12 @@ const StripePaymentLegalBlurb = () => (
 
 const DefaultPaymentLegalBlurb = () => (
   <div className="payment-legal-blurb">
-    <Localized id="payment-legal-copy-stripe-and-paypal">
+    <Localized id="payment-legal-copy-stripe-and-paypal-2">
       <p>Mozilla uses Stripe and Paypal for secure payment processing.</p>
     </Localized>
 
     <Localized
-      id="payment-legal-link-stripe-and-paypal"
+      id="payment-legal-link-stripe-and-paypal-2"
       elems={{
         stripePrivacyLink: (
           <a

--- a/packages/fxa-payments-server/src/components/PaymentProcessing/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentProcessing/index.test.tsx
@@ -28,7 +28,7 @@ describe('PaymentProcessing tests', () => {
     const footer = queryByTestId('footer');
     expect(footer).toBeInTheDocument();
 
-    const expected = 'Please wait while we process your payment...';
+    const expected = 'Please wait while we process your payment…';
     const actual = getLocalizedMessage(
       bundle,
       'payment-processing-message',

--- a/packages/fxa-payments-server/src/components/SubscriptionTitle/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/SubscriptionTitle/index.test.tsx
@@ -68,7 +68,7 @@ describe('SubscriptionTitle', () => {
     const { findByTestId } = subject();
     const component = await findByTestId('subscription-processing-title');
 
-    const expectedTitle = 'Confirming subscription...';
+    const expectedTitle = 'Confirming subscription…';
     expect(component).toHaveTextContent(expectedTitle);
     const actualTitle = getLocalizedMessage(
       bundle,

--- a/packages/fxa-payments-server/src/components/SubscriptionTitle/index.tsx
+++ b/packages/fxa-payments-server/src/components/SubscriptionTitle/index.tsx
@@ -17,8 +17,8 @@ export const SubscriptionTitle = ({
   } = {
     create: 'Set up your subscription',
     success: 'Subscription confirmation',
-    processing: 'Confirming subscription...',
-    error: 'Error confirming subscription...',
+    processing: 'Confirming subscription…',
+    error: 'Error confirming subscription…',
   };
   return (
     <div

--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -27,7 +27,7 @@ const CARD_ERROR = 'card-error';
 const BASIC_ERROR = 'basic-error-message';
 const PAYMENT_ERROR_1 = 'payment-error-1';
 const PAYMENT_ERROR_2 = 'payment-error-2';
-const PAYMENT_ERROR_3 = 'payment-error-3';
+const PAYMENT_ERROR_3 = 'payment-error-3b';
 
 /*
  * errorToErrorMessageMap - the keys are lookups, that


### PR DESCRIPTION
## Because

- @peiying2 noticed some problems with the ftl file for payments

## This pull request

* Treats 'Stripe' as an untranslated brand, similar to how we handle 'Paypal'

* Corrects a typo (occured vs occurred)

* Replaces 3 periods with ellipses (thankfully this change doesn't require updating the l10n string IDs)

## Issue that this pull request solves

Closes: #mozilla/fxa-content-server-l10n#480.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
