### PR TITLE
fix(auth-server): handle failed checkout payments

### DIFF
--- a/packages/fxa-auth-server/scripts/paypal-processor.ts
+++ b/packages/fxa-auth-server/scripts/paypal-processor.ts
@@ -6,6 +6,7 @@ import { setupAuthDatabase } from 'fxa-shared/db';
 import { StatsD } from 'hot-shots';
 import Container from 'typedi';
 
+import error from '../lib/error';
 import { PayPalHelper } from '../lib/payments/paypal';
 import { PaypalProcessor } from '../lib/payments/paypal-processor';
 import { StripeHelper } from '../lib/payments/stripe';


### PR DESCRIPTION
Because:

* We cannot mark send_invoice subscriptions as incomplete when an
  initial payment fails to require another payment attempt before
  activating the subscription.
* We should send subscription failed emails when processing an invoice
  via webhook.

This commit:

* Updates the checkout flow code so that the billing agreement and
  subscription are removed if the PayPal transaction fails. This allows
  the user to choose a new payment option and prevents temporary
  subscription entitlements.
* Adds error handling for invoice processing in the stripe webhook
  triggered invoice processing to ensure the customer is notified should
  the invoice fail to get paid.

Closes #7852

Co-authored-by: Se Yeon Kim <say-yawn@users.noreply.github.com>

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
