### PR TITLE
fix(settings): fix session ttl in settings

### DIFF
--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -55,7 +55,10 @@ export const App = ({ flowQueryParams, navigatorLanguages }: AppProps) => {
     Metrics.init(flowQueryParams);
   }, [flowQueryParams]);
 
-  if (loading) {
+  // In case of an invalid token the page will redirect,
+  // but to prevent a flash of the error message we show
+  // the spinner.
+  if (loading || error?.message.includes('Invalid token')) {
     return (
       <LoadingSpinner className="bg-grey-20 flex items-center flex-col justify-center h-screen select-none" />
     );

--- a/packages/fxa-shared/db/models/auth/index.ts
+++ b/packages/fxa-shared/db/models/auth/index.ts
@@ -21,20 +21,26 @@ export type PayPalBillingAgreementStatusType =
 
 export async function sessionTokenData(
   tokenId: string
-): Promise<SessionToken | undefined> {
+): Promise<SessionToken | null> {
   let tokenBuffer: Buffer;
   try {
     tokenBuffer = uuidTransformer.to(tokenId);
   } catch (err) {
-    return;
+    return null;
   }
   const knex = Account.knex();
   const [result] = await knex.raw('Call sessionWithDevice_18(?)', tokenBuffer);
   const rowPacket = result.shift();
   if (rowPacket.length === 0) {
-    return;
+    return null;
   }
-  return SessionToken.fromDatabaseRow(rowPacket[0]);
+  const token = SessionToken.fromDatabaseRow(rowPacket[0]);
+  //TODO FIXME unhardcode the 28 day expiry
+  if (token.deviceId || token.createdAt > Date.now() - 2419200000) {
+    return token;
+  }
+  // expired
+  return null;
 }
 
 export async function accountExists(uid: string) {


### PR DESCRIPTION
We weren't accounting for token ttl when fetching the session token from the gql-api server, which would cause the frontend to think it was ok, but the auth-server would 401/110 the requests for data, triggering a GAE error.

This is a temporary fix for #7876