### PR TITLE
fix(content-server): Navigate to settings as an external app

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/signed-in-notification-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signed-in-notification-mixin.js
@@ -14,7 +14,12 @@ var Mixin = {
   _navigateToSignedInView(event) {
     if (this.broker.hasCapability('handleSignedInNotification')) {
       this.user.setSignedInAccountByUid(event.uid);
-      this.navigate(this.relier.get('redirectTo') || 'settings');
+      const redirectTo = this.relier.get('redirectTo');
+      if (redirectTo) {
+        this.navigate(redirectTo);
+      } else {
+        this.navigateAway('settings');
+      }
     }
 
     return Promise.resolve();

--- a/packages/fxa-content-server/app/scripts/views/ready.js
+++ b/packages/fxa-content-server/app/scripts/views/ready.js
@@ -133,7 +133,7 @@ const View = FormView.extend({
   },
 
   createRecoveryKey() {
-    this.navigate('settings/account_recovery');
+    this.navigateAway('settings/account_recovery');
   },
 
   gotoProductPage() {
@@ -141,7 +141,7 @@ const View = FormView.extend({
   },
 
   gotoSettings() {
-    this.navigate('settings');
+    this.navigateAway('settings');
   },
 
   isPasswordReset() {


### PR DESCRIPTION
A few spots in the recovery / reset flow navigated to settings URLs, but
because the settings app is now external to the backbone app, it's
necessary to navigateAway, otherwise attempts to navigate will appear to
do nothing.

Fixes #7815.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
