### PR TITLE
fix(pair): update pairing complete link to point to new settings

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/pair/auth_complete.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/pair/auth_complete.mustache
@@ -13,7 +13,7 @@
     {{{ unsafeDeviceBeingPairedHTML }}}
 
     <div class="button-row">
-      <a href="/settings/clients/" class="button primary-button">{{#t}}Manage devices{{/t}}</a>
+      <a href="/settings#connected-services" class="button primary-button">{{#t}}Manage devices{{/t}}</a>
     </div>
   </section>
 </div>


### PR DESCRIPTION
## Because

- Shouldn't redirect to old settings pages

## This pull request

- Updates the link on pairing complete

## Issue that this pull request solves

Closes: #7872 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

