### PR TITLE
chore(payments): Add paymentProvider property to Subscription Managem…

### DIFF
--- a/packages/fxa-payments-server/src/lib/amplitude.test.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.test.ts
@@ -71,7 +71,7 @@ it('should call logAmplitudeEvent with subscription plan info', () => {
   const metricsData: Amplitude.EventProperties = {
     plan_id: '123xyz_hourly',
     product_id: '123xyz',
-    paymentProvider: 'Stripe',
+    paymentProvider: 'stripe',
   };
   Amplitude.createSubscription_PENDING(metricsData);
   const eventProps = (<jest.Mock>(

--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -1,6 +1,6 @@
 import sentryMetrics from './sentry';
 import { logAmplitudeEvent } from './flow-event';
-import { config } from './config';
+import { ProviderType } from '../lib/PaymentProvider';
 import { selectors } from '../store/selectors';
 import { Store } from '../store';
 
@@ -37,7 +37,7 @@ export type EventProperties = GlobalEventProperties & {
   plan_id?: string;
   productId?: string;
   product_id?: string;
-  paymentProvider?: 'Stripe' | 'PayPal';
+  paymentProvider?: ProviderType;
   error?: Error;
 };
 
@@ -246,24 +246,28 @@ export function createSubscriptionWithPaymentMethod_REJECTED(
   );
 }
 
-export function updateDefaultPaymentMethod_PENDING() {
+export function updateDefaultPaymentMethod_PENDING(
+  eventProperties: EventProperties
+) {
   safeLogAmplitudeEvent(
     eventGroupNames.updateDefaultPaymentMethod,
     eventTypeNames.submit3DS,
-    {}
+    eventProperties
   );
 }
 
-export function updateDefaultPaymentMethod_FULFILLED() {
+export function updateDefaultPaymentMethod_FULFILLED(
+  eventProperties: EventProperties
+) {
   safeLogAmplitudeEvent(
     eventGroupNames.updateDefaultPaymentMethod,
     eventTypeNames.success3DS,
-    {}
+    eventProperties
   );
   safeLogAmplitudeEvent(
     eventGroupNames.updateDefaultPaymentMethod,
     eventTypeNames.complete3DS,
-    {}
+    eventProperties
   );
 }
 

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -59,6 +59,7 @@ import {
   apiGetPaypalCheckoutToken,
   apiCapturePaypalPayment,
 } from './apiClient';
+import { ProviderType } from './PaymentProvider';
 
 describe('APIError', () => {
   it('can be created without params', () => {
@@ -176,10 +177,12 @@ describe('API requests', () => {
       subscriptionId: 'sub_987675',
       planId: 'plan_2345',
       productId: 'prod_4567',
+      paymentProvider: 'paypal' as ProviderType,
     };
     const metricsOptions = {
       planId: params.planId,
       productId: params.productId,
+      paymentProvider: params.paymentProvider,
     };
 
     it('PUT {auth-server}/v1/oauth/subscriptions/active', async () => {
@@ -226,10 +229,12 @@ describe('API requests', () => {
       subscriptionId: 'sub_987675',
       planId: 'plan_2345',
       productId: 'prod_4567',
+      paymentProvider: 'paypal' as ProviderType,
     };
     const metricsOptions = {
       planId: params.planId,
       productId: params.productId,
+      paymentProvider: params.paymentProvider,
     };
 
     it('DELETE {auth-server}/v1/oauth/subscriptions/active/', async () => {
@@ -316,7 +321,7 @@ describe('API requests', () => {
     const metricsOptions = {
       planId: params.priceId,
       productId: params.productId,
-      paymentProvider: 'Stripe',
+      paymentProvider: 'stripe',
     };
 
     it(`POST {auth-server}${path}`, async () => {
@@ -408,7 +413,9 @@ describe('API requests', () => {
     const params = {
       paymentMethodId: 'pm_test',
     };
-    const metricsOptions = {};
+    const metricsOptions = {
+      paymentProvider: 'stripe',
+    };
 
     it(`POST {auth-server}${path}`, async () => {
       const requestMock = nock(AUTH_BASE_URL)
@@ -419,8 +426,12 @@ describe('API requests', () => {
         MOCK_CUSTOMER
       );
 
-      expect(<jest.Mock>updateDefaultPaymentMethod_PENDING).toBeCalledWith();
-      expect(<jest.Mock>updateDefaultPaymentMethod_FULFILLED).toBeCalledWith();
+      expect(<jest.Mock>updateDefaultPaymentMethod_PENDING).toBeCalledWith(
+        metricsOptions
+      );
+      expect(<jest.Mock>updateDefaultPaymentMethod_FULFILLED).toBeCalledWith(
+        metricsOptions
+      );
       requestMock.done();
     });
 
@@ -436,8 +447,11 @@ describe('API requests', () => {
         error = e;
       }
       expect(error).not.toBeNull();
-      expect(<jest.Mock>updateDefaultPaymentMethod_PENDING).toBeCalledWith();
+      expect(<jest.Mock>updateDefaultPaymentMethod_PENDING).toBeCalledWith(
+        metricsOptions
+      );
       expect(<jest.Mock>updateDefaultPaymentMethod_REJECTED).toBeCalledWith({
+        ...metricsOptions,
         error,
       });
       requestMock.done();
@@ -480,7 +494,7 @@ describe('API requests', () => {
     };
     const metricsOptions = {
       planId: params.priceId,
-      paymentProvider: 'PayPal',
+      paymentProvider: 'paypal',
     };
 
     it('POST {auth-server}/v1/oauth/subscriptions/active/new-paypal', async () => {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.test.tsx
@@ -95,7 +95,8 @@ describe('routes/Product/SubscriptionUpgrade', () => {
     fireEvent.click(getByTestId('submit'));
     expect(updateSubscriptionPlanAndRefresh).toBeCalledWith(
       CUSTOMER.subscriptions[0].subscription_id,
-      SELECTED_PLAN
+      SELECTED_PLAN,
+      CUSTOMER.payment_provider
     );
   });
 
@@ -180,7 +181,9 @@ describe('routes/Product/SubscriptionUpgrade', () => {
         const expectedAmount = getLocalizedCurrency(plan.amount, plan.currency);
 
         expect(legalCheckbox.props.vars.amount).toStrictEqual(expectedAmount);
-        expect(legalCheckbox.props.vars.intervalCount).toBe(plan.interval_count);
+        expect(legalCheckbox.props.vars.intervalCount).toBe(
+          plan.interval_count
+        );
         expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
       }
 
@@ -403,11 +406,13 @@ describe('PlanDetailsCard', () => {
       });
       const expectedAmount = getLocalizedCurrency(plan.amount, plan.currency);
 
-      expect(planPriceComponent.props.vars.amount).toStrictEqual(expectedAmount);
-      expect(planPriceComponent.props.vars.intervalCount).toBe(plan.interval_count);
-      expect(planPriceComponent.props.children).toBe(
-        expectedMsg
+      expect(planPriceComponent.props.vars.amount).toStrictEqual(
+        expectedAmount
       );
+      expect(planPriceComponent.props.vars.intervalCount).toBe(
+        plan.interval_count
+      );
+      expect(planPriceComponent.props.children).toBe(expectedMsg);
     }
 
     describe('When plan has day interval', () => {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -86,7 +86,8 @@ export const SubscriptionUpgrade = ({
       if (validator.allValid()) {
         updateSubscriptionPlanAndRefresh(
           upgradeFromSubscription.subscription_id,
-          selectedPlan
+          selectedPlan,
+          paymentProvider
         );
       }
     },
@@ -95,6 +96,7 @@ export const SubscriptionUpgrade = ({
       updateSubscriptionPlanAndRefresh,
       upgradeFromSubscription,
       selectedPlan,
+      paymentProvider,
     ]
   );
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
@@ -17,12 +17,14 @@ import { SelectorReturns } from '../../../store/selectors';
 import { SubscriptionsProps } from '../index';
 import { metadataFromPlan } from 'fxa-shared/subscriptions/metadata';
 import * as Amplitude from '../../../lib/amplitude';
+import { ProviderType } from 'fxa-payments-server/src/lib/PaymentProvider';
 
 export type CancelSubscriptionPanelProps = {
   plan: Plan;
   cancelSubscription: SubscriptionsProps['cancelSubscription'];
   customerSubscription: CustomerSubscription;
   cancelSubscriptionStatus: SelectorReturns['cancelSubscriptionStatus'];
+  paymentProvider: ProviderType | undefined;
 };
 
 const CancelSubscriptionPanel = ({
@@ -30,6 +32,7 @@ const CancelSubscriptionPanel = ({
   cancelSubscription,
   customerSubscription: { subscription_id, current_period_end },
   cancelSubscriptionStatus,
+  paymentProvider,
 }: CancelSubscriptionPanelProps) => {
   const [cancelRevealed, revealCancel, hideCancel] = useBooleanState();
   const [confirmationChecked, onConfirmationChanged] = useCheckboxState();
@@ -42,12 +45,12 @@ const CancelSubscriptionPanel = ({
   const confirmCancellation = useCallback(async () => {
     setIsLocalCancellation();
     try {
-      await cancelSubscription(subscription_id, plan);
+      await cancelSubscription(subscription_id, plan, paymentProvider);
     } catch (err) {
       // no-op, error is displayed in the Subscriptions route parent
     }
     resetIsLocalCancellation();
-  }, [cancelSubscription, subscription_id, plan]);
+  }, [cancelSubscription, subscription_id, plan, paymentProvider]);
 
   const viewed = useRef(false);
   const engaged = useRef(false);

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -13,6 +13,7 @@ import AppContext from '../../lib/AppContext';
 
 import CancelSubscriptionPanel from './Cancel/CancelSubscriptionPanel';
 import ReactivateSubscriptionPanel from './Reactivate/ManagementPanel';
+import { ProviderType } from 'fxa-payments-server/src/lib/PaymentProvider';
 
 export type SubscriptionItemProps = {
   customerSubscription: CustomerSubscription;
@@ -32,6 +33,8 @@ export const SubscriptionItem = ({
   customerSubscription,
 }: SubscriptionItemProps) => {
   const { locationReload } = useContext(AppContext);
+
+  const paymentProvider: ProviderType | undefined = customer?.payment_provider;
 
   if (!plan) {
     // TODO: This really shouldn't happen, would mean the user has a
@@ -62,6 +65,7 @@ export const SubscriptionItem = ({
               cancelSubscriptionStatus,
               customerSubscription,
               plan,
+              paymentProvider,
             }}
           />
         ) : (

--- a/packages/fxa-payments-server/src/store/actions/api.ts
+++ b/packages/fxa-payments-server/src/store/actions/api.ts
@@ -10,6 +10,7 @@ import {
 } from '../../lib/apiClient';
 
 import { Plan } from '../types';
+import { ProviderType } from 'fxa-payments-server/src/lib/PaymentProvider';
 
 export default {
   fetchProfile: () =>
@@ -24,7 +25,11 @@ export default {
   },
   fetchCustomer: () =>
     ({ type: 'fetchCustomer', payload: apiFetchCustomer() } as const),
-  updateSubscriptionPlan: (subscriptionId: string, plan: Plan) =>
+  updateSubscriptionPlan: (
+    subscriptionId: string,
+    plan: Plan,
+    paymentProvider: ProviderType | undefined
+  ) =>
     ({
       type: 'updateSubscriptionPlan',
       meta: { subscriptionId, plan },
@@ -32,9 +37,14 @@ export default {
         subscriptionId,
         planId: plan.plan_id,
         productId: plan.product_id,
+        paymentProvider,
       }),
     } as const),
-  cancelSubscription: (subscriptionId: string, plan: Plan) =>
+  cancelSubscription: (
+    subscriptionId: string,
+    plan: Plan,
+    paymentProvider: ProviderType | undefined
+  ) =>
     ({
       type: 'cancelSubscription',
       meta: { plan },
@@ -43,6 +53,7 @@ export default {
           subscriptionId,
           planId: plan.plan_id,
           productId: plan.product_id,
+          paymentProvider,
         });
         // Cancellation response does not include subscriptionId, but we want it.
         return { ...result, subscriptionId };

--- a/packages/fxa-payments-server/src/store/sequences.test.ts
+++ b/packages/fxa-payments-server/src/store/sequences.test.ts
@@ -33,6 +33,7 @@ const dispatchError = jest.fn().mockImplementation(() => {
 describe('updateSubscriptionPlanAndRefresh', () => {
   const plan = MOCK_PLANS[0];
   const subscriptionId = 'sub-8675309';
+  const paymentProvider = 'paypal';
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -41,11 +42,16 @@ describe('updateSubscriptionPlanAndRefresh', () => {
   it('handles action exceptions as expected', async () => {
     await sequences.updateSubscriptionPlanAndRefresh(
       subscriptionId,
-      plan
+      plan,
+      paymentProvider
     )(dispatchError);
 
     expect(dispatchError).toHaveBeenCalledTimes(1);
-    expect(actions.updateSubscriptionPlan).toBeCalledWith(subscriptionId, plan);
+    expect(actions.updateSubscriptionPlan).toBeCalledWith(
+      subscriptionId,
+      plan,
+      paymentProvider
+    );
     expect(actions.fetchCustomer).not.toBeCalled();
     expect(actions.fetchSubscriptions).not.toBeCalled();
   });
@@ -53,11 +59,16 @@ describe('updateSubscriptionPlanAndRefresh', () => {
   it('calls actions as expected', async () => {
     await sequences.updateSubscriptionPlanAndRefresh(
       subscriptionId,
-      plan
+      plan,
+      paymentProvider
     )(dispatch);
 
     expect(dispatch).toHaveBeenCalledTimes(3);
-    expect(actions.updateSubscriptionPlan).toBeCalledWith(subscriptionId, plan);
+    expect(actions.updateSubscriptionPlan).toBeCalledWith(
+      subscriptionId,
+      plan,
+      paymentProvider
+    );
     expect(actions.fetchCustomer).toBeCalled();
   });
 });

--- a/packages/fxa-payments-server/src/store/sequences.ts
+++ b/packages/fxa-payments-server/src/store/sequences.ts
@@ -1,6 +1,7 @@
 import { actions } from './actions';
 import { Plan } from './types';
 import { FunctionWithIgnoredReturn } from '../lib/types';
+import { ProviderType } from '../lib/PaymentProvider';
 
 const {
   fetchProfile,
@@ -52,10 +53,13 @@ export const fetchCustomerAndSubscriptions = () => async (
 
 export const updateSubscriptionPlanAndRefresh = (
   subscriptionId: string,
-  plan: Plan
+  plan: Plan,
+  paymentProvider: ProviderType | undefined
 ) => async (dispatch: Function) => {
   try {
-    await dispatch(updateSubscriptionPlan(subscriptionId, plan));
+    await dispatch(
+      updateSubscriptionPlan(subscriptionId, plan, paymentProvider)
+    );
     await dispatch(fetchCustomerAndSubscriptions());
   } catch (err) {
     handleThunkError(err);
@@ -64,10 +68,11 @@ export const updateSubscriptionPlanAndRefresh = (
 
 export const cancelSubscriptionAndRefresh = (
   subscriptionId: string,
-  plan: Plan
+  plan: Plan,
+  paymentProvider: ProviderType | undefined
 ) => async (dispatch: Function, getState: Function) => {
   try {
-    await dispatch(cancelSubscription(subscriptionId, plan));
+    await dispatch(cancelSubscription(subscriptionId, plan, paymentProvider));
     await dispatch(fetchCustomerAndSubscriptions());
   } catch (err) {
     handleThunkError(err);


### PR DESCRIPTION
…ent Amplitude events.

## Because

- We want to differentiate Subscription Management events between Stripe and PayPal customers to answer specific product questions (e.g. Do more PayPal customers cancel their subscriptions?).

## This pull request

- Use `ProviderType` everywhere `paymentProvider` is specified, including in previously added Checkout events (#7701 )
- Add `paymentProvider` property to existing Subscription Management events
  - `Amplitude.updateSubscriptionPlan_*`
  - `Amplitude.cancelSubscription_*`
  - `Amplitude.updateDefaultPaymentMethod_*`
    - Note: This one will only ever have a value of `'stripe'`, see #7883 .

## Issue that this pull request solves

Closes: #7262 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
