### PR TITLE
feature(payments): Fix missing American Express logo

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentProviderDetails/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentProviderDetails/index.scss
@@ -58,7 +58,7 @@
   background-image: url('../../images/mastercard.svg');
 }
 
-.american::before {
+.amex::before {
   background-image: url('../../images/amex.svg');
 }
 
@@ -69,7 +69,6 @@
 .stack-card-details > p.c-card {
   flex-direction: column;
   align-items: flex-start;
-  
 }
 
 .stack-card-details > p.c-card,


### PR DESCRIPTION
## Because

- We want the American Express logo to show up on the subscription confirmation and subscription information pages

## This pull request

- Adds a CSS rule to make the American Express logo visible

## Issue that this pull request solves

Closes: #7904 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
.
<img width="648" alt="Screen Shot 2021-03-19 at 6 39 02 PM" src="https://user-images.githubusercontent.com/22355127/111851842-d3a93400-88e2-11eb-84d6-47a3f9d5ef4f.png">
<img width="697" alt="Screen Shot 2021-03-19 at 6 42 45 PM" src="https://user-images.githubusercontent.com/22355127/111851885-f8051080-88e2-11eb-9c69-65d759b92951.png">


## Other information (Optional)

Any other information that is important to this pull request.
