### PR TITLE
fix(settings): Remove time from password change

### DIFF
--- a/packages/fxa-settings/src/components/Profile/index.tsx
+++ b/packages/fxa-settings/src/components/Profile/index.tsx
@@ -12,8 +12,6 @@ export const Profile = () => {
     year: 'numeric',
     month: 'numeric',
     day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
   }).format(new Date(passwordCreated));
 
   return (


### PR DESCRIPTION
## Because

-

## This pull request

- removes date from `Localized` inside the `UnitRow` component in the `/settings/change_password` route

## Issue that this pull request solves

Closes: 
#7761 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
![image](https://user-images.githubusercontent.com/37609519/111864497-37853880-8987-11eb-8f06-e9efa06c1a0c.png)


## Other information (Optional)

Any other information that is important to this pull request.
