### PR TITLE
fix(signout): Fix missing avatar when signing out

### DIFF
--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
@@ -32,9 +32,11 @@ export const DropDownAvatarMenu = () => {
   const alertBar = useAlertBar();
   const dropDownId = 'drop-down-avatar-menu';
 
-  const [destroySession, { data }] = useMutation(DESTROY_SESSION_MUTATION, {
+  const [destroySession] = useMutation(DESTROY_SESSION_MUTATION, {
     onCompleted: () => {
       // cannot use a hook here since this callback is not called in a hook
+      clearSignedInAccountUid();
+      window.location.assign(`${window.location.origin}/signin`);
       logViewEvent(settingsViewName, 'signout.success');
     },
     onError: (error) => {
@@ -47,12 +49,6 @@ export const DropDownAvatarMenu = () => {
       variables: { input: {} },
     });
   };
-
-  if (data) {
-    clearSignedInAccountUid();
-    window.location.assign(`${window.location.origin}/signin`);
-    return null;
-  }
 
   return (
     <>


### PR DESCRIPTION
## Because

- Returning null removes the component and avatar from the header

## This pull request

- Don't return null when session destroy is completed, redirect will take user to correct location

## Issue that this pull request solves

Closes: #6918

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
