### PR TITLE
fix(l10n): Fix profile-heading l10n label typo.

### DIFF
--- a/packages/fxa-settings/src/components/Profile/en-US.ftl
+++ b/packages/fxa-settings/src/components/Profile/en-US.ftl
@@ -1,6 +1,6 @@
 ## Profile section
 
-porfile-heading = Profile
+profile-heading = Profile
 profile-display-name =
   .header = Display name
 profile-password =


### PR DESCRIPTION
Noticed this while working on other PRs.