### PR TITLE
feat(auth-server): send uncaught IPN type to Sentry

### DIFF
--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
@@ -134,7 +134,7 @@ describe('PayPalNotificationHandler', () => {
       sinon.assert.calledOnceWithExactly(handler.handleMpCancel, ipnMessage);
     });
 
-    it('handles an unknown request successfully', async () => {
+    it('handles an unknown IPN request successfully', async () => {
       const request = {
         payload: 'samplepayload',
       };
@@ -151,6 +151,22 @@ describe('PayPalNotificationHandler', () => {
       sinon.assert.calledWithExactly(log.debug, 'Unhandled Ipn message', {
         payload: ipnMessage,
       });
+    });
+
+    it('handles an excluded IPN request successfully', async () => {
+      const request = {
+        payload: 'samplepayload',
+      };
+      const ipnMessage = {
+        txn_type: 'mp_signup',
+      };
+      paypalHelper.verifyIpnMessage = sinon.fake.resolves(true);
+      paypalHelper.extractIpnMessage = sinon.fake.returns(ipnMessage);
+      handler.handleMerchPayment = sinon.fake.resolves({});
+      const result = await handler.verifyAndDispatchEvent(request);
+      assert.deepEqual(result, false);
+      sinon.assert.calledOnce(paypalHelper.verifyIpnMessage);
+      sinon.assert.calledOnce(paypalHelper.extractIpnMessage);
     });
 
     it('handles an invalid request successfully', async () => {


### PR DESCRIPTION
## Because

- we want to document any IPN we are not handling for

## This pull request

- sends a "Unhandled Ipn message" error with the IPN's txn_type to Sentry

## Issue that this pull request solves

Closes: #7792

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
