### PR TITLE
fix(settings): Fix avatar black image on iOS

### DIFF
--- a/packages/fxa-settings/src/components/PageAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/index.tsx
@@ -242,8 +242,8 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
         />
         <RotateBtn
           onClick={() => {
-            if (rotation < 315) {
-              return setRotation(rotation + 45);
+            if (rotation < 270) {
+              return setRotation(rotation + 90);
             } else {
               return setRotation(0);
             }

--- a/packages/fxa-settings/src/components/PageAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/index.tsx
@@ -206,13 +206,13 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
           crop={crop}
           zoom={zoom}
           rotation={rotation}
+          aspect={1}
           showGrid={false}
           cropShape="round"
           onCropChange={setCrop}
           onCropComplete={onCropComplete}
           onZoomChange={setZoom}
           disableAutomaticStylesInjection={true}
-          cropSize={{ width: 160, height: 160 }}
           style={{ containerStyle: { borderRadius: '8px' } }}
         />
       </div>

--- a/packages/fxa-settings/src/lib/canvas-utils.tsx
+++ b/packages/fxa-settings/src/lib/canvas-utils.tsx
@@ -29,11 +29,11 @@ export async function getCroppedImg(
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');
 
+  // Calculate a safe area to store image so that it isn't clipped during rotation by
+  // canvas context. The 1.5 multiplier was found during manual testing of various
+  // photos on default iOS.
   const maxSize = Math.max(image.width, image.height);
-  const safeArea = 2 * ((maxSize / 2) * Math.sqrt(2));
-
-  // set each dimensions to double largest dimension to allow for a safe area for the
-  // image to rotate in without being clipped by canvas context
+  const safeArea = 1.5 * ((maxSize / 2) * Math.sqrt(2));
   canvas.width = safeArea;
   canvas.height = safeArea;
 

--- a/packages/fxa-settings/src/lib/canvas-utils.tsx
+++ b/packages/fxa-settings/src/lib/canvas-utils.tsx
@@ -25,44 +25,62 @@ export async function getCroppedImg(
   pixelCrop: { width: number; height: number; x: number; y: number },
   rotation = 0
 ): Promise<Blob | null> {
-  const image: any = await createImage(imageSrc);
+  const image = await createImage(imageSrc);
   const canvas = document.createElement('canvas');
   const ctx = canvas.getContext('2d');
-
-  // Calculate a safe area to store image so that it isn't clipped during rotation by
-  // canvas context. The 1.5 multiplier was found during manual testing of various
-  // photos on default iOS.
-  const maxSize = Math.max(image.width, image.height);
-  const safeArea = 1.5 * ((maxSize / 2) * Math.sqrt(2));
-  canvas.width = safeArea;
-  canvas.height = safeArea;
-
-  if (ctx !== null) {
-    // translate canvas context to a central location on image to allow rotating around the center.
-    ctx.translate(safeArea / 2, safeArea / 2);
-    ctx.rotate(getRadianAngle(rotation));
-    ctx.translate(-safeArea / 2, -safeArea / 2);
-
-    // draw rotated image and store data.
-    ctx.drawImage(
-      image,
-      safeArea / 2 - image.width * 0.5,
-      safeArea / 2 - image.height * 0.5
-    );
-    const data = ctx?.getImageData(0, 0, safeArea, safeArea);
-
-    // set canvas width to final desired crop size - this will clear existing context
-    canvas.width = pixelCrop.width;
-    canvas.height = pixelCrop.height;
-
-    // paste generated rotate image with correct offsets for x,y crop values.
-    if (data)
-      ctx.putImageData(
-        data,
-        Math.round(0 - safeArea / 2 + image.width * 0.5 - pixelCrop.x),
-        Math.round(0 - safeArea / 2 + image.height * 0.5 - pixelCrop.y)
-      );
+  if (!ctx) {
+    return null;
   }
+
+  canvas.width = 160;
+  canvas.height = 160;
+  const xCenterCanvas = Math.floor(canvas.width / 2);
+  const yCenterCanvas = Math.floor(canvas.height / 2);
+
+  const radians = getRadianAngle(rotation);
+
+  ctx.translate(xCenterCanvas, yCenterCanvas);
+  ctx.rotate(radians);
+  ctx.translate(-xCenterCanvas, -yCenterCanvas);
+
+  // pixelCrop x,y are post-rotation coordinates
+  // rotate pixelCrop x,y back to the 0 rotation of the source image
+  const xCenterImage = Math.floor(image.width / 2);
+  const yCenterImage = Math.floor(image.height / 2);
+  const rx =
+    (pixelCrop.x - xCenterImage) * Math.trunc(Math.cos(-radians)) -
+    (pixelCrop.y - yCenterImage) * Math.trunc(Math.sin(-radians)) +
+    xCenterImage;
+  const ry =
+    (pixelCrop.x - xCenterImage) * Math.trunc(Math.sin(-radians)) +
+    (pixelCrop.y - yCenterImage) * Math.trunc(Math.cos(-radians)) +
+    yCenterImage;
+
+  // find the top-left corner of the crop area
+  let left = pixelCrop.x;
+  let top = pixelCrop.y;
+  if (rotation === 90) {
+    left = rx;
+    top = ry - pixelCrop.height;
+  } else if (rotation === 180) {
+    left = rx - pixelCrop.width;
+    top = ry - pixelCrop.height;
+  } else if (rotation === 270) {
+    left = rx - pixelCrop.width;
+    top = ry;
+  }
+
+  ctx.drawImage(
+    image,
+    left,
+    top,
+    pixelCrop.width,
+    pixelCrop.height,
+    0,
+    0,
+    canvas.width,
+    canvas.height
+  );
 
   return new Promise((resolve) => {
     canvas.toBlob(
@@ -70,7 +88,7 @@ export async function getCroppedImg(
         resolve(blob);
       },
       'image/jpeg',
-      1
+      0.8
     );
   });
 }


### PR DESCRIPTION
## Because

- Avatar would not be set correctly on iOS devices and safari

## This pull request

- Cherry-picked @dannycoates [commit](https://github.com/mozilla/fxa/pull/7924/commits/1e73748e411d77ed8c644f2f8729610ee57f0cf5) which simpifes our `getCroppedImg` logic
- Set aspect ratio to 1 on cropper since it made testing a little easier

## Issue that this pull request solves

Closes: #7555
Closes: #7705

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To test, open iOS simulator and goto settings page. Select and set image.
