### PR TITLE
feat(emails): add email for payment method cancellation

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -25,6 +25,10 @@ const EMAIL_TYPES = {
   subscriptionDowngrade: 'subscription_downgrade',
   subscriptionPaymentExpired: 'subscription_payment_expired',
   subscriptionsPaymentExpired: 'subscriptions_payment_expired',
+  subscriptionPaymentProviderCancelled:
+    'subscription_payment_provider_cancelled',
+  subscriptionsPaymentProviderCancelled:
+    'subscriptions_payment_provider_cancelled',
   subscriptionPaymentFailed: 'subscription_payment_failed',
   subscriptionAccountDeletion: 'subscription_account_deletion',
   subscriptionCancellation: 'subscription_cancellation',

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1588,6 +1588,57 @@ export class StripeHelper {
     };
   }
 
+  async formatSubscriptionsForEmails(customer: Readonly<Stripe.Customer>) {
+    if (!customer.subscriptions) {
+      return [];
+    }
+
+    let formattedSubscptions = [];
+
+    for (const subscription of customer.subscriptions.data) {
+      if (ACTIVE_SUBSCRIPTION_STATUSES.includes(subscription.status)) {
+        if (!subscription.plan) {
+          throw error.internalValidationError(
+            'extractSourceDetailsForEmail',
+            customer,
+            new Error(
+              `Multiple plans for a subscription not supported: ${subscription.id}`
+            )
+          );
+        }
+
+        const plan = await this.expandResource(
+          subscription.plan,
+          PLAN_RESOURCE
+        );
+        const abbrevProduct = await this.expandAbbrevProductForPlan(plan);
+
+        const {
+          product_id: productId,
+          product_name: productName,
+        } = abbrevProduct;
+        const { id: planId, nickname: planName } = plan;
+        const productMetadata = this.mergeMetadata(plan, abbrevProduct);
+        const {
+          emailIconURL: planEmailIconURL = '',
+          downloadURL: planDownloadURL = '',
+        } = productMetadata;
+
+        formattedSubscptions.push({
+          productId,
+          productName,
+          planId,
+          planName,
+          planEmailIconURL,
+          planDownloadURL,
+          productMetadata,
+        });
+      }
+    }
+
+    return formattedSubscptions;
+  }
+
   async extractCardDetails({ charge }: { charge: Stripe.Charge | null }) {
     let lastFour: string | null = null;
     let cardType: string | null = null;
@@ -1637,48 +1688,7 @@ export class StripeHelper {
       );
     }
 
-    let subscriptions = [];
-
-    for (const subscription of customer.subscriptions.data) {
-      if (ACTIVE_SUBSCRIPTION_STATUSES.includes(subscription.status)) {
-        if (!subscription.plan) {
-          throw error.internalValidationError(
-            'extractSourceDetailsForEmail',
-            customer,
-            new Error(
-              `Multiple plans for a subscription not supported: ${subscription.id}`
-            )
-          );
-        }
-
-        const plan = await this.expandResource(
-          subscription.plan,
-          PLAN_RESOURCE
-        );
-        const abbrevProduct = await this.expandAbbrevProductForPlan(plan);
-
-        const {
-          product_id: productId,
-          product_name: productName,
-        } = abbrevProduct;
-        const { id: planId, nickname: planName } = plan;
-        const productMetadata = this.mergeMetadata(plan, abbrevProduct);
-        const {
-          emailIconURL: planEmailIconURL = '',
-          downloadURL: planDownloadURL = '',
-        } = productMetadata;
-
-        subscriptions.push({
-          productId,
-          productName,
-          planId,
-          planName,
-          planEmailIconURL,
-          planDownloadURL,
-          productMetadata,
-        });
-      }
-    }
+    const subscriptions = await this.formatSubscriptionsForEmails(customer);
 
     if (subscriptions.length === 0) {
       throw error.missingSubscriptionForSourceError(

--- a/packages/fxa-auth-server/lib/senders/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/templates/_versions.json
@@ -4,6 +4,8 @@
   "subscriptionDowngrade": 1,
   "subscriptionPaymentExpired": 1,
   "subscriptionsPaymentExpired": 1,
+  "subscriptionPaymentProviderCancelled": 1,
+  "subscriptionsPaymentProviderCancelled": 1,
   "subscriptionPaymentFailed": 1,
   "subscriptionAccountDeletion": 1,
   "subscriptionCancellation": 1,

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionPaymentProviderCancelled.html
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionPaymentProviderCancelled.html
@@ -1,0 +1,15 @@
+{{#*inline "title"}}
+  {{t "Sorry, we’re having trouble with your payment method" }}
+{{/inline}}
+
+{{#*inline "content"}}
+  {{t "We have detected a problem with your payment method for %(productName)s." }}
+  <br><br>
+  {{t "It may be that your credit card has expired, or your current payment method is out of date." }}
+  <br><br>
+  {{{t "To prevent any interruption to your service, please <a href=\"%(updateBillingUrl)s\">update your payment information</a> as soon as possible." }}}
+  <br><br>
+  {{{t "Questions about your subscription? Our <a href=\"%(subscriptionSupportUrl)s\">support team</a> is here to help you." }}}
+{{/inline}}
+
+{{> subscriptionEmail}}

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionPaymentProviderCancelled.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionPaymentProviderCancelled.txt
@@ -1,0 +1,15 @@
+{{{subject}}}
+
+{{{t "Sorry, we’re having trouble with your payment method" }}}
+
+{{{t "We have detected a problem with your payment method for %(productName)s." }}}
+
+{{{t "It may be that your credit card has expired, or your current payment method is out of date." }}}
+
+{{{t "To prevent any interruption to your service, please update your payment information as soon as possible:" }}}
+
+{{{updateBillingUrl}}}
+
+{{{t "Questions about your subscription? Our support team is here to help you:" }}}
+
+{{{subscriptionSupportUrl}}}

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionsPaymentProviderCancelled.html
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionsPaymentProviderCancelled.html
@@ -1,15 +1,17 @@
 {{#*inline "title"}}
-  {{t "Your credit card is about to expire" }}
+  {{t "Sorry, we’re having trouble with your payment method" }}
 {{/inline}}
 
 {{#*inline "content"}}
-  {{t "The credit card you're using to make payments for the following subscriptions is about to expire." }}
+  {{t "We have detected a problem with your payment method for the following subscriptions." }}
   <br><br>
   <ul>
     {{#subscriptions}}
     <li>{{productName }}</li>
     {{/subscriptions}}
   </ul>
+  <br><br>
+  {{t "It may be that your credit card has expired, or your current payment method is out of date." }}
   <br><br>
   {{{t "To prevent any interruption to your service, please <a href=\"%(updateBillingUrl)s\">update your payment information</a> as soon as possible." }}}
   <br><br>

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionsPaymentProviderCancelled.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionsPaymentProviderCancelled.txt
@@ -1,0 +1,19 @@
+{{{subject}}}
+
+{{{t "Sorry, we’re having trouble with your payment method" }}}
+
+{{{t "We have detected a problem with your payment method for the following subscriptions." }}}
+
+{{#subscriptions}}
+  - {{productName}}
+{{/subscriptions}}
+
+{{{t "It may be that your credit card has expired, or your current payment method is out of date." }}}
+
+{{{t "To prevent any interruption to your service, please update your payment information as soon as possible:" }}}
+
+{{{updateBillingUrl}}}
+
+{{{t "Questions about your subscriptions? Our support team is here to help you:" }}}
+
+{{{subscriptionSupportUrl}}}

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -144,7 +144,7 @@ const COMMON_TESTS = new Map([
 ]);
 
 // prettier-ignore
-const TESTS = new Map([
+const TESTS = [
   ['verifySecondaryCodeEmail', new Map([
     ['subject', { test: 'equal', expected: 'Confirm secondary email' }],
     ['headers', new Map([
@@ -370,7 +370,7 @@ const TESTS = new Map([
     ])],
     ['html', [
       { test: 'include', expected: configHref('subscriptionPrivacyUrl', 'subscription-payment-expired', 'subscription-privacy') },
-      { test: 'include', expected: configHref('subscriptionSettingsUrl', 'subscription-payment-expired', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email') },
+      { test: 'include', expected: configHref('subscriptionSettingsUrl', 'subscription-payment-expired', 'update-billing', 'plan_id', 'product_id', 'uid', 'email') },
       { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-payment-expired', 'subscription-terms') },
       { test: 'include', expected: `for ${MESSAGE.productName} is about to expire.` },
       { test: 'notInclude', expected: 'utm_source=email' },
@@ -379,7 +379,9 @@ const TESTS = new Map([
       { test: 'include', expected: `for ${MESSAGE.productName} is about to expire.` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
-  ])],
+  ]),
+    {updateTemplateValues: x => (
+      {...x, subscriptions: [{planId: MESSAGE.planId, productId: MESSAGE.productId, ...x.subscriptions[0]}]})}],
   ['subscriptionPaymentExpiredEmail', new Map([
     ['subject', { test: 'equal', expected: 'Credit card for your subscriptions is expiring soon' }],
     ['headers', new Map([
@@ -388,12 +390,52 @@ const TESTS = new Map([
       ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionPaymentExpired }],
     ])],
     ['html', [
-      { test: 'include', expected: configHref('subscriptionSettingsUrl', 'subscriptions-payment-expired', 'cancel-subscription', 'email', 'uid') },
+      { test: 'include', expected: configHref('subscriptionSettingsUrl', 'subscriptions-payment-expired', 'update-billing', 'email', 'uid') },
       { test: 'include', expected: 'using to make payments for the following subscriptions is about to expire.' },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
       { test: 'include', expected: 'using to make payments for the following subscriptions is about to expire.' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ]), {updateTemplateValues: x => ({...x, productName: undefined})}],
+  ['subscriptionPaymentProviderCancelledEmail', new Map([
+    ['subject', { test: 'equal', expected: `Payment information update required for ${MESSAGE.productName}` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionPaymentProviderCancelled') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionPaymentProviderCancelled' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionPaymentProviderCancelled }],
+    ])],
+    ['html', [
+      { test: 'include', expected: configHref('subscriptionPrivacyUrl', 'subscription-payment-provider-cancelled', 'subscription-privacy') },
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-payment-provider-cancelled', 'subscription-terms') },
+      { test: 'include', expected: configHref('subscriptionSettingsUrl', 'subscription-payment-provider-cancelled', 'update-billing', 'plan_id', 'product_id', 'uid', 'email') },
+      { test: 'include', expected: `We have detected a problem with your payment method for ${MESSAGE.productName}.` },
+      { test: 'include', expected: 'It may be that your credit card has expired, or your current payment method is out of date.' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `We have detected a problem with your payment method for ${MESSAGE.productName}.` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ]),
+    {updateTemplateValues: x => (
+      {...x, subscriptions: [{planId: MESSAGE.planId, productId: MESSAGE.productId, ...x.subscriptions[0]}]})}],
+  ['subscriptionPaymentProviderCancelledEmail', new Map([
+    ['subject', { test: 'equal', expected: 'Payment information update required for Mozilla subscriptions' }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionsPaymentProviderCancelled') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionsPaymentProviderCancelled' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionsPaymentProviderCancelled }],
+    ])],
+    ['html', [
+      { test: 'include', expected: configHref('subscriptionSettingsUrl', 'subscriptions-payment-provider-cancelled', 'update-billing', 'email', 'uid') },
+      { test: 'include', expected: 'We have detected a problem with your payment method for the following subscriptions.' },
+      { test: 'include', expected: 'It may be that your credit card has expired, or your current payment method is out of date.' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: 'We have detected a problem with your payment method for the following subscriptions.' },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ]), {updateTemplateValues: x => ({...x, productName: undefined})}],
@@ -1196,7 +1238,7 @@ const TESTS = new Map([
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
-]);
+];
 
 const PAYPAL_MESSAGE = Object.assign({}, MESSAGE);
 

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -114,6 +114,7 @@ const MAILER_METHOD_NAMES = [
   'sendSubscriptionUpgradeEmail',
   'sendSubscriptionDowngradeEmail',
   'sendSubscriptionPaymentExpiredEmail',
+  'sendSubscriptionPaymentProviderCancelledEmail',
   'sendSubscriptionPaymentFailedEmail',
   'sendSubscriptionAccountDeletionEmail',
   'sendSubscriptionCancellationEmail',


### PR DESCRIPTION
Because:
 - we should let a customer when their payment method for active
   subscriptions has a problem

This commit:
 - send an email on a billing agreement cancelled event from PayPal

This commit also changes the declarative email tests from a Map to an
array.  A previous patch (mistakenly) treated the tests as an array, and
this patch changes that list of tests to match.  The change to an array
allows multiple tests of the same mailer method, which we need in this
patch.


## Issue that this pull request solves

Closes: #7784 
