### PR TITLE
fix(tests): Re-enable settings_change_email 'can change primary email, delete account' test

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/views/mixins/password-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/password-mixin.js
@@ -150,7 +150,7 @@ describe('views/mixins/password-mixin', function () {
         view.showPassword('#password');
 
         assert.equal($passwordEl.attr('type'), 'text');
-        assert.equal($passwordEl.attr('autocapitalize'), 'off');
+        assert.equal($passwordEl.attr('autocapitalize'), 'none');
         assert.equal($passwordEl.attr('autocorrect'), 'off');
 
         // Ensure the show password state stays in sync

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/signed-in-notification-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/signed-in-notification-mixin.js
@@ -57,7 +57,7 @@ describe('views/mixins/signed-in-notification-mixin', () => {
             return Promise.resolve();
           }),
         };
-        view.navigate = sinon.spy();
+        view.navigateAway = sinon.spy();
         notifier.triggerAll = sinon.spy();
         return notifier.on.args[0][1]({
           uid: 'uid',
@@ -80,13 +80,13 @@ describe('views/mixins/signed-in-notification-mixin', () => {
         assert.isTrue(view.user.setSignedInAccountByUid.calledWith('uid'));
       });
 
-      it('calls navigate correctly', () => {
-        assert.equal(view.navigate.callCount, 1);
-        assert.isTrue(view.navigate.alwaysCalledOn(view));
+      it('calls navigateAway correctly', () => {
+        assert.equal(view.navigateAway.callCount, 1);
+        assert.isTrue(view.navigateAway.alwaysCalledOn(view));
         assert.isTrue(
-          view.navigate.calledAfter(view.user.setSignedInAccountByUid)
+          view.navigateAway.calledAfter(view.user.setSignedInAccountByUid)
         );
-        const args = view.navigate.args[0];
+        const args = view.navigateAway.args[0];
         assert.lengthOf(args, 1);
         assert.equal(args[0], 'settings');
       });
@@ -108,7 +108,7 @@ describe('views/mixins/signed-in-notification-mixin', () => {
             return Promise.resolve();
           }),
         };
-        view.navigate = sinon.spy();
+        view.navigateAway = sinon.spy();
         notifier.on.args[0][1]({
           uid: 'uid',
         });
@@ -122,8 +122,8 @@ describe('views/mixins/signed-in-notification-mixin', () => {
         assert.isFalse(view.user.setSignedInAccountByUid.called);
       });
 
-      it('does not call navigate', () => {
-        assert.equal(view.navigate.callCount, 0);
+      it('does not call navigateAway', () => {
+        assert.equal(view.navigateAway.callCount, 0);
       });
     });
 
@@ -140,6 +140,7 @@ describe('views/mixins/signed-in-notification-mixin', () => {
           }),
         };
         view.navigate = sinon.spy();
+        view.navigateAway = sinon.spy();
       });
 
       describe('without relier.redirectTo', () => {
@@ -158,9 +159,9 @@ describe('views/mixins/signed-in-notification-mixin', () => {
           assert.isTrue(view.user.setSignedInAccountByUid.calledWith('uid'));
         });
 
-        it('calls navigate correctly', () => {
-          assert.equal(view.navigate.callCount, 1);
-          assert.equal(view.navigate.args[0][0], 'settings');
+        it('calls navigateAway correctly', () => {
+          assert.equal(view.navigateAway.callCount, 1);
+          assert.equal(view.navigateAway.args[0][0], 'settings');
         });
       });
 

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -82,6 +82,7 @@ module.exports = testsSettingsV2.concat([
   'tests/functional/tos.js',
   'tests/functional/verification_reminders.js',
 ]);
+*/
 
 // Mocha tests are only exposed during local dev, not on prod-like
 // instances such as latest, stable, stage, and prod. To avoid
@@ -90,4 +91,3 @@ module.exports = testsSettingsV2.concat([
 if (!process.env.SKIP_MOCHA) {
   module.exports.unshift('tests/functional/mocha.js');
 }
-*/

--- a/packages/fxa-content-server/tests/functional/settings_change_email.js
+++ b/packages/fxa-content-server/tests/functional/settings_change_email.js
@@ -23,6 +23,7 @@ const {
   click,
   createEmail,
   fillOutChangePassword,
+  fillOutDeleteAccount,
   fillOutEmailFirstSignUp,
   fillOutEmailFirstSignIn,
   fillOutSignInUnblock,
@@ -232,7 +233,6 @@ registerSuite('settings change email', {
       );
     },
 
-    /* Disabled - failing on CI but not locally. Followup bug #7863.
     'can change primary email, delete account': function () {
       return (
         this.remote
@@ -252,6 +252,12 @@ registerSuite('settings change email', {
           .then(openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER))
           .then(fillOutEmailFirstSignUp(secondaryEmail, NEW_PASSWORD))
           .then(testElementExists(selectors.CONFIRM_SIGNUP_CODE.HEADER))
+          .then(
+            testElementTextInclude(
+              selectors.CONFIRM_SIGNUP_CODE.EMAIL_FIELD,
+              secondaryEmail
+            )
+          )
           .then(fillOutSignUpCode(secondaryEmail, 3))
           .then(testElementExists(selectors.SETTINGS.HEADER))
 
@@ -286,7 +292,6 @@ registerSuite('settings change email', {
           .then(testSuccessWasShown())
       );
     },
-    */
   },
 });
 


### PR DESCRIPTION
## Because

- This test was failing on CI, but not locally, blocking #7776 from landing. It was temporarily disabled.

## This pull request

- Re-enables the failing test to see if it will now pass on CI.
- Also fixes a few broken mocha tests and re-enables mocha tests.

## Issue that this pull request solves

Closes: #7863

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
