### PR TITLE
style(subscriptions): use the same shade of grey in checkout

### DIFF
--- a/packages/fxa-payments-server/src/styles/_mixins.scss
+++ b/packages/fxa-payments-server/src/styles/_mixins.scss
@@ -14,7 +14,6 @@
   background: $color-white;
   box-shadow: 0px 1px 4px rgba(12, 12, 13, 0.1);
   border-radius: 8px;
-  // margin: 0 16px 32px; processing
   color: rgba(12, 12, 13, 0.8);
   padding: 16px 16px 60px;
 
@@ -26,7 +25,6 @@
   @include min-width("desktop") {
     min-width: 60%;
     padding: 0 48px 48px;
-    // padding: 28px 48px 48px; processing
   }
 
   .wrapper {
@@ -37,7 +35,7 @@
 
   p {
     margin: 0;
-    color: $grey-40;
+    color: $grey-50;
   }
 
   .footer {


### PR DESCRIPTION
Because:
 - some text in the checkout process use a different, lighter, shade of
   grey

This commit:
 - change the grey to the same shade we've been using for checkout

## Issue that this pull request solves

Closes: #7810 

