### PR TITLE
fix(auth-server): restrict invoices to currenct subs

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -185,9 +185,13 @@ export class PayPalHandler extends StripeWebhookHandler {
     );
 
     const nowSeconds = msToSec(Date.now());
-    const invoices = await this.stripeHelper
-      .fetchOpenInvoices(nowSeconds, customer.id)
-      .autoPagingToArray({ limit: 10 });
+    const invoices = [];
+    for await (const invoice of this.stripeHelper.fetchOpenInvoices(
+      nowSeconds,
+      customer.id
+    )) {
+      invoices.push(invoice);
+    }
     if (invoices.length) {
       for (const invoice of invoices) {
         this.processInvoiceInBackground(request, customer, invoice);

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -1106,16 +1106,27 @@ describe('StripeHelper', () => {
 
   describe('fetchOpenInvoices', () => {
     it('returns customer paypal agreement id', async () => {
-      sandbox.stub(stripeHelper.stripe.invoices, 'list').resolves({});
-      const actual = await stripeHelper.fetchOpenInvoices(0);
-      assert.deepEqual(actual, {});
+      const invoice = deepCopy(invoicePaidSubscriptionCreate);
+      invoice.subscription = { status: 'active' };
+      const invoice2 = deepCopy(invoicePaidSubscriptionCreate);
+      invoice2.subscription = { status: 'cancelled' };
+      async function* genInvoice() {
+        yield invoice;
+        yield invoice2;
+      }
+      sandbox.stub(stripeHelper.stripe.invoices, 'list').returns(genInvoice());
+      const actual = [];
+      for await (const item of stripeHelper.fetchOpenInvoices(0)) {
+        actual.push(item);
+      }
+      assert.deepEqual(actual, [invoice]);
       sinon.assert.calledOnceWithExactly(stripeHelper.stripe.invoices.list, {
         customer: undefined,
         limit: 100,
         collection_method: 'send_invoice',
         status: 'open',
         created: 0,
-        expand: ['data.customer'],
+        expand: ['data.customer', 'data.subscription'],
       });
     });
   });


### PR DESCRIPTION
Because:

* Invoices can remain open for non-currenct subscriptions and we should
  only process invoices for current subscriptions.

This commit:

* Restricts the invoices located to be fulfilled to subscriptions that
  are in an active status.

Closes #7941

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
