### PR TITLE
fix: use created date on reactivate

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1907,7 +1907,7 @@ export class StripeHelper {
     const {
       total: invoiceTotalInCents,
       currency: invoiceTotalCurrency,
-      next_payment_attempt: nextInvoiceDate,
+      created: nextInvoiceDate,
     } = upcomingInvoice;
 
     return {
@@ -1922,9 +1922,6 @@ export class StripeHelper {
       invoiceTotalCurrency,
       cardType,
       lastFour,
-      // TODO: According to Stripe, this value will be null for invoices where collection_method=send_invoice
-      // Our subscriptions use collection_method=charge_automatically - so this shouldn't happen?
-      // Do trial subscriptions run into this?
       nextInvoiceDate: nextInvoiceDate
         ? new Date(nextInvoiceDate * 1000)
         : null,

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -2758,7 +2758,7 @@ describe('StripeHelper', () => {
       ...mockInvoice,
       id: 'inv_upcoming',
       amount_due: 299000,
-      next_payment_attempt: 1590018018,
+      created: 1590018018,
     };
 
     const mockCharge = {


### PR DESCRIPTION
Because:

* The next_payment_attempt attribute of invoices is only for those that
  Stripe charges for, resulting in a null for invoiced subscriptions.

This commit:

* Uses the proper created attribute of the invoice to reflect the actual
  next invoice billing date.

Closes #7874

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
