### PR TITLE
fix(import): Use relative import for production

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -4,7 +4,7 @@
 import { ServerRoute } from '@hapi/hapi';
 import isA from '@hapi/joi';
 import * as Sentry from '@sentry/node';
-import { PayPalClientError } from 'fxa-auth-server/lib/payments/paypal-client';
+import { PayPalClientError } from '../../payments/paypal-client';
 import {
   PAYPAL_BILLING_AGREEMENT_INVALID,
   PAYPAL_SOURCE_ERRORS,


### PR DESCRIPTION
Fix `Error: Cannot find module 'fxa-auth-server/lib/payments/paypal-client'` while running in stage