### PR TITLE
chore(auth): Update legal URLs in transactional emails

### DIFF
--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -81,26 +81,33 @@ Run tests with:
 
     npm test
 
-To select a specific glob of tests to run:
-
-    npm test -- test/local/account_routes.js test/local/password_*
-
-- Note: stop the auth-server before running tests. Otherwise, they will fail with obscure errors.
-- You can use `LOG_LEVEL`, such as `LOG_LEVEL=debug` to specify the test logging level.
-
-## Testing
-
-This package uses [Mocha](https://mochajs.org/) to test its code. By default `npm test` will run a series of NPM test scripts and then lint the code:
-
 Run specific tests with the following commands:
 
 ```bash
 # Test only test/local/account_routes.js
+# Note: This command does not work for remote tests.
 npm test -- test/local/account_routes.js
 
 # Grep for "SQSReceiver"
 NODE_ENV=dev npx mocha -r ts-node/register test/*/** -g "SQSReceiver"
 ```
+
+To select a specific glob of tests to run:
+
+```
+npm test -- test/local/account_routes.js test/local/password_*
+```
+
+To run a certain suite of tests (e.g. all remote tests):
+
+```
+npm test -- test/remote
+```
+
+- Note: stop the auth-server before running tests. Otherwise, they will fail with obscure errors.
+- You can use `LOG_LEVEL`, such as `LOG_LEVEL=debug` to specify the test logging level.
+
+This package uses [Mocha](https://mochajs.org/) to test its code. By default `npm test` will run a series of NPM test scripts and then lint the code:
 
 Refer to Mocha's [CLI documentation](https://mochajs.org/#command-line-usage) for more advanced test configuration.
 

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -158,7 +158,10 @@
   },
   "subscriptions": {
     "enabled": true,
-    "sharedSecret": "devsecret"
+    "sharedSecret": "devsecret",
+    "paymentsServer": {
+      "url": "http://localhost:3031/"
+    }
   },
   "totp": {
     "recoveryCodes": {

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -794,6 +794,14 @@ const conf = convict({
       env: 'SUBSCRIPTIONS_ENABLED',
       default: false,
     },
+    paymentsServer: {
+      url: {
+        doc: 'The url of the corresponding fxa-payments-server instance',
+        env: 'PAYMENTS_SERVER_URL',
+        format: 'url',
+        default: 'https://subscriptions.firefox.com',
+      },
+    },
     paypalNvpSigCredentials: {
       enabled: {
         doc: 'Indicates whether PayPal APIs are enabled',

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -30,6 +30,8 @@ module.exports = function (log, config) {
   );
   const cadReminders = require('../cad-reminders')(config, log);
 
+  const paymentsServerURL = new URL(config.subscriptions.paymentsServer.url);
+
   // Email template to UTM campaign map, each of these should be unique and
   // map to exactly one email template.
   const templateNameToCampaignMap = {
@@ -2540,6 +2542,10 @@ module.exports = function (log, config) {
     };
   });
 
+  Mailer.prototype._legalDocsRedirectUrl = function (url) {
+    return `${paymentsServerURL.origin}/legal-docs?url=${encodeURI(url)}`;
+  };
+
   Mailer.prototype._generateUTMLink = function (
     link,
     query,
@@ -2715,17 +2721,21 @@ module.exports = function (log, config) {
 
     links.cancellationSurveyLinkAttributes = `href="${links.cancellationSurveyUrl}" style="text-decoration: none; color: #0060DF;"`;
 
-    links.subscriptionTermsUrl = this._generateUTMLink(
-      termsOfServiceDownloadURL,
-      {},
-      templateName,
-      'subscription-terms'
+    links.subscriptionTermsUrl = this._legalDocsRedirectUrl(
+      this._generateUTMLink(
+        termsOfServiceDownloadURL,
+        {},
+        templateName,
+        'subscription-terms'
+      )
     );
-    links.subscriptionPrivacyUrl = this._generateUTMLink(
-      privacyNoticeDownloadURL,
-      {},
-      templateName,
-      'subscription-privacy'
+    links.subscriptionPrivacyUrl = this._legalDocsRedirectUrl(
+      this._generateUTMLink(
+        privacyNoticeDownloadURL,
+        {},
+        templateName,
+        'subscription-privacy'
+      )
     );
     links.cancelSubscriptionUrl = this._generateUTMLink(
       this.subscriptionSettingsUrl,

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -2026,7 +2026,13 @@ function configUrl(key, campaign, content, ...params) {
     ['utm_content', `fx-${content}`],
   ].forEach(([key, value]) => out.searchParams.append(key, value));
 
-  return out.toString();
+  const url = out.toString();
+  if (['subscriptionTermsUrl', 'subscriptionPrivacyUrl'].includes(key)) {
+    const parsedUrl = new URL(config.subscriptions.paymentsServer.url);
+    return `${parsedUrl.origin}/legal-docs?url=${encodeURI(url)}`;
+  }
+
+  return url;
 }
 
 async function setup(log, config, mocks, locale = 'en', sender = null) {

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -28,6 +28,7 @@ describe('remote subscriptions:', function () {
     config.subscriptions.stripeApiKey = null;
     config.subscriptions = {
       sharedSecret: 'wibble',
+      paymentsServer: config.subscriptions.paymentsServer,
     };
   });
 


### PR DESCRIPTION
## Because

- We have localized PDFs for legal documents, and there is a new redirect endpoint (#7688 ). The payments server links were updated in #7850 for this, and we should also update links in transactional emails.

## This pull request

- Updates legal URLs (links to product terms of service and privacy policy documents) in transactional emails.
- Removes one of the "Testing" sections in the README and updates a command/note for remote tests.

## Issue that this pull request solves

Closes: #7690 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
