### PR TITLE
Default monogram avatar

### DIFF
--- a/packages/fxa-content-server/server/lib/csp/blocking.js
+++ b/packages/fxa-content-server/server/lib/csp/blocking.js
@@ -88,6 +88,8 @@ module.exports = function (config) {
         // their profile image.
         GRAVATAR,
         PROFILE_IMAGES_SERVER,
+        // default monogram avatars
+        PROFILE_SERVER,
       ]),
       mediaSrc: [BLOB],
       objectSrc: [NONE],

--- a/packages/fxa-content-server/tests/server/csp.js
+++ b/packages/fxa-content-server/tests/server/csp.js
@@ -73,11 +73,12 @@ suite.tests['blockingRules'] = function () {
   assert.isAbove(frameSrc.length, 1);
 
   const imgSrc = directives.imgSrc;
-  assert.lengthOf(imgSrc, 6);
+  assert.lengthOf(imgSrc, 7);
   assert.include(imgSrc, Sources.SELF);
   assert.include(imgSrc, Sources.DATA);
   assert.include(imgSrc, Sources.GRAVATAR);
   assert.include(imgSrc, Sources.PROFILE_IMAGES_SERVER);
+  assert.include(imgSrc, Sources.PROFILE_SERVER);
   assert.include(imgSrc, CDN_SERVER);
 
   const mediaSrc = directives.mediaSrc;

--- a/packages/fxa-graphql-api/src/backend/profile-client.service.spec.ts
+++ b/packages/fxa-graphql-api/src/backend/profile-client.service.spec.ts
@@ -71,4 +71,15 @@ describe('ProfileClientService', () => {
     const result = await service.avatarUpload('token', 'app/json', 'somefile');
     expect(result.url).toBe('testurl');
   });
+
+  it('fetches the profile', async () => {
+    authClient.createOAuthToken = jest
+      .fn()
+      .mockResolvedValue({ access_token: 'test' });
+    (jest.spyOn(superagent, 'get') as jest.Mock).mockReturnValueOnce({
+      set: jest.fn().mockResolvedValue({ text: '{"avatar":"x"}' }),
+    });
+    const result = await service.getProfile('token');
+    expect(result).toStrictEqual({ avatar: 'x' });
+  });
 });

--- a/packages/fxa-graphql-api/src/backend/profile-client.service.ts
+++ b/packages/fxa-graphql-api/src/backend/profile-client.service.ts
@@ -79,4 +79,12 @@ export class ProfileClientService {
 
     return result.text === '{}';
   }
+
+  public async getProfile(token: string) {
+    const accessToken = await this.fetchToken(token);
+    const result = await superagent
+      .get(this.profileServerUrl + '/profile')
+      .set('Authorization', 'Bearer ' + accessToken);
+    return JSON.parse(result.text);
+  }
 }

--- a/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
+++ b/packages/fxa-graphql-api/src/gql/account.resolver.spec.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Provider } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Account, accountByUid } from 'fxa-shared/db/models/auth';
 import { CustomsService } from 'fxa-shared/nestjs/customs/customs.service';
@@ -43,6 +44,10 @@ describe('AccountResolver', () => {
         { provide: CustomsService, useValue: {} },
         { provide: AuthClientService, useValue: authClient },
         { provide: ProfileClientService, useValue: profileClient },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue({ url: 'test' }) },
+        },
       ],
     }).compile();
 

--- a/packages/fxa-profile-server/lib/db/mysql/index.js
+++ b/packages/fxa-profile-server/lib/db/mysql/index.js
@@ -115,6 +115,7 @@ const Q_SELECTED_AVATAR =
   'avatar_selected ON (avatars.id = avatar_selected.avatarId) WHERE ' +
   'avatars.userId=? AND avatar_selected.avatarId IS NOT NULL';
 const Q_AVATAR_DELETE = 'DELETE FROM avatars WHERE id=?';
+const Q_USER_AVATARS_DELETE = 'DELETE FROM avatars where userId=?';
 
 const Q_PROVIDER_INSERT = 'INSERT INTO avatar_providers (name) VALUES (?)';
 const Q_PROVIDER_GET_BY_NAME = 'SELECT * FROM avatar_providers WHERE name=?';
@@ -183,6 +184,10 @@ MysqlStore.prototype = {
 
   deleteAvatar: function deleteAvatar(id) {
     return this._write(Q_AVATAR_DELETE, [buf(id)]);
+  },
+
+  deleteUserAvatars: function deleteUserAvatars(uid) {
+    return this._write(Q_USER_AVATARS_DELETE, [buf(uid)]);
   },
 
   addProvider: function addProvider(name) {

--- a/packages/fxa-profile-server/lib/routes/avatar/_shared.js
+++ b/packages/fxa-profile-server/lib/routes/avatar/_shared.js
@@ -12,4 +12,9 @@ function fxaUrl(id) {
 
 module.exports = {
   fxaUrl: fxaUrl,
+  DEFAULT_AVATAR: {
+    avatar: fxaUrl(config.get('img.defaultAvatarId')),
+    avatarDefault: true,
+    id: config.get('img.defaultAvatarId'),
+  },
 };

--- a/packages/fxa-profile-server/lib/routes/avatar/default.js
+++ b/packages/fxa-profile-server/lib/routes/avatar/default.js
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports = {
+  handler: async function (request, h) {
+    const monogram = /^[a-zA-Z0-9]$/.test(request.params.id)
+      ? request.params.id
+      : '?';
+
+    // Only Firefox understands context-* values
+    const ua = request.headers['user-agent'] || '';
+    const useContext = ua.includes('Firefox/');
+    const fill = useContext ? 'context-fill #B2B2B4' : '#B2B2B4';
+    // contex-fill-opacity doesn't work on Firefox when a fallback value is present
+    const fillOpacity = useContext ? 'context-fill-opacity' : '0.7';
+
+    return h
+      .response(
+        `<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <mask id="monogram">
+            <rect x="0" y="0" width="100%" height="100%" fill="white"/>
+            <text
+              x="50%" y="50%"
+              dominant-baseline="central"
+              text-anchor="middle"
+              fill="black"
+              font-family='-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif'
+              font-weight="700"
+              font-size="4rem">${monogram.toUpperCase()}</text>
+          </mask>
+        </defs>
+        <circle cx="50" cy="50" r="50" fill="${fill}" fill-opacity="${fillOpacity}" mask="url(#monogram)"/>
+      </svg>`
+      )
+      .type('image/svg+xml; charset=UTF-8')
+      .header('Cache-Control', 'public, max-age=604800, immutable')
+      .header('Vary', 'user-agent');
+  },
+};

--- a/packages/fxa-profile-server/lib/routing.js
+++ b/packages/fxa-profile-server/lib/routing.js
@@ -60,6 +60,11 @@ module.exports = [
     config: require('./routes/avatar/get'),
   },
   {
+    method: 'GET',
+    path: v('/avatar/{id}'),
+    config: require('./routes/avatar/default'),
+  },
+  {
     method: 'POST',
     path: v('/avatar/upload'),
     config: require('./routes/avatar/upload'),

--- a/packages/fxa-profile-server/test/api.js
+++ b/packages/fxa-profile-server/test/api.js
@@ -13,10 +13,7 @@ const sinon = require('sinon');
 const assert = require('insist');
 const P = require('../lib/promise');
 const config = require('../lib/config');
-const avatarShared = require('../lib/routes/avatar/_shared');
 const assertSecurityHeaders = require('./lib/util').assertSecurityHeaders;
-
-const DEFAULT_AVATAR_ID = config.get('img.defaultAvatarId');
 
 function randomHex(bytes) {
   return crypto.randomBytes(bytes).toString('hex');
@@ -149,13 +146,13 @@ describe('api', function () {
           assert.equal(res.result.email, 'user@example.domain');
           assert.equal(
             res.result.avatar,
-            avatarShared.fxaUrl(DEFAULT_AVATAR_ID),
-            'return default avatar'
+            'http://localhost:1111/v1/avatar/u',
+            'returns monogram avatar for the mock email address'
           );
           assert.equal(
             res.result.avatarDefault,
-            true,
-            'has the default avatar flag'
+            false,
+            'uses a monogram avatar'
           );
           assertSecurityHeaders(res);
         });

--- a/packages/fxa-settings/src/components/Avatar/index.tsx
+++ b/packages/fxa-settings/src/components/Avatar/index.tsx
@@ -22,10 +22,7 @@ export const Avatar = ({ className }: AvatarProps) => {
           data-testid="avatar-nondefault"
           src={avatar.url}
           alt="Your avatar"
-          className={classNames(
-            'rounded-full bg-grey-200 text-grey-200',
-            className
-          )}
+          className={classNames('rounded-full bg-white', className)}
         />
       </Localized>
     );

--- a/packages/fxa-settings/src/components/PageAvatar/buttons.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/buttons.tsx
@@ -9,7 +9,7 @@ import { useNavigate } from '@reach/router';
 import { Localized, useLocalization } from '@fluent/react';
 import { useAlertBar } from '../../lib/hooks';
 import firefox from '../../lib/firefox';
-import { useAccount } from '../../models';
+import { useAccount, getNextAvatar } from '../../models';
 
 import { HomePath } from '../../constants';
 import ButtonIcon from '../ButtonIcon';
@@ -42,7 +42,7 @@ export const DELETE_AVATAR_MUTATION = gql`
 export const RemovePhotoBtn = () => {
   const navigate = useNavigate();
   const alertBar = useAlertBar();
-  const { uid, avatar } = useAccount();
+  const { uid, avatar, primaryEmail, displayName } = useAccount();
   const { l10n } = useLocalization();
 
   const [deleteAvatar] = useMutation(DELETE_AVATAR_MUTATION, {
@@ -59,7 +59,12 @@ export const RemovePhotoBtn = () => {
         id: cache.identify({ __typename: 'Account' }),
         fields: {
           avatar() {
-            return { id: null, url: null };
+            return getNextAvatar(
+              undefined,
+              undefined,
+              primaryEmail.email,
+              displayName
+            );
           },
         },
       });

--- a/packages/fxa-settings/src/components/PageAvatar/index.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/index.tsx
@@ -61,7 +61,7 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
         id: cache.identify({ __typename: 'Account' }),
         fields: {
           avatar() {
-            return newAvatar;
+            return { ...newAvatar, isDefault: false };
           },
         },
       });
@@ -331,7 +331,7 @@ export const PageAddAvatar = (_: RouteComponentProps) => {
                     }}
                   />
                 )}
-                {avatar.url && !capturing && <RemovePhotoBtn />}
+                {!avatar.isDefault && !capturing && <RemovePhotoBtn />}
               </div>
               {confirmBtns}
             </>

--- a/packages/fxa-settings/src/components/PageDisplayName/index.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.tsx
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { navigate, RouteComponentProps } from '@reach/router';
-import { useAccount } from '../../models';
+import { useAccount, getNextAvatar } from '../../models';
 import { useForm } from 'react-hook-form';
 import React, { useState } from 'react';
 import FlowContainer from '../FlowContainer';
@@ -11,7 +11,7 @@ import InputText from '../InputText';
 import firefox from '../../lib/firefox';
 import { alertTextExternal } from '../../lib/cache';
 import { useAlertBar, useMutation } from '../../lib/hooks';
-import { gql } from '@apollo/client';
+import { gql, Reference } from '@apollo/client';
 import AlertBar from '../AlertBar';
 import { HomePath } from '../../constants';
 import { Localized, useLocalization } from '@fluent/react';
@@ -80,6 +80,16 @@ export const PageDisplayName = (_: RouteComponentProps) => {
         fields: {
           displayName() {
             return displayName;
+          },
+          avatar(existing: Reference, { readField }) {
+            const id = readField<string>('id', existing);
+            const oldUrl = readField<string>('url', existing);
+            return getNextAvatar(
+              id,
+              oldUrl,
+              account.primaryEmail.email,
+              displayName
+            );
           },
         },
       });

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import React, { ReactNode, useState } from 'react';
-import { gql } from '@apollo/client';
+import { gql, Reference } from '@apollo/client';
 import { useNavigate } from '@reach/router';
 import firefox from '../../lib/firefox';
 import { useAlertBar } from '../../lib/hooks';
-import { useAccount, useLazyAccount, Email } from '../../models';
+import { useAccount, useLazyAccount, Email, getNextAvatar } from '../../models';
 import UnitRow from '../UnitRow';
 import AlertBar from '../AlertBar';
 import ModalVerifySession from '../ModalVerifySession';
@@ -110,6 +110,11 @@ export const UnitRowSecondaryEmail = () => {
                 }
                 return e;
               });
+            },
+            avatar(existing: Reference, { readField }) {
+              const id = readField<string>('id', existing);
+              const oldUrl = readField<string>('url', existing);
+              return getNextAvatar(id, oldUrl, email, account.displayName);
             },
           },
         });

--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -1,6 +1,7 @@
 import { InMemoryCache, gql, makeVar } from '@apollo/client';
 import Storage from './storage';
 import { Email } from '../models';
+import config from './config';
 
 const storage = Storage.factory('localStorage');
 
@@ -93,6 +94,20 @@ export const cache = new InMemoryCache({
         },
       },
       keyFields: [],
+    },
+    Avatar: {
+      fields: {
+        isDefault: {
+          read(_, o) {
+            const url = o.readField<string>('url');
+            const id = o.readField<string>('id');
+            return !!(
+              url?.startsWith(config.servers.profile.url) ||
+              id?.startsWith('default')
+            );
+          },
+        },
+      },
     },
     Session: {
       fields: {

--- a/packages/fxa-settings/src/models/Account.test.ts
+++ b/packages/fxa-settings/src/models/Account.test.ts
@@ -7,8 +7,17 @@ import {
   hasSecondaryEmail,
   hasSecondaryVerifiedEmail,
   hasTwoStepAuthentication,
+  getNextAvatar,
 } from './Account';
 import { mockEmail, MOCK_ACCOUNT } from './_mocks';
+
+jest.mock('../lib/config', () => ({
+  servers: {
+    profile: {
+      url: 'default-url',
+    },
+  },
+}));
 
 describe('Account', () => {
   describe('hasSecondaryEmail', () => {
@@ -90,6 +99,48 @@ describe('Account', () => {
     it('should be true when TOTP exists and verified', () => {
       const actual = hasTwoStepAuthentication(MOCK_ACCOUNT);
       expect(actual).toBe(true);
+    });
+  });
+
+  describe('getNextAvatar', () => {
+    it('should favor profile pictures', () => {
+      const avatar = getNextAvatar('id', 'url', 'test@example.com', 'me');
+      expect(avatar.id).toBe('id');
+      expect(avatar.url).toBe('url');
+    });
+
+    it('should favor display name over email', () => {
+      const avatar = getNextAvatar(
+        'default-x',
+        'default-url',
+        'test@example.com',
+        'me'
+      );
+      expect(avatar.id).toBe('default-m');
+      expect(avatar.url).toBe('default-url/v1/avatar/m');
+    });
+
+    it('should use email when display name is out of range', () => {
+      const avatar = getNextAvatar(
+        undefined,
+        undefined,
+        'test@example.com',
+        '$$'
+      );
+      expect(avatar.id).toBe('default-t');
+      expect(avatar.url).toBe('default-url/v1/avatar/t');
+    });
+
+    it('should use the first character for a-z0-9 letters', () => {
+      const avatar = getNextAvatar(undefined, undefined, 'test@example.com');
+      expect(avatar.id).toBe('default-t');
+      expect(avatar.url).toBe('default-url/v1/avatar/t');
+    });
+
+    it('should be "null" as a last resort', () => {
+      const avatar = getNextAvatar(undefined, undefined, '!@example.com', '@#');
+      expect(avatar.id).toBe(null);
+      expect(avatar.url).toBe(null);
     });
   });
 });

--- a/packages/fxa-settings/src/models/_mocks.tsx
+++ b/packages/fxa-settings/src/models/_mocks.tsx
@@ -36,6 +36,7 @@ export const MOCK_ACCOUNT: Account = {
   avatar: {
     id: 'abc1234',
     url: 'http://placekitten.com/512/512',
+    isDefault: false,
   },
   accountCreated: 123456789,
   passwordCreated: 123456789,


### PR DESCRIPTION
When an account has no avatar set we attempt to create a default avatar using the first letter of either display name or email address. These avatars use theme colors within the Firefox native UI and a neutral grey in web content and are served by the profile server.

To test with theme colors in Firefox change `svg.context-properties.content.enabled` to `true` in `about:config`.