### PR TITLE
fix(gql): dont report apollo errors

### DIFF
--- a/packages/fxa-shared/nestjs/sentry/sentry.plugin.ts
+++ b/packages/fxa-shared/nestjs/sentry/sentry.plugin.ts
@@ -27,7 +27,10 @@ export const SentryPlugin = {
         for (const err of ctx.errors) {
           // Only report internal server errors,
           // all errors extending ApolloError should be user-facing
-          if (err instanceof ApolloError) {
+          if (
+            err instanceof ApolloError ||
+            err.originalError instanceof ApolloError
+          ) {
             continue;
           }
           // Skip errors with a status already set or already reported


### PR DESCRIPTION
Because:

* ApolloErrors are user facing already and don't need to be reported to
  Sentry.

This commit:

* Updates the error check to ensure the originalError is not an instance
  of ApolloError.

Fixes #7647

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
