### PR TITLE
style(subscriptions): match alert bar width to content

### DIFF
--- a/packages/fxa-payments-server/src/components/AlertBar/index.scss
+++ b/packages/fxa-payments-server/src/components/AlertBar/index.scss
@@ -1,3 +1,13 @@
+@import '../../../../fxa-content-server/app/styles/breakpoints';
+
+.portal#top-bar {
+  padding: 0 32px;
+
+  @include respond-to('small') {
+    padding: 0;
+  }
+}
+
 #top-bar .alert {
   background: rgba(0, 0, 0, 0.1);
   font-weight: bold;
@@ -38,5 +48,9 @@
   border-radius: 6px;
   margin: 0 auto;
   position: relative;
-  width: 80%;
+  width: 100%;
+
+  @include respond-to('big') {
+    max-width: 640px;
+  }
 }


### PR DESCRIPTION
Because:
 - the alert bar extends beyond the width of the content and would
   overlap the Firefox Accounts heading

This commit:
 - matches the width of the alert bar to the content, thus reducing the
   potential overlaps

Note that this was not a bug; the alert bar has been styled that way
prior to the recent Subscription Platform changes.  Furthermore, there
will be follow-up changes to update the styles of the notifications.  In
other words, this change is likely fairly short-lived.


## Issue that this pull request solves

Closes: #7903


## Screenshots (Optional)

![image](https://user-images.githubusercontent.com/198055/112652400-61bd7700-8e1b-11eb-9735-865731c71c19.png)
