### PR TITLE
fix(l10n): Localize DropDownAvatarMenu and BentoMenu component

### DIFF
--- a/packages/fxa-content-server/tests/functional/settings_v2/display_name.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/display_name.js
@@ -17,6 +17,7 @@ const {
   getWebChannelMessageData,
   storeWebChannelMessageData,
   testElementTextEquals,
+  testElementTextInclude,
   type,
 } = FunctionalHelpers.helpersRemoteWrapped;
 const CHANGE_PROFILE_COMMAND = 'profile:change';
@@ -53,7 +54,7 @@ describe('display name', () => {
       selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.MENU_BUTTON,
       remote
     );
-    await testElementTextEquals(
+    await testElementTextInclude(
       selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.DISPLAY_NAME_LABEL,
       'Test User',
       remote
@@ -80,7 +81,7 @@ describe('display name', () => {
       selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.MENU_BUTTON,
       remote
     );
-    await testElementTextEquals(
+    await testElementTextInclude(
       selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.DISPLAY_NAME_LABEL,
       email,
       remote
@@ -115,7 +116,7 @@ describe('display name', () => {
       selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.MENU_BUTTON,
       remote
     );
-    await testElementTextEquals(
+    await testElementTextInclude(
       selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.DISPLAY_NAME_LABEL,
       'New User',
       remote
@@ -148,7 +149,7 @@ describe('display name', () => {
       selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.MENU_BUTTON,
       remote
     );
-    await testElementTextEquals(
+    await testElementTextInclude(
       selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.DISPLAY_NAME_LABEL,
       'Test User',
       remote
@@ -181,7 +182,7 @@ describe('display name', () => {
       selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.MENU_BUTTON,
       remote
     );
-    await testElementTextEquals(
+    await testElementTextInclude(
       selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.DISPLAY_NAME_LABEL,
       email,
       remote

--- a/packages/fxa-settings/src/components/App/en-US.ftl
+++ b/packages/fxa-settings/src/components/App/en-US.ftl
@@ -20,6 +20,7 @@
 # This is used to refer to a user's account, e.g. "update your Firefox account ..."
 -product-firefox-account = Firefox account
 product-mozilla-vpn = Mozilla VPN
+product-pocket = Pocket
 product-firefox-monitor = Firefox Monitor
 
 ##

--- a/packages/fxa-settings/src/components/BentoMenu/en-US.ftl
+++ b/packages/fxa-settings/src/components/BentoMenu/en-US.ftl
@@ -1,0 +1,12 @@
+# BentoMenu component
+
+bento-menu-title = { -brand-firefox } Bento Menu
+bento-menu-firefox-title = { -brand-firefox } is tech that fights for your online privacy.
+
+bento-menu-vpn = { product-mozilla-vpn }
+bento-menu-monitor = { product-firefox-monitor }
+bento-menu-pocket = { product-pocket }
+bento-menu-firefox-desktop = { -brand-firefox } Browser for Desktop
+bento-menu-firefox-mobile = { -brand-firefox } Browser for Mobile
+
+bento-menu-made-by-mozilla = Made by { -brand-mozilla }

--- a/packages/fxa-settings/src/components/BentoMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/BentoMenu/index.test.tsx
@@ -14,7 +14,7 @@ describe('BentoMenu', () => {
     const dropDownId = 'drop-down-bento-menu';
     const dropDown = screen.queryByTestId(dropDownId);
 
-    expect(toggleButton).toHaveAttribute('title', 'Firefox Bento Menu');
+    expect(toggleButton).toHaveAttribute('title', 'bento-menu-title');
     expect(toggleButton).toHaveAttribute('aria-controls', dropDownId);
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
     expect(dropDown).not.toBeInTheDocument;

--- a/packages/fxa-settings/src/components/BentoMenu/index.tsx
+++ b/packages/fxa-settings/src/components/BentoMenu/index.tsx
@@ -15,6 +15,7 @@ import mobileIcon from './mobile.svg';
 import vpnIcon from './vpn-logo.svg';
 import { ReactComponent as BentoIcon } from './bento.svg';
 import { ReactComponent as CloseIcon } from 'fxa-react/images/close.svg';
+import { Localized, useLocalization } from '@fluent/react';
 
 export const BentoMenu = () => {
   const [isRevealed, setRevealed] = useState(false);
@@ -24,13 +25,14 @@ export const BentoMenu = () => {
   useEscKeydownEffect(setRevealed);
   const dropDownId = 'drop-down-bento-menu';
   const iconClassNames = 'inline-block w-5 -mb-1 ltr:pr-1 rtl:pl-1';
+  const { l10n } = useLocalization();
 
   return (
     <div className="relative self-center flex" ref={bentoMenuInsideRef}>
       <button
         onClick={toggleRevealed}
         data-testid="drop-down-bento-menu-toggle"
-        title="Firefox Bento Menu"
+        title={l10n.getString('bento-menu-title')}
         aria-expanded={isRevealed}
         aria-controls={dropDownId}
         className="rounded p-1 w-7 mx-2 border-transparent hover:bg-grey-200 focus:outline-none transition-standard desktop:mx-8"
@@ -56,7 +58,9 @@ export const BentoMenu = () => {
               </button>
               <div className="mt-12 text-center p-8 pt-2 pb-2 mobileLandscape:mt-0">
                 <img src={firefoxIcon} alt="" className="my-2 mx-auto w-10" />
-                <h2>Firefox is tech that fights for your online privacy.</h2>
+                <Localized id="bento-menu-firefox-title">
+                  <h2>Firefox is tech that fights for your online privacy.</h2>
+                </Localized>
               </div>
               <div className="w-full text-xs mt-2">
                 <ul className="list-none">
@@ -69,7 +73,9 @@ export const BentoMenu = () => {
                       <div className={iconClassNames}>
                         <img src={monitorIcon} alt="" />
                       </div>
-                      Firefox Monitor
+                      <Localized id="bento-menu-monitor">
+                        Firefox Monitor
+                      </Localized>
                     </LinkExternal>
                   </li>
                   <li>
@@ -81,7 +87,7 @@ export const BentoMenu = () => {
                       <div className={iconClassNames}>
                         <img src={pocketIcon} alt="" />
                       </div>
-                      Pocket
+                      <Localized id="bento-menu-pocket">Pocket</Localized>
                     </LinkExternal>
                   </li>
                   <li>
@@ -93,7 +99,9 @@ export const BentoMenu = () => {
                       <div className={iconClassNames}>
                         <img src={desktopIcon} alt="" />
                       </div>
-                      Firefox Browser for Desktop
+                      <Localized id="bento-menu-firefox-desktop">
+                        Firefox Browser for Desktop
+                      </Localized>
                     </LinkExternal>
                   </li>
                   <li>
@@ -105,7 +113,9 @@ export const BentoMenu = () => {
                       <div className={iconClassNames}>
                         <img src={mobileIcon} alt="" />
                       </div>
-                      Firefox Browser for Mobile
+                      <Localized id="bento-menu-firefox-mobile">
+                        Firefox Browser for Mobile
+                      </Localized>
                     </LinkExternal>
                   </li>
                   <li>
@@ -117,18 +127,20 @@ export const BentoMenu = () => {
                       <div className={iconClassNames}>
                         <img src={vpnIcon} alt="" />
                       </div>
-                      Mozilla VPN
+                      <Localized id="bento-menu-vpn">Mozilla VPN</Localized>
                     </LinkExternal>
                   </li>
                 </ul>
               </div>
-              <LinkExternal
-                data-testid="mozilla-link"
-                className="link-blue text-xs w-full text-center block m-2 p-2 hover:bg-grey-100"
-                href="https://www.mozilla.org/"
-              >
-                Made by Mozilla
-              </LinkExternal>
+              <Localized id="bento-menu-made-by-mozilla">
+                <LinkExternal
+                  data-testid="mozilla-link"
+                  className="link-blue text-xs w-full text-center block m-2 p-2 hover:bg-grey-100"
+                  href="https://www.mozilla.org/"
+                >
+                  Made by Mozilla
+                </LinkExternal>
+              </Localized>
             </div>
           </div>
         </div>

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/en-US.ftl
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/en-US.ftl
@@ -1,0 +1,7 @@
+# DropDownAvatarMenu component
+
+drop-down-menu-title = Firefox Account Menu
+drop-down-menu-signed-in-as = Signed in as
+drop-down-menu-sign-out = Sign out
+
+drop-down-menu-sign-out-error = Sorry, there was a problem signing you out.

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/en-US.ftl
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/en-US.ftl
@@ -1,7 +1,10 @@
 # DropDownAvatarMenu component
 
-drop-down-menu-title = Firefox Account Menu
-drop-down-menu-signed-in-as = Signed in as
+drop-down-menu-title = { -product-firefox-account } menu
+# This string is used to show the current user's name or email in the settings page menu.
+# Variables:
+#   $user (String) - the user's name (or email address, if they haven't added their name to their account)
+drop-down-menu-signed-in-as = <signin>Signed in as</signin><user>{ $user }</user>
 drop-down-menu-sign-out = Sign out
 
 drop-down-menu-sign-out-error = Sorry, there was a problem signing you out.

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.test.tsx
@@ -56,7 +56,7 @@ describe('DropDownAvatarMenu', () => {
     const dropDownId = 'drop-down-avatar-menu';
     const dropDown = screen.queryByTestId(dropDownId);
 
-    expect(toggleButton).toHaveAttribute('title', 'Firefox Account Menu');
+    expect(toggleButton).toHaveAttribute('title', 'drop-down-menu-title');
     expect(toggleButton).toHaveAttribute('aria-controls', dropDownId);
     expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
     expect(dropDown).not.toBeInTheDocument;
@@ -159,7 +159,7 @@ describe('DropDownAvatarMenu', () => {
       });
 
       expect(screen.getByTestId('sign-out-error').textContent).toContain(
-        'Sorry, there was a problem signing you out.'
+        'drop-down-menu-sign-out-error'
       );
     });
   });

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
@@ -82,17 +82,29 @@ export const DropDownAvatarMenu = () => {
                 <div className="ltr:mr-3 rtl:ml-3 flex-none">
                   <Avatar className="w-10" />
                 </div>
-                <p className="leading-5 max-w-full truncate">
-                  <Localized id="drop-down-menu-signed-in-as">
+                <Localized
+                  id="drop-down-menu-signed-in-as"
+                  vars={{ user: displayName || primaryEmail.email }}
+                  elems={{
+                    user: (
+                      <span
+                        className="font-bold block truncate"
+                        data-testid="drop-down-name-or-email"
+                      ></span>
+                    ),
+                    signin: <span className="text-grey-400 text-xs"></span>,
+                  }}
+                >
+                  <p className="leading-5 max-w-full truncate">
                     <span className="text-grey-400 text-xs">Signed in as</span>
-                  </Localized>
-                  <span
-                    className="font-bold block truncate"
-                    data-testid="drop-down-name-or-email"
-                  >
-                    {displayName || primaryEmail.email}
-                  </span>
-                </p>
+                    <span
+                      className="font-bold block truncate"
+                      data-testid="drop-down-name-or-email"
+                    >
+                      {displayName || primaryEmail.email}
+                    </span>
+                  </p>
+                </Localized>
               </div>
               <div className="w-full">
                 <div className="bg-gradient-to-r from-blue-500 via-pink-700 to-yellow-500 h-px" />

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.tsx
@@ -12,6 +12,7 @@ import { useClickOutsideEffect } from 'fxa-react/lib/hooks';
 import { useEscKeydownEffect, useMutation, useAlertBar } from '../../lib/hooks';
 import { ReactComponent as SignOut } from './sign-out.svg';
 import { logViewEvent, settingsViewName } from 'fxa-settings/src/lib/metrics';
+import { Localized, useLocalization } from '@fluent/react';
 
 export const DESTROY_SESSION_MUTATION = gql`
   mutation destroySession($input: DestroySessionInput!) {
@@ -31,6 +32,7 @@ export const DropDownAvatarMenu = () => {
   useEscKeydownEffect(setRevealed);
   const alertBar = useAlertBar();
   const dropDownId = 'drop-down-avatar-menu';
+  const { l10n } = useLocalization();
 
   const [destroySession] = useMutation(DESTROY_SESSION_MUTATION, {
     onCompleted: () => {
@@ -40,7 +42,7 @@ export const DropDownAvatarMenu = () => {
       logViewEvent(settingsViewName, 'signout.success');
     },
     onError: (error) => {
-      alertBar.error('Sorry, there was a problem signing you out.', error);
+      alertBar.error(l10n.getString('drop-down-menu-sign-out-error'));
     },
   });
 
@@ -62,7 +64,7 @@ export const DropDownAvatarMenu = () => {
           type="button"
           onClick={toggleRevealed}
           data-testid="drop-down-avatar-menu-toggle"
-          title="Firefox Account Menu"
+          title={l10n.getString('drop-down-menu-title')}
           aria-expanded={isRevealed}
           aria-controls={dropDownId}
           className="rounded-full border-2 border-transparent hover:border-purple-500 focus:border-purple-500 focus:outline-none active:border-purple-700 transition-standard"
@@ -81,7 +83,9 @@ export const DropDownAvatarMenu = () => {
                   <Avatar className="w-10" />
                 </div>
                 <p className="leading-5 max-w-full truncate">
-                  <span className="text-grey-400 text-xs">Signed in as</span>
+                  <Localized id="drop-down-menu-signed-in-as">
+                    <span className="text-grey-400 text-xs">Signed in as</span>
+                  </Localized>
                   <span
                     className="font-bold block truncate"
                     data-testid="drop-down-name-or-email"
@@ -103,7 +107,9 @@ export const DropDownAvatarMenu = () => {
                       width="18"
                       className="ltr:mr-3 rtl:ml-3 inline-block stroke-current align-middle transform rtl:-scale-x-1"
                     />
-                    <span className="group-hover:underline">Sign out</span>
+                    <Localized id="drop-down-menu-sign-out">
+                      <span className="group-hover:underline">Sign out</span>
+                    </Localized>
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Because

- DropDownAvatarMenu and BentoMenu  were not localized

## This pull request

- Localizes them

## Issue that this pull request solves

Closes: #7939
Closes: #7938

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
