### PR TITLE
fix(auth-server): address processor running bugs

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal.ts
@@ -296,7 +296,7 @@ export class PayPalHelper {
       state: response.STATE,
       street: response.STREET,
       street2: response.STREET2,
-      zip: response.ZIP
+      zip: response.ZIP,
     };
   }
 
@@ -345,6 +345,10 @@ export class PayPalHelper {
     options: TransactionSearchOptions
   ): Promise<TransactionSearchResult[]> {
     const results = await this.client.transactionSearch(options);
+    if (!(results.L instanceof Array)) {
+      return [];
+    }
+
     return results.L.map((r) => ({
       amount: r.AMT,
       currencyCode: r.CURRENCYCODE,
@@ -461,6 +465,11 @@ export class PayPalHelper {
       if (err instanceof PayPalClientError && !batchProcessing) {
         throwPaypalCodeError(err);
       }
+      this.log.error('processInvoice', {
+        err,
+        nvpData: err.data,
+        invoiceId: invoice.id,
+      });
       throw err;
     }
     await this.stripeHelper.updatePaymentAttempts(invoice);

--- a/packages/fxa-auth-server/scripts/paypal-processor.ts
+++ b/packages/fxa-auth-server/scripts/paypal-processor.ts
@@ -7,7 +7,9 @@ import { StatsD } from 'hot-shots';
 import Container from 'typedi';
 
 import error from '../lib/error';
+import { CurrencyHelper } from '../lib/payments/currencies';
 import { PayPalHelper } from '../lib/payments/paypal';
+import { PayPalClient } from '../lib/payments/paypal-client';
 import { PaypalProcessor } from '../lib/payments/paypal-processor';
 import { StripeHelper } from '../lib/payments/stripe';
 import { configureSentry } from '../lib/sentry';
@@ -16,6 +18,22 @@ const pckg = require('../package.json');
 const config = require('../config').getProperties();
 
 export async function init() {
+  // Load program options
+  program
+    .version(pckg.version)
+    .option('-g, --grace [days]', 'Grace days to allow. Defaults to 1.', '1')
+    .option(
+      '-r, --retries [times]',
+      'Retry attempts to per day. Defaults to 1.',
+      '1'
+    )
+    .option(
+      '-i, --invoice-age [hours]',
+      'How old the invoice must be to get processed. Defaults to 6.',
+      '6'
+    )
+    .parse(process.argv);
+
   configureSentry(undefined, config);
   // Establish database connection and bind instance to Model using Knex
   setupAuthDatabase(config.database.mysql.auth);
@@ -66,23 +84,14 @@ export async function init() {
     process.exit(1);
   }
 
-  program
-    .version(pckg.version)
-    .option('-g, --grace [days]', 'Grace days to allow. Defaults to 1.', '1')
-    .option(
-      '-r, --retries [times]',
-      'Retry attempts to per day. Defaults to 1.',
-      '1'
-    )
-    .option(
-      '-i, --invoice-age [hours]',
-      'How old the invoice must be to get processed. Defaults to 6.',
-      '6'
-    )
-    .parse(process.argv);
-
+  const currencyHelper = new CurrencyHelper(config);
+  Container.set(CurrencyHelper, currencyHelper);
   const stripeHelper = new StripeHelper(log, config);
   Container.set(StripeHelper, stripeHelper);
+  const paypalClient = new PayPalClient(
+    config.subscriptions.paypalNvpSigCredentials
+  );
+  Container.set(PayPalClient, paypalClient);
   const paypalHelper = new PayPalHelper({ log });
   Container.set(PayPalHelper, paypalHelper);
 
@@ -91,7 +100,7 @@ export async function init() {
     config,
     parseInt(program.grace),
     parseInt(program.retries),
-    parseInt(program.invoice_age),
+    parseInt(program.invoiceAge),
     database,
     senders.email
   );
@@ -102,7 +111,7 @@ export async function init() {
 if (require.main === module) {
   init()
     .catch((err) => {
-      console.error(err.message);
+      console.error(err);
       process.exit(1);
     })
     .then((result) => process.exit(result));

--- a/packages/fxa-auth-server/test/local/payments/paypal-processor.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-processor.js
@@ -108,7 +108,7 @@ describe('PaypalProcessor', () => {
       );
       sinon.assert.calledOnceWithExactly(
         mockStripeHelper.cancelSubscription,
-        paidInvoice.subscription
+        paidInvoice.subscription.id
       );
     });
   });
@@ -611,9 +611,13 @@ describe('PaypalProcessor', () => {
         },
       });
       await processor.processInvoices();
-      sinon.assert.calledOnceWithExactly(mockLog.info, 'processInvoice', {
-        invoiceId: invoice.id,
-      });
+      sinon.assert.calledOnceWithExactly(
+        mockLog.info,
+        'processInvoice.processing',
+        {
+          invoiceId: invoice.id,
+        }
+      );
       sinon.assert.notCalled(mockLog.error);
     });
 
@@ -632,11 +636,16 @@ describe('PaypalProcessor', () => {
         await processor.processInvoices();
         assert.fail('Process invoicce should fail');
       } catch (err) {
-        sinon.assert.calledOnceWithExactly(mockLog.info, 'processInvoice', {
-          invoiceId: invoice.id,
-        });
+        sinon.assert.calledOnceWithExactly(
+          mockLog.info,
+          'processInvoice.processing',
+          {
+            invoiceId: invoice.id,
+          }
+        );
         sinon.assert.calledOnceWithExactly(mockLog.error, 'processInvoice', {
           err: throwErr,
+          nvpData: undefined,
           invoiceId: invoice.id,
         });
       }


### PR DESCRIPTION
Because:

* Multiple imports and config were not setup propertly.
* The seconds should be an integer, not a float when querying Stripe.
* If transaction results aren't found, then the attribute will not be
  present for mapping over.

This commit:

* Adds additional missing imports and configures paypal client objects
  as needed.
* Rounds the seconds to produce an integer for Stripe queries.
* Handles empty transaction results correctly.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
