### PR TITLE
fix(tests): fix and re-enable sign_up_with_code.js

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/views/mixins/signed-in-notification-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/signed-in-notification-mixin.js
@@ -57,7 +57,7 @@ describe('views/mixins/signed-in-notification-mixin', () => {
             return Promise.resolve();
           }),
         };
-        view.navigate = sinon.spy();
+        view.navigateAway = sinon.spy();
         notifier.triggerAll = sinon.spy();
         return notifier.on.args[0][1]({
           uid: 'uid',
@@ -80,13 +80,13 @@ describe('views/mixins/signed-in-notification-mixin', () => {
         assert.isTrue(view.user.setSignedInAccountByUid.calledWith('uid'));
       });
 
-      it('calls navigate correctly', () => {
-        assert.equal(view.navigate.callCount, 1);
-        assert.isTrue(view.navigate.alwaysCalledOn(view));
+      it('calls navigateAway correctly', () => {
+        assert.equal(view.navigateAway.callCount, 1);
+        assert.isTrue(view.navigateAway.alwaysCalledOn(view));
         assert.isTrue(
-          view.navigate.calledAfter(view.user.setSignedInAccountByUid)
+          view.navigateAway.calledAfter(view.user.setSignedInAccountByUid)
         );
-        const args = view.navigate.args[0];
+        const args = view.navigateAway.args[0];
         assert.lengthOf(args, 1);
         assert.equal(args[0], 'settings');
       });
@@ -108,7 +108,7 @@ describe('views/mixins/signed-in-notification-mixin', () => {
             return Promise.resolve();
           }),
         };
-        view.navigate = sinon.spy();
+        view.navigateAway = sinon.spy();
         notifier.on.args[0][1]({
           uid: 'uid',
         });
@@ -122,8 +122,8 @@ describe('views/mixins/signed-in-notification-mixin', () => {
         assert.isFalse(view.user.setSignedInAccountByUid.called);
       });
 
-      it('does not call navigate', () => {
-        assert.equal(view.navigate.callCount, 0);
+      it('does not call navigateAway', () => {
+        assert.equal(view.navigateAway.callCount, 0);
       });
     });
 
@@ -140,6 +140,7 @@ describe('views/mixins/signed-in-notification-mixin', () => {
           }),
         };
         view.navigate = sinon.spy();
+        view.navigateAway = sinon.spy();
       });
 
       describe('without relier.redirectTo', () => {
@@ -158,9 +159,9 @@ describe('views/mixins/signed-in-notification-mixin', () => {
           assert.isTrue(view.user.setSignedInAccountByUid.calledWith('uid'));
         });
 
-        it('calls navigate correctly', () => {
-          assert.equal(view.navigate.callCount, 1);
-          assert.equal(view.navigate.args[0][0], 'settings');
+        it('calls navigateAway correctly', () => {
+          assert.equal(view.navigateAway.callCount, 1);
+          assert.equal(view.navigateAway.args[0][0], 'settings');
         });
       });
 

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -90,5 +90,5 @@ module.exports = testsSettingsV2.concat([
 // Teamcity failing trying to run mocha tests, expose an environment
 // variable it can use to skip the mocha tests.
 if (!process.env.SKIP_MOCHA) {
-  //  module.exports.unshift('tests/functional/mocha.js');
+  module.exports.unshift('tests/functional/mocha.js');
 }

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -3,9 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // TODO: temporarily just run the smoke tests. See #7879.
-module.exports = require('./functional_smoke');
-
-/*
+module.exports = require('./functional_smoke').concat([
+  /*
 const testsSettingsV2 = require('./functional_settings_v2');
 // Run the new settings tests first
 module.exports = testsSettingsV2.concat([
@@ -13,7 +12,9 @@ module.exports = testsSettingsV2.concat([
   'tests/functional/oauth_webchannel.js',
   'tests/functional/reset_password.js',
   'tests/functional/oauth_require_totp.js',
+*/
   'tests/functional/sign_up_with_code.js',
+  /*
   // new and flaky tests above here',
   'tests/functional/404.js',
   'tests/functional/500.js',
@@ -81,6 +82,7 @@ module.exports = testsSettingsV2.concat([
   'tests/functional/sync_v3_settings.js',
   'tests/functional/tos.js',
   'tests/functional/verification_reminders.js',
+*/
 ]);
 
 // Mocha tests are only exposed during local dev, not on prod-like
@@ -88,6 +90,5 @@ module.exports = testsSettingsV2.concat([
 // Teamcity failing trying to run mocha tests, expose an environment
 // variable it can use to skip the mocha tests.
 if (!process.env.SKIP_MOCHA) {
-  module.exports.unshift('tests/functional/mocha.js');
+  //  module.exports.unshift('tests/functional/mocha.js');
 }
-*/

--- a/packages/fxa-content-server/tests/functional/sign_up_with_code.js
+++ b/packages/fxa-content-server/tests/functional/sign_up_with_code.js
@@ -71,7 +71,7 @@ registerSuite('signup with code', {
         .then(testElementExists(selectors.SETTINGS.HEADER))
         .then(testSuccessWasShown())
         .goBack()
-        .then(testAtConfirmScreen(email));
+        .then(testElementExists(selectors.SETTINGS.HEADER));
     },
 
     'invalid code': function () {


### PR DESCRIPTION
Hitting the back button at the end of this particular test flow leaves you at the settings page, not the confirm page.

Fixes #7991.
