### PR TITLE
fix(tests): correct error selector in cookies_disabled test

### DIFF
--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -24,7 +24,9 @@ module.exports = testsSettingsV2.concat([
   'tests/functional/change_password.js',
   'tests/functional/confirm.js',
   'tests/functional/connect_another_device.js',
+  */
   'tests/functional/cookies_disabled.js',
+  /*
   'tests/functional/delete_account.js',
   'tests/functional/email_domain_mx_validation.js',
   'tests/functional/email_opt_in.js',

--- a/packages/fxa-content-server/tests/functional/cookies_disabled.js
+++ b/packages/fxa-content-server/tests/functional/cookies_disabled.js
@@ -46,7 +46,7 @@ registerSuite('cookies_disabled', {
         .then(click(selectors.COOKIES_DISABLED.RETRY))
 
         // show an error message after second try
-        .then(testErrorWasShown())
+        .then(testErrorWasShown(null, '.error'))
     );
   },
 

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -2144,7 +2144,7 @@ function testSuccessWasNotShown(selector) {
  */
 function testErrorWasShown(message, selector) {
   selector = selector || selectors.SETTINGS.ERROR;
-  return testElementWasShown(selector);
+  return testElementWasShown(selector, message);
 }
 
 /**


### PR DESCRIPTION
Fixes #7980.

The error selector has been updated to the new-settings AlertBar, but sometimes we do hit an error on the sign in or sign up pages, as happened here. Might be worth extracting into lib/selectors?