### PR TITLE
fix(tests): get sign_in functional tests passing

### DIFF
--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -59,7 +59,7 @@ module.exports = testsSettingsV2.concat([
   'tests/functional/robots_txt.js',
   'tests/functional/security_events.js',
   'tests/functional/send_sms.js',
-  // #7985 'tests/functional/sign_in.js',
+  'tests/functional/sign_in.js',
   // #7982 'tests/functional/sign_in_blocked.js',
   'tests/functional/sign_in_cached.js',
   // #8049 'tests/functional/sign_in_recovery_code.js',

--- a/packages/fxa-content-server/tests/functional/sign_in.js
+++ b/packages/fxa-content-server/tests/functional/sign_in.js
@@ -160,9 +160,19 @@ registerSuite('signin', {
           .then(fillOutEmailFirstSignIn(email, PASSWORD))
 
           // success is seeing the header
-          .then(visibleByQSA(selectors.SETTINGS.HEADER))
           .then(testElementExists(selectors.SETTINGS.HEADER))
-          .then(click(selectors.SETTINGS.SIGNOUT, selectors.ENTER_EMAIL.HEADER))
+          .then(
+            click(
+              selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.MENU_BUTTON,
+              selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.SIGNOUT_BUTTON
+            )
+          )
+          .then(
+            click(
+              selectors.SETTINGS_V2.AVATAR_DROP_DOWN_MENU.SIGNOUT_BUTTON,
+              selectors.ENTER_EMAIL.HEADER
+            )
+          )
 
           // login as existing user
           .then(type(selectors.ENTER_EMAIL.EMAIL, email))
@@ -176,7 +186,7 @@ registerSuite('signin', {
           .then(click(selectors.SIGNIN.SUBMIT))
 
           // success is seeing the existing user logged in
-          .then(visibleByQSA(selectors.SETTINGS.HEADER))
+          .then(testElementExists(selectors.SETTINGS.HEADER))
       );
     },
 


### PR DESCRIPTION

## Because

- We want to get our functional tests passing

## This pull request

* Updated the sign out flow in one test

* Replaced a couple instances of querySelectorAll-based checks with
  testElementExists checks. Seems like using QSA while the browser is
  still navigating to the react settings app can trigger a crash in the
  webdriver session :-\


## Issue that this pull request solves

Fixes #7985.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
