### PR TITLE
fix(tests): re-enable all but the broken functional tests

### DIFF
--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -2,41 +2,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// TODO: temporarily just run the smoke tests. See #7879.
-module.exports = require('./functional_smoke').concat([
-  /*
 const testsSettingsV2 = require('./functional_settings_v2');
 // Run the new settings tests first
 module.exports = testsSettingsV2.concat([
   'tests/functional/fx_browser_relier.js',
-  'tests/functional/oauth_webchannel.js',
-  'tests/functional/reset_password.js',
+  // #7981 'tests/functional/oauth_webchannel.js',
+  // #7977 'tests/functional/reset_password.js',
   'tests/functional/oauth_require_totp.js',
-*/
   'tests/functional/sign_up_with_code.js',
-  /*
   // new and flaky tests above here',
   'tests/functional/404.js',
   'tests/functional/500.js',
-  'tests/functional/avatar.js',
+  // #7979 'tests/functional/avatar.js',
   'tests/functional/back_button_after_start.js',
   'tests/functional/bounced_email.js',
   'tests/functional/change_password.js',
-  'tests/functional/confirm.js',
+  // #7987 'tests/functional/confirm.js',
   'tests/functional/connect_another_device.js',
-  */
   'tests/functional/cookies_disabled.js',
-  /*
   'tests/functional/delete_account.js',
   'tests/functional/email_domain_mx_validation.js',
-  'tests/functional/email_opt_in.js',
+  // #7990 'tests/functional/email_opt_in.js',
   'tests/functional/email_service.js',
-  */
   'tests/functional/force_auth.js',
-  /*
-  'tests/functional/fx_desktop_handshake.js',
+  // #7978 'tests/functional/fx_desktop_handshake.js',
   'tests/functional/fx_fennec_v1_force_auth.js',
-  'tests/functional/fx_fennec_v1_settings.js',
+  // #8003 'tests/functional/fx_fennec_v1_settings.js',
   'tests/functional/fx_fennec_v1_sign_in.js',
   'tests/functional/fx_fennec_v1_sign_up.js',
   'tests/functional/fx_firstrun_v2.js',
@@ -45,14 +36,12 @@ module.exports = testsSettingsV2.concat([
   'tests/functional/legal.js',
   'tests/functional/oauth_force_auth.js',
   'tests/functional/oauth_handshake.js',
-  'tests/functional/oauth_permissions.js',
+  // #7983 'tests/functional/oauth_permissions.js',
   'tests/functional/oauth_prompt_none.js',
   'tests/functional/oauth_query_param_validation.js',
   'tests/functional/oauth_reset_password.js',
-  'tests/functional/oauth_settings_clients.js',
-  */
+  // #7989 'tests/functional/oauth_settings_clients.js',
   'tests/functional/oauth_sign_in.js',
-  /*
   'tests/functional/oauth_sign_in_token_code.js',
   'tests/functional/oauth_sign_up.js',
   'tests/functional/oauth_sync_sign_in.js',
@@ -70,12 +59,12 @@ module.exports = testsSettingsV2.concat([
   'tests/functional/robots_txt.js',
   'tests/functional/security_events.js',
   'tests/functional/send_sms.js',
-  'tests/functional/sign_in.js',
-  'tests/functional/sign_in_blocked.js',
+  // #7985 'tests/functional/sign_in.js',
+  // #7982 'tests/functional/sign_in_blocked.js',
   'tests/functional/sign_in_cached.js',
-  'tests/functional/sign_in_recovery_code.js',
+  // #8049 'tests/functional/sign_in_recovery_code.js',
   'tests/functional/sign_in_totp.js',
-  'tests/functional/sign_up.js',
+  // #7988 'tests/functional/sign_up.js',
   'tests/functional/subscriptions.js',
   'tests/functional/support.js',
   'tests/functional/sync_v1.js',
@@ -85,10 +74,9 @@ module.exports = testsSettingsV2.concat([
   'tests/functional/sync_v3_sign_up.js',
   'tests/functional/sync_v3_force_auth.js',
   'tests/functional/sync_v3_reset_password.js',
-  'tests/functional/sync_v3_settings.js',
+  // #7976 'tests/functional/sync_v3_settings.js',
   'tests/functional/tos.js',
   'tests/functional/verification_reminders.js',
-*/
 ]);
 
 // Mocha tests are only exposed during local dev, not on prod-like


### PR DESCRIPTION
* We have bugs filed for specific test failures, but most tests did pass
  in the test run. Let's just re-enable everything except the broken
  stuff.

* Since we are going back to a mostly-complete standard test run, also
  stop running the smoke tests in the main suite. 