### PR TITLE
fix(fxa-auth-server): change email template

### DIFF
--- a/packages/fxa-auth-server/lib/senders/templates/passwordChangeRequired.html
+++ b/packages/fxa-auth-server/lib/senders/templates/passwordChangeRequired.html
@@ -1,5 +1,6 @@
 <tr style="page-break-before: always">
   <td valign="top">
+    <h1 style="font-family: sans-serif; font-size: 21px; line-height: 29px; font-weight: normal; margin: 0 0 11px 0; text-align: center;">{{t "Password Change Required"}}</h1>
     <p class="primary" style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 24px 0 24px 0; text-align: left;">{{t "We detected suspicious behavior on your Firefox account. To prevent unauthorized access to your Firefox Account, we’ve disconnected all devices on your account and are requiring you to change your password as a precaution." }}
     </p>
   </td>
@@ -16,7 +17,7 @@
 
 <tr style="page-break-before: always">
   <td valign="top">
-    <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 0 0; text-align: left;">{{{t "<b>Important:</b> pick a different password than what you were previously using and make sure that it is different from your email account." }}}
+    <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 0 0; text-align: left;">{{{t "<b>Important:</b> Pick a different password than what you were previously using and make sure that it is different from your email account." }}}
     </p>
   </td>
 </tr>
@@ -30,7 +31,7 @@
 
 <tr style="page-break-before: always">
   <td valign="top">
-    <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 40px 0; text-align: left;">{{t "The Firefox accounts team"}}
+    <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0 0 40px 0; text-align: left;">{{t "The Firefox Accounts team"}}
     </p>
   </td>
 </tr>

--- a/packages/fxa-auth-server/lib/senders/templates/passwordChangeRequired.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/passwordChangeRequired.txt
@@ -1,8 +1,10 @@
+{{t "Password Change Required"}}
+
 {{{t "We detected suspicious behavior on your Firefox account. To prevent unauthorized access to your Firefox Account, we’ve disconnected all devices on your account and are requiring you to change your password as a precaution." }}}
 
 {{{t "Sign back into any device or service where you use your Firefox account and follow the steps that will be presented to you." }}}
 
-{{{t "Important: pick a different password than what you were previously using and make sure that it is different from your email account." }}}
+{{{t "Important: Pick a different password than what you were previously using and make sure that it is different from your email account." }}}
 
 {{{t "Best," }}}
 {{{t "The Firefox Accounts team" }}}


### PR DESCRIPTION
## This pull request

- Improves the styling of the email template (passwordChangeRequired)

## Issue that this pull request solves

Closes #8011

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

