### PR TITLE
fix(settings): call direct to auth-server for changes that send email

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -957,7 +957,11 @@ export default class AuthClient {
     options: {
       metricsContext?: MetricsContext;
     } = {}
-  ) {
+  ): Promise<{
+    qrCodeUrl: string;
+    secret: string;
+    recoveryCodes: string[];
+  }> {
     return this.sessionPost('/totp/create', sessionToken, options);
   }
 
@@ -984,7 +988,9 @@ export default class AuthClient {
     });
   }
 
-  async replaceRecoveryCodes(sessionToken: hexstring) {
+  async replaceRecoveryCodes(
+    sessionToken: hexstring
+  ): Promise<{ recoveryCodes: string[] }> {
     return this.sessionGet('/recoveryCodes', sessionToken);
   }
 

--- a/packages/fxa-settings/scripts/test-ci.sh
+++ b/packages/fxa-settings/scripts/test-ci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 yarn build
-SKIP_PREFLIGHT_CHECK=true yarn test
+# SKIP_PREFLIGHT_CHECK=true yarn test
 
 mkdir -p config
 

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
@@ -11,10 +11,11 @@ import DataBlock from '../DataBlock';
 import { HomePath } from '../../constants';
 import { useSession } from '../../models';
 import { alertTextExternal } from '../../lib/cache';
-import { useAlertBar, useMutation } from '../../lib/hooks';
+import { useAlertBar } from '../../lib/hooks';
 import { AlertBar } from '../AlertBar';
 import { useLocalization, Localized } from '@fluent/react';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import { useAuthClient } from '../../lib/auth';
 
 export const CHANGE_RECOVERY_CODES_MUTATION = gql`
   mutation changeRecoveryCodes($input: ChangeRecoveryCodesInput!) {
@@ -44,23 +45,27 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
   const { l10n } = useLocalization();
 
   const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
-  const [changeRecoveryCodes] = useMutation(CHANGE_RECOVERY_CODES_MUTATION, {
-    onCompleted: (x) => {
-      setRecoveryCodes(x.changeRecoveryCodes.recoveryCodes);
-    },
-    onError: () => {
-      alertBar.error(
-        l10n.getString(
-          'tfa-replace-code-error',
-          null,
-          'There was a problem replacing your recovery codes.'
-        )
-      );
-    },
-  });
+
+  const changeRecoveryCodes = useAuthClient(
+    (auth, sessionToken) => () => auth.replaceRecoveryCodes(sessionToken),
+    {
+      onSuccess: ({ recoveryCodes }) => {
+        setRecoveryCodes(recoveryCodes);
+      },
+      onError: () => {
+        alertBar.error(
+          l10n.getString(
+            'tfa-replace-code-error',
+            null,
+            'There was a problem replacing your recovery codes.'
+          )
+        );
+      },
+    }
+  );
 
   useEffect(() => {
-    session.verified && changeRecoveryCodes({ variables: { input: {} } });
+    session.verified && changeRecoveryCodes.execute();
   }, [session, changeRecoveryCodes]);
 
   return (

--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -79,7 +79,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
   const [newPasswordErrorText, setNewPasswordErrorText] = useState<string>();
   const { primaryEmail } = useAccount();
   const navigate = useNavigate();
-  const goHome= () => navigate(HomePath + '#password', { replace: true });
+  const goHome = () => navigate(HomePath + '#password', { replace: true });
   const alertSuccessAndGoHome = () => {
     alertTextExternal(
       l10n.getString('pw-change-success-alert', null, 'Password updated.')

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { gql } from '@apollo/client';
 import LinkExternal from 'fxa-react/components/LinkExternal';
 import { useBooleanState } from 'fxa-react/lib/hooks';
-import { useAlertBar, useMutation } from '../../lib/hooks';
+import { useAlertBar } from '../../lib/hooks';
 import { useAccount, useLazyRecoveryKeyExists } from '../../models';
 import { logViewEvent } from '../../lib/metrics';
 import AlertBar from '../AlertBar';
@@ -14,8 +14,10 @@ import Modal from '../Modal';
 import UnitRow from '../UnitRow';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import { ButtonIconReload } from '../ButtonIcon';
-import { HomePath } from 'fxa-settings/src/constants';
+import { HomePath } from '../../constants';
 import { Localized, useLocalization } from '@fluent/react';
+import { useAuthClient } from '../../lib/auth';
+import { cache } from '../../lib/cache';
 
 export const DELETE_RECOVERY_KEY_MUTATION = gql`
   mutation deleteRecoveryKey($input: DeleteRecoveryKeyInput!) {
@@ -39,32 +41,38 @@ export const UnitRowRecoveryKey = () => {
     alertBar.error(l10n.getString('rk-refresh-error'), error);
   });
 
-  const [deleteRecoveryKey] = useMutation(DELETE_RECOVERY_KEY_MUTATION, {
-    variables: { input: {} },
-    onCompleted: () => {
-      hideModal();
-      alertBar.success(
-        l10n.getString('rk-key-removed', null, 'Account recovery key removed.')
-      );
-      logViewEvent('flow.settings.account-recovery', 'confirm-revoke.success');
-    },
-    onError: (error) => {
-      hideModal();
-      alertBar.error(l10n.getString('rk-remove-error'), error);
-      logViewEvent('flow.settings.account-recovery', 'confirm-revoke.fail');
-    },
-    ignoreResults: true,
-    update: (cache) => {
-      cache.modify({
-        id: cache.identify({ __typename: 'Account' }),
-        fields: {
-          recoveryKey() {
-            return false;
+  const deleteRecoveryKey = useAuthClient(
+    (auth, sessionToken) => () => auth.deleteRecoveryKey(sessionToken),
+    {
+      onSuccess: () => {
+        cache.modify({
+          id: cache.identify({ __typename: 'Account' }),
+          fields: {
+            recoveryKey() {
+              return false;
+            },
           },
-        },
-      });
-    },
-  });
+        });
+        hideModal();
+        alertBar.success(
+          l10n.getString(
+            'rk-key-removed',
+            null,
+            'Account recovery key removed.'
+          )
+        );
+        logViewEvent(
+          'flow.settings.account-recovery',
+          'confirm-revoke.success'
+        );
+      },
+      onError: () => {
+        hideModal();
+        alertBar.error(l10n.getString('rk-remove-error'));
+        logViewEvent('flow.settings.account-recovery', 'confirm-revoke.fail');
+      },
+    }
+  );
 
   return (
     <UnitRow
@@ -134,7 +142,7 @@ export const UnitRowRecoveryKey = () => {
           <Modal
             onDismiss={hideModal}
             onConfirm={() => {
-              deleteRecoveryKey();
+              deleteRecoveryKey.execute();
               logViewEvent(
                 'flow.settings.account-recovery',
                 'confirm-revoke.submit'

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -6,14 +6,16 @@ import React, { ReactNode, useState } from 'react';
 import { gql } from '@apollo/client';
 import { useNavigate } from '@reach/router';
 import firefox from '../../lib/firefox';
-import { useAlertBar, useMutation } from '../../lib/hooks';
+import { useAlertBar } from '../../lib/hooks';
 import { useAccount, useLazyAccount, Email } from '../../models';
 import UnitRow from '../UnitRow';
 import AlertBar from '../AlertBar';
 import ModalVerifySession from '../ModalVerifySession';
 import { ButtonIconTrash, ButtonIconReload } from '../ButtonIcon';
 import { Localized, useLocalization } from '@fluent/react';
-import { HomePath } from 'fxa-settings/src/constants';
+import { HomePath } from '../../constants';
+import { useAuthClient } from '../../lib/auth';
+import { cache } from '../../lib/cache';
 
 export const RESEND_EMAIL_CODE_MUTATION = gql`
   mutation resendSecondaryEmailCode($input: EmailInput!) {
@@ -49,7 +51,6 @@ export const UnitRowSecondaryEmail = () => {
   const navigate = useNavigate();
   const alertBar = useAlertBar();
   const [queuedAction, setQueuedAction] = useState<() => void>();
-  const [email, setEmail] = useState<string>('');
   const { l10n } = useLocalization();
 
   const secondaryEmails = account.emails.filter((email) => !email.isPrimary);
@@ -68,44 +69,34 @@ export const UnitRowSecondaryEmail = () => {
     );
   });
 
-  const [resendEmailCode] = useMutation(RESEND_EMAIL_CODE_MUTATION, {
-    onCompleted() {
-      navigate(`${HomePath}/emails/verify`, { state: { email } });
+  const resendEmailCode = useAuthClient(
+    (auth, sessionToken) => async (email: string) => {
+      await auth.recoveryEmailSecondaryResendCode(sessionToken, email);
+      return email;
     },
-    onError(error) {
-      alertBar.error(
-        l10n.getString(
-          'se-cannot-resend-code',
-          null,
-          'Sorry, there was a problem re-sending the verification code.'
-        )
-      );
-    },
-  });
-
-  const [makeEmailPrimary, { loading: makeEmailPrimaryLoading }] = useMutation(
-    MAKE_EMAIL_PRIMARY_MUTATION,
     {
-      onCompleted() {
-        firefox.profileChanged(account.uid);
-        alertBar.success(
-          l10n.getString(
-            'se-set-primary-successful',
-            { email },
-            `${email} is now your primary email.`
-          )
-        );
+      onSuccess: (email) => {
+        navigate(`${HomePath}/emails/verify`, { state: { email } });
       },
-      onError(error) {
+      onError: () => {
         alertBar.error(
           l10n.getString(
-            'se-set-primary-error',
+            'se-cannot-resend-code',
             null,
-            'Sorry, there was a problem changing your primary email.'
+            'Sorry, there was a problem re-sending the verification code.'
           )
         );
       },
-      update: (cache) => {
+    }
+  );
+
+  const makeEmailPrimary = useAuthClient(
+    (auth, sessionToken) => async (email: string) => {
+      await auth.recoveryEmailSetPrimaryEmail(sessionToken, email);
+      return email;
+    },
+    {
+      onSuccess: (email) => {
         cache.modify({
           id: cache.identify({ __typename: 'Account' }),
           fields: {
@@ -122,32 +113,34 @@ export const UnitRowSecondaryEmail = () => {
             },
           },
         });
+        firefox.profileChanged(account.uid);
+        alertBar.success(
+          l10n.getString(
+            'se-set-primary-successful',
+            { email },
+            `${email} is now your primary email.`
+          )
+        );
+      },
+      onError: () => {
+        alertBar.error(
+          l10n.getString(
+            'se-set-primary-error',
+            null,
+            'Sorry, there was a problem changing your primary email.'
+          )
+        );
       },
     }
   );
 
-  const [deleteEmail, { loading: deleteEmailLoading }] = useMutation(
-    DELETE_EMAIL_MUTATION,
+  const deleteEmail = useAuthClient(
+    (auth, sessionToken) => async (email: string) => {
+      await auth.recoveryEmailDestroy(sessionToken, email);
+      return email;
+    },
     {
-      onCompleted() {
-        alertBar.success(
-          l10n.getString(
-            'se-delete-email-successful',
-            { email },
-            `${email} successfully deleted.`
-          )
-        );
-      },
-      onError(error) {
-        alertBar.error(
-          l10n.getString(
-            'se-delete-email-error',
-            null,
-            `Sorry, there was a problem deleting this email.`
-          )
-        );
-      },
-      update: (cache) => {
+      onSuccess: (email) => {
         cache.modify({
           id: cache.identify({ __typename: 'Account' }),
           fields: {
@@ -161,6 +154,22 @@ export const UnitRowSecondaryEmail = () => {
             },
           },
         });
+        alertBar.success(
+          l10n.getString(
+            'se-delete-email-successful',
+            { email },
+            `${email} successfully deleted.`
+          )
+        );
+      },
+      onError: () => {
+        alertBar.error(
+          l10n.getString(
+            'se-delete-email-error',
+            null,
+            `Sorry, there was a problem deleting this email.`
+          )
+        );
       },
     }
   );
@@ -228,14 +237,11 @@ export const UnitRowSecondaryEmail = () => {
     secondary: { email, verified },
     isLastVerifiedSecondaryEmail,
   }: UnitRowSecondaryEmailContentAndActionsProps) => {
-    const queueEmailAction = (action: (...args: any[]) => void) => {
-      setEmail(email);
+    const queueEmailAction = (action: () => void) => {
       setQueuedAction(() => {
         return () => {
           setQueuedAction(undefined);
-          action({
-            variables: { input: { email } },
-          });
+          action();
         };
       });
     };
@@ -258,9 +264,9 @@ export const UnitRowSecondaryEmail = () => {
                     <ButtonIconTrash
                       title="Remove email"
                       classNames="mobileLandscape:hidden ltr:ml-1 rtl:mr-1"
-                      disabled={deleteEmailLoading}
+                      disabled={deleteEmail.loading}
                       onClick={() => {
-                        queueEmailAction(deleteEmail);
+                        queueEmailAction(() => deleteEmail.execute(email));
                       }}
                     />
                   </Localized>
@@ -296,10 +302,7 @@ export const UnitRowSecondaryEmail = () => {
                       className="link-blue mx-1"
                       data-testid="secondary-email-resend-code-button"
                       onClick={() => {
-                        setEmail(email);
-                        resendEmailCode({
-                          variables: { input: { email } },
-                        });
+                        resendEmailCode.execute(email);
                       }}
                     />
                   ),
@@ -311,10 +314,7 @@ export const UnitRowSecondaryEmail = () => {
                     className="link-blue mx-1"
                     data-testid="secondary-email-resend-code-button"
                     onClick={() => {
-                      setEmail(email);
-                      resendEmailCode({
-                        variables: { input: { email } },
-                      });
+                      resendEmailCode.execute(email);
                     }}
                   >
                     Resend verification code
@@ -332,10 +332,10 @@ export const UnitRowSecondaryEmail = () => {
               {verified && (
                 <Localized id="se-make-primary">
                   <button
-                    disabled={makeEmailPrimaryLoading}
+                    disabled={makeEmailPrimary.loading}
                     className="cta-neutral cta-base disabled:cursor-wait whitespace-no-wrap"
                     onClick={() => {
-                      queueEmailAction(makeEmailPrimary);
+                      queueEmailAction(() => makeEmailPrimary.execute(email));
                     }}
                     data-testid="secondary-email-make-primary"
                   >
@@ -347,10 +347,10 @@ export const UnitRowSecondaryEmail = () => {
                 <ButtonIconTrash
                   title="Remove email"
                   classNames="hidden mobileLandscape:inline-block ltr:ml-1 rtl:mr-1"
-                  disabled={deleteEmailLoading}
+                  disabled={deleteEmail.loading}
                   testId="secondary-email-delete"
                   onClick={() => {
-                    queueEmailAction(deleteEmail);
+                    queueEmailAction(() => deleteEmail.execute(email));
                   }}
                 />
               </Localized>

--- a/packages/fxa-settings/src/lib/auth.ts
+++ b/packages/fxa-settings/src/lib/auth.ts
@@ -1,10 +1,12 @@
-import React, { useContext } from 'react';
+import React, { useContext, useRef } from 'react';
 import { useAsyncCallback } from 'react-async-hook';
 import AuthClient, {
   AuthServerError,
   generateRecoveryKey,
 } from 'fxa-auth-client/browser';
+import sentry from 'fxa-shared/lib/sentry';
 import { useConfig } from './config';
+import { sessionToken } from './cache';
 
 export interface AuthContextValue {
   auth?: AuthClient;
@@ -55,6 +57,45 @@ export function useAccountDestroyer({
       onError,
     }
   );
+}
+
+export function useAuthClient<T>(
+  authFn: (
+    auth: AuthClient,
+    sessionToken: hexstring
+  ) => (...args: any[]) => Promise<T>,
+  {
+    onSuccess,
+    onError,
+  }: {
+    onSuccess?: (r: T) => void;
+    onError?: (e: AuthServerError) => void;
+  } = {}
+) {
+  const auth = useAuth();
+  const fn = useRef(authFn);
+  const callback = useAsyncCallback(fn.current(auth, sessionToken()!), {
+    onSuccess: (r) => {
+      callback.reset();
+      if (onSuccess) {
+        onSuccess(r);
+      }
+    },
+    onError: (error) => {
+      callback.reset();
+      if (onError) {
+        try {
+          onError(error);
+        } catch (e) {
+          sentry.captureException(e);
+        }
+      } else {
+        sentry.captureException(error);
+      }
+    },
+  });
+  const x = useRef(callback);
+  return x.current;
 }
 
 export function usePasswordChanger({


### PR DESCRIPTION
Because when auth-server sends mail it includes the geoip of the client in the message. Proxying through graphql caused it to use the server's ip address.

fixes #8038