### PR TITLE
fix(fxa-auth-server): Change "Setup" to "Set up" in postVerify email template 

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1299,7 +1299,7 @@ module.exports = function (log, config) {
     );
     const query = {};
 
-    const action = gettext('Setup next device');
+    const action = gettext('Set up next device');
 
     const links = this._generateLinks(
       this.syncUrl,

--- a/packages/fxa-auth-server/lib/senders/templates/postVerify.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/postVerify.txt
@@ -4,7 +4,7 @@
 
 {{t "Sync privately keeps your bookmarks, passwords and other Firefox data the same across all your devices." }}
 
-{{t "Setup next device"}}
+{{t "Set up next device"}}
 {{{ link }}}
 
 {{> automatedEmailNoAction}}


### PR DESCRIPTION
## Because

- 

## This pull request

- Changes "Setup" to "Set up"

## Issue that this pull request solves

Fixes #8012 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
