### PR TITLE
fix(fxa-settings): add background in menu category

### DIFF
--- a/packages/fxa-react/configs/tailwind.js
+++ b/packages/fxa-react/configs/tailwind.js
@@ -149,7 +149,7 @@ module.exports = {
       white: '#fff',
       grey: {
         10: '#FAFAFB',
-        50: '#F9F9FA',
+        50: '#F0F0F4',
         100: '#E7E7E7',
         200: '#C2C2C2',
         300: '#9E9E9E',

--- a/packages/fxa-settings/src/components/Nav/index.tsx
+++ b/packages/fxa-settings/src/components/Nav/index.tsx
@@ -21,7 +21,7 @@ export const Nav = () => {
       primaryEmail
     )}`;
 
-  const activeClasses = 'font-bold text-blue-500 rounded-sm';
+  const activeClasses = 'font-bold text-blue-500 rounded-sm bg-grey-50';
   return (
     <nav
       className="font-header fixed bg-white w-full inset-0 mt-18 ltr:mr-24 rtl:ml-24 desktop:mt-11 desktop:static desktop:bg-transparent text-xl desktop:text-base"


### PR DESCRIPTION
## Because

* Indicates current user's location

## This pull request

* Adds grey background for blue category text
* Changes padding of that category

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/7757

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

