### PR TITLE
Release 1.203.3

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,13 +22,13 @@ bini11
 Brandon Ebersohl
 Brian Warner
 byrw
+César Carruitero
 championshuttler
 Chris Heilmann
 Chris Karlof
 Christian Murphy
 ckarlof
 Cronus1007
-César Carruitero
 Dan Callahan
 Danny Amey
 Danny Coates

--- a/packages/fxa-admin-panel/CHANGELOG.md
+++ b/packages/fxa-admin-panel/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.203.3
+
+No changes.
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-panel",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "description": "FxA Admin Panel",
   "scripts": {
     "build-postcss": "postcss src/styles/tailwind.css -o src/styles/tailwind.out.css",

--- a/packages/fxa-admin-server/CHANGELOG.md
+++ b/packages/fxa-admin-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.203.3
+
+No changes.
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-server",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "description": "FxA GraphQL Admin Server",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/fxa-auth-db-mysql/CHANGELOG.md
+++ b/packages/fxa-auth-db-mysql/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.203.3
+
+No changes.
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-auth-db-mysql/package.json
+++ b/packages/fxa-auth-db-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-db-mysql",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "description": "MySQL backend for Firefox Accounts",
   "main": "index.js",
   "repository": {

--- a/packages/fxa-auth-server/CHANGELOG.md
+++ b/packages/fxa-auth-server/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.203.3
+
+### New features
+
+- fxa-payments-server: add paypal to subscription management ([1379ec958](https://github.com/mozilla/fxa/commit/1379ec958))
+
+### Bug fixes
+
+- auth-server: address processor running bugs ([335ba82a0](https://github.com/mozilla/fxa/commit/335ba82a0))
+- codes: Fix issue where user could not login if they have low recovery codes ([a3dcbd7ad](https://github.com/mozilla/fxa/commit/a3dcbd7ad))
+
 ## 1.203.2
 
 ### Bug fixes

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "description": "Firefox Accounts, an identity provider for Mozilla cloud services",
   "bin": {
     "fxa-auth": "./bin/key_server.js"

--- a/packages/fxa-content-server/CHANGELOG.md
+++ b/packages/fxa-content-server/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.203.3
+
+### Bug fixes
+
+- codes: Fix issue where user could not login if they have low recovery codes ([a3dcbd7ad](https://github.com/mozilla/fxa/commit/a3dcbd7ad))
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "description": "Firefox Accounts Content Server",
   "scripts": {
     "build": "tsc --build ../fxa-react && NODE_ENV=production grunt build",

--- a/packages/fxa-customs-server/CHANGELOG.md
+++ b/packages/fxa-customs-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.203.3
+
+No changes.
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-customs-server",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "description": "Firefox Accounts Customs Server",
   "author": "Mozilla (https://mozilla.org/)",
   "license": "MPL-2.0",

--- a/packages/fxa-email-event-proxy/package.json
+++ b/packages/fxa-email-event-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-email-event-proxy",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "description": "Proxies events from Sendgrid to FxA SQS queues",
   "main": "index.js",
   "scripts": {

--- a/packages/fxa-email-service/CHANGELOG.md
+++ b/packages/fxa-email-service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.203.3
+
+No changes.
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-email-service/Cargo.lock
+++ b/packages/fxa-email-service/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "fxa_email_service"
-version = "1.203.2"
+version = "1.203.3"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/packages/fxa-email-service/Cargo.toml
+++ b/packages/fxa-email-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fxa_email_service"
-version = "1.203.2"
+version = "1.203.3"
 publish = false
 edition = "2018"
 

--- a/packages/fxa-event-broker/CHANGELOG.md
+++ b/packages/fxa-event-broker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.203.3
+
+No changes.
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-event-broker",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "description": "Firefox Accounts Event Broker",
   "scripts": {
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",

--- a/packages/fxa-geodb/CHANGELOG.md
+++ b/packages/fxa-geodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.203.3
+
+No changes.
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-geodb",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "description": "Firefox Accounts GeoDB Repo for Geolocation based services",
   "main": "lib/fxa-geodb.js",
   "directories": {

--- a/packages/fxa-graphql-api/CHANGELOG.md
+++ b/packages/fxa-graphql-api/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.203.3
+
+No changes.
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-graphql-api",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "description": "FxA GraphQL API",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/fxa-payments-server/CHANGELOG.md
+++ b/packages/fxa-payments-server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change history
 
+## 1.203.3
+
+### New features
+
+- fxa-payments-server: add paypal to subscription management ([1379ec958](https://github.com/mozilla/fxa/commit/1379ec958))
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-payments-server",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "description": "Firefox Accounts Payments Service",
   "scripts": {
     "postinstall": "../../_scripts/clone-l10n.sh fxa-payments-server",

--- a/packages/fxa-profile-server/CHANGELOG.md
+++ b/packages/fxa-profile-server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.203.3
+
+No changes.
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-profile-server",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "private": true,
   "description": "Firefox Accounts Profile service.",
   "scripts": {

--- a/packages/fxa-react/CHANGELOG.md
+++ b/packages/fxa-react/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.203.3
+
+No changes.
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-react",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "description": "Shared components for FxA React Apps",
   "exports": {
     "./components/": "./dist/components/",

--- a/packages/fxa-settings/CHANGELOG.md
+++ b/packages/fxa-settings/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.203.3
+
+### Bug fixes
+
+- settings: call direct to auth-server for changes that send email ([df2ee530b](https://github.com/mozilla/fxa/commit/df2ee530b))
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-settings",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "homepage": "https://accounts.firefox.com/settings",
   "private": true,
   "scripts": {

--- a/packages/fxa-shared/CHANGELOG.md
+++ b/packages/fxa-shared/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.203.3
+
+No changes.
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "description": "Shared module for FxA repositories",
   "main": "dist/index.js",
   "exports": {

--- a/packages/fxa-support-panel/CHANGELOG.md
+++ b/packages/fxa-support-panel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history
 
+## 1.203.3
+
+No changes.
+
 ## 1.203.2
 
 No changes.

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-support-panel",
-  "version": "1.203.2",
+  "version": "1.203.3",
   "description": "Small app to help customer support access FxA details",
   "directories": {
     "test": "test"


### PR DESCRIPTION
The 203.3 train contained only commits that had already been merged into main, so after resolving conflicts (a `LoadingSpinner` import in `packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx`), the only bit that lands into main is the changelog commit.