### PR TITLE
feat(payments): Add processing screen for PayPal invalid billing agre…

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -26,6 +26,11 @@ import { AuthLogger, AuthRequest } from '../../types';
 import { splitCapabilities } from '../utils/subscriptions';
 import validators from '../validators';
 import { handleAuth, ThenArg } from './utils';
+import { PaypalPaymentError } from 'fxa-shared/subscriptions/types';
+import {
+  PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,
+  PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE,
+} from 'fxa-shared/subscriptions/types';
 
 /**
  * Delete any metadata keys prefixed by `capabilities:` before
@@ -43,8 +48,6 @@ export function sanitizePlans(plans: AbbrevPlan[]) {
     return plan;
   });
 }
-
-export type PaypalPaymentError = 'missing_agreement' | 'funding_source';
 
 type PaymentBillingDetails = ReturnType<
   StripeHandler['extractBillingDetails']
@@ -386,9 +389,9 @@ export class StripeHandler {
       this.stripeHelper.hasSubscriptionRequiringPaymentMethod(customer)
     ) {
       if (!this.stripeHelper.getCustomerPaypalAgreement(customer)) {
-        billingDetails.paypal_payment_error = 'missing_agreement';
+        billingDetails.paypal_payment_error = PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT;
       } else if (this.stripeHelper.hasOpenInvoice(customer)) {
-        billingDetails.paypal_payment_error = 'funding_source';
+        billingDetails.paypal_payment_error = PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE;
       }
     }
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -13,6 +13,10 @@ const mocks = require('../../../mocks');
 const error = require('../../../../lib/error');
 const { StripeHelper } = require('../../../../lib/payments/stripe');
 const { CurrencyHelper } = require('../../../../lib/payments/currencies');
+const {
+  PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,
+  PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE,
+} = require('fxa-shared/subscriptions/types');
 const WError = require('verror').WError;
 const uuidv4 = require('uuid').v4;
 
@@ -1403,7 +1407,10 @@ describe('DirectStripeRoutes', () => {
             VALID_REQUEST
           );
           assert.strictEqual(actual.payment_provider, 'paypal');
-          assert.strictEqual(actual.paypal_payment_error, 'missing_agreement');
+          assert.strictEqual(
+            actual.paypal_payment_error,
+            PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT
+          );
           sinon.assert.calledOnceWithExactly(
             directStripeRoutesInstance.stripeHelper
               .hasSubscriptionRequiringPaymentMethod,
@@ -1437,7 +1444,10 @@ describe('DirectStripeRoutes', () => {
             VALID_REQUEST
           );
           assert.strictEqual(actual.payment_provider, 'paypal');
-          assert.strictEqual(actual.paypal_payment_error, 'funding_source');
+          assert.strictEqual(
+            actual.paypal_payment_error,
+            PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE
+          );
           sinon.assert.calledOnceWithExactly(
             directStripeRoutesInstance.stripeHelper
               .hasSubscriptionRequiringPaymentMethod,

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -308,8 +308,9 @@ sub-customer-error =
   .title = Problem loading customer
 sub-billing-update-success = Your billing information has been updated successfully
 sub-route-payment-modal-heading = Invalid billing information
-sub-route-payment-modal-copy = There seems to be an error with your Paypal account, we need you to take the necessary steps to resolve this payment issue.
-sub-route-invalid-payment = Invalid payment information, there is an error with your account. <div>Manage</div>
+sub-route-payment-modal-message = There seems to be an error with your { -brand-name-paypal } account, we need you to take the necessary steps to resolve this payment issue.
+sub-route-missing-billing-agreement-payment-alert = Invalid payment information; there is an error with your account. <div>Manage</div>
+sub-route-funding-source-payment-alert = Invalid payment information; there is an error with your account. This alert may take some time to clear after you successfully update your information. <div>Manage</div>
 pay-update-manage-btn = Manage
 
 ## subscription create

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -316,6 +316,11 @@ export const MOCK_PAYPAL_SUBSCRIPTION_RESULT = {
   subscription: { what: 'ever' },
 };
 
+export const MOCK_PAYPAL_CUSTOMER_RESULT = {
+  invoice_settings: {},
+  subscriptions: [{ what: 'ever' }],
+};
+
 export const STRIPE_FIELDS = [
   'cardNumberElement',
   'cardCVCElement',

--- a/packages/fxa-payments-server/src/routes/Subscriptions/ActionButton.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/ActionButton.test.tsx
@@ -6,6 +6,10 @@ import ActionButton, { ActionButtonProps } from './ActionButton';
 import { CUSTOMER } from '../../lib/mock-data';
 import { PickPartial } from '../../lib/types';
 import { defaultConfig } from '../../lib/config';
+import {
+  PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE,
+  PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,
+} from 'fxa-shared/subscriptions/types';
 
 const { apiUrl } = defaultConfig().paypal;
 
@@ -65,7 +69,7 @@ describe('routes/Subscriptions/ActionButton', () => {
         customer={{
           ...CUSTOMER,
           payment_provider: 'paypal',
-          paypal_payment_error: 'funding_source',
+          paypal_payment_error: PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE,
         }}
       />
     );
@@ -84,7 +88,7 @@ describe('routes/Subscriptions/ActionButton', () => {
         customer={{
           ...CUSTOMER,
           payment_provider: 'paypal',
-          paypal_payment_error: 'missing_agreement',
+          paypal_payment_error: PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,
           billing_agreement_id: '',
         }}
       />

--- a/packages/fxa-payments-server/src/routes/Subscriptions/ActionButton.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/ActionButton.tsx
@@ -10,6 +10,10 @@ import AppContext from '../../lib/AppContext';
 
 import * as PaymentProvider from '../../lib/PaymentProvider';
 import { lastEventId } from '@sentry/browser';
+import {
+  PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE,
+  PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,
+} from 'fxa-shared/subscriptions/types';
 
 export type ActionButtonProps = {
   customer: Customer;
@@ -93,10 +97,10 @@ export const ActionButton = ({
       return stripeActionButton();
     }
     switch (paypal_payment_error) {
-      case 'missing_agreement': {
+      case PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT: {
         return paypalMissingAgreementActionButton();
       }
-      case 'funding_source': {
+      case PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE: {
         return paypalFundingSourceActionButton();
       }
       default: {

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
@@ -11,14 +11,20 @@ import '@testing-library/jest-dom/extend-expect';
 import waitForExpect from 'wait-for-expect';
 
 import PaymentUpdateForm, { PaymentUpdateFormProps } from './PaymentUpdateForm';
+import { ButtonBaseProps } from '../../components/PayPalButton';
 import {
   mockStripeElementOnChangeFns,
   elementChangeResponse,
+  MOCK_PAYPAL_CUSTOMER_RESULT,
 } from '../../lib/test-utils';
 import { CUSTOMER, FILTERED_SETUP_INTENT, PLAN } from '../../lib/mock-data';
 
 import { PickPartial } from '../../lib/types';
-import { defaultConfig } from '../../lib/config';
+import { defaultConfig, updateConfig } from '../../lib/config';
+import {
+  PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE,
+  PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,
+} from 'fxa-shared/subscriptions/types';
 
 const { apiUrl } = defaultConfig().paypal;
 
@@ -41,6 +47,7 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
     refreshSubscriptions = jest.fn(),
     setUpdatePaymentIsSuccess = jest.fn(),
     resetUpdatePaymentIsSuccess = jest.fn(),
+    ...props
   }: SubjectProps) => {
     return (
       <PaymentUpdateForm
@@ -53,6 +60,7 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
           paymentErrorInitialState,
           stripeOverride,
           apiClientOverrides,
+          ...props,
         }}
       />
     );
@@ -107,16 +115,43 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
     ).toEqual(`${apiUrl}/myaccount/autopay/connect/ba-131243`);
   });
 
-  it('renders correctly for missing billing agreement for paypal', async () => {
-    render(
-      <Subject
-        customer={{
-          ...CUSTOMER,
-          payment_provider: 'paypal',
-          paypal_payment_error: 'missing_agreement',
-        }}
-      />
-    );
+  it('renders correctly for missing billing agreement for paypal with successful POST to update the agreement', async () => {
+    const apiClientOverrides = {
+      ...defaultApiClientOverrides(),
+      apiUpdateBillingAgreement: jest
+        .fn()
+        .mockResolvedValue(MOCK_PAYPAL_CUSTOMER_RESULT),
+    };
+
+    const refreshSubscriptions = jest.fn();
+
+    const MockedButtonBase = ({ onApprove }: ButtonBaseProps) => {
+      return <button data-testid="paypal-button" onClick={onApprove} />;
+    };
+
+    updateConfig({
+      featureFlags: {
+        usePaypalUIByDefault: true,
+      },
+    });
+
+    await act(async () => {
+      render(
+        <Subject
+          {...{
+            customer: {
+              ...CUSTOMER,
+              payment_provider: 'paypal',
+              paypal_payment_error: PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,
+            },
+            apiClientOverrides,
+            refreshSubscriptions,
+            paypalButtonBase: MockedButtonBase,
+          }}
+        />
+      );
+    });
+
     expect(
       screen.queryAllByTestId('reveal-payment-modal-button').length
     ).toEqual(2);
@@ -130,6 +165,84 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
     await waitForExpect(() =>
       expect(screen.queryByTestId('billing-info-modal')).toBeInTheDocument()
     );
+
+    const paypalButton = screen.getByTestId('paypal-button');
+    await waitForExpect(() => expect(paypalButton).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(paypalButton);
+    });
+    const loadingOverlay = screen.getByTestId('loading-overlay');
+    expect(loadingOverlay).toBeInTheDocument();
+    expect(apiClientOverrides.apiUpdateBillingAgreement).toHaveBeenCalledTimes(
+      1
+    );
+    expect(refreshSubscriptions).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders correctly for missing billing agreement for paypal with failed POST to update the agreement', async () => {
+    const apiClientOverrides = {
+      ...defaultApiClientOverrides(),
+      apiUpdateBillingAgreement: jest
+        .fn()
+        .mockRejectedValue('barf apiUpdateBillingAgreement'),
+    };
+
+    const refreshSubscriptions = jest.fn();
+
+    const MockedButtonBase = ({ onApprove }: ButtonBaseProps) => {
+      return <button data-testid="paypal-button" onClick={onApprove} />;
+    };
+
+    updateConfig({
+      featureFlags: {
+        usePaypalUIByDefault: true,
+      },
+    });
+
+    await act(async () => {
+      render(
+        <Subject
+          {...{
+            customer: {
+              ...CUSTOMER,
+              payment_provider: 'paypal',
+              paypal_payment_error: PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,
+            },
+            apiClientOverrides,
+            refreshSubscriptions,
+            paypalButtonBase: MockedButtonBase,
+          }}
+        />
+      );
+    });
+
+    expect(
+      screen.queryAllByTestId('reveal-payment-modal-button').length
+    ).toEqual(2);
+
+    await act(async () => {
+      fireEvent.click(
+        screen.queryAllByTestId('reveal-payment-modal-button')[0]
+      );
+    });
+
+    await waitForExpect(() =>
+      expect(screen.queryByTestId('billing-info-modal')).toBeInTheDocument()
+    );
+
+    const paypalButton = screen.getByTestId('paypal-button');
+    await waitForExpect(() => expect(paypalButton).toBeInTheDocument());
+
+    await act(async () => {
+      fireEvent.click(paypalButton);
+    });
+    const loadingOverlay = screen.getByTestId('loading-overlay');
+    expect(loadingOverlay).toBeInTheDocument();
+    expect(apiClientOverrides.apiUpdateBillingAgreement).toHaveBeenCalledTimes(
+      1
+    );
+    expect(refreshSubscriptions).toHaveBeenCalledTimes(1);
   });
 
   it('renders correctly for incorrect funding source for paypal', async () => {
@@ -138,7 +251,7 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
         customer={{
           ...CUSTOMER,
           payment_provider: 'paypal',
-          paypal_payment_error: 'funding_source',
+          paypal_payment_error: PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE,
         }}
       />
     );

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.scss
@@ -150,7 +150,6 @@
 
       a {
         color: inherit;
-        font-size: inherit;
         text-decoration: inherit;
       }
 

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -1,3 +1,4 @@
+import { PaypalPaymentError } from 'fxa-shared/subscriptions/types';
 import { ProviderType } from '../lib/PaymentProvider';
 
 export type {
@@ -78,7 +79,7 @@ export type Customer = {
   last4?: string;
   payment_provider?: ProviderType;
   payment_type?: string;
-  paypal_payment_error?: string;
+  paypal_payment_error?: PaypalPaymentError;
   subscriptions: Array<CustomerSubscription>;
 };
 

--- a/packages/fxa-shared/subscriptions/metadata.ts
+++ b/packages/fxa-shared/subscriptions/metadata.ts
@@ -1,6 +1,7 @@
 import {
   Plan,
   RawMetadata,
+  PaypalPaymentError,
   ProductMetadata,
   ProductDetails,
   ProductDetailsStringProperties,

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -98,3 +98,9 @@ export type AccountSubscription = Pick<
     >;
     subscription_id: Stripe.Subscription['id'];
   };
+
+export const PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT = 'missing_agreement';
+export const PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE = 'funding_source';
+export type PaypalPaymentError =
+  | typeof PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT
+  | typeof PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE;


### PR DESCRIPTION
…ement modal

## Because

- If a subscriber cancels their billing agreement in PayPal, they have to reauthorize recurring payments to keep their subscription active.
- This requires [creating a new billing agreement and some other processing on the back-end](https://github.com/mozilla/fxa/blob/38834e96445ce64a33afcdd8738a96e65fe792d7/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts#L359-L378), so we should indicate to the user that this processing is taking place and whether it completed successfully or not.

## This pull request

- Adds a processing screen after the user successfully reauthorizes payment in PayPal for a subscription in the `PaymentUpdateForm` component of the Subscription Management page.
- Refreshes the page when processing is complete.
- Updates the `AlertBar` error message for funding source problems, since that error won't clear until the next time we run the [PayPal Processor script](https://github.com/mozilla/fxa/blob/38834e96445ce64a33afcdd8738a96e65fe792d7/packages/fxa-auth-server/scripts/paypal-processor.ts) (currently 1x/hour) and fixes a comma splice and incorrect localization ID for the original message.
- Makes the font size of the "Change" `ActionButton` the same size as the other buttons on the page.

## Issue that this pull request solves

Closes: #7945 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Screenshot_2021-03-31 Firefox Accounts](https://user-images.githubusercontent.com/17437436/113244981-aada5480-927b-11eb-8e7b-2c78ff7cf51c.png)
 
For the funding source error alert message, I added an extra sentence to inform the subscriber that the error may not clear immediately after they fix the problem in PayPal:

Before:
> Invalid payment information, there is an error with your account.

After:
> Invalid payment information; there is an error with your account. This alert may take some time to clear after you successfully update your information.

@jess-cook03: Does this message seem acceptable to you? Note: I _thought_ #7903 was going to handle the overlap onto the header (CC @chenba ), but that issue is closed, so it may need to be a separate follow-up here.
