### PR TITLE
fix(fxa-settings): make eye behavior for password consistent

### DIFF
--- a/packages/fxa-settings/src/components/InputPassword/index.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/index.tsx
@@ -55,8 +55,8 @@ export const InputPassword = ({
       <button
         type="button"
         data-testid={formatDataTestId('visibility-toggle')}
-        className={`w-5 px-3 py-2 text-grey-600 focus:text-blue-500 box-content ${
-          hasContent ? '-ml-3' : 'hidden'
+        className={`px-3 py-2 text-grey-600 box-content ${
+          !hasContent && 'hidden'
         }`}
         tabIndex={-1}
         onClick={() => {

--- a/packages/fxa-settings/src/components/InputText/index.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.tsx
@@ -83,7 +83,7 @@ export const InputText = ({
       ${disabled ? 'border-grey-100 bg-grey-10' : 'bg-white'} ${className}`}
       data-testid={formatDataTestId('input-container')}
     >
-      <span className="block relative flex-auto">
+      <span className="block flex-auto">
         <span
           className={classNames(
             'px-3 w-full cursor-text absolute text-sm origin-top-left transition-all duration-100 ease-in-out truncate font-body',


### PR DESCRIPTION
## Because

- To make the interface consistent

## This pull request

- Makes eye icon focus behavior consistent with Sign in page


## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/8025

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

