### PR TITLE
fix(tests): re-enable reset_password test

### DIFF
--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -7,7 +7,7 @@ const testsSettingsV2 = require('./functional_settings_v2');
 module.exports = testsSettingsV2.concat([
   'tests/functional/fx_browser_relier.js',
   // #7981 'tests/functional/oauth_webchannel.js',
-  // #7977 'tests/functional/reset_password.js',
+  'tests/functional/reset_password.js',
   'tests/functional/oauth_require_totp.js',
   'tests/functional/sign_up_with_code.js',
   // new and flaky tests above here',


### PR DESCRIPTION
This passes locally for me, not sure if there is a bug here.

Closes #7977.
