### PR TITLE
fix(tests): update selectors in oauth_permissions tests

### DIFF
--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -36,7 +36,7 @@ module.exports = testsSettingsV2.concat([
   'tests/functional/legal.js',
   'tests/functional/oauth_force_auth.js',
   'tests/functional/oauth_handshake.js',
-  // #7983 'tests/functional/oauth_permissions.js',
+  'tests/functional/oauth_permissions.js',
   'tests/functional/oauth_prompt_none.js',
   'tests/functional/oauth_query_param_validation.js',
   'tests/functional/oauth_reset_password.js',

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -645,9 +645,10 @@ module.exports = {
       SETTINGS_V2.DELETE_ACCOUNT.TOOLTIP_INCORRECT_PASSWORD, // 'input[type=password] ~ .tooltip',
   },
   SETTINGS_DISPLAY_NAME: {
-    INPUT_DISPLAY_NAME: '#display-name input[type=text]',
-    MENU_BUTTON: '#display-name button.settings-unit-toggle',
-    SUBMIT: '#display-name button[type=submit]',
+    INPUT_LABEL_DISPLAY_NAME: SETTINGS_V2.DISPLAY_NAME.TEXTBOX_LABEL,
+    INPUT_DISPLAY_NAME: SETTINGS_V2.DISPLAY_NAME.TEXTBOX_FIELD, // '#display-name input[type=text]',
+    MENU_BUTTON: SETTINGS_V2.DISPLAY_NAME.ADD_BUTTON, // '#display-name button.settings-unit-toggle',
+    SUBMIT: SETTINGS_V2.DISPLAY_NAME.SUBMIT_BUTTON, // '#display-name button[type=submit]',
   },
   SIGNIN: {
     EMAIL: 'input[type=email]',

--- a/packages/fxa-content-server/tests/functional/oauth_permissions.js
+++ b/packages/fxa-content-server/tests/functional/oauth_permissions.js
@@ -23,7 +23,6 @@ let email;
 
 const {
   click,
-  closeCurrentWindow,
   createEmail,
   createUser,
   fillOutForceAuth,
@@ -35,8 +34,6 @@ const {
   openFxaFromRp: openFxaFromTrustedRp,
   openFxaFromUntrustedRp,
   openPage,
-  openSettingsInNewTab,
-  switchToWindow,
   testElementExists,
   testUrlEquals,
   type,
@@ -181,6 +178,7 @@ registerSuite('oauth permissions for untrusted reliers', {
       );
     },
 
+    /* TODO: This test is dependent on the fix in #8281
     'signin with new permission available b/c of new account information': function () {
       return (
         this.remote
@@ -240,6 +238,7 @@ registerSuite('oauth permissions for untrusted reliers', {
           )
       );
     },
+    */
 
     'signin with additional requested permission': function () {
       return (
@@ -250,6 +249,7 @@ registerSuite('oauth permissions for untrusted reliers', {
 
           // make display_name available from the start
           .then(click(selectors.SETTINGS_DISPLAY_NAME.MENU_BUTTON))
+          .then(click(selectors.SETTINGS_DISPLAY_NAME.INPUT_LABEL_DISPLAY_NAME))
           .then(
             type(
               selectors.SETTINGS_DISPLAY_NAME.INPUT_DISPLAY_NAME,
@@ -315,6 +315,7 @@ registerSuite('oauth permissions for untrusted reliers', {
 
           // make display_name available from the start
           .then(click(selectors.SETTINGS_DISPLAY_NAME.MENU_BUTTON))
+          .then(click(selectors.SETTINGS_DISPLAY_NAME.INPUT_LABEL_DISPLAY_NAME))
           .then(
             type(
               selectors.SETTINGS_DISPLAY_NAME.INPUT_DISPLAY_NAME,


### PR DESCRIPTION
Fixes 2 of 3 broken tests in #7983.

The remaining broken test is ` oauth permissions for untrusted reliers - signin with new permission available b/c of new account information`, moved into followup bug #8281.