### PR TITLE
fix(Settings): Add correct 'Replacing your recovery codes' 2FA link

### DIFF
--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.tsx
@@ -183,7 +183,7 @@ export const UnitRowTwoStepAuth = () => {
                 linkExternal: (
                   <LinkExternal
                     className="link-blue"
-                    href="https://support.mozilla.org/en-US/kb/reset-your-firefox-account-password-recovery-keys"
+                    href="https://support.mozilla.org/en-US/kb/changing-your-two-step-authentication-device-firefox-account"
                   >
                     {' '}
                   </LinkExternal>


### PR DESCRIPTION
## Because

-

## This pull request

- Adds the correct redirection link for when the user clicks on 'Replacing your recovery codes' 2FA link in the Security section of Settings page

## Issue that this pull request solves

Closes: #8092 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

![image](https://user-images.githubusercontent.com/37609519/113412256-6fec3400-93d5-11eb-9c5f-a079ac5d44d9.png)


## Other information (Optional)

Any other information that is important to this pull request.
