### PR TITLE
style (fxa-settings): change border of red buttons on focus from none…

### DIFF
--- a/packages/fxa-react/configs/tailwind.js
+++ b/packages/fxa-react/configs/tailwind.js
@@ -84,6 +84,9 @@ module.exports = {
         '30': '0.3',
         '40': '0.4',
       },
+      outline: {
+        'black-dotted': '1px dotted #000',
+      },
     },
     screens: {
       mobileLandscape: '480px',

--- a/packages/fxa-settings/src/styles/ctas.scss
+++ b/packages/fxa-settings/src/styles/ctas.scss
@@ -48,7 +48,7 @@
   }
 
   &:focus {
-    @apply border-0;
+    @apply border-transparent;
   }
 
   &:disabled {

--- a/packages/fxa-settings/src/styles/ctas.scss
+++ b/packages/fxa-settings/src/styles/ctas.scss
@@ -48,7 +48,7 @@
   }
 
   &:focus {
-    @apply border-transparent outline-black-dotted;;
+    @apply border-transparent outline-black-dotted;
   }
 
   &:disabled {

--- a/packages/fxa-settings/src/styles/ctas.scss
+++ b/packages/fxa-settings/src/styles/ctas.scss
@@ -48,7 +48,7 @@
   }
 
   &:focus {
-    @apply border-transparent;
+    @apply border-transparent outline-black-dotted;;
   }
 
   &:disabled {


### PR DESCRIPTION
## Because

- Two red buttons in profile dashboard: Disable two-step-authentication and Delete Account would lose their borders on focus.

## This pull request

- Add transparent borders to buttons on focus so whole design on the page doesn't move
- Add dotted outline to buttons on focus

## Issue that this pull request solves

- Closes: [7970](https://github.com/mozilla/fxa/issues/7970#issue-841181979)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)


https://user-images.githubusercontent.com/76935202/113506620-3825ed80-9589-11eb-84c7-df6329dd3937.mov


https://user-images.githubusercontent.com/76935202/113654847-18eba500-96dc-11eb-85b8-b6f1c1bbbe80.mov



## Other information (Optional)


