### PR TITLE
fixed modal padding

### DIFF
--- a/packages/fxa-settings/src/components/Modal/index.tsx
+++ b/packages/fxa-settings/src/components/Modal/index.tsx
@@ -76,7 +76,7 @@ export const Modal = ({
             </button>
           </div>
 
-          <div className="px-4 tablet:px-10 pb-10">
+          <div className="px-6 tablet:px-10 pb-10">
             <div>{children}</div>
             {hasButtons && (
               <div className="flex justify-center mx-auto mt-6 max-w-64">


### PR DESCRIPTION
## Because

- To fix the padding on Remove Recovery Key Modal
 
## This pull request

- Deletes the previous padding from body of recovery model.
- Adds padding to the modal container.  px-6 tablet:px-10
- Proper padding appears on all devices when checked with dev tools.

## Issue that this pull request solves

Closes: #7762

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
![Screenshot from 2021-04-05 18-41-19](https://user-images.githubusercontent.com/69427216/113578313-3c611200-9640-11eb-98cd-da841fbe3022.png)


## Other information (Optional)

Any other information that is important to this pull request.
