### PR TITLE
feat(email): add a pre-header option to email template

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -647,6 +647,7 @@ module.exports = function (log, config) {
         subject,
         supportLinkAttributes: links.supportLinkAttributes,
         supportUrl: links.supportUrl,
+        preHeader: 'Copy/paste this code into your registration form.',
       },
     });
   };

--- a/packages/fxa-auth-server/lib/senders/templates/layouts/fxa.html
+++ b/packages/fxa-auth-server/lib/senders/templates/layouts/fxa.html
@@ -7,6 +7,17 @@
   </head>
 
   <body style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; margin: 0; padding: 0;">
+    {{#if preHeader}}
+      <div style="display: none; width: 0; height: 0; max-height: 0; line-height: 0; overflow: hidden;">
+        {{preHeader}}
+
+        &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+        &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+        &nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+        ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;
+        ‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌&nbsp;‌‌‌
+      </div>
+    {{/if}}
     <table
      align="center"
      border="0"


### PR DESCRIPTION
## Because

- Registration email pre-header is not very informative.

## This pull request

- Add a pre-header option to email template.
- Use the pre-header in the verify short code email. 

## Issue that this pull request solves

Closes: #7973

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Captura de Tela 2021-04-05 às 17 45 51](https://user-images.githubusercontent.com/42356378/113593525-d1f7a400-9636-11eb-992f-cae8dba38ec3.png)


## Other information (Optional)

Hey folks, I have some questions about the changes. 

1. I didn't change the `.txt` file, because I didn't know if it was necessary. 
2. Should I add pre-headers in other emails? 
3. I was reading in this [blog post](https://www.activecampaign.com/blog/email-preheader) about pre-headers and it says it is good if the pre-header has 40-130 characters long. 
Should I add validation around this? 

Cheers! 