### PR TITLE
feat(subscriptions): create subscriptions for existing PayPal customer

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -105,6 +105,8 @@ const ERRNO = {
   ECOSYSTEM_ANON_ID_UPDATE_CONFLICT: 190,
   ECOSYSTEM_ANON_ID_NO_CONDITION: 191,
   BILLING_AGREEMENT_EXISTS: 192,
+  MISSING_PAYPAL_PAYMENT_TOKEN: 193,
+  MISSING_PAYPAL_BILLING_AGREEMENT: 194,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -694,6 +696,34 @@ AppError.billingAgreementExists = (customerId) => {
       error: 'Bad Request',
       errno: ERRNO.BILLING_AGREEMENT_EXISTS,
       message: `Billing agreement already on file for this customer.`,
+    },
+    {
+      customerId,
+    }
+  );
+};
+
+AppError.missingPaypalPaymentToken = (customerId) => {
+  return new AppError(
+    {
+      code: 400,
+      error: 'Bad Request',
+      errno: ERRNO.MISSING_PAYPAL_PAYMENT_TOKEN,
+      message: `PayPal payment token is missing.`,
+    },
+    {
+      customerId,
+    }
+  );
+};
+
+AppError.missingPaypalBillingAgreement = (customerId) => {
+  return new AppError(
+    {
+      code: 400,
+      error: 'Bad Request',
+      errno: ERRNO.MISSING_PAYPAL_BILLING_AGREEMENT,
+      message: `PayPal billing agreement is missing for the existing subscriber.`,
     },
     {
       customerId,

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -11,6 +11,7 @@ import {
   updatePayPalBA,
 } from 'fxa-shared/db/models/auth';
 import { AbbrevPlan, AbbrevProduct } from 'fxa-shared/dist/subscriptions/types';
+import { ACTIVE_SUBSCRIPTION_STATUSES } from 'fxa-shared/subscriptions/stripe';
 import { StatsD } from 'hot-shots';
 import ioredis from 'ioredis';
 import moment from 'moment';
@@ -41,13 +42,6 @@ export enum STRIPE_INVOICE_METADATA {
   EMAIL_SENT = 'emailSent',
   RETRY_ATTEMPTS = 'paymentAttempts',
 }
-
-/** Represents all subscription statuses that are considered active for a customer */
-export const ACTIVE_SUBSCRIPTION_STATUSES: Stripe.Subscription['status'][] = [
-  'active',
-  'past_due',
-  'trialing',
-];
 
 const VALID_RESOURCE_TYPES = [
   CUSTOMER_RESOURCE,

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -6,6 +6,7 @@ import isA from '@hapi/joi';
 import { AbbrevPlan } from 'fxa-shared/dist/subscriptions/types';
 import { metadataFromPlan } from 'fxa-shared/subscriptions/metadata';
 import {
+  ACTIVE_SUBSCRIPTION_STATUSES,
   DeepPartial,
   filterCustomer,
   filterIntent,
@@ -18,10 +19,7 @@ import { Stripe } from 'stripe';
 
 import { ConfigType } from '../../../config';
 import error from '../../error';
-import {
-  StripeHelper,
-  ACTIVE_SUBSCRIPTION_STATUSES,
-} from '../../payments/stripe';
+import { StripeHelper } from '../../payments/stripe';
 import { AuthLogger, AuthRequest } from '../../types';
 import { splitCapabilities } from '../utils/subscriptions';
 import validators from '../validators';

--- a/packages/fxa-shared/subscriptions/stripe.ts
+++ b/packages/fxa-shared/subscriptions/stripe.ts
@@ -9,6 +9,13 @@ export type DeepPartial<T> = {
   [P in keyof T]?: DeepPartial<T[P]>;
 };
 
+/** Represents all subscription statuses that are considered active for a customer */
+export const ACTIVE_SUBSCRIPTION_STATUSES: Stripe.Subscription['status'][] = [
+  'active',
+  'past_due',
+  'trialing',
+];
+
 /**
  * Filter a customer for client-safe attributes.
  *
@@ -164,3 +171,10 @@ export function filterIntent<
     'status'
   );
 }
+
+export const hasPaypalSubscription = (customer: Stripe.Customer) =>
+  customer.subscriptions?.data.some(
+    (sub) =>
+      ACTIVE_SUBSCRIPTION_STATUSES.includes(sub.status) &&
+      sub.collection_method === 'send_invoice'
+  );


### PR DESCRIPTION
Because:
 - a customer using PayPal as the payment provider should be able to
   subscribe to more than one product

This commit:
 - update the API to allow the frontend to create a new subscription
   without creating a PayPal billing agreement first

This commit maintains the same API surface and branches on the now
optional PayPal payment token request payload value to
`/oauth/subscriptions/active/new-paypal`.


## Issue that this pull request solves

Closes: #7589 
