### PR TITLE
fix(fxa-settings): make "Save" button stable

### DIFF
--- a/packages/fxa-react/configs/tailwind.js
+++ b/packages/fxa-react/configs/tailwind.js
@@ -52,6 +52,7 @@ module.exports = {
         tablet: '768px',
         desktop: '1024px',
         desktopXl: '1441px',
+        32: '8rem',
         48: '12rem',
         64: '16rem',
       },

--- a/packages/fxa-settings/src/components/PageAvatar/buttons.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/buttons.tsx
@@ -171,7 +171,7 @@ export const ConfirmBtns = ({
     <div className="mt-4 flex items-center justify-center">
       <Localized id="avatar-page-close-button">
         <button
-          className="cta-neutral mx-2 px-10"
+          className="cta-neutral mx-2 px-10 w-full max-w-32"
           onClick={() => navigate(HomePath, { replace: true })}
           data-testid="close-button"
         >
@@ -180,7 +180,7 @@ export const ConfirmBtns = ({
       </Localized>
       <Localized id={saveStringId}>
         <button
-          className="cta-primary mx-2 px-10"
+          className="cta-primary mx-2 px-10 w-full max-w-32"
           onClick={onSave}
           disabled={!saveEnabled}
           data-testid="save-button"


### PR DESCRIPTION
## Because

-"Save" button changed its size during the saving process

## This pull request

-Removes strict padding
-Adds specific width

## Issue that this pull request solves

Closes:  https://github.com/mozilla/fxa/issues/7702

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

