### PR TITLE
RFC: settings refactor

### DIFF
--- a/packages/fxa-settings/src/components/PageChangePassword/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.test.tsx
@@ -6,7 +6,6 @@ import 'mutationobserver-shim';
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { act, fireEvent, screen, wait } from '@testing-library/react';
-import { AuthContext, createAuthClient } from '../../lib/auth';
 import { HomePath } from '../../constants';
 import { MockedCache, renderWithRouter } from '../../models/_mocks';
 import PageChangePassword from '.';
@@ -16,17 +15,9 @@ import {
   usePageViewEvent,
 } from '../../lib/metrics';
 import { typeByTestIdFn } from '../../lib/test-utils';
+import { AccountContext, Account } from '../../models';
 
-jest.mock('../../lib/auth', () => ({
-  ...jest.requireActual('../../lib/auth'),
-  usePasswordChanger: jest
-    .fn()
-    .mockImplementation(({ onSuccess, onError }) => ({
-      execute: () => onSuccess({ sessionToken: 'FFFF' }),
-      reset: () => {},
-    })),
-}));
-jest.mock('fxa-settings/src/lib/metrics', () => ({
+jest.mock('../../lib/metrics', () => ({
   usePageViewEvent: jest.fn(),
   logViewEvent: jest.fn(),
   settingsViewName: 'quuz',
@@ -37,15 +28,18 @@ jest.mock('@reach/router', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-const client = createAuthClient('none');
+const account = ({
+  primaryEmail: {
+    email: 'test@example.com',
+  },
+  changePassword: jest.fn().mockResolvedValue(true),
+} as unknown) as Account;
 
 const render = async () => {
   await renderWithRouter(
-    <AuthContext.Provider value={{ auth: client }}>
-      <MockedCache>
-        <PageChangePassword />
-      </MockedCache>
-    </AuthContext.Provider>
+    <AccountContext.Provider value={{ account }}>
+      <PageChangePassword />
+    </AccountContext.Provider>
   );
 };
 

--- a/packages/fxa-settings/src/index.tsx
+++ b/packages/fxa-settings/src/index.tsx
@@ -8,12 +8,12 @@ import { ApolloProvider, gql } from '@apollo/client';
 import AppErrorBoundary from 'fxa-react/components/AppErrorBoundary';
 import sentryMetrics from 'fxa-shared/lib/sentry';
 import App from './components/App';
-import { AuthContext, createAuthClient } from './lib/auth';
+import { createAuthClient } from './lib/auth';
 import config, { readConfigMeta, ConfigContext } from './lib/config';
 import firefox, { FirefoxCommand } from './lib/firefox';
 import { createApolloClient } from './lib/gql';
 import { searchParams } from './lib/utilities';
-import { GET_PROFILE_INFO } from './models';
+import { Account, AccountContext, GET_PROFILE_INFO } from './models';
 import './index.scss';
 
 try {
@@ -24,6 +24,7 @@ try {
   sentryMetrics.configure(config.sentry.dsn, config.version);
   const authClient = createAuthClient(config.servers.auth.url);
   const apolloClient = createApolloClient(config.servers.gql.url);
+  const account = new Account(authClient, apolloClient);
   const flowQueryParams = searchParams(
     window.location.search
   ) as FlowQueryParams;
@@ -78,7 +79,7 @@ try {
   render(
     <React.StrictMode>
       <ApolloProvider client={apolloClient}>
-        <AuthContext.Provider value={{ auth: authClient }}>
+        <AccountContext.Provider value={{ account }}>
           <ConfigContext.Provider value={config}>
             <AppErrorBoundary>
               <App
@@ -89,7 +90,7 @@ try {
               />
             </AppErrorBoundary>
           </ConfigContext.Provider>
-        </AuthContext.Provider>
+        </AccountContext.Provider>
       </ApolloProvider>
     </React.StrictMode>,
     document.getElementById('root')


### PR DESCRIPTION
I noticed while working on #8055 that we do a lot of our "heavy lifting" from within the react components, which so far has been _fine_, but doing so makes them less resilient to low level changes and testing them is heavy because of how much needs to be mocked.

I present a sketch for how we could push down that work to a lower level so that the component can be lighter and more resistant to changes like #8055 in the future.

The idea is that the `Account` class exposes an api that components can easily call / mock, while internally handling the server calls, cache updates, etc. So instead of a component using apollo or authClient and passing in data from Account, it just calls a function, like `account.changePassword(...)`. All we'll need in components is `useAccount`.

This will eliminate the need for `MockedCache` in tests, instead just mocking the parts of Account in use via an `AccountContext.Provider`

As for "why now?"... I broke a lot of the component tests with #8055 and I need to fix those anyway, so I'd rather do it like this than kick the can down the road. It'll be a big diff but not much more work than is required anyway.
