### PR TITLE
fix(fxa-settings): add focus effect to Bento icon

### DIFF
--- a/packages/fxa-settings/src/components/BentoMenu/index.tsx
+++ b/packages/fxa-settings/src/components/BentoMenu/index.tsx
@@ -35,7 +35,7 @@ export const BentoMenu = () => {
         title={l10n.getString('bento-menu-title')}
         aria-expanded={isRevealed}
         aria-controls={dropDownId}
-        className="rounded p-1 w-7 mx-2 border-transparent hover:bg-grey-200 focus:outline-none transition-standard desktop:mx-8"
+        className="rounded p-1 w-7 mx-2 border-transparent hover:bg-grey-200 transition-standard desktop:mx-8"
       >
         <BentoIcon className="cursor-pointer" />
       </button>


### PR DESCRIPTION
## Because

- Needed to add a focus effect on the Bento icon

## This pull request

- Adds the focus effect

## Issue that this pull request solves

Closes: #7706

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

![Screenshot from 2021-04-06 13-50-51](https://user-images.githubusercontent.com/40818234/113681511-a977b480-96df-11eb-863a-1484a7b2be01.png)
