### PR TITLE
fix(auth): flip true/false value for errors on PayPal request metrics.

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal.ts
@@ -178,7 +178,7 @@ export class PayPalHelper {
       this.client.on('response', (response) => {
         this.metrics.timing('paypal_request', response.elapsed, undefined, {
           method: response.method,
-          error: response.error ? 'false' : 'true',
+          error: response.error ? 'true' : 'false',
         });
       });
     }


### PR DESCRIPTION
## Because

- PayPal requests that result in errors need to be correctly tagged for metrics/alerting.

## This pull request

- Correctly sets the `error` type for the response timing metric to be `true` when there is an error in the PayPal response.

## Issue that this pull request solves

Closes: # No issue on file

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
