### PR TITLE
fix(fxa-settings): Change close button to cancel in delete account step 1

### DIFF
--- a/packages/fxa-settings/src/components/PageDeleteAccount/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/en-US.ftl
@@ -19,7 +19,7 @@ delete-account-chk-box-3 =
 delete-account-chk-box-4 =
  .label = Any extensions and themes that you published to addons.mozilla.org will be deleted
 
-delete-account-close-button = Close
+
 delete-account-continue-button = Continue
 
 delete-account-password-input =

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.test.tsx
@@ -46,7 +46,7 @@ describe('PageDeleteAccount', () => {
     expect(screen.getByTestId('delete-account-confirm').textContent).toContain(
       'deleting your account'
     );
-    expect(screen.getByTestId('close-button').textContent).toContain('Close');
+    expect(screen.getByTestId('cancel-button').textContent).toContain('Cancel');
     expect(screen.getByTestId('continue-button').textContent).toContain(
       'Continue'
     );

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.test.tsx
@@ -2,109 +2,109 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import 'mutationobserver-shim';
-import React from 'react';
-import { screen, fireEvent, act } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
-import { AuthContext, createAuthClient } from '../../lib/auth';
-import { MockedCache, renderWithRouter } from '../../models/_mocks';
-import { PageDeleteAccount } from '.';
-import { typeByTestIdFn } from '../../lib/test-utils';
+ import 'mutationobserver-shim';
+ import React from 'react';
+ import { screen, fireEvent, act } from '@testing-library/react';
+ import '@testing-library/jest-dom/extend-expect';
+ import { AuthContext, createAuthClient } from '../../lib/auth';
+ import { MockedCache, renderWithRouter } from '../../models/_mocks';
+ import { PageDeleteAccount } from '.';
+ import { typeByTestIdFn } from '../../lib/test-utils';
 
-jest.mock('../../lib/auth', () => ({
-  ...jest.requireActual('../../lib/auth'),
-  useAccountDestroyer: jest
-    .fn()
-    .mockImplementation(({ onSuccess, onError }) => ({
-      execute: () => onSuccess(),
-      reset: () => {},
-    })),
-}));
+ jest.mock('../../lib/auth', () => ({
+   ...jest.requireActual('../../lib/auth'),
+   useAccountDestroyer: jest
+     .fn()
+     .mockImplementation(({ onSuccess, onError }) => ({
+       execute: () => onSuccess(),
+       reset: () => {},
+     })),
+ }));
 
-const client = createAuthClient('none');
-window.URL.createObjectURL = jest.fn();
+ const client = createAuthClient('none');
+ window.URL.createObjectURL = jest.fn();
 
-const advanceStep = async () => {
-  await act(async () => {
-    const inputs = screen.getAllByTestId('checkbox-input');
-    inputs.forEach((el) => fireEvent.click(el));
-    const continueBtn = await screen.findByTestId('continue-button');
-    fireEvent.click(continueBtn);
-  });
-};
+ const advanceStep = async () => {
+   await act(async () => {
+     const inputs = screen.getAllByTestId('checkbox-input');
+     inputs.forEach((el) => fireEvent.click(el));
+     const continueBtn = await screen.findByTestId('continue-button');
+     fireEvent.click(continueBtn);
+   });
+ };
 
-describe('PageDeleteAccount', () => {
-  it('renders as expected', () => {
-    renderWithRouter(
-      <AuthContext.Provider value={{ auth: client }}>
-        <MockedCache>
-          <PageDeleteAccount />
-        </MockedCache>
-      </AuthContext.Provider>
-    );
+ describe('PageDeleteAccount', () => {
+   it('renders as expected', () => {
+     renderWithRouter(
+       <AuthContext.Provider value={{ auth: client }}>
+         <MockedCache>
+           <PageDeleteAccount />
+         </MockedCache>
+       </AuthContext.Provider>
+     );
 
-    expect(screen.getByTestId('delete-account-confirm').textContent).toContain(
-      'deleting your account'
-    );
-    expect(screen.getByTestId('cancel-button').textContent).toContain('Cancel');
-    expect(screen.getByTestId('continue-button').textContent).toContain(
-      'Continue'
-    );
-  });
+     expect(screen.getByTestId('delete-account-confirm').textContent).toContain(
+       'deleting your account'
+     );
+     expect(screen.getByTestId('cancel-button').textContent).toContain('Cancel');
+     expect(screen.getByTestId('continue-button').textContent).toContain(
+       'Continue'
+     );
+   });
 
-  it('Enables "continue" button once all 4 inputs are valid', async () => {
-    renderWithRouter(
-      <AuthContext.Provider value={{ auth: client }}>
-        <MockedCache>
-          <PageDeleteAccount />
-        </MockedCache>
-      </AuthContext.Provider>
-    );
+   it('Enables "continue" button once all 4 inputs are valid', async () => {
+     renderWithRouter(
+       <AuthContext.Provider value={{ auth: client }}>
+         <MockedCache>
+           <PageDeleteAccount />
+         </MockedCache>
+       </AuthContext.Provider>
+     );
 
-    expect(screen.getByTestId('continue-button')).toBeDisabled();
+     expect(screen.getByTestId('continue-button')).toBeDisabled();
 
-    await act(async () => {
-      const inputs = screen.getAllByTestId('checkbox-input');
-      inputs.forEach((el) => fireEvent.click(el));
-    });
+     await act(async () => {
+       const inputs = screen.getAllByTestId('checkbox-input');
+       inputs.forEach((el) => fireEvent.click(el));
+     });
 
-    expect(screen.getByTestId('continue-button')).toBeEnabled();
-  });
+     expect(screen.getByTestId('continue-button')).toBeEnabled();
+   });
 
-  it('Does not Enable "continue" button if all for checks are not confirmed', async () => {
-    renderWithRouter(
-      <AuthContext.Provider value={{ auth: client }}>
-        <MockedCache>
-          <PageDeleteAccount />
-        </MockedCache>
-      </AuthContext.Provider>
-    );
+   it('Does not Enable "continue" button if all for checks are not confirmed', async () => {
+     renderWithRouter(
+       <AuthContext.Provider value={{ auth: client }}>
+         <MockedCache>
+           <PageDeleteAccount />
+         </MockedCache>
+       </AuthContext.Provider>
+     );
 
-    await act(async () => {
-      const inputs = screen.getAllByTestId('checkbox-input');
-      // drop last checkbox so all will not be selected
-      inputs.pop();
-      inputs.forEach((el) => fireEvent.click(el));
-    });
+     await act(async () => {
+       const inputs = screen.getAllByTestId('checkbox-input');
+       // drop last checkbox so all will not be selected
+       inputs.pop();
+       inputs.forEach((el) => fireEvent.click(el));
+     });
 
-    expect(screen.getByTestId('continue-button')).toBeDisabled();
-  });
+     expect(screen.getByTestId('continue-button')).toBeDisabled();
+   });
 
-  it('Gets valid response on submit', async () => {
-    renderWithRouter(
-      <AuthContext.Provider value={{ auth: client }}>
-        <MockedCache>
-          <PageDeleteAccount />
-        </MockedCache>
-      </AuthContext.Provider>
-    );
+   it('Gets valid response on submit', async () => {
+     renderWithRouter(
+       <AuthContext.Provider value={{ auth: client }}>
+         <MockedCache>
+           <PageDeleteAccount />
+         </MockedCache>
+       </AuthContext.Provider>
+     );
 
-    await advanceStep();
-    await typeByTestIdFn('delete-account-confirm-input-field')('hunter6');
+     await advanceStep();
+     await typeByTestIdFn('delete-account-confirm-input-field')('hunter6');
 
-    const deleteAccountButton = screen.getByTestId('delete-account-button');
-    expect(deleteAccountButton).toBeEnabled();
+     const deleteAccountButton = screen.getByTestId('delete-account-button');
+     expect(deleteAccountButton).toBeEnabled();
 
-    expect(location.pathname).toContainEqual('/');
-  });
-});
+     expect(location.pathname).toContainEqual('/');
+   });
+ });

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -2,254 +2,255 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import React, { useCallback, useState, ChangeEvent } from 'react';
-import { useForm } from 'react-hook-form';
-import { RouteComponentProps, useNavigate } from '@reach/router';
-import { useAccountDestroyer } from '../../lib/auth';
-import { sessionToken } from '../../lib/cache';
-import firefox from '../../lib/firefox';
-import { useAlertBar } from '../../lib/hooks';
-import { useAccount } from '../../models';
-import InputPassword from '../InputPassword';
-import FlowContainer from '../FlowContainer';
-import VerifiedSessionGuard from '../VerifiedSessionGuard';
-import AlertBar from '../AlertBar';
-import {
-  HomePath,
-  LockwiseLink,
-  MonitorLink,
-  ROOTPATH,
-  VPNLink,
-} from '../../constants';
-import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
-import { Checkbox } from '../Checkbox';
-import { useLocalization } from '@fluent/react';
-import { Localized } from '@fluent/react';
-import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
+ import React, { useCallback, useState, ChangeEvent } from 'react';
+ import { useForm } from 'react-hook-form';
+ import { RouteComponentProps, useNavigate } from '@reach/router';
+ import { useAccountDestroyer } from '../../lib/auth';
+ import { sessionToken } from '../../lib/cache';
+ import firefox from '../../lib/firefox';
+ import { useAlertBar } from '../../lib/hooks';
+ import { useAccount } from '../../models';
+ import InputPassword from '../InputPassword';
+ import FlowContainer from '../FlowContainer';
+ import VerifiedSessionGuard from '../VerifiedSessionGuard';
+ import AlertBar from '../AlertBar';
+ import {
+   HomePath,
+   LockwiseLink,
+   MonitorLink,
+   ROOTPATH,
+   VPNLink,
+ } from '../../constants';
+ import { logViewEvent, usePageViewEvent } from '../../lib/metrics';
+ import { Checkbox } from '../Checkbox';
+ import { useLocalization } from '@fluent/react';
+ import { Localized } from '@fluent/react';
+ import { AuthUiErrors } from '../../lib/auth-errors/auth-errors';
 
-type FormData = {
-  password: string;
-};
+ type FormData = {
+   password: string;
+ };
 
-const checkboxLabels = [
-  'delete-account-chk-box-1',
-  'delete-account-chk-box-2',
-  'delete-account-chk-box-3',
-  'delete-account-chk-box-4',
-];
+ const checkboxLabels = [
+   'delete-account-chk-box-1',
+   'delete-account-chk-box-2',
+   'delete-account-chk-box-3',
+   'delete-account-chk-box-4',
+ ];
 
-export const PageDeleteAccount = (_: RouteComponentProps) => {
-  usePageViewEvent('settings.delete-account');
-  const { l10n } = useLocalization();
-  const { handleSubmit, register, formState, setValue } = useForm<FormData>({
-    mode: 'all',
-    defaultValues: {
-      password: '',
-    },
-  });
-  // TODO: the `.errors.password` clause shouldn't be necessary, but `isValid` isn't updating
-  // properly. I think this is a bug in react-hook-form.
-  const disabled =
-    !formState.isDirty || !formState.isValid || !!formState.errors.password;
-  const [errorText, setErrorText] = useState<string>();
-  const [confirmed, setConfirmed] = useState<boolean>(false);
-  const [subtitleText, setSubtitleText] = useState<string>(
-    l10n.getString('delete-account-step-1-2')
-  );
-  const [checkedBoxes, setCheckedBoxes] = useState<string[]>([]);
-  const allBoxesChecked = checkboxLabels.every((element) =>
-    checkedBoxes.includes(element)
-  );
-  const navigate = useNavigate();
-  const alertBar = useAlertBar();
-  const goHome = useCallback(() => window.history.back(), []);
+ export const PageDeleteAccount = (_: RouteComponentProps) => {
+   usePageViewEvent('settings.delete-account');
+   const { l10n } = useLocalization();
+   const { handleSubmit, register, formState, setValue } = useForm<FormData>({
+     mode: 'all',
+     defaultValues: {
+       password: '',
+     },
+   });
+   // TODO: the `.errors.password` clause shouldn't be necessary, but `isValid` isn't updating
+   // properly. I think this is a bug in react-hook-form.
+   const disabled =
+     !formState.isDirty || !formState.isValid || !!formState.errors.password;
+   const [errorText, setErrorText] = useState<string>();
+   const [confirmed, setConfirmed] = useState<boolean>(false);
+   const [subtitleText, setSubtitleText] = useState<string>(
+     l10n.getString('delete-account-step-1-2')
+   );
+   const [checkedBoxes, setCheckedBoxes] = useState<string[]>([]);
+   const allBoxesChecked = checkboxLabels.every((element) =>
+     checkedBoxes.includes(element)
+   );
+   const navigate = useNavigate();
+   const alertBar = useAlertBar();
+   const goHome = useCallback(() => window.history.back(), []);
 
-  const { primaryEmail, uid } = useAccount();
+   const { primaryEmail, uid } = useAccount();
 
-  const advanceStep = () => {
-    setSubtitleText(l10n.getString('delete-account-step-2-2'));
-    setConfirmed(true);
+   const advanceStep = () => {
+     setSubtitleText(l10n.getString('delete-account-step-2-2'));
+     setConfirmed(true);
 
-    logViewEvent('flow.settings.account-delete', 'terms-checked.success');
-  };
+     logViewEvent('flow.settings.account-delete', 'terms-checked.success');
+   };
 
-  const deleteAccount = useAccountDestroyer({
-    onSuccess: () => {
-      firefox.accountDeleted(uid);
-      // must use location.href over navigate() since this is an external link
-      window.location.href = `${ROOTPATH}?delete_account_success=true`;
-      logViewEvent('flow.settings.account-delete', 'confirm-password.success');
-    },
-    onError: (error) => {
-      const localizedError = l10n.getString(
-        `auth-error-${AuthUiErrors.INCORRECT_PASSWORD.errno}`,
-        null,
-        AuthUiErrors.INCORRECT_PASSWORD.message
-      );
-      if (error.errno === AuthUiErrors.INCORRECT_PASSWORD.errno) {
-        setErrorText(localizedError);
-        setValue('password', '');
-      } else {
-        alertBar.setType('error');
-        alertBar.setContent(localizedError);
-        alertBar.show();
-        logViewEvent('flow.settings.account-delete', 'confirm-password.fail');
-      }
-    },
-  });
+   const deleteAccount = useAccountDestroyer({
+     onSuccess: () => {
+       firefox.accountDeleted(uid);
+       // must use location.href over navigate() since this is an external link
+       window.location.href = `${ROOTPATH}?delete_account_success=true`;
+       logViewEvent('flow.settings.account-delete', 'confirm-password.success');
+     },
+     onError: (error) => {
+       const localizedError = l10n.getString(
+         `auth-error-${AuthUiErrors.INCORRECT_PASSWORD.errno}`,
+         null,
+         AuthUiErrors.INCORRECT_PASSWORD.message
+       );
+       if (error.errno === AuthUiErrors.INCORRECT_PASSWORD.errno) {
+         setErrorText(localizedError);
+         setValue('password', '');
+       } else {
+         alertBar.setType('error');
+         alertBar.setContent(localizedError);
+         alertBar.show();
+         logViewEvent('flow.settings.account-delete', 'confirm-password.fail');
+       }
+     },
+   });
 
-  const handleConfirmChange = (labelText: string) => (
-    event: ChangeEvent<HTMLInputElement>
-  ) => {
-    event.persist();
-    setCheckedBoxes((existing) => {
-      if (event.target.checked) {
-        return [...existing, labelText];
-      } else {
-        return [...existing.filter((text) => text !== labelText)];
-      }
-    });
-  };
+   const handleConfirmChange = (labelText: string) => (
+     event: ChangeEvent<HTMLInputElement>
+   ) => {
+     event.persist();
+     setCheckedBoxes((existing) => {
+       if (event.target.checked) {
+         return [...existing, labelText];
+       } else {
+         return [...existing.filter((text) => text !== labelText)];
+       }
+     });
+   };
 
-  const onFormSubmit = ({ password }: FormData) => {
-    deleteAccount.execute(primaryEmail.email, password, sessionToken()!);
-  };
+   const onFormSubmit = ({ password }: FormData) => {
+     deleteAccount.execute(primaryEmail.email, password, sessionToken()!);
+   };
 
-  return (
-    <Localized id="delete-account-header" attrs={{ title: true }}>
-      <FlowContainer title="Delete account" subtitle={subtitleText}>
-        {alertBar.visible && (
-          <AlertBar onDismiss={alertBar.hide} type={alertBar.type}>
-            <p data-testid="delete-account-error">{alertBar.content}</p>
-          </AlertBar>
-        )}
-        <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
-        {!confirmed && (
-          <div className="my-4 text-sm" data-testid="delete-account-confirm">
-            <Localized id="delete-account-confirm-title-2">
-              <p className="mb-4">
-                You've connected your Firefox account to Mozilla products that
-                keep you secure and productive on the web:
-              </p>
-            </Localized>
-            <div className="p-2">
-              <ul className="list-inside mb-4">
-                <li className="list-disc">
-                  <a className="link-blue" href={VPNLink}>
-                    <Localized id="product-mozilla-vpn">Mozilla VPN</Localized>
-                  </a>
-                </li>
-                <li className="list-disc">
-                  <a className="link-blue" href={LockwiseLink}>
-                    <Localized id="firefox-lockwise">
-                      Firefox Lockwise
-                    </Localized>
-                  </a>
-                </li>
-                <li className="list-disc">
-                  <a className="link-blue" href={MonitorLink}>
-                    <Localized id="product-firefox-monitor">
-                      Firefox Monitor
-                    </Localized>
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <Localized id="delete-account-acknowledge">
-              <p className="mb-4">
-                Please acknowledge that by deleting your account:
-              </p>
-            </Localized>
-            <form>
-              <ul className="mt-4 text-xs">
-                {checkboxLabels.map((label, i) => (
-                  <li className="py-2" key={i}>
-                    <Localized id={label} attrs={{ label: true }}>
-                      <Checkbox
-                        data-testid="required-confirm"
-                        label={label}
-                        onChange={handleConfirmChange(label)}
-                      />
-                    </Localized>
-                  </li>
-                ))}
-              </ul>
-            </form>
-            <div className="flex items-center justify-center">
-              <Localized id="delete-account-cancel-button">
-                <button
-                  type="button"
-                  className="cta-neutral mx-2 px-4 tablet:px-10"
-                  data-testid="cancel-button"
-                  onClick={goHome}
-                >
-                  Cancel
-                </button>
-              </Localized>
-              <Localized id="delete-account-continue-button">
-                <button
-                  className="cta-primary mx-2 px-10"
-                  disabled={!allBoxesChecked}
-                  onClick={() => advanceStep()}
-                  data-testid="continue-button"
-                >
-                  Continue
-                </button>
-              </Localized>
-            </div>
-          </div>
-        )}
-        {confirmed && (
-          <form onSubmit={handleSubmit(onFormSubmit)}>
-            <div className="mt-4 mb-6" data-testid="delete-account-input">
-              <Localized
-                id="delete-account-password-input"
-                attrs={{ label: true }}
-              >
-                <InputPassword
-                  name="password"
-                  label="Enter password"
-                  prefixDataTestId="delete-account-confirm"
-                  onChange={() => {
-                    if (errorText) {
-                      setErrorText(undefined);
-                    }
-                  }}
-                  inputRef={register({
-                    required: true,
-                  })}
-                  {...{ errorText }}
-                />
-              </Localized>
-            </div>
+   return (
+     <Localized id="delete-account-header" attrs={{ title: true }}>
+       <FlowContainer title="Delete account" subtitle={subtitleText}>
+         {alertBar.visible && (
+           <AlertBar onDismiss={alertBar.hide} type={alertBar.type}>
+             <p data-testid="delete-account-error">{alertBar.content}</p>
+           </AlertBar>
+         )}
+         <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
+         {!confirmed && (
+           <div className="my-4 text-sm" data-testid="delete-account-confirm">
+             <Localized id="delete-account-confirm-title-2">
+               <p className="mb-4">
+                 You've connected your Firefox account to Mozilla products that
+                 keep you secure and productive on the web:
+               </p>
+             </Localized>
+             <div className="p-2">
+               <ul className="list-inside mb-4">
+                 <li className="list-disc">
+                   <a className="link-blue" href={VPNLink}>
+                     <Localized id="product-mozilla-vpn">Mozilla VPN</Localized>
+                   </a>
+                 </li>
+                 <li className="list-disc">
+                   <a className="link-blue" href={LockwiseLink}>
+                     <Localized id="firefox-lockwise">
+                       Firefox Lockwise
+                     </Localized>
+                   </a>
+                 </li>
+                 <li className="list-disc">
+                   <a className="link-blue" href={MonitorLink}>
+                     <Localized id="product-firefox-monitor">
+                       Firefox Monitor
+                     </Localized>
+                   </a>
+                 </li>
+               </ul>
+             </div>
+             <Localized id="delete-account-acknowledge">
+               <p className="mb-4">
+                 Please acknowledge that by deleting your account:
+               </p>
+             </Localized>
+             <form>
+               <ul className="mt-4 text-xs">
+                 {checkboxLabels.map((label, i) => (
+                   <li className="py-2" key={i}>
+                     <Localized id={label} attrs={{ label: true }}>
+                       <Checkbox
+                         data-testid="required-confirm"
+                         label={label}
+                         onChange={handleConfirmChange(label)}
+                       />
+                     </Localized>
+                   </li>
+                 ))}
+               </ul>
+             </form>
+             <div className="mt-4 flex items-center justify-center">
+               <Localized id="delete-account-cancel-button">
+                 <button
+                   className="cta-neutral mx-2 px-10"
+                   onClick={() =>
+                     navigate(HomePath + '#delete-account', { replace: true })
+                   }
+                   data-testid="cancel-button"
+                 >
+                   Cancel
+                 </button>
+               </Localized>
+               <Localized id="delete-account-continue-button">
+                 <button
+                   className="cta-primary mx-2 px-10"
+                   disabled={!allBoxesChecked}
+                   onClick={() => advanceStep()}
+                   data-testid="continue-button"
+                 >
+                   Continue
+                 </button>
+               </Localized>
+             </div>
+           </div>
+         )}
+         {confirmed && (
+           <form onSubmit={handleSubmit(onFormSubmit)}>
+             <div className="mt-4 mb-6" data-testid="delete-account-input">
+               <Localized
+                 id="delete-account-password-input"
+                 attrs={{ label: true }}
+               >
+                 <InputPassword
+                   name="password"
+                   label="Enter password"
+                   prefixDataTestId="delete-account-confirm"
+                   onChange={() => {
+                     if (errorText) {
+                       setErrorText(undefined);
+                     }
+                   }}
+                   inputRef={register({
+                     required: true,
+                   })}
+                   {...{ errorText }}
+                 />
+               </Localized>
+             </div>
 
-            <div className="flex items-center justify-center">
-              <Localized id="delete-account-cancel-button">
-                <button
-                  type="button"
-                  className="cta-neutral mx-2 px-4 tablet:px-10"
-                  data-testid="cancel-button"
-                  onClick={goHome}
-                >
-                  Cancel
-                </button>
-              </Localized>
-              <Localized id="delete-account-delete-button-2">
-                <button
-                  type="submit"
-                  className="cta-primary mx-2 px-4"
-                  data-testid="delete-account-button"
-                  disabled={disabled}
-                >
-                  Delete
-                </button>
-              </Localized>
-            </div>
-          </form>
-        )}
-      </FlowContainer>
-    </Localized>
-  );
-};
+             <div className="flex items-center justify-center">
+               <Localized id="delete-account-cancel-button">
+                 <button
+                   type="button"
+                   className="cta-neutral mx-2 px-4 tablet:px-10"
+                   data-testid="cancel-button"
+                   onClick={goHome}
+                 >
+                   Cancel
+                 </button>
+               </Localized>
+               <Localized id="delete-account-delete-button-2">
+                 <button
+                   type="submit"
+                   className="cta-primary mx-2 px-4"
+                   data-testid="delete-account-button"
+                   disabled={disabled}
+                 >
+                   Delete
+                 </button>
+               </Localized>
+             </div>
+           </form>
+         )}
+       </FlowContainer>
+     </Localized>
+   );
+ };
 
-export default PageDeleteAccount;
+ export default PageDeleteAccount;

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -175,7 +175,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
                 ))}
               </ul>
             </form>
-            <div className="mt-4 flex items-center justify-center">
+            <div className="flex items-center justify-center">
             <Localized id="delete-account-cancel-button">
                 <button
                   type="button"

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -176,15 +176,14 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
               </ul>
             </form>
             <div className="mt-4 flex items-center justify-center">
-              <Localized id="delete-account-close-button">
+            <Localized id="delete-account-cancel-button">
                 <button
-                  className="cta-neutral mx-2 px-10"
-                  onClick={() =>
-                    navigate(HomePath + '#delete-account', { replace: true })
-                  }
-                  data-testid="close-button"
+                  type="button"
+                  className="cta-neutral mx-2 px-4 tablet:px-10"
+                  data-testid="cancel-button"
+                  onClick={goHome}
                 >
-                  Close
+                  Cancel
                 </button>
               </Localized>
               <Localized id="delete-account-continue-button">

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -176,7 +176,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
               </ul>
             </form>
             <div className="flex items-center justify-center">
-            <Localized id="delete-account-cancel-button">
+              <Localized id="delete-account-cancel-button">
                 <button
                   type="button"
                   className="cta-neutral mx-2 px-4 tablet:px-10"


### PR DESCRIPTION
## Because

- Dashboard in delete account on first step instead of button Cancel we had Close

![106765284-4fa43100-6641-11eb-8340-3c96835c5aa7](https://user-images.githubusercontent.com/76935202/113797654-071a0880-9795-11eb-9945-be27c5c39474.png)


## This pull request

- Change button Close to button Cancel

## Issue that this pull request solves

Closes: #7414

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)


https://user-images.githubusercontent.com/76935202/113797737-32045c80-9795-11eb-9ba4-a0d91ccddc57.mov



## Other information (Optional)

macOS Catalina
Google Chrome