### PR TITLE
fix(fxa-settings): change Add Photo and Take photo buttons' styling

### DIFF
--- a/packages/fxa-settings/src/components/PageAvatar/buttons.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/buttons.tsx
@@ -106,7 +106,7 @@ export const TakePhotoBtn = ({
         />
       </Localized>
       <Localized id="avatar-page-take-photo">
-        <p>Take photo</p>
+        <p className="mt-2">Take photo</p>
       </Localized>
     </div>
   );
@@ -148,7 +148,7 @@ export const AddPhotoBtn = ({
         />
       </Localized>
       <Localized id="avatar-page-add-photo">
-        <p>Add photo</p>
+        <p className="mt-2">Add photo</p>
       </Localized>
     </div>
   );


### PR DESCRIPTION


## Because

- Names of the buttons are too close to the icons


## This pull request

- Add margin-top to the button names

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/7413

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
