### PR TITLE
fix(fxa-settings): add 2FA icons states

### DIFF
--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -55,7 +55,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
           )}
           download={`${primaryEmail.email} Firefox.txt`}
           data-testid="databutton-download"
-          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 active:outline-black-dotted focus:outline-black-dotted"
+          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 active:outline-black-dotted focus:outline-black-dotted hover:bg-grey-50"
           onClick={() => onAction?.('download')}
         >
           <DownloadIcon
@@ -76,7 +76,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
             onAction?.('copy');
           }}
           data-testid="databutton-copy"
-          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 active:outline-black-dotted focus:outline-black-dotted"
+          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 active:outline-black-dotted focus:outline-black-dotted hover:bg-grey-50"
         >
           <CopyIcon
             width="21"
@@ -98,7 +98,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
             onAction?.('print');
           }}
           data-testid="databutton-print"
-          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 active:outline-black-dotted focus:outline-black-dotted"
+          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 active:outline-black-dotted focus:outline-black-dotted hover:bg-grey-50"
         >
           <PrintIcon
             height="24"


### PR DESCRIPTION
## Because

- 2FA icons do not have states

## This pull request

- Adds hover to the download/copy/print icons

## Issue that this pull request solves

Related: https://github.com/mozilla/fxa/issues/7025

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

