### PR TITLE
fix(bug): Redirect to client/services page from legacy link

### DIFF
--- a/packages/fxa-content-server/tests/functional/settings_v2/connected_services_oauth_clients.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/connected_services_oauth_clients.js
@@ -12,7 +12,7 @@ const FunctionalHelpers = require('../lib/helpers');
 const { createEmail } = FunctionalHelpers;
 
 describe('connected services: oauth clients', () => {
-  const email = createEmail();
+  let email;
   const password = 'topnotchsupercoolpassworddealwithit';
   let clearBrowserState,
     openFxaFromRp,
@@ -52,6 +52,7 @@ describe('connected services: oauth clients', () => {
   });
 
   it('lists and disconnects RP clients', async () => {
+    email = createEmail();
     await openFxaFromRp('enter-email');
     await fillOutEmailFirstSignUp(email, password);
     await testElementExists(selectors.CONFIRM_SIGNUP_CODE.HEADER);
@@ -98,6 +99,22 @@ describe('connected services: oauth clients', () => {
     await click(selectors.SETTINGS_V2.CONNECTED_SERVICES.REFRESH_BUTTON);
     await noSuchElement(
       `${selectors.SETTINGS_V2.CONNECTED_SERVICES.HEADER} #service:nth-child(4) ${selectors.SETTINGS_V2.CONNECTED_SERVICES.SIGN_OUT}`
+    );
+  });
+
+  it('redirect from /settings/clients', async () => {
+    email = createEmail();
+    await openFxaFromRp('enter-email');
+    await fillOutEmailFirstSignUp(email, password);
+    await testElementExists(selectors.CONFIRM_SIGNUP_CODE.HEADER);
+    await fillOutSignUpCode(email, 0);
+    await testElementExists(selectors['123DONE'].AUTHENTICATED);
+    const oldUrl = `${config.fxaSettingsV2Root}/clients`;
+    // page is redirected and client list is shown
+    await openPage(oldUrl, selectors.SETTINGS_V2.CONNECTED_SERVICES.HEADER);
+    await testElementTextInclude(
+      selectors.SETTINGS_V2.CONNECTED_SERVICES.HEADER,
+      '123Done'
     );
   });
 });

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -27,6 +27,7 @@ import { useConfig } from 'fxa-settings/src/lib/config';
 import { observeNavigationTiming } from 'fxa-shared/metrics/navigation-timing';
 import AppLocalizationProvider from 'fxa-react/lib/AppLocalizationProvider';
 import PageAvatar from '../PageAvatar';
+import { Redirect } from '@reach/router';
 
 export const GET_INITIAL_STATE = gql`
   query GetInitialState {
@@ -88,6 +89,11 @@ export const App = ({ flowQueryParams, navigatorLanguages }: AppProps) => {
             <PageTwoStepAuthentication path="/two_step_authentication" />
             <Page2faReplaceRecoveryCodes path="/two_step_authentication/replace_codes" />
             <PageDeleteAccount path="/delete_account" />
+            <Redirect
+              from="/clients"
+              to="/settings#connected-services"
+              noThrow
+            />
           </ScrollToTop>
         </Router>
       </AppLayout>

--- a/packages/fxa-settings/src/components/ScrollToTop/index.tsx
+++ b/packages/fxa-settings/src/components/ScrollToTop/index.tsx
@@ -30,7 +30,8 @@ export const ScrollToTop = (
     // to it, because reach router can't handle hashes (see reach router
     // issue 32) 🙄
     if (hasHash) {
-      const el = document.querySelector(url.hash);
+      const hashTokens = url.hash.split('?');
+      const el = document.querySelector(hashTokens[0]);
       if (el) el.scrollIntoView();
     } else if (
       !hasHash &&


### PR DESCRIPTION
## Because

- Open manage devices link from Firefox is broken (From within the Sync Tabs submenu)

## This pull request

- Adds a redirect from the legacy url `/settings/clients` to the new url `/settings#connected-services`

## Issue that this pull request solves

Closes: #8047

## Checklist


- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
