### PR TITLE
fix(ci): The docker image should get pip from apt, not easy_install

### DIFF
--- a/_dev/docker/circleci/Dockerfile
+++ b/_dev/docker/circleci/Dockerfile
@@ -4,9 +4,9 @@ USER root
 RUN apt-get update && apt-get install -y \
     python-setuptools \
     python-dev \
+    python-pip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN easy_install pip
 RUN pip install mozdownload mozinstall
 RUN mozdownload --version latest-esr --destination firefox.tar.bz2
 


### PR DESCRIPTION
Attempting to build the circle-ci docker image locally, by going to `_dev/docker/circleci/` and doing `docker build -t "mozilla/fxa-circleci:latest" .`, fails because pip doesn't install properly.

@dannycoates pointed out that the installation process does work if we obtain pip from apt-get instead of easy_install 🧙, so let's make that change permanent 