### PR TITLE
fix(bug): include email in filename for recovery keys/codes

### DIFF
--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -8,6 +8,7 @@ import { copy } from '../../lib/clipboard';
 import { ReactComponent as CopyIcon } from './copy.svg';
 import { ReactComponent as DownloadIcon } from './download.svg';
 import { ReactComponent as PrintIcon } from './print.svg';
+import { useAccount } from '../../models';
 
 export type GetDataTrioProps = {
   value: string | string[];
@@ -40,6 +41,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
     printWindow.print();
     printWindow.close();
   }, [value, pageTitle]);
+  const { primaryEmail } = useAccount();
 
   return (
     <div className="flex justify-between w-4/5 max-w-48">
@@ -51,7 +53,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
               type: 'text/plain',
             })
           )}
-          download
+          download={`${primaryEmail.email} Firefox.txt`}
           data-testid="databutton-download"
           className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500"
           onClick={() => onAction?.('download')}


### PR DESCRIPTION
## Because

- Browser might not be able to open the file or detect the wrong file type

## This pull request

- Includes the email in the filename

## Issue that this pull request solves

Closes: #8180

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots

<img width="376" alt="image" src="https://user-images.githubusercontent.com/1295288/113927191-2592fa80-97bb-11eb-92c6-f87034a0e77b.png">