### PR TITLE
fix(fxa-settings):change Close button to Cancel in delete

### DIFF
--- a/packages/fxa-settings/src/components/PageDeleteAccount/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/en-US.ftl
@@ -19,7 +19,7 @@ delete-account-chk-box-3 =
 delete-account-chk-box-4 =
  .label = Any extensions and themes that you published to addons.mozilla.org will be deleted
 
-delete-account-close-button = Close
+
 delete-account-continue-button = Continue
 
 delete-account-password-input =

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -176,15 +176,15 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
               </ul>
             </form>
             <div className="mt-4 flex items-center justify-center">
-              <Localized id="delete-account-close-button">
+              <Localized id="delete-account-cancel-button">
                 <button
                   className="cta-neutral mx-2 px-10"
                   onClick={() =>
                     navigate(HomePath + '#delete-account', { replace: true })
                   }
-                  data-testid="close-button"
+                  data-testid="cancel-button"
                 >
-                  Close
+                  Cancel
                 </button>
               </Localized>
               <Localized id="delete-account-continue-button">


### PR DESCRIPTION
## Because

- Dashboard in delete account on first step instead of button Cancel we had Close
 
![106765284-4fa43100-6641-11eb-8340-3c96835c5aa7](https://user-images.githubusercontent.com/76935202/113955275-bf5fb380-985e-11eb-912e-d2223c40b77c.png)


## This pull request

- Change button Close to button Cancel

## Issue that this pull request solves

Closes: #7414

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)


https://user-images.githubusercontent.com/76935202/113955314-d6060a80-985e-11eb-8b40-926ca21dd0db.mov



## Other information (Optional)

macOS Catalina
Google Chrome
