### PR TITLE
fix(fxa-settings):change plural header to single

### DIFF
--- a/packages/fxa-settings/src/components/HeaderLockup/en-US.ftl
+++ b/packages/fxa-settings/src/components/HeaderLockup/en-US.ftl
@@ -4,5 +4,5 @@ header-menu-open = Close menu
 header-menu-closed = Site navigation menu
 header-back-to-top-link =
   .title = Back to top
-header-title = { -product-firefox-accounts }
+header-title = Firefox Account
 header-help = Help

--- a/packages/fxa-settings/src/components/HeaderLockup/index.tsx
+++ b/packages/fxa-settings/src/components/HeaderLockup/index.tsx
@@ -51,7 +51,7 @@ export const HeaderLockup = () => {
             <>
               <Localized id="header-title">
                 <span className="font-bold ltr:mr-2 rtl:ml-2">
-                  Firefox accounts
+                  Firefox Account
                 </span>
               </Localized>
             </>


### PR DESCRIPTION
## Because

- The page header is at plural - 'Firefox Accounts' - has to be single "Firefox Account"

## This pull request

- Change plural header to single

## Issue that this pull request solves

Closes: #7676 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1440" alt="Screen Shot 2021-04-08 at 12 16 52 am" src="https://user-images.githubusercontent.com/76935202/113956351-ad7f1000-9860-11eb-853c-5e0c20e6823a.png">


## Other information (Optional)

macOS Catalina
Google Chrome