### PR TITLE
Release 1.203.7

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,18 +22,19 @@ bini11
 Brandon Ebersohl
 Brian Warner
 byrw
+César Carruitero
 championshuttler
 Chris Heilmann
 Chris Karlof
 Christian Murphy
 ckarlof
 Cronus1007
-César Carruitero
 Dan Callahan
 Danny Amey
 Danny Coates
 Dave Justice
 dave justice
+Deeksha Tiwari
 Deepti
 dependabot[bot]
 DEV Akash Mathur
@@ -64,6 +65,7 @@ Ian Bicking
 irrationalagent
 Jackie Munroe
 Jamon Camisso
+Jane Kotovich
 Jared Hirsch
 Jarek
 Jason Strutz
@@ -75,12 +77,15 @@ John Morrison
 johngruen
 Jon Buckley
 Jon Petto
+Josef Weldemariam
 jotes
 JR Conlin
 Juan García Basilio
 Jurgen Brunink
 ka7
 Karan Sapolia
+Karina Bekbayeva
+karinabk
 Kit Cambridge
 Kohei Yoshino
 Kurt Bauer
@@ -137,6 +142,7 @@ ricky rosario
 Rishi Baldawa
 Robert Kowalski
 Roger Meier
+Rukshan Jayasekara
 Ryan Feeley
 Ryan Kelly
 Sai Chandramouli
@@ -151,6 +157,7 @@ Sean McArthur
 Shane Tomlinson
 shikhar-scs
 Shivam Singhal
+shivanisinghnitp
 shreya99oak
 Shubham Kumar
 Soumya Himanish Mohapatra
@@ -160,6 +167,7 @@ Staś Małolepszy
 steekid
 Sunakshi Tejwani
 suyashchauhan
+Tayeeb Hasan
 tiagomoraismorgado
 Tim Taubert
 tomer@gmx.net

--- a/packages/fxa-admin-panel/CHANGELOG.md
+++ b/packages/fxa-admin-panel/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.203.7
+
+### Other changes
+
+- deps-dev: bump @types/supertest from 2.0.10 to 2.0.11 ([a983465ae](https://github.com/mozilla/fxa/commit/a983465ae))
+- deps-dev: bump @typescript-eslint/parser from 2.33.0 to 4.21.0 ([9ead758c7](https://github.com/mozilla/fxa/commit/9ead758c7))
+- deps-dev: bump @types/jest from 26.0.20 to 26.0.22 ([fd9972286](https://github.com/mozilla/fxa/commit/fd9972286))
+- deps-dev: bump @typescript-eslint/eslint-plugin ([ee0205595](https://github.com/mozilla/fxa/commit/ee0205595))
+- deps-dev: bump ts-node from 8.10.2 to 9.1.1 ([78f6296fc](https://github.com/mozilla/fxa/commit/78f6296fc))
+- deps-dev: downgrade @storybook/react from 6.1.21 to 5.3.19 ([c670cc984](https://github.com/mozilla/fxa/commit/c670cc984))
+- deps: bump @apollo/client from 3.3.11 to 3.3.13 ([498af659b](https://github.com/mozilla/fxa/commit/498af659b))
+- deps-dev: bump @types/serve-static from 1.13.5 to 1.13.9 ([92ff1a1e1](https://github.com/mozilla/fxa/commit/92ff1a1e1))
+
 ## 1.203.6
 
 No changes.

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-panel",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "description": "FxA Admin Panel",
   "scripts": {
     "build-postcss": "postcss src/styles/tailwind.css -o src/styles/tailwind.out.css",

--- a/packages/fxa-admin-server/CHANGELOG.md
+++ b/packages/fxa-admin-server/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 1.203.7
+
+### Refactorings
+
+- auth: use direct db connection for reads ([f4dc15a81](https://github.com/mozilla/fxa/commit/f4dc15a81))
+
+### Other changes
+
+- deps-dev: bump @types/supertest from 2.0.10 to 2.0.11 ([a983465ae](https://github.com/mozilla/fxa/commit/a983465ae))
+- deps: bump @nestjs/mapped-types from 0.4.0 to 0.4.1 ([19f9af5cb](https://github.com/mozilla/fxa/commit/19f9af5cb))
+- deps: bump @nestjs/common from 7.6.13 to 7.6.15 ([95b1532d7](https://github.com/mozilla/fxa/commit/95b1532d7))
+- deps-dev: bump @types/yargs from 15.0.13 to 16.0.1 ([4f027af02](https://github.com/mozilla/fxa/commit/4f027af02))
+- deps: bump @nestjs/graphql from 7.9.10 to 7.10.3 ([959a6d324](https://github.com/mozilla/fxa/commit/959a6d324))
+- deps: bump class-validator from 0.12.2 to 0.13.1 ([1f39c4e36](https://github.com/mozilla/fxa/commit/1f39c4e36))
+- deps-dev: bump @types/node from 14.14.5 to 14.14.37 ([2d4131afe](https://github.com/mozilla/fxa/commit/2d4131afe))
+- deps: bump apollo-server-express from 2.21.1 to 2.22.2 ([015021329](https://github.com/mozilla/fxa/commit/015021329))
+- deps-dev: bump chai from 4.2.0 to 4.3.4 ([65530821d](https://github.com/mozilla/fxa/commit/65530821d))
+- deps-dev: bump ts-node from 8.10.2 to 9.1.1 ([78f6296fc](https://github.com/mozilla/fxa/commit/78f6296fc))
+
 ## 1.203.6
 
 No changes.

--- a/packages/fxa-auth-db-mysql/CHANGELOG.md
+++ b/packages/fxa-auth-db-mysql/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.203.4
+
+### Other changes
+
+- deps-dev: bump chai from 4.2.0 to 4.3.4 ([65530821d](https://github.com/mozilla/fxa/commit/65530821d))
+
 ## 1.203.6
 
 No changes.

--- a/packages/fxa-auth-db-mysql/package.json
+++ b/packages/fxa-auth-db-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-db-mysql",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "description": "MySQL backend for Firefox Accounts",
   "main": "index.js",
   "repository": {

--- a/packages/fxa-auth-server/CHANGELOG.md
+++ b/packages/fxa-auth-server/CHANGELOG.md
@@ -1,3 +1,50 @@
+## 1.203.7
+
+### New features
+
+- graphql-api: enhance must-change-password script to accept a plain text list ([bd7f60bf9](https://github.com/mozilla/fxa/commit/bd7f60bf9))
+- subscriptions: create subscriptions for existing PayPal customer ([7c4058585](https://github.com/mozilla/fxa/commit/7c4058585))
+- fxa-auth-server: move time to a new line ([1a15228bf](https://github.com/mozilla/fxa/commit/1a15228bf))
+- payments: Add processing screen for PayPal invalid billing agreement modal ([056dcba71](https://github.com/mozilla/fxa/commit/056dcba71))
+- fxa-payments-server: add paypal to subscription management ([a0aa9f8b8](https://github.com/mozilla/fxa/commit/a0aa9f8b8))
+- emails: add email for payment method cancellation ([05f1688f7](https://github.com/mozilla/fxa/commit/05f1688f7))
+
+### Bug fixes
+
+- auth: flip true/false value for errors on PayPal request metrics. ([970521926](https://github.com/mozilla/fxa/commit/970521926))
+- codes: Fix issue where user could not login if they have low recovery codes ([35769e8f2](https://github.com/mozilla/fxa/commit/35769e8f2))
+- fxa-auth-server: change email template This commit: * Improves the styling of the email template (passwordChangeRequired) fixes #8011 ([f764a8ec3](https://github.com/mozilla/fxa/commit/f764a8ec3))
+- auth-server: address processor running bugs ([68f39a47c](https://github.com/mozilla/fxa/commit/68f39a47c))
+- import: Use relative import for production ([a4e190806](https://github.com/mozilla/fxa/commit/a4e190806))
+- import: Use relative import for production ([9e06ef6d4](https://github.com/mozilla/fxa/commit/9e06ef6d4))
+
+### Refactorings
+
+- auth: use direct db connection for reads ([f4dc15a81](https://github.com/mozilla/fxa/commit/f4dc15a81))
+- fxa-auth-server: change string in registration email ([1485a1374](https://github.com/mozilla/fxa/commit/1485a1374))
+
+### Other changes
+
+- deps: bump cbor from 7.0.4 to 7.0.5 ([432601567](https://github.com/mozilla/fxa/commit/432601567))
+- fxa-auth-server: add tests for email date and time ([a78566dd5](https://github.com/mozilla/fxa/commit/a78566dd5))
+- deps: bump ioredis from 4.23.0 to 4.25.0 ([06cc94819](https://github.com/mozilla/fxa/commit/06cc94819))
+- deps: bump hot-shots from 8.3.0 to 8.3.1 ([8593d39cd](https://github.com/mozilla/fxa/commit/8593d39cd))
+- deps: bump aws-sdk from 2.851.0 to 2.879.0 ([66e6e3e1f](https://github.com/mozilla/fxa/commit/66e6e3e1f))
+- b29fc53a3 Made changes in setup copy ([b29fc53a3](https://github.com/mozilla/fxa/commit/b29fc53a3))
+- deps: bump google-libphonenumber from 3.2.18 to 3.2.19 ([cd8d91e1a](https://github.com/mozilla/fxa/commit/cd8d91e1a))
+- fxa-payments-server: add paypal to subscription management"" ([d31f14b87](https://github.com/mozilla/fxa/commit/d31f14b87))
+- fxa-payments-server: add paypal to subscription management" ([097ae6075](https://github.com/mozilla/fxa/commit/097ae6075))
+- deps: bump cldr-localenames-full from 38.0.0 to 38.1.0 ([7919b7f86](https://github.com/mozilla/fxa/commit/7919b7f86))
+- deps-dev: bump @types/node from 14.14.5 to 14.14.37 ([2d4131afe](https://github.com/mozilla/fxa/commit/2d4131afe))
+- deps: bump @google-cloud/firestore from 4.9.6 to 4.9.8 ([36a17f048](https://github.com/mozilla/fxa/commit/36a17f048))
+- deps-dev: bump grunt-cli from 1.3.2 to 1.4.1 ([e1a79b550](https://github.com/mozilla/fxa/commit/e1a79b550))
+- deps-dev: bump @types/jsonwebtoken from 8.5.0 to 8.5.1 ([ed8f213e2](https://github.com/mozilla/fxa/commit/ed8f213e2))
+- deps-dev: bump chai from 4.2.0 to 4.3.4 ([65530821d](https://github.com/mozilla/fxa/commit/65530821d))
+- deps: bump hot-shots from 8.2.0 to 8.3.0 ([da62dc16c](https://github.com/mozilla/fxa/commit/da62dc16c))
+- deps-dev: bump ts-node from 8.10.2 to 9.1.1 ([78f6296fc](https://github.com/mozilla/fxa/commit/78f6296fc))
+- auth: Update legal URLs in transactional emails ([849839a9d](https://github.com/mozilla/fxa/commit/849839a9d))
+- deps: bump google-libphonenumber from 3.2.13 to 3.2.18 ([7f29b919b](https://github.com/mozilla/fxa/commit/7f29b919b))
+
 ## 1.203.6
 
 No changes.

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "description": "Firefox Accounts, an identity provider for Mozilla cloud services",
   "bin": {
     "fxa-auth": "./bin/key_server.js"

--- a/packages/fxa-content-server/CHANGELOG.md
+++ b/packages/fxa-content-server/CHANGELOG.md
@@ -1,3 +1,39 @@
+## 1.203.7
+
+### New features
+
+- profile: create a monogram default avatar ([57d004be9](https://github.com/mozilla/fxa/commit/57d004be9))
+
+### Bug fixes
+
+- bug: Redirect to client/services page from legacy link ([bfe58b92c](https://github.com/mozilla/fxa/commit/bfe58b92c))
+- tests: get avatar functional tests working ([b43be01ef](https://github.com/mozilla/fxa/commit/b43be01ef))
+- tests: re-enable reset_password test ([568b39591](https://github.com/mozilla/fxa/commit/568b39591))
+- tests: update selectors to get email_opt_in passing ([ab81ef594](https://github.com/mozilla/fxa/commit/ab81ef594))
+- tests: get sign_in_blocked tests passing ([5d3bcab75](https://github.com/mozilla/fxa/commit/5d3bcab75))
+- codes: Fix issue where user could not login if they have low recovery codes ([35769e8f2](https://github.com/mozilla/fxa/commit/35769e8f2))
+- tests: get oauth_settings_clients test passing ([34ca8ccc2](https://github.com/mozilla/fxa/commit/34ca8ccc2))
+- tests: get sign_in functional tests passing ([e04640969](https://github.com/mozilla/fxa/commit/e04640969))
+- l10n: Localize BentoMenu component ([56a2dba43](https://github.com/mozilla/fxa/commit/56a2dba43))
+- tests: re-enable all but the broken functional tests ([a76a73bd7](https://github.com/mozilla/fxa/commit/a76a73bd7))
+- tests: get oauth_sign_in tests passing ([a5a07f751](https://github.com/mozilla/fxa/commit/a5a07f751))
+- tests: correct error selector in cookies_disabled test ([dd2e1fa7e](https://github.com/mozilla/fxa/commit/dd2e1fa7e))
+- tests: update sign out flow in force_auth test ([6ec6eb8a1](https://github.com/mozilla/fxa/commit/6ec6eb8a1))
+- tests: fix and re-enable mocha tests ([0017686b4](https://github.com/mozilla/fxa/commit/0017686b4))
+- tests: fix and re-enable sign_up_with_code.js ([93c0fdd31](https://github.com/mozilla/fxa/commit/93c0fdd31))
+- path: Update location of settings page on disk ([e023bd1e6](https://github.com/mozilla/fxa/commit/e023bd1e6))
+
+### Other changes
+
+- chore: echo firefox version when running circle ci tests ([f559103a5](https://github.com/mozilla/fxa/commit/f559103a5))
+- deps: bump hot-shots from 8.3.0 to 8.3.1 ([8593d39cd](https://github.com/mozilla/fxa/commit/8593d39cd))
+- deps-dev: bump @babel/cli from 7.7.4 to 7.13.14 ([df09c6e86](https://github.com/mozilla/fxa/commit/df09c6e86))
+- deps-dev: bump got from 11.8.0 to 11.8.2 ([95ed39e98](https://github.com/mozilla/fxa/commit/95ed39e98))
+- deps-dev: bump chai from 4.2.0 to 4.3.4 ([65530821d](https://github.com/mozilla/fxa/commit/65530821d))
+- deps: bump hot-shots from 8.2.0 to 8.3.0 ([da62dc16c](https://github.com/mozilla/fxa/commit/da62dc16c))
+- deps-dev: bump ts-node from 8.10.2 to 9.1.1 ([78f6296fc](https://github.com/mozilla/fxa/commit/78f6296fc))
+- deps-dev: bump sinon-chai from 3.5.0 to 3.6.0 ([f3f1fe814](https://github.com/mozilla/fxa/commit/f3f1fe814))
+
 ## 1.203.6
 
 ### New features

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "description": "Firefox Accounts Content Server",
   "scripts": {
     "build": "tsc --build ../fxa-react && NODE_ENV=production grunt build",

--- a/packages/fxa-customs-server/CHANGELOG.md
+++ b/packages/fxa-customs-server/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.203.7
+
+### Other changes
+
+- deps-dev: bump grunt-cli from 1.3.2 to 1.4.1 ([e1a79b550](https://github.com/mozilla/fxa/commit/e1a79b550))
+- deps-dev: bump chai from 4.2.0 to 4.3.4 ([65530821d](https://github.com/mozilla/fxa/commit/65530821d))
+
 ## 1.203.6
 
 No changes.

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-customs-server",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "description": "Firefox Accounts Customs Server",
   "author": "Mozilla (https://mozilla.org/)",
   "license": "MPL-2.0",

--- a/packages/fxa-email-event-proxy/package.json
+++ b/packages/fxa-email-event-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-email-event-proxy",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "description": "Proxies events from Sendgrid to FxA SQS queues",
   "main": "index.js",
   "scripts": {

--- a/packages/fxa-email-service/CHANGELOG.md
+++ b/packages/fxa-email-service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.203.7
+
+No changes.
+
 ## 1.203.6
 
 No changes.

--- a/packages/fxa-email-service/Cargo.lock
+++ b/packages/fxa-email-service/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "fxa_email_service"
-version = "1.203.6"
+version = "1.203.7"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/packages/fxa-email-service/Cargo.toml
+++ b/packages/fxa-email-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fxa_email_service"
-version = "1.203.6"
+version = "1.203.7"
 publish = false
 edition = "2018"
 

--- a/packages/fxa-event-broker/CHANGELOG.md
+++ b/packages/fxa-event-broker/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Change history
 
+## 1.203.7
+
+### Other changes
+
+- deps-dev: bump @types/supertest from 2.0.10 to 2.0.11 ([a983465ae](https://github.com/mozilla/fxa/commit/a983465ae))
+- deps-dev: bump @typescript-eslint/parser from 2.33.0 to 4.21.0 ([9ead758c7](https://github.com/mozilla/fxa/commit/9ead758c7))
+- deps: bump @nestjs/mapped-types from 0.4.0 to 0.4.1 ([19f9af5cb](https://github.com/mozilla/fxa/commit/19f9af5cb))
+- deps: bump @nestjs/common from 7.6.13 to 7.6.15 ([95b1532d7](https://github.com/mozilla/fxa/commit/95b1532d7))
+- deps-dev: bump @nestjs/testing from 7.6.5 to 7.6.15 ([27b2c0358](https://github.com/mozilla/fxa/commit/27b2c0358))
+- deps: bump hot-shots from 8.3.0 to 8.3.1 ([8593d39cd](https://github.com/mozilla/fxa/commit/8593d39cd))
+- deps: bump @nestjs/graphql from 7.9.10 to 7.10.3 ([959a6d324](https://github.com/mozilla/fxa/commit/959a6d324))
+- deps: bump aws-sdk from 2.851.0 to 2.879.0 ([66e6e3e1f](https://github.com/mozilla/fxa/commit/66e6e3e1f))
+- deps-dev: bump @types/jest from 26.0.20 to 26.0.22 ([fd9972286](https://github.com/mozilla/fxa/commit/fd9972286))
+- deps-dev: bump @typescript-eslint/eslint-plugin ([ee0205595](https://github.com/mozilla/fxa/commit/ee0205595))
+- deps: bump class-validator from 0.12.2 to 0.13.1 ([1f39c4e36](https://github.com/mozilla/fxa/commit/1f39c4e36))
+- deps-dev: bump @types/node from 14.14.5 to 14.14.37 ([2d4131afe](https://github.com/mozilla/fxa/commit/2d4131afe))
+- deps: bump @google-cloud/firestore from 4.9.6 to 4.9.8 ([36a17f048](https://github.com/mozilla/fxa/commit/36a17f048))
+- deps: bump hot-shots from 8.2.0 to 8.3.0 ([da62dc16c](https://github.com/mozilla/fxa/commit/da62dc16c))
+- deps-dev: bump ts-node from 8.10.2 to 9.1.1 ([78f6296fc](https://github.com/mozilla/fxa/commit/78f6296fc))
+- deps-dev: bump @nestjs/schematics from 7.2.6 to 7.3.0 ([b86830f9f](https://github.com/mozilla/fxa/commit/b86830f9f))
+
 ## 1.203.6
 
 No changes.

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-event-broker",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "description": "Firefox Accounts Event Broker",
   "scripts": {
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",

--- a/packages/fxa-geodb/CHANGELOG.md
+++ b/packages/fxa-geodb/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change history
 
+## 1.203.7
+
+### Other changes
+
+- deps-dev: bump chai from 4.2.0 to 4.3.4 ([65530821d](https://github.com/mozilla/fxa/commit/65530821d))
+
 ## 1.203.6
 
 No changes.

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-geodb",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "description": "Firefox Accounts GeoDB Repo for Geolocation based services",
   "main": "lib/fxa-geodb.js",
   "directories": {

--- a/packages/fxa-graphql-api/CHANGELOG.md
+++ b/packages/fxa-graphql-api/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 1.203.7
+
+### New features
+
+- graphql-api: enhance must-change-password script to accept a plain text list ([bd7f60bf9](https://github.com/mozilla/fxa/commit/bd7f60bf9))
+- profile: create a monogram default avatar ([57d004be9](https://github.com/mozilla/fxa/commit/57d004be9))
+
+### Refactorings
+
+- auth: use direct db connection for reads ([f4dc15a81](https://github.com/mozilla/fxa/commit/f4dc15a81))
+
+### Other changes
+
+- deps-dev: bump @types/supertest from 2.0.10 to 2.0.11 ([a983465ae](https://github.com/mozilla/fxa/commit/a983465ae))
+- deps: bump @nestjs/mapped-types from 0.4.0 to 0.4.1 ([19f9af5cb](https://github.com/mozilla/fxa/commit/19f9af5cb))
+- deps: bump @nestjs/common from 7.6.13 to 7.6.15 ([95b1532d7](https://github.com/mozilla/fxa/commit/95b1532d7))
+- deps-dev: bump @types/yargs from 15.0.13 to 16.0.1 ([4f027af02](https://github.com/mozilla/fxa/commit/4f027af02))
+- deps: bump ioredis from 4.23.0 to 4.25.0 ([06cc94819](https://github.com/mozilla/fxa/commit/06cc94819))
+- deps: bump @nestjs/graphql from 7.9.10 to 7.10.3 ([959a6d324](https://github.com/mozilla/fxa/commit/959a6d324))
+- deps: bump apollo-datasource from 0.7.3 to 0.8.0 ([79eadf741](https://github.com/mozilla/fxa/commit/79eadf741))
+- deps: bump class-validator from 0.12.2 to 0.13.1 ([1f39c4e36](https://github.com/mozilla/fxa/commit/1f39c4e36))
+- deps-dev: bump @types/node from 14.14.5 to 14.14.37 ([2d4131afe](https://github.com/mozilla/fxa/commit/2d4131afe))
+- deps: bump apollo-server-express from 2.21.1 to 2.22.2 ([015021329](https://github.com/mozilla/fxa/commit/015021329))
+- deps-dev: bump ts-node from 8.10.2 to 9.1.1 ([78f6296fc](https://github.com/mozilla/fxa/commit/78f6296fc))
+
 ## 1.203.6
 
 ### New features

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-graphql-api",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "description": "FxA GraphQL API",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/fxa-payments-server/CHANGELOG.md
+++ b/packages/fxa-payments-server/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Change history
 
+## 1.203.7
+
+### New features
+
+- payments: Add processing screen for PayPal invalid billing agreement modal ([056dcba71](https://github.com/mozilla/fxa/commit/056dcba71))
+- fxa-payments-server: add paypal to subscription management ([a0aa9f8b8](https://github.com/mozilla/fxa/commit/a0aa9f8b8))
+
+### Bug fixes
+
+- fxa-payment-server: remove debugging code from ActionButton ([6a6d11377](https://github.com/mozilla/fxa/commit/6a6d11377))
+- fxa-payment-server: remove debugging code from ActionButton ([000c349ec](https://github.com/mozilla/fxa/commit/000c349ec))
+
+### Other changes
+
+- deps-dev: bump @typescript-eslint/parser from 2.33.0 to 4.21.0 ([9ead758c7](https://github.com/mozilla/fxa/commit/9ead758c7))
+- deps: bump hot-shots from 8.3.0 to 8.3.1 ([8593d39cd](https://github.com/mozilla/fxa/commit/8593d39cd))
+- deps-dev: bump @types/jest from 26.0.20 to 26.0.22 ([fd9972286](https://github.com/mozilla/fxa/commit/fd9972286))
+- fxa-payments-server: add paypal to subscription management"" ([d31f14b87](https://github.com/mozilla/fxa/commit/d31f14b87))
+- fxa-payments-server: add paypal to subscription management" ([097ae6075](https://github.com/mozilla/fxa/commit/097ae6075))
+- fxa-payments-server: Checkout error view layout issue ([4b50880ad](https://github.com/mozilla/fxa/commit/4b50880ad))
+- deps-dev: bump @typescript-eslint/eslint-plugin ([ee0205595](https://github.com/mozilla/fxa/commit/ee0205595))
+- deps-dev: bump @types/node from 14.14.5 to 14.14.37 ([2d4131afe](https://github.com/mozilla/fxa/commit/2d4131afe))
+- deps: bump hot-shots from 8.2.0 to 8.3.0 ([da62dc16c](https://github.com/mozilla/fxa/commit/da62dc16c))
+- deps-dev: bump ts-node from 8.10.2 to 9.1.1 ([78f6296fc](https://github.com/mozilla/fxa/commit/78f6296fc))
+- deps-dev: downgrade @storybook/react from 6.1.21 to 5.3.19 ([c670cc984](https://github.com/mozilla/fxa/commit/c670cc984))
+- subscriptions: match alert bar width to content ([53ff63bf2](https://github.com/mozilla/fxa/commit/53ff63bf2))
+- deps-dev: bump @types/react-transition-group from 4.4.0 to 4.4.1 ([671ba5be0](https://github.com/mozilla/fxa/commit/671ba5be0))
+- deps: bump @stripe/react-stripe-js from 1.2.0 to 1.4.0 ([912647092](https://github.com/mozilla/fxa/commit/912647092))
+- payments: Fix missing American Express logo ([735840cee](https://github.com/mozilla/fxa/commit/735840cee))
+
 ## 1.203.6
 
 No changes.

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-payments-server",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "description": "Firefox Accounts Payments Service",
   "scripts": {
     "postinstall": "../../_scripts/clone-l10n.sh fxa-payments-server",

--- a/packages/fxa-profile-server/CHANGELOG.md
+++ b/packages/fxa-profile-server/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.203.7
+
+### New features
+
+- profile: create a monogram default avatar ([57d004be9](https://github.com/mozilla/fxa/commit/57d004be9))
+
+### Other changes
+
+- deps: bump aws-sdk from 2.851.0 to 2.879.0 ([66e6e3e1f](https://github.com/mozilla/fxa/commit/66e6e3e1f))
+- deps: bump sharp from 0.27.2 to 0.28.0 ([019624fe9](https://github.com/mozilla/fxa/commit/019624fe9))
+
 ## 1.203.6
 
 ### New features

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-profile-server",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "private": true,
   "description": "Firefox Accounts Profile service.",
   "scripts": {

--- a/packages/fxa-react/CHANGELOG.md
+++ b/packages/fxa-react/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.203.7
+
+### Bug fixes
+
+- fxa-settings: make Save button stable Because: Save was not consistent ([eeb0531ec](https://github.com/mozilla/fxa/commit/eeb0531ec))
+- fxa-settings: add background in menu category ([b73040f0b](https://github.com/mozilla/fxa/commit/b73040f0b))
+
+### Other changes
+
+- fxa-settings: add outline border for caution btn on focus ([5fe86fb85](https://github.com/mozilla/fxa/commit/5fe86fb85))
+- deps-dev: bump @types/jest from 26.0.20 to 26.0.22 ([fd9972286](https://github.com/mozilla/fxa/commit/fd9972286))
+- deps-dev: bump @types/node from 14.14.5 to 14.14.37 ([2d4131afe](https://github.com/mozilla/fxa/commit/2d4131afe))
+- deps-dev: downgrade @storybook/react from 6.1.21 to 5.3.19 ([c670cc984](https://github.com/mozilla/fxa/commit/c670cc984))
+- deps-dev: bump @types/react-transition-group from 4.4.0 to 4.4.1 ([671ba5be0](https://github.com/mozilla/fxa/commit/671ba5be0))
+
 ## 1.203.6
 
 No changes.

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-react",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "description": "Shared components for FxA React Apps",
   "exports": {
     "./components/": "./dist/components/",

--- a/packages/fxa-settings/CHANGELOG.md
+++ b/packages/fxa-settings/CHANGELOG.md
@@ -1,3 +1,50 @@
+## 1.203.7
+
+### New features
+
+- profile: create a monogram default avatar ([57d004be9](https://github.com/mozilla/fxa/commit/57d004be9))
+
+### Bug fixes
+
+- fxa-settings: change Close button to Cancel in delete ([1265a5dc7](https://github.com/mozilla/fxa/commit/1265a5dc7))
+- bug: Set email in text file download from recovery keys/codes ([ed7d314b2](https://github.com/mozilla/fxa/commit/ed7d314b2))
+- bug: Redirect to client/services page from legacy link ([bfe58b92c](https://github.com/mozilla/fxa/commit/bfe58b92c))
+- tests: get avatar functional tests working ([b43be01ef](https://github.com/mozilla/fxa/commit/b43be01ef))
+- fxa-settings: change Close button to Cancel ([accc148fd](https://github.com/mozilla/fxa/commit/accc148fd))
+- fxa-settings: make Add Photo and Take photo buttons consistent with Figma Because: names of the buttons are too close to the icons ([d2ab42d52](https://github.com/mozilla/fxa/commit/d2ab42d52))
+- fxa-settings: make Save button stable Because: Save was not consistent ([eeb0531ec](https://github.com/mozilla/fxa/commit/eeb0531ec))
+- fxa-settings: fixes modal padding for recovery and 2FA ([afaa4cae9](https://github.com/mozilla/fxa/commit/afaa4cae9))
+- l10n: Fix remaining localization issues ([dc85fb4c2](https://github.com/mozilla/fxa/commit/dc85fb4c2))
+- fxa-settings: add focus effect to Bento icon ([7744c2df2](https://github.com/mozilla/fxa/commit/7744c2df2))
+- fxa-settings: make eye behavior for password consistent ([f699152c7](https://github.com/mozilla/fxa/commit/f699152c7))
+- fxa-settings: add background in menu category ([b73040f0b](https://github.com/mozilla/fxa/commit/b73040f0b))
+- settings: picture buttons are correctly aligned to right ([68bc01f98](https://github.com/mozilla/fxa/commit/68bc01f98))
+- Settings: Add correct 'Replacing your recovery codes' 2FA link ([0230056e8](https://github.com/mozilla/fxa/commit/0230056e8))
+- l10n: Localize ModalVerifySession component ([094a40333](https://github.com/mozilla/fxa/commit/094a40333))
+- settings: call direct to auth-server for changes that send email ([05e09e05d](https://github.com/mozilla/fxa/commit/05e09e05d))
+- tests: get oauth_settings_clients test passing ([34ca8ccc2](https://github.com/mozilla/fxa/commit/34ca8ccc2))
+- l10n: Localize BentoMenu component ([56a2dba43](https://github.com/mozilla/fxa/commit/56a2dba43))
+- l10n: Localize DropDownAvatarMenu component ([8abdcfe4f](https://github.com/mozilla/fxa/commit/8abdcfe4f))
+- settings: fulfilling the requested change ([94ce8125f](https://github.com/mozilla/fxa/commit/94ce8125f))
+- settings: resolve ci tests failing problem ([fc9b59686](https://github.com/mozilla/fxa/commit/fc9b59686))
+- l10n: Fix recovery key l10n issues ([5ad103343](https://github.com/mozilla/fxa/commit/5ad103343))
+- settings: resolve two auth new recovery code styling issue ([aa3606d35](https://github.com/mozilla/fxa/commit/aa3606d35))
+
+### Other changes
+
+- fxa-settings: ee8bc507b style (fxa-settings) apply consistency to smaller breakpoints ([ee8bc507b](https://github.com/mozilla/fxa/commit/ee8bc507b))
+- fxa-settings: aremove extra semi-colon in scss ([01793c5ac](https://github.com/mozilla/fxa/commit/01793c5ac))
+- fxa-settings: add outline border for caution btn on focus ([5fe86fb85](https://github.com/mozilla/fxa/commit/5fe86fb85))
+- fxa-settings: a686a0625 style (fxa-settings) align category headers to subcategroies ([a686a0625](https://github.com/mozilla/fxa/commit/a686a0625))
+- fxa-settings: change border of red buttons on focus from none to transparent ([015bab685](https://github.com/mozilla/fxa/commit/015bab685))
+- deps-dev: bump @types/jest from 26.0.20 to 26.0.22 ([fd9972286](https://github.com/mozilla/fxa/commit/fd9972286))
+- deps: bump react-async-hook from 3.6.1 to 3.6.2 ([3b7c41ef7](https://github.com/mozilla/fxa/commit/3b7c41ef7))
+- deps-dev: bump @types/node from 14.14.5 to 14.14.37 ([2d4131afe](https://github.com/mozilla/fxa/commit/2d4131afe))
+- deps-dev: bump webpack-merge-and-include-globally ([85d66ef0e](https://github.com/mozilla/fxa/commit/85d66ef0e))
+- deps-dev: downgrade @storybook/react from 6.1.21 to 5.3.19 ([c670cc984](https://github.com/mozilla/fxa/commit/c670cc984))
+- deps: bump @apollo/client from 3.3.11 to 3.3.13 ([498af659b](https://github.com/mozilla/fxa/commit/498af659b))
+- deps: bump react-hook-form from 6.15.4 to 6.15.5 ([a81f2100a](https://github.com/mozilla/fxa/commit/a81f2100a))
+
 ## 1.203.6
 
 ### New features

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-settings",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "homepage": "https://accounts.firefox.com/settings",
   "private": true,
   "scripts": {

--- a/packages/fxa-shared/CHANGELOG.md
+++ b/packages/fxa-shared/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Change history
 
+## 1.203.7
+
+### New features
+
+- subscriptions: create subscriptions for existing PayPal customer ([7c4058585](https://github.com/mozilla/fxa/commit/7c4058585))
+- payments: Add processing screen for PayPal invalid billing agreement modal ([056dcba71](https://github.com/mozilla/fxa/commit/056dcba71))
+
+### Bug fixes
+
+- gql: dont report apollo errors ([27ae3ed33](https://github.com/mozilla/fxa/commit/27ae3ed33))
+
+### Refactorings
+
+- auth: use direct db connection for reads ([f4dc15a81](https://github.com/mozilla/fxa/commit/f4dc15a81))
+
+### Other changes
+
+- deps: bump @nestjs/mapped-types from 0.4.0 to 0.4.1 ([19f9af5cb](https://github.com/mozilla/fxa/commit/19f9af5cb))
+- deps: bump @nestjs/common from 7.6.13 to 7.6.15 ([95b1532d7](https://github.com/mozilla/fxa/commit/95b1532d7))
+- deps-dev: bump @nestjs/testing from 7.6.5 to 7.6.15 ([27b2c0358](https://github.com/mozilla/fxa/commit/27b2c0358))
+- deps: bump hot-shots from 8.3.0 to 8.3.1 ([8593d39cd](https://github.com/mozilla/fxa/commit/8593d39cd))
+- deps: bump @nestjs/graphql from 7.9.10 to 7.10.3 ([959a6d324](https://github.com/mozilla/fxa/commit/959a6d324))
+- deps: bump aws-sdk from 2.851.0 to 2.879.0 ([66e6e3e1f](https://github.com/mozilla/fxa/commit/66e6e3e1f))
+- deps: bump redis from 3.0.2 to 3.1.0 ([c5856f6bc](https://github.com/mozilla/fxa/commit/c5856f6bc))
+- deps-dev: bump @types/jest from 26.0.20 to 26.0.22 ([fd9972286](https://github.com/mozilla/fxa/commit/fd9972286))
+- deps: bump class-validator from 0.12.2 to 0.13.1 ([1f39c4e36](https://github.com/mozilla/fxa/commit/1f39c4e36))
+- deps-dev: bump @types/node from 14.14.5 to 14.14.37 ([2d4131afe](https://github.com/mozilla/fxa/commit/2d4131afe))
+- deps-dev: bump chai from 4.2.0 to 4.3.4 ([65530821d](https://github.com/mozilla/fxa/commit/65530821d))
+- deps: bump hot-shots from 8.2.0 to 8.3.0 ([da62dc16c](https://github.com/mozilla/fxa/commit/da62dc16c))
+- deps-dev: bump ts-node from 8.10.2 to 9.1.1 ([78f6296fc](https://github.com/mozilla/fxa/commit/78f6296fc))
+
 ## 1.203.6
 
 No changes.

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "description": "Shared module for FxA repositories",
   "main": "dist/index.js",
   "exports": {

--- a/packages/fxa-support-panel/CHANGELOG.md
+++ b/packages/fxa-support-panel/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change history
 
+## 1.203.4
+
+### Other changes
+
+- deps-dev: bump @types/supertest from 2.0.10 to 2.0.11 ([a983465ae](https://github.com/mozilla/fxa/commit/a983465ae))
+- deps: bump @nestjs/mapped-types from 0.4.0 to 0.4.1 ([19f9af5cb](https://github.com/mozilla/fxa/commit/19f9af5cb))
+- deps: bump @nestjs/common from 7.6.13 to 7.6.15 ([95b1532d7](https://github.com/mozilla/fxa/commit/95b1532d7))
+- deps: bump class-validator from 0.12.2 to 0.13.1 ([1f39c4e36](https://github.com/mozilla/fxa/commit/1f39c4e36))
+- deps-dev: bump @types/node from 14.14.5 to 14.14.37 ([2d4131afe](https://github.com/mozilla/fxa/commit/2d4131afe))
+- deps-dev: bump ts-node from 8.10.2 to 9.1.1 ([78f6296fc](https://github.com/mozilla/fxa/commit/78f6296fc))
+
 ## 1.203.6
 
 No changes.

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-support-panel",
-  "version": "1.203.6",
+  "version": "1.203.7",
   "description": "Small app to help customer support access FxA details",
   "directories": {
     "test": "test"


### PR DESCRIPTION
For historical reference, the current train 203 is going a week longer than usual, to synchronize with Firefox release schedule, but we need to test some stuff on staging that's already landed in main.

The simplest way to handle this is to create another point release on 203 that is not intended for release, but just for QA testing.

See also #8200.
