### PR TITLE
[docker] Include the ping command

### DIFF
--- a/_dev/docker/mono/Dockerfile
+++ b/_dev/docker/mono/Dockerfile
@@ -11,6 +11,7 @@ RUN set -x \
 RUN apt-get update && apt-get install -y \
     netcat \
     openssl \
+    iputils-ping \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=fxa-builder:latest --chown=app:app /fxa /fxa


### PR DESCRIPTION
## Because

I've noticed quite frequent complete server failures in a self-hosted environment (on Kubernetes) the last log messages containing:

```
Error: spawn ping ENOENT
    at Process.ChildProcess._handle.onexit (internal/child_process.js:269:19)
    at onErrorNT (internal/child_process.js:465:16)
    at processTicksAndRejections (internal/process/task_queues.js:80:21)
```

## This pull request

Just makes sure that the `ping` utility is available in the Docker image, which solved the issue completely.

## Issue that this pull request solves

Closes: #7539

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
