### PR TITLE
fix(fxa-settings): add focus border to download button

### DIFF
--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -55,7 +55,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
           )}
           download={`${primaryEmail.email} Firefox.txt`}
           data-testid="databutton-download"
-          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 focus:outline-black-dotted"
+          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 active:outline-black-dotted focus:outline-black-dotted"
           onClick={() => onAction?.('download')}
         >
           <DownloadIcon
@@ -76,7 +76,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
             onAction?.('copy');
           }}
           data-testid="databutton-copy"
-          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 focus:outline-black-dotted"
+          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 active:outline-black-dotted focus:outline-black-dotted"
         >
           <CopyIcon
             width="21"
@@ -98,7 +98,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
             onAction?.('print');
           }}
           data-testid="databutton-print"
-          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 focus:outline-black-dotted"
+          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 active:outline-black-dotted focus:outline-black-dotted"
         >
           <PrintIcon
             height="24"

--- a/packages/fxa-settings/src/components/GetDataTrio/index.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.tsx
@@ -55,7 +55,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
           )}
           download={`${primaryEmail.email} Firefox.txt`}
           data-testid="databutton-download"
-          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500"
+          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 focus:outline-black-dotted"
           onClick={() => onAction?.('download')}
         >
           <DownloadIcon
@@ -76,7 +76,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
             onAction?.('copy');
           }}
           data-testid="databutton-copy"
-          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500"
+          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 focus:outline-black-dotted"
         >
           <CopyIcon
             width="21"
@@ -98,7 +98,7 @@ export const GetDataTrio = ({ value, onAction }: GetDataTrioProps) => {
             onAction?.('print');
           }}
           data-testid="databutton-print"
-          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500"
+          className="w-12 h-12 relative inline-block text-grey-500 rounded active:text-blue-500 focus:outline-black-dotted"
         >
           <PrintIcon
             height="24"


### PR DESCRIPTION
## Because

- clicking on download button should display focus border, just like copy and print buttons

## This pull request

- add focus border to the recovery key download button, just like the copy and the print buttons

## Issue that this pull request solves

Closes: #8117 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
