### PR TITLE
fix(avatar): add profile server to payments img-src CSP

### DIFF
--- a/packages/fxa-payments-server/server/lib/csp.test.js
+++ b/packages/fxa-payments-server/server/lib/csp.test.js
@@ -53,10 +53,11 @@ describe('CSP blocking rules', () => {
   it('has correct imgSrc directives', () => {
     const { imgSrc } = directives;
 
-    expect(imgSrc).toHaveLength(6);
+    expect(imgSrc).toHaveLength(7);
     expect(imgSrc).toContain(Sources.SELF);
     expect(imgSrc).toContain(Sources.DATA);
     expect(imgSrc).toContain(Sources.GRAVATAR);
+    expect(imgSrc).toContain(Sources.PROFILE_SERVER);
     expect(imgSrc).toContain(Sources.PROFILE_IMAGES_SERVER);
     expect(imgSrc).toContain(Sources.ACCOUNTS_STATIC_CDN);
     expect(imgSrc).toContain(CDN_SERVER);

--- a/packages/fxa-payments-server/server/lib/csp/blocking.js
+++ b/packages/fxa-payments-server/server/lib/csp/blocking.js
@@ -87,6 +87,7 @@ module.exports = function (config) {
         // to break the site for users who already use a Gravatar as
         // their profile image.
         GRAVATAR,
+        PROFILE_SERVER,
         PROFILE_IMAGES_SERVER,
         ACCOUNTS_STATIC_CDN,
         ...EXTRA_IMG_SRC,


### PR DESCRIPTION
Because:
 - payments server's CSP was blocking the new default avatar that's served
   from the profile server

This commit:
 - add the profile server to payments server's CSP's img-src directive


## Issue that this pull request solves

Closes: #8157 

