### PR TITLE
fix(Settings): Enable 'Delete Account' button when the password lenth is 8 or more

### DIFF
--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.test.tsx
@@ -90,17 +90,29 @@ describe('PageDeleteAccount', () => {
     expect(screen.getByTestId('continue-button')).toBeDisabled();
   });
 
-  it('Gets valid response on submit', async () => {
+  it('Enables "Delete" button once the password length is of 8 characters or more', async () => {
     renderWithRouter(
-      <AuthContext.Provider value={{ auth: client }}>
-        <MockedCache>
-          <PageDeleteAccount />
-        </MockedCache>
-      </AuthContext.Provider>
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <PageDeleteAccount />
+      </AppContext.Provider>
     );
 
     await advanceStep();
-    await typeByTestIdFn('delete-account-confirm-input-field')('hunter6');
+    expect(screen.getByTestId('delete-account-button')).toBeDisabled();
+
+    await typeByTestIdFn('delete-account-confirm-input-field')('password');
+    expect(screen.getByTestId('delete-account-button')).toBeEnabled();
+  });
+
+  it('Gets valid response on submit', async () => {
+    renderWithRouter(
+      <AppContext.Provider value={mockAppContext({ account })}>
+        <PageDeleteAccount />
+      </AppContext.Provider>
+    );
+
+    await advanceStep();
+    await typeByTestIdFn('delete-account-confirm-input-field')('hunter67');
 
     const deleteAccountButton = screen.getByTestId('delete-account-button');
     expect(deleteAccountButton).toBeEnabled();

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -218,6 +218,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
                   }}
                   inputRef={register({
                     required: true,
+                    minLength: 8,
                   })}
                   {...{ errorText }}
                 />


### PR DESCRIPTION
## Because

- “Delete account” button from Step 2 Delete account page enables when the password length is one or greater than one

## This pull request

- Intends to fix the above-mentioned issue by setting the minimum length of the password to be 8 for the button to get enabled

## Issue that this pull request solves

Closes: #7419

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
I'm creating a draft PR since I'm supposed to add tests for this issue which I will once I get my queries cleared.