### PR TITLE
fix(tests): fix and re-enable confirm.js functional test

### DIFF
--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -17,7 +17,7 @@ module.exports = testsSettingsV2.concat([
   'tests/functional/back_button_after_start.js',
   'tests/functional/bounced_email.js',
   'tests/functional/change_password.js',
-  // #7987 'tests/functional/confirm.js',
+  'tests/functional/confirm.js',
   'tests/functional/connect_another_device.js',
   'tests/functional/cookies_disabled.js',
   'tests/functional/delete_account.js',

--- a/packages/fxa-content-server/tests/functional/confirm.js
+++ b/packages/fxa-content-server/tests/functional/confirm.js
@@ -38,7 +38,7 @@ registerSuite('confirm', {
     },
 
     'sign up, wait for confirmation screen, click resend': function () {
-      const email = 'test_signin' + Math.random() + '@restmail.dev.lcip.org';
+      const email = 'test_signin' + Math.random() + '@restmail.net';
 
       return (
         this.remote
@@ -58,7 +58,7 @@ registerSuite('confirm', {
           // the test below depends on the speed of the email resent XHR
           // we have to wait until the resent request completes and the
           // success notification is visible
-          .then(testSuccessWasShown())
+          .then(testSuccessWasShown(null, '.success'))
       );
     },
   },


### PR DESCRIPTION
Fixes #7987.

The first test was failing the MX record check for restmail.dev.lcip.org, so I changed the email domain to restmail.net. Doesn't seem to break anything 🤷 

Also updated a success check to check for the old-style success element. Really looking forward to improving this API in #7882.