### PR TITLE
fix(tests): fix and re-enable sign_up.js functional test

### DIFF
--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -64,7 +64,7 @@ module.exports = testsSettingsV2.concat([
   'tests/functional/sign_in_cached.js',
   'tests/functional/sign_in_recovery_code.js',
   'tests/functional/sign_in_totp.js',
-  // #7988 'tests/functional/sign_up.js',
+  'tests/functional/sign_up.js',
   'tests/functional/subscriptions.js',
   'tests/functional/support.js',
   'tests/functional/sync_v1.js',

--- a/packages/fxa-content-server/tests/functional/sign_up.js
+++ b/packages/fxa-content-server/tests/functional/sign_up.js
@@ -27,6 +27,7 @@ const {
   openPage,
   openSignUpInNewTab,
   pollUntilHiddenByQSA,
+  signOut,
   switchToWindow,
   testAttributeIncludes,
   testElementExists,
@@ -95,7 +96,7 @@ registerSuite('signup here', {
 
         .then(testElementExists(selectors.SETTINGS.HEADER))
         .then(testSuccessWasShown())
-        .then(click(selectors.SETTINGS.SIGNOUT))
+        .then(signOut())
 
         .then(testElementExists(selectors.ENTER_EMAIL.HEADER))
 
@@ -105,7 +106,7 @@ registerSuite('signup here', {
 
         .then(testElementExists(selectors.SETTINGS.HEADER))
         .then(testSuccessWasShown())
-        .then(click(selectors.SETTINGS.SIGNOUT))
+        .then(signOut())
 
         .then(testElementExists(selectors.ENTER_EMAIL.HEADER))
         .then(fillOutEmailFirstSignIn(email, PASSWORD))
@@ -215,7 +216,7 @@ registerSuite('signup here', {
           // The original tab should transition to the settings page w/ success
           // message.
           .then(testElementExists(selectors.SETTINGS.HEADER))
-          .then(click(selectors.SETTINGS.SIGNOUT))
+          .then(signOut())
 
           .then(testElementExists(selectors.ENTER_EMAIL.HEADER))
           // check the email address was cleared


### PR DESCRIPTION
Updating the old sign out selector to the `signOut` helper seems to have fixed the bugs here.

Fixes #7988.