### PR TITLE
fix(auth-server): fix stripe webhook errors

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal-error-codes.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-error-codes.ts
@@ -83,3 +83,11 @@ export const PAYPAL_BILLING_AGREEMENT_INVALID = 10201;
  * Returned with a transaction if the message sub id was seen before.
  */
 export const PAYPAL_REPEAT_MESSAGE_SUB_ID = 11607;
+
+/**
+ * Returned with a transaction where the billing agreement was created
+ * with a different business account.
+ *
+ * Should only occur when using multiple dev apps on the same Stripe account.
+ */
+export const PAYPAL_BILLING_TRANSACTION_WRONG_ACCOUNT = 11451;

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1486,7 +1486,13 @@ export class StripeHelper {
   }
 
   /**
-   * Extract invoice details for billing emails
+   * Extract invoice details for billing emails.
+   *
+   * Note that this function throws an error in the following cases:
+   *   - Stripe customer is deleted.
+   *   - No plan in the invoice.
+   *   - No product attached to the plan.
+   *   - No email on the customer object.
    */
   async extractInvoiceDetailsForEmail(latestInvoice: Stripe.Invoice | string) {
     const invoice = await this.expandResource(latestInvoice, INVOICES_RESOURCE);


### PR DESCRIPTION
Because:

* We were rejecting Stripe payloads that exceeded 16Kb, some were as
  large as 22Kb.
* Stripe webhooks that sent emails to customers who deleted their
  account were throwing errors that Stripe keeps retrying.

This commit:

* Updates the maxBytes for the Stripe webhook to accomodate the larger
  payload sizes observed.
* Adds error catching to the email calls in the webhooks to capture and
  report errors that we expect (account deleted), but returns a proper
  200 to Stripe.

Fixes #7203

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
