### PR TITLE
fix(fxa-settings): changes the color of Delete Button

### DIFF
--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.tsx
@@ -238,7 +238,7 @@ export const PageDeleteAccount = (_: RouteComponentProps) => {
               <Localized id="delete-account-delete-button-2">
                 <button
                   type="submit"
-                  className="cta-primary mx-2 px-4"
+                  className="cta-caution mx-2 px-4 tablet:px-10"
                   data-testid="delete-account-button"
                   disabled={disabled}
                 >


### PR DESCRIPTION
fixes #7417

## Because

- Delete button on the page 2 of 2 of Delete Account page has a primary(blue) color.

## This pull request

- changes the color of the delete button
- adds cta-caution to delete button, similar to delete account link.
- has a proper display on all screen widths


## Issue that this pull request solves

Closes: #7417 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.
![Screenshot from 2021-04-11 10-16-44](https://user-images.githubusercontent.com/69427216/114292837-1d82d580-9aaf-11eb-8306-8a6e75da1aa3.png)


## Other information (Optional)

Any other information that is important to this pull request.
