### PR TITLE
[fxa-auth-server] Avoid logging errors for missing metrics flow

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/events.js
+++ b/packages/fxa-auth-server/lib/metrics/events.js
@@ -52,12 +52,18 @@ const IGNORE_FLOW_EVENTS_FROM_SERVICES = {
 };
 
 const IGNORE_ROUTE_FLOW_EVENTS_FOR_PATHS = new Set([
+  '/',
+  '/__version__',
+  '/__heartbeat__',
+  '/__lbheartbeat__',
   '/account/devices',
   '/account/profile',
   '/account/sessions',
   '/certificate/sign',
   '/password/forgot/status',
   '/recovery_email/status',
+  '/jwks',
+  '/introspect',
 ]);
 
 const IGNORE_ROUTE_FLOW_EVENTS_REGEX = /^\/recoveryKey\/[0-9A-Fa-f]+$/;


### PR DESCRIPTION
## Because

Metrics flow ID's are usually not available (and not very helpful) for internal system-to-system communication.

## This pull request

Adds some fxa-auth-server resource paths commonly used by autonomous (and external-to-FxA) HTTP clients to the list of ignored paths for missing-metrics-flow logging:

* `/` - the root doesn't have any functionality other than presenting the version
* `/__version__` - fetching the version with `curl` shouldn't log an error
* `/__heartbeat__` - integrating health checks (Docker, Kubernetes, ...)
* `/__lbheartbeat__` - integrating health checks (Docker, Kubernetes, ...)
* `/jwks` - queried by the tokenserver (at least in self-hosted environments)
* `/introspect` - standard integration resource for external clients

## Issue that this pull request solves

Closes: #8234

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
