### PR TITLE
[fxa-auth-server]: Fix "Cannot read property 'trim' of undefined"

### DIFF
--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -177,6 +177,7 @@ async function create(log, error, config, routes, db, translator, statsd) {
       xff.push(request.info.remoteAddress);
 
       return xff
+        .filter(Boolean)
         .map((address) => address.trim())
         .filter(
           (address) => !joi.validate(address, IP_ADDRESS.required()).error


### PR DESCRIPTION
## Because

The error is being logged in Sentry for quite some time and very often:
```
TypeError: Cannot read property 'trim' of undefined
  File "/fxa/packages/fxa-auth-server/dist/fxa-auth-server/lib/server.js", line 180, col 35, in null.<anonymous>
    .map((address) => address.trim())
  ?, in Array.map
  File "/fxa/packages/fxa-auth-server/dist/fxa-auth-server/lib/server.js", line 180, col 10, in null.<anonymous>
    .map((address) => address.trim())
  File "/fxa/packages/fxa-auth-server/dist/fxa-auth-server/lib/server.js", line 377, col 17, in Object.get
    value = getter();
  File "/fxa/packages/fxa-auth-server/dist/fxa-auth-server/lib/server.js", line 187, col 46, in null.<anonymous>
    const remoteAddressChain = request.app.remoteAddressChain;
  File "/fxa/packages/fxa-auth-server/dist/fxa-auth-server/lib/server.js", line 377, col 17, in Object.get
    value = getter();
  File "/fxa/packages/fxa-auth-server/dist/fxa-auth-server/lib/server.js", line 209, col 30, in null.<anonymous>
    getGeoData(request.app.clientAddress)
...
```

## This pull request

Ensures that all IP address entries in the array actually represent some value, which filters out cases like the following:
* `undefined`
* `null`
* `""`

## Issue that this pull request solves

Closes: #7297

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
