### PR TITLE
fix(tests): Fix firefox handshake functional tests

### DIFF
--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -25,7 +25,7 @@ module.exports = testsSettingsV2.concat([
   'tests/functional/email_opt_in.js',
   'tests/functional/email_service.js',
   'tests/functional/force_auth.js',
-  // #7978 'tests/functional/fx_desktop_handshake.js',
+  'tests/functional/fx_desktop_handshake.js',
   'tests/functional/fx_fennec_v1_force_auth.js',
   'tests/functional/fx_fennec_v1_settings.js',
   'tests/functional/fx_fennec_v1_sign_in.js',

--- a/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js
+++ b/packages/fxa-content-server/tests/functional/fx_desktop_handshake.js
@@ -26,7 +26,6 @@ const SYNC_ENTER_EMAIL_PAGE_URL = `${ENTER_EMAIL_PAGE_URL}&service=sync`;
 const SETTINGS_PAGE_URL = `${
   config.fxaContentRoot
 }settings?forceUA=${encodeURIComponent(userAgent)}`;
-const SYNC_SETTINGS_PAGE_URL = `${SETTINGS_PAGE_URL}&service=sync`;
 
 const SYNC_SMS_PAGE_URL = `${
   config.fxaContentRoot
@@ -325,6 +324,9 @@ registerSuite('Firefox desktop user info handshake', {
         .then(testElementValueEquals(selectors.FORCE_AUTH.EMAIL, otherEmail));
     },
 
+    // TODO: These tests are dependent on the changes in #8244
+    //
+    /*
     'Sync settings page - user signed into browser': function () {
       return this.remote
         .then(
@@ -374,6 +376,7 @@ registerSuite('Firefox desktop user info handshake', {
         openPage(SETTINGS_PAGE_URL, selectors.ENTER_EMAIL.HEADER)
       );
     },
+    */
 
     'Non-Sync settings page - no user signed into browser, user signed in locally': function () {
       return this.remote


### PR DESCRIPTION
## Because

- These tests were disabled after migrating to new settings

## This pull request

- Re-enables most of them however the others are broken because of https://github.com/mozilla/fxa/issues/8244

## Issue that this pull request solves

Closes: #7978 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
