### PR TITLE
fix(tests): Make fxa-settings and fxa-content-server tests dependent on each other

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
         "fxa-auth-client",
         "fxa-shared",
         "fxa-profile-server",
-        "fxa-payments-server"
+        "fxa-payments-server",
+        "fxa-settings"
       ],
       "fxa-auth-server": [
         "fxa-auth-db-mysql",
@@ -71,7 +72,8 @@
       ],
       "fxa-settings": [
         "fxa-shared",
-        "fxa-react"
+        "fxa-react",
+        "fxa-content-server"
       ]
     }
   },


### PR DESCRIPTION
## Because

- A lot of the sign-in/sign-up functional tests go through various flows in new settings so we should ensure that both suites of tests run when a change occurs in either project

## This pull request

- Makes fxa-settings and fxa-content-server tests dependent on each other

## Issue that this pull request solves

Closes: NA

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
