### PR TITLE
fix(auth-server): handle empty responses

### DIFF
--- a/packages/fxa-shared/nestjs/sentry/reporting.ts
+++ b/packages/fxa-shared/nestjs/sentry/reporting.ts
@@ -122,12 +122,6 @@ export function reportRequestException(
   excContexts: ExtraContext[] = [],
   request?: Request
 ) {
-  // Don't report HttpExceptions, we test for its two attributes as its more reliable
-  // than instance checks of HttpException
-  if (exception.status && exception.response) {
-    return;
-  }
-
   // Don't report already reported exceptions
   if (exception.reported) {
     return;


### PR DESCRIPTION
Because:

* We relay the exact response back from the RP we deliver to, and
  the HttpException test only triggers if the data is present.

This commit:

* Changes the HttpException property testing to check if the properties
  exist rather than their value.

Fixes #7067

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
