### PR TITLE
fix: Use relative imports within the same package.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,8 @@
   "files.trimTrailingWhitespace": true,
   "files.trimFinalNewlines": true,
   "files.insertFinalNewline": true,
+  "typescript.preferences.importModuleSpecifier": "relative",
+  "javascript.preferences.importModuleSpecifier": "relative",
   "[javascript]": {
     "editor.detectIndentation": false,
     "editor.tabSize": 2,


### PR DESCRIPTION
Because:

* The prod package build works different from stage in terms of yarn workspaces and namespaces.

This commit:

* Prevents VSCode from automatically using absolute imports in this situation.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
