### PR TITLE
fix(emails): encode the legal docs redirect url query param correctly

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -2682,7 +2682,9 @@ module.exports = function (log, config) {
   });
 
   Mailer.prototype._legalDocsRedirectUrl = function (url) {
-    return `${paymentsServerURL.origin}/legal-docs?url=${encodeURI(url)}`;
+    return `${paymentsServerURL.origin}/legal-docs?url=${encodeURIComponent(
+      url
+    )}`;
   };
 
   Mailer.prototype._generateUTMLink = function (

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -2137,7 +2137,7 @@ function configUrl(key, campaign, content, ...params) {
   const url = out.toString();
   if (['subscriptionTermsUrl', 'subscriptionPrivacyUrl'].includes(key)) {
     const parsedUrl = new URL(config.subscriptions.paymentsServer.url);
-    return `${parsedUrl.origin}/legal-docs?url=${encodeURI(url)}`;
+    return `${parsedUrl.origin}/legal-docs?url=${encodeURIComponent(url)}`;
   }
 
   return url;


### PR DESCRIPTION
Because:
 - the url query parameter for the legal docs redirect endpoint links in
   the subscription emails was not encoded correctly

This commit:
 - encode the url query param as a URI component

## Issue that this pull request solves

Closes: #8268 

