### PR TITLE
fix(l10n): use en-CA not en-GB for settings and payments

### DIFF
--- a/packages/fxa-auth-server/test/local/mailer_locales.js
+++ b/packages/fxa-auth-server/test/local/mailer_locales.js
@@ -50,7 +50,6 @@ describe('mailer locales', () => {
     const locales = [
       // [ locale, expected result ]
       ['', 'en'],
-      ['en-CA', 'en'],
       ['db-LB', 'en'],
       ['el-GR', 'el'],
       ['es-BO', 'es'],

--- a/packages/fxa-react/lib/AppLocalizationProvider.tsx
+++ b/packages/fxa-react/lib/AppLocalizationProvider.tsx
@@ -9,7 +9,7 @@ import React, { Component } from 'react';
 
 import availableLocales from 'fxa-shared/l10n/supportedLanguages.json';
 
-const OTHER_EN_LOCALES = ['en-NZ', 'en-CA', 'en-SG', 'en-MY'];
+const OTHER_EN_LOCALES = ['en-NZ', 'en-SG', 'en-MY'];
 
 async function fetchMessages(baseDir: string, locale: string, bundle: string) {
   try {

--- a/packages/fxa-shared/l10n/supportedLanguages.json
+++ b/packages/fxa-shared/l10n/supportedLanguages.json
@@ -15,6 +15,7 @@
   "el",
   "en",
   "en-GB",
+  "en-CA",
   "en-US",
   "es",
   "es-AR",


### PR DESCRIPTION
Because:
 - we are using en-GB messages for en-CA even though we have
   translations for en-CA

This commit:
 - remove en-CA from the list of locales that falls back to en-GB
 - add en-CA to the list of supported languages

## Issue that this pull request solves

Closes: #8204 
