### PR TITLE
fix(tests): Fix oauth webchannel tests

### DIFF
--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -6,7 +6,7 @@ const testsSettingsV2 = require('./functional_settings_v2');
 // Run the new settings tests first
 module.exports = testsSettingsV2.concat([
   'tests/functional/fx_browser_relier.js',
-  // #7981 'tests/functional/oauth_webchannel.js',
+  'tests/functional/oauth_webchannel.js',
   'tests/functional/reset_password.js',
   'tests/functional/oauth_require_totp.js',
   'tests/functional/sign_up_with_code.js',

--- a/packages/fxa-content-server/tests/functional/oauth_webchannel.js
+++ b/packages/fxa-content-server/tests/functional/oauth_webchannel.js
@@ -4,7 +4,6 @@
 
 'use strict';
 
-const config = intern._config;
 const { registerSuite } = intern.getInterface('object');
 const FunctionalHelpers = require('./lib/helpers');
 const selectors = require('./lib/selectors');
@@ -20,7 +19,6 @@ const {
   fillOutEmailFirstSignIn,
   fillOutEmailFirstSignUp,
   fillOutSignUpCode,
-  openPage,
   openFxaFromRp,
   testElementExists,
   testIsBrowserNotified,
@@ -106,6 +104,7 @@ registerSuite('oauth webchannel', {
         .then(fillOutEmailFirstSignIn(email, PASSWORD))
         .then(testIsBrowserNotified('fxaccounts:oauth_login'));
     },
+    /* TODO: This test is dependent on the fix in #8244
     settings: function () {
       const SETTINGS_PAGE_URL = `${config.fxaContentRoot}settings?context=oauth_webchannel_v1`;
 
@@ -131,5 +130,6 @@ registerSuite('oauth webchannel', {
           );
         });
     },
+    */
   },
 });


### PR DESCRIPTION
## Because

- These tests were disabled

## This pull request

- Enables all oauth webchannel tests except the one test that is dependent on changes from https://github.com/mozilla/fxa/issues/8244

## Issue that this pull request solves

Closes: #7981

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
