### PR TITLE
chore(auth): append PayPalClientError message with PayPal error code

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal-client.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-client.ts
@@ -122,7 +122,7 @@ type BillToAddressData = {
   STREET: string;
   STREET2: string;
   ZIP: string;
-}
+};
 
 export type TransactionStatus =
   | 'Pending'
@@ -159,7 +159,9 @@ export type NVPDoReferenceTransactionResponse = NVPResponse &
 
 export type NVPRefundTransactionResponse = NVPResponse & RefundTransactionData;
 
-export type NVPBAUpdateTransactionResponse = NVPResponse & BAUpdateData & BillToAddressData;
+export type NVPBAUpdateTransactionResponse = NVPResponse &
+  BAUpdateData &
+  BillToAddressData;
 
 export type NVPTransactionSearchResponse = TransactionSearchData & NVPResponse;
 
@@ -255,13 +257,12 @@ export class PayPalClientError extends Error {
   constructor(raw: string, data: NVPResponse, ...params: any) {
     super(...params);
     this.name = 'PayPalClientError';
+    this.errorCode = data.L?.length ? parseInt(data.L[0].ERRORCODE) : undefined;
     if (!this.message) {
-      this.message =
-        'PayPal NVP returned a non-success ACK. See "this.raw" or "this.data" for more details.';
+      this.message = `PayPal NVP returned a non-success ACK. See "this.raw" or "this.data" for more details. PayPal error code: ${this.errorCode}`;
     }
     this.raw = raw;
     this.data = data;
-    this.errorCode = data.L?.length ? parseInt(data.L[0].ERRORCODE) : undefined;
   }
 }
 

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -230,6 +230,7 @@ describe('PayPalClient', () => {
         assert.equal(err.name, 'PayPalClientError');
         assert.include(err.raw, 'ACK=Failure');
         assert.equal(err.data.ACK, 'Failure');
+        assert.equal(err.errorCode, 15005);
       }
     });
   });


### PR DESCRIPTION
Because:

* The default message for PayPalClientError doesn't provide any specific information about the error.

This commit:

* Adds the PayPal error code to the default PayPalClientError message.

Closes #8266

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).