### PR TITLE
fix: stop reporting apollo errors

### DIFF
--- a/packages/fxa-shared/nestjs/sentry/sentry.interceptor.ts
+++ b/packages/fxa-shared/nestjs/sentry/sentry.interceptor.ts
@@ -4,10 +4,11 @@
 import {
   CallHandler,
   ExecutionContext,
+  HttpException,
   Injectable,
   NestInterceptor,
-  HttpException,
 } from '@nestjs/common';
+import { ApolloError } from 'apollo-server';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
@@ -27,6 +28,10 @@ export class SentryInterceptor implements NestInterceptor {
             if ((exception as HttpException).getStatus() < 500) {
               return;
             }
+          }
+          // Skip ApolloErrors
+          if (exception instanceof ApolloError) {
+            return;
           }
           processException(context, exception);
         },


### PR DESCRIPTION
Because:

* Apollo Errors are already internally processed and used for control
  flow. They should not be reported to Sentry as the underlying error
  was already reported.

This commit:

* Properly ignores ApolloError's in the interceptor.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

This is from Sentry: https://sentry.prod.mozaws.net/operations/fxa-graphql-prod/issues/10391832/
An issue was not filed.