### PR TITLE
fix(test): fix oauth functional test

### DIFF
--- a/packages/fxa-content-server/tests/functional/oauth_permissions.js
+++ b/packages/fxa-content-server/tests/functional/oauth_permissions.js
@@ -23,6 +23,7 @@ let email;
 
 const {
   click,
+  closeCurrentWindow,
   createEmail,
   createUser,
   fillOutForceAuth,
@@ -34,6 +35,8 @@ const {
   openFxaFromRp: openFxaFromTrustedRp,
   openFxaFromUntrustedRp,
   openPage,
+  openSettingsInNewTab,
+  switchToWindow,
   testElementExists,
   testUrlEquals,
   type,
@@ -178,7 +181,6 @@ registerSuite('oauth permissions for untrusted reliers', {
       );
     },
 
-    /* TODO: This test is dependent on the fix in #8281
     'signin with new permission available b/c of new account information': function () {
       return (
         this.remote
@@ -238,7 +240,6 @@ registerSuite('oauth permissions for untrusted reliers', {
           )
       );
     },
-    */
 
     'signin with additional requested permission': function () {
       return (

--- a/packages/fxa-content-server/tests/functional/settings_v2/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/settings_v2/lib/helpers.js
@@ -15,6 +15,7 @@ const {
   createUser,
   openPage,
   fillOutEmailFirstSignIn,
+  testElementExists,
 } = FunctionalHelpers.helpersRemoteWrapped;
 
 async function navigateToSettingsV2(remote) {
@@ -24,7 +25,7 @@ async function navigateToSettingsV2(remote) {
 
   await openPage(EMAIL_FIRST, selectors.ENTER_EMAIL.HEADER, remote);
   await fillOutEmailFirstSignIn(email, password, remote);
-
+  await testElementExists(selectors.SETTINGS_V2.APP, remote);
   return email;
 }
 

--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -9,6 +9,7 @@ export interface OldSettingsData {
   uid: hexstring;
   sessionToken: hexstring;
   alertText?: string;
+  displayName?: string;
 }
 
 type LocalAccount = OldSettingsData | undefined;
@@ -22,7 +23,7 @@ function accounts(accounts?: LocalAccounts) {
   return storage.get('accounts') as LocalAccounts;
 }
 
-function currentAccount(account?: OldSettingsData) {
+export function currentAccount(account?: OldSettingsData) {
   const all = accounts() || {};
   const uid = storage.get('currentAccountUid') as hexstring;
   if (account) {

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -1,7 +1,7 @@
 import { gql, ApolloClient, Reference } from '@apollo/client';
 import config from '../lib/config';
 import AuthClient, { generateRecoveryKey } from 'fxa-auth-client/browser';
-import { sessionToken } from '../lib/cache';
+import { currentAccount, sessionToken } from '../lib/cache';
 import firefox from '../lib/firefox';
 
 export interface DeviceLocation {
@@ -375,6 +375,9 @@ export class Account implements AccountData {
         variables: { input: { displayName } },
       })
     );
+    const legacyLocalStorageAccount = currentAccount()!;
+    legacyLocalStorageAccount.displayName = displayName;
+    currentAccount(legacyLocalStorageAccount);
     firefox.profileChanged(this.uid);
   }
 


### PR DESCRIPTION
Ummmmmm. Local storage is not a good way to handle oauth permission prompts but fixing that is much different than fixing the test case.

fixes #8281