### PR TITLE
7012 fxa settings fix footer links

### DIFF
--- a/packages/fxa-react/components/Footer/index.tsx
+++ b/packages/fxa-react/components/Footer/index.tsx
@@ -11,7 +11,7 @@ export const Footer = () => {
   const { l10n } = useLocalization();
   return (
     <footer
-      className="py-4 mt-16 mx-4 flex-wrap mobileLandscape:flex-no-wrap mobileLandscape:mx-8 mobileLandscape:pb-6 mobileLandscape:flex-col flex border-t border-grey-100 text-grey-400"
+      className="py-4 mt-16 mx-4 flex-col mobileLandscape:flex-row mobileLandscape:mx-8 mobileLandscape:pb-6 mobileLandscape:flex-col flex border-t border-grey-100 text-grey-400"
       data-testid="footer"
     >
       <LinkExternal

--- a/packages/fxa-react/components/Footer/index.tsx
+++ b/packages/fxa-react/components/Footer/index.tsx
@@ -11,7 +11,7 @@ export const Footer = () => {
   const { l10n } = useLocalization();
   return (
     <footer
-      className="py-4 mt-16 mx-4 flex-wrap mobileLandscape:flex-no-wrap mobileLandscape:mx-8 mobileLandscape:pb-6 flex border-t border-grey-100 text-grey-400"
+      className="py-4 mt-16 mx-4 flex-wrap mobileLandscape:flex-no-wrap mobileLandscape:mx-8 mobileLandscape:pb-6 mobileLandscape:flex-col flex border-t border-grey-100 text-grey-400"
       data-testid="footer"
     >
       <LinkExternal
@@ -28,7 +28,7 @@ export const Footer = () => {
         <LinkExternal
           data-testid="link-privacy"
           href="https://www.mozilla.org/en-US/privacy/websites/"
-          className="transition-standard w-full text-xs my-3 hover:text-grey-500 hover:underline mobileLandscape:my-0 mobileLandscape:w-auto mobileLandscape:mx-10 mobileLandscape:self-end"
+          className="transition-standard w-full text-xs my-3 hover:text-grey-500 hover:underline mobileLandscape:my-0 mobileLandscape:w-max mobileLandscape:mx-10 mobileLandscape:self-end"
         >
           Website Privacy Notice
         </LinkExternal>
@@ -37,7 +37,7 @@ export const Footer = () => {
         <LinkExternal
           data-testid="link-terms"
           href="https://www.mozilla.org/en-US/about/legal/terms/services/"
-          className="transition-standard w-full text-xs mobileLandscape:self-end hover:text-grey-500 hover:underline mobileLandscape:w-auto"
+          className="transition-standard w-full text-xs mobileLandscape:self-end hover:text-grey-500 hover:underline mobileLandscape:w-max"
         >
           Terms of Service
         </LinkExternal>

--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -290,7 +290,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
 
           <Localized id="pw-change-forgot-password-link">
             <a
-              className="link-blue text-sm justify-center flex"
+              className="link-blue text-sm justify-center flex mobileLandscape:w-max"
               data-testid="nav-link-reset-password"
               href="/reset_password"
             >


### PR DESCRIPTION
## Because

- Clickable spaces are extended to the entire width of the footer.

## This pull request

- The clickable spaces now encompass the text of the link only.

## Issue that this pull request solves

Closes: #7012

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="222" alt="footer problem" src="https://user-images.githubusercontent.com/73819616/114902309-9cf50980-9e0d-11eb-909b-9727b91583ce.PNG">
<img width="224" alt="footer fix" src="https://user-images.githubusercontent.com/73819616/114902325-9feffa00-9e0d-11eb-8714-ce8b22e2aaea.PNG">


Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)
Issue was fixed, however I will like to suggest a more colorful UI for the Firefox accounts in future that can be eye-catching to create a lasting user experience.

Any other information that is important to this pull request.
