### PR TITLE
fix(settings): ensure the object returned from useSession is stable

### DIFF
--- a/packages/fxa-content-server/tests/intern.js
+++ b/packages/fxa-content-server/tests/intern.js
@@ -44,7 +44,7 @@ const fxaProduction = !!args.fxaProduction;
 const fxaDevBox = !!args.fxaDevBox;
 
 const fxaToken = args.fxaToken || 'http://';
-const asyncTimeout = parseInt(args.asyncTimeout || 5000, 10);
+const asyncTimeout = parseInt(args.asyncTimeout || 10000, 10);
 
 // On Circle, we bail after the first failure.
 // args.bailAfterFirstFailure comes in as a string.


### PR DESCRIPTION
Because the ModalVerifySession has a useEffect that depends on the session to send a verification email. Without this it could send multiple emails.