### PR TITLE
Allow to use non-localhost databases

### DIFF
--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -111,6 +111,23 @@ This package uses [Mocha](https://mochajs.org/) to test its code. By default `np
 
 Refer to Mocha's [CLI documentation](https://mochajs.org/#command-line-usage) for more advanced test configuration.
 
+### Testing with non-local databases
+
+Executing tests using remote databases (MySQL, Redis, Memcached) is possible by specifying (and exporting) the following environment variables:
+
+- MySQL:
+  - MYSQL_HOST
+  - MYSQL_SLAVE_HOST
+  - AUTH_MYSQL_HOST
+- Redis:
+  - REDIS_HOST
+  - ACCESS_TOKEN_REDIS_HOST
+  - REFRESH_TOKEN_REDIS_HOST
+- Memcached:
+  - MEMCACHE_METRICS_CONTEXT_ADDRESS
+
+This also allows to use temporary throw-away Docker containers to provide these.
+
 ## Mailer
 
 The mailer library is located in `mailer/` directory.

--- a/packages/fxa-auth-server/lib/verification-reminders.js
+++ b/packages/fxa-auth-server/lib/verification-reminders.js
@@ -32,6 +32,25 @@ const METADATA_KEY = 'metadata';
  * @returns {VerificationReminders}
  */
 module.exports = (log, config) => {
+  if (!config.redis || !config.redis.host) {
+    return {
+      keys: [],
+      async create(uid, flowId, flowBeginTime) {
+        return {};
+      },
+      async delete(uid) {
+        return {};
+      },
+      async process() {
+        return {};
+      },
+      async reinstate(key, reminders) {
+        return {};
+      },
+      async close() {},
+    };
+  }
+
   const redis = require('./redis')(
     {
       ...config.redis,

--- a/packages/fxa-auth-server/test/local/db.js
+++ b/packages/fxa-auth-server/test/local/db.js
@@ -11,6 +11,7 @@ const mocks = require('../mocks');
 const P = require(`${LIB_DIR}/promise`);
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
+const config = require('../../config').getProperties();
 
 const models = {
   Device: {
@@ -45,7 +46,11 @@ describe('db, session tokens expire:', () => {
       'fxa-shared/db': { setupAuthDatabase: () => {} },
       'fxa-shared/db/models/auth': models,
     })(
-      { tokenLifetimes, tokenPruning: {}, redis: { enabled: true } },
+      {
+        tokenLifetimes,
+        tokenPruning: {},
+        redis: { ...config.redis, enabled: true },
+      },
       log,
       tokens,
       {}
@@ -110,7 +115,11 @@ describe('db, session tokens do not expire:', () => {
       'fxa-shared/db': { setupAuthDatabase: () => {} },
       'fxa-shared/db/models/auth': models,
     })(
-      { tokenLifetimes, tokenPruning: {}, redis: { enabled: true } },
+      {
+        tokenLifetimes,
+        tokenPruning: {},
+        redis: { ...config.redis, enabled: true },
+      },
       log,
       tokens,
       {}

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -80,8 +80,8 @@ const mockConfig = {
 };
 
 const mockRedisConfig = {
-  host: 'localhost',
-  port: 6379,
+  host: process.env.REDIS_HOST || 'localhost',
+  port: process.env.REDIS_PORT || 6379,
   maxPending: 1000,
   retryCount: 5,
   initialBackoff: '100 milliseconds',
@@ -141,10 +141,10 @@ const testKnexConfig = {
   client: 'mysql',
   connection: {
     charset: 'UTF8MB4_BIN',
-    host: 'localhost',
-    password: '',
-    port: 3306,
-    user: 'root',
+    host: process.env.MYSQL_HOST || 'localhost',
+    password: process.env.MYSQL_PASSWORD || '',
+    port: process.env.MYSQL_PORT || 3306,
+    user: process.env.MYSQL_USERNAME || 'root',
   },
 };
 
@@ -152,10 +152,10 @@ mockConfig.database = {
   mysql: {
     auth: {
       database: 'testStripeHelper',
-      host: 'localhost',
-      password: '',
-      port: 3306,
-      user: 'root',
+      host: process.env.MYSQL_HOST || 'localhost',
+      password: process.env.MYSQL_PASSWORD || '',
+      port: process.env.MYSQL_PORT || 3306,
+      user: process.env.MYSQL_USERNAME || 'root',
     },
   },
 };


### PR DESCRIPTION
## Because

I want to run test locally without the need to run databases at the developer machine.

## This pull request

Fixes some issues in tests for the fxa-auth-server package that prevented from configuring remote databases such as:
* MySQL
* Redis
* Memcached

Provides documentation about which concrete environment variables to export when running the tests.

Also fixed the many times (thousands at least) of these:
```
➤ YN0000: [ioredis] Unhandled error event: Error: connect ECONNREFUSED 127.0.0.1:6379
➤ YN0000:     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1146:16)
```
Caused by the verification reminder which always initialized Redis, no matter if an actual configuration was there or not.

## Issue that this pull request solves

Closes: #8316 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Documentation added for how to configure basic settings related to this.

Verified using Docker containers:
```bash
docker run --name fxa-mysql-test --detach --env ALLOW_EMPTY_PASSWORD=yes bitnami/mariadb:10.5
docker run --name fxa-redis-test --detach --env ALLOW_EMPTY_PASSWORD=yes bitnami/redis:6.2
docker run --name fxa-memcached-test --detach bitnami/memcached:1-debian-10
```

Resulting environment variable configuration example:
```bash
docker inspect fxa-mysql-test fxa-redis-test fxa-memcached-test | jq -r '.[] | "\(.Name[1:]) \([.NetworkSettings.Networks | to_entries[]][0].value.IPAddress) \(.NetworkSettings.Ports | to_entries[0].key | split("/")[0])"' | awk '$1 ~ /mysql/ {printf("MYSQL_HOST=%s\nMYSQL_SLAVE_HOST=%s\nAUTH_MYSQL_HOST=%s\n", $2, $2, $2);} $1 ~ /redis/ {printf("REDIS_HOST=%s\nACCESS_TOKEN_REDIS_HOST=%s\nREFRESH_TOKEN_REDIS_HOST=%s\n", $2, $2, $2)} $1 ~ /memcached/ {printf("MEMCACHE_METRICS_CONTEXT_ADDRESS=%s:%d\n", $2, $3)}'

MYSQL_HOST=172.17.0.4
MYSQL_SLAVE_HOST=172.17.0.4
AUTH_MYSQL_HOST=172.17.0.4
REDIS_HOST=172.17.0.3
ACCESS_TOKEN_REDIS_HOST=172.17.0.3
REFRESH_TOKEN_REDIS_HOST=172.17.0.3
MEMCACHE_METRICS_CONTEXT_ADDRESS=172.17.0.2:11211
```

Test execution:
```bash
$ yarn test fxa-auth-server
➤ YN0000: keys file already exists
➤ YN0000: Local tests
...
➤ YN0000: done
➤ YN0000: Done in 5m 1s
```

Remaining error being logged but not resulting into any failure (known-issues, also in CircleCI):
```
➤ YN0000: Local tests
➤ YN0000: (node:2325081) UnhandledPromiseRejectionWarning: Error: connect ETIMEDOUT
➤ YN0000:     at PoolConnection.Connection._handleConnectTimeout (/srv/dev/enote/fxa/node_modules/mysql/lib/Connection.js:409:13)
➤ YN0000:     at Object.onceWrapper (events.js:421:28)
➤ YN0000:     at Socket.emit (events.js:315:20)
➤ YN0000:     at Socket.EventEmitter.emit (domain.js:467:12)
➤ YN0000:     at Socket._onTimeout (net.js:483:8)
➤ YN0000:     at listOnTimeout (internal/timers.js:554:17)
➤ YN0000:     at processTimers (internal/timers.js:497:7)
➤ YN0000:     --------------------
➤ YN0000:     at Protocol._enqueue (/srv/dev/enote/fxa/node_modules/mysql/lib/protocol/Protocol.js:144:48)
➤ YN0000:     at Protocol.handshake (/srv/dev/enote/fxa/node_modules/mysql/lib/protocol/Protocol.js:51:23)
➤ YN0000:     at PoolConnection.connect (/srv/dev/enote/fxa/node_modules/mysql/lib/Connection.js:116:18)
➤ YN0000:     at Pool.getConnection (/srv/dev/enote/fxa/node_modules/mysql/lib/Pool.js:48:16)
➤ YN0000:     at /srv/dev/enote/fxa/packages/fxa-auth-server/lib/oauth/db/mysql/index.js:96:6
➤ YN0000:     at new Promise (<anonymous>)
➤ YN0000:     at MysqlStore._getConnection (/srv/dev/enote/fxa/packages/fxa-auth-server/lib/oauth/db/mysql/index.js:96:6)
➤ YN0000:     at MysqlStore._query (/srv/dev/enote/fxa/packages/fxa-auth-server/lib/oauth/db/mysql/index.js:109:36)
➤ YN0000:     at MysqlStore._read (/srv/dev/enote/fxa/packages/fxa-auth-server/lib/oauth/db/mysql/index.js:96:6)
➤ YN0000:     at MysqlStore._readOne (/srv/dev/enote/fxa/packages/fxa-auth-server/lib/oauth/db/mysql/index.js:96:6)
➤ YN0000:     at MysqlStore.getClient (/srv/dev/enote/fxa/packages/fxa-auth-server/lib/oauth/db/mysql/index.js:36:50)
➤ YN0000:     at OauthDB.<computed> [as getClient] (/srv/dev/enote/fxa/packages/fxa-auth-server/lib/oauth/db/index.js:3:63)
➤ YN0000:     at async Promise.all (index 0)
➤ YN0000:     at /srv/dev/enote/fxa/packages/fxa-auth-server/lib/oauth/db/index.js:3:63
```
