### PR TITLE
fix(payments): Set plan as a required prop for the TermsAndPrivacy co…

### DIFF
--- a/packages/fxa-payments-server/src/components/AppLayout/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.test.tsx
@@ -7,10 +7,16 @@ import { AppContext, defaultAppContext } from '../../lib/AppContext';
 import AppLayout, { SignInLayout, SettingsLayout } from './index';
 import TermsAndPrivacy from '../TermsAndPrivacy';
 import { DEFAULT_PRODUCT_DETAILS } from 'fxa-shared/subscriptions/metadata';
+import { SELECTED_PLAN } from '../../lib/mock-data';
 
 afterEach(cleanup);
 
-const { termsOfServiceURL, privacyNoticeURL } = DEFAULT_PRODUCT_DETAILS;
+const {
+  product_metadata: {
+    'product:termsOfServiceURL': termsOfServiceURL,
+    'product:privacyNoticeURL': privacyNoticeURL,
+  },
+} = SELECTED_PLAN;
 
 describe('AppLayout', () => {
   const subject = () => {
@@ -18,7 +24,7 @@ describe('AppLayout', () => {
       <AppContext.Provider value={defaultAppContext}>
         <AppLayout>
           <div data-testid="children">
-            <TermsAndPrivacy />
+            <TermsAndPrivacy plan={SELECTED_PLAN} />
           </div>
         </AppLayout>
       </AppContext.Provider>

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.stories.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { PaymentErrorView } from './index';
+import { SELECTED_PLAN } from '../../lib/mock-data';
 
 storiesOf('components/PaymentError', module).add('default', () => (
   <PaymentErrorView
     error={{ code: 'general-paypal-error' }}
     onRetry={() => {}}
+    plan={SELECTED_PLAN}
   />
 ));

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.test.tsx
@@ -8,6 +8,7 @@ import {
 
 import { PaymentErrorView } from './index';
 import SubscriptionTitle, { titles } from '../SubscriptionTitle';
+import { SELECTED_PLAN } from '../../lib/mock-data';
 
 const mockHistoryPush = jest.fn();
 jest.mock('react-router-dom', () => ({
@@ -25,6 +26,7 @@ describe('PaymentErrorView test with l10n', () => {
       <PaymentErrorView
         onRetry={() => {}}
         error={{ code: 'general-paypal-error' }}
+        plan={SELECTED_PLAN}
       />
     );
     const spinner = queryByAltText('error icon');
@@ -51,6 +53,7 @@ describe('PaymentErrorView test with l10n', () => {
       <PaymentErrorView
         onRetry={onRetry}
         error={{ code: 'general-paypal-error' }}
+        plan={SELECTED_PLAN}
       />
     );
 
@@ -66,6 +69,7 @@ describe('PaymentErrorView test with l10n', () => {
       <PaymentErrorView
         onRetry={() => {}}
         error={{ code: 'returning_paypal_customer_error' }}
+        plan={SELECTED_PLAN}
       />
     );
     const spinner = queryByAltText('error icon');
@@ -95,6 +99,7 @@ describe('PaymentErrorView test with l10n', () => {
       <PaymentErrorView
         onRetry={() => {}}
         error={{ code: 'returning_paypal_customer_error' }}
+        plan={SELECTED_PLAN}
       />
     );
 
@@ -111,6 +116,7 @@ describe('PaymentErrorView test with l10n', () => {
         subscriptionTitle={<SubscriptionTitle screenType={'noupgrade'} />}
         onRetry={() => {}}
         error={{ code: 'no_subscription_upgrades' }}
+        plan={SELECTED_PLAN}
       />
     );
 

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
@@ -9,9 +9,11 @@ import SubscriptionTitle from '../SubscriptionTitle';
 import TermsAndPrivacy from '../TermsAndPrivacy';
 
 import './index.scss';
+import { Plan } from '../../store/types';
 
 export type PaymentErrorViewProps = {
   onRetry: Function;
+  plan: Plan;
   error?: StripeError | GeneralError;
   className?: string;
   subscriptionTitle?: React.ReactElement<SubscriptionTitle>;
@@ -45,6 +47,7 @@ const manageSubButtonFn = (onClick: VoidFunction) => {
 
 export const PaymentErrorView = ({
   onRetry,
+  plan,
   error,
   className = '',
   subscriptionTitle,
@@ -87,7 +90,7 @@ export const PaymentErrorView = ({
 
         <div className="footer" data-testid="footer">
           <ActionButton />
-          <TermsAndPrivacy />
+          <TermsAndPrivacy plan={plan} />
         </div>
       </section>
     </>

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.test.tsx
@@ -30,10 +30,16 @@ const plan = {
   },
 };
 
+const planWithNoLegalLinks = {
+  ...MOCK_PLANS[0],
+};
+
 afterEach(cleanup);
 
-it('renders as expected with no plan', () => {
-  const { queryByTestId } = render(<TermsAndPrivacy />);
+it('renders as expected with a plan with no legal doc links metadata', () => {
+  const { queryByTestId } = render(
+    <TermsAndPrivacy plan={planWithNoLegalLinks} />
+  );
 
   const termsLink = queryByTestId('terms');
   expect(termsLink).toBeInTheDocument();

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
@@ -11,7 +11,7 @@ import './index.scss';
 import { legalDocsRedirectUrl } from 'fxa-payments-server/src/lib/formats';
 
 export type TermsAndPrivacyProps = {
-  plan?: Plan;
+  plan: Plan;
 };
 
 export const TermsAndPrivacy = ({ plan }: TermsAndPrivacyProps) => {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -181,6 +181,7 @@ export const SubscriptionCreate = ({
           className={classNames({
             hidden: !paymentError,
           })}
+          plan={selectedPlan}
         />
         <PaymentProcessing
           provider="paypal"

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgradeRoadblock/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgradeRoadblock/index.tsx
@@ -32,6 +32,7 @@ export const SubscriptionUpgradeRoadblock = ({
             subscriptionTitle: title,
             error: { code: 'no_subscription_upgrades' },
             onRetry: () => {}, // PaymentErrorView actually ignores this
+            plan: selectedPlan,
           }}
         />
 


### PR DESCRIPTION
…mponent

Because:

* When the legal links metadata is missing from a Stripe product/plan, we use [fallback details](https://github.com/mozilla/fxa/blob/c950d28a5333f4718761aeed68cef258476ee520/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx#L23-L29), which can be incorrect.
* Since we only use the TermsAndPrivacy React component during Checkout, where there is only ever one Stripe product/plan selected, we should require the plan to be passed in instead of it being optional.

This commit:
* Makes the plan a required prop on the TermsAndPrivacy component, which ensures the same legal links are used throughout the Checkout process, and that they pull from Stripe product/plan metadata first.

In general, legal links to ToS and privacy notices should always be present on Stripe product/plan metadata (#8260), and we should not rely on a fallback at all (#7856).

Closes #8296

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).