### PR TITLE
fix(config): use a regex for default config values instead of string

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1458,11 +1458,9 @@ const conf = convict({
   },
   forcePasswordChange: {
     forcedEmailAddresses: {
-      doc:
-        'Force sign-in confirmation for email addresses matching this regex.',
+      doc: 'Force password change for email addresses matching this regex.',
       format: RegExp,
-      default: '^$', // default is no one
-
+      default: /^$/, // default is no one
       env: 'FORCE_PASSWORD_CHANGE_EMAIL_REGEX',
     },
   },
@@ -1515,7 +1513,7 @@ const conf = convict({
       doc:
         'If feature enabled, force sign-in unblock for email addresses matching this regex.',
       format: RegExp,
-      default: '^$', // default is no one
+      default: /^$/, // default is no one
       env: 'SIGNIN_UNBLOCK_FORCED_EMAILS',
     },
   },


### PR DESCRIPTION
## Because

- This should actually be a regex value instead of a string

## This pull request

- Updates the default value be what is needed in the functional tests

## Issue that this pull request solves

Closes: NA

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
