### PR TITLE
fix(profile): drop profileCache if the avatar changes

### DIFF
--- a/packages/fxa-profile-server/lib/routes/profile.js
+++ b/packages/fxa-profile-server/lib/routes/profile.js
@@ -23,8 +23,7 @@ function computeEtag(profile) {
   return false;
 }
 
-function checkAvatar(response, uid) {
-  const result = response.value;
+function nextAvatar(result) {
   if (
     result.avatar &&
     (result.avatarDefault || result.avatar.startsWith(monogramUrl))
@@ -33,29 +32,27 @@ function checkAvatar(response, uid) {
     let avatarUrl = result.avatar;
     if (displayName && ALPHANUMERIC.test(displayName)) {
       avatarUrl = `${monogramUrl}/v1/avatar/${displayName[0]}`;
-      result.avatarDefault = false;
     } else if (ALPHANUMERIC.test(result.email)) {
       avatarUrl = `${monogramUrl}/v1/avatar/${result.email[0]}`;
-      result.avatarDefault = false;
     } else {
       avatarUrl = avatarShared.DEFAULT_AVATAR.avatar;
-      result.avatarDefault = true;
     }
-    if (avatarUrl !== result.avatar) {
-      result.avatar = avatarUrl;
-      if (result.avatarDefault) {
-        db.deleteUserAvatars(uid);
-      } else {
-        db.addAvatar(
-          crypto.randomBytes(16).toString('hex'),
-          uid,
-          result.avatar,
-          'fxa'
-        );
-      }
-    }
+    return avatarUrl;
   }
-  return response;
+  return result.avatar;
+}
+
+async function changeAvatar(avatarUrl, uid) {
+  if (avatarUrl === avatarShared.DEFAULT_AVATAR.avatar) {
+    await db.deleteUserAvatars(uid);
+  } else {
+    await db.addAvatar(
+      crypto.randomBytes(16).toString('hex'),
+      uid,
+      avatarUrl,
+      'fxa'
+    );
+  }
 }
 
 module.exports = {
@@ -124,21 +121,26 @@ module.exports = {
       return rep.header('last-modified', lastModified.toUTCString());
     }
 
-    return server.methods.profileCache.get(req).then((response) => {
-      const result = response.value;
-      // Check to see if the oauth-server is reporting a newer `profileChangedAt`
-      // timestamp from validating the token, if so, lets invalidate the cache
-      // and set new value.
-      if (result.profileChangedAt < creds.profile_changed_at) {
-        return server.methods.profileCache.drop(creds.user).then(() => {
-          logger.info('profileChangedAt:cacheCleared', { uid: creds.user });
-          return server.methods.profileCache.get(req).then((response) => {
-            return createResponse(checkAvatar(response, creds.user));
-          });
-        });
+    let response = await server.methods.profileCache.get(req);
+    const result = response.value;
+    const newAvatar = nextAvatar(result);
+    const avatarChanged = result.avatar !== newAvatar;
+    if (avatarChanged) {
+      // Check if the db needs to be updated or just the profileCache
+      const selectedAvatar = await db.getSelectedAvatar(creds.user);
+      if (!selectedAvatar || selectedAvatar.url !== newAvatar) {
+        await changeAvatar(newAvatar, creds.user);
       }
+    }
+    // Check to see if the oauth-server is reporting a newer `profileChangedAt`
+    // timestamp from validating the token, if so, lets invalidate the cache
+    // and set new value.
+    if (avatarChanged || result.profileChangedAt < creds.profile_changed_at) {
+      await server.methods.profileCache.drop(creds.user);
+      logger.info('profileChangedAt:cacheCleared', { uid: creds.user });
+      response = await server.methods.profileCache.get(req);
+    }
 
-      return createResponse(checkAvatar(response, creds.user));
-    });
+    return createResponse(response);
   },
 };

--- a/packages/fxa-profile-server/test/api.js
+++ b/packages/fxa-profile-server/test/api.js
@@ -129,6 +129,15 @@ describe('api', function () {
     var tok = token();
     var user = uid();
 
+    before(async () => {
+      await db.addAvatar(
+        avatarId(),
+        USERID,
+        'http://localhost:1111/v1/avatar/u',
+        'fxa'
+      );
+    });
+
     it('should return all of a profile', function () {
       mock.tokenGood();
       mock.email('user@example.domain');
@@ -350,6 +359,27 @@ describe('api', function () {
         .then(function (res) {
           assert.equal(res.statusCode, 503);
           assert.equal(res.result.errno, 104);
+          assertSecurityHeaders(res);
+        });
+    });
+
+    it('should update the avatar when it needs to', async function () {
+      mock.token({
+        user: user,
+        scope: ['profile'],
+      });
+      mock.email('user@example.domain');
+      mock.email('user@example.domain'); // a second time for the refetch
+      return Server.api
+        .get({
+          url: '/profile',
+          headers: {
+            authorization: 'Bearer ' + tok,
+          },
+        })
+        .then(function (res) {
+          assert.equal(res.statusCode, 200);
+          assert.equal(res.result.avatar, 'http://localhost:1111/v1/avatar/u');
           assertSecurityHeaders(res);
         });
     });

--- a/packages/fxa-profile-server/test/profileCache.js
+++ b/packages/fxa-profile-server/test/profileCache.js
@@ -37,8 +37,8 @@ const imagePath = path.join(__dirname, 'lib', 'firefox.png');
 const imageData = fs.readFileSync(imagePath);
 
 const tok = token();
-const NAME = 'Fennec';
-const MOZILLA_EMAIL = 'user@mozilla.com';
+const NAME = '@Fennec';
+const MOZILLA_EMAIL = '!user@mozilla.com';
 const PROFILE_CHANGED_AT = Date.now();
 const PROFILE_CHANGED_AT_LATER_TIME = PROFILE_CHANGED_AT + 1000;
 


### PR DESCRIPTION
We weren't dropping the profileCache when the avatar was changing so subsequent requests would also think the avatar needed to change and would write to the db until something else triggered the cache to be updated.

This change ensures the cache is dropped when the avatar changes.
