### PR TITLE
fix(content-server): retain utm_ parameters

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
@@ -127,6 +127,23 @@ export default BaseAuthenticationBroker.extend({
       if (state) {
         extraParams.state = state;
       }
+
+      // Pull in valid UTM parameters if present
+      const utmKeyMap = {
+        utmCampaign: 'utm_campaign',
+        utmContent: 'utm_content',
+        utmMedium: 'utm_medium',
+        utmSource: 'utm_source',
+        utmTerm: 'utm_term',
+      };
+      for (const utmKey of Object.keys(utmKeyMap)) {
+        const utmValue = this.relier.get(utmKey);
+        if (utmValue) {
+          // We have to rename the key, as the relier renames these to camelcase on the way in.
+          extraParams[utmKeyMap[utmKey]] = utmValue;
+        }
+      }
+
       this.window.location.href = Url.updateSearchString(
         result.redirect,
         extraParams

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-redirect.js
@@ -301,6 +301,7 @@ describe('models/auth_brokers/oauth-redirect', () => {
 
     describe('with existing query parameters', () => {
       it('passes through existing parameters unchanged', () => {
+        relier.set({ utmSource: 'web' }); //eslint-disable-line camelcase
         return broker
           .sendOAuthResultToRelier({
             error: 'error',
@@ -311,6 +312,23 @@ describe('models/auth_brokers/oauth-redirect', () => {
             assert.include(windowMock.location.href, 'test=param');
             assert.include(windowMock.location.href, 'error=error');
             assert.include(windowMock.location.href, 'state=state');
+            assert.include(windowMock.location.href, 'utm_source=web');
+          });
+      });
+
+      it('ignores invalid UTM query parameters', () => {
+        relier.set({ utmhoop: 'web' });
+        return broker
+          .sendOAuthResultToRelier({
+            error: 'error',
+            redirect: REDIRECT_TO + '?test=param',
+          })
+          .then(() => {
+            assert.include(windowMock.location.href, REDIRECT_TO);
+            assert.include(windowMock.location.href, 'test=param');
+            assert.include(windowMock.location.href, 'error=error');
+            assert.include(windowMock.location.href, 'state=state');
+            assert.notInclude(windowMock.location.href, 'utmhoop=web');
           });
       });
     });


### PR DESCRIPTION
Because:

* We want to retain UTM parameters through the OAuth flow.

This commit:

* Extracts URL keys beginning with utm_ to include on the final
  redirect.

Closes #3412

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
