### PR TITLE
fix(fxa-settings): change clickable footer link spaces to fit width o…

### DIFF
--- a/packages/fxa-react/components/Footer/index.tsx
+++ b/packages/fxa-react/components/Footer/index.tsx
@@ -24,24 +24,28 @@ export const Footer = () => {
           className="transition-standard w-18 h-auto opacity-75 hover:opacity-100"
         />
       </LinkExternal>
-      <Localized id="app-footer-privacy-notice">
-        <LinkExternal
-          data-testid="link-privacy"
-          href="https://www.mozilla.org/en-US/privacy/websites/"
-          className="transition-standard w-full text-xs my-3 hover:text-grey-500 hover:underline mobileLandscape:my-0 mobileLandscape:w-auto mobileLandscape:mx-10 mobileLandscape:self-end"
-        >
-          Website Privacy Notice
-        </LinkExternal>
-      </Localized>
-      <Localized id="app-footer-terms-of-service">
-        <LinkExternal
-          data-testid="link-terms"
-          href="https://www.mozilla.org/en-US/about/legal/terms/services/"
-          className="transition-standard w-full text-xs mobileLandscape:self-end hover:text-grey-500 hover:underline mobileLandscape:w-auto"
-        >
-          Terms of Service
-        </LinkExternal>
-      </Localized>
+      <div className="w-full mobileLandscape:w-auto flex items-center mt-3 mobileLandscape:mt-0 mobileLandscape:ml-10">
+        <Localized id="app-footer-privacy-notice">
+          <LinkExternal
+            data-testid="link-privacy"
+            href="https://www.mozilla.org/en-US/privacy/websites/"
+            className="transition-standard text-xs hover:text-grey-500 hover:underline mobileLandscape:self-end"
+          >
+            Website Privacy Notice
+          </LinkExternal>
+        </Localized>
+      </div>
+      <div className="w-full mobileLandscape:w-auto flex items-center mt-3 mobileLandscape:mt-0 mobileLandscape:ml-10">
+        <Localized id="app-footer-terms-of-service">
+          <LinkExternal
+            data-testid="link-terms"
+            href="https://www.mozilla.org/en-US/about/legal/terms/services/"
+            className="transition-standard text-xs mobileLandscape:self-end hover:text-grey-500 hover:underline"
+          >
+            Terms of Service
+          </LinkExternal>
+        </Localized>
+      </div>
     </footer>
   );
 };

--- a/packages/fxa-settings/src/components/PageChangePassword/index.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.tsx
@@ -290,7 +290,7 @@ export const PageChangePassword = ({}: RouteComponentProps) => {
 
           <Localized id="pw-change-forgot-password-link">
             <a
-              className="link-blue text-sm justify-center flex"
+              className="link-blue text-sm justify-center flex w-max my-0 mx-auto"
               data-testid="nav-link-reset-password"
               href="/reset_password"
             >


### PR DESCRIPTION
…f text for privacy notice and terms of services and forgot password links

## Because

-Clickable spaces are extended to the entire width of the footer.

## This pull request

-The clickable spaces now encompass the text of the link only.

## Issue that this pull request solves

Closes: # (7012)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="222" alt="footer problem" src="https://user-images.githubusercontent.com/73819616/115850469-ca4d4300-a41d-11eb-85a7-8676f313a6aa.PNG">
em.PNG…]()
<img width="224" alt="footer fix" src="https://user-images.githubusercontent.com/73819616/115850156-8f4b0f80-a41d-11eb-9f66-f6277a5b995d.PNG">



Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
