### PR TITLE
fix(auth): Pass statsd argument of correct type to StripeHelper in pa…

### DIFF
--- a/packages/fxa-auth-server/scripts/paypal-processor.ts
+++ b/packages/fxa-auth-server/scripts/paypal-processor.ts
@@ -46,11 +46,11 @@ export async function init() {
           log.error('statsd.error', err);
         },
       })
-    : {
+    : (({
         increment: () => {},
         timing: () => {},
         close: () => {},
-      };
+      } as unknown) as StatsD);
   Container.set(StatsD, statsd);
 
   const log = require('../lib/log')({ ...config.log, statsd });
@@ -86,7 +86,7 @@ export async function init() {
 
   const currencyHelper = new CurrencyHelper(config);
   Container.set(CurrencyHelper, currencyHelper);
-  const stripeHelper = new StripeHelper(log, config);
+  const stripeHelper = new StripeHelper(log, config, statsd);
   Container.set(StripeHelper, stripeHelper);
   const paypalClient = new PayPalClient(
     config.subscriptions.paypalNvpSigCredentials


### PR DESCRIPTION
…ypal-processor

Because:

* The patch for #8358 made the `statsd` param required for the StripeHelper constructor, and we need pass the type check in the PayPal processor script.

This commit:

* Sets the type of `statsd` when it's disabled in the auth server config to be of type StatsD.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
