### PR TITLE
Update 123Done and add support for heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test": "_scripts/test-package.sh",
     "config-fxios": "node _scripts/config-fxios.js",
     "format": "yarn workspaces foreach run format",
-    "ports": "pm2 jlist | json -d'\t' -a -c 'this.pm2_env.env.PORT' pm2_env.env.PORT name"
+    "ports": "pm2 jlist | json -d'\t' -a -c 'this.pm2_env.env.PORT' pm2_env.env.PORT name",
+    "heroku-postbuild": "yarn workspace 123done install"
   },
   "homepage": "https://github.com/mozilla/fxa",
   "bugs": {

--- a/packages/123done/Procfile
+++ b/packages/123done/Procfile
@@ -1,0 +1,1 @@
+web: node ./packages/123done/server.js

--- a/packages/123done/README.md
+++ b/packages/123done/README.md
@@ -2,22 +2,25 @@
 
 ## Running locally
 
-1. install [git], [node] and [redis]
-1. get a local copy of the repository: `git clone https://github.com/mozilla/123done`
-1. `cd 123done`
-1. install dependencies: `npm install`
-1. generate keys `node scripts/gen_keys.js`
-1. run the server: `npm start`
-1. visit it in your browser: `http://localhost:8080/`
-1. hack and reload! (web resources don't require a server restart)
-
-[git]: http://git-scm.org
-[node]: http://nodejs.org
-[redis]: http://redis.io
+1. Complete prerequisites for running [FxA](https://github.com/mozilla/fxa#getting-started)
+1. Run the server: `yarn start`
+1. Visit it in your browser: `http://localhost:8080/`
+1. Hack and reload! (web resources don't require a server restart)
 
 ### Ansible Deployment
 
 See [fxa-dev 123done](https://github.com/mozilla/fxa-dev/tree/docker/roles/rp) Ansible configuration for details.
+
+### Heroku Deployment
+
+1. Signup for heroku
+1. Install [heroku cli](https://devcenter.heroku.com/articles/heroku-cli) and login
+1. Create [heroku app](https://devcenter.heroku.com/articles/creating-apps) for 123done trusted and untrusted clients
+1. Create a new [config](https://github.com/mozilla/fxa/blob/1dd1b038d4d7eb7fbb697f3ef49f4a93e7f1145f/packages/123done/config.json) for each 123done app
+1. Set heroku app env value `CONFIG_123DONE=relative/path/to/config` for each app
+1. Add heroku multipack support `heroku buildpacks:add -a <app> https://github.com/heroku/heroku-buildpack-multi-procfile`
+1. Set heroku app env value `PROCFILE=relative/path/to/Procfile/in/your/codebase`
+1. Deploy with `git push heroku main`
 
 ## Testing
 

--- a/packages/123done/config-local.json
+++ b/packages/123done/config-local.json
@@ -1,9 +1,9 @@
 {
   "client_id": "dcdb5ae7add825d2",
   "client_secret": "b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8",
-  "redirect_uri": "http://localhost:8080/api/oauth",
   "issuer_uri": "http://localhost:3030",
-  "scopes": "profile openid",
   "pkce_client_id": "38a6b9b3a65a1871",
-  "pkce_redirect_uri": "http://localhost:8080/?oauth_pkce_redirect=1"
+  "pkce_redirect_uri": "http://localhost:8080/?oauth_pkce_redirect=1",
+  "redirect_uri": "http://localhost:8080/api/oauth",
+  "scopes": "profile openid"
 }

--- a/packages/123done/config-stage-untrusted.json
+++ b/packages/123done/config-stage-untrusted.json
@@ -2,7 +2,7 @@
   "cookie_name": "321done",
   "client_id": "325b4083e32fe8e7",
   "client_secret": "a084f4c36501ea1eb2de33258421af97b2e67ffbe107d2812f4a14f3579900ef",
-  "redirect_uri": "http://localhost:10139/api/oauth",
-  "issuer_uri": "http://localhost:3030",
+  "redirect_uri": "https://stage-123done-untrusted.herokuapp.com/api/oauth",
+  "issuer_uri": "https://accounts.stage.mozaws.net",
   "scopes": "profile:display_name profile:email profile:uid openid"
 }

--- a/packages/123done/config-stage.json
+++ b/packages/123done/config-stage.json
@@ -1,0 +1,9 @@
+{
+  "client_id": "dcdb5ae7add825d2",
+  "client_secret": "b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8",
+  "redirect_uri": "https://stage-123done.herokuapp.com/api/oauth",
+  "issuer_uri": "https://accounts.stage.mozaws.net",
+  "scopes": "profile openid",
+  "pkce_client_id": "38a6b9b3a65a1871",
+  "pkce_redirect_uri": "https://stage-123done.herokuapp.com/?oauth_pkce_redirect=1"
+}

--- a/packages/123done/config.js
+++ b/packages/123done/config.js
@@ -1,12 +1,76 @@
-var path = require('path');
+const fs = require('fs');
+const path = require('path');
+const convict = require('convict');
+convict.addFormats(require('convict-format-with-validator'));
 
-var configTarget = process.env.CONFIG_123DONE || './config.json';
-var configFile = path.resolve(__dirname, configTarget);
+const conf = convict({
+  client_id: {
+    doc: 'Oauth client id',
+    default: 'dcdb5ae7add825d2',
+    format: String,
+    env: 'CLIENT_ID',
+  },
+  client_secret: {
+    doc: 'Oauth client secret',
+    default: 'b93ef8a8f3e553a430d7e5b904c6132b2722633af9f03128029201d24a97f2a8',
+    format: String,
+    env: 'CLIENT_SECRET',
+  },
+  redirect_uri: {
+    doc: 'Oauth client redirect',
+    default: 'http://localhost:8080/api/oauth',
+    format: 'url',
+    env: 'REDIRECT_URI',
+  },
+  issuer_uri: {
+    doc: 'Oauth client issuer uri',
+    default: 'http://localhost:3030',
+    format: 'url',
+    env: 'ISSUER_URI',
+  },
+  scopes: {
+    doc: 'Oauth client requesting scopes',
+    default: 'profile openid',
+    format: String,
+    env: 'SCOPES',
+  },
+  pkce_client_id: {
+    doc: 'Oauth pkce client id',
+    default: '38a6b9b3a65a1871',
+    format: String,
+    env: 'PKCE_CLIENT_ID',
+  },
+  pkce_redirect_uri: {
+    doc: 'Oauth pkce client id',
+    default: 'http://localhost:8080/?oauth_pkce_redirect=1',
+    format: 'url',
+    env: 'PKCE_REDIRECT_URI',
+  },
+  cookie_secret: {
+    doc: 'Cookie secret',
+    default: 'define a real secret, please',
+    format: String,
+    env: 'COOKIE_SECRET',
+  },
+  cookie_name: {
+    doc: 'Cookie name',
+    default: '123done',
+    format: String,
+    env: 'COOKIE_NAME',
+  },
+  port: {
+    doc: 'Port to run service',
+    default: 8080,
+    format: Number,
+    env: 'PORT',
+  },
+});
 
-var now = '[' + new Date().toISOString() + ']';
-console.log(now, 'loading configuration File', configFile); //eslint-disable-line no-console
+const configTarget = process.env.CONFIG_123DONE || './config.json';
+const configFile = path.resolve(__dirname, configTarget);
+const file = [configFile].filter(fs.existsSync);
+conf.loadFile(file);
 
-var config = require(configFile);
-console.log(now, 'config:', JSON.stringify(config, null, 2)); //eslint-disable-line no-console
+conf.validate();
 
-module.exports = config;
+module.exports = conf;

--- a/packages/123done/oauth.js
+++ b/packages/123done/oauth.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var config = require('./config');
+var config = require('./config').getProperties();
+
 var crypto = require('crypto');
 var request = require('request');
 var querystring = require('querystring');

--- a/packages/123done/package.json
+++ b/packages/123done/package.json
@@ -2,6 +2,9 @@
   "name": "123done",
   "description": "A simple tasklist app that demonstrates FxA Sign-In",
   "version": "0.0.2",
+  "engines": {
+    "node": "14.x"
+  },
   "author": {
     "name": "Mozilla",
     "url": "https://mozilla.org/"
@@ -21,6 +24,8 @@
   "private": true,
   "dependencies": {
     "client-sessions": "0.8.x",
+    "convict": "^6.0.1",
+    "convict-format-with-validator": "^6.0.1",
     "express": "^4.17.1",
     "fxa-jwtool": "0.7.x",
     "morgan": "^1.10.0",
@@ -29,6 +34,8 @@
     "request": "^2.88.2"
   },
   "devDependencies": {
+    "@types/convict": "^5.2.2",
+    "@types/convict-format-with-validator": "^6",
     "audit-filter": "0.5.0",
     "eslint": "^7.17.0",
     "eslint-plugin-fxa": "^2.0.2",

--- a/packages/123done/server.js
+++ b/packages/123done/server.js
@@ -35,8 +35,8 @@ app.use(function (req, res, next) {
     res.setHeader('Cache-Control', 'no-cache, max-age=0');
 
     return sessions({
-      cookieName: config.cookieName || '123done',
-      secret: process.env['COOKIE_SECRET'] || 'define a real secret, please',
+      cookieName: config.get('cookie_name'),
+      secret: config.get('cookie_secret'),
       requestKey: 'session',
       cookie: {
         path: '/api',
@@ -120,6 +120,6 @@ app.get(/^\/iframe(:?\/(?:index.html)?)?$/, function (req, res, next) {
 
 app.use(express.static(path.join(__dirname, 'static')));
 
-const port = process.env['PORT'] || config.port || 8080;
+const port = config.get('port');
 app.listen(port, '0.0.0.0');
 console.log('123done started on port', port); //eslint-disable-line no-console

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,8 +9,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "123done@workspace:packages/123done"
   dependencies:
+    "@types/convict": ^5.2.2
+    "@types/convict-format-with-validator": ^6
     audit-filter: 0.5.0
     client-sessions: 0.8.x
+    convict: ^6.0.1
+    convict-format-with-validator: ^6.0.1
     eslint: ^7.17.0
     eslint-plugin-fxa: ^2.0.2
     express: ^4.17.1
@@ -6726,6 +6730,24 @@ __metadata:
   version: 0.5.3
   resolution: "@types/content-disposition@npm:0.5.3"
   checksum: 1b7d94b19ae8564816233b74df5f662052d393d0fdb317c81d894f5e1e762010c46b1812ce01a1492a72603e182afd18a59673e25ae737efc3e470ba261697d7
+  languageName: node
+  linkType: hard
+
+"@types/convict-format-with-validator@npm:^6":
+  version: 6.0.2
+  resolution: "@types/convict-format-with-validator@npm:6.0.2"
+  dependencies:
+    "@types/convict": "*"
+  checksum: 7092c0263b72d9faf20e7389be438ff6118206bec632f0233ebb44954032b1616f46f37a7f4ce3dd610972dbebd27993ab36732c5b713e4d7a23ea812213a976
+  languageName: node
+  linkType: hard
+
+"@types/convict@npm:*":
+  version: 6.0.1
+  resolution: "@types/convict@npm:6.0.1"
+  dependencies:
+    "@types/node": "*"
+  checksum: 929960b0376e7ab897f008b8250c79d0cf7e4864b3458435c8d8be002cd35f07bb78a27b61a98d7605721990777eb69f7aa036f25922396c6b3a42e1e38450ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Because

- 123done config is a bit outdated to support heroku
- If we go the route of hosting this service in heroku we will need to update AWS to point to new [trusted](stage-123done.herokuapp.com/) and [untrusted](http://stage-123done-untrusted.herokuapp.com/) versions.

## This pull request

- Exposes config the same way other services work
- Add docs for pushing 123done to heroku

## Issue that this pull request solves

Closes: #8491

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
