### PR TITLE
style(subscriptions): use different spinner in cancel btn

### DIFF
--- a/packages/fxa-payments-server/src/components/AppLayout/index.scss
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.scss
@@ -27,8 +27,9 @@
     background-image: url('./images/spinnerwhite.svg');
   }
 
+  .secondary-button &,
   &.spinner-settings-fetch {
-    background-image: url('./images/spinnergrey.png');
+    background-image: url('./images/spinnerlight.svg');
   }
 }
 


### PR DESCRIPTION
Because:
 - there was not enough contrast between the grey cancel button
   background and the white spinner image

This commit:
 - use another spinner image



Closes: #7898 
