### PR TITLE
fix(tooltip): Show the correct hide/show tooltips on login pages

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/mixins/password-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/password-mixin.js
@@ -7,6 +7,7 @@
 import KeyCodes from '../../lib/key-codes';
 import AuthErrors from '../../lib/auth-errors';
 import showPasswordTemplate from 'templates/partial/show-password.mustache';
+const t = (msg) => msg;
 
 export default {
   events: {
@@ -140,6 +141,7 @@ export default {
 
     const $showPasswordEl = $passwordEl.siblings('.show-password');
     $showPasswordEl.attr('checked', true);
+    this.$('.show-password-label').attr('title', t('Hide password'));
 
     this.logViewEvent('password.visible');
   },
@@ -163,6 +165,7 @@ export default {
 
     const $showPasswordEl = $passwordEl.siblings('.show-password');
     $showPasswordEl.removeAttr('checked');
+    this.$('.show-password-label').attr('title', t('Show password'));
 
     this.logViewEvent('password.hidden');
     this.focus($passwordEl);


### PR DESCRIPTION
## Because

- Tooltip always has "Show" regardless of state

## This pull request

- Updates to say show or hide depending on tooltip state

## Issue that this pull request solves

Closes: #8068

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="528" alt="Screen Shot 2021-05-05 at 12 27 36 PM" src="https://user-images.githubusercontent.com/1295288/117176052-79363b00-ad9d-11eb-9f2c-3ab11fbcf9a6.png">
<img width="497" alt="Screen Shot 2021-05-05 at 12 27 27 PM" src="https://user-images.githubusercontent.com/1295288/117176065-7b989500-ad9d-11eb-8718-659208e3b4f4.png">

