### PR TITLE
Re-enable oauth regression testing in stage

### DIFF
--- a/packages/fxa-content-server/scripts/test-ci-remote.sh
+++ b/packages/fxa-content-server/scripts/test-ci-remote.sh
@@ -14,8 +14,8 @@ function test_suite() {
     --suites="${suite}" \
     --fxaAuthRoot=https://api-accounts.stage.mozaws.net/v1 \
     --fxaContentRoot=https://accounts.stage.mozaws.net/ \
-    --fxaOAuthApp=https://123done-stage.dev.lcip.org/ \
-    --fxaUntrustedOauthApp=https://321done-stage.dev.lcip.org/ \
+    --fxaOAuthApp=https://stage-123done.herokuapp.com/ \
+    --fxaUntrustedOauthApp=https://stage-123done-untrusted.herokuapp.com/ \
     --fxaEmailRoot=http://restmail.net \
     --fxaProduction=true \
     --output="../../artifacts/tests/${suite}-${numGroups}-${i}-results.xml" \
@@ -27,8 +27,8 @@ function test_suite() {
     --suites="${suite}" \
     --fxaAuthRoot=https://api-accounts.stage.mozaws.net/v1 \
     --fxaContentRoot=https://accounts.stage.mozaws.net/ \
-    --fxaOAuthApp=https://123done-stage.dev.lcip.org/ \
-    --fxaUntrustedOauthApp=https://321done-stage.dev.lcip.org/ \
+    --fxaOAuthApp=https://stage-123done.herokuapp.com/ \
+    --fxaUntrustedOauthApp=https://stage-123done-untrusted.herokuapp.com/ \
     --fxaEmailRoot=http://restmail.net \
     --fxaProduction=true \
     --output="../../artifacts/tests/${suite}-${numGroups}-${i}-results.xml" \

--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -1545,7 +1545,7 @@ const openFxaFromRp = thenify(function (page, options = {}) {
 
   // By introducing a small delay (100ms), it gives the Rp some time to setup
   // their page and helps improve overall test performance.
-  const delay = 100 || options.delay;
+  const delay = 150 || options.delay;
 
   if (page === 'enter-email') {
     buttonSelector = '.email-first-button';

--- a/packages/fxa-content-server/tests/functional/oauth_query_param_validation.js
+++ b/packages/fxa-content-server/tests/functional/oauth_query_param_validation.js
@@ -65,7 +65,7 @@ registerSuite('oauth query parameter validation', {
     return this.remote
       .then(
         clearBrowserState({
-          contentServer: true,
+          forceAll: true,
         })
       )
       .then(openFxaFromRp('enter-email'))

--- a/packages/fxa-content-server/tests/functional/settings/connected_services_oauth_clients.js
+++ b/packages/fxa-content-server/tests/functional/settings/connected_services_oauth_clients.js
@@ -25,6 +25,9 @@ describe('connected services: oauth clients', () => {
     click,
     pollUntilGoneByQSA,
     noSuchElement,
+    openTab,
+    switchToWindow,
+    closeCurrentWindow,
   } = FunctionalHelpers;
 
   beforeEach(async ({ remote }) => {
@@ -39,6 +42,9 @@ describe('connected services: oauth clients', () => {
       click,
       pollUntilGoneByQSA,
       noSuchElement,
+      openTab,
+      switchToWindow,
+      closeCurrentWindow,
     } = FunctionalHelpers.applyRemote(remote));
 
     await clearBrowserState({
@@ -64,24 +70,22 @@ describe('connected services: oauth clients', () => {
       '123Done'
     );
 
-    // TODO: We can up re-enable this once the fix for
-    // https://github.com/mozilla/fxa/issues/5291 has landed
-    // await openTab(config.fxaUntrustedOauthApp);
-    // await switchToWindow(1);
-    // await click(selectors['123DONE'].BUTTON_SIGNIN);
-    //
-    // await click(selectors.SIGNIN_PASSWORD.SUBMIT_USE_SIGNED_IN);
-    //
-    // await testElementExists(selectors.OAUTH_PERMISSIONS.HEADER);
-    // await click(selectors.OAUTH_PERMISSIONS.SUBMIT);
-    // await testElementExists(selectors['123DONE'].AUTHENTICATED);
-    // await closeCurrentWindow();
+    await openTab(config.fxaUntrustedOauthApp);
+    await switchToWindow(1);
+    await click(selectors['123DONE'].BUTTON_SIGNIN);
+
+    await click(selectors.SIGNIN_PASSWORD.SUBMIT_USE_SIGNED_IN);
+
+    await testElementExists(selectors.OAUTH_PERMISSIONS.HEADER);
+    await click(selectors.OAUTH_PERMISSIONS.SUBMIT);
+    await testElementExists(selectors['123DONE'].AUTHENTICATED);
+    await closeCurrentWindow();
     // refresh the list
-    // await click(selectors.SETTINGS.CONNECTED_SERVICES.REFRESH_BUTTON);
-    // await testElementTextInclude(
-    //   selectors.SETTINGS.CONNECTED_SERVICES.HEADER,
-    //   '321Done'
-    // );
+    await click(selectors.SETTINGS.CONNECTED_SERVICES.REFRESH_BUTTON);
+    await testElementTextInclude(
+      selectors.SETTINGS.CONNECTED_SERVICES.HEADER,
+      '321Done'
+    );
 
     // disconnect
     await click(

--- a/packages/fxa-content-server/tests/functional_regression.js
+++ b/packages/fxa-content-server/tests/functional_regression.js
@@ -5,12 +5,10 @@
 const testsSettings = require('./functional_settings');
 
 module.exports = testsSettings.concat([
-  // These oauth tests use untrusted clients which
-  // would fixed when https://github.com/mozilla/fxa/issues/5291 lands
-  // 'tests/functional/oauth_settings_clients.js',
-  // 'tests/functional/oauth_prompt_none.js',
-  // 'tests/functional/oauth_permissions.js',
-  // 'tests/functional/oauth_query_param_validation.js',
+  'tests/functional/oauth_settings_clients.js',
+  'tests/functional/oauth_prompt_none.js',
+  'tests/functional/oauth_permissions.js',
+  'tests/functional/oauth_query_param_validation.js',
 
   // new and flaky tests above here',
   'tests/functional/404.js',


### PR DESCRIPTION
## Because

- Paired with jbuck to get 123done setup properly in stage
- Our oauth tests were disabled for regression testing

## This pull request

- Re-enables oauth tests

## Issue that this pull request solves

Closes: #5291

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
