### PR TITLE
fix(tests): rerun settings functional tests on failure and mark beforeEach as failure

### DIFF
--- a/packages/fxa-content-server/tests/functional/settings/change_email.js
+++ b/packages/fxa-content-server/tests/functional/settings/change_email.js
@@ -38,7 +38,6 @@ const {
   testSuccessWasShown,
   type,
   visibleByQSA,
-  waitForUrl,
 } = FunctionalHelpers;
 
 registerSuite('settings change email', {
@@ -52,8 +51,8 @@ registerSuite('settings change email', {
         .then(fillOutEmailFirstSignUp(email, PASSWORD))
         .then(testElementExists(selectors.CONFIRM_SIGNUP_CODE.HEADER))
         .then(fillOutSignUpCode(email, 0))
-        .then(waitForUrl((url) => !url.includes('settings')))
-        .then(testElementExists(selectors.SETTINGS.AVATAR_ROW.HEADER))
+
+        .then(visibleByQSA(selectors.SETTINGS.PROFILE_HEADER))
         .then(click(selectors.EMAIL.MENU_BUTTON))
 
         .then(addAndVerifySecondaryEmail(secondaryEmail))

--- a/packages/fxa-content-server/tests/intern.js
+++ b/packages/fxa-content-server/tests/intern.js
@@ -174,6 +174,12 @@ if (args.firefoxBinary) {
 
 const failed = [];
 
+intern.on('suiteEnd', (test) => {
+  if (test.error) {
+    failed.push(test);
+  }
+});
+
 intern.on('testEnd', (test) => {
   if (test.error) {
     failed.push(test);

--- a/packages/fxa-settings/scripts/test-ci.sh
+++ b/packages/fxa-settings/scripts/test-ci.sh
@@ -31,4 +31,13 @@ _scripts/check-url.sh localhost:3030/bundle/app.bundle.js
 
 cd packages/fxa-content-server
 mozinstall /firefox.tar.bz2
-node tests/intern.js --suites="settings" --output="../../artifacts/tests/results.xml" --firefoxBinary=./firefox/firefox
+node tests/intern.js \
+  --suites="settings" \
+  --output="../../artifacts/tests/results.xml" \
+  --firefoxBinary=./firefox/firefox \
+  || \
+node tests/intern.js \
+  --suites="settings" \
+  --output="../../artifacts/tests/results.xml" \
+  --firefoxBinary=./firefox/firefox \
+  --grep="$(<rerun.txt)"


### PR DESCRIPTION
## Because

- Re-running failed test will better help confirm that the test is not flake
- Test failing in the `beforeEach` for functional tests were not marked as failures

## This pull request

- Re-runs those tests
- Marks `beforeEach` as failures

## Issue that this pull request solves

Closes: #8527

## Checklist


- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

