### PR TITLE
fix(sms): Fix sms link on QR CAD page

### DIFF
--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/scan_code.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/scan_code.js
@@ -40,6 +40,7 @@ describe('views/post_verify/cad_qr/scan_code', () => {
     account = new Account({
       email: 'a@a.com',
       uid: 'uid',
+      sessionToken: 'sessionToken',
     });
     model = new Backbone.Model({
       account,
@@ -59,6 +60,9 @@ describe('views/post_verify/cad_qr/scan_code', () => {
 
     sinon.stub(view, 'getSignedInAccount').callsFake(() => account);
     sinon.stub(account, 'fetchDeviceList').callsFake(() => Promise.resolve([]));
+    sinon
+      .stub(account, 'isSignedIn')
+      .callsFake(() => Promise.resolve(account.get('sessionToken')));
     sinon.stub(account, 'createSigninCode').callsFake(() =>
       Promise.resolve({
         code: 'code',
@@ -98,6 +102,7 @@ describe('views/post_verify/cad_qr/scan_code', () => {
     beforeEach(() => {
       account.unset('uid');
       account.unset('email');
+      account.unset('sessionToken');
       view.waitForDeviceConnected.resetHistory();
       account.createSigninCode.resetHistory();
       return view.render();


### PR DESCRIPTION
## Because

- Sms page wasn't loading on the Scan code page

## This pull request

- Moves attaching `click` events in the backbone initalize function
- Fixes a tiny edge case where page wouldn't generate QR if using unverified session

## Issue that this pull request solves

Closes: #8448 

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

Any other information that is important to this pull request.
