### PR TITLE
feat(sql): Use `JSON_OBJECTAGG` instead of aggregateNameValuePairs in session sql

### DIFF
--- a/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
+++ b/packages/fxa-auth-db-mysql/db-server/test/backend/db_tests.js
@@ -1820,7 +1820,7 @@ module.exports = function (config, DB) {
             'callbackIsExpired'
           );
           assert.deepEqual(
-            s.deviceAvailableCommands,
+            JSON.parse(s.deviceAvailableCommands),
             sessionDeviceInfo.availableCommands,
             'availableCommands'
           );

--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -513,8 +513,6 @@ module.exports = function (log, error) {
     return this.readAllResults(SESSION_DEVICE, [id]).then((results) => {
       if (results.length === 0) {
         throw error.notFound();
-      } else if (!results[0].tokenData) {
-        throw error.notFound();
       }
       return results[0];
     });

--- a/packages/fxa-auth-db-mysql/lib/db/mysql.js
+++ b/packages/fxa-auth-db-mysql/lib/db/mysql.js
@@ -507,25 +507,17 @@ module.exports = function (log, error) {
   //          ut.tokenVerificationId, ut.mustVerify
   // Where  : t.tokenId = $1 AND t.uid = a.uid AND t.tokenId = d.sessionTokenId AND
   //          t.uid = d.uid AND t.tokenId = u.tokenId
-  var SESSION_DEVICE = 'CALL sessionWithDevice_18(?)';
+  var SESSION_DEVICE = 'CALL sessionWithDevice_19(?)';
 
   MySql.prototype.sessionToken = function (id) {
-    return this.readAllResults(SESSION_DEVICE, [id])
-      .then((rows) =>
-        dbUtil.aggregateNameValuePairs(
-          rows,
-          'deviceId',
-          'deviceCommandName',
-          'deviceCommandData',
-          'deviceAvailableCommands'
-        )
-      )
-      .then((results) => {
-        if (results.length === 0) {
-          throw error.notFound();
-        }
-        return results[0];
-      });
+    return this.readAllResults(SESSION_DEVICE, [id]).then((results) => {
+      if (results.length === 0) {
+        throw error.notFound();
+      } else if (!results[0].tokenData) {
+        throw error.notFound();
+      }
+      return results[0];
+    });
   };
 
   // Select : sessionTokens t, devices d

--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 115;
+module.exports.level = 116;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-115-116.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-115-116.sql
@@ -64,8 +64,8 @@ BEGIN
     ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
   LEFT JOIN (
     (SELECT dc.uid, dc.deviceId, JSON_OBJECTAGG(ci.commandName, dc.commandData) AS deviceAvailableCommands
-    FROM deviceCommands AS dc FORCE INDEX (PRIMARY)
-		INNER JOIN deviceCommandIdentifiers AS ci FORCE INDEX (PRIMARY)
+    FROM deviceCommands AS dc FORCE INDEX (PRIMARY, commandId)
+		INNER JOIN deviceCommandIdentifiers AS ci FORCE INDEX (PRIMARY, commandName)
 		ON ci.commandId = dc.commandId WHERE ci.commandName IS NOT NULL
         GROUP BY dc.uid
     ) AS dac )

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-115-116.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-115-116.sql
@@ -1,0 +1,75 @@
+--
+-- This migration uses the `JSON_OBJECTAGG` function to aggregate available device commands.
+-- Previously we were using a helper function `aggregateNameValuePairs` introduced in
+-- https://github.com/mozilla/fxa-auth-db-mysql/pull/354
+--
+-- Some things to note in this migration, `JSON_OBJECTAGG` errors if any key is NULL,
+-- which might happen when joining deviceCommands and deviceCommandIdentifiers tables.
+-- To handle this, the procedure replaces NULL values with a specific named key, which
+-- then gets removed by `JSON_REMOVE`. The procedure `sessionWithDevice_19` is hit
+-- a lot by many routes so the performance impact of this is TBD.
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('115');
+
+-- Per https://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html
+-- MySQL will reject the query because it "uses nonaggregated columns that are
+-- neither named in the GROUP BY clause nor are functionally dependent on them".
+SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));
+
+CREATE PROCEDURE `sessionWithDevice_19` (
+  IN `tokenIdArg` BINARY(32)
+)
+BEGIN
+  SELECT
+    t.tokenData,
+    t.uid,
+    t.createdAt,
+    t.uaBrowser,
+    t.uaBrowserVersion,
+    t.uaOS,
+    t.uaOSVersion,
+    t.uaDeviceType,
+    t.uaFormFactor,
+    t.lastAccessTime,
+    t.verificationMethod,
+    t.verifiedAt,
+    COALESCE(t.authAt, t.createdAt) AS authAt,
+    e.isVerified AS emailVerified,
+    e.email,
+    e.emailCode,
+    a.verifierSetAt,
+    a.locale,
+    COALESCE(a.profileChangedAt, a.verifierSetAt, a.createdAt) AS profileChangedAt,
+    COALESCE(a.keysChangedAt, a.verifierSetAt, a.createdAt) AS keysChangedAt,
+    a.createdAt AS accountCreatedAt,
+    d.id AS deviceId,
+    d.nameUtf8 AS deviceName,
+    d.type AS deviceType,
+    d.createdAt AS deviceCreatedAt,
+    d.callbackURL AS deviceCallbackURL,
+    d.callbackPublicKey AS deviceCallbackPublicKey,
+    d.callbackAuthKey AS deviceCallbackAuthKey,
+    d.callbackIsExpired AS deviceCallbackIsExpired,
+    JSON_REMOVE(JSON_OBJECTAGG(IFNULL(ci.commandName, 'null__'), dc.commandData), '$.null__') AS deviceAvailableCommands,
+    ut.tokenVerificationId,
+    COALESCE(t.mustVerify, ut.mustVerify) AS mustVerify
+  FROM sessionTokens AS t
+  LEFT JOIN accounts AS a
+    ON t.uid = a.uid
+  LEFT JOIN emails AS e
+    ON t.uid = e.uid
+    AND e.isPrimary = true
+  LEFT JOIN devices AS d
+    ON (t.tokenId = d.sessionTokenId AND t.uid = d.uid)
+  LEFT JOIN (
+    deviceCommands AS dc FORCE INDEX (PRIMARY)
+    INNER JOIN deviceCommandIdentifiers AS ci FORCE INDEX (PRIMARY)
+      ON ci.commandId = dc.commandId
+  ) ON (dc.uid = d.uid AND dc.deviceId = d.id)
+  LEFT JOIN unverifiedTokens AS ut
+    ON t.tokenId = ut.tokenId
+  WHERE t.tokenId = tokenIdArg;
+END;
+
+UPDATE dbMetadata SET value = '116' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-116-115.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-116-115.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DROP PROCEDURE `sessionWithDevice_19`;
+
+-- UPDATE dbMetadata SET value = '115' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/util.js
+++ b/packages/fxa-auth-db-mysql/lib/db/util.js
@@ -155,7 +155,7 @@ module.exports = {
   //   +-------+----------------------------------+
   //
   // Unfortunately, we're not on newer versions of MySQL, so this function implements
-  // the same aggregation logic in sofware.  To use it, select all the target rows
+  // the same aggregation logic in software.  To use it, select all the target rows
   // and ensure they're sorted by grouping id:
   //
   //    rows = db.readAllResults("

--- a/packages/fxa-shared/db/models/auth/auth-base.ts
+++ b/packages/fxa-shared/db/models/auth/auth-base.ts
@@ -16,7 +16,7 @@ export enum Proc {
   PasswordChangeToken = 'passwordChangeToken_3',
   PasswordForgotToken = 'passwordForgotToken_2',
   RecoveryKey = 'getRecoveryKey_4',
-  SessionWithDevice = 'sessionWithDevice_18',
+  SessionWithDevice = 'sessionWithDevice_19',
   Sessions = 'sessions_11',
   TotpToken = 'totpToken_2',
 }

--- a/packages/fxa-shared/db/models/auth/index.ts
+++ b/packages/fxa-shared/db/models/auth/index.ts
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-import { uuidTransformer, aggregateNameValuePairs } from '../../transformers';
+import { uuidTransformer } from '../../transformers';
 import { Account, AccountOptions } from './account';
 import { AccountCustomers } from './account-customers';
 import { AccountResetToken } from './account-reset-token';

--- a/packages/fxa-shared/db/models/auth/session-token.ts
+++ b/packages/fxa-shared/db/models/auth/session-token.ts
@@ -90,15 +90,7 @@ export class SessionToken extends AuthBaseModel {
     if (!rows.length) {
       return null;
     }
-    const token = SessionToken.fromDatabaseJson(
-      aggregateNameValuePairs(
-        rows,
-        'deviceId',
-        'deviceCommandName',
-        'deviceCommandData',
-        'deviceAvailableCommands'
-      )[0]
-    );
+    const token = SessionToken.fromDatabaseJson(rows[0]);
     return notExpired(token) ? token : null;
   }
 


### PR DESCRIPTION
## Because

- MySQL 5.7 has some neat JSON functions
- We can use JSON_OBJECTAGG to do the same thing we are doing in [code](https://github.com/mozilla/fxa/blob/491ac1f553c928923ef0710771d66164c693acd2/packages/fxa-auth-db-mysql/lib/db/util.js#L125)

## This pull request

- Updates the `sessionTokenWithDevice` stored procedure to use `JSON_OBJECTAGG`

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/8573

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
