### PR TITLE
feat(auth): create script to send subscription renewal reminder emails

### DIFF
--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 115;
+module.exports.level = 116;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-115-116.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-115-116.sql
@@ -1,0 +1,12 @@
+--
+-- This migration adds the subscriptionRenewalReminder emailType to
+-- the emailTypes table.
+--
+
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('115');
+
+INSERT INTO emailTypes (emailType) VALUE ('subscriptionRenewalReminder');
+
+UPDATE dbMetadata SET value = '116' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-116-115.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-116-115.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+--
+-- DELETE FROM emailTypes WHERE emailType = 'subscriptionRenewalReminder';
+--
+-- UPDATE dbMetadata SET value = '115' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -21,6 +21,7 @@ const { version: VERSION } = require('../../package.json');
 // Maps template name to email type
 const EMAIL_TYPES = {
   subscriptionReactivation: 'subscription_reactivation',
+  subscriptionRenewalReminder: 'subscription_renewal_reminder',
   subscriptionUpgrade: 'subscription_upgrade',
   subscriptionDowngrade: 'subscription_downgrade',
   subscriptionPaymentExpired: 'subscription_payment_expired',

--- a/packages/fxa-auth-server/lib/payments/processing-tasks-shared.ts
+++ b/packages/fxa-auth-server/lib/payments/processing-tasks-shared.ts
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { setupAuthDatabase } from 'fxa-shared/db';
+import { StatsD } from 'hot-shots';
+import Container from 'typedi';
+import { Logger } from 'mozlog';
+
+import error from '../error';
+import { CurrencyHelper } from '../payments/currencies';
+import { StripeHelper } from './stripe';
+import { configureSentry } from '../sentry';
+
+const config = require('../../config').getProperties();
+
+export type AdditionalSetupFn = ({ log }: { log: Logger }) => void;
+
+export async function initShared(additionalSetupFn?: AdditionalSetupFn) {
+  configureSentry(undefined, config);
+  // Establish database connection and bind instance to Model using Knex
+  setupAuthDatabase(config.database.mysql.auth);
+
+  const statsd = config.statsd.enabled
+    ? new StatsD({
+        ...config.statsd,
+        errorHandler: (err) => {
+          // eslint-disable-next-line no-use-before-define
+          log.error('statsd.error', err);
+        },
+      })
+    : (({
+        increment: () => {},
+        timing: () => {},
+        close: () => {},
+      } as unknown) as StatsD);
+  Container.set(StatsD, statsd);
+
+  const log = require('../log')({ ...config.log, statsd });
+
+  const translator = await require('../senders/translator')(
+    config.i18n.supportedLanguages,
+    config.i18n.defaultLanguage
+  );
+  const senders = await require('../senders')(
+    log,
+    config,
+    error,
+    translator,
+    statsd
+  );
+  const redis = require('../redis')(
+    { ...config.redis, ...config.redis.sessionTokens },
+    log
+  );
+  const DB = require('../db')(
+    config,
+    log,
+    require('../tokens')(log, config),
+    require('../crypto/random').base32(config.signinUnblock.codeLength)
+  );
+  let database = null;
+  try {
+    database = await DB.connect(config, redis);
+  } catch (err) {
+    log.error('DB.connect', { err: { message: err.message } });
+    process.exit(1);
+  }
+
+  const currencyHelper = new CurrencyHelper(config);
+  Container.set(CurrencyHelper, currencyHelper);
+  const stripeHelper = new StripeHelper(log, config, statsd);
+  Container.set(StripeHelper, stripeHelper);
+
+  if (additionalSetupFn) {
+    additionalSetupFn({ log });
+  }
+
+  return {
+    log,
+    database,
+    senders,
+    stripeHelper,
+  };
+}

--- a/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
+++ b/packages/fxa-auth-server/lib/payments/subscription-reminders.ts
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Logger } from 'mozlog';
+import Stripe from 'stripe';
+
+import { ConfigType } from '../../config';
+import { reportSentryError } from '../sentry';
+import { SentEmailParams, Plan } from 'fxa-shared/subscriptions/types';
+import { StripeHelper, TimeSpanInS } from './stripe';
+import { SentEmail } from 'fxa-shared/db/models/auth';
+
+export const EMAIL_TYPE: string = 'subscriptionRenewalReminder';
+const DAYS_IN_A_WEEK: number = 7;
+const DAYS_IN_A_MONTH: number = 30;
+const DAYS_IN_A_YEAR: number = 365;
+export const MS_IN_A_DAY: number = 24 * 60 * 60 * 1000;
+
+interface EligiblePlansByInterval {
+  day(plan: Plan, planLength: number): Boolean;
+  week(plan: Plan, planLength: number): Boolean;
+  month(plan: Plan, planLength: number): Boolean;
+  year(plan: Plan, planLength: number): Boolean;
+}
+
+const eligiblePlansByInterval: EligiblePlansByInterval = {
+  day: (plan, planLength) => plan.interval_count >= planLength,
+  week: (plan, planLength) =>
+    plan.interval_count >= planLength / DAYS_IN_A_WEEK,
+  month: (plan, planLength) =>
+    plan.interval_count >= planLength / DAYS_IN_A_MONTH,
+  year: (plan, planLength) =>
+    plan.interval_count >= planLength / DAYS_IN_A_YEAR,
+};
+
+export class SubscriptionReminders {
+  private db: any;
+  private mailer: any;
+  private stripeHelper: StripeHelper;
+
+  constructor(
+    private log: Logger,
+    config: ConfigType,
+    private planLength: number,
+    private reminderLength: number,
+    db: any,
+    mailer: any,
+    stripeHelper: StripeHelper
+  ) {
+    this.db = db;
+    this.mailer = mailer;
+    this.planLength = planLength;
+    this.reminderLength = reminderLength;
+    this.stripeHelper = stripeHelper;
+  }
+
+  /**
+   * For all possible plan.intervals, determine if the plan is sufficiently
+   * long based on planLength.
+   */
+  private isEligiblePlan(plan: Plan): Boolean {
+    const { interval } = plan;
+    if (eligiblePlansByInterval[interval]) {
+      return eligiblePlansByInterval[interval](plan, this.planLength);
+    }
+    return false;
+  }
+
+  private async getEligiblePlans(): Promise<Plan[]> {
+    const allPlans = await this.stripeHelper.allPlans();
+    return allPlans.filter((plan) => this.isEligiblePlan(plan));
+  }
+
+  /**
+   * Returns a window of time in seconds { startTimeS, endTimeS }
+   * that is exactly one day, reminderLength days from now in UTC.
+   */
+  private getStartAndEndTimes(reminderLengthMs: number): TimeSpanInS {
+    const reminderDay = new Date(Date.now() + reminderLengthMs);
+    // Get hour 0, minute 0, second 0 for today's date
+    const startingTimestamp = new Date(
+      Date.UTC(
+        reminderDay.getUTCFullYear(),
+        reminderDay.getUTCMonth(),
+        reminderDay.getUTCDate(),
+        0,
+        0,
+        0
+      )
+    );
+    // Get hour 0, minute, 0, second 0 for one day from today's date
+    const endingTimestamp = new Date(startingTimestamp.getTime() + MS_IN_A_DAY);
+
+    const startTimeS = Math.floor(startingTimestamp.getTime() / 1000);
+    const endTimeS = Math.floor(endingTimestamp.getTime() / 1000);
+    return {
+      startTimeS,
+      endTimeS,
+    };
+  }
+
+  private async alreadySentEmail(
+    uid: string,
+    currentPeriodStartMs: number,
+    emailParams: SentEmailParams
+  ) {
+    const emailRecord = await SentEmail.findLatestSentEmailByType(
+      uid,
+      EMAIL_TYPE,
+      emailParams
+    );
+    // This could be the first email for a given subscription or a subsequent one.
+    return !!emailRecord && emailRecord.sentAt > currentPeriodStartMs;
+  }
+
+  private async updateSentEmail(uid: string, emailParams: SentEmailParams) {
+    await SentEmail.createSentEmail(uid, EMAIL_TYPE, emailParams);
+  }
+
+  /**
+   * Send out a renewal reminder email if we haven't already sent one.
+   */
+  async sendSubscriptionRenewalReminderEmail(
+    subscription: Stripe.Subscription
+  ): Promise<Boolean> {
+    const customer: Stripe.Customer | Stripe.DeletedCustomer | string =
+      subscription.customer;
+    if (typeof customer === 'string' || customer?.deleted) {
+      return false;
+    }
+    const uid = customer.metadata.userid;
+    if (!uid) {
+      return false;
+    }
+    const emailParams = { subscriptionId: subscription.id };
+    if (
+      await this.alreadySentEmail(
+        uid,
+        Math.floor(subscription.current_period_start * 1000),
+        emailParams
+      )
+    ) {
+      return false;
+    }
+    try {
+      const account = await this.db.account(uid);
+      this.log.info('sendSubscriptionRenewalReminderEmail', {
+        message: 'Sending a renewal reminder email.',
+        subscriptionId: subscription.id,
+        currentPeriodStart: subscription.current_period_start,
+        currentPeriodEnd: subscription.current_period_end,
+        currentDateMs: Date.now(),
+      });
+      await this.mailer.sendSubscriptionRenewalReminderEmail(
+        account.emails,
+        account,
+        {
+          acceptLanguage: account.locale,
+        }
+      );
+      await this.updateSentEmail(uid, emailParams);
+      return true;
+    } catch (err) {
+      this.log.error('sendSubscriptionRenewalReminderEmail', {
+        err,
+        subscriptionId: subscription.id,
+      });
+      reportSentryError(err);
+      return false;
+    }
+  }
+
+  /**
+   * Sends a reminder email for all active subscriptions for all plans
+   * as long or longer than `planLength`:
+   *   1. Get a list of all plans of sufficient `planLength`
+   *   2. For each plan get active subscriptions with `current_period_end`
+   *      dates `reminderLength` away from now.
+   *   3. Send a reminder email if one hasn't already been sent.
+   */
+  public async sendReminders() {
+    let success = true;
+
+    // 1
+    const plans = await this.getEligiblePlans();
+
+    // 2
+    const timePeriod = this.getStartAndEndTimes(
+      this.reminderLength * MS_IN_A_DAY
+    );
+    for (const { plan_id } of plans) {
+      // 3
+      for await (const subscription of this.stripeHelper.findActiveSubscriptionsByPlanId(
+        plan_id,
+        timePeriod
+      )) {
+        try {
+          await this.sendSubscriptionRenewalReminderEmail(subscription);
+        } catch (err) {
+          this.log.error('sendSubscriptionRenewalReminderEmail', {
+            err,
+            subscriptionId: subscription.id,
+          });
+          reportSentryError(err);
+          success = false;
+        }
+      }
+    }
+    return success;
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -36,6 +36,7 @@ module.exports = function (log, config) {
   // map to exactly one email template.
   const templateNameToCampaignMap = {
     subscriptionReactivation: 'subscription-reactivation',
+    subscriptionRenewalReminder: 'subscription-renewal-reminder',
     subscriptionUpgrade: 'subscription-upgrade',
     subscriptionDowngrade: 'subscription-downgrade',
     subscriptionPaymentExpired: 'subscription-payment-expired',
@@ -84,6 +85,7 @@ module.exports = function (log, config) {
   // when you add new templates.
   const templateNameToContentMap = {
     subscriptionReactivation: 'subscriptions',
+    subscriptionRenewalReminder: 'subscriptions',
     subscriptionUpgrade: 'subscriptions',
     subscriptionDowngrade: 'subscriptions',
     subscriptionPaymentExpired: 'subscriptions',
@@ -2403,6 +2405,10 @@ module.exports = function (log, config) {
         nextInvoiceDate,
       },
     });
+  };
+
+  Mailer.prototype.subscriptionRenewalReminderEmail = async function (message) {
+    // TODO: Implementation handled by #8223
   };
 
   Mailer.prototype.subscriptionSubsequentInvoiceEmail = async function (

--- a/packages/fxa-auth-server/lib/senders/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/templates/_versions.json
@@ -1,5 +1,6 @@
 {
   "subscriptionReactivation": 1,
+  "subscriptionRenewalReminder": 1,
   "subscriptionUpgrade": 1,
   "subscriptionDowngrade": 1,
   "subscriptionPaymentExpired": 1,

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -26,7 +26,8 @@
     "gen-keys": "ts-node ./scripts/gen_keys.js; ts-node ./scripts/oauth_gen_keys.js; ts-node ./scripts/gen_vapid_keys.js",
     "write-emails": "node -r ts-node/register ./scripts/write-emails-to-disk.js",
     "clean-up-old-ci-stripe-customers": "ts-node ./scripts/clean-up-old-ci-stripe-customers.js",
-    "paypal-processor": "CONFIG_FILES='config/secrets.json' ts-node ./scripts/paypal-processor.ts"
+    "paypal-processor": "CONFIG_FILES='config/secrets.json' ts-node ./scripts/paypal-processor.ts",
+    "subscription-reminders": "CONFIG_FILES='config/secrets.json' ts-node ./scripts/subscription-reminders.ts"
   },
   "repository": {
     "type": "git",

--- a/packages/fxa-auth-server/scripts/paypal-processor.ts
+++ b/packages/fxa-auth-server/scripts/paypal-processor.ts
@@ -2,20 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import program from 'commander';
-import { setupAuthDatabase } from 'fxa-shared/db';
-import { StatsD } from 'hot-shots';
-import Container from 'typedi';
 
-import error from '../lib/error';
-import { CurrencyHelper } from '../lib/payments/currencies';
+import Container from 'typedi';
 import { PayPalHelper } from '../lib/payments/paypal';
 import { PayPalClient } from '../lib/payments/paypal-client';
+
+import {
+  AdditionalSetupFn,
+  initShared,
+} from '../lib/payments/processing-tasks-shared';
 import { PaypalProcessor } from '../lib/payments/paypal-processor';
-import { StripeHelper } from '../lib/payments/stripe';
-import { configureSentry } from '../lib/sentry';
 
 const pckg = require('../package.json');
 const config = require('../config').getProperties();
+
+const additionalSetup: AdditionalSetupFn = ({ log }) => {
+  const paypalClient = new PayPalClient(
+    config.subscriptions.paypalNvpSigCredentials
+  );
+  Container.set(PayPalClient, paypalClient);
+  const paypalHelper = new PayPalHelper({ log });
+  Container.set(PayPalHelper, paypalHelper);
+};
 
 export async function init() {
   // Load program options
@@ -34,66 +42,7 @@ export async function init() {
     )
     .parse(process.argv);
 
-  configureSentry(undefined, config);
-  // Establish database connection and bind instance to Model using Knex
-  setupAuthDatabase(config.database.mysql.auth);
-
-  const statsd = config.statsd.enabled
-    ? new StatsD({
-        ...config.statsd,
-        errorHandler: (err) => {
-          // eslint-disable-next-line no-use-before-define
-          log.error('statsd.error', err);
-        },
-      })
-    : (({
-        increment: () => {},
-        timing: () => {},
-        close: () => {},
-      } as unknown) as StatsD);
-  Container.set(StatsD, statsd);
-
-  const log = require('../lib/log')({ ...config.log, statsd });
-
-  const translator = await require('../lib/senders/translator')(
-    config.i18n.supportedLanguages,
-    config.i18n.defaultLanguage
-  );
-  const senders = await require('../lib/senders')(
-    log,
-    config,
-    error,
-    translator,
-    statsd
-  );
-  const redis = require('../lib/redis')(
-    { ...config.redis, ...config.redis.sessionTokens },
-    log
-  );
-  const DB = require('../lib/db')(
-    config,
-    log,
-    require('../lib/tokens')(log, config),
-    require('../lib/crypto/random').base32(config.signinUnblock.codeLength)
-  );
-  let database = null;
-  try {
-    database = await DB.connect(config, redis);
-  } catch (err) {
-    log.error('DB.connect', { err: { message: err.message } });
-    process.exit(1);
-  }
-
-  const currencyHelper = new CurrencyHelper(config);
-  Container.set(CurrencyHelper, currencyHelper);
-  const stripeHelper = new StripeHelper(log, config, statsd);
-  Container.set(StripeHelper, stripeHelper);
-  const paypalClient = new PayPalClient(
-    config.subscriptions.paypalNvpSigCredentials
-  );
-  Container.set(PayPalClient, paypalClient);
-  const paypalHelper = new PayPalHelper({ log });
-  Container.set(PayPalHelper, paypalHelper);
+  const { log, database, senders } = await initShared(additionalSetup);
 
   const processor = new PaypalProcessor(
     log,

--- a/packages/fxa-auth-server/scripts/subscription-reminders.ts
+++ b/packages/fxa-auth-server/scripts/subscription-reminders.ts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import program from 'commander';
+
+import { initShared } from '../lib/payments/processing-tasks-shared';
+import { SubscriptionReminders } from '../lib/payments/subscription-reminders';
+
+const pckg = require('../package.json');
+const config = require('../config').getProperties();
+
+const DEFAULT_PLAN_LENGTH = 180;
+const DEFAULT_REMINDER_LENGTH = 14;
+
+async function init() {
+  program
+    .version(pckg.version)
+    .option(
+      '-p, --plan-length [days]',
+      'Plan length in days beyond which a reminder email before the next recurring charge should be sent. Defaults to 180.',
+      DEFAULT_PLAN_LENGTH
+    )
+    .option(
+      '-r, --reminder-length [days]',
+      'Reminder length in days before the renewal date to send the reminder email. Defaults to 14.',
+      DEFAULT_REMINDER_LENGTH
+    )
+    .parse(process.argv);
+
+  const { log, database, senders, stripeHelper } = await initShared();
+
+  const subscriptionReminders = new SubscriptionReminders(
+    log,
+    config,
+    parseInt(program.planLength),
+    parseInt(program.reminderLength),
+    database,
+    senders.email,
+    stripeHelper
+  );
+  await subscriptionReminders.sendReminders();
+  return 0;
+}
+
+if (require.main === module) {
+  init()
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    })
+    .then((result) => process.exit(result));
+}

--- a/packages/fxa-auth-server/test/local/payments/subscription-reminders.js
+++ b/packages/fxa-auth-server/test/local/payments/subscription-reminders.js
@@ -1,0 +1,377 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+const sinon = require('sinon');
+const { Container } = require('typedi');
+
+const { mockLog } = require('../../mocks');
+const { CurrencyHelper } = require('../../../lib/payments/currencies');
+const { StripeHelper } = require('../../../lib/payments/stripe');
+const { SentEmail } = require('fxa-shared/db/models/auth/sent-email');
+const {
+  EMAIL_TYPE,
+  SubscriptionReminders,
+  MS_IN_A_DAY,
+} = require('../../../lib/payments/subscription-reminders');
+const longPlan1 = require('./fixtures/stripe/plan1.json');
+const longPlan2 = require('./fixtures/stripe/plan2.json');
+const shortPlan1 = require('./fixtures/stripe/plan3.json');
+const longSubscription1 = require('./fixtures/stripe/subscription1.json'); // sub to plan 1
+const longSubscription2 = require('./fixtures/stripe/subscription2.json'); // sub to plan 2
+const planLength = 30; // days
+const reminderLength = 14; // days
+
+const sandbox = sinon.createSandbox();
+
+/**
+ * To prevent the modification of the test objects loaded, which can impact other tests referencing the object,
+ * a deep copy of the object can be created which uses the test object as a template
+ *
+ * @param {Object} object
+ */
+function deepCopy(object) {
+  return JSON.parse(JSON.stringify(object));
+}
+
+describe('SubscriptionReminders', () => {
+  let mockStripeHelper;
+  let reminder;
+  let mockConfig;
+
+  beforeEach(() => {
+    mockConfig = {
+      currenciesToCountries: { ZAR: ['AS', 'CA'] },
+    };
+    mockStripeHelper = {
+      findActiveSubscriptionsByPlanId: () => {},
+    };
+    const currencyHelper = new CurrencyHelper(mockConfig);
+    Container.set(CurrencyHelper, currencyHelper);
+    Container.set(StripeHelper, mockStripeHelper);
+    reminder = new SubscriptionReminders(
+      mockLog,
+      mockConfig,
+      planLength,
+      reminderLength,
+      {},
+      {},
+      mockStripeHelper
+    );
+  });
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  describe('constructor', () => {
+    it('sets log, planLength, reminderLength and stripe helper', () => {
+      assert.strictEqual(reminder.log, mockLog);
+      assert.equal(reminder.planLength, planLength);
+      assert.equal(reminder.reminderLength, reminderLength);
+      assert.strictEqual(reminder.stripeHelper, mockStripeHelper);
+    });
+  });
+
+  describe('isEligiblePlan', () => {
+    it('returns true with eligible (i.e. sufficently long) plan', () => {
+      const result = reminder.isEligiblePlan(longPlan1);
+      assert.isTrue(result);
+    });
+
+    it('returns false with ineligible (i.e. insufficiently long) plan', () => {
+      const result = reminder.isEligiblePlan(shortPlan1);
+      assert.isFalse(result);
+    });
+  });
+
+  describe('getEligiblePlans', () => {
+    it('returns [] when no plans are eligible', async () => {
+      const shortPlan2 = deepCopy(shortPlan1);
+      shortPlan2.interval = 'week';
+      mockStripeHelper.allPlans = sandbox.fake.resolves([
+        shortPlan1,
+        shortPlan2,
+      ]);
+      const result = await reminder.getEligiblePlans();
+      assert.isEmpty(result);
+    });
+    it('returns a partial list when some plans are eligible', async () => {
+      mockStripeHelper.allPlans = sandbox.fake.resolves([
+        shortPlan1,
+        longPlan1,
+        longPlan2,
+      ]);
+      const expected = [longPlan1, longPlan2];
+      const actual = await reminder.getEligiblePlans();
+      assert.deepEqual(actual, expected);
+    });
+    it('returns all when all plans are eligible', async () => {
+      mockStripeHelper.allPlans = sandbox.fake.resolves([longPlan1, longPlan2]);
+      const expected = [longPlan1, longPlan2];
+      const actual = await reminder.getEligiblePlans();
+      assert.deepEqual(actual, expected);
+    });
+  });
+
+  describe('getStartAndEndTimes', () => {
+    it('returns a startTimeS and endTimeS window of 1 day reminderLength days from "now" in UTC', () => {
+      const realDateNow = Date.now.bind(global.Date);
+      Date.now = sinon.fake(() => 1620864742024);
+      const expected = {
+        startTimeS: 1622073600,
+        endTimeS: 1622160000,
+      };
+      const reminderLengthMs = reminderLength * MS_IN_A_DAY;
+      const actual = reminder.getStartAndEndTimes(reminderLengthMs);
+      assert.deepEqual(actual, expected);
+      assert.equal(
+        (expected.endTimeS - expected.startTimeS) * 1000,
+        MS_IN_A_DAY
+      );
+      Date.now = realDateNow;
+    });
+  });
+
+  describe('alreadySentEmail', () => {
+    const args = ['uid', 12345, { subscriptionId: 'sub_123' }];
+    const sentEmailArgs = ['uid', EMAIL_TYPE, { subscriptionId: 'sub_123' }];
+    it('returns true for email already sent for this cycle', async () => {
+      SentEmail.findLatestSentEmailByType = sandbox.fake.resolves({
+        sentAt: 12346,
+      });
+      const result = await reminder.alreadySentEmail(...args);
+      assert.isTrue(result);
+      sinon.assert.calledOnceWithExactly(
+        SentEmail.findLatestSentEmailByType,
+        ...sentEmailArgs
+      );
+    });
+    it('returns false for email that has not been sent during this billing cycle', async () => {
+      SentEmail.findLatestSentEmailByType = sandbox.fake.resolves({
+        sentAt: 12344,
+      });
+      const result = await reminder.alreadySentEmail(...args);
+      assert.isFalse(result);
+      sinon.assert.calledOnceWithExactly(
+        SentEmail.findLatestSentEmailByType,
+        ...sentEmailArgs
+      );
+    });
+    it('returns false for email that has never been sent', async () => {
+      SentEmail.findLatestSentEmailByType = sandbox.fake.resolves(undefined);
+      const result = await reminder.alreadySentEmail(...args);
+      assert.isFalse(result);
+      sinon.assert.calledOnceWithExactly(
+        SentEmail.findLatestSentEmailByType,
+        ...sentEmailArgs
+      );
+    });
+  });
+
+  describe('updateSentEmail', () => {
+    it('creates a record in the SentEmails table', async () => {
+      const sentEmailArgs = ['uid', EMAIL_TYPE, { subscriptionId: 'sub_123' }];
+      SentEmail.createSentEmail = sandbox.fake.resolves({});
+      await reminder.updateSentEmail('uid', { subscriptionId: 'sub_123' });
+      sinon.assert.calledOnceWithExactly(
+        SentEmail.createSentEmail,
+        ...sentEmailArgs
+      );
+    });
+  });
+
+  describe('sendSubscriptionRenewalReminderEmail', () => {
+    it('returns false if customer uid is not provided', async () => {
+      const subscription = deepCopy(longSubscription1);
+      subscription.customer = {
+        metadata: {
+          userid: null,
+        },
+      };
+      const result = await reminder.sendSubscriptionRenewalReminderEmail(
+        subscription
+      );
+      assert.isFalse(result);
+    });
+
+    it('returns false if email already sent', async () => {
+      const subscription = deepCopy(longSubscription1);
+      subscription.customer = {
+        email: 'abc@123.com',
+        metadata: {
+          userid: 'uid',
+        },
+      };
+      reminder.alreadySentEmail = sandbox.fake.resolves(true);
+      const result = await reminder.sendSubscriptionRenewalReminderEmail(
+        subscription
+      );
+      assert.isFalse(result);
+      sinon.assert.calledOnceWithExactly(
+        reminder.alreadySentEmail,
+        subscription.customer.metadata.userid,
+        Math.floor(subscription.current_period_start * 1000),
+        {
+          subscriptionId: subscription.id,
+        }
+      );
+    });
+
+    it('returns true if it sends a reminder email', async () => {
+      const subscription = deepCopy(longSubscription1);
+      subscription.customer = {
+        email: 'abc@123.com',
+        metadata: {
+          userid: 'uid',
+        },
+      };
+      reminder.alreadySentEmail = sandbox.fake.resolves(false);
+      const account = { emails: [], locale: 'NZ' };
+      reminder.db.account = sandbox.fake.resolves(account);
+      mockLog.info = sandbox.fake.returns({});
+      reminder.mailer.sendSubscriptionRenewalReminderEmail = sandbox.fake.resolves(
+        {}
+      );
+      reminder.updateSentEmail = sandbox.fake.resolves({});
+      const realDateNow = Date.now.bind(global.Date);
+      Date.now = sinon.fake(() => 1620864742024);
+      const result = await reminder.sendSubscriptionRenewalReminderEmail(
+        subscription
+      );
+      assert.isTrue(result);
+      sinon.assert.calledOnceWithExactly(
+        reminder.db.account,
+        subscription.customer.metadata.userid
+      );
+      sinon.assert.calledOnceWithExactly(
+        mockLog.info,
+        'sendSubscriptionRenewalReminderEmail',
+        {
+          message: 'Sending a renewal reminder email.',
+          subscriptionId: subscription.id,
+          currentPeriodStart: subscription.current_period_start,
+          currentPeriodEnd: subscription.current_period_end,
+          currentDateMs: Date.now(),
+        }
+      );
+      sinon.assert.calledOnceWithExactly(
+        reminder.mailer.sendSubscriptionRenewalReminderEmail,
+        account.emails,
+        account,
+        {
+          acceptLanguage: account.locale,
+        }
+      );
+      sinon.assert.calledOnceWithExactly(
+        reminder.updateSentEmail,
+        subscription.customer.metadata.userid,
+        { subscriptionId: subscription.id }
+      );
+      Date.now = realDateNow;
+    });
+
+    it('returns false if an error is caught when trying to send a reminder email', async () => {
+      const subscription = deepCopy(longSubscription1);
+      subscription.customer = {
+        email: 'abc@123.com',
+        metadata: {
+          userid: 'uid',
+        },
+      };
+      reminder.alreadySentEmail = sandbox.fake.resolves(false);
+      reminder.db.account = sandbox.fake.resolves({});
+      reminder.updateSentEmail = sandbox.fake.resolves({});
+      mockLog.info = sandbox.fake.returns({});
+      mockLog.error = sandbox.fake.returns({});
+      const errMessage = 'Something went wrong.';
+      const throwErr = new Error(errMessage);
+      reminder.mailer.sendSubscriptionRenewalReminderEmail = sandbox.fake.rejects(
+        throwErr
+      );
+      const result = await reminder.sendSubscriptionRenewalReminderEmail(
+        subscription
+      );
+      assert.isFalse(result);
+      sinon.assert.calledOnceWithExactly(
+        reminder.db.account,
+        subscription.customer.metadata.userid
+      );
+      sinon.assert.calledOnceWithExactly(
+        mockLog.error,
+        'sendSubscriptionRenewalReminderEmail',
+        {
+          err: throwErr,
+          subscriptionId: subscription.id,
+        }
+      );
+      sinon.assert.notCalled(reminder.updateSentEmail);
+    });
+  });
+
+  describe('sendReminders', () => {
+    beforeEach(() => {
+      reminder.getEligiblePlans = sandbox.fake.resolves([longPlan1, longPlan2]);
+      reminder.getStartAndEndTimes = sandbox.fake.returns({
+        startTimeS: 1622073600,
+        endTimeS: 1622160000,
+      });
+      async function* genSubscriptionForPlan1() {
+        yield longSubscription1;
+      }
+      async function* genSubscriptionForPlan2() {
+        yield longSubscription2;
+      }
+      const stub = sandbox.stub(
+        mockStripeHelper,
+        'findActiveSubscriptionsByPlanId'
+      );
+      stub.onFirstCall().callsFake(genSubscriptionForPlan1);
+      stub.onSecondCall().callsFake(genSubscriptionForPlan2);
+    });
+    it('returns true if it can process all eligible subscriptions', async () => {
+      reminder.sendSubscriptionRenewalReminderEmail = sandbox.fake.resolves({});
+      const result = await reminder.sendReminders();
+      assert.isTrue(result);
+      sinon.assert.calledOnce(reminder.getEligiblePlans);
+      sinon.assert.calledOnceWithExactly(
+        reminder.getStartAndEndTimes,
+        reminderLength * MS_IN_A_DAY
+      );
+      // We iterate through each plan, longPlan1 and longPlan2, and there is one
+      // subscription, longSubscription1 and longSubscription2 respectively,
+      // returned for each plan.
+      sinon.assert.calledTwice(
+        mockStripeHelper.findActiveSubscriptionsByPlanId
+      );
+      sinon.assert.calledTwice(reminder.sendSubscriptionRenewalReminderEmail);
+    });
+    it('returns false and logs an error for any eligible subscription that it fails to process', async () => {
+      mockLog.error = sandbox.fake.returns({});
+      const errMessage = 'Something went wrong.';
+      const throwErr = new Error(errMessage);
+      const stub = sandbox.stub(
+        reminder,
+        'sendSubscriptionRenewalReminderEmail'
+      );
+      stub.onFirstCall().rejects(throwErr);
+      stub.onSecondCall().resolves({});
+      const result = await reminder.sendReminders();
+      assert.isFalse(result);
+      sinon.assert.calledOnceWithExactly(
+        mockLog.error,
+        'sendSubscriptionRenewalReminderEmail',
+        {
+          err: throwErr,
+          subscriptionId: longSubscription1.id,
+        }
+      );
+      stub.firstCall.calledWithExactly(longSubscription1);
+      stub.secondCall.calledWithExactly(longSubscription2);
+      sinon.assert.calledTwice(stub);
+    });
+  });
+});

--- a/packages/fxa-shared/db/models/auth/sent-email.ts
+++ b/packages/fxa-shared/db/models/auth/sent-email.ts
@@ -80,7 +80,7 @@ export class SentEmail extends AuthBaseModel {
     return SentEmail.query().findOne({ id: result[0] });
   }
 
-  static async findLatestSentEmaiByType(
+  static async findLatestSentEmailByType(
     uid: string,
     emailType: string,
     params?: any

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -104,3 +104,8 @@ export const PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE = 'funding_source';
 export type PaypalPaymentError =
   | typeof PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT
   | typeof PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE;
+
+export type SentEmailParams = {
+  subscriptionId: string;
+  planId?: string;
+};

--- a/packages/fxa-shared/test/db/models/auth/sent-emails.spec.ts
+++ b/packages/fxa-shared/test/db/models/auth/sent-emails.spec.ts
@@ -56,12 +56,12 @@ describe('SentEmail', () => {
     });
   });
 
-  describe('findLatestSentEmaiByType', () => {
+  describe('findLatestSentEmailByType', () => {
     it('finds the correct record without params', async () => {
       const acct = randomAccount();
       await SentEmail.createSentEmail(acct.uid, emailType);
       const expected = await SentEmail.createSentEmail(acct.uid, emailType);
-      const actual = await SentEmail.findLatestSentEmaiByType(
+      const actual = await SentEmail.findLatestSentEmailByType(
         acct.uid,
         emailType
       );
@@ -76,7 +76,7 @@ describe('SentEmail', () => {
         emailType,
         emailParams
       );
-      const actual = await SentEmail.findLatestSentEmaiByType(
+      const actual = await SentEmail.findLatestSentEmailByType(
         acct.uid,
         emailType,
         emailParams
@@ -87,7 +87,7 @@ describe('SentEmail', () => {
     it('returns undefined when no match record is found', async () => {
       const acct = randomAccount();
       await SentEmail.createSentEmail(acct.uid, emailType, emailParams);
-      const actual = await SentEmail.findLatestSentEmaiByType(
+      const actual = await SentEmail.findLatestSentEmailByType(
         acct.uid,
         'subscriptionPaymentExpired',
         emailParams


### PR DESCRIPTION
Because:
* There is a legal requirement to send a reminder email two weeks before a subscription for a plan longer than 180 days is renewed.

This commit:
* Adds a new `subscription-reminder` script intended to be run on a (bi-)daily basis that queries active subscriptions with longer plan lengths and sends renewal reminder emails as needed.
* Adds `subscriptionRenewalReminder` emailType to `EmailTypes` table with forward and reverse migrations.
  * The template for this email will be added in #8223.

Closes #8224

Co-authored-by: Barry Chen <chenba@gmail.com>

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).