### PR TITLE
chore(emails): update copy for failed payment email

### DIFF
--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionPaymentFailed.html
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionPaymentFailed.html
@@ -7,9 +7,7 @@
   <br><br>
   {{t "It may be that your credit card has expired, or your current payment method is out of date." }}
   <br><br>
-  {{{t "Help us fix it by <a href=\"%(updateBillingUrl)s\">updating your payment information</a> within 24 hours." }}}
-  <br><br>
-  {{t "Unfortunately, if we don’t hear from you within 24 hours, you’ll lose access to %(productName)s." }}
+  {{t "We’ll try your payment again over the next few days, but you may need to help us fix it by <a href=\"%(updateBillingUrl)s\">updating your payment information</a>."}}
   <br><br>
   {{{t "Questions about your subscription? Our <a href=\"%(subscriptionSupportUrl)s\">support team</a> is here to help you." }}}
 {{/inline}}

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionPaymentFailed.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionPaymentFailed.txt
@@ -6,11 +6,9 @@
 
 {{{t "It may be that your credit card has expired, or your current payment method is out of date." }}}
 
-{{{t "Help us fix it by updating your payment information within 24 hours:" }}}
+{{{t "We’ll try your payment again over the next few days, but you may need to help us fix it by updating your payment information:" }}}
 
 {{{updateBillingUrl}}}
-
-{{{t "Unfortunately, if we don’t hear from you within 24 hours, you’ll lose access to %(productName)s." }}}
 
 {{{t "Questions about your subscription? Our support team is here to help you:" }}}
 

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -351,12 +351,12 @@ const TESTS = [
       { test: 'include', expected: configHref('subscriptionSettingsUrl', 'subscription-payment-failed', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email') },
       { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-payment-failed', 'subscription-terms') },
       { test: 'include', expected: `latest payment for ${MESSAGE.productName}.` },
-      { test: 'include', expected: `you’ll lose access to ${MESSAGE.productName}.` },
+      { test: 'include', expected: 'We’ll try your payment again over the next few days, but you may need to help us fix it' },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
       { test: 'include', expected: `latest payment for ${MESSAGE.productName}.` },
-      { test: 'include', expected: `you’ll lose access to ${MESSAGE.productName}.` },
+      { test: 'include', expected: 'We’ll try your payment again over the next few days, but you may need to help us fix it' },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],


### PR DESCRIPTION
Because:
 - the grace period mentioned in the failed payment email is no longer
   accurate

This commit:
 - update the failed payment email copy

## Issue that this pull request solves

Closes: #8355 

