### PR TITLE
fix(session): Update sessionToken data in redis when used by route

### DIFF
--- a/packages/fxa-auth-server/lib/db/index.js
+++ b/packages/fxa-auth-server/lib/db/index.js
@@ -581,7 +581,7 @@ module.exports = (config, log, Token, UnblockCode = null) => {
    * frequently-called routes.
    *
    * To do a cheaper write of transient metadata that only hits
-   * redis, use touchSessionToken isntead.
+   * redis, use touchSessionToken instead.
    */
   SAFE_URLS.updateSessionToken = new SafeUrl(
     '/sessionToken/:id/update',

--- a/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
+++ b/packages/fxa-auth-server/lib/routes/devices-and-sessions.js
@@ -238,7 +238,7 @@ module.exports = (
 
         const response = await pushbox.retrieve(uid, deviceId, limit, index);
 
-        // To measure command delivery, we emit a "retrieved" event for each retreived
+        // To measure command delivery, we emit a "retrieved" event for each retrieved
         // command, which should match to an "invoked" event emitted when it was invoked.
         for (const msg of response.messages) {
           const data = msg.data || {}; // should always be present, but you never know...

--- a/packages/fxa-auth-server/test/local/routes/attached-clients.js
+++ b/packages/fxa-auth-server/test/local/routes/attached-clients.js
@@ -82,6 +82,10 @@ describe('/account/attached_clients', () => {
       credentials: {
         id: crypto.randomBytes(16).toString('hex'),
         uid: uid,
+        setUserAgentInfo: sinon.spy(() => {}),
+      },
+      headers: {
+        'user-agent': 'fake agent',
       },
     });
     const accountRoutes = makeRoutes({
@@ -197,6 +201,12 @@ describe('/account/attached_clients', () => {
     const result = await route(request);
 
     assert.equal(result.length, 6);
+
+    assert.equal(db.touchSessionToken.callCount, 1);
+    const args = db.touchSessionToken.args[0];
+    assert.equal(args.length, 2);
+    const laterDate = Date.now() - 60 * 1000;
+    assert.equal(laterDate < args[0].lastAccessTime, true);
 
     // The device with just a sessionToken.
     assert.deepEqual(result[0], {

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -513,6 +513,7 @@ function mockDB(data, errors) {
         uaOSVersion: data.uaOSVersion,
         uaDeviceType: data.uaDeviceType,
         expired: () => data.expired || false,
+        setUserAgentInfo: sinon.spy(() => {}),
       };
       // SessionToken is a class, and tokenTypeID is a class attribute. Fake that.
       res.constructor.tokenTypeID = 'sessionToken';


### PR DESCRIPTION
## Because

- Previously, the only time the "last access" value on a session token was updated was on the `/certification/sign` route which leads to confusing last accessed time

## This pull request

- Calls the `db.touchSessionToken` in the `/account/attach_devices` route to update the last used time
- This route is a lower volume route and should allow us to test out the overall performance

## Issue that this pull request solves

Closes: #7039

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
