### PR TITLE
feat(subscriptions): allow redirects to Payments without token

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/payment-server.js
+++ b/packages/fxa-content-server/app/scripts/lib/payment-server.js
@@ -7,6 +7,10 @@
 
 import Url from './url';
 
+const allowedUnauthenticatedRoutes = ['product'];
+const isAllowedUnauthenticatedRoute = (redirectPath) =>
+  allowedUnauthenticatedRoutes.some((route) => redirectPath.startsWith(route));
+
 const PaymentServer = {
   /**
    * Navigate to the payments server after flushing metrics.
@@ -16,7 +20,7 @@ const PaymentServer = {
    * @param {String} redirectPath
    * @param {Object} [queryParams={}]
    */
-  navigateToPaymentServer(
+  async navigateToPaymentServer(
     view,
     subscriptionsConfig,
     redirectPath,
@@ -29,37 +33,53 @@ const PaymentServer = {
       managementUrl,
     } = subscriptionsConfig;
 
-    const {
-      deviceId,
-      flowBeginTime,
-      flowId,
-    } = view.metrics.getFlowEventMetadata();
+    const { deviceId, flowBeginTime, flowId } =
+      view.metrics.getFlowEventMetadata();
 
-    return view
-      .getSignedInAccount()
-      .createOAuthToken(managementClientId, {
-        scope: managementScopes,
-        ttl: managementTokenTTL,
-      })
-      .then((accessToken) => {
-        const queryString = Url.objToSearchString({
-          // device_id, flow_begin_time, and flow_id need to be propagated to
-          // the payments server so that the user funnel can be traced from the RP,
-          // through the content server, and to the payments server, appearing as
-          // the same user throughout.
-          device_id: deviceId,
-          flow_begin_time: flowBeginTime,
-          flow_id: flowId,
-          ...queryParams,
-        });
+    const queryString = Url.objToSearchString({
+      // device_id, flow_begin_time, and flow_id need to be propagated to
+      // the payments server so that the user funnel can be traced from the RP,
+      // through the content server, and to the payments server, appearing as
+      // the same user throughout.
+      device_id: deviceId,
+      flow_begin_time: flowBeginTime,
+      flow_id: flowId,
+      ...queryParams,
+    });
+    const url = `${managementUrl}/${redirectPath}${queryString}`;
+    const account = view.getSignedInAccount();
+    const unauthenticatedRedirect = () => {
+      if (isAllowedUnauthenticatedRoute(redirectPath)) {
+        return view.navigateAway(url);
+      }
 
-        const hashString = Url.objToHashString({
-          accessToken: accessToken.get('token'),
-        });
+      view.navigate('/');
+    };
 
-        const url = `${managementUrl}/${redirectPath}${queryString}${hashString}`;
-        view.navigateAway(url);
-      });
+    if (account) {
+      try {
+        const isSignedIn = await account.isSignedIn();
+
+        if (isSignedIn) {
+          const accessToken = await account.createOAuthToken(
+            managementClientId,
+            {
+              scope: managementScopes,
+              ttl: managementTokenTTL,
+            }
+          );
+          const hashString = Url.objToHashString({
+            accessToken: accessToken.get('token'),
+          });
+
+          return view.navigateAway(`${url}${hashString}`);
+        }
+      } catch (_) {
+        unauthenticatedRedirect();
+      }
+    }
+
+    unauthenticatedRedirect();
   },
 };
 

--- a/packages/fxa-content-server/app/scripts/views/subscriptions_product_redirect.js
+++ b/packages/fxa-content-server/app/scripts/views/subscriptions_product_redirect.js
@@ -10,7 +10,6 @@ import PaymentServer from '../lib/payment-server';
 import Url from '../lib/url';
 
 class SubscriptionsProductRedirectView extends FormView {
-  mustAuth = true;
   template = Template;
 
   initialize(options) {
@@ -22,6 +21,8 @@ class SubscriptionsProductRedirectView extends FormView {
     if (options && options.config && options.config.subscriptions) {
       this._subscriptionsConfig = options.config.subscriptions;
     }
+
+    this.mustAuth = !this._subscriptionsConfig.allowUnauthenticatedRedirects;
 
     // Flow events need to be initialized before the navigation
     // so the flow_id and flow_begin_time are propagated

--- a/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
@@ -80,6 +80,30 @@ describe('views/subscriptions_product_redirect', function () {
       });
       assert.equal(PRODUCT_ID, relier.get('subscriptionProductId'));
     });
+
+    it('sets mustAuth to true when allowUnauthenticatedRedirects false', () => {
+      view.initialize({
+        currentPage: `/subscriptions/products/${PRODUCT_ID}`,
+        config: {
+          subscriptions: {
+            allowUnauthenticatedRedirects: false,
+          },
+        },
+      });
+      assert.isTrue(view.mustAuth, 'mustAuth should be true');
+    });
+
+    it('sets mustAuth to false when allowUnauthenticatedRedirects true', () => {
+      view.initialize({
+        currentPage: `/subscriptions/products/${PRODUCT_ID}`,
+        config: {
+          subscriptions: {
+            allowUnauthenticatedRedirects: true,
+          },
+        },
+      });
+      assert.isFalse(view.mustAuth, 'mustAuth should be false');
+    });
   });
 
   describe('render', () => {

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -687,6 +687,13 @@ const conf = (module.exports = convict({
       env: 'SUBSCRIPTIONS_MANAGEMENT_URL',
       format: String,
     },
+    allowUnauthenticatedRedirects: {
+      default: false,
+      doc:
+        'Whether to allow any redirects to Payments for an unauthenticated user',
+      env: 'SUBSCRIPTIONS_UNAUTHED_REDIRECTS',
+      formlat: Boolean,
+    },
   },
   surveyFeature: {
     enabled: {


### PR DESCRIPTION
Because:
 - we want to enable people to sign up and subscribe on Payments in a
   new checkout flow

This commit:
 - allow unauthenticated redirects to the product route on Payments from
   content-server
 - add a feature flag to toggle the behavior (default is off)


Closes: #8571 

