### PR TITLE
feat(subscriptions): allow plans list access without auth

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -256,7 +256,6 @@ export class StripeHandler {
 
   async listPlans(request: AuthRequest) {
     this.log.begin('subscriptions.listPlans', request);
-    await handleAuth(this.db, request.auth);
     const plans = await this.stripeHelper.allPlans();
     return sanitizePlans(plans);
   }
@@ -856,10 +855,6 @@ export const stripeRoutes = (
       method: 'GET',
       path: '/oauth/subscriptions/plans',
       options: {
-        auth: {
-          payload: false,
-          strategy: 'oauthToken',
-        },
         response: {
           schema: isA.array().items(validators.subscriptionsPlanValidator),
         },

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -1222,33 +1222,14 @@ describe('DirectStripeRoutes', () => {
   });
 
   describe('listPlans', () => {
-    it('returns the available plans when auth headers are valid', async () => {
+    it('returns the available plans without auth headers present', async () => {
       const expected = sanitizePlans(PLANS);
+      const request = {};
 
       directStripeRoutesInstance.stripeHelper.allPlans.resolves(PLANS);
-      const actual = await directStripeRoutesInstance.listPlans(VALID_REQUEST);
+      const actual = await directStripeRoutesInstance.listPlans(request);
 
       assert.deepEqual(actual, expected);
-    });
-
-    it('results in an error when auth headers are invalid', async () => {
-      const invalid_request = {
-        auth: {
-          credentials: {
-            scope: ['profile'],
-            user: `${UID}`,
-            email: `${TEST_EMAIL}`,
-          },
-        },
-      };
-
-      return directStripeRoutesInstance.listPlans(invalid_request).then(
-        () => Promise.reject(new Error('Method expected to reject')),
-        (err) => {
-          assert.instanceOf(err, WError);
-          assert.equal(err.message, 'Requested scopes are not allowed');
-        }
-      );
     });
   });
 


### PR DESCRIPTION
Because:
 - users who are not authenticated should be allow to access product
   plans

This commit:
 - stop requiring an access token on the plans endpoint


Closes: #8598 
