### PR TITLE
feat(emails): add email for subscription renewal reminder

### DIFF
--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionRenewalReminder.html
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionRenewalReminder.html
@@ -1,0 +1,17 @@
+{{#*inline "title"}}
+  {{t "Your subscription will be renewed soon" }}
+{{/inline}}
+
+{{#*inline "content"}}
+  {{{t "Your current subscription is set to automatically renew in %(reminderLength)s days. At that time, Mozilla will renew your %(planIntervalCount)s %(planInterval)s subscription and a charge of %(invoiceTotal)s will be applied to the payment method on your account." }}}
+  <br><br>
+  {{{t "You can ensure that your payment method and account information are up to date <a href=\"%(updateBillingUrl)s\">here</a>." }}}
+  <br><br>
+  {{{t "Thank you for subscribing to %(productName)s. If you have any questions about your subscription or need more information about %(productName)s please <a href=\"%(subscriptionSupportUrl)s\">contact us</a>." }}}
+  <br><br>
+  {{{t "Sincerely," }}}
+  <br><br>
+  {{{t "The %(productName)s team" }}}
+{{/inline}}
+
+{{> subscriptionEmail}}

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionRenewalReminder.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionRenewalReminder.txt
@@ -1,0 +1,17 @@
+{{{subject}}}
+
+{{{t "Your subscription will be renewed soon" }}}
+
+{{{t "Your current subscription is set to automatically renew in %(reminderLength)s days. At that time, Mozilla will renew your %(planIntervalCount)s %(planInterval)s subscription and a charge of %(invoiceTotal)s will be applied to the payment method on your account." }}}
+
+{{{t "You can ensure that your payment method and account information are up to date here:" }}}
+
+{{{updateBillingUrl}}}
+
+{{{t "Thank you for subscribing to %(productName)s. If you have any questions about your subscription or need more information about %(productName)s please contact us:" }}}
+
+{{{subscriptionSupportUrl}}}
+
+{{{t "Sincerely," }}}
+
+{{{t "The %(productName)s team" }}}

--- a/packages/fxa-auth-server/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/scripts/write-emails-to-disk.js
@@ -110,6 +110,8 @@ function sendMail(mailer, messageToSend) {
     productName: 'Firefox Fortress',
     planEmailIconURL: 'http://placekitten.com/512/512',
     planDownloadURL: 'http://getfirefox.com/',
+    planInterval: 'week',
+    planIntervalCount: 4,
     playStoreLink: 'https://example.com/play-store',
     invoiceNumber: '8675309',
     cardType: 'mastercard',
@@ -131,6 +133,7 @@ function sendMail(mailer, messageToSend) {
     paymentProratedCurrency: 'usd',
     productPaymentCycle: 'month',
     redirectTo: 'https://redirect.com/',
+    reminderLength: 14,
     resume:
       'eyJjYW1wYWlnbiI6bnVsbCwiZW50cnlwb2ludCI6bnVsbCwiZmxvd0lkIjoiM2Q1ODZiNzY4Mzc2NGJhOWFiNzhkMzMxMTdjZDU4Y2RmYjk3Mzk5MWU5NTk0NjgxODBlMDUyMmY2MThhNmEyMSIsInJlc2V0UGFzc3dvcmRDb25maXJtIjp0cnVlLCJ1bmlxdWVVc2VySWQiOiI1ODNkOGFlYS00NzU3LTRiZTQtYWJlNC0wZWQ2NWZhY2Y2YWQiLCJ1dG1DYW1wYWlnbiI6bnVsbCwidXRtQ29udGVudCI6bnVsbCwidXRtTWVkaXVtIjpudWxsLCJ1dG1Tb3VyY2UiOm51bGwsInV0bVRlcm0iOm51bGx9',
     secondaryEmail: 'secondary@email',
@@ -147,6 +150,14 @@ function sendMail(mailer, messageToSend) {
     tokenCode: 'LIT12345',
     uid: '6510cb04abd742c6b3e4abefc7e39c9f',
     productMetadata,
+    subscription: {
+      planDownloadURL: 'http://getfirefox.com/',
+      planEmailIconURL: 'http://placekitten.com/512/512',
+      planId: 'plan-example',
+      productId: '0123456789abcdef',
+      productMetadata,
+      productName: 'Firefox Fortress',
+    },
     subscriptions: [
       {
         planDownloadURL: 'http://getfirefox.com/',

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -58,6 +58,8 @@ const MESSAGE = {
   productName: 'Firefox Fortress',
   planEmailIconURL: 'http://example.com/icon.jpg',
   planDownloadURL: 'http://getfirefox.com/',
+  planInterval: 'day',
+  planIntervalCount: 2,
   playStoreLink: 'https://example.com/play-store',
   invoiceNumber: '8675309',
   cardType: 'mastercard',
@@ -80,7 +82,13 @@ const MESSAGE = {
   paymentProratedCurrency: 'usd',
   productPaymentCycle: 'month',
   productMetadata,
+  reminderLength: 14,
   service: 'sync',
+  subscription: {
+    productName: 'Cooking with Foxkeh',
+    planId: 'plan-example',
+    productId: 'wibble',
+  },
   subscriptions: [
     { productName: 'Firefox Fortress' },
     { productName: 'Cooking with Foxkeh' },
@@ -316,6 +324,26 @@ const TESTS = [
     ]],
     ['text', [
       { test: 'include', expected: `reactivating your ${MESSAGE.productName} subscription` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ])],
+  ['subscriptionRenewalReminderEmail', new Map([
+    ['subject', { test: 'equal', expected: `${MESSAGE.subscription.productName} automatic renewal notice` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionRenewalReminder') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionRenewalReminder' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionRenewalReminder }],
+    ])],
+    ['html', [
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-renewal-reminder', 'subscription-terms') },
+      { test: 'include', expected: configHref('subscriptionSettingsUrl', 'subscription-renewal-reminder', 'update-billing', 'plan_id', 'product_id', 'uid', 'email') },
+      { test: 'include', expected: configHref('subscriptionSupportUrl', 'subscription-renewal-reminder', 'subscription-support') },
+      { test: 'include', expected: `Your current subscription is set to automatically renew in ${MESSAGE.reminderLength} days. At that time, Mozilla will renew your ${MESSAGE.planIntervalCount} ${MESSAGE.planInterval} subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `${MESSAGE.subscription.productName} automatic renewal notice` },
+      { test: 'include', expected: `Your current subscription is set to automatically renew in ${MESSAGE.reminderLength} days. At that time, Mozilla will renew your ${MESSAGE.planIntervalCount} ${MESSAGE.planInterval} subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],


### PR DESCRIPTION
Because:
* There is a legal requirement to send a reminder email two weeks before a subscription for a plan longer than 180 days is renewed.

This commit:
* Adds a new subscriptionRenewalReminder email template
* Sends the new email for a qualifying subscription as determined by #8224

Closes #8223

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="739" alt="Screen Shot 2021-05-24 at 10 03 57 PM" src="https://user-images.githubusercontent.com/17437436/119433485-f9d0c300-bcdb-11eb-9995-d34ea8c0a348.png">

