### PR TITLE
feat(push): Add basic support for verifying a login via push

### DIFF
--- a/packages/fxa-auth-server/lib/push.js
+++ b/packages/fxa-auth-server/lib/push.js
@@ -17,6 +17,7 @@ const PUSH_COMMANDS = {
   PASSWORD_RESET: 'fxaccounts:password_reset',
   ACCOUNT_DESTROYED: 'fxaccounts:account_destroyed',
   COMMAND_RECEIVED: 'fxaccounts:command_received',
+  LOGIN_REQUEST: 'fxaccounts:verify_login',
 };
 
 const PUSH_REASONS = new Set([
@@ -30,6 +31,7 @@ const PUSH_REASONS = new Set([
   'devicesNotify',
   'accountDestroyed',
   'commandReceived',
+  'verifyLogin',
 ]);
 
 const PUSH_ERRORS = new Set([
@@ -335,6 +337,25 @@ module.exports = function (log, db, config, statsd) {
           },
         },
         TTL: TTL_ACCOUNT_DESTROYED,
+      });
+    },
+
+    /**
+     * Notify a device to verify a login request. The push notification
+     * contains location, UA and verification code in the url.
+     *
+     * @param {String} uid
+     * @param {Device[]} devices
+     * @param {Object} data
+     * @promise
+     */
+    notifyVerifyLoginRequest(uid, devices, data) {
+      return this.sendPush(uid, devices, 'verifyLogin', {
+        data: {
+          version: PUSH_PAYLOAD_SCHEMA_VERSION,
+          command: PUSH_COMMANDS.LOGIN_REQUEST,
+          data,
+        },
       });
     },
 

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -165,6 +165,7 @@ const PUSH_METHOD_NAMES = [
   'notifyAccountDestroyed',
   'notifyCommandReceived',
   'notifyProfileUpdated',
+  'notifyVerifyLoginRequest',
   'sendPush',
 ];
 
@@ -641,18 +642,18 @@ function mockMetricsContext(methods) {
                 flow_id: this.payload.metricsContext.flowId,
                 flow_time: time - this.payload.metricsContext.flowBeginTime,
                 flowBeginTime: this.payload.metricsContext.flowBeginTime,
-                flowCompleteSignal: this.payload.metricsContext
-                  .flowCompleteSignal,
+                flowCompleteSignal:
+                  this.payload.metricsContext.flowCompleteSignal,
                 flowType: this.payload.metricsContext.flowType,
               },
               this.headers && this.headers.dnt === '1'
                 ? {}
                 : {
                     entrypoint: this.payload.metricsContext.entrypoint,
-                    entrypoint_experiment: this.payload.metricsContext
-                      .entrypointExperiment,
-                    entrypoint_variation: this.payload.metricsContext
-                      .entrypointVariation,
+                    entrypoint_experiment:
+                      this.payload.metricsContext.entrypointExperiment,
+                    entrypoint_variation:
+                      this.payload.metricsContext.entrypointVariation,
                     utm_campaign: this.payload.metricsContext.utmCampaign,
                     utm_content: this.payload.metricsContext.utmContent,
                     utm_medium: this.payload.metricsContext.utmMedium,


### PR DESCRIPTION
## Because

-  We need a way for a user to trigger sending a push notification to verify a login

## This pull request

- Adds basic support for sending the login verificatio push notification
- Passes location, UA, IP as url params because this will allow us from having to add a new push notifiation type on desktop client

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/4778

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
