### PR TITLE
feat(content-server): return flow params to relier party

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/scripts/models/auth_brokers/oauth-redirect.js
@@ -128,19 +128,24 @@ export default BaseAuthenticationBroker.extend({
         extraParams.state = state;
       }
 
-      // Pull in valid UTM parameters if present
-      const utmKeyMap = {
+      // Pull in valid parameters to return if present
+      const paramKeyMap = {
+        // utm params
         utmCampaign: 'utm_campaign',
         utmContent: 'utm_content',
         utmMedium: 'utm_medium',
         utmSource: 'utm_source',
         utmTerm: 'utm_term',
+        // flow params
+        flowId: 'flow_id',
+        flowBeginTime: 'flow_begin_time',
+        deviceId: 'device_id',
       };
-      for (const utmKey of Object.keys(utmKeyMap)) {
-        const utmValue = this.relier.get(utmKey);
-        if (utmValue) {
+      for (const key of Object.keys(paramKeyMap)) {
+        const value = this.relier.get(key);
+        if (value) {
           // We have to rename the key, as the relier renames these to camelcase on the way in.
-          extraParams[utmKeyMap[utmKey]] = utmValue;
+          extraParams[paramKeyMap[key]] = value;
         }
       }
 

--- a/packages/fxa-content-server/app/scripts/models/reliers/relier.js
+++ b/packages/fxa-content-server/app/scripts/models/reliers/relier.js
@@ -60,6 +60,10 @@ const QUERY_PARAMETER_SCHEMA = {
   utm_medium: Vat.string().renameTo('utmMedium'),
   utm_source: Vat.string().renameTo('utmSource'),
   utm_term: Vat.string().renameTo('utmTerm'),
+  // Flow params
+  flow_id: Vat.string().renameTo('flowId'),
+  flow_begin_time: Vat.string().renameTo('flowBeginTime'),
+  device_id: Vat.string().renameTo('deviceId'),
 };
 
 const EMAIL_FIRST_EMAIL_SCHEMA = {

--- a/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/models/auth_brokers/oauth-redirect.js
@@ -301,7 +301,7 @@ describe('models/auth_brokers/oauth-redirect', () => {
 
     describe('with existing query parameters', () => {
       it('passes through existing parameters unchanged', () => {
-        relier.set({ utmSource: 'web' }); //eslint-disable-line camelcase
+        relier.set({ utmSource: 'web', flowId: 'flowbee' }); //eslint-disable-line camelcase
         return broker
           .sendOAuthResultToRelier({
             error: 'error',
@@ -313,6 +313,7 @@ describe('models/auth_brokers/oauth-redirect', () => {
             assert.include(windowMock.location.href, 'error=error');
             assert.include(windowMock.location.href, 'state=state');
             assert.include(windowMock.location.href, 'utm_source=web');
+            assert.include(windowMock.location.href, 'flow_id=flowbee');
           });
       });
 


### PR DESCRIPTION
## Because:

- We want to retain flow parameters through the OAuth flow.

##This commit:

    Extracts the flow params to include on the fina redirect.


## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


