### PR TITLE
fix(emails): address the customer in the subscriptionRenewalReminder …

### DIFF
--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionRenewalReminder.html
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionRenewalReminder.html
@@ -3,6 +3,8 @@
 {{/inline}}
 
 {{#*inline "content"}}
+  {{{t "Dear %(productName)s customer," }}}
+  <br><br>
   {{{t "Your current subscription is set to automatically renew in %(reminderLength)s days. At that time, Mozilla will renew your %(planIntervalCount)s %(planInterval)s subscription and a charge of %(invoiceTotal)s will be applied to the payment method on your account." }}}
   <br><br>
   {{{t "You can ensure that your payment method and account information are up to date <a href=\"%(updateBillingUrl)s\">here</a>." }}}

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionRenewalReminder.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionRenewalReminder.txt
@@ -2,6 +2,8 @@
 
 {{{t "Your subscription will be renewed soon" }}}
 
+{{{t "Dear %(productName)s customer," }}}
+
 {{{t "Your current subscription is set to automatically renew in %(reminderLength)s days. At that time, Mozilla will renew your %(planIntervalCount)s %(planInterval)s subscription and a charge of %(invoiceTotal)s will be applied to the payment method on your account." }}}
 
 {{{t "You can ensure that your payment method and account information are up to date here:" }}}

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -338,12 +338,18 @@ const TESTS = [
       { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-renewal-reminder', 'subscription-terms') },
       { test: 'include', expected: configHref('subscriptionSettingsUrl', 'subscription-renewal-reminder', 'update-billing', 'plan_id', 'product_id', 'uid', 'email') },
       { test: 'include', expected: configHref('subscriptionSupportUrl', 'subscription-renewal-reminder', 'subscription-support') },
+      { test: 'include', expected: `Dear ${MESSAGE.subscription.productName} customer` },
       { test: 'include', expected: `Your current subscription is set to automatically renew in ${MESSAGE.reminderLength} days. At that time, Mozilla will renew your ${MESSAGE.planIntervalCount} ${MESSAGE.planInterval} subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.` },
+      { test: 'include', expected: "Sincerely," },
+      { test: 'include', expected: `The ${MESSAGE.subscription.productName} team` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
       { test: 'include', expected: `${MESSAGE.subscription.productName} automatic renewal notice` },
+      { test: 'include', expected: `Dear ${MESSAGE.subscription.productName} customer` },
       { test: 'include', expected: `Your current subscription is set to automatically renew in ${MESSAGE.reminderLength} days. At that time, Mozilla will renew your ${MESSAGE.planIntervalCount} ${MESSAGE.planInterval} subscription and a charge of ${MESSAGE_FORMATTED.invoiceTotal} will be applied to the payment method on your account.` },
+      { test: 'include', expected: "Sincerely," },
+      { test: 'include', expected: `The ${MESSAGE.subscription.productName} team` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],


### PR DESCRIPTION
…email

Because:

* The specified email copy has a 'Dear X' address at the beginning, but the email did not.

This commit:

* Adds 'Dear X'

Follow-up for #8223

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="771" alt="Screen Shot 2021-06-01 at 10 57 55 AM" src="https://user-images.githubusercontent.com/17437436/120345180-ddc2b800-c2bf-11eb-8dd6-c57c0e22d119.png">

