### PR TITLE
refactor(db): move more auth-db functions into fxa-shared

### DIFF
--- a/packages/fxa-shared/db/models/auth/account-reset-token.ts
+++ b/packages/fxa-shared/db/models/auth/account-reset-token.ts
@@ -18,6 +18,13 @@ export class AccountResetToken extends AuthBaseModel {
   // joined fields (from accountResetToken_# stored proc)
   verifierSetAt!: number;
 
+  static async delete(id: string) {
+    return AccountResetToken.callProcedure(
+      Proc.DeleteAccountResetToken,
+      uuidTransformer.to(id)
+    );
+  }
+
   static async findByTokenId(id: string) {
     const rows = await AccountResetToken.callProcedure(
       Proc.AccountResetToken,

--- a/packages/fxa-shared/db/models/auth/auth-base.ts
+++ b/packages/fxa-shared/db/models/auth/auth-base.ts
@@ -3,11 +3,29 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { BaseModel } from '../base';
+import { Knex } from 'knex';
 
 export enum Proc {
   AccountRecord = 'accountRecord_7',
   AccountResetToken = 'accountResetToken_1',
   AccountDevices = 'accountDevices_16',
+  CreateAccount = 'createAccount_9',
+  CreateDevice = 'createDevice_5',
+  CreateKeyFetchToken = 'createKeyFetchToken_2',
+  CreatePasswordChangeToken = 'createPasswordChangeToken_2',
+  CreatePasswordForgotToken = 'createPasswordForgotToken_2',
+  CreateRecoveryKey = 'createRecoveryKey_4',
+  CreateSessionToken = 'createSessionToken_9',
+  CreateTotpToken = 'createTotpToken_1',
+  DeleteAccount = 'deleteAccount_19',
+  DeleteAccountResetToken = 'deleteAccountResetToken_1',
+  DeleteDevice = 'deleteDevice_4',
+  DeleteKeyFetchToken = 'deleteKeyFetchToken_2',
+  DeletePasswordChangeToken = 'deletePasswordChangeToken_1',
+  DeletePasswordForgotToken = 'deletePasswordForgotToken_1',
+  DeleteRecoveryKey = 'deleteRecoveryKey_2',
+  DeleteSessionToken = 'deleteSessionToken_4',
+  DeleteTotpToken = 'deleteTotpToken_4',
   Device = 'device_3',
   DeviceFromTokenVerificationId = 'deviceFromTokenVerificationId_6',
   EmailBounces = 'fetchEmailBounces_1',
@@ -16,9 +34,12 @@ export enum Proc {
   PasswordChangeToken = 'passwordChangeToken_3',
   PasswordForgotToken = 'passwordForgotToken_2',
   RecoveryKey = 'getRecoveryKey_4',
+  ResetAccount = 'resetAccount_16',
   SessionWithDevice = 'sessionWithDevice_18',
   Sessions = 'sessions_11',
   TotpToken = 'totpToken_2',
+  UpdateSessionToken = 'updateSessionToken_3',
+  UpsertAvailableCommands = 'upsertAvailableCommand_1',
 }
 
 function callString(name: Proc, argCount: number) {
@@ -27,9 +48,20 @@ function callString(name: Proc, argCount: number) {
 }
 
 export abstract class AuthBaseModel extends BaseModel {
+  static async callProcedure(
+    name: Proc,
+    txn: Knex.Transaction,
+    ...args: any[]
+  ): Promise<object[]>;
+  static async callProcedure(name: Proc, ...args: any[]): Promise<object[]>;
   static async callProcedure(name: Proc, ...args: any[]) {
-    const knex = this.knex();
-    const [result] = await knex.raw(callString(name, args.length), args);
+    let [txn, ...rest] = args;
+    const knex = this.knex() as Knex;
+    const query =
+      txn && typeof txn.commit === 'function'
+        ? knex.raw(callString(name, rest.length), rest).transacting(txn)
+        : knex.raw(callString(name, args.length), args);
+    const [result] = await query;
     return result[0] as object[];
   }
 }

--- a/packages/fxa-shared/db/models/auth/key-fetch-token.ts
+++ b/packages/fxa-shared/db/models/auth/key-fetch-token.ts
@@ -22,6 +22,35 @@ export class KeyFetchToken extends AuthBaseModel {
   verifierSetAt!: number;
   tokenVerificationId?: string;
 
+  static async create({
+    id,
+    authKey,
+    uid,
+    keyBundle,
+    createdAt,
+    tokenVerificationId,
+  }: Pick<
+    KeyFetchToken,
+    'authKey' | 'uid' | 'keyBundle' | 'createdAt' | 'tokenVerificationId'
+  > & { id: string }) {
+    return KeyFetchToken.callProcedure(
+      Proc.CreateKeyFetchToken,
+      uuidTransformer.to(id),
+      uuidTransformer.to(authKey),
+      uuidTransformer.to(uid),
+      uuidTransformer.to(keyBundle),
+      createdAt,
+      tokenVerificationId ? uuidTransformer.to(tokenVerificationId) : null
+    );
+  }
+
+  static async delete(id: string) {
+    return KeyFetchToken.callProcedure(
+      Proc.DeleteKeyFetchToken,
+      uuidTransformer.to(id)
+    );
+  }
+
   static async findByTokenId(
     id: string,
     withVerificationStatus: boolean = false

--- a/packages/fxa-shared/db/models/auth/password-change-token.ts
+++ b/packages/fxa-shared/db/models/auth/password-change-token.ts
@@ -19,6 +19,31 @@ export class PasswordChangeToken extends AuthBaseModel {
   email!: string;
   verifierSetAt!: number;
 
+  static async create({
+    id,
+    data,
+    uid,
+    createdAt,
+  }: Pick<PasswordChangeToken, 'uid' | 'createdAt'> & {
+    id: string;
+    data: string;
+  }) {
+    return PasswordChangeToken.callProcedure(
+      Proc.CreatePasswordChangeToken,
+      uuidTransformer.to(id),
+      uuidTransformer.to(data),
+      uuidTransformer.to(uid),
+      createdAt
+    );
+  }
+
+  static async delete(id: string) {
+    return PasswordChangeToken.callProcedure(
+      Proc.DeletePasswordChangeToken,
+      uuidTransformer.to(id)
+    );
+  }
+
   static async findByTokenId(id: string) {
     const rows = await PasswordChangeToken.callProcedure(
       Proc.PasswordChangeToken,

--- a/packages/fxa-shared/db/models/auth/password-forgot-token.ts
+++ b/packages/fxa-shared/db/models/auth/password-forgot-token.ts
@@ -21,6 +21,35 @@ export class PasswordForgotToken extends AuthBaseModel {
   email!: string;
   verifierSetAt!: number;
 
+  static async create({
+    id,
+    data,
+    uid,
+    passCode,
+    createdAt,
+    tries,
+  }: Pick<PasswordForgotToken, 'uid' | 'createdAt' | 'passCode' | 'tries'> & {
+    id: string;
+    data: string;
+  }) {
+    return PasswordForgotToken.callProcedure(
+      Proc.CreatePasswordForgotToken,
+      uuidTransformer.to(id),
+      uuidTransformer.to(data),
+      uuidTransformer.to(uid),
+      uuidTransformer.to(passCode),
+      createdAt,
+      tries
+    );
+  }
+
+  static async delete(id: string) {
+    return PasswordForgotToken.callProcedure(
+      Proc.DeletePasswordForgotToken,
+      uuidTransformer.to(id)
+    );
+  }
+
   static async findByTokenId(id: string) {
     const rows = await PasswordForgotToken.callProcedure(
       Proc.PasswordForgotToken,

--- a/packages/fxa-shared/db/models/auth/totp-token.ts
+++ b/packages/fxa-shared/db/models/auth/totp-token.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { AuthBaseModel, Proc } from './auth-base';
 import { uuidTransformer } from '../../transformers';
+import { convertError } from '../../mysql';
 
 export class TotpToken extends AuthBaseModel {
   public static tableName = 'totp';
@@ -18,6 +19,30 @@ export class TotpToken extends AuthBaseModel {
   createdAt!: number;
   verified!: boolean;
   enabled!: boolean;
+
+  static async create({
+    uid,
+    sharedSecret,
+    epoch,
+  }: Pick<TotpToken, 'uid' | 'sharedSecret' | 'epoch'>) {
+    try {
+      await TotpToken.callProcedure(
+        Proc.CreateTotpToken,
+        uuidTransformer.to(uid),
+        sharedSecret,
+        epoch,
+        Date.now()
+      );
+    } catch (e) {
+      throw convertError(e);
+    }
+  }
+  static async delete(uid: string) {
+    return TotpToken.callProcedure(
+      Proc.DeleteTotpToken,
+      uuidTransformer.to(uid)
+    );
+  }
 
   static async findByUid(uid: string) {
     const rows = await TotpToken.callProcedure(

--- a/packages/fxa-shared/db/mysql.ts
+++ b/packages/fxa-shared/db/mysql.ts
@@ -1,0 +1,32 @@
+export enum MysqlErrors {
+  // http://dev.mysql.com/doc/refman/5.5/en/error-messages-server.html
+  ER_DUP_ENTRY = 1062,
+  ER_TOO_MANY_CONNECTIONS = 1040,
+  ER_LOCK_WAIT_TIMEOUT = 1205,
+  ER_LOCK_TABLE_FULL = 1206,
+  ER_LOCK_DEADLOCK = 1213,
+  ER_LOCK_ABORTED = 1689,
+  // custom mysql errors
+  ER_DELETE_PRIMARY_EMAIL = 2100,
+  ER_EXPIRED_TOKEN_VERIFICATION_CODE = 2101,
+  ER_SIGNAL_NOT_FOUND = 1643,
+}
+
+export function convertError(error: Error & { errno: number }) {
+  const e: any = new Error();
+  // Return an error that looks like the old db-mysql version (for now)
+  switch (error.errno) {
+    case MysqlErrors.ER_DUP_ENTRY:
+      e.errno = 101;
+      e.statusCode = 409;
+      break;
+    case MysqlErrors.ER_SIGNAL_NOT_FOUND:
+      e.errno = 116;
+      e.statusCode = 404;
+      break;
+    default:
+      e.errno = error.errno;
+      e.statusCode = 500;
+  }
+  return e as Error & { errno: number; statusCode: number };
+}


### PR DESCRIPTION
This is a continuation of #7652. It moves where the create and delete queries are executed from the auth-db-server to the auth-server via fxa-shared.