### PR TITLE
feat(payments): Use custom action button label if specified in Paymen…

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
@@ -28,6 +28,14 @@ const selectedPlan: Plan = {
   product_metadata: null,
 };
 
+const selectedPlanWithMetadata: Plan = {
+  ...selectedPlan,
+  product_metadata: {
+    'product:successActionButtonLabel': 'Do something else',
+    'product:successActionButtonLabel:xx-pirate': 'Yarr...',
+  },
+};
+
 const customer: Customer = {
   billing_name: 'Jane Doe',
   payment_provider: 'stripe',
@@ -54,13 +62,38 @@ const customer: Customer = {
 
 const productUrl = 'https://mozilla.org';
 
-storiesOf('components/PaymentConfirmation', module).add('default', () => (
-  <MockApp>
-    <PaymentConfirmation
-      {...{ profile: userProfile, selectedPlan, customer, productUrl }}
-    />
-  </MockApp>
-));
+storiesOf('components/PaymentConfirmation', module)
+  .add('default', () => (
+    <MockApp>
+      <PaymentConfirmation
+        {...{ profile: userProfile, selectedPlan, customer, productUrl }}
+      />
+    </MockApp>
+  ))
+  .add('custom action button label', () => (
+    <MockApp>
+      <PaymentConfirmation
+        {...{
+          profile: userProfile,
+          selectedPlan: selectedPlanWithMetadata,
+          customer,
+          productUrl,
+        }}
+      />
+    </MockApp>
+  ))
+  .add('custom action button label localized to xx-pirate', () => (
+    <MockApp languages={['xx-pirate']}>
+      <PaymentConfirmation
+        {...{
+          profile: userProfile,
+          selectedPlan: selectedPlanWithMetadata,
+          customer,
+          productUrl,
+        }}
+      />
+    </MockApp>
+  ));
 storiesOf('components/PaymentConfirmation', module).add('paypal', () => (
   <MockApp>
     <PaymentConfirmation

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Localized } from '@fluent/react';
+import React, { useContext } from 'react';
+import { Localized, useLocalization } from '@fluent/react';
 import * as Provider from '../../lib/PaymentProvider';
 import { getLocalizedCurrency, formatPlanPricing } from '../../lib/formats';
 import { Plan, Profile, Customer } from '../../store/types';
@@ -11,6 +11,8 @@ import PaymentLegalBlurb from '../PaymentLegalBlurb';
 import circledCheckbox from './images/circled-confirm.svg';
 
 import './index.scss';
+import { productDetailsFromPlan } from 'fxa-shared/subscriptions/metadata';
+import { AppContext } from '../../lib/AppContext';
 
 type PaymentConfirmationProps = {
   customer: Customer;
@@ -27,16 +29,17 @@ export const PaymentConfirmation = ({
   productUrl,
   className = 'default',
 }: PaymentConfirmationProps) => {
-  const {
-    amount,
-    currency,
-    interval,
-    interval_count,
-    product_name,
-  } = selectedPlan;
+  const { navigatorLanguages } = useContext(AppContext);
+  const { amount, currency, interval, interval_count, product_name } =
+    selectedPlan;
   const { displayName, email } = profile;
 
   const { payment_provider, subscriptions } = customer;
+
+  const buttonLabel = productDetailsFromPlan(
+    selectedPlan,
+    navigatorLanguages
+  ).successActionButtonLabel;
 
   const invoiceNumber = subscriptions[0].latest_invoice;
   const date = new Date().toLocaleDateString(navigator.language, {
@@ -51,6 +54,8 @@ export const PaymentConfirmation = ({
     interval,
     interval_count
   );
+
+  const { l10n } = useLocalization();
 
   return (
     <>
@@ -123,15 +128,18 @@ export const PaymentConfirmation = ({
         </div>
 
         <div className="footer" data-testid="footer">
-          <Localized id="payment-confirmation-download-button">
-            <a
-              data-testid="download-link"
-              className="button download-link"
-              href={productUrl}
-            >
-              Continue to download
-            </a>
-          </Localized>
+          <a
+            data-testid="download-link"
+            className="button download-link"
+            href={productUrl}
+          >
+            {buttonLabel ||
+              l10n.getString(
+                'payment-confirmation-download-button',
+                null,
+                'Continue to download'
+              )}
+          </a>
           <PaymentLegalBlurb provider={payment_provider} />
           <TermsAndPrivacy plan={selectedPlan} />
         </div>

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.stories.tsx
@@ -56,12 +56,7 @@ storiesOf('components/PlanDetail', module)
     </MockApp>
   ))
   .add('localized to xx-pirate', () => (
-    <MockApp
-      appContextValue={{
-        ...defaultAppContext,
-        navigatorLanguages: ['xx-pirate'],
-      }}
-    >
+    <MockApp languages={['xx-pirate']}>
       <PlanDetails
         {...{
           profile: userProfile,

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.stories.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { TermsAndPrivacy } from './index';
-import { defaultAppContext, AppContext } from '../../lib/AppContext';
 import { SELECTED_PLAN } from '../../lib/mock-data';
+import MockApp from '../../../.storybook/components/MockApp';
 
 storiesOf('components/TermsAndPrivacy', module)
   .add('default locale', () => <TermsAndPrivacy plan={SELECTED_PLAN} />)
   .add('with fr locale', () => (
-    <AppContext.Provider
-      value={{ ...defaultAppContext, navigatorLanguages: ['fr'] }}
-    >
+    <MockApp languages={['fr']}>
       <TermsAndPrivacy plan={SELECTED_PLAN} />
-    </AppContext.Provider>
+    </MockApp>
   ));

--- a/packages/fxa-shared/subscriptions/metadata.ts
+++ b/packages/fxa-shared/subscriptions/metadata.ts
@@ -36,7 +36,6 @@ export const DEFAULT_PRODUCT_DETAILS: ProductDetails = {
 
 // Support some default null values for product / plan metadata and
 // allow plan metadata to override product metadata
-// TODO: move to fxa-shared?
 export const metadataFromPlan = (plan: Plan): ProductMetadata => ({
   productSet: null,
   productOrder: null,
@@ -143,26 +142,27 @@ export const productDetailsFromPlan = (
  * Parse out the 'support:app:' metadata into a dictionary keyed by the product
  * id.  This is used for the app/service select on the support form.
  */
-export const getProductSupportApps = (subscriptions: AccountSubscription[]) => (
-  plans: AbbrevPlan[]
-) => {
-  const metadataPrefix = 'support:app:';
-  return plans.reduce((acc: { [keys: string]: string[] }, p) => {
-    if (
-      !acc[p.product_id] &&
-      subscriptions.some((s) => p.product_id === s.product_id) &&
-      Object.keys(p.product_metadata).some((k) => k.startsWith(metadataPrefix))
-    ) {
-      acc[p.product_id] = Object.entries(p.product_metadata).reduce(
-        (apps: string[], [k, v]) => {
-          if (k.startsWith(metadataPrefix)) {
-            apps.push(v);
-          }
-          return apps;
-        },
-        []
-      );
-    }
-    return acc;
-  }, {});
-};
+export const getProductSupportApps =
+  (subscriptions: AccountSubscription[]) => (plans: AbbrevPlan[]) => {
+    const metadataPrefix = 'support:app:';
+    return plans.reduce((acc: { [keys: string]: string[] }, p) => {
+      if (
+        !acc[p.product_id] &&
+        subscriptions.some((s) => p.product_id === s.product_id) &&
+        Object.keys(p.product_metadata).some((k) =>
+          k.startsWith(metadataPrefix)
+        )
+      ) {
+        acc[p.product_id] = Object.entries(p.product_metadata).reduce(
+          (apps: string[], [k, v]) => {
+            if (k.startsWith(metadataPrefix)) {
+              apps.push(v);
+            }
+            return apps;
+          },
+          []
+        );
+      }
+      return acc;
+    }, {});
+  };

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -43,6 +43,7 @@ export interface ProductMetadata {
 // make Stripe metadata parsing & validation easier.
 export enum ProductDetailsStringProperties {
   'subtitle',
+  'successActionButtonLabel',
   'termsOfServiceURL',
   'termsOfServiceDownloadURL',
   'privacyNoticeURL',
@@ -51,8 +52,10 @@ export enum ProductDetailsStringProperties {
 export enum ProductDetailsListProperties {
   'details',
 }
-export type ProductDetailsStringProperty = keyof typeof ProductDetailsStringProperties;
-export type ProductDetailsListProperty = keyof typeof ProductDetailsListProperties;
+export type ProductDetailsStringProperty =
+  keyof typeof ProductDetailsStringProperties;
+export type ProductDetailsListProperty =
+  keyof typeof ProductDetailsListProperties;
 export type ProductDetails = {
   [key in ProductDetailsStringProperty]?: string;
 } &

--- a/packages/fxa-shared/test/subscriptions/metadata.ts
+++ b/packages/fxa-shared/test/subscriptions/metadata.ts
@@ -100,6 +100,7 @@ describe('subscriptions/metadata', () => {
           'https://example.org/en-US/terms/download',
         'product:privacyNoticeDownloadURL':
           'https://example.org/en-US/privacy/download',
+        'product:successActionButtonLabel': 'Do something else',
         'product:subtitle:xx-pirate': 'VPN fer yer full-device',
         'product:foobar:9:xx-pirate': 'what even is this',
         'product:details:4:xx-pirate': "Available fer Windows, iOS an' Android",
@@ -115,6 +116,7 @@ describe('subscriptions/metadata', () => {
           'https://example.org/xx-pirate/terms/download',
         'product:privacyNoticeDownloadURL:xx-pirate':
           'https://example.org/xx-pirate/privacy/download',
+        'product:successActionButtonLabel:xx-pirate': 'Yarr...',
         'product:subtitle:xx-partial': 'Partial localization',
         'product:details:1:xx-partial': true,
         'product:termsOfServiceURL:xx-partial':
@@ -141,6 +143,7 @@ describe('subscriptions/metadata', () => {
         privacyNoticeURL: 'https://example.org/en-US/privacy',
         termsOfServiceDownloadURL: 'https://example.org/en-US/terms/download',
         privacyNoticeDownloadURL: 'https://example.org/en-US/privacy/download',
+        successActionButtonLabel: 'Do something else',
       });
     });
 
@@ -159,6 +162,7 @@ describe('subscriptions/metadata', () => {
           'https://example.org/xx-pirate/terms/download',
         privacyNoticeDownloadURL:
           'https://example.org/xx-pirate/privacy/download',
+        successActionButtonLabel: 'Yarr...',
       });
     });
 
@@ -175,6 +179,7 @@ describe('subscriptions/metadata', () => {
         privacyNoticeURL: 'https://example.org/en-US/privacy',
         termsOfServiceDownloadURL: 'https://example.org/en-US/terms/download',
         privacyNoticeDownloadURL: 'https://example.org/en-US/privacy/download',
+        successActionButtonLabel: 'Do something else',
       });
     });
 
@@ -191,6 +196,7 @@ describe('subscriptions/metadata', () => {
         privacyNoticeURL: 'https://example.org/en-US/privacy',
         termsOfServiceDownloadURL: 'https://example.org/en-US/terms/download',
         privacyNoticeDownloadURL: 'https://example.org/en-US/privacy/download',
+        successActionButtonLabel: 'Do something else',
       });
     });
   });


### PR DESCRIPTION
…tConfirmation

Because:

* Unlike the VPN, some subscription products (e.g. web apps/services) may not have software for the subscriber to download.

This commit:

* Uses a custom action button label instead of 'Continue to download' or its localized equivalent if a new 'successActionButtonLabel' key/value is specified in Stripe product or plan metadata.

Closes #8713

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).