### PR TITLE
feat(subscriptions): update sub plan upgrade eligibility logic

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -20,13 +20,10 @@ const { Container } = require('typedi');
 const chance = new Chance();
 let mockRedis;
 const proxyquire = require('proxyquire').noPreserveCache();
-const {
-  StripeHelper,
-  STRIPE_INVOICE_METADATA,
-  SUBSCRIPTION_UPDATE_TYPES,
-} = proxyquire('../../../lib/payments/stripe', {
-  '../redis': (config, log) => mockRedis.init(config, log),
-});
+const { StripeHelper, STRIPE_INVOICE_METADATA, SUBSCRIPTION_UPDATE_TYPES } =
+  proxyquire('../../../lib/payments/stripe', {
+    '../redis': (config, log) => mockRedis.init(config, log),
+  });
 const { CurrencyHelper } = require('../../../lib/payments/currencies');
 
 const customer1 = require('./fixtures/stripe/customer1.json');
@@ -841,10 +838,11 @@ describe('StripeHelper', () => {
   describe('updateInvoiceWithPaypalRefundTransactionId', () => {
     it('works successfully', async () => {
       sandbox.stub(stripeHelper.stripe.invoices, 'update').resolves({});
-      const actual = await stripeHelper.updateInvoiceWithPaypalRefundTransactionId(
-        unpaidInvoice,
-        'tid'
-      );
+      const actual =
+        await stripeHelper.updateInvoiceWithPaypalRefundTransactionId(
+          unpaidInvoice,
+          'tid'
+        );
       assert.deepEqual(actual, {});
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripe.invoices.update,
@@ -1256,16 +1254,14 @@ describe('StripeHelper', () => {
         payment_intent: { ...closedPaymementIntent },
       };
       const subscription = { ...subscription2, latest_invoice };
-      const result = stripeHelper.extractSourceCountryFromSubscription(
-        subscription
-      );
+      const result =
+        stripeHelper.extractSourceCountryFromSubscription(subscription);
       assert.equal(result, 'US');
     });
 
     it('returns null with no invoice', () => {
-      const result = stripeHelper.extractSourceCountryFromSubscription(
-        subscription2
-      );
+      const result =
+        stripeHelper.extractSourceCountryFromSubscription(subscription2);
       assert.equal(result, null);
     });
 
@@ -1282,9 +1278,8 @@ describe('StripeHelper', () => {
         payment_intent: { charges: { data: [] } },
       };
       const subscription = { ...subscription2, latest_invoice };
-      const result = stripeHelper.extractSourceCountryFromSubscription(
-        subscription
-      );
+      const result =
+        stripeHelper.extractSourceCountryFromSubscription(subscription);
       assert.equal(result, null);
 
       assert.isTrue(
@@ -1423,19 +1418,25 @@ describe('StripeHelper', () => {
   });
 
   describe('verifyPlanUpdateForSubscription', () => {
-    it('does nothing for valid upgrade or downgrade', async () => {
+    it('does nothing for a valid upgrade', async () => {
       assert.isUndefined(
         await stripeHelper.verifyPlanUpdateForSubscription(
           'plan_G93lTs8hfK7NNG',
           'plan_G93mMKnIFCjZek'
         )
       );
-      assert.isUndefined(
+    });
+
+    it('throws an invalidPlanUpdate when it is a downgrade', async () => {
+      try {
         await stripeHelper.verifyPlanUpdateForSubscription(
           'plan_G93mMKnIFCjZek',
           'plan_G93lTs8hfK7NNG'
-        )
-      );
+        );
+        assert.fail('An invalidPlanUpdate should have been thrown.');
+      } catch (e) {
+        assert.equal(e.errno, error.ERRNO.INVALID_PLAN_UPDATE);
+      }
     });
 
     describe('when the upgrade is invalid', () => {
@@ -3226,9 +3227,10 @@ describe('StripeHelper', () => {
         const event = deepCopy(eventCustomerSubscriptionUpdated);
         event.data.object.cancel_at_period_end = true;
         event.data.previous_attributes = { cancel_at_period_end: false };
-        const result = await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
-          event
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
+            event
+          );
         assert.equal(result, mockCancellationDetails);
         assertOnlyExpectedHelperCalledWith(
           'extractSubscriptionUpdateCancellationDetailsForEmail',
@@ -3242,9 +3244,10 @@ describe('StripeHelper', () => {
         const event = deepCopy(eventCustomerSubscriptionUpdated);
         event.data.object.cancel_at_period_end = false;
         event.data.previous_attributes = { cancel_at_period_end: true };
-        const result = await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
-          event
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
+            event
+          );
         assert.equal(result, mockReactivationDetails);
         assertOnlyExpectedHelperCalledWith(
           'extractSubscriptionUpdateReactivationDetailsForEmail',
@@ -3258,9 +3261,10 @@ describe('StripeHelper', () => {
         const event = deepCopy(eventCustomerSubscriptionUpdated);
         event.data.object.cancel_at_period_end = false;
         event.data.previous_attributes.cancel_at_period_end = false;
-        const result = await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
-          event
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
+            event
+          );
         assert.equal(result, mockUpgradeDowngradeDetails);
         assertOnlyExpectedHelperCalledWith(
           'extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail',
@@ -3277,9 +3281,10 @@ describe('StripeHelper', () => {
         const event = deepCopy(eventCustomerSubscriptionUpdated);
         event.data.object.cancel_at_period_end = false;
         event.data.previous_attributes.cancel_at_period_end = true;
-        const result = await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
-          event
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
+            event
+          );
         assert.equal(result, mockUpgradeDowngradeDetails);
         assertOnlyExpectedHelperCalledWith(
           'extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail',
@@ -3345,14 +3350,15 @@ describe('StripeHelper', () => {
           ? 1
           : 2;
 
-        const result = await stripeHelper.extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail(
-          event.data.object,
-          baseDetails,
-          mockInvoice,
-          mockCustomer,
-          event.data.object.plan.metadata.productOrder,
-          event.data.previous_attributes.plan
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail(
+            event.data.object,
+            baseDetails,
+            mockInvoice,
+            mockCustomer,
+            event.data.object.plan.metadata.productOrder,
+            event.data.previous_attributes.plan
+          );
 
         // issue #5546: ensure we're looking for the upcoming invoice for this specific subscription
         assert.deepEqual(mockStripe.invoices.retrieveUpcoming.args, [
@@ -3425,11 +3431,12 @@ describe('StripeHelper', () => {
       it('extracts expected details for a subscription reactivation', async () => {
         const event = deepCopy(eventCustomerSubscriptionUpdated);
         sandbox.stub(stripeHelper, 'customer').resolves(mockCustomer);
-        const result = await stripeHelper.extractSubscriptionUpdateReactivationDetailsForEmail(
-          event.data.object,
-          expectedBaseUpdateDetails,
-          mockInvoice
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateReactivationDetailsForEmail(
+            event.data.object,
+            expectedBaseUpdateDetails,
+            mockInvoice
+          );
         assert.deepEqual(mockStripe.invoices.retrieveUpcoming.args, [
           [
             {
@@ -3445,11 +3452,12 @@ describe('StripeHelper', () => {
         const customer = deepCopy(mockCustomer);
         customer.invoice_settings.default_payment_method = null;
         sandbox.stub(stripeHelper, 'customer').resolves(customer);
-        const result = await stripeHelper.extractSubscriptionUpdateReactivationDetailsForEmail(
-          event.data.object,
-          expectedBaseUpdateDetails,
-          mockInvoice
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateReactivationDetailsForEmail(
+            event.data.object,
+            expectedBaseUpdateDetails,
+            mockInvoice
+          );
         assert.deepEqual(result, {
           ...defaultExpected,
           lastFour: null,
@@ -3541,11 +3549,12 @@ describe('StripeHelper', () => {
     describe('extractSubscriptionUpdateCancellationDetailsForEmail', () => {
       it('extracts expected details for a subscription cancellation', async () => {
         const event = deepCopy(eventCustomerSubscriptionUpdated);
-        const result = await stripeHelper.extractSubscriptionUpdateCancellationDetailsForEmail(
-          event.data.object,
-          expectedBaseUpdateDetails,
-          mockInvoice
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateCancellationDetailsForEmail(
+            event.data.object,
+            expectedBaseUpdateDetails,
+            mockInvoice
+          );
         const subscription = event.data.object;
         assert.deepEqual(result, {
           updateType: SUBSCRIPTION_UPDATE_TYPES.CANCELLATION,

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -170,7 +170,8 @@ function injectStripe<P extends Object>(
       <WrappedComponent
         {...{
           ...props,
-          stripe: mockStripe as ReactStripeElements.InjectedStripeProps['stripe'],
+          stripe:
+            mockStripe as ReactStripeElements.InjectedStripeProps['stripe'],
         }}
         as
         any
@@ -346,7 +347,9 @@ export const MOCK_PLANS: Plan[] = [
     interval_count: 1,
     amount: 500,
     currency: 'usd',
-    plan_metadata: null,
+    plan_metadata: {
+      productOrder: 3,
+    },
     product_metadata: {
       productSet: 'example_upgrade',
       webIconURL: 'http://example.com/product.jpg',
@@ -377,7 +380,37 @@ export const MOCK_PLANS: Plan[] = [
     interval_count: 1,
     amount: 5900,
     currency: 'usd',
-    plan_metadata: null,
+    plan_metadata: {
+      productOrder: 5,
+    },
+    product_metadata: {
+      productSet: 'example_upgrade',
+    },
+  },
+  {
+    plan_id: 'plan_no_upgrade',
+    product_id: 'prod_upgrade',
+    product_name: 'Upgrade Product',
+    interval: 'month' as const,
+    interval_count: 1,
+    amount: 5900,
+    currency: 'usd',
+    plan_metadata: {},
+    product_metadata: {
+      productSet: 'example_upgrade',
+    },
+  },
+  {
+    plan_id: 'plan_no_downgrade',
+    product_id: 'prod_upgrade',
+    product_name: 'upside down product',
+    interval: 'month' as const,
+    interval_count: 1,
+    amount: 5900,
+    currency: 'usd',
+    plan_metadata: {
+      productOrder: 1,
+    },
     product_metadata: {
       productSet: 'example_upgrade',
     },

--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -271,6 +271,48 @@ describe('routes/Product', () => {
     expectNockScopesDone(apiMocks);
   });
 
+  it('does not offer upgrade if another plan in the same product set does not have product order', async () => {
+    const apiMocks = initSubscribedApiMocks();
+    const { findAllByText, queryByTestId } = render(
+      <Subject
+        {...{
+          planId: 'plan_no_upgrade',
+          productId: 'prod_upgrade',
+          appContext: {
+            config: {
+              ...defaultConfig(),
+              featureFlags: { allowSubscriptionUpgrades: true },
+            },
+          },
+        }}
+      />
+    );
+    await findAllByText('Set up your subscription');
+    expect(queryByTestId('subscription-upgrade')).not.toBeInTheDocument();
+    expectNockScopesDone(apiMocks);
+  });
+
+  it('does not allow a downgrade', async () => {
+    const apiMocks = initSubscribedApiMocks();
+    const { findAllByText, queryByTestId } = render(
+      <Subject
+        {...{
+          planId: 'plan_no_downgrade',
+          productId: 'prod_upgrade',
+          appContext: {
+            config: {
+              ...defaultConfig(),
+              featureFlags: { allowSubscriptionUpgrades: true },
+            },
+          },
+        }}
+      />
+    );
+    await findAllByText('Set up your subscription');
+    expect(queryByTestId('subscription-upgrade')).not.toBeInTheDocument();
+    expectNockScopesDone(apiMocks);
+  });
+
   it('blocks upgrade when the feature flag disallows it', async () => {
     initSubscribedApiMocks();
     const { findByTestId } = render(

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -12,6 +12,7 @@ import { actions, ActionFunctions } from '../../store/actions';
 import { selectors, SelectorReturns } from '../../store/selectors';
 import { CustomerSubscription, Plan, ProductMetadata } from '../../store/types';
 import { metadataFromPlan } from 'fxa-shared/subscriptions/metadata';
+import { isValidSubscriptionPlanUpdate } from 'fxa-shared/subscriptions/stripe';
 
 import '../Product/index.scss';
 
@@ -56,9 +57,8 @@ export const Product = ({
   resetUpdateSubscriptionPlan,
   updateSubscriptionPlanStatus,
 }: ProductProps) => {
-  const { locationReload, queryParams, matchMediaDefault, config } = useContext(
-    AppContext
-  );
+  const { locationReload, queryParams, matchMediaDefault, config } =
+    useContext(AppContext);
 
   const isMobile = !useMatchMedia('(min-width: 768px)', matchMediaDefault);
   const planId = queryParams.plan;
@@ -257,15 +257,10 @@ const findUpgradeFromPlan = (
   subscription: CustomerSubscription;
 } | null => {
   if (customerSubscriptions) {
-    const selectedPlanInfo = plansById[selectedPlan.plan_id];
     for (const customerSubscription of customerSubscriptions) {
       const subscriptionPlanInfo = plansById[customerSubscription.plan_id];
       if (
-        selectedPlan.plan_id !== customerSubscription.plan_id &&
-        selectedPlanInfo.metadata.productSet &&
-        subscriptionPlanInfo.metadata.productSet &&
-        selectedPlanInfo.metadata.productSet ===
-          subscriptionPlanInfo.metadata.productSet
+        isValidSubscriptionPlanUpdate(subscriptionPlanInfo.plan, selectedPlan)
       ) {
         return {
           plan: subscriptionPlanInfo.plan,

--- a/packages/fxa-shared/subscriptions/stripe.ts
+++ b/packages/fxa-shared/subscriptions/stripe.ts
@@ -1,6 +1,8 @@
 import Stripe from 'stripe';
 import pick from 'lodash.pick';
 import omitBy from 'lodash.omitby';
+import { Plan } from './types';
+import { metadataFromPlan } from './metadata';
 
 const isCapabilityKey = (value: string, key: string) =>
   key.startsWith('capabilities');
@@ -189,3 +191,32 @@ export function singlePlan(
   const subItems = subscription.items.data;
   return subItems.length > 1 ? null : subItems[0].plan;
 }
+
+/**
+ * Given two plans, A and B, determine whether B is eligible for a subscription
+ * update (upgrade/downgrade) from A.
+ */
+
+export const isValidSubscriptionPlanUpdate = (
+  currentPlan: Plan,
+  newPlan: Plan
+) => {
+  const currentPlanMetaData = metadataFromPlan(currentPlan);
+  const newPlanMetaData = metadataFromPlan(newPlan);
+  const currentOrder =
+    !!currentPlanMetaData.productOrder &&
+    parseInt(currentPlanMetaData.productOrder);
+  const newOrder =
+    !!newPlanMetaData.productOrder && parseInt(newPlanMetaData.productOrder);
+
+  return (
+    currentPlan.plan_id !== newPlan.plan_id &&
+    !!currentPlanMetaData.productSet &&
+    currentPlanMetaData.productSet === newPlanMetaData.productSet &&
+    !!currentOrder &&
+    !Number.isNaN(currentOrder) &&
+    !!newOrder &&
+    !Number.isNaN(newOrder) &&
+    newOrder > currentOrder
+  );
+};

--- a/packages/fxa-shared/test/subscriptions/stripe.ts
+++ b/packages/fxa-shared/test/subscriptions/stripe.ts
@@ -10,11 +10,14 @@ import {
   filterProduct,
   filterIntent,
   filterInvoice,
+  isValidSubscriptionPlanUpdate,
 } from '../../subscriptions/stripe';
+import { Plan } from '../../subscriptions/types';
 
 const customer1WithSubscription = require('../fixtures/stripe/customer1_with_subscription.json');
 const subscriptionExpanded = require('../fixtures/stripe/subscription_expanded.json');
 const price1 = require('../fixtures/stripe/price1_with_product.json');
+const plan = require('../fixtures/stripe/plan1_with_product.json');
 
 function assertSubscription(item?: DeepPartial<Stripe.Subscription>) {
   assert.hasAllKeys(item, [
@@ -144,6 +147,95 @@ describe('stripe', () => {
         subscriptionExpanded.latest_invoice.payment_intent
       );
       assertIntent(result as any);
+    });
+  });
+
+  describe('isValidSubscriptionPlanUpdate', () => {
+    const currentPlan: Plan = {
+      ...plan,
+      plan_id: plan.id,
+      plan_metadata: {
+        ...plan.metadata,
+        productOrder: '3',
+      },
+      plan_name: plan.name,
+      product_id: plan.product.id,
+      product_metadata: plan.product.metadata,
+      product_name: plan.product.name,
+    };
+    const newPlan: Plan = {
+      ...currentPlan,
+      plan_id: 'quux',
+      plan_metadata: {
+        ...plan.metadata,
+        productOrder: '8',
+      },
+      plan_name: 'something with better value!',
+      product_id: plan.product.id,
+      product_metadata: plan.product.metadata,
+      product_name: plan.product.name,
+    };
+
+    it('returns false when the same plan is passed', () => {
+      const actual = isValidSubscriptionPlanUpdate(currentPlan, currentPlan);
+      assert.isFalse(actual);
+    });
+
+    it('returns true when plan "upgrade" is allowed', () => {
+      const actual = isValidSubscriptionPlanUpdate(currentPlan, newPlan);
+      assert.isTrue(actual);
+    });
+
+    it('returns false for a plan "downgrade"', () => {
+      const actual = isValidSubscriptionPlanUpdate(newPlan, currentPlan);
+      assert.isFalse(actual);
+    });
+
+    it('returns false when a plan is not in a product set', () => {
+      const x = {
+        ...newPlan,
+        plan_metadata: { ...newPlan.plan_metadata, productSet: undefined },
+      };
+      assert.isFalse(isValidSubscriptionPlanUpdate(currentPlan, x));
+      assert.isFalse(isValidSubscriptionPlanUpdate(x, currentPlan));
+    });
+
+    it('returns false when the product sets do not match', () => {
+      const x = {
+        ...newPlan,
+        plan_metadata: { ...newPlan.plan_metadata, productSet: 'testo' },
+      };
+      assert.isFalse(isValidSubscriptionPlanUpdate(currentPlan, x));
+    });
+
+    it('returns false when a plan does not have a product order', () => {
+      const x = {
+        ...newPlan,
+        plan_metadata: { ...newPlan.plan_metadata, productOrder: undefined },
+      };
+      assert.isFalse(isValidSubscriptionPlanUpdate(currentPlan, x));
+    });
+
+    it('returns false when when a plan has a product order that is not a number', () => {
+      const x = {
+        ...newPlan,
+        plan_metadata: {
+          ...newPlan.plan_metadata,
+          productOrder: 'not a number',
+        },
+      };
+      assert.isFalse(isValidSubscriptionPlanUpdate(currentPlan, x));
+    });
+
+    it('returns false when the plans has the same product order', () => {
+      const x = {
+        ...newPlan,
+        plan_metadata: {
+          ...newPlan.plan_metadata,
+          productOrder: currentPlan.plan_metadata!.productOrder,
+        },
+      };
+      assert.isFalse(isValidSubscriptionPlanUpdate(currentPlan, x));
     });
   });
 });


### PR DESCRIPTION
Because:
 - we want to allow upgrades between plans of the same "product set"

This commit:
 - determine subscription plan upgrade eligibility with the coalesced
   product+plan metadata, where
   - the plans must have the same 'productSet' value
   - the plans must have different 'productOrder' values
   - the new plan must have a higher 'productOrder' than the existing
     plan

## Issue that this pull request solves

Closes: #8785 

