### PR TITLE
fix(sessions): Add support for touchSessionToken to only update the lastAccess session property

### DIFF
--- a/packages/fxa-auth-server/lib/routes/attached-clients.js
+++ b/packages/fxa-auth-server/lib/routes/attached-clients.js
@@ -65,7 +65,8 @@ module.exports = (log, db, devices, clientUtils) => {
         const sessionToken = request.auth && request.auth.credentials;
 
         sessionToken.lastAccessTime = Date.now();
-        await db.touchSessionToken(sessionToken, request.app.geo);
+
+        await db.touchSessionToken(sessionToken, {}, true);
 
         const { uid } = sessionToken;
 

--- a/packages/fxa-auth-server/test/local/redis.js
+++ b/packages/fxa-auth-server/test/local/redis.js
@@ -90,6 +90,23 @@ describe('Redis', () => {
       const rawData = await redis.get(uid);
       assert.equal(rawData, `{"token1":[1,null,"x"]}`);
     });
+
+    it('only updates changed values', async () => {
+      await redis.touchSessionToken(uid, {
+        id: 'token1',
+        lastAccessTime: 1,
+        uaBrowser: 'x',
+      });
+      let rawData = await redis.get(uid);
+      assert.equal(rawData, `{"token1":[1,null,"x"]}`);
+
+      await redis.touchSessionToken(uid, {
+        id: 'token1',
+        lastAccessTime: 2,
+      });
+      rawData = await redis.get(uid);
+      assert.equal(rawData, `{"token1":[2,null,"x"]}`);
+    });
   });
 
   describe('getSessionTokens', () => {

--- a/packages/fxa-auth-server/test/local/routes/attached-clients.js
+++ b/packages/fxa-auth-server/test/local/routes/attached-clients.js
@@ -33,7 +33,8 @@ function makeRoutes(options = {}) {
     defaultLanguage: 'en',
   };
   config.push = {
-    allowedServerRegex: /^https:\/\/updates\.push\.services\.mozilla\.com(\/.*)?$/,
+    allowedServerRegex:
+      /^https:\/\/updates\.push\.services\.mozilla\.com(\/.*)?$/,
   };
   config.lastAccessTimeUpdates = {
     earliestSaneTimestamp: EARLIEST_SANE_TIMESTAMP,
@@ -204,7 +205,7 @@ describe('/account/attached_clients', () => {
 
     assert.equal(db.touchSessionToken.callCount, 1);
     const args = db.touchSessionToken.args[0];
-    assert.equal(args.length, 2);
+    assert.equal(args.length, 3);
     const laterDate = Date.now() - 60 * 1000;
     assert.equal(laterDate < args[0].lastAccessTime, true);
 

--- a/packages/fxa-auth-server/test/remote/db_tests.js
+++ b/packages/fxa-auth-server/test/remote/db_tests.js
@@ -410,9 +410,9 @@ describe('remote db', function () {
           'uaFormFactor property is correct'
         );
         assert.equal(
-          sessions[0].location,
-          null,
-          'location property is correct'
+          sessions[0].location.country,
+          'United Kingdom',
+          'country is correct'
         );
       })
       .then(() => {


### PR DESCRIPTION
## Because

- Active sessions in device manager is showing "Boardman, OR, United States" for some devices, this is an AWS server that the gql request is coming from
- ~~Targeting as a point release on train 207 since it is a regression~~ Changin to main branch and will do a cherry pick to train-207

## This pull request

- Add support to only update the last access time property of a session token

## Issue that this pull request solves

Closes: TBD

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
