### PR TITLE
fix(fxa-payments-server): fix upgrade view layout

### DIFF
--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.scss
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.scss
@@ -13,8 +13,16 @@
   }
 }
 
-.product-payment {
+.subscription-title + .product-payment {
   grid-row: 2/3;
+
+  @include max-width('tablet') {
+    grid-row: 3/4;
+  }
+}
+
+.product-payment {
+  grid-row: 1/3;
   background: $color-white;
   box-shadow: 0px 1px 4px 0px rgba(12, 12, 13, 0.1);
   border-radius: 8px;

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -56,9 +56,8 @@ export const Product = ({
   resetUpdateSubscriptionPlan,
   updateSubscriptionPlanStatus,
 }: ProductProps) => {
-  const { locationReload, queryParams, matchMediaDefault, config } = useContext(
-    AppContext
-  );
+  const { locationReload, queryParams, matchMediaDefault, config } =
+    useContext(AppContext);
 
   const isMobile = !useMatchMedia('(min-width: 768px)', matchMediaDefault);
   const planId = queryParams.plan;


### PR DESCRIPTION
## Because

- we need to allow users to view the upgrade page in a non broken way :)

## This pull request

- updated Product/SubscriptionCreate/index.scss to account for layout
differences with the `grid` rule. We needed different ratios based on
whether `.subscription-title` section was present or not.

## Issue that this pull request solves

Closes: #5369 
Closes: #7805

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

product page desktop
![image](https://user-images.githubusercontent.com/1844554/121053218-1fa0a200-c789-11eb-8409-ede6ad0ba99a.png)

product page mobile
![image](https://user-images.githubusercontent.com/1844554/121053382-4959c900-c789-11eb-9e31-5160bbc1e4c5.png)

upgrade page desktop
![image](https://user-images.githubusercontent.com/1844554/121053451-6098b680-c789-11eb-9265-ff581875adfd.png)

upgrade page mobile
![image](https://user-images.githubusercontent.com/1844554/121053508-727a5980-c789-11eb-9c02-94ffc7cff082.png)
