### PR TITLE
task(fxa-payments-server): update to change copy

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -156,8 +156,8 @@ default-input-error = This field is required
 input-error-is-required = { $label } is required
 
 ## subscription upgrade
-product-plan-upgrade-heading = Review your upgrade
-sub-update-failed = Plan update failed
+product-plan-change-heading = Review your change
+sub-change-failed = Plan change failed
 sub-update-payment-title = Payment information
 sub-update-card-exp = Expires { $cardExpMonth }/{ $cardExpYear }
 sub-update-copy =
@@ -187,9 +187,9 @@ sub-update-confirm-with-legal-links-year = { $intervalCount ->
 }
 
 ##
-sub-update-submit = Confirm upgrade
-sub-update-indicator =
-  .aria-label = upgrade indicator
+sub-change-submit = Confirm change
+sub-change-indicator =
+  .aria-label = change indicator
 sub-update-current-plan-label = Current plan
 sub-update-new-plan-label = New plan
 sub-update-total-label = New total

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -108,8 +108,8 @@ export const SubscriptionUpgrade = ({
   const mobileUpdateHeading = isMobile ? (
     <div className="mobile-subscription-title">
       <div className="subscription-update-heading">
-        <Localized id="product-plan-upgrade-heading">
-          <h2>Review your upgrade</h2>
+        <Localized id="product-plan-change-heading">
+          <h2>Review your change</h2>
         </Localized>
       </div>
     </div>
@@ -122,8 +122,8 @@ export const SubscriptionUpgrade = ({
           className="dialog-error"
           onDismiss={resetUpdateSubscriptionPlan}
         >
-          <Localized id="sub-update-failed">
-            <h4 data-testid="error-plan-update-failed">Plan update failed</h4>
+          <Localized id="sub-change-failed">
+            <h4 data-testid="error-plan-update-failed">Plan change failed</h4>
           </Localized>
           <p>{updateSubscriptionPlanStatus.error.message}</p>
         </DialogMessage>
@@ -138,8 +138,8 @@ export const SubscriptionUpgrade = ({
             className="subscription-update-heading"
             data-testid="subscription-update-heading"
           >
-            <Localized id="product-plan-upgrade-heading">
-              <h2>Review your upgrade</h2>
+            <Localized id="product-plan-change-heading">
+              <h2>Review your change</h2>
             </Localized>
             <p className="subheading"></p>
           </div>
@@ -235,8 +235,8 @@ export const SubscriptionUpgrade = ({
                     &nbsp;
                   </span>
                 ) : (
-                  <Localized id="sub-update-submit">
-                    <span>Confirm upgrade</span>
+                  <Localized id="sub-change-submit">
+                    <span>Confirm change</span>
                   </Localized>
                 )}
               </SubmitButton>


### PR DESCRIPTION
## Because

- This patch aims to eliminate any language around "upgrading" or
"downgrading" plans or products. This allows more flexibility for
user's changing plans/products without creating extra complexity for us
in determining which UI to show.

## This pull request

- `upgrade` 👉 `change`

## Issue that this pull request solves

Closes: #5521

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
