### PR TITLE
Release 1.208.0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,7 +23,6 @@ bini11
 Brandon Ebersohl
 Brian Warner
 byrw
-César Carruitero
 championshuttler
 Chiamaka-Uzuegbu
 Chris Heilmann
@@ -32,6 +31,7 @@ Christian Murphy
 ckarlof
 claubatista
 Cronus1007
+César Carruitero
 Dan Callahan
 Danny Amey
 Danny Coates

--- a/packages/fxa-admin-panel/CHANGELOG.md
+++ b/packages/fxa-admin-panel/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.208.0
+
+### Other changes
+
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+- deps: updated pm2 ([34704ba14](https://github.com/mozilla/fxa/commit/34704ba14))
+- deps-dev: bump @types/eslint from 7.2.11 to 7.2.13 ([01c70484e](https://github.com/mozilla/fxa/commit/01c70484e))
+- admin: remove unnecessary columns from admin panel queries ([0c65675bf](https://github.com/mozilla/fxa/commit/0c65675bf))
+- deps-dev: bump @typescript-eslint/eslint-plugin ([e99484693](https://github.com/mozilla/fxa/commit/e99484693))
+- deps-dev: bump @types/express from 4.17.11 to 4.17.12 ([08dc9b8e1](https://github.com/mozilla/fxa/commit/08dc9b8e1))
+- deps: bump @emotion/react from 11.1.5 to 11.4.0 ([986562f22](https://github.com/mozilla/fxa/commit/986562f22))
+- deps: updated knex ([e02c6720e](https://github.com/mozilla/fxa/commit/e02c6720e))
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-panel",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "description": "FxA Admin Panel",
   "scripts": {
     "build-postcss": "postcss src/styles/tailwind.css -o src/styles/tailwind.out.css",

--- a/packages/fxa-admin-server/CHANGELOG.md
+++ b/packages/fxa-admin-server/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.208.0
+
+### Other changes
+
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+- deps: updated pm2 ([34704ba14](https://github.com/mozilla/fxa/commit/34704ba14))
+- deps: updated sentry/* packages ([9095a1c13](https://github.com/mozilla/fxa/commit/9095a1c13))
+- deps: bump apollo-server from 2.24.1 to 2.25.0 ([00b502af8](https://github.com/mozilla/fxa/commit/00b502af8))
+- deps-dev: bump @types/node from 14.14.5 to 15.12.2 ([1fd38c54d](https://github.com/mozilla/fxa/commit/1fd38c54d))
+- admin: remove unnecessary columns from admin panel queries ([0c65675bf](https://github.com/mozilla/fxa/commit/0c65675bf))
+- deps: bump apollo-server-express from 2.24.1 to 2.25.0 ([cc4bbc0a1](https://github.com/mozilla/fxa/commit/cc4bbc0a1))
+- deps: updated knex ([e02c6720e](https://github.com/mozilla/fxa/commit/e02c6720e))
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-admin-server",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "description": "FxA GraphQL Admin Server",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/fxa-auth-db-mysql/CHANGELOG.md
+++ b/packages/fxa-auth-db-mysql/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.208.0
+
+### Other changes
+
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+- deps: updated pm2 ([34704ba14](https://github.com/mozilla/fxa/commit/34704ba14))
+- deps: updated sentry/* packages ([9095a1c13](https://github.com/mozilla/fxa/commit/9095a1c13))
+- deps-dev: bump nock from 13.0.11 to 13.1.0 ([4d52527d8](https://github.com/mozilla/fxa/commit/4d52527d8))
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-auth-db-mysql/package.json
+++ b/packages/fxa-auth-db-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-db-mysql",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "description": "MySQL backend for Firefox Accounts",
   "main": "index.js",
   "repository": {

--- a/packages/fxa-auth-server/CHANGELOG.md
+++ b/packages/fxa-auth-server/CHANGELOG.md
@@ -1,3 +1,39 @@
+## 1.208.0
+
+### New features
+
+- push: Add basic support for verifying a login via push ([875fa4b26](https://github.com/mozilla/fxa/commit/875fa4b26))
+
+### Bug fixes
+
+- sessions: Add support for touchSessionToken to only update the lastAccess session property ([e67a60330](https://github.com/mozilla/fxa/commit/e67a60330))
+- emails: address the customer in the subscriptionRenewalReminder email ([888b3efeb](https://github.com/mozilla/fxa/commit/888b3efeb))
+- l10n: added missing commas ([d13ad71f0](https://github.com/mozilla/fxa/commit/d13ad71f0))
+
+### Refactorings
+
+- db: move more auth-db functions into fxa-shared ([d5b587472](https://github.com/mozilla/fxa/commit/d5b587472))
+- auth: convert account to TS and class ([ef2d33a38](https://github.com/mozilla/fxa/commit/ef2d33a38))
+
+### Other changes
+
+- deps: bump stripe from 8.153.0 to 8.154.0 ([e1292ff7c](https://github.com/mozilla/fxa/commit/e1292ff7c))
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+- deps: updated pm2 ([34704ba14](https://github.com/mozilla/fxa/commit/34704ba14))
+- deps: updated sentry/* packages ([9095a1c13](https://github.com/mozilla/fxa/commit/9095a1c13))
+- deps: bump aws-sdk from 2.920.0 to 2.923.0 ([3cb5b950c](https://github.com/mozilla/fxa/commit/3cb5b950c))
+- deps-dev: bump @types/node from 14.14.5 to 15.12.2 ([1fd38c54d](https://github.com/mozilla/fxa/commit/1fd38c54d))
+- deps: bump stripe from 8.149.0 to 8.153.0 ([d80d64d43](https://github.com/mozilla/fxa/commit/d80d64d43))
+- deps-dev: bump nock from 13.0.11 to 13.1.0 ([4d52527d8](https://github.com/mozilla/fxa/commit/4d52527d8))
+- deps: bump hot-shots from 8.3.1 to 8.3.2 ([0cb43b6aa](https://github.com/mozilla/fxa/commit/0cb43b6aa))
+- deps: bump aws-sdk from 2.919.0 to 2.920.0 ([434cb0a53](https://github.com/mozilla/fxa/commit/434cb0a53))
+- deps: bump aws-sdk from 2.913.0 to 2.919.0 ([a616dc89a](https://github.com/mozilla/fxa/commit/a616dc89a))
+- deps-dev: bump grunt-cli from 1.4.2 to 1.4.3 ([957082de2](https://github.com/mozilla/fxa/commit/957082de2))
+- deps: bump cldr-core from 38.1.0 to 39.0.0 ([af815470a](https://github.com/mozilla/fxa/commit/af815470a))
+- deps: bump google-libphonenumber from 3.2.19 to 3.2.21 ([a287f7291](https://github.com/mozilla/fxa/commit/a287f7291))
+- auth-server: asyncify signin ([98c1a09bf](https://github.com/mozilla/fxa/commit/98c1a09bf))
+- deps: updated knex ([e02c6720e](https://github.com/mozilla/fxa/commit/e02c6720e))
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-auth-server",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "description": "Firefox Accounts, an identity provider for Mozilla cloud services",
   "bin": {
     "fxa-auth": "./bin/key_server.js"

--- a/packages/fxa-content-server/CHANGELOG.md
+++ b/packages/fxa-content-server/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 1.208.0
+
+### New features
+
+- subscriptions: allow redirects to Payments without token ([7aaec564a](https://github.com/mozilla/fxa/commit/7aaec564a))
+- content-server: return flow params to relier party ([d9b6ff577](https://github.com/mozilla/fxa/commit/d9b6ff577))
+
+### Other changes
+
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+- deps: updated pm2 ([34704ba14](https://github.com/mozilla/fxa/commit/34704ba14))
+- deps: updated sentry/* packages ([9095a1c13](https://github.com/mozilla/fxa/commit/9095a1c13))
+- deps-dev: bump intern from 4.9.0 to 4.9.1 ([db73a46db](https://github.com/mozilla/fxa/commit/db73a46db))
+- deps-dev: bump webpack-dev-middleware from 4.3.0 to 5.0.0 ([461c44486](https://github.com/mozilla/fxa/commit/461c44486))
+- deps: bump hot-shots from 8.3.1 to 8.3.2 ([0cb43b6aa](https://github.com/mozilla/fxa/commit/0cb43b6aa))
+- deps-dev: bump sinon-chai from 3.6.0 to 3.7.0 ([35aa62f09](https://github.com/mozilla/fxa/commit/35aa62f09))
+- deps: bump autoprefixer from 9.8.6 to 10.2.6 ([9facccb2b](https://github.com/mozilla/fxa/commit/9facccb2b))
+
 ## 1.207.1
 
 ### New features

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-content-server",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "description": "Firefox Accounts Content Server",
   "scripts": {
     "build": "tsc --build ../fxa-react && NODE_ENV=production grunt build",

--- a/packages/fxa-customs-server/CHANGELOG.md
+++ b/packages/fxa-customs-server/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.208.0
+
+### Other changes
+
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+- deps: updated pm2 ([34704ba14](https://github.com/mozilla/fxa/commit/34704ba14))
+- deps: updated sentry/* packages ([9095a1c13](https://github.com/mozilla/fxa/commit/9095a1c13))
+- deps-dev: bump grunt-cli from 1.4.2 to 1.4.3 ([957082de2](https://github.com/mozilla/fxa/commit/957082de2))
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-customs-server",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "description": "Firefox Accounts Customs Server",
   "author": "Mozilla (https://mozilla.org/)",
   "license": "MPL-2.0",

--- a/packages/fxa-email-event-proxy/package.json
+++ b/packages/fxa-email-event-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-email-event-proxy",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "description": "Proxies events from Sendgrid to FxA SQS queues",
   "main": "index.js",
   "scripts": {

--- a/packages/fxa-email-service/CHANGELOG.md
+++ b/packages/fxa-email-service/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.208.0
+
+No changes.
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-email-service/Cargo.lock
+++ b/packages/fxa-email-service/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "fxa_email_service"
-version = "1.207.1"
+version = "1.208.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/packages/fxa-email-service/Cargo.toml
+++ b/packages/fxa-email-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fxa_email_service"
-version = "1.207.1"
+version = "1.208.0"
 publish = false
 edition = "2018"
 

--- a/packages/fxa-event-broker/CHANGELOG.md
+++ b/packages/fxa-event-broker/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change history
 
+## 1.208.0
+
+### Other changes
+
+- deps: bump google-auth-library from 7.1.0 to 7.1.1 ([1bcf8cd58](https://github.com/mozilla/fxa/commit/1bcf8cd58))
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+- deps: updated pm2 ([34704ba14](https://github.com/mozilla/fxa/commit/34704ba14))
+- deps: updated sentry/* packages ([9095a1c13](https://github.com/mozilla/fxa/commit/9095a1c13))
+- deps: bump aws-sdk from 2.920.0 to 2.923.0 ([3cb5b950c](https://github.com/mozilla/fxa/commit/3cb5b950c))
+- deps-dev: bump @types/node from 14.14.5 to 15.12.2 ([1fd38c54d](https://github.com/mozilla/fxa/commit/1fd38c54d))
+- deps-dev: bump nock from 13.0.11 to 13.1.0 ([4d52527d8](https://github.com/mozilla/fxa/commit/4d52527d8))
+- deps: bump hot-shots from 8.3.1 to 8.3.2 ([0cb43b6aa](https://github.com/mozilla/fxa/commit/0cb43b6aa))
+- deps: bump aws-sdk from 2.919.0 to 2.920.0 ([434cb0a53](https://github.com/mozilla/fxa/commit/434cb0a53))
+- deps-dev: bump eslint-plugin-import from 2.23.3 to 2.23.4 ([9fd13a43d](https://github.com/mozilla/fxa/commit/9fd13a43d))
+- deps-dev: bump @typescript-eslint/eslint-plugin ([e99484693](https://github.com/mozilla/fxa/commit/e99484693))
+- deps: bump aws-sdk from 2.913.0 to 2.919.0 ([a616dc89a](https://github.com/mozilla/fxa/commit/a616dc89a))
+- deps-dev: bump @types/express from 4.17.11 to 4.17.12 ([08dc9b8e1](https://github.com/mozilla/fxa/commit/08dc9b8e1))
+- deps: bump google-auth-library from 7.0.2 to 7.1.0 ([3c0dc8f2c](https://github.com/mozilla/fxa/commit/3c0dc8f2c))
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-event-broker",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "description": "Firefox Accounts Event Broker",
   "scripts": {
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",

--- a/packages/fxa-geodb/CHANGELOG.md
+++ b/packages/fxa-geodb/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change history
 
+## 1.208.0
+
+### Other changes
+
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-geodb/package.json
+++ b/packages/fxa-geodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-geodb",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "description": "Firefox Accounts GeoDB Repo for Geolocation based services",
   "main": "lib/fxa-geodb.js",
   "directories": {

--- a/packages/fxa-graphql-api/CHANGELOG.md
+++ b/packages/fxa-graphql-api/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.208.0
+
+### Other changes
+
+- deps-dev: bump @types/graphql-upload from 8.0.4 to 8.0.5 ([834a4eafb](https://github.com/mozilla/fxa/commit/834a4eafb))
+- deps: bump graphql-parse-resolve-info from 4.11.0 to 4.12.0 ([6c03d0a14](https://github.com/mozilla/fxa/commit/6c03d0a14))
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+- deps: updated pm2 ([34704ba14](https://github.com/mozilla/fxa/commit/34704ba14))
+- deps: updated sentry/* packages ([9095a1c13](https://github.com/mozilla/fxa/commit/9095a1c13))
+- deps: bump apollo-server from 2.24.1 to 2.25.0 ([00b502af8](https://github.com/mozilla/fxa/commit/00b502af8))
+- deps-dev: bump @types/node from 14.14.5 to 15.12.2 ([1fd38c54d](https://github.com/mozilla/fxa/commit/1fd38c54d))
+- deps-dev: bump nock from 13.0.11 to 13.1.0 ([4d52527d8](https://github.com/mozilla/fxa/commit/4d52527d8))
+- deps: bump apollo-server-express from 2.24.1 to 2.25.0 ([cc4bbc0a1](https://github.com/mozilla/fxa/commit/cc4bbc0a1))
+- deps: updated knex ([e02c6720e](https://github.com/mozilla/fxa/commit/e02c6720e))
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-graphql-api",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "description": "FxA GraphQL API",
   "scripts": {
     "prebuild": "rimraf dist",

--- a/packages/fxa-payments-server/CHANGELOG.md
+++ b/packages/fxa-payments-server/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Change history
 
+## 1.208.0
+
+### New features
+
+- payments: Use custom action button label if specified in PaymentConfirmation ([617be5182](https://github.com/mozilla/fxa/commit/617be5182))
+
+### Other changes
+
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+- deps: updated pm2 ([34704ba14](https://github.com/mozilla/fxa/commit/34704ba14))
+- deps: updated sentry/* packages ([9095a1c13](https://github.com/mozilla/fxa/commit/9095a1c13))
+- deps-dev: bump @types/node from 14.14.5 to 15.12.2 ([1fd38c54d](https://github.com/mozilla/fxa/commit/1fd38c54d))
+- deps-dev: bump @types/react-router from 5.1.14 to 5.1.15 ([9f0a795f6](https://github.com/mozilla/fxa/commit/9f0a795f6))
+- deps: bump nocache from 2.1.0 to 3.0.0 ([f6ee69767](https://github.com/mozilla/fxa/commit/f6ee69767))
+- deps-dev: bump nock from 13.0.11 to 13.1.0 ([4d52527d8](https://github.com/mozilla/fxa/commit/4d52527d8))
+- deps: bump hot-shots from 8.3.1 to 8.3.2 ([0cb43b6aa](https://github.com/mozilla/fxa/commit/0cb43b6aa))
+- deps-dev: bump @typescript-eslint/eslint-plugin ([e99484693](https://github.com/mozilla/fxa/commit/e99484693))
+- deps-dev: bump caniuse-lite from 1.0.30001228 to 1.0.30001230 ([3b22d03a6](https://github.com/mozilla/fxa/commit/3b22d03a6))
+- deps: updated knex ([e02c6720e](https://github.com/mozilla/fxa/commit/e02c6720e))
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-payments-server",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "description": "Firefox Accounts Payments Service",
   "scripts": {
     "postinstall": "../../_scripts/clone-l10n.sh fxa-payments-server",

--- a/packages/fxa-profile-server/CHANGELOG.md
+++ b/packages/fxa-profile-server/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.208.0
+
+### Other changes
+
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+- deps: updated pm2 ([34704ba14](https://github.com/mozilla/fxa/commit/34704ba14))
+- deps: updated sentry/* packages ([9095a1c13](https://github.com/mozilla/fxa/commit/9095a1c13))
+- deps: bump aws-sdk from 2.920.0 to 2.923.0 ([3cb5b950c](https://github.com/mozilla/fxa/commit/3cb5b950c))
+- deps-dev: bump nock from 13.0.11 to 13.1.0 ([4d52527d8](https://github.com/mozilla/fxa/commit/4d52527d8))
+- deps: bump aws-sdk from 2.919.0 to 2.920.0 ([434cb0a53](https://github.com/mozilla/fxa/commit/434cb0a53))
+- deps: bump aws-sdk from 2.913.0 to 2.919.0 ([a616dc89a](https://github.com/mozilla/fxa/commit/a616dc89a))
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-profile-server",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "private": true,
   "description": "Firefox Accounts Profile service.",
   "scripts": {

--- a/packages/fxa-react/CHANGELOG.md
+++ b/packages/fxa-react/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.208.0
+
+### Other changes
+
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+- deps: updated pm2 ([34704ba14](https://github.com/mozilla/fxa/commit/34704ba14))
+- deps-dev: bump @types/node from 14.14.5 to 15.12.2 ([1fd38c54d](https://github.com/mozilla/fxa/commit/1fd38c54d))
+- deps-dev: bump sass from 1.32.8 to 1.34.1 ([ebb076f71](https://github.com/mozilla/fxa/commit/ebb076f71))
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-react",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "description": "Shared components for FxA React Apps",
   "exports": {
     "./components/": "./dist/components/",

--- a/packages/fxa-settings/CHANGELOG.md
+++ b/packages/fxa-settings/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 1.208.0
+
+### Bug fixes
+
+- 1e5952aa1 fix long device name layout issue ([1e5952aa1](https://github.com/mozilla/fxa/commit/1e5952aa1))
+
+### Other changes
+
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+- deps: updated pm2 ([34704ba14](https://github.com/mozilla/fxa/commit/34704ba14))
+- deps: updated sentry/* packages ([9095a1c13](https://github.com/mozilla/fxa/commit/9095a1c13))
+- deps-dev: bump @types/node from 14.14.5 to 15.12.2 ([1fd38c54d](https://github.com/mozilla/fxa/commit/1fd38c54d))
+- deps-dev: bump @testing-library/react-hooks from 6.0.0 to 7.0.0 ([68260b929](https://github.com/mozilla/fxa/commit/68260b929))
+- deps: bump react-easy-crop from 3.4.0 to 3.5.1 ([269a5b56f](https://github.com/mozilla/fxa/commit/269a5b56f))
+- deps: bump react-webcam from 5.2.3 to 5.2.4 ([8fec4aef6](https://github.com/mozilla/fxa/commit/8fec4aef6))
+- deps: bump react-easy-crop from 3.3.3 to 3.4.0 ([c8c947b31](https://github.com/mozilla/fxa/commit/c8c947b31))
+- deps: bump @emotion/react from 11.1.5 to 11.4.0 ([986562f22](https://github.com/mozilla/fxa/commit/986562f22))
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-settings",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "homepage": "https://accounts.firefox.com/settings",
   "private": true,
   "scripts": {

--- a/packages/fxa-shared/CHANGELOG.md
+++ b/packages/fxa-shared/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Change history
 
+## 1.208.0
+
+### New features
+
+- payments: Use custom action button label if specified in PaymentConfirmation ([617be5182](https://github.com/mozilla/fxa/commit/617be5182))
+
+### Refactorings
+
+- db: move more auth-db functions into fxa-shared ([d5b587472](https://github.com/mozilla/fxa/commit/d5b587472))
+
+### Other changes
+
+- deps: bump stripe from 8.153.0 to 8.154.0 ([e1292ff7c](https://github.com/mozilla/fxa/commit/e1292ff7c))
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+- deps: updated pm2 ([34704ba14](https://github.com/mozilla/fxa/commit/34704ba14))
+- deps: updated sentry/* packages ([9095a1c13](https://github.com/mozilla/fxa/commit/9095a1c13))
+- deps: bump apollo-server from 2.24.1 to 2.25.0 ([00b502af8](https://github.com/mozilla/fxa/commit/00b502af8))
+- deps: bump aws-sdk from 2.920.0 to 2.923.0 ([3cb5b950c](https://github.com/mozilla/fxa/commit/3cb5b950c))
+- deps-dev: bump @types/node from 14.14.5 to 15.12.2 ([1fd38c54d](https://github.com/mozilla/fxa/commit/1fd38c54d))
+- deps: bump stripe from 8.149.0 to 8.153.0 ([d80d64d43](https://github.com/mozilla/fxa/commit/d80d64d43))
+- deps: bump hot-shots from 8.3.1 to 8.3.2 ([0cb43b6aa](https://github.com/mozilla/fxa/commit/0cb43b6aa))
+- deps: bump aws-sdk from 2.919.0 to 2.920.0 ([434cb0a53](https://github.com/mozilla/fxa/commit/434cb0a53))
+- deps: bump aws-sdk from 2.913.0 to 2.919.0 ([a616dc89a](https://github.com/mozilla/fxa/commit/a616dc89a))
+- deps-dev: bump @types/redis from 2.8.28 to 2.8.29 ([7a3df7c82](https://github.com/mozilla/fxa/commit/7a3df7c82))
+- deps-dev: bump jsdom from 16.5.3 to 16.6.0 ([15c547814](https://github.com/mozilla/fxa/commit/15c547814))
+- deps: updated knex ([e02c6720e](https://github.com/mozilla/fxa/commit/e02c6720e))
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-shared",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "description": "Shared module for FxA repositories",
   "main": "dist/index.js",
   "exports": {

--- a/packages/fxa-support-panel/CHANGELOG.md
+++ b/packages/fxa-support-panel/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change history
 
+## 1.208.0
+
+### Other changes
+
+- deps: updated some deps ([fa895572c](https://github.com/mozilla/fxa/commit/fa895572c))
+- deps: updated pm2 ([34704ba14](https://github.com/mozilla/fxa/commit/34704ba14))
+- deps: updated sentry/* packages ([9095a1c13](https://github.com/mozilla/fxa/commit/9095a1c13))
+- deps-dev: bump @types/node from 14.14.5 to 15.12.2 ([1fd38c54d](https://github.com/mozilla/fxa/commit/1fd38c54d))
+- deps-dev: bump @types/eslint from 7.2.11 to 7.2.13 ([01c70484e](https://github.com/mozilla/fxa/commit/01c70484e))
+
 ## 1.207.1
 
 No changes.

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-support-panel",
-  "version": "1.207.1",
+  "version": "1.208.0",
   "description": "Small app to help customer support access FxA details",
   "directories": {
     "test": "test"


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1715636



### Marked needs:qa (FxA)

* https://github.com/mozilla/fxa/issues?utf8=%E2%9C%93&q=label%3Aneeds%3Aqa+is%3Aclosed+updated%3A%3E2021-05-26

### Marked qa+ (SubPlat)

* https://github.com/mozilla/fxa/issues?utf8=%E2%9C%93&q=label%3Aqa%2B+is%3Aclosed+updated%3A%3E2021-05-26

### Tags

* https://github.com/mozilla/fxa/releases/tag/v1.208.0

### Pertinent changelogs

* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-auth-db-mysql/CHANGELOG.md        
* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-auth-server/CHANGELOG.md
* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-admin-server/CHANGELOG.md
* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-admin-panel/CHANGELOG.md
* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-content-server/CHANGELOG.md       
* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-customs-server/CHANGELOG.md       
* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-event-broker/CHANGELOG.md
* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-geodb/CHANGELOG.md
* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-graphql-api/CHANGELOG.md
* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-payments-server/CHANGELOG.md      
* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-profile-server/CHANGELOG.md       
* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-react/CHANGELOG.md
* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-settings/CHANGELOG.md
* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-shared/CHANGELOG.md
* https://github.com/mozilla/fxa/blob/v1.208.0/packages/fxa-support-panel/CHANGELOG.md   
