### PR TITLE
feat(auth): add tax rate retrieval functions

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/taxRateDe.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/taxRateDe.json
@@ -1,0 +1,16 @@
+{
+  "id": "txr_1J3CjpJNcmPzuWtRwa1MitM6",
+  "object": "tax_rate",
+  "active": true,
+  "country": "DE",
+  "created": 1623903717,
+  "description": "VAT Germany",
+  "display_name": "VAT",
+  "inclusive": false,
+  "jurisdiction": "DE",
+  "livemode": false,
+  "metadata": {},
+  "percentage": 19.0,
+  "state": null,
+  "tax_type": "vat"
+}

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/taxRateFr.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/taxRateFr.json
@@ -1,0 +1,16 @@
+{
+      "id": "txr_1J3CjpJNcmPzuWtRwa1MitM8",
+      "object": "tax_rate",
+      "active": true,
+      "country": "FR",
+      "created": 1623903717,
+      "description": "VAT France",
+      "display_name": "VAT",
+      "inclusive": false,
+      "jurisdiction": "DE",
+      "livemode": false,
+      "metadata": {},
+      "percentage": 20.0,
+      "state": null,
+      "tax_type": "vat"
+    }


### PR DESCRIPTION
Because:

* We want to have tax rates available to add to subscriptions when
  they're created.

This commit:

* Adds a tax rate helper function to StripeHelper.

Closes #8893

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
