### PR TITLE
feat(subscriptions): update sub plan upgrade eligibility logic

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -10,9 +10,14 @@ import {
   getAccountCustomerByUid,
   updatePayPalBA,
 } from 'fxa-shared/db/models/auth';
-import { AbbrevPlan, AbbrevProduct } from 'fxa-shared/dist/subscriptions/types';
+import {
+  AbbrevPlan,
+  AbbrevProduct,
+  SubscriptionUpdateEligibility,
+} from 'fxa-shared/subscriptions/types';
 import {
   ACTIVE_SUBSCRIPTION_STATUSES,
+  getSubscriptionUpdateEligibility,
   singlePlan,
 } from 'fxa-shared/subscriptions/stripe';
 import { StatsD } from 'hot-shots';
@@ -81,39 +86,6 @@ type BillingAddressOptions = {
   postalCode: string;
   state: string;
 };
-
-/**
- * Determine for two product metadata object's whether the new one
- * is a valid upgrade for the old one.
- *
- * Throws errors if necessary metadata is not present to determine
- * if its an upgrade.
- *
- * @param {AbbrevProduct['product_metadata']} oldMetadata Old product metadata
- * @param {AbbrevProduct['product_metadata']} newMetadata New product metadata
- * @returns {boolean} Whether the new product is an upgrade.
- */
-function validateProductUpdate(
-  oldMetadata: AbbrevProduct['product_metadata'],
-  newMetadata: AbbrevProduct['product_metadata']
-): boolean {
-  if (!oldMetadata || !newMetadata) {
-    throw error.unknownSubscriptionPlan();
-  }
-
-  const oldId = oldMetadata.productSet;
-  const newId = newMetadata.productSet;
-  if (!oldId || oldId !== newId) {
-    // Incompatible product sets
-    return false;
-  }
-  const oldOrder = Number.parseInt(oldMetadata.productOrder);
-  const newOrder = Number.parseInt(newMetadata.productOrder);
-  if (isNaN(oldOrder) || isNaN(newOrder)) {
-    throw error.unknownSubscriptionPlan();
-  }
-  return oldOrder !== newOrder;
-}
 
 export class StripeHelper {
   // Note that this isn't quite accurate, as the auth-server logger has some extras
@@ -701,10 +673,10 @@ export class StripeHelper {
     return Promise.all(
       sources.data.map(
         (s) =>
-          (this.stripe.customers.deleteSource(
+          this.stripe.customers.deleteSource(
             customerId,
             s.id
-          ) as unknown) as Promise<Stripe.Card>
+          ) as unknown as Promise<Stripe.Card>
       )
     );
   }
@@ -870,10 +842,11 @@ export class StripeHelper {
 
     // We need to get all the subscriptions for a customer
     if (customer.subscriptions && customer.subscriptions.has_more) {
-      const additionalSubscriptions = await this.fetchAllSubscriptionsForCustomer(
-        customer.id,
-        customer.subscriptions.data[customer.subscriptions.data.length - 1].id
-      );
+      const additionalSubscriptions =
+        await this.fetchAllSubscriptionsForCustomer(
+          customer.id,
+          customer.subscriptions.data[customer.subscriptions.data.length - 1].id
+        );
       customer.subscriptions.data.push(...additionalSubscriptions);
       customer.subscriptions.has_more = false;
     }
@@ -1139,28 +1112,25 @@ export class StripeHelper {
     currentPlanId: string,
     newPlanId: string
   ): Promise<void> {
-    const allPlans = await this.allPlans();
-    const currentPlan = allPlans
-      .filter((plan) => plan.plan_id === currentPlanId)
-      .shift();
-
-    const newPlan = allPlans
-      .filter((plan) => plan.plan_id === newPlanId)
-      .shift();
-    if (!newPlan || !currentPlan) {
-      throw error.unknownSubscriptionPlan();
-    }
-
     if (currentPlanId === newPlanId) {
       throw error.subscriptionAlreadyChanged();
     }
 
-    if (
-      !validateProductUpdate(
-        currentPlan.product_metadata,
-        newPlan.product_metadata
-      )
-    ) {
+    const allPlans = await this.allPlans();
+    const currentPlan = allPlans.find((plan) => plan.plan_id === currentPlanId);
+    const newPlan = allPlans.find((plan) => plan.plan_id === newPlanId);
+
+    if (!newPlan || !currentPlan) {
+      throw error.unknownSubscriptionPlan();
+    }
+
+    const planUpdateEligibility = getSubscriptionUpdateEligibility(
+      currentPlan,
+      newPlan
+    );
+
+    // We only allow upgrades
+    if (planUpdateEligibility !== SubscriptionUpdateEligibility.UPGRADE) {
       throw error.invalidPlanUpdate();
     }
   }
@@ -1695,10 +1665,8 @@ export class StripeHelper {
     let lastFour: string | null = null;
     let cardType: string | null = null;
     if (charge?.payment_method_details?.card) {
-      ({
-        brand: cardType,
-        last4: lastFour,
-      } = charge.payment_method_details.card);
+      ({ brand: cardType, last4: lastFour } =
+        charge.payment_method_details.card);
     }
     return { lastFour, cardType };
   }
@@ -1829,10 +1797,8 @@ export class StripeHelper {
       amount: paymentAmountNewInCents,
       currency: paymentAmountNewCurrency,
     } = planNew;
-    const {
-      product_id: productIdNew,
-      product_name: productNameNew,
-    } = abbrevProductNew;
+    const { product_id: productIdNew, product_name: productNameNew } =
+      abbrevProductNew;
     const productNewMetadata = this.mergeMetadata(planNew, abbrevProductNew);
     const {
       productOrder: productOrderNew,
@@ -1955,13 +1921,11 @@ export class StripeHelper {
       productIconURLNew: planEmailIconURL,
     } = baseDetails;
 
-    const {
-      lastFour,
-      cardType,
-    } = await this.extractCustomerDefaultPaymentDetails({
-      uid,
-      email,
-    });
+    const { lastFour, cardType } =
+      await this.extractCustomerDefaultPaymentDetails({
+        uid,
+        email,
+      });
 
     const upcomingInvoice = await this.stripe.invoices.retrieveUpcoming({
       subscription: subscription.id,
@@ -2064,10 +2028,8 @@ export class StripeHelper {
       amount: paymentAmountOldInCents,
       currency: paymentAmountOldCurrency,
     } = planOld;
-    const {
-      product_id: productIdOld,
-      product_name: productNameOld,
-    } = abbrevProductOld;
+    const { product_id: productIdOld, product_name: productNameOld } =
+      abbrevProductOld;
     const {
       productOrder: productOrderOld,
       emailIconURL: productIconURLOld = '',

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -20,13 +20,10 @@ const { Container } = require('typedi');
 const chance = new Chance();
 let mockRedis;
 const proxyquire = require('proxyquire').noPreserveCache();
-const {
-  StripeHelper,
-  STRIPE_INVOICE_METADATA,
-  SUBSCRIPTION_UPDATE_TYPES,
-} = proxyquire('../../../lib/payments/stripe', {
-  '../redis': (config, log) => mockRedis.init(config, log),
-});
+const { StripeHelper, STRIPE_INVOICE_METADATA, SUBSCRIPTION_UPDATE_TYPES } =
+  proxyquire('../../../lib/payments/stripe', {
+    '../redis': (config, log) => mockRedis.init(config, log),
+  });
 const { CurrencyHelper } = require('../../../lib/payments/currencies');
 
 const customer1 = require('./fixtures/stripe/customer1.json');
@@ -841,10 +838,11 @@ describe('StripeHelper', () => {
   describe('updateInvoiceWithPaypalRefundTransactionId', () => {
     it('works successfully', async () => {
       sandbox.stub(stripeHelper.stripe.invoices, 'update').resolves({});
-      const actual = await stripeHelper.updateInvoiceWithPaypalRefundTransactionId(
-        unpaidInvoice,
-        'tid'
-      );
+      const actual =
+        await stripeHelper.updateInvoiceWithPaypalRefundTransactionId(
+          unpaidInvoice,
+          'tid'
+        );
       assert.deepEqual(actual, {});
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripe.invoices.update,
@@ -1256,16 +1254,14 @@ describe('StripeHelper', () => {
         payment_intent: { ...closedPaymementIntent },
       };
       const subscription = { ...subscription2, latest_invoice };
-      const result = stripeHelper.extractSourceCountryFromSubscription(
-        subscription
-      );
+      const result =
+        stripeHelper.extractSourceCountryFromSubscription(subscription);
       assert.equal(result, 'US');
     });
 
     it('returns null with no invoice', () => {
-      const result = stripeHelper.extractSourceCountryFromSubscription(
-        subscription2
-      );
+      const result =
+        stripeHelper.extractSourceCountryFromSubscription(subscription2);
       assert.equal(result, null);
     });
 
@@ -1282,9 +1278,8 @@ describe('StripeHelper', () => {
         payment_intent: { charges: { data: [] } },
       };
       const subscription = { ...subscription2, latest_invoice };
-      const result = stripeHelper.extractSourceCountryFromSubscription(
-        subscription
-      );
+      const result =
+        stripeHelper.extractSourceCountryFromSubscription(subscription);
       assert.equal(result, null);
 
       assert.isTrue(
@@ -1423,19 +1418,25 @@ describe('StripeHelper', () => {
   });
 
   describe('verifyPlanUpdateForSubscription', () => {
-    it('does nothing for valid upgrade or downgrade', async () => {
+    it('does nothing for a valid upgrade', async () => {
       assert.isUndefined(
         await stripeHelper.verifyPlanUpdateForSubscription(
           'plan_G93lTs8hfK7NNG',
           'plan_G93mMKnIFCjZek'
         )
       );
-      assert.isUndefined(
+    });
+
+    it('throws an invalidPlanUpdate when it is a downgrade', async () => {
+      try {
         await stripeHelper.verifyPlanUpdateForSubscription(
           'plan_G93mMKnIFCjZek',
           'plan_G93lTs8hfK7NNG'
-        )
-      );
+        );
+        assert.fail('An invalidPlanUpdate should have been thrown.');
+      } catch (e) {
+        assert.equal(e.errno, error.ERRNO.INVALID_PLAN_UPDATE);
+      }
     });
 
     describe('when the upgrade is invalid', () => {
@@ -3226,9 +3227,10 @@ describe('StripeHelper', () => {
         const event = deepCopy(eventCustomerSubscriptionUpdated);
         event.data.object.cancel_at_period_end = true;
         event.data.previous_attributes = { cancel_at_period_end: false };
-        const result = await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
-          event
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
+            event
+          );
         assert.equal(result, mockCancellationDetails);
         assertOnlyExpectedHelperCalledWith(
           'extractSubscriptionUpdateCancellationDetailsForEmail',
@@ -3242,9 +3244,10 @@ describe('StripeHelper', () => {
         const event = deepCopy(eventCustomerSubscriptionUpdated);
         event.data.object.cancel_at_period_end = false;
         event.data.previous_attributes = { cancel_at_period_end: true };
-        const result = await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
-          event
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
+            event
+          );
         assert.equal(result, mockReactivationDetails);
         assertOnlyExpectedHelperCalledWith(
           'extractSubscriptionUpdateReactivationDetailsForEmail',
@@ -3258,9 +3261,10 @@ describe('StripeHelper', () => {
         const event = deepCopy(eventCustomerSubscriptionUpdated);
         event.data.object.cancel_at_period_end = false;
         event.data.previous_attributes.cancel_at_period_end = false;
-        const result = await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
-          event
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
+            event
+          );
         assert.equal(result, mockUpgradeDowngradeDetails);
         assertOnlyExpectedHelperCalledWith(
           'extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail',
@@ -3277,9 +3281,10 @@ describe('StripeHelper', () => {
         const event = deepCopy(eventCustomerSubscriptionUpdated);
         event.data.object.cancel_at_period_end = false;
         event.data.previous_attributes.cancel_at_period_end = true;
-        const result = await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
-          event
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateEventDetailsForEmail(
+            event
+          );
         assert.equal(result, mockUpgradeDowngradeDetails);
         assertOnlyExpectedHelperCalledWith(
           'extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail',
@@ -3345,14 +3350,15 @@ describe('StripeHelper', () => {
           ? 1
           : 2;
 
-        const result = await stripeHelper.extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail(
-          event.data.object,
-          baseDetails,
-          mockInvoice,
-          mockCustomer,
-          event.data.object.plan.metadata.productOrder,
-          event.data.previous_attributes.plan
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateUpgradeDowngradeDetailsForEmail(
+            event.data.object,
+            baseDetails,
+            mockInvoice,
+            mockCustomer,
+            event.data.object.plan.metadata.productOrder,
+            event.data.previous_attributes.plan
+          );
 
         // issue #5546: ensure we're looking for the upcoming invoice for this specific subscription
         assert.deepEqual(mockStripe.invoices.retrieveUpcoming.args, [
@@ -3425,11 +3431,12 @@ describe('StripeHelper', () => {
       it('extracts expected details for a subscription reactivation', async () => {
         const event = deepCopy(eventCustomerSubscriptionUpdated);
         sandbox.stub(stripeHelper, 'customer').resolves(mockCustomer);
-        const result = await stripeHelper.extractSubscriptionUpdateReactivationDetailsForEmail(
-          event.data.object,
-          expectedBaseUpdateDetails,
-          mockInvoice
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateReactivationDetailsForEmail(
+            event.data.object,
+            expectedBaseUpdateDetails,
+            mockInvoice
+          );
         assert.deepEqual(mockStripe.invoices.retrieveUpcoming.args, [
           [
             {
@@ -3445,11 +3452,12 @@ describe('StripeHelper', () => {
         const customer = deepCopy(mockCustomer);
         customer.invoice_settings.default_payment_method = null;
         sandbox.stub(stripeHelper, 'customer').resolves(customer);
-        const result = await stripeHelper.extractSubscriptionUpdateReactivationDetailsForEmail(
-          event.data.object,
-          expectedBaseUpdateDetails,
-          mockInvoice
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateReactivationDetailsForEmail(
+            event.data.object,
+            expectedBaseUpdateDetails,
+            mockInvoice
+          );
         assert.deepEqual(result, {
           ...defaultExpected,
           lastFour: null,
@@ -3541,11 +3549,12 @@ describe('StripeHelper', () => {
     describe('extractSubscriptionUpdateCancellationDetailsForEmail', () => {
       it('extracts expected details for a subscription cancellation', async () => {
         const event = deepCopy(eventCustomerSubscriptionUpdated);
-        const result = await stripeHelper.extractSubscriptionUpdateCancellationDetailsForEmail(
-          event.data.object,
-          expectedBaseUpdateDetails,
-          mockInvoice
-        );
+        const result =
+          await stripeHelper.extractSubscriptionUpdateCancellationDetailsForEmail(
+            event.data.object,
+            expectedBaseUpdateDetails,
+            mockInvoice
+          );
         const subscription = event.data.object;
         assert.deepEqual(result, {
           updateType: SUBSCRIPTION_UPDATE_TYPES.CANCELLATION,

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -29,7 +29,7 @@ payment-error-manage-subscription-button = Manage my subscription
 country-currency-mismatch = The currency of this subscription is not valid for the country associated with your payment.
 currency-currency-mismatch = Sorry. You can't switch between currencies.
 
-no-subscription-upgrades = Sorry. You can't upgrade or downgrade your subscription at this time. Please check back soon.
+no-subscription-change = Sorry. You can't change your subscription plan.
 
 expired-card-error = It looks like your credit card has expired. Try another card.
 insufficient-funds-error = It looks like your card has insufficient funds. Try another card.
@@ -53,7 +53,7 @@ subscription-create-title = Set up your subscription
 subscription-success-title = Subscription confirmation
 subscription-processing-title = Confirming subscription…
 subscription-error-title = Error confirming subscription…
-subscription-noupgrade-title = Subscription tier changes are not supported
+subscription-noplanchange-title = This subscription plan change is not supported
 
 ##  $productName (String) - The name of the subscribed product.
 ##  $amount (Number) - The amount billed. It will be formatted as currency.

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -15,23 +15,14 @@ const conf = convict({
   featureFlags: {
     useSCAPaymentUIByDefault: {
       default: false,
-      doc:
-        'Whether to use newer SCA payment UI components by default rather than at the /v2 sub-path',
+      doc: 'Whether to use newer SCA payment UI components by default rather than at the /v2 sub-path',
       env: 'FEATURE_USE_SCA_PAYMENT_UI_BY_DEFAULT',
       format: Boolean,
     },
     usePaypalUIByDefault: {
       default: false,
-      doc:
-        'Whether to use PayPal payment UI by default rather than Stripe payment UI alone',
+      doc: 'Whether to use PayPal payment UI by default rather than Stripe payment UI alone',
       env: 'FEATURE_USE_PAYPAL_UI_BY_DEFAULT',
-      format: Boolean,
-    },
-    allowSubscriptionUpgrades: {
-      default: false,
-      doc:
-        'Whether to allow subsciption upgrades and downgrades between pricing plans',
-      env: 'FEATURE_ALLOW_SUBSCRIPTION_UPGRADES',
       format: Boolean,
     },
   },
@@ -142,8 +133,7 @@ const conf = convict({
     },
     httpResCacheLimit: {
       default: 65536,
-      doc:
-        'The max number of entries in the redirect endpoint HTTP results cache.  0 means unlimited and the memory usage on the cache could reach the max of Map (1GB on V8)',
+      doc: 'The max number of entries in the redirect endpoint HTTP results cache.  0 means unlimited and the memory usage on the cache could reach the max of Map (1GB on V8)',
       env: 'PAYMENT_LEGAL_DOWNLOAD_CACHE_LIMIT',
       format: Number,
     },
@@ -210,8 +200,7 @@ const conf = convict({
   },
   proxyStaticResourcesFrom: {
     default: '',
-    doc:
-      'Instead of loading static resources from disk, get them by proxy from this URL (typically a special reloading dev server)',
+    doc: 'Instead of loading static resources from disk, get them by proxy from this URL (typically a special reloading dev server)',
     env: 'PROXY_STATIC_RESOURCES_FROM',
     format: String,
   },

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.test.tsx
@@ -68,7 +68,7 @@ describe('PaymentErrorView test with l10n', () => {
     const { getByTestId } = render(
       <PaymentErrorView
         onRetry={() => {}}
-        error={{ code: 'no_subscription_upgrades' }}
+        error={{ code: 'no_subscription_change' }}
         plan={SELECTED_PLAN}
       />
     );
@@ -83,15 +83,15 @@ describe('PaymentErrorView test with l10n', () => {
   it('uses the given SubscriptionTitle', async () => {
     const { getByTestId } = render(
       <PaymentErrorView
-        subscriptionTitle={<SubscriptionTitle screenType={'noupgrade'} />}
+        subscriptionTitle={<SubscriptionTitle screenType={'noplanchange'} />}
         onRetry={() => {}}
-        error={{ code: 'no_subscription_upgrades' }}
+        error={{ code: 'no_subscription_change' }}
         plan={SELECTED_PLAN}
       />
     );
 
-    const expectedTitle = titles.noupgrade;
-    expect(getByTestId('subscription-noupgrade-title')).toHaveTextContent(
+    const expectedTitle = titles.noplanchange;
+    expect(getByTestId('subscription-noplanchange-title')).toHaveTextContent(
       expectedTitle
     );
 

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
@@ -58,7 +58,7 @@ export const PaymentErrorView = ({
   // on the type of error
   const ActionButton = () => {
     switch (error?.code) {
-      case 'no_subscription_upgrades':
+      case 'no_subscription_change':
         return manageSubButtonFn(() => history.push('/subscriptions'));
       default:
         return retryButtonFn(onRetry);

--- a/packages/fxa-payments-server/src/components/SubscriptionTitle/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/SubscriptionTitle/index.test.tsx
@@ -87,24 +87,27 @@ describe('SubscriptionTitle', () => {
     const subject = () => {
       return render(
         <SubscriptionTitle
-          {...{ screenType: 'noupgrade', subtitle: <p>quuz</p> }}
+          {...{
+            screenType: 'noplanchange',
+            subtitle: <p>{titles.noplanchange}</p>,
+          }}
         />
       );
     };
     const { findByTestId } = subject();
-    const component = await findByTestId('subscription-noupgrade-title');
+    const component = await findByTestId('subscription-noplanchange-title');
 
-    const expectedTitle = titles.noupgrade;
+    const expectedTitle = titles.noplanchange;
     expect(component).toHaveTextContent(expectedTitle);
     const actualTitle = getLocalizedMessage(
       bundle,
-      'subscription-noupgrade-title',
+      'subscription-noplanchange-title',
       {}
     );
     expect(actualTitle).toEqual(expectedTitle);
 
     const defaultSubtitle = '30-day money-back guarantee';
     expect(component).not.toHaveTextContent(defaultSubtitle);
-    expect(component).toHaveTextContent('quuz');
+    expect(component).toHaveTextContent(titles.noplanchange);
   });
 });

--- a/packages/fxa-payments-server/src/components/SubscriptionTitle/index.tsx
+++ b/packages/fxa-payments-server/src/components/SubscriptionTitle/index.tsx
@@ -8,7 +8,7 @@ export const titles = {
   success: 'Subscription confirmation',
   processing: 'Confirming subscription…',
   error: 'Error confirming subscription…',
-  noupgrade: 'Subscription tier changes are not supported',
+  noplanchange: 'This subscription plan change is not supported',
 } as const;
 
 export type SubscriptionTitleProps = {

--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -48,7 +48,7 @@ const errorToErrorMessageMap: { [key: string]: string } = {
   'Funding source country does not match plan currency.':
     'country-currency-mismatch',
   'Changing currencies is not permitted.': 'currency-currency-mismatch',
-  no_subscription_upgrades: 'no-subscription-upgrades',
+  no_subscription_change: 'no-subscription-change',
 };
 
 const cardErrors = ['card_declined', 'incorrect_cvc'];

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -347,7 +347,9 @@ export const MOCK_PLANS: Plan[] = [
     interval_count: 1,
     amount: 500,
     currency: 'usd',
-    plan_metadata: null,
+    plan_metadata: {
+      productOrder: 3,
+    },
     product_metadata: {
       productSet: 'example_upgrade',
       webIconURL: 'http://example.com/product.jpg',
@@ -378,7 +380,37 @@ export const MOCK_PLANS: Plan[] = [
     interval_count: 1,
     amount: 5900,
     currency: 'usd',
-    plan_metadata: null,
+    plan_metadata: {
+      productOrder: 5,
+    },
+    product_metadata: {
+      productSet: 'example_upgrade',
+    },
+  },
+  {
+    plan_id: 'plan_no_upgrade',
+    product_id: 'prod_upgrade',
+    product_name: 'Upgrade Product',
+    interval: 'month' as const,
+    interval_count: 1,
+    amount: 5900,
+    currency: 'usd',
+    plan_metadata: {},
+    product_metadata: {
+      productSet: 'example_upgrade',
+    },
+  },
+  {
+    plan_id: 'plan_no_downgrade',
+    product_id: 'prod_upgrade',
+    product_name: 'upside down product',
+    interval: 'month' as const,
+    interval_count: 1,
+    amount: 5900,
+    currency: 'usd',
+    plan_metadata: {
+      productOrder: 1,
+    },
     product_metadata: {
       productSet: 'example_upgrade',
     },

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionChangeRoadblock/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionChangeRoadblock/index.stories.tsx
@@ -7,11 +7,11 @@ import { SignInLayout } from '../../../components/AppLayout';
 
 import { SELECTED_PLAN, PROFILE } from '../../../lib/mock-data';
 
-import SubscriptionUpgradeRoadblock, {
-  SubscriptionUpgradeRoadblockProps,
+import SubscriptionChangeRoadblock, {
+  SubscriptionDowngradeRoadblockProps,
 } from './index';
 
-const MOCK_PROPS: SubscriptionUpgradeRoadblockProps = {
+const MOCK_PROPS: SubscriptionDowngradeRoadblockProps = {
   isMobile: false,
   profile: PROFILE,
   selectedPlan: SELECTED_PLAN,
@@ -21,12 +21,12 @@ const SubscriptionUpgradeRoadlbockView = ({
   props = MOCK_PROPS,
   appContextValue = defaultAppContext,
 }: {
-  props?: SubscriptionUpgradeRoadblockProps;
+  props?: SubscriptionDowngradeRoadblockProps;
   appContextValue?: AppContextType;
 }) => (
   <MockApp appContextValue={appContextValue}>
     <SignInLayout>
-      <SubscriptionUpgradeRoadblock {...props} />
+      <SubscriptionChangeRoadblock {...props} />
     </SignInLayout>
   </MockApp>
 );

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionChangeRoadblock/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionChangeRoadblock/index.test.tsx
@@ -5,11 +5,11 @@ import '@testing-library/jest-dom/extend-expect';
 import { MockApp } from '../../../lib/test-utils';
 import { SELECTED_PLAN, PROFILE } from '../../../lib/mock-data';
 import { SignInLayout } from '../../../components/AppLayout';
-import SubscriptionUpgradeRoadblock, {
-  SubscriptionUpgradeRoadblockProps,
+import SubscriptionChangeRoadblock, {
+  SubscriptionDowngradeRoadblockProps,
 } from './index';
 
-const MOCK_PROPS: SubscriptionUpgradeRoadblockProps = {
+const MOCK_PROPS: SubscriptionDowngradeRoadblockProps = {
   profile: PROFILE,
   selectedPlan: SELECTED_PLAN,
   isMobile: false,
@@ -19,16 +19,16 @@ const Subject = () => {
   return (
     <MockApp>
       <SignInLayout>
-        <SubscriptionUpgradeRoadblock {...MOCK_PROPS} />
+        <SubscriptionChangeRoadblock {...MOCK_PROPS} />
       </SignInLayout>
     </MockApp>
   );
 };
 
-describe('routes/Product/SubscriptionUpgradeRoadblock', () => {
+describe('routes/Product/SubscriptionDowngradeRoadblock', () => {
   it('renders as expected', async () => {
     const { findByTestId } = render(<Subject />);
-    const titleEl = await findByTestId('subscription-noupgrade-title');
+    const titleEl = await findByTestId('subscription-noplanchange-title');
     expect(titleEl).toBeInTheDocument();
     const errorEl = await findByTestId('payment-error');
     expect(errorEl).toBeInTheDocument();

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionChangeRoadblock/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionChangeRoadblock/index.tsx
@@ -9,18 +9,18 @@ import { SubscriptionUpgradeProps } from '../SubscriptionUpgrade';
 import { SubscriptionTitle } from '../../../components/SubscriptionTitle';
 import PaymentErrorView from 'fxa-payments-server/src/components/PaymentErrorView';
 
-export type SubscriptionUpgradeRoadblockProps = Pick<
+export type SubscriptionDowngradeRoadblockProps = Pick<
   SubscriptionUpgradeProps,
   'profile' | 'isMobile' | 'selectedPlan'
 >;
 
-export const SubscriptionUpgradeRoadblock = ({
+export const SubscriptionChangeRoadblock = ({
   profile,
   isMobile,
   selectedPlan,
-}: SubscriptionUpgradeRoadblockProps) => {
+}: SubscriptionDowngradeRoadblockProps) => {
   const title = (
-    <SubscriptionTitle {...{ screenType: 'noupgrade', subtitle: <p></p> }} />
+    <SubscriptionTitle {...{ screenType: 'noplanchange', subtitle: <p></p> }} />
   );
 
   return (
@@ -30,7 +30,7 @@ export const SubscriptionUpgradeRoadblock = ({
         <PaymentErrorView
           {...{
             subscriptionTitle: title,
-            error: { code: 'no_subscription_upgrades' },
+            error: { code: 'no_subscription_change' },
             onRetry: () => {}, // PaymentErrorView actually ignores this
             plan: selectedPlan,
           }}
@@ -49,4 +49,4 @@ export const SubscriptionUpgradeRoadblock = ({
   );
 };
 
-export default SubscriptionUpgradeRoadblock;
+export default SubscriptionChangeRoadblock;

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -111,3 +111,12 @@ export type PaypalPaymentError =
 export type SentEmailParams = {
   subscriptionId: string;
 };
+
+export const SubscriptionUpdateEligibility = {
+  UPGRADE: 'upgrade',
+  DOWNGRADE: 'downgrade',
+  INVALID: 'invalid',
+} as const;
+
+export type SubscriptionUpdateEligibility =
+  typeof SubscriptionUpdateEligibility[keyof typeof SubscriptionUpdateEligibility];


### PR DESCRIPTION
Because:
 - we want to allow upgrades between plans of the same "product set"

This commit:
 - determine subscription plan upgrade eligibility with the coalesced
   product+plan metadata, where
   - the plans must have the same 'productSet' value
   - the plans must have different 'productOrder' values
   - the new plan must have a higher 'productOrder' than the existing
     plan
 - remove the subscription upgrade feature flag and the roadblock screen
 - add roadblock screen for plan changes that are not upgrades

## Issue that this pull request solves

Closes: #9351 
