### PR TITLE
Add feature flag for 2FA via push

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiment.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiment.js
@@ -26,6 +26,7 @@ const MANUAL_EXPERIMENTS = {
   sendSms: BaseExperiment,
   newsletterSync: BaseExperiment,
   qrCodeCad: BaseExperiment,
+  pushLogin: BaseExperiment,
 };
 
 const ALL_EXPERIMENTS = _.extend({}, STARTUP_EXPERIMENTS, MANUAL_EXPERIMENTS);

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
@@ -16,6 +16,7 @@ const experimentGroupingRules = [
   require('./send-sms-install-link'),
   require('./sentry'),
   require('./newsletter-sync'),
+  require('./push'),
 ].map((ExperimentGroupingRule) => new ExperimentGroupingRule());
 
 class ExperimentChoiceIndex {

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/push.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/push.js
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * This defines experiment groups the 2FA via push feature. Please reference
+ * https://docs.google.com/document/d/16fdARc6MC9XO7FBG9YJ4bpeqhHcv1G3ua0uzeS4EckY/edit#
+ *
+ */
+'use strict';
+
+const BaseGroupingRule = require('./base');
+const GROUPS = [
+  'control',
+  // Treatment branches
+  'treatment',
+];
+
+// This experiment is disabled by default. If you would like to go through
+// the flow, load email-first screen and append query params
+// `?forceExperiment=pushLogin&forceExperimentGroup=treatment`
+const ROLLOUT_RATE = 0.0;
+
+module.exports = class NewsletterSync extends BaseGroupingRule {
+  constructor() {
+    super();
+    this.name = 'pushLogin';
+
+    // Easier to set class properties for testability
+    this.groups = GROUPS;
+    this.rolloutRate = ROLLOUT_RATE;
+  }
+
+  /**
+   * For this experiment, we are doing a staged rollout.`
+   *
+   * @param {Object} subject data used to decide
+   *  @param {Boolean} isSync is this a sync signup?
+   * @returns {Any}
+   */
+  choose(subject = {}) {
+    let choice = false;
+    const { isSync } = subject;
+
+    // Only enroll for sync users
+    if (!isSync) {
+      return false;
+    }
+
+    // TODO: Find out how Softvision plans to test and verify this in
+    // if(this.isTestEmail(subject.account.get('email'))) {
+    //   return 'push';
+    // }
+
+    if (this.bernoulliTrial(this.rolloutRate, subject.uniqueUserId)) {
+      choice = this.uniformChoice(GROUPS, subject.uniqueUserId);
+    }
+
+    return choice;
+  }
+};

--- a/packages/fxa-content-server/app/scripts/views/mixins/push-login-experiment-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/push-login-experiment-mixin.js
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import ExperimentMixin from './experiment-mixin';
+const EXPERIMENT_NAME = 'pushLogin';
+
+export default {
+  dependsOn: [ExperimentMixin],
+
+  isInPushLoginExperiment() {
+    const experimentGroup = this.getAndReportExperimentGroup(EXPERIMENT_NAME, {
+      isSync: this.relier.isSync(),
+    });
+
+    return experimentGroup === 'treatment';
+  },
+};

--- a/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/signin-mixin.js
@@ -10,9 +10,10 @@ import NavigateBehavior from '../behaviors/navigate';
 import ResumeTokenMixin from './resume-token-mixin';
 import VerificationMethods from '../../lib/verification-methods';
 import VerificationReasons from '../../lib/verification-reasons';
+import PushLoginExperiment from './push-login-experiment-mixin';
 
 export default {
-  dependsOn: [ResumeTokenMixin],
+  dependsOn: [ResumeTokenMixin, PushLoginExperiment],
 
   /**
    * Sign in a user
@@ -185,6 +186,10 @@ export default {
         (verificationReason === VerificationReasons.CHANGE_PASSWORD &&
           verificationMethod === VerificationMethods.EMAIL_OTP)
       ) {
+        if (this.isInPushLoginExperiment()) {
+          return this.navigate('/push/send_login');
+        }
+
         return this.navigate('signin_token_code', { account });
       }
 

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 
 describe('lib/experiments/grouping-rules/index', () => {
   it('EXPERIMENT_NAMES is exported', () => {
-    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 5);
+    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 6);
   });
 
   describe('choose', () => {

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/push.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/push.js
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import Experiment from 'lib/experiments/grouping-rules/push';
+
+describe('lib/experiments/grouping-rules/push', () => {
+  let experiment;
+
+  beforeEach(() => {
+    experiment = new Experiment();
+  });
+
+  describe('choose', () => {
+    it('returns false if not Sync', () => {
+      assert.isFalse(
+        experiment.choose({
+          experimentGroupingRules: { choose: () => experiment.name },
+          isSync: false,
+          uniqueUserId: 'user-id',
+        })
+      );
+    });
+
+    it('returns false if rollout 0%', () => {
+      experiment.rolloutRate = 0;
+      assert.isFalse(
+        experiment.choose({
+          experimentGroupingRules: { choose: () => experiment.name },
+          isSync: true,
+          uniqueUserId: 'user-id',
+        })
+      );
+    });
+
+    it('returns treatment if rollout 100%', () => {
+      experiment.rolloutRate = 1;
+      assert.isTrue(
+        experiment.groups.includes(
+          experiment.choose({
+            experimentGroupingRules: { choose: () => experiment.name },
+            isSync: true,
+            uniqueUserId: 'user-id',
+          })
+        )
+      );
+    });
+  });
+});

--- a/packages/fxa-content-server/app/tests/spec/views/mixins/signin-mixin.js
+++ b/packages/fxa-content-server/app/tests/spec/views/mixins/signin-mixin.js
@@ -73,6 +73,7 @@ describe('views/mixins/signin-mixin', function () {
         signIn: SignInMixin.signIn,
         unsafeDisplayError: sinon.spy(),
         user: user,
+        isInPushLoginExperiment: sinon.spy(),
       };
     });
 

--- a/packages/fxa-content-server/app/tests/test_start.js
+++ b/packages/fxa-content-server/app/tests/test_start.js
@@ -46,6 +46,7 @@ require('./spec/lib/experiments/grouping-rules/communication-prefs');
 require('./spec/lib/experiments/grouping-rules/index');
 require('./spec/lib/experiments/grouping-rules/is-sampled-user');
 require('./spec/lib/experiments/grouping-rules/newsletter-sync');
+require('./spec/lib/experiments/grouping-rules/push');
 require('./spec/lib/experiments/grouping-rules/send-sms-install-link');
 require('./spec/lib/experiments/grouping-rules/sentry');
 require('./spec/lib/fxa-client');

--- a/packages/fxa-content-server/tests/functional.js
+++ b/packages/fxa-content-server/tests/functional.js
@@ -50,6 +50,7 @@ module.exports = testsSettings.concat([
   'tests/functional/post_verify/account_recovery.js',
   'tests/functional/post_verify/secondary_email.js',
   'tests/functional/post_verify/cad_qr.js',
+  'tests/functional/push.js',
   'tests/functional/pp.js',
   'tests/functional/refreshes_metrics.js',
   'tests/functional/robots_txt.js',

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -240,15 +240,15 @@ module.exports = {
     BUTTON_SUBSCRIBE: '.btn-subscribe',
     SUBSCRIBED: '.pro-status',
   },
-  '400': {
+  400: {
     ERROR: '.error',
     HEADER: '#fxa-400-header',
   },
-  '404': {
+  404: {
     HEADER: '#fxa-404-header',
     LINK_HOME: '#fxa-404-home',
   },
-  '500': {
+  500: {
     HEADER: '#fxa-500-header',
     LINK_HOME: '#fxa-500-home',
   },
@@ -542,6 +542,11 @@ module.exports = {
     SUBMIT: 'button[type="submit"]',
     USE_SMS: '#use-sms-link',
     DONE: '#done-link',
+  },
+  PUSH_VERIFY_LOGIN: {
+    HEADER: '#fxa-push-send-login-header',
+    RESEND: '#resend',
+    SEND_EMAIL: '#send-email',
   },
   RECOVERY_KEY: {
     CANCEL_BUTTON: '.cancel',

--- a/packages/fxa-content-server/tests/functional/push.js
+++ b/packages/fxa-content-server/tests/functional/push.js
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { registerSuite } = intern.getInterface('object');
+const FunctionalHelpers = require('./lib/helpers');
+const selectors = require('./lib/selectors');
+const config = intern._config;
+
+const QUERY_PARAMS = '?context=fx_desktop_v3&service=sync&action=email';
+const ENTER_EMAIL_URL = `${config.fxaContentRoot}${QUERY_PARAMS}`;
+
+const PASSWORD = 'password1234567';
+let email;
+
+const {
+  clearBrowserState,
+  click,
+  createEmail,
+  createUser,
+  fillOutEmailFirstSignIn,
+  openPage,
+  testElementExists,
+} = FunctionalHelpers;
+
+registerSuite('push_login', {
+  beforeEach: function () {
+    email = createEmail('sync{id}');
+
+    return this.remote
+      .then(clearBrowserState({ force: true }))
+      .then(createUser(email, PASSWORD, { preVerified: true }));
+  },
+
+  tests: {
+    'verify login via push - treatment': function () {
+      return this.remote
+        .then(
+          openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
+            query: {
+              forceExperiment: 'pushLogin',
+              forceExperimentGroup: 'treatment',
+            },
+          })
+        )
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+        .then(testElementExists(selectors.PUSH_VERIFY_LOGIN.HEADER))
+
+        .then(click(selectors.PUSH_VERIFY_LOGIN.RESEND))
+        .then(click(selectors.PUSH_VERIFY_LOGIN.SEND_EMAIL))
+
+        .then(testElementExists(selectors.SIGNIN_TOKEN_CODE.HEADER));
+    },
+    control: function () {
+      return this.remote
+        .then(
+          openPage(ENTER_EMAIL_URL, selectors.ENTER_EMAIL.HEADER, {
+            query: {
+              forceExperiment: 'pushLogin',
+              forceExperimentGroup: 'control',
+            },
+          })
+        )
+        .then(fillOutEmailFirstSignIn(email, PASSWORD))
+
+        .then(testElementExists(selectors.SIGNIN_TOKEN_CODE.HEADER));
+    },
+  },
+});


### PR DESCRIPTION
## Because

- We need to be able to control the rollout of this feature
- To test, log into sync with new FF profile, then in new FF profile open http://localhost:3030/?context=fx_desktop_v3&entrypoint=fxa_discoverability_native&action=email&service=sync&forceExperiment=pushLogin&forceExperimentGroup=treatment and login with same account

## This pull request

- Adds a feature flag and rollout config
- Adds supporting functional tests

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/9580

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
