### PR TITLE
fix(emails): send email for cancelation due to failed payments

### DIFF
--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 117;
+module.exports.level = 118;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-117-118.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-117-118.sql
@@ -1,0 +1,12 @@
+--
+-- This migration adds the subscriptionFailedPaymentsCancellation emailType to
+-- the emailTypes table.
+--
+
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('117');
+
+INSERT INTO emailTypes (emailType) VALUE ('subscriptionFailedPaymentsCancellation');
+
+UPDATE dbMetadata SET value = '118' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-118-117.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-118-117.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+--
+-- DELETE FROM emailTypes WHERE emailType = 'subscriptionFailedPaymentsCancellation';
+--
+-- UPDATE dbMetadata SET value = '117' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -33,6 +33,8 @@ const EMAIL_TYPES = {
   subscriptionPaymentFailed: 'subscription_payment_failed',
   subscriptionAccountDeletion: 'subscription_account_deletion',
   subscriptionCancellation: 'subscription_cancellation',
+  subscriptionFailedPaymentsCancellation:
+    'subscription_failed_payments_cancellation',
   subscriptionSubsequentInvoice: 'subscription_subsequent_invoice',
   subscriptionFirstInvoice: 'subscription_first_invoice',
   downloadSubscription: 'subscription_download',

--- a/packages/fxa-auth-server/lib/senders/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/templates/_versions.json
@@ -10,6 +10,7 @@
   "subscriptionPaymentFailed": 1,
   "subscriptionAccountDeletion": 1,
   "subscriptionCancellation": 1,
+  "subscriptionFailedPaymentsCancellation": 1,
   "subscriptionSubsequentInvoice": 1,
   "subscriptionFirstInvoice": 1,
   "downloadSubscription": 1,

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionFailedPaymentsCancellation.html
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionFailedPaymentsCancellation.html
@@ -1,0 +1,15 @@
+{{! Cancellation email has no icon }}
+{{#*inline "icon"}}
+{{/inline}}
+
+{{#*inline "title"}}
+  {{t "Your subscription has been cancelled" }}
+{{/inline}}
+
+{{#*inline "content"}}
+  {{t "We've cancelled your %(productName)s subscription because multiple payment attempts failed. To get access again, start a new subscription with an updated payment method." }}
+  <br><br>
+  {{{t "Please help us improve our services by taking this <a %(cancellationSurveyLinkAttributes)s>short survey</a>." }}}
+{{/inline}}
+
+{{> subscriptionEmail}}

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionFailedPaymentsCancellation.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionFailedPaymentsCancellation.txt
@@ -1,0 +1,9 @@
+{{{subject}}}
+
+{{{t "Your subscription has been cancelled" }}}
+
+{{{t "We've cancelled your %(productName)s subscription because multiple payment attempts failed.  To get access again, start a new subscription with an updated payment method." }}}
+
+{{{t "Please help us improve our services by taking this short survey:" }}}
+
+{{{cancellationSurveyUrl}}}

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -315,6 +315,20 @@ const TESTS = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],
+  ['subscriptionFailedPaymentsCancellationEmail', new Map([
+    ['subject', { test: 'equal', expected: `Your ${MESSAGE.productName} subscription has been cancelled` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionFailedPaymentsCancellation') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionFailedPaymentsCancellation' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionFailedPaymentsCancellation }],
+    ])],
+    ['html', [
+      { test: 'include', expected: `cancelled your ${MESSAGE.productName} subscription because multiple payment attempts failed` },
+    ]],
+    ['text', [
+      { test: 'include', expected: `cancelled your ${MESSAGE.productName} subscription because multiple payment attempts failed` },
+    ]]
+  ])],
   ['subscriptionReactivationEmail', new Map([
     ['subject', { test: 'equal', expected: `${MESSAGE.productName} subscription reactivated` }],
     ['headers', new Map([

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -116,6 +116,7 @@ const MAILER_METHOD_NAMES = [
   'sendSubscriptionPaymentExpiredEmail',
   'sendSubscriptionPaymentProviderCancelledEmail',
   'sendSubscriptionPaymentFailedEmail',
+  'sendSubscriptionFailedPaymentsCancellationEmail',
   'sendSubscriptionAccountDeletionEmail',
   'sendSubscriptionCancellationEmail',
   'sendSubscriptionReactivationEmail',


### PR DESCRIPTION
Because:
 - we should let a customer know that their subscription was canceled
   due to failed payments

This commit:
 - send an email on a subscription deleted event if the deletion is not
   from an account deletion or customer initiated cancelation

## Issue that this pull request solves

Closes: #9172 

## Screenshots (Optional)
![image](https://user-images.githubusercontent.com/198055/123006264-0436b900-d37d-11eb-8097-fa52c6313640.png)