### PR TITLE
feat(emails) - Update VPN exit survey URL

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -2160,8 +2160,14 @@ module.exports = function (log, config) {
   };
 
   Mailer.prototype.subscriptionPaymentFailedEmail = async function (message) {
-    const { email, uid, productId, planId, planEmailIconURL, productName } =
-      message;
+    const {
+      email,
+      uid,
+      productId,
+      planId,
+      planEmailIconURL,
+      productName,
+    } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
     log.trace('mailer.subscriptionPaymentFailed', {
@@ -2907,13 +2913,16 @@ module.exports = function (log, config) {
       query
     );
 
-    links['revokeAccountRecoveryLink'] =
-      this.createRevokeAccountRecoveryLink(templateName);
-    links['revokeAccountRecoveryLinkAttributes'] =
-      this._revokeAccountRecoveryLinkAttributes(templateName);
+    links['revokeAccountRecoveryLink'] = this.createRevokeAccountRecoveryLink(
+      templateName
+    );
+    links[
+      'revokeAccountRecoveryLinkAttributes'
+    ] = this._revokeAccountRecoveryLinkAttributes(templateName);
 
-    links['createAccountRecoveryLink'] =
-      this.createAccountRecoveryLink(templateName);
+    links['createAccountRecoveryLink'] = this.createAccountRecoveryLink(
+      templateName
+    );
 
     links.accountSettingsUrl = this._generateUTMLink(
       this.accountSettingsUrl,
@@ -2924,7 +2933,7 @@ module.exports = function (log, config) {
     links.accountSettingsLinkAttributes = `href="${links.accountSettingsUrl}" target="_blank" rel="noopener noreferrer" style="color:#ffffff;font-weight:500;"`;
 
     links.cancellationSurveyUrl =
-      'https://qsurvey.mozilla.com/s3/fpn-cancellation';
+      'https://qsurvey.mozilla.com/s3/VPN-Exit-Survey-2021';
 
     links.cancellationSurveyLinkAttributes = `href="${links.cancellationSurveyUrl}" style="text-decoration: none; color: #0060DF;"`;
 


### PR DESCRIPTION
## Because

- The Mozilla VPN 'Quicker to Value' team needs to better understand what contributes to subscriber turnover. They've created a new exit survey and would like subscription cancellation emails to point to this new survey.

## This pull request

- Updates the link in subscription cancellation emails (`link.cancellationSurveyUrl`) to the new exit survey.

## Issue that this pull request solves

An issue wasn't filed for this change 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

