### PR TITLE
fix(stripe): Enable CHF currency in paypal

### DIFF
--- a/packages/fxa-auth-server/lib/payments/currencies.ts
+++ b/packages/fxa-auth-server/lib/payments/currencies.ts
@@ -89,7 +89,7 @@ export class CurrencyHelper {
    * handled any restrictions.
    *
    */
-  static supportedPayPalCurrencies = ['USD', 'EUR'];
+  static supportedPayPalCurrencies = ['USD', 'EUR', 'CHF'];
 
   /*
    * List of valid country codes taken from https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2


### PR DESCRIPTION
## This pull request

- Adds CHF to hardcoded paypal currency
- Targetted as point release for 208. Needs to be merged and tag before we tag 209 train

## Issue that this pull request solves

Closes: TBD

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).