### PR TITLE
feat(auth): don't delete an unverified account with an active subscri…

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -107,6 +107,7 @@ const ERRNO = {
   BILLING_AGREEMENT_EXISTS: 192,
   MISSING_PAYPAL_PAYMENT_TOKEN: 193,
   MISSING_PAYPAL_BILLING_AGREEMENT: 194,
+  UNVERIFIED_PRIMARY_EMAIL_HAS_ACTIVE_SUBSCRIPTION: 195,
 
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
@@ -122,11 +123,11 @@ const DEFAULTS = {
   error: 'Internal Server Error',
   errno: ERRNO.UNEXPECTED_ERROR,
   message: 'Unspecified error',
-  info:
-    'https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#response-format',
+  info: 'https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#response-format',
 };
 
-const TOO_LARGE = /^Payload (?:content length|size) greater than maximum allowed/;
+const TOO_LARGE =
+  /^Payload (?:content length|size) greater than maximum allowed/;
 
 const BAD_SIGNATURE_ERRORS = [
   'Bad mac',
@@ -860,6 +861,15 @@ AppError.unverifiedPrimaryEmailNewlyCreated = () => {
     error: 'Bad Request',
     errno: ERRNO.UNVERIFIED_PRIMARY_EMAIL_NEWLY_CREATED,
     message: 'Email already exists',
+  });
+};
+
+AppError.unverifiedPrimaryEmailHasActiveSubscription = () => {
+  return new AppError({
+    code: 400,
+    error: 'Bad Request',
+    errno: ERRNO.UNVERIFIED_PRIMARY_EMAIL_HAS_ACTIVE_SUBSCRIPTION,
+    message: 'Account for this email has an active subscription',
   });
 };
 

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -816,6 +816,20 @@ export class StripeHelper {
   }
 
   /**
+   * Returns true if the FxA account with uid has an active subscription.
+   */
+  async hasActiveSubscription(uid: string): Promise<Boolean> {
+    const customer = await this.fetchCustomer(uid, ['subscriptions']);
+    if (!customer) {
+      return false;
+    }
+    const subscription = customer.subscriptions?.data.find((sub) =>
+      ACTIVE_SUBSCRIPTION_STATUSES.includes(sub.status)
+    );
+    return !!subscription;
+  }
+
+  /**
    * Returns whether or not the customer has any active subscriptions that
    * have an open invoice (payment has not been processed).
    *

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -81,10 +81,15 @@ export class AccountHandler {
   private async deleteAccountIfUnverified(request: AuthRequest, email: string) {
     try {
       const secondaryEmailRecord = await this.db.getSecondaryEmail(email);
-      // Currently, users can not create an account from a verified
+      // Currently, users cannot create an account from a verified
       // secondary email address
       if (secondaryEmailRecord.isPrimary) {
-        if (secondaryEmailRecord.isVerified) {
+        if (
+          secondaryEmailRecord.isVerified ||
+          (await this.stripeHelper.hasActiveSubscription(
+            secondaryEmailRecord.uid
+          ))
+        ) {
           throw error.accountExists(secondaryEmailRecord.email);
         }
         request.app.accountRecreated = true;
@@ -1771,4 +1776,7 @@ export const accountRoutes = (
   return routes;
 };
 
-module.exports = accountRoutes;
+module.exports = {
+  accountRoutes,
+  AccountHandler,
+};

--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -53,7 +53,8 @@ module.exports = function (
   const grant = require('../oauth/grant');
   const oauthRawDB = require('../oauth/db');
   grant.setStripeHelper(stripeHelper);
-  const account = require('./account')(
+  const { accountRoutes } = require('./account');
+  const account = accountRoutes(
     log,
     db,
     mailer,

--- a/packages/fxa-auth-server/test/local/ip_profiling.js
+++ b/packages/fxa-auth-server/test/local/ip_profiling.js
@@ -44,7 +44,11 @@ function makeRoutes(options = {}, requireMocks) {
     cadReminders
   );
   signinUtils.checkPassword = () => Promise.resolve(true);
-  return proxyquire('../../lib/routes/account', requireMocks || {})(
+  const { accountRoutes } = proxyquire(
+    '../../lib/routes/account',
+    requireMocks || {}
+  );
+  return accountRoutes(
     log,
     db,
     mailer,
@@ -67,8 +71,9 @@ function runTest(route, request, assertions) {
   }).then(assertions);
 }
 
-describe('IP Profiling', () => {
+describe('IP Profiling', function () {
   let route, accountRoutes, mockDB, mockMailer, mockRequest;
+  this.timeout(30000);
 
   beforeEach(() => {
     mockDB = mocks.mockDB({

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -442,6 +442,39 @@ describe('StripeHelper', () => {
     });
   });
 
+  describe('hasActiveSubscription', () => {
+    let customerExpanded, subscription;
+    beforeEach(() => {
+      customerExpanded = deepCopy(customer1);
+      subscription = deepCopy(subscription2);
+    });
+
+    it('returns true for an active subscription', async () => {
+      subscription.status = 'active';
+      customerExpanded.subscriptions.data[0] = subscription;
+      sandbox.stub(stripeHelper, 'fetchCustomer').resolves(customerExpanded);
+      assert.isTrue(
+        await stripeHelper.hasActiveSubscription(customerExpanded.uid)
+      );
+    });
+
+    it('returns false when there is no Stripe customer', async () => {
+      const uid = '123';
+      customerExpanded = undefined;
+      sandbox.stub(stripeHelper, 'fetchCustomer').resolves(customerExpanded);
+      assert.isFalse(await stripeHelper.hasActiveSubscription(uid));
+    });
+
+    it('returns false when there is no active subscription', async () => {
+      subscription.status = 'canceled';
+      customerExpanded.subscriptions.data[0] = subscription;
+      sandbox.stub(stripeHelper, 'fetchCustomer').resolves(customerExpanded);
+      assert.isFalse(
+        await stripeHelper.hasActiveSubscription(customerExpanded.uid)
+      );
+    });
+  });
+
   describe('hasOpenInvoice', () => {
     let customerExpanded;
     let invoice;


### PR DESCRIPTION
…ption

Because:

* We currently delete unverified accounts in a number of places, but with [FXA-3486](https://mozilla-hub.atlassian.net/browse/FXA-3486), it will be possible for an unverified account to have an active subscription.

This commit:

* Ensures we don't delete unverified accounts that have active subscriptions.

Closes #8745

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
