### PR TITLE
feat(subscriptions): add query param to force sign in on checkout link

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/subscriptions_product_redirect.js
+++ b/packages/fxa-content-server/app/scripts/views/subscriptions_product_redirect.js
@@ -15,6 +15,7 @@ class SubscriptionsProductRedirectView extends FormView {
   initialize(options) {
     this._currentPage = options.currentPage;
     this._productId = this._currentPage.split('/').pop();
+    this._queryParams = Url.searchParams(this.window.location.search);
     this.relier.set('subscriptionProductId', this._productId);
 
     this._subscriptionsConfig = {};
@@ -22,7 +23,9 @@ class SubscriptionsProductRedirectView extends FormView {
       this._subscriptionsConfig = options.config.subscriptions;
     }
 
-    this.mustAuth = !this._subscriptionsConfig.allowUnauthenticatedRedirects;
+    this.mustAuth =
+      !!this._queryParams.signin ||
+      !this._subscriptionsConfig.allowUnauthenticatedRedirects;
 
     // Flow events need to be initialized before the navigation
     // so the flow_id and flow_begin_time are propagated
@@ -30,13 +33,13 @@ class SubscriptionsProductRedirectView extends FormView {
   }
 
   afterRender() {
-    const queryParams = Url.searchParams(this.window.location.search);
+    delete this._queryParams.signin;
     const redirectPath = `products/${this._productId}`;
     return PaymentServer.navigateToPaymentServer(
       this,
       this._subscriptionsConfig,
       redirectPath,
-      queryParams
+      this._queryParams
     );
   }
 }

--- a/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
+++ b/packages/fxa-content-server/app/tests/spec/views/subscriptions_product_redirect.js
@@ -104,6 +104,19 @@ describe('views/subscriptions_product_redirect', function () {
       });
       assert.isFalse(view.mustAuth, 'mustAuth should be false');
     });
+
+    it('sets mustAuth to true when signin query param exists', () => {
+      windowMock.location.search = 'signin=true';
+      view.initialize({
+        currentPage: `/subscriptions/products/${PRODUCT_ID}`,
+        config: {
+          subscriptions: {
+            allowUnauthenticatedRedirects: true,
+          },
+        },
+      });
+      assert.isTrue(view.mustAuth, 'mustAuth should be true');
+    });
   });
 
   describe('render', () => {
@@ -125,6 +138,10 @@ describe('views/subscriptions_product_redirect', function () {
     it('works with a local redirect with no query params', () => {
       windowMock.location.href = `http://localhost:3030/subscriptions/products/${PRODUCT_ID}`;
       windowMock.location.search = '';
+      view.initialize({
+        currentPage: `/subscriptions/products/${PRODUCT_ID}`,
+        config,
+      });
       return render().then(() => {
         assert.isTrue(
           PaymentServer.navigateToPaymentServer.calledOnceWith(


### PR DESCRIPTION
Because:
 - we allow people to check out without signing in so that they can sign
   up during checkout, but we also need to have a way for current users
   to sign in

This commit:
 - add a query param to signal to the checkout link to force sign in


## Issue that this pull request solves

Closes: #9759 