### PR TITLE
feat(emails): Add mjml feature flag

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -424,5 +424,9 @@
   "cadReminders": {
     "firstInterval": "1s",
     "secondInterval": "2s"
+  },
+  "mjml": {
+    "enabledEmailAddress": "@mozilla.com$",
+    "templates":  []
   }
 }

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1452,6 +1452,18 @@ const conf = convict({
       env: 'SIGNIN_UNBLOCK_FORCED_EMAILS',
     },
   },
+  mjml: {
+    enabledEmailAddress: {
+      doc: 'If mjml email templates are enabled for specific email regex',
+      format: RegExp,
+      default: /^$/, // default is no one
+    },
+    templates: {
+      doc: 'Templates that have mjml email support',
+      format: Array,
+      default: [],
+    },
+  },
   push: {
     allowedServerRegex: {
       doc: 'RegExp that validates the URI format of the Push Server',

--- a/packages/fxa-auth-server/lib/features.js
+++ b/packages/fxa-auth-server/lib/features.js
@@ -40,6 +40,24 @@ module.exports = (config) => {
      * @param key        String
      */
     isSampledUser: isSampledUser,
+
+    /**
+     * Feature flag for MJML email rendering.
+     *
+     * @param email current user email
+     * @param template template being sent
+     */
+    isMjmlEnabledForUser: function (email, template) {
+      if (!config.mjml.templates.includes(template)) {
+        return false;
+      }
+
+      if (!config.mjml.enabledEmailAddress.test(email)) {
+        return false;
+      }
+
+      return true;
+    },
   };
 };
 

--- a/packages/fxa-auth-server/test/local/features.js
+++ b/packages/fxa-auth-server/test/local/features.js
@@ -19,6 +19,7 @@ const crypto = {
 
 const config = {
   lastAccessTimeUpdates: {},
+  mjml: {},
   signinConfirmation: {},
   signinUnblock: {},
   securityHistory: {},
@@ -46,7 +47,7 @@ describe('features', () => {
     assert.equal(typeof features, 'object', 'object type should be exported');
     assert.equal(
       Object.keys(features).length,
-      2,
+      3,
       'object should have correct number of properties'
     );
     assert.equal(
@@ -58,6 +59,11 @@ describe('features', () => {
       typeof features.isLastAccessTimeEnabledForUser,
       'function',
       'isLastAccessTimeEnabledForUser should be function'
+    );
+    assert.equal(
+      typeof features.isMjmlEnabledForUser,
+      'function',
+      'isMjmlEnabledForUser should be function'
     );
 
     assert.equal(
@@ -358,6 +364,35 @@ describe('features', () => {
       features.isLastAccessTimeEnabledForUser(uid, email),
       false,
       'should return false when feature is disabled'
+    );
+  });
+
+  it('isMjmlEnabledForUser', () => {
+    config.mjml.enabledEmailAddress = /@mozilla.com$/;
+    config.mjml.templates = ['verify'];
+
+    assert.equal(
+      features.isMjmlEnabledForUser('bar@mozilla.com', 'verify'),
+      true,
+      'should return true when using valid email and template'
+    );
+
+    assert.equal(
+      features.isMjmlEnabledForUser('yo@dwag.com', 'verify'),
+      false,
+      'should return false when using invalid email'
+    );
+
+    assert.equal(
+      features.isMjmlEnabledForUser('bar@mozilla.com', 'noValidTemplate'),
+      false,
+      'should return false when using invalid template'
+    );
+
+    assert.equal(
+      features.isMjmlEnabledForUser('yo@dwag.com', 'noValidTemplate'),
+      false,
+      'should return false when using invalid template and email'
     );
   });
 });


### PR DESCRIPTION
## Because

- We need a feature flag to quickly and easily test the new mjml rendered email templates

## This pull request

- Allows you to specify which email template and which emails get the feature

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/9252

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
