### PR TITLE
feat(auth): include invoice link in emails

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -819,6 +819,7 @@ const conf = convict({
     format: Object,
     default: {
       USD: ['US', 'GB', 'NZ', 'MY', 'SG', 'CA', 'AS', 'GU', 'MP', 'PR', 'VI'],
+      EUR: ['FR', 'DE'],
     },
     env: 'CURRENCIES',
   },

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1606,6 +1606,7 @@ export class StripeHelper {
       created: invoiceDate,
       currency: invoiceTotalCurrency,
       total: invoiceTotalInCents,
+      hosted_invoice_url: invoiceLink,
       lines: {
         data: [
           {
@@ -1633,6 +1634,7 @@ export class StripeHelper {
       cardType,
       lastFour,
       payment_provider,
+      invoiceLink,
       invoiceNumber,
       invoiceTotalInCents,
       invoiceTotalCurrency,

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -2474,6 +2474,7 @@ module.exports = function (log, config) {
       planId,
       planEmailIconURL,
       productName,
+      invoiceLink,
       invoiceNumber,
       invoiceDate,
       invoiceTotalInCents,
@@ -2541,6 +2542,7 @@ module.exports = function (log, config) {
         icon: planEmailIconURL,
         product: productName,
         subject: translator.format(subject, translatorParams),
+        invoiceLink,
         invoiceNumber,
         invoiceDate,
         invoiceTotal: this._getLocalizedCurrencyString(
@@ -2568,6 +2570,7 @@ module.exports = function (log, config) {
       productName,
       invoiceNumber,
       invoiceDate,
+      invoiceLink,
       invoiceTotalInCents,
       invoiceTotalCurrency,
       payment_provider,
@@ -2620,6 +2623,7 @@ module.exports = function (log, config) {
         icon: planEmailIconURL,
         product: productName,
         subject: translator.format(subject, translatorParams),
+        invoiceLink,
         invoiceNumber,
         invoiceDate,
         invoiceTotal: this._getLocalizedCurrencyString(

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionFirstInvoice.html
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionFirstInvoice.html
@@ -12,6 +12,8 @@
   {{{t "Invoice Number: <b>%(invoiceNumber)s</b>" }}}
   <br>
   {{t "Charged %(invoiceTotal)s on %(invoiceDateOnly)s" }}
+  <br>
+  {{{t "<a href=\"%(invoiceLink)s\">View your invoice</a>." }}}
   {{> paymentProvider }}
   <br><br>
   {{t "Next Invoice: %(nextInvoiceDateOnly)s" }}

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionFirstInvoice.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionFirstInvoice.txt
@@ -9,6 +9,9 @@
 {{{t "Invoice Number: %(invoiceNumber)s" }}}
 
 {{{t "Charged %(invoiceTotal)s on %(invoiceDateOnly)s" }}}
+
+{{{t "View Invoice: %(invoiceLink)s" }}}
+
 {{> paymentProvider }}
 
 {{{t "Next Invoice: %(nextInvoiceDateOnly)s" }}}

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionSubsequentInvoice.html
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionSubsequentInvoice.html
@@ -12,6 +12,8 @@
     <br>
   {{/showProratedAmount}}
   {{t "Charged %(invoiceTotal)s on %(invoiceDateOnly)s" }}
+  <br>
+  {{{t "<a href=\"%(invoiceLink)s\">View your invoice</a>." }}}
   {{> paymentProvider }}
   <br><br>
   {{t "Next Invoice: %(nextInvoiceDateOnly)s" }}

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionSubsequentInvoice.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionSubsequentInvoice.txt
@@ -7,6 +7,9 @@
 {{#showProratedAmount}}{{{t "Plan change: %(paymentProrated)s" }}}{{/showProratedAmount}}
 
 {{{t "Charged %(invoiceTotal)s on %(invoiceDateOnly)s" }}}
+
+{{{t "View Invoice: %(invoiceLink)s" }}}
+
 {{> paymentProvider }}
 
 {{{t "Next Invoice: %(nextInvoiceDateOnly)s" }}}

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_invoice_paid_with_vat.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_invoice_paid_with_vat.json
@@ -1,0 +1,192 @@
+{
+  "id": "evt_1GQf15BVqmGyQTMamwMk1kdP",
+  "object": "event",
+  "api_version": "2019-12-03",
+  "created": 1585164955,
+  "data": {
+    "object": {
+      "id": "in_1JALYiBVqmGyQTMaaZor1lV1",
+      "object": "invoice",
+      "account_country": "US",
+      "account_name": "SUB_PLAT_DEV",
+      "account_tax_ids": null,
+      "amount_due": 500,
+      "amount_paid": 500,
+      "amount_remaining": 0,
+      "application_fee_amount": null,
+      "attempt_count": 1,
+      "attempted": true,
+      "auto_advance": false,
+      "automatic_tax": {
+        "enabled": false,
+        "status": null
+      },
+      "billing_reason": "subscription_create",
+      "charge": "ch_1JALYjBVqmGyQTMatF8FS2pC",
+      "collection_method": "charge_automatically",
+      "created": 1625605920,
+      "currency": "eur",
+      "custom_fields": null,
+      "customer": "cus_JnxEPZbPxkC6qx",
+      "customer_address": null,
+      "customer_email": "test+20200324@example.com",
+      "customer_name": "Fred Smith",
+      "customer_phone": null,
+      "customer_shipping": null,
+      "customer_tax_exempt": "none",
+      "customer_tax_ids": [],
+      "default_payment_method": null,
+      "default_source": null,
+      "default_tax_rates": [],
+      "description": null,
+      "discount": null,
+      "discounts": [],
+      "due_date": null,
+      "ending_balance": 0,
+      "footer": null,
+      "hosted_invoice_url": "https://invoice.stripe.com/i/acct_1GCAr3BVqmGyQTMa/invst_JnxT6ob7qmcZMNY5yOIkmJVknjxeALL",
+      "invoice_pdf": "https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_JnxT6ob7qmcZMNY5yOIkmJVknjxeALL/pdf",
+      "last_finalization_error": null,
+      "lines": {
+        "object": "list",
+        "data": [
+          {
+            "id": "il_1JALYiBVqmGyQTMaD98AKogQ",
+            "object": "line_item",
+            "amount": 500,
+            "currency": "eur",
+            "description": "1 × 123Done Pro (at €5.00 / month)",
+            "discount_amounts": [],
+            "discountable": true,
+            "discounts": [],
+            "livemode": false,
+            "metadata": {},
+            "period": {
+              "end": 1628284320,
+              "start": 1625605920
+            },
+            "plan": {
+              "id": "price_1H8NnnBVqmGyQTMaLwLRKbF3",
+              "object": "plan",
+              "active": true,
+              "aggregate_usage": null,
+              "amount": 500,
+              "amount_decimal": "500",
+              "billing_scheme": "per_unit",
+              "created": 1595585215,
+              "currency": "eur",
+              "interval": "month",
+              "interval_count": 1,
+              "livemode": false,
+              "metadata": {},
+              "nickname": null,
+              "product": "prod_GqM9ToKK62qjkK",
+              "tiers": null,
+              "tiers_mode": null,
+              "transform_usage": null,
+              "trial_period_days": null,
+              "usage_type": "licensed"
+            },
+            "price": {
+              "id": "price_1H8NnnBVqmGyQTMaLwLRKbF3",
+              "object": "price",
+              "active": true,
+              "billing_scheme": "per_unit",
+              "created": 1595585215,
+              "currency": "eur",
+              "livemode": false,
+              "lookup_key": null,
+              "metadata": {},
+              "nickname": null,
+              "product": "prod_GqM9ToKK62qjkK",
+              "recurring": {
+                "aggregate_usage": null,
+                "interval": "month",
+                "interval_count": 1,
+                "trial_period_days": null,
+                "usage_type": "licensed"
+              },
+              "tiers_mode": null,
+              "transform_quantity": null,
+              "type": "recurring",
+              "unit_amount": 500,
+              "unit_amount_decimal": "500"
+            },
+            "proration": false,
+            "quantity": 1,
+            "subscription": "sub_JnxTobz69QOK1S",
+            "subscription_item": "si_JnxTjaEAfziBCs",
+            "tax_amounts": [
+              {
+                "amount": 83,
+                "inclusive": true,
+                "tax_rate": "txr_1JAL9yBVqmGyQTMaW1h4IkCp"
+              }
+            ],
+            "tax_rates": [
+              {
+                "id": "txr_1JAL9yBVqmGyQTMaW1h4IkCp",
+                "object": "tax_rate",
+                "active": true,
+                "country": "FR",
+                "created": 1625604386,
+                "description": "FR VAT",
+                "display_name": "VAT",
+                "inclusive": true,
+                "jurisdiction": null,
+                "livemode": false,
+                "metadata": {},
+                "percentage": 20,
+                "state": null
+              }
+            ],
+            "type": "subscription"
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/invoices/in_1JALYiBVqmGyQTMaaZor1lV1/lines"
+      },
+      "livemode": false,
+      "metadata": {},
+      "next_payment_attempt": null,
+      "number": "F760A6C6-0002",
+      "on_behalf_of": null,
+      "paid": true,
+      "payment_intent": "pi_1JALYiBVqmGyQTMaP70YgS1c",
+      "payment_settings": {
+        "payment_method_options": null,
+        "payment_method_types": null
+      },
+      "period_end": 1625605920,
+      "period_start": 1625605920,
+      "post_payment_credit_notes_amount": 0,
+      "pre_payment_credit_notes_amount": 0,
+      "receipt_number": null,
+      "starting_balance": 0,
+      "statement_descriptor": null,
+      "status": "paid",
+      "status_transitions": {
+        "finalized_at": 1625605920,
+        "marked_uncollectible_at": null,
+        "paid_at": 1625605920,
+        "voided_at": null
+      },
+      "subscription": "sub_JnxTobz69QOK1S",
+      "subtotal": 500,
+      "tax": 83,
+      "tax_percent": null,
+      "total": 500,
+      "total_discount_amounts": [],
+      "total_tax_amounts": [
+        {
+          "amount": 83,
+          "inclusive": true,
+          "tax_rate": "txr_1JAL9yBVqmGyQTMaW1h4IkCp"
+        }
+      ],
+      "transfer_data": null,
+      "webhooks_delivered_at": null
+    }
+  }
+}

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -2975,6 +2975,8 @@ describe('StripeHelper', () => {
         email,
         cardType: 'visa',
         lastFour: '5309',
+        invoiceLink:
+          'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
         invoiceNumber: 'AAF2CECC-0001',
         invoiceTotalCurrency: 'usd',
         invoiceTotalInCents: 500,

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -65,6 +65,8 @@ const MESSAGE = {
   cardType: 'mastercard',
   lastFour: '5309',
   payment_provider: 'stripe',
+  invoiceLink:
+    'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
   invoiceDate: new Date(1584747098816),
   nextInvoiceDate: new Date(1587339098816),
   serviceLastActiveDate: new Date(1587339098816),
@@ -240,6 +242,7 @@ const TESTS = [
       { test: 'include', expected: `MasterCard card ending in 5309` },
       { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
       { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View your invoice` },
       { test: 'notInclude', expected: 'utm_source=email' },
       { test: 'notInclude', expected: 'PayPal' },
     ]],
@@ -250,6 +253,7 @@ const TESTS = [
       { test: 'include', expected: `MasterCard card ending in 5309` },
       { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
       { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View Invoice: ${MESSAGE.invoiceLink}` },
       { test: 'notInclude', expected: 'utm_source=email' },
       { test: 'notInclude', expected: 'PayPal' },
     ]]
@@ -271,6 +275,7 @@ const TESTS = [
       { test: 'include', expected: `MasterCard card ending in 5309` },
       { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
       { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View your invoice` },
       { test: 'notInclude', expected: 'utm_source=email' },
       { test: 'notInclude', expected: 'PayPal' },
     ]],
@@ -282,6 +287,7 @@ const TESTS = [
       { test: 'include', expected: `MasterCard card ending in 5309` },
       { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
       { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View Invoice: ${MESSAGE.invoiceLink}` },
       { test: 'notInclude', expected: 'utm_source=email' },
       { test: 'notInclude', expected: 'PayPal' },
     ]]


### PR DESCRIPTION
Because:

* VAT customers need a receipt that includes a VAT breakdown.

This commit:

* Adds a link to the invoice emails to view the Stripe hosted invoice
  that includes VAT information.

Closes #9329

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
