### PR TITLE
fix(subscriptions): update idempotency key on PayPal btn callback

### DIFF
--- a/packages/fxa-payments-server/src/components/PayPalButton/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.stories.tsx
@@ -15,6 +15,7 @@ const Subject = ({
   currencyCode = 'USD',
   customer = CUSTOMER,
   idempotencyKey = '',
+  refreshSubmitNonce = () => {},
   priceId = PLAN.plan_id,
   newPaypalAgreement = false,
   refreshSubscriptions = linkTo('routes/Product', 'success'),
@@ -26,6 +27,7 @@ const Subject = ({
   | 'currencyCode'
   | 'customer'
   | 'idempotencyKey'
+  | 'refreshSubmitNonce'
   | 'priceId'
   | 'newPaypalAgreement'
   | 'refreshSubscriptions'
@@ -39,6 +41,7 @@ const Subject = ({
         currencyCode,
         customer,
         idempotencyKey,
+        refreshSubmitNonce,
         priceId,
         newPaypalAgreement,
         refreshSubscriptions,

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.test.tsx
@@ -10,6 +10,7 @@ const Subject = ({
   currencyCode = 'USD',
   customer = CUSTOMER,
   idempotencyKey = '',
+  refreshSubmitNonce = () => {},
   priceId = PLAN.plan_id,
   newPaypalAgreement = false,
   refreshSubscriptions = () => {},
@@ -21,6 +22,7 @@ const Subject = ({
   | 'currencyCode'
   | 'customer'
   | 'idempotencyKey'
+  | 'refreshSubmitNonce'
   | 'priceId'
   | 'newPaypalAgreement'
   | 'refreshSubscriptions'
@@ -33,6 +35,7 @@ const Subject = ({
         currencyCode,
         customer,
         idempotencyKey,
+        refreshSubmitNonce,
         priceId,
         newPaypalAgreement,
         refreshSubscriptions,

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
@@ -16,6 +16,7 @@ export type PaypalButtonProps = {
   currencyCode: string;
   customer: Customer | null;
   idempotencyKey: string;
+  refreshSubmitNonce: () => void;
   refreshSubscriptions: () => void;
   setPaymentError: Function;
   priceId?: string;
@@ -47,6 +48,7 @@ export const PaypalButton = ({
   currencyCode,
   customer,
   idempotencyKey,
+  refreshSubmitNonce,
   refreshSubscriptions,
   setPaymentError,
   priceId,
@@ -119,6 +121,7 @@ export const PaypalButton = ({
           refreshSubscriptions();
         }
       }
+      refreshSubmitNonce();
       return null;
     },
     [

--- a/packages/fxa-payments-server/src/lib/AppContext.tsx
+++ b/packages/fxa-payments-server/src/lib/AppContext.tsx
@@ -31,8 +31,7 @@ export const defaultAppContext = {
   stripePromise: Promise.resolve(null),
 };
 
-export const AppContext = React.createContext<AppContextType>(
-  defaultAppContext
-);
+export const AppContext =
+  React.createContext<AppContextType>(defaultAppContext);
 
 export default AppContext;

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -43,8 +43,8 @@ import '../../Product/SubscriptionCreate/index.scss';
 import AppContext from '../../../lib/AppContext';
 import { ButtonBaseProps } from '../../../components/PayPalButton';
 import { apiCapturePaypalPayment } from '../../../lib/apiClient';
-const PaypalButton = React.lazy(() =>
-  import('../../../components/PayPalButton')
+const PaypalButton = React.lazy(
+  () => import('../../../components/PayPalButton')
 );
 
 export type SubscriptionCreateStripeAPIs = Pick<
@@ -123,72 +123,70 @@ export const SubscriptionCreate = ({
     }
   }, [paymentError, setPaymentError]);
 
-  const onStripeFormSubmit:
-    | StripeSubmitHandler
-    | StripeUpdateHandler = useCallback(
-    async ({
-      stripe: stripeFromParams,
-      ...params
-    }: StripePaymentSubmitResult | StripePaymentUpdateResult) => {
-      setInProgress(true);
-      try {
-        await handleSubscriptionPayment({
-          ...params,
-          ...apiClient,
-          ...apiClientOverrides,
-          stripe:
-            stripeOverride /* istanbul ignore next - used for testing */ ||
-            stripeFromParams,
-          selectedPlan,
-          customer,
-          retryStatus,
-          onSuccess: refreshSubscriptions,
-          onFailure: setPaymentError,
-          onRetry: (status: RetryStatus) => {
-            setRetryStatus(status);
-            setPaymentError({ type: 'card_error', code: 'card_declined' });
-          },
-        });
-      } catch (error) {
-        console.error('handleSubscriptionPayment failed', error);
-        setPaymentError(error);
-      }
-      setInProgress(false);
-      refreshSubmitNonce();
-    },
-    [
-      selectedPlan,
-      customer,
-      retryStatus,
-      apiClientOverrides,
-      stripeOverride,
-      setInProgress,
-      refreshSubscriptions,
-      refreshSubmitNonce,
-      setPaymentError,
-      setRetryStatus,
-    ]
-  );
+  const onStripeFormSubmit: StripeSubmitHandler | StripeUpdateHandler =
+    useCallback(
+      async ({
+        stripe: stripeFromParams,
+        ...params
+      }: StripePaymentSubmitResult | StripePaymentUpdateResult) => {
+        setInProgress(true);
+        try {
+          await handleSubscriptionPayment({
+            ...params,
+            ...apiClient,
+            ...apiClientOverrides,
+            stripe:
+              stripeOverride /* istanbul ignore next - used for testing */ ||
+              stripeFromParams,
+            selectedPlan,
+            customer,
+            retryStatus,
+            onSuccess: refreshSubscriptions,
+            onFailure: setPaymentError,
+            onRetry: (status: RetryStatus) => {
+              setRetryStatus(status);
+              setPaymentError({ type: 'card_error', code: 'card_declined' });
+            },
+          });
+        } catch (error) {
+          console.error('handleSubscriptionPayment failed', error);
+          setPaymentError(error);
+        }
+        setInProgress(false);
+        refreshSubmitNonce();
+      },
+      [
+        selectedPlan,
+        customer,
+        retryStatus,
+        apiClientOverrides,
+        stripeOverride,
+        setInProgress,
+        refreshSubscriptions,
+        refreshSubmitNonce,
+        setPaymentError,
+        setRetryStatus,
+      ]
+    );
 
-  const onPaypalFormSubmit: (
-    x: PaypalPaymentSubmitResult
-  ) => void = useCallback(
-    async ({ priceId, idempotencyKey }: PaypalPaymentSubmitResult) => {
-      setInProgress(true);
-      try {
-        await apiCapturePaypalPayment({
-          idempotencyKey,
-          priceId,
-        });
-        refreshSubscriptions();
-      } catch (error) {
-        setPaymentError(error);
-      }
-      setInProgress(false);
-      refreshSubmitNonce();
-    },
-    [setInProgress, refreshSubmitNonce, refreshSubscriptions]
-  );
+  const onPaypalFormSubmit: (x: PaypalPaymentSubmitResult) => void =
+    useCallback(
+      async ({ priceId, idempotencyKey }: PaypalPaymentSubmitResult) => {
+        setInProgress(true);
+        try {
+          await apiCapturePaypalPayment({
+            idempotencyKey,
+            priceId,
+          });
+          refreshSubscriptions();
+        } catch (error) {
+          setPaymentError(error);
+        }
+        setInProgress(false);
+        refreshSubmitNonce();
+      },
+      [setInProgress, refreshSubmitNonce, refreshSubscriptions]
+    );
 
   const onSubmit = getPaymentProviderMappedVal<
     BasePaymentFormProps['onSubmit']
@@ -250,6 +248,7 @@ export const SubscriptionCreate = ({
                           currencyCode={selectedPlan.currency}
                           customer={customer}
                           idempotencyKey={submitNonce}
+                          refreshSubmitNonce={refreshSubmitNonce}
                           priceId={selectedPlan.plan_id}
                           newPaypalAgreement={true}
                           refreshSubscriptions={refreshSubscriptions}

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -77,11 +77,8 @@ export const PaymentUpdateForm = ({
   ] = useBooleanState(false);
   const [transactionInProgress, setTransactionInProgress] = useState(false);
 
-  const [
-    fixPaymentModalRevealed,
-    revealFixPaymentModal,
-    hideFixPaymentModal,
-  ] = useBooleanState(false);
+  const [fixPaymentModalRevealed, revealFixPaymentModal, hideFixPaymentModal] =
+    useBooleanState(false);
 
   const [paymentError, setPaymentError] = useState<PaymentUpdateError>(
     paymentErrorInitialState
@@ -99,12 +96,8 @@ export const PaymentUpdateForm = ({
     resetUpdatePaymentIsSuccess,
   ]);
 
-  const {
-    exp_month,
-    exp_year,
-    payment_provider,
-    paypal_payment_error,
-  } = customer;
+  const { exp_month, exp_year, payment_provider, paypal_payment_error } =
+    customer;
 
   const actionButton = (
     <ActionButton
@@ -248,6 +241,7 @@ export const PaymentUpdateForm = ({
                     currencyCode={currencyCode}
                     customer={customer}
                     idempotencyKey={submitNonce}
+                    refreshSubmitNonce={refreshSubmitNonce}
                     priceId={planId}
                     newPaypalAgreement={false}
                     refreshSubscriptions={refreshSubscriptions}


### PR DESCRIPTION
Because:
 - the idempotency key used for Stripe requests was not updated
   between PayPal subscription attempts

This commit:
 - refresh the idempotency key in the PayPal button callback

## Issue that this pull request solves

Closes: #9345 
