### PR TITLE
feat(payments): create new Checkout route for unauthenticated users

### DIFF
--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -21,6 +21,7 @@ import { LoadingOverlay } from './components/LoadingOverlay';
 import * as FlowEvents from './lib/flow-event';
 import { observeNavigationTiming } from 'fxa-shared/metrics/navigation-timing';
 
+const Checkout = React.lazy(() => import('./routes/Checkout'));
 const Product = React.lazy(() => import('./routes/Product'));
 const Subscriptions = React.lazy(() => import('./routes/Subscriptions'));
 
@@ -106,6 +107,14 @@ export const App = ({
                           render={(props) => (
                             <SignInLayout>
                               <Product {...props} />
+                            </SignInLayout>
+                          )}
+                        />
+                        <Route
+                          path="/checkout/:productId"
+                          render={(props) => (
+                            <SignInLayout>
+                              <Checkout {...props} />
                             </SignInLayout>
                           )}
                         />

--- a/packages/fxa-payments-server/src/components/PlanErrorDialog/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PlanErrorDialog/index.stories.tsx
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { PlanErrorDialog } from './index';
+import { PLANS } from '../../lib/mock-data';
+import { FetchState, Plan } from '../../store/types';
+
+const locationReload = () => {};
+const plans: FetchState<Plan[], any> = {
+  error: null,
+  loading: false,
+  result: PLANS,
+};
+
+storiesOf('components/PlanErrorDialog', module)
+  .add('no plan for product', () => (
+    <PlanErrorDialog locationReload={locationReload} plans={plans} />
+  ))
+  .add('problem loading plans', () => (
+    <PlanErrorDialog
+      locationReload={locationReload}
+      plans={{ ...plans, result: null }}
+    />
+  ));

--- a/packages/fxa-payments-server/src/components/PlanErrorDialog/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PlanErrorDialog/index.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import PlanErrorDialog from './index';
+import { PLANS } from '../../lib/mock-data';
+import { FetchState, Plan } from '../../store/types';
+
+const locationReload = () => {};
+const plans: FetchState<Plan[], any> = {
+  error: null,
+  loading: false,
+  result: null,
+};
+
+afterEach(cleanup);
+
+describe('PlanErrorDialog', () => {
+  it('renders as expected for no plan for product', () => {
+    const subject = () => {
+      return render(
+        <PlanErrorDialog
+          {...{
+            locationReload,
+            plans,
+          }}
+        />
+      );
+    };
+    const { queryByTestId } = subject();
+    const errorMessage = queryByTestId('error-loading-plans');
+    expect(errorMessage).toBeInTheDocument();
+  });
+
+  it('renders as expected for no selectedPlan', () => {
+    const subject = () => {
+      return render(
+        <PlanErrorDialog
+          {...{
+            locationReload,
+            plans: { ...plans, result: PLANS },
+          }}
+        />
+      );
+    };
+    const { queryByTestId, queryByText } = subject();
+    const errorMessage = queryByTestId('no-such-plan-error');
+    expect(errorMessage).toBeInTheDocument();
+    expect(queryByText('Plan not found')).toBeInTheDocument();
+  });
+});

--- a/packages/fxa-payments-server/src/components/PlanErrorDialog/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanErrorDialog/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Localized } from '@fluent/react';
+
+import DialogMessage from '../../components/DialogMessage';
+import FetchErrorDialogMessage from '../../components/FetchErrorDialogMessage';
+
+import { SelectorReturns } from '../../store/selectors';
+
+type PlanErrorDialogProps = {
+  locationReload: () => void;
+  plans: SelectorReturns['plans'];
+};
+
+export const PlanErrorDialog = ({
+  locationReload,
+  plans,
+}: PlanErrorDialogProps) => {
+  if (!plans.result || plans.error !== null) {
+    return (
+      <Localized id="product-plan-error">
+        <FetchErrorDialogMessage
+          testid="error-loading-plans"
+          title="Problem loading plans"
+          fetchState={plans}
+          onDismiss={locationReload}
+        />
+      </Localized>
+    );
+  }
+
+  return (
+    <DialogMessage className="dialog-error">
+      <Localized id="product-plan-not-found">
+        <h4>Plan not found</h4>
+      </Localized>
+      <Localized id="product-no-such-plan">
+        <p data-testid="no-such-plan-error">No such plan for this product.</p>
+      </Localized>
+    </DialogMessage>
+  );
+};
+
+export default PlanErrorDialog;

--- a/packages/fxa-payments-server/src/lib/plan.ts
+++ b/packages/fxa-payments-server/src/lib/plan.ts
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Plan } from '../store/types';
+
+// Figure out a selected plan for a product, either from planId or first plan.
+export function getSelectedPlan(
+  productId: string,
+  planId: string | undefined,
+  filterFn: (_: string) => Array<Plan>
+) {
+  const productPlans = filterFn(productId);
+  let selectedPlan = productPlans.filter((plan) => plan.plan_id === planId)[0];
+  if (!selectedPlan) {
+    selectedPlan = productPlans[0];
+  }
+  return selectedPlan;
+}

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -639,7 +639,7 @@ export function getLocalizedMessage(
 ): string {
   let localizedMessage = bundle.getMessage(msgId);
   if (localizedMessage === undefined || localizedMessage.value === null) {
-    throw Error(`unable to locate fluent message with id: '${msgId}'`);
+    throw Error(`unable to locate fluent message with id: ${msgId}`);
   }
 
   return bundle.formatPattern(localizedMessage.value, { ...args });

--- a/packages/fxa-payments-server/src/lib/types.tsx
+++ b/packages/fxa-payments-server/src/lib/types.tsx
@@ -1,6 +1,5 @@
 export interface QueryParams {
   plan?: string;
-  activated?: string;
   device_id?: string;
   flow_id?: string;
   flow_begin_time?: number;

--- a/packages/fxa-payments-server/src/routes/Checkout/index.scss
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.scss
@@ -1,0 +1,3 @@
+#checkout-route-container {
+    border: 1px solid black;
+}

--- a/packages/fxa-payments-server/src/routes/Checkout/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.stories.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import MockApp, {
+  defaultAppContextValue,
+} from '../../../.storybook/components/MockApp';
+import { QueryParams } from '../../lib/types';
+import { APIError } from '../../lib/apiClient';
+import { SignInLayout } from '../../components/AppLayout';
+import { Checkout, CheckoutProps } from './index';
+import { PLANS, PRODUCT_ID } from '../../lib/mock-data';
+
+function init() {
+  storiesOf('routes/Checkout', module)
+    .add('subscribing with a new account', () => (
+      <CheckoutRoute
+        routeProps={{
+          ...MOCK_PROPS,
+        }}
+      />
+    ))
+    .add('plans loading', () => (
+      <CheckoutRoute
+        routeProps={{
+          ...MOCK_PROPS,
+          plans: { loading: true, error: null, result: null },
+        }}
+      />
+    ))
+    .add('plans error', () => (
+      <CheckoutRoute
+        routeProps={{
+          ...MOCK_PROPS,
+          plans: {
+            loading: false,
+            result: null,
+            error: new APIError({
+              statusCode: 500,
+              message: 'Internal Server Error',
+            }),
+          },
+        }}
+      />
+    ));
+}
+
+type CheckoutRouteProps = {
+  routeProps?: CheckoutProps;
+  queryParams?: QueryParams;
+  applyStubsToStripe?: (orig: stripe.Stripe) => stripe.Stripe;
+};
+const CheckoutRoute = ({
+  routeProps = MOCK_PROPS,
+  queryParams = defaultAppContextValue.queryParams,
+  applyStubsToStripe,
+}: CheckoutRouteProps) => (
+  <MockApp
+    applyStubsToStripe={applyStubsToStripe}
+    appContextValue={{
+      ...defaultAppContextValue,
+      queryParams,
+    }}
+  >
+    <SignInLayout>
+      <Checkout {...routeProps} />
+    </SignInLayout>
+  </MockApp>
+);
+
+const MOCK_PROPS: CheckoutProps = {
+  match: {
+    params: {
+      productId: PRODUCT_ID,
+    },
+  },
+  plans: {
+    error: null,
+    loading: false,
+    result: PLANS,
+  },
+  plansByProductId: (_: string) => PLANS,
+  fetchCheckoutRouteResources: action('fetchCheckoutRouteResources'),
+};
+
+init();

--- a/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import noc from 'nock';
+
+function nock(it: any) {
+  //@ts-ignore
+  return noc(...arguments).defaultReplyHeaders({
+    'Access-Control-Allow-Origin': '*',
+  });
+}
+
+import {
+  PRODUCT_ID,
+  PRODUCT_REDIRECT_URLS,
+  MOCK_PLANS,
+  expectNockScopesDone,
+  defaultAppContextValue,
+  MockApp,
+  setupMockConfig,
+  mockConfig,
+  mockServerUrl,
+  mockOptionsResponses,
+} from '../../lib/test-utils';
+
+jest.mock('../../lib/sentry');
+
+jest.mock('../../lib/flow-event');
+
+import { SignInLayout } from '../../components/AppLayout';
+import Checkout from './index';
+import { AppContextType } from '../../lib/AppContext';
+import { PLANS } from '../../lib/mock-data';
+
+describe('routes/Checkout', () => {
+  let authServer = '';
+  let profileServer = '';
+
+  beforeEach(() => {
+    setupMockConfig({
+      ...mockConfig,
+      productRedirectURLs: PRODUCT_REDIRECT_URLS,
+    });
+    authServer = mockServerUrl('auth');
+    mockOptionsResponses(authServer);
+    profileServer = mockServerUrl('profile');
+    mockOptionsResponses(profileServer);
+  });
+
+  afterEach(() => {
+    noc.cleanAll();
+    return cleanup();
+  });
+
+  const Subject = ({
+    productId = PRODUCT_ID,
+    planId,
+    matchMedia = jest.fn(() => false),
+    navigateToUrl = jest.fn(),
+    appContext = defaultAppContextValue(),
+  }: {
+    productId?: string;
+    planId?: string;
+    matchMedia?: (query: string) => boolean;
+    navigateToUrl?: (url: string) => void;
+    appContext?: Partial<AppContextType>;
+  }) => {
+    const props = {
+      match: {
+        params: {
+          productId,
+        },
+      },
+      plans: PLANS,
+      plansByProductId: () => PLANS[0],
+      fetchCheckoutRouteResources: () => PLANS,
+    };
+    const appContextValue = {
+      ...defaultAppContextValue(),
+      ...appContext,
+      matchMedia,
+      navigateToUrl: navigateToUrl || jest.fn(),
+      queryParams: {
+        plan: planId,
+      },
+    };
+    return (
+      <MockApp {...{ appContextValue }}>
+        <SignInLayout>
+          <Checkout {...props} />
+        </SignInLayout>
+      </MockApp>
+    );
+  };
+
+  const initApiMocks = () => [
+    nock(authServer)
+      .get('/v1/oauth/subscriptions/plans')
+      .reply(200, MOCK_PLANS, { 'Access-Control-Allow-Origin': '*' }),
+  ];
+
+  it('renders as expected', async () => {
+    const apiMocks = initApiMocks();
+    const { findByTestId } = render(<Subject />);
+    if (window.onload) {
+      dispatchEvent(new Event('load'));
+    }
+
+    const checkoutEle = await findByTestId('checkout-route-container');
+    expect(checkoutEle).toBeInTheDocument();
+    expectNockScopesDone(apiMocks);
+  });
+
+  it('displays an error with invalid product ID', async () => {
+    const apiMocks = initApiMocks();
+    const { findByTestId, queryByTestId } = render(
+      <Subject productId="bad_product" />
+    );
+    await findByTestId('no-such-plan-error');
+    expect(queryByTestId('dialog-dismiss')).not.toBeInTheDocument();
+    expectNockScopesDone(apiMocks);
+  });
+
+  it('displays an error on failure to load plans', async () => {
+    const apiMocks = [
+      nock(authServer)
+        .get('/v1/oauth/subscriptions/plans')
+        .reply(400, MOCK_PLANS),
+    ];
+    const { findByTestId } = render(<Subject />);
+    const errorEl = await findByTestId('error-loading-plans');
+    expect(errorEl).toBeInTheDocument();
+    expectNockScopesDone(apiMocks);
+  });
+});

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useContext, useMemo } from 'react';
+import { connect } from 'react-redux';
+import { AppContext } from '../../lib/AppContext';
+import { LoadingOverlay } from '../../components/LoadingOverlay';
+import { PlanErrorDialog } from '../../components/PlanErrorDialog';
+import { useMatchMedia } from '../../lib/hooks';
+import { getSelectedPlan } from '../../lib/plan';
+
+import { State } from '../../store/state';
+import { sequences, SequenceFunctions } from '../../store/sequences';
+import { selectors, SelectorReturns } from '../../store/selectors';
+
+import './index.scss';
+
+export type CheckoutProps = {
+  match: {
+    params: {
+      productId: string;
+    };
+  };
+  plans: SelectorReturns['plans'];
+  plansByProductId: SelectorReturns['plansByProductId'];
+  fetchCheckoutRouteResources: SequenceFunctions['fetchCheckoutRouteResources'];
+};
+
+export const Checkout = ({
+  match: {
+    params: { productId },
+  },
+  plans,
+  plansByProductId,
+  fetchCheckoutRouteResources,
+}: CheckoutProps) => {
+  const { locationReload, queryParams, matchMediaDefault } =
+    useContext(AppContext);
+
+  const isMobile = !useMatchMedia('(min-width: 768px)', matchMediaDefault);
+  const planId = queryParams.plan;
+
+  // Fetch plans on initial render or change in product ID
+  useEffect(() => {
+    fetchCheckoutRouteResources();
+  }, [fetchCheckoutRouteResources]);
+
+  const selectedPlan = useMemo(
+    () => getSelectedPlan(productId, planId, plansByProductId),
+    [plans]
+  );
+
+  if (plans.loading) {
+    return <LoadingOverlay isLoading={true} />;
+  }
+
+  if (!plans.result || plans.error !== null || !selectedPlan) {
+    return <PlanErrorDialog locationReload={locationReload} plans={plans} />;
+  }
+
+  return (
+    <div data-testid="checkout-route-container">{selectedPlan?.plan_id}</div>
+  );
+};
+
+export default connect(
+  (state: State) => ({
+    plans: selectors.plans(state),
+    plansByProductId: selectors.plansByProductId(state),
+  }),
+  {
+    fetchCheckoutRouteResources: sequences.fetchCheckoutRouteResources,
+  }
+)(Checkout);

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.stories.tsx
@@ -25,7 +25,7 @@ const wait = (delay: number) =>
   new Promise((resolve) => setTimeout(resolve, delay));
 
 function init() {
-  storiesOf('routes/ProductV2/SubscriptionCreate', module)
+  storiesOf('routes/Product/SubscriptionCreate', module)
     .add('default', () => <Subject />)
     .add('with retry', () => (
       <Subject
@@ -66,7 +66,7 @@ function init() {
       />
     ));
 
-  storiesOf('routes/ProductV2/SubscriptionCreate/failures', module)
+  storiesOf('routes/Product/SubscriptionCreate/failures', module)
     .add('createPaymentMethod', () => (
       <Subject
         stripeOverride={{
@@ -139,7 +139,7 @@ function init() {
       />
     ));
 
-  storiesOf('routes/ProductV2/SubscriptionCreate/errors', module)
+  storiesOf('routes/Product/SubscriptionCreate/errors', module)
     .add('card declined', () => (
       <Subject
         paymentErrorInitialState={{

--- a/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
@@ -15,9 +15,7 @@ import { PAYPAL_CUSTOMER } from '../../lib/mock-data';
 
 function init() {
   storiesOf('routes/Product', module)
-    .add('subscribing with new account', () => (
-      <ProductRoute queryParams={{ activated: '1' }} />
-    ))
+    .add('subscribing with new account', () => <ProductRoute />)
     .add('subscribing with existing Stripe account', () => (
       <ProductRoute
         routeProps={{

--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -63,7 +63,6 @@ describe('routes/Product', () => {
   const Subject = ({
     productId = PRODUCT_ID,
     planId,
-    accountActivated,
     matchMedia = jest.fn(() => false),
     navigateToUrl = jest.fn(),
     appContext = defaultAppContextValue(),
@@ -72,7 +71,6 @@ describe('routes/Product', () => {
     planId?: string;
     matchMedia?: (query: string) => boolean;
     navigateToUrl?: (url: string) => void;
-    accountActivated?: string;
     appContext?: Partial<AppContextType>;
   }) => {
     const props = {
@@ -91,7 +89,6 @@ describe('routes/Product', () => {
       navigateToUrl: navigateToUrl || jest.fn(),
       queryParams: {
         plan: planId,
-        activated: accountActivated,
       },
     };
     return (

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -119,10 +119,10 @@ export const Subscriptions = ({
     fetchSubscriptionsRouteResources();
   }, [fetchSubscriptionsRouteResources]);
 
-  const onSupportClick = useCallback(() => navigateToUrl(SUPPORT_FORM_URL), [
-    navigateToUrl,
-    SUPPORT_FORM_URL,
-  ]);
+  const onSupportClick = useCallback(
+    () => navigateToUrl(SUPPORT_FORM_URL),
+    [navigateToUrl, SUPPORT_FORM_URL]
+  );
 
   if (customer.loading || profile.loading || plans.loading) {
     return <LoadingOverlay isLoading={true} />;
@@ -291,7 +291,8 @@ export const Subscriptions = ({
                 customer: customer.result,
                 refreshSubscriptions: fetchSubscriptionsRouteResources,
                 setUpdatePaymentIsSuccess,
-                resetUpdatePaymentIsSuccess: resetUpdatePaymentIsSuccessAndAlert,
+                resetUpdatePaymentIsSuccess:
+                  resetUpdatePaymentIsSuccessAndAlert,
                 stripeOverride: paymentUpdateStripeOverride,
                 apiClientOverrides: paymentUpdateApiClientOverrides,
               }}
@@ -312,7 +313,8 @@ export const Subscriptions = ({
                   plan: planForId(customerSubscription.plan_id, plans.result),
                   refreshSubscriptions: fetchSubscriptionsRouteResources,
                   setUpdatePaymentIsSuccess,
-                  resetUpdatePaymentIsSuccess: resetUpdatePaymentIsSuccessAndAlert,
+                  resetUpdatePaymentIsSuccess:
+                    resetUpdatePaymentIsSuccessAndAlert,
                   paymentUpdateStripeOverride,
                   paymentUpdateApiClientOverrides,
                 }}
@@ -412,8 +414,6 @@ const ProfileBanner = ({
   </header>
 );
 
-// TODO replace this with Redux hooks in component function body
-// https://github.com/mozilla/fxa/issues/3020
 export default connect(
   (state: State) => ({
     plans: selectors.plans(state),

--- a/packages/fxa-payments-server/src/store/sequences.ts
+++ b/packages/fxa-payments-server/src/store/sequences.ts
@@ -27,6 +27,10 @@ const handleThunkError = (err: any) => {
 };
 
 // Convenience functions to produce action sequences via react-thunk functions
+export const fetchCheckoutRouteResources = () => async (dispatch: Function) => {
+  await Promise.all([dispatch(fetchPlans())]).catch(handleThunkError);
+};
+
 export const fetchProductRouteResources = () => async (dispatch: Function) => {
   await Promise.all([
     dispatch(fetchPlans()),
@@ -35,63 +39,65 @@ export const fetchProductRouteResources = () => async (dispatch: Function) => {
   ]).catch(handleThunkError);
 };
 
-export const fetchSubscriptionsRouteResources = () => async (
-  dispatch: Function
-) => {
-  await Promise.all([
-    dispatch(fetchPlans()),
-    dispatch(fetchProfile()),
-    dispatch(fetchCustomer()),
-  ]).catch(handleThunkError);
-};
+export const fetchSubscriptionsRouteResources =
+  () => async (dispatch: Function) => {
+    await Promise.all([
+      dispatch(fetchPlans()),
+      dispatch(fetchProfile()),
+      dispatch(fetchCustomer()),
+    ]).catch(handleThunkError);
+  };
 
-export const fetchCustomerAndSubscriptions = () => async (
-  dispatch: Function
-) => {
-  await Promise.all([dispatch(fetchCustomer())]).catch(handleThunkError);
-};
+export const fetchCustomerAndSubscriptions =
+  () => async (dispatch: Function) => {
+    await Promise.all([dispatch(fetchCustomer())]).catch(handleThunkError);
+  };
 
-export const updateSubscriptionPlanAndRefresh = (
-  subscriptionId: string,
-  plan: Plan,
-  paymentProvider: PaymentProvider | undefined
-) => async (dispatch: Function) => {
-  try {
-    await dispatch(
-      updateSubscriptionPlan(subscriptionId, plan, paymentProvider)
-    );
-    await dispatch(fetchCustomerAndSubscriptions());
-  } catch (err) {
-    handleThunkError(err);
-  }
-};
+export const updateSubscriptionPlanAndRefresh =
+  (
+    subscriptionId: string,
+    plan: Plan,
+    paymentProvider: PaymentProvider | undefined
+  ) =>
+  async (dispatch: Function) => {
+    try {
+      await dispatch(
+        updateSubscriptionPlan(subscriptionId, plan, paymentProvider)
+      );
+      await dispatch(fetchCustomerAndSubscriptions());
+    } catch (err) {
+      handleThunkError(err);
+    }
+  };
 
-export const cancelSubscriptionAndRefresh = (
-  subscriptionId: string,
-  plan: Plan,
-  paymentProvider: PaymentProvider | undefined
-) => async (dispatch: Function, getState: Function) => {
-  try {
-    await dispatch(cancelSubscription(subscriptionId, plan, paymentProvider));
-    await dispatch(fetchCustomerAndSubscriptions());
-  } catch (err) {
-    handleThunkError(err);
-  }
-};
+export const cancelSubscriptionAndRefresh =
+  (
+    subscriptionId: string,
+    plan: Plan,
+    paymentProvider: PaymentProvider | undefined
+  ) =>
+  async (dispatch: Function, getState: Function) => {
+    try {
+      await dispatch(cancelSubscription(subscriptionId, plan, paymentProvider));
+      await dispatch(fetchCustomerAndSubscriptions());
+    } catch (err) {
+      handleThunkError(err);
+    }
+  };
 
-export const reactivateSubscriptionAndRefresh = (
-  subscriptionId: string,
-  plan: Plan
-) => async (dispatch: Function, getState: Function) => {
-  try {
-    await dispatch(reactivateSubscription(subscriptionId, plan));
-    await dispatch(fetchCustomerAndSubscriptions());
-  } catch (err) {
-    handleThunkError(err);
-  }
-};
+export const reactivateSubscriptionAndRefresh =
+  (subscriptionId: string, plan: Plan) =>
+  async (dispatch: Function, getState: Function) => {
+    try {
+      await dispatch(reactivateSubscription(subscriptionId, plan));
+      await dispatch(fetchCustomerAndSubscriptions());
+    } catch (err) {
+      handleThunkError(err);
+    }
+  };
 
 export const sequences = {
+  fetchCheckoutRouteResources,
   fetchProductRouteResources,
   fetchSubscriptionsRouteResources,
   fetchCustomerAndSubscriptions,


### PR DESCRIPTION
Because:

* We are creating a [passwordless flow](https://mozilla-hub.atlassian.net/browse/FXA-3486) for new users to sign up for a subscription.

This commit:

* Creates a new {payments-server}/checkout/:productid route; this is where the new flow ([designs](https://www.figma.com/file/cOIAuHIIbrPbAlAIcpejNM/%F0%9F%8E%A1MVP-Subscription-Optimization-Flow?node-id=400%3A2098)) will live.

Closes #9701

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

To try this out, you can go to http://localhost:3031/checkout/{productId}. It's just an empty page right now that will display the `selectedPlan` if available, else a plan error.
