### PR TITLE
feat(auth): add tax ID to customer invoices

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -804,6 +804,15 @@ const conf = convict({
       format: String,
       doc: 'A shared secret to authenticate Stripe webhook requests',
     },
+    taxIds: {
+      doc: 'Mapping of currency to tax ID to show on invoices.',
+      format: Object,
+      default: {
+        EUR: 'EU1234',
+        CHF: 'CH1234',
+      },
+      env: 'TAXIDS',
+    },
     transactionalEmails: {
       // See also: https://jira.mozilla.com/browse/FXA-1148
       enabled: {

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -143,6 +143,11 @@ export class PayPalHandler extends StripeWebhookHandler {
     const taxRate = await this.stripeHelper.taxRateByCountryCode(
       agreementDetails.countryCode
     );
+
+    if (!this.stripeHelper.customerTaxId(customer)) {
+      await this.stripeHelper.addTaxIdToCustomer(customer, currency);
+    }
+
     let subscription;
     [subscription, customer] = await Promise.all([
       this.stripeHelper.createSubscriptionWithPaypal({
@@ -196,6 +201,12 @@ export class PayPalHandler extends StripeWebhookHandler {
     const taxRate = customer.address?.country
       ? await this.stripeHelper.taxRateByCountryCode(customer.address?.country)
       : undefined;
+
+    const currency = (await this.stripeHelper.findPlanById(priceId)).currency;
+    if (!this.stripeHelper.customerTaxId(customer)) {
+      await this.stripeHelper.addTaxIdToCustomer(customer, currency);
+    }
+
     const subscription = await this.stripeHelper.createSubscriptionWithPaypal({
       customer,
       priceId,

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -512,6 +512,9 @@ export class StripeHandler {
         throw error.currencyCountryMismatch(planCurrency, paymentMethodCountry);
       }
       if (paymentMethodCountry) {
+        if (!this.stripeHelper.customerTaxId(customer)) {
+          await this.stripeHelper.addTaxIdToCustomer(customer, planCurrency);
+        }
         taxRateId = (
           await this.stripeHelper.taxRateByCountryCode(paymentMethodCountry)
         )?.id;

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -181,6 +181,8 @@ describe('subscriptions payPalRoutes', () => {
       payPalHelper.agreementDetails = sinon.fake.resolves({
         countryCode: 'CA',
       });
+      stripeHelper.customerTaxId = sinon.fake.returns(undefined);
+      stripeHelper.addTaxIdToCustomer = sinon.fake.resolves({});
       stripeHelper.createSubscriptionWithPaypal =
         sinon.fake.resolves(subscription);
       stripeHelper.updateCustomerPaypalAgreement =
@@ -271,6 +273,8 @@ describe('subscriptions payPalRoutes', () => {
         sinon.assert.calledOnce(stripeHelper.updateCustomerPaypalAgreement);
         sinon.assert.calledOnce(payPalHelper.processInvoice);
         sinon.assert.calledOnce(stripeHelper.taxRateByCountryCode);
+        sinon.assert.calledOnce(stripeHelper.customerTaxId);
+        sinon.assert.calledOnce(stripeHelper.addTaxIdToCustomer);
         sinon.assert.calledWithExactly(
           stripeHelper.createSubscriptionWithPaypal,
           {
@@ -446,6 +450,8 @@ describe('subscriptions payPalRoutes', () => {
         sinon.assert.notCalled(stripeHelper.updateCustomerPaypalAgreement);
         sinon.assert.notCalled(stripeHelper.updateCustomerBillingAddress);
         sinon.assert.calledOnce(stripeHelper.taxRateByCountryCode);
+        sinon.assert.calledOnce(stripeHelper.customerTaxId);
+        sinon.assert.calledOnce(stripeHelper.addTaxIdToCustomer);
         sinon.assert.calledWithExactly(
           stripeHelper.createSubscriptionWithPaypal,
           {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -619,6 +619,8 @@ describe('DirectStripeRoutes', () => {
       directStripeRoutesInstance.stripeHelper.createSubscriptionWithPMI.resolves(
         expected
       );
+      directStripeRoutesInstance.stripeHelper.customerTaxId.returns(false);
+      directStripeRoutesInstance.stripeHelper.addTaxIdToCustomer.resolves({});
       VALID_REQUEST.payload = {
         priceId: 'Jane Doe',
         paymentMethodId: 'pm_asdf',
@@ -638,6 +640,12 @@ describe('DirectStripeRoutes', () => {
       sinon.assert.calledOnceWithExactly(
         directStripeRoutesInstance.stripeHelper.taxRateByCountryCode,
         'US'
+      );
+      sinon.assert.calledOnce(
+        directStripeRoutesInstance.stripeHelper.customerTaxId
+      );
+      sinon.assert.calledOnce(
+        directStripeRoutesInstance.stripeHelper.addTaxIdToCustomer
       );
 
       assert.deepEqual(


### PR DESCRIPTION
Because:

* We want to add a tax ID to customer invoices.

This commit:

* Adds the tax id as a custom field so it will show up on customers
  in VAT countries such using currency such as EUR and CHF.

Closes #9825

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
