### PR TITLE
feat(passwords): Add initial view for finishing setup of passwordless accounts

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/router.js
+++ b/packages/fxa-content-server/app/scripts/lib/router.js
@@ -154,6 +154,9 @@ const Router = Backbone.Router.extend({
         type: VerificationReasons.RECOVERY_KEY,
       }
     ),
+    'post_verify/finish_account_setup/set_password': createViewHandler(
+      'post_verify/finish_account_setup/set_password'
+    ),
     'post_verify/cad_qr/get_started': createViewHandler(
       'post_verify/cad_qr/get_started'
     ),

--- a/packages/fxa-content-server/app/scripts/lib/validate.js
+++ b/packages/fxa-content-server/app/scripts/lib/validate.js
@@ -21,10 +21,12 @@ const B64URL_STRING = /^[A-Za-z0-9-_]+$/;
 const B32_STRING = /^[0-9A-HJ-NP-TV-Z]+$/;
 
 // URL RegEx taken from http://blog.mattheworiordan.com/post/13174566389/url-regular-expression-for-links-with-or-without
-const urlRegEx = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/; //eslint-disable-line max-len
+const urlRegEx =
+  /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/; //eslint-disable-line max-len
 
 // Matches a UUID, e.g.: 12345678-1234-1234-1234-1234567890ab
-const uuidRegEx = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const uuidRegEx =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // case insensitive match of an unblock code, e.g.: AB12YU7Z
 const unblockCodeRegExpStr = `^[a-z0-9]{${UNBLOCK_CODE_LENGTH}}$`;
@@ -36,6 +38,9 @@ const TOTP_CODE = /^[0-9]{6}$/;
 const RECOVERY_CODE = /^([a-zA-Z0-9]{8,10})$/;
 
 const utmRegex = /^[\w\/.%-]{1,128}$/;
+
+const verificationRedirectUrlRegex =
+  /^(https:\/\/)(www\.mozilla\.org|accounts\.firefox\.com)/;
 
 var Validate = {
   /**
@@ -255,6 +260,16 @@ var Validate = {
    */
   isUtmValid(value) {
     return utmRegex.test(value);
+  },
+
+  /**
+   * Check if verification redirect is valid
+   *
+   * @param {String} value
+   * @returns {Boolean}
+   */
+  isVerificationRedirectValid(value) {
+    return verificationRedirectUrlRegex.test(value);
   },
 };
 

--- a/packages/fxa-content-server/app/scripts/models/verification/set-password.js
+++ b/packages/fxa-content-server/app/scripts/models/verification/set-password.js
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * A model to hold account verification data for accounts created
+ * without a password.
+ */
+
+import Vat from '../../lib/vat';
+import VerificationInfo from './base';
+
+export default VerificationInfo.extend({
+  defaults: {
+    code: null,
+    token: null,
+    email: null,
+    productName: null,
+    redirectUrl: null,
+    service: null,
+  },
+
+  validation: {
+    code: Vat.verificationCode(),
+    token: Vat.token(),
+    email: Vat.email(),
+    redirectUrl: Vat.verificationRedirect(),
+  },
+});

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/finish_account_setup/set_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/finish_account_setup/set_password.mustache
@@ -1,0 +1,62 @@
+<div id="main-content" class="card account-setup-set-password">
+    {{#isLinkValid}}
+        <header>
+            <h1 id="fxa-account-setup-set-damaged-header">{{#t}}Link damaged{{/t}}</h1>
+        </header>
+
+        <section>
+            <p>
+                {{#t}}The link you clicked was missing characters, and may have been broken by your email client.{{/t}}
+            </p>
+        </section>
+    {{/isLinkValid}}
+
+    {{^isLinkValid}}
+    <header>
+        <h1 id="fxa-account-setup-set-password-header">
+        {{#productName}}
+            <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(productName)s" -->
+            {{#t}}Create a Firefox Account{{/t}} <span class="service">{{#t}}to continue to %(productName)s{{/t}}</span>
+        {{/productName}}
+        {{^productName}}
+            {{#t}}Create a Firefox Account{{/t}}
+        {{/productName}}
+        </h1>
+    </header>
+
+    <section>
+        <div class="error"></div>
+
+        <form novalidate>
+            <p id="email">{{ email }}</p>
+
+            <!-- hidden email field is to allow Fx password manager
+                 to correctly save the updated password. Without it,
+                 the password manager tries to save the old password
+                 as the username. -->
+            <input type="email" value="{{email}}" class="hidden"/>
+
+            <div class="input-row password-row">
+                <input type="password" class="password check-password tooltip-below" id="password"
+                       placeholder="{{#t}}Enter a password{{/t}}" pattern=".{8,}" required autofocus
+                       data-synchronize-show="true"/>
+                <div class="helper-balloon" tabindex="-1"></div>
+            </div>
+
+
+            <div class="input-row password-row">
+                <input type="password" class="password tooltip-below" id="vpassword"
+                       placeholder="{{#t}}Confirm password{{/t}}" required pattern=".{8,}" data-synchronize-show="true"/>
+            </div>
+
+            <div class="button-row ">
+                <button type="submit">{{#t}}Create Password{{/t}}</button>
+            </div>
+
+            <div class="tos-pp faint">
+                {{#unsafeTranslate}}By proceeding, you agree to the <a id="fxa-tos" href="/legal/terms">Terms of Service</a> and <a id="fxa-pp" href="/legal/privacy">Privacy Notice</a>.{{/unsafeTranslate}}
+            </div>
+        </form>
+    </section>
+    {{/isLinkValid}}
+</div>

--- a/packages/fxa-content-server/app/scripts/views/post_verify/finish_account_setup/set_password.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/finish_account_setup/set_password.js
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import _ from 'underscore';
+import FormView from '../../form';
+import Template from '../../../templates/post_verify/finish_account_setup/set_password.mustache';
+import Cocktail from '../../../lib/cocktail';
+import FlowEventsMixin from '../../mixins/flow-events-mixin';
+import PasswordMixin from '../../mixins/password-mixin';
+import PasswordStrengthMixin from '../../mixins/password-strength-mixin';
+import AuthErrors from '../../../lib/auth-errors';
+import Url from '../../../lib/url';
+import VerificationInfo from '../../../models/verification/set-password';
+
+const PASSWORD_INPUT_SELECTOR = '#password';
+const VPASSWORD_INPUT_SELECTOR = '#vpassword';
+
+class SetPassword extends FormView {
+  template = Template;
+
+  initialize(options) {
+    const searchParams = Url.searchParams(this.window.location.search);
+    this._verificationInfo = new VerificationInfo(searchParams);
+  }
+
+  _getPassword() {
+    return this.$(PASSWORD_INPUT_SELECTOR).val();
+  }
+
+  _getVPassword() {
+    return this.$(VPASSWORD_INPUT_SELECTOR).val();
+  }
+
+  getAccount() {
+    return this.user.initAccount({
+      email: this._verificationInfo.get('email'),
+    });
+  }
+
+  isValidEnd() {
+    return this._getPassword() === this._getVPassword();
+  }
+
+  showValidationErrorsEnd() {
+    if (this._getPassword() !== this._getVPassword()) {
+      const err = AuthErrors.toError('PASSWORDS_DO_NOT_MATCH');
+      this.showValidationError(this.$(PASSWORD_INPUT_SELECTOR), err, true);
+    }
+  }
+
+  setInitialContext(context) {
+    const email = this.getAccount().get('email');
+    context.set({
+      email,
+      escapedEmail: `<span class="email">${_.escape(email)}</span>`,
+      productName: this._verificationInfo.get('productName'),
+      isLinkValid: !this._verificationInfo.isValid(),
+    });
+  }
+
+  beforeRender() {
+    const account = this.getAccount();
+    return account.checkEmailExists().then((status) => {
+      if (!status) {
+        return this.navigate('/', {}, { clearQueryParams: true });
+      }
+
+      if (!this._verificationInfo.isValid()) {
+        return;
+      }
+
+      const token = this._verificationInfo.get('token');
+      return account.isPasswordResetComplete(token).then((isComplete) => {
+        if (isComplete) {
+          return this.navigateAway(this._verificationInfo.get('redirectUrl'));
+        }
+      });
+    });
+  }
+
+  submit() {
+    const account = this.getAccount();
+    const password = this._getPassword();
+    const token = this._verificationInfo.get('token');
+    const code = this._verificationInfo.get('code');
+    return this.user
+      .completeAccountPasswordReset(account, password, token, code, this.relier)
+      .then(() => {
+        return this.navigateAway(this._verificationInfo.get('redirectUrl'));
+      })
+      .catch((err) => {
+        if (AuthErrors.is(err, 'INVALID_TOKEN')) {
+          this.logError(err);
+          // The token has expired since the first check, re-render to
+          // show a view that allows the user to receive a new link.
+          return this.render();
+        }
+
+        // all other errors are unexpected, bail.
+        throw err;
+      });
+  }
+}
+
+Cocktail.mixin(
+  SetPassword,
+  PasswordMixin,
+  PasswordStrengthMixin({
+    balloonEl: '.helper-balloon',
+    passwordEl: '#password',
+  }),
+  FlowEventsMixin
+);
+
+export default SetPassword;

--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/finish_account_setup/set_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/finish_account_setup/set_password.js
@@ -1,0 +1,189 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import _ from 'underscore';
+import { assert } from 'chai';
+import Account from 'models/account';
+import Backbone from 'backbone';
+import BaseBroker from 'models/auth_brokers/base';
+import Metrics from 'lib/metrics';
+import Relier from 'models/reliers/relier';
+import SentryMetrics from 'lib/sentry';
+import sinon from 'sinon';
+import User from 'models/user';
+import View from 'views/post_verify/finish_account_setup/set_password';
+import WindowMock from '../../../../mocks/window';
+import $ from 'jquery';
+
+describe('views/post_verify/finish_account_setup/set_password', () => {
+  let account;
+  let broker;
+  let metrics;
+  let model;
+  let notifier;
+  let relier;
+  let sentryMetrics;
+  let user;
+  let view;
+  let windowMock;
+
+  beforeEach(() => {
+    windowMock = new WindowMock();
+    windowMock.location.search =
+      '?email=a@asdf.com&productName=123&token=e39ed2d69690c9392d74fb8a98603c426002eb3f25215c71fc7085ff74c31f34&code=90cf17f3b75c1b76d79500bc1499caac&redirectUrl=https://www.mozilla.org/en-US/products/vpn/';
+
+    relier = new Relier({
+      window: windowMock,
+    });
+    broker = new BaseBroker({
+      relier,
+      window: windowMock,
+    });
+    account = new Account({
+      email: 'a@a.com',
+      uid: 'uid',
+    });
+    model = new Backbone.Model({
+      account,
+    });
+    notifier = _.extend({}, Backbone.Events);
+    sentryMetrics = new SentryMetrics();
+    metrics = new Metrics({ notifier, sentryMetrics });
+    user = new User();
+    view = new View({
+      broker,
+      metrics,
+      model,
+      notifier,
+      relier,
+      user,
+      window: windowMock,
+    });
+
+    sinon.stub(view, 'getAccount').callsFake(() => account);
+
+    sinon
+      .stub(account, 'checkEmailExists')
+      .callsFake(() => Promise.resolve(true));
+
+    sinon
+      .stub(account, 'isPasswordResetComplete')
+      .callsFake(() => Promise.resolve(false));
+
+    sinon
+      .stub(view, '_createPasswordWithStrengthBalloonView')
+      .callsFake(() => ({
+        afterRender() {},
+        on() {},
+      }));
+
+    return view.render().then(() => $('#container').html(view.$el));
+  });
+
+  afterEach(function () {
+    metrics.destroy();
+    view.remove();
+    view.destroy();
+  });
+
+  describe('render', () => {
+    it('renders the view', () => {
+      assert.lengthOf(view.$('#fxa-account-setup-set-password-header'), 1);
+      assert.equal(view.$('#email').text(), 'a@a.com');
+      assert.lengthOf(view.$('#password'), 1);
+      assert.lengthOf(view.$('#vpassword'), 1);
+      assert.lengthOf(view.$('button[type=submit]'), 1);
+    });
+  });
+
+  describe('with non-existent email', () => {
+    beforeEach(() => {
+      account.checkEmailExists.restore();
+      sinon
+        .stub(account, 'checkEmailExists')
+        .callsFake(() => Promise.resolve(false));
+      sinon.spy(view, 'navigate');
+      return view.render().then(() => $('#container').html(view.$el));
+    });
+
+    it('should redirect to `/`', () => {
+      assert.isTrue(
+        view.navigate.calledWith('/', {}, { clearQueryParams: true })
+      );
+    });
+  });
+
+  describe('with invalid params', () => {
+    it('invalid code', async () => {
+      view._verificationInfo.set('code', 'invalid');
+      await view.render();
+      assert.lengthOf(view.$('#fxa-account-setup-set-damaged-header'), 1);
+    });
+
+    it('invalid redirectUrl', async () => {
+      view._verificationInfo.set('redirectUrl', 'invalid');
+      await view.render();
+      assert.lengthOf(view.$('#fxa-account-setup-set-damaged-header'), 1);
+    });
+
+    it('invalid token', async () => {
+      view._verificationInfo.set('token', 'invalid');
+      await view.render();
+      assert.lengthOf(view.$('#fxa-account-setup-set-damaged-header'), 1);
+    });
+  });
+
+  describe('with used password reset code', () => {
+    beforeEach(() => {
+      account.isPasswordResetComplete.restore();
+      sinon
+        .stub(account, 'isPasswordResetComplete')
+        .callsFake(() => Promise.resolve(true));
+      sinon.spy(view, 'navigateAway');
+    });
+    it('should call redirectUrl', async () => {
+      await view.render();
+      assert.isTrue(
+        view.navigateAway.calledWith(
+          'https://www.mozilla.org/en-US/products/vpn/'
+        )
+      );
+    });
+  });
+
+  describe('submit', () => {
+    describe('success', () => {
+      beforeEach(() => {
+        sinon
+          .stub(user, 'completeAccountPasswordReset')
+          .callsFake(() => Promise.resolve(true));
+        sinon.spy(view, 'navigateAway');
+        view.$('#password').val('password');
+        view.$('#vpassword').val('password');
+        return view.submit();
+      });
+      it('set password and navigates to redirectUrl', () => {
+        assert.isTrue(
+          view.navigateAway.calledWith(
+            'https://www.mozilla.org/en-US/products/vpn/'
+          )
+        );
+      });
+    });
+
+    describe('errors', () => {
+      it('with error', () => {
+        sinon
+          .stub(user, 'completeAccountPasswordReset')
+          .callsFake(() => Promise.reject(new Error('failed')));
+        try {
+          view.submit();
+          assert.fail('should have failed');
+        } catch (err) {
+          assert.isTrue(true);
+        }
+      });
+    });
+  });
+});

--- a/packages/fxa-content-server/app/tests/test_start.js
+++ b/packages/fxa-content-server/app/tests/test_start.js
@@ -233,6 +233,7 @@ require('./spec/views/post_verify/cad_qr/get_started');
 require('./spec/views/post_verify/cad_qr/ready_to_scan');
 require('./spec/views/post_verify/cad_qr/scan_code');
 require('./spec/views/post_verify/cad_qr/connected');
+require('./spec/views/post_verify/finish_account_setup/set_password');
 require('./spec/views/post_verify/newsletters/add_newsletters');
 require('./spec/views/post_verify/password/force_password_change');
 require('./spec/views/post_verify/secondary_email/add_secondary_email');

--- a/packages/fxa-content-server/server/lib/routes/get-frontend.js
+++ b/packages/fxa-content-server/server/lib/routes/get-frontend.js
@@ -43,6 +43,7 @@ module.exports = function () {
     'post_verify/cad_qr/ready_to_scan',
     'post_verify/cad_qr/scan_code',
     'post_verify/cad_qr/connected',
+    'post_verify/finish_account_setup/set_password',
     'post_verify/newsletters/add_newsletters',
     'post_verify/password/force_password_change',
     'post_verify/secondary_email/add_secondary_email',


### PR DESCRIPTION
## Because

- We need need a dedicated view for users to set the password on accounts created without a password

## This pull request

- Adds new screens
- Checks for valid query params
  - token (password forgot token)
  - code (account reset code)
  - email
  - redirectUrl
- If email are not valid redirects to standard account create page

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/9301

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Based on UX at https://www.figma.com/file/cOIAuHIIbrPbAlAIcpejNM/%F0%9F%8E%A1MVP-Subscription-Optimization-Flow

<img width="830" alt="Screen Shot 2021-07-14 at 1 36 26 PM" src="https://user-images.githubusercontent.com/1295288/125667013-9661978b-cba8-4719-8220-12e4886c68b7.png">


## Testing

While all the parts to the passwordless account creation is not completed, we can still test the set password bits with these steps.

* Create an account but do not verify it
* Initiate a password reset flow and get the reset url
  * Copy the `token=sometoken&code=somecode` bits from the reset url
* Open url `http://localhost:3030/post_verify/finish_account_setup/set_password` and append params
  * email: user email
  * productName: some product name
  * token: password reset token
  * code: password reset code
  * redirectUrl: can currently only be `https://www.mozilla.org` or `https://accounts.firefox.com` domain
* Set password and get redirected to redirectUrl