### PR TITLE
fix(auth): update vat populate script to handle change

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -869,6 +869,13 @@ export class StripeHelper {
   }
 
   /**
+   * Returns the correct tax id for a customer.
+   */
+  getTaxIdForCustomer(customer: Stripe.Customer) {
+    return this.taxIds[customer.currency?.toUpperCase() ?? ''];
+  }
+
+  /**
    * Returns the customers tax id if they have one.
    **/
   customerTaxId(customer: Stripe.Customer) {


### PR DESCRIPTION
Because:

* The tax ID may change, requiring all customers to get the new default
  custom field.
* An incorrect tax rate might be deployed causing new customers to have
  the wrong tax added to their subscription.

This commit:

* Will check the prior tax id value to the current one so updates will
  be made if they don't match.
* Checks the current tax on the subscription and updates it if
  necessary.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
