### PR TITLE
fix(errors): Fix issue where rate limit was not being localized

### DIFF
--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
@@ -8,7 +8,7 @@ import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import { isEmailValid } from 'fxa-shared/email/helpers';
 import { useAccount, useAlertBar } from 'fxa-settings/src/models';
-import { AuthUiErrors } from 'fxa-settings/src/lib/auth-errors/auth-errors';
+import { AuthUiErrorNos } from 'fxa-settings/src/lib/auth-errors/auth-errors';
 
 export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   usePageViewEvent('settings.emails');
@@ -32,8 +32,8 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
         if (e.errno) {
           const errorText = l10n.getString(
             `auth-error-${e.errno}`,
-            null,
-            AuthUiErrors.EMAIL_PRIMARY_EXISTS.message
+            { retryAfter: e.retryAfterLocalized },
+            AuthUiErrorNos[e.errno].message
           );
           setErrorText(errorText);
         } else {

--- a/packages/fxa-settings/src/lib/auth-errors/en-US.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en-US.ftl
@@ -6,8 +6,10 @@ auth-error-110 = Invalid token
 # This string is the amount of time required before a user can attempt another request.
 # Variables:
 #   $retryAfter (String) - Time required before retrying a request. This text is localized
-#                          by our server based on the accept language in request.
-#                           (for example: "15 minutes")
+#                          by our server based on accept language in request. Our timestamp
+#                          formatting library (momentjs) will automatically add the word `in`
+#                          as part of the string.
+#                           (for example: "in 15 minutes")
 auth-error-114 = You've tried too many times. Please try again { $retryAfter }.
 auth-error-138 = Unverified session
 auth-error-155 = TOTP token not found


### PR DESCRIPTION
## Because

- We were not localizing text in add secondary email page

## This pull request

- Passes the `retryAfter` value to fluent
- Also updates our comment to mention the momentjs automatically adds the `in` string when a timestamp is in the future. Ref https://momentjs.com/docs/#/displaying/fromnow/

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/9874

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="554" alt="Screen Shot 2021-07-16 at 12 22 06 PM" src="https://user-images.githubusercontent.com/1295288/125981103-8c7cb4a7-e8fa-49ef-a8ef-46bd38966231.png">

