### PR TITLE
fix(tests): force signin on subscription functional tests

### DIFF
--- a/packages/fxa-content-server/tests/functional/lib/helpers.js
+++ b/packages/fxa-content-server/tests/functional/lib/helpers.js
@@ -2801,7 +2801,7 @@ const typeIntoStripeElement = thenify(function (fieldName, subFieldName, text) {
  * @param {string} currency - Currency test product is required in.
  */
 function getTestProductSubscriptionUrl(currency = 'usd') {
-  return `${config.fxaContentRoot}subscriptions/products/${config.testProductId}?plan=${config.testPlanId}`;
+  return `${config.fxaContentRoot}subscriptions/products/${config.testProductId}?plan=${config.testPlanId}&signin=true`;
 }
 
 /**


### PR DESCRIPTION
Because:
 - a functional test was expecting the user to sign in and be redirected
   to the specified product page on Payments, but in some environments
   we allow user to continue to Payments without signing in first,
   causing Payments to take the user to Settings.

This commmit:
 - fix the test by forcing the user to sign in before going to Payments
