### PR TITLE
refactor(payments): check for access token in routes

### DIFF
--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -36,6 +36,7 @@ type RouterOverride = () => (props: { children: ReactNode }) => JSX.Element;
 export type AppProps = {
   config: Config;
   store: Store;
+  accessToken: string | null;
   queryParams: QueryParams;
   matchMedia: (query: string) => boolean;
   matchMediaDefault: (query: string) => MediaQueryList;
@@ -50,6 +51,7 @@ export type AppProps = {
 export const App = ({
   config,
   store,
+  accessToken,
   queryParams,
   matchMedia,
   matchMediaDefault,
@@ -68,6 +70,7 @@ export const App = ({
   const appContextValue: AppContextType = {
     config,
     queryParams,
+    accessToken,
     matchMedia,
     matchMediaDefault,
     navigateToUrl,

--- a/packages/fxa-payments-server/src/index.tsx
+++ b/packages/fxa-payments-server/src/index.tsx
@@ -24,33 +24,32 @@ async function init() {
   const hashParams = await getHashParams();
   const accessToken = await getVerifiedAccessToken(hashParams);
   Amplitude.subscribeToReduxStore(store);
+  updateAPIClientConfig(config);
 
-  // We should have gotten an accessToken or else redirected, but guard here
-  // anyway because App component requires a token.
   if (accessToken) {
-    updateAPIClientConfig(config);
     updateAPIClientToken(accessToken);
     store.dispatch(actions.fetchToken());
     store.dispatch(actions.fetchProfile());
-
-    render(
-      <App
-        {...{
-          config,
-          store,
-          queryParams,
-          matchMedia,
-          matchMediaDefault,
-          navigateToUrl,
-          getScreenInfo,
-          locationReload,
-          navigatorLanguages: navigator.languages,
-          stripePromise: loadStripe(config.stripe.apiKey),
-        }}
-      />,
-      document.getElementById('root')
-    );
   }
+
+  render(
+    <App
+      {...{
+        config,
+        store,
+        accessToken,
+        queryParams,
+        matchMedia,
+        matchMediaDefault,
+        navigateToUrl,
+        getScreenInfo,
+        locationReload,
+        navigatorLanguages: navigator.languages,
+        stripePromise: loadStripe(config.stripe.apiKey),
+      }}
+    />,
+    document.getElementById('root')
+  );
 }
 
 function headQuerySelector(name: string) {
@@ -125,12 +124,6 @@ async function getVerifiedAccessToken({
   } catch (err) {
     console.log('accessToken verify error', err);
     accessToken = null;
-  }
-
-  if (!accessToken) {
-    // TODO: bounce through a login redirect to get back here with a token
-    window.location.href = `${config.servers.content.url}/settings`;
-    return accessToken;
   }
 
   console.log('accessToken verified');

--- a/packages/fxa-payments-server/src/lib/AppContext.test.tsx
+++ b/packages/fxa-payments-server/src/lib/AppContext.test.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { render, cleanup, fireEvent } from '@testing-library/react';
+import { render, cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import { defaultAppContext, AppContext, AppContextType } from './AppContext';
@@ -10,11 +10,12 @@ const MOCK_LANG = 'xx-pirate';
 
 it('passes along given app-global props', () => {
   const Subject = () => {
-    const { config, getScreenInfo } = useContext(AppContext);
+    const { config, accessToken, getScreenInfo } = useContext(AppContext);
     return (
       <div>
         <span data-testid="lang">{config.lang}</span>
         <span data-testid="screeninfo">{'' + getScreenInfo().clientWidth}</span>
+        <span data-testid="accesstoken">{accessToken}</span>
       </div>
     );
   };
@@ -25,6 +26,7 @@ it('passes along given app-global props', () => {
       ...defaultAppContext.config,
       lang: MOCK_LANG,
     },
+    accessToken: 'lettherightonein',
   };
 
   const { getByTestId } = render(
@@ -35,4 +37,5 @@ it('passes along given app-global props', () => {
 
   expect(getByTestId('lang')).toHaveTextContent(MOCK_LANG);
   expect(getByTestId('screeninfo')).toHaveTextContent('undefined');
+  expect(getByTestId('accesstoken')).toHaveTextContent('lettherightonein');
 });

--- a/packages/fxa-payments-server/src/lib/AppContext.tsx
+++ b/packages/fxa-payments-server/src/lib/AppContext.tsx
@@ -7,6 +7,7 @@ import { loadStripe } from '@stripe/stripe-js';
 export type AppContextType = {
   config: Config;
   queryParams: QueryParams;
+  accessToken: string | null;
   matchMedia: (query: string) => boolean;
   matchMediaDefault: (query: string) => MediaQueryList;
   navigateToUrl: (url: string) => void;
@@ -21,12 +22,13 @@ const noopFunction = () => {};
 
 export const defaultAppContext = {
   config,
+  queryParams: {},
+  accessToken: null,
   getScreenInfo: () => new ScreenInfo(),
   locationReload: noopFunction,
   matchMedia: () => false,
   matchMediaDefault: (query: string) => matchMedia(query),
   navigateToUrl: noopFunction,
-  queryParams: {},
   navigatorLanguages: ['en-US', 'en'],
   stripePromise: Promise.resolve(null),
 };

--- a/packages/fxa-payments-server/src/lib/hooks.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.tsx
@@ -8,7 +8,9 @@ import React, {
   useEffect,
   useRef,
   ChangeEvent,
+  useContext,
 } from 'react';
+import AppContext from './AppContext';
 import { v4 as uuidv4 } from 'uuid';
 import { ButtonBaseProps } from '../components/PayPalButton';
 
@@ -33,9 +35,10 @@ export function useCheckboxState(
   defaultState: boolean = false
 ): useCheckboxStateResult {
   const [state, setState] = useState(defaultState);
-  const onChanged = useCallback((ev) => setState(ev.target.checked), [
-    setState,
-  ]);
+  const onChanged = useCallback(
+    (ev) => setState(ev.target.checked),
+    [setState]
+  );
   return [state, onChanged];
 }
 

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -242,6 +242,7 @@ export const defaultAppContextValue = (): AppContextType => ({
     flow_begin_time: Date.now(),
     flow_id: 'thisisanid',
   },
+  accessToken: 'lettherightonein',
   matchMedia: jest.fn().mockImplementation((query) => false),
   matchMediaDefault: jest.fn().mockImplementation((query) => {
     return {

--- a/packages/fxa-payments-server/src/routes/Product/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.tsx
@@ -130,17 +130,26 @@ export const Product = ({
   resetUpdateSubscriptionPlan,
   updateSubscriptionPlanStatus,
 }: ProductProps) => {
-  const { locationReload, queryParams, matchMediaDefault } =
-    useContext(AppContext);
+  const {
+    accessToken,
+    config,
+    locationReload,
+    queryParams,
+    matchMediaDefault,
+  } = useContext(AppContext);
 
-  const isMobile = !useMatchMedia('(min-width: 768px)', matchMediaDefault);
   const planId = queryParams.plan;
+
+  if (!accessToken) {
+    window.location.href = `${config.servers.content.url}/subscriptions/products/${productId}?plan=${planId}&signin=yes`;
+  }
 
   // Fetch plans on initial render, change in product ID, or auth change.
   useEffect(() => {
     fetchProductRouteResources();
   }, [fetchProductRouteResources]);
 
+  const isMobile = !useMatchMedia('(min-width: 768px)', matchMediaDefault);
   const plansById = useMemo(() => indexPlansById(plans), [plans]);
 
   const selectedPlan = useMemo(
@@ -148,7 +157,7 @@ export const Product = ({
     [plans]
   );
 
-  if (customer.loading || plans.loading || profile.loading) {
+  if (!accessToken || customer.loading || plans.loading || profile.loading) {
     return <LoadingOverlay isLoading={true} />;
   }
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.tsx
@@ -67,7 +67,12 @@ export const Subscriptions = ({
   paymentUpdateStripeOverride,
   paymentUpdateApiClientOverrides,
 }: SubscriptionsProps) => {
-  const { config, locationReload, navigateToUrl } = useContext(AppContext);
+  const { accessToken, config, locationReload, navigateToUrl } =
+    useContext(AppContext);
+
+  if (!accessToken) {
+    window.location.href = `${config.servers.content.url}/subscriptions`;
+  }
 
   const [
     updatePaymentIsSuccessViaSCA,
@@ -124,7 +129,7 @@ export const Subscriptions = ({
     [navigateToUrl, SUPPORT_FORM_URL]
   );
 
-  if (customer.loading || profile.loading || plans.loading) {
+  if (!accessToken || customer.loading || profile.loading || plans.loading) {
     return <LoadingOverlay isLoading={true} />;
   }
 


### PR DESCRIPTION
Because:
 - we want some routes in Payments to be accessible without a valid
   access token

This commit:
 - stop immediately redirecting to Settings when there is no valid
   access token on a Payments page load
 - store the access token in the AppContext
 - check for a valid access token in the products and subscriptions
   routes and redirect to the correct content-server route (instead of
   Settings)


## Issue that this pull request solves

Closes: #9792 
