### PR TITLE
feat(auth): add /account/stub route

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -359,6 +359,7 @@
         "termsUri": "",
         "privacyUri": "",
         "trusted": true,
+        "allowedScopes": "https://identity.mozilla.com/account/subscriptions",
         "publicClient": true
       },
       {

--- a/packages/fxa-auth-server/lib/db/index.js
+++ b/packages/fxa-auth-server/lib/db/index.js
@@ -77,7 +77,8 @@ module.exports = (config, log, Token, UnblockCode = null) => {
   DB.prototype.createAccount = async function (data) {
     const { uid, email } = data;
     log.trace('DB.createAccount', { uid, email });
-    data.createdAt = data.verifierSetAt = Date.now();
+    data.verifierSetAt = data.verifierSetAt ?? Date.now(); // allow 0 to indicate no-password-set
+    data.createdAt = Date.now();
     data.normalizedEmail = normalizeEmail(data.email);
     try {
       await Account.create(data);

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -539,7 +539,9 @@ export class StripeHandler {
       uid,
       subscriptionId: subscription.id,
     });
-
+    // TODO
+    // If this fxa user is a stub (no-password) this is where we should
+    // send the "create a password" email
     return {
       sourceCountry,
       subscription: filterSubscription(subscription),


### PR DESCRIPTION
Enables subscription services to create an account without a password.

closes #9327