### PR TITLE
feat(subscriptions): add fn for creating resume tokens

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/resume-token.js
+++ b/packages/fxa-content-server/app/scripts/models/resume-token.js
@@ -9,37 +9,16 @@
 
 import _ from 'underscore';
 import Backbone from 'backbone';
-
-const ALLOWED_KEYS = [
-  'deviceId',
-  'email',
-  'entrypoint',
-  'entrypointExperiment',
-  'entrypointVariation',
-  'flowBegin',
-  'flowId',
-  'newsletters',
-  'planId',
-  'productId',
-  'resetPasswordConfirm',
-  'style',
-  'uniqueUserId',
-  'utmCampaign',
-  'utmContent',
-  'utmMedium',
-  'utmSource',
-  'utmTerm',
-];
+import {
+  ALLOWED_KEYS,
+  DEFAULTS,
+  parse,
+  stringify,
+} from 'fxa-shared/lib/resume-token';
 
 const ResumeToken = Backbone.Model.extend(
   {
-    defaults: {
-      utmCampaign: null,
-      utmContent: null,
-      utmMedium: null,
-      utmSource: null,
-      utmTerm: null,
-    },
+    defaults: DEFAULTS,
 
     initialize(options) {
       // get rid of any data in the options block that is not expected.
@@ -60,19 +39,6 @@ const ResumeToken = Backbone.Model.extend(
     stringify,
   }
 );
-
-function parse(resumeToken) {
-  try {
-    return JSON.parse(atob(resumeToken));
-  } catch (e) {
-    // do nothing, its an invalid token.
-  }
-}
-
-function stringify(resumeObj) {
-  const encoded = btoa(JSON.stringify(resumeObj));
-  return encoded;
-}
 
 function createFromStringifiedResumeToken(stringifiedResumeToken) {
   const parsedResumeToken = parse(stringifiedResumeToken);

--- a/packages/fxa-payments-server/src/lib/resume-token.test.ts
+++ b/packages/fxa-payments-server/src/lib/resume-token.test.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { createResumeToken } from './resume-token';
+import { DEFAULTS, parse, ResumeToken } from 'fxa-shared/lib/resume-token';
+
+it('should include the default values', () => {
+  const t = createResumeToken({});
+  const tokenVal = parse(t);
+  expect(tokenVal).toEqual(DEFAULTS);
+});
+
+it('should exclude properties that are not in the allowed list', () => {
+  const t = createResumeToken({ productId: 'dabest', dmr: 'chrono' });
+  const tokenVal = parse(t) as ResumeToken;
+  expect(tokenVal['productId']).toBe('dabest');
+  expect(tokenVal['dmr']).toBeUndefined();
+});
+
+it('should overwrite the default values', () => {
+  const t = createResumeToken({
+    productId: 'dabest',
+    utmCampaign: 'wibble',
+    utmContent: 'quux',
+  });
+  const tokenVal = parse(t) as ResumeToken;
+  expect(tokenVal).toEqual({
+    ...DEFAULTS,
+    productId: 'dabest',
+    utmCampaign: 'wibble',
+    utmContent: 'quux',
+  });
+});

--- a/packages/fxa-payments-server/src/lib/resume-token.ts
+++ b/packages/fxa-payments-server/src/lib/resume-token.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * We need to create a Resume Token for the sign up process.  The exported
+ * function will produce a resume token that's compatible with the
+ * content-server.
+ */
+
+import {
+  ALLOWED_KEYS,
+  DEFAULTS,
+  ResumeToken,
+  stringify,
+} from 'fxa-shared/lib/resume-token';
+
+export function createResumeToken(x: ResumeToken) {
+  const merged: ResumeToken = { ...DEFAULTS, ...x };
+  const picked = Object.keys(merged).reduce((acc: ResumeToken, k) => {
+    if (ALLOWED_KEYS.includes(k)) {
+      acc[k] = merged[k];
+    }
+    return acc;
+  }, {});
+  return stringify(picked);
+}
+
+export default createResumeToken;

--- a/packages/fxa-shared/lib/resume-token.ts
+++ b/packages/fxa-shared/lib/resume-token.ts
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * This is shareable code extracted from the content-server so that we can use
+ * it in Payments.  Not all of the Resume Token code was moved because the
+ * model in content-server depends on backbone.js and underscore.js.
+ *
+ * The tests are in content-server and Payments.
+ */
+
+export type ResumeToken = { [key: string]: any };
+
+export const ALLOWED_KEYS = [
+  'deviceId',
+  'email',
+  'entrypoint',
+  'entrypointExperiment',
+  'entrypointVariation',
+  'flowBegin',
+  'flowId',
+  'newsletters',
+  'planId',
+  'productId',
+  'resetPasswordConfirm',
+  'style',
+  'uniqueUserId',
+  'utmCampaign',
+  'utmContent',
+  'utmMedium',
+  'utmSource',
+  'utmTerm',
+];
+
+export const DEFAULTS = {
+  utmCampaign: null,
+  utmContent: null,
+  utmMedium: null,
+  utmSource: null,
+  utmTerm: null,
+};
+
+export function parse(resumeToken: string): ResumeToken | void {
+  try {
+    return JSON.parse(atob(resumeToken));
+  } catch (e) {
+    // do nothing, it's an invalid token.
+  }
+}
+
+export function stringify(resumeObj: ResumeToken) {
+  const encoded = btoa(JSON.stringify(resumeObj));
+  return encoded;
+}
+
+export default { ALLOWED_KEYS, DEFAULTS, parse, stringify };


### PR DESCRIPTION
Because:
 - we need to, at a minimum, use a "resume token" to pass the
   newsletter the new user opted into on the new funnel flow

This commit:
 - move shareable resume token related code into fxa-shared
 - add a function in Payments for creating resume tokens

## Issue that this pull request solves

Part of #9786 
