### PR TITLE
task(fxa-payments-server) Add email validation

### DIFF
--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.stories.tsx
@@ -4,6 +4,6 @@ import { NewUserEmailForm } from './index';
 
 storiesOf('components/NewUserEmailForm', module).add('default', () => (
   <div style={{ display: 'flex' }}>
-    <NewUserEmailForm />
+    <NewUserEmailForm getString={(id: string) => id} />
   </div>
 ));

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
 import { NewUserEmailForm } from './index';
 
 describe('NewUserEmailForm test', () => {
   it('renders as expected', () => {
-    const { queryByTestId } = render(<NewUserEmailForm />);
+    const { queryByTestId } = render(
+      <NewUserEmailForm getString={(id: string) => id} />
+    );
     const form = queryByTestId('new-user-email-form');
     expect(form).toBeInTheDocument();
 
@@ -26,5 +28,52 @@ describe('NewUserEmailForm test', () => {
 
     const assuranceCopy = queryByTestId('assurance-copy');
     expect(assuranceCopy).toBeInTheDocument();
+  });
+
+  it('shows error when invalid email is input to first field', () => {
+    const { getByTestId, queryByText } = render(
+      <NewUserEmailForm getString={(id: string) => id} />
+    );
+    const firstEmail = getByTestId('new-user-email');
+    fireEvent.change(firstEmail, { target: { value: 'invalid-email' } });
+    fireEvent.blur(firstEmail);
+    expect(queryByText('new-user-email-validate')).toBeVisible();
+  });
+
+  it('shows no error when valid email is input to first field', () => {
+    const { getByTestId, queryByText } = render(
+      <NewUserEmailForm getString={(id: string) => id} />
+    );
+    const firstEmail = getByTestId('new-user-email');
+    fireEvent.change(firstEmail, { target: { value: 'valid@email.com' } });
+    fireEvent.blur(firstEmail);
+    expect(queryByText('new-user-email-validate')).toBeFalsy();
+  });
+
+  it('shows error when emails do not match', () => {
+    const { getByTestId, queryByText } = render(
+      <NewUserEmailForm getString={(id: string) => id} />
+    );
+    const firstEmail = getByTestId('new-user-email');
+    const secondEmail = getByTestId('new-user-confirm-email');
+    fireEvent.change(firstEmail, { target: { value: 'valid@email.com' } });
+    fireEvent.change(secondEmail, {
+      target: { value: 'not.the.same@email.com' },
+    });
+    fireEvent.blur(secondEmail);
+    expect(queryByText('new-user-email-validate-confirm')).toBeVisible();
+  });
+
+  it('shows no error when emails match', () => {
+    const { getByTestId, queryByText } = render(
+      <NewUserEmailForm getString={(id: string) => id} />
+    );
+    const firstEmail = getByTestId('new-user-email');
+    const secondEmail = getByTestId('new-user-confirm-email');
+    fireEvent.change(firstEmail, { target: { value: 'valid@email.com' } });
+    fireEvent.blur(firstEmail);
+    fireEvent.change(secondEmail, { target: { value: 'valid@email.com' } });
+    fireEvent.blur(secondEmail);
+    expect(queryByText('new-user-email-validate-confirm')).toBeFalsy();
   });
 });


### PR DESCRIPTION
## Because

- We need to validate the new user email

## This pull request

- Adds validation checks to the email input on new user form
- Adds a check to ensure the confirm input matches the original email value

## Issue that this pull request solves

Closes: #9354

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Luckily our email validation method was in `fxa-shared` which saved a lot of time.
