### PR TITLE
feat(emails): Add the finish account setup email for passwordless accounts

### DIFF
--- a/packages/fxa-auth-db-mysql/lib/db/patch.js
+++ b/packages/fxa-auth-db-mysql/lib/db/patch.js
@@ -5,4 +5,4 @@
 // The expected patch level of the database. Update if you add a new
 // patch in the ./schema/ directory.
 
-module.exports.level = 118;
+module.exports.level = 119;

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-118-119.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-118-119.sql
@@ -1,0 +1,13 @@
+--
+-- This migration adds the subscriptionAccountFinishSetup emailType to
+-- the emailTypes table. This email contains link to set
+-- password on a passwordless account.
+--
+
+SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+CALL assertPatchLevel('118');
+
+INSERT INTO emailTypes (emailType) VALUE ('subscriptionAccountFinishSetup');
+
+UPDATE dbMetadata SET value = '119' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-db-mysql/lib/db/schema/patch-119-118.sql
+++ b/packages/fxa-auth-db-mysql/lib/db/schema/patch-119-118.sql
@@ -1,0 +1,5 @@
+-- SET NAMES utf8mb4 COLLATE utf8mb4_bin;
+
+-- DELETE FROM emailTypes WHERE emailType = 'subscriptionAccountFinishSetup';
+
+-- UPDATE dbMetadata SET value = '118' WHERE name = 'schema-patch-level';

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1857,6 +1857,10 @@ conf.set(
   `${baseUri}/settings/change_password`
 );
 conf.set('smtp.verifyLoginUrl', `${baseUri}/complete_signin`);
+conf.set(
+  'smtp.accountFinishSetupUrl',
+  `${baseUri}/post_verify/finish_account_setup/set_password`
+);
 conf.set('smtp.reportSignInUrl', `${baseUri}/report_signin`);
 conf.set(
   'smtp.revokeAccountRecoveryUrl',

--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -20,6 +20,7 @@ const { version: VERSION } = require('../../package.json');
 
 // Maps template name to email type
 const EMAIL_TYPES = {
+  subscriptionAccountFinishSetup: 'subscription_account_finish_setup',
   subscriptionReactivation: 'subscription_reactivation',
   subscriptionRenewalReminder: 'subscription_renewal_reminder',
   subscriptionUpgrade: 'subscription_upgrade',

--- a/packages/fxa-auth-server/lib/senders/templates/_versions.json
+++ b/packages/fxa-auth-server/lib/senders/templates/_versions.json
@@ -1,4 +1,5 @@
 {
+  "subscriptionAccountFinishSetup": 1,
   "subscriptionReactivation": 1,
   "subscriptionRenewalReminder": 1,
   "subscriptionUpgrade": 1,

--- a/packages/fxa-auth-server/lib/senders/templates/partials/paymentPlanDetails.html
+++ b/packages/fxa-auth-server/lib/senders/templates/partials/paymentPlanDetails.html
@@ -1,0 +1,9 @@
+<p style="font-family:sans-serif; font-size: 13px; line-height: 20px; font-weight: normal; margin: 24px 0 24px 0px; text-align: left; color: #4a4a4f;">
+  <b>{{t "Payment details:" }}</b>
+  <ul>
+    {{#if productName }}<li>{{ productName }}{{/if}}
+    {{#if invoiceNumber }}<li>{{t "Invoice number: %(invoiceNumber)s" }}{{/if}}
+    {{#if invoiceTotal }}<li>{{t "Charged: %(invoiceTotal)s on %(invoiceDateOnly)s" }}{{/if}}
+    {{#if nextInvoiceDateOnly }}<li>{{t "Next invoice: %(nextInvoiceDateOnly)s" }}{{/if}}
+  </ul>
+</p>

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionAccountFinishSetup.html
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionAccountFinishSetup.html
@@ -1,0 +1,32 @@
+{{#*inline "icon"}}
+  <tr style="page-break-before: always">
+    <td align="center" style="padding: 20px 0 10px;">
+      <img src="{{{icon}}}" width="58" height="58" alt="" style="-ms-interpolation-mode: bicubic;" />
+    </td>
+  </tr>
+{{/inline}}
+
+{{#*inline "title"}}
+  {{t "Welcome to %(productName)s" }}
+{{/inline}}
+
+{{#*inline "content"}}
+  {{t "Your payment is processing and may take up to four business days to complete. Your subscription will renew automatically each billing period unless you choose to cancel." }}
+
+  {{> paymentPlanDetails }}
+
+  {{t "Next, you'll create a Firefox account password and download %(productName)s." }}
+
+  <br><br>
+
+  <table style="background-color: #FFFFFF; min-width: 100%;">
+    {{> button}}
+  </table>
+
+  <br>
+
+  {{{t "Questions about your subscription? Our <a href=\"%(subscriptionSupportUrl)s\">support team</a> is here to help you." }}}
+
+{{/inline}}
+
+{{> subscriptionEmail}}

--- a/packages/fxa-auth-server/lib/senders/templates/subscriptionAccountFinishSetup.txt
+++ b/packages/fxa-auth-server/lib/senders/templates/subscriptionAccountFinishSetup.txt
@@ -1,0 +1,18 @@
+{{{subject}}}
+
+{{t "Welcome to %(productName)s" }}
+
+{{{t "Your payment is processing and may take up to four business days to complete. Your subscription will renew automatically each billing period unless you choose to cancel." }}}
+
+{{#if productPlan }}{{ productPlan }}{{/if}}
+{{#if invoiceNumber }}{{{t "Invoice number: %(invoiceNumber)s" }}}{{/if}}
+{{#if invoiceTotal }}{{{t "Charged: %(invoiceTotal)s on %(invoiceDateOnly)s" }}}{{/if}}
+{{#if nextInvoiceDateOnly }}{{{t "Next invoice: %(nextInvoiceDateOnly)s" }}}{{/if}}
+
+{{{t "Next, you'll create a Firefox account password and download %(productName)s." }}}
+
+{{{ link }}}
+
+{{{t "Questions about your subscription? Our support team is here to help you:" }}}
+
+{{{ subscriptionSupportUrl }}}

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -85,6 +85,7 @@ const MESSAGE = {
   productPaymentCycle: 'month',
   productMetadata,
   reminderLength: 14,
+  redirectUrl: 'http://getfirefox.com/',
   service: 'sync',
   subscription: {
     productName: 'Cooking with Foxkeh',
@@ -98,6 +99,7 @@ const MESSAGE = {
   time: '5:48:20 PM (PDT)',
   timeZone: 'America/Los_Angeles',
   tokenCode: 'abc123',
+  token: 'abc123',
   type: 'secondary',
   uaBrowser: 'Firefox',
   uaBrowserVersion: '70.0a1',
@@ -126,6 +128,9 @@ const MESSAGE_PARAMS = new Map([
   ['service', 'service'],
   ['uid', 'uid'],
   ['unblockCode', 'unblockCode'],
+  ['redirectUrl', 'redirectUrl'],
+  ['productName', 'productName'],
+  ['token', 'token'],
 ]);
 
 const COMMON_TESTS = new Map([
@@ -256,6 +261,34 @@ const TESTS = [
       { test: 'include', expected: `View Invoice: ${MESSAGE.invoiceLink}` },
       { test: 'notInclude', expected: 'utm_source=email' },
       { test: 'notInclude', expected: 'PayPal' },
+    ]]
+  ])],
+  ['subscriptionAccountFinishSetupEmail', new Map([
+    ['subject', { test: 'equal', expected: `${MESSAGE.productName} payment confirmed` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionAccountFinishSetup') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionAccountFinishSetup' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionAccountFinishSetup }],
+    ])],
+    ['html', [
+      { test: 'include', expected: configHref('accountFinishSetupUrl', 'subscription-account-finish-setup', 'subscriptions', 'email', 'productName', 'token', 'code', 'redirectUrl') },
+      { test: 'include', expected: configHref('subscriptionSupportUrl', 'subscription-account-finish-setup', 'subscription-support') },
+      { test: 'include', expected: `Welcome to ${MESSAGE.productName}` },
+      { test: 'include', expected: `Invoice number: ${MESSAGE.invoiceNumber}` },
+      { test: 'include', expected: `Charged: ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next invoice: 04/19/2020` },
+      { test: 'include', expected: `create a Firefox account password and download ${MESSAGE.productName}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: configUrl('accountFinishSetupUrl', 'subscription-account-finish-setup', 'subscriptions', 'email', 'productName', 'token', 'code', 'redirectUrl') },
+      { test: 'include', expected: configUrl('subscriptionSupportUrl', 'subscription-account-finish-setup', 'subscription-support') },
+      { test: 'include', expected: `Welcome to ${MESSAGE.productName}` },
+      { test: 'include', expected: `Invoice number: ${MESSAGE.invoiceNumber}` },
+      { test: 'include', expected: `Charged: ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next invoice: 04/19/2020` },
+      { test: 'include', expected: `create a Firefox account password and download ${MESSAGE.productName}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],
   ['subscriptionSubsequentInvoiceEmail', new Map([


### PR DESCRIPTION
## Because

- Users should recieve an email with information on how to finsh setting up their account (create new password)

## This pull request

- Adds the email template based on https://www.figma.com/file/cOIAuHIIbrPbAlAIcpejNM/%F0%9F%8E%A1MVP-Subscription-Optimization-Flow?node-id=315%3A12945
- Added migration for new template `subscriptionAccountFinishSetup`

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/9330

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Current template

<img width="586" alt="Screen Shot 2021-07-21 at 3 30 59 PM" src="https://user-images.githubusercontent.com/1295288/126548548-9d7e9fbe-b64f-4048-b501-46202ab0a68e.png">

