### PR TITLE
task(fxa-auth-server): mark privacyNoticeDownloadURL as optional

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -410,7 +410,7 @@ module.exports.subscriptionProductMetadataBaseValidator = isA
     'product:privacyNoticeDownloadURL': isA
       .string()
       .regex(legalResourceDomainPattern)
-      .required(),
+      .optional(),
     'product:privacyNoticeURL': isA.string().uri().required(),
   })
   .pattern(capabilitiesClientIdPattern, isA.string(), {

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -475,9 +475,6 @@ describe('lib/routes/validators:', () => {
       res = deletePropAndValidate('product:privacyNoticeURL');
       assert.ok(res.error);
 
-      res = deletePropAndValidate('product:privacyNoticeDownloadURL');
-      assert.ok(res.error);
-
       res = deletePropAndValidate('product:termsOfServiceURL');
       assert.ok(res.error);
 


### PR DESCRIPTION
- fixes #9926

## Because

- We need to have `product:privacyNoticeDownloadURL` marked as optional so that VPN can pass our validation

## This pull request

- marks privacyNoticeDownloadURL as optional

## Issue that this pull request solves

Closes: #9926

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).


## Other information (Optional)

This will require a DOT release cc/ @biancadanforth 
