### PR TITLE
 feat(emails)- Update exit survey link in subscription exit emails

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -2994,7 +2994,7 @@ module.exports = function (log, config) {
     links.accountSettingsLinkAttributes = `href="${links.accountSettingsUrl}" target="_blank" rel="noopener noreferrer" style="color:#ffffff;font-weight:500;"`;
 
     links.cancellationSurveyUrl =
-      'https://qsurvey.mozilla.com/s3/VPN-Exit-Survey-2021';
+      'https://survey.alchemer.com/s3/6351954/Cancellation-of-Service-Mozilla-VPN-Q2-21';
 
     links.cancellationSurveyLinkAttributes = `href="${links.cancellationSurveyUrl}" style="text-decoration: none; color: #0060DF;"`;
 


### PR DESCRIPTION
## Because

- We'd like to gather information from people who have cancelled their VPN subscription and use that information to inform future product improvements and feature development.

## This pull request

- Changes the survey link in subscription exit emails to point to a newly created survey

## Issue that this pull request solves

Closes: No issue was filed for this change

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
