### PR TITLE
feat(content): redirect to new checkout route for unauthenticated users

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/payment-server.js
+++ b/packages/fxa-content-server/app/scripts/lib/payment-server.js
@@ -7,7 +7,7 @@
 
 import Url from './url';
 
-const allowedUnauthenticatedRoutes = ['product'];
+const allowedUnauthenticatedRoutes = ['checkout'];
 const isAllowedUnauthenticatedRoute = (redirectPath) =>
   allowedUnauthenticatedRoutes.some((route) => redirectPath.startsWith(route));
 

--- a/packages/fxa-content-server/app/tests/spec/lib/payment-server.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/payment-server.js
@@ -89,8 +89,8 @@ describe('lib/payment-server-redirect', () => {
     });
   });
 
-  it('redirects to the product route when there is no account', () => {
-    const REDIRECT_PATH = 'product/bleepbloop';
+  it('redirects to the checkout route when there is no account', () => {
+    const REDIRECT_PATH = 'checkout/bleepbloop';
     view.getSignedInAccount = sinon.stub().returns(null);
     PaymentServer.navigateToPaymentServer(
       view,
@@ -105,8 +105,8 @@ describe('lib/payment-server-redirect', () => {
     );
   });
 
-  it('redirects to the product route when account is not signed in', () => {
-    const REDIRECT_PATH = 'product/bleepbloop';
+  it('redirects to the checkout route when account is not signed in', () => {
+    const REDIRECT_PATH = 'checkout/bleepbloop';
     account._fxaClient = {
       isSignedIn: sinon.stub().resolves(false),
     };


### PR DESCRIPTION
Because:

* There is a new Checkout route on the payments server for unauthned users that will create a FxA account (if none exists) at the same time as creating a new subscription.

This commit:

* Conditionally sets the redirectPath for redirecting to the payments server based on a user's authn state and the subscriptionsConfig.allowUnauthenticatedRedirects flag.
* The latter will ensure that we do not redirect unauthned users in prod to the new checkout route until we are ready to do so.

Closes #9793

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I filed [FXA-3790](https://mozilla-hub.atlassian.net/browse/FXA-3790) to set `allowUnauthenticatedRedirects` to `true` in `prod` as it is [currently only enabled in `dev` and `stage`](https://github.com/mozilla-services/cloudops-deployment/pull/4335) for testing (thanks Barry).
