### PR TITLE
fix(l10n): Update `continue to ...` text to match other usages

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/post_verify/finish_account_setup/set_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/finish_account_setup/set_password.mustache
@@ -16,7 +16,7 @@
         <h1 id="fxa-account-setup-set-password-header">
         {{#productName}}
             <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(productName)s" -->
-            {{#t}}Create a Firefox Account{{/t}} <span class="service">{{#t}}to continue to %(productName)s{{/t}}</span>
+            {{#t}}Create a Firefox Account{{/t}} <span class="service">{{#t}}Continue to %(productName)s{{/t}}</span>
         {{/productName}}
         {{^productName}}
             {{#t}}Create a Firefox Account{{/t}}


### PR DESCRIPTION
Matches how we use `Continue to ...` in our other views.

Fixes https://github.com/mozilla/fxa/issues/9937