### PR TITLE
feat(auth): add google iap service class

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -10,6 +10,8 @@ const { StatsD } = require('hot-shots');
 const { Container } = require('typedi');
 const { StripeHelper } = require('../lib/payments/stripe');
 const { CurrencyHelper } = require('../lib/payments/currencies');
+const { AuthLogger, AuthFirestore } = require('../lib/types');
+const { setupFirestore } = require('../lib/firestore-db.ts');
 
 async function run(config) {
   const statsd = config.statsd.enabled
@@ -28,6 +30,12 @@ async function run(config) {
   Container.set(StatsD, statsd);
 
   const log = require('../lib/log')({ ...config.log, statsd });
+  Container.set(AuthLogger, log);
+
+  if (config.authFirestore.enabled) {
+    const authFirestore = setupFirestore(config);
+    Container.set(AuthFirestore, authFirestore);
+  }
 
   const redis = require('../lib/redis')(
     { ...config.redis, ...config.redis.sessionTokens },

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -60,6 +60,47 @@ const conf = convict({
       format: String,
     },
   },
+  // Prefixed with service name to disambiguate from above firestore config
+  authFirestore: {
+    credentials: {
+      client_email: {
+        default: 'test@localtest.com',
+        doc: 'GCP Client key credential',
+        env: 'AUTH_FIRESTORE_CLIENT_EMAIL_CREDENTIAL',
+        format: String,
+      },
+      private_key: {
+        default: '',
+        doc: 'GCP Private key credential',
+        env: 'AUTH_FIRESTORE_PRIVATE_KEY_CREDENTIAL',
+        format: String,
+      },
+    },
+    enabled: {
+      default: true,
+      doc: 'Whether to use firestore',
+      env: 'AUTH_FIRESTORE_ENABLED',
+      format: Boolean,
+    },
+    keyFilename: {
+      default: path.resolve(__dirname, 'secret-key.json'),
+      doc: 'Path to GCP key file',
+      env: 'AUTH_FIRESTORE_KEY_FILE',
+      format: String,
+    },
+    prefix: {
+      default: 'fxa-auth-',
+      doc: 'Firestore collection prefix',
+      env: 'AUTH_FIRESTORE_COLLECTION_PREFIX',
+      format: String,
+    },
+    projectId: {
+      default: '',
+      doc: 'GCP Project id',
+      env: 'AUTH_FIRESTORE_PROJECT_ID',
+      format: String,
+    },
+  },
   geodb: {
     dbPath: {
       doc: 'Path to the maxmind database file',

--- a/packages/fxa-auth-server/lib/firestore-db.ts
+++ b/packages/fxa-auth-server/lib/firestore-db.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Firestore } from '@google-cloud/firestore';
+import * as grpc from '@grpc/grpc-js';
+
+import { ConfigType } from '../config';
+
+export function setupFirestore(config: ConfigType) {
+  const fsConfig = Object.assign({}, config.authFirestore);
+  // keyFilename takes precedence over credentials
+  if (fsConfig.keyFilename) {
+    /* istanbul ignore next */
+    // @ts-ignore
+    delete fsConfig.credentials;
+  }
+
+  // Utilize the local firestore emulator when the env indicates
+  if (process.env.AUTH_FIRESTORE_EMULATOR_HOST) {
+    return new Firestore({
+      customHeaders: {
+        Authorization: 'Bearer owner',
+      },
+      port: 9090,
+      projectId: 'fx-auth-server',
+      servicePath: 'localhost',
+      sslCreds: grpc.credentials.createInsecure(),
+    });
+  } else {
+    return new Firestore(fsConfig);
+  }
+}

--- a/packages/fxa-auth-server/lib/payments/google-iap.ts
+++ b/packages/fxa-auth-server/lib/payments/google-iap.ts
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Firestore } from '@google-cloud/firestore';
+import { Container } from 'typedi';
+
+import { AuthFirestore, AuthLogger } from '../types';
+
+export class GoogleIAP {
+  private firestore: Firestore;
+  private log: AuthLogger;
+
+  constructor() {
+    this.firestore = Container.get(AuthFirestore);
+    this.log = Container.get(AuthLogger);
+  }
+}

--- a/packages/fxa-auth-server/lib/types.ts
+++ b/packages/fxa-auth-server/lib/types.ts
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Request, RequestApplicationState } from '@hapi/hapi';
+import { Token } from 'typedi';
 import { Logger } from 'mozlog';
+import { Firestore } from '@google-cloud/firestore';
 
 export type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T;
 
@@ -62,3 +64,7 @@ export interface AuthRequest extends Request {
   stashMetricsContext: any;
   propagateMetricsContext: any;
 }
+
+// Container token types
+export const AuthLogger = new Token<AuthLogger>('AUTH_LOGGER');
+export const AuthFirestore = new Token<Firestore>('AUTH_FIRESTORE');

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -178,6 +178,7 @@
     "sinon": "^9.0.3",
     "through": "2.3.8",
     "ts-node": "^10.0.0",
+    "typesafe-node-firestore": "^1.4.0",
     "typescript": "^4.2.4",
     "webpack": "^4.43.0",
     "webpack-watch-files-plugin": "^1.1.0",

--- a/packages/fxa-auth-server/test/local/payments/google-iap.js
+++ b/packages/fxa-auth-server/test/local/payments/google-iap.js
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const sinon = require('sinon');
+const { assert } = require('chai');
+const { default: Container } = require('typedi');
+
+const { mockLog } = require('../../mocks');
+const { AuthFirestore, AuthLogger } = require('../../../lib/types');
+const { GoogleIAP } = require('../../../lib/payments/google-iap');
+
+describe('GoogleIAP', () => {
+  let sandbox;
+  let firestore;
+  let log;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    firestore = {};
+    log = mockLog();
+    Container.set(AuthFirestore, firestore);
+    Container.set(AuthLogger, log);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('can be instantiated', () => {
+    const googleIap = Container.get(GoogleIAP);
+    assert.strictEqual(googleIap.log, log);
+    assert.strictEqual(googleIap.firestore, firestore);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -18314,6 +18314,7 @@ fsevents@~2.1.1:
     through: 2.3.8
     ts-node: ^10.0.0
     typedi: ^0.8.0
+    typesafe-node-firestore: ^1.4.0
     typescript: ^4.2.4
     uuid: ^8.3.2
     verror: ^1.10.0


### PR DESCRIPTION
Because:

* We want to support Google IAP data using Firestore.

This commit:

* Sets up a Google IAP service class that uses Firestore.

Closes #9878

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
