### PR TITLE
feat(auth): add google plans endpoint

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -10,10 +10,12 @@ const { StatsD } = require('hot-shots');
 const { Container } = require('typedi');
 const { StripeHelper } = require('../lib/payments/stripe');
 const { CurrencyHelper } = require('../lib/payments/currencies');
-const { AuthLogger, AuthFirestore } = require('../lib/types');
+const { AuthLogger, AuthFirestore, AppConfig } = require('../lib/types');
 const { setupFirestore } = require('../lib/firestore-db.ts');
 
 async function run(config) {
+  Container.set(AppConfig, config);
+
   const statsd = config.statsd.enabled
     ? new StatsD({
         ...config.statsd,
@@ -181,6 +183,7 @@ async function run(config) {
 
 async function main() {
   const config = require('../config');
+
   try {
     const server = await run(config.getProperties());
     process.on('uncaughtException', (err) => {

--- a/packages/fxa-auth-server/docs/api.md
+++ b/packages/fxa-auth-server/docs/api.md
@@ -102,6 +102,7 @@ see [`fxa-auth-client`](https://github.com/mozilla/fxa/tree/main/packages/fxa-au
     - [POST /oauth/subscriptions/updatePayment (:lock: oauthToken)](#post-subscriptionsupdatepayment)
     - [GET /oauth/subscriptions/customer (:lock: oauthToken)](#get-subscriptionscustomer)
     - [GET /oauth/subscriptions/paypal-checkout (:lock: oauthToken)](#get-paypalcheckout)
+    - [GET /oauth/subscriptions/google/plans](#get-googleplans)
   - [Totp](#totp)
     - [POST /totp/create (:lock: sessionToken)](#post-totpcreate)
     - [POST /totp/destroy (:lock: sessionToken)](#post-totpdestroy)
@@ -3626,6 +3627,10 @@ Create a new setup intent for attaching a new payment method to the user.
 
 :lock: authenticated with OAuth bearer token
 Update a user's default payment method for invoices to the attached payment method id.
+
+#### GET /oauth/subscriptions/google/plans
+
+Returns available plans for Android clients.
 
 ### Totp
 

--- a/packages/fxa-auth-server/lib/payments/firestore-types.ts
+++ b/packages/fxa-auth-server/lib/payments/firestore-types.ts
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Represents the plan blob that is returned to the client as-is.
+ */
+export interface GooglePlans {
+  plans: any;
+}

--- a/packages/fxa-auth-server/lib/routes/subscriptions/google.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/google.ts
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { ServerRoute } from '@hapi/hapi';
+import { Container } from 'typedi';
+
+import { AuthLogger, AuthRequest } from '../../types';
+import { GoogleIAP } from '../../payments/google-iap';
+
+export class GoogleIapHandler {
+  private log: AuthLogger;
+  private googleIap: GoogleIAP;
+
+  constructor() {
+    this.log = Container.get(AuthLogger);
+    this.googleIap = Container.get(GoogleIAP);
+  }
+
+  /**
+   * Retrieve all the Android plans for the client.
+   */
+  public plans(request: AuthRequest) {
+    this.log.begin('googleIap.plans', request);
+    return this.googleIap.plans();
+  }
+}
+
+export const googleIapRoutes = (): ServerRoute[] => {
+  const googleIapHandler = new GoogleIapHandler();
+  return [
+    {
+      method: 'GET',
+      path: '/oauth/subscriptions/google/plans',
+      options: {
+        // No auth needed to fetch the plan blob.
+        auth: false,
+      },
+      handler: (request: AuthRequest) => googleIapHandler.plans(request),
+    },
+  ];
+};

--- a/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
@@ -7,12 +7,13 @@ import zendesk from 'node-zendesk';
 import { ConfigType } from '../../../config';
 import { StripeHelper } from '../../payments/stripe';
 import { AuthLogger } from '../../types';
+import { googleIapRoutes } from './google';
 import { paypalRoutes } from './paypal';
 import { paypalNotificationRoutes } from './paypal-notifications';
 import { sanitizePlans, StripeHandler, stripeRoutes } from './stripe';
 import { stripeWebhookRoutes } from './stripe-webhook';
-import { handleAuth } from './utils';
 import { supportRoutes } from './support';
+import { handleAuth } from './utils';
 
 const createRoutes = (
   log: AuthLogger,
@@ -84,6 +85,9 @@ const createRoutes = (
         stripeHelper
       )
     );
+  }
+  if (config.authFirestore.enabled) {
+    routes.push(...googleIapRoutes());
   }
 
   return routes;

--- a/packages/fxa-auth-server/lib/types.ts
+++ b/packages/fxa-auth-server/lib/types.ts
@@ -5,6 +5,7 @@ import { Request, RequestApplicationState } from '@hapi/hapi';
 import { Token } from 'typedi';
 import { Logger } from 'mozlog';
 import { Firestore } from '@google-cloud/firestore';
+import { ConfigType } from '../config';
 
 export type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T;
 
@@ -68,3 +69,4 @@ export interface AuthRequest extends Request {
 // Container token types
 export const AuthLogger = new Token<AuthLogger>('AUTH_LOGGER');
 export const AuthFirestore = new Token<Firestore>('AUTH_FIRESTORE');
+export const AppConfig = new Token<ConfigType>('APP_CONFIG');

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/google.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/google.js
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const sinon = require('sinon');
+const assert = { ...sinon.assert, ...require('chai').assert };
+
+const { mockLog } = require('../../../mocks');
+const {
+  GoogleIapHandler,
+} = require('../../../../lib/routes/subscriptions/google');
+const { default: Container } = require('typedi');
+const { AuthLogger } = require('../../../../lib/types');
+const { GoogleIAP } = require('../../../../lib/payments/google-iap');
+
+describe('GoogleIapHandler', () => {
+  let googleIap;
+  let log;
+  let googleIapHandler;
+
+  beforeEach(() => {
+    log = mockLog();
+    googleIap = {};
+    Container.set(AuthLogger, log);
+    Container.set(GoogleIAP, googleIap);
+    googleIapHandler = new GoogleIapHandler();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('plans', () => {
+    it('returns the plans', async () => {
+      googleIap.plans = sinon.fake.resolves({ test: 'plan' });
+      const result = await googleIapHandler.plans();
+      assert.calledOnce(googleIap.plans);
+      assert.deepEqual(result, { test: 'plan' });
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
@@ -41,6 +41,9 @@ describe('PayPalNotificationHandler', () => {
 
   beforeEach(() => {
     config = {
+      authFirestore: {
+        enabled: false,
+      },
       subscriptions: {
         enabled: true,
         stripeApiKey: 'sk_test_1234',
@@ -579,10 +582,10 @@ describe('PayPalNotificationHandler', () => {
       stripeHelper.customer = sinon.fake.resolves(mockCustomer);
       stripeHelper.removeCustomerPaypalAgreement = sinon.fake.resolves({});
       stripeHelper.getPaymentProvider = sinon.fake.returns('paypal');
-      stripeHelper.formatSubscriptionsForEmails = sinon.fake.resolves(
-        mockFormattedSubs
-      );
-      mailer.sendSubscriptionPaymentProviderCancelledEmail = sinon.fake.resolves();
+      stripeHelper.formatSubscriptionsForEmails =
+        sinon.fake.resolves(mockFormattedSubs);
+      mailer.sendSubscriptionPaymentProviderCancelledEmail =
+        sinon.fake.resolves();
 
       await handler.handleMpCancel(billingAgreementCancelNotification);
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -91,6 +91,9 @@ describe('subscriptions payPalRoutes', () => {
 
   beforeEach(() => {
     config = {
+      authFirestore: {
+        enabled: false,
+      },
       subscriptions: {
         enabled: true,
         paypalNvpSigCredentials: {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -183,6 +183,9 @@ describe('StripeWebhookHandler', () => {
     sandbox = sinon.createSandbox();
 
     config = {
+      authFirestore: {
+        enabled: false,
+      },
       subscriptions: {
         enabled: true,
         managementClientId: MOCK_CLIENT_ID,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -202,6 +202,9 @@ describe('sanitizePlans', () => {
 describe('subscriptions stripeRoutes', () => {
   beforeEach(() => {
     config = {
+      authFirestore: {
+        enabled: false,
+      },
       subscriptions: {
         enabled: true,
         managementClientId: MOCK_CLIENT_ID,


### PR DESCRIPTION
Because:

* We want to provide the available plans for Android clients.

This commit:

* Adds an unauthenticated endpoint for Android clients to use that will
  fetch a maintained list of available subscription plans.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
