### PR TITLE
Train 211.1 uplift

### DIFF
--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -410,7 +410,7 @@ module.exports.subscriptionProductMetadataBaseValidator = isA
     'product:privacyNoticeDownloadURL': isA
       .string()
       .regex(legalResourceDomainPattern)
-      .required(),
+      .optional(),
     'product:privacyNoticeURL': isA.string().uri().required(),
   })
   .pattern(capabilitiesClientIdPattern, isA.string(), {

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -475,9 +475,6 @@ describe('lib/routes/validators:', () => {
       res = deletePropAndValidate('product:privacyNoticeURL');
       assert.ok(res.error);
 
-      res = deletePropAndValidate('product:privacyNoticeDownloadURL');
-      assert.ok(res.error);
-
       res = deletePropAndValidate('product:termsOfServiceURL');
       assert.ok(res.error);
 


### PR DESCRIPTION
## Because

- `fetchAllPlans` won't return a `plan` if it fails validation, and we have a `plan` in prod with no `product:privacyNoticeDownloadURL`.

## This pull request

- Uplift a patch that ensures all prod plans are correctly returned by cherry-picking a patch that makes this property optional.

## Issue that this pull request solves

Closes: (See original PR: #9927 )
