### PR TITLE
feat(passwords): Ensure password set on account before changing primary

### DIFF
--- a/packages/fxa-admin-panel/tsconfig.json
+++ b/packages/fxa-admin-panel/tsconfig.json
@@ -14,12 +14,15 @@
     ],
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "jsx": "react-jsx"
   },
   "include": [
     "src"
   ],
   "references": [
-    {"path": "../fxa-react"}
+    {
+      "path": "../fxa-react"
+    }
   ]
 }

--- a/packages/fxa-auth-server/test/local/routes/emails.js
+++ b/packages/fxa-auth-server/test/local/routes/emails.js
@@ -1712,6 +1712,24 @@ describe('/recovery_email', () => {
           )
       );
     });
+
+    it('should fail when setting email has no password set', () => {
+      mockDB.getSecondaryEmail = sinon.spy(() => {
+        return Promise.resolve({
+          uid: mockRequest.auth.credentials.uid,
+          isVerified: true,
+          isPrimary: true,
+        });
+      });
+
+      mockRequest.auth.credentials.verifierSetAt = 0;
+
+      route = getRoute(accountRoutes, '/recovery_email/set_primary');
+      return runTest(route, mockRequest).then(
+        () => assert.fail('should have errored'),
+        (err) => assert.equal(err.errno, 104, 'unverified account errno')
+      );
+    });
   });
 
   describe('/recovery_email/secondary/verify_code', () => {


### PR DESCRIPTION
## Because

- Users should not be able to change their primary email if the account has no password set. In practice I don't think this flow would be accessible, but wouldn't hurt to be explict in the endpoint.

## This pull request

- Checks that user has set password else throws errro
- Renames variables to make things clearer on what is happening

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/9730

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
