### PR TITLE
fix(sentry): Add ifNoneMatch when setting new anonId

### DIFF
--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -459,6 +459,8 @@ const Account = Backbone.Model.extend(
 
           if (oldEcosystemAnonId) {
             updateOptions.ifMatch = oldEcosystemAnonId;
+          } else {
+            updateOptions.ifNoneMatch = '*';
           }
 
           this.set('ecosystemAnonId', newEcosystemAnonId);

--- a/packages/fxa-content-server/app/tests/spec/models/account.js
+++ b/packages/fxa-content-server/app/tests/spec/models/account.js
@@ -3229,7 +3229,7 @@ describe('models/account', function () {
       );
     });
 
-    it('does not supply ifMatch if an old eco anon id does not exist', async () => {
+    it('sets ifNoneMatch if an old eco anon id does not exist', async () => {
       fxaClient.accountProfile.restore();
       sandbox.stub(fxaClient, 'accountProfile').resolves({
         ecosystemAnonId: null,
@@ -3254,7 +3254,9 @@ describe('models/account', function () {
         fxaClient.updateEcosystemAnonId.calledWithExactly(
           SESSION_TOKEN,
           'test id',
-          {}
+          {
+            ifNoneMatch: '*',
+          }
         )
       );
     });


### PR DESCRIPTION
## Because

- Only fair to fix some sentry errors if we will be adding some 

## This pull request

- Adds `ifNoneMatch` when no anon id is set
- From [here](https://github.com/mozilla/fxa/blob/f88701a3a7978557236a4fbe41f3fe156d4d6379/packages/fxa-auth-server/lib/routes/account.ts#L1480) it seems like we need to specify `*` to fail on any exisitng id

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/9106

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
