### PR TITLE
feat(subscriptions): create acct and subscribe with Stripe

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -359,7 +359,7 @@
         "termsUri": "",
         "privacyUri": "",
         "trusted": true,
-        "allowedScopes": "https://identity.mozilla.com/account/subscriptions",
+        "allowedScopes": "https://identity.mozilla.com/account/subscriptions https://identity.mozilla.com/account/newsletters",
         "publicClient": true
       },
       {
@@ -428,6 +428,6 @@
   },
   "mjml": {
     "enabledEmailAddress": "@testuser.com$",
-    "templates":  ["cadReminderFirst"]
+    "templates": ["cadReminderFirst"]
   }
 }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/utils.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/utils.ts
@@ -3,17 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import ScopeSet from 'fxa-shared/oauth/scopes';
+import { OAUTH_SCOPE_SUBSCRIPTIONS } from 'fxa-shared/oauth/constants';
 import error from '../../error';
-
-const SUBSCRIPTIONS_MANAGEMENT_SCOPE =
-  'https://identity.mozilla.com/account/subscriptions';
 
 /**
  * Authentication handler for subscription routes.
  */
 export async function handleAuth(db: any, auth: any, fetchEmail = false) {
   const scope = ScopeSet.fromArray(auth.credentials.scope);
-  if (!scope.contains(SUBSCRIPTIONS_MANAGEMENT_SCOPE)) {
+  if (!scope.contains(OAUTH_SCOPE_SUBSCRIPTIONS)) {
     throw error.invalidScopes();
   }
   const { user: uid } = auth.credentials;

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -23,11 +23,10 @@ const { filterSubscription } = require('fxa-shared/subscriptions/stripe');
 const { CurrencyHelper } = require('../../../../lib/payments/currencies');
 
 const ACCOUNT_LOCALE = 'en-US';
-const SUBSCRIPTIONS_MANAGEMENT_SCOPE =
-  'https://identity.mozilla.com/account/subscriptions';
+const { OAUTH_SCOPE_SUBSCRIPTIONS } = require('fxa-shared/oauth/constants');
 const TEST_EMAIL = 'test@email.com';
 const UID = uuid.v4({}, Buffer.alloc(16)).toString('hex');
-const MOCK_SCOPES = ['profile:email', SUBSCRIPTIONS_MANAGEMENT_SCOPE];
+const MOCK_SCOPES = ['profile:email', OAUTH_SCOPE_SUBSCRIPTIONS];
 
 let log,
   config,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -60,8 +60,7 @@ let config,
   request,
   requestOptions;
 
-const SUBSCRIPTIONS_MANAGEMENT_SCOPE =
-  'https://identity.mozilla.com/account/subscriptions';
+const { OAUTH_SCOPE_SUBSCRIPTIONS } = require('fxa-shared/oauth/constants');
 
 const ACCOUNT_LOCALE = 'en-US';
 const TEST_EMAIL = 'test@email.com';
@@ -124,7 +123,7 @@ const ACTIVE_SUBSCRIPTIONS = [
 
 const MOCK_CLIENT_ID = '3c49430b43dfba77';
 const MOCK_TTL = 3600;
-const MOCK_SCOPES = ['profile:email', SUBSCRIPTIONS_MANAGEMENT_SCOPE];
+const MOCK_SCOPES = ['profile:email', OAUTH_SCOPE_SUBSCRIPTIONS];
 
 function runTest(routePath, requestOptions, payments = null) {
   routes = require('../../../../lib/routes/subscriptions')(

--- a/packages/fxa-auth-server/test/local/routes/support.js
+++ b/packages/fxa-auth-server/test/local/routes/support.js
@@ -22,15 +22,14 @@ let config,
   requestOptions,
   zendeskClient;
 
-const SUBSCRIPTIONS_MANAGEMENT_SCOPE =
-  'https://identity.mozilla.com/account/subscriptions';
+const { OAUTH_SCOPE_SUBSCRIPTIONS } = require('fxa-shared/oauth/constants');
 
 const TEST_EMAIL = 'test@email.com';
 const UID = uuid.v4({}, Buffer.alloc(16)).toString('hex');
 const REQUESTER_ID = 987654321;
 const SUBDOMAIN = 'test';
 
-const MOCK_SCOPES = ['profile:email', SUBSCRIPTIONS_MANAGEMENT_SCOPE];
+const MOCK_SCOPES = ['profile:email', OAUTH_SCOPE_SUBSCRIPTIONS];
 
 const ORG_ID = 123456789;
 // Returns a 201

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -7,6 +7,7 @@
 const ROOT_DIR = '../..';
 
 const { assert } = require('chai');
+const { OAUTH_SCOPE_SUBSCRIPTIONS } = require('fxa-shared/oauth/constants');
 const clientFactory = require('../client')();
 const config = require(`${ROOT_DIR}/config`).getProperties();
 const error = require(`${ROOT_DIR}/lib/error`);
@@ -117,7 +118,7 @@ describe('remote subscriptions:', function () {
       const tokenResponse3 = await client.grantOAuthTokensFromSessionToken({
         grant_type: 'fxa-credentials',
         client_id: CLIENT_ID,
-        scope: 'profile https://identity.mozilla.com/account/subscriptions',
+        scope: `profile ${OAUTH_SCOPE_SUBSCRIPTIONS}`,
       });
 
       tokens = [

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -10,8 +10,9 @@ const path = require('path');
 
 const versionInfo = require('./version');
 
-const DEFAULT_SUPPORTED_LANGUAGES = require('fxa-shared').l10n
-  .supportedLanguages;
+const { OAUTH_SCOPE_SUBSCRIPTIONS } = require('fxa-shared/oauth/constants');
+const DEFAULT_SUPPORTED_LANGUAGES =
+  require('fxa-shared').l10n.supportedLanguages;
 
 convict.addFormats(require('convict-format-with-moment'));
 convict.addFormats(require('convict-format-with-validator'));
@@ -19,8 +20,7 @@ convict.addFormats(require('convict-format-with-validator'));
 const conf = (module.exports = convict({
   allowed_iframe_contexts: {
     default: [],
-    doc:
-      'DEPRECATED - context query parameters allowed to embed FxA within an IFRAME',
+    doc: 'DEPRECATED - context query parameters allowed to embed FxA within an IFRAME',
     format: Array,
   },
   allowed_metrics_flow_cors_origins: {
@@ -116,8 +116,7 @@ const conf = (module.exports = convict({
     },
     reportOnly: {
       default: false,
-      doc:
-        'DEPRECATED - Only send the "Content-Security-Policy-Report-Only" header',
+      doc: 'DEPRECATED - Only send the "Content-Security-Policy-Report-Only" header',
       env: 'CSP_REPORT_ONLY',
     },
     reportOnlyEnabled: {
@@ -142,8 +141,7 @@ const conf = (module.exports = convict({
   },
   env: {
     default: 'production',
-    doc:
-      "What environment are we running in?  Note: all hosted environments are 'production'.",
+    doc: "What environment are we running in?  Note: all hosted environments are 'production'.",
     env: 'NODE_ENV',
     format: ['production', 'development'],
   },
@@ -169,8 +167,7 @@ const conf = (module.exports = convict({
       },
       initialBackoff: {
         default: '100 milliseconds',
-        doc:
-          'Initial backoff for feature-flagging Redis connection retries, increases exponentially with each attempt',
+        doc: 'Initial backoff for feature-flagging Redis connection retries, increases exponentially with each attempt',
         env: 'FEATURE_FLAGS_REDIS_TIMEOUT',
         format: 'duration',
       },
@@ -296,29 +293,25 @@ const conf = (module.exports = convict({
     fonts: {
       unsupportedLanguages: {
         default: [],
-        doc:
-          'DEPRECATED: These languages should use system fonts instead of Fira Sans',
+        doc: 'DEPRECATED: These languages should use system fonts instead of Fira Sans',
         format: Array,
       },
     },
     localeSubdirSuffix: {
       default: '',
-      doc:
-        'Enable alternative localized resources for Mozilla Online with private use subtag',
+      doc: 'Enable alternative localized resources for Mozilla Online with private use subtag',
       env: 'I18N_LOCALE_SUBDIR_SUFFIX',
       format: ['', '_x_mococn'],
     },
     supportedLanguages: {
       default: DEFAULT_SUPPORTED_LANGUAGES,
-      doc:
-        'List of languages this deployment should detect and display localized strings.',
+      doc: 'List of languages this deployment should detect and display localized strings.',
       env: 'I18N_SUPPORTED_LANGUAGES',
       format: Array,
     },
     translationDirectory: {
       default: path.resolve(__dirname, '../../app/i18n/'),
-      doc:
-        'The directory where per-locale .json files containing translations reside',
+      doc: 'The directory where per-locale .json files containing translations reside',
       env: 'I18N_TRANSLATION_DIR',
       format: String,
     },
@@ -388,8 +381,7 @@ const conf = (module.exports = convict({
       dcdb5ae7add825d2: '123done',
       '325b4083e32fe8e7': '321done',
     },
-    doc:
-      'Mappings from client id to service name: { "id1": "name-1", "id2": "name-2" }',
+    doc: 'Mappings from client id to service name: { "id1": "name-1", "id2": "name-2" }',
     env: 'OAUTH_CLIENT_IDS',
     format: Object,
   },
@@ -430,8 +422,7 @@ const conf = (module.exports = convict({
   },
   page_template_subdirectory: {
     default: 'src',
-    doc:
-      'Subdirectory of page_template_root for server-rendered page templates',
+    doc: 'Subdirectory of page_template_root for server-rendered page templates',
     env: 'PAGE_TEMPLATE_SUBDIRECTORY',
     format: ['src', 'dist'],
   },
@@ -442,8 +433,7 @@ const conf = (module.exports = convict({
         'a2270f727f45f648', // Fenix
         '1b1a3e44c54fbb58', // Firefox for iOS
       ],
-      doc:
-        'OAuth Client IDs that are allowed to pair. Remove all clients from this list to disable pairing.',
+      doc: 'OAuth Client IDs that are allowed to pair. Remove all clients from this list to disable pairing.',
       env: 'PAIRING_CLIENTS',
       format: Array,
     },
@@ -538,15 +528,13 @@ const conf = (module.exports = convict({
   sentry: {
     client_errors_dsn: {
       default: undefined,
-      doc:
-        'Sentry config for client side errors. If not set, then no errors reported.',
+      doc: 'Sentry config for client side errors. If not set, then no errors reported.',
       env: 'SENTRY_CLIENT_ERRORS_DSN',
       format: String,
     },
     server_errors_dsn: {
       default: undefined,
-      doc:
-        'Sentry config for Express server-side errors. If not set, then no errors reported.',
+      doc: 'Sentry config for Express server-side errors. If not set, then no errors reported.',
       env: 'SENTRY_SERVER_ERRORS_DSN',
       format: String,
     },
@@ -576,16 +564,14 @@ const conf = (module.exports = convict({
       targetURITemplateiOS: {
         default:
           'https://app.adjust.com/jsr?url=https%3A%2F%2Fnn8g.adj.st%2Ffxa-signin%3Futm_source%3Dsms%26signin%3D${ signinCode }%26adj_t%3D${ channel }%26adj_campaign%3Dfxa-conf-page%26adj_adgroup%3Dsms%26adj_creative%3Dlink%26adjust_deeplink_js%3D1', //eslint-disable-line max-len
-        doc:
-          'iOS Redirect URI - ES6 format template string. The variables `channel` and `signinCode` are interpolated',
+        doc: 'iOS Redirect URI - ES6 format template string. The variables `channel` and `signinCode` are interpolated',
         env: 'SMS_REDIRECT_TARGET_URI_TEMPLATE_IOS',
         format: String,
       },
       targetURITemplate: {
         default:
           'https://app.adjust.com/${ channel }?campaign=fxa-conf-page&adgroup=sms&creative=link&deep_link=firefox%3A%2F%2Ffxa-signin%3Futm_source%3Dsms%26signin%3D${ signinCode }', //eslint-disable-line max-len
-        doc:
-          'Default Redirect URI - ES6 format template string. The variables `channel` and `signinCode` are interpolated',
+        doc: 'Default Redirect URI - ES6 format template string. The variables `channel` and `signinCode` are interpolated',
         env: 'SMS_REDIRECT_TARGET_URI_TEMPLATE',
         format: String,
       },
@@ -593,8 +579,7 @@ const conf = (module.exports = convict({
   },
   sourceMapType: {
     default: 'source-map',
-    doc:
-      'Type of source maps created. See https://webpack.js.org/configuration/devtool/',
+    doc: 'Type of source maps created. See https://webpack.js.org/configuration/devtool/',
     env: 'SOURCE_MAP_TYPE',
     format: String,
   },
@@ -668,16 +653,14 @@ const conf = (module.exports = convict({
       format: String,
     },
     managementScopes: {
-      default: 'profile https://identity.mozilla.com/account/subscriptions',
-      doc:
-        'OAuth scopes needed for the subscription management pages to access auth server APIs',
+      default: `profile ${OAUTH_SCOPE_SUBSCRIPTIONS}`,
+      doc: 'OAuth scopes needed for the subscription management pages to access auth server APIs',
       env: 'SUBSCRIPTIONS_MANAGEMENT_SCOPES',
       format: String,
     },
     managementTokenTTL: {
       default: 1800,
-      doc:
-        'OAuth token time-to-live (in seconds) for subscriptions management pages',
+      doc: 'OAuth token time-to-live (in seconds) for subscriptions management pages',
       env: 'SUBSCRIPTIONS_MANAGEMENT_TOKEN_TTL',
       format: 'nat',
     },
@@ -689,8 +672,7 @@ const conf = (module.exports = convict({
     },
     allowUnauthenticatedRedirects: {
       default: false,
-      doc:
-        'Whether to allow any redirects to Payments for an unauthenticated user',
+      doc: 'Whether to allow any redirects to Payments for an unauthenticated user',
       env: 'SUBSCRIPTIONS_UNAUTHED_REDIRECTS',
       formlat: Boolean,
     },
@@ -718,14 +700,12 @@ const conf = (module.exports = convict({
   ecosystem_anon_id: {
     keys_file: {
       default: '',
-      doc:
-        'Path to a file containing an array of Account Ecosystem Telemetry pipeline JWK public key objects for encrypting the ecosystem user ID to the ecosystem anon ID',
+      doc: 'Path to a file containing an array of Account Ecosystem Telemetry pipeline JWK public key objects for encrypting the ecosystem user ID to the ecosystem anon ID',
       env: 'ECOSYSTEM_ANON_ID_KEYS_FILE',
       format: String,
     },
     keys: {
-      doc:
-        'Array of Account Ecosystem Telemetry pipeline JWK public key objects for encrypting the ecosystem user ID to the ecosystem anon ID',
+      doc: 'Array of Account Ecosystem Telemetry pipeline JWK public key objects for encrypting the ecosystem user ID to the ecosystem anon ID',
       default: [],
     },
   },
@@ -747,8 +727,7 @@ const conf = (module.exports = convict({
   use_https: false,
   var_path: {
     default: path.resolve(__dirname, '..', 'var'),
-    doc:
-      'The path where deployment specific resources will be sought (keys, etc), and logs will be kept.',
+    doc: 'The path where deployment specific resources will be sought (keys, etc), and logs will be kept.',
     env: 'VAR_PATH',
   },
 }));

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -40,6 +40,8 @@ duplicate-transaction = Hmm. Looks like an identical transaction was just sent. 
 coupon-expired = It looks like that promo code has expired.
 card-error = Your transaction could not be processed. Please verify your credit card information and try again.
 
+fxa-signup-error = There was a problem creating your account.  Please try again later.
+
 ## settings
 settings-home = Account Home
 settings-subscriptions-title = Subscriptions

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -242,6 +242,12 @@ const conf = convict({
         env: 'OAUTH_SERVER_URL',
         format: 'url',
       },
+      clientId: {
+        default: '59cceb6f8c32317c',
+        doc: 'The Payments frontend OAuth client id.',
+        env: 'OAUTH_SUBSCRIPTIONS_CLIENT_ID',
+        format: 'String',
+      },
     },
     profile: {
       url: {

--- a/packages/fxa-payments-server/server/lib/server.js
+++ b/packages/fxa-payments-server/server/lib/server.js
@@ -79,6 +79,7 @@ module.exports = () => {
       },
       oauth: {
         url: config.get('servers.oauth.url'),
+        clientId: config.get('servers.oauth.clientId'),
       },
       profile: {
         url: config.get('servers.profile.url'),

--- a/packages/fxa-payments-server/src/lib/account.test.ts
+++ b/packages/fxa-payments-server/src/lib/account.test.ts
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+jest.mock('./apiClient', () => ({
+  apiCreatePasswordlessAccount: jest
+    .fn()
+    .mockResolvedValue({ uid: 'wibble', access_token: 'quux' }),
+  updateAPIClientToken: jest.fn(),
+}));
+jest.mock('./sentry', () => ({
+  __esModule: true,
+  default: { captureException: jest.fn() },
+}));
+import {
+  apiCreatePasswordlessAccount,
+  updateAPIClientToken,
+} from './apiClient';
+import { FXA_SIGNUP_ERROR, handlePasswordlessSignUp } from './account';
+import sentry from './sentry';
+
+const accountParam = { email: 'me@example.com', clientId: 'tests' };
+
+beforeEach(() => {
+  (apiCreatePasswordlessAccount as jest.Mock).mockClear();
+  (updateAPIClientToken as jest.Mock).mockClear();
+});
+
+describe('lib/account', () => {
+  describe('handlePasswordlessSignUp', () => {
+    it('updates the API client token on success', async () => {
+      await handlePasswordlessSignUp(accountParam);
+      expect(updateAPIClientToken).toBeCalledWith('quux');
+    });
+
+    it('throws an error on failure', async () => {
+      (apiCreatePasswordlessAccount as jest.Mock)
+        .mockReset()
+        .mockRejectedValue(FXA_SIGNUP_ERROR);
+      await expect(handlePasswordlessSignUp(accountParam)).rejects.toBe(
+        FXA_SIGNUP_ERROR
+      );
+      expect(updateAPIClientToken).not.toHaveBeenCalled();
+      expect(sentry.captureException).toHaveBeenCalledWith(FXA_SIGNUP_ERROR);
+    });
+  });
+});

--- a/packages/fxa-payments-server/src/lib/account.ts
+++ b/packages/fxa-payments-server/src/lib/account.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  apiCreatePasswordlessAccount,
+  updateAPIClientToken,
+} from './apiClient';
+import { GeneralError } from './errors';
+import sentry from './sentry';
+export const FXA_SIGNUP_ERROR: GeneralError = { code: 'fxa_signup_error' };
+
+export async function handlePasswordlessSignUp({
+  email,
+  clientId,
+}: {
+  email: string;
+  clientId: string;
+}) {
+  try {
+    const { access_token: accessToken } = await apiCreatePasswordlessAccount({
+      email,
+      clientId,
+    });
+    updateAPIClientToken(accessToken);
+  } catch (e) {
+    sentry.captureException(e);
+    throw FXA_SIGNUP_ERROR;
+  }
+}
+
+export type PasswordlessSignupHandlerParam = Parameters<
+  typeof handlePasswordlessSignUp
+>[0];

--- a/packages/fxa-payments-server/src/lib/amplitude.test.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.test.ts
@@ -4,7 +4,6 @@ jest.mock('../lib/flow-event');
 jest.mock('./sentry');
 
 import * as Amplitude from './amplitude';
-import { Store } from '../store';
 
 beforeEach(() => {
   (<jest.Mock>FlowEvent.logAmplitudeEvent).mockClear();
@@ -16,13 +15,6 @@ it('should call logAmplitudeEvent with the correct event group and type names', 
     ['manageSubscriptionsEngaged', ['subManage', 'engage']],
     ['createSubscriptionMounted', ['subPaySetup', 'view']],
     ['createSubscriptionEngaged', ['subPaySetup', 'engage']],
-    ['createSubscription_PENDING', ['subPaySetup', 'submit']],
-    [
-      'createSubscription_FULFILLED',
-      ['subPaySetup', 'success'],
-      ['subPaySetup', 'complete'],
-    ],
-    ['createSubscription_REJECTED', ['subPaySetup', 'fail']],
     ['updateSubscriptionPlanMounted', ['subPayUpgrade', 'view']],
     ['updateSubscriptionPlanEngaged', ['subPayUpgrade', 'engage']],
     ['updateSubscriptionPlan_PENDING', ['subPayUpgrade', 'submit']],
@@ -53,97 +45,4 @@ it('should call logAmplitudeEvent with the correct event group and type names', 
 
     (<jest.Mock>FlowEvent.logAmplitudeEvent).mockClear();
   }
-});
-
-it('should capture error during logAmplitudeEvent', () => {
-  (<jest.Mock>FlowEvent.logAmplitudeEvent).mockImplementationOnce(() => {
-    throw 'oopsie';
-  });
-  expect(() => {
-    Amplitude.createSubscription_PENDING({
-      plan_id: '123xyz_hourly',
-      product_id: '123xyz',
-    });
-  }).not.toThrow();
-});
-
-it('should call logAmplitudeEvent with subscription plan info', () => {
-  const metricsData: Amplitude.EventProperties = {
-    plan_id: '123xyz_hourly',
-    product_id: '123xyz',
-    paymentProvider: 'stripe',
-  };
-  Amplitude.createSubscription_PENDING(metricsData);
-  const eventProps = (<jest.Mock>(
-    FlowEvent.logAmplitudeEvent
-  )).mock.calls[0].pop();
-
-  expect(eventProps).toMatchObject({
-    planId: metricsData.plan_id,
-    productId: metricsData.product_id,
-    paymentProvider: metricsData.paymentProvider,
-  });
-});
-
-it('should call logAmplitudeEvent with reason for failure on fail event', () => {
-  const metricsData: Amplitude.EventProperties = {
-    plan_id: '123xyz_hourly',
-    product_id: '123xyz',
-  };
-  const payload = { message: 'oopsie daisies' };
-  Amplitude.createSubscription_REJECTED({
-    ...metricsData,
-    error: payload,
-  });
-  const eventProps = (<jest.Mock>(
-    FlowEvent.logAmplitudeEvent
-  )).mock.calls[0].pop();
-
-  expect(eventProps).toMatchObject({
-    planId: metricsData.plan_id,
-    productId: metricsData.product_id,
-    reason: payload.message,
-  });
-});
-
-describe('subscribes to the redux store for the uid', () => {
-  const uid = 'abc123xyz';
-  const plan = { plan_id: '123xyz_hourly', product_id: '123xyz' };
-  const payload = { message: 'oopsie daisies' };
-  const unsubscribe = jest.fn();
-  let callbackFromAmplitudeLib: Function;
-  let storeMock = {
-    subscribe: (cb: Function) => {
-      callbackFromAmplitudeLib = cb;
-      return unsubscribe;
-    },
-    getState: jest
-      .fn()
-      .mockReturnValueOnce({})
-      .mockReturnValueOnce({ profile: { result: { uid } } }),
-  };
-
-  it('should set the uid on the event properties then unsubscribe', () => {
-    Amplitude.subscribeToReduxStore((storeMock as unknown) as Store);
-    callbackFromAmplitudeLib();
-    expect(unsubscribe).not.toHaveBeenCalled();
-    callbackFromAmplitudeLib();
-    expect(unsubscribe).toHaveBeenCalled();
-
-    Amplitude.createSubscription_REJECTED({
-      ...plan,
-      error: payload,
-    });
-
-    const eventProps = (<jest.Mock>(
-      FlowEvent.logAmplitudeEvent
-    )).mock.calls[0].pop();
-
-    expect(eventProps).toMatchObject({
-      planId: plan.plan_id,
-      productId: plan.product_id,
-      reason: payload.message,
-      uid: uid, // this was added
-    });
-  });
 });

--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -139,37 +139,6 @@ export function createSubscriptionEngaged(eventProperties: EventProperties) {
   );
 }
 
-export function createSubscription_PENDING(eventProperties: EventProperties) {
-  safeLogAmplitudeEvent(
-    eventGroupNames.createSubscription,
-    eventTypeNames.submit,
-    eventProperties
-  );
-}
-
-export function createSubscription_FULFILLED(
-  eventProperties: SuccessfulSubscriptionEventProperties
-) {
-  safeLogAmplitudeEvent(
-    eventGroupNames.createSubscription,
-    eventTypeNames.success,
-    eventProperties
-  );
-  safeLogAmplitudeEvent(
-    eventGroupNames.createSubscription,
-    eventTypeNames.complete,
-    eventProperties
-  );
-}
-
-export function createSubscription_REJECTED(eventProperties: EventProperties) {
-  safeLogAmplitudeEvent(
-    eventGroupNames.createSubscription,
-    eventTypeNames.fail,
-    eventProperties
-  );
-}
-
 export function updatePaymentMounted() {
   safeLogAmplitudeEvent(eventGroupNames.updatePayment, eventTypeNames.view, {});
 }

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -73,7 +73,7 @@ async function apiFetch(
     ...options,
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${accessToken}`,
+      Authorization: accessToken ? `Bearer ${accessToken}` : undefined,
       ...(options.headers || {}),
     },
   });
@@ -199,6 +199,15 @@ export async function apiReactivateSubscription({
     subscriptionId,
     planId,
   };
+}
+
+export async function apiCreatePasswordlessAccount(params: {
+  email: string;
+  clientId: string;
+}) {
+  return apiFetch('POST', `${config.servers.auth.url}/v1/account/stub`, {
+    body: JSON.stringify(params),
+  });
 }
 
 export async function apiCreateCustomer(params: {

--- a/packages/fxa-payments-server/src/lib/config.test.ts
+++ b/packages/fxa-payments-server/src/lib/config.test.ts
@@ -135,6 +135,7 @@ const expectedMergedConfig = {
     },
     oauth: {
       url: '',
+      clientId: '',
     },
     profile: {
       url: '',
@@ -155,28 +156,30 @@ const expectedMergedConfig = {
 
 const headSelector = (name: string | null) => `meta[name="${name}"]`;
 
-const mkHeadQuerySelector = (
-  configValue: string | null,
-  flagsValue: string | null,
-  missing: string | null
-) => (selector: string) =>
-  selector === headSelector(missing)
-    ? null
-    : {
-        getAttribute: (name: string) => {
-          if (name !== 'content') {
-            return null;
-          }
-          switch (selector) {
-            case headSelector(META_CONFIG):
-              return configValue;
-            case headSelector(META_FEATURE_FLAGS):
-              return flagsValue;
-            default:
+const mkHeadQuerySelector =
+  (
+    configValue: string | null,
+    flagsValue: string | null,
+    missing: string | null
+  ) =>
+  (selector: string) =>
+    selector === headSelector(missing)
+      ? null
+      : {
+          getAttribute: (name: string) => {
+            if (name !== 'content') {
               return null;
-          }
-        },
-      };
+            }
+            switch (selector) {
+              case headSelector(META_CONFIG):
+                return configValue;
+              case headSelector(META_FEATURE_FLAGS):
+                return flagsValue;
+              default:
+                return null;
+            }
+          },
+        };
 
 const baseHeadQuerySelector = mkHeadQuerySelector(
   encodedConfig,

--- a/packages/fxa-payments-server/src/lib/config.ts
+++ b/packages/fxa-payments-server/src/lib/config.ts
@@ -24,6 +24,7 @@ export interface Config {
     };
     oauth: {
       url: string;
+      clientId: string;
     };
     profile: {
       url: string;
@@ -68,6 +69,7 @@ export function defaultConfig(): Config {
       },
       oauth: {
         url: '',
+        clientId: '',
       },
       profile: {
         url: '',

--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -28,6 +28,7 @@ const BASIC_ERROR = 'basic-error-message';
 const PAYMENT_ERROR_1 = 'payment-error-1';
 const PAYMENT_ERROR_2 = 'payment-error-2';
 const PAYMENT_ERROR_3 = 'payment-error-3b';
+const FXA_SIGNUP_ERROR = 'fxa-signup-error';
 
 /*
  * errorToErrorMessageMap - the keys are lookups, that
@@ -128,12 +129,14 @@ const paymentErrors2 = [
 ];
 
 const paymentErrors3 = ['general-paypal-error'];
+const signupErrors = ['fxa_signup_error'];
 
 cardErrors.forEach((k) => (errorToErrorMessageMap[k] = CARD_ERROR));
 basicErrors.forEach((k) => (errorToErrorMessageMap[k] = BASIC_ERROR));
 paymentErrors1.forEach((k) => (errorToErrorMessageMap[k] = PAYMENT_ERROR_1));
 paymentErrors2.forEach((k) => (errorToErrorMessageMap[k] = PAYMENT_ERROR_2));
 paymentErrors3.forEach((k) => (errorToErrorMessageMap[k] = PAYMENT_ERROR_3));
+signupErrors.forEach((k) => (errorToErrorMessageMap[k] = FXA_SIGNUP_ERROR));
 
 function getErrorMessage(error: undefined | StripeError | GeneralError) {
   if (!error) {

--- a/packages/fxa-payments-server/src/lib/stripe.test.ts
+++ b/packages/fxa-payments-server/src/lib/stripe.test.ts
@@ -2,9 +2,101 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { localeToStripeLocale } from './stripe';
+jest.mock('./account', () => ({
+  handlePasswordlessSignUp: jest.fn(),
+}));
+jest.mock('./apiClient');
+
+import * as apiClient from './apiClient';
+import { FXA_SIGNUP_ERROR, handlePasswordlessSignUp } from './account';
+import { handlePasswordlessSubscription, localeToStripeLocale } from './stripe';
+import { NEW_CUSTOMER, PLAN } from './mock-data';
+
+const stripeOverride = {
+  createPaymentMethod: jest.fn().mockResolvedValue({ paymentMethod: {} }),
+  confirmCardPayment: jest.fn().mockResolvedValue({}),
+};
+const apiClientOverrides = {
+  apiCreateCustomer: jest.fn().mockResolvedValue(NEW_CUSTOMER),
+  apiCreateSubscriptionWithPaymentMethod: jest.fn().mockResolvedValue({
+    latest_invoice: {
+      payment_intent: {
+        status: 'succeeded',
+      },
+    },
+  }),
+  apiRetryInvoice: jest.fn().mockResolvedValue({
+    payment_intent: {
+      status: 'succeeded',
+    },
+  }),
+  apiDetachFailedPaymentMethod: jest.fn().mockResolvedValue({}),
+};
 
 // handleSubscriptionPayment and handlePaymentIntent are tested as part of SubscriptionCreate
+
+// At the time of writing, there is no UI component that uses
+// handlePasswordlessSubscription; once we have that implementation, we should
+// test handlePasswordlessSubscription in the same fashion that we test
+// handleSubscriptionPayment.
+// #TODO https://github.com/mozilla/fxa/issues/9358
+describe('handlePasswordlessSubscription', () => {
+  const email = 'testo@example.com';
+  const clientId = 'thebestprogram';
+  const noop = () => {};
+
+  beforeEach(() => {
+    (handlePasswordlessSignUp as jest.Mock).mockClear();
+  });
+
+  it('calls handlePasswordlessSignUp then handleSubscriptionPayment on success', async () => {
+    const onFailure = jest.fn();
+
+    (handlePasswordlessSignUp as jest.Mock).mockResolvedValue({});
+    await handlePasswordlessSubscription({
+      email,
+      clientId,
+      stripe: stripeOverride,
+      name: 'BMO',
+      card: null,
+      idempotencyKey: 'dontrepeat',
+      selectedPlan: PLAN,
+      customer: null,
+      retryStatus: undefined,
+      ...apiClientOverrides,
+      onFailure,
+      onRetry: noop,
+      onSuccess: noop,
+    });
+
+    expect(handlePasswordlessSignUp).toBeCalledWith({ email, clientId });
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+
+  it('calls the onFailure callback on error', async () => {
+    const onFailure = jest.fn();
+
+    (handlePasswordlessSignUp as jest.Mock).mockRejectedValue(FXA_SIGNUP_ERROR);
+    await handlePasswordlessSubscription({
+      email,
+      clientId,
+      stripe: stripeOverride,
+      name: 'BMO',
+      card: null,
+      idempotencyKey: 'dontrepeat',
+      selectedPlan: PLAN,
+      customer: null,
+      retryStatus: undefined,
+      ...apiClientOverrides,
+      onFailure,
+      onRetry: noop,
+      onSuccess: noop,
+    });
+
+    expect(handlePasswordlessSignUp).toBeCalledWith({ email, clientId });
+    expect(onFailure).toHaveBeenCalledWith(FXA_SIGNUP_ERROR);
+  });
+});
 
 describe('localeToStripeLocale', () => {
   it('handles known Stripe locales as expected', () => {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.stories.tsx
@@ -142,7 +142,7 @@ function init() {
   storiesOf('routes/Product/SubscriptionCreate/errors', module)
     .add('card declined', () => (
       <Subject
-        paymentErrorInitialState={{
+        subscriptionErrorInitialState={{
           type: 'card_error',
           code: 'card_declined',
           message: 'Should not be displayed',
@@ -151,7 +151,7 @@ function init() {
     ))
     .add('incorrect cvc', () => (
       <Subject
-        paymentErrorInitialState={{
+        subscriptionErrorInitialState={{
           type: 'card_error',
           code: 'incorrect_cvc',
           message: 'Should not be displayed',
@@ -160,7 +160,7 @@ function init() {
     ))
     .add('card expired', () => (
       <Subject
-        paymentErrorInitialState={{
+        subscriptionErrorInitialState={{
           type: 'card_error',
           code: 'expired_card',
           message: 'Your card has expired.',
@@ -169,7 +169,7 @@ function init() {
     ))
     .add('other error', () => (
       <Subject
-        paymentErrorInitialState={{
+        subscriptionErrorInitialState={{
           type: 'api_error',
         }}
       />

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -147,7 +147,7 @@ const defaultStripeOverride = () => ({
   confirmCardPayment: jest.fn().mockResolvedValue(CONFIRM_CARD_RESULT),
 });
 
-describe('routes/ProductV2/SubscriptionCreate', () => {
+describe('routes/Product/SubscriptionCreate', () => {
   let consoleSpy: jest.SpyInstance<void, [any?, ...any[]]>;
 
   beforeEach(() => {

--- a/packages/fxa-shared/oauth/constants.js
+++ b/packages/fxa-shared/oauth/constants.js
@@ -5,7 +5,9 @@
 module.exports = {
   OAUTH_SCOPE_OLD_SYNC: 'https://identity.mozilla.com/apps/oldsync',
   OAUTH_SCOPE_SESSION_TOKEN: 'https://identity.mozilla.com/tokens/session',
-  OAUTH_SCOPE_NEWSLETTERS: 'https://identity.mozilla.com/accounts/newsletters',
+  OAUTH_SCOPE_NEWSLETTERS: 'https://identity.mozilla.com/account/newsletters',
+  OAUTH_SCOPE_SUBSCRIPTIONS:
+    'https://identity.mozilla.com/account/subscriptions',
   SHORT_ACCESS_TOKEN_TTL_IN_MS: 1000 * 60 * 60 * 6,
   // Maximum age an account is considered "new", useful when sending
   // notification emails


### PR DESCRIPTION
Because:
 - we need to create an account and then subscribe to a plan for a new
   Payments route

This commit:
 - add the Payments OAuth client id as a config
 - add functions for creating the passwordless account and setting the
   access token for the API client
 - add a function that can be used in callbacks to create an account and
   then subscribe to a plan with Stripe payments

## Issue that this pull request solves

part of #9358 
