### PR TITLE
fix(content): fix inline totp edge case

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/inline_totp_setup.js
+++ b/packages/fxa-content-server/app/scripts/views/inline_totp_setup.js
@@ -76,6 +76,7 @@ var View = FormView.extend({
 
     if (!account.get('sessionToken')) {
       this.navigate(this._getMissingSessionTokenScreen());
+      return;
     }
 
     return account.sessionVerificationStatus().then(({ sessionVerified }) => {


### PR DESCRIPTION
This sentry event https://sentry.prod.mozaws.net/operations/fxa-content-client-prod/issues/10992802/events/3323a6cddda74ce2b23852828b802b65/

is caused by a session being in an unverified state when the flow first starts. Here we were checking for the sessionToken and navigating, but also continuing to execute the sessionVerificationStatus which threw and error. It was benign but still sent it to sentry.