### PR TITLE
feat(payments): add newsletter signup helper functions and config

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -41,6 +41,7 @@ coupon-expired = It looks like that promo code has expired.
 card-error = Your transaction could not be processed. Please verify your credit card information and try again.
 
 fxa-signup-error = There was a problem creating your account.  Please try again later.
+fxa-newsletter-signup-error = There was a problem subscribing you to the newsletter.
 
 ## settings
 settings-home = Account Home

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -61,6 +61,7 @@ import {
   apiCapturePaypalPayment,
   apiUpdateBillingAgreement,
   apiCreatePasswordlessAccount,
+  apiSignupForNewsletter,
 } from './apiClient';
 import { PaymentProvider } from './PaymentProvider';
 
@@ -636,6 +637,18 @@ describe('API requests', () => {
         ...metricsOptions,
         error,
       });
+      requestMock.done();
+    });
+  });
+
+  describe('apiSignupForNewsletter', () => {
+    it('POST {auth-server}/v1/account/newsletters', async () => {
+      const arg = { newsletterId: 'cooking-with-foxkeh' };
+      const resp = {};
+      const requestMock = nock(AUTH_BASE_URL)
+        .post('/v1/newsletters', arg)
+        .reply(200, resp);
+      expect(await apiSignupForNewsletter(arg)).toEqual(resp);
       requestMock.done();
     });
   });

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -312,6 +312,14 @@ export async function apiCreateSubscriptionWithPaymentMethod(params: {
   }
 }
 
+export async function apiSignupForNewsletter(params: {
+  newsletterId: string;
+}): Promise<{}> {
+  return apiFetch('POST', `${config.servers.auth.url}/v1/newsletters`, {
+    body: JSON.stringify(params),
+  });
+}
+
 export async function apiRetryInvoice(params: {
   invoiceId: string;
   paymentMethodId: string;

--- a/packages/fxa-payments-server/src/lib/config.test.ts
+++ b/packages/fxa-payments-server/src/lib/config.test.ts
@@ -116,6 +116,7 @@ const expectedMergedConfig = {
     privacyNotice: 'https://abc.xyz/privacy',
     termsOfService: 'https://abc.xyz/terms',
   },
+  newsletterId: 'mozilla-and-you',
   productRedirectURLs: {},
   sample: {
     example: {

--- a/packages/fxa-payments-server/src/lib/config.ts
+++ b/packages/fxa-payments-server/src/lib/config.ts
@@ -8,6 +8,7 @@ export interface Config {
     privacyNotice: string;
     termsOfService: string;
   };
+  newsletterId: string;
   productRedirectURLs: {
     [productId: string]: string;
   };
@@ -55,6 +56,7 @@ export function defaultConfig(): Config {
       privacyNotice: '',
       termsOfService: '',
     },
+    newsletterId: 'mozilla-and-you',
     productRedirectURLs: {},
     sentry: {
       url: 'https://sentry.prod.mozaws.net',

--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -29,6 +29,7 @@ const PAYMENT_ERROR_1 = 'payment-error-1';
 const PAYMENT_ERROR_2 = 'payment-error-2';
 const PAYMENT_ERROR_3 = 'payment-error-3b';
 const FXA_SIGNUP_ERROR = 'fxa-signup-error';
+const FXA_NEWSLETTER_SIGNUP_ERROR = 'fxa-newsletter-signup-error';
 
 /*
  * errorToErrorMessageMap - the keys are lookups, that
@@ -130,6 +131,7 @@ const paymentErrors2 = [
 
 const paymentErrors3 = ['general-paypal-error'];
 const signupErrors = ['fxa_signup_error'];
+const newsletterSignupErrors = ['fxa_newsletter_signup_error'];
 
 cardErrors.forEach((k) => (errorToErrorMessageMap[k] = CARD_ERROR));
 basicErrors.forEach((k) => (errorToErrorMessageMap[k] = BASIC_ERROR));
@@ -137,6 +139,9 @@ paymentErrors1.forEach((k) => (errorToErrorMessageMap[k] = PAYMENT_ERROR_1));
 paymentErrors2.forEach((k) => (errorToErrorMessageMap[k] = PAYMENT_ERROR_2));
 paymentErrors3.forEach((k) => (errorToErrorMessageMap[k] = PAYMENT_ERROR_3));
 signupErrors.forEach((k) => (errorToErrorMessageMap[k] = FXA_SIGNUP_ERROR));
+newsletterSignupErrors.forEach(
+  (k) => (errorToErrorMessageMap[k] = FXA_NEWSLETTER_SIGNUP_ERROR)
+);
 
 function getErrorMessage(error: undefined | StripeError | GeneralError) {
   if (!error) {

--- a/packages/fxa-payments-server/src/lib/newsletter.test.ts
+++ b/packages/fxa-payments-server/src/lib/newsletter.test.ts
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { apiSignupForNewsletter } from './apiClient';
+import {
+  FXA_NEWSLETTER_SIGNUP_ERROR,
+  handleNewsletterSignup,
+} from './newsletter';
+import sentry from './sentry';
+
+jest.mock('./apiClient', () => ({
+  apiSignupForNewsletter: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('./sentry', () => ({
+  __esModule: true,
+  default: { captureException: jest.fn() },
+}));
+
+beforeEach(() => {
+  (apiSignupForNewsletter as jest.Mock).mockClear();
+});
+
+describe('lib/newsletter', () => {
+  describe('handleNewsletterSignup', () => {
+    it('resolves to undefined on success', async () => {
+      await handleNewsletterSignup();
+      await expect(handleNewsletterSignup()).resolves.toBe(undefined);
+    });
+
+    it('throws an error on failure', async () => {
+      (apiSignupForNewsletter as jest.Mock)
+        .mockReset()
+        .mockRejectedValue(FXA_NEWSLETTER_SIGNUP_ERROR);
+      await expect(handleNewsletterSignup()).rejects.toBe(
+        FXA_NEWSLETTER_SIGNUP_ERROR
+      );
+      expect(sentry.captureException).toHaveBeenCalledWith(
+        FXA_NEWSLETTER_SIGNUP_ERROR
+      );
+    });
+  });
+});

--- a/packages/fxa-payments-server/src/lib/newsletter.ts
+++ b/packages/fxa-payments-server/src/lib/newsletter.ts
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { apiSignupForNewsletter } from './apiClient';
+import { config } from './config';
+import { GeneralError } from './errors';
+import sentry from './sentry';
+export const FXA_NEWSLETTER_SIGNUP_ERROR: GeneralError = {
+  code: 'fxa_newsletter_signup_error',
+};
+
+export async function handleNewsletterSignup() {
+  try {
+    await apiSignupForNewsletter({
+      newsletterId: config.newsletterId,
+    });
+  } catch (e) {
+    sentry.captureException(e);
+    throw FXA_NEWSLETTER_SIGNUP_ERROR;
+  }
+}


### PR DESCRIPTION
Because:
 -  When a new user is subscribing to a product, we want to provide an easy way for them to sign up for our products newsletter at the same time.

This commit:
 - Adds the handleNewsletterSignup helper function and apiSignupForNewsletter method to the payments client.
 - This function will be called in the Stripe and Paypal onSubmit handlers to be added to the new Checkout route in #9358.

## Issue that this pull request solves

part of #9786 

## Notes
While this PR has no dependencies, ultimately closing #9786 depends on #9750 and #9358 , as I will need to do the following in the Checkout route in a subsequent patch:
* Add a `useState` hook to the newsletter sign up checkbox in `NewUserEmailForm`
* Pass the state update function down into `NewUserEmailForm` (to be included in the route in #9750 ) and
* Conditionally call `handleNewsletterSignup` based on that state in two new onSubmit callbacks for Stripe and PayPal (callbacks to be created in #9358).

I've worked out most of this additional code already at https://github.com/mozilla/fxa/tree/9786-wire-up-newsletter-checkbox.

This PR is modeled after PR #10007 .