### PR TITLE
chore(subscriptions): fix a scope rename that should've been in 3ced8935b

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/utils.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/utils.ts
@@ -28,7 +28,7 @@ export async function handleAuth(db: any, auth: any, fetchEmail = false) {
 
 export function handleUidAuth(auth: any): string {
   const scope = ScopeSet.fromArray(auth.credentials.scope);
-  if (!scope.contains(SUBSCRIPTIONS_MANAGEMENT_SCOPE)) {
+  if (!scope.contains(OAUTH_SCOPE_SUBSCRIPTIONS)) {
     throw error.invalidScopes();
   }
   return auth.credentials.user;


### PR DESCRIPTION
Not sure how I missed that one spot.  But the subscription management scope was moved into a shared constant and renamed, and somehow I changed just one of two instances it in a particular file.