### PR TITLE
feat(subscriptions): add an optional cb called in PayPal's createOrder

### DIFF
--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -595,13 +595,12 @@ describe('routes/Product/SubscriptionCreate', () => {
   });
 
   it('creates a new customer if needed for PayPal', async () => {
-    const MockedButtonBase = ({ createOrder }: ButtonBaseProps) => {
-      return <button data-testid="paypal-button" onClick={createOrder} />;
+    const MockedButtonBase = ({ onApprove }: ButtonBaseProps) => {
+      return <button data-testid="paypal-button" onClick={onApprove} />;
     };
     const apiClientOverrides = {
       ...defaultApiClientOverrides(),
       apiCreateCustomer: jest.fn(),
-      apiGetPaypalCheckoutToken: jest.fn(),
     };
     updateConfig({
       featureFlags: {


### PR DESCRIPTION
Because:
 - we need a way to create a Firefox account before the PayPal button
   gets the PayPal checkout token

This commit:
 - add an optional callback to PayPalButton's props that's called at the
   start of its createOrder function


## Issue that this pull request solves

part of #9358; follows #10007

