### PR TITLE
task(fxa-payments-server): paypal button disable

### DIFF
--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.stories.tsx
@@ -9,6 +9,7 @@ const WrapNewUserEmailForm = ({
 }) => {
   const [validEmail, setValidEmail] = useState<string>('');
   const [accountExists, setAccountExists] = useState(false);
+  const [emailsMatch, setEmailsMatch] = useState(false);
   return (
     <div style={{ display: 'flex' }}>
       <NewUserEmailForm
@@ -17,6 +18,7 @@ const WrapNewUserEmailForm = ({
         }
         setValidEmail={setValidEmail}
         setAccountExists={setAccountExists}
+        setEmailsMatch={setEmailsMatch}
         getString={(id: string) => id}
         checkAccountExists={() =>
           Promise.resolve({ exists: accountExistsReturnValue })

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
@@ -20,12 +20,14 @@ const WrapNewUserEmailForm = ({
 }) => {
   const [validEmail, setValidEmail] = useState<string>('');
   const [accountExists, setAccountExists] = useState(false);
+  const [emailsMatch, setEmailsMatch] = useState(false);
   return (
     <div style={{ display: 'flex' }}>
       <NewUserEmailForm
         signInURL={
           'https://localhost:3031/subscriptions/products/productId?plan=planId&signin=yes'
         }
+        setEmailsMatch={setEmailsMatch}
         setValidEmail={setValidEmail}
         setAccountExists={setAccountExists}
         getString={(id: string) => id}

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -20,6 +20,7 @@ export type NewUserEmailFormProps = {
   signInURL: string;
   setValidEmail: (value: string) => void;
   setAccountExists: (value: boolean) => void;
+  setEmailsMatch: (value: boolean) => void;
   checkAccountExists: (email: string) => Promise<{ exists: boolean }>;
   validatorInitialState?: ValidatorState;
   validatorMiddlewareReducer?: ValidatorMiddlewareReducer;
@@ -30,6 +31,7 @@ export const NewUserEmailForm = ({
   signInURL,
   setValidEmail,
   setAccountExists,
+  setEmailsMatch,
   checkAccountExists,
   validatorInitialState,
   validatorMiddlewareReducer,
@@ -91,6 +93,7 @@ export const NewUserEmailForm = ({
               value,
               focused,
               emailInputState,
+              setEmailsMatch,
               getString
             );
           }}
@@ -181,11 +184,12 @@ export function emailConfirmationValidation(
   value: string,
   focused: boolean,
   emailInputState: string | undefined,
+  setEmailsMatch: (value: boolean) => void,
   getString?: Function
 ) {
   let valid = false;
 
-  valid = emailInputState === value;
+  setEmailsMatch((valid = emailInputState === value));
 
   const errorMsg = getString
     ? /* istanbul ignore next - not testing l10n here */

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.scss
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.scss
@@ -1,0 +1,14 @@
+.disabled-overlay {
+    position: relative;
+    &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background-color: white;
+        opacity: .6;
+        z-index: 1000;
+    }
+}

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.stories.tsx
@@ -11,6 +11,7 @@ const defaultApiClientOverrides = {
 };
 
 const Subject = ({
+  disabled = false,
   apiClientOverrides = defaultApiClientOverrides,
   currencyCode = 'USD',
   customer = CUSTOMER,
@@ -24,6 +25,7 @@ const Subject = ({
   ...props
 }: PickPartial<
   PaypalButtonProps,
+  | 'disabled'
   | 'currencyCode'
   | 'customer'
   | 'idempotencyKey'
@@ -37,6 +39,7 @@ const Subject = ({
   return (
     <PaypalButton
       {...{
+        disabled,
         apiClientOverrides,
         currencyCode,
         customer,
@@ -53,6 +56,6 @@ const Subject = ({
   );
 };
 
-storiesOf('routes/Product/PaypalButton', module).add('default', () => (
-  <Subject />
-));
+storiesOf('routes/Product/PaypalButton', module)
+  .add('default', () => <Subject />)
+  .add('disabled', () => <Subject disabled={true} />);

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.test.tsx
@@ -7,6 +7,7 @@ import { PickPartial } from '../../lib/types';
 import { CUSTOMER, PLAN } from '../../lib/mock-data';
 
 const Subject = ({
+  disabled = false,
   currencyCode = 'USD',
   customer = CUSTOMER,
   idempotencyKey = '',
@@ -19,6 +20,7 @@ const Subject = ({
   ...props
 }: PickPartial<
   PaypalButtonProps,
+  | 'disabled'
   | 'currencyCode'
   | 'customer'
   | 'idempotencyKey'
@@ -32,6 +34,7 @@ const Subject = ({
   return (
     <PaypalButton
       {...{
+        disabled,
         currencyCode,
         customer,
         idempotencyKey,

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
@@ -1,12 +1,15 @@
 // This file must be lazy loaded. Otherwise we have a race condition with
 // usePaypalButton hook (script loading) and the button will not render.
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
 import * as apiClient from '../../lib/apiClient';
 import { Customer } from '../../store/types';
 import { SubscriptionCreateAuthServerAPIs } from '../../routes/Product/SubscriptionCreate';
 import { PaymentUpdateAuthServerAPIs } from '../../routes/Subscriptions/PaymentUpdateForm';
+import classNames from 'classnames';
+
+import './index.scss';
 
 declare var paypal: {
   Buttons: {
@@ -17,6 +20,7 @@ declare var paypal: {
 export type PaypalButtonProps = {
   currencyCode: string;
   customer: Customer | null;
+  disabled: boolean;
   idempotencyKey: string;
   refreshSubmitNonce: () => void;
   refreshSubscriptions: () => void;
@@ -49,6 +53,7 @@ export const PaypalButtonBase =
 export const PaypalButton = ({
   currencyCode,
   customer,
+  disabled,
   idempotencyKey,
   refreshSubmitNonce,
   refreshSubscriptions,
@@ -143,6 +148,35 @@ export const PaypalButton = ({
     [setPaymentError]
   );
 
+  type PaypalButtonActionsType = {
+    disable: () => void;
+    enable: () => void;
+  };
+
+  const [paypalButtonActions, setPaypalButtonActions] =
+    useState<PaypalButtonActionsType>();
+
+  useEffect(() => {
+    if (paypalButtonActions) {
+      if (disabled) {
+        paypalButtonActions.disable();
+      } else {
+        paypalButtonActions.enable();
+      }
+    }
+  });
+
+  const onInit = useCallback(
+    (data, actions) => {
+      // set our actions for availability in useEffect
+      setPaypalButtonActions(actions);
+      if (disabled) {
+        actions.disable();
+      }
+    },
+    [disabled]
+  );
+
   // Style docs: https://developer.paypal.com/docs/business/checkout/reference/style-guide/
   const styleOptions = {
     layout: 'horizontal',
@@ -155,15 +189,22 @@ export const PaypalButton = ({
 
   return (
     <>
-      {ButtonBase && (
-        <ButtonBase
-          style={styleOptions}
-          data-testid="paypal-button"
-          createOrder={createOrder}
-          onApprove={onApprove}
-          onError={onError}
-        />
-      )}
+      <div
+        className={classNames({
+          'disabled-overlay': disabled,
+        })}
+      >
+        {ButtonBase && (
+          <ButtonBase
+            style={styleOptions}
+            data-testid="paypal-button"
+            createOrder={createOrder}
+            onInit={onInit}
+            onApprove={onApprove}
+            onError={onError}
+          />
+        )}
+      </div>
     </>
   );
 };

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -78,6 +78,7 @@ export const Checkout = ({
   const [checkboxSet, setCheckboxSet] = useState(false);
   const [validEmail, setValidEmail] = useState<string>('');
   const [accountExists, setAccountExists] = useState(false);
+  const [emailsMatch, setEmailsMatch] = useState(false);
   const [paypalScriptLoaded, setPaypalScriptLoaded] = useState(false);
   const [inProgress, setInProgress] = useState(false);
   const [paymentError, setPaymentError] = useState<PaymentError>(
@@ -165,6 +166,7 @@ export const Checkout = ({
             signInURL={signInURL}
             setAccountExists={setAccountExists}
             checkAccountExists={checkAccountExists}
+            setEmailsMatch={setEmailsMatch}
           />
 
           <hr />
@@ -190,6 +192,12 @@ export const Checkout = ({
                       <PaypalButton
                         currencyCode={selectedPlan.currency}
                         customer={null}
+                        disabled={
+                          !checkboxSet ||
+                          validEmail === '' ||
+                          accountExists ||
+                          !emailsMatch
+                        }
                         idempotencyKey={submitNonce}
                         refreshSubmitNonce={refreshSubmitNonce}
                         refreshSubscriptions={refreshSubscriptions}
@@ -231,7 +239,10 @@ export const Checkout = ({
                 submitButtonL10nId: 'new-user-submit',
                 submitButtonCopy: 'Subscribe Now',
                 shouldAllowSubmit:
-                  checkboxSet && validEmail !== '' && !accountExists,
+                  checkboxSet &&
+                  validEmail !== '' &&
+                  !accountExists &&
+                  emailsMatch,
 
                 inProgress,
                 validatorInitialState,

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -248,6 +248,7 @@ export const SubscriptionCreate = ({
                       </Localized>
                       <div className="paypal-button">
                         <PaypalButton
+                          disabled={false}
                           apiClientOverrides={apiClientOverrides}
                           currencyCode={selectedPlan.currency}
                           customer={customer}

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.tsx
@@ -238,6 +238,7 @@ export const PaymentUpdateForm = ({
               <Suspense fallback={<div>Loading...</div>}>
                 <div className="paypal-button">
                   <PaypalButton
+                    disabled={false}
                     currencyCode={currencyCode}
                     customer={customer}
                     idempotencyKey={submitNonce}


### PR DESCRIPTION
## Because

- We need to disable the paypal button if the consent checkbox is not checked

## This pull request

- Add styling for the disabled paypal button
- watches for changes and disables/enables the paypal button

## Issue that this pull request solves

Closes: #9361

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
![disabled-paypal-btn](https://user-images.githubusercontent.com/1844554/128749336-34c9ece5-dfb9-4ae0-8d15-cc202e322ed4.png)
![enabled-paypal-btn](https://user-images.githubusercontent.com/1844554/128749359-9b398950-ab06-4bae-bea0-9bb21d9b5037.png)

## Other information (Optional)

Any other information that is important to this pull request.
