### PR TITLE
feat(payments): Display localized account exists tooltip in NewUserEm…

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -358,6 +358,6 @@ new-user-subscribe-product-updates = I'd like to receive product updates from { 
 new-user-subscribe-product-assurance = We only use your email to create your account. We will never sell it to a third party.
 new-user-email-validate = Email is not valid
 new-user-email-validate-confirm = Emails do not match
-new-user-existing-account-sign-in = You already have an account, <a>Sign in</a>
+new-user-already-has-account-sign-in = You already have an account. <a>Sign in</a>
 new-user-card-title = Enter your card information
 new-user-submit = Subscribe Now

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -74,6 +74,7 @@ export const NewUserEmailForm = ({
               setAccountExists,
               setEmailInputState,
               checkAccountExists,
+              signInURL,
               getString
             );
           }}
@@ -140,6 +141,7 @@ export async function emailInputValidationAndAccountCheck(
   setAccountExists: (value: boolean) => void,
   setEmailInputState: (value: string) => void,
   checkAccountExists: (email: string) => Promise<{ exists: boolean }>,
+  signInURL: string,
   getString?: (id: string) => string
 ) {
   let error = null;
@@ -161,9 +163,19 @@ export async function emailInputValidationAndAccountCheck(
       getString('new-user-email-validate')
     : 'Email is not valid';
 
-  const accountExistsMsg = getString
-    ? getString('new-user-existing-account-sign-in')
-    : `You already have an account, <a>Sign in</a>`;
+  const accountExistsMsg = (
+    <Localized
+      id="new-user-already-has-account-sign-in"
+      elems={{ a: <a href={signInURL}></a> }}
+    >
+      <>
+        You already have an account.{' '}
+        <a data-testid="already-have-account-link" href={signInURL}>
+          Sign in
+        </a>
+      </>
+    </Localized>
+  );
 
   if (!valid && !focused && errorMsg) {
     error = errorMsg;

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -7,7 +7,7 @@ import React, {
   Suspense,
 } from 'react';
 import { connect } from 'react-redux';
-import { Localized } from '@fluent/react';
+import { Localized, useLocalization } from '@fluent/react';
 import classNames from 'classnames';
 
 import { PaymentError } from '../../lib/stripe';
@@ -71,6 +71,7 @@ export const Checkout = ({
   const { locationReload, queryParams, matchMediaDefault } =
     useContext(AppContext);
   const { config } = useContext(AppContext);
+  const { l10n } = useLocalization();
   const checkboxValidator = useValidatorState();
   const isMobile = !useMatchMedia('(min-width: 768px)', matchMediaDefault);
   const [submitNonce, refreshSubmitNonce] = useNonce();
@@ -167,6 +168,7 @@ export const Checkout = ({
             setAccountExists={setAccountExists}
             checkAccountExists={checkAccountExists}
             setEmailsMatch={setEmailsMatch}
+            getString={l10n.getString.bind(l10n)}
           />
 
           <hr />


### PR DESCRIPTION
…ailForm

Because:

* It's possible that a user has an FxA account already, so we want to direct them to the existing flow. The new passwordless flow is for users who do not yet have an FxA account.

This commit:

* Updates the tooltip copy to have a localized message string with a link where users can go to sign in if we determine based on their email address that they already have an FxA account.

Closes #9387

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="598" alt="Screen Shot 2021-08-10 at 6 43 54 AM" src="https://user-images.githubusercontent.com/17437436/128853614-2db9e6a8-5075-48bf-a731-393faa12c90b.png">