### PR TITLE
style(auth-server): update docs and formatting nits

### DIFF
--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -153,7 +153,7 @@ In 2021, FxA began converting the email templating system from Mustache, inline 
 
 #### MJML Feature Flag for Testing
 
-The auth-server has an `MJML` configuration value that designates which email templates have been converted to the new stack (`mjml.templates` array) and controls which user emails will receive those templates (`mjml.enabledEmailAddress` regex). The auth-server exposes a feature flag method to check these values and send the correct rendered template accordingly (old or new) which allows for testing across environments.
+The auth-server has an `MJML` configuration value that designates which email templates have been converted to the new stack (`mjml.templates` array) and controls which user emails will receive those templates (`mjml.enabledEmailAddress` regex). The auth-server exposes a feature flag method to check these values and send the correct rendered template accordingly (old or new) which allows for testing across environments. To generate these new templates locally until we enable them for other environments, change `mjml.enabledEmailAddress` in dev config to `@testuser.com$`.
 
 This flag and logic around it can be removed, as well as old templates and documentation, once all templates have been converted, verified by QA, and tested in production.
 

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -428,6 +428,6 @@
   },
   "mjml": {
     "enabledEmailAddress": "b@c.com",
-    "templates":  ["cadReminderFirst"]
+    "templates": ["cadReminderFirst"]
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
@@ -115,7 +115,10 @@ class FluentLocalizer {
         key = key.replace(/\s/g, '');
         val = val.replace(/"/g, '').trim();
         // get the value from fluent using the extracted key
-        const localizedValue = await l10n.formatValue(key);
+        const localizedValue = await l10n.formatValue(key, {
+          ...variables.templateValues,
+          ...variables,
+        });
         plainTextArr[i] = localizedValue ? localizedValue : val;
       }
     }

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/en-US.ftl
@@ -1,2 +1,2 @@
 fxa-privacy-url = Mozilla Privacy Policy
-fxa-support-url = Firefox Cloud Terms of Service
+fxa-service-url = Firefox Cloud Terms of Service

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.ts
@@ -41,8 +41,8 @@ export const render = (body: string) => {
       <mj-section>
         <mj-column>
           <mj-text css-class="secondary-text">Mozilla. 2 Harrison St, #175, San Francisco, CA 94105</mj-text>
-          <mj-text css-class="secondary-text privacy-url"><a class="link-blue" data-l10n-id="fxa-privacy-url" href="<%- privacyUrl %>">Mozilla Privacy Policy</a></mj-text>
-          <mj-text css-class="secondary-text support-url"><a class="link-blue" data-l10n-id="fxa-support-url" href="<%- supportUrl %>">Firefox Cloud Terms of Service</a></mj-text>
+          <mj-text css-class="secondary-text"><a class="link-blue" data-l10n-id="fxa-privacy-url" href="<%- privacyUrl %>">Mozilla Privacy Policy</a></mj-text>
+          <mj-text css-class="secondary-text"><a class="link-blue" data-l10n-id="fxa-service-url" href="https://www.mozilla.org/about/legal/terms/services/">Firefox Cloud Terms of Service</a></mj-text>
         </mj-column>
       </mj-section>
     </mj-body>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/appBadges/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/appBadges/index.ts
@@ -29,7 +29,7 @@ export const appBadges = `
         <a href="<%- link %>" class="link-blue" data-l10n-name="anotherDeviceLink">another desktop device</a></span>
       </mj-text>
       <% } else { %>
-      <mj-text css-class="secondary-text mb-3 install-device-link"><span data-l10n-id="another-device"> Or, install on
+      <mj-text css-class="secondary-text mb-3"><span data-l10n-id="another-device"> Or, install on
         <a href="<%- link %>" class="link-blue" data-l10n-name="anotherDeviceLink">another device</a></span>
         <% } %>
       </mj-text>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -75,65 +75,64 @@ interface Test {
 
 // prettier-ignore
 const COMMON_TESTS = new Map<string, Test | any>([
-   ['from', { test: 'equal', expected: config.smtp.sender }],
-   ['sender', { test: 'equal', expected: config.smtp.sender }],
-   [
-     'headers',
-     new Map([
-       ['X-Device-Id', { test: 'equal', expected: MESSAGE.deviceId }],
-       ['X-Email-Service', { test: 'equal', expected: 'fxa-auth-server' }],
-       ['X-Flow-Begin-Time', { test: 'equal', expected: MESSAGE.flowBeginTime }],
-       ['X-Flow-Id', { test: 'equal', expected: MESSAGE.flowId }],
-       ['X-Service-Id', { test: 'equal', expected: MESSAGE.service }],
-       [
-         'X-SES-CONFIGURATION-SET',
-         { test: 'equal', expected: config.smtp.sesConfigurationSet },
-       ],
-       ['X-Uid', { test: 'equal', expected: MESSAGE.uid }],
-     ]),
-   ],
-   [
-     'text',
-     [
-       // Ensure no HTML character entities appear in plaintext emails, &amp; etc
-       { test: 'notMatch', expected: /(?:&#x?[0-9a-f]+;)|(?:&[a-z]+;)/i },
-     ],
-   ],
- ]);
+  ['from', { test: 'equal', expected: config.smtp.sender }],
+  ['sender', { test: 'equal', expected: config.smtp.sender }],
+  [
+    'headers',
+    new Map([
+      ['X-Device-Id', { test: 'equal', expected: MESSAGE.deviceId }],
+      ['X-Email-Service', { test: 'equal', expected: 'fxa-auth-server' }],
+      ['X-Flow-Begin-Time', { test: 'equal', expected: MESSAGE.flowBeginTime }],
+      ['X-Flow-Id', { test: 'equal', expected: MESSAGE.flowId }],
+      ['X-Service-Id', { test: 'equal', expected: MESSAGE.service }],
+      [
+        'X-SES-CONFIGURATION-SET',
+        { test: 'equal', expected: config.smtp.sesConfigurationSet },
+      ],
+      ['X-Uid', { test: 'equal', expected: MESSAGE.uid }],
+    ]),
+  ],
+  [
+    'text',
+    [
+      // Ensure no HTML character entities appear in plaintext emails, &amp; etc
+      { test: 'notMatch', expected: /(?:&#x?[0-9a-f]+;)|(?:&[a-z]+;)/i },
+    ],
+  ],
+]);
 
 // prettier-ignore
 const TESTS: [string, any][] = [
-    ['cadReminderFirstEmail', new Map<string, Test | any>([
-      ['subject', { test: 'equal', expected: 'Your Friendly Reminder: How To Complete Your Sync Setup' }],
-      ['headers', new Map([
-        ['X-Link', { test: 'equal', expected: configUrl('syncUrl', 'cad-reminder-first', 'connect-device') }],
-        ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('cadReminderFirst') }],
-        ['X-Template-Name', { test: 'equal', expected: 'cadReminderFirst' }],
-        ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.cadReminderFirst }],
-      ])],
-      ['html', [
-        { test: 'include', expected: "Here's your reminder to sync devices." },
-        { test: 'include', expected: 'It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.' },
-        { test: 'include', expected: decodeUrl(configHref('syncUrl', 'cad-reminder-first', 'connect-device')) },
-        { test: 'include', expected: decodeUrl(config.smtp.androidUrl) },
-        { test: 'include', expected: decodeUrl(config.smtp.iosUrl) },
-        { test: 'include', expected: 'another device' },
-        { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'cad-reminder-first', 'privacy')) },
-        { test: 'include', expected: decodeUrl(configHref('supportUrl', 'cad-reminder-first', 'support')) },
-        { test: 'notInclude', expected: config.smtp.firefoxDesktopUrl },
-      ]],
-      ['text', [
-        { test: 'include', expected: "Here's your reminder to sync devices." },
-        { test: 'include', expected: 'It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.' },
-        { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'cad-reminder-first', 'privacy')}` },
-        { test: 'include', expected: config.smtp.syncUrl },
-        { test: 'notInclude', expected: config.smtp.androidUrl },
-        { test: 'notInclude', expected: config.smtp.iosUrl },
-        { test: 'notInclude', expected: 'utm_source=email' },
-      ]],
+  ['cadReminderFirstEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Your Friendly Reminder: How To Complete Your Sync Setup' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('syncUrl', 'cad-reminder-first', 'connect-device') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('cadReminderFirst') }],
+      ['X-Template-Name', { test: 'equal', expected: 'cadReminderFirst' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.cadReminderFirst }],
     ])],
-    
-  ];
+    ['html', [
+      { test: 'include', expected: "Here's your reminder to sync devices." },
+      { test: 'include', expected: 'It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.' },
+      { test: 'include', expected: decodeUrl(configHref('syncUrl', 'cad-reminder-first', 'connect-device')) },
+      { test: 'include', expected: decodeUrl(config.smtp.androidUrl) },
+      { test: 'include', expected: decodeUrl(config.smtp.iosUrl) },
+      { test: 'include', expected: 'another device' },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'cad-reminder-first', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'cad-reminder-first', 'support')) },
+      { test: 'notInclude', expected: config.smtp.firefoxDesktopUrl },
+    ]],
+    ['text', [
+      { test: 'include', expected: "Here's your reminder to sync devices." },
+      { test: 'include', expected: 'It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.' },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'cad-reminder-first', 'privacy')}` },
+      { test: 'include', expected: config.smtp.syncUrl },
+      { test: 'notInclude', expected: config.smtp.androidUrl },
+      { test: 'notInclude', expected: config.smtp.iosUrl },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],  
+];
 
 describe('lib/senders/mjml-emails:', () => {
   type LocalizeFn = (message: Record<any, any>) => Promise<Record<any, string>>;


### PR DESCRIPTION
## Because

- auth-server email docs needed a little update and there were some formatting nits pending

## This pull request

- Updates the docs and corrects the formatting

## Issue that this pull request solves

Closes: #10064 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
