### PR TITLE
task(fxa-payments-server): add legal links to checkout form

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -51,6 +51,7 @@ settings-subscriptions-title = Subscriptions
 ## legal footer
 terms = Terms of Service
 privacy = Privacy Notice
+terms-download = Download Terms
 
 ## Subscription titles
 subscription-create-title = Set up your subscription
@@ -94,13 +95,13 @@ product-no-such-plan = No such plan for this product.
 
 ## payment legal blurb
 payment-legal-copy-stripe-and-paypal-2 = { -brand-name-mozilla } uses { -brand-name-stripe } and { -brand-name-paypal } for secure payment processing.
-payment-legal-link-stripe-and-paypal-2 = View the <stripePrivacyLink>{ -brand-name-stripe } privacy policy</stripePrivacyLink> and <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
+payment-legal-link-stripe-space-paypal = <stripePrivacyLink>{ -brand-name-stripe } privacy policy</stripePrivacyLink> &nbsp; <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
 
 payment-legal-copy-paypal = { -brand-name-mozilla } uses { -brand-name-paypal } for secure payment processing.
-payment-legal-link-paypal = View the <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
+payment-legal-link-paypal-2 = <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
 
 payment-legal-copy-stripe-2 = { -brand-name-mozilla } uses { -brand-name-stripe } for secure payment processing.
-payment-legal-link-stripe-2 = View the <stripePrivacyLink>{ -brand-name-stripe } privacy policy</stripePrivacyLink>.
+payment-legal-link-stripe-3 = <stripePrivacyLink>{ -brand-name-stripe } privacy policy</stripePrivacyLink>.
 
 ## payment form
 payment-name =

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.scss
@@ -15,24 +15,6 @@ form.payment {
     }
   }
 
-  .legal-blurb {
-    clear: both;
-    color: #686869;
-    font-size: 12px;
-    font-weight: 500;
-    line-height: 16px;
-    text-align: center;
-
-    p {
-      margin-bottom: 4px;
-      margin-top: 0;
-    }
-
-    p:last-child {
-      margin-bottom: 0;
-    }
-  }
-
   hr {
     margin: 24px 0 0;
 

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.tsx
@@ -27,7 +27,6 @@ import { useCallbackOnce } from '../../lib/hooks';
 import { getLocalizedCurrency } from '../../lib/formats';
 import { AppContext } from '../../lib/AppContext';
 import { Plan, Customer } from '../../store/types';
-import { productDetailsFromPlan } from 'fxa-shared/subscriptions/metadata';
 
 import './index.scss';
 import { localeToStripeLocale, STRIPE_ELEMENT_STYLES } from '../../lib/stripe';
@@ -43,7 +42,6 @@ import {
 } from '../../lib/PaymentProvider';
 import { PaymentProviderDetails } from '../PaymentProviderDetails';
 import { PaymentConsentCheckbox } from '../PaymentConsentCheckbox';
-import PaymentLegalBlurb from '../PaymentLegalBlurb';
 
 export type StripePaymentSubmitResult = {
   stripe: Stripe;
@@ -75,7 +73,6 @@ export type BasePaymentFormProps = {
   customer?: Customer | null;
   getString?: (id: string) => string;
   onCancel?: () => void;
-  showLegal?: boolean;
   submitButtonL10nId?: string;
   submitButtonCopy?: string;
   shouldAllowSubmit?: boolean;
@@ -96,7 +93,6 @@ export const PaymentForm = ({
   getString,
   onSubmit: onSubmitForParent,
   onCancel,
-  showLegal = false,
   submitButtonL10nId = '',
   submitButtonCopy = 'Pay Now',
   shouldAllowSubmit = true,
@@ -181,15 +177,6 @@ export const PaymentForm = ({
     [PaymentProviders.paypal]: onPaypalFormSubmit,
   });
 
-  const { navigatorLanguages } = useContext(AppContext);
-
-  let termsOfServiceURL, privacyNoticeURL;
-  if (plan && confirm) {
-    ({ termsOfServiceURL, privacyNoticeURL } = productDetailsFromPlan(
-      plan,
-      navigatorLanguages
-    ));
-  }
   const paymentSource =
     plan && isExistingCustomer(customer) ? (
       <div className="pricing-and-saved-payment">
@@ -305,17 +292,6 @@ export const PaymentForm = ({
       {...{ onChange }}
     >
       {paymentSource}
-
-      {showLegal ? (
-        <>
-          <br />
-          <br />
-          <br />
-          <PaymentLegalBlurb provider={undefined} />
-        </>
-      ) : (
-        <hr />
-      )}
 
       {confirm && plan && (
         <>

--- a/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.scss
@@ -1,14 +1,13 @@
 .payment-legal-blurb {
   clear: both;
-  color: #686869;
-  font-size: 12px;
+  color: #3D3D3D;
+  font-size: 11px;
   font-weight: 500;
-  line-height: 16px;
+  line-height: 18px;
   text-align: center;
 
-  p {
-    margin-bottom: 4px;
-    margin-top: 0;
+  a {
+    text-decoration: underline;
   }
 
   p:last-child {

--- a/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
@@ -6,29 +6,32 @@ import * as PaymentProvider from '../../lib/PaymentProvider';
 import './index.scss';
 
 function getPrivacyLinkText(): string {
-  return 'View the <stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> and <paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>.';
+  return '<stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> <paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>.';
 }
 
 function getPaypalPrivacyLinkText(): string {
-  return 'View the <paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>.';
+  return '<paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>.';
 }
 
 function getStripePrivacyLinkText(): string {
-  return 'View the <stripePrivacyLink>Stripe privacy policy</stripePrivacyLink>.';
+  return '<stripePrivacyLink>Stripe privacy policy</stripePrivacyLink>.';
 }
 
 const PaypalPaymentLegalBlurb = () => (
-  <div className="payment-legal-blurb">
+  <div
+    className="payment-legal-blurb"
+    data-testid="payment-legal-blurb-component"
+  >
     <Localized id="payment-legal-copy-paypal">
       <p>Mozilla uses Paypal for secure payment processing.</p>
     </Localized>
 
     <Localized
-      id="payment-legal-link-paypal"
+      id="payment-legal-link-paypal-2"
       elems={{
         paypalPrivacyLink: (
           <a
-            href="https://paypal.com/privacy"
+            href="https://www.paypal.com/webapps/mpp/ua/privacy-full"
             target="_blank"
             rel="noopener noreferrer"
           ></a>
@@ -47,7 +50,7 @@ const StripePaymentLegalBlurb = () => (
     </Localized>
 
     <Localized
-      id="payment-legal-link-stripe-2"
+      id="payment-legal-link-stripe-3"
       elems={{
         stripePrivacyLink: (
           <a
@@ -70,7 +73,7 @@ const DefaultPaymentLegalBlurb = () => (
     </Localized>
 
     <Localized
-      id="payment-legal-link-stripe-and-paypal-2"
+      id="payment-legal-link-stripe-space-paypal"
       elems={{
         stripePrivacyLink: (
           <a

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.scss
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.scss
@@ -1,11 +1,16 @@
-.terms,
-.privacy {
-  display: flex;
-  font-size: 15px;
-  justify-content: center;
-  margin-top: 24px;
+.terms {
+  line-height: 18px;
+  clear: both;
+  text-align: center;
+  font-size: 11px;
+
+  a {
+    text-decoration: underline;
+    font-weight: 400;
+  }
 }
 
-.terms {
-  margin-top: 32px;
+.legal-heading {
+  color: #3D3D3D;
+  font-weight: 600;
 }

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.stories.tsx
@@ -5,9 +5,23 @@ import { SELECTED_PLAN } from '../../lib/mock-data';
 import MockApp from '../../../.storybook/components/MockApp';
 
 storiesOf('components/TermsAndPrivacy', module)
-  .add('default locale', () => <TermsAndPrivacy plan={SELECTED_PLAN} />)
+  .add('default locale', () => (
+    <MockApp languages={[]}>
+      <TermsAndPrivacy plan={SELECTED_PLAN} />
+    </MockApp>
+  ))
+  .add('default locale with fxa links', () => (
+    <MockApp languages={[]}>
+      <TermsAndPrivacy plan={SELECTED_PLAN} showFXALinks={true} />
+    </MockApp>
+  ))
   .add('with fr locale', () => (
     <MockApp languages={['fr']}>
       <TermsAndPrivacy plan={SELECTED_PLAN} />
+    </MockApp>
+  ))
+  .add('with fr locale and fxa links', () => (
+    <MockApp languages={['fr']}>
+      <TermsAndPrivacy plan={SELECTED_PLAN} showFXALinks={true} />
     </MockApp>
   ));

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.test.tsx
@@ -6,6 +6,7 @@ import { MOCK_PLANS } from '../../lib/test-utils';
 import { TermsAndPrivacy } from './index';
 import { defaultAppContext, AppContext } from '../../lib/AppContext';
 import { DEFAULT_PRODUCT_DETAILS } from 'fxa-shared/subscriptions/metadata';
+import { config } from '../../lib/config';
 
 const enTermsOfServiceURL =
   'https://www.mozilla.org/en-US/about/legal/terms/services/';
@@ -61,6 +62,15 @@ it('renders as expected with a plan with no legal doc links metadata', () => {
     'href',
     DEFAULT_PRODUCT_DETAILS.privacyNoticeURL
   );
+});
+
+it('renders as expected when passed "showFXALinks" option', () => {
+  const { queryByTestId } = render(
+    <TermsAndPrivacy plan={planWithNoLegalLinks} showFXALinks={true} />
+  );
+
+  const fxaLegalSection = queryByTestId('fxa-legal-links');
+  expect(fxaLegalSection).toBeInTheDocument();
 });
 
 it('renders as expected with default locale', () => {

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
@@ -1,74 +1,114 @@
 import React, { useContext } from 'react';
 import { Localized } from '@fluent/react';
-import { AppContext } from '../../lib/AppContext';
+
 import {
   productDetailsFromPlan,
   DEFAULT_PRODUCT_DETAILS,
 } from 'fxa-shared/subscriptions/metadata';
+
 import { Plan } from '../../store/types';
 
+import { AppContext } from '../../lib/AppContext';
+import { legalDocsRedirectUrl } from '../../lib/formats';
+
 import './index.scss';
-import { legalDocsRedirectUrl } from 'fxa-payments-server/src/lib/formats';
 
 export type TermsAndPrivacyProps = {
   plan: Plan;
+  showFXALinks?: boolean;
+  contentServerURL?: string;
 };
 
-export const TermsAndPrivacy = ({ plan }: TermsAndPrivacyProps) => {
+export const TermsAndPrivacy = ({
+  plan,
+  showFXALinks = false,
+  contentServerURL,
+}: TermsAndPrivacyProps) => {
   const { navigatorLanguages } = useContext(AppContext);
 
   // TODO: if a plan is not supplied, fall back to default details
   // This mainly happens in ProductUpdateForm where we're updating payment
   // details across *all* plans - are there better URLs to pick in that case?
-  const {
-    termsOfServiceURL,
-    termsOfServiceDownloadURL,
-    privacyNoticeURL,
-  } = plan
-    ? productDetailsFromPlan(plan, navigatorLanguages)
-    : DEFAULT_PRODUCT_DETAILS;
+  const { termsOfServiceURL, termsOfServiceDownloadURL, privacyNoticeURL } =
+    plan
+      ? productDetailsFromPlan(plan, navigatorLanguages)
+      : DEFAULT_PRODUCT_DETAILS;
 
   const tosUrl = termsOfServiceDownloadURL
     ? legalDocsRedirectUrl(termsOfServiceDownloadURL)
     : termsOfServiceDownloadURL;
 
-  return (
-    <div>
-      <div className="terms">
+  const productLegalBlurb = (
+    <p>
+      <Localized id="terms">
+        <a
+          href={termsOfServiceURL}
+          target="_blank"
+          data-testid="terms"
+          rel="noopener noreferrer"
+        >
+          Terms of Service
+        </a>
+      </Localized>
+      &nbsp;&nbsp;&nbsp;
+      <Localized id="privacy">
+        <a
+          href={privacyNoticeURL}
+          target="_blank"
+          data-testid="privacy"
+          rel="noopener noreferrer"
+        >
+          Privacy Notice
+        </a>
+      </Localized>{' '}
+      &nbsp;&nbsp;&nbsp;
+      <Localized id="terms-download">
+        <a
+          href={tosUrl}
+          target="_blank"
+          data-testid="terms-download"
+          rel="noopener noreferrer"
+        >
+          Download Terms
+        </a>
+      </Localized>
+    </p>
+  );
+
+  const FXALegal = showFXALinks ? (
+    <>
+      <p className="legal-heading">Firefox Accounts</p>
+      <p data-testid="fxa-legal-links">
         <Localized id="terms">
           <a
-            rel="noopener noreferrer"
+            href={`${contentServerURL}/legal/terms`}
             target="_blank"
-            data-testid="terms"
-            href={termsOfServiceURL}
+            rel="noopener noreferrer"
+            data-testid="fxa-terms"
           >
             Terms of Service
           </a>
         </Localized>
-        &nbsp;&#x2022;&nbsp;
-        <Localized id="termsDownload">
+        &nbsp;&nbsp;&nbsp;
+        <Localized id="accounts-legal-copy">
           <a
-            rel="noopener noreferrer"
+            href={`${contentServerURL}/legal/privacy`}
             target="_blank"
-            data-testid="terms-download"
-            href={tosUrl}
-          >
-            Download Terms
-          </a>
-        </Localized>
-      </div>
-      <div className="privacy">
-        <Localized id="privacy">
-          <a
             rel="noopener noreferrer"
-            target="_blank"
-            data-testid="privacy"
-            href={privacyNoticeURL}
+            data-testid="fxa-privacy"
           >
             Privacy Notice
           </a>
         </Localized>
-      </div>
+      </p>
+    </>
+  ) : null;
+
+  return (
+    <div className="terms" data-testid="terms-and-privacy-component">
+      {FXALegal}
+      <p className="legal-heading">{plan?.product_name}</p>
+      {productLegalBlurb}
     </div>
   );
 };

--- a/packages/fxa-payments-server/src/routes/Checkout/index.scss
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.scss
@@ -1,9 +1,12 @@
 @import '../../../../fxa-content-server/app/styles/variables';
 @import '../../../../fxa-content-server/app/styles/breakpoints';
-@import '../../styles/variables';
 
 .subscription-title {
   padding-top: 20px;
+}
+
+.subscription-create-footer {
+  margin-top: 40px;
 }
 
 .assurance-copy {

--- a/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
@@ -180,6 +180,12 @@ describe('routes/Checkout', () => {
 
     const planDetailsEl = getByTestId('plan-details-component');
     expect(planDetailsEl).toBeInTheDocument();
+
+    const paymentLegalBlurbEl = getByTestId('payment-legal-blurb-component');
+    expect(paymentLegalBlurbEl).toBeInTheDocument();
+
+    const termsAndPrivacyEl = getByTestId('terms-and-privacy-component');
+    expect(termsAndPrivacyEl).toBeInTheDocument();
   });
 
   it('displays an error with invalid product ID', async () => {

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -26,8 +26,9 @@ import Header from '../../components/Header';
 import { Form } from '../../components/fields';
 import PaymentProcessing from '../../components/PaymentProcessing';
 import SubscriptionTitle from '../../components/SubscriptionTitle';
-import TermsAndPrivacy from '../../components/TermsAndPrivacy';
 import PlanDetails from '../../components/PlanDetails';
+import TermsAndPrivacy from '../../components/TermsAndPrivacy';
+import PaymentLegalBlurb from '../../components/PaymentLegalBlurb';
 import { PaymentConsentCheckbox } from '../../components/PaymentConsentCheckbox';
 
 import { State } from '../../store/state';
@@ -60,7 +61,6 @@ import { apiFetchCustomer, apiFetchProfile } from '../../lib/apiClient';
 import * as apiClient from '../../lib/apiClient';
 import sentry from '../../lib/sentry';
 import { ButtonBaseProps } from '../../components/PayPalButton';
-
 const PaypalButton = React.lazy(() => import('../../components/PayPalButton'));
 
 export type CheckoutProps = {
@@ -338,8 +338,6 @@ export const Checkout = ({
                 submitNonce,
                 onSubmit: onStripeSubmit,
                 onChange,
-
-                showLegal: true,
                 submitButtonL10nId: 'new-user-submit',
                 submitButtonCopy: 'Subscribe Now',
                 shouldAllowSubmit:
@@ -360,7 +358,14 @@ export const Checkout = ({
           </div>
 
           <div className="subscription-create-footer">
-            {selectedPlan && <TermsAndPrivacy plan={selectedPlan} />}
+            <>
+              <PaymentLegalBlurb provider={undefined} />
+              <TermsAndPrivacy
+                showFXALinks={true}
+                plan={selectedPlan}
+                contentServerURL={config.servers.content.url}
+              />
+            </>
           </div>
         </div>
         <PlanDetails

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -141,8 +141,8 @@ describe('routes/Product/SubscriptionCreate', () => {
     expect(queryByTestId('subscription-create')).toBeInTheDocument();
     expect(queryByText('Payment information')).toBeInTheDocument();
     expect(queryByTestId('paypal-button')).not.toBeInTheDocument();
-    expect(queryByText('Terms of Service')).toBeInTheDocument();
-    expect(queryByText('Privacy Notice')).toBeInTheDocument();
+    expect(queryByTestId('terms')).toBeInTheDocument();
+    expect(queryByTestId('privacy')).toBeInTheDocument();
     expect(
       queryByText(
         'Mozilla uses Stripe and Paypal for secure payment processing.'

--- a/packages/fxa-shared/subscriptions/metadata.ts
+++ b/packages/fxa-shared/subscriptions/metadata.ts
@@ -44,6 +44,9 @@ export const metadataFromPlan = (plan: Plan): ProductMetadata => ({
   webIconBackground: null,
   upgradeCTA: null,
   downloadURL: null,
+  'product:termsOfServiceDownloadURL': '',
+  'product:termsOfServiceURL': '',
+  'product:privacyNoticeURL': '',
   ...plan.product_metadata,
   ...plan.plan_metadata,
 });

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -31,14 +31,18 @@ export interface PlanMetadata {
 export interface ProductMetadata {
   appStoreLink?: string;
   capabilities?: string;
-  downloadURL?: string | null;
+  downloadURL: string | null;
   emailIconURL?: string | null;
   playStoreLink?: string;
   productOrder?: string | null;
   productSet?: string | null;
   upgradeCTA?: string | null;
   webIconBackground?: string | null;
-  webIconURL?: string | null;
+  webIconURL: string | null;
+  'product:termsOfServiceDownloadURL': string;
+  'product:termsOfServiceURL': string;
+  'product:privacyNoticeDownloadURL'?: string;
+  'product:privacyNoticeURL': string;
   // capabilities:{clientID}: string // filtered out or ignored for now
 }
 

--- a/packages/fxa-shared/test/subscriptions/metadata.ts
+++ b/packages/fxa-shared/test/subscriptions/metadata.ts
@@ -21,6 +21,9 @@ const NULL_METADATA = {
   webIconBackground: null,
   upgradeCTA: null,
   downloadURL: null,
+  'product:termsOfServiceURL': '',
+  'product:termsOfServiceDownloadURL': '',
+  'product:privacyNoticeURL': '',
 };
 
 const PLAN: Plan = {
@@ -36,6 +39,14 @@ const PLAN: Plan = {
   product_metadata: null,
 };
 
+const requiredProductMetadata = {
+  'product:termsOfServiceURL': '',
+  'product:termsOfServiceDownloadURL': '',
+  'product:privacyNoticeURL': '',
+  downloadURL: null,
+  webIconURL: null,
+};
+
 describe('subscriptions/metadata', () => {
   describe('metadataFromPlan', () => {
     it('produces default null values', () => {
@@ -43,10 +54,13 @@ describe('subscriptions/metadata', () => {
     });
 
     it('extracts product metadata', () => {
-      const product_metadata: ProductMetadata = {
-        productSet: 'foo',
-        productOrder: '1',
-      };
+      const product_metadata: ProductMetadata = Object.assign(
+        requiredProductMetadata,
+        {
+          productSet: 'foo',
+          productOrder: '1',
+        }
+      );
       expect(metadataFromPlan({ ...PLAN, product_metadata })).to.deep.equal({
         ...NULL_METADATA,
         ...product_metadata,
@@ -54,10 +68,13 @@ describe('subscriptions/metadata', () => {
     });
 
     it('extracts plan metadata', () => {
-      const plan_metadata: ProductMetadata = {
-        productSet: 'foo',
-        productOrder: '1',
-      };
+      const plan_metadata: ProductMetadata = Object.assign(
+        requiredProductMetadata,
+        {
+          productSet: 'foo',
+          productOrder: '1',
+        }
+      );
       expect(metadataFromPlan({ ...PLAN, plan_metadata })).to.deep.equal({
         ...NULL_METADATA,
         ...plan_metadata,
@@ -65,13 +82,19 @@ describe('subscriptions/metadata', () => {
     });
 
     it('overrides product metadata with plan metadata', () => {
-      const product_metadata: ProductMetadata = {
-        productSet: 'foo',
-        productOrder: '1',
-      };
-      const plan_metadata: ProductMetadata = {
-        productSet: 'bar',
-      };
+      const product_metadata: ProductMetadata = Object.assign(
+        requiredProductMetadata,
+        {
+          productSet: 'foo',
+          productOrder: '1',
+        }
+      );
+      const plan_metadata: ProductMetadata = Object.assign(
+        requiredProductMetadata,
+        {
+          productSet: 'bar',
+        }
+      );
       expect(
         metadataFromPlan({ ...PLAN, plan_metadata, product_metadata })
       ).to.deep.equal({


### PR DESCRIPTION
## This pull request

- Adds legal links for products and fxa to the payment form on checkout page.

## Issue that this pull request solves

Closes: #9794

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots

![image](https://user-images.githubusercontent.com/1844554/129057446-2df05d7c-3169-467c-ba9c-14352e8caca6.png)


