### PR TITLE
feat(metrics): Emit metric when viewing account create form in payments

### DIFF
--- a/packages/123done/static/index.html
+++ b/packages/123done/static/index.html
@@ -72,6 +72,9 @@
         class="btn btn-persona btn-subscribe" data-currency="myr"
         >Subscribe to Pro (MYR)</a
       >
+      <a class="btn btn-persona btn-subscribe-pwdless" data-currency="usd"
+       >Subscribe to Pro (Passwordless)</a
+      >
       </div>
     </div>
 
@@ -206,6 +209,9 @@
         <a
           class="btn btn-persona btn-subscribe" data-currency="myr"
           >Subscribe to Pro (MYR)</a
+        >
+        <a class="btn btn-persona btn-subscribe-pwdless" data-currency="usd"
+          >Subscribe to Pro (Passwordless)</a
         >
         </div>
 

--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -21,6 +21,17 @@ $(document).ready(function () {
     prod: 'https://accounts.firefox.com/subscriptions/products',
   };
 
+  const contentURL = {
+    local: '//localhost:3030/',
+    dev: 'https://latest.dev.lcip.org/',
+    stage: 'https://accounts.stage.mozaws.net/',
+    prod: 'https://accounts.firefox.com/',
+  };
+
+  const pwdlessPaymentURL = {
+    local: '//localhost:3031/checkout/',
+  };
+
   const subscriptionConfig = {
     default: {
       product: 'prod_GqM9ToKK62qjkK',
@@ -48,26 +59,45 @@ $(document).ready(function () {
       paymentConfig = {
         env: paymentURL.dev,
         ...subscriptionConfig.default,
+        contentEnv: contentURL.dev,
       };
       break;
     case '123done-stage.dev.lcip.org':
       paymentConfig = {
         env: paymentURL.stage,
         ...subscriptionConfig.stage,
+        contentEnv: contentURL.stage,
       };
       break;
     case '123done-prod.dev.lcip.org':
       paymentConfig = {
         env: 'prod',
+        contentEnv: contentURL.prod,
       };
       break;
     default:
       paymentConfig = {
         env: paymentURL.local,
         ...subscriptionConfig.default,
+        contentEnv: contentURL.local,
       };
       break;
   }
+
+  let flowData;
+  $.getJSON(
+    `${paymentConfig.contentEnv}metrics-flow?form_type=subscribe&utm_campaign=123done`
+  ).done(function (data) {
+    $('.btn-subscribe-pwdless').each(function (index) {
+      let currencyMappedURL = $(this).attr('href');
+
+      if (data) {
+        currencyMappedURL = `${currencyMappedURL}&flow_id=${data.flowId}&flow_begin_time=${data.flowBeginTime}&device_id=${data.deviceId}`;
+      }
+
+      $(this).attr('href', currencyMappedURL);
+    });
+  });
 
   // Since we don't set up test payment stuff in prod,
   // we can just hide the buttons for that env
@@ -78,6 +108,13 @@ $(document).ready(function () {
       const { env, plans, product } = paymentConfig;
       const currency = $(this).attr('data-currency');
       const currencyMappedURL = `${env}${product}?plan=${plans[currency]}`;
+      $(this).attr('href', currencyMappedURL);
+    });
+
+    $('.btn-subscribe-pwdless').each(function (index) {
+      const { plans, product } = paymentConfig;
+      const currency = $(this).attr('data-currency');
+      const currencyMappedURL = `${pwdlessPaymentURL.local}${product}?plan=${plans[currency]}`;
       $(this).attr('href', currencyMappedURL);
     });
   }

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/event-properties.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/event-properties.ts
@@ -30,6 +30,7 @@ const EVENT_PROPERTIES: {
   [GROUPS.subCancel]: NOP,
   [GROUPS.subManage]: NOP,
   [GROUPS.subPayManage]: NOP,
+  [GROUPS.subPayAccountSetup]: NOP,
   [GROUPS.subPaySetup]: NOP,
   [GROUPS.subPayUpgrade]: NOP,
   [GROUPS.subSupport]: NOP,
@@ -76,7 +77,8 @@ export function createAmplitudeEventPropertiesMapper(
   servicePropMapper: ServiceNameAndClientIdMapper
 ) {
   return (evt: Event, context: EventContext): AmplitudeEventProperties => {
-    const { serviceName: service, clientId: oauthClientId } = servicePropMapper(context);
+    const { serviceName: service, clientId: oauthClientId } =
+      servicePropMapper(context);
 
     return {
       plan_id: context.planId,
@@ -105,8 +107,11 @@ function mapAmplitudeEventPropertiesFromGroup(
 
 function mapConnectDeviceFlow(evt: Event): ConnectDeviceEventProperties | {} {
   if (evt.category && evt.category in CONNECT_DEVICE_FLOWS) {
-    const connectDeviceFlow = CONNECT_DEVICE_FLOWS[evt.category as ConnectDeviceFlowKeys];
-    const result: ConnectDeviceEventProperties = { connect_device_flow: connectDeviceFlow };
+    const connectDeviceFlow =
+      CONNECT_DEVICE_FLOWS[evt.category as ConnectDeviceFlowKeys];
+    const result: ConnectDeviceEventProperties = {
+      connect_device_flow: connectDeviceFlow,
+    };
 
     if (evt.target) {
       result.connect_device_os = evt.target;
@@ -118,8 +123,15 @@ function mapConnectDeviceFlow(evt: Event): ConnectDeviceEventProperties | {} {
   return {};
 }
 
-function mapEmailType(evt: Event, context: EventContext): EmailTypeEventProperties | {} {
-  if (evt.category && context.emailTypes && evt.category in context.emailTypes) {
+function mapEmailType(
+  evt: Event,
+  context: EventContext
+): EmailTypeEventProperties | {} {
+  if (
+    evt.category &&
+    context.emailTypes &&
+    evt.category in context.emailTypes
+  ) {
     const emailType = context.emailTypes[evt.category];
     const result: EmailTypeEventProperties = {
       email_type: emailType,

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/types.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/types.ts
@@ -21,6 +21,7 @@ export enum GROUPS {
   subCancel = 'fxa_subscribe_cancel',
   subManage = 'fxa_subscribe_manage',
   subPayManage = 'fxa_pay_manage',
+  subPayAccountSetup = 'fxa_pay_account_setup',
   subPaySetup = 'fxa_pay_setup',
   subPayUpgrade = 'fxa_pay_upgrade',
   subSupport = 'fxa_subscribe_support',

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.stories.tsx
@@ -23,6 +23,7 @@ const WrapNewUserEmailForm = ({
         checkAccountExists={() =>
           Promise.resolve({ exists: accountExistsReturnValue })
         }
+        selectedPlan={{}}
       />
     </div>
   );

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
@@ -13,6 +13,23 @@ import {
   checkAccountExists,
 } from './index';
 import { Localized } from '@fluent/react';
+const selectedPlan = {
+  plan_id: 'planId',
+  plan_name: 'Pro level',
+  product_id: 'fpnID',
+  product_name: 'Firefox Private Network Pro',
+  currency: 'usd',
+  amount: 935,
+  interval: 'month' as const,
+  interval_count: 1,
+  plan_metadata: {
+    'product:subtitle': 'FPN subtitle',
+    'product:details:1': 'Detail 1',
+    'product:details:2': 'Detail 2',
+    'product:details:3': 'Detail 3',
+  },
+  checkout_type: 'without-account',
+};
 
 const WrapNewUserEmailForm = ({
   accountExistsReturnValue,
@@ -35,6 +52,7 @@ const WrapNewUserEmailForm = ({
         checkAccountExists={() =>
           Promise.resolve({ exists: accountExistsReturnValue })
         }
+        selectedPlan={selectedPlan}
       />
     </div>
   );

--- a/packages/fxa-payments-server/src/lib/amplitude.test.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.test.ts
@@ -34,6 +34,8 @@ it('should call logAmplitudeEvent with the correct event group and type names', 
       ['subCancel', 'complete'],
     ],
     ['cancelSubscription_REJECTED', ['subCancel', 'fail']],
+    ['createAccountMounted', ['subPayAccountSetup', 'view']],
+    ['createAccountEngaged', ['subPayAccountSetup', 'engage']],
   ];
 
   for (const [actionType, ...expectedArgs] of testCases) {

--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -5,6 +5,7 @@ import { selectors } from '../store/selectors';
 import { Store } from '../store';
 
 const eventGroupNames = {
+  createAccount: 'subPayAccountSetup',
   createSubscription: 'subPaySetup',
   upgradeSubscription: 'subPayUpgrade',
   updatePayment: 'subPayManage',
@@ -39,6 +40,7 @@ export type EventProperties = GlobalEventProperties & {
   product_id?: string;
   paymentProvider?: PaymentProvider;
   error?: Error;
+  checkoutType?: string;
 };
 
 type SuccessfulSubscriptionEventProperties = EventProperties & {
@@ -341,6 +343,22 @@ export function updateSubscriptionPlan_REJECTED(
   safeLogAmplitudeEvent(
     eventGroupNames.upgradeSubscription,
     eventTypeNames.fail,
+    eventProperties
+  );
+}
+
+export function createAccountMounted(eventProperties: EventProperties) {
+  safeLogAmplitudeEvent(
+    eventGroupNames.createAccount,
+    eventTypeNames.view,
+    eventProperties
+  );
+}
+
+export function createAccountEngaged(eventProperties: EventProperties) {
+  safeLogAmplitudeEvent(
+    eventGroupNames.createAccount,
+    eventTypeNames.engage,
     eventProperties
   );
 }

--- a/packages/fxa-payments-server/src/lib/flow-event.ts
+++ b/packages/fxa-payments-server/src/lib/flow-event.ts
@@ -1,5 +1,4 @@
 import sentryMetrics from './sentry';
-import { config } from './config';
 
 interface FlowEventParams {
   device_id?: string;

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -119,6 +119,9 @@ export const Checkout = ({
   const onSubmit = (evt: any) => {
     // Will be added in https://mozilla-hub.atlassian.net/browse/FXA-3666
     console.log('Not yet implemented: ', evt);
+
+    // For testing purposes, this will always succeed
+    Amplitude.createSubscriptionWithPaymentMethod_FULFILLED(selectedPlan);
   };
 
   usePaypalButtonSetup(config, setPaypalScriptLoaded);
@@ -169,6 +172,7 @@ export const Checkout = ({
             checkAccountExists={checkAccountExists}
             setEmailsMatch={setEmailsMatch}
             getString={l10n.getString.bind(l10n)}
+            selectedPlan={selectedPlan}
           />
 
           <hr />

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -30,6 +30,7 @@ const GROUPS = {
   subManage: 'fxa_subscribe_manage',
   subPayManage: 'fxa_pay_manage',
   subPaySetup: 'fxa_pay_setup',
+  subPayAccountSetup: 'fxa_pay_account_setup',
   subPayUpgrade: 'fxa_pay_upgrade',
   subSupport: 'fxa_subscribe_support',
   qrConnectDevice: 'fxa_qr_connect_device',
@@ -61,6 +62,7 @@ const EVENT_PROPERTIES = {
   [GROUPS.subManage]: NOP,
   [GROUPS.subPayManage]: NOP,
   [GROUPS.subPaySetup]: mapSubscriptionPaymentEventProperties,
+  [GROUPS.subPayAccountSetup]: mapSubscriptionPaymentEventProperties,
   [GROUPS.subPayUpgrade]: NOP,
   [GROUPS.subSupport]: NOP,
   [GROUPS.qrConnectDevice]: NOP,
@@ -134,8 +136,18 @@ function mapSubscriptionPaymentEventProperties(
   eventTarget,
   data
 ) {
-  if (data && data.sourceCountry) {
-    return { source_country: data.sourceCountry };
+  if (data) {
+    const properties = {};
+
+    if (data.sourceCountry) {
+      properties['source_country'] = data.sourceCountry;
+    }
+
+    if (data.checkoutType) {
+      properties['checkout_type'] = data.checkoutType;
+    }
+
+    return properties;
   }
 }
 

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -444,26 +444,29 @@ describe('metrics/amplitude:', () => {
       });
     });
 
-    describe('transform an event with sourceCountry:', () => {
-      it('did not include the source country in event properties when the event was not in the fxa_pay_setup group', () => {
+    describe('transform an event with subscription event details:', () => {
+      it('did not include the subscription event details in event properties when the event was not in the fxa_pay_setup group', () => {
         const actual = transform(
           { type: 'wibble.blee' },
-          { sourceCountry: 'GD' }
+          { sourceCountry: 'GD', checkoutType: 'without-account' }
         );
         assert.deepEqual(actual.event_properties, {});
       });
 
-      it('did not include the source country in event properties when none was found', () => {
+      it('did not include the subscription event details in event properties when none was found', () => {
         const actual = transform({ type: 'fxa_pay_setup.blee.quuz' }, {});
         assert.deepEqual(actual.event_properties, {});
       });
 
-      it('returned the correct source country event properties', () => {
+      it('returned the correct subscription event details event properties', () => {
         const actual = transform(
           { type: 'fxa_pay_setup.blee.quuz' },
-          { sourceCountry: 'GD' }
+          { sourceCountry: 'GD', checkoutType: 'without-account' }
         );
-        assert.deepEqual(actual.event_properties, { source_country: 'GD' });
+        assert.deepEqual(actual.event_properties, {
+          source_country: 'GD',
+          checkout_type: 'without-account',
+        });
       });
     });
   });


### PR DESCRIPTION
## Because

- New password less payment pages need telemetry
- Adds P1 metrics from https://docs.google.com/document/d/1x0lYak98rM8ickwDciTn99Sd9-r1j6PmvAa8SP7CxGg/edit#heading=h.yzcz14jk0h70

## This pull request

- Adds support for emitting metrics on the new create account payments view (`fxa_pay_account_setup - view`, `fxa_pay_account_setup - engage`)
- Adds new event property `checkout_type`, which can be empty (regular flow), without_account
- Adds support in 123Done to initiate the passwordless flow, goto http://localhost:8080/ click `Subscribe to Pro (Passwordless)`. This will also generate unique flowIds and append to url.

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/9791

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

Example of metrics going through the passwordless flow from (123Done).

```
30|content  | 2021-08-11T13:57:52: INFO fxa-content-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_subscribe - view","time":1628704672272,"device_id":"5709dc64a9784c62aaac16fe7748a1b4","app_version":"212.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{},"user_properties":{"flow_id":"2f4351a8d53b2f2d76400b56e859177c538a77f7a4648de08e4e53cc4ea6b2bc","ua_browser":"Firefox","ua_version":"88.0","utm_campaign":"123done"}}

31|payments  | 2021-08-11T14:54:09: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_account_setup - view","time":1628708049543,"user_id":"afdffdc884dd4e2f921039548208cb03","device_id":"5709dc64a9784c62aaac16fe7748a1b4","session_id":1628704672272,"app_version":"212.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","checkout_type":"without-account"},"user_properties":{"flow_id":"2f4351a8d53b2f2d76400b56e859177c538a77f7a4648de08e4e53cc4ea6b2bc","ua_browser":"Firefox","ua_version":"88.0"}}
31|payments  | 2021-08-11T14:54:09: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_setup - view","time":1628708049544,"user_id":"afdffdc884dd4e2f921039548208cb03","device_id":"5709dc64a9784c62aaac16fe7748a1b4","session_id":1628704672272,"app_version":"212.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","checkout_type":"without-account"},"user_properties":{"flow_id":"2f4351a8d53b2f2d76400b56e859177c538a77f7a4648de08e4e53cc4ea6b2bc","ua_browser":"Firefox","ua_version":"88.0"}}
31|payments  | 2021-08-11T14:54:10: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_account_setup - engage","time":1628708050830,"user_id":"afdffdc884dd4e2f921039548208cb03","device_id":"5709dc64a9784c62aaac16fe7748a1b4","session_id":1628704672272,"app_version":"212.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","checkout_type":"without-account"},"user_properties":{"flow_id":"2f4351a8d53b2f2d76400b56e859177c538a77f7a4648de08e4e53cc4ea6b2bc","ua_browser":"Firefox","ua_version":"88.0"}}
31|payments  | 2021-08-11T14:54:22: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_setup - engage","time":1628708062581,"user_id":"afdffdc884dd4e2f921039548208cb03","device_id":"5709dc64a9784c62aaac16fe7748a1b4","session_id":1628704672272,"app_version":"212.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","checkout_type":"without-account"},"user_properties":{"flow_id":"2f4351a8d53b2f2d76400b56e859177c538a77f7a4648de08e4e53cc4ea6b2bc","ua_browser":"Firefox","ua_version":"88.0"}}
31|payments  | 2021-08-11T14:54:33: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_setup - 3ds_success","time":1628708073435,"user_id":"afdffdc884dd4e2f921039548208cb03","device_id":"5709dc64a9784c62aaac16fe7748a1b4","session_id":1628704672272,"app_version":"212.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","checkout_type":"without-account"},"user_properties":{"flow_id":"2f4351a8d53b2f2d76400b56e859177c538a77f7a4648de08e4e53cc4ea6b2bc","ua_browser":"Firefox","ua_version":"88.0"}}
31|payments  | 2021-08-11T14:54:33: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_setup - 3ds_complete","time":1628708073435,"user_id":"afdffdc884dd4e2f921039548208cb03","device_id":"5709dc64a9784c62aaac16fe7748a1b4","session_id":1628704672272,"app_version":"212.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","checkout_type":"without-account"},"user_properties":{"flow_id":"2f4351a8d53b2f2d76400b56e859177c538a77f7a4648de08e4e53cc4ea6b2bc","ua_browser":"Firefox","ua_version":"88.0"}}
```
