### PR TITLE
fix(payments): ensure plan is never undefined in Checkout signInURL

### DIFF
--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -86,14 +86,14 @@ export const Checkout = ({
     paymentErrorInitialState
   );
 
-  const planId = queryParams.plan;
-  const signInURL = `${config.servers.content.url}/subscriptions/products/${productId}?plan=${planId}&signin=yes`;
-
   // Fetch plans on initial render or change in product ID
   useEffect(() => {
     fetchCheckoutRouteResources();
   }, [fetchCheckoutRouteResources]);
 
+  const planId = queryParams.plan;
+  const planQueryParam = planId ? `plan=${planId}&` : '';
+  const signInURL = `${config.servers.content.url}/subscriptions/products/${productId}?${planQueryParam}signin=yes`;
   const selectedPlan = useMemo(
     () => getSelectedPlan(productId, planId, plansByProductId),
     [productId, planId, plansByProductId]


### PR DESCRIPTION
Because:

* If we are going to pass along a plan queryParam for signInURL in the Checkout route, it should not be undefined.

This commit:

* Omits the plan queryParam if it is undefined.
* Note: If the plan queryParam is undefined, selectedPlan will be the first plan in the list of plans for the given product ID.

Closes #10076

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).