### PR TITLE
feat(fxa-auth-server): Convert lowRecoveryCodes template to new stack

### DIFF
--- a/packages/fxa-auth-server/bin/mjml-server.ts
+++ b/packages/fxa-auth-server/bin/mjml-server.ts
@@ -30,16 +30,16 @@ async function handleRequest(
     const data = JSON.parse(body.trim());
     const { template: templateName, layout: layoutName, ...variables } = data;
     variables.baseUrl = baseUrl;
-    const localized = await fluentLocalizer.localizeEmail(
+    const { html, subject } = await fluentLocalizer.localizeEmail(
       templateName,
       layoutName || 'fxa',
       variables,
       variables.acceptLanguage
     );
-    const result = localized.html;
+    const result = JSON.stringify({ html, subject });
 
     res.writeHead(200, {
-      'Content-Type': 'text/html',
+      'Content-Type': 'application/json',
       'Access-Control-Allow-Origin': '*',
     });
     res.write(result.trim());

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -428,6 +428,6 @@
   },
   "mjml": {
     "enabledEmailAddress": "b@c.com",
-    "templates": ["cadReminderFirst"]
+    "templates": ["cadReminderFirst", "lowRecoveryCodes"]
   }
 }

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1728,6 +1728,9 @@ module.exports = function (log, config) {
       'X-Link': links.link,
     };
 
+    // For now, passing down the subject using gettext since email.js tests were failing
+    // Fluent is still going to conditionally render the subject
+    // based on numberRemaining var for the new templates
     let subject;
     if (numberRemaining === 1) {
       subject = gettext('1 recovery code remaining');

--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -77,3 +77,17 @@ tr > td:first-child {
   text-decoration: none;
   font-family: $font-sans;
 }
+
+.header-text div {
+  @extend .text-xl;
+  @extend .font-sans;
+  text-align: center !important;
+  @extend .mb-5;
+}
+
+.primary-text div {
+  @extend .text-sm;
+  @extend .mb-5;
+  @extend .font-sans;
+  text-align: center !important;
+}

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.txt
@@ -5,5 +5,5 @@ Mozilla. 2 Harrison St, #175, San Francisco, CA 94105
 fxa-privacy-url = "Mozilla Privacy Policy"
 <%- privacyUrl %>
 
-fxa-support-url = "Firefox Cloud Terms of Service"
-<%- supportUrl %>
+fxa-service-url = "Firefox Cloud Terms of Service"
+https://www.mozilla.org/about/legal/terms/services/

--- a/packages/fxa-auth-server/lib/senders/emails/load-ftl-files.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/load-ftl-files.ts
@@ -24,21 +24,21 @@ const getAllFiles = function (dirPath: string, arrayOfFiles: Array<any>) {
 };
 
 export function loadFtlFiles(dirPath: string) {
-  const ftlMap2: Record<any, any> = {};
+  const ftlMap: Record<string, string> = {};
   const fileArr: Array<any> = [];
   const ftlArr: Array<any> = getAllFiles(dirPath, fileArr);
 
   ftlArr.forEach((file) => {
     const indexLocale = path.parse(file).name;
     try {
-      ftlMap2[`${indexLocale}`]
-        ? (ftlMap2[`${indexLocale}`] += readFileSync(file, 'utf8'))
-        : (ftlMap2[`${indexLocale}`] = readFileSync(file, 'utf8'));
+      ftlMap[`${indexLocale}`]
+        ? (ftlMap[`${indexLocale}`] += readFileSync(file, 'utf8'))
+        : (ftlMap[`${indexLocale}`] = readFileSync(file, 'utf8'));
     } catch (e) {
-      ftlMap2[`${indexLocale}`]
-        ? (ftlMap2[`${indexLocale}`] += '')
-        : (ftlMap2[`${indexLocale}`] = '');
+      ftlMap[`${indexLocale}`]
+        ? (ftlMap[`${indexLocale}`] += '')
+        : (ftlMap[`${indexLocale}`] = '');
     }
   });
-  return ftlMap2;
+  return ftlMap;
 }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/cadReminder/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/cadReminder/index.scss
@@ -4,22 +4,8 @@
 
 @use '../../global.scss';
 
-.header-text div {
-  @extend .text-xl;
-  @extend .font-sans;
-  text-align: center !important;
-  @extend .mb-5;
-}
-
 .sync-logo img {
   width: 240px !important;
   margin: 0 auto;
   @extend .mb-5;
-}
-
-.primary-text div {
-  @extend .text-sm;
-  @extend .mb-5;
-  @extend .font-sans;
-  text-align: center !important;
 }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/support/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/support/en-US.ftl
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+support-message = For more information, please visit { $supportUrl }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/support/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/support/index.txt
@@ -1,0 +1,1 @@
+support-message = "For more information, please visit <%- supportUrl %>"

--- a/packages/fxa-auth-server/lib/senders/emails/renderer.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/renderer.ts
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import fs from 'fs';
+import { readFileSync } from 'fs';
 import { join } from 'path';
 import ejs = require('ejs');
 import mjml2html = require('mjml');
@@ -33,9 +33,10 @@ function compile(
     template = ejs.compile(
       layouts[templateName as keyof typeof layouts].render(subTemplate.mjml)
     );
-    const layoutText = fs
-      .readFileSync(join(TEMPLATES_DIR, 'layouts', templateName, 'index.txt'))
-      .toString();
+    const layoutText = readFileSync(
+      join(TEMPLATES_DIR, 'layouts', templateName, 'index.txt'),
+      'utf8'
+    );
 
     templateText = ejs.render(
       layoutText,
@@ -46,9 +47,10 @@ function compile(
     template = ejs.compile(
       templates[templateName as keyof typeof templates].render()
     );
-    templateText = fs
-      .readFileSync(join(TEMPLATES_DIR, 'templates', templateName, 'index.txt'))
-      .toString();
+    templateText = readFileSync(
+      join(TEMPLATES_DIR, 'templates', templateName, 'index.txt'),
+      'utf8'
+    );
   }
   const plainText = ejs.render(templateText, context, ejsConfig);
   const mjmlTemplate = template(context);
@@ -69,11 +71,10 @@ export function renderWithOptionalLayout(
   if (layoutName) {
     const subTemplate = {
       mjml: templates[templateName as keyof typeof templates].render(),
-      text: fs
-        .readFileSync(
-          join(TEMPLATES_DIR, 'templates', templateName, 'index.txt')
-        )
-        .toString(),
+      text: readFileSync(
+        join(TEMPLATES_DIR, 'templates', templateName, 'index.txt'),
+        'utf8'
+      ),
     };
     return compile(context, layoutName, subTemplate);
   } else return compile(context, templateName);

--- a/packages/fxa-auth-server/lib/senders/emails/templates/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/index.ts
@@ -3,3 +3,4 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export * as cadReminderFirst from './cadReminderFirst';
+export * as lowRecoveryCodes from './lowRecoveryCodes';

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/en-US.ftl
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+codes-reminder-title = Low recovery codes remaining
+codes-reminder-description = We noticed that you are running low on recovery codes. Please consider generating new codes to avoid getting locked out of your account.
+codes-generate = Generate codes:
+lowRecoveryCodes-subject =
+    { NUMBER($numberRemaining) ->
+        [one] 1 recovery code remaining
+       *[other] { NUMBER($numberRemaining) } recovery codes remaining
+    }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.stories.ts
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Story, Meta } from '@storybook/html';
+import storybookEmail, { StorybookEmailArgs } from '../../storybook-email';
+
+export default {
+  title: 'Emails/lowRecoveryCodes',
+} as Meta;
+
+const Template: Story<StorybookEmailArgs> = (args) => storybookEmail(args);
+
+const defaultVariables = {
+  action: 'Generate codes',
+  link: 'http://localhost:3030/settings/two_step_authentication/replace_codes?low_recovery_codes=true',
+  subject: '2 recovery codes remaining',
+  privacyUrl: 'https://www.mozilla.org/privacy',
+  supportUrl:
+    'https://support.mozilla.org/kb/im-having-problems-with-my-firefox-account',
+  acceptLanguage: 'en-US',
+  numberRemaining: 1,
+};
+
+const commonPropsWithOverrides = (
+  overrides: Partial<typeof defaultVariables> = {}
+) =>
+  Object.assign({
+    template: 'lowRecoveryCodes',
+    layout: 'fxa',
+    doc: 'Low Recovery Code emails are sent when a user has 2 or less recovery codes remaining',
+    variables: {
+      ...defaultVariables,
+      ...overrides,
+    },
+  });
+
+export const LowRecoveryCodesOne = Template.bind({});
+LowRecoveryCodesOne.args = commonPropsWithOverrides({
+  numberRemaining: 1,
+});
+LowRecoveryCodesOne.storyName = 'User has 1 recovery code remaining';
+
+export const LowRecoveryCodesMultiple = Template.bind({});
+LowRecoveryCodesMultiple.args = commonPropsWithOverrides({
+  numberRemaining: 2,
+});
+LowRecoveryCodesMultiple.storyName =
+  'User has more than 1 recovery codes remaining';

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { automatedEmailNoAction, button } from '../../partials';
+
+export const render = () => `
+  <mj-include path="./lib/senders/emails/css/global.css" type="css" css-inline="inline" />
+  <mj-section>
+    <mj-column>
+    <mj-text css-class="header-text"><span data-l10n-id="codes-reminder-title">Low recovery codes remaining</span></mj-text>
+    </mj-column>
+  </mj-section>
+  <mj-section>
+    <mj-column>
+    <mj-text css-class="primary-text"><span data-l10n-id="codes-reminder-description">We noticed that you are running low on recovery codes. Please consider generating new codes to avoid getting locked out of your account.</span></mj-text>
+    </mj-column>
+  </mj-section>
+  ${button}
+  ${automatedEmailNoAction}
+`;

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.txt
@@ -1,0 +1,8 @@
+codes-reminder-title = "Low recovery codes remaining"
+
+codes-reminder-description = "We noticed that you are running low on recovery codes. Please consider generating new codes to avoid getting locked out of your account."
+
+codes-generate = "Generate codes:"
+<%- link %>
+
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -131,7 +131,34 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: config.smtp.iosUrl },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
-  ])],  
+  ])],
+  
+  ['lowRecoveryCodesEmail', new Map<string, Test | any>([
+    ['subject', [
+      { test: 'include', expected: '2' },
+      { test: 'include', expected: 'recovery codes remaining' },
+      { test: 'notInclude', expected: '1' },
+    ]],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('accountRecoveryCodesUrl', 'low-recovery-codes', 'recovery-codes', 'low_recovery_codes=true', 'email', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('lowRecoveryCodes') }],
+      ['X-Template-Name', { test: 'equal', expected: 'lowRecoveryCodes' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.lowRecoveryCodes }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('accountRecoveryCodesUrl', 'low-recovery-codes', 'recovery-codes', 'low_recovery_codes=true', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'low-recovery-codes', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'low-recovery-codes', 'support')) },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Generate codes:\n${configUrl('accountRecoveryCodesUrl', 'low-recovery-codes', 'recovery-codes', 'low_recovery_codes=true', 'email', 'uid')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'low-recovery-codes', 'privacy')}` },
+      { test: 'include', expected: 'For more information, please visit' },
+      { test: 'include', expected: configUrl('supportUrl', 'low-recovery-codes', 'support') },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {
@@ -306,7 +333,7 @@ function applyAssertions(
 
   describe(`${type} - ${property}`, () => {
     assertions.forEach(({ test, expected }: Test) => {
-      it.only(`${test} - ${expected}`, () => {
+      it(`${test} - ${expected}`, () => {
         /* @ts-ignore */
         assert[test](target, expected, `${type}: ${property}`);
       });


### PR DESCRIPTION
## Because

- We want to convert lowRecoveryCodes template to new stack

## This pull request

- Converts the said email template to new templating stack

## Issue that this pull request solves

Closes: #9269 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
