### PR TITLE
feat(subscriptions): handle passwordless subscriptions

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -42,6 +42,7 @@ card-error = Your transaction could not be processed. Please verify your credit 
 
 fxa-signup-error = There was a problem creating your account.  Please try again later.
 fxa-newsletter-signup-error = There was a problem subscribing you to the newsletter.
+fxa-post-passwordless-sub-error = Subscription confirmed, but the confirmation page failed to load. Please check your email to set up your account.
 
 ## settings
 settings-home = Account Home

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
@@ -7,11 +7,12 @@ import {
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
-import {
-  NewUserEmailForm,
-  emailInputValidationAndAccountCheck,
-  checkAccountExists,
-} from './index';
+jest.mock('../../lib/apiClient', () => ({
+  apiFetchAccountStatus: jest.fn(),
+}));
+import { apiFetchAccountStatus } from '../../lib/apiClient';
+
+import { NewUserEmailForm, emailInputValidationAndAccountCheck } from './index';
 import { Localized } from '@fluent/react';
 const selectedPlan = {
   plan_id: 'planId',
@@ -39,6 +40,10 @@ const WrapNewUserEmailForm = ({
   const [validEmail, setValidEmail] = useState<string>('');
   const [accountExists, setAccountExists] = useState(false);
   const [emailsMatch, setEmailsMatch] = useState(false);
+  (apiFetchAccountStatus as jest.Mock)
+    .mockClear()
+    .mockResolvedValue({ exists: accountExistsReturnValue });
+
   return (
     <div style={{ display: 'flex' }}>
       <NewUserEmailForm

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -13,9 +13,9 @@ import {
 } from '../../lib/validator';
 
 import './index.scss';
-import { config } from '../../lib/config';
 import * as Amplitude from '../../lib/amplitude';
 import { useCallbackOnce } from '../../lib/hooks';
+import { apiFetchAccountStatus } from '../../lib/apiClient';
 
 export type NewUserEmailFormProps = {
   getString?: (id: string) => string;
@@ -147,14 +147,7 @@ export const NewUserEmailForm = ({
 };
 
 export async function checkAccountExists(userEmail: string) {
-  const response = await fetch(`${config.servers.auth.url}/v1/account/status`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ email: userEmail }),
-  });
-  return response.json();
+  return apiFetchAccountStatus(userEmail);
 }
 
 export async function emailInputValidationAndAccountCheck(

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
@@ -23,7 +23,7 @@ export type PaypalButtonProps = {
   disabled: boolean;
   idempotencyKey: string;
   refreshSubmitNonce: () => void;
-  refreshSubscriptions: () => void;
+  refreshSubscriptions: (() => void) | (() => Promise<void>);
   beforeCreateOrder?: () => Promise<void>;
   setPaymentError: Function;
   priceId?: string;
@@ -36,10 +36,10 @@ export type PaypalButtonProps = {
 };
 
 export type ButtonBaseProps = {
-  createOrder?: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  onApprove?: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  onError?: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  createOrder?: () => void;
+  onApprove?: (data: { orderID: string }) => void;
+  onError?: () => void;
+  onClick?: (...args: any[]) => void;
 };
 
 export const GENERAL_PAYPAL_ERROR_ID = 'general-paypal-error';
@@ -94,7 +94,9 @@ export const PaypalButton = ({
       const isNewSubscription = newPaypalAgreement && priceId;
       /* istanbul ignore next */
       try {
-        if (setTransactionInProgress) setTransactionInProgress(true);
+        if (setTransactionInProgress) {
+          setTransactionInProgress(true);
+        }
         const {
           apiCreateCustomer,
           apiCapturePaypalPayment,
@@ -122,7 +124,7 @@ export const PaypalButton = ({
             token,
           });
         }
-        refreshSubscriptions();
+        await refreshSubscriptions();
       } catch (error) {
         if (isNewSubscription) {
           if (!error.code) {
@@ -130,7 +132,7 @@ export const PaypalButton = ({
           }
           setPaymentError(error);
         } else {
-          refreshSubscriptions();
+          await refreshSubscriptions();
         }
       }
       refreshSubmitNonce();

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -90,6 +90,14 @@ async function apiFetch(
   return response.json();
 }
 
+export async function apiFetchAccountStatus(
+  email: string
+): Promise<{ exists: boolean }> {
+  return apiFetch('POST', `${config.servers.auth.url}/v1/account/status`, {
+    body: JSON.stringify({ email }),
+  });
+}
+
 export async function apiFetchProfile(): Promise<Profile> {
   return apiFetch('GET', `${config.servers.profile.url}/v1/profile`);
 }

--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -30,6 +30,7 @@ const PAYMENT_ERROR_2 = 'payment-error-2';
 const PAYMENT_ERROR_3 = 'payment-error-3b';
 const FXA_SIGNUP_ERROR = 'fxa-signup-error';
 const FXA_NEWSLETTER_SIGNUP_ERROR = 'fxa-newsletter-signup-error';
+const FXA_POST_PASSWORDLESS_SUB_ERROR = 'fxa-post-passwordless-sub-error';
 
 /*
  * errorToErrorMessageMap - the keys are lookups, that
@@ -132,6 +133,7 @@ const paymentErrors2 = [
 const paymentErrors3 = ['general-paypal-error'];
 const signupErrors = ['fxa_signup_error'];
 const newsletterSignupErrors = ['fxa_newsletter_signup_error'];
+const postSuccessSubErrors = ['fxa_fetch_profile_customer_error'];
 
 cardErrors.forEach((k) => (errorToErrorMessageMap[k] = CARD_ERROR));
 basicErrors.forEach((k) => (errorToErrorMessageMap[k] = BASIC_ERROR));
@@ -141,6 +143,9 @@ paymentErrors3.forEach((k) => (errorToErrorMessageMap[k] = PAYMENT_ERROR_3));
 signupErrors.forEach((k) => (errorToErrorMessageMap[k] = FXA_SIGNUP_ERROR));
 newsletterSignupErrors.forEach(
   (k) => (errorToErrorMessageMap[k] = FXA_NEWSLETTER_SIGNUP_ERROR)
+);
+postSuccessSubErrors.forEach(
+  (k) => (errorToErrorMessageMap[k] = FXA_POST_PASSWORDLESS_SUB_ERROR)
 );
 
 function getErrorMessage(error: undefined | StripeError | GeneralError) {

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -1,5 +1,6 @@
 import { Profile, Plan, Customer } from '../store/types';
 import { FilteredSetupIntent } from '../lib/apiClient';
+import { PaymentIntent, PaymentMethod } from '@stripe/stripe-js';
 
 export const PROFILE: Profile = {
   amrValues: [],
@@ -159,4 +160,45 @@ export const FILTERED_SETUP_INTENT: FilteredSetupIntent = {
   next_action: null,
   payment_method: 'card_1GnXR2Kb9q6OnNsLuymjpC5P',
   status: 'succeeded',
+};
+
+export const STUB_ACCOUNT_RESULT = {
+  uid: 'newquux',
+  access_token: 'keytothecity',
+};
+
+export const SUBSCRIPTION_RESULT = {
+  id: 'sub_1234',
+  latest_invoice: {
+    id: 'invoice_5678',
+    payment_intent: {
+      id: 'pi_7890',
+      client_secret: 'cs_abcd',
+      status: 'succeeded',
+    },
+  },
+};
+
+export const RETRY_INVOICE_RESULT = {
+  id: 'invoice_5678',
+  payment_intent: {
+    id: 'pi_9876',
+    client_secret: 'cs_erty',
+    status: 'succeeded',
+  },
+};
+
+export const DETACH_PAYMENT_METHOD_RESULT = {
+  id: 'pm_80808',
+  foo: 'quux',
+};
+
+export const PAYMENT_METHOD_RESULT = {
+  paymentMethod: { id: 'pm_4567' } as PaymentMethod,
+  error: undefined,
+};
+
+export const CONFIRM_CARD_RESULT = {
+  paymentIntent: { status: 'succeeded' } as PaymentIntent,
+  error: undefined,
 };

--- a/packages/fxa-payments-server/src/lib/stripe.ts
+++ b/packages/fxa-payments-server/src/lib/stripe.ts
@@ -33,6 +33,11 @@ export type SubscriptionPaymentHandlerParam = {
   onSuccess: () => void;
 };
 
+export type SubscriptionCreateStripeAPIs = Pick<
+  Stripe,
+  'createPaymentMethod' | 'confirmCardPayment'
+>;
+
 export async function handlePasswordlessSubscription({
   email,
   clientId,

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -49,6 +49,7 @@ export const mockConfig = {
     },
     oauth: {
       url: 'https://oauth.example',
+      clientId: 'HAL',
     },
     profile: {
       url: 'https://profile.example',

--- a/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
@@ -1,38 +1,82 @@
 /**
  * @jest-environment jsdom
  */
-import React from 'react';
-import { render, cleanup } from '@testing-library/react';
+import {
+  render,
+  cleanup,
+  fireEvent,
+  act,
+  screen,
+} from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import noc from 'nock';
-
-function nock(it: any) {
-  //@ts-ignore
-  return noc(...arguments).defaultReplyHeaders({
-    'Access-Control-Allow-Origin': '*',
-  });
-}
+import waitForExpect from 'wait-for-expect';
 
 import {
   PRODUCT_ID,
   PRODUCT_REDIRECT_URLS,
-  MOCK_PLANS,
-  expectNockScopesDone,
   defaultAppContextValue,
   MockApp,
   setupMockConfig,
   mockConfig,
   mockServerUrl,
   mockOptionsResponses,
+  mockStripeElementOnChangeFns,
+  elementChangeResponse,
+  MOCK_CHECKOUT_TOKEN,
+  MOCK_PAYPAL_SUBSCRIPTION_RESULT,
 } from '../../lib/test-utils';
 
-jest.mock('../../lib/sentry');
-
-jest.mock('../../lib/flow-event');
-
-import Checkout from './index';
+import Checkout, { CheckoutProps } from './index';
 import { AppContextType } from '../../lib/AppContext';
-import { PLANS } from '../../lib/mock-data';
+import {
+  CONFIRM_CARD_RESULT,
+  CUSTOMER,
+  NEW_CUSTOMER,
+  PAYMENT_METHOD_RESULT,
+  PLANS,
+  PROFILE,
+  STUB_ACCOUNT_RESULT,
+  SUBSCRIPTION_RESULT,
+} from '../../lib/mock-data';
+
+jest.mock('../../lib/apiClient', () => {
+  return {
+    ...jest.requireActual('../../lib/apiClient'),
+    updateAPIClientConfig: jest.fn(),
+    updateAPIClientToken: jest.fn(),
+    apiCreatePasswordlessAccount: jest.fn(),
+    apiFetchProfile: jest.fn(),
+    apiFetchAccountStatus: jest.fn(),
+    apiFetchPlans: jest.fn(),
+    apiCreateCustomer: jest.fn(),
+    apiFetchCustomer: jest.fn(),
+    apiCreateSubscriptionWithPaymentMethod: jest.fn(),
+    apiGetPaypalCheckoutToken: jest.fn(),
+    apiCapturePaypalPayment: jest.fn(),
+  };
+});
+
+const stripeOverride = {
+  createPaymentMethod: jest.fn(),
+  confirmCardPayment: jest.fn(),
+};
+
+import {
+  updateAPIClientToken,
+  apiCreateCustomer,
+  apiCreatePasswordlessAccount,
+  apiFetchCustomer,
+  apiFetchPlans,
+  apiFetchProfile,
+  apiCreateSubscriptionWithPaymentMethod,
+  apiFetchAccountStatus,
+  apiGetPaypalCheckoutToken,
+  apiCapturePaypalPayment,
+} from '../../lib/apiClient';
+import { ButtonBaseProps } from '../../components/PayPalButton';
+import { updateConfig } from '../../lib/config';
+
+const newAccountEmail = 'testo@example.gd';
 
 describe('routes/Checkout', () => {
   let authServer = '';
@@ -47,10 +91,40 @@ describe('routes/Checkout', () => {
     mockOptionsResponses(authServer);
     profileServer = mockServerUrl('profile');
     mockOptionsResponses(profileServer);
+
+    (updateAPIClientToken as jest.Mock).mockClear();
+    (apiFetchPlans as jest.Mock).mockClear().mockResolvedValue(PLANS);
+    (apiFetchAccountStatus as jest.Mock)
+      .mockClear()
+      .mockResolvedValue({ exists: false });
+    (apiCreatePasswordlessAccount as jest.Mock)
+      .mockClear()
+      .mockResolvedValue(STUB_ACCOUNT_RESULT);
+    (apiCreateCustomer as jest.Mock)
+      .mockClear()
+      .mockResolvedValue(NEW_CUSTOMER);
+
+    (apiCreateSubscriptionWithPaymentMethod as jest.Mock)
+      .mockClear()
+      .mockResolvedValue(SUBSCRIPTION_RESULT);
+    (apiFetchProfile as jest.Mock).mockClear().mockResolvedValue(PROFILE);
+    (apiFetchCustomer as jest.Mock).mockClear().mockResolvedValue(CUSTOMER);
+    (apiGetPaypalCheckoutToken as jest.Mock)
+      .mockClear()
+      .mockResolvedValue(MOCK_CHECKOUT_TOKEN);
+    (apiCapturePaypalPayment as jest.Mock)
+      .mockClear()
+      .mockResolvedValue(MOCK_PAYPAL_SUBSCRIPTION_RESULT);
+
+    stripeOverride.createPaymentMethod
+      .mockClear()
+      .mockResolvedValue(PAYMENT_METHOD_RESULT);
+    stripeOverride.confirmCardPayment
+      .mockClear()
+      .mockResolvedValue(CONFIRM_CARD_RESULT);
   });
 
   afterEach(() => {
-    noc.cleanAll();
     return cleanup();
   });
 
@@ -60,13 +134,14 @@ describe('routes/Checkout', () => {
     matchMedia = jest.fn(() => false),
     navigateToUrl = jest.fn(),
     appContext = defaultAppContextValue(),
+    ...additionalProps
   }: {
     productId?: string;
     planId?: string;
     matchMedia?: (query: string) => boolean;
     navigateToUrl?: (url: string) => void;
     appContext?: Partial<AppContextType>;
-  }) => {
+  } & Partial<CheckoutProps>) => {
     const props = {
       match: {
         params: {
@@ -76,6 +151,7 @@ describe('routes/Checkout', () => {
       plans: PLANS,
       plansByProductId: () => PLANS[0],
       fetchCheckoutRouteResources: () => PLANS,
+      stripeOverride,
     };
     const appContextValue = {
       ...defaultAppContextValue(),
@@ -88,23 +164,13 @@ describe('routes/Checkout', () => {
     };
     return (
       <MockApp {...{ appContextValue }}>
-        <Checkout {...props} />
+        <Checkout {...{ ...props, ...additionalProps }} />
       </MockApp>
     );
   };
 
-  const initApiMocks = () => [
-    nock(authServer)
-      .get('/v1/oauth/subscriptions/plans')
-      .reply(200, MOCK_PLANS, { 'Access-Control-Allow-Origin': '*' }),
-  ];
-
   it('renders as expected', async () => {
-    const apiMocks = initApiMocks();
     const { findByTestId, getByTestId } = render(<Subject />);
-    if (window.onload) {
-      dispatchEvent(new Event('load'));
-    }
 
     const formEl = await findByTestId('new-user-email-form');
     expect(formEl).toBeInTheDocument();
@@ -114,29 +180,337 @@ describe('routes/Checkout', () => {
 
     const planDetailsEl = getByTestId('plan-details-component');
     expect(planDetailsEl).toBeInTheDocument();
-
-    expectNockScopesDone(apiMocks);
   });
 
   it('displays an error with invalid product ID', async () => {
-    const apiMocks = initApiMocks();
     const { findByTestId, queryByTestId } = render(
       <Subject productId="bad_product" />
     );
     await findByTestId('no-such-plan-error');
     expect(queryByTestId('dialog-dismiss')).not.toBeInTheDocument();
-    expectNockScopesDone(apiMocks);
   });
 
   it('displays an error on failure to load plans', async () => {
-    const apiMocks = [
-      nock(authServer)
-        .get('/v1/oauth/subscriptions/plans')
-        .reply(400, MOCK_PLANS),
-    ];
+    (apiFetchPlans as jest.Mock).mockRejectedValue({});
     const { findByTestId } = render(<Subject />);
     const errorEl = await findByTestId('error-loading-plans');
     expect(errorEl).toBeInTheDocument();
-    expectNockScopesDone(apiMocks);
+  });
+
+  describe('handling a passwordless Stripe subscription', () => {
+    const fillOutZeForm = async () => {
+      const { getByTestId } = screen;
+      fireEvent.change(getByTestId('new-user-email'), {
+        target: { value: newAccountEmail },
+      });
+      fireEvent.change(getByTestId('new-user-confirm-email'), {
+        target: { value: newAccountEmail },
+      });
+      fireEvent.change(getByTestId('name'), {
+        target: { value: 'BMO' },
+      });
+      fireEvent.click(getByTestId('confirm'));
+      await act(async () => {
+        mockStripeElementOnChangeFns.cardElement(
+          elementChangeResponse({ complete: true, value: 'testo' })
+        );
+      });
+      await act(async () => {
+        fireEvent.click(getByTestId('submit'));
+      });
+    };
+
+    it('creates the account and subscription successfully', async () => {
+      await act(async () => {
+        render(<Subject />);
+      });
+      await fillOutZeForm();
+      await waitForExpect(() => {
+        expect(apiCreatePasswordlessAccount).toHaveBeenCalledWith({
+          email: newAccountEmail,
+          clientId: mockConfig.servers.oauth.clientId,
+        });
+        expect(updateAPIClientToken).toHaveBeenCalledWith(
+          STUB_ACCOUNT_RESULT.access_token
+        );
+        expect(stripeOverride.createPaymentMethod).toHaveBeenCalledTimes(1);
+        expect(apiCreateCustomer).toHaveBeenCalledTimes(1);
+        expect(apiCreateSubscriptionWithPaymentMethod).toHaveBeenCalledTimes(1);
+        expect(apiFetchProfile).toHaveBeenCalledTimes(1);
+        expect(apiFetchCustomer).toHaveBeenCalledTimes(1);
+      });
+
+      expect(screen.getByTestId('payment-confirmation')).toBeInTheDocument();
+    });
+
+    it('displays an error when account creation failed', async () => {
+      (apiCreatePasswordlessAccount as jest.Mock).mockRejectedValue('nope');
+      await act(async () => {
+        render(<Subject />);
+      });
+      await fillOutZeForm();
+      await waitForExpect(() => {
+        expect(apiCreatePasswordlessAccount).toHaveBeenCalledWith({
+          email: newAccountEmail,
+          clientId: mockConfig.servers.oauth.clientId,
+        });
+        expect(updateAPIClientToken).not.toHaveBeenCalled();
+        expect(stripeOverride.createPaymentMethod).not.toHaveBeenCalled();
+        expect(apiCreateCustomer).not.toHaveBeenCalled();
+        expect(apiCreateSubscriptionWithPaymentMethod).not.toHaveBeenCalled();
+        expect(apiFetchProfile).not.toHaveBeenCalled();
+        expect(apiFetchCustomer).not.toHaveBeenCalled();
+      });
+
+      expect(screen.getByTestId('payment-error')).toBeInTheDocument();
+    });
+
+    it('displays an error when payment failed', async () => {
+      stripeOverride.createPaymentMethod.mockRejectedValue({
+        paymentIntent: undefined,
+        error: 'nope',
+      });
+      await act(async () => {
+        render(<Subject />);
+      });
+      await fillOutZeForm();
+      await waitForExpect(() => {
+        expect(apiCreatePasswordlessAccount).toHaveBeenCalledWith({
+          email: newAccountEmail,
+          clientId: mockConfig.servers.oauth.clientId,
+        });
+        expect(updateAPIClientToken).toHaveBeenCalledWith(
+          STUB_ACCOUNT_RESULT.access_token
+        );
+        expect(stripeOverride.createPaymentMethod).toHaveBeenCalledTimes(1);
+        expect(apiCreateCustomer).not.toHaveBeenCalled();
+        expect(apiCreateSubscriptionWithPaymentMethod).not.toHaveBeenCalled();
+        expect(apiFetchProfile).not.toHaveBeenCalled();
+        expect(apiFetchCustomer).not.toHaveBeenCalled();
+      });
+
+      expect(screen.getByTestId('payment-error')).toBeInTheDocument();
+    });
+
+    it('displays a message when fetching user profile failed', async () => {
+      (apiFetchProfile as jest.Mock).mockRejectedValue(null);
+      await act(async () => {
+        render(<Subject />);
+      });
+      await fillOutZeForm();
+      await waitForExpect(() => {
+        expect(apiCreatePasswordlessAccount).toHaveBeenCalledWith({
+          email: newAccountEmail,
+          clientId: mockConfig.servers.oauth.clientId,
+        });
+        expect(updateAPIClientToken).toHaveBeenCalledWith(
+          STUB_ACCOUNT_RESULT.access_token
+        );
+        expect(stripeOverride.createPaymentMethod).toHaveBeenCalledTimes(1);
+        expect(apiCreateCustomer).toHaveBeenCalledTimes(1);
+        expect(apiCreateSubscriptionWithPaymentMethod).toHaveBeenCalledTimes(1);
+        expect(apiFetchProfile).toHaveBeenCalledTimes(1);
+        expect(apiFetchCustomer).toHaveBeenCalledTimes(1);
+      });
+
+      expect(screen.getByTestId('payment-error')).toBeInTheDocument();
+    });
+
+    it('displays a message when fetching customer failed', async () => {
+      (apiFetchCustomer as jest.Mock).mockRejectedValue(null);
+      await act(async () => {
+        render(<Subject />);
+      });
+      await fillOutZeForm();
+      await waitForExpect(() => {
+        expect(apiCreatePasswordlessAccount).toHaveBeenCalledWith({
+          email: newAccountEmail,
+          clientId: mockConfig.servers.oauth.clientId,
+        });
+        expect(updateAPIClientToken).toHaveBeenCalledWith(
+          STUB_ACCOUNT_RESULT.access_token
+        );
+        expect(stripeOverride.createPaymentMethod).toHaveBeenCalledTimes(1);
+        expect(apiCreateCustomer).toHaveBeenCalledTimes(1);
+        expect(apiCreateSubscriptionWithPaymentMethod).toHaveBeenCalledTimes(1);
+        expect(apiFetchProfile).toHaveBeenCalledTimes(1);
+        expect(apiFetchCustomer).toHaveBeenCalledTimes(1);
+      });
+
+      expect(screen.getByTestId('payment-error')).toBeInTheDocument();
+    });
+  });
+
+  describe('handling a passwordless PayPal subscription', () => {
+    updateConfig({
+      featureFlags: {
+        usePaypalUIByDefault: true,
+      },
+    });
+
+    const fillOutZeForm = async () => {
+      const { getByTestId } = screen;
+      fireEvent.change(getByTestId('new-user-email'), {
+        target: { value: newAccountEmail },
+      });
+      fireEvent.change(getByTestId('new-user-confirm-email'), {
+        target: { value: newAccountEmail },
+      });
+      await act(async () => {
+        fireEvent.click(getByTestId('confirm'));
+      });
+      await act(async () => {
+        fireEvent.click(getByTestId('paypal-button'));
+      });
+    };
+
+    it('creates the account and subscription successfully', async () => {
+      const paypalButtonBase = ({
+        createOrder,
+        onApprove,
+      }: ButtonBaseProps) => {
+        return (
+          <button
+            data-testid="paypal-button"
+            onClick={async () => {
+              await createOrder!();
+              await onApprove!({ orderID: 'new-sub' });
+            }}
+          />
+        );
+      };
+      await act(async () => {
+        render(<Subject paypalButtonBase={paypalButtonBase} />);
+      });
+      await fillOutZeForm();
+      await waitForExpect(() => {
+        expect(apiCreatePasswordlessAccount).toHaveBeenCalledWith({
+          email: newAccountEmail,
+          clientId: mockConfig.servers.oauth.clientId,
+        });
+        expect(updateAPIClientToken).toHaveBeenCalledWith(
+          STUB_ACCOUNT_RESULT.access_token
+        );
+        expect(apiGetPaypalCheckoutToken).toHaveBeenCalledTimes(1);
+        expect(apiCreateCustomer).toHaveBeenCalledTimes(1);
+        expect(apiCapturePaypalPayment).toHaveBeenCalledTimes(1);
+        expect(apiFetchProfile).toHaveBeenCalledTimes(1);
+        expect(apiFetchCustomer).toHaveBeenCalledTimes(1);
+      });
+
+      expect(screen.getByTestId('payment-confirmation')).toBeInTheDocument();
+    });
+
+    it('shows an error when account creation failed', async () => {
+      (apiCreatePasswordlessAccount as jest.Mock).mockRejectedValue('nope');
+      const paypalButtonBase = ({ createOrder }: ButtonBaseProps) => {
+        return (
+          <button
+            data-testid="paypal-button"
+            onClick={async () => {
+              await createOrder!();
+            }}
+          />
+        );
+      };
+      await act(async () => {
+        render(<Subject paypalButtonBase={paypalButtonBase} />);
+      });
+      await fillOutZeForm();
+      await waitForExpect(() => {
+        expect(apiCreatePasswordlessAccount).toHaveBeenCalledWith({
+          email: newAccountEmail,
+          clientId: mockConfig.servers.oauth.clientId,
+        });
+        expect(updateAPIClientToken).not.toHaveBeenCalled();
+        expect(apiGetPaypalCheckoutToken).not.toHaveBeenCalled();
+      });
+
+      expect(screen.getByTestId('payment-error')).toBeInTheDocument();
+    });
+
+    it('shows an error when failed to get a PayPal checkout token', async () => {
+      (apiGetPaypalCheckoutToken as jest.Mock).mockRejectedValue({
+        message: 'nogo',
+      });
+      const paypalButtonBase = ({ createOrder }: ButtonBaseProps) => {
+        return (
+          <button
+            data-testid="paypal-button"
+            onClick={async () => {
+              await createOrder!();
+            }}
+          />
+        );
+      };
+      await act(async () => {
+        render(<Subject paypalButtonBase={paypalButtonBase} />);
+      });
+      await fillOutZeForm();
+      await waitForExpect(() => {
+        expect(apiCreatePasswordlessAccount).toHaveBeenCalledWith({
+          email: newAccountEmail,
+          clientId: mockConfig.servers.oauth.clientId,
+        });
+        expect(updateAPIClientToken).toHaveBeenCalledWith(
+          STUB_ACCOUNT_RESULT.access_token
+        );
+        expect(apiGetPaypalCheckoutToken).toHaveBeenCalledTimes(1);
+      });
+
+      expect(screen.getByTestId('payment-error')).toBeInTheDocument();
+    });
+
+    it('shows an error when customer creation failed', async () => {
+      (apiCreateCustomer as jest.Mock).mockRejectedValue({});
+      const paypalButtonBase = ({ onApprove }: ButtonBaseProps) => {
+        return (
+          <button
+            data-testid="paypal-button"
+            onClick={async () => {
+              await onApprove!({ orderID: 'new-sub' });
+            }}
+          />
+        );
+      };
+      await act(async () => {
+        render(<Subject paypalButtonBase={paypalButtonBase} />);
+      });
+      await fillOutZeForm();
+      await waitForExpect(() => {
+        expect(apiCreateCustomer).toHaveBeenCalledTimes(1);
+        expect(apiCapturePaypalPayment).not.toHaveBeenCalled();
+        expect(apiFetchProfile).not.toHaveBeenCalled();
+        expect(apiFetchCustomer).not.toHaveBeenCalled();
+      });
+
+      expect(screen.getByTestId('payment-error')).toBeInTheDocument();
+    });
+
+    it('shows an error when payment capture failed', async () => {
+      (apiCapturePaypalPayment as jest.Mock).mockRejectedValue({});
+      const paypalButtonBase = ({ onApprove }: ButtonBaseProps) => {
+        return (
+          <button
+            data-testid="paypal-button"
+            onClick={async () => {
+              await onApprove!({ orderID: 'new-sub' });
+            }}
+          />
+        );
+      };
+      await act(async () => {
+        render(<Subject paypalButtonBase={paypalButtonBase} />);
+      });
+      await fillOutZeForm();
+      await waitForExpect(() => {
+        expect(apiCreateCustomer).toHaveBeenCalledTimes(1);
+        expect(apiCapturePaypalPayment).toHaveBeenCalledTimes(1);
+        expect(apiFetchProfile).not.toHaveBeenCalled();
+        expect(apiFetchCustomer).not.toHaveBeenCalled();
+      });
+
+      expect(screen.getByTestId('payment-error')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import React from 'react';
 import {
   screen,
   render,
@@ -10,7 +9,7 @@ import {
   fireEvent,
 } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { PaymentMethod, PaymentIntent } from '@stripe/stripe-js';
+import { PaymentMethod } from '@stripe/stripe-js';
 import { SignInLayout } from '../../../components/AppLayout';
 import {
   CUSTOMER,
@@ -18,6 +17,11 @@ import {
   PLAN,
   NEW_CUSTOMER,
   PAYPAL_CUSTOMER,
+  SUBSCRIPTION_RESULT,
+  DETACH_PAYMENT_METHOD_RESULT,
+  RETRY_INVOICE_RESULT,
+  PAYMENT_METHOD_RESULT,
+  CONFIRM_CARD_RESULT,
 } from '../../../lib/mock-data';
 import { PickPartial } from '../../../lib/types';
 
@@ -94,32 +98,6 @@ const Subject = ({
   );
 };
 
-const SUBSCRIPTION_RESULT = {
-  id: 'sub_1234',
-  latest_invoice: {
-    id: 'invoice_5678',
-    payment_intent: {
-      id: 'pi_7890',
-      client_secret: 'cs_abcd',
-      status: 'succeeded',
-    },
-  },
-};
-
-const RETRY_INVOICE_RESULT = {
-  id: 'invoice_5678',
-  payment_intent: {
-    id: 'pi_9876',
-    client_secret: 'cs_erty',
-    status: 'succeeded',
-  },
-};
-
-const DETACH_PAYMENT_METHOD_RESULT = {
-  id: 'pm_80808',
-  foo: 'quux',
-};
-
 const defaultApiClientOverrides = () => ({
   apiCreateCustomer: jest.fn().mockResolvedValue(NEW_CUSTOMER),
   apiCreateSubscriptionWithPaymentMethod: jest
@@ -131,16 +109,6 @@ const defaultApiClientOverrides = () => ({
     .mockResolvedValue(DETACH_PAYMENT_METHOD_RESULT),
   apiGetPaypalCheckoutToken: jest.fn().mockResolvedValue(MOCK_CHECKOUT_TOKEN),
 });
-
-const PAYMENT_METHOD_RESULT = {
-  paymentMethod: { id: 'pm_4567' } as PaymentMethod,
-  error: undefined,
-};
-
-const CONFIRM_CARD_RESULT = {
-  paymentIntent: { status: 'succeeded' } as PaymentIntent,
-  error: undefined,
-};
 
 const defaultStripeOverride = () => ({
   createPaymentMethod: jest.fn().mockResolvedValue(PAYMENT_METHOD_RESULT),
@@ -557,7 +525,12 @@ describe('routes/Product/SubscriptionCreate', () => {
 
   it('handles a successful PayPal payment submission as new customer', async () => {
     const MockedButtonBase = ({ onApprove }: ButtonBaseProps) => {
-      return <button data-testid="paypal-button" onClick={onApprove} />;
+      return (
+        <button
+          data-testid="paypal-button"
+          onClick={async () => onApprove!({ orderID: 'quux' })}
+        />
+      );
     };
     const apiClientOverrides = {
       ...defaultApiClientOverrides(),
@@ -596,7 +569,12 @@ describe('routes/Product/SubscriptionCreate', () => {
 
   it('creates a new customer if needed for PayPal', async () => {
     const MockedButtonBase = ({ onApprove }: ButtonBaseProps) => {
-      return <button data-testid="paypal-button" onClick={onApprove} />;
+      return (
+        <button
+          data-testid="paypal-button"
+          onClick={async () => onApprove!({ orderID: 'quux' })}
+        />
+      );
     };
     const apiClientOverrides = {
       ...defaultApiClientOverrides(),
@@ -883,7 +861,12 @@ describe('routes/Product/SubscriptionCreate', () => {
     const [_, refreshSubmitNonce] = useNonce();
     (refreshSubmitNonce as jest.Mock).mockClear();
     const MockedButtonBase = ({ onApprove }: ButtonBaseProps) => {
-      return <button data-testid="paypal-button" onClick={onApprove} />;
+      return (
+        <button
+          data-testid="paypal-button"
+          onClick={async () => onApprove!({ orderID: 'quux' })}
+        />
+      );
     };
     const apiClientOverrides = {
       ...defaultApiClientOverrides(),

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback, Suspense, useContext } from 'react';
-import { Stripe } from '@stripe/stripe-js';
 import classNames from 'classnames';
 import { Plan, Profile, Customer } from '../../../store/types';
 import { State as ValidatorState } from '../../../lib/validator';
@@ -32,6 +31,7 @@ import {
   handleSubscriptionPayment,
   PaymentError,
   RetryStatus,
+  SubscriptionCreateStripeAPIs,
 } from '../../../lib/stripe';
 
 import * as Amplitude from '../../../lib/amplitude';
@@ -48,11 +48,6 @@ const PaypalButton = React.lazy(
   () => import('../../../components/PayPalButton')
 );
 
-export type SubscriptionCreateStripeAPIs = Pick<
-  Stripe,
-  'createPaymentMethod' | 'confirmCardPayment'
->;
-
 export type SubscriptionCreateAuthServerAPIs = Pick<
   typeof apiClient,
   | 'apiCreateCustomer'
@@ -66,7 +61,7 @@ export type SubscriptionCreateProps = {
   profile: Profile;
   customer: Customer | null;
   selectedPlan: Plan;
-  refreshSubscriptions: () => void;
+  refreshSubscriptions: (() => void) | (() => Promise<void>);
   validatorInitialState?: ValidatorState;
   subscriptionErrorInitialState?: PaymentError;
   stripeOverride?: SubscriptionCreateStripeAPIs;

--- a/packages/fxa-payments-server/src/routes/Product/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.test.tsx
@@ -136,9 +136,6 @@ describe('routes/Product', () => {
     const displayName = 'Foo Barson';
     const apiMocks = initApiMocks(displayName);
     const { findAllByText, queryByText, queryAllByText } = render(<Subject />);
-    if (window.onload) {
-      dispatchEvent(new Event('load'));
-    }
 
     await findAllByText('Set up your subscription');
     expect(


### PR DESCRIPTION
Because:
 - we need to create passwordless subscriptions

This commit:
 - handles the checkout form submission to create a FxA account and a
   subscription with either Stripe or PayPal

## Issue that this pull request solves

Closes: #9358 
Follows #10007, #10051
Part of #9366
