### PR TITLE
fix(emails): Don't send download subscription for passwordless accounts

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -556,7 +556,12 @@ export class StripeWebhookHandler extends StripeHandler {
     switch (invoice.billing_reason) {
       case 'subscription_create':
         await this.mailer.sendSubscriptionFirstInvoiceEmail(...mailParams);
-        await this.mailer.sendDownloadSubscriptionEmail(...mailParams);
+
+        // To not overwhelm users with emails, we only send download subscription email
+        // for existing accounts. Passwordless accounts get their own email.
+        if (account.verifierSetAt > 0) {
+          await this.mailer.sendDownloadSubscriptionEmail(...mailParams);
+        }
         break;
       default:
         // Other billing reasons should be covered in subsequent invoice email


### PR DESCRIPTION
## Because

- Users already recieve 2 subscription emails when they signup via the passwordless account flow, don't need another one

## This pull request

- Only sends download subscription email if it is an existing account

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/10099

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
