### PR TITLE
fix(storybook): add access token to app context in Payments storybook

### DIFF
--- a/packages/fxa-payments-server/.storybook/components/MockApp.tsx
+++ b/packages/fxa-payments-server/.storybook/components/MockApp.tsx
@@ -38,6 +38,7 @@ export const defaultAppContextValue: AppContextType = {
     },
   },
   queryParams: {},
+  accessToken: 'lettherightonein',
   navigateToUrl: action('navigateToUrl'),
   getScreenInfo: () => new ScreenInfo(window),
   matchMedia: (query: string) => window.matchMedia(query).matches,


### PR DESCRIPTION
Because:
 - some routes in Payments need an access token

This commit:
 - prevent a redirect to sign in Storybook by adding an access token in
   the mocked app context
