### PR TITLE
feat(auth-server): Convert postRemoveSecondary template to new stack

### DIFF
--- a/packages/fxa-auth-server/README.md
+++ b/packages/fxa-auth-server/README.md
@@ -219,7 +219,9 @@ Fluent will take care of the rest, populating the element with the message value
 </p>
 ```
 
-By default emails render from left to right which could hamper the accessibility of emails for some locales so along with localizing the emails, we took care of rendering the emails from right to left for rtl locales and vice versa.
+Note that in order to access variables in the dom, we need to pass down a JSON object to the `data-l10n-args` attribute which will be used by the localizer to translate the text.
+
+By default emails render from left to right which could hamper their accessibility for some locales so along with localizing the emails, we took care of rendering them from right to left for rtl locales and vice versa.
 
 ##### Fluent for plaintext files
 

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -432,7 +432,8 @@
       "cadReminderFirst",
       "cadReminderSecond",
       "lowRecoveryCodes",
-      "postVerify"
+      "postVerify",
+      "postRemoveSecondary"
     ]
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
@@ -78,7 +78,7 @@ class FluentLocalizer {
     let selectedLocale: string = 'en-US';
 
     async function* generateBundles(currentLocales: Array<string>) {
-      let bundle = new FluentBundle(currentLocales);
+      let bundle = new FluentBundle(currentLocales, { useIsolating: false });
       for (const locale of currentLocales) {
         let source = await fetchResource(locale);
         if (source !== '' && locale !== 'en-US') {

--- a/packages/fxa-auth-server/lib/senders/emails/partials/button/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/button/index.ts
@@ -6,7 +6,7 @@ export const button = `
   <mj-include path="./lib/senders/emails/css/button/index.css" type="css" css-inline="inline" />
   <mj-section>
     <mj-column>
-      <mj-button css-class="primary-button" href="<%- link %>"><%- action %></mj-button>
+      <mj-button css-class="primary-button" href="<%- link %>"><span data-l10n-id="<%- templateName %>-action"><%- action %></span></mj-button>
     </mj-column>
   </mj-section>
 `;

--- a/packages/fxa-auth-server/lib/senders/emails/partials/manageAccount/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/manageAccount/en-US.ftl
@@ -2,5 +2,5 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cadReminderFirst-subject = Your Friendly Reminder: How To Complete Your Sync Setup
-cadReminderFirst-action = Sync another device
+manage-account = Manage account
+manage-account-plaintext = { manage-account }:

--- a/packages/fxa-auth-server/lib/senders/emails/partials/manageAccount/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/manageAccount/index.txt
@@ -1,0 +1,2 @@
+manage-account-plaintext = "Manage account:"
+<%- link %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/en-US.ftl
@@ -3,3 +3,4 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 cadReminderSecond-subject = Final Reminder: Complete Sync Setup
+cadReminderSecond-action = Sync another device

--- a/packages/fxa-auth-server/lib/senders/emails/templates/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/index.ts
@@ -6,3 +6,4 @@ export * as cadReminderFirst from './cadReminderFirst';
 export * as cadReminderSecond from './cadReminderSecond';
 export * as lowRecoveryCodes from './lowRecoveryCodes';
 export * as postVerify from './postVerify';
+export * as postRemoveSecondary from './postRemoveSecondary';

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/en-US.ftl
@@ -4,9 +4,11 @@
 
 codes-reminder-title = Low recovery codes remaining
 codes-reminder-description = We noticed that you are running low on recovery codes. Please consider generating new codes to avoid getting locked out of your account.
-codes-generate = Generate codes:
+codes-generate = Generate codes
+codes-generate-plaintext = { codes-generate }:
 lowRecoveryCodes-subject =
     { NUMBER($numberRemaining) ->
         [one] 1 recovery code remaining
        *[other] { NUMBER($numberRemaining) } recovery codes remaining
     }
+lowRecoveryCodes-action = { codes-generate }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.txt
@@ -2,7 +2,7 @@ codes-reminder-title = "Low recovery codes remaining"
 
 codes-reminder-description = "We noticed that you are running low on recovery codes. Please consider generating new codes to avoid getting locked out of your account."
 
-codes-generate = "Generate codes:"
+codes-generate-plaintext = "Generate codes:"
 <%- link %>
 
 <%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/en-US.ftl
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+post-remove-secondary-title = Secondary email removed
+post-remove-secondary-description = You have successfully removed { $secondaryEmail } as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address.
+postRemoveSecondary-subject = Secondary email removed
+postRemoveSecondary-action = { manage-account }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.stories.ts
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { Template, commonArgs } from '../../storybook-email';
+
+export default {
+  title: 'Emails/postRemoveSecondary',
+} as Meta;
+
+const defaultVariables = {
+  ...commonArgs,
+  action: 'Manage account',
+  link: 'http://localhost:3030/settings',
+  subject: 'Secondary email removed',
+  secondaryEmail: 'secondary@email',
+};
+
+const commonPropsWithOverrides = (
+  overrides: Partial<typeof defaultVariables> = {}
+) =>
+  Object.assign({
+    template: 'postRemoveSecondary',
+    layout: 'fxa',
+    doc: 'Post Remove Secondary email is sent when user removes the secondary-email associated with his account',
+    variables: {
+      ...defaultVariables,
+      ...overrides,
+    },
+  });
+
+export const PostRemoveSecondary = Template.bind({});
+PostRemoveSecondary.args = commonPropsWithOverrides();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.ts
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { automatedEmailNoAction, button } from '../../partials';
+
+export const render = () => `
+  <mj-include path="./lib/senders/emails/css/global.css" type="css" css-inline="inline" />
+  <mj-section>
+    <mj-column>
+    <mj-text css-class="header-text"><span data-l10n-id="post-remove-secondary-title">Secondary email removed</span></mj-text>
+    </mj-column>
+  </mj-section>
+  <mj-section>
+    <mj-column>
+    <mj-text css-class="primary-text"><span data-l10n-id="post-remove-secondary-description" data-l10n-args='<%= JSON.stringify({secondaryEmail: locals.secondaryEmail}) %>'>You have successfully removed secondary@email as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address.</span></mj-text>
+    </mj-column>
+  </mj-section>
+  ${button}
+  ${automatedEmailNoAction}
+`;

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.txt
@@ -1,0 +1,9 @@
+post-remove-secondary-title = "Secondary email removed"
+
+post-remove-secondary-description = "You have successfully removed { $secondaryEmail } as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address."
+
+<%- include('/partials/manageAccount/index.txt') %>
+
+<%- include('/partials/automatedEmailNoAction/index.txt') %>
+
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -163,9 +163,7 @@ const TESTS: [string, any][] = [
   
   ['lowRecoveryCodesEmail', new Map<string, Test | any>([
     ['subject', [
-      { test: 'include', expected: '2' },
-      { test: 'include', expected: 'recovery codes remaining' },
-      { test: 'notInclude', expected: '1' },
+      { test: 'include', expected: '2 recovery codes remaining' }
     ]],
     ['headers', new Map([
       ['X-Link', { test: 'equal', expected: configUrl('accountRecoveryCodesUrl', 'low-recovery-codes', 'recovery-codes', 'low_recovery_codes=true', 'email', 'uid') }],
@@ -182,8 +180,7 @@ const TESTS: [string, any][] = [
     ['text', [
       { test: 'include', expected: `Generate codes:\n${configUrl('accountRecoveryCodesUrl', 'low-recovery-codes', 'recovery-codes', 'low_recovery_codes=true', 'email', 'uid')}` },
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'low-recovery-codes', 'privacy')}` },
-      { test: 'include', expected: 'For more information, please visit' },
-      { test: 'include', expected: configUrl('supportUrl', 'low-recovery-codes', 'support') },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'low-recovery-codes', 'support')}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
@@ -218,6 +215,28 @@ const TESTS: [string, any][] = [
       { test: 'include', expected: config.smtp.syncUrl },
       { test: 'notInclude', expected: config.smtp.androidUrl },
       { test: 'notInclude', expected: config.smtp.iosUrl },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
+
+  ['postRemoveSecondaryEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Secondary email removed' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-email-removed', 'account-email-removed', 'email', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postRemoveSecondary') }],
+      ['X-Template-Name', { test: 'equal', expected: 'postRemoveSecondary' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postRemoveSecondary }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-email-removed', 'account-email-removed', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-email-removed', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'account-email-removed', 'support')) },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-email-removed', 'account-email-removed', 'email', 'uid')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-email-removed', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'account-email-removed', 'support')}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],


### PR DESCRIPTION
## Because

- We have setup new templating stack in fxa auth server

## This pull request

- Converts postRemoveSecondary email template to new stack 

## Issue that this pull request solves

Closes: #9273 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
