### PR TITLE
Use JWT for finish_setup

### DIFF
--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -448,6 +448,16 @@ export default class AuthClient {
     return accountData;
   }
 
+  async finishSetup(token: string, email: string, newPassword: string) {
+    const credentials = await crypto.getCredentials(email, newPassword);
+    const payload = {
+      token,
+      authPW: credentials.authPW,
+    };
+    await this.request('POST', '/account/finish_setup', payload);
+    return;
+  }
+
   async accountKeys(
     keyFetchToken: hexstring,
     unwrapBKey: hexstring

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -127,7 +127,6 @@ export class PayPalHandler extends StripeWebhookHandler {
       uid,
       account,
       subscription,
-      db: this.db,
       stripeHelper: this.stripeHelper,
       mailer: this.mailer,
     });

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -552,7 +552,6 @@ export class StripeHandler {
       uid,
       account,
       subscription,
-      db: this.db,
       stripeHelper: this.stripeHelper,
       mailer: this.mailer,
     });

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1924,7 +1924,6 @@ module.exports = function (log, config) {
       invoiceDate,
       nextInvoiceDate,
       token,
-      code,
     } = message;
 
     const enabled = config.subscriptions.transactionalEmails.enabled;
@@ -1943,7 +1942,6 @@ module.exports = function (log, config) {
       email,
       product_name: productName,
       token,
-      code,
       product_id: productId,
     };
     const template = 'subscriptionAccountFinishSetup';

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -269,7 +269,7 @@ const TESTS = [
       ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionAccountFinishSetup }],
     ])],
     ['html', [
-      { test: 'include', expected: configHref('accountFinishSetupUrl', 'subscription-account-finish-setup', 'subscriptions', 'email', 'product_name', 'token', 'code', 'product_id') },
+      { test: 'include', expected: configHref('accountFinishSetupUrl', 'subscription-account-finish-setup', 'subscriptions', 'email', 'product_name', 'token', 'product_id') },
       { test: 'include', expected: configHref('subscriptionSupportUrl', 'subscription-account-finish-setup', 'subscription-support') },
       { test: 'include', expected: `Welcome to ${MESSAGE.productName}` },
       { test: 'include', expected: `Invoice number: ${MESSAGE.invoiceNumber}` },
@@ -279,7 +279,7 @@ const TESTS = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
     ['text', [
-      { test: 'include', expected: configUrl('accountFinishSetupUrl', 'subscription-account-finish-setup', 'subscriptions', 'email', 'product_name', 'token', 'code', 'product_id') },
+      { test: 'include', expected: configUrl('accountFinishSetupUrl', 'subscription-account-finish-setup', 'subscriptions', 'email', 'product_name', 'token', 'product_id') },
       { test: 'include', expected: configUrl('subscriptionSupportUrl', 'subscription-account-finish-setup', 'subscription-support') },
       { test: 'include', expected: `Welcome to ${MESSAGE.productName}` },
       { test: 'include', expected: `Invoice number: ${MESSAGE.invoiceNumber}` },

--- a/packages/fxa-content-server/app/scripts/lib/fxa-client.js
+++ b/packages/fxa-content-server/app/scripts/lib/fxa-client.js
@@ -1424,6 +1424,8 @@ FxaClientWrapper.prototype = {
    * @returns {Promise} resolves with response when complete.
    */
   sendPushLoginRequest: createClientDelegate('sendPushLoginRequest'),
+
+  finishSetup: createClientDelegate('finishSetup'),
 };
 
 export default FxaClientWrapper;

--- a/packages/fxa-content-server/app/scripts/lib/validate.js
+++ b/packages/fxa-content-server/app/scripts/lib/validate.js
@@ -17,6 +17,8 @@ const HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/;
 // taken from the fxa-oauth-server
 const B64URL_STRING = /^[A-Za-z0-9-_]+$/;
 
+const JWT_STRING = /^[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+$/;
+
 // Crockford base32 Regex. Excludes I, L, O, U
 const B32_STRING = /^[0-9A-HJ-NP-TV-Z]+$/;
 
@@ -226,6 +228,10 @@ var Validate = {
    */
   isBase64Url(value) {
     return B64URL_STRING.test(value);
+  },
+
+  isJWT(value) {
+    return JWT_STRING.test(value);
   },
 
   /**

--- a/packages/fxa-content-server/app/scripts/lib/vat.js
+++ b/packages/fxa-content-server/app/scripts/lib/vat.js
@@ -22,6 +22,7 @@ Vat.register('hex', Vat.string().test(Validate.isHexValid));
 Vat.register('idToken', Vat.string());
 Vat.register('keyFetchToken', Vat.string());
 Vat.register('keysJwk', Vat.string().test(Validate.isBase64Url));
+Vat.register('jwt', Vat.string().test(Validate.isJWT));
 Vat.register(
   'newslettersArray',
   Vat.any().test(Validate.isNewslettersArrayValid)

--- a/packages/fxa-content-server/app/scripts/models/account.js
+++ b/packages/fxa-content-server/app/scripts/models/account.js
@@ -1171,6 +1171,10 @@ const Account = Backbone.Model.extend(
         });
     },
 
+    finishSetup(token, email, password) {
+      return this._fxaClient.finishSetup(token, email, password);
+    },
+
     /**
      * Fetch the account's list of attached clients.
      *

--- a/packages/fxa-content-server/app/scripts/models/verification/set-password.js
+++ b/packages/fxa-content-server/app/scripts/models/verification/set-password.js
@@ -14,7 +14,6 @@ import VerificationInfo from './base';
 
 export default VerificationInfo.extend({
   defaults: {
-    code: null,
     token: null,
     email: null,
     product_name: null,
@@ -23,8 +22,7 @@ export default VerificationInfo.extend({
   },
 
   validation: {
-    code: Vat.verificationCode(),
-    token: Vat.token(),
+    token: Vat.jwt(),
     email: Vat.email(),
   },
 });

--- a/packages/fxa-content-server/app/scripts/views/post_verify/finish_account_setup/set_password.js
+++ b/packages/fxa-content-server/app/scripts/views/post_verify/finish_account_setup/set_password.js
@@ -87,13 +87,6 @@ class SetPassword extends FormView {
         this.logError(AuthErrors.toError('DAMAGED_VERIFICATION_LINK'));
         return;
       }
-
-      const token = this._verificationInfo.get('token');
-      return account.isPasswordResetComplete(token).then((isComplete) => {
-        if (isComplete) {
-          return this.redirectToProduct(account);
-        }
-      });
     });
   }
 
@@ -101,25 +94,15 @@ class SetPassword extends FormView {
     const account = this.getAccount();
     const password = this._getPassword();
     const token = this._verificationInfo.get('token');
-    const code = this._verificationInfo.get('code');
-    return this.user
-      .completeAccountPasswordReset(account, password, token, code, this.relier)
-      .then(
-        () => {
-          return this.redirectToProduct(account);
-        },
-        (err) => {
-          if (AuthErrors.is(err, 'INVALID_TOKEN')) {
-            // The token has expired since the first check, re-render to
-            // show a view that allows the user to receive a new link.
-            return this.render();
-          }
-
-          // all other errors are unexpected, bail.
-          this.logError(err);
-          throw err;
-        }
-      );
+    return account.finishSetup(token, account.get('email'), password).then(
+      () => {
+        return this.redirectToProduct(account);
+      },
+      (err) => {
+        this.logError(err);
+        throw err;
+      }
+    );
   }
 }
 

--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/finish_account_setup/set_password.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/finish_account_setup/set_password.js
@@ -31,7 +31,7 @@ describe('views/post_verify/finish_account_setup/set_password', () => {
   beforeEach(() => {
     windowMock = new WindowMock();
     windowMock.location.search =
-      '?email=a@asdf.com&product_name=123&token=e39ed2d69690c9392d74fb8a98603c426002eb3f25215c71fc7085ff74c31f34&code=90cf17f3b75c1b76d79500bc1499caac';
+      '?email=a@asdf.com&product_name=123&token=a.test.jwt';
 
     relier = new Relier({
       window: windowMock,
@@ -121,13 +121,6 @@ describe('views/post_verify/finish_account_setup/set_password', () => {
       sinon.spy(view, 'logError');
     });
 
-    it('invalid code', async () => {
-      view._verificationInfo.set('code', 'invalid');
-      await view.render();
-      assert.lengthOf(view.$('#fxa-account-setup-set-damaged-header'), 1);
-      assert.isTrue(view.logError.calledWith(sinon.match.has('errno', 1026)));
-    });
-
     it('invalid token', async () => {
       view._verificationInfo.set('token', 'invalid');
       await view.render();
@@ -136,28 +129,11 @@ describe('views/post_verify/finish_account_setup/set_password', () => {
     });
   });
 
-  describe('with used password reset code', () => {
-    beforeEach(() => {
-      account.isPasswordResetComplete.restore();
-      sinon
-        .stub(account, 'isPasswordResetComplete')
-        .callsFake(() => Promise.resolve(true));
-      sinon
-        .stub(account, 'fetchSubscriptionPlans')
-        .callsFake(() => Promise.resolve([{}]));
-      sinon.spy(view, 'navigateAway');
-    });
-    it('should navigate', async () => {
-      await view.render();
-      assert.isTrue(view.navigateAway.calledOnce);
-    });
-  });
-
   describe('submit', () => {
     describe('success', () => {
       beforeEach(() => {
         sinon
-          .stub(user, 'completeAccountPasswordReset')
+          .stub(account, 'finishSetup')
           .callsFake(() => Promise.resolve(true));
         sinon
           .stub(account, 'fetchSubscriptionPlans')
@@ -177,7 +153,7 @@ describe('views/post_verify/finish_account_setup/set_password', () => {
         const error = new Error('failed');
         sinon.spy(view, 'logError');
         sinon
-          .stub(user, 'completeAccountPasswordReset')
+          .stub(account, 'finishSetup')
           .callsFake(() => Promise.reject(error));
         try {
           await view.submit();


### PR DESCRIPTION
Instead of using the existing password reset flow, where the `passwordForgotToken` expires, this method creates a jwt that can be used until a password is set on the account.

closes #10043