### PR TITLE
 feat(payments): handle new/previously unhandled errors in passwordless checkout

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -40,8 +40,8 @@ duplicate-transaction = Hmm. Looks like an identical transaction was just sent. 
 coupon-expired = It looks like that promo code has expired.
 card-error = Your transaction could not be processed. Please verify your credit card information and try again.
 
-fxa-signup-error = There was a problem creating your account.  Please try again later.
-fxa-newsletter-signup-error = There was a problem subscribing you to the newsletter.
+fxa-account-signup-error = A system error caused your ${ productName } sign-up to fail. Your payment method has not been charged. Please try again.
+newsletter-signup-error = You're not signed up for product update emails. You can try again in your account settings.
 fxa-post-passwordless-sub-error = Subscription confirmed, but the confirmation page failed to load. Please check your email to set up your account.
 
 ## settings

--- a/packages/fxa-payments-server/src/components/AlertBar/index.scss
+++ b/packages/fxa-payments-server/src/components/AlertBar/index.scss
@@ -10,7 +10,9 @@
 
 #top-bar .alert {
   background: rgba(0, 0, 0, 0.1);
-  font-weight: bold;
+  font-weight: 400;
+  font-size: 13px;
+  line-height: 21px;
   margin: 4px auto;
   min-height: 2em;
   padding: 0.5em;
@@ -36,6 +38,11 @@
 
 #top-bar .alertError {
   background: #FF4F5E;
+}
+
+#top-bar .newsletter-error {
+  color: #3D3D3D;
+  background: #FFA436;
 }
 
 .alert span.checked::before {

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.test.tsx
@@ -45,6 +45,8 @@ describe('PaymentErrorView test with l10n', () => {
 
     const termsAndPrivacy = queryByTestId('terms');
     expect(termsAndPrivacy).toBeInTheDocument();
+
+    expect(queryByTestId('fxa-legal-links')).not.toBeInTheDocument();
   });
 
   it('calls passed onRetry function when retry button clicked', async () => {
@@ -99,5 +101,40 @@ describe('PaymentErrorView test with l10n', () => {
       fireEvent.click(getByTestId('manage-subscription-link'));
     });
     expect(mockHistoryPush).toHaveBeenCalledWith('/subscriptions');
+  });
+
+  it('does not render the ActionButton for post-subscription creation errors', async () => {
+    const { queryByTestId } = render(
+      <PaymentErrorView
+        onRetry={() => {}}
+        error={{ code: 'fxa_fetch_profile_customer_error' }}
+        plan={SELECTED_PLAN}
+      />
+    );
+
+    const expected =
+      'Subscription confirmed, but the confirmation page failed to load. Please check your email to set up your account.';
+    const actual = getLocalizedMessage(
+      bundle,
+      'fxa-post-passwordless-sub-error',
+      {}
+    );
+    expect(actual).toEqual(expected);
+
+    const actionButton = queryByTestId('error-view-action-button');
+    expect(actionButton).not.toBeInTheDocument();
+  });
+
+  it('shows FxA legal links in footer when isPasswordlessCheckout is true', async () => {
+    const { queryByTestId } = render(
+      <PaymentErrorView
+        onRetry={() => {}}
+        error={{ code: 'general-paypal-error' }}
+        plan={SELECTED_PLAN}
+        isPasswordlessCheckout={true}
+      />
+    );
+
+    expect(queryByTestId('fxa-legal-links')).toBeInTheDocument();
   });
 });

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.scss
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.scss
@@ -14,3 +14,7 @@
   color: #3D3D3D;
   font-weight: 600;
 }
+
+.payment-error .legal-heading {
+  margin-top: 16px;
+}

--- a/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
+++ b/packages/fxa-payments-server/src/components/TermsAndPrivacy/index.tsx
@@ -60,7 +60,7 @@ export const TermsAndPrivacy = ({
         >
           Privacy Notice
         </a>
-      </Localized>{' '}
+      </Localized>
       &nbsp;&nbsp;&nbsp;
       <Localized id="terms-download">
         <a

--- a/packages/fxa-payments-server/src/lib/account.ts
+++ b/packages/fxa-payments-server/src/lib/account.ts
@@ -8,7 +8,9 @@ import {
 } from './apiClient';
 import { GeneralError } from './errors';
 import sentry from './sentry';
-export const FXA_SIGNUP_ERROR: GeneralError = { code: 'fxa_signup_error' };
+export const FXA_SIGNUP_ERROR: GeneralError = {
+  code: 'fxa_account_signup_error',
+};
 
 export async function handlePasswordlessSignUp({
   email,

--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -28,8 +28,8 @@ const BASIC_ERROR = 'basic-error-message';
 const PAYMENT_ERROR_1 = 'payment-error-1';
 const PAYMENT_ERROR_2 = 'payment-error-2';
 const PAYMENT_ERROR_3 = 'payment-error-3b';
-const FXA_SIGNUP_ERROR = 'fxa-signup-error';
-const FXA_NEWSLETTER_SIGNUP_ERROR = 'fxa-newsletter-signup-error';
+const FXA_SIGNUP_ERROR = 'fxa-account-signup-error';
+const FXA_NEWSLETTER_SIGNUP_ERROR = 'newsletter-signup-error';
 const FXA_POST_PASSWORDLESS_SUB_ERROR = 'fxa-post-passwordless-sub-error';
 
 /*
@@ -131,7 +131,7 @@ const paymentErrors2 = [
 ];
 
 const paymentErrors3 = ['general-paypal-error'];
-const signupErrors = ['fxa_signup_error'];
+const signupErrors = ['fxa_account_signup_error'];
 const newsletterSignupErrors = ['fxa_newsletter_signup_error'];
 const postSuccessSubErrors = ['fxa_fetch_profile_customer_error'];
 

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -202,3 +202,14 @@ export const CONFIRM_CARD_RESULT = {
   paymentIntent: { status: 'succeeded' } as PaymentIntent,
   error: undefined,
 };
+
+export const MOCK_STRIPE_CARD_ERROR = {
+  code: 'card_declined',
+};
+
+export const MOCK_FXA_POST_PASSWORDLESS_SUB_ERROR = {
+  code: 'fxa_fetch_profile_customer_error',
+};
+export const MOCK_GENERAL_PAYPAL_ERROR = {
+  code: 'general-paypal-error',
+};

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.tsx
@@ -34,7 +34,7 @@ export const SubscriptionSuccess = ({
 
   return (
     <>
-      <Header {...{ profile: profile }} />
+      <Header {...{ profile }} />
       <div className="main-content">
         <PaymentConfirmation
           {...{


### PR DESCRIPTION
**Important:** This PR is based on Dave's PR #10074 for FXA-3715; it should not be merged until that PR merges. Only the second commit is new.

Because:
* The new passwordless checkout flow adds two new types of errors (account creation and newsletter signup) that we need to handle, and there is a previously unhandled error related to loading the success page.
* These errors should all be caught, and we should display an appropriate and relevant error message to the user when they occur if possible.

This commit:
* Makes sure we handle the following errors in the new passwordless flow and display error messages based on the MVP designs.
  - FxA account creation
  - Subscription creation/payment
  - Newsletter signup
  - Success screen loading

Closes #9366

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Note: The success page (including legal links) is not final; it will be updated in #9365 .

![Screenshot 2021-08-16 at 23-01-03 Firefox Accounts](https://user-images.githubusercontent.com/17437436/129665479-a6400ed4-e9b4-49ab-a02d-fac845141869.png)

I also added the new legal links to the `PaymentErrorView` component.

![Screenshot 2021-08-17 at 00-45-38 Firefox Accounts](https://user-images.githubusercontent.com/17437436/129665476-3d68b3a7-42aa-4b18-8da9-0a4791d4ef2c.png)

