### PR TITLE
feat(auth-server): Convert verificationReminder templates to new stack

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -433,7 +433,9 @@
       "cadReminderSecond",
       "lowRecoveryCodes",
       "postVerify",
-      "postRemoveSecondary"
+      "postRemoveSecondary",
+      "verificationReminderFirst",
+      "verificationReminderSecond"
     ]
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -49,19 +49,18 @@ $s-10: 40px;
 }
 
 .mt {
-  &-2 div {
+  &-2 {
     margin-top: $s-2 !important;
   }
-  &-6 div {
+  &-6 {
     margin-top: $s-6 !important;
   }
 }
 
 .mb {
-  &-3 div {
+  &-3 {
     margin-bottom: $s-3 !important;
   }
-
   &-5 {
     margin-bottom: $s-5 !important;
   }
@@ -84,22 +83,46 @@ tr > td:first-child {
   font-family: $font-sans;
 }
 
-.header-text div {
+.text-header div {
   @extend .text-xl;
   @extend .font-sans;
+  @extend .mb-3;
   text-align: center !important;
+}
+
+%text-body-common {
+  @extend .text-sm;
+  @extend .font-sans;
+  text-align: center !important;
+}
+
+.text-body div {
+  @extend %text-body-common;
   @extend .mb-5;
 }
 
-.primary-text div {
-  @extend .text-sm;
-  @extend .mb-5;
+.text-sub-body div {
+  @extend %text-body-common;
+  @extend .mb-3;
+}
+
+.text-footer div {
+  @extend .text-xs;
   @extend .font-sans;
   text-align: center !important;
+  color: $grey-400 !important;
 }
 
 .sync-logo img {
   width: 240px !important;
   margin: 0 auto;
   @extend .mb-5;
+  @extend .mt-2;
+}
+
+.graphic-devices img {
+  width: 240px !important;
+  margin: 0 auto;
+  @extend .mb-5;
+  @extend .mt-2;
 }

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.scss
@@ -25,10 +25,3 @@
   height: 137px;
   width: 270px;
 }
-
-.secondary-text div {
-  @extend .font-sans;
-  @extend .text-xs;
-  text-align: center !important;
-  color: global.$grey-400 !important;
-}

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.ts
@@ -40,9 +40,9 @@ export const render = (body: string) => {
       ${body}
       <mj-section>
         <mj-column>
-          <mj-text css-class="secondary-text">Mozilla. 2 Harrison St, #175, San Francisco, CA 94105</mj-text>
-          <mj-text css-class="secondary-text"><a class="link-blue" data-l10n-id="fxa-privacy-url" href="<%- privacyUrl %>">Mozilla Privacy Policy</a></mj-text>
-          <mj-text css-class="secondary-text"><a class="link-blue" data-l10n-id="fxa-service-url" href="https://www.mozilla.org/about/legal/terms/services/">Firefox Cloud Terms of Service</a></mj-text>
+          <mj-text css-class="text-footer">Mozilla. 2 Harrison St, #175, San Francisco, CA 94105</mj-text>
+          <mj-text css-class="text-footer"><a class="link-blue" data-l10n-id="fxa-privacy-url" href="<%- privacyUrl %>">Mozilla Privacy Policy</a></mj-text>
+          <mj-text css-class="text-footer"><a class="link-blue" data-l10n-id="fxa-service-url" href="https://www.mozilla.org/about/legal/terms/services/">Firefox Cloud Terms of Service</a></mj-text>
         </mj-column>
       </mj-section>
     </mj-body>

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.txt
@@ -1,5 +1,4 @@
 <%- body %>
-
 Mozilla. 2 Harrison St, #175, San Francisco, CA 94105
 
 fxa-privacy-url = "Mozilla Privacy Policy"

--- a/packages/fxa-auth-server/lib/senders/emails/partials/appBadges/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/appBadges/index.scss
@@ -13,9 +13,9 @@
   }
 }
 
-.secondary-text div {
-  @extend .font-sans;
-  @extend .text-xs;
-  text-align: center !important;
-  color: global.$grey-400 !important;
+.text-footer-appBadges {
+  @extend .text-footer;
+  div {
+    @extend .mb-5;
+  }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/appBadges/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/appBadges/index.ts
@@ -25,11 +25,11 @@ export const appBadges = `
   <mj-section>
     <mj-column>
       <% if (locals.onDesktopOrTabletDevice) { %>
-      <mj-text css-class="secondary-text mb-5"><span data-l10n-id="another-desktop-device"> Or, install on
+      <mj-text css-class="text-footer-appBadges"><span data-l10n-id="another-desktop-device"> Or, install on
         <a href="<%- desktopLink %>" class="link-blue" data-l10n-name="anotherDeviceLink">another desktop device</a></span>
       </mj-text>
       <% } else { %>
-      <mj-text css-class="secondary-text mb-5"><span data-l10n-id="another-device"> Or, install on
+      <mj-text css-class="text-footer-appBadges"><span data-l10n-id="another-device"> Or, install on
         <a href="<%- link %>" class="link-blue" data-l10n-name="anotherDeviceLink">another device</a></span>
         <% } %>
       </mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailNoAction/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailNoAction/index.scss
@@ -2,9 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-export * from './appBadges';
-export * from './button';
-export * from './metadata';
-export * from './automatedEmailNoAction';
-export * from './cadReminder';
-export * from './verificationReminder';
+@use '../../global.scss';
+
+.text-footer-automatedEmail {
+  @extend .text-footer;
+  div {
+    @extend .mb-3;
+    @extend .mt-6;
+  }
+}

--- a/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailNoAction/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailNoAction/index.ts
@@ -3,10 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 export const automatedEmailNoAction = `
-<mj-section>
-  <mj-column>
-    <mj-text css-class="secondary-text mt-6 mb-3"><span data-l10n-id="automated-email">This is an automated email; if you received it in error, no action is
-      required. For more information, please visit <a class="link-blue" href="<%- supportUrl %>" data-l10n-name="supportLink">Mozilla Support</a>.</span></mj-text>
-  </mj-column>
-</mj-section>
+  <mj-include path="./lib/senders/emails/css/automatedEmailNoAction/index.css" type="css" css-inline="inline" />
+  <mj-section>
+    <mj-column>
+      <mj-text css-class="text-footer-automatedEmail"><span data-l10n-id="automated-email">This is an automated email; if you received it in error, no action is
+        required. For more information, please visit <a class="link-blue" href="<%- supportUrl %>" data-l10n-name="supportLink">Mozilla Support</a>.</span></mj-text>
+    </mj-column>
+  </mj-section>
 `;

--- a/packages/fxa-auth-server/lib/senders/emails/partials/cadReminder/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/cadReminder/index.ts
@@ -5,15 +5,16 @@
 import { appBadges, button, automatedEmailNoAction } from '../../partials';
 
 export const cadReminder = `
+  <mj-include path="./lib/senders/emails/css/global.css" type="css" css-inline="inline" />
   <mj-section>
     <mj-column>
-      <mj-text css-class="header-text"><span data-l10n-id="<%- templateName %>-title"><%- headerText %></span></mj-text>
-      <mj-image css-class="sync-logo" alt="Devices" src="https://accounts-static.cdn.mozilla.net/other/graphic-laptop-mobile.png"></mj-image>
+      <mj-text css-class="text-header"><span data-l10n-id="<%- templateName %>-title"><%- headerText %></span></mj-text>
+      <mj-image css-class="graphic-devices" alt="Devices" src="https://accounts-static.cdn.mozilla.net/other/graphic-laptop-mobile.png"></mj-image>
     </mj-column>
   </mj-section>
   <mj-section>
     <mj-column>
-      <mj-text css-class="primary-text"><span data-l10n-id="<%- templateName %>-description"><%- bodyText %></span></mj-text>
+      <mj-text css-class="text-body"><span data-l10n-id="<%- templateName %>-description"><%- bodyText %></span></mj-text>
     </mj-column>
   </mj-section>
   ${button}

--- a/packages/fxa-auth-server/lib/senders/emails/partials/verificationReminder/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/verificationReminder/index.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { automatedEmailNoAction, button } from '../../partials';
+
+export const verificationReminder = ({
+  title,
+  description,
+  subDescription,
+}: Record<any, string>) => `
+   <mj-include path="./lib/senders/emails/css/global.css" type="css" css-inline="inline" />
+   <mj-section>
+     <mj-column>
+     <mj-text css-class="text-header"><span data-l10n-id="<%- templateName %>-title">${title}</span></mj-text>
+     </mj-column>
+   </mj-section>
+   <mj-section>
+     <mj-column>
+     <mj-text css-class="text-sub-body"><span data-l10n-id="<%- templateName %>-description">${description}</span></mj-text>
+     <mj-text css-class="text-body"><span data-l10n-id="<%- templateName %>-sub-description">${subDescription}</span></mj-text>
+     </mj-column>
+   </mj-section>
+   ${button}
+   ${automatedEmailNoAction}
+`;

--- a/packages/fxa-auth-server/lib/senders/emails/partials/verificationReminder/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/verificationReminder/index.txt
@@ -1,0 +1,5 @@
+confirm-email-plaintext = "Confirm email:"
+<%- link %>
+
+<%- include('/partials/automatedEmailNoAction/index.txt') %>
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.stories.ts
@@ -37,9 +37,9 @@ const commonPropsWithOverrides = (
     },
   });
 
-export const CadReminderMobile = Template.bind({});
-CadReminderMobile.args = commonPropsWithOverrides();
-CadReminderMobile.storyName = 'User is on mobile device';
+export const CadReminderDefault = Template.bind({});
+CadReminderDefault.args = commonPropsWithOverrides();
+CadReminderDefault.storyName = 'default';
 
 export const CadReminderArLocale = Template.bind({});
 CadReminderArLocale.args = commonPropsWithOverrides({

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.stories.ts
@@ -11,7 +11,7 @@ export default {
 } as Meta;
 
 const defaultVariables = {
-  ...cadReminderFirst.CadReminderMobile.args.variables,
+  ...cadReminderFirst.CadReminderDefault.args.variables,
   bodyText:
     'Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.',
   headerText: 'Last reminder to sync devices!',
@@ -30,6 +30,6 @@ const commonPropsWithOverrides = (
     },
   });
 
-export const CadReminderMobile = Template.bind({});
-CadReminderMobile.args = commonPropsWithOverrides();
-CadReminderMobile.storyName = 'User is on mobile device';
+export const CadReminderDefault = Template.bind({});
+CadReminderDefault.args = commonPropsWithOverrides();
+CadReminderDefault.storyName = 'default';

--- a/packages/fxa-auth-server/lib/senders/emails/templates/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/index.ts
@@ -7,3 +7,5 @@ export * as cadReminderSecond from './cadReminderSecond';
 export * as lowRecoveryCodes from './lowRecoveryCodes';
 export * as postVerify from './postVerify';
 export * as postRemoveSecondary from './postRemoveSecondary';
+export * as verificationReminderFirst from './verificationReminderFirst';
+export * as verificationReminderSecond from './verificationReminderSecond';

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.ts
@@ -8,12 +8,12 @@ export const render = () => `
   <mj-include path="./lib/senders/emails/css/global.css" type="css" css-inline="inline" />
   <mj-section>
     <mj-column>
-    <mj-text css-class="header-text"><span data-l10n-id="codes-reminder-title">Low recovery codes remaining</span></mj-text>
+    <mj-text css-class="text-header"><span data-l10n-id="codes-reminder-title">Low recovery codes remaining</span></mj-text>
     </mj-column>
   </mj-section>
   <mj-section>
     <mj-column>
-    <mj-text css-class="primary-text"><span data-l10n-id="codes-reminder-description">We noticed that you are running low on recovery codes. Please consider generating new codes to avoid getting locked out of your account.</span></mj-text>
+    <mj-text css-class="text-body"><span data-l10n-id="codes-reminder-description">We noticed that you are running low on recovery codes. Please consider generating new codes to avoid getting locked out of your account.</span></mj-text>
     </mj-column>
   </mj-section>
   ${button}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.stories.ts
@@ -32,3 +32,4 @@ const commonPropsWithOverrides = (
 
 export const PostRemoveSecondary = Template.bind({});
 PostRemoveSecondary.args = commonPropsWithOverrides();
+PostRemoveSecondary.storyName = 'default';

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.ts
@@ -8,12 +8,12 @@ export const render = () => `
   <mj-include path="./lib/senders/emails/css/global.css" type="css" css-inline="inline" />
   <mj-section>
     <mj-column>
-    <mj-text css-class="header-text"><span data-l10n-id="post-remove-secondary-title">Secondary email removed</span></mj-text>
+    <mj-text css-class="text-header"><span data-l10n-id="post-remove-secondary-title">Secondary email removed</span></mj-text>
     </mj-column>
   </mj-section>
   <mj-section>
     <mj-column>
-    <mj-text css-class="primary-text"><span data-l10n-id="post-remove-secondary-description" data-l10n-args='<%= JSON.stringify({secondaryEmail: locals.secondaryEmail}) %>'>You have successfully removed secondary@email as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address.</span></mj-text>
+    <mj-text css-class="text-body"><span data-l10n-id="post-remove-secondary-description" data-l10n-args='<%= JSON.stringify({secondaryEmail}) %>'>You have successfully removed secondary@email as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address.</span></mj-text>
     </mj-column>
   </mj-section>
   ${button}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/en-US.ftl
@@ -6,5 +6,6 @@ postVerify-sub-title = Firefox Account verified. You're almost there.
 postVerify-title = Next sync between your devices!
 postVerify-description = Sync privately keeps your bookmarks, passwords and other Firefox data the same across all your devices.
 postVerify-subject = Account verified. Next, sync another device to finish setup
-postVerify-setup-text = Set up next device
+postVerify-setup = Set up next device
 postVerify-support = Have questions? Visit { $supportUrl }
+postVerify-action = { postVerify-setup }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.ts
@@ -8,14 +8,14 @@ export const render = () => `
   <mj-include path="./lib/senders/emails/css/global.css" type="css" css-inline="inline" />
    <mj-section>
      <mj-column>
-       <mj-text css-class="primary-text"><span data-l10n-id="postVerify-sub-title">Firefox Account verified. You're almost there.</span></mj-text>
-       <mj-text css-class="header-text"><span data-l10n-id="postVerify-title">Next sync between your devices!</span></mj-text>
+       <mj-text css-class="text-sub-body"><span data-l10n-id="postVerify-sub-title">Firefox Account verified. You're almost there.</span></mj-text>
+       <mj-text css-class="text-header"><span data-l10n-id="postVerify-title">Next sync between your devices!</span></mj-text>
        <mj-image css-class="sync-logo" alt="Devices" src="https://accounts-static.cdn.mozilla.net/other/graphic-laptop-mobile.png"></mj-image>
      </mj-column>
    </mj-section>
    <mj-section>
      <mj-column>
-       <mj-text css-class="primary-text"><span data-l10n-id="postVerify-description">Sync privately keeps your bookmarks, passwords and other Firefox data the same across all your devices.</span></mj-text>
+       <mj-text css-class="text-body"><span data-l10n-id="postVerify-description">Sync privately keeps your bookmarks, passwords and other Firefox data the same across all your devices.</span></mj-text>
      </mj-column>
    </mj-section>
    ${button}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.txt
@@ -4,7 +4,7 @@ postVerify-title = "Next sync between your devices!"
 
 postVerify-description = "Sync privately keeps your bookmarks, passwords and other Firefox data the same across all your devices."
 
-postVerify-setup-text = "Set up next device"
+postVerify-setup = "Set up next device"
 <%- link %>
 
 <%- include('/partials/automatedEmailNoAction/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/en-US.ftl
@@ -1,0 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+verificationReminderFirst-subject = Reminder: Finish creating your account
+verificationReminderFirst-title = Welcome to the Firefox family
+verificationReminderFirst-description = A few days ago you created a Firefox account, but never confirmed it.
+verificationReminderFirst-sub-description = Confirm now and get technology that fights for and protects your privacy, arms you with practical knowledge, and the respect you deserve.
+confirm-email = Confirm email
+verificationReminderFirst-action = { confirm-email }
+confirm-email-plaintext = { confirm-email }:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.stories.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Story, Meta } from '@storybook/html';
+import storybookEmail, {
+  StorybookEmailArgs,
+  commonArgs,
+} from '../../storybook-email';
+import { templateVariables } from '.';
+
+export default {
+  title: 'Emails/verificationReminderFirst',
+} as Meta;
+
+const Template: Story<StorybookEmailArgs> = (args) => storybookEmail(args);
+
+const defaultVariables = {
+  ...commonArgs,
+  ...templateVariables,
+  action: 'Confirm email',
+  link: 'http://localhost:3030/verify_email',
+  subject: 'Reminder: Finish creating your account',
+};
+
+const commonPropsWithOverrides = (
+  overrides: Partial<typeof defaultVariables> = {}
+) =>
+  Object.assign({
+    template: 'verificationReminderFirst',
+    variables: {
+      ...defaultVariables,
+      ...overrides,
+    },
+  });
+
+export const verificationReminderFirst = Template.bind({});
+verificationReminderFirst.args = commonPropsWithOverrides();
+verificationReminderFirst.storyName = 'default';

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.ts
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { verificationReminder } from '../../partials';
+
+export const templateVariables = {
+  title: 'Welcome to the Firefox family',
+  description:
+    'A few days ago you created a Firefox account, but never confirmed it.',
+  subDescription:
+    'Confirm now and get technology that fights for and protects your privacy, arms you with practical knowledge, and the respect you deserve.',
+};
+
+export const render = () => verificationReminder(templateVariables);

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.txt
@@ -1,0 +1,7 @@
+verificationReminderFirst-title = "Welcome to the Firefox family"
+
+verificationReminderFirst-description = "A few days ago you created a Firefox account, but never confirmed it."
+
+verificationReminderFirst-sub-description = "Confirm now and get technology that fights for and protects your privacy, arms you with practical knowledge, and the respect you deserve."
+
+<%- include('/partials/verificationReminder/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/en-US.ftl
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+verificationReminderSecond-subject = Final reminder: Activate your account
+verificationReminderSecond-title = Still there?
+verificationReminderSecond-description = Almost a week ago you created a Firefox Account but never verified it. We’re worried about you.
+verificationReminderSecond-sub-description = Confirm this email address to activate your account and let us know you're okay.
+verificationReminderSecond-action = { confirm-email }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.stories.ts
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Story, Meta } from '@storybook/html';
+import storybookEmail, {
+  StorybookEmailArgs,
+  commonArgs,
+} from '../../storybook-email';
+import { templateVariables } from '.';
+
+export default {
+  title: 'Emails/verificationReminderSecond',
+} as Meta;
+
+const Template: Story<StorybookEmailArgs> = (args) => storybookEmail(args);
+
+const defaultVariables = {
+  ...commonArgs,
+  ...templateVariables,
+  action: 'Confirm email',
+  link: 'http://localhost:3030/verify_email',
+  subject: 'Final reminder: Activate your account',
+};
+
+const commonPropsWithOverrides = (
+  overrides: Partial<typeof defaultVariables> = {}
+) =>
+  Object.assign({
+    template: 'verificationReminderSecond',
+    variables: {
+      ...defaultVariables,
+      ...overrides,
+    },
+  });
+
+export const verificationReminderSecond = Template.bind({});
+verificationReminderSecond.args = commonPropsWithOverrides();
+verificationReminderSecond.storyName = 'default';

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.ts
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { verificationReminder } from '../../partials';
+
+export const templateVariables = {
+  title: 'Still there?',
+  description:
+    'Almost a week ago you created a Firefox Account but never verified it. We’re worried about you.',
+  subDescription:
+    "Confirm this email address to activate your account and let us know you're okay.",
+};
+
+export const render = () => verificationReminder(templateVariables);

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.txt
@@ -1,0 +1,7 @@
+verificationReminderSecond-title = "Still there?"
+
+verificationReminderSecond-description = "Almost a week ago you created a Firefox Account but never verified it. We’re worried about you."
+
+verificationReminderSecond-sub-description = "Confirm this email address to activate your account and let us know you're okay."
+
+<%- include('/partials/verificationReminder/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -240,6 +240,52 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['verificationReminderFirstEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Reminder: Finish creating your account' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('verificationUrl', 'first-verification-reminder', 'confirm-email', 'code', 'reminder=first', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verificationReminderFirst') }],
+      ['X-Template-Name', { test: 'equal', expected: 'verificationReminderFirst' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.verificationReminderFirst }],
+      ['X-Verify-Code', { test: 'equal', expected: MESSAGE.code }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'first-verification-reminder', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'first-verification-reminder', 'support')) },
+      { test: 'include', expected: decodeUrl(configHref('verificationUrl', 'first-verification-reminder', 'confirm-email', 'code', 'reminder=first', 'uid')) },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'first-verification-reminder', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'first-verification-reminder', 'support')}` },
+      { test: 'include', expected: `Confirm email:\n${configUrl('verificationUrl', 'first-verification-reminder', 'confirm-email', 'code', 'reminder=first', 'uid')}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
+
+  ['verificationReminderSecondEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Final reminder: Activate your account' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('verificationUrl', 'second-verification-reminder', 'confirm-email', 'code', 'reminder=second', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verificationReminderSecond') }],
+      ['X-Template-Name', { test: 'equal', expected: 'verificationReminderSecond' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.verificationReminderSecond }],
+      ['X-Verify-Code', { test: 'equal', expected: MESSAGE.code }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'second-verification-reminder', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'second-verification-reminder', 'support')) },
+      { test: 'include', expected: decodeUrl(configHref('verificationUrl', 'second-verification-reminder', 'confirm-email', 'code', 'reminder=second', 'uid')) },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'second-verification-reminder', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'second-verification-reminder', 'support')}` },
+      { test: 'include', expected: `Confirm email:\n${configUrl('verificationUrl', 'second-verification-reminder', 'confirm-email', 'code', 'reminder=second', 'uid')}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {


### PR DESCRIPTION
## Because

- We have setup new templating stack in fxa auth server

## This pull request

- Converts verificationReminderFirst and verificationReminderSecond email templates to new stack

## Issue that this pull request solves

Closes: #9281 and #9285 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
