### PR TITLE
fix: allow Play config with private key

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -842,23 +842,37 @@ const conf = convict({
       },
     },
     playApiServiceAccount: {
+      credentials: {
+        client_email: {
+          default: 'test@localtest.com',
+          doc: 'The email of the service account to use for Play API calls',
+          env: 'SUBSCRIPTIONS_PLAY_CLIENT_EMAIL_CREDENTIAL',
+          format: String,
+        },
+        private_key: {
+          default: '',
+          doc: 'The private key of the service account to use for Play API calls',
+          env: 'SUBSCRIPTIONS_PLAY_PRIVATE_KEY_CREDENTIAL',
+          format: String,
+        },
+      },
+      keyFilename: {
+        default: '',
+        doc: 'Path to GCP key file',
+        env: 'SUBSCRIPTIONS_PLAY_KEY_FILE',
+        format: String,
+      },
+      projectId: {
+        default: '',
+        doc: 'GCP Project id for Play Store Account',
+        env: 'SUBSCRIPTIONS_PLAY_API_PROJECT_ID',
+        format: String,
+      },
       enabled: {
         doc: 'Indicates whether the Play API is enabled',
         format: Boolean,
         default: false,
         env: 'SUBSCRIPTIONS_PLAY_API_ENABLED',
-      },
-      clientEmail: {
-        doc: 'The email of the service account to use for Play API calls',
-        format: String,
-        default: 'email',
-        env: 'SUBSCRIPTIONS_PLAY_API_CLIENT_EMAIL',
-      },
-      privateKey: {
-        doc: 'The private key of the service account to use for Play API calls',
-        format: String,
-        default: 'key',
-        env: 'SUBSCRIPTIONS_PLAY_API_PRIVATE_KEY',
       },
     },
     sharedSecret: {

--- a/packages/fxa-auth-server/test/local/payments/google-play/play-billing.js
+++ b/packages/fxa-auth-server/test/local/payments/google-play/play-billing.js
@@ -22,8 +22,10 @@ const mockConfig = {
   },
   subscriptions: {
     playApiServiceAccount: {
-      clientEmail: 'mock-client-email',
-      privateKey: 'mock-private-key',
+      credentials: {
+        clientEmail: 'mock-client-email',
+      },
+      keyFile: 'mock-private-keyfile',
     },
   },
 };


### PR DESCRIPTION
Because:

* We want to use consistent Google service account configuration.

This commit:

* Allows use of private key files for Google Play API access.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
