### PR TITLE
fix(auth): use proper jwks key plugin

### DIFF
--- a/packages/fxa-auth-server/lib/routes/auth-schemes/pubsub.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/pubsub.js
@@ -21,7 +21,7 @@ exports.strategy = (config) => {
   return {
     // Get the complete decoded token, because we need info from the header (the kid)
     complete: true,
-    key: jwksRsa.hapiJwt2Key({
+    key: jwksRsa.hapiJwt2KeyAsync({
       cache: true,
       rateLimit: true,
       jwksRequestsPerMinute: 5,


### PR DESCRIPTION
Because:

* We're using a newer version of hapi that expects the key function to
  be Promise based.

This commit:

* Uses the async hapiJwt2KeyAsync function instead of the older callback
  version.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
