### PR TITLE
fix(auth): rename subject of subscriptionAccountFinishSetup email

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1960,7 +1960,9 @@ module.exports = function (log, config) {
     const action = gettext('Create a password');
     const translatorParams = { productName };
     const subject = translator.format(
-      translator.gettext('%(productName)s payment confirmed'),
+      translator.gettext(
+        'Welcome to %(productName)s: Please set your password.'
+      ),
       translatorParams
     );
 

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -262,7 +262,7 @@ const TESTS = [
     ]]
   ])],
   ['subscriptionAccountFinishSetupEmail', new Map([
-    ['subject', { test: 'equal', expected: `${MESSAGE.productName} payment confirmed` }],
+    ['subject', { test: 'equal', expected: `Welcome to ${MESSAGE.productName}: Please set your password.` }],
     ['headers', new Map([
       ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionAccountFinishSetup') }],
       ['X-Template-Name', { test: 'equal', expected: 'subscriptionAccountFinishSetup' }],


### PR DESCRIPTION
Because:

* The subscriptionAccountFinishSetup and subscriptionFirstInvoice emails previously had the same subject. This can cause confusion, since we send both after a subscription is successfully created.

This commit:

* Renames the subject of the subscriptionAccountFinishSetup email per the MVP spec to 'Welcome to %(productName)s: Please set your password.'

Closes #10152

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
