### PR TITLE
fix(fxa-payments-server): do not show fxa terms to existing users

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -33,7 +33,7 @@ export const PaymentConfirmation = ({
   className = 'default',
   accountExists = true,
 }: PaymentConfirmationProps) => {
-  const { navigatorLanguages } = useContext(AppContext);
+  const { config, navigatorLanguages } = useContext(AppContext);
   const { amount, currency, interval, interval_count, product_name } =
     selectedPlan;
   const { displayName, email } = profile;
@@ -160,7 +160,11 @@ export const PaymentConfirmation = ({
 
         <div className="footer" data-testid="footer">
           <PaymentLegalBlurb provider={payment_provider} />
-          <TermsAndPrivacy plan={selectedPlan} showFXALinks={true} />
+          <TermsAndPrivacy
+            plan={selectedPlan}
+            showFXALinks={!accountExists}
+            contentServerURL={config.servers.content.url}
+          />
         </div>
       </section>
     </>

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -259,7 +259,7 @@ export const Checkout = ({
             customer,
             profile,
             isMobile,
-            accountExists
+            accountExists,
           }}
         />
       </>
@@ -413,7 +413,7 @@ export const Checkout = ({
             <>
               <PaymentLegalBlurb provider={undefined} />
               <TermsAndPrivacy
-                showFXALinks={true}
+                showFXALinks={!accountExists}
                 plan={selectedPlan}
                 contentServerURL={config.servers.content.url}
               />


### PR DESCRIPTION
## This pull request

- passes `accountExists` to TermsAndPrivacy showFXALinks prop, to that we don't show to existing users.

## Issue that this pull request solves

Closes: #10171

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
