### PR TITLE
fix(fxa-payments-server): fix skipped paypal legal link

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -96,7 +96,7 @@ product-no-such-plan = No such plan for this product.
 
 ## payment legal blurb
 payment-legal-copy-stripe-and-paypal-2 = { -brand-name-mozilla } uses { -brand-name-stripe } and { -brand-name-paypal } for secure payment processing.
-payment-legal-link-stripe-space-paypal = <stripePrivacyLink>{ -brand-name-stripe } privacy policy</stripePrivacyLink> &nbsp; <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
+payment-legal-link-stripe-paypal = <stripePrivacyLink>{ -brand-name-stripe } privacy policy</stripePrivacyLink> &nbsp; <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
 
 payment-legal-copy-paypal = { -brand-name-mozilla } uses { -brand-name-paypal } for secure payment processing.
 payment-legal-link-paypal-2 = <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.

--- a/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
@@ -73,7 +73,7 @@ const DefaultPaymentLegalBlurb = () => (
     </Localized>
 
     <Localized
-      id="payment-legal-link-stripe-space-paypal"
+      id="payment-legal-link-stripe-paypal"
       elems={{
         stripePrivacyLink: (
           <a
@@ -84,7 +84,7 @@ const DefaultPaymentLegalBlurb = () => (
         ),
         paypalPrivacyLink: (
           <a
-            href="https://paypal.com/privacy"
+            href="https://www.paypal.com/webapps/mpp/ua/privacy-full"
             target="_blank"
             rel="noopener noreferrer"
           ></a>


### PR DESCRIPTION
## This pull request

- We hadn't updated one of the paypal privacy links, this pr addresses that

## Issue that this pull request solves

Closes: #10164

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
