### PR TITLE
fix(fxa-payment-server): fluent syntax typo in error message

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -41,7 +41,7 @@ coupon-expired = It looks like that promo code has expired.
 card-error = Your transaction could not be processed. Please verify your credit card information and try again.
 
 ##  $productName (String) - The name of the subscribed product.
-fxa-account-signup-error = A system error caused your ${ productName } sign-up to fail. Your payment method has not been charged. Please try again.
+fxa-account-signup-error-2 = A system error caused your { $productName } sign-up to fail. Your payment method has not been charged. Please try again.
 newsletter-signup-error = You're not signed up for product update emails. You can try again in your account settings.
 fxa-post-passwordless-sub-error = Subscription confirmed, but the confirmation page failed to load. Please check your email to set up your account.
 

--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -28,7 +28,7 @@ const BASIC_ERROR = 'basic-error-message';
 const PAYMENT_ERROR_1 = 'payment-error-1';
 const PAYMENT_ERROR_2 = 'payment-error-2';
 const PAYMENT_ERROR_3 = 'payment-error-3b';
-const FXA_SIGNUP_ERROR = 'fxa-account-signup-error';
+const FXA_SIGNUP_ERROR = 'fxa-account-signup-error-2';
 const FXA_NEWSLETTER_SIGNUP_ERROR = 'newsletter-signup-error';
 const FXA_POST_PASSWORDLESS_SUB_ERROR = 'fxa-post-passwordless-sub-error';
 


### PR DESCRIPTION
- fixes 
## This pull request

- Syntax for fluent variable was incorrect
- updated fluent id 

## Issue that this pull request solves

Closes: #10169

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
