### PR TITLE
fix(payment): fix stripe timestamp issue in finish account setup email

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/account.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/account.ts
@@ -45,8 +45,8 @@ export async function sendFinishSetupEmailForStubAccount({
       invoiceTotalInCents: invoice.total,
       invoiceTotalCurrency: invoice.currency,
       planEmailIconURL: meta.emailIconURL,
-      invoiceDate: invoice.created,
-      nextInvoiceDate: subscription.current_period_end,
+      invoiceDate: new Date(invoice.created * 1000),
+      nextInvoiceDate: new Date(subscription.current_period_end * 1000),
       token,
     });
   }

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/account.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/account.js
@@ -96,8 +96,8 @@ describe('routes/subscriptions/account', () => {
           invoiceTotalInCents: invoice.total,
           invoiceTotalCurrency: invoice.currency,
           planEmailIconURL: subscription.plan.plan_metadata.emailIconURL,
-          invoiceDate: invoice.created,
-          nextInvoiceDate: subscription.current_period_end,
+          invoiceDate: new Date(invoice.created * 1000),
+          nextInvoiceDate: new Date(subscription.current_period_end * 1000),
           token,
         }
       );


### PR DESCRIPTION
## Because

- Stripe uses seconds instead of ms for time, which caused our emails to have an invalid date

## This pull request

- Uses correct date formatting 

## Issue that this pull request solves

Closes: #

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
