### PR TITLE
fix(emails): handle Stripe timestamps that are in seconds

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/account.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/account.ts
@@ -32,21 +32,13 @@ export async function sendFinishSetupEmailForStubAccount({
         },
       }
     );
-    const invoice: Stripe.Invoice =
-      subscription.latest_invoice as Stripe.Invoice;
     const plan = await stripeHelper.findPlanById(subscription.plan!.id);
     const meta = metadataFromPlan(plan);
+    const invoiceDetails = await stripeHelper.extractInvoiceDetailsForEmail(
+      subscription.latest_invoice
+    );
     await mailer.sendSubscriptionAccountFinishSetupEmail([], account, {
-      email,
-      uid,
-      productId: subscription.plan!.product,
-      productName: plan.product_name,
-      invoiceNumber: invoice.number,
-      invoiceTotalInCents: invoice.total,
-      invoiceTotalCurrency: invoice.currency,
-      planEmailIconURL: meta.emailIconURL,
-      invoiceDate: invoice.created,
-      nextInvoiceDate: subscription.current_period_end,
+      ...invoiceDetails,
       token,
     });
   }


### PR DESCRIPTION
Because:
 - Stripe uses seconds instead of milliseconds for timestamps

This commit:
 - update the finish stub account setup email to use a function that
   handle those timestamps


## Issue that this pull request solves

Closes: #10166 