### PR TITLE
fix(auth): use token handler for token endpoint

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/google.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/google.ts
@@ -109,7 +109,8 @@ export const googleIapRoutes = (): ServerRoute[] => {
             .required(),
         },
       },
-      handler: (request: AuthRequest) => googleIapHandler.plans(request),
+      handler: (request: AuthRequest) =>
+        googleIapHandler.registerToken(request),
     },
   ];
 };


### PR DESCRIPTION
Because:

* The token handler should be used for the token endpoint.

This commit:

* Uses the correct handler for the token endpoint.

Closes #10195

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
