### PR TITLE
fix(auth/payments): ensure /newsletters endpoint validates request an…

### DIFF
--- a/packages/fxa-auth-server/lib/routes/newsletters.js
+++ b/packages/fxa-auth-server/lib/routes/newsletters.js
@@ -21,7 +21,7 @@ module.exports = (log, db) => {
         },
         validate: {
           payload: {
-            newsletters: validators.newsletters,
+            newsletters: validators.newsletters.required(),
           },
         },
       },

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -643,7 +643,7 @@ describe('API requests', () => {
 
   describe('apiSignupForNewsletter', () => {
     it('POST {auth-server}/v1/account/newsletters', async () => {
-      const arg = { newsletterId: 'cooking-with-foxkeh' };
+      const arg = { newsletters: ['cooking-with-foxkeh'] };
       const resp = {};
       const requestMock = nock(AUTH_BASE_URL)
         .post('/v1/newsletters', arg)

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -321,7 +321,7 @@ export async function apiCreateSubscriptionWithPaymentMethod(params: {
 }
 
 export async function apiSignupForNewsletter(params: {
-  newsletterId: string;
+  newsletters: String[];
 }): Promise<{}> {
   return apiFetch('POST', `${config.servers.auth.url}/v1/newsletters`, {
     body: JSON.stringify(params),

--- a/packages/fxa-payments-server/src/lib/newsletter.ts
+++ b/packages/fxa-payments-server/src/lib/newsletter.ts
@@ -13,7 +13,7 @@ export const FXA_NEWSLETTER_SIGNUP_ERROR: GeneralError = {
 export async function handleNewsletterSignup() {
   try {
     await apiSignupForNewsletter({
-      newsletterId: config.newsletterId,
+      newsletters: [config.newsletterId],
     });
   } catch (e) {
     sentry.captureException(e);


### PR DESCRIPTION
…d passes newsletters on to SQS

Because:

* The /newsletters route on the auth server was not validating the request parameters correctly, as 'newsletters' was optional. That means if it was missing, we'd get a 200 response from the auth server.
* The payments server wasn't sending the correct /newsletters parameter in the request body (newsletterId: string instead of newsletters: string[]).

This commit:

* Makes the 'newsletters' key a required field for the /newsletters route.
* Passes a 'newsletters' key of type string[] as expected when POSTing to the /newsletters endpoint.

Closes #10168

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).