### PR TITLE
fix(auth): use IAP scope for token register

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/google.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/google.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { ServerRoute } from '@hapi/hapi';
 import isA from '@hapi/joi';
+import { OAUTH_SCOPE_SUBSCRIPTIONS_IAP } from 'fxa-shared/oauth/constants';
 import { Container } from 'typedi';
 
 import error from '../../error';
@@ -10,7 +11,7 @@ import { PlayBilling } from '../../payments/google-play/play-billing';
 import { PurchaseUpdateError } from '../../payments/google-play/types/errors';
 import { SkuType } from '../../payments/google-play/types/purchases';
 import { AuthLogger, AuthRequest } from '../../types';
-import { handleUidAuth } from './utils';
+import { handleAuthScoped } from './utils';
 
 export class GoogleIapHandler {
   private log: AuthLogger;
@@ -35,7 +36,9 @@ export class GoogleIapHandler {
    */
   public async registerToken(request: AuthRequest) {
     this.log.begin('googleIap.registerToken', request);
-    const uid = handleUidAuth(request.auth);
+    const { uid } = handleAuthScoped(request.auth, [
+      OAUTH_SCOPE_SUBSCRIPTIONS_IAP,
+    ]);
 
     const { appName } = request.params;
     const { sku, token } = request.payload as any;

--- a/packages/fxa-auth-server/lib/routes/subscriptions/utils.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/utils.ts
@@ -1,15 +1,20 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-import ScopeSet from 'fxa-shared/oauth/scopes';
 import { OAUTH_SCOPE_SUBSCRIPTIONS } from 'fxa-shared/oauth/constants';
+import ScopeSet from 'fxa-shared/oauth/scopes';
+
 import error from '../../error';
+import { AuthRequest } from '../../types';
 
 /**
  * Authentication handler for subscription routes.
  */
-export async function handleAuth(db: any, auth: any, fetchEmail = false) {
+export async function handleAuth(
+  db: any,
+  auth: AuthRequest['auth'],
+  fetchEmail = false
+) {
   const scope = ScopeSet.fromArray(auth.credentials.scope);
   if (!scope.contains(OAUTH_SCOPE_SUBSCRIPTIONS)) {
     throw error.invalidScopes();
@@ -23,15 +28,30 @@ export async function handleAuth(db: any, auth: any, fetchEmail = false) {
     account = await db.account(uid);
     ({ email } = account.primaryEmail);
   }
-  return { uid, email, account };
+  return { uid, email, account } as {
+    uid: string;
+    email: string;
+    account: any;
+  };
 }
 
-export function handleUidAuth(auth: any): string {
+export function handleUidAuth(auth: AuthRequest['auth']): string {
   const scope = ScopeSet.fromArray(auth.credentials.scope);
   if (!scope.contains(OAUTH_SCOPE_SUBSCRIPTIONS)) {
     throw error.invalidScopes();
   }
-  return auth.credentials.user;
+  return auth.credentials.user as string;
+}
+
+export function handleAuthScoped(auth: AuthRequest['auth'], scopes: string[]) {
+  const scope = ScopeSet.fromArray(auth.credentials.scope);
+  for (const requiredScope of scopes) {
+    if (!scope.contains(requiredScope)) {
+      throw error.invalidScopes();
+    }
+  }
+  const { user: uid, email } = auth.credentials;
+  return { uid, email } as { uid: string; email: string };
 }
 
 export type ThenArg<T> = T extends PromiseLike<infer U> ? U : T;

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/google.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/google.js
@@ -18,10 +18,9 @@ const {
 const error = require('../../../../lib/error');
 const { AuthLogger } = require('../../../../lib/types');
 const { PlayBilling } = require('../../../../lib/payments/google-play');
+const { OAUTH_SCOPE_SUBSCRIPTIONS_IAP } = require('fxa-shared/oauth/constants');
 
-const SUBSCRIPTIONS_MANAGEMENT_SCOPE =
-  'https://identity.mozilla.com/account/subscriptions';
-const MOCK_SCOPES = ['profile:email', SUBSCRIPTIONS_MANAGEMENT_SCOPE];
+const MOCK_SCOPES = ['profile:email', OAUTH_SCOPE_SUBSCRIPTIONS_IAP];
 
 const VALID_REQUEST = {
   auth: {

--- a/packages/fxa-shared/oauth/constants.js
+++ b/packages/fxa-shared/oauth/constants.js
@@ -2,12 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const OAUTH_SCOPE_SUBSCRIPTIONS =
+  'https://identity.mozilla.com/account/subscriptions';
+
 module.exports = {
   OAUTH_SCOPE_OLD_SYNC: 'https://identity.mozilla.com/apps/oldsync',
   OAUTH_SCOPE_SESSION_TOKEN: 'https://identity.mozilla.com/tokens/session',
   OAUTH_SCOPE_NEWSLETTERS: 'https://identity.mozilla.com/account/newsletters',
-  OAUTH_SCOPE_SUBSCRIPTIONS:
-    'https://identity.mozilla.com/account/subscriptions',
+  OAUTH_SCOPE_SUBSCRIPTIONS,
+  OAUTH_SCOPE_SUBSCRIPTIONS_IAP: `${OAUTH_SCOPE_SUBSCRIPTIONS}/iap`,
   SHORT_ACCESS_TOKEN_TTL_IN_MS: 1000 * 60 * 60 * 6,
   // Maximum age an account is considered "new", useful when sending
   // notification emails


### PR DESCRIPTION
Because:

* We should use a narrowly scoped permission for IAP token registration.

This commit:

* Adds a new scope for IAP access and applies it to the token
  registration endpoint.

Closes #10202

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
