### PR TITLE
fix(payments): set PaymentErrorView action button background color an…

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.scss
@@ -28,6 +28,10 @@
     }
   }
 
+  .button.primary-button {
+    margin-bottom: 40px;
+  }
+
   #error-icon {
     margin: 60px auto 40px;
   }

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.tsx
@@ -26,7 +26,7 @@ const retryButtonFn = (onRetry: PaymentErrorViewProps['onRetry']) => (
   <Localized id="payment-error-retry-button">
     <button
       data-testid="retry-link"
-      className="button retry-link"
+      className="button retry-link primary-button"
       onClick={() => onRetry()}
     >
       Try again
@@ -39,7 +39,7 @@ const manageSubButtonFn = (onClick: VoidFunction) => {
     <Localized id="payment-error-manage-subscription-button">
       <button
         data-testid="manage-subscription-link"
-        className="button"
+        className="button primary-button"
         onClick={onClick}
       >
         Manage my subscription


### PR DESCRIPTION
…d margin-bottom correctly

Because:

* The action button was grey and there was no white space between it and the legal links below.

This commit:

* Gives the action button a class of primary-button, so that it's default and hover state are shades of blue and adds a margin-bottom of 40px.

Closes #10163

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
![Screen Shot 2021-08-23 at 2 36 03 PM](https://user-images.githubusercontent.com/17437436/130499541-74e284b1-d4e1-4ea2-a675-a44cefa0040b.png)

