### PR TITLE
fix(subscriptions): copy query params into sign-in link

### DIFF
--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -86,7 +86,10 @@ export const NewUserEmailForm = ({
         elems={{ a: <a href={signInURL}></a> }}
       >
         <p className="sign-in-copy" data-testid="sign-in-copy">
-          Already have a Firefox account? <a href={signInURL}>Sign in</a>
+          Already have a Firefox account?{' '}
+          <a data-testid="sign-in-link" href={signInURL}>
+            Sign in
+          </a>
         </p>
       </Localized>
       <Localized id="new-user-email" attrs={{ placeholder: true, label: true }}>

--- a/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
@@ -170,6 +170,7 @@ describe('routes/Checkout', () => {
       navigateToUrl: navigateToUrl || jest.fn(),
       queryParams: {
         plan: planId,
+        extra: 'goodstuff',
       },
     };
     return (
@@ -180,7 +181,17 @@ describe('routes/Checkout', () => {
   };
 
   it('renders as expected', async () => {
-    const { findByTestId, getByTestId } = render(<Subject />);
+    await act(async () => {
+      render(<Subject planId="testo" />);
+    });
+
+    const { findByTestId, getByTestId } = screen;
+
+    const signInLink = getByTestId('sign-in-link');
+    expect(signInLink).toHaveAttribute(
+      'href',
+      `${mockConfig.servers.content.url}/subscriptions/products/${PRODUCT_ID}?plan=testo&extra=goodstuff&signin=yes`
+    );
 
     const formEl = await findByTestId('new-user-email-form');
     expect(formEl).toBeInTheDocument();

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -132,9 +132,12 @@ export const Checkout = ({
   }, [fetchCheckoutRouteResources]);
   usePaypalButtonSetup(config, setPaypalScriptLoaded, paypalButtonBase);
 
+  const signInQueryParams = { ...queryParams, signin: 'yes' };
+  const signInQueryParamString = Object.entries(signInQueryParams)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('&');
   const planId = queryParams.plan;
-  const planQueryParam = planId ? `plan=${planId}&` : '';
-  const signInURL = `${config.servers.content.url}/subscriptions/products/${productId}?${planQueryParam}signin=yes`;
+  const signInURL = `${config.servers.content.url}/subscriptions/products/${productId}?${signInQueryParamString}`;
   const selectedPlan = useMemo(
     () => getSelectedPlan(productId, planId, plansByProductId),
     [productId, planId, plansByProductId]


### PR DESCRIPTION
Because:
 - we need to keep the query params when an existing user use the
   sign-in link on the passwordless flow

This commit:
 - copy the query params from the checkout page into the sign-in link


## Issue that this pull request solves

Closes: #10223 
