### PR TITLE
feat(fxa-auth-server): Convert verifyEmail Template to new stack

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -435,7 +435,8 @@
       "postVerify",
       "postRemoveSecondary",
       "verificationReminderFirst",
-      "verificationReminderSecond"
+      "verificationReminderSecond",
+      "verify"
     ]
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -9,6 +9,7 @@ $font-sans: sans-serif;
 $blue-400: #0090ed;
 $white: #fff;
 $grey-400: #6d6d6e;
+$grey-500: #4b5563;
 
 // Spacing values for margin and padding
 $s-0: 0px;
@@ -63,6 +64,9 @@ $s-10: 40px;
   }
   &-5 {
     margin-bottom: $s-5 !important;
+  }
+  &-6 {
+    margin-bottom: $s-6 !important;
   }
 }
 

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.mjml
@@ -30,7 +30,7 @@
       <% if (!locals.sync) { %>
         <img src="https://accounts-static.cdn.mozilla.net/product-icons/firefox-logo.png" class="fxa-logo" alt="Firefox logo"/>
       <% } else { %>
-        <img src="https://accounts-static.cdn.mozilla.net/other/sync-devices.png" class="sync" alt="Sync devices"/>
+        <img src="https://accounts-static.cdn.mozilla.net/other/sync-devices.png" class="sync-img" alt="Sync devices"/>
       <% } %>
     </mj-raw>
 

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.scss
@@ -21,7 +21,10 @@
   display: block !important;
 }
 
-.sync {
+.sync-img {
+  padding: global.$s-5 global.$s-0 !important;
   height: 137px;
   width: 270px;
+  margin: 0 auto !important;
+  display: block !important;
 }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailNoAction/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailNoAction/en-US.ftl
@@ -2,5 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-automated-email = This is an automated email; if you received it in error, no action is required. For more information, please visit <a data-l10n-name="supportLink">Mozilla Support</a>.
+automated-email = This is an automated email; if you received it in error, no action is required. 
+  For more information, please visit <a data-l10n-name="supportLink">Mozilla Support</a>.
 automated-email-plaintext = This is an automated email; if you received it in error, no action is required.

--- a/packages/fxa-auth-server/lib/senders/emails/partials/location/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/location/en-US.ftl
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+user-ip = IP address: { $ip }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/location/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/location/index.mjml
@@ -1,0 +1,30 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-include path="./css/location/index.css" type="css" css-inline="inline" />
+  
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body-grey">
+    <% if (locals.primaryEmail) { %>
+      <span><%- primaryEmail %></span><br />
+    <% } %> 
+    <% if (locals.device) { %>
+      <span><%- device %></span><br /> 
+    <% } %> 
+    <% if (locals.location) { %>
+      <span><%- location %></span><br /> 
+    <% } %> 
+    <% if (locals.ip) { %>
+      <span data-l10n-id="user-ip" data-l10n-args='<%= JSON.stringify({ip}) %>'>IP address: <%- ip %></span><br /> 
+    <% } %> 
+    <% if (locals.date) { %>
+      <span><%- date %></span><br /> 
+    <% } %> 
+    <% if (locals.time) { %>
+      <span><%- time %><br /></span> 
+    <% } %>        
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/location/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/location/index.scss
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@use '../../global.scss';
+
+.text-body-grey div {
+  @extend %text-body-common;
+  @extend .mb-6;
+  color: global.$grey-500 !important;
+}

--- a/packages/fxa-auth-server/lib/senders/emails/partials/location/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/location/index.txt
@@ -1,0 +1,6 @@
+<% if (locals.primaryEmail) { %><%- primaryEmail %><% } %>
+<% if (locals.device) { %><%- device %><% } %>
+<% if (locals.location) { %><%- location %><% } %>
+<% if (locals.ip) { %> user-ip = "IP address: <%- ip %>" <% } %>
+<% if (locals.date) { %><%- date %><% } %>
+<% if (locals.time) { %><%- time %><% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/en-US.ftl
@@ -1,0 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+verify-title = Activate the Firefox family of products
+verify-description-common = Confirm your account and get the most out of Firefox everywhere you sign in
+verify-description-plaintext = { verify-description-common }.
+verify-description = { verify-description-common } starting with:
+verify-subject = Finish creating your account
+verify-action = { confirm-email }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.mjml
@@ -1,0 +1,21 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-include path="./css/global.css" type="css" css-inline="inline" />
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header"><span data-l10n-id="verify-title">Activate the Firefox family of products</span></mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body"><span data-l10n-id="verify-description">Confirm your account and get the most out of Firefox everywhere you sign in starting with:</span></mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/location/index.mjml') %>
+<%- include('/partials/button/index.mjml') %>
+<%- include('/partials/automatedEmailNoAction/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.stories.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { commonArgs, Template } from '../../storybook-email';
+
+export default {
+  title: 'Emails/verify',
+} as Meta;
+
+const defaultVariables = {
+  ...commonArgs,
+  location: 'Madrid, Spain (estimated)',
+  device: 'Firefox on Mac OSX 10.11',
+  ip: '10.246.67.38',
+  link: 'http://localhost:3030/verify_email',
+  action: 'Confirm email',
+  subject: 'Finish creating your account',
+  sync: true,
+};
+
+export const verifyEmail = Template.bind({});
+verifyEmail.args = {
+  template: 'verify',
+  doc: 'Low Recovery Code emails are sent when a user has 2 or less recovery codes remaining',
+  variables: {
+    ...defaultVariables,
+  },
+};
+verifyEmail.storyName = 'default';

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.txt
@@ -1,0 +1,10 @@
+verify-title = "Activate the Firefox family of products"
+
+verify-description-plaintext = "Confirm your account and get the most out of Firefox everywhere you sign in."
+
+confirm-email-plaintext = "Confirm email:"
+<%- link %>
+
+<%- include('/partials/automatedEmailNoAction/index.txt') %>
+
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -286,6 +286,34 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['verifyEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Finish creating your account' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('verificationUrl', 'welcome', 'activate', 'uid', 'code', 'service') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verify') }],
+      ['X-Template-Name', { test: 'equal', expected: 'verify' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.verify }],
+      ['X-Verify-Code', { test: 'equal', expected: MESSAGE.code }],
+    ])],
+    ['html', [
+      { test: 'include', expected: 'Confirm your account and get the most out of Firefox everywhere you sign in starting with:' },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'welcome', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'welcome', 'support')) },
+      { test: 'include', expected: decodeUrl(configHref('verificationUrl', 'welcome', 'activate', 'uid', 'code', 'service')) },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: 'Confirm your account and get the most out of Firefox everywhere you sign in.' },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'welcome', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'welcome', 'support')}` },
+      { test: 'include', expected: `Confirm email:\n${configUrl('verificationUrl', 'welcome', 'activate', 'uid', 'code', 'service')}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])]
 ];
 
 describe('lib/senders/mjml-emails:', () => {


### PR DESCRIPTION
## Because

- We have setup new templating stack in fxa auth server


## This pull request

- Converts verify email template to new stack

## Issue that this pull request solves

Closes: #9289 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
