### PR TITLE
fix(auth): retain userid in subsription purchase copy

### DIFF
--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -9,6 +9,7 @@ const jwtool = require('fxa-jwtool');
 const { StatsD } = require('hot-shots');
 const { Container } = require('typedi');
 const { StripeHelper } = require('../lib/payments/stripe');
+const { PlayBilling } = require('../lib/payments/google-play');
 const { CurrencyHelper } = require('../lib/payments/currencies');
 const {
   AuthLogger,
@@ -92,6 +93,15 @@ async function run(config) {
       const paypalHelper = new PayPalHelper({ log });
       Container.set(PayPalHelper, paypalHelper);
     }
+  }
+
+  // Create PlayBilling if enabled by fetching it.
+  if (
+    config.subscriptions &&
+    config.subscriptions.playApiServiceAccount &&
+    config.subscriptions.playApiServiceAccount.enabled
+  ) {
+    Container.get(PlayBilling);
   }
 
   const translator = await require('../lib/senders/translator')(

--- a/packages/fxa-auth-server/lib/payments/google-play/subscription-purchase.ts
+++ b/packages/fxa-auth-server/lib/payments/google-play/subscription-purchase.ts
@@ -19,7 +19,7 @@
 import { NotificationType, Purchase, SkuType } from './types';
 import { PaymentState, PurchaseType } from './types/purchases';
 
-const FIRESTORE_OBJECT_INTERNAL_KEYS = ['skuType', 'formOfPayment', 'userId'];
+const FIRESTORE_OBJECT_INTERNAL_KEYS = ['skuType', 'formOfPayment'];
 export const GOOGLE_PLAY_FORM_OF_PAYMENT = 'GOOGLE_PLAY';
 
 /* This file contains internal implementation of classes and utilities that is only used inside of the library
@@ -46,7 +46,7 @@ export function mergePurchaseWithFirestorePurchaseRecord(
   purchase: any,
   firestoreObject: any
 ) {
-  // Copy all keys that exist in Firestore but not in Purchase object to the Purchase object (ex. userId)
+  // Copy all keys that exist in Firestore but not in Purchase object to the Purchase object.
   Object.keys(firestoreObject).map((key) => {
     // Skip the internal key-value pairs assigned by convertToFirestorePurchaseRecord()
     if (

--- a/packages/fxa-auth-server/test/local/payments/google-play/subscription-purchase.js
+++ b/packages/fxa-auth-server/test/local/payments/google-play/subscription-purchase.js
@@ -164,7 +164,7 @@ describe('SubscriptionPurchase', () => {
       const result = SubscriptionPurchase.fromFirestoreObject(firestoreObj);
       // Internal keys are not defined on the subscription purchase.
       assert.isUndefined(result.skuType);
-      assert.isUndefined(result.userId);
+      assert.strictEqual(result.userId, 'testUser');
     });
 
     it('merges purchase with firestore object', () => {


### PR DESCRIPTION
Because:

* We need the userid in the merged subscription purchase.

This commit:

* No longer skips the userid when copying firestore data to the purchase
  object.

Fixes #10236

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
