### PR TITLE
fix(auth): refresh profile if needed

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -75,14 +75,14 @@ export class CapabilityService {
    * Return a list of subscribed product ids for the user.
    */
   public async subscribedProductIds(uid: string, email: string) {
-    let subscribedProducts = await this.fetchSubscribedProductsFromStripe(
-      uid,
-      email
-    );
-    subscribedProducts = subscribedProducts.concat(
-      await this.fetchSubscribedProductsFromPlay(uid)
-    );
-    return [...new Set(subscribedProducts)];
+    const [subscribedStripeProducts, subscribedPlayProducts] =
+      await Promise.all([
+        this.fetchSubscribedProductsFromStripe(uid, email),
+        this.fetchSubscribedProductsFromPlay(uid),
+      ]);
+    return [
+      ...new Set([...subscribedStripeProducts, ...subscribedPlayProducts]),
+    ];
   }
 
   /**

--- a/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
@@ -88,7 +88,7 @@ const createRoutes = (
     );
   }
   if (config.authFirestore.enabled) {
-    routes.push(...googleIapRoutes());
+    routes.push(...googleIapRoutes(db));
     routes.push(...playPubsubRoutes(db));
   }
 

--- a/packages/fxa-auth-server/lib/routes/subscriptions/play-pubsub.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/play-pubsub.ts
@@ -126,10 +126,7 @@ export const playPubsubRoutes = (db: any): ServerRoute[] => {
       method: 'POST',
       path: '/oauth/subscriptions/iap/rtdn',
       options: {
-        auth: {
-          payload: false,
-          strategy: 'pubsub',
-        },
+        auth: 'pubsub',
         validate: {
           payload: isA
             .object({


### PR DESCRIPTION
Because:

* Validating a Google IAP token should immediately grant access to
  the purchased product.

This commit:

* Checks product ids before and after registering a token to see if
  access has changed, and removes profile cache if so.

Closes #10242

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
