### PR TITLE
fix(auth): use object only for auth

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/play-pubsub.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/play-pubsub.ts
@@ -126,7 +126,9 @@ export const playPubsubRoutes = (db: any): ServerRoute[] => {
       method: 'POST',
       path: '/oauth/subscriptions/iap/rtdn',
       options: {
-        auth: 'pubsub',
+        auth: {
+          strategy: 'pubsub',
+        },
         validate: {
           payload: isA
             .object({


### PR DESCRIPTION
Because:

* While using a strategy string for auth is valid for hapi, we have
  custom hapi code that attempts to assign to it as if it was an
  object.

This commit:

* Reverts to using an object.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
