### PR TITLE
fix(auth): use header only for jwt and return data

### DIFF
--- a/packages/fxa-auth-server/lib/payments/google-play/purchase-manager.ts
+++ b/packages/fxa-auth-server/lib/payments/google-play/purchase-manager.ts
@@ -338,7 +338,7 @@ export class PurchaseManager {
     ) {
       // We can safely ignore SUBSCRIPTION_PURCHASED because with new subscription, our Android app will send the same token to server for verification
       // For other type of notification, we query Play Developer API to update our purchase record cache in Firestore
-      return await this.querySubscriptionPurchase(
+      return this.querySubscriptionPurchase(
         packageName,
         subscriptionNotification.subscriptionId,
         subscriptionNotification.purchaseToken,

--- a/packages/fxa-auth-server/lib/routes/auth-schemes/pubsub.js
+++ b/packages/fxa-auth-server/lib/routes/auth-schemes/pubsub.js
@@ -28,6 +28,11 @@ exports.strategy = (config) => {
       jwksUri: 'https://www.googleapis.com/oauth2/v3/certs',
     }),
 
+    // Disable reading token from anything other than the header.
+    urlKey: false,
+    cookieKey: false,
+    payloadKey: false,
+
     validate: validateSender,
 
     verifyOptions: {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/play-pubsub.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/play-pubsub.js
@@ -92,7 +92,7 @@ describe('PlayPubsubHandler', () => {
   describe('rtdn', () => {
     it('notification that requires profile updating', async () => {
       const result = await playPubsubHandlerInstance.rtdn(mockRequest);
-      assert.isUndefined(result);
+      assert.deepEqual(result, {});
       assert.calledOnce(playPubsubHandlerInstance.extractMessage);
       assert.calledOnce(mockPlayBilling.purchaseManager.getPurchase);
       assert.calledOnce(db.account);
@@ -109,7 +109,7 @@ describe('PlayPubsubHandler', () => {
         'prod_1234',
       ]);
       const result = await playPubsubHandlerInstance.rtdn(mockRequest);
-      assert.isUndefined(result);
+      assert.deepEqual(result, {});
       assert.calledOnce(playPubsubHandlerInstance.extractMessage);
       assert.calledOnce(mockPlayBilling.purchaseManager.getPurchase);
       assert.calledOnce(db.account);
@@ -124,7 +124,7 @@ describe('PlayPubsubHandler', () => {
     it('test notification', async () => {
       mockDeveloperNotification.testNotification = true;
       const result = await playPubsubHandlerInstance.rtdn(mockRequest);
-      assert.isUndefined(result);
+      assert.deepEqual(result, {});
       assert.calledOnceWithExactly(
         log.info,
         'play-test-notification',
@@ -136,7 +136,7 @@ describe('PlayPubsubHandler', () => {
     it('missing subscription notification', async () => {
       mockDeveloperNotification.subscriptionNotification = null;
       const result = await playPubsubHandlerInstance.rtdn(mockRequest);
-      assert.isUndefined(result);
+      assert.deepEqual(result, {});
       assert.calledOnceWithExactly(
         log.info,
         'play-other-notification',
@@ -148,7 +148,7 @@ describe('PlayPubsubHandler', () => {
     it('non-existing purchase', async () => {
       mockPlayBilling.purchaseManager.getPurchase = sinon.fake.resolves(null);
       const result = await playPubsubHandlerInstance.rtdn(mockRequest);
-      assert.isUndefined(result);
+      assert.deepEqual(result, {});
       assert.calledOnce(
         mockPlayBilling.purchaseManager.processDeveloperNotification
       );
@@ -158,7 +158,7 @@ describe('PlayPubsubHandler', () => {
     it('no userId', async () => {
       mockPurchase.userId = null;
       const result = await playPubsubHandlerInstance.rtdn(mockRequest);
-      assert.isUndefined(result);
+      assert.deepEqual(result, {});
       assert.notCalled(
         mockPlayBilling.purchaseManager.processDeveloperNotification
       );


### PR DESCRIPTION
Because:

* Handlers need to return something other than undefined.
* JWT plugin looks at locations other than the header for the
  token, which has a field called token that isn't the right token.
* Missing user lookups should not error the handler.

This commit:

* Returns data for a proper 200 instead of undefined.
* Restricts the JWT plugin to only search the authorization header.
* Catches user lookups and reports them to sentry while returning a 200.

Closes #10249

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
