### PR TITLE
feat(auth-server): start rendering plaintext emails alongside html in storybook

### DIFF
--- a/packages/fxa-auth-server/.storybook/preview.js
+++ b/packages/fxa-auth-server/.storybook/preview.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import '../lib/senders/emails/storybook.css';
+
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
 };
@@ -28,12 +30,3 @@ export const globalTypes = {
     },
   },
 };
-
-const withTextDirectionality = (Story, context) => {
-  const container = document.createElement('div');
-  container.classList.add(context.globals.direction);
-  container.appendChild(Story(context));
-  return container;
-};
-
-export const decorators = [withTextDirectionality];

--- a/packages/fxa-auth-server/bin/mjml-server.ts
+++ b/packages/fxa-auth-server/bin/mjml-server.ts
@@ -35,13 +35,13 @@ async function handleRequest(
       ...variables
     } = data;
     variables.baseUrl = baseUrl;
-    const { html, subject } = await fluentLocalizer.localizeEmail(
+    const { html, subject, text } = await fluentLocalizer.localizeEmail(
       templateName,
       layoutName || 'fxa',
       variables,
       acceptLanguage
     );
-    const result = JSON.stringify({ html, subject });
+    const result = JSON.stringify({ html, subject, text });
 
     res.writeHead(200, {
       'Content-Type': 'application/json',

--- a/packages/fxa-auth-server/lib/senders/emails/storybook.css
+++ b/packages/fxa-auth-server/lib/senders/emails/storybook.css
@@ -1,0 +1,73 @@
+.email-template .message {
+  margin: 0;
+}
+
+.email-template .message,
+.email-template header,
+.template-container .badge {
+  font-family: 'Helvetica Neue', Helvetica, arial, sans-serif;
+}
+
+.email-template header {
+  background: #f2f2f2;
+  padding: 16px;
+  border-radius: 4px;
+}
+
+.template-name {
+  font-size: 22px;
+  margin: 0 0 10px;
+}
+
+.template-name span {
+  color: #777;
+  font-weight: 500;
+}
+
+.template-description {
+  color: #777;
+  margin: 0;
+}
+
+.email-subject {
+  margin: 16px 0 0;
+  font-family: monospace;
+  font-size: 14px;
+}
+
+.template-container {
+  display: flex;
+  flex-direction: row;
+  margin-top: 28px;
+}
+
+.template-html {
+  flex: 0.75 0 0;
+  border-right: 1px solid #ddd;
+  margin-right: 28px;
+}
+
+.template-plaintext {
+  flex: 0.25 0 0;
+}
+
+.template-plaintext div {
+  padding-top: 24px;
+  font-family: monospace;
+  white-space: pre-wrap;
+}
+
+.template-plaintext .rtl {
+  direction: rtl;
+}
+
+.template-container .badge {
+  font-size: 12px;
+  text-transform: uppercase;
+  background-color: #eee;
+  padding: 3px 5px;
+  letter-spacing: 0.05em;
+  font-weight: 500;
+  border-radius: 3px;
+  color: #444;
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.stories.ts
@@ -2,18 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Story, Meta } from '@storybook/html';
-import storybookEmail, {
-  StorybookEmailArgs,
-  commonArgs,
-} from '../../storybook-email';
+import { Meta } from '@storybook/html';
+import { commonArgs, Template } from '../../storybook-email';
 import { templateVariables } from '.';
 
 export default {
   title: 'Emails/verificationReminderFirst',
 } as Meta;
-
-const Template: Story<StorybookEmailArgs> = (args) => storybookEmail(args);
 
 const defaultVariables = {
   ...commonArgs,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.stories.ts
@@ -2,18 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { Story, Meta } from '@storybook/html';
-import storybookEmail, {
-  StorybookEmailArgs,
-  commonArgs,
-} from '../../storybook-email';
+import { Meta } from '@storybook/html';
+import { commonArgs, Template } from '../../storybook-email';
 import { templateVariables } from '.';
 
 export default {
   title: 'Emails/verificationReminderSecond',
 } as Meta;
-
-const Template: Story<StorybookEmailArgs> = (args) => storybookEmail(args);
 
 const defaultVariables = {
   ...commonArgs,


### PR DESCRIPTION
## Because

- We want to display plaintext versions of emails in storybook

## This pull request

- Passes along the plaintext rendered version of the email through the MJML server up to Storybook
- Updates the Storybook layout of emails so that plaintext is displayed alongside the HTML version
- Cosmetic tweaks
- Moves the usage of the ltr/rtl Storybook context value out of a decorator and down into the Story rendering so that it doesn't also target Story rendering UI (like the header element)

## Issue that this pull request solves

Closes: #10217

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="1792" alt="Screen Shot 2021-08-25 at 9 51 41 AM" src="https://user-images.githubusercontent.com/6392049/130793798-1acef555-1bf1-4768-8bae-b8316c39ee1d.png">

