### PR TITLE
fix(auth): don't send a subscription reminder email for cancel_at_per…

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1091,7 +1091,8 @@ export class StripeHelper {
   }
 
   /**
-   * Find all active subscriptions for the given `planId`.
+   * Find all active subscriptions for the given `planId`. Filter out
+   * any subscriptions marked as `cancel_at_period_end`.
    *
    * It is expected that the `customer` is expanded.
    */
@@ -1107,7 +1108,10 @@ export class StripeHelper {
       expand: ['data.customer'],
     };
     for await (const subscription of this.stripe.subscriptions.list(params)) {
-      if (!ACTIVE_SUBSCRIPTION_STATUSES.includes(subscription.status)) {
+      if (
+        !ACTIVE_SUBSCRIPTION_STATUSES.includes(subscription.status) ||
+        subscription.cancel_at_period_end
+      ) {
         continue;
       }
       yield subscription;


### PR DESCRIPTION
…iod_end

Because:

* We currently send the subscription renewal reminder email to active subscriptions marked as cancel_at_period_end.

This commit:

* Filters out this kind of subscription from the findActiveSubscriptionsByPlanId Stripe helper, so that we don't send an email in that case.

Closes #9692

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).