### PR TITLE
fix(tests): Add functional test for passwordless flows

### DIFF
--- a/packages/123done/static/index.html
+++ b/packages/123done/static/index.html
@@ -72,7 +72,7 @@
         class="btn btn-persona btn-subscribe" data-currency="myr"
         >Subscribe to Pro (MYR)</a
       >
-      <a class="btn btn-persona btn-subscribe-pwdless" data-currency="usd"
+      <a id="pwdless-button" class="btn btn-persona btn-subscribe-pwdless" data-currency="usd"
        >Subscribe to Pro (Passwordless)</a
       >
       </div>

--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -62,7 +62,7 @@ $(document).ready(function () {
         contentEnv: contentURL.dev,
       };
       break;
-    case '123done-stage.dev.lcip.org':
+    case 'stage-123done.herokuapp.com':
       paymentConfig = {
         env: paymentURL.stage,
         ...subscriptionConfig.stage,

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -238,6 +238,7 @@ module.exports = {
     BUTTON_SIGNUP: '.sign-in-button.signup',
     LINK_LOGOUT: '#logout',
     BUTTON_SUBSCRIBE: '.btn-subscribe',
+    BUTTON_SUBSCRIBE_PASSWORDLESS: '#pwdless-button',
     SUBSCRIBED: '.pro-status',
   },
   400: {
@@ -397,6 +398,12 @@ module.exports = {
   },
   FIREFOX_NOTES: {
     HEADER: '#notes-by-firefox',
+  },
+  FINISH_ACCOUNT_SETUP: {
+    HEADER: '#fxa-account-setup-set-password-header',
+    PASSWORD: '#password',
+    VPASSWORD: '#vpassword',
+    SUBMIT: 'button[type="submit"]',
   },
   FORCE_AUTH: {
     EMAIL: 'input[type=email]',


### PR DESCRIPTION
## Because

- We should have functional tests that cover these flows

## This pull request

- Adds functiona tests that subscribes using the passwordless account flow, sets password from email, logins in

## Issue that this pull request solves

Closes: #9888

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
