### PR TITLE
chore(content): set SUBSCRIPTIONS_UNAUTHED_REDIRECTS to true by default

### DIFF
--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -671,7 +671,7 @@ const conf = (module.exports = convict({
       format: String,
     },
     allowUnauthenticatedRedirects: {
-      default: false,
+      default: true,
       doc: 'Whether to allow any redirects to Payments for an unauthenticated user',
       env: 'SUBSCRIPTIONS_UNAUTHED_REDIRECTS',
       formlat: Boolean,

--- a/packages/fxa-content-server/tests/functional/sign_up.js
+++ b/packages/fxa-content-server/tests/functional/sign_up.js
@@ -48,7 +48,7 @@ const ENTER_EMAIL_ENTRYPOINT = `entrypoint=${encodeURIComponent(
 var SYNC_CONTEXT_ANDROID = 'context=fx_fennec_v1';
 var SYNC_CONTEXT_DESKTOP = 'context=fx_desktop_v3';
 var SYNC_SERVICE = 'service=sync';
-const PRODUCT_URL = `${config.fxaContentRoot}subscriptions/products/${config.testProductId}?signin`;
+const PRODUCT_URL = `${config.fxaContentRoot}subscriptions/products/${config.testProductId}?signin=true`;
 
 function testAtConfirmScreen(email) {
   return function () {


### PR DESCRIPTION
Because:

* We have deployed the [passwordless flow feature](https://mozilla-hub.atlassian.net/browse/FXA-3486) to production, and it has been QA-verified.
* Therefore, we can safely enable the feature via this flag in all environments, which we have done everywhere except in the content server config file.

This commit:

* Sets SUBSCRIPTIONS_UNAUTHED_REDIRECTS to true by default to make this behavior the default in the content server config file; this saves the step of setting the flag and restarting the content server for local development.

Closes #10234

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
