### PR TITLE
fix(logging): Report webchannel errors as sentry errors

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/channels/receivers/web-channel.js
+++ b/packages/fxa-content-server/app/scripts/lib/channels/receivers/web-channel.js
@@ -91,7 +91,7 @@ _.extend(WebChannelReceiver.prototype, Backbone.Events, {
       // Do not report "No Such Channel" errors to Sentry.
       // This error is already muted in Sentry and is not actionable.
     } else {
-      this._sentry.captureMessage('WebChannel error: ' + error.message, {
+      this._sentry.captureException('WebChannel error: ' + error.message, {
         // manually capture the stack as a custom field
         extra: {
           stackTrace: error.stack,

--- a/packages/fxa-content-server/app/tests/spec/lib/channels/receivers/web-channel.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/channels/receivers/web-channel.js
@@ -15,7 +15,7 @@ describe('lib/channels/receivers/web-channel', () => {
   beforeEach(() => {
     windowMock = new WindowMock();
     Sentry = {
-      captureMessage: () => {},
+      captureException: () => {},
     };
     receiver = new WebChannelReceiver();
     receiver.initialize({
@@ -23,7 +23,7 @@ describe('lib/channels/receivers/web-channel', () => {
       window: windowMock,
       Sentry,
     });
-    sinon.spy(receiver._sentry, 'captureMessage');
+    sinon.spy(receiver._sentry, 'captureException');
   });
 
   afterEach(() => {
@@ -114,7 +114,7 @@ describe('lib/channels/receivers/web-channel', () => {
         )
       );
       assert.isTrue(receiver._reportError.calledOnce);
-      assert.isTrue(receiver._sentry.captureMessage.calledOnce);
+      assert.isTrue(receiver._sentry.captureException.calledOnce);
       assert.isTrue(receiver.trigger.calledOnce);
       assert.isTrue(receiver.trigger.calledWith('error', message));
     });
@@ -142,7 +142,7 @@ describe('lib/channels/receivers/web-channel', () => {
         )
       );
       assert.isTrue(receiver._reportError.calledOnce);
-      assert.isFalse(receiver._sentry.captureMessage.calledOnce);
+      assert.isFalse(receiver._sentry.captureException.calledOnce);
       assert.isTrue(receiver.trigger.calledOnce);
       assert.isTrue(receiver.trigger.calledWith('error', message));
     });


### PR DESCRIPTION
## Because

- These errors are sent by FF browser are not really info level. Unfortunatley, the majority (if not all) of them would need to be fixed by landing code in FF.
- Removes all info based sentry logging for the content-server

## This pull request

- Marks them as sentry errors instead of info

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/9470

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).