### PR TITLE
fix(subscriptions): show correct payment provider info for upgrades

### DIFF
--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -37,6 +37,7 @@ import './index.scss';
 
 import { ProductProps } from '../index';
 import { PaymentConsentCheckbox } from '../../../components/PaymentConsentCheckbox';
+import { PaymentProviderDetails } from '../../../components/PaymentProviderDetails';
 
 export type SubscriptionUpgradeProps = {
   isMobile: boolean;
@@ -151,20 +152,7 @@ export const SubscriptionUpgrade = ({
                 <span className="title">Payment information</span>
               </Localized>
             </h3>
-
-            <div>
-              <Localized
-                id="payment-confirmation-cc-card-ending-in"
-                vars={{
-                  last4: cardLast4 as string,
-                }}
-              >
-                <p className={`c-card ${cardBrandLc}`}>
-                  {' '}
-                  Card ending in {cardLast4}
-                </p>
-              </Localized>
-            </div>
+            <PaymentProviderDetails customer={customer!} />
           </div>
 
           <Form


### PR DESCRIPTION
Because:
 - the upgrade checkout page does not display the correct payment
   provider information when the customer uses PayPal

This commit:
 - use an existing component to show a customer's current payment
   provider info

## Issue that this pull request solves

Closes: #9957
