### PR TITLE
refactor(support): convert support panel to direct db access

### DIFF
--- a/packages/fxa-support-panel/src/app.module.ts
+++ b/packages/fxa-support-panel/src/app.module.ts
@@ -11,6 +11,8 @@ import { getVersionInfo } from 'fxa-shared/nestjs/version';
 import { AppController } from './app/app.controller';
 import Config, { AppConfig } from './config';
 import { RemoteLookupService } from './remote-lookup/remote-lookup.service';
+import { DatabaseModule } from './database/database.module';
+import { DatabaseService } from './database/database.service';
 
 const version = getVersionInfo(__dirname);
 
@@ -20,11 +22,13 @@ const version = getVersionInfo(__dirname);
       load: [(): AppConfig => Config.getProperties()],
       isGlobal: true,
     }),
+    DatabaseModule,
     HealthModule.forRootAsync({
-      imports: [],
-      inject: [],
-      useFactory: async () => ({
+      imports: [DatabaseModule],
+      inject: [DatabaseService],
+      useFactory: async (db: DatabaseService) => ({
         version,
+        extraHealthData: () => db.dbHealthCheck(),
       }),
     }),
     LoggerModule,

--- a/packages/fxa-support-panel/src/app/app.controller.spec.ts
+++ b/packages/fxa-support-panel/src/app/app.controller.spec.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Account, Device, TotpToken } from 'fxa-shared/db/models/auth';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
 
 import { RemoteLookupService } from '../remote-lookup/remote-lookup.service';
@@ -51,15 +52,21 @@ describe('AppController', () => {
 
   describe('index', () => {
     it('returns successfully', async () => {
-      mockRemote.account = jest.fn().mockResolvedValue(MOCKDATA.account);
-      mockRemote.devices = jest.fn().mockResolvedValue(MOCKDATA.devices);
+      (jest.spyOn(Account, 'findByUid') as jest.Mock).mockReturnValue(
+        MOCKDATA.account
+      );
+      (jest.spyOn(Device, 'findByUid') as jest.Mock).mockReturnValue(
+        MOCKDATA.devices
+      );
+      (jest.spyOn(TotpToken, 'findByUid') as jest.Mock).mockReturnValue(
+        MOCKDATA.totp
+      );
       mockRemote.subscriptions = jest
         .fn()
         .mockResolvedValue(formattedSubscriptions);
       mockRemote.signinLocations = jest
         .fn()
         .mockResolvedValue(formattedSigninLocations);
-      mockRemote.totpEnabled = jest.fn().mockResolvedValue(true);
 
       expect(
         await controller.root('testuser', { uid: 'testuid' })

--- a/packages/fxa-support-panel/src/config.ts
+++ b/packages/fxa-support-panel/src/config.ts
@@ -4,6 +4,7 @@
 import convict from 'convict';
 import fs from 'fs';
 import path from 'path';
+import { makeMySQLConfig } from 'fxa-shared/db/config';
 
 convict.addFormats(require('convict-format-with-moment'));
 convict.addFormats(require('convict-format-with-validator'));
@@ -41,11 +42,10 @@ const conf = convict({
       format: String,
     },
   },
-  authdbUrl: {
-    default: 'http://localhost:8000',
-    doc: 'fxa-auth-db-mysql url',
-    env: 'AUTHDB_URL',
-    format: String,
+  database: {
+    mysql: {
+      auth: makeMySQLConfig('AUTH', 'fxa'),
+    },
   },
   env: {
     default: 'production',
@@ -105,8 +105,7 @@ const conf = convict({
   csp: {
     frameAncestors: {
       default: 'none',
-      doc:
-        'https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors',
+      doc: 'https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors',
       env: 'CSP_FRAME_ANCESTORS',
     },
   },

--- a/packages/fxa-support-panel/src/database/database.module.ts
+++ b/packages/fxa-support-panel/src/database/database.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { DatabaseService } from './database.service';
+
+@Module({
+  providers: [DatabaseService],
+  exports: [DatabaseService],
+})
+export class DatabaseModule {}

--- a/packages/fxa-support-panel/src/database/database.service.spec.ts
+++ b/packages/fxa-support-panel/src/database/database.service.spec.ts
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DatabaseService } from './database.service';
+import { Provider } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Account } from 'fxa-shared/db/models/auth';
+
+describe('DatabaseService', () => {
+  let service: DatabaseService;
+
+  beforeEach(async () => {
+    const dbConfig = {
+      database: 'testAdmin',
+      host: 'localhost',
+      password: '',
+      port: 3306,
+      user: 'root',
+    };
+    const MockConfig: Provider = {
+      provide: ConfigService,
+      useValue: {
+        get: jest.fn().mockReturnValue({
+          mysql: {
+            auth: dbConfig,
+          },
+        }),
+      },
+    };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DatabaseService, MockConfig],
+    }).compile();
+
+    service = module.get<DatabaseService>(DatabaseService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('returns success', async () => {
+    (jest.spyOn(Account, 'query') as jest.Mock).mockReturnValue({
+      limit: jest.fn().mockResolvedValue({}),
+    });
+    const result = await service.dbHealthCheck();
+    expect(result).toStrictEqual({ db: { status: 'ok' } });
+  });
+
+  it('returns error', async () => {
+    (jest.spyOn(Account, 'query') as jest.Mock).mockReturnValue({
+      limit: jest.fn().mockRejectedValue({}),
+    });
+    const result = await service.dbHealthCheck();
+    expect(result).toStrictEqual({ db: { status: 'error' } });
+  });
+});

--- a/packages/fxa-support-panel/src/database/database.service.ts
+++ b/packages/fxa-support-panel/src/database/database.service.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { setupAuthDatabase } from 'fxa-shared/db';
+import { Account } from 'fxa-shared/db/models/auth';
+import { Knex } from 'knex';
+
+import { AppConfig } from '../config';
+
+@Injectable()
+export class DatabaseService {
+  public authKnex: Knex;
+
+  constructor(configService: ConfigService<AppConfig>) {
+    const dbConfig = configService.get('database') as AppConfig['database'];
+    this.authKnex = setupAuthDatabase(dbConfig.mysql.auth);
+  }
+
+  async dbHealthCheck(): Promise<Record<string, any>> {
+    let status = 'ok';
+    try {
+      await Account.query().limit(1);
+    } catch (err) {
+      status = 'error';
+    }
+    return {
+      db: { status },
+    };
+  }
+}

--- a/packages/fxa-support-panel/src/remote-lookup/remote-lookup.service.spec.ts
+++ b/packages/fxa-support-panel/src/remote-lookup/remote-lookup.service.spec.ts
@@ -149,20 +149,6 @@ describe('RemoteLookupService', () => {
     );
   });
 
-  it('returns an account', async () => {
-    (jest.spyOn(superagent, 'get') as jest.Mock).mockResolvedValue({
-      body: MOCKDATA.account,
-    });
-    expect(await service.account('test')).toStrictEqual(MOCKDATA.account);
-  });
-
-  it('returns the devices', async () => {
-    (jest.spyOn(superagent, 'get') as jest.Mock).mockResolvedValue({
-      body: MOCKDATA.devices,
-    });
-    expect(await service.devices('test')).toStrictEqual(MOCKDATA.devices);
-  });
-
   describe('subscriptions', () => {
     it('returns successfully', async () => {
       service.authServerGetBody = jest
@@ -200,33 +186,5 @@ describe('RemoteLookupService', () => {
     expect(await service.signinLocations('test')).toStrictEqual(
       formattedSigninLocations
     );
-  });
-
-  describe('totpEnabled', () => {
-    it('returns successfully', async () => {
-      (jest.spyOn(superagent, 'get') as jest.Mock).mockResolvedValue({
-        body: MOCKDATA.totp,
-      });
-      expect(await service.totpEnabled('test')).toBe(true);
-    });
-
-    it('returns false on 404', async () => {
-      (jest.spyOn(superagent, 'get') as jest.Mock).mockRejectedValue({
-        status: 404,
-      });
-      expect(await service.totpEnabled('test')).toBe(false);
-    });
-
-    it('re-throws other errors', async () => {
-      expect.assertions(1);
-      (jest.spyOn(superagent, 'get') as jest.Mock).mockRejectedValue(
-        new Error('unknown')
-      );
-      try {
-        await service.totpEnabled('test');
-      } catch (err) {
-        expect(err).toStrictEqual(new Error('unknown'));
-      }
-    });
   });
 });

--- a/packages/fxa-support-panel/src/remote-lookup/remote-lookup.service.ts
+++ b/packages/fxa-support-panel/src/remote-lookup/remote-lookup.service.ts
@@ -7,8 +7,6 @@ import superagent from 'superagent';
 
 import { AppConfig } from '../config';
 import {
-  AccountResponse,
-  DevicesResponse,
   SubscriptionResponse,
   SigninLocationResponse,
 } from './remote-responses.dto';
@@ -17,11 +15,9 @@ const MS_IN_SEC = 1000;
 
 @Injectable()
 export class RemoteLookupService {
-  private authdbUrl: string;
   private authServer: AppConfig['authServer'];
 
   constructor(configService: ConfigService<AppConfig>) {
-    this.authdbUrl = configService.get('authdbUrl') as string;
     this.authServer = configService.get(
       'authServer'
     ) as AppConfig['authServer'];
@@ -38,18 +34,6 @@ export class RemoteLookupService {
       .set('Authorization', `Bearer ${this.authServer.secretBearerToken}`)
       .set('accept', 'json')
       .then((response) => response.body);
-  }
-
-  async account(uid: string): Promise<AccountResponse> {
-    const response = await superagent.get(`${this.authdbUrl}/account/${uid}`);
-    return response.body;
-  }
-
-  async devices(uid: string): Promise<DevicesResponse> {
-    const response = await superagent.get(
-      `${this.authdbUrl}/account/${uid}/devices`
-    );
-    return response.body;
   }
 
   async subscriptions(
@@ -92,17 +76,5 @@ export class RemoteLookupService {
       ...v,
       lastAccessTime: new Date(v.lastAccessTime),
     }));
-  }
-
-  async totpEnabled(uid: string): Promise<boolean> {
-    try {
-      const response = await superagent.get(`${this.authdbUrl}/totp/${uid}`);
-      return response.body.enabled;
-    } catch (err) {
-      if (err.status === 404) {
-        return false;
-      }
-      throw err;
-    }
   }
 }

--- a/packages/fxa-support-panel/src/remote-lookup/remote-responses.dto.ts
+++ b/packages/fxa-support-panel/src/remote-lookup/remote-responses.dto.ts
@@ -5,20 +5,6 @@
 // Note that these `*.Response` interfaces are purely for access to known
 // response keys and not an attempt to validate the return payloads from
 // fxa-auth-db-mysql.
-export interface AccountResponse {
-  email: string;
-  emailVerified: boolean;
-  locale: string;
-  createdAt: number;
-}
-
-interface Device {
-  name: string;
-  type: string;
-  createdAt: number;
-}
-
-export interface DevicesResponse extends Array<Device> {}
 
 interface Subscription {
   created: string;
@@ -54,7 +40,6 @@ export interface TotpTokenResponse {
 /** SupportController configuration */
 export type SupportConfig = {
   authHeader: string;
-  authdbUrl: string;
   authServer: {
     secretBearerToken: string;
     signinLocationsSearchPath: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2620,16 +2620,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hapi/boom@npm:9.x.x, @hapi/boom@npm:^9.0.0, @hapi/boom@npm:^9.1.0":
-  version: 9.1.3
-  resolution: "@hapi/boom@npm:9.1.3"
-  dependencies:
-    "@hapi/hoek": 9.x.x
-  checksum: b7f54fa3fd4e9ea60c33a4be93ae9cd67cf1b4f000d9feb0393e9f617c5f49a753de66d7ca0048c90c9ca71e722cf1d0ce62e436d8076e69a6943cbf26f2c2f7
-  languageName: node
-  linkType: hard
-
-"@hapi/boom@npm:~9.1.4":
+"@hapi/boom@npm:9.x.x, @hapi/boom@npm:^9.0.0, @hapi/boom@npm:^9.1.0, @hapi/boom@npm:~9.1.4":
   version: 9.1.4
   resolution: "@hapi/boom@npm:9.1.4"
   dependencies:
@@ -8105,7 +8096,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^4.29.3":
+"@typescript-eslint/eslint-plugin@npm:^4.29.3, @typescript-eslint/eslint-plugin@npm:^4.5.0":
   version: 4.29.3
   resolution: "@typescript-eslint/eslint-plugin@npm:4.29.3"
   dependencies:
@@ -8126,44 +8117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^4.5.0":
-  version: 4.29.2
-  resolution: "@typescript-eslint/eslint-plugin@npm:4.29.2"
-  dependencies:
-    "@typescript-eslint/experimental-utils": 4.29.2
-    "@typescript-eslint/scope-manager": 4.29.2
-    debug: ^4.3.1
-    functional-red-black-tree: ^1.0.1
-    regexpp: ^3.1.0
-    semver: ^7.3.5
-    tsutils: ^3.21.0
-  peerDependencies:
-    "@typescript-eslint/parser": ^4.0.0
-    eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 3d3646059daa3d95200d71945a1ec8daebf62c7fedc3f29e1bece87bee9d689b06856fb18a8c55917f9c0bb5e86ddc8bc4c4f65f171e7d5784756dd59e3ff51d
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/experimental-utils@npm:4.29.2, @typescript-eslint/experimental-utils@npm:^4.0.1":
-  version: 4.29.2
-  resolution: "@typescript-eslint/experimental-utils@npm:4.29.2"
-  dependencies:
-    "@types/json-schema": ^7.0.7
-    "@typescript-eslint/scope-manager": 4.29.2
-    "@typescript-eslint/types": 4.29.2
-    "@typescript-eslint/typescript-estree": 4.29.2
-    eslint-scope: ^5.1.1
-    eslint-utils: ^3.0.0
-  peerDependencies:
-    eslint: "*"
-  checksum: e07b6b58f386ba84801d10bfe494548c3af20448c2f5596b77d13ba8621345ced4e1c6cf946dcf118c1e8566e0eed8284200f3f3a96f89aa7f367d9cdf6549a3
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/experimental-utils@npm:4.29.3":
+"@typescript-eslint/experimental-utils@npm:4.29.3, @typescript-eslint/experimental-utils@npm:^4.0.1":
   version: 4.29.3
   resolution: "@typescript-eslint/experimental-utils@npm:4.29.3"
   dependencies:
@@ -8194,7 +8148,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^4.29.3":
+"@typescript-eslint/parser@npm:^4.29.3, @typescript-eslint/parser@npm:^4.5.0":
   version: 4.29.3
   resolution: "@typescript-eslint/parser@npm:4.29.3"
   dependencies:
@@ -8208,43 +8162,6 @@ __metadata:
     typescript:
       optional: true
   checksum: 3fac6b5219de8b9aea361cc2fa170105661068d5eee5594f2f68526801a66b9525a766fc17427a8d410ada0da2d852f8c021d0b2fac7442a1e913f248ac85d90
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/parser@npm:^4.5.0":
-  version: 4.29.0
-  resolution: "@typescript-eslint/parser@npm:4.29.0"
-  dependencies:
-    "@typescript-eslint/scope-manager": 4.29.0
-    "@typescript-eslint/types": 4.29.0
-    "@typescript-eslint/typescript-estree": 4.29.0
-    debug: ^4.3.1
-  peerDependencies:
-    eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 78d1a558dc92e6baeef3b0bb6850108d3bb792282646678e276626b940b07e601d35abd790f8f02cb4625fe1656c57c9a7ae776c731984f36ab886cb93ed3b26
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/scope-manager@npm:4.29.0":
-  version: 4.29.0
-  resolution: "@typescript-eslint/scope-manager@npm:4.29.0"
-  dependencies:
-    "@typescript-eslint/types": 4.29.0
-    "@typescript-eslint/visitor-keys": 4.29.0
-  checksum: 3f3d211ae56a0b35e21d16dca4be5d8599928eb97045d191e2ab8065b90312b92c0b15a9c37dc2022056a1be3a2aa83ff704f3ecf41155df772951e12dc341bc
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/scope-manager@npm:4.29.2":
-  version: 4.29.2
-  resolution: "@typescript-eslint/scope-manager@npm:4.29.2"
-  dependencies:
-    "@typescript-eslint/types": 4.29.2
-    "@typescript-eslint/visitor-keys": 4.29.2
-  checksum: f89d11cf7ce28c37a913db432d3dd2c4e5f5bc431bac205dd55c3d49704be691a28d5f27ae96fde7feee23d3e80192d7aff3d8350aef53b415e5b0b53cd965d7
   languageName: node
   linkType: hard
 
@@ -8262,20 +8179,6 @@ __metadata:
   version: 3.10.1
   resolution: "@typescript-eslint/types@npm:3.10.1"
   checksum: 3ea820d37c2595d457acd6091ffda8b531e5d916e1cce708336bf958aa8869126f95cca3268a724f453ce13be11c5388a0a4143bf09bca51be1020ec46635d92
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/types@npm:4.29.0":
-  version: 4.29.0
-  resolution: "@typescript-eslint/types@npm:4.29.0"
-  checksum: ce42a50ba69f6eaa83661b752132ddd058a619025dfccf16f1cc4e21dcfda57787e2bce106b2396cc7ebf6b29473460f90ac12d277a2115c1a9000b6236fcfcb
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/types@npm:4.29.2":
-  version: 4.29.2
-  resolution: "@typescript-eslint/types@npm:4.29.2"
-  checksum: 0bcab66bb1848e2361bb366abebe1f94baa56d7d2058b62467f14c054b969b72d1aa17717a52c11f48e9cfb50846f0e227e49ccc7f06ff750b9eb28ca8b064de
   languageName: node
   linkType: hard
 
@@ -8305,42 +8208,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:4.29.0":
-  version: 4.29.0
-  resolution: "@typescript-eslint/typescript-estree@npm:4.29.0"
-  dependencies:
-    "@typescript-eslint/types": 4.29.0
-    "@typescript-eslint/visitor-keys": 4.29.0
-    debug: ^4.3.1
-    globby: ^11.0.3
-    is-glob: ^4.0.1
-    semver: ^7.3.5
-    tsutils: ^3.21.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: e1f893c2dff1bb2eb800039871ba08a9d96d8d3ca976389426df8e75438031afa443b863925582fa610d19c40d4b9a787d130ed8bcf11c4aeb2cb63c78d592c3
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/typescript-estree@npm:4.29.2":
-  version: 4.29.2
-  resolution: "@typescript-eslint/typescript-estree@npm:4.29.2"
-  dependencies:
-    "@typescript-eslint/types": 4.29.2
-    "@typescript-eslint/visitor-keys": 4.29.2
-    debug: ^4.3.1
-    globby: ^11.0.3
-    is-glob: ^4.0.1
-    semver: ^7.3.5
-    tsutils: ^3.21.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 90342d27f3f0837ad39f9b7e7d7c3c0b6de9c5b0770f5a18d490ebaf7be78efa65ba46ce0ca3004ad946ca1adc5865c5d3ba3b049c95b3b193bfdf0eb5e23095
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/typescript-estree@npm:4.29.3":
   version: 4.29.3
   resolution: "@typescript-eslint/typescript-estree@npm:4.29.3"
@@ -8365,26 +8232,6 @@ __metadata:
   dependencies:
     eslint-visitor-keys: ^1.1.0
   checksum: 0c4825b9829b1c11258a73aaee70d64834ba6d9b24157e7624e80f27f6537f468861d4dd33ad233c13ad2c6520afb9008c0675da6d792f26e82d75d6bfe9b0c6
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/visitor-keys@npm:4.29.0":
-  version: 4.29.0
-  resolution: "@typescript-eslint/visitor-keys@npm:4.29.0"
-  dependencies:
-    "@typescript-eslint/types": 4.29.0
-    eslint-visitor-keys: ^2.0.0
-  checksum: 3be974c6b2dd4eee3dbe01409bd6bf0e175bac5fe42df4256782ad1a4b05aded64bee711f0b6e597f732b1b506f72c25f7415370211af4b526557e872fc7f94b
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/visitor-keys@npm:4.29.2":
-  version: 4.29.2
-  resolution: "@typescript-eslint/visitor-keys@npm:4.29.2"
-  dependencies:
-    "@typescript-eslint/types": 4.29.2
-    eslint-visitor-keys: ^2.0.0
-  checksum: 34185d8c6466340aba746d69b36d357da2d06577d73f58358648c142bd0f181d7fae01ca1138188a665ef074ea7e1bc6306ef9d50f29914c8bcea4e9ea1f82f2
   languageName: node
   linkType: hard
 
@@ -16487,16 +16334,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-node@npm:^0.3.5":
-  version: 0.3.5
-  resolution: "eslint-import-resolver-node@npm:0.3.5"
-  dependencies:
-    debug: ^3.2.7
-    resolve: ^1.20.0
-  checksum: 93a8176205f18c40d2c11c444fab89aa3990c5a5eed226ef03a893b5779e7cd4d1f5f52b2bbbbbe4b13fb2a75ef629278be0b52099480cbe6e7024888d9982dd
-  languageName: node
-  linkType: hard
-
 "eslint-import-resolver-node@npm:^0.3.6":
   version: 0.3.6
   resolution: "eslint-import-resolver-node@npm:0.3.6"
@@ -16542,32 +16379,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:^2.22.1":
-  version: 2.24.0
-  resolution: "eslint-plugin-import@npm:2.24.0"
-  dependencies:
-    array-includes: ^3.1.3
-    array.prototype.flat: ^1.2.4
-    debug: ^2.6.9
-    doctrine: ^2.1.0
-    eslint-import-resolver-node: ^0.3.5
-    eslint-module-utils: ^2.6.2
-    find-up: ^2.0.0
-    has: ^1.0.3
-    is-core-module: ^2.4.0
-    minimatch: ^3.0.4
-    object.values: ^1.1.3
-    pkg-up: ^2.0.0
-    read-pkg-up: ^3.0.0
-    resolve: ^1.20.0
-    tsconfig-paths: ^3.9.0
-  peerDependencies:
-    eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0
-  checksum: 79fb1094197cd1dc720725bd29e5c5fe7d123fd9dd31eb182849993a81a8c18e2bfbc4d267a2caabe02bd4d21aafb1eca1da2f55aca7e5df99fd8ba908e7b869
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-import@npm:^2.24.1":
+"eslint-plugin-import@npm:^2.22.1, eslint-plugin-import@npm:^2.24.1":
   version: 2.24.1
   resolution: "eslint-plugin-import@npm:2.24.1"
   dependencies:
@@ -22887,16 +22699,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.0.0, is-core-module@npm:^2.2.0, is-core-module@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "is-core-module@npm:2.4.0"
-  dependencies:
-    has: ^1.0.3
-  checksum: c498902d4c4d0e8eba3a2e8293ccd442158cfe49a71d7cfad136ccf9902b6a41de34ddaa86cdc95c8b7c22f872e59572d8a5d994cbec04c8ecf27ffe75137119
-  languageName: node
-  linkType: hard
-
-"is-core-module@npm:^2.6.0":
+"is-core-module@npm:^2.0.0, is-core-module@npm:^2.2.0, is-core-module@npm:^2.6.0":
   version: 2.6.0
   resolution: "is-core-module@npm:2.6.0"
   dependencies:
@@ -28886,7 +28689,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"object.values@npm:^1.1.0, object.values@npm:^1.1.3, object.values@npm:^1.1.4":
+"object.values@npm:^1.1.0, object.values@npm:^1.1.4":
   version: 1.1.4
   resolution: "object.values@npm:1.1.4"
   dependencies:


### PR DESCRIPTION
fxa-auth-db-mysql is deprecated. this converts the support-panel to use fxa-shared and with direct db access.

closes #9724

config PR https://github.com/mozilla-services/cloudops-deployment/pull/4373