### PR TITLE
chore(auth): add eventId to Sentry errors for customer.subscription.u…

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -227,6 +227,9 @@ export class StripeWebhookHandler extends StripeHandler {
       ({ uid, email } = await this.sendSubscriptionUpdatedEmail(event));
     } catch (err) {
       // It's unexpected that we don't know about the customer or an error happens.
+      if (err.output && typeof err.output.payload === 'object') {
+        err.output.payload = { ...err.output.payload, eventId: event.id };
+      }
       reportSentryError(err, request);
       return;
     }


### PR DESCRIPTION
…pdated events

Because:

* We are seeing some e.g. ['Unknown account' errors](https://sentry.prod.mozaws.net/operations/fxa-auth-prod/issues/12712546/?query=is%3Aunresolved) in Sentry following the deploy of the new [passwordless subscription flow](https://mozilla-hub.atlassian.net/browse/FXA-3486) to production.
* The error payload does not have any identifying information to map the error to a particular event in Stripe, making it difficult to debug.

This commit:

* Appends error.output.payload with the eventId.

Closes #10302

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).