### PR TITLE
feat(auth-server): convert verifyShortCode and verifySecondaryCode templates to new stack

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -437,7 +437,8 @@
       "verificationReminderFirst",
       "verificationReminderSecond",
       "verify",
-      "verifyShortCode"
+      "verifyShortCode",
+      "verifySecondaryCode"
     ]
   }
 }

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -436,7 +436,8 @@
       "postRemoveSecondary",
       "verificationReminderFirst",
       "verificationReminderSecond",
-      "verify"
+      "verify",
+      "verifyShortCode"
     ]
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
@@ -116,8 +116,11 @@ class FluentLocalizer {
         plainTextArr[i] = localizedValue ? localizedValue : val;
       }
     }
-    // convert back to string
-    const localizedPlainText = plainTextArr.join('\n');
+    // convert back to string and
+    // strip excessive line breaks
+    const localizedPlainText = plainTextArr
+      .join('\n')
+      .replace(/(\n){2,}/g, '\n\n');
 
     return {
       html: document.documentElement.outerHTML,

--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -38,6 +38,10 @@ $s-10: 40px;
     font-size: 20px !important;
     line-height: 28px !important;
   }
+  &-3xl {
+    font-size: 32px !important;
+    line-height: 26px !important;
+  }
 }
 
 // Utility classes
@@ -129,4 +133,11 @@ tr > td:first-child {
   margin: 0 auto;
   @extend .mb-5;
   @extend .mt-2;
+}
+
+.large-code div {
+  text-align: center !important;
+  font-family: monospace;
+  @extend .text-3xl;
+  @extend .mb-6;
 }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/en-US.ftl
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+verifySecondaryCode-subject = Confirm secondary email
+verifySecondaryCode-title = Verify secondary email
+verifySecondaryCode-explainer = A request to use { $email } as a secondary email address has been made from the following Firefox Account:
+verifySecondaryCode-prompt = Use this verification code:
+verifySecondaryCode-expiry-notice = It expires in 5 minutes. Once verified, this address will begin receiving security notifications and confirmations.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.mjml
@@ -1,0 +1,35 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-include path="./css/global.css" type="css" css-inline="inline" />
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="verifySecondaryCode-title">Verify secondary email</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="verifySecondaryCode-explainer" data-l10n-args='<%= JSON.stringify({email}) %>'>A request to use <%= email %> as a secondary email address has been made from the following Firefox Account:</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/location/index.mjml') %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="verifySecondaryCode-prompt">Use this verification code:</span>
+    </mj-text>
+
+    <mj-text css-class="large-code"><%- code %></mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="verifySecondaryCode-expiry-notice">It expires in 5 minutes. Once verified, this address will begin receiving security notifications and confirmations.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/automatedEmailNoAction/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.stories.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { commonArgs, Template } from '../../storybook-email';
+
+export default {
+  title: 'Emails/verifySecondaryCode',
+} as Meta;
+
+export const verifySecondaryCode = Template.bind({});
+verifySecondaryCode.args = {
+  template: 'verifySecondaryCode',
+  variables: {
+    ...commonArgs,
+    location: 'Madrid, Spain (estimated)',
+    device: 'Firefox on Mac OSX 10.11',
+    ip: '10.246.67.38',
+    email: 'foo@bar.com',
+    code: '918398',
+    subject: 'Confirm secondary email',
+  },
+};
+verifySecondaryCode.storyName = 'default';

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.txt
@@ -1,0 +1,13 @@
+verifySecondaryCode-title = "Verify secondary email"
+
+verifySecondaryCode-explainer = "A request to use { $email } as a secondary email address has been made from the following Firefox Account:"
+
+<%- include('/partials/location/index.txt') %>
+
+verifySecondaryCode-prompt = "Use this verification code:"
+<%- code %>
+
+verifySecondaryCode-expiry-notice = "It expires in 5 minutes. Once verified, this address will begin receiving security notifications and confirmations."
+
+<%- include('/partials/automatedEmailNoAction/index.txt') %>
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/en-US.ftl
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+verifyShortCode-subject = Verification code: { $code }
+verifyShortCode-title = Is this you signing up?
+verifyShortCode-prompt = If yes, use this verification code in your registration form:
+verifyShortCode-expiry-notice = It expires in 5 minutes.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.mjml
@@ -1,0 +1,31 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-include path="./css/global.css" type="css" css-inline="inline" />
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="verifyShortCode-title">Is this you signing up?</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/location/index.mjml') %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="verifyShortCode-prompt">If yes, use this verification code in your registration form:</span>
+    </mj-text>
+
+    <mj-text css-class="large-code"><%- code %></mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="verifyShortCode-expiry-notice">It expires in 5 minutes.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/automatedEmailNoAction/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.stories.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { commonArgs, Template } from '../../storybook-email';
+
+export default {
+  title: 'Emails/verifyShortCode',
+} as Meta;
+
+export const verifyShortCode = Template.bind({});
+verifyShortCode.args = {
+  template: 'verifyShortCode',
+  variables: {
+    ...commonArgs,
+    location: 'Madrid, Spain (estimated)',
+    device: 'Firefox on Mac OSX 10.11',
+    ip: '10.246.67.38',
+    code: '918398',
+    subject: 'Verification code: 918398',
+  },
+};
+verifyShortCode.storyName = 'default';

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.txt
@@ -1,0 +1,11 @@
+verifyShortCode-title = "Is this you signing up?"
+
+<%- include('/partials/location/index.txt') %>
+
+verifyShortCode-prompt = "If yes, use this verification code in your registration form:"
+<%- code %>
+
+verifyShortCode-expiry-notice = "It expires in 5 minutes."
+
+<%- include('/partials/automatedEmailNoAction/index.txt') %>
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -346,6 +346,45 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['verifySecondaryCodeEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Confirm secondary email' }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verifySecondaryCode') }],
+      ['X-Template-Name', { test: 'equal', expected: 'verifySecondaryCode' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.verifySecondaryCode }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'welcome-secondary', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'welcome-secondary', 'support')) },
+      { test: 'include', expected: 'Verify secondary email' },
+      { test: 'include', expected: `A request to use ${MESSAGE.email} as a secondary email address has been made from the following Firefox Account:` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: 'Use this verification code:' },
+      { test: 'include', expected: `${MESSAGE.code}` },
+      { test: 'include', expected: 'It expires in 5 minutes. Once verified, this address will begin receiving security notifications and confirmations.' },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: configUrl('privacyUrl', 'welcome-secondary', 'privacy') },
+      { test: 'include', expected: configUrl('supportUrl', 'welcome-secondary', 'support') },
+      { test: 'include', expected: 'Verify secondary email' },
+      { test: 'include', expected: `A request to use ${MESSAGE.email} as a secondary email address has been made from the following Firefox Account:` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: 'Use this verification code:' },
+      { test: 'include', expected: `${MESSAGE.code}` },
+      { test: 'include', expected: 'It expires in 5 minutes. Once verified, this address will begin receiving security notifications and confirmations.' },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -160,7 +160,7 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
-  
+
   ['lowRecoveryCodesEmail', new Map<string, Test | any>([
     ['subject', [
       { test: 'include', expected: '2 recovery codes remaining' }
@@ -313,7 +313,39 @@ const TESTS: [string, any][] = [
       { test: 'include', expected: `Confirm email:\n${configUrl('verificationUrl', 'welcome', 'activate', 'uid', 'code', 'service')}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
-  ])]
+  ])],
+
+  ['verifyShortCodeEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `Verification code: ${MESSAGE.code}` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verify') }],
+      ['X-Template-Name', { test: 'equal', expected: 'verifyShortCode' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.verifyShortCode }],
+      ['X-Verify-Short-Code', { test: 'equal', expected: MESSAGE.code }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'welcome', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'welcome', 'support')) },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'include', expected: 'If yes, use this verification code in your registration form:' },
+      { test: 'include', expected: MESSAGE.code },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'welcome', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'welcome', 'support')}` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'include', expected: `If yes, use this verification code in your registration form:\n${MESSAGE.code}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {


### PR DESCRIPTION
## Because

- We need to convert the templates for verifyShortCode and verifySecondaryCode to our new MJML stack

## This pull request

- Converts them to the new stack
- Updates fluent localizer to strip excessive line breaks in plaintext emails

## Issue that this pull request solves

Closes: #9302
Closes: #9297

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).