### PR TITLE
fix: allow patch version > 9

### DIFF
--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -263,7 +263,7 @@ module.exports = {
 
         let version;
         try {
-          version = /([0-9]+)\.([0-9])$/.exec(data.version)[0];
+          version = /([0-9]+)\.([0-9]+)$/.exec(data.version)[0];
         } catch (err) {}
 
         // minimal data should be enabled for routes used by internal

--- a/packages/fxa-shared/test/metrics/amplitude.js
+++ b/packages/fxa-shared/test/metrics/amplitude.js
@@ -9,7 +9,7 @@ const { assert } = require('chai');
 const DAY = 1000 * 60 * 60 * 24;
 const WEEK = DAY * 7;
 const FOUR_WEEKS = WEEK * 4;
-const APP_VERSION = /^([0-9]+)\.([0-9])$/; // Matches `XXX.X` version number
+const APP_VERSION = /^([0-9]+)\.([0-9]+)$/; // Matches `XXX.X` version number
 
 describe('metrics/amplitude:', () => {
   let amplitude;


### PR DESCRIPTION
Because:

* We want to support patch versions > 9.

This commit:

* Changes the last reference to version checking for > 9.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
