### PR TITLE
feat(auth-server): Add env vars for MJML addresses/templates

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1562,11 +1562,13 @@ const conf = convict({
       doc: 'If mjml email templates are enabled for specific email regex',
       format: RegExp,
       default: /^$/, // default is no one
+      env: 'MJML_ENABLED_EMAIL_ADDRESS',
     },
     templates: {
       doc: 'Templates that have mjml email support',
       format: Array,
       default: [],
+      env: 'MJML_TEMPLATES',
     },
   },
   push: {


### PR DESCRIPTION
Because:
* We need to set these to values in staging

This commit:
* Creates two env vars: one for mjml enabled email addresses, and one for mjml templates