### PR TITLE
fix(subscriptions): fix product fetching for up/downgrade email

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2295,21 +2295,21 @@ export class StripeHelper {
       return this.abbrevProductFromStripeProduct(product);
     };
 
-    // If we already have an expanded Product, just extract from that.
-    if (typeof plan.product === 'object') {
-      return checkDeletedProduct(plan.product);
-    }
+    // The "plan" argument might not have any product info on it.
+    const planWithProductId = await this.findPlanById(plan.id);
 
     // Next, look for product details in cache
     const products = await this.allProducts();
-    const productCached = products.find((p) => p.product_id === plan.product);
+    const productCached = products.find(
+      (p) => p.product_id === planWithProductId.product_id
+    );
     if (productCached) {
       return productCached;
     }
 
     // Finally, do a direct Stripe fetch if none of the above works.
     return checkDeletedProduct(
-      await this.stripe.products.retrieve(plan.product)
+      await this.stripe.products.retrieve(planWithProductId.product_id)
     );
   }
 

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_customer_subscription_updated.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_customer_subscription_updated.json
@@ -116,30 +116,16 @@
     "previous_attributes": {
       "plan": {
         "id": "OLD_00000000000000",
-        "object": "plan",
-        "active": true,
-        "aggregate_usage": null,
         "amount": 1000000,
         "amount_decimal": "1000000",
-        "billing_scheme": "per_unit",
-        "created": 1585088835,
-        "currency": "usd",
         "interval": "month",
         "interval_count": 1,
-        "livemode": false,
         "metadata": {
           "productOrder": 1,
           "emailIconURL": "http://example.com/icon-old",
           "downloadURL": "http://example.com/download-old"
         },
-        "nickname": "123 Done Pro Plus Monthly",
-        "product": "prod_123doneproplus",
-        "tiers": null,
-        "tiers_mode": null,
-        "transform_usage": null,
-        "trial_period_days": null,
-        "usage_type": "licensed",
-        "name": "Old plan"
+        "trial_period_days": null
       }
     }
   }

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -3163,7 +3163,7 @@ describe('StripeHelper', () => {
       },
     };
 
-    let sandbox, mockCustomer, mockStripe, mockAllProducts;
+    let sandbox, mockCustomer, mockStripe, mockAllProducts, mockAllPlans;
     beforeEach(() => {
       sandbox = sinon.createSandbox();
 
@@ -3199,7 +3199,9 @@ describe('StripeHelper', () => {
           product_metadata: {},
         },
       ];
+      mockAllPlans = [{ ...mockPlan, plan_id: planId, product_id: productId }];
       sandbox.stub(stripeHelper, 'allProducts').resolves(mockAllProducts);
+      sandbox.stub(stripeHelper, 'allPlans').resolves(mockAllPlans);
 
       mockStripe = Object.entries({
         plans: mockPlan,
@@ -3304,7 +3306,7 @@ describe('StripeHelper', () => {
         const result = await stripeHelper.extractInvoiceDetailsForEmail(
           fixture
         );
-        assert.isFalse(stripeHelper.allProducts.called);
+        assert.isTrue(stripeHelper.allProducts.called);
         assert.isFalse(mockStripe.products.retrieve.called);
         assert.isFalse(mockStripe.customers.retrieve.called);
         assert.isFalse(mockStripe.charges.retrieve.called);
@@ -3324,7 +3326,7 @@ describe('StripeHelper', () => {
         const result = await stripeHelper.extractInvoiceDetailsForEmail(
           fixture
         );
-        assert.isFalse(stripeHelper.allProducts.called);
+        assert.isTrue(stripeHelper.allProducts.called);
         assert.isFalse(mockStripe.products.retrieve.called);
         assert.isFalse(mockStripe.customers.retrieve.called);
         assert.isFalse(mockStripe.charges.retrieve.called);
@@ -3683,6 +3685,18 @@ describe('StripeHelper', () => {
               emailIconUrl: productIconURLNew,
               downloadURL: productDownloadURLNew,
             },
+          }
+        );
+        mockAllPlans.unshift(
+          {
+            ...event.data.previous_attributes.plan,
+            plan_id: event.data.previous_attributes.plan.id,
+            product_id: productIdOld,
+          },
+          {
+            ...event.data.object.plan,
+            plan_id: event.data.object.plan.id,
+            product_id: productIdNew,
           }
         );
 


### PR DESCRIPTION
Because:
 - maybe at some point the plan in a subscription updated event's
   'previous_attributes' changed so it no long has a product id that we
   need

This commit:
 - use a plan id to get a plan that has a product id and use that
   product id to find the product needed for the emails


## Issue that this pull request solves

Closes: #9958

