### PR TITLE
feat(auth-server): convert newDeviceLogin template to new stack

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -439,7 +439,8 @@
       "verify",
       "verifyShortCode",
       "verifySecondaryCode",
-      "passwordReset"
+      "passwordReset",
+      "newDeviceLogin"
     ]
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailChangePassword/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailChangePassword/en-US.ftl
@@ -1,0 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+automated-email-change = This is an automated email; if you did not authorize this action, then <a data-l10n-name="passwordChangeLink">please change your password</a>.
+  For more information, please visit <a data-l10n-name="supportLink">Mozilla Support</a>.
+automated-email-change-plaintext = This is an automated email; if you didn’t add a new device to your Firefox Account, you should change your password immediately at { $passwordChangeLink }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailChangePassword/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailChangePassword/index.mjml
@@ -1,0 +1,16 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-footer-automatedEmail">
+      <span data-l10n-id="automated-email-change">
+        This is an automated email; if you did not authorize this action, then
+        <a class="link-blue" href="<%- passwordChangeLink %>" data-l10n-name="passwordChangeLink">please change your password</a>.
+        For more information, please visit
+        <a class="link-blue" href="<%- supportUrl %>" data-l10n-name="supportLink">Mozilla Support</a>.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailChangePassword/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailChangePassword/index.txt
@@ -1,0 +1,1 @@
+automated-email-change-plaintext = "This is an automated email; if you didn’t add a new device to your Firefox Account, you should change your password immediately at { $passwordChangeLink }"

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/en-US.ftl
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+newDeviceLogin-subject = New sign-in to { $clientName }
+newDeviceLogin-title = { newDeviceLogin-subject }
+newDeviceLogin-action = Manage account
+newDeviceLogin-action-plaintext = { newDeviceLogin-action }:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.mjml
@@ -1,0 +1,17 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-include path="./css/global.css" type="css" css-inline="inline" />
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="newDeviceLogin-title" data-l10n-args='<%= JSON.stringify({clientName}) %>'>New sign-in to <%- clientName %></span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/location/index.mjml') %>
+<%- include('/partials/button/index.mjml') %>
+<%- include('/partials/automatedEmailChangePassword/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.stories.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { commonArgs, Template } from '../../storybook-email';
+
+export default {
+  title: 'Emails/newDeviceLogin',
+} as Meta;
+
+export const newDeviceLogin = Template.bind({});
+newDeviceLogin.args = {
+  template: 'newDeviceLogin',
+  variables: {
+    ...commonArgs,
+    date: 'Thursday, Sep 2, 2021',
+    device: 'Firefox on Mac OSX 10.11',
+    ip: '10.246.67.38',
+    location: 'Madrid, Spain (estimated)',
+    time: '12:26:44 AM (CEST)',
+    action: 'Manage account',
+    clientName: 'Firefox',
+    passwordChangeLink: 'http://localhost:3030/settings/change_password',
+    subject: 'New sign-in to Firefox',
+  },
+};
+newDeviceLogin.storyName = 'default';

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.txt
@@ -1,0 +1,9 @@
+newDeviceLogin-title = "New sign-in to { $clientName }"
+
+<%- include('/partials/location/index.txt') %>
+
+<%- include('/partials/manageAccount/index.txt') %>
+
+<%- include('/partials/automatedEmailChangePassword/index.txt') %>
+
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -406,6 +406,40 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['newDeviceLoginEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'New sign-in to Mock Relier' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('initiatePasswordChangeUrl', 'new-device-signin', 'change-password', 'email') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('newDeviceLogin') }],
+      ['X-Template-Name', { test: 'equal', expected: 'newDeviceLogin' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.newDeviceLogin }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'new-device-signin', 'manage-account', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'new-device-signin', 'change-password', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'new-device-signin', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'new-device-signin', 'support')) },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'new-device-signin', 'manage-account', 'email', 'uid')}` },
+      { test: 'include', expected: `change your password immediately at ${configUrl('initiatePasswordChangeUrl', 'new-device-signin', 'change-password', 'email')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'new-device-signin', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'new-device-signin', 'support')}` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {


### PR DESCRIPTION
## Because

- We need to convert the template for newDeviceLogin to our new MJML stack

## This pull request

- Converts it to the new stack
- Moved `text-footer-automatedEmail` to global styles for re-use

## Issue that this pull request solves

Closes: #9264

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).