### PR TITLE
fix(subscriptions): ignore email complaint errors on webhooks

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -26,6 +26,7 @@ import { StripeHandler } from './stripe';
 const IGNORABLE_STRIPE_WEBHOOK_ERRNOS = [
   error.ERRNO.UNKNOWN_SUBSCRIPTION_FOR_SOURCE,
   error.ERRNO.BOUNCE_HARD,
+  error.ERRNO.BOUNCE_COMPLAINT,
 ];
 
 export class StripeWebhookHandler extends StripeHandler {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -346,6 +346,11 @@ describe('StripeWebhookHandler', () => {
         );
 
         it(
+          'ignores emailComplaint',
+          commonIgnorableErrorTest(error.emailComplaint(42))
+        );
+
+        it(
           'ignores missingSubscriptionForSourceError',
           commonIgnorableErrorTest(
             error.missingSubscriptionForSourceError(


### PR DESCRIPTION
Because:
 - we get errors in Sentry and Stripe when there's an email complaint
   error while handling a webhook event

This commit:
 - ignore the email complaint error so that Stripe stops retrying the
   webhook event


## Issue that this pull request solves

Closes: #9906 

