### PR TITLE
feat(auth-server): refactor email storybook, renderer, and localizer to be more dry

### DIFF
--- a/packages/fxa-auth-server/bin/mjml-server.ts
+++ b/packages/fxa-auth-server/bin/mjml-server.ts
@@ -28,19 +28,14 @@ async function handleRequest(
   try {
     const body = await readStream(req);
     const data = JSON.parse(body.trim());
-    const {
-      template: templateName,
-      layout: layoutName,
-      acceptLanguage,
-      ...variables
-    } = data;
+    const { template, layout, acceptLanguage, ...variables } = data;
     variables.baseUrl = baseUrl;
-    const { html, subject, text } = await fluentLocalizer.localizeEmail(
-      templateName,
-      layoutName || 'fxa',
-      variables,
-      acceptLanguage
-    );
+    const { html, subject, text } = await fluentLocalizer.localizeEmail({
+      template,
+      layout: layout || 'fxa',
+      acceptLanguage,
+      ...variables,
+    });
     const result = JSON.stringify({ html, subject, text });
 
     res.writeHead(200, {

--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -80,7 +80,7 @@ tr > td:first-child {
   padding: $s-0 !important;
 }
 
-.body-80 {
+.body {
   max-width: 310px !important;
   margin: $s-0 auto !important;
 }

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.mjml
@@ -11,7 +11,7 @@
     <%- include('/partials/metadata.mjml') %>
   </mj-head>
 
-  <mj-body css-class="body-80">
+  <mj-body css-class="body">
     <mj-include path="./css/global.css" type="css" css-inline="inline" />
     <mj-include path="./css/fxa/index.css" type="css" css-inline="inline" />
     <mj-include path="./css/locale-dir.css" type="css" />

--- a/packages/fxa-auth-server/lib/senders/emails/partials/button/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/button/index.mjml
@@ -7,7 +7,7 @@
 <mj-section>
   <mj-column>
     <mj-button css-class="primary-button" href="<%- link %>">
-      <span data-l10n-id="<%- templateName %>-action"><%- action %></span>
+      <span data-l10n-id="<%- template %>-action">Click here</span>
     </mj-button>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/cadReminder/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/cadReminder/en-US.ftl
@@ -1,8 +1,0 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-cadReminderFirst-title = Here's your reminder to sync devices.
-cadReminderFirst-description = It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.
-cadReminderSecond-title = Last reminder to sync devices!
-cadReminderSecond-description = Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.

--- a/packages/fxa-auth-server/lib/senders/emails/partials/cadReminder/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/cadReminder/index.mjml
@@ -7,7 +7,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="<%- templateName %>-title"><%- headerText %></span>
+      <span data-l10n-id="<%- template %>-title">Here's your reminder to sync devices.</span>
     </mj-text>
     <mj-image css-class="graphic-devices" alt="Devices" src="https://accounts-static.cdn.mozilla.net/other/graphic-laptop-mobile.png"></mj-image>
   </mj-column>
@@ -16,7 +16,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-body">
-      <span data-l10n-id="<%- templateName %>-description"><%- bodyText %></span>
+      <span data-l10n-id="<%- template %>-description">It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.</span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/cadReminder/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/cadReminder/index.txt
@@ -1,6 +1,6 @@
-<%- templateName %>-title = "<%- headerText %>"
+<%- template %>-title = "Here's your reminder to sync devices."
 
-<%- templateName %>-description = "<%- bodyText %>"
+<%- template %>-description = "It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox."
 
 <%- link %>
 

--- a/packages/fxa-auth-server/lib/senders/emails/partials/location/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/location/index.mjml
@@ -3,28 +3,28 @@
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
 <mj-include path="./css/location/index.css" type="css" css-inline="inline" />
-  
+
 <mj-section>
   <mj-column>
     <mj-text css-class="text-body-grey">
     <% if (locals.primaryEmail) { %>
       <span><%- primaryEmail %></span><br />
-    <% } %> 
+    <% } %>
     <% if (locals.device) { %>
-      <span><%- device %></span><br /> 
-    <% } %> 
+      <span><%- device %></span><br />
+    <% } %>
     <% if (locals.location) { %>
-      <span><%- location %></span><br /> 
-    <% } %> 
+      <span><%- location %></span><br />
+    <% } %>
     <% if (locals.ip) { %>
-      <span data-l10n-id="user-ip" data-l10n-args='<%= JSON.stringify({ip}) %>'>IP address: <%- ip %></span><br /> 
-    <% } %> 
+      <span data-l10n-id="user-ip" data-l10n-args='<%= JSON.stringify({ip}) %>'>IP address: <%- ip %></span><br />
+    <% } %>
     <% if (locals.date) { %>
-      <span><%- date %></span><br /> 
-    <% } %> 
+      <span><%- date %></span><br />
+    <% } %>
     <% if (locals.time) { %>
-      <span><%- time %><br /></span> 
-    <% } %>        
+      <span><%- time %><br /></span>
+    <% } %>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/verificationReminder/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/verificationReminder/index.mjml
@@ -7,7 +7,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="<%- templateName %>-title"><%- title %></span>
+      <span data-l10n-id="<%- template %>-title">Welcome to the Firefox family</span>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -15,10 +15,10 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-sub-body">
-      <span data-l10n-id="<%- templateName %>-description"><%- description %></span>
+      <span data-l10n-id="<%- template %>-description">A few days ago you created a Firefox account, but never confirmed it.</span>
     </mj-text>
     <mj-text css-class="text-body">
-      <span data-l10n-id="<%- templateName %>-sub-description"><%- subDescription %></span>
+      <span data-l10n-id="<%- template %>-sub-description">Confirm now and get technology that fights for and protects your privacy, arms you with practical knowledge, and the respect you deserve.</span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/renderer.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/renderer.ts
@@ -48,24 +48,19 @@ function renderEjs(
 }
 
 export function render(
-  templateName: string,
+  template: string,
   context: TemplateContext,
-  layoutName?: string
+  layout?: string
 ) {
   let rendered: { html: string; text: string };
-  context = { ...context, templateName };
+  context = { ...context, template };
 
-  if (layoutName) {
-    const renderedBody = renderEjs(templateName, 'templates', context);
-    const { mjml, text } = renderEjs(
-      layoutName,
-      'layouts',
-      context,
-      renderedBody
-    );
+  if (layout) {
+    const renderedBody = renderEjs(template, 'templates', context);
+    const { mjml, text } = renderEjs(layout, 'layouts', context, renderedBody);
     rendered = { html: mjml2html(mjml, mjmlConfig).html, text };
   } else {
-    const { mjml, text } = renderEjs(templateName, 'templates', context);
+    const { mjml, text } = renderEjs(template, 'templates', context);
     rendered = { html: mjml2html(mjml, mjmlConfig).html, text };
   }
 

--- a/packages/fxa-auth-server/lib/senders/emails/storybook-email.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/storybook-email.ts
@@ -4,7 +4,7 @@
 
 import { Story } from '@storybook/html';
 
-export interface StorybookEmailArgs {
+interface StorybookEmailArgs {
   template: string;
   layout: string;
   acceptLanguage: string;
@@ -14,18 +14,17 @@ export interface StorybookEmailArgs {
 }
 
 /* in production, `utm` parameters may also exist in the urls */
-export const commonArgs = {
+const commonArgs = {
   androidUrl:
-    'https://accounts-static.cdn.mozilla.net/product-icons/google-play.png',
+    'https://play.google.com/store/apps/details?id=org.mozilla.firefox',
   iosUrl:
-    'https://accounts-static.cdn.mozilla.net/product-icons/apple-app-store.png',
-  link: 'http://localhost:3030/connect_another_device',
-  privacyUrl: 'https://www.mozilla.org/privacy',
+    'https://apps.apple.com/us/app/firefox-private-safe-browser/id989804926',
   supportUrl:
     'https://support.mozilla.org/kb/im-having-problems-with-my-firefox-account',
+  privacyUrl: 'https://www.mozilla.org/privacy',
 };
 
-export const storybookEmail = ({
+const storybookEmail = ({
   template,
   layout = 'fxa',
   acceptLanguage = 'en-US',
@@ -94,7 +93,26 @@ async function renderUsingMJML({
   return { html, subject, text };
 }
 
-export const Template: Story<StorybookEmailArgs> = (args, context) =>
+const Template: Story<StorybookEmailArgs> = (args, context) =>
   storybookEmail({ ...args, direction: context.globals.direction });
 
-export default storybookEmail;
+export const storyWithProps = (
+  templateName: string,
+  templateDoc = '',
+  defaultArgs = {}
+) => {
+  return (overrides: Record<string, any> = {}, storyName = 'Default') => {
+    const template = Template.bind({});
+    template.args = {
+      template: templateName,
+      doc: templateDoc,
+      variables: {
+        ...commonArgs,
+        ...defaultArgs,
+        ...overrides,
+      },
+    };
+    template.storyName = storyName;
+    return template;
+  };
+};

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/en-US.ftl
@@ -4,3 +4,5 @@
 
 cadReminderFirst-subject = Your Friendly Reminder: How To Complete Your Sync Setup
 cadReminderFirst-action = Sync another device
+cadReminderFirst-title = Here's your reminder to sync devices.
+cadReminderFirst-description = It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.stories.ts
@@ -3,46 +3,26 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import {
-  Template,
-  commonArgs,
-  StorybookEmailArgs,
-} from '../../storybook-email';
+import { storyWithProps } from '../../storybook-email';
 
 export default {
   title: 'Emails/cadReminderFirst',
 } as Meta;
 
-const defaultVariables = {
-  ...commonArgs,
-  action: 'Sync another device',
-  oneClickLink: true,
-  bodyText:
-    'It takes two to sync. Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.',
-  headerText: "Here's your reminder to sync devices.",
-  subject: 'Your Friendly Reminder: How To Complete Your Sync Setup',
-};
+const createStory = storyWithProps(
+  'cadReminderFirst',
+  'Sent 8 hours after a user clicks "send me a reminder" on the connect another device page.',
+  {
+    oneClickLink: 'http://localhost:3030/connect_another_device?one_click=true',
+    link: 'http://localhost:3030/connect_another_device',
+  }
+);
 
-const commonPropsWithOverrides = (
-  overrides: Partial<
-    typeof defaultVariables | StorybookEmailArgs['variables']
-  > = {}
-) =>
-  Object.assign({
-    template: 'cadReminderFirst',
-    doc: 'Connect Another Device (CAD) first reminder email is sent out 8 hours after a user clicks "send me a reminder" on the connect another device page.',
-    variables: {
-      ...defaultVariables,
-      ...overrides,
-    },
-  });
+export const CadReminderDefault = createStory();
 
-export const CadReminderDefault = Template.bind({});
-CadReminderDefault.args = commonPropsWithOverrides();
-CadReminderDefault.storyName = 'default';
-
-export const CadReminderArLocale = Template.bind({});
-CadReminderArLocale.args = commonPropsWithOverrides({
-  acceptLanguage: 'ar',
-});
-CadReminderArLocale.storyName = 'User has ar locale';
+export const CadReminderArLocale = createStory(
+  {
+    acceptLanguage: 'ar',
+  },
+  'User has Arabic locale'
+);

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/en-US.ftl
@@ -4,3 +4,5 @@
 
 cadReminderSecond-subject = Final Reminder: Complete Sync Setup
 cadReminderSecond-action = Sync another device
+cadReminderSecond-title = Last reminder to sync devices!
+cadReminderSecond-description = Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.stories.ts
@@ -3,33 +3,17 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { Template } from '../../storybook-email';
+import { storyWithProps } from '../../storybook-email';
 import * as cadReminderFirst from '../cadReminderFirst/index.stories';
 
 export default {
   title: 'Emails/cadReminderSecond',
 } as Meta;
 
-const defaultVariables = {
-  ...cadReminderFirst.CadReminderDefault.args.variables,
-  bodyText:
-    'Syncing another device with Firefox privately keeps your bookmarks, passwords and other Firefox data the same everywhere you use Firefox.',
-  headerText: 'Last reminder to sync devices!',
-  subject: 'Final Reminder: Complete Sync Setup',
-};
+const createStory = storyWithProps(
+  'cadReminderSecond',
+  'Sent 72 hours after a user clicks "send me a reminder" on the connect another device page.',
+  cadReminderFirst.CadReminderDefault.args.variables
+);
 
-const commonPropsWithOverrides = (
-  overrides: Partial<typeof defaultVariables> = {}
-) =>
-  Object.assign({
-    template: 'cadReminderSecond',
-    doc: 'Connect Another Device (CAD) second reminder email is sent out 72 hours after a user clicks "send me a reminder" on the connect another device page.',
-    variables: {
-      ...defaultVariables,
-      ...overrides,
-    },
-  });
-
-export const CadReminderDefault = Template.bind({});
-CadReminderDefault.args = commonPropsWithOverrides();
-CadReminderDefault.storyName = 'default';
+export const CadReminderDefault = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.stories.ts
@@ -3,41 +3,31 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { Template, commonArgs } from '../../storybook-email';
+import { Template, storyWithProps } from '../../storybook-email';
 
 export default {
   title: 'Emails/lowRecoveryCodes',
 } as Meta;
 
-const defaultVariables = {
-  ...commonArgs,
-  action: 'Generate codes',
-  link: 'http://localhost:3030/settings/two_step_authentication/replace_codes?low_recovery_codes=true',
-  numberRemaining: 1,
-  subject: '2 recovery codes remaining',
-};
+const createStory = storyWithProps(
+  'lowRecoveryCodes',
+  'Sent when a user has 2 or less recovery codes remaining.',
+  {
+    link: 'http://localhost:3030/settings/two_step_authentication/replace_codes?low_recovery_codes=true',
+    numberRemaining: 1,
+  }
+);
 
-const commonPropsWithOverrides = (
-  overrides: Partial<typeof defaultVariables> = {}
-) =>
-  Object.assign({
-    template: 'lowRecoveryCodes',
-    doc: 'Low Recovery Code emails are sent when a user has 2 or less recovery codes remaining',
-    variables: {
-      ...defaultVariables,
-      ...overrides,
-    },
-  });
+export const LowRecoveryCodesOne = createStory(
+  {
+    numberRemaining: 1,
+  },
+  'User has 1 recovery code remaining'
+);
 
-export const LowRecoveryCodesOne = Template.bind({});
-LowRecoveryCodesOne.args = commonPropsWithOverrides({
-  numberRemaining: 1,
-});
-LowRecoveryCodesOne.storyName = 'User has 1 recovery code remaining';
-
-export const LowRecoveryCodesMultiple = Template.bind({});
-LowRecoveryCodesMultiple.args = commonPropsWithOverrides({
-  numberRemaining: 2,
-});
-LowRecoveryCodesMultiple.storyName =
-  'User has more than 1 recovery codes remaining';
+export const LowRecoveryCodesMultiple = createStory(
+  {
+    numberRemaining: 2,
+  },
+  'User has 2 recovery codes remaining'
+);

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.stories.ts
@@ -3,26 +3,25 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { commonArgs, Template } from '../../storybook-email';
+import { storyWithProps } from '../../storybook-email';
 
 export default {
   title: 'Emails/newDeviceLogin',
 } as Meta;
 
-export const newDeviceLogin = Template.bind({});
-newDeviceLogin.args = {
-  template: 'newDeviceLogin',
-  variables: {
-    ...commonArgs,
+const createStory = storyWithProps(
+  'newDeviceLogin',
+  'Sent to notify the account that a new device has signed in.',
+  {
     date: 'Thursday, Sep 2, 2021',
     device: 'Firefox on Mac OSX 10.11',
     ip: '10.246.67.38',
     location: 'Madrid, Spain (estimated)',
     time: '12:26:44 AM (CEST)',
-    action: 'Manage account',
     clientName: 'Firefox',
     passwordChangeLink: 'http://localhost:3030/settings/change_password',
-    subject: 'New sign-in to Firefox',
-  },
-};
-newDeviceLogin.storyName = 'default';
+    link: 'http://localhost:3030/settings',
+  }
+);
+
+export const NewDeviceLogin = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordReset/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordReset/index.stories.ts
@@ -3,19 +3,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { commonArgs, Template } from '../../storybook-email';
+import { storyWithProps } from '../../storybook-email';
 
 export default {
   title: 'Emails/passwordReset',
 } as Meta;
 
-export const passwordReset = Template.bind({});
-passwordReset.args = {
-  template: 'passwordReset',
-  variables: {
-    ...commonArgs,
+const createStory = storyWithProps(
+  'passwordReset',
+  'Sent when password has been reset.',
+  {
     resetLink: 'http://localhost:3030/settings/change_password',
-    subject: 'Password updated',
-  },
-};
-passwordReset.storyName = 'default';
+  }
+);
+
+export const PasswordReset = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.stories.ts
@@ -3,33 +3,19 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { Template, commonArgs } from '../../storybook-email';
+import { storyWithProps } from '../../storybook-email';
 
 export default {
   title: 'Emails/postRemoveSecondary',
 } as Meta;
 
-const defaultVariables = {
-  ...commonArgs,
-  action: 'Manage account',
-  link: 'http://localhost:3030/settings',
-  subject: 'Secondary email removed',
-  secondaryEmail: 'secondary@email',
-};
+const createStory = storyWithProps(
+  'postRemoveSecondary',
+  'Sent to primary email after secondary email is removed.',
+  {
+    link: 'http://localhost:3030/settings',
+    secondaryEmail: 'secondary@email.com',
+  }
+);
 
-const commonPropsWithOverrides = (
-  overrides: Partial<typeof defaultVariables> = {}
-) =>
-  Object.assign({
-    template: 'postRemoveSecondary',
-    layout: 'fxa',
-    doc: 'Post Remove Secondary email is sent when user removes the secondary-email associated with his account',
-    variables: {
-      ...defaultVariables,
-      ...overrides,
-    },
-  });
-
-export const PostRemoveSecondary = Template.bind({});
-PostRemoveSecondary.args = commonPropsWithOverrides();
-PostRemoveSecondary.storyName = 'default';
+export const PostRemoveSecondary = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.stories.ts
@@ -3,40 +3,32 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { Template, commonArgs } from '../../storybook-email';
+import { storyWithProps } from '../../storybook-email';
 
 export default {
   title: 'Emails/postVerify',
 } as Meta;
 
-const defaultVariables = {
-  ...commonArgs,
-  action: 'Set up next device',
-  desktopLink: 'https://firefox.com',
-  subject: 'Account verified. Next, sync another device to finish setup',
-  onDesktopOrTabletDevice: true,
-};
+const createStory = storyWithProps(
+  'postVerify',
+  'Sent after account is confirmed during Sync registration.',
+  {
+    link: 'http://localhost:3030/connect_another_device',
+    desktopLink: 'https://firefox.com',
+    onDesktopOrTabletDevice: true,
+  }
+);
 
-const commonPropsWithOverrides = (
-  overrides: Partial<typeof defaultVariables> = {}
-) =>
-  Object.assign({
-    template: 'postVerify',
-    doc: 'postVerify template',
-    variables: {
-      ...defaultVariables,
-      ...overrides,
-    },
-  });
+export const PostVerifyDesktopTablet = createStory(
+  {
+    onDesktopOrTabletDevice: true,
+  },
+  'User is on desktop or tablet device'
+);
 
-export const PostVerifyDesktopTablet = Template.bind({});
-PostVerifyDesktopTablet.args = commonPropsWithOverrides({
-  onDesktopOrTabletDevice: true,
-});
-PostVerifyDesktopTablet.storyName = 'User is on desktop or tablet device';
-
-export const PostVerifyMobile = Template.bind({});
-PostVerifyMobile.args = commonPropsWithOverrides({
-  onDesktopOrTabletDevice: false,
-});
-PostVerifyMobile.storyName = 'User is on mobile device';
+export const PostVerifyMobile = createStory(
+  {
+    onDesktopOrTabletDevice: false,
+  },
+  'User is on mobile device'
+);

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.mjml
@@ -2,8 +2,4 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<%- include('/partials/verificationReminder/index.mjml', {
-  title: 'Welcome to the Firefox family',
-  description: 'A few days ago you created a Firefox account, but never confirmed it.',
-  subDescription: 'Confirm now and get technology that fights for and protects your privacy, arms you with practical knowledge, and the respect you deserve.'
-}) %>
+<%- include('/partials/verificationReminder/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.stories.ts
@@ -3,35 +3,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { commonArgs, Template } from '../../storybook-email';
+import { storyWithProps } from '../../storybook-email';
 
 export default {
   title: 'Emails/verificationReminderFirst',
 } as Meta;
 
-const defaultVariables = {
-  ...commonArgs,
-  title: 'Welcome to the Firefox family',
-  description:
-    'A few days ago you created a Firefox account, but never confirmed it.',
-  subDescription:
-    'Confirm now and get technology that fights for and protects your privacy, arms you with practical knowledge, and the respect you deserve.',
-  action: 'Confirm email',
-  link: 'http://localhost:3030/verify_email',
-  subject: 'Reminder: Finish creating your account',
-};
+const createStory = storyWithProps(
+  'verificationReminderFirst',
+  'Reminder sent 1 day after an ignored verification.',
+  {
+    link: 'http://localhost:3030/verify_email',
+  }
+);
 
-const commonPropsWithOverrides = (
-  overrides: Partial<typeof defaultVariables> = {}
-) =>
-  Object.assign({
-    template: 'verificationReminderFirst',
-    variables: {
-      ...defaultVariables,
-      ...overrides,
-    },
-  });
-
-export const verificationReminderFirst = Template.bind({});
-verificationReminderFirst.args = commonPropsWithOverrides();
-verificationReminderFirst.storyName = 'default';
+export const VerificationReminderFirst = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.mjml
@@ -2,8 +2,4 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<%- include('/partials/verificationReminder/index.mjml', {
-  title: 'Still there?',
-  description: 'Almost a week ago you created a Firefox Account but never verified it. We’re worried about you.',
-  subDescription: "Confirm this email address to activate your account and let us know you're okay."
-}) %>
+<%- include('/partials/verificationReminder/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.stories.ts
@@ -3,35 +3,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { commonArgs, Template } from '../../storybook-email';
+import { storyWithProps } from '../../storybook-email';
 
 export default {
   title: 'Emails/verificationReminderSecond',
 } as Meta;
 
-const defaultVariables = {
-  ...commonArgs,
-  title: 'Still there?',
-  description:
-    'Almost a week ago you created a Firefox Account but never verified it. We’re worried about you.',
-  subDescription:
-    "Confirm this email address to activate your account and let us know you're okay.",
-  action: 'Confirm email',
-  link: 'http://localhost:3030/verify_email',
-  subject: 'Final reminder: Activate your account',
-};
+const createStory = storyWithProps(
+  'verificationReminderSecond',
+  'Reminder sent 5 days after an ignored verification.',
+  {
+    link: 'http://localhost:3030/verify_email',
+  }
+);
 
-const commonPropsWithOverrides = (
-  overrides: Partial<typeof defaultVariables> = {}
-) =>
-  Object.assign({
-    template: 'verificationReminderSecond',
-    variables: {
-      ...defaultVariables,
-      ...overrides,
-    },
-  });
-
-export const verificationReminderSecond = Template.bind({});
-verificationReminderSecond.args = commonPropsWithOverrides();
-verificationReminderSecond.storyName = 'default';
+export const verificationReminderSecond = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.stories.ts
@@ -3,29 +3,22 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { commonArgs, Template } from '../../storybook-email';
+import { storyWithProps } from '../../storybook-email';
 
 export default {
   title: 'Emails/verify',
 } as Meta;
 
-const defaultVariables = {
-  ...commonArgs,
-  location: 'Madrid, Spain (estimated)',
-  device: 'Firefox on Mac OSX 10.11',
-  ip: '10.246.67.38',
-  link: 'http://localhost:3030/verify_email',
-  action: 'Confirm email',
-  subject: 'Finish creating your account',
-  sync: true,
-};
+const createStory = storyWithProps(
+  'verify',
+  'Received by all who complete FxA registration form.',
+  {
+    location: 'Madrid, Spain (estimated)',
+    device: 'Firefox on Mac OSX 10.11',
+    ip: '10.246.67.38',
+    link: 'http://localhost:3030/verify_email',
+    sync: true,
+  }
+);
 
-export const verifyEmail = Template.bind({});
-verifyEmail.args = {
-  template: 'verify',
-  doc: 'Low Recovery Code emails are sent when a user has 2 or less recovery codes remaining',
-  variables: {
-    ...defaultVariables,
-  },
-};
-verifyEmail.storyName = 'default';
+export const VerifyEmail = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.stories.ts
@@ -3,23 +3,22 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { commonArgs, Template } from '../../storybook-email';
+import { storyWithProps, commonArgs, Template } from '../../storybook-email';
 
 export default {
   title: 'Emails/verifySecondaryCode',
 } as Meta;
 
-export const verifySecondaryCode = Template.bind({});
-verifySecondaryCode.args = {
-  template: 'verifySecondaryCode',
-  variables: {
-    ...commonArgs,
+const createStory = storyWithProps(
+  'verifySecondaryCode',
+  'Sent to verify the addition of a secondary email via code.',
+  {
     location: 'Madrid, Spain (estimated)',
     device: 'Firefox on Mac OSX 10.11',
     ip: '10.246.67.38',
     email: 'foo@bar.com',
     code: '918398',
-    subject: 'Confirm secondary email',
-  },
-};
-verifySecondaryCode.storyName = 'default';
+  }
+);
+
+export const VerifySecondaryCode = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.stories.ts
@@ -3,22 +3,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { commonArgs, Template } from '../../storybook-email';
+import { storyWithProps, commonArgs, Template } from '../../storybook-email';
 
 export default {
   title: 'Emails/verifyShortCode',
 } as Meta;
 
-export const verifyShortCode = Template.bind({});
-verifyShortCode.args = {
-  template: 'verifyShortCode',
-  variables: {
-    ...commonArgs,
+const createStory = storyWithProps(
+  'verifyShortCode',
+  'Sent to verify an account via code.',
+  {
     location: 'Madrid, Spain (estimated)',
     device: 'Firefox on Mac OSX 10.11',
     ip: '10.246.67.38',
     code: '918398',
-    subject: 'Verification code: 918398',
-  },
-};
-verifyShortCode.storyName = 'default';
+  }
+);
+
+export const VerifyShortCode = createStory();


### PR DESCRIPTION
## Because

- There were a few areas where we were passing strings to the template for rendering, when they weren't necessary (most can be derived from Fluent now)
- I noticed a few other spots where we could tighten up some of the code

## This pull request

- The big one is reducing the need to define template-level strings anywhere but the Fluent file (and in the templates themselves as fallbacks). This includes:
  - No longer needing to define a `subject` in any Storybook story, this is now automatically passed down in the localizer
  - No longer needing to define `headerText` or `bodyText` in CAD Storybook stories or pass them down as variables in the mailer, these are now automatically passed down in the localizer
  - No longer needing to pass down `title`, `description`, and `subDescription` in the Verification Reminder templates
- Updates some of the default common arguments
- Updated all Storybook stories to use a new `buildStory` function, which takes a template name, description, and default arguments, and then returns a function to create and return a story with optional overrides. This makes stories much more DRY.
- Some minor whitespace removal, consolidation of object destructuring, and flipping things around

## Issue that this pull request solves

(As much as I could)

Closes: #10219

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This PR hopes to establish that **all** template-level strings should now be defined in the en-US FTL file for the US English translation, and in the MJML and TXT files as fallbacks. They should not need to be defined in Storybook, in the mailer on delivery, as variables in the EJS `include` function, or anywhere else.

Also, pretty much all Storybook work is done under the hood now, so creating an email template story looks something like this:

```js
import { buildStory } from '../../storybook-email';

const createStory = buildStory(
  'myFancyTemplate',
  'This is where we put the description of the template',
  {
    someArgument: true
  }
);

export const FancyTemplateDefault = createStory();

export const FancyTemplateAlt = createStory(
  {
    someArgument: false
  },
  'With Some Argument set to False'
);
```