### PR TITLE
feat(auth-server): convert verifySecondary, passwordChanged, and unblockCode templates to new mjml stack

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -442,7 +442,8 @@
       "passwordReset",
       "newDeviceLogin",
       "verifySecondary",
-      "passwordChanged"
+      "passwordChanged",
+      "unblockCode"
     ]
   }
 }

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -441,7 +441,8 @@
       "verifySecondaryCode",
       "passwordReset",
       "newDeviceLogin",
-      "verifySecondary"
+      "verifySecondary",
+      "passwordChanged"
     ]
   }
 }

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -440,7 +440,8 @@
       "verifyShortCode",
       "verifySecondaryCode",
       "passwordReset",
-      "newDeviceLogin"
+      "newDeviceLogin",
+      "verifySecondary"
     ]
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -18,6 +18,7 @@ $s-3: 12px;
 $s-4: 16px;
 $s-5: 20px;
 $s-6: 24px;
+$s-8: 32px;
 $s-10: 40px;
 
 // Font-size and line-height
@@ -62,6 +63,9 @@ $s-10: 40px;
   }
   &-6 {
     margin-top: $s-6 !important;
+  }
+  &-8 {
+    margin-top: $s-8 !important;
   }
 }
 
@@ -112,10 +116,13 @@ tr > td:first-child {
   @extend .mb-5;
 }
 
-.text-body-top-padded div {
+.text-body-no-margin div {
+  @extend %text-body-common;
+}
+
+.text-body-top-margin div {
   @extend %text-body-common;
   @extend .mt-5;
-  @extend .mb-5;
 }
 
 .text-sub-body div {
@@ -134,7 +141,7 @@ tr > td:first-child {
   @extend .text-footer;
   div {
     @extend .mb-3;
-    @extend .mt-6;
+    @extend .mt-8;
   }
 }
 

--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -152,9 +152,20 @@ tr > td:first-child {
   @extend .mt-2;
 }
 
-.large-code div {
+%code-common {
   text-align: center !important;
   font-family: monospace;
-  @extend .text-3xl;
   @extend .mb-6;
+}
+
+.code {
+  &-medium div {
+    @extend %code-common;
+    @extend .text-lg;
+  }
+
+  &-large div {
+    @extend %code-common;
+    @extend .text-3xl;
+  }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -57,6 +57,9 @@ $s-10: 40px;
   &-2 {
     margin-top: $s-2 !important;
   }
+  &-5 {
+    margin-top: $s-5 !important;
+  }
   &-6 {
     margin-top: $s-6 !important;
   }
@@ -106,6 +109,12 @@ tr > td:first-child {
 
 .text-body div {
   @extend %text-body-common;
+  @extend .mb-5;
+}
+
+.text-body-top-padded div {
+  @extend %text-body-common;
+  @extend .mt-5;
   @extend .mb-5;
 }
 

--- a/packages/fxa-auth-server/lib/senders/emails/partials/appBadges/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/appBadges/index.scss
@@ -15,7 +15,4 @@
 
 .text-footer-appBadges {
   @extend .text-footer;
-  div {
-    @extend .mb-5;
-  }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/en-US.ftl
@@ -1,0 +1,3 @@
+passwordChanged-subject = Password updated
+passwordChanged-title = Password changed successfully
+passwordChanged-description = Your Firefox Account password was successfully changed from the following device:

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/index.mjml
@@ -1,0 +1,20 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-include path="./css/global.css" type="css" css-inline="inline" />
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="passwordChanged-title">Password changed successfully/span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="passwordChanged-description">Your Firefox Account password was successfully changed from the following device:</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/location/index.mjml') %>
+<%- include('/partials/automatedEmailResetPassword/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/index.stories.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { buildStory } from '../../storybook-email';
+
+export default {
+  title: 'Emails/passwordChanged',
+} as Meta;
+
+const createStory = buildStory(
+  'passwordChanged',
+  'Sent when password has been changed.',
+  {
+    location: 'Madrid, Spain (estimated)',
+    device: 'Firefox on Mac OSX 10.11',
+    ip: '10.246.67.38',
+    resetLink: 'http://localhost:3030/settings/change_password',
+  }
+);
+
+export const PasswordChanged = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/index.txt
@@ -1,0 +1,8 @@
+passwordChanged-title = "Password changed successfully"
+
+passwordChanged-description = "Your Firefox Account password was successfully changed from the following device:"
+
+<%- include('/partials/location/index.txt') %>
+
+<%- include('/partials/automatedEmailResetPassword/index.txt') %>
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordReset/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordReset/index.mjml
@@ -14,7 +14,7 @@
 
 <mj-section>
   <mj-column>
-    <mj-text css-class="text-body">
+    <mj-text css-class="text-body-no-margin">
       <span data-l10n-id="passwordReset-description">You will need to enter your new password on other devices to resume syncing.</span>
     </mj-text>
   </mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/en-US.ftl
@@ -1,0 +1,6 @@
+unblockCode-subject = Account authorization code
+unblockCode-title = Is this you signing in?
+unblockCode-prompt = If yes, here is the authorization code you need:
+unblockCode-prompt-plaintext = If yes, here is the authorization code you need: { $unblockCode }
+unblockCode-report = If no, help us fend off intruders and <a data-l10n-name="reportSignInLink">report it to us</a>.
+unblockCode-report-plaintext = If no, help us fend off intruders and report it to us.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/index.mjml
@@ -7,7 +7,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="verifyShortCode-title">Is this you signing up?</span>
+      <span data-l10n-id="verifyShortCode-title">Is this you signing in?</span>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -17,15 +17,18 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-body">
-      <span data-l10n-id="verifyShortCode-prompt">If yes, use this verification code in your registration form:</span>
+      <span data-l10n-id="unblockCode-prompt">If yes, here is the authorization code you need:</span>
     </mj-text>
 
-    <mj-text css-class="code-large"><%- code %></mj-text>
+    <mj-text css-class="code-medium">
+      <code><%- unblockCode %></code>
+    </mj-text>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="verifyShortCode-expiry-notice">It expires in 5 minutes.</span>
+      <span data-l10n-id="unblockCode-report">
+        If no, help us fend off intruders and
+        <a class="link-blue" href="<%- reportSignInLink %>" data-l10n-name="reportSignInLink">report it to us</a>.
+      </span>
     </mj-text>
   </mj-column>
 </mj-section>
-
-<%- include('/partials/automatedEmailNoAction/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/index.stories.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { buildStory } from '../../storybook-email';
+
+export default {
+  title: 'Emails/unblockCode',
+} as Meta;
+
+const createStory = buildStory(
+  'unblockCode',
+  'Sent to verify an account sign-in via code.',
+  {
+    location: 'Madrid, Spain (estimated)',
+    device: 'Firefox on Mac OSX 10.11',
+    ip: '10.246.67.38',
+    unblockCode: '1ILO0Z5P',
+    reportSignInLink: 'http://localhost:3030/report_signin',
+  }
+);
+
+export const UnblockCode = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/index.txt
@@ -1,0 +1,8 @@
+unblockCode-title = "Is this you signing in?"
+
+<%- include('/partials/location/index.txt') %>
+
+unblockCode-prompt-plaintext = "If yes, here is the authorization code you need: <%- unblockCode %>"
+
+unblockCode-report-plaintext = "If no, help us fend off intruders and report it to us."
+<%- reportSignInLink %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/en-US.ftl
@@ -1,0 +1,6 @@
+verifySecondary-subject = Confirm secondary email
+verifySecondary-title = Verify secondary email
+verifySecondary-explainer = A request to use { $email } as a secondary email address has been made from the following Firefox Account:
+verifySecondary-action = Verify email
+verifySecondary-prompt = { verifySecondary-action }:
+verifySecondary-post-verification = Once verified, this address will begin receiving security notifications and confirmations.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/index.mjml
@@ -1,0 +1,30 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-include path="./css/global.css" type="css" css-inline="inline" />
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="verifySecondary-title">Verify secondary email</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="verifySecondary-explainer" data-l10n-args='<%= JSON.stringify({email}) %>'>A request to use <%= email %> as a secondary email address has been made from the following Firefox Account:</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/location/index.mjml') %>
+<%- include('/partials/button/index.mjml') %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body-top-padded">
+      <span data-l10n-id="verifySecondary-post-verification">Once verified, this address will begin receiving security notifications and confirmations.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/automatedEmailNoAction/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/index.mjml
@@ -21,7 +21,7 @@
 
 <mj-section>
   <mj-column>
-    <mj-text css-class="text-body-top-padded">
+    <mj-text css-class="text-body-top-margin">
       <span data-l10n-id="verifySecondary-post-verification">Once verified, this address will begin receiving security notifications and confirmations.</span>
     </mj-text>
   </mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/index.stories.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { buildStory } from '../../storybook-email';
+
+export default {
+  title: 'Emails/verifySecondary',
+} as Meta;
+
+const createStory = buildStory(
+  'verifySecondary',
+  'Sent to verify the addition of a secondary email via link.',
+  {
+    location: 'Madrid, Spain (estimated)',
+    device: 'Firefox on Mac OSX 10.11',
+    ip: '10.246.67.38',
+    email: 'foo@bar.com',
+    link: 'http://localhost:3030/verify_email',
+  }
+);
+
+export const VerifySecondary = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/index.txt
@@ -1,0 +1,11 @@
+verifySecondary-title = "Verify secondary email"
+
+verifySecondary-explainer = "A request to use { $email } as a secondary email address has been made from the following Firefox Account:"
+
+<%- include('/partials/location/index.txt') %>
+
+verifySecondary-prompt = "Verify email:"
+<%- link %>
+
+<%- include('/partials/automatedEmailNoAction/index.txt') %>
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.mjml
@@ -24,7 +24,7 @@
       <span data-l10n-id="verifySecondaryCode-prompt">Use this verification code:</span>
     </mj-text>
 
-    <mj-text css-class="large-code"><%- code %></mj-text>
+    <mj-text css-class="code-large"><%- code %></mj-text>
 
     <mj-text css-class="text-body">
       <span data-l10n-id="verifySecondaryCode-expiry-notice">It expires in 5 minutes. Once verified, this address will begin receiving security notifications and confirmations.</span>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.mjml
@@ -26,7 +26,7 @@
 
     <mj-text css-class="code-large"><%- code %></mj-text>
 
-    <mj-text css-class="text-body">
+    <mj-text css-class="text-body-no-margin">
       <span data-l10n-id="verifySecondaryCode-expiry-notice">It expires in 5 minutes. Once verified, this address will begin receiving security notifications and confirmations.</span>
     </mj-text>
   </mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.mjml
@@ -22,7 +22,7 @@
 
     <mj-text css-class="code-large"><%- code %></mj-text>
 
-    <mj-text css-class="text-body">
+    <mj-text css-class="text-body-no-margin">
       <span data-l10n-id="verifyShortCode-expiry-notice">It expires in 5 minutes.</span>
     </mj-text>
   </mj-column>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -508,6 +508,39 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['unblockCodeEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Account authorization code' }],
+    ['headers', new Map([
+      ['X-Report-SignIn-Link', { test: 'equal', expected: configUrl('reportSignInUrl', 'new-unblock', 'report', 'uid', 'unblockCode') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('unblockCode') }],
+      ['X-Template-Name', { test: 'equal', expected: 'unblockCode' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.unblockCode }],
+      ['X-Unblock-Code', { test: 'equal', expected: MESSAGE.unblockCode }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'new-unblock', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('reportSignInUrl', 'new-unblock', 'report', 'uid', 'unblockCode')) },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: MESSAGE.unblockCode },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'new-unblock', 'privacy')}` },
+      { test: 'include', expected: configUrl('reportSignInUrl', 'new-unblock', 'report', 'uid', 'unblockCode') },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `If yes, here is the authorization code you need: ${MESSAGE.unblockCode}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -440,6 +440,43 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['verifySecondaryEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Confirm secondary email' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('verifySecondaryEmailUrl', 'welcome-secondary', 'activate', 'code', 'uid', 'type=secondary', 'secondary_email_verified', 'service') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('verifySecondary') }],
+      ['X-Template-Name', { test: 'equal', expected: 'verifySecondary' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.verifySecondary }],
+      ['X-Verify-Code', { test: 'equal', expected: MESSAGE.code }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'welcome-secondary', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'welcome-secondary', 'support')) },
+      { test: 'include', expected: decodeUrl(configHref('verifySecondaryEmailUrl', 'welcome-secondary', 'activate', 'code', 'uid', 'type=secondary', 'secondary_email_verified', 'service')) },
+      { test: 'include', expected: `A request to use ${MESSAGE.email} as a secondary email address has been made from the following Firefox Account` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: MESSAGE.primaryEmail },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'welcome-secondary', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'welcome-secondary', 'support')}` },
+      { test: 'include', expected: `Verify email:\n${configUrl('verifySecondaryEmailUrl', 'welcome-secondary', 'activate', 'code', 'uid', 'type=secondary', 'secondary_email_verified', 'service')}` },
+      { test: 'include', expected: `A request to use ${MESSAGE.email} as a secondary email address has been made from the following Firefox Account` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: MESSAGE.primaryEmail },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -477,6 +477,37 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['passwordChangedEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Password updated' }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('passwordChanged') }],
+      ['X-Template-Name', { test: 'equal', expected: 'passwordChanged' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.passwordChanged }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('initiatePasswordResetUrl', 'password-changed-success', 'reset-password', 'email', 'reset_password_confirm=false', 'email_to_hash_with=')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'password-changed-success', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'password-changed-success', 'support')) },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: configUrl('initiatePasswordResetUrl', 'password-changed-success', 'reset-password', 'email', 'reset_password_confirm=false', 'email_to_hash_with=') },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'password-changed-success', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'password-changed-success', 'support')}` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {


### PR DESCRIPTION
## Because

- We need to convert email templates to the new MJML stack

## This pull request

- Converts the `verifySecondary`, `passwordChanged`, and `unblockCode` templates to our new MJML stack

## Issue that this pull request solves

Closes: #9294
Closes: #9308
Closes: #9262

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).