### PR TITLE
fix(subscriptions): capitalize "required" on checkout page

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -360,6 +360,10 @@ payment-confirmation-cc-card-ending-in = Card ending in { $last4 }
 new-user-sign-in-link = Already have a { -brand-name-firefox } account? <a>Sign in</a>
 new-user-step-1 = 1. Create a { -brand-name-firefox } account
 new-user-step-2 = 2. Choose your payment method
+# "Required" to indicate that the user must use the checkbox below this text to
+# agree to a payment method's terms of service and privacy notice in order to
+# continue.
+new-user-required-payment-consent = Required
 new-user-email =
   .placeholder = foxy@mozilla.com
   .label = Enter your email

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -325,7 +325,9 @@ export const Checkout = ({
           <Localized id="new-user-step-2">
             <h2 className="step-header">2. Choose your payment method</h2>
           </Localized>
-          <strong>required</strong>
+          <Localized id="new-user-required-payment-consent">
+            <strong>Required</strong>
+          </Localized>
           <Form validator={checkboxValidator}>
             <PaymentConsentCheckbox
               plan={selectedPlan}


### PR DESCRIPTION
Because:
 - capitalization of "require" was not matching Figma

This commit:
 - capitalize "require"
 - add L10n for "Required"


## Issue that this pull request solves

Closes: #10241
