### PR TITLE
fix(metrics): Update new payment flow metrics to support utm and append uid

### DIFF
--- a/packages/123done/static/js/123done.js
+++ b/packages/123done/static/js/123done.js
@@ -86,13 +86,13 @@ $(document).ready(function () {
 
   let flowData;
   $.getJSON(
-    `${paymentConfig.contentEnv}metrics-flow?form_type=subscribe&utm_campaign=123done`
+    `${paymentConfig.contentEnv}metrics-flow?form_type=button&utm_campaign=123done`
   ).done(function (data) {
     $('.btn-subscribe-pwdless').each(function (index) {
       let currencyMappedURL = $(this).attr('href');
 
       if (data) {
-        currencyMappedURL = `${currencyMappedURL}&flow_id=${data.flowId}&flow_begin_time=${data.flowBeginTime}&device_id=${data.deviceId}`;
+        currencyMappedURL = `${currencyMappedURL}&utm_campaign=123done&flow_id=${data.flowId}&flow_begin_time=${data.flowBeginTime}&device_id=${data.deviceId}`;
       }
 
       $(this).attr('href', currencyMappedURL);

--- a/packages/fxa-payments-server/server/lib/routes/post-metrics.js
+++ b/packages/fxa-payments-server/server/lib/routes/post-metrics.js
@@ -14,12 +14,23 @@ const MAX_EVENT_OFFSET = clientMetricsConfig.maxEventOffset;
 const EVENT_TYPE_PATTERN = /^[\w\s.:-]+$/; // the space is to allow for error contexts that contain spaces, e.g., `error.unknown context.auth.108`
 const OFFSET_TYPE = joi.number().integer().min(0);
 const STRING_TYPE = joi.string().max(1024);
+const UTM = joi
+  .string()
+  .max(128)
+  // eslint-disable-next-line no-useless-escape
+  .regex(/^[\w\/.%-]+$/); // values here can be 'firefox/sync'
+const UTM_CAMPAIGN = UTM.allow('page+referral+-+not+part+of+a+campaign');
 const BODY_SCHEMA = {
   data: joi
     .object()
     .keys({
       flowBeginTime: OFFSET_TYPE.optional(),
       flowId: STRING_TYPE.hex().length(64).optional(),
+      utm_campaign: UTM_CAMPAIGN.optional(),
+      utm_content: UTM.optional(),
+      utm_medium: UTM.optional(),
+      utm_source: UTM.optional(),
+      utm_term: UTM.optional(),
     })
     .unknown(true)
     .required(),

--- a/packages/fxa-payments-server/src/index.tsx
+++ b/packages/fxa-payments-server/src/index.tsx
@@ -23,6 +23,7 @@ async function init() {
   const queryParams = parseParams(window.location.search);
   const hashParams = await getHashParams();
   const accessToken = await getVerifiedAccessToken(hashParams);
+  Amplitude.addGlobalEventProperties({ ...queryParams });
   Amplitude.subscribeToReduxStore(store);
   updateAPIClientConfig(config);
 

--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -41,6 +41,11 @@ export type EventProperties = GlobalEventProperties & {
   paymentProvider?: PaymentProvider;
   error?: Error;
   checkoutType?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_medium?: string;
+  utm_source?: string;
+  utm_term?: string;
 };
 
 type SuccessfulSubscriptionEventProperties = EventProperties & {
@@ -52,7 +57,7 @@ type Error = { message?: string } | null;
 // These can still be overwritten in the event logging function.
 let globalEventProperties = {};
 
-function addGlobalEventProperties(props: GlobalEventProperties) {
+export function addGlobalEventProperties(props: GlobalEventProperties) {
   globalEventProperties = { ...globalEventProperties, ...props };
 }
 
@@ -97,6 +102,11 @@ const normalizeEventProperties = (eventProperties: EventProperties) => {
     productId = undefined,
     product_id = undefined,
     paymentProvider = undefined,
+    utm_campaign = undefined,
+    utm_content = undefined,
+    utm_medium = undefined,
+    utm_source = undefined,
+    utm_term = undefined,
     ...otherEventProperties
   } = eventProperties;
 
@@ -105,6 +115,11 @@ const normalizeEventProperties = (eventProperties: EventProperties) => {
     productId: productId || product_id,
     paymentProvider,
     reason: error && error.message ? error.message : undefined,
+    utm_campaign,
+    utm_content,
+    utm_medium,
+    utm_source,
+    utm_term,
     ...otherEventProperties,
   };
 };

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -246,6 +246,9 @@ export const Checkout = ({
       ]);
       setProfile(profile);
       setCustomer(customer);
+      // Our stub accounts have a uid, append it to all future metric
+      // events
+      Amplitude.addGlobalEventProperties({ uid: profile.uid });
     } catch (e) {
       sentry.captureException(e);
       setSubscriptionError({ code: 'fxa_fetch_profile_customer_error' });


### PR DESCRIPTION
## Because

- FxA might not log utm params properly
- FxA should log the uid in metrics when the stub user account is created

## This pull request

- Fixes those issues

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/10375

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Logs

With utms params passed through all flows and the `user_id` set on the success and complete events

```
31|payments  | 2021-09-07T14:21:22: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_account_setup - view","time":1631038882350,"device_id":"6a77ed01d32b4a6b9ac088bdae51cd45","session_id":1631038827645,"app_version":"214.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","checkout_type":"without-account"},"user_properties":{"flow_id":"c46d9c61217878c6b67a297e0260304a0564cba0f08638e033a7ac97af923aef","ua_browser":"Firefox","ua_version":"88.0","utm_campaign":"123done"}}
31|payments  | 2021-09-07T14:21:22: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_setup - view","time":1631038882353,"device_id":"6a77ed01d32b4a6b9ac088bdae51cd45","session_id":1631038827645,"app_version":"214.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","checkout_type":"without-account"},"user_properties":{"flow_id":"c46d9c61217878c6b67a297e0260304a0564cba0f08638e033a7ac97af923aef","ua_browser":"Firefox","ua_version":"88.0","utm_campaign":"123done"}}
31|payments  | 2021-09-07T14:21:30: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_account_setup - engage","time":1631038890537,"device_id":"6a77ed01d32b4a6b9ac088bdae51cd45","session_id":1631038827645,"app_version":"214.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","checkout_type":"without-account"},"user_properties":{"flow_id":"c46d9c61217878c6b67a297e0260304a0564cba0f08638e033a7ac97af923aef","ua_browser":"Firefox","ua_version":"88.0","utm_campaign":"123done"}}
31|payments  | 2021-09-07T14:21:38: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_setup - engage","time":1631038898675,"device_id":"6a77ed01d32b4a6b9ac088bdae51cd45","session_id":1631038827645,"app_version":"214.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","checkout_type":"without-account"},"user_properties":{"flow_id":"c46d9c61217878c6b67a297e0260304a0564cba0f08638e033a7ac97af923aef","ua_browser":"Firefox","ua_version":"88.0","utm_campaign":"123done"}}
31|payments  | 2021-09-07T14:21:44: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_setup - submit","time":1631038904791,"device_id":"6a77ed01d32b4a6b9ac088bdae51cd45","session_id":1631038827645,"app_version":"214.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","payment_provider":"stripe"},"user_properties":{"flow_id":"c46d9c61217878c6b67a297e0260304a0564cba0f08638e033a7ac97af923aef","ua_browser":"Firefox","ua_version":"88.0","utm_campaign":"123done"}}
31|payments  | 2021-09-07T14:21:50: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_setup - 3ds_success","time":1631038910252,"device_id":"6a77ed01d32b4a6b9ac088bdae51cd45","session_id":1631038827645,"app_version":"214.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","payment_provider":"stripe","source_country":"US"},"user_properties":{"flow_id":"c46d9c61217878c6b67a297e0260304a0564cba0f08638e033a7ac97af923aef","ua_browser":"Firefox","ua_version":"88.0","utm_campaign":"123done"}}
31|payments  | 2021-09-07T14:21:50: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_setup - 3ds_complete","time":1631038910253,"device_id":"6a77ed01d32b4a6b9ac088bdae51cd45","session_id":1631038827645,"app_version":"214.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","payment_provider":"stripe","source_country":"US"},"user_properties":{"flow_id":"c46d9c61217878c6b67a297e0260304a0564cba0f08638e033a7ac97af923aef","ua_browser":"Firefox","ua_version":"88.0","utm_campaign":"123done"}}
31|payments  | 2021-09-07T14:21:50: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_setup - 3ds_success","time":1631038910857,"user_id":"b434849a7ab649e3847ff5bd3ef65039","device_id":"6a77ed01d32b4a6b9ac088bdae51cd45","session_id":1631038827645,"app_version":"214.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","checkout_type":"without-account"},"user_properties":{"flow_id":"c46d9c61217878c6b67a297e0260304a0564cba0f08638e033a7ac97af923aef","ua_browser":"Firefox","ua_version":"88.0","utm_campaign":"123done"}}
31|payments  | 2021-09-07T14:21:50: INFO fxa-payments-server.amplitudeEvent: {"op":"amplitudeEvent","event_type":"fxa_pay_setup - 3ds_complete","time":1631038910858,"user_id":"b434849a7ab649e3847ff5bd3ef65039","device_id":"6a77ed01d32b4a6b9ac088bdae51cd45","session_id":1631038827645,"app_version":"214.0","os_name":"Mac OS X","os_version":"10.15","event_properties":{"plan_id":"plan_GqM9N6qyhvxaVk","product_id":"prod_GqM9ToKK62qjkK","checkout_type":"without-account"},"user_properties":{"flow_id":"c46d9c61217878c6b67a297e0260304a0564cba0f08638e033a7ac97af923aef","ua_browser":"Firefox","ua_version":"88.0","utm_campaign":"123done"}}
```