### PR TITLE
feat(subscriptions): accept Guardian submitted support tickets

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1923,6 +1923,14 @@ const conf = convict({
     env: 'SYNC_TOKENSERVER_URL',
     format: 'url',
   },
+  support: {
+    secretBearerToken: {
+      default: 'YOU MUST CHANGE ME',
+      doc: 'Shared secret to access the support endpoint.',
+      env: 'SUPPORT_AUTH_SECRET_BEARER_TOKEN',
+      format: 'String',
+    },
+  },
 });
 
 // handle configuration files.  you can specify a CSV list of configuration

--- a/packages/fxa-auth-server/lib/server.js
+++ b/packages/fxa-auth-server/lib/server.js
@@ -365,6 +365,14 @@ async function create(log, error, config, routes, db, translator, statsd) {
   );
   server.auth.strategy('supportPanelSecret', 'supportPanelSecret');
 
+  server.auth.scheme(
+    'supportSecret',
+    sharedSecretAuth.strategy(`Bearer ${config.support.secretBearerToken}`, {
+      throwOnFailure: false,
+    })
+  );
+  server.auth.strategy('supportSecret', 'supportSecret');
+
   server.auth.strategy('pubsub', 'jwt', pubsubAuth.strategy(config));
 
   // routes should be registered after all auth strategies have initialized:

--- a/packages/fxa-auth-server/test/local/routes/auth-schemes/shared-secret.js
+++ b/packages/fxa-auth-server/test/local/routes/auth-schemes/shared-secret.js
@@ -6,9 +6,12 @@ const { assert } = require('chai');
 const AppError = require('../../../../lib/error');
 const SharedSecretScheme = require('../../../../lib/routes/auth-schemes/shared-secret');
 const authStrategy = SharedSecretScheme.strategy('goodsecret')();
+const noThrowStrategy = SharedSecretScheme.strategy('goodsecret', {
+  throwOnFailure: false,
+})();
 const sinon = require('sinon');
 
-describe('lib/routes/auth-schemes/auth-oauth', () => {
+describe('lib/routes/auth-schemes/shared-secret', () => {
   it('should throws an invalid token error if the secrets do not match', () => {
     const request = { headers: { authorization: 'badsecret' } };
 
@@ -25,5 +28,17 @@ describe('lib/routes/auth-schemes/auth-oauth', () => {
     const request = { headers: { authorization: 'goodsecret' } };
     authStrategy.authenticate(request, { authenticated: faker });
     assert.isTrue(faker.calledOnceWith({ credentials: {} }));
+  });
+
+  it('should not throw if the secrets do not match', () => {
+    const request = { headers: { authorization: 'badsecret' } };
+
+    try {
+      const error = noThrowStrategy.authenticate(request, {});
+      assert.isTrue(error.isBoom);
+      assert.isTrue(error.isMissing);
+    } catch (err) {
+      assert.fail('No error should have been thrown');
+    }
   });
 });

--- a/packages/fxa-auth-server/test/local/server.js
+++ b/packages/fxa-auth-server/test/local/server.js
@@ -673,5 +673,8 @@ function getConfig() {
       verificationToken: '',
     },
     verificationReminders: {},
+    support: {
+      secretBearerToken: 'topsecrets',
+    },
   };
 }


### PR DESCRIPTION
Because:
 - Guardian wants to submit support tickets on the behalf of users

This commit:
 - update the support ticket endpoint to
   - allow authn through a shared secret
   - look up a user by email from the payload

## Issue that this pull request solves

Closes: #10177
