### PR TITLE
feat(auth): convert passwordResetAccountRecovery and postAddAccountRecovery emails to new mjml stack

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -447,7 +447,8 @@
       "verifyLogin",
       "verifyLoginCode",
       "verifyPrimary",
-      "passwordResetAccountRecovery"
+      "passwordResetAccountRecovery",
+      "postAddAccountRecovery"
     ]
   }
 }

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -446,7 +446,8 @@
       "unblockCode",
       "verifyLogin",
       "verifyLoginCode",
-      "verifyPrimary"
+      "verifyPrimary",
+      "passwordResetAccountRecovery"
     ]
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/en-US.ftl
@@ -1,0 +1,8 @@
+passwordResetAccountRecovery-subject = Password updated using recovery key
+passwordResetAccountRecovery-title = Your account password was reset with a recovery key
+passwordResetAccountRecovery-description = You have successfully reset your password using a recovery key from the following device:
+passwordResetAccountRecovery-action = Create new recovery key
+passwordResetAccountRecovery-regen-required = You will need to generate a new recovery key.
+passwordResetAccountRecovery-create-key = Create new recovery key:
+passwordResetAccountRecovery-email-change = This is an automated email; if you did not authorize this action, then <a data-l10n-name="passwordChangeLink">please change your password</a>.
+  For more information, please visit <a data-l10n-name="supportLink">Mozilla Support</a>.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/index.mjml
@@ -1,0 +1,31 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-include path="./css/global.css" type="css" css-inline="inline" />
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="passwordResetAccountRecovery-title">Your account password was reset with a recovery key</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="passwordResetAccountRecovery-description">You have successfully reset your password using a recovery key from the following device:</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/location/index.mjml') %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="passwordResetAccountRecovery-regen-required">You will need to generate a new recovery key.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/button/index.mjml') %>
+
+<%- include('/partials/automatedEmailChangePassword/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/index.stories.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { MOCK_LOCATION } from '../../partials/location/mocks';
+import { storyWithProps } from '../../storybook-email';
+
+export default {
+  title: 'Emails/passwordResetAccountRecovery',
+} as Meta;
+
+const createStory = storyWithProps(
+  'passwordResetAccountRecovery',
+  'Sent when recovery key is used',
+  {
+    ...MOCK_LOCATION,
+    link: 'http://localhost:3030/settings/account_recovery',
+    passwordChangeLink: 'http://localhost:3030/settings/change_password',
+  }
+);
+
+export const PasswordResetAccountRecovery = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/index.txt
@@ -1,0 +1,14 @@
+passwordResetAccountRecovery-title = "Your account password was reset with a recovery key"
+
+passwordResetAccountRecovery-description = "You have successfully reset your password using a recovery key from the following device:"
+
+<%- include('/partials/location/index.txt') %>
+
+passwordResetAccountRecovery-regen-required = "You will need to generate a new recovery key."
+
+passwordResetAccountRecovery-create-key = "Create new recovery key:"
+<%- link %>
+
+<%- include('/partials/changePassword/index.txt') %>
+
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/en-US.ftl
@@ -1,0 +1,8 @@
+postAddAccountRecovery-subject = Account recovery key generated
+postAddAccountRecovery-title = { postAddAccountRecovery-subject }
+postAddAccountRecovery-description = You have successfully generated an account recovery key for your Firefox Account using the following device:
+postAddAccountRecovery-action = Manage account
+postAddAccountRecovery-recovery = If this was not you, <a data-l10n-name="revokeAccountRecoveryLink">click here</a>.
+postAddAccountRecovery-revoke = If this was not you, revoke key.
+postAddAccountRecovery-email-change = This is an automated email; if you did not authorize this action, then <a data-l10n-name="passwordChangeLink">please change your password</a>.
+  For more information, please visit <a data-l10n-name="supportLink">Mozilla Support</a>.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.mjml
@@ -1,0 +1,34 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-include path="./css/global.css" type="css" css-inline="inline" />
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="postAddAccountRecovery-title">Account recovery key generated</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postAddAccountRecovery-description">You have successfully generated an account recovery key for your Firefox Account using the following device:</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/location/index.mjml') %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postAddAccountRecovery-recovery">
+        If this was not you,
+        <a class="link-blue" href="<%- revokeAccountRecoveryLink %>" data-l10n-name="revokeAccountRecoveryLink">click here</a>.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/button/index.mjml') %>
+
+<%- include('/partials/automatedEmailChangePassword/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.stories.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { MOCK_LOCATION } from '../../partials/location/mocks';
+import { storyWithProps } from '../../storybook-email';
+
+export default {
+  title: 'Emails/postAddAccountRecovery',
+} as Meta;
+
+const createStory = storyWithProps(
+  'postAddAccountRecovery',
+  'Sent when new recovery key is generated',
+  {
+    ...MOCK_LOCATION,
+    link: 'http://localhost:3030/settings',
+    passwordChangeLink: 'http://localhost:3030/settings/change_password',
+    revokeAccountRecoveryLink:
+      'http://localhost:3030/settings/account_recovery',
+  }
+);
+
+export const PostAddAccountRecovery = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.txt
@@ -1,0 +1,15 @@
+postAddAccountRecovery-title = "Account recovery key generated"
+
+postAddAccountRecovery-description = "You have successfully generated an account recovery key for your Firefox Account from the following device:"
+
+<%- include('/partials/location/index.txt') %>
+
+postAddAccountRecovery-revoke = "If this was not you, revoke key."
+
+<%- revokeAccountRecoveryLink %>
+
+<%- include('/partials/manageAccount/index.txt') %>
+
+<%- include('/partials/changePassword/index.txt') %>
+
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -674,6 +674,34 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['postAddAccountRecoveryEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Account recovery key generated' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-recovery-generated', 'manage-account', 'email', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postAddAccountRecovery') }],
+      ['X-Template-Name', { test: 'equal', expected: 'postAddAccountRecovery' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postAddAccountRecovery }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-recovery-generated', 'manage-account', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-recovery-generated', 'change-password', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-recovery-generated', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'account-recovery-generated', 'support')) },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-recovery-generated', 'manage-account', 'email', 'uid')}` },
+      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'account-recovery-generated', 'change-password', 'email')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-recovery-generated', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'account-recovery-generated', 'support')}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -640,6 +640,40 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['passwordResetAccountRecoveryEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Password updated using recovery key' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('createAccountRecoveryUrl', 'password-reset-account-recovery-success', 'create-recovery-key', 'email', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('passwordResetAccountRecovery') }],
+      ['X-Template-Name', { test: 'equal', expected: 'passwordResetAccountRecovery' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.passwordResetAccountRecovery }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('createAccountRecoveryUrl', 'password-reset-account-recovery-success', 'create-recovery-key', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'password-reset-account-recovery-success', 'change-password', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'password-reset-account-recovery-success', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'password-reset-account-recovery-success', 'support')) },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: configUrl('createAccountRecoveryUrl', 'password-reset-account-recovery-success', 'create-recovery-key', 'email', 'uid') },
+      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'password-reset-account-recovery-success', 'change-password', 'email')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'password-reset-account-recovery-success', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'password-reset-account-recovery-success', 'support')}` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {


### PR DESCRIPTION
## Because

- We need to convert email templates to the new MJML stack

## This pull request

- Converts the `passwordResetAccountRecovery` and `postAddAccountRecovery` templates to our new MJML stack

## Issue that this pull request solves

Closes: #9271
Closes: #9268

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).