### PR TITLE
chore(subscriptions): increase support ticket payload limit

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -1942,6 +1942,12 @@ const conf = convict({
       env: 'SUPPORT_AUTH_SECRET_BEARER_TOKEN',
       format: 'String',
     },
+    ticketPayloadLimit: {
+      default: 131072,
+      doc: 'The payload limit in bytes, default is 2^17',
+      env: 'SUPPORT_TICKET_PAYLOAD_LIMIT',
+      format: Number,
+    },
   },
 });
 

--- a/packages/fxa-auth-server/lib/routes/subscriptions/support.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/support.ts
@@ -56,6 +56,9 @@ export const supportRoutes = (
           // the oauthToken strategy is tried.
           strategies: ['supportSecret', 'oauthToken'],
         },
+        payload: {
+          maxBytes: config.support.ticketPayloadLimit,
+        },
         validate: {
           payload: isA.object().keys({
             email: email().optional(),

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -102,6 +102,9 @@ describe('subscriptions payPalRoutes', () => {
       currenciesToCountries: {
         USD: ['US', 'CA', 'GB'],
       },
+      support: {
+        ticketPayloadLimit: 131072,
+      },
     };
     currencyHelper = new CurrencyHelper(config);
     log = mocks.mockLog();

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -214,6 +214,9 @@ describe('subscriptions stripeRoutes', () => {
         },
       },
       currenciesToCountries: { USD: ['US', 'GB', 'CA'] },
+      support: {
+        ticketPayloadLimit: 131072,
+      },
     };
 
     const currencyHelper = new CurrencyHelper(config);

--- a/packages/fxa-auth-server/test/local/routes/support.js
+++ b/packages/fxa-auth-server/test/local/routes/support.js
@@ -142,6 +142,9 @@ describe('support', () => {
         subdomain: 'test',
         productNameFieldId: '192837465',
       },
+      support: {
+        ticketPayloadLimit: 131072,
+      },
     };
 
     log = mocks.mockLog();

--- a/packages/fxa-auth-server/test/local/server.js
+++ b/packages/fxa-auth-server/test/local/server.js
@@ -675,6 +675,7 @@ function getConfig() {
     verificationReminders: {},
     support: {
       secretBearerToken: 'topsecrets',
+      ticketPayloadLimit: 131072,
     },
   };
 }


### PR DESCRIPTION
Because:
 - other services might want to include debugging info in the support
   tickets

This commit:
 - increase the payload limit on the support ticket endpoint

## Issue that this pull request solves

Closes: #10419
