### PR TITLE
chore(subscriptions): remove email input placeholder text

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -365,7 +365,6 @@ new-user-step-2 = 2. Choose your payment method
 # continue.
 new-user-required-payment-consent = Required
 new-user-email =
-  .placeholder = foxy@mozilla.com
   .label = Enter your email
 new-user-confirm-email =
   .label = Confirm your email

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -92,13 +92,12 @@ export const NewUserEmailForm = ({
           </a>
         </p>
       </Localized>
-      <Localized id="new-user-email" attrs={{ placeholder: true, label: true }}>
+      <Localized id="new-user-email" attrs={{ label: true }}>
         <Input
           type="email"
           name="new-user-email"
           label="Enter your email"
           data-testid="new-user-email"
-          placeholder="foxy@mozilla.com"
           required
           spellCheck={false}
           onValidatePromise={(value: string, focused: boolean) =>


### PR DESCRIPTION
Because:
 - it was misleading people to think they are signing up for an account
   for an @mozilla.com email address

This commit:
 - remove the placeholder text for the email address input

## Issue that this pull request solves

Closes: #10422 