### PR TITLE
style(subscriptions): move the "already have an acct" message

### DIFF
--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.scss
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.scss
@@ -6,11 +6,8 @@
     .sign-in-copy {
         color: $grey-50;
         font-weight: 400;
-        font-size: 10px;
-        position: absolute;
-        right: 0;
-        top: -5px;
-        z-index: 2;
+        margin-top: -8px;
+        margin-left: 24px;
 
         a {
             color: $grey-50;

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -92,6 +92,7 @@ export const NewUserEmailForm = ({
           </a>
         </p>
       </Localized>
+      <hr />
       <Localized id="new-user-email" attrs={{ label: true }}>
         <Input
           type="email"

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -310,7 +310,6 @@ export const Checkout = ({
           <Localized id="new-user-step-1">
             <h2 className="step-header">1. Create a Firefox account</h2>
           </Localized>
-          <hr />
           <NewUserEmailForm
             setValidEmail={setValidEmail}
             signInURL={signInURL}


### PR DESCRIPTION
Because:
 - absolute positioning the "already have an account" message cause
   layout issues with certain languages

This commit:
 - move the message to its own line(s)


## Issue that this pull request solves

Closes: #10192

