### PR TITLE
feat(auth-server): Allow layout-only email stories

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/fluent-localizer.ts
@@ -85,7 +85,9 @@ class FluentLocalizer {
     const l10n = new DOMLocalization(currentLocales, generateBundles);
 
     context = { ...context, ...context.templateValues };
-    context.subject = await l10n.formatValue(`${template}-subject`, context);
+    if (template !== '_storybook') {
+      context.subject = await l10n.formatValue(`${template}-subject`, context);
+    }
 
     // metadata.mjml needs a localized version of `action`,
     // but only if oneClickLink is present.

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.scss
@@ -24,7 +24,7 @@
 .sync-img {
   padding: global.$s-5 global.$s-0 !important;
   height: 137px;
-  width: 270px;
+  width: 300px;
   margin: 0 auto !important;
   display: block !important;
 }

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/index.stories.ts
@@ -3,21 +3,24 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Templates/verify',
+  title: 'Layouts/FxA',
 } as Meta;
 
-const createStory = storyWithProps(
-  'verify',
-  'Received by all who complete FxA registration form.',
-  {
-    ...MOCK_LOCATION,
-    link: 'http://localhost:3030/verify_email',
-    sync: true,
-  }
-);
+const createStory = storyWithProps('_storybook', 'The FxA email base layout.', {
+  sync: false,
+  subject: 'N/A',
+});
 
-export const VerifyEmail = createStory();
+export const NotThroughSyncFlow = createStory(
+  {},
+  'Email not triggered through sync flow'
+);
+export const ThroughSyncFlow = createStory(
+  {
+    sync: true,
+  },
+  'Email triggered through sync flow'
+);

--- a/packages/fxa-auth-server/lib/senders/emails/partials/cadReminder/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/cadReminder/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/partials/verificationReminder/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/verificationReminder/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/_storybook/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_storybook/index.mjml
@@ -2,20 +2,20 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
+<%# This file is used for layout-only storybook stories. It is not used as an email template. %>
+
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="passwordReset-title">Your account password was changed</span>
+      Email header
     </mj-text>
   </mj-column>
 </mj-section>
 
 <mj-section>
   <mj-column>
-    <mj-text css-class="text-body-no-margin">
-      <span data-l10n-id="passwordReset-description">You will need to enter your new password on other devices to resume syncing.</span>
+    <mj-text css-class="text-body">
+      Email body text, images, and other footers if applicable are displayed here.
     </mj-text>
   </mj-column>
 </mj-section>
-
-<%- include('/partials/automatedEmailResetPassword/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/_storybook/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/_storybook/index.txt
@@ -1,0 +1,1 @@
+<%# This isn't used but the renderer expects every template file to have a corresponding txt file. %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderFirst/index.stories.ts
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/html';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/cadReminderFirst',
+  title: 'Templates/cadReminderFirst',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/cadReminderSecond/index.stories.ts
@@ -7,7 +7,7 @@ import { storyWithProps } from '../../storybook-email';
 import * as cadReminderFirst from '../cadReminderFirst/index.stories';
 
 export default {
-  title: 'Emails/cadReminderSecond',
+  title: 'Templates/cadReminderSecond',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/lowRecoveryCodes/index.stories.ts
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/html';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/lowRecoveryCodes',
+  title: 'Templates/lowRecoveryCodes',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/newDeviceLogin',
+  title: 'Templates/newDeviceLogin',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/passwordChanged',
+  title: 'Templates/passwordChanged',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordReset/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordReset/index.stories.ts
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/html';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/passwordReset',
+  title: 'Templates/passwordReset',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/passwordResetAccountRecovery',
+  title: 'Templates/passwordResetAccountRecovery',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/postAddAccountRecovery',
+  title: 'Templates/postAddAccountRecovery',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.stories.ts
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/html';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/postRemoveSecondary',
+  title: 'Templates/postRemoveSecondary',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-sub-body">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerify/index.stories.ts
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/html';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/postVerify',
+  title: 'Templates/postVerify',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/unblockCode',
+  title: 'Templates/unblockCode',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderFirst/index.stories.ts
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/html';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/verificationReminderFirst',
+  title: 'Templates/verificationReminderFirst',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verificationReminderSecond/index.stories.ts
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/html';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/verificationReminderSecond',
+  title: 'Templates/verificationReminderSecond',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header"><span data-l10n-id="verify-title">Activate the Firefox family of products</span></mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyLogin/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyLogin/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyLogin/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyLogin/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/verifyLogin',
+  title: 'Templates/verifyLogin',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyLoginCode/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/verifyLoginCode',
+  title: 'Templates/verifyLoginCode',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyPrimary/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyPrimary/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyPrimary/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyPrimary/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/verifyPrimary',
+  title: 'Templates/verifyPrimary',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/verifySecondary',
+  title: 'Templates/verifySecondary',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/verifySecondaryCode',
+  title: 'Templates/verifySecondaryCode',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifyShortCode/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/verifyShortCode',
+  title: 'Templates/verifyShortCode',
 } as Meta;
 
 const createStory = storyWithProps(


### PR DESCRIPTION
## Because

* Our emails have a different state at the layout level ('if sync') and we want to show those states. Also, a different layout exists for the SubPlat emails and we want to be able to show that.

## This pull request

* Adds a storybook-only directory with template and txt file, as the renderer expects to pull in a template and txt file from the templates/ dir. This was preferable over modifying when the renderer pulls in files because that same code is ran in prod and we didn't want to modify it just for layout-specific storybook files.
* Removes the global CSS file from templates, it's already included in the fxa layout file
* Fixes the width on sync image to correct ratio