### PR TITLE
Revert "chore(deps): bump @fluent/react from 0.13.1 to 0.14.0"

### DIFF
--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -45,7 +45,7 @@
     "@babel/register": "^7.15.3",
     "@fluent/bundle": "^0.16.1",
     "@fluent/langneg": "^0.5.2",
-    "@fluent/react": "^0.14.0",
+    "@fluent/react": "^0.13.1",
     "@rescripts/cli": "~0.0.16",
     "@storybook/addon-actions": "^6.3.7",
     "@storybook/addon-links": "^6.3.8",

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@fluent/bundle": "^0.16.1",
     "@fluent/langneg": "^0.5.2",
-    "@fluent/react": "^0.14.0",
+    "@fluent/react": "^0.13.1",
     "async-wait-until": "^2.0.7",
     "classnames": "^2.3.1",
     "fetch-mock": "^9.11.0",

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@apollo/client": "^3.4.5",
     "@emotion/react": "^11.4.1",
-    "@fluent/react": "^0.14.0",
+    "@fluent/react": "^0.13.1",
     "@material-ui/core": "v5.0.0-alpha.24",
     "@reach/router": "^1.3.4",
     "@types/material-ui": "^0.21.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2383,26 +2383,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@fluent/react@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@fluent/react@npm:0.14.0"
+"@fluent/react@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "@fluent/react@npm:0.13.1"
   dependencies:
-    "@fluent/sequence": ^0.7.0
-    cached-iterable: ^0.3.0
+    "@fluent/sequence": 0.5.0
+    cached-iterable: ^0.2.1
     prop-types: ^15.7.2
   peerDependencies:
-    "@fluent/bundle": ">=0.16.0 <0.18.0"
+    "@fluent/bundle": ">=0.16.0 <0.17.0"
     react: ">=16.8.0"
-  checksum: 60ed824cebe5972d4e134a758f5eb0a24142326ae2207e83c7383c667702e2f656ba327948aab5faa59a83eacb4dfd2304f01c81c2293d4b0c62ba9e8d209401
+  checksum: 129dd2856fd0ee0f0fce97e0594f6c22cf841b5e59f419a63d0376c9db17b15881376be453caeb7bc198fdf90346cc536767eff94e4ef84404e72c4733725f0c
   languageName: node
   linkType: hard
 
-"@fluent/sequence@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@fluent/sequence@npm:0.7.0"
+"@fluent/sequence@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@fluent/sequence@npm:0.5.0"
   peerDependencies:
     "@fluent/bundle": ">= 0.13.0"
-  checksum: 569c52674552dc735e2febcbd75056145be463b59a3e25a30575d69be2ef41af78f0be9a5bb59017ed08838a076dfb4689a2a73d5cbbe077483592736f689942
+  checksum: 68e482b4927f68ff5a8c30b48373b033335784a171d4c01b71e1109fcb88591a01c8ca71c20320e5553d1a536aa4fa56c28ed80f63ae02ef5a96038cb2f3820b
   languageName: node
   linkType: hard
 
@@ -12698,7 +12698,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cached-iterable@npm:^0.3, cached-iterable@npm:^0.3.0":
+"cached-iterable@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "cached-iterable@npm:0.2.1"
+  checksum: 3b9be982710a368ebed79055ed509128802d948d7d1db0fa4b9524c2c323e66922ad561a9a21b6cedd1684e8c8c235de1c5bdd523bc52d0cf07999510de77735
+  languageName: node
+  linkType: hard
+
+"cached-iterable@npm:^0.3":
   version: 0.3.0
   resolution: "cached-iterable@npm:0.3.0"
   checksum: ec486d37c6fd5df38992b785a49de611ccb8e87825e533f91c33e9e02e7061769cd1ac7bb958e828057ff2ecb6b290c9922fb49bfb7c21a04acb0c4f35ca230a
@@ -19764,7 +19771,7 @@ fsevents@~2.1.1:
     "@babel/register": ^7.15.3
     "@fluent/bundle": ^0.16.1
     "@fluent/langneg": ^0.5.2
-    "@fluent/react": ^0.14.0
+    "@fluent/react": ^0.13.1
     "@rescripts/cli": ~0.0.16
     "@sentry/browser": ^6.12.0
     "@sentry/node": ^6.12.0
@@ -19929,7 +19936,7 @@ fsevents@~2.1.1:
     "@babel/core": ^7.15.0
     "@fluent/bundle": ^0.16.1
     "@fluent/langneg": ^0.5.2
-    "@fluent/react": ^0.14.0
+    "@fluent/react": ^0.13.1
     "@storybook/addon-actions": ^6.3.7
     "@storybook/addon-links": ^6.3.8
     "@storybook/addons": ^6.3.6
@@ -19990,7 +19997,7 @@ fsevents@~2.1.1:
     "@apollo/client": ^3.4.5
     "@babel/core": ^7.15.0
     "@emotion/react": ^11.4.1
-    "@fluent/react": ^0.14.0
+    "@fluent/react": ^0.13.1
     "@material-ui/core": v5.0.0-alpha.24
     "@reach/router": ^1.3.4
     "@rescripts/cli": 0.0.16


### PR DESCRIPTION
Reverts mozilla/fxa#10432

Things be [broken](https://github.com/mozilla/fxa/pull/10432#issuecomment-919422417).