### PR TITLE
feat(auth): convert various email templates to new mjml stack

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -453,7 +453,8 @@
       "postRemoveTwoStepAuthentication",
       "postVerifySecondary",
       "postAddTwoStepAuthentication",
-      "postChangePrimary"
+      "postChangePrimary",
+      "postConsumeRecoveryCode"
     ]
   }
 }

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -454,7 +454,8 @@
       "postVerifySecondary",
       "postAddTwoStepAuthentication",
       "postChangePrimary",
-      "postConsumeRecoveryCode"
+      "postConsumeRecoveryCode",
+      "postNewRecoveryCodes"
     ]
   }
 }

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -452,7 +452,8 @@
       "postRemoveAccountRecovery",
       "postRemoveTwoStepAuthentication",
       "postVerifySecondary",
-      "postAddTwoStepAuthentication"
+      "postAddTwoStepAuthentication",
+      "postChangePrimary"
     ]
   }
 }

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -455,7 +455,8 @@
       "postAddTwoStepAuthentication",
       "postChangePrimary",
       "postConsumeRecoveryCode",
-      "postNewRecoveryCodes"
+      "postNewRecoveryCodes",
+      "passwordChangeRequired"
     ]
   }
 }

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -451,7 +451,8 @@
       "postAddAccountRecovery",
       "postRemoveAccountRecovery",
       "postRemoveTwoStepAuthentication",
-      "postVerifySecondary"
+      "postVerifySecondary",
+      "postAddTwoStepAuthentication"
     ]
   }
 }

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -1251,6 +1251,7 @@ module.exports = function (log, config) {
         passwordManagerInfoUrl: links.passwordManagerInfoUrl,
         privacyUrl: links.privacyUrl,
         resetLink: links.resetLink,
+        supportUrl: links.supportUrl,
         subject,
       },
     });

--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -82,6 +82,9 @@ $s-10: 40px;
   &-6 {
     margin-bottom: $s-6 !important;
   }
+  &-8 {
+    margin-bottom: $s-8 !important;
+  }
 }
 
 // Global styles
@@ -128,9 +131,17 @@ tr > td:first-child {
   @extend .mt-5;
 }
 
+.lg-bottom-margin div {
+  @extend .mb-8;
+}
+
 .text-sub-body div {
   @extend %text-body-common;
   @extend .mb-3;
+}
+
+.align-left div {
+  text-align: left !important;
 }
 
 .text-footer div {

--- a/packages/fxa-auth-server/lib/senders/emails/global.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/global.scss
@@ -131,7 +131,8 @@ tr > td:first-child {
   @extend .mt-5;
 }
 
-.lg-bottom-margin div {
+.text-body-lg-bottom-margin div {
+  @extend %text-body-common;
   @extend .mb-8;
 }
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/en-US.ftl
@@ -1,0 +1,9 @@
+passwordChangeRequired-subject = Suspicious activity detected
+passwordChangeRequired-title = Password Change Required
+passwordChangeRequired-suspicious-activity = We detected suspicious behavior on your Firefox account. To prevent unauthorized access to your Firefox Account, we’ve disconnected all devices on your account and are requiring you to change your password as a precaution.
+passwordChangeRequired-sign-in = Sign back into any device or service where you use your Firefox account and follow the steps that will be presented to you.
+passwordChangeRequired-different-password = <b>Important:</b> Pick a different password than what you were previously using and make sure that it is different from your email account.
+passwordChangeRequired-signoff = Best,<br />The Firefox Accounts Team
+passwordChangeRequired-different-password-plaintext = Important: Pick a different password than what you were previously using and make sure that it is different from your email account.
+passwordChangeRequired-signoff-plaintext = Best,
+  The Firefox Accounts Team

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
@@ -26,7 +24,7 @@
       <span data-l10n-id="passwordChangeRequired-different-password"><b>Important:</b> Pick a different password than what you were previously using and make sure that it is different from your email account.</span>
     </mj-text>
 
-    <mj-text css-class="text-body align-left lg-bottom-margin">
+    <mj-text css-class="text-body-lg-bottom-margin align-left">
       <span data-l10n-id="passwordChangeRequired-signoff">
         Best,<br />
         The Firefox Accounts Team

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.mjml
@@ -1,0 +1,36 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-include path="./css/global.css" type="css" css-inline="inline" />
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="passwordChangeRequired-title">Password Change Required</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body align-left">
+      <span data-l10n-id="passwordChangeRequired-suspicious-activity">We detected suspicious behavior on your Firefox account. To prevent unauthorized access to your Firefox Account, we’ve disconnected all devices on your account and are requiring you to change your password as a precaution.</span>
+    </mj-text>
+
+    <mj-text css-class="text-body align-left">
+      <span data-l10n-id="passwordChangeRequired-sign-in">Sign back into any device or service where you use your Firefox account and follow the steps that will be presented to you.</span>
+    </mj-text>
+
+    <mj-text css-class="text-body align-left">
+      <span data-l10n-id="passwordChangeRequired-different-password"><b>Important:</b> Pick a different password than what you were previously using and make sure that it is different from your email account.</span>
+    </mj-text>
+
+    <mj-text css-class="text-body align-left lg-bottom-margin">
+      <span data-l10n-id="passwordChangeRequired-signoff">
+        Best,<br />
+        The Firefox Accounts Team
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.stories.ts
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { storyWithProps } from '../../storybook-email';
+
+export default {
+  title: 'Emails/passwordChangeRequired',
+} as Meta;
+
+const createStory = storyWithProps(
+  'passwordChangeRequired',
+  "Sent when an account's devices are disconnected and a password change is required due to suspicious activity"
+);
+
+export const PasswordChangeRequired = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.stories.ts
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/html';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/passwordChangeRequired',
+  title: 'Templates/passwordChangeRequired',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChangeRequired/index.txt
@@ -1,0 +1,11 @@
+passwordChangeRequired-title = "Password Change Required"
+
+passwordChangeRequired-suspicious-activity = "We detected suspicious behavior on your Firefox account. To prevent unauthorized access to your Firefox Account, we’ve disconnected all devices on your account and are requiring you to change your password as a precaution."
+
+passwordChangeRequired-sign-in = "Sign back into any device or service where you use your Firefox account and follow the steps that will be presented to you."
+
+passwordChangeRequired-different-password-plaintext = "Important: Pick a different password than what you were previously using and make sure that it is different from your email account."
+
+passwordChangeRequired-signoff-plaintext = "Best, The Firefox Accounts Team"
+
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/en-US.ftl
@@ -1,6 +1,6 @@
 postAddTwoStepAuthentication-subject = Two-step authentication enabled
-postAddTwoStepAuthentication-title = Two-step authentication enabled
+postAddTwoStepAuthentication-title = { postAddTwoStepAuthentication-subject }
 postAddTwoStepAuthentication-description-plaintext = You have successfully enabled two-step authentication on your Firefox Account. Security codes from your authentication app will now be required at each sign-in.
 postAddTwoStepAuthentication-description = You have successfully enabled two-step authentication on your Firefox Account from the following device:
-postAddTwoStepAuthentication-action = Manage account
+postAddTwoStepAuthentication-action = { manage-account }
 postAddTwoStepAuthentication-code-required = Security codes from your authentication app will now be required at each sign-in.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/en-US.ftl
@@ -1,0 +1,6 @@
+postAddTwoStepAuthentication-subject = Two-step authentication enabled
+postAddTwoStepAuthentication-title = Two-step authentication enabled
+postAddTwoStepAuthentication-description-plaintext = You have successfully enabled two-step authentication on your Firefox Account. Security codes from your authentication app will now be required at each sign-in.
+postAddTwoStepAuthentication-description = You have successfully enabled two-step authentication on your Firefox Account from the following device:
+postAddTwoStepAuthentication-action = Manage account
+postAddTwoStepAuthentication-code-required = Security codes from your authentication app will now be required at each sign-in.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.mjml
@@ -1,0 +1,31 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-include path="./css/global.css" type="css" css-inline="inline" />
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="postAddTwoStepAuthentication-title">Two-step authentication enabled</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postAddTwoStepAuthentication-description">You have successfully enabled two-step authentication on your Firefox Account from the following device:</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/location/index.mjml') %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postAddTwoStepAuthentication-code-required">Security codes from your authentication app will now be required at each sign-in.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/button/index.mjml') %>
+
+<%- include('/partials/automatedEmailChangePassword/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/postAddTwoStepAuthentication',
+  title: 'Templates/postAddTwoStepAuthentication',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.stories.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { MOCK_LOCATION } from '../../partials/location/mocks';
+import { storyWithProps } from '../../storybook-email';
+
+export default {
+  title: 'Emails/postAddTwoStepAuthentication',
+} as Meta;
+
+const createStory = storyWithProps(
+  'postAddTwoStepAuthentication',
+  'Sent when a user has enabled 2FA on their account, informing them of the change and new requirement to use a security code',
+  {
+    ...MOCK_LOCATION,
+    link: 'http://localhost:3030/settings',
+    passwordChangeLink: 'http://localhost:3030/settings/change_password',
+  }
+);
+
+export const PostAddTwoStepAuthentication = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.txt
@@ -1,0 +1,11 @@
+postAddTwoStepAuthentication-title = "Two-step authentication enabled"
+
+postAddTwoStepAuthentication-description-plaintext = "You have successfully reset your password using a recovery key from the following device:"
+
+<%- include('/partials/location/index.txt') %>
+
+<%- include('/partials/manageAccount/index.txt') %>
+
+<%- include('/partials/changePassword/index.txt') %>
+
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/en-US.ftl
@@ -1,0 +1,4 @@
+postChangePrimary-subject = Primary email updated
+postChangePrimary-title = New primary email
+postChangePrimary-description = You have successfully changed your primary email to { $email }. This address is now your username for signing in to your Firefox Account, as well as receiving security notifications and sign-in confirmations.
+postChangePrimary-action = Manage account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/en-US.ftl
@@ -1,4 +1,4 @@
 postChangePrimary-subject = Primary email updated
 postChangePrimary-title = New primary email
 postChangePrimary-description = You have successfully changed your primary email to { $email }. This address is now your username for signing in to your Firefox Account, as well as receiving security notifications and sign-in confirmations.
-postChangePrimary-action = Manage account
+postChangePrimary-action = { manage-account }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.mjml
@@ -1,0 +1,21 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-include path="./css/global.css" type="css" css-inline="inline" />
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="postChangePrimary-title">New primary email</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postChangePrimary-description" data-l10n-args='<%= JSON.stringify({ email }) %>'>You have successfully changed your primary email to <%- email %>. This address is now your username for signing in to your Firefox Account, as well as receiving security notifications and sign-in confirmations.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/button/index.mjml') %>
+
+<%- include('/partials/automatedEmailChangePassword/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.stories.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { MOCK_LOCATION } from '../../partials/location/mocks';
+import { storyWithProps } from '../../storybook-email';
+
+export default {
+  title: 'Emails/postChangePrimary',
+} as Meta;
+
+const createStory = storyWithProps(
+  'postChangePrimary',
+  'Sent to new primary email when it has been updated',
+  {
+    ...MOCK_LOCATION,
+    email: 'foo@bar.com',
+    link: 'http://localhost:3030/settings',
+    passwordChangeLink: 'http://localhost:3030/settings/change_password',
+  }
+);
+
+export const PostChangePrimary = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/postChangePrimary',
+  title: 'Templates/postChangePrimary',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.txt
@@ -1,0 +1,9 @@
+postChangePrimary-subject = "New primary email"
+
+postChangePrimary-description = "You have successfully changed your primary email to { $email }. This address is now your username for signing in to your Firefox Account, as well as receiving security notifications and sign-in confirmations."
+
+<%- include('/partials/manageAccount/index.txt') %>
+
+<%- include('/partials/changePassword/index.txt') %>
+
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.txt
@@ -1,4 +1,4 @@
-postChangePrimary-subject = "New primary email"
+postChangePrimary-title = "New primary email"
 
 postChangePrimary-description = "You have successfully changed your primary email to { $email }. This address is now your username for signing in to your Firefox Account, as well as receiving security notifications and sign-in confirmations."
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/en-US.ftl
@@ -1,4 +1,4 @@
 postConsumeRecoveryCode-subject = Recovery code used
 postConsumeRecoveryCode-title = Recovery code consumed
 postConsumeRecoveryCode-description = You have successfully consumed a recovery code from the following device:
-postConsumeRecoveryCode-action = Manage account
+postConsumeRecoveryCode-action = { manage-account }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/en-US.ftl
@@ -1,0 +1,4 @@
+postConsumeRecoveryCode-subject = Recovery code used
+postConsumeRecoveryCode-title = Recovery code consumed
+postConsumeRecoveryCode-description = You have successfully consumed a recovery code from the following device:
+postConsumeRecoveryCode-action = Manage account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/index.mjml
@@ -1,0 +1,23 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-include path="./css/global.css" type="css" css-inline="inline" />
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="postConsumeRecoveryCode-title">Recovery code consumed</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postConsumeRecoveryCode-description">You have successfully consumed a recovery code from the following device:</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/location/index.mjml') %>
+
+<%- include('/partials/button/index.mjml') %>
+
+<%- include('/partials/automatedEmailChangePassword/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/postConsumeRecoveryCode',
+  title: 'Templates/postConsumeRecoveryCode',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/index.stories.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { MOCK_LOCATION } from '../../partials/location/mocks';
+import { storyWithProps } from '../../storybook-email';
+
+export default {
+  title: 'Emails/postConsumeRecoveryCode',
+} as Meta;
+
+const createStory = storyWithProps(
+  'postConsumeRecoveryCode',
+  'Sent when user has used a recovery code',
+  {
+    ...MOCK_LOCATION,
+    link: 'http://localhost:3030/settings/account_recovery',
+    passwordChangeLink: 'http://localhost:3030/settings/change_password',
+  }
+);
+
+export const PostConsumeRecoveryCode = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postConsumeRecoveryCode/index.txt
@@ -1,0 +1,11 @@
+postConsumeRecoveryCode-title = "Recovery code consumed"
+
+postConsumeRecoveryCode-description = "You have successfully consumed a recovery code from the following device:"
+
+<%- include('/partials/location/index.txt') %>
+
+<%- include('/partials/manageAccount/index.txt') %>
+
+<%- include('/partials/changePassword/index.txt') %>
+
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/en-US.ftl
@@ -1,0 +1,4 @@
+postNewRecoveryCodes-subject = New recovery codes generated
+postNewRecoveryCodes-title = { postNewRecoveryCodes-subject }
+postNewRecoveryCodes-description = You have successfully generated new recovery codes from the following device:
+postNewRecoveryCodes-action = Manage account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/en-US.ftl
@@ -1,4 +1,4 @@
 postNewRecoveryCodes-subject = New recovery codes generated
 postNewRecoveryCodes-title = { postNewRecoveryCodes-subject }
 postNewRecoveryCodes-description = You have successfully generated new recovery codes from the following device:
-postNewRecoveryCodes-action = Manage account
+postNewRecoveryCodes-action = { manage-account }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/index.mjml
@@ -1,0 +1,23 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-include path="./css/global.css" type="css" css-inline="inline" />
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="postNewRecoveryCodes-title">New recovery codes generated</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postNewRecoveryCodes-description">You have successfully generated new recovery codes from the following device:</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/location/index.mjml') %>
+
+<%- include('/partials/button/index.mjml') %>
+
+<%- include('/partials/automatedEmailChangePassword/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/index.mjml
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<mj-include path="./css/global.css" type="css" css-inline="inline" />
-
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/postNewRecoveryCodes',
+  title: 'Templates/postNewRecoveryCodes',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/index.stories.ts
@@ -7,12 +7,12 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/postConsumeRecoveryCode',
+  title: 'Emails/postNewRecoveryCodes',
 } as Meta;
 
 const createStory = storyWithProps(
-  'postConsumeRecoveryCode',
-  'Sent when user has used a recovery code',
+  'postNewRecoveryCodes',
+  'Sent when user has created new recovery codes, resetting their existing ones',
   {
     ...MOCK_LOCATION,
     link: 'http://localhost:3030/settings',
@@ -20,4 +20,4 @@ const createStory = storyWithProps(
   }
 );
 
-export const PostConsumeRecoveryCode = createStory();
+export const PostNewRecoveryCodes = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postNewRecoveryCodes/index.txt
@@ -1,0 +1,11 @@
+postNewRecoveryCodes-title = "New recovery codes generated"
+
+postNewRecoveryCodes-description = "You have successfully generated new recovery codes from the following device:"
+
+<%- include('/partials/location/index.txt') %>
+
+<%- include('/partials/manageAccount/index.txt') %>
+
+<%- include('/partials/changePassword/index.txt') %>
+
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -794,6 +794,40 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['postAddTwoStepAuthenticationEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Two-step authentication enabled' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-two-step-enabled', 'manage-account', 'email', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postAddTwoStepAuthentication') }],
+      ['X-Template-Name', { test: 'equal', expected: 'postAddTwoStepAuthentication' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postAddTwoStepAuthentication }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-two-step-enabled', 'manage-account', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-two-step-enabled', 'change-password', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-two-step-enabled', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'account-two-step-enabled', 'support')) },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-two-step-enabled', 'manage-account', 'email', 'uid')}` },
+      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'account-two-step-enabled', 'change-password', 'email')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-two-step-enabled', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'account-two-step-enabled', 'support')}` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -828,6 +828,30 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['postChangePrimaryEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Primary email updated' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-email-changed', 'account-email-changed', 'email', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postChangePrimary') }],
+      ['X-Template-Name', { test: 'equal', expected: 'postChangePrimary' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postChangePrimary }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-email-changed', 'account-email-changed', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-email-changed', 'change-password', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-email-changed', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'account-email-changed', 'support')) },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-email-changed', 'account-email-changed', 'email', 'uid')}` },
+      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'account-email-changed', 'change-password', 'email')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-email-changed', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'account-email-changed', 'support')}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -920,6 +920,25 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['passwordChangeRequiredEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Suspicious activity detected' }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('passwordChangeRequired') }],
+      ['X-Template-Name', { test: 'equal', expected: 'passwordChangeRequired' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.passwordChangeRequired }],
+    ])],
+    ['html', [
+      { test: 'include', expected: 'change your password as a precaution' },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'password-change-required', 'privacy')) },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: 'change your password as a precaution' },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'password-change-required', 'privacy')}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -852,6 +852,40 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['postConsumeRecoveryCodeEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Recovery code used' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-consume-recovery-code', 'manage-account', 'email', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postConsumeRecoveryCode') }],
+      ['X-Template-Name', { test: 'equal', expected: 'postConsumeRecoveryCode' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postConsumeRecoveryCode }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-consume-recovery-code', 'manage-account', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-consume-recovery-code', 'change-password', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-consume-recovery-code', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'account-consume-recovery-code', 'support')) },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-consume-recovery-code', 'manage-account', 'email', 'uid')}` },
+      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'account-consume-recovery-code', 'change-password', 'email')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-consume-recovery-code', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'account-consume-recovery-code', 'support')}` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -886,6 +886,40 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['postNewRecoveryCodesEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'New recovery codes generated' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-replace-recovery-codes', 'manage-account', 'email', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postNewRecoveryCodes') }],
+      ['X-Template-Name', { test: 'equal', expected: 'postNewRecoveryCodes' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postNewRecoveryCodes }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-replace-recovery-codes', 'manage-account', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-replace-recovery-codes', 'change-password', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-replace-recovery-codes', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'account-replace-recovery-codes', 'support')) },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-replace-recovery-codes', 'manage-account', 'email', 'uid')}` },
+      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'account-replace-recovery-codes', 'change-password', 'email')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-replace-recovery-codes', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'account-replace-recovery-codes', 'support')}` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {


### PR DESCRIPTION
## This pull request

Updates the following email to our MJML stack:

- postAddTwoStepAuthentication
- postChangePrimary
- postConsumeRecoveryCode
- postNewRecoveryCodes
- passwordChangeRequired

## Issue that this pull request solves

Closes #9313
Closes #9290
Closes #9286
Closes #9280
Closes #9275

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
