### PR TITLE
Revert "chore(deps): bump ajv from 6.12.6 to 8.6.3"

### DIFF
--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -57,7 +57,7 @@
     "@type-cacheable/ioredis-adapter": "^5.2.0",
     "@types/ejs": "^3.0.6",
     "@types/mjml": "^4.7.0",
-    "ajv": "^8.6.3",
+    "ajv": "^6.12.2",
     "aws-sdk": "^2.987.0",
     "base64url": "3.0.1",
     "buf": "0.1.1",

--- a/packages/fxa-metrics-processor/package.json
+++ b/packages/fxa-metrics-processor/package.json
@@ -27,7 +27,7 @@
     "@sentry/integrations": "^6.12.0",
     "@sentry/node": "^6.12.0",
     "@types/convict": "^5.2.2",
-    "ajv": "^8.6.3",
+    "ajv": "^6.12.2",
     "convict": "^6.2.0",
     "convict-format-with-moment": "^6.2.0",
     "convict-format-with-validator": "^6.2.0",

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -83,7 +83,7 @@
     "@sentry/node": "^6.12.0",
     "@types/js-md5": "^0.4.2",
     "accept-language": "^2.0.17",
-    "ajv": "^8.6.3",
+    "ajv": "^6.12.2",
     "apollo-server": "^2.25.2",
     "aws-sdk": "^2.987.0",
     "celebrate": "^10.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9495,18 +9495,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.6.3":
-  version: 8.6.3
-  resolution: "ajv@npm:8.6.3"
-  dependencies:
-    fast-deep-equal: ^3.1.1
-    json-schema-traverse: ^1.0.0
-    require-from-string: ^2.0.2
-    uri-js: ^4.2.2
-  checksum: 690ffb9408415fdab43686b3f92037ba0c8362f5d0709a123ba3fb546e6ad81414455f80a2b5cc432ce924afe9864671198f022bc331a19c072d4ede152ec3ca
-  languageName: node
-  linkType: hard
-
 "align-text@npm:^0.1.1, align-text@npm:^0.1.3":
   version: 0.1.4
   resolution: "align-text@npm:0.1.4"
@@ -19188,7 +19176,7 @@ fsevents@~2.1.1:
     "@types/verror": ^1.10.4
     "@types/webpack": 5.28.0
     acorn: ^8.0.1
-    ajv: ^8.6.3
+    ajv: ^6.12.2
     audit-filter: ^0.5.0
     aws-sdk: ^2.987.0
     babel-loader: ^8.2.2
@@ -19735,7 +19723,7 @@ fsevents@~2.1.1:
     "@types/mocha": ^8.2.2
     "@types/node": ^15.12.2
     "@types/sinon": 10.0.1
-    ajv: ^8.6.3
+    ajv: ^6.12.2
     audit-filter: ^0.5.0
     chai: ^4.3.4
     convict: ^6.2.0
@@ -20105,7 +20093,7 @@ fsevents@~2.1.1:
     "@types/sinon": 10.0.1
     "@types/superagent": ^4.1.11
     accept-language: ^2.0.17
-    ajv: ^8.6.3
+    ajv: ^6.12.2
     apollo-server: ^2.25.2
     audit-filter: ^0.5.0
     aws-sdk: ^2.987.0


### PR DESCRIPTION
This reverts commit 21ec92aa66bea2732e3c1efc586110e9999bb0e8.

Dependabot just loves breaking main today.