### PR TITLE
feat(auth-server): Convert postRemoveAccountRecovery, postRemoveTwoStepAuthentication, & postVerifySecondary to new email stack

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -448,7 +448,8 @@
       "verifyLoginCode",
       "verifyPrimary",
       "passwordResetAccountRecovery",
-      "postAddAccountRecovery"
+      "postAddAccountRecovery",
+      "postRemoveAccountRecovery"
     ]
   }
 }

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -449,7 +449,8 @@
       "verifyPrimary",
       "passwordResetAccountRecovery",
       "postAddAccountRecovery",
-      "postRemoveAccountRecovery"
+      "postRemoveAccountRecovery",
+      "postRemoveTwoStepAuthentication"
     ]
   }
 }

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -450,7 +450,8 @@
       "passwordResetAccountRecovery",
       "postAddAccountRecovery",
       "postRemoveAccountRecovery",
-      "postRemoveTwoStepAuthentication"
+      "postRemoveTwoStepAuthentication",
+      "postVerifySecondary"
     ]
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/en-US.ftl
@@ -1,4 +1,3 @@
 newDeviceLogin-subject = New sign-in to { $clientName }
 newDeviceLogin-title = { newDeviceLogin-subject }
-newDeviceLogin-action = Manage account
-newDeviceLogin-action-plaintext = { newDeviceLogin-action }:
+newDeviceLogin-action = { manage-account }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordResetAccountRecovery/en-US.ftl
@@ -4,5 +4,3 @@ passwordResetAccountRecovery-description = You have successfully reset your pass
 passwordResetAccountRecovery-action = Create new recovery key
 passwordResetAccountRecovery-regen-required = You will need to generate a new recovery key.
 passwordResetAccountRecovery-create-key = Create new recovery key:
-passwordResetAccountRecovery-email-change = This is an automated email; if you did not authorize this action, then <a data-l10n-name="passwordChangeLink">please change your password</a>.
-  For more information, please visit <a data-l10n-name="supportLink">Mozilla Support</a>.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/en-US.ftl
@@ -1,8 +1,6 @@
 postAddAccountRecovery-subject = Account recovery key generated
 postAddAccountRecovery-title = { postAddAccountRecovery-subject }
 postAddAccountRecovery-description = You have successfully generated an account recovery key for your Firefox Account using the following device:
-postAddAccountRecovery-action = Manage account
+postAddAccountRecovery-action = { manage-account }
 postAddAccountRecovery-recovery = If this was not you, <a data-l10n-name="revokeAccountRecoveryLink">click here</a>.
 postAddAccountRecovery-revoke = If this was not you, revoke key.
-postAddAccountRecovery-email-change = This is an automated email; if you did not authorize this action, then <a data-l10n-name="passwordChangeLink">please change your password</a>.
-  For more information, please visit <a data-l10n-name="supportLink">Mozilla Support</a>.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/en-US.ftl
@@ -1,5 +1,5 @@
 postRemoveAccountRecovery-subject = Account recovery key removed
 postRemoveAccountRecovery-title = { postRemoveAccountRecovery-subject }
-postRemoveAccountRecovery-description = You have successfully generated new recovery codes from the following device:
+postRemoveAccountRecovery-description = You have successfully removed an account recovery key for your Firefox Account using the following device:
 postRemoveAccountRecovery-action = { manage-account }
 postRemoveAccountRecovery-invalid = This recovery key can no longer be used to recover your account.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/en-US.ftl
@@ -1,0 +1,5 @@
+postRemoveAccountRecovery-subject = Account recovery key removed
+postRemoveAccountRecovery-title = { postRemoveAccountRecovery-subject }
+postRemoveAccountRecovery-description = You have successfully generated new recovery codes from the following device:
+postRemoveAccountRecovery-action = { manage-account }
+postRemoveAccountRecovery-invalid = This recovery key can no longer be used to recover your account.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/index.mjml
@@ -1,0 +1,29 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="postRemoveAccountRecovery-title">Account recovery key removed</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postRemoveAccountRecovery-description">You have successfully removed an account recovery key for your Firefox Account using the following device:</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/location/index.mjml') %>
+
+<mj-section>
+  <mj-column>
+<mj-text css-class="text-body">
+  <span data-l10n-id="postRemoveAccountRecovery-invalid">This recovery key can no longer be used to recover your account.</span>
+</mj-text>
+</mj-column>
+</mj-section>
+
+<%- include('/partials/button/index.mjml') %>
+
+<%- include('/partials/automatedEmailChangePassword/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/index.stories.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { MOCK_LOCATION } from '../../partials/location/mocks';
+import { storyWithProps } from '../../storybook-email';
+
+export default {
+  title: 'Emails/postRemoveAccountRecovery',
+} as Meta;
+
+const createStory = storyWithProps(
+  'postRemoveAccountRecovery',
+  'Sent when an account recovery key is removed.',
+  {
+    ...MOCK_LOCATION,
+    link: 'http://localhost:3030/settings',
+    passwordChangeLink: 'http://localhost:3030/settings/change_password',
+  }
+);
+
+export const PostRemoveAccountRecovery = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveAccountRecovery/index.txt
@@ -1,0 +1,13 @@
+postRemoveAccountRecovery-title = "Account recovery key removed"
+
+postRemoveAccountRecovery-description = "You have successfully removed an account recovery key for your Firefox Account using the following device:"
+
+<%- include('/partials/location/index.txt') %>
+
+<%- include('/partials/manageAccount/index.txt') %>
+
+postRemoveAccountRecovery-invalid = "This recovery key can no longer be used to recover your account."
+
+<%- include('/partials/changePassword/index.txt') %>
+
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/en-US.ftl
@@ -1,4 +1,4 @@
-post-remove-secondary-title = Secondary email removed
-post-remove-secondary-description = You have successfully removed { $secondaryEmail } as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address.
 postRemoveSecondary-subject = Secondary email removed
+postRemoveSecondary-title = { postRemoveSecondary-subject }
+postRemoveSecondary-description = You have successfully removed { $secondaryEmail } as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address.
 postRemoveSecondary-action = { manage-account }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.mjml
@@ -5,7 +5,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="post-remove-secondary-title">Secondary email removed</span>
+      <span data-l10n-id="postRemoveSecondary-title">Secondary email removed</span>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -13,7 +13,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-body">
-      <span data-l10n-id="post-remove-secondary-description" data-l10n-args='<%= JSON.stringify({secondaryEmail}) %>'>You have successfully removed secondary@email as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address.</span>
+      <span data-l10n-id="postRemoveSecondary-description" data-l10n-args='<%= JSON.stringify({secondaryEmail}) %>'>You have successfully removed secondary@email as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address.</span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.txt
@@ -1,6 +1,6 @@
-post-remove-secondary-title = "Secondary email removed"
+postRemoveSecondary-title = "Secondary email removed"
 
-post-remove-secondary-description = "You have successfully removed { $secondaryEmail } as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address."
+postRemoveSecondary-description = "You have successfully removed { $secondaryEmail } as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address."
 
 <%- include('/partials/manageAccount/index.txt') %>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/en-US.ftl
@@ -1,5 +1,6 @@
 postRemoveTwoStepAuthentication-subject = Two-step verification is off
 postRemoveTwoStepAuthentication-title = Two-step authentication disabled
 postRemoveTwoStepAuthentication-description = You have successfully disabled two-step authentication on your Firefox Account from the following device:
+postRemoveTwoStepAuthentication-description-plaintext = You have successfully disabled two-step authentication on your Firefox Account. Security codes will no longer be required at each sign-in.
 postRemoveTwoStepAuthentication-action = { manage-account }
 postRemoveTwoStepAuthentication-not-required = Security codes will no longer be required at each sign-in.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/en-US.ftl
@@ -1,0 +1,5 @@
+postRemoveTwoStepAuthentication-subject = Two-step verification is off
+postRemoveTwoStepAuthentication-title = Two-step authentication disabled
+postRemoveTwoStepAuthentication-description = You have successfully disabled two-step authentication on your Firefox Account from the following device:
+postRemoveTwoStepAuthentication-action = { manage-account }
+postRemoveTwoStepAuthentication-not-required = Security codes will no longer be required at each sign-in.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/index.mjml
@@ -1,0 +1,29 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="postRemoveTwoStepAuthentication-title">Two-step authentication disabled</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postRemoveTwoStepAuthentication-description">You have successfully disabled two-step authentication on your Firefox Account from the following device:</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/location/index.mjml') %>
+
+<mj-section>
+  <mj-column>
+<mj-text css-class="text-body">
+  <span data-l10n-id="postRemoveTwoStepAuthentication-not-required">Security codes will no longer be required at each sign-in.</span>
+</mj-text>
+</mj-column>
+</mj-section>
+
+<%- include('/partials/button/index.mjml') %>
+
+<%- include('/partials/automatedEmailChangePassword/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/index.stories.ts
@@ -7,7 +7,7 @@ import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Emails/postRemoveTwoStepAuthentication',
+  title: 'Templates/postRemoveTwoStepAuthentication',
 } as Meta;
 
 const createStory = storyWithProps(

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/index.stories.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { MOCK_LOCATION } from '../../partials/location/mocks';
+import { storyWithProps } from '../../storybook-email';
+
+export default {
+  title: 'Emails/postRemoveTwoStepAuthentication',
+} as Meta;
+
+const createStory = storyWithProps(
+  'postRemoveTwoStepAuthentication',
+  'Sent when a user disables two-step authentication.',
+  {
+    ...MOCK_LOCATION,
+    link: 'http://localhost:3030/settings',
+    passwordChangeLink: 'http://localhost:3030/settings/change_password',
+  }
+);
+
+export const PostRemoveAccountRecovery = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/index.txt
@@ -1,0 +1,14 @@
+postRemoveTwoStepAuthentication-title = "Two-step authentication disabled"
+
+postRemoveTwoStepAuthentication-description = "You have successfully disabled two-step authentication on your Firefox Account from the following device:"
+
+<%- include('/partials/location/index.txt') %>
+
+postRemoveTwoStepAuthentication-not-required = "Security codes will no longer be required at each sign-in."
+
+<%- include('/partials/manageAccount/index.txt') %>
+
+
+<%- include('/partials/changePassword/index.txt') %>
+
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveTwoStepAuthentication/index.txt
@@ -1,13 +1,10 @@
 postRemoveTwoStepAuthentication-title = "Two-step authentication disabled"
 
-postRemoveTwoStepAuthentication-description = "You have successfully disabled two-step authentication on your Firefox Account from the following device:"
+postRemoveTwoStepAuthentication-description-plaintext = "You have successfully disabled two-step authentication on your Firefox Account. Security codes will no longer be required at each sign-in."
 
 <%- include('/partials/location/index.txt') %>
 
-postRemoveTwoStepAuthentication-not-required = "Security codes will no longer be required at each sign-in."
-
 <%- include('/partials/manageAccount/index.txt') %>
-
 
 <%- include('/partials/changePassword/index.txt') %>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/en-US.ftl
@@ -1,0 +1,4 @@
+postVerifySecondary-subject = Secondary email added
+postVerifySecondary-title = { postVerifySecondary-subject }
+postVerifySecondary-description = You have successfully verified { $secondaryEmail } as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will now be delivered to both email addresses.
+postVerifySecondary-action = { manage-account }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.mjml
@@ -1,0 +1,22 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="postVerifySecondary-title">Secondary email added</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="postVerifySecondary-description" data-l10n-args='<%= JSON.stringify({secondaryEmail}) %>'>You have successfully verified secondary@email as a secondary email for your Firefox Account. Security notifications and sign-in confirmations will now be delivered to both email addresses.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/button/index.mjml') %>
+<%- include('/partials/automatedEmailChangePassword/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.stories.ts
@@ -3,21 +3,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Meta } from '@storybook/html';
-import { MOCK_LOCATION } from '../../partials/location/mocks';
 import { storyWithProps } from '../../storybook-email';
 
 export default {
-  title: 'Templates/postRemoveAccountRecovery',
+  title: 'Templates/postVerifySecondary',
 } as Meta;
 
 const createStory = storyWithProps(
-  'postRemoveAccountRecovery',
-  'Sent when an account recovery key is removed.',
+  'postVerifySecondary',
+  'Sent to primary email after secondary email is verified.',
   {
-    ...MOCK_LOCATION,
     link: 'http://localhost:3030/settings',
+    secondaryEmail: 'secondary@email.com',
     passwordChangeLink: 'http://localhost:3030/settings/change_password',
   }
 );
 
-export const PostRemoveAccountRecovery = createStory();
+export const PostVerifySecondary = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.txt
@@ -1,0 +1,7 @@
+postVerifySecondary-title = "Secondary email added"
+
+postVerifySecondary-description = "You have successfully added { $secondaryEmail } as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will now be delivered to both email addresses."
+
+<%- include('/partials/manageAccount/index.txt') %>
+
+<%- include('/partials/changePassword/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -702,6 +702,40 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['postRemoveAccountRecoveryEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Account recovery key removed' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-recovery-removed', 'manage-account', 'email', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postRemoveAccountRecovery') }],
+      ['X-Template-Name', { test: 'equal', expected: 'postRemoveAccountRecovery' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postRemoveAccountRecovery }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-recovery-removed', 'manage-account', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-recovery-removed', 'change-password', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-recovery-removed', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'account-recovery-removed', 'support')) },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-recovery-removed', 'manage-account', 'email', 'uid')}` },
+      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'account-recovery-removed', 'change-password', 'email')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-recovery-removed', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'account-recovery-removed', 'support')}` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -736,6 +736,40 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['postRemoveTwoStepAuthenticationEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Two-step verification is off' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-two-step-disabled', 'manage-account', 'email', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postRemoveTwoStepAuthentication') }],
+      ['X-Template-Name', { test: 'equal', expected: 'postRemoveTwoStepAuthentication' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postRemoveTwoStepAuthentication }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-two-step-disabled', 'manage-account', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-two-step-disabled', 'change-password', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-two-step-disabled', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'account-two-step-disabled', 'support')) },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-two-step-disabled', 'manage-account', 'email', 'uid')}` },
+      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'account-two-step-disabled', 'change-password', 'email')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-two-step-disabled', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'account-two-step-disabled', 'support')}` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -770,6 +770,30 @@ const TESTS: [string, any][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
   ])],
+
+  ['postVerifySecondaryEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Secondary email added' }],
+    ['headers', new Map([
+      ['X-Link', { test: 'equal', expected: configUrl('accountSettingsUrl', 'account-email-verified', 'manage-account', 'email', 'uid') }],
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('postVerifySecondary') }],
+      ['X-Template-Name', { test: 'equal', expected: 'postVerifySecondary' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.postVerifySecondary }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('accountSettingsUrl', 'account-email-verified', 'manage-account', 'email', 'uid')) },
+      { test: 'include', expected: decodeUrl(configHref('initiatePasswordChangeUrl', 'account-email-verified', 'change-password', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'account-email-verified', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'account-email-verified', 'support')) },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Manage account:\n${configUrl('accountSettingsUrl', 'account-email-verified', 'manage-account', 'email', 'uid')}` },
+      { test: 'include', expected: `please change your password.\n${configUrl('initiatePasswordChangeUrl', 'account-email-verified', 'change-password', 'email')}` },
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'account-email-verified', 'privacy')}` },
+      { test: 'notInclude', expected: config.smtp.supportUrl },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {


### PR DESCRIPTION
Because:
* We're converting all of our email templates to a new MJML stack

This commit:
* Converts postRemoveAccountRecovery, postRemoveTwoStepAuthentication, and postVerifySecondary email templates, adds tests and stories
* Removes a couple of FTL references we don't need, updates others to use the manageAccount partial or for consistent casing

fixes #9295
fixes #9300
fixes #9303