### PR TITLE
fix(auth): include emails-scss in build command

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/renderer.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/renderer.ts
@@ -10,7 +10,7 @@ import mjml2html = require('mjml');
 type TemplateComponent = 'layouts' | 'templates' | 'partials';
 export type TemplateContext = Record<string, any>;
 
-const TEMPLATES_DIR = './lib/senders/emails/';
+const TEMPLATES_DIR = __dirname;
 const mjmlConfig: Parameters<typeof mjml2html>[1] = {
   validationLevel: 'strict',
   filePath: __dirname,

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -9,7 +9,7 @@
     "test": "test"
   },
   "scripts": {
-    "build": "tsc --build && cp -R config fxa-content-server-l10n lib scripts dist/fxa-auth-server",
+    "build": "yarn emails-scss && tsc --build && cp -R config fxa-content-server-l10n lib scripts dist/fxa-auth-server",
     "bump-template-versions": "node scripts/template-version-bump",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint": "eslint .",


### PR DESCRIPTION
Discovered by Danny, this just adds the `emails-scss` command to the build command in the auth server. This should resolve the sending issues in stage.

Confirmed that this works for me locally when sending emails using the dist auth server - and after understanding the solution was able to effectively repro the issue.

(The auth server build command copies everything from the lib folder, and I had been manually running that command so it was including the compiled CSS already, which is why I wasn't seeing it locally when trying to repro.)