### PR TITLE
feat(auth): Convert 'recovery' email to mjml stack

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -456,7 +456,8 @@
       "postChangePrimary",
       "postConsumeRecoveryCode",
       "postNewRecoveryCodes",
-      "passwordChangeRequired"
+      "passwordChangeRequired",
+      "recovery"
     ]
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/recovery/en-US.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/recovery/en-US.ftl
@@ -1,0 +1,4 @@
+recovery-subject = Reset your password
+recovery-title = Need to reset your password?
+recovery-description = Click the button within the next hour to create a new password. The request came from the following device:
+recovery-action = Create new password

--- a/packages/fxa-auth-server/lib/senders/emails/templates/recovery/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/recovery/index.mjml
@@ -1,0 +1,22 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public #
+License, v. 2.0. If a copy of the MPL was not distributed with this # file, You
+can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="recovery-title">Need to reset your password?</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="recovery-description">
+        Click the button within the next hour to create a new password. The
+        request came from the following device:
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/location/index.mjml') %>
+<%- include('/partials/button/index.mjml') %>
+<%- include('/partials/automatedEmailNoAction/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/recovery/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/recovery/index.stories.ts
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { MOCK_LOCATION } from '../../partials/location/mocks';
+import { storyWithProps } from '../../storybook-email';
+
+export default {
+  title: 'Templates/recovery',
+} as Meta;
+
+const createStory = storyWithProps(
+  'recovery',
+  'Sent when user begins password reset flow',
+  {
+    ...MOCK_LOCATION,
+    link: 'http://localhost:3030/complete_reset_password',
+  }
+);
+
+export const Recovery = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/recovery/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/recovery/index.txt
@@ -1,0 +1,12 @@
+recovery-title = "Need to reset your password?"
+
+recovery-description = "Click the button within the next hour to create a new password. The request came from the following device:"
+
+<%- include('/partials/location/index.txt') %>
+
+recovery-action = "Create new password"
+<%- link %>
+
+<%- include('/partials/automatedEmailNoAction/index.txt') %>
+
+<%- include('/partials/support/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -641,6 +641,35 @@ const TESTS: [string, any][] = [
     ]],
   ])],
 
+  ['recoveryEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Reset your password' }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('recovery') }],
+      ['X-Template-Name', { test: 'equal', expected: 'recovery' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.recovery }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('privacyUrl', 'forgot-password', 'privacy')) },
+      { test: 'include', expected: decodeUrl(configHref('supportUrl', 'forgot-password', 'support')) },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'forgot-password', 'privacy')}` },
+      { test: 'include', expected: `For more information, please visit ${configUrl('supportUrl', 'forgot-password', 'support')}` },
+      { test: 'include', expected: `IP address: ${MESSAGE.ip}` },
+      { test: 'include', expected: `${MESSAGE.location.city}, ${MESSAGE.location.stateCode}, ${MESSAGE.location.country} (estimated)` },
+      { test: 'include', expected: `${MESSAGE.uaBrowser} on ${MESSAGE.uaOS} ${MESSAGE.uaOSVersion}` },
+      { test: 'include', expected: `${MESSAGE.date}` },
+      { test: 'include', expected: `${MESSAGE.time}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+  ])],
+
   ['passwordResetAccountRecoveryEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: 'Password updated using recovery key' }],
     ['headers', new Map([


### PR DESCRIPTION

fixes #10478

## Because

- We're converting all emails over to the new stack

## This pull request

- * Converts 'recovery' to new stack

## Issue that this pull request solves

Closes: #10478

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).