### PR TITLE
feat(shared): handle more query object types

### DIFF
--- a/packages/fxa-shared/nestjs/sentry/reporting.spec.ts
+++ b/packages/fxa-shared/nestjs/sentry/reporting.spec.ts
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import * as uuid from 'uuid';
+
+import { filterObject } from './reporting';
+
+const FILTERED = '[Filtered]';
+
+describe('filterObject', () => {
+  it('should be defined', () => {
+    expect(filterObject).toBeDefined();
+  });
+
+  // Test Sentry QueryParams filtering types
+  it('should filter array of key/value arrays', () => {
+    const input = [
+      ['foo', uuid.v4().replace(/-/g, '')],
+      ['baz', uuid.v4().replace(/-/g, '')],
+      ['bar', 'fred'],
+    ];
+    const expected = [
+      ['foo', FILTERED],
+      ['baz', FILTERED],
+      ['bar', 'fred'],
+    ];
+    const output = filterObject(input);
+    expect(output).toEqual(expected);
+  });
+
+  it('should filter an object of key/value pairs', () => {
+    const input = {
+      foo: uuid.v4().replace(/-/g, ''),
+      baz: uuid.v4().replace(/-/g, ''),
+      bar: 'fred',
+    };
+    const expected = {
+      foo: FILTERED,
+      baz: FILTERED,
+      bar: 'fred',
+    };
+    const output = filterObject(input);
+    expect(output).toEqual(expected);
+  });
+
+  it('should skip nested arrays that are not valid key/value arrays', () => {
+    const input = [
+      ['foo', uuid.v4().replace(/-/g, '')],
+      ['bar', 'fred'],
+      ['fizz', 'buzz', 'parrot'],
+    ];
+    const expected = [
+      ['foo', FILTERED],
+      ['bar', 'fred'],
+      ['fizz', 'buzz', 'parrot'],
+    ];
+    const output = filterObject(input);
+    expect(output).toEqual(expected);
+  });
+});

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -82,6 +82,7 @@
     "@sentry/integrations": "^6.12.0",
     "@sentry/node": "^6.12.0",
     "@types/js-md5": "^0.4.2",
+    "@types/uuid": "^8.3.1",
     "accept-language": "^2.0.17",
     "ajv": "^6.12.2",
     "apollo-server": "^2.25.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8293,6 +8293,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/uuid@npm:^8.3.1":
+  version: 8.3.1
+  resolution: "@types/uuid@npm:8.3.1"
+  checksum: b41bdc5e86c6f0f1899306be10455636da0f2168c9489b869edd6837ddeb7c0e501b1ff7d857402462986bada2a379125743dd895fa801d03437cd632116a373
+  languageName: node
+  linkType: hard
+
 "@types/validator@npm:^13.1.3":
   version: 13.1.3
   resolution: "@types/validator@npm:13.1.3"
@@ -19996,6 +20003,7 @@ fsevents@~2.1.1:
     "@types/proxyquire": ^1.3.28
     "@types/sinon": 10.0.1
     "@types/superagent": ^4.1.11
+    "@types/uuid": ^8.3.1
     accept-language: ^2.0.17
     ajv: ^6.12.2
     apollo-server: ^2.25.2


### PR DESCRIPTION
Because:

* QueryParams in Sentry is not just a string, it can be an array of
  arrays or an object. Using replace on them throws an error when
  attempting to report an error which obscures legitimate errors.

This commit:

* Properly handles all the QueryParams types.

Closes #9963

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
