### PR TITLE
fix(subscriptions): restore input cursor position post async render

### DIFF
--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -95,7 +95,7 @@ export const NewUserEmailForm = ({
       <hr />
       <Localized id="new-user-email" attrs={{ label: true }}>
         <Input
-          type="email"
+          type="text"
           name="new-user-email"
           label="Enter your email"
           data-testid="new-user-email"
@@ -118,7 +118,7 @@ export const NewUserEmailForm = ({
 
       <Localized id="new-user-confirm-email" attrs={{ label: true }}>
         <Input
-          type="email"
+          type="text"
           name="new-user-confirm-email"
           label="Confirm your email"
           data-testid="new-user-confirm-email"

--- a/packages/fxa-payments-server/src/components/fields/index.tsx
+++ b/packages/fxa-payments-server/src/components/fields/index.tsx
@@ -169,11 +169,25 @@ const UnwrappedInput = (props: InputProps) => {
     async (ev) => {
       const { value } = ev.target;
       if (onValidatePromise) {
+        const { selectionStart, selectionEnd } =
+          tooltipParentRef?.current as HTMLInputElement;
         const result = await onValidatePromise(value, true, props, getString);
+
         validator.updateField({
           name,
           ...result,
         });
+
+        // If the value hasn't changed since the cursor position was saved,
+        // restore it.  If we do nothing, the cursor will be moved to the end,
+        // regardless of the cursor position when the user started typing.
+        if (
+          tooltipParentRef.current &&
+          value === tooltipParentRef.current.value
+        ) {
+          tooltipParentRef.current.selectionStart = selectionStart;
+          tooltipParentRef.current.selectionEnd = selectionEnd;
+        }
       } else {
         validator.updateField({
           name,


### PR DESCRIPTION
Because:
 - the input cursor moves the end when the user types in the email
   address field on the passwordless checkout page

This commit:
 - save and restore the cursor position after the field update re-render

This patch fixes the symptom of the issue by restoring the cursor
position.  It's not perfect: sometimes you can see that the cursor
flashes at the end of the input value before it moves back.

## Issue that this pull request solves

Closes: #10233
