### PR TITLE
chore(payments): remove useSCAPaymentUIByDefault feature flag

### DIFF
--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -13,12 +13,6 @@ convict.addFormats(require('convict-format-with-validator'));
 
 const conf = convict({
   featureFlags: {
-    useSCAPaymentUIByDefault: {
-      default: false,
-      doc: 'Whether to use newer SCA payment UI components by default rather than at the /v2 sub-path',
-      env: 'FEATURE_USE_SCA_PAYMENT_UI_BY_DEFAULT',
-      format: Boolean,
-    },
     usePaypalUIByDefault: {
       default: false,
       doc: 'Whether to use PayPal payment UI by default rather than Stripe payment UI alone',

--- a/packages/fxa-payments-server/src/App.tsx
+++ b/packages/fxa-payments-server/src/App.tsx
@@ -65,8 +65,6 @@ export const App = ({
   /* istanbul ignore next - router override is only used for tests */
   const Router = routerOverride ? routerOverride() : BrowserRouter;
 
-  const { useSCAPaymentUIByDefault = false } = config.featureFlags;
-
   const appContextValue: AppContextType = {
     config,
     queryParams,


### PR DESCRIPTION
Because:
* This feature flag is no longer used.

This commit:
* Removes the unnecessary useSCAPaymentUIBeDefault flag.

Closes: #9070

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).