### PR TITLE
chore(payments): create storybook for PaymentLegalBlurb

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -96,13 +96,13 @@ product-no-such-plan = No such plan for this product.
 
 ## payment legal blurb
 payment-legal-copy-stripe-and-paypal-2 = { -brand-name-mozilla } uses { -brand-name-stripe } and { -brand-name-paypal } for secure payment processing.
-payment-legal-link-stripe-paypal = <stripePrivacyLink>{ -brand-name-stripe } privacy policy</stripePrivacyLink> &nbsp; <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
+payment-legal-link-stripe-paypal = <stripePrivacyLink>{ -brand-name-stripe } privacy policy</stripePrivacyLink> &nbsp; <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>
 
 payment-legal-copy-paypal = { -brand-name-mozilla } uses { -brand-name-paypal } for secure payment processing.
-payment-legal-link-paypal-2 = <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>.
+payment-legal-link-paypal-2 = <paypalPrivacyLink>{ -brand-name-paypal } privacy policy</paypalPrivacyLink>
 
 payment-legal-copy-stripe-2 = { -brand-name-mozilla } uses { -brand-name-stripe } for secure payment processing.
-payment-legal-link-stripe-3 = <stripePrivacyLink>{ -brand-name-stripe } privacy policy</stripePrivacyLink>.
+payment-legal-link-stripe-3 = <stripePrivacyLink>{ -brand-name-stripe } privacy policy</stripePrivacyLink>
 
 ## payment form
 payment-name =

--- a/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.stories.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { MockApp } from '../../../.storybook/components/MockApp';
+import PaymentLegalBlub from './index';
+import * as PaymentProvider from '../../lib/PaymentProvider';
+
+storiesOf('components/PaymentLegalBlurb', module)
+  .add('default', () => (
+    <MockApp>
+      <PaymentLegalBlub {...{ provider: undefined }}></PaymentLegalBlub>
+    </MockApp>
+  ))
+  .add('paypal', () => (
+    <MockApp>
+      <PaymentLegalBlub
+        {...{ provider: PaymentProvider.PaymentProviders.paypal }}
+      ></PaymentLegalBlub>
+    </MockApp>
+  ))
+  .add('stripe', () => (
+    <MockApp>
+      <PaymentLegalBlub
+        {...{ provider: PaymentProvider.PaymentProviders.stripe }}
+      ></PaymentLegalBlub>
+    </MockApp>
+  ));

--- a/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentLegalBlurb/index.tsx
@@ -6,15 +6,15 @@ import * as PaymentProvider from '../../lib/PaymentProvider';
 import './index.scss';
 
 function getPrivacyLinkText(): string {
-  return '<stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> <paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>.';
+  return '<stripePrivacyLink>Stripe privacy policy</stripePrivacyLink> <paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>';
 }
 
 function getPaypalPrivacyLinkText(): string {
-  return '<paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>.';
+  return '<paypalPrivacyLink>Paypal privacy policy</paypalPrivacyLink>';
 }
 
 function getStripePrivacyLinkText(): string {
-  return '<stripePrivacyLink>Stripe privacy policy</stripePrivacyLink>.';
+  return '<stripePrivacyLink>Stripe privacy policy</stripePrivacyLink>';
 }
 
 const PaypalPaymentLegalBlurb = () => (


### PR DESCRIPTION
Because:

* We would like to have storybook coverage for react components.

This commit:

* Adds a storybook component for all three cases: paypal, stripe, default.

Closes #10102

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
