### PR TITLE
feat(auth): enable nodemailer SES transport

### DIFF
--- a/_dev/pm2/infrastructure.config.js
+++ b/_dev/pm2/infrastructure.config.js
@@ -1,73 +1,66 @@
 module.exports = {
   apps: [
     {
-      name: "mysql",
-      script: "_scripts/mysql.sh",
-      max_restarts: "1",
-      min_uptime: "2m",
-      kill_timeout: 20000
+      name: 'mysql',
+      script: '_scripts/mysql.sh',
+      max_restarts: '1',
+      min_uptime: '2m',
+      kill_timeout: 20000,
     },
     {
-      name: "redis",
-      script: "_scripts/redis.sh",
+      name: 'redis',
+      script: '_scripts/redis.sh',
       env: {
-        PORT: "6379"
+        PORT: '6379',
       },
-      max_restarts: "1",
-      min_uptime: "2m",
-      kill_timeout: 20000
+      max_restarts: '1',
+      min_uptime: '2m',
+      kill_timeout: 20000,
     },
     {
-      name: "memcache",
-      script: "_scripts/memcached.sh",
-      max_restarts: "1",
-      min_uptime: "2m",
-      kill_timeout: 20000
+      name: 'memcache',
+      script: '_scripts/memcached.sh',
+      max_restarts: '1',
+      min_uptime: '2m',
+      kill_timeout: 20000,
     },
     {
-      name: "sns",
-      script: "_scripts/goaws.sh",
-      max_restarts: "1",
-      min_uptime: "2m",
+      name: 'sns',
+      script: '_scripts/goaws.sh',
+      max_restarts: '1',
+      min_uptime: '2m',
       autorestart: false,
-      kill_timeout: 20000
+      kill_timeout: 20000,
     },
     {
-      name: "pubsub",
-      script: "_scripts/pubsub.sh",
-      max_restarts: "1",
-      min_uptime: "2m",
-      kill_timeout: 20000
+      name: 'pubsub',
+      script: '_scripts/pubsub.sh',
+      max_restarts: '1',
+      min_uptime: '2m',
+      kill_timeout: 20000,
     },
     {
-      name: "firestore",
-      script: "_scripts/firestore.sh",
-      max_restarts: "1",
-      min_uptime: "2m",
-      kill_timeout: 20000
+      name: 'firestore',
+      script: '_scripts/firestore.sh',
+      max_restarts: '1',
+      min_uptime: '2m',
+      kill_timeout: 20000,
     },
     {
-      name: "sync",
-      script: "_scripts/syncserver.sh",
-      max_restarts: "1",
-      min_uptime: "2m",
+      name: 'sync',
+      script: '_scripts/syncserver.sh',
+      max_restarts: '1',
+      min_uptime: '2m',
       autorestart: false,
-      kill_timeout: 20000
+      kill_timeout: 20000,
     },
     {
-      name: "pushbox",
-      script: "_scripts/pushbox.sh",
-      max_restarts: "1",
-      min_uptime: "2m",
-      args: "3306 root@mydb:3306",
-      kill_timeout: 20000
+      name: 'pushbox',
+      script: '_scripts/pushbox.sh',
+      max_restarts: '1',
+      min_uptime: '2m',
+      args: '3306 root@mydb:3306',
+      kill_timeout: 20000,
     },
-    {
-      name: "email",
-      script: "_scripts/fxa-email-service.sh",
-      max_restarts: "1",
-      min_uptime: "2m",
-      kill_timeout: 20000
-    }
-  ]
+  ],
 };

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -110,10 +110,11 @@ async function run(config) {
   );
   const profile = require('../lib/profile/client')(log, config, statsd);
   Container.set(ProfileClient, profile);
+  const bounces = require('../lib/bounces')(config, database);
   const senders = await require('../lib/senders')(
     log,
     config,
-    error,
+    bounces,
     translator,
     statsd
   );

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -17,7 +17,9 @@
     "port": 9999,
     "secure": false,
     "redirectDomain": "localhost",
-    "subscriptionTermsUrl": "https://www.mozilla.org/about/legal/terms/firefox-private-network/"
+    "subscriptionTermsUrl": "https://www.mozilla.org/about/legal/terms/firefox-private-network/",
+    "user": "local",
+    "password": "local"
   },
   "snsTopicArn": "arn:aws:sns:local-01:000000000000:local-topic1",
   "snsTopicEndpoint": "http://localhost:4100/",

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -8,6 +8,8 @@ import url from 'url';
 import { makeMySQLConfig } from 'fxa-shared/db/config';
 
 const DEFAULT_SUPPORTED_LANGUAGES = require('./supportedLanguages');
+const ONE_DAY = 1000 * 60 * 60 * 24;
+const FIVE_MINUTES = 1000 * 60 * 5;
 
 convict.addFormats(require('convict-format-with-moment'));
 convict.addFormats(require('convict-format-with-validator'));
@@ -386,6 +388,44 @@ const conf = convict({
       format: String,
       default: '',
       env: 'SES_CONFIGURATION_SET',
+    },
+    bounces: {
+      enabled: {
+        doc: 'Flag to enable checking for bounces before sending email',
+        format: Boolean,
+        default: true,
+        env: 'BOUNCES_ENABLED',
+      },
+      complaint: {
+        doc: 'Tiers of max allowed complaints per amount of milliseconds',
+        format: Object,
+        default: {
+          // 0 are allowed in the past day.
+          // 1 is allowed in the past year. TODO: a year seems insanely long
+          0: ONE_DAY,
+          1: 365 * ONE_DAY,
+        },
+        env: 'BOUNCES_COMPLAINT',
+      },
+      hard: {
+        doc: 'Tiers of max allowed hard bounces per amount of milliseconds',
+        format: Object,
+        default: {
+          // 0 are allowed in the past day.
+          // 1 is allowed in the past year. TODO: a year seems insanely long
+          0: ONE_DAY,
+          1: 365 * ONE_DAY,
+        },
+        env: 'BOUNCES_HARD',
+      },
+      soft: {
+        doc: 'Tiers of max allowed soft bounces per amount of milliseconds',
+        format: Object,
+        default: {
+          0: FIVE_MINUTES,
+        },
+        env: 'BOUNCES_SOFT',
+      },
     },
   },
   maxEventLoopDelay: {

--- a/packages/fxa-auth-server/lib/bounces.js
+++ b/packages/fxa-auth-server/lib/bounces.js
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const error = require('./error');
+
+module.exports = (config, db) => {
+  const configBounces = (config.smtp && config.smtp.bounces) || {};
+  const BOUNCES_ENABLED = !!configBounces.enabled;
+
+  const BOUNCE_TYPE_HARD = 1;
+  const BOUNCE_TYPE_SOFT = 2;
+  const BOUNCE_TYPE_COMPLAINT = 3;
+
+  const freeze = Object.freeze;
+  const BOUNCE_RULES = freeze({
+    [BOUNCE_TYPE_HARD]: freeze(configBounces.hard || {}),
+    [BOUNCE_TYPE_SOFT]: freeze(configBounces.soft || {}),
+    [BOUNCE_TYPE_COMPLAINT]: freeze(configBounces.complaint || {}),
+  });
+
+  const ERRORS = {
+    [BOUNCE_TYPE_HARD]: error.emailBouncedHard,
+    [BOUNCE_TYPE_SOFT]: error.emailBouncedSoft,
+    [BOUNCE_TYPE_COMPLAINT]: error.emailComplaint,
+  };
+
+  function checkBounces(email) {
+    return db.emailBounces(email).then(applyRules);
+  }
+
+  // Relies on the order of the bounces array to be sorted by date,
+  // descending. So, each bounce in the array must be older than the
+  // previous.
+  function applyRules(bounces) {
+    const tallies = {
+      [BOUNCE_TYPE_HARD]: {
+        count: 0,
+        latest: 0,
+      },
+      [BOUNCE_TYPE_COMPLAINT]: {
+        count: 0,
+        latest: 0,
+      },
+      [BOUNCE_TYPE_SOFT]: {
+        count: 0,
+        latest: 0,
+      },
+    };
+    const now = Date.now();
+
+    bounces.forEach((bounce) => {
+      const type = bounce.bounceType;
+      const ruleSet = BOUNCE_RULES[type];
+      if (ruleSet) {
+        const tally = tallies[type];
+        const tier = ruleSet[tally.count];
+        if (!tally.latest) {
+          tally.latest = bounce.createdAt;
+        }
+        if (tier && bounce.createdAt > now - tier) {
+          throw ERRORS[type](tally.latest);
+        }
+        tally.count++;
+      }
+    });
+  }
+
+  function disabled() {
+    return Promise.resolve();
+  }
+
+  return {
+    check: BOUNCES_ENABLED ? checkBounces : disabled,
+  };
+};

--- a/packages/fxa-auth-server/lib/payments/processing-tasks-setup.ts
+++ b/packages/fxa-auth-server/lib/payments/processing-tasks-setup.ts
@@ -5,7 +5,6 @@ import { setupAuthDatabase } from 'fxa-shared/db';
 import { StatsD } from 'hot-shots';
 import Container from 'typedi';
 
-import error from '../error';
 import { CurrencyHelper } from '../payments/currencies';
 import { StripeHelper } from './stripe';
 import { configureSentry } from '../sentry';
@@ -25,11 +24,11 @@ export async function setupProcesingTaskObjects() {
           log.error('statsd.error', err);
         },
       })
-    : (({
+    : ({
         increment: () => {},
         timing: () => {},
         close: () => {},
-      } as unknown) as StatsD);
+      } as unknown as StatsD);
   Container.set(StatsD, statsd);
 
   const log = require('../log')({ ...config.log, statsd });
@@ -41,7 +40,7 @@ export async function setupProcesingTaskObjects() {
   const senders = await require('../senders')(
     log,
     config,
-    error,
+    { check: () => Promise.resolve() },
     translator,
     statsd
   );

--- a/packages/fxa-auth-server/lib/senders/index.js
+++ b/packages/fxa-auth-server/lib/senders/index.js
@@ -10,13 +10,13 @@ const createSms = require('./sms');
 module.exports = async (
   log,
   config,
-  error,
+  bounces,
   translator,
   statsd,
   sender // This is only used in tests
 ) => {
   const defaultLanguage = config.i18n.defaultLanguage;
-  const Mailer = createMailer(log, config);
+  const Mailer = createMailer(log, config, bounces);
 
   async function createSenders() {
     const templates = await require('./templates')(log, translator);

--- a/packages/fxa-auth-server/pm2.config.js
+++ b/packages/fxa-auth-server/pm2.config.js
@@ -23,6 +23,7 @@ module.exports = {
         SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX: '^sync.*@restmail\\.net$',
         FORCE_PASSWORD_CHANGE_EMAIL_REGEX: 'forcepwdchange',
         CONFIG_FILES: 'config/secrets.json',
+        EMAIL_CONFIG_USE_REDIS: 'false',
         PORT: '9000',
         PATH,
       },

--- a/packages/fxa-auth-server/scripts/bulk-mailer/index.js
+++ b/packages/fxa-auth-server/scripts/bulk-mailer/index.js
@@ -6,7 +6,6 @@
 
 const chunk = require('lodash.chunk');
 const config = require('../../config').getProperties();
-const error = require('../../lib/error');
 const readUserRecords = require('./read-user-records');
 const sendEmailBatches = require('./send-email-batches');
 const Senders = require('../../lib/senders');
@@ -120,7 +119,16 @@ async function createMailer(
 ) {
   const sender = shouldSend ? null : createSenderMock(emailOutputDirname);
 
-  return (await Senders(log, config, error, translator, null, sender)).email;
+  return (
+    await Senders(
+      log,
+      config,
+      { check: () => Promise.resolve() },
+      translator,
+      {},
+      sender
+    )
+  ).email;
 }
 
 function createSenderMock(emailOutputDirname) {

--- a/packages/fxa-auth-server/scripts/sms/send.js
+++ b/packages/fxa-auth-server/scripts/sms/send.js
@@ -16,7 +16,12 @@ require('../../lib/senders/translator')(
   config.i18n.defaultLanguage
 )
   .then((translator) => {
-    return require('../../lib/senders')(log, config, null, translator);
+    return require('../../lib/senders')(
+      log,
+      config,
+      { check: () => Promise.resolve() },
+      translator
+    );
   })
   .then((senders) => {
     return senders.sms.send.apply(null, args);

--- a/packages/fxa-auth-server/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/scripts/write-emails-to-disk.js
@@ -21,7 +21,6 @@
 process.env.NODE_ENV = 'dev';
 
 const config = require('../config').getProperties();
-const error = require('../lib/error');
 const createSenders = require('../lib/senders');
 const fs = require('fs');
 const log = require('../lib/log')({});
@@ -53,7 +52,14 @@ require('../lib/senders/translator')(
   config.i18n.defaultLanguage
 )
   .then((translator) => {
-    return createSenders(log, config, error, translator, {}, mailSender);
+    return createSenders(
+      log,
+      config,
+      { check: () => Promise.resolve() },
+      translator,
+      {},
+      mailSender
+    );
   })
   .then((senders) => {
     const mailer = senders.email._ungatedMailer;

--- a/packages/fxa-auth-server/test/local/bounces.js
+++ b/packages/fxa-auth-server/test/local/bounces.js
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const ROOT_DIR = '../..';
+
+const assert = require('assert');
+const config = require(`${ROOT_DIR}/config`).getProperties();
+const createBounces = require(`${ROOT_DIR}/lib/bounces`);
+const error = require(`${ROOT_DIR}/lib/error`);
+const sinon = require('sinon');
+
+const EMAIL = Math.random() + '@example.test';
+const BOUNCE_TYPE_HARD = 1;
+const BOUNCE_TYPE_COMPLAINT = 3;
+
+const NOW = Date.now();
+
+describe('bounces', () => {
+  it('succeeds if bounces not over limit', () => {
+    const db = {
+      emailBounces: sinon.spy(() => Promise.resolve([])),
+    };
+    return createBounces(config, db)
+      .check(EMAIL)
+      .then(() => {
+        assert.equal(db.emailBounces.callCount, 1);
+      });
+  });
+
+  it('error if complaints over limit', () => {
+    const conf = Object.assign({}, config);
+    conf.smtp = {
+      bounces: {
+        enabled: true,
+        complaint: {
+          0: Infinity,
+        },
+      },
+    };
+    const db = {
+      emailBounces: sinon.spy(() =>
+        Promise.resolve([
+          {
+            bounceType: BOUNCE_TYPE_COMPLAINT,
+            createdAt: NOW,
+          },
+        ])
+      ),
+    };
+    return createBounces(conf, db)
+      .check(EMAIL)
+      .then(
+        () => assert(false),
+        (e) => {
+          assert.equal(db.emailBounces.callCount, 1);
+          assert.equal(e.errno, error.ERRNO.BOUNCE_COMPLAINT);
+        }
+      );
+  });
+
+  it('error if hard bounces over limit', () => {
+    const conf = Object.assign({}, config);
+    conf.smtp = {
+      bounces: {
+        enabled: true,
+        hard: {
+          0: 100,
+          1: 5000,
+        },
+      },
+    };
+    const DATE = Date.now() - 1000;
+    const db = {
+      emailBounces: sinon.spy(() =>
+        Promise.resolve([
+          {
+            bounceType: BOUNCE_TYPE_HARD,
+            createdAt: DATE,
+          },
+          {
+            bounceType: BOUNCE_TYPE_HARD,
+            createdAt: DATE - 1000,
+          },
+        ])
+      ),
+    };
+    return createBounces(conf, db)
+      .check(EMAIL)
+      .then(
+        () => assert(false),
+        (e) => {
+          assert.equal(db.emailBounces.callCount, 1);
+          assert.equal(e.errno, error.ERRNO.BOUNCE_HARD);
+          assert.equal(e.output.payload.bouncedAt, DATE);
+        }
+      );
+  });
+
+  it('does not error if not enough bounces in duration', () => {
+    const conf = Object.assign({}, config);
+    conf.smtp = {
+      bounces: {
+        enabled: true,
+        hard: {
+          0: 5000,
+          1: 50000,
+        },
+      },
+    };
+    const db = {
+      emailBounces: sinon.spy(() =>
+        Promise.resolve([
+          {
+            bounceType: BOUNCE_TYPE_HARD,
+            createdAt: Date.now() - 20000,
+          },
+        ])
+      ),
+    };
+    return createBounces(conf, db)
+      .check(EMAIL)
+      .then(() => {
+        assert.equal(db.emailBounces.callCount, 1);
+      });
+  });
+
+  it('does not error if not enough complaints in duration', () => {
+    const conf = Object.assign({}, config);
+    conf.smtp = {
+      bounces: {
+        enabled: true,
+        complaint: {
+          0: 5000,
+          1: 50000,
+        },
+      },
+    };
+    const db = {
+      emailBounces: sinon.spy(() =>
+        Promise.resolve([
+          {
+            bounceType: BOUNCE_TYPE_COMPLAINT,
+            createdAt: Date.now() - 20000,
+          },
+        ])
+      ),
+    };
+    return createBounces(conf, db)
+      .check(EMAIL)
+      .then(() => {
+        assert.equal(db.emailBounces.callCount, 1);
+      });
+  });
+
+  describe('disabled', () => {
+    it('does not call bounces.check if disabled', () => {
+      const conf = Object.assign({}, config);
+      conf.smtp = {
+        bounces: {
+          enabled: false,
+        },
+      };
+      const db = {
+        emailBounces: sinon.spy(() =>
+          Promise.resolve([
+            {
+              bounceType: BOUNCE_TYPE_HARD,
+              createdAt: Date.now() - 20000,
+            },
+          ])
+        ),
+      };
+      assert.equal(db.emailBounces.callCount, 0);
+      return createBounces(conf, db)
+        .check(EMAIL)
+        .then(() => {
+          assert.equal(db.emailBounces.callCount, 0);
+        });
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/local/senders/email.js
+++ b/packages/fxa-auth-server/test/local/senders/email.js
@@ -19,6 +19,8 @@ if (!config.smtp.prependVerificationSubdomain.enabled) {
 if (!config.smtp.sesConfigurationSet) {
   config.smtp.sesConfigurationSet = 'ses-config';
 }
+config.smtp.user = 'test';
+config.smtp.password = 'test';
 config.smtp.subscriptionTermsUrl = 'http://example.com/terms';
 
 // Force enable the subscription transactional emails
@@ -1698,19 +1700,6 @@ describe('lib/senders/email:', () => {
       });
     });
 
-    it('resolves sendMail status', () => {
-      const message = {
-        email: 'test@restmail.net',
-        subject: 'subject',
-        template: 'verifyLogin',
-        uid: 'foo',
-      };
-
-      return mailer.send(message).then((status) => {
-        assert.deepEqual(status, [{ resp: 'ok' }]);
-      });
-    });
-
     it('logs emailEvent on send', () => {
       const message = {
         email: 'test@restmail.net',
@@ -2210,7 +2199,10 @@ async function setup(log, config, mocks, locale = 'en', sender = null) {
   ]);
   const Mailer = proxyquire(`${ROOT_DIR}/lib/senders/email`, mocks)(
     log,
-    config
+    config,
+    {
+      check: () => Promise.resolve(),
+    }
   );
   return new Mailer(translator, templates, config.smtp, sender);
 }

--- a/packages/fxa-auth-server/test/local/senders/index.js
+++ b/packages/fxa-auth-server/test/local/senders/index.js
@@ -9,7 +9,6 @@ const ROOT_DIR = '../../..';
 const { assert } = require('chai');
 const config = require(`${ROOT_DIR}/config`).getProperties();
 const crypto = require('crypto');
-const error = require(`${ROOT_DIR}/lib/error`);
 const mocks = require(`${ROOT_DIR}/test/mocks`);
 const senders = require(`${ROOT_DIR}/lib/senders`);
 const sinon = require('sinon');
@@ -50,7 +49,9 @@ describe('lib/senders/index', () => {
             enableBudgetChecks: false,
           },
         }),
-        error,
+        {
+          check: sinon.stub().resolves(null),
+        },
         {}
       ).then((sndrs) => {
         const email = sndrs.email;
@@ -163,8 +164,8 @@ describe('lib/senders/index', () => {
               1
             );
 
-            const args = email._ungatedMailer.passwordChangedEmail.getCall(0)
-              .args;
+            const args =
+              email._ungatedMailer.passwordChangedEmail.getCall(0).args;
             assert.equal(args[0].email, EMAIL, 'email correctly set');
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set');
             assert.equal(
@@ -190,8 +191,8 @@ describe('lib/senders/index', () => {
           .then(() => {
             assert.equal(email._ungatedMailer.passwordResetEmail.callCount, 1);
 
-            const args = email._ungatedMailer.passwordResetEmail.getCall(0)
-              .args;
+            const args =
+              email._ungatedMailer.passwordResetEmail.getCall(0).args;
             assert.equal(args[0].email, EMAIL, 'email correctly set');
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set');
             assert.equal(
@@ -217,8 +218,8 @@ describe('lib/senders/index', () => {
           .then(() => {
             assert.equal(email._ungatedMailer.newDeviceLoginEmail.callCount, 1);
 
-            const args = email._ungatedMailer.newDeviceLoginEmail.getCall(0)
-              .args;
+            const args =
+              email._ungatedMailer.newDeviceLoginEmail.getCall(0).args;
             assert.equal(args[0].email, EMAIL, 'email correctly set');
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set');
             assert.equal(
@@ -300,9 +301,10 @@ describe('lib/senders/index', () => {
               1
             );
 
-            const args = email._ungatedMailer.postAddTwoStepAuthenticationEmail.getCall(
-              0
-            ).args;
+            const args =
+              email._ungatedMailer.postAddTwoStepAuthenticationEmail.getCall(
+                0
+              ).args;
             assert.equal(args[0].email, EMAIL, 'email correctly set');
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set');
             assert.equal(
@@ -320,9 +322,8 @@ describe('lib/senders/index', () => {
         return createSender(config)
           .then((e) => {
             email = e;
-            email._ungatedMailer.postRemoveTwoStepAuthenticationEmail = sinon.spy(
-              () => Promise.resolve({})
-            );
+            email._ungatedMailer.postRemoveTwoStepAuthenticationEmail =
+              sinon.spy(() => Promise.resolve({}));
             return email.sendPostRemoveTwoStepAuthenticationEmail(
               EMAILS,
               acct,
@@ -336,9 +337,10 @@ describe('lib/senders/index', () => {
               1
             );
 
-            const args = email._ungatedMailer.postRemoveTwoStepAuthenticationEmail.getCall(
-              0
-            ).args;
+            const args =
+              email._ungatedMailer.postRemoveTwoStepAuthenticationEmail.getCall(
+                0
+              ).args;
             assert.equal(args[0].email, EMAIL, 'email correctly set');
             assert.equal(args[0].ccEmails.length, 1, 'email correctly set');
             assert.equal(

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -1103,7 +1103,10 @@ async function setup(
   ]);
   const Mailer = proxyquire(`${ROOT_DIR}/lib/senders/email`, mocks)(
     log,
-    config
+    config,
+    {
+      check: () => Promise.resolve(),
+    }
   );
   return new Mailer(translator, templates, config.smtp, sender);
 }

--- a/packages/fxa-auth-server/test/mock-sns.js
+++ b/packages/fxa-auth-server/test/mock-sns.js
@@ -34,7 +34,7 @@ function MockSNS(options, config) {
     },
 
     publish(params) {
-      const promise = new Promise((resolve) => {
+      const promise = new Promise((resolve, reject) => {
         // HACK: Enable remote tests to see what was sent
         mailer.sendMail(
           {
@@ -43,7 +43,10 @@ function MockSNS(options, config) {
             subject: 'MockSNS.publish',
             text: params.Message,
           },
-          () => {
+          (err) => {
+            if (err) {
+              return reject(err);
+            }
             resolve({
               MessageId: 'fake message id',
             });

--- a/packages/fxa-shared/db/models/auth/email-bounce.ts
+++ b/packages/fxa-shared/db/models/auth/email-bounce.ts
@@ -59,6 +59,6 @@ export class EmailBounce extends BaseAuthModel {
 
   static async findByEmail(email: string) {
     const { rows } = await EmailBounce.callProcedure(Proc.EmailBounces, email);
-    return rows.map((row: any) => EmailBounce.fromDatabaseJson(rows));
+    return rows.map((row: any) => EmailBounce.fromDatabaseJson(row));
   }
 }


### PR DESCRIPTION
## Because

- I'd like to deprecate email-service

## This pull request

- Adds the nodemailer SES transport
- The AWS config is set by the environment and is used when no SMTP user:password are set
- We _could_ use liveConfig to run a subset of addresses through direct SES vs email-service
  - https://github.com/mozilla/fxa/blob/auth-ses/packages/fxa-auth-server/lib/senders/select_email_services.js#L18
- Gets used 100% when email-service has been configed off with `EMAIL_CONFIG_USE_REDIS=false`
- Resurrects some old code from https://github.com/mozilla/fxa-auth-server/pull/1934 🧟 🧙

## Notes

After this we'll have 3 ways to send via SES: API direct, SMTP, fxa-email-service. The goal is to use API direct and eliminate fxa-email-service, with an SMTP "backup" in case we need to support other providers.

## Issue that this pull request solves

Closes: #9725

