### PR TITLE
Added Step x of x wording to Secondary Email

### DIFF
--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/en-US.ftl
@@ -1,5 +1,6 @@
 ## Add secondary email page
 
+add-secondary-email-step-1 = Step 1 of 2
 add-secondary-email-error = There was a problem creating this email.
 add-secondary-email-page-title =
   .title = Secondary email

--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
@@ -17,6 +17,12 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   const [email, setEmail] = useState<string>();
   const inputRef = useRef<HTMLInputElement>(null);
   const { l10n } = useLocalization();
+
+  const subtitleText = l10n.getString(
+    'add-secondary-email-step-1',
+    null,
+    'Step 1 of 1'
+  );
   const navigate = useNavigate();
   const alertBar = useAlertBar();
   const account = useAccount();
@@ -63,7 +69,7 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
 
   return (
     <Localized id="add-secondary-email-page-title" attrs={{ title: true }}>
-      <FlowContainer title="Secondary email">
+      <FlowContainer title="Secondary email" subtitle={subtitleText}>
         <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
         <form
           onSubmit={(ev) => {

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/en-US.ftl
@@ -1,5 +1,6 @@
 ## Verify secondary email page
 
+add-secondary-email-step-2 = Step 2 of 2
 verify-secondary-email-error = There was a problem sending the verification code.
 verify-secondary-email-page-title =
   .title = Secondary email

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.tsx
@@ -43,6 +43,11 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
     },
     [alertBar, l10n, navigate]
   );
+  const subtitleText = l10n.getString(
+    'add-secondary-email-step-2',
+    null,
+    'Step 2 of 2'
+  );
   // Using 'any' here, instead of FluentVariable, to avoid having to import @fluent/bundle.
   const email = (location?.state as any)?.email as string | undefined | any;
 
@@ -85,7 +90,7 @@ export const PageSecondaryEmailVerify = ({ location }: RouteComponentProps) => {
     !formState.isDirty || !formState.isValid || account.loading;
   return (
     <Localized id="verify-secondary-email-page-title" attrs={{ title: true }}>
-      <FlowContainer title="Secondary email">
+      <FlowContainer title="Secondary email" subtitle={subtitleText}>
         <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
         <form
           data-testid="secondary-email-verify-form"


### PR DESCRIPTION
feature: fxa-settings

## Because
The secondary field popup is inconsistent with other multi-step popups. 


## This pull request

adds the wording "Step 1 of 2" and "Step 2 of 2" in the secondary email popup.

## Issue that this pull request solves

Closes: # FXA-3829

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
