### PR TITLE
chore(auth): add email template name to log.error if sending email fails

### DIFF
--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -549,6 +549,7 @@ module.exports = function (log, config) {
                   to: emailConfig && emailConfig.to,
                   emailSender,
                   emailService,
+                  template,
                 });
 
                 return reject(err);


### PR DESCRIPTION
Because:

* We want to know when a user is blocked from logging in because they can't receive FxA emails.

This commit:

* Records the email template name when we fail to send an email, so we can filter for the emails which must be opened before the user can sign in (enumerated in #10527).

Closes: #10527

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I am confirming with @jbuck that we can pull in log data from the auth server into Grafana, as ultimately, this data needs to go into a new panel. Otherwise, I will resubmit this PR using a StatsD metric.