### PR TITLE
fix(payments): do not show error message on empty confirm email input 

### DIFF
--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
@@ -122,19 +122,17 @@ describe('NewUserEmailForm test', () => {
   });
 
   it('shows error when emails do not match', async () => {
-    let subject;
-    await act(async () => {
-      subject = render(
-        <WrapNewUserEmailForm accountExistsReturnValue={false} />
-      );
-      const firstEmail = subject.getByTestId('new-user-email');
-      const secondEmail = subject.getByTestId('new-user-confirm-email');
-      fireEvent.change(firstEmail, { target: { value: 'valid@email.com' } });
-      fireEvent.change(secondEmail, {
-        target: { value: 'not.the.same@email.com' },
-      });
-      fireEvent.blur(secondEmail);
+    let subject = render(
+      <WrapNewUserEmailForm accountExistsReturnValue={false} />
+    );
+    const firstEmail = subject.getByTestId('new-user-email');
+    const secondEmail = subject.getByTestId('new-user-confirm-email');
+    fireEvent.change(firstEmail, { target: { value: 'valid@email.com' } });
+    fireEvent.change(secondEmail, {
+      target: { value: 'not.the.same@email.com' },
     });
+    fireEvent.blur(secondEmail);
+
     expect(
       subject.queryByText('new-user-email-validate-confirm')
     ).toBeVisible();

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
@@ -121,6 +121,21 @@ describe('NewUserEmailForm test', () => {
     expect(subject.queryByText('new-user-email-validate')).toBeFalsy();
   });
 
+  it('shows no error when empty string is provided to second field', async () => {
+    let subject = render(
+      <WrapNewUserEmailForm accountExistsReturnValue={false} />
+    );
+
+    const firstEmail = subject.getByTestId('new-user-email');
+    const secondEmail = subject.getByTestId('new-user-confirm-email');
+
+    fireEvent.change(firstEmail, { target: { value: 'valid@email.com' } });
+    fireEvent.change(secondEmail, { target: { value: '' } });
+
+    expect(subject.queryByText('new-user-email-validate-confirm')).toBeFalsy();
+    expect(secondEmail.classList.contains('invalid')).toBeFalsy();
+  });
+
   it('shows error when emails do not match', async () => {
     let subject = render(
       <WrapNewUserEmailForm accountExistsReturnValue={false} />

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -241,8 +241,8 @@ export function emailConfirmationValidation(
 
   return {
     value,
-    valid,
-    error: !valid && !focused ? errorMsg : null,
+    valid: valid || !value,
+    error: !valid && !focused && !!value ? errorMsg : null,
   };
 }
 


### PR DESCRIPTION
Because:

* We would like UI that only displays errors on user input

This commit:

* Hides the error state unless there is an error due to user input

Closes: #10448

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
