### PR TITLE
fix(auth-server): Update x2 hard-coded email addresses in new email templates

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.mjml
@@ -13,7 +13,13 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-body">
-      <span data-l10n-id="postRemoveSecondary-description" data-l10n-args='<%= JSON.stringify({secondaryEmail}) %>'>You have successfully removed secondary@email as a secondary email from your Firefox Account. Security notifications and sign-in confirmations will no longer be delivered to this address.</span>
+      <span
+        data-l10n-id="postRemoveSecondary-description"
+        data-l10n-args="<%= JSON.stringify({secondaryEmail}) %>">
+        You have successfully removed <%- secondaryEmail %> as a secondary
+        email from your Firefox Account. Security notifications and sign-in
+        confirmations will no longer be delivered to this address.
+      </span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.mjml
@@ -5,7 +5,9 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="postVerifySecondary-title">Secondary email added</span>
+      <span data-l10n-id="postVerifySecondary-title">
+        Secondary email added
+      </span>
     </mj-text>
   </mj-column>
 </mj-section>
@@ -13,7 +15,13 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-body">
-      <span data-l10n-id="postVerifySecondary-description" data-l10n-args='<%= JSON.stringify({secondaryEmail}) %>'>You have successfully verified secondary@email as a secondary email for your Firefox Account. Security notifications and sign-in confirmations will now be delivered to both email addresses.</span>
+      <span
+        data-l10n-id="postVerifySecondary-description"
+        data-l10n-args="<%= JSON.stringify({secondaryEmail}) %>">
+        You have successfully verified <%- secondaryEmail %> as a secondary
+        email for your Firefox Account. Security notifications and sign-in
+        confirmations will now be delivered to both email addresses.
+      </span>
     </mj-text>
   </mj-column>
 </mj-section>


### PR DESCRIPTION

## Because

- I noticed this when checking some emails in staging - secondary email should not be hard-coded, whoops. The text files are both fine as-is.

## This pull request

- References the dynamic variable rather than hard-coded value
