### PR TITLE
chore(payments): remove usePaypalUIByDefault feature flag

### DIFF
--- a/packages/fxa-payments-server/.storybook/components/MockApp.tsx
+++ b/packages/fxa-payments-server/.storybook/components/MockApp.tsx
@@ -24,9 +24,6 @@ type MockAppProps = {
 export const defaultAppContextValue: AppContextType = {
   config: {
     ...config,
-    featureFlags: {
-      usePaypalUIByDefault: true,
-    },
     productRedirectURLs: {
       product_8675309: 'https://example.com/product',
     },

--- a/packages/fxa-payments-server/README.md
+++ b/packages/fxa-payments-server/README.md
@@ -2,8 +2,6 @@
 
 This is the server that handles payments.
 
-To enable PayPal, restart the server with its feature flag enabled: `FEATURE_USE_PAYPAL_UI_BY_DEFAULT=true pm2 restart payments --update-env`
-
 ## Storybook
 
 This project uses [Storybook](https://storybook.js.org/) to show each screen without requiring a full stack.

--- a/packages/fxa-payments-server/server/config/index.js
+++ b/packages/fxa-payments-server/server/config/index.js
@@ -12,14 +12,7 @@ convict.addFormats(require('convict-format-with-moment'));
 convict.addFormats(require('convict-format-with-validator'));
 
 const conf = convict({
-  featureFlags: {
-    usePaypalUIByDefault: {
-      default: false,
-      doc: 'Whether to use PayPal payment UI by default rather than Stripe payment UI alone',
-      env: 'FEATURE_USE_PAYPAL_UI_BY_DEFAULT',
-      format: Boolean,
-    },
-  },
+  featureFlags: {},
   amplitude: {
     enabled: {
       default: true,

--- a/packages/fxa-payments-server/src/lib/hooks.tsx
+++ b/packages/fxa-payments-server/src/lib/hooks.tsx
@@ -73,10 +73,6 @@ export function usePaypalButtonSetup(
 ) {
   /* istanbul ignore next */
   useEffect(() => {
-    if (!config.featureFlags.usePaypalUIByDefault) {
-      return;
-    }
-
     if (paypalButtonBase) {
       setPaypalScriptLoaded(true);
       return;

--- a/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.test.tsx
@@ -458,11 +458,6 @@ describe('routes/Checkout', () => {
   });
 
   describe('handling a passwordless PayPal subscription', () => {
-    updateConfig({
-      featureFlags: {
-        usePaypalUIByDefault: true,
-      },
-    });
     const fillOutZeForm = async (shouldSubscribeToNewsletter = false) => {
       const { getByTestId } = screen;
       fireEvent.change(getByTestId('new-user-email'), {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.test.tsx
@@ -152,11 +152,6 @@ describe('routes/Product/SubscriptionCreate', () => {
 
   it('renders as expected with PayPal UI enabled', async () => {
     const { queryByTestId } = screen;
-    updateConfig({
-      featureFlags: {
-        usePaypalUIByDefault: true,
-      },
-    });
     const MockedButtonBase = ({}: ButtonBaseProps) => {
       return <button data-testid="paypal-button" />;
     };
@@ -176,11 +171,6 @@ describe('routes/Product/SubscriptionCreate', () => {
 
   it('renders as expected with PayPal UI enabled and an existing Stripe customer', async () => {
     const { queryByTestId } = screen;
-    updateConfig({
-      featureFlags: {
-        usePaypalUIByDefault: true,
-      },
-    });
     const MockedButtonBase = ({}: ButtonBaseProps) => {
       return <button data-testid="paypal-button" />;
     };
@@ -199,11 +189,6 @@ describe('routes/Product/SubscriptionCreate', () => {
 
   it('renders as expected with PayPal UI enabled and an existing PayPal customer', async () => {
     const { queryByTestId } = screen;
-    updateConfig({
-      featureFlags: {
-        usePaypalUIByDefault: true,
-      },
-    });
     const MockedButtonBase = ({}: ButtonBaseProps) => {
       return <button data-testid="paypal-button" />;
     };
@@ -539,11 +524,6 @@ describe('routes/Product/SubscriptionCreate', () => {
         .mockResolvedValue(MOCK_PAYPAL_SUBSCRIPTION_RESULT),
     };
     const refreshSubscriptions = jest.fn();
-    updateConfig({
-      featureFlags: {
-        usePaypalUIByDefault: true,
-      },
-    });
     await act(async () => {
       render(
         <Subject
@@ -580,11 +560,6 @@ describe('routes/Product/SubscriptionCreate', () => {
       ...defaultApiClientOverrides(),
       apiCreateCustomer: jest.fn(),
     };
-    updateConfig({
-      featureFlags: {
-        usePaypalUIByDefault: true,
-      },
-    });
     await act(async () => {
       render(
         <Subject
@@ -806,11 +781,7 @@ describe('routes/Product/SubscriptionCreate', () => {
           .fn()
           .mockRejectedValue({ code: 'barf apiGetPaypalCheckoutToken' }),
       };
-      updateConfig({
-        featureFlags: {
-          usePaypalUIByDefault: true,
-        },
-      });
+
       await act(async () => {
         render(
           <Subject
@@ -835,11 +806,6 @@ describe('routes/Product/SubscriptionCreate', () => {
     const MockedButtonBase = ({ onError }: ButtonBaseProps) => {
       return <button data-testid="paypal-button" onClick={onError} />;
     };
-    updateConfig({
-      featureFlags: {
-        usePaypalUIByDefault: true,
-      },
-    });
     await act(async () => {
       render(
         <Subject
@@ -874,11 +840,6 @@ describe('routes/Product/SubscriptionCreate', () => {
         .fn()
         .mockRejectedValue({ code: 'barf apiCapturePaypalPayment' }),
     };
-    updateConfig({
-      featureFlags: {
-        usePaypalUIByDefault: true,
-      },
-    });
     await act(async () => {
       render(
         <Subject

--- a/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/PaymentUpdateForm.test.tsx
@@ -129,12 +129,6 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
       return <button data-testid="paypal-button" onClick={onApprove} />;
     };
 
-    updateConfig({
-      featureFlags: {
-        usePaypalUIByDefault: true,
-      },
-    });
-
     await act(async () => {
       render(
         <Subject
@@ -193,12 +187,6 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
     const MockedButtonBase = ({ onApprove }: ButtonBaseProps) => {
       return <button data-testid="paypal-button" onClick={onApprove} />;
     };
-
-    updateConfig({
-      featureFlags: {
-        usePaypalUIByDefault: true,
-      },
-    });
 
     await act(async () => {
       render(
@@ -315,11 +303,8 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
   ];
 
   it('updates payment method as expected', async () => {
-    const {
-      apiClientOverrides,
-      stripeOverride,
-      refreshSubscriptions,
-    } = await commonSubmitSetup();
+    const { apiClientOverrides, stripeOverride, refreshSubscriptions } =
+      await commonSubmitSetup();
 
     expect(
       screen.queryByTestId('error-message-container')
@@ -363,18 +348,15 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
   });
 
   it('displays an error if apiCreateSetupIntent throws', async () => {
-    const {
-      apiClientOverrides,
-      stripeOverride,
-      refreshSubscriptions,
-    } = await commonSubmitSetup({
-      apiClientOverrides: {
-        ...defaultApiClientOverrides(),
-        apiCreateSetupIntent: jest
-          .fn()
-          .mockRejectedValue('barf apiCreateSetupIntent'),
-      },
-    });
+    const { apiClientOverrides, stripeOverride, refreshSubscriptions } =
+      await commonSubmitSetup({
+        apiClientOverrides: {
+          ...defaultApiClientOverrides(),
+          apiCreateSetupIntent: jest
+            .fn()
+            .mockRejectedValue('barf apiCreateSetupIntent'),
+        },
+      });
 
     expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
     expect(screen.getByText('basic-error-message')).toBeInTheDocument();
@@ -388,16 +370,15 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
   });
 
   it('displays an error if confirmCardSetup throws', async () => {
-    const {
-      apiClientOverrides,
-      stripeOverride,
-      refreshSubscriptions,
-    } = await commonSubmitSetup({
-      stripeOverride: {
-        ...defaultStripeOverride(),
-        confirmCardSetup: jest.fn().mockRejectedValue('barf confirmCardSetup'),
-      },
-    });
+    const { apiClientOverrides, stripeOverride, refreshSubscriptions } =
+      await commonSubmitSetup({
+        stripeOverride: {
+          ...defaultStripeOverride(),
+          confirmCardSetup: jest
+            .fn()
+            .mockRejectedValue('barf confirmCardSetup'),
+        },
+      });
 
     expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
     expect(screen.getByText('basic-error-message')).toBeInTheDocument();
@@ -413,18 +394,15 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
   });
 
   it('displays an error if confirmCardSetup returns an error', async () => {
-    const {
-      apiClientOverrides,
-      stripeOverride,
-      refreshSubscriptions,
-    } = await commonSubmitSetup({
-      stripeOverride: {
-        ...defaultStripeOverride(),
-        confirmCardSetup: jest
-          .fn()
-          .mockResolvedValue({ error: { code: 'expired_card' } }),
-      },
-    });
+    const { apiClientOverrides, stripeOverride, refreshSubscriptions } =
+      await commonSubmitSetup({
+        stripeOverride: {
+          ...defaultStripeOverride(),
+          confirmCardSetup: jest
+            .fn()
+            .mockResolvedValue({ error: { code: 'expired_card' } }),
+        },
+      });
 
     expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
     expect(screen.getByText('expired-card-error')).toBeInTheDocument();
@@ -440,16 +418,13 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
   });
 
   it('displays an error if confirmCardSetup returns an empty setupIntent', async () => {
-    const {
-      apiClientOverrides,
-      stripeOverride,
-      refreshSubscriptions,
-    } = await commonSubmitSetup({
-      stripeOverride: {
-        ...defaultStripeOverride(),
-        confirmCardSetup: jest.fn().mockResolvedValue({ setupIntent: null }),
-      },
-    });
+    const { apiClientOverrides, stripeOverride, refreshSubscriptions } =
+      await commonSubmitSetup({
+        stripeOverride: {
+          ...defaultStripeOverride(),
+          confirmCardSetup: jest.fn().mockResolvedValue({ setupIntent: null }),
+        },
+      });
 
     expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
     expect(screen.getByText('basic-error-message')).toBeInTheDocument();
@@ -465,18 +440,15 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
   });
 
   it('displays an error if confirmCardSetup returns a setupIntent without a payment method ID', async () => {
-    const {
-      apiClientOverrides,
-      stripeOverride,
-      refreshSubscriptions,
-    } = await commonSubmitSetup({
-      stripeOverride: {
-        ...defaultStripeOverride(),
-        confirmCardSetup: jest
-          .fn()
-          .mockResolvedValue({ setupIntent: { payment_method: false } }),
-      },
-    });
+    const { apiClientOverrides, stripeOverride, refreshSubscriptions } =
+      await commonSubmitSetup({
+        stripeOverride: {
+          ...defaultStripeOverride(),
+          confirmCardSetup: jest
+            .fn()
+            .mockResolvedValue({ setupIntent: { payment_method: false } }),
+        },
+      });
 
     expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
     expect(screen.getByText('basic-error-message')).toBeInTheDocument();
@@ -492,18 +464,15 @@ describe('routes/Subscriptions/PaymentUpdateFormV2', () => {
   });
 
   it('displays an error if apiUpdateDefaultPaymentMethod throws', async () => {
-    const {
-      apiClientOverrides,
-      stripeOverride,
-      refreshSubscriptions,
-    } = await commonSubmitSetup({
-      apiClientOverrides: {
-        ...defaultApiClientOverrides(),
-        apiUpdateDefaultPaymentMethod: jest
-          .fn()
-          .mockRejectedValue('barf apiUpdateDefaultPaymentMethod'),
-      },
-    });
+    const { apiClientOverrides, stripeOverride, refreshSubscriptions } =
+      await commonSubmitSetup({
+        apiClientOverrides: {
+          ...defaultApiClientOverrides(),
+          apiUpdateDefaultPaymentMethod: jest
+            .fn()
+            .mockRejectedValue('barf apiUpdateDefaultPaymentMethod'),
+        },
+      });
 
     expect(screen.queryByTestId('error-message-container')).toBeInTheDocument();
     expect(screen.getByText('basic-error-message')).toBeInTheDocument();


### PR DESCRIPTION
Because:

* This UI is enabled by default for all environments, it is no longer necessary for local/dev.

This commit:

* Removes the feature flag, removes references to it, and updates the README

Closes #10531

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).
