### PR TITLE
bug(settings): fixed wording for step 1 of secondary email

### DIFF
--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.tsx
@@ -21,7 +21,7 @@ export const PageSecondaryEmailAdd = (_: RouteComponentProps) => {
   const subtitleText = l10n.getString(
     'add-secondary-email-step-1',
     null,
-    'Step 1 of 1'
+    'Step 1 of 2'
   );
   const navigate = useNavigate();
   const alertBar = useAlertBar();


### PR DESCRIPTION
## Because
* the current text says step 1 of 1 instead of 1 of 2

## This pull request
* fixes the wording

Closes:  #10572

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

