### PR TITLE
fix(auth): wrap span in '<' in the reset password email 

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/passwordChanged/index.mjml
@@ -5,7 +5,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="passwordChanged-title">Password changed successfully/span>
+      <span data-l10n-id="passwordChanged-title">Password changed successfully</span>
     </mj-text>
 
     <mj-text css-class="text-body">


### PR DESCRIPTION
## Because

- we are seeing html tags in the reset password email header

## This pull request

- adds '<' to the html tag so it is no longer rendered as test

## Issue that this pull request solves

Closes: #10575

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
