### PR TITLE
fix(email-service): increase /send body size limit

### DIFF
--- a/packages/fxa-email-service/src/api/send/mod.rs
+++ b/packages/fxa-email-service/src/api/send/mod.rs
@@ -49,7 +49,7 @@ impl FromDataSimple for Email {
 
     fn from_data(request: &Request, data: Data) -> Outcome<Self, Self::Error> {
         let mut email_address = String::new();
-        if let Err(error) = data.open().take(32768).read_to_string(&mut email_address) {
+        if let Err(error) = data.open().take(131072).read_to_string(&mut email_address) {
             return Outcome::Failure((
                 Status::InternalServerError,
                 AppErrorKind::Internal(error.to_string()).into(),


### PR DESCRIPTION
## Because

- we hit a error with the `subscriptionAccountFinishSetup` email being too large for email-service after adding metrics in #10516

## This pull request

- increases the limit to 128kb

## Issue that this pull request solves

fixes #10573

