### PR TITLE
feat(payments): add email address to download link

### DIFF
--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -60,7 +60,10 @@ export const PaymentConfirmation = ({
   );
 
   const { l10n } = useLocalization();
-  const downloadLink = productUrl + `/?email=${encodeURIComponent(email)}`;
+  const downloadLink: string =
+    productUrl.indexOf('?') > -1
+      ? productUrl + `&email=${encodeURIComponent(email)}`
+      : productUrl + `?email=${encodeURIComponent(email)}`;
 
   return (
     <>

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -60,10 +60,8 @@ export const PaymentConfirmation = ({
   );
 
   const { l10n } = useLocalization();
-  const downloadLink: string =
-    productUrl.indexOf('?') > -1
-      ? productUrl + `&email=${encodeURIComponent(email)}`
-      : productUrl + `?email=${encodeURIComponent(email)}`;
+  const downloadUrl: URL = new URL(productUrl);
+  downloadUrl.searchParams.append('email', email);
 
   return (
     <>
@@ -150,7 +148,7 @@ export const PaymentConfirmation = ({
             <a
               data-testid="download-link"
               className="button download-link"
-              href={downloadLink}
+              href={downloadUrl.href}
             >
               {buttonLabel ||
                 l10n.getString(

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -60,6 +60,7 @@ export const PaymentConfirmation = ({
   );
 
   const { l10n } = useLocalization();
+  const downloadLink = productUrl + `/?email=${encodeURIComponent(email)}`;
 
   return (
     <>
@@ -146,7 +147,7 @@ export const PaymentConfirmation = ({
             <a
               data-testid="download-link"
               className="button download-link"
-              href={productUrl + `/?email=${encodeURIComponent(email)}`}
+              href={downloadLink}
             >
               {buttonLabel ||
                 l10n.getString(

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -146,7 +146,7 @@ export const PaymentConfirmation = ({
             <a
               data-testid="download-link"
               className="button download-link"
-              href={productUrl}
+              href={productUrl + `/?email=${encodeURIComponent(email)}`}
             >
               {buttonLabel ||
                 l10n.getString(

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
@@ -11,7 +11,6 @@ import {
 } from '../../../lib/test-utils';
 
 import { SubscriptionSuccess } from './index';
-import { profile } from 'console';
 
 afterEach(cleanup);
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
@@ -51,7 +51,7 @@ describe('SubscriptionSuccess', () => {
     assertRedirectForProduct(
       '123doneProProduct',
       'local',
-      `http://localhost:8080?email=${encodeURIComponent(MOCK_PROFILE.email)}`
+      `http://localhost:8080/?email=${encodeURIComponent(MOCK_PROFILE.email)}`
     );
   });
 
@@ -59,7 +59,7 @@ describe('SubscriptionSuccess', () => {
     assertRedirectForProduct(
       'beepBoop',
       'bazquux',
-      `https://mozilla.org?email=${encodeURIComponent(MOCK_PROFILE.email)}`
+      `https://mozilla.org/?email=${encodeURIComponent(MOCK_PROFILE.email)}`
     );
   });
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../../lib/test-utils';
 
 import { SubscriptionSuccess } from './index';
+import { profile } from 'console';
 
 afterEach(cleanup);
 
@@ -42,7 +43,7 @@ function assertRedirectForProduct(
     </AppContext.Provider>
   );
   expect(getByTestId('download-link').getAttribute('href')).toEqual(
-    expectedUrl
+    expectedUrl + `/?email=${encodeURIComponent(MOCK_PROFILE.email)}`
   );
 }
 

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
@@ -23,7 +23,7 @@ function assertRedirectForProduct(
     ...defaultConfig,
     env: 'testing',
     productRedirectURLs: {
-      '123doneProProduct': 'http://localhost:8080/',
+      '123doneProProduct': 'http://localhost:8080',
     },
   };
   const navigateToUrl = jest.fn();
@@ -42,7 +42,7 @@ function assertRedirectForProduct(
     </AppContext.Provider>
   );
   expect(getByTestId('download-link').getAttribute('href')).toEqual(
-    expectedUrl + `/?email=${encodeURIComponent(MOCK_PROFILE.email)}`
+    expectedUrl
   );
 }
 
@@ -51,12 +51,16 @@ describe('SubscriptionSuccess', () => {
     assertRedirectForProduct(
       '123doneProProduct',
       'local',
-      'http://localhost:8080/'
+      `http://localhost:8080/?email=${encodeURIComponent(MOCK_PROFILE.email)}`
     );
   });
 
   it('performs a redirect to the default URL for unknown product', () => {
-    assertRedirectForProduct('beepBoop', 'bazquux', 'https://mozilla.org');
+    assertRedirectForProduct(
+      'beepBoop',
+      'bazquux',
+      `https://mozilla.org/?email=${encodeURIComponent(MOCK_PROFILE.email)}`
+    );
   });
 
   it('renders the PlanDetails component on mobile', () => {

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionSuccess/index.test.tsx
@@ -51,7 +51,7 @@ describe('SubscriptionSuccess', () => {
     assertRedirectForProduct(
       '123doneProProduct',
       'local',
-      `http://localhost:8080/?email=${encodeURIComponent(MOCK_PROFILE.email)}`
+      `http://localhost:8080?email=${encodeURIComponent(MOCK_PROFILE.email)}`
     );
   });
 
@@ -59,7 +59,7 @@ describe('SubscriptionSuccess', () => {
     assertRedirectForProduct(
       'beepBoop',
       'bazquux',
-      `https://mozilla.org/?email=${encodeURIComponent(MOCK_PROFILE.email)}`
+      `https://mozilla.org?email=${encodeURIComponent(MOCK_PROFILE.email)}`
     );
   });
 


### PR DESCRIPTION
Because:

* MDN requested to have the email address appeneded to the download link as a query param

This commit:

* URI encodes the email address of the user and appends to the download link on a successful subscription

Closes #10489

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).

