### PR TITLE
feat(auth): store stripe docs in firestore

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -32,9 +32,10 @@ import { ConfigType } from '../../config';
 import error from '../error';
 import Redis from '../redis';
 import { subscriptionProductMetadataValidator } from '../routes/validators';
+import { AuthFirestore } from '../types';
 import { CurrencyHelper } from './currencies';
 import { SubscriptionPurchase } from './google-play/subscription-purchase';
-import { StripeFirestore } from './stripe-firestore';
+import { FirestoreStripeError, StripeFirestore } from './stripe-firestore';
 
 export const CUSTOMER_RESOURCE = 'customers';
 export const SUBSCRIPTIONS_RESOURCE = 'subscriptions';
@@ -108,8 +109,8 @@ export class StripeHelper {
   private redis: ioredis.Redis | undefined;
   private statsd: StatsD;
   private taxIds: { [key: string]: string };
-  private firestore: Firestore;
-  private stripeFirestore: StripeFirestore;
+  private firestore?: Firestore;
+  private stripeFirestore?: StripeFirestore;
   public currencyHelper: CurrencyHelper;
 
   /**
@@ -122,12 +123,6 @@ export class StripeHelper {
     this.webhookSecret = config.subscriptions.stripeWebhookSecret;
     this.taxIds = config.subscriptions.taxIds;
     this.currencyHelper = Container.get(CurrencyHelper);
-    this.firestore = Container.get(Firestore);
-
-    const firestore_prefix = `${config.authFirestore.prefix}stripe-`;
-    const customerCollectionDbRef = this.firestore.collection(
-      `${firestore_prefix}customers`
-    );
 
     // TODO (FXA-949 / issue #3922): The TTL setting here is serving double-duty for
     // both TTL and whether caching should be enabled at all. We should
@@ -146,11 +141,20 @@ export class StripeHelper {
       apiVersion: '2020-08-27',
       maxNetworkRetries: 3,
     });
-    this.stripeFirestore = new StripeFirestore(
-      this.firestore,
-      customerCollectionDbRef,
-      this.stripe
-    );
+
+    if (Container.has(AuthFirestore)) {
+      this.firestore = Container.get(AuthFirestore);
+      const firestore_prefix = `${config.authFirestore.prefix}stripe-`;
+      const customerCollectionDbRef = this.firestore.collection(
+        `${firestore_prefix}customers`
+      );
+      this.stripeFirestore = new StripeFirestore(
+        this.firestore,
+        customerCollectionDbRef,
+        this.stripe,
+        firestore_prefix
+      );
+    }
 
     cacheManager.setOptions({
       // Ensure the StripeHelper instance is passed into TTLBuilder functions
@@ -1713,8 +1717,7 @@ export class StripeHelper {
    *   - No product attached to the plan.
    *   - No email on the customer object.
    */
-  async extractInvoiceDetailsForEmail(latestInvoice: Stripe.Invoice | string) {
-    const invoice = await this.expandResource(latestInvoice, INVOICES_RESOURCE);
+  async extractInvoiceDetailsForEmail(invoice: Stripe.Invoice) {
     const customer = await this.expandResource(
       invoice.customer,
       CUSTOMER_RESOURCE
@@ -2284,19 +2287,123 @@ export class StripeHelper {
       throw error;
     }
 
+    if (this.stripeFirestore) {
+      switch (resourceType) {
+        case CUSTOMER_RESOURCE:
+          // @ts-ignore
+          const customer = await this.stripeFirestore.retrieveAndFetchCustomer(
+            resource
+          );
+          const subscriptions =
+            await this.stripeFirestore.retrieveCustomerSubscriptions(resource);
+          if (subscriptions.length) {
+            (customer as any).subscriptions = {
+              data: subscriptions as any,
+              has_more: false,
+            };
+          }
+          // @ts-ignore
+          return customer;
+        case SUBSCRIPTIONS_RESOURCE:
+          // @ts-ignore
+          return this.stripeFirestore.retrieveAndFetchSubscription(resource);
+        case INVOICES_RESOURCE:
+          try {
+            const invoice = await this.stripeFirestore.retrieveInvoice(
+              resource
+            );
+            // @ts-ignore
+            return invoice;
+          } catch (err) {
+            if (err.name === FirestoreStripeError.FIRESTORE_INVOICE_NOT_FOUND) {
+              const invoice = await this.stripe.invoices.retrieve(resource);
+              await this.stripeFirestore.retrieveAndFetchCustomer(
+                invoice.customer as string
+              );
+              await this.stripeFirestore.insertInvoiceRecord(invoice);
+              // @ts-ignore
+              return invoice;
+            }
+            throw err;
+          }
+      }
+    }
+
     // We make an exception here for customers because we need to get the
     // subscriptions for the customer.  The Stripe API stopped including
     // subscriptions for a customer in version 2020-08-27; this ensures
     // backwards compatibility for our code that's relying on that behavior.
     if (resourceType === CUSTOMER_RESOURCE) {
       // @ts-ignore
-      return this.stripe[CUSTOMER_RESOURCE].retrieve(resource, {
+      return this.stripe.customers.retrieve(resource, {
         expand: [SUBSCRIPTIONS_RESOURCE],
       });
     }
 
     // @ts-ignore
     return this.stripe[resourceType].retrieve(resource);
+  }
+
+  async processWebhookEventToFirestore(event: Stripe.Event) {
+    if (!this.stripeFirestore) {
+      return;
+    }
+
+    const { type, data } = event;
+
+    // Note that we must insert before any event handled by the general
+    // webhook code to ensure the object is up to date in Firestore before
+    // our code handles the event.
+    try {
+      switch (type as Stripe.WebhookEndpointUpdateParams.EnabledEvent) {
+        case 'invoice.created':
+        case 'invoice.finalized':
+        case 'invoice.paid':
+        case 'invoice.payment_failed':
+        case 'invoice.updated':
+        case 'invoice.deleted':
+          const invoice = data.object as Stripe.Invoice;
+          await this.stripeFirestore.retrieveAndFetchSubscription(
+            invoice.subscription as string
+          );
+          // Now that the subscription is fetched, we can safely insert the
+          // invoice record.
+          await this.stripeFirestore.insertInvoiceRecord(invoice);
+          break;
+        case 'customer.created':
+        case 'customer.updated':
+        case 'customer.deleted':
+          const customer = data.object as Stripe.Customer;
+          // Ensure the customer and its subscriptions exist in Firestore.
+          // Note that we still insert the object here in case we've already
+          // fetched the customer previously.
+          await this.stripeFirestore.retrieveAndFetchCustomer(customer.id);
+          await this.stripeFirestore.insertCustomerRecord(
+            customer.metadata.userid,
+            customer
+          );
+          break;
+        case 'customer.subscription.created':
+        case 'customer.subscription.updated':
+        case 'customer.subscription.deleted':
+          const subscription = data.object as Stripe.Subscription;
+          await this.stripeFirestore.retrieveAndFetchSubscription(
+            subscription.id
+          );
+          await this.stripeFirestore.insertSubscriptionRecord(subscription);
+          break;
+        default: {
+        }
+      }
+    } catch (err) {
+      if (err.name === FirestoreStripeError.STRIPE_CUSTOMER_DELETED) {
+        // We cannot back-fill Firestore with records for deleted customers
+        // as they're missing necessary metadata for us to know which user
+        // the customer belongs to.
+        return;
+      }
+      throw err;
+    }
   }
 
   /**

--- a/packages/fxa-auth-server/test/local/payments/capability.js
+++ b/packages/fxa-auth-server/test/local/payments/capability.js
@@ -117,6 +117,10 @@ describe('CapabilityService', () => {
     capabilityService = new CapabilityService();
   });
 
+  afterEach(() => {
+    Container.reset();
+  });
+
   describe('stripeUpdate', () => {
     beforeEach(() => {
       mockStripeHelper.getCustomerUidEmailFromSubscription =

--- a/packages/fxa-auth-server/test/local/payments/google-play/play-billing.js
+++ b/packages/fxa-auth-server/test/local/payments/google-play/play-billing.js
@@ -56,6 +56,7 @@ describe('PlayBilling', () => {
   });
 
   afterEach(() => {
+    Container.reset();
     sandbox.restore();
   });
 

--- a/packages/fxa-auth-server/test/local/payments/google-play/purchase-manager.js
+++ b/packages/fxa-auth-server/test/local/payments/google-play/purchase-manager.js
@@ -42,6 +42,10 @@ describe('PurchaseManager', () => {
     Container.set(AuthLogger, log);
   });
 
+  afterEach(() => {
+    Container.reset();
+  });
+
   it('can be instantiated', () => {
     const purchaseManager = new PurchaseManager(
       mockPurchaseDbRef,

--- a/packages/fxa-auth-server/test/local/payments/google-play/user-manager.js
+++ b/packages/fxa-auth-server/test/local/payments/google-play/user-manager.js
@@ -56,6 +56,10 @@ describe('UserManager', () => {
     userManager = new UserManager(mockCollRef, mockPurchaseManager);
   });
 
+  afterEach(() => {
+    Container.reset();
+  });
+
   describe('queryCurrentSubscriptions', () => {
     it('returns the current subscriptions', async () => {
       const subscriptionPurchase = SubscriptionPurchase.fromApiResponse(

--- a/packages/fxa-auth-server/test/local/payments/paypal-processor.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-processor.js
@@ -23,6 +23,7 @@ const {
   PAYPAL_SOURCE_ERRORS,
 } = require('../../../lib/payments/paypal-error-codes');
 const { CurrencyHelper } = require('../../../lib/payments/currencies');
+const { CapabilityService } = require('../../../lib/payments/capability');
 
 const sandbox = sinon.createSandbox();
 
@@ -57,11 +58,13 @@ describe('PaypalProcessor', () => {
     Container.set(CurrencyHelper, currencyHelper);
     Container.set(StripeHelper, mockStripeHelper);
     Container.set(PayPalHelper, mockPaypalHelper);
+    Container.set(CapabilityService, {});
     processor = new PaypalProcessor(mockLog, mockConfig, 1, 1, {}, {});
     processor.webhookHandler = mockHandler;
   });
 
   afterEach(() => {
+    Container.reset();
     sandbox.reset();
   });
 
@@ -152,9 +155,8 @@ describe('PaypalProcessor', () => {
     });
 
     it('returns true if success', async () => {
-      mockStripeHelper.updateInvoiceWithPaypalTransactionId = sandbox.fake.resolves(
-        {}
-      );
+      mockStripeHelper.updateInvoiceWithPaypalTransactionId =
+        sandbox.fake.resolves({});
       mockStripeHelper.payInvoiceOutOfBand = sandbox.fake.resolves({});
       const result = await processor.handlePaidTransaction(unpaidInvoice, [
         { status: 'Completed', transactionId: 'test1234' },
@@ -168,9 +170,8 @@ describe('PaypalProcessor', () => {
     });
 
     it('returns true and logs if > 1 success', async () => {
-      mockStripeHelper.updateInvoiceWithPaypalTransactionId = sandbox.fake.resolves(
-        {}
-      );
+      mockStripeHelper.updateInvoiceWithPaypalTransactionId =
+        sandbox.fake.resolves({});
       mockStripeHelper.payInvoiceOutOfBand = sandbox.fake.resolves({});
       mockLog.error = sandbox.fake.returns({});
       const result = await processor.handlePaidTransaction(unpaidInvoice, [
@@ -290,9 +291,8 @@ describe('PaypalProcessor', () => {
       mockStripeHelper.removeCustomerPaypalAgreement = sandbox.fake.resolves(
         {}
       );
-      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.returns(
-        'testba'
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sandbox.fake.returns('testba');
       mockStripeHelper.getEmailTypes = sandbox.fake.returns([]);
       mockHandler.sendSubscriptionPaymentFailedEmail = sandbox.fake.resolves(
         {}
@@ -323,9 +323,8 @@ describe('PaypalProcessor', () => {
       mockStripeHelper.removeCustomerPaypalAgreement = sandbox.fake.resolves(
         {}
       );
-      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.returns(
-        'testba'
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sandbox.fake.returns('testba');
       mockStripeHelper.getEmailTypes = sandbox.fake.returns([]);
       mockHandler.sendSubscriptionPaymentFailedEmail = sandbox.fake.resolves(
         {}
@@ -360,9 +359,8 @@ describe('PaypalProcessor', () => {
       mockStripeHelper.removeCustomerPaypalAgreement = sandbox.fake.resolves(
         {}
       );
-      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.returns(
-        'testba'
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sandbox.fake.returns('testba');
 
       const result = await processor.makePaymentAttempt(invoice);
       assert.isFalse(result);
@@ -404,9 +402,8 @@ describe('PaypalProcessor', () => {
       processor.handlePaidTransaction = sandbox.fake.resolves(false);
       processor.handlePendingTransaction = sandbox.fake.resolves(false);
       processor.inGracePeriod = sandbox.fake.returns(true);
-      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.returns(
-        'b-1234'
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sandbox.fake.returns('b-1234');
       processor.attemptsToday = sandbox.fake.returns(0);
       processor.makePaymentAttempt = sandbox.fake.resolves({});
 
@@ -496,9 +493,8 @@ describe('PaypalProcessor', () => {
       processor.handlePaidTransaction = sandbox.fake.resolves(false);
       processor.handlePendingTransaction = sandbox.fake.resolves(false);
       processor.inGracePeriod = sandbox.fake.returns(true);
-      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.returns(
-        undefined
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sandbox.fake.returns(undefined);
       processor.attemptsToday = sandbox.fake.returns(0);
       mockStripeHelper.getEmailTypes = sandbox.fake.returns(['paymentFailed']);
       mockHandler.sendSubscriptionPaymentFailedEmail = sandbox.fake.resolves(
@@ -543,9 +539,8 @@ describe('PaypalProcessor', () => {
       processor.handlePaidTransaction = sandbox.fake.resolves(false);
       processor.handlePendingTransaction = sandbox.fake.resolves(false);
       processor.inGracePeriod = sandbox.fake.returns(false);
-      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.returns(
-        'b-1234'
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sandbox.fake.returns('b-1234');
       processor.cancelInvoiceSubscription = sandbox.fake.resolves({});
 
       const result = await processor.attemptInvoiceProcessing(invoice);
@@ -573,9 +568,8 @@ describe('PaypalProcessor', () => {
       processor.handlePaidTransaction = sandbox.fake.resolves(false);
       processor.handlePendingTransaction = sandbox.fake.resolves(false);
       processor.inGracePeriod = sandbox.fake.returns(true);
-      mockStripeHelper.getCustomerPaypalAgreement = sandbox.fake.returns(
-        'b-1234'
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sandbox.fake.returns('b-1234');
       processor.attemptsToday = sandbox.fake.returns(20);
       processor.makePaymentAttempt = sandbox.fake.resolves({});
 

--- a/packages/fxa-auth-server/test/local/payments/paypal.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal.js
@@ -101,6 +101,10 @@ describe('PayPalHelper', () => {
     paypalHelper = new PayPalHelper({ log: mockLog });
   });
 
+  afterEach(() => {
+    Container.reset();
+  });
+
   describe('constructor', () => {
     it('sets client, statsd, logger, and currencyHelper', () => {
       const paypalClient = new PayPalClient({
@@ -199,9 +203,8 @@ describe('PayPalHelper', () => {
     };
 
     it('calls createBillingAgreement with passed options', async () => {
-      paypalHelper.client.createBillingAgreement = sinon.fake.resolves(
-        expectedResponse
-      );
+      paypalHelper.client.createBillingAgreement =
+        sinon.fake.resolves(expectedResponse);
       const response = await paypalHelper.createBillingAgreement(validOptions);
       sinon.assert.calledOnceWithExactly(
         paypalHelper.client.createBillingAgreement,
@@ -226,9 +229,10 @@ describe('PayPalHelper', () => {
       );
       await paypalHelper.chargeCustomer(validOptions);
       const expectedOptions = {
-        amount: paypalHelper.currencyHelper.getPayPalAmountStringFromAmountInCents(
-          validOptions.amountInCents
-        ),
+        amount:
+          paypalHelper.currencyHelper.getPayPalAmountStringFromAmountInCents(
+            validOptions.amountInCents
+          ),
         billingAgreementId: validOptions.billingAgreementId,
         invoiceNumber: validOptions.invoiceNumber,
         idempotencyKey: validOptions.idempotencyKey,
@@ -309,9 +313,8 @@ describe('PayPalHelper', () => {
     const transactionId = '9EG80664Y1384290G';
 
     it('successfully refunds completed transaction', async () => {
-      mockStripeHelper.updateInvoiceWithPaypalRefundTransactionId = sinon.fake.resolves(
-        {}
-      );
+      mockStripeHelper.updateInvoiceWithPaypalRefundTransactionId =
+        sinon.fake.resolves({});
       paypalHelper.refundTransaction = sinon.fake.resolves({
         pendingReason: successfulRefundTransactionResponse.PENDINGREASON,
         refundStatus: successfulRefundTransactionResponse.REFUNDSTATUS,
@@ -333,9 +336,8 @@ describe('PayPalHelper', () => {
     });
 
     it('unsuccessfully refunds completed transaction', async () => {
-      mockStripeHelper.updateInvoiceWithPaypalRefundTransactionId = sinon.fake.resolves(
-        {}
-      );
+      mockStripeHelper.updateInvoiceWithPaypalRefundTransactionId =
+        sinon.fake.resolves({});
       paypalHelper.refundTransaction = sinon.fake.resolves({
         pendingReason: successfulRefundTransactionResponse.PENDINGREASON,
         refundStatus: 'None',
@@ -506,9 +508,8 @@ describe('PayPalHelper', () => {
 
   describe('conditionallyRemoveBillingAgreement', () => {
     it('returns false with no billing agreement found', async () => {
-      mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
-        undefined
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sinon.fake.returns(undefined);
       const result = await paypalHelper.conditionallyRemoveBillingAgreement(
         mockCustomer
       );
@@ -516,9 +517,8 @@ describe('PayPalHelper', () => {
     });
 
     it('returns false with no paypal subscriptions', async () => {
-      mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
-        'ba-test'
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sinon.fake.returns('ba-test');
       mockCustomer.subscriptions = {
         data: [{ status: 'active', collection_method: 'send_invoice' }],
       };
@@ -529,9 +529,8 @@ describe('PayPalHelper', () => {
     });
 
     it('returns true if it cancelled and removed the billing agreement', async () => {
-      mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
-        'ba-test'
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sinon.fake.returns('ba-test');
       mockCustomer.subscriptions = { data: [] };
       paypalHelper.cancelBillingAgreement = sinon.fake.resolves({});
       mockStripeHelper.removeCustomerPaypalAgreement = sinon.fake.resolves({});
@@ -585,17 +584,15 @@ describe('PayPalHelper', () => {
         amount_due: 499,
         currency: 'eur',
       };
-      mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
-        agreementId
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sinon.fake.returns(agreementId);
       mockStripeHelper.getPaymentAttempts = sinon.fake.returns(paymentAttempts);
       paypalHelper.chargeCustomer = sinon.fake.resolves({
         paymentStatus: 'Completed',
         transactionId,
       });
-      mockStripeHelper.updateInvoiceWithPaypalTransactionId = sinon.fake.resolves(
-        { transactionId }
-      );
+      mockStripeHelper.updateInvoiceWithPaypalTransactionId =
+        sinon.fake.resolves({ transactionId });
       mockStripeHelper.payInvoiceOutOfBand = sinon.fake.resolves({});
       mockStripeHelper.updatePaymentAttempts = sinon.fake.resolves({});
 
@@ -641,18 +638,16 @@ describe('PayPalHelper', () => {
         status: 'draft',
         amount_due: 499,
       };
-      mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
-        agreementId
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sinon.fake.returns(agreementId);
       mockStripeHelper.finalizeInvoice = sinon.fake.resolves({});
       mockStripeHelper.getPaymentAttempts = sinon.fake.returns(paymentAttempts);
       paypalHelper.chargeCustomer = sinon.fake.resolves({
         paymentStatus: 'Completed',
         transactionId,
       });
-      mockStripeHelper.updateInvoiceWithPaypalTransactionId = sinon.fake.resolves(
-        { transactionId }
-      );
+      mockStripeHelper.updateInvoiceWithPaypalTransactionId =
+        sinon.fake.resolves({ transactionId });
       mockStripeHelper.payInvoiceOutOfBand = sinon.fake.resolves({});
       mockStripeHelper.updatePaymentAttempts = sinon.fake.resolves({});
 
@@ -700,9 +695,8 @@ describe('PayPalHelper', () => {
         status: 'open',
         amount_due: 499,
       };
-      mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
-        agreementId
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sinon.fake.returns(agreementId);
       mockStripeHelper.getPaymentAttempts = sinon.fake.returns(paymentAttempts);
       paypalHelper.chargeCustomer = sinon.fake.resolves({
         paymentStatus: 'Pending',
@@ -741,9 +735,8 @@ describe('PayPalHelper', () => {
         status: 'open',
         amount_due: 499,
       };
-      mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
-        agreementId
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sinon.fake.returns(agreementId);
       mockStripeHelper.getPaymentAttempts = sinon.fake.returns(paymentAttempts);
       paypalHelper.chargeCustomer = sinon.fake.resolves({
         paymentStatus: 'Denied',
@@ -793,9 +786,8 @@ describe('PayPalHelper', () => {
         status: 'open',
         amount_due: 499,
       };
-      mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
-        agreementId
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sinon.fake.returns(agreementId);
       mockStripeHelper.getPaymentAttempts = sinon.fake.returns(paymentAttempts);
       mockStripeHelper.updatePaymentAttempts = sinon.fake.returns({});
       paypalHelper.log = { error: sinon.fake.returns({}) };
@@ -842,9 +834,8 @@ describe('PayPalHelper', () => {
     });
 
     it('throws error for invoice without PayPal Billing Agreement ID', async () => {
-      mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
-        undefined
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sinon.fake.returns(undefined);
 
       try {
         await paypalHelper.processInvoice({
@@ -872,9 +863,8 @@ describe('PayPalHelper', () => {
         status: 'paid',
       };
 
-      mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
-        agreementId
-      );
+      mockStripeHelper.getCustomerPaypalAgreement =
+        sinon.fake.returns(agreementId);
 
       try {
         await paypalHelper.processInvoice({
@@ -915,12 +905,10 @@ describe('PayPalHelper', () => {
           status: 'open',
           amount_due: 499,
         };
-        mockStripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(
-          agreementId
-        );
-        mockStripeHelper.getPaymentAttempts = sinon.fake.returns(
-          paymentAttempts
-        );
+        mockStripeHelper.getCustomerPaypalAgreement =
+          sinon.fake.returns(agreementId);
+        mockStripeHelper.getPaymentAttempts =
+          sinon.fake.returns(paymentAttempts);
         mockStripeHelper.updatePaymentAttempts = sinon.fake.returns({});
         paypalHelper.log = { error: sinon.fake.returns({}) };
       });

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -62,6 +62,9 @@ const invoicePaidSubscriptionCreate = require('./fixtures/stripe/invoice_paid_su
 const eventCustomerSourceExpiring = require('./fixtures/stripe/event_customer_source_expiring.json');
 const eventCustomerSubscriptionUpdated = require('./fixtures/stripe/event_customer_subscription_updated.json');
 const subscriptionCreatedInvoice = require('./fixtures/stripe/invoice_paid_subscription_create.json');
+const eventInvoiceCreated = require('./fixtures/stripe/event_invoice_created.json');
+const eventSubscriptionUpdated = require('./fixtures/stripe/event_customer_subscription_updated.json');
+const eventCustomerUpdated = require('./fixtures/stripe/event_customer_updated.json');
 const closedPaymementIntent = require('./fixtures/stripe/paymentIntent_succeeded.json');
 const newSetupIntent = require('./fixtures/stripe/setup_intent_new.json');
 const {
@@ -71,6 +74,12 @@ const {
 const {
   SubscriptionPurchase,
 } = require('../../../lib/payments/google-play/subscription-purchase');
+const { AuthFirestore } = require('../../../lib/types');
+const { INVOICES_RESOURCE } = require('../../../lib/payments/stripe');
+const {
+  FirestoreStripeError,
+  newFirestoreStripeError,
+} = require('../../../lib/payments/stripe-firestore');
 
 const mockConfig = {
   authFirestore: {
@@ -218,6 +227,7 @@ describe('StripeHelper', () => {
     // Make currencyHelper
     const currencyHelper = new CurrencyHelper(mockConfig);
     Container.set(CurrencyHelper, currencyHelper);
+
     stripeHelper = new StripeHelper(log, mockConfig, mockStatsd);
     stripeHelper.redis = mockRedis;
     listStripePlans = sandbox
@@ -232,6 +242,7 @@ describe('StripeHelper', () => {
   });
 
   afterEach(() => {
+    Container.reset();
     sandbox.restore();
   });
 
@@ -3964,6 +3975,169 @@ describe('StripeHelper', () => {
         stripeHelper.stripe.customers.retrieve,
         customerId,
         { expand: [SUBSCRIPTIONS_RESOURCE] }
+      );
+    });
+
+    describe('with stripeFirestore', () => {
+      let stripeFirestore;
+      let customer;
+
+      beforeEach(() => {
+        customer = deepCopy(customer1);
+        stripeHelper.stripeFirestore = stripeFirestore = {};
+        Container.set(AuthFirestore, {});
+      });
+
+      afterEach(() => {
+        Container.remove(AuthFirestore);
+      });
+
+      it('expands the customer', async () => {
+        stripeFirestore.retrieveAndFetchCustomer = sandbox
+          .stub()
+          .resolves(deepCopy(customer));
+        stripeFirestore.retrieveCustomerSubscriptions = sandbox
+          .stub()
+          .resolves(deepCopy(customer.subscriptions.data));
+        const result = await stripeHelper.expandResource(
+          customer.id,
+          CUSTOMER_RESOURCE
+        );
+        // Note that top level will mismatch because subscriptions is copied
+        // without the object type.
+        assert.deepEqual(
+          result.subscriptions.data,
+          customer.subscriptions.data
+        );
+        assert.hasAllKeys(result, customer);
+        sinon.assert.calledOnceWithExactly(
+          stripeHelper.stripeFirestore.retrieveAndFetchCustomer,
+          customer.id
+        );
+        sinon.assert.calledOnceWithExactly(
+          stripeHelper.stripeFirestore.retrieveCustomerSubscriptions,
+          customer.id
+        );
+      });
+
+      it('expands the subscription', async () => {
+        stripeFirestore.retrieveAndFetchSubscription = sandbox
+          .stub()
+          .resolves(deepCopy(subscription1));
+        const result = await stripeHelper.expandResource(
+          subscription1.id,
+          SUBSCRIPTIONS_RESOURCE
+        );
+        assert.deepEqual(result, subscription1);
+        sinon.assert.calledOnceWithExactly(
+          stripeHelper.stripeFirestore.retrieveAndFetchSubscription,
+          subscription1.id
+        );
+      });
+
+      it('expands the invoice', async () => {
+        stripeFirestore.retrieveInvoice = sandbox
+          .stub()
+          .resolves(invoicePaidSubscriptionCreate);
+        const result = await stripeHelper.expandResource(
+          invoicePaidSubscriptionCreate.id,
+          INVOICES_RESOURCE
+        );
+        assert.deepEqual(result, invoicePaidSubscriptionCreate);
+        sinon.assert.calledOnceWithExactly(
+          stripeHelper.stripeFirestore.retrieveInvoice,
+          invoicePaidSubscriptionCreate.id
+        );
+      });
+
+      it('expands invoice when invoice isnt found and inserts it', async () => {
+        stripeFirestore.retrieveInvoice = sandbox
+          .stub()
+          .rejects(
+            newFirestoreStripeError(
+              'not found',
+              FirestoreStripeError.FIRESTORE_INVOICE_NOT_FOUND
+            )
+          );
+        stripeFirestore.retrieveAndFetchCustomer = sandbox
+          .stub()
+          .resolves(customer);
+        stripeHelper.stripe.invoices.retrieve = sandbox
+          .stub()
+          .resolves(deepCopy(invoicePaidSubscriptionCreate));
+        stripeFirestore.insertInvoiceRecord = sandbox.stub().resolves({});
+
+        const result = await stripeHelper.expandResource(
+          invoicePaidSubscriptionCreate.id,
+          INVOICES_RESOURCE
+        );
+        assert.deepEqual(result, invoicePaidSubscriptionCreate);
+        sinon.assert.calledOnceWithExactly(
+          stripeHelper.stripeFirestore.retrieveInvoice,
+          invoicePaidSubscriptionCreate.id
+        );
+        sinon.assert.calledOnceWithExactly(
+          stripeHelper.stripeFirestore.retrieveAndFetchCustomer,
+          invoicePaidSubscriptionCreate.customer
+        );
+      });
+    });
+  });
+
+  describe('processWebhookEventToFirestore', () => {
+    let stripeFirestore;
+
+    beforeEach(() => {
+      stripeHelper.stripeFirestore = stripeFirestore = {};
+    });
+
+    it('handles invoice operations', async () => {
+      const event = deepCopy(eventInvoiceCreated);
+      stripeFirestore.retrieveAndFetchSubscription = sandbox
+        .stub()
+        .resolves({});
+      stripeFirestore.insertInvoiceRecord = sandbox.stub().resolves({});
+      await stripeHelper.processWebhookEventToFirestore(event);
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripeFirestore.retrieveAndFetchSubscription,
+        event.data.object.subscription
+      );
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripeFirestore.insertInvoiceRecord,
+        event.data.object
+      );
+    });
+
+    it('handles customer operations', async () => {
+      const event = deepCopy(eventCustomerUpdated);
+      stripeFirestore.retrieveAndFetchCustomer = sandbox.stub().resolves({});
+      stripeFirestore.insertCustomerRecord = sandbox.stub().resolves({});
+      await stripeHelper.processWebhookEventToFirestore(event);
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripeFirestore.retrieveAndFetchCustomer,
+        event.data.object.id
+      );
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripeFirestore.insertCustomerRecord,
+        event.data.object.metadata.userid,
+        event.data.object
+      );
+    });
+
+    it('handles subscription operations', async () => {
+      const event = deepCopy(eventSubscriptionUpdated);
+      stripeFirestore.retrieveAndFetchSubscription = sandbox
+        .stub()
+        .resolves({});
+      stripeFirestore.insertSubscriptionRecord = sandbox.stub().resolves({});
+      await stripeHelper.processWebhookEventToFirestore(event);
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripeFirestore.retrieveAndFetchSubscription,
+        event.data.object.id
+      );
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripeFirestore.insertSubscriptionRecord,
+        event.data.object
       );
     });
   });

--- a/packages/fxa-auth-server/test/local/payments/subscription-reminders.js
+++ b/packages/fxa-auth-server/test/local/payments/subscription-reminders.js
@@ -73,6 +73,7 @@ describe('SubscriptionReminders', () => {
   });
 
   afterEach(() => {
+    Container.reset();
     sandbox.reset();
   });
 

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -1533,7 +1533,6 @@ describe('/account/login', () => {
     check: () => Promise.resolve(),
     flag: () => Promise.resolve(),
   };
-  Container.set(CapabilityService, sinon.fake);
   const mockCadReminders = mocks.mockCadReminders();
   const accountRoutes = makeRoutes({
     checkPassword: function () {
@@ -1551,6 +1550,10 @@ describe('/account/login', () => {
 
   const defaultEmailRecord = mockDB.emailRecord;
   const defaultEmailAccountRecord = mockDB.accountRecord;
+
+  beforeEach(() => {
+    Container.set(CapabilityService, sinon.fake);
+  });
 
   afterEach(() => {
     mockLog.activityEvent.resetHistory();
@@ -1575,6 +1578,7 @@ describe('/account/login', () => {
     mockRequest.payload.email = TEST_EMAIL;
     mockRequest.payload.verificationMethod = undefined;
     mockCadReminders.delete.resetHistory();
+    Container.reset();
   });
 
   it('emits the correct series of calls and events', () => {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/google.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/google.js
@@ -61,6 +61,7 @@ describe('GoogleIapHandler', () => {
   });
 
   afterEach(() => {
+    Container.reset();
     sinon.restore();
   });
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal-notifications.js
@@ -19,6 +19,7 @@ const {
   PayPalNotificationHandler,
 } = require('../../../../lib/routes/subscriptions/paypal-notifications');
 const { PayPalHelper } = require('../../../../lib/payments/paypal');
+const { CapabilityService } = require('../../../../lib/payments/capability');
 
 const ACCOUNT_LOCALE = 'en-US';
 const TEST_EMAIL = 'test@email.com';
@@ -73,6 +74,7 @@ describe('PayPalNotificationHandler', () => {
     paypalHelper = {};
 
     Container.set(PayPalHelper, paypalHelper);
+    Container.set(CapabilityService, {});
 
     handler = new PayPalNotificationHandler(
       log,
@@ -87,6 +89,7 @@ describe('PayPalNotificationHandler', () => {
   });
 
   afterEach(() => {
+    Container.reset();
     sinon.restore();
   });
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -21,9 +21,11 @@ const subscription2 = require('../../payments/fixtures/stripe/subscription2.json
 const openInvoice = require('../../payments/fixtures/stripe/invoice_open.json');
 const { filterSubscription } = require('fxa-shared/subscriptions/stripe');
 const { CurrencyHelper } = require('../../../../lib/payments/currencies');
+const buildRoutes = require('../../../../lib/routes/subscriptions');
 
 const ACCOUNT_LOCALE = 'en-US';
 const { OAUTH_SCOPE_SUBSCRIPTIONS } = require('fxa-shared/oauth/constants');
+const { CapabilityService } = require('../../../../lib/payments/capability');
 const TEST_EMAIL = 'test@email.com';
 const UID = uuid.v4({}, Buffer.alloc(16)).toString('hex');
 const MOCK_SCOPES = ['profile:email', OAUTH_SCOPE_SUBSCRIPTIONS];
@@ -45,7 +47,7 @@ function runTest(routePath, requestOptions) {
     email: TEST_EMAIL,
     locale: ACCOUNT_LOCALE,
   });
-  const routes = require('../../../../lib/routes/subscriptions')(
+  const routes = buildRoutes(
     log,
     db,
     config,
@@ -116,7 +118,12 @@ describe('subscriptions payPalRoutes', () => {
     payPalHelper.currencyHelper = currencyHelper;
     Container.set(PayPalHelper, payPalHelper);
     profile = {};
+    Container.set(CapabilityService, {});
     push = {};
+  });
+
+  afterEach(() => {
+    Container.reset();
   });
 
   describe('POST /oauth/subscriptions/paypal-checkout', () => {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/play-pubsub.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/play-pubsub.js
@@ -76,6 +76,7 @@ describe('PlayPubsubHandler', () => {
   });
 
   afterEach(() => {
+    Container.reset();
     sandbox.restore();
   });
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -48,8 +48,6 @@ const currencyHelper = new CurrencyHelper({
   currenciesToCountries: { USD: ['US', 'GB', 'CA'] },
 });
 const mockCapabilityService = {};
-Container.set(CurrencyHelper, currencyHelper);
-Container.set(CapabilityService, mockCapabilityService);
 
 let config,
   log,
@@ -203,6 +201,7 @@ describe('sanitizePlans', () => {
  */
 describe('subscriptions stripeRoutes', () => {
   beforeEach(() => {
+    Container.reset();
     config = {
       authFirestore: {
         enabled: false,
@@ -224,6 +223,7 @@ describe('subscriptions stripeRoutes', () => {
 
     const currencyHelper = new CurrencyHelper(config);
     Container.set(CurrencyHelper, currencyHelper);
+    Container.set(CapabilityService, mockCapabilityService);
 
     log = mocks.mockLog();
     customs = mocks.mockCustoms();
@@ -260,6 +260,7 @@ describe('subscriptions stripeRoutes', () => {
   });
 
   afterEach(() => {
+    Container.reset();
     sinon.restore();
   });
 


### PR DESCRIPTION
Because:

* We want to keep firestore copies of Stripe docs up to date.
* We want to use our firestore copy of Stripe data instead of
  hitting Stripe frequently.

This commit:

* Uses the stripe webhook to populate Firestore with up-to-date
  objects from Stripe.
* Uses Firestore first when possible to fetch Stripe documents
  when expanding the resourcce.

Closes #10530

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
