### PR TITLE
feat(flags): Add feature flag for pocket migration

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/experiment.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiment.js
@@ -27,6 +27,7 @@ const MANUAL_EXPERIMENTS = {
   newsletterSync: BaseExperiment,
   qrCodeCad: BaseExperiment,
   pushLogin: BaseExperiment,
+  pocketMigration: BaseExperiment,
 };
 
 const ALL_EXPERIMENTS = _.extend({}, STARTUP_EXPERIMENTS, MANUAL_EXPERIMENTS);

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/index.js
@@ -17,6 +17,7 @@ const experimentGroupingRules = [
   require('./sentry'),
   require('./newsletter-sync'),
   require('./push'),
+  require('./pocket-migration'),
 ].map((ExperimentGroupingRule) => new ExperimentGroupingRule());
 
 class ExperimentChoiceIndex {

--- a/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/pocket-migration.js
+++ b/packages/fxa-content-server/app/scripts/lib/experiments/grouping-rules/pocket-migration.js
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Feature flag for pocket migration.
+ *
+ */
+'use strict';
+
+const BaseGroupingRule = require('./base');
+const GROUPS = [
+  'control',
+  // Treatment branch is the migration flow
+  'treatment',
+];
+const POCKET_CLIENTIDS = [
+  '7377719276ad44ee', // pocket-mobile
+  '749818d3f2e7857f', // pocket-web
+  'dcdb5ae7add825d2', // 123done
+];
+
+// This experiment is disabled by default. If you would like to go through
+// the flow, load email-first screen and append query params
+// `?forceExperiment=pocketMigration&forceExperimentGroup=treatment`
+const ROLLOUT_RATE = 1.0;
+
+module.exports = class PocketMigration extends BaseGroupingRule {
+  constructor() {
+    super();
+    this.name = 'pocketMigration';
+
+    // Easier to set class properties for testability
+    this.groups = GROUPS;
+    this.rolloutRate = ROLLOUT_RATE;
+  }
+
+  /**
+   * Enable pocket migration flow based on if user is in
+   * correct group.
+   *
+   * @param {Object} subject data used to decide
+   *  @param {Boolean} clientId
+   * @returns {Any}
+   */
+  choose(subject = {}) {
+    let choice = false;
+    const { clientId } = subject;
+
+    // Only enroll for pocket clients
+    if (!POCKET_CLIENTIDS.includes(clientId)) {
+      return false;
+    }
+
+    if (this.bernoulliTrial(this.rolloutRate, subject.uniqueUserId)) {
+      choice = this.uniformChoice(GROUPS, subject.uniqueUserId);
+    }
+
+    return choice;
+  }
+};
+
+module.exports.POCKET_CLIENTIDS = POCKET_CLIENTIDS;

--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -2,7 +2,14 @@
   <header>
     <h1 id="fxa-enter-email-header">
       <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-      {{#t}}Enter your email{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+      {{#t}}Enter your email{{/t}}
+        {{#isInPocketMigration}}
+            <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+        {{/isInPocketMigration}}
+
+        {{^isInPocketMigration}}
+            <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+        {{/isInPocketMigration}}
     </h1>
   </header>
 

--- a/packages/fxa-content-server/app/scripts/views/index.js
+++ b/packages/fxa-content-server/app/scripts/views/index.js
@@ -22,6 +22,7 @@ import SignedInNotificationMixin from './mixins/signed-in-notification-mixin';
 import SyncSuggestionMixin from './mixins/sync-suggestion-mixin';
 import Template from 'templates/index.mustache';
 import checkEmailDomain from '../lib/email-domain-validator';
+import PocketMigrationMixin from './mixins/pocket-migration-mixin';
 
 const EMAIL_SELECTOR = 'input[type=email]';
 
@@ -269,7 +270,8 @@ Cocktail.mixin(
   SyncSuggestionMixin({
     entrypoint: 'fxa:enter_email',
     flowEvent: 'link.signin',
-  })
+  }),
+  PocketMigrationMixin
 );
 
 export default IndexView;

--- a/packages/fxa-content-server/app/scripts/views/mixins/pocket-migration-mixin.js
+++ b/packages/fxa-content-server/app/scripts/views/mixins/pocket-migration-mixin.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import ExperimentMixin from './experiment-mixin';
+const EXPERIMENT_NAME = 'pocketMigration';
+
+export default {
+  dependsOn: [ExperimentMixin],
+
+  setInitialContext(context) {
+    context.set({
+      isInPocketMigration: this.isInPocketMigrationTreatment(),
+    });
+  },
+
+  isInPocketMigrationTreatment() {
+    const experimentGroup = this.getAndReportExperimentGroup(EXPERIMENT_NAME, {
+      clientId: this.relier.get('clientId'),
+    });
+    return experimentGroup === 'treatment';
+  },
+};

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/index.js
@@ -9,7 +9,7 @@ import sinon from 'sinon';
 
 describe('lib/experiments/grouping-rules/index', () => {
   it('EXPERIMENT_NAMES is exported', () => {
-    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 6);
+    assert.lengthOf(ExperimentGroupingRules.EXPERIMENT_NAMES, 7);
   });
 
   describe('choose', () => {

--- a/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/pocket-migration.js
+++ b/packages/fxa-content-server/app/tests/spec/lib/experiments/grouping-rules/pocket-migration.js
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import Experiment, {
+  POCKET_CLIENTIDS,
+} from 'lib/experiments/grouping-rules/pocket-migration';
+
+describe('lib/experiments/grouping-rules/pocket-migration', () => {
+  let experiment;
+
+  beforeEach(() => {
+    experiment = new Experiment();
+  });
+
+  describe('choose', () => {
+    it('returns false if invalid client id', () => {
+      assert.isFalse(
+        experiment.choose({
+          experimentGroupingRules: { choose: () => experiment.name },
+          clientId: 'foo',
+        })
+      );
+    });
+
+    it('returns false if rollout 0%', () => {
+      experiment.rolloutRate = 0;
+      assert.isFalse(
+        experiment.choose({
+          experimentGroupingRules: { choose: () => experiment.name },
+          clientId: POCKET_CLIENTIDS[0],
+        })
+      );
+    });
+
+    it('returns treatment if rollout 100%', () => {
+      experiment.rolloutRate = 1;
+      assert.isTrue(
+        experiment.groups.includes(
+          experiment.choose({
+            experimentGroupingRules: { choose: () => experiment.name },
+            clientId: POCKET_CLIENTIDS[0],
+          })
+        )
+      );
+    });
+  });
+});

--- a/packages/fxa-content-server/app/tests/test_start.js
+++ b/packages/fxa-content-server/app/tests/test_start.js
@@ -46,6 +46,7 @@ require('./spec/lib/experiments/grouping-rules/communication-prefs');
 require('./spec/lib/experiments/grouping-rules/index');
 require('./spec/lib/experiments/grouping-rules/is-sampled-user');
 require('./spec/lib/experiments/grouping-rules/newsletter-sync');
+require('./spec/lib/experiments/grouping-rules/pocket-migration');
 require('./spec/lib/experiments/grouping-rules/push');
 require('./spec/lib/experiments/grouping-rules/send-sms-install-link');
 require('./spec/lib/experiments/grouping-rules/sentry');


### PR DESCRIPTION
## Because

- We need to control the rollout of the pocket migration views

## This pull request

- Adds a feature flag using our existing experiments framework. This has the benefit of sending experiment data so that we can properly track the performance of the new flow
- You can force going through the flow by appending `?forceExperiment=pocketMigration&forceExperimentGroup=treatment` to url
- This needs some unit tests

## Issue that this pull request solves

Closes: #10635 

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate)
