### PR TITLE
refactor(storybook): Use nested sections, tweak design guide bar

### DIFF
--- a/packages/fxa-react/components/AppErrorDialog/index.stories.tsx
+++ b/packages/fxa-react/components/AppErrorDialog/index.stories.tsx
@@ -2,6 +2,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import AppErrorDialog from './index';
 
-storiesOf('Components|AppErrorDialog', module).add('basic', () => (
+storiesOf('Components/AppErrorDialog', module).add('basic', () => (
   <AppErrorDialog error={new Error('Uh oh!')} />
 ));

--- a/packages/fxa-react/components/Footer/index.stories.tsx
+++ b/packages/fxa-react/components/Footer/index.stories.tsx
@@ -6,4 +6,4 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { Footer } from './index';
 
-storiesOf('Components|Footer', module).add('default', () => <Footer />);
+storiesOf('Components/Footer', module).add('default', () => <Footer />);

--- a/packages/fxa-react/components/Head/index.stories.tsx
+++ b/packages/fxa-react/components/Head/index.stories.tsx
@@ -6,6 +6,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import Head from './index';
 
-storiesOf('Components|Head', module)
+storiesOf('Components/Head', module)
   .add('basic', () => <Head />)
   .add('with title', () => <Head title="neat feature" />);

--- a/packages/fxa-react/components/Header/index.stories.tsx
+++ b/packages/fxa-react/components/Header/index.stories.tsx
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { Header } from './index';
 import { LogoLockup } from '../LogoLockup';
 
-storiesOf('Components|Header', module)
+storiesOf('Components/Header', module)
   .add('basic', () => (
     <Header left={<div>left content</div>} right={<div>right content</div>} />
   ))

--- a/packages/fxa-react/components/LinkExternal/index.stories.tsx
+++ b/packages/fxa-react/components/LinkExternal/index.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import LinkExternal from './index';
 
-storiesOf('Components|LinkExternal', module).add('basic', () => (
+storiesOf('Components/LinkExternal', module).add('basic', () => (
   <LinkExternal href="https://mozilla.org">
     Keep the internet open and accessible to all.
   </LinkExternal>

--- a/packages/fxa-react/components/LoadingSpinner/index.stories.tsx
+++ b/packages/fxa-react/components/LoadingSpinner/index.stories.tsx
@@ -2,6 +2,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import LoadingSpinner from './index';
 
-storiesOf('Components|LoadingSpinner', module).add('basic', () => (
+storiesOf('Components/LoadingSpinner', module).add('basic', () => (
   <LoadingSpinner />
 ));

--- a/packages/fxa-react/components/Survey/index.stories.tsx
+++ b/packages/fxa-react/components/Survey/index.stories.tsx
@@ -5,7 +5,7 @@ import './index.scss';
 
 const surveyURL = 'https://www.surveygizmo.com/s3/5541940/pizza';
 
-storiesOf('Components|Survey', module)
+storiesOf('Components/Survey', module)
   .add('default', () => {
     const [showSurvey, setShowSurvey] = useState(true);
 

--- a/packages/fxa-settings/.storybook/design-guide/Header.tsx
+++ b/packages/fxa-settings/.storybook/design-guide/Header.tsx
@@ -3,7 +3,7 @@ import LinkExternal from 'fxa-react/components/LinkExternal';
 
 const Header = () => {
   return (
-    <div className="bg-grey-50 flex items-center justify-between sticky z-20 top-0 pt-8  pb-5 border-b border-grey-400 border-opacity-25 px-2 -ml-2 -mr-2">
+    <div className="bg-grey-50 flex items-center justify-between sticky z-20 top-0 pt-4 pb-3 border-b border-grey-400 border-opacity-25 px-2 -mt-4 -ml-12 -mr-12">
       <div className="flex items-center">
         <img src="logo.svg" className="mr-3" />
         <h1 className="text-xl font-bold text-grey-600">Design Guide</h1>

--- a/packages/fxa-settings/.storybook/design-guide/main.stories.tsx
+++ b/packages/fxa-settings/.storybook/design-guide/main.stories.tsx
@@ -10,22 +10,22 @@ import Breakpoints from './pages/Breakpoints';
 
 const fullConfig = resolveConfig(tailwindConfig);
 
-storiesOf('Design Guide|Settings', module).add('Introduction', () => (
+storiesOf('Design Guide/Settings', module).add('Introduction', () => (
   <Introduction />
 ));
 
-storiesOf('Design Guide|Settings', module).add('Colors', () => (
+storiesOf('Design Guide/Settings', module).add('Colors', () => (
   <Colors config={fullConfig} />
 ));
 
-storiesOf('Design Guide|Settings', module).add('Typography', () => (
+storiesOf('Design Guide/Settings', module).add('Typography', () => (
   <Typography config={fullConfig} />
 ));
 
-storiesOf('Design Guide|Settings', module).add('Spacing', () => (
+storiesOf('Design Guide/Settings', module).add('Spacing', () => (
   <Spacing config={fullConfig} />
 ));
 
-storiesOf('Design Guide|Settings', module).add('Breakpoints', () => (
+storiesOf('Design Guide/Settings', module).add('Breakpoints', () => (
   <Breakpoints config={fullConfig} />
 ));

--- a/packages/fxa-settings/src/components/AppLayout/index.stories.tsx
+++ b/packages/fxa-settings/src/components/AppLayout/index.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import AppLayout from './index';
 
-storiesOf('Components|AppLayout', module).add('basic', () => (
+storiesOf('Components/AppLayout', module).add('basic', () => (
   <AppLayout>
     <p>App contents go here</p>
   </AppLayout>

--- a/packages/fxa-settings/src/components/Avatar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Avatar/index.stories.tsx
@@ -13,7 +13,7 @@ const account = {
     id: null,
   },
 } as any;
-storiesOf('Components|Avatar', module)
+storiesOf('Components/Avatar', module)
   .add('default avatar', () => (
     <AppContext.Provider value={{ account }}>
       <Avatar className="w-32 h-32" />

--- a/packages/fxa-settings/src/components/BentoMenu/index.stories.tsx
+++ b/packages/fxa-settings/src/components/BentoMenu/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import BentoMenu from '.';
 
-storiesOf('Components|BentoMenu', module).add('default', () => (
+storiesOf('Components/BentoMenu', module).add('default', () => (
   <div className="w-full flex justify-end">
     <div className="flex tablet:pr-10 pt-4">
       <BentoMenu />

--- a/packages/fxa-settings/src/components/ButtonIcon/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ButtonIcon/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { ButtonIconTrash, ButtonIconReload } from '.';
 
-storiesOf('Components|ButtonIcon', module)
+storiesOf('Components/ButtonIcon', module)
   .add('ButtonIconTrash', () => (
     <div className="p-10 max-w-lg">
       <ButtonIconTrash title="Remove email" />

--- a/packages/fxa-settings/src/components/Checkbox/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Checkbox/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import Checkbox from './index';
 
-storiesOf('Components|Checkbox', module).add('default', () => (
+storiesOf('Components/Checkbox', module).add('default', () => (
   <div className="p-10 max-w-lg">
     <div className="mb-3">
       <Checkbox />

--- a/packages/fxa-settings/src/components/ConnectAnotherDevicePromo/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ConnectAnotherDevicePromo/index.stories.tsx
@@ -2,13 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- import React from 'react';
- import { storiesOf } from '@storybook/react';
- import { LocationProvider } from '@reach/router';
- import { ConnectAnotherDevicePromo } from '.';
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { LocationProvider } from '@reach/router';
+import { ConnectAnotherDevicePromo } from '.';
 
- storiesOf('Components|ConnectAnotherDevice', module)
-   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
-   .add('default', () => (
-     <ConnectAnotherDevicePromo />
-   ));
+storiesOf('Components/ConnectAnotherDevice', module)
+  .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
+  .add('default', () => <ConnectAnotherDevicePromo />);

--- a/packages/fxa-settings/src/components/ConnectedServices/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/index.stories.tsx
@@ -11,7 +11,7 @@ import { MOCK_SERVICES } from './MOCK_SERVICES';
 import { AppContext } from 'fxa-settings/src/models';
 import { mockAppContext } from 'fxa-settings/src/models/_mocks';
 
-storiesOf('Components|ConnectedServices', module)
+storiesOf('Components/ConnectedServices', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => (
     <AppContext.Provider

--- a/packages/fxa-settings/src/components/DataBlock/index.stories.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import DataBlock from './index';
 
-storiesOf('Components|DataBlock', module)
+storiesOf('Components/DataBlock', module)
   .add('single', () => (
     <div className="p-10 max-w-lg">
       <DataBlock value="ANMD 1S09 7Y2Y 4EES 02CW BJ6Z PYKP H69F" />

--- a/packages/fxa-settings/src/components/DropDownAvatarMenu/index.stories.tsx
+++ b/packages/fxa-settings/src/components/DropDownAvatarMenu/index.stories.tsx
@@ -18,7 +18,7 @@ const account = {
   },
 } as any;
 
-storiesOf('Components|DropDownAvatarMenu', module)
+storiesOf('Components/DropDownAvatarMenu', module)
   .add('default - no avatar or display name', () => (
     <AppContext.Provider value={mockAppContext({ account })}>
       <div className="w-full flex justify-end">

--- a/packages/fxa-settings/src/components/FlowContainer/index.stories.tsx
+++ b/packages/fxa-settings/src/components/FlowContainer/index.stories.tsx
@@ -7,6 +7,6 @@ import { storiesOf } from '@storybook/react';
 import { FlowContainer } from '.';
 import { LocationProvider } from '@reach/router';
 
-storiesOf('Components|FlowContainer', module)
+storiesOf('Components/FlowContainer', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => <FlowContainer title="Flow container title" />);

--- a/packages/fxa-settings/src/components/GetDataTrio/index.stories.tsx
+++ b/packages/fxa-settings/src/components/GetDataTrio/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import GetDataTrio from './index';
 
-storiesOf('Components|GetDataTrio', module).add('default', () => (
+storiesOf('Components/GetDataTrio', module).add('default', () => (
   <div className="p-10 max-w-xs">
     <GetDataTrio value="Copy that" />
   </div>

--- a/packages/fxa-settings/src/components/HeaderLockup/index.stories.tsx
+++ b/packages/fxa-settings/src/components/HeaderLockup/index.stories.tsx
@@ -18,7 +18,7 @@ const account = {
   },
 } as any;
 
-storiesOf('Components|HeaderLockup', module)
+storiesOf('Components/HeaderLockup', module)
   .add('with default avatar', () => (
     <AppContext.Provider value={mockAppContext({ account })}>
       <HeaderLockup />

--- a/packages/fxa-settings/src/components/InputPassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/InputPassword/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import InputPassword from '.';
 
-storiesOf('Components|InputPassword', module).add('default', () => (
+storiesOf('Components/InputPassword', module).add('default', () => (
   <div className="p-10 max-w-lg">
     <InputPassword label="You think you know how to password? Enter it here." />
   </div>

--- a/packages/fxa-settings/src/components/InputText/index.stories.tsx
+++ b/packages/fxa-settings/src/components/InputText/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import InputText from './index';
 
-storiesOf('Components|InputText', module)
+storiesOf('Components/InputText', module)
   .add('type text (default)', () => (
     <div className="p-10 pt-16 max-w-lg">
       <div className="mb-3">

--- a/packages/fxa-settings/src/components/Modal/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Modal/index.stories.tsx
@@ -8,7 +8,7 @@ import { useBooleanState } from 'fxa-react/lib/hooks';
 import { Modal } from '.';
 import { LocationProvider } from '@reach/router';
 
-storiesOf('Components|Modal', module)
+storiesOf('Components/Modal', module)
   .add('basic', () => (
     <LocationProvider>
       <ModalToggle>

--- a/packages/fxa-settings/src/components/ModalVerifySession/index.stories.tsx
+++ b/packages/fxa-settings/src/components/ModalVerifySession/index.stories.tsx
@@ -22,7 +22,7 @@ account.verifySession = (code: string) => {
   return Promise.reject(AuthUiErrors.INVALID_EXPIRED_SIGNUP_CODE);
 };
 
-storiesOf('Components|ModalVerifySession', module).add(
+storiesOf('Components/ModalVerifySession', module).add(
   'valid code: 123456',
   () => (
     <LocationProvider>

--- a/packages/fxa-settings/src/components/Nav/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Nav/index.stories.tsx
@@ -15,7 +15,7 @@ const account = {
   },
   subscriptions: [{ created: 1, productName: 'x' }],
 } as any;
-storiesOf('Components|Nav', module)
+storiesOf('Components/Nav', module)
   .add('basic', () => <Nav />)
   .add('with link to Subscriptions', () => (
     <AppContext.Provider value={{ account, session: mockSession() }}>

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.stories.tsx
@@ -27,7 +27,7 @@ const account = {
     }),
 } as any;
 
-storiesOf('Pages|2faReplaceRecoveryCodes', module)
+storiesOf('Pages/2faReplaceRecoveryCodes', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => (
     <AppContext.Provider value={mockAppContext({ account })}>

--- a/packages/fxa-settings/src/components/PageAvatar/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageAvatar/index.stories.tsx
@@ -10,7 +10,7 @@ import AppLayout from '../AppLayout';
 
 import PageAvatar from './';
 
-storiesOf('Pages|PageAvatar', module)
+storiesOf('Pages/PageAvatar', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => (
     <AppLayout>

--- a/packages/fxa-settings/src/components/PageChangePassword/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageChangePassword/index.stories.tsx
@@ -8,7 +8,7 @@ import { PageChangePassword } from '.';
 import { LocationProvider } from '@reach/router';
 import AppLayout from '../AppLayout';
 
-storiesOf('Pages|ChangePassword', module)
+storiesOf('Pages/ChangePassword', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => (
     <AppLayout>

--- a/packages/fxa-settings/src/components/PageDeleteAccount/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageDeleteAccount/index.stories.tsx
@@ -8,7 +8,7 @@ import { PageDeleteAccount } from '.';
 import { LocationProvider } from '@reach/router';
 import AppLayout from '../AppLayout';
 
-storiesOf('Pages|DeleteAccount', module)
+storiesOf('Pages/DeleteAccount', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => (
     <AppLayout>

--- a/packages/fxa-settings/src/components/PageDisplayName/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageDisplayName/index.stories.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { PageDisplayName } from '.';
 import AppLayout from '../AppLayout';
 
-storiesOf('Pages|DisplayNmae', module)
+storiesOf('Pages/DisplayNmae', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => (
     <AppLayout>

--- a/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageRecoveryKeyAdd/index.stories.tsx
@@ -8,7 +8,7 @@ import { PageRecoveryKeyAdd } from '.';
 import { LocationProvider } from '@reach/router';
 import AppLayout from '../AppLayout';
 
-storiesOf('Pages|RecoveryKey', module)
+storiesOf('Pages/RecoveryKey', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => (
     <AppLayout>

--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/index.stories.tsx
@@ -8,7 +8,7 @@ import { storiesOf } from '@storybook/react';
 import { AppLayout } from '../AppLayout';
 import { PageSecondaryEmailAdd } from '.';
 
-storiesOf('Pages|SecondaryEmailAdd', module)
+storiesOf('Pages/SecondaryEmailAdd', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('Default empty', () => (
     <AppLayout>

--- a/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailVerify/index.stories.tsx
@@ -8,11 +8,11 @@ import { PageSecondaryEmailVerify } from '.';
 import { AppLayout } from '../AppLayout';
 import { WindowLocation, LocationProvider } from '@reach/router';
 
-const mockLocation = ({
+const mockLocation = {
   state: { email: 'johndope@example.com' },
-} as unknown) as WindowLocation;
+} as unknown as WindowLocation;
 
-storiesOf('Pages|SecondaryEmailVerify', module)
+storiesOf('Pages/SecondaryEmailVerify', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('valid: 1234, invalid: 4444', () => {
     return (

--- a/packages/fxa-settings/src/components/PageSettings/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageSettings/index.stories.tsx
@@ -14,7 +14,7 @@ import { AppContext } from 'fxa-settings/src/models';
 
 const SERVICES_NON_MOBILE = MOCK_SERVICES.filter((d) => !isMobileDevice(d));
 
-storiesOf('Pages|Settings', module)
+storiesOf('Pages/Settings', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('cold start', () => (
     <AppContext.Provider

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.stories.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.stories.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { PageTwoStepAuthentication } from '.';
 import AppLayout from '../AppLayout';
 
-storiesOf('Pages|TwoStepAuthentication', module)
+storiesOf('Pages/TwoStepAuthentication', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => (
     <AppLayout>

--- a/packages/fxa-settings/src/components/Profile/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Profile/index.stories.tsx
@@ -7,6 +7,6 @@ import { storiesOf } from '@storybook/react';
 import { LocationProvider } from '@reach/router';
 import { Profile } from '.';
 
-storiesOf('Components|Profile', module)
+storiesOf('Components/Profile', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => <Profile />);

--- a/packages/fxa-settings/src/components/Security/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Security/index.stories.tsx
@@ -9,7 +9,7 @@ import { Security } from '.';
 import { AppContext } from 'fxa-settings/src/models';
 import { mockAppContext } from 'fxa-settings/src/models/_mocks';
 
-storiesOf('Components|Security', module)
+storiesOf('Components/Security', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default', () => (
     <AppContext.Provider

--- a/packages/fxa-settings/src/components/Tooltip/index.stories.tsx
+++ b/packages/fxa-settings/src/components/Tooltip/index.stories.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import Tooltip from './index';
 
-storiesOf('Components|Tooltip', module)
+storiesOf('Components/Tooltip', module)
   .add('default', () => (
     <div className="p-20 max-w-md">
       <div className="mb-3">

--- a/packages/fxa-settings/src/components/UnitRow/index.stories.tsx
+++ b/packages/fxa-settings/src/components/UnitRow/index.stories.tsx
@@ -11,7 +11,7 @@ import { UnitRow } from '.';
 import { Modal } from '../Modal';
 import { AppContext } from 'fxa-settings/src/models';
 
-storiesOf('Components|UnitRow', module)
+storiesOf('Components/UnitRow', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('basic, with falsey headerValue', () => (
     <UnitRow header="Some header" headerValue={null} />
@@ -64,11 +64,8 @@ storiesOf('Components|UnitRow', module)
     }
   )
   .add('with modal-triggering secondary CTA', () => {
-    const [
-      secondaryModalRevealed,
-      revealSecondaryModal,
-      hideModal,
-    ] = useBooleanState();
+    const [secondaryModalRevealed, revealSecondaryModal, hideModal] =
+      useBooleanState();
     return (
       <UnitRow
         header="Display name"

--- a/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.stories.tsx
+++ b/packages/fxa-settings/src/components/UnitRowRecoveryKey/index.stories.tsx
@@ -9,7 +9,7 @@ import UnitRowRecoveryKey from '.';
 import { AppContext } from 'fxa-settings/src/models';
 import { mockAppContext, mockSession } from 'fxa-settings/src/models/_mocks';
 
-storiesOf('Components|UnitRowRecoveryKey', module)
+storiesOf('Components/UnitRowRecoveryKey', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('with recovery key', () => (
     <AppContext.Provider

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.stories.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.stories.tsx
@@ -10,7 +10,7 @@ import { LocationProvider } from '@reach/router';
 
 import { AppContext } from 'fxa-settings/src/models';
 
-storiesOf('Components|UnitRowSecondaryEmail', module)
+storiesOf('Components/UnitRowSecondaryEmail', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('No secondary email set', () => <UnitRowSecondaryEmail />)
   .add('One secondary email set, unverified', () => {

--- a/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.stories.tsx
+++ b/packages/fxa-settings/src/components/UnitRowTwoStepAuth/index.stories.tsx
@@ -9,7 +9,7 @@ import UnitRowTwoStepAuth from '.';
 import { AppContext } from 'fxa-settings/src/models';
 import { mockAppContext } from 'fxa-settings/src/models/_mocks';
 
-storiesOf('Components|UnitRowTwoStepAuth', module)
+storiesOf('Components/UnitRowTwoStepAuth', module)
   .addDecorator((getStory) => <LocationProvider>{getStory()}</LocationProvider>)
   .add('default unset', () => (
     <AppContext.Provider


### PR DESCRIPTION
## Because

* We need to update Storybook nested syntax from '|' to '/' with a previous update to use nested sections
* The design guide top bar seemed very large and in the way


## This pull request

* Tweaks relevant storybook files


## Screenshots (Optional)

Feel free to push back on anything here, I'd just started on the FE piece of the legal opt-out epic and this started to bother me.

Before:
<img width="979" alt="image" src="https://user-images.githubusercontent.com/13018240/136284325-6f53c2ef-097b-400e-99f2-0a7b2c2289ef.png">


After: 
﻿
<img width="867" alt="image" src="https://user-images.githubusercontent.com/13018240/136283979-050698cc-8805-43c6-be0c-95aba74b4d22.png">

