### PR TITLE
feat(content-server): render pocket logo in password updated screen for pocket clients

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/ready.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/ready.mustache
@@ -17,7 +17,13 @@
 
     {{^isSync}}
       {{#isFromRelyingParty}}
-        <p class="account-ready-service">{{#t}}You are now ready to use %(serviceName)s{{/t}}</p>
+        {{#isInPocketMigration}}
+          {{#unsafeTranslate}}You are now ready to use{{/unsafeTranslate}}
+          <img id="graphic-client-pocket" src="/images/pocket_logo_rounded.svg" alt="Pocket" />
+        {{/isInPocketMigration}}
+        {{^isInPocketMigration}}
+          <p class="account-ready-service">{{#t}}You are now ready to use %(serviceName)s{{/t}}</p>
+        {{/isInPocketMigration}}
         {{#showContinueButton}}
           <div class="button-row">
             <button class="primary-button btn-continue">{{#t}}Continue{{/t}}</button>

--- a/packages/fxa-content-server/app/scripts/views/ready.js
+++ b/packages/fxa-content-server/app/scripts/views/ready.js
@@ -19,6 +19,7 @@ import PulseGraphicMixin from './mixins/pulse-graphic-mixin';
 import ServiceMixin from './mixins/service-mixin';
 import Template from 'templates/ready.mustache';
 import VerificationReasonMixin from './mixins/verification-reason-mixin';
+import PocketMigrationMixin from './mixins/pocket-migration-mixin';
 
 const t = (msg) => msg;
 
@@ -193,7 +194,8 @@ Cocktail.mixin(
   MarketingMixin({ marketingId: Constants.MARKETING_ID_SPRING_2015 }),
   PulseGraphicMixin,
   ServiceMixin,
-  VerificationReasonMixin
+  VerificationReasonMixin,
+  PocketMigrationMixin
 );
 
 export default View;

--- a/packages/fxa-content-server/tests/functional/oauth_reset_password.js
+++ b/packages/fxa-content-server/tests/functional/oauth_reset_password.js
@@ -41,6 +41,7 @@ const {
   type,
   visibleByQSA,
 } = FunctionalHelpers;
+const rmHelpers = FunctionalHelpers.helpersRemoteWrapped;
 
 registerSuite('oauth reset password', {
   beforeEach: function () {
@@ -105,70 +106,46 @@ registerSuite('oauth reset password', {
       );
     },
 
-    'reset password, verify same browser with original tab closed': function () {
-      return (
-        this.remote
-          .then(openFxaFromRp('enter-email'))
-          .then(type(selectors.ENTER_EMAIL.EMAIL, email))
-          .then(
-            click(
-              selectors.ENTER_EMAIL.SUBMIT,
-              selectors.SIGNIN_PASSWORD.HEADER
+    'reset password, verify same browser with original tab closed':
+      function () {
+        return (
+          this.remote
+            .then(openFxaFromRp('enter-email'))
+            .then(type(selectors.ENTER_EMAIL.EMAIL, email))
+            .then(
+              click(
+                selectors.ENTER_EMAIL.SUBMIT,
+                selectors.SIGNIN_PASSWORD.HEADER
+              )
             )
-          )
 
-          .then(
-            click(
-              selectors.SIGNIN_PASSWORD.LINK_FORGOT_PASSWORD,
-              selectors.RESET_PASSWORD.HEADER
+            .then(
+              click(
+                selectors.SIGNIN_PASSWORD.LINK_FORGOT_PASSWORD,
+                selectors.RESET_PASSWORD.HEADER
+              )
             )
-          )
 
-          .then(fillOutResetPassword(email))
-          .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
+            .then(fillOutResetPassword(email))
+            .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
 
-          // user browses to another site.
-          .then(openExternalSite())
-          .then(openVerificationLinkInNewTab(email, 0))
+            // user browses to another site.
+            .then(openExternalSite())
+            .then(openVerificationLinkInNewTab(email, 0))
 
-          .then(switchToWindow(1))
+            .then(switchToWindow(1))
 
-          .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
-          .then(testElementExists(selectors.RESET_PASSWORD_COMPLETE.HEADER))
+            .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
+            .then(testElementExists(selectors.RESET_PASSWORD_COMPLETE.HEADER))
 
-          // switch to the original window
-          .then(closeCurrentWindow())
-      );
-    },
+            // switch to the original window
+            .then(closeCurrentWindow())
+        );
+      },
 
-    'reset password, verify same browser by replacing the original tab': function () {
-      return this.remote
-        .then(openFxaFromRp('enter-email'))
-        .then(type(selectors.ENTER_EMAIL.EMAIL, email))
-        .then(
-          click(selectors.ENTER_EMAIL.SUBMIT, selectors.SIGNIN_PASSWORD.HEADER)
-        )
-
-        .then(
-          click(
-            selectors.SIGNIN_PASSWORD.LINK_FORGOT_PASSWORD,
-            selectors.RESET_PASSWORD.HEADER
-          )
-        )
-
-        .then(fillOutResetPassword(email))
-
-        .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
-
-        .then(openVerificationLinkInSameTab(email, 0))
-        .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
-
-        .then(testElementExists(selectors['123DONE'].AUTHENTICATED));
-    },
-
-    "reset password, verify in a different browser, from the original tab's P.O.V.": function () {
-      return (
-        this.remote
+    'reset password, verify same browser by replacing the original tab':
+      function () {
+        return this.remote
           .then(openFxaFromRp('enter-email'))
           .then(type(selectors.ENTER_EMAIL.EMAIL, email))
           .then(
@@ -188,63 +165,127 @@ registerSuite('oauth reset password', {
           .then(fillOutResetPassword(email))
 
           .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
-          .then(openPasswordResetLinkInDifferentBrowser(email, PASSWORD))
 
-          // user verified in a new browser, they have to enter
-          // their updated credentials in the original tab.
-          .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER))
-          .then(visibleByQSA(selectors.SIGNIN_PASSWORD.SUCCESS))
-          .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
-          .then(
-            click(
-              selectors.SIGNIN_PASSWORD.SUBMIT,
-              selectors['123DONE'].AUTHENTICATED
-            )
-          )
-
-          // user is redirected to RP
-          .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
-      );
-    },
-
-    "reset password, verify in a different browser, from the new browser's P.O.V.": function () {
-      return (
-        this.remote
-          .then(openFxaFromRp('enter-email'))
-          .then(type(selectors.ENTER_EMAIL.EMAIL, email))
-          .then(
-            click(
-              selectors.ENTER_EMAIL.SUBMIT,
-              selectors.SIGNIN_PASSWORD.HEADER
-            )
-          )
-
-          .then(
-            click(
-              selectors.SIGNIN_PASSWORD.LINK_FORGOT_PASSWORD,
-              selectors.RESET_PASSWORD.HEADER
-            )
-          )
-
-          .then(testElementExists(selectors.RESET_PASSWORD.HEADER))
-          .then(fillOutResetPassword(email))
-
-          .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
-
-          // clear all browser state, simulate opening in a new browser
-          .then(
-            clearBrowserState({
-              forceAll: true,
-            })
-          )
           .then(openVerificationLinkInSameTab(email, 0))
-
-          .then(testElementExists(selectors.COMPLETE_RESET_PASSWORD.HEADER))
           .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
-          .then(testElementExists(selectors.RESET_PASSWORD_COMPLETE.HEADER))
-          // user sees the name of the rp, but cannot redirect
-          .then(testElementTextInclude('.account-ready-service', '123done'))
+          .then(testElementExists(selectors['123DONE'].AUTHENTICATED));
+      },
+
+    "reset password, verify in a different browser, from the original tab's P.O.V.":
+      function () {
+        return (
+          this.remote
+            .then(openFxaFromRp('enter-email'))
+            .then(type(selectors.ENTER_EMAIL.EMAIL, email))
+            .then(
+              click(
+                selectors.ENTER_EMAIL.SUBMIT,
+                selectors.SIGNIN_PASSWORD.HEADER
+              )
+            )
+
+            .then(
+              click(
+                selectors.SIGNIN_PASSWORD.LINK_FORGOT_PASSWORD,
+                selectors.RESET_PASSWORD.HEADER
+              )
+            )
+
+            .then(fillOutResetPassword(email))
+
+            .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
+            .then(openPasswordResetLinkInDifferentBrowser(email, PASSWORD))
+
+            // user verified in a new browser, they have to enter
+            // their updated credentials in the original tab.
+            .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER))
+            .then(visibleByQSA(selectors.SIGNIN_PASSWORD.SUCCESS))
+            .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
+            .then(
+              click(
+                selectors.SIGNIN_PASSWORD.SUBMIT,
+                selectors['123DONE'].AUTHENTICATED
+              )
+            )
+
+            // user is redirected to RP
+            .then(testElementExists(selectors['123DONE'].AUTHENTICATED))
+        );
+      },
+
+    "reset password, verify in a different browser, from the new browser's P.O.V.":
+      function () {
+        return (
+          this.remote
+            .then(openFxaFromRp('enter-email'))
+            .then(type(selectors.ENTER_EMAIL.EMAIL, email))
+            .then(
+              click(
+                selectors.ENTER_EMAIL.SUBMIT,
+                selectors.SIGNIN_PASSWORD.HEADER
+              )
+            )
+
+            .then(
+              click(
+                selectors.SIGNIN_PASSWORD.LINK_FORGOT_PASSWORD,
+                selectors.RESET_PASSWORD.HEADER
+              )
+            )
+
+            .then(testElementExists(selectors.RESET_PASSWORD.HEADER))
+            .then(fillOutResetPassword(email))
+
+            .then(testElementExists(selectors.CONFIRM_RESET_PASSWORD.HEADER))
+
+            // clear all browser state, simulate opening in a new browser
+            .then(
+              clearBrowserState({
+                forceAll: true,
+              })
+            )
+            .then(openVerificationLinkInSameTab(email, 0))
+
+            .then(testElementExists(selectors.COMPLETE_RESET_PASSWORD.HEADER))
+            .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
+
+            .then(testElementExists(selectors.RESET_PASSWORD_COMPLETE.HEADER))
+            // user sees the name of the rp, but cannot redirect
+            .then(testElementTextInclude('.account-ready-service', '123done'))
+        );
+      },
+    'reset password using rp in pocket migration experiment': async ({
+      remote,
+    }) => {
+      await rmHelpers.openFxaFromRp('enter-email', {}, remote);
+      await rmHelpers.type(selectors.ENTER_EMAIL.EMAIL, email, remote);
+      await rmHelpers.click(
+        selectors.ENTER_EMAIL.SUBMIT,
+        selectors.SIGNIN_PASSWORD.HEADER,
+        remote
+      );
+      await rmHelpers.click(
+        selectors.SIGNIN_PASSWORD.LINK_FORGOT_PASSWORD,
+        selectors.RESET_PASSWORD.HEADER,
+        remote
+      );
+      await rmHelpers.fillOutResetPassword(email, {}, remote);
+      await rmHelpers.openVerificationLinkInSameTab(
+        email,
+        0,
+        {
+          query: {
+            forceExperiment: 'pocketMigration',
+            forceExperimentGroup: 'treatment',
+          },
+        },
+        remote
+      );
+      await rmHelpers.fillOutCompleteResetPassword(PASSWORD, PASSWORD, remote);
+      await rmHelpers.testElementExists(
+        selectors.POCKET_OAUTH.LOGO_IMG,
+        remote
       );
     },
   },
@@ -331,45 +372,47 @@ registerSuite('oauth reset password with TOTP', {
         .then(testElementExists(selectors.RESET_PASSWORD_COMPLETE.HEADER));
     },
 
-    "reset password, verify in a different browser, from the original tab's P.O.V.": function () {
-      return (
-        this.remote
-          .then(openPasswordResetLinkInDifferentBrowser(email, PASSWORD, 1))
+    "reset password, verify in a different browser, from the original tab's P.O.V.":
+      function () {
+        return (
+          this.remote
+            .then(openPasswordResetLinkInDifferentBrowser(email, PASSWORD, 1))
 
-          // user verified in a new browser, they have to enter
-          // their password in the original tab.
-          .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER))
+            // user verified in a new browser, they have to enter
+            // their password in the original tab.
+            .then(testElementExists(selectors.SIGNIN_PASSWORD.HEADER))
 
-          .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
-          .then(
-            click(
-              selectors.SIGNIN_PASSWORD.SUBMIT,
-              selectors.TOTP_SIGNIN.HEADER
+            .then(type(selectors.SIGNIN_PASSWORD.PASSWORD, PASSWORD))
+            .then(
+              click(
+                selectors.SIGNIN_PASSWORD.SUBMIT,
+                selectors.TOTP_SIGNIN.HEADER
+              )
             )
-          )
 
-          .then(testElementExists(selectors.TOTP_SIGNIN.HEADER))
-          .then(type(selectors.TOTP_SIGNIN.INPUT, generateTotpCode(secret)))
-          .then(
-            click(
-              selectors.TOTP_SIGNIN.SUBMIT,
-              selectors['123DONE'].AUTHENTICATED_TOTP
+            .then(testElementExists(selectors.TOTP_SIGNIN.HEADER))
+            .then(type(selectors.TOTP_SIGNIN.INPUT, generateTotpCode(secret)))
+            .then(
+              click(
+                selectors.TOTP_SIGNIN.SUBMIT,
+                selectors['123DONE'].AUTHENTICATED_TOTP
+              )
             )
-          )
-      );
-    },
+        );
+      },
 
-    "reset password, verify in a different browser from new browser's P.O.V.": function () {
-      return (
-        this.remote
-          // clear all browser state, simulate opening in a new browser
-          .then(clearBrowserState({ forceAll: true }))
-          .then(openVerificationLinkInSameTab(email, 1))
-          .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
+    "reset password, verify in a different browser from new browser's P.O.V.":
+      function () {
+        return (
+          this.remote
+            // clear all browser state, simulate opening in a new browser
+            .then(clearBrowserState({ forceAll: true }))
+            .then(openVerificationLinkInSameTab(email, 1))
+            .then(fillOutCompleteResetPassword(PASSWORD, PASSWORD))
 
-          // this tab's success is seeing the reset password complete header.
-          .then(testElementExists(selectors.RESET_PASSWORD_COMPLETE.HEADER))
-      );
-    },
+            // this tab's success is seeing the reset password complete header.
+            .then(testElementExists(selectors.RESET_PASSWORD_COMPLETE.HEADER))
+        );
+      },
   },
 });


### PR DESCRIPTION
## Because

- We want to enhance the password reset UI for pocket clients

## This pull request

- Uses the same PocketMigrationMixin to conditionally render the Pocket logo in the UI when resetting password via a matching Pocket client ID

## Issue that this pull request solves

Closes: #10621

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)

<img width="623" alt="Screen Shot 2021-10-08 at 10 17 00 AM" src="https://user-images.githubusercontent.com/6392049/136571739-91692f9b-ff44-458f-99e2-9da1f3ad0ad4.png">


