### PR TITLE
feat(subscriptions): add endpoint for billing details and IAP & Stripe subscriptions

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -352,9 +352,7 @@ export class CapabilityService {
    * Fetch the list of subscription purchases from Google Play and return
    * the ids of the products purchased.
    */
-  private async fetchSubscribedProductsFromPlay(
-    uid: string
-  ): Promise<string[]> {
+  public async fetchSubscribedProductsFromPlay(uid: string): Promise<string[]> {
     if (!this.playBilling) {
       return [];
     }

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -25,6 +25,7 @@ import { AuthLogger, AuthRequest, Awaited } from '../types';
 import emailUtils from './utils/email';
 import requestHelper from './utils/request_helper';
 import validators from './validators';
+import { MozillaSubscription } from 'fxa-shared/subscriptions/types';
 
 const METRICS_CONTEXT_SCHEMA = require('../metrics/context').schema;
 
@@ -1467,9 +1468,7 @@ export class AccountHandler {
 
     const { uid, email } = request.auth.credentials;
 
-    let subscriptions: Awaited<
-      ReturnType<StripeHelper['subscriptionsToResponse']>
-    > = [];
+    let subscriptions: Awaited<MozillaSubscription[]> = [];
 
     if (this.config.subscriptions.enabled) {
       try {

--- a/packages/fxa-auth-server/lib/routes/subscriptions/account.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/account.ts
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Stripe from 'stripe';
 import { metadataFromPlan } from 'fxa-shared/subscriptions/metadata';
 import jwt from '../../oauth/jwt';
 

--- a/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
@@ -13,6 +13,7 @@ import { paypalNotificationRoutes } from './paypal-notifications';
 import { playPubsubRoutes } from './play-pubsub';
 import { sanitizePlans, StripeHandler, stripeRoutes } from './stripe';
 import { stripeWebhookRoutes } from './stripe-webhook';
+import { mozillaSubscriptionRoutes } from './mozilla';
 import { supportRoutes } from './support';
 import { handleAuth } from './utils';
 
@@ -60,6 +61,9 @@ const createRoutes = (
       )
     );
     routes.push(...supportRoutes(log, db, config, customs, zendeskClient));
+    routes.push(
+      ...mozillaSubscriptionRoutes({ log, db, customs, stripeHelper })
+    );
   }
   if (stripeHelper && config.subscriptions.paypalNvpSigCredentials.enabled) {
     routes.push(

--- a/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ServerRoute } from '@hapi/hapi';
+import { Container } from 'typedi';
+import error from '../../error';
+import { PaymentBillingDetails, StripeHelper } from '../../payments/stripe';
+import { CapabilityService } from '../../../lib/payments/capability';
+import { MozillaSubscription } from '../../../../fxa-shared/subscriptions/types';
+import { AuthLogger, AuthRequest } from '../../types';
+import {
+  handleAuth,
+  subscribedProductIdsToIapGooglePlaySubscriptions,
+} from './utils';
+import validators from '../validators';
+
+export const mozillaSubscriptionRoutes = ({
+  log,
+  db,
+  customs,
+  stripeHelper,
+  capabilityService,
+}: {
+  log: AuthLogger;
+  db: any;
+  customs: any;
+  stripeHelper: StripeHelper;
+  capabilityService?: CapabilityService;
+}): ServerRoute[] => {
+  if (!capabilityService) {
+    capabilityService = Container.get(CapabilityService);
+  }
+  const mozillaSubscriptionHandler = new MozillaSubscriptionHandler(
+    log,
+    db,
+    customs,
+    stripeHelper,
+    capabilityService
+  );
+  return [
+    {
+      method: 'GET',
+      path: '/oauth/mozilla-subscriptions/customer/billing-and-subscriptions',
+      options: {
+        auth: {
+          payload: false,
+          strategy: 'oauthToken',
+        },
+        response: {
+          schema: validators.subscriptionsMozillaSubscriptionsValidator,
+        },
+      },
+      handler: (request: AuthRequest) =>
+        mozillaSubscriptionHandler.getBillingDetailsAndSubscriptions(request),
+    },
+  ];
+};
+
+export class MozillaSubscriptionHandler {
+  constructor(
+    protected log: AuthLogger,
+    protected db: any,
+    protected customs: any,
+    protected stripeHelper: StripeHelper,
+    protected capabilityService: CapabilityService
+  ) {}
+
+  async getBillingDetailsAndSubscriptions(request: AuthRequest) {
+    this.log.begin(
+      'mozillaSubscriptions.customerBillingAndSubscriptions',
+      request
+    );
+
+    const { uid, email } = await handleAuth(this.db, request.auth, true);
+    await this.customs.check(
+      request,
+      email,
+      'mozillaSubscriptionsCustomerBillingAndSubscriptions'
+    );
+
+    const stripeBillingDetailsAndSubscriptions =
+      await this.stripeHelper.getBillingDetailsAndSubscriptions(uid);
+    const iapSubscribedGooglePlayProducts =
+      await this.capabilityService.fetchSubscribedProductsFromPlay(uid);
+
+    if (
+      !stripeBillingDetailsAndSubscriptions &&
+      iapSubscribedGooglePlayProducts.length === 0
+    ) {
+      throw error.unknownCustomer(uid);
+    }
+
+    const response: {
+      customerId?: string;
+      subscriptions: MozillaSubscription[];
+    } & Partial<PaymentBillingDetails> = stripeBillingDetailsAndSubscriptions || {
+      subscriptions: [],
+    };
+    const iapGooglePlaySubscriptions =
+      subscribedProductIdsToIapGooglePlaySubscriptions(
+        iapSubscribedGooglePlayProducts
+      );
+
+    return {
+      ...response,
+      subscriptions: [...response.subscriptions, ...iapGooglePlaySubscriptions],
+    };
+  }
+}

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -3,7 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { ServerRoute } from '@hapi/hapi';
 import isA from '@hapi/joi';
-import { AbbrevPlan } from 'fxa-shared/dist/subscriptions/types';
+import {
+  AbbrevPlan,
+  WebSubscription,
+} from 'fxa-shared/dist/subscriptions/types';
 import { metadataFromPlan } from 'fxa-shared/subscriptions/metadata';
 import {
   ACTIVE_SUBSCRIPTION_STATUSES,
@@ -49,13 +52,6 @@ export function sanitizePlans(plans: AbbrevPlan[]) {
     return plan;
   });
 }
-
-type PaymentBillingDetails = ReturnType<
-  StripeHandler['extractBillingDetails']
-> & {
-  paypal_payment_error?: PaypalPaymentError;
-  billing_agreement_id?: string;
-};
 
 export class StripeHandler {
   constructor(
@@ -313,106 +309,33 @@ export class StripeHandler {
   }
 
   /**
-   * Extracts billing details if a customer has a source on file.
+   * This is a misnomer: it does not return a customer.  It returns an object
+   * with Stripe billing details and a list of subscriptions.
    */
-  extractBillingDetails(customer: Stripe.Customer) {
-    const defaultPayment = customer.invoice_settings.default_payment_method;
-    const paymentProvider = this.stripeHelper.getPaymentProvider(customer);
-
-    if (defaultPayment) {
-      if (typeof defaultPayment === 'string') {
-        // This should always be expanded here.
-        throw error.backendServiceFailure('stripe', 'paymentExpansion');
-      }
-
-      if (defaultPayment.card) {
-        return {
-          billing_name: defaultPayment.billing_details.name,
-          payment_provider: paymentProvider,
-          payment_type: defaultPayment.card.funding,
-          last4: defaultPayment.card.last4,
-          exp_month: defaultPayment.card.exp_month,
-          exp_year: defaultPayment.card.exp_year,
-          brand: defaultPayment.card.brand,
-        };
-      }
-    }
-    if (customer.sources && customer.sources.data.length > 0) {
-      // Currently assume a single source, and we can only access these attributes
-      // on cards.
-      const src = customer.sources.data[0];
-      if (src.object === 'card') {
-        return {
-          billing_name: src.name,
-          payment_provider: paymentProvider,
-          payment_type: src.funding,
-          last4: src.last4,
-          exp_month: src.exp_month,
-          exp_year: src.exp_year,
-          brand: src.brand,
-        };
-      }
-    }
-
-    return {
-      payment_provider: paymentProvider,
-    };
-  }
-
   async getCustomer(request: AuthRequest) {
     this.log.begin('subscriptions.getCustomer', request);
 
     const { uid, email } = await handleAuth(this.db, request.auth, true);
     await this.customs.check(request, email, 'getCustomer');
+    const billingDetailsAndSubscriptions =
+      await this.stripeHelper.getBillingDetailsAndSubscriptions(uid);
 
-    const customer = await this.stripeHelper.fetchCustomer(uid, [
-      'subscriptions.data.latest_invoice',
-      'invoice_settings.default_payment_method',
-    ]);
-    if (!customer) {
+    if (!billingDetailsAndSubscriptions) {
       throw error.unknownCustomer(uid);
     }
-    const billingDetails = this.extractBillingDetails(
-      customer
-    ) as PaymentBillingDetails;
-
-    if (billingDetails.payment_provider === 'paypal') {
-      billingDetails.billing_agreement_id =
-        this.stripeHelper.getCustomerPaypalAgreement(customer);
-    }
-
     if (
-      billingDetails.payment_provider === 'paypal' &&
-      this.stripeHelper.hasSubscriptionRequiringPaymentMethod(customer)
+      billingDetailsAndSubscriptions &&
+      (!billingDetailsAndSubscriptions.subscriptions ||
+        billingDetailsAndSubscriptions.subscriptions.length === 0)
     ) {
-      if (!this.stripeHelper.getCustomerPaypalAgreement(customer)) {
-        billingDetails.paypal_payment_error =
-          PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT;
-      } else if (this.stripeHelper.hasOpenInvoice(customer)) {
-        billingDetails.paypal_payment_error =
-          PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE;
-      }
-    }
-
-    const response = {
-      subscriptions: [] as ThenArg<
-        ReturnType<StripeHelper['subscriptionsToResponse']>
-      >,
-      ...billingDetails,
-    };
-
-    if (!customer.subscriptions) {
       throw error.internalValidationError(
-        'listActive',
-        { customerId: customer.id },
+        'subscriptionsGetCustomer',
+        { customerId: billingDetailsAndSubscriptions.customerId },
         'Customer has no subscriptions.'
       );
     }
 
-    response.subscriptions = await this.stripeHelper.subscriptionsToResponse(
-      customer.subscriptions
-    );
-    return response;
+    return billingDetailsAndSubscriptions;
   }
 
   /**

--- a/packages/fxa-auth-server/lib/routes/subscriptions/utils.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/utils.ts
@@ -3,6 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { OAUTH_SCOPE_SUBSCRIPTIONS } from 'fxa-shared/oauth/constants';
 import ScopeSet from 'fxa-shared/oauth/scopes';
+import {
+  GooglePlaySubscription,
+  MozillaSubscriptionTypes,
+} from 'fxa-shared/subscriptions/types';
 
 import error from '../../error';
 import { AuthRequest } from '../../types';
@@ -52,6 +56,15 @@ export function handleAuthScoped(auth: AuthRequest['auth'], scopes: string[]) {
   }
   const { user: uid, email } = auth.credentials;
   return { uid, email } as { uid: string; email: string };
+}
+
+export function subscribedProductIdsToIapGooglePlaySubscriptions(
+  productIds: string[]
+): GooglePlaySubscription[] {
+  return productIds.map((productId) => ({
+    _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+    product_id: productId,
+  }));
 }
 
 export type ThenArg<T> = T extends PromiseLike<infer U> ? U : T;

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -8,6 +8,7 @@
 const { URL } = require('url');
 const punycode = require('punycode.js');
 const isA = require('@hapi/joi');
+const { MozillaSubscriptionTypes } = require('fxa-shared/subscriptions/types');
 
 // Match any non-empty hex-encoded string.
 const HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/;
@@ -349,6 +350,7 @@ module.exports.subscriptionsInvoicePIExpandedValidator = isA
 
 // This is subhub's perspective on an active subscription
 module.exports.subscriptionsSubscriptionValidator = isA.object({
+  _subscription_type: MozillaSubscriptionTypes.WEB,
   created: isA.number().required(),
   current_period_end: isA.number().required(),
   current_period_start: isA.number().required(),
@@ -451,6 +453,7 @@ module.exports.subscriptionsPlanValidator = isA.object({
 });
 
 module.exports.subscriptionsCustomerValidator = isA.object({
+  customerId: isA.string().optional(),
   billing_name: isA
     .alternatives(isA.string(), isA.any().allow(null))
     .optional(),
@@ -554,6 +557,11 @@ module.exports.subscriptionsStripeSubscriptionValidator = isA
   })
   .unknown(true);
 
+module.exports.subscriptionsGooglePlaySubscriptionValidator = isA.object({
+  _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+  product_id: isA.string().required(),
+});
+
 module.exports.subscriptionsStripeCustomerValidator = isA
   .object({
     invoices_settings: isA
@@ -571,6 +579,33 @@ module.exports.subscriptionsStripeCustomerValidator = isA
       })
       .unknown(true)
       .optional(),
+  })
+  .unknown(true);
+
+module.exports.subscriptionsMozillaSubscriptionsValidator = isA
+  .object({
+    customerId: isA.string().optional(),
+    billing_name: isA
+      .alternatives(isA.string(), isA.any().allow(null))
+      .optional(),
+    exp_month: isA.number().optional(),
+    exp_year: isA.number().optional(),
+    last4: isA.string().optional(),
+    payment_provider: isA.string().optional(),
+    payment_type: isA.string().optional(),
+    paypal_payment_error: isA.string().optional(),
+    brand: isA.string().optional(),
+    billing_agreement_id: isA
+      .alternatives(isA.string(), isA.any().allow(null))
+      .optional(),
+    subscriptions: isA
+      .array()
+      .items(
+        module.exports.subscriptionsSubscriptionValidator,
+        module.exports.subscriptionsGooglePlaySubscriptionValidator
+      )
+      .min(1)
+      .required(),
   })
   .unknown(true);
 

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -80,6 +80,11 @@ const {
   FirestoreStripeError,
   newFirestoreStripeError,
 } = require('../../../lib/payments/stripe-firestore');
+const {
+  MozillaSubscriptionTypes,
+  PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE,
+  PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,
+} = require('../../../../fxa-shared/subscriptions/types');
 
 const mockConfig = {
   authFirestore: {
@@ -2851,13 +2856,14 @@ describe('StripeHelper', () => {
 
         const expected = [
           {
+            _subscription_type: MozillaSubscriptionTypes.WEB,
             created: pastDueSubscription.created,
             current_period_end: pastDueSubscription.current_period_end,
             current_period_start: pastDueSubscription.current_period_start,
             cancel_at_period_end: false,
             end_at: null,
             plan_id: pastDueSubscription.plan.id,
-            product_id: productId,
+            product_id: product1.id,
             product_name: productName,
             status: 'past_due',
             subscription_id: pastDueSubscription.id,
@@ -2877,6 +2883,7 @@ describe('StripeHelper', () => {
           it('includes charge failure information with the subscription data', async () => {
             invoice.charge = failedChargeCopy;
             subscription.latest_invoice = invoice;
+            subscription.plan.product = product1.id;
 
             const input = { data: [subscription] };
 
@@ -2915,13 +2922,14 @@ describe('StripeHelper', () => {
               .resolves(paidInvoice);
             const expected = [
               {
+                _subscription_type: MozillaSubscriptionTypes.WEB,
                 created: subscription1.created,
                 current_period_end: subscription1.current_period_end,
                 current_period_start: subscription1.current_period_start,
                 cancel_at_period_end: false,
                 end_at: null,
                 plan_id: subscription1.plan.id,
-                product_id: productId,
+                product_id: product1.id,
                 product_name: productName,
                 status: 'active',
                 subscription_id: subscription1.id,
@@ -2946,13 +2954,14 @@ describe('StripeHelper', () => {
               .resolves(paidInvoice);
             const expected = [
               {
+                _subscription_type: MozillaSubscriptionTypes.WEB,
                 created: subscription.created,
                 current_period_end: subscription.current_period_end,
                 current_period_start: subscription.current_period_start,
                 cancel_at_period_end: true,
                 end_at: null,
                 plan_id: subscription.plan.id,
-                product_id: productId,
+                product_id: product1.id,
                 product_name: productName,
                 status: 'active',
                 subscription_id: subscription.id,
@@ -2969,12 +2978,15 @@ describe('StripeHelper', () => {
 
         describe('when the subscription has already ended', () => {
           it('set end_at to the last active day of the subscription', async () => {
-            const input = { data: [cancelledSubscription] };
+            const sub = deepCopy(cancelledSubscription);
+            sub.plan.product = product1.id;
+            const input = { data: [sub] };
             sandbox
               .stub(stripeHelper.stripe.invoices, 'retrieve')
               .resolves(paidInvoice);
             const expected = [
               {
+                _subscription_type: MozillaSubscriptionTypes.WEB,
                 created: cancelledSubscription.created,
                 current_period_end: cancelledSubscription.current_period_end,
                 current_period_start:
@@ -2982,8 +2994,8 @@ describe('StripeHelper', () => {
                 cancel_at_period_end: false,
                 end_at: cancelledSubscription.ended_at,
                 plan_id: cancelledSubscription.plan.id,
-                product_id: productId,
-                product_name: productName,
+                product_id: product1.id,
+                product_name: product1.name,
                 status: 'canceled',
                 subscription_id: cancelledSubscription.id,
                 failure_code: undefined,
@@ -4203,6 +4215,234 @@ describe('StripeHelper', () => {
       event.type = 'wibble';
       const result = await stripeHelper.processWebhookEventToFirestore(event);
       assert.isFalse(result);
+    });
+  });
+
+  describe('getBillingDetailsAndSubscriptions', () => {
+    const customer = { id: 'cus_xyz' };
+    const billingDetails = { payment_provider: 'paypal' };
+    const billingAgreementId = 'ba-123';
+
+    beforeEach(() => {
+      sandbox.stub(stripeHelper, 'fetchCustomer').resolves(customer);
+      sandbox
+        .stub(stripeHelper, 'extractBillingDetails')
+        .returns(billingDetails);
+      sandbox
+        .stub(stripeHelper, 'getCustomerPaypalAgreement')
+        .returns(billingAgreementId);
+      sandbox
+        .stub(stripeHelper, 'hasSubscriptionRequiringPaymentMethod')
+        .returns(true);
+      sandbox.stub(stripeHelper, 'hasOpenInvoice').returns(true);
+    });
+
+    it('returns null when no customer is found', async () => {
+      stripeHelper.fetchCustomer.restore();
+      sandbox.stub(stripeHelper, 'fetchCustomer').resolves(undefined);
+
+      const actual = await stripeHelper.getBillingDetailsAndSubscriptions(
+        'uid'
+      );
+
+      assert.equal(actual, null);
+      sinon.assert.calledOnceWithExactly(stripeHelper.fetchCustomer, 'uid', [
+        'subscriptions.data.latest_invoice',
+        'invoice_settings.default_payment_method',
+      ]);
+    });
+
+    it('includes the customer Stripe billing details', async () => {
+      const billingDetails = { payment_provider: 'stripe' };
+      stripeHelper.extractBillingDetails.restore();
+      sandbox
+        .stub(stripeHelper, 'extractBillingDetails')
+        .returns(billingDetails);
+
+      const actual = await stripeHelper.getBillingDetailsAndSubscriptions(
+        'uid'
+      );
+
+      assert.deepEqual(actual, {
+        customerId: customer.id,
+        subscriptions: [],
+        ...billingDetails,
+      });
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.extractBillingDetails,
+        customer
+      );
+    });
+
+    it('includes the customer PayPal billing details', async () => {
+      stripeHelper.hasSubscriptionRequiringPaymentMethod.restore();
+      sandbox
+        .stub(stripeHelper, 'hasSubscriptionRequiringPaymentMethod')
+        .returns(false);
+
+      const actual = await stripeHelper.getBillingDetailsAndSubscriptions(
+        'uid'
+      );
+
+      assert.deepEqual(actual, {
+        customerId: customer.id,
+        subscriptions: [],
+        billing_agreement_id: billingAgreementId,
+        ...billingDetails,
+      });
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.getCustomerPaypalAgreement,
+        customer
+      );
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.hasSubscriptionRequiringPaymentMethod,
+        customer
+      );
+    });
+
+    it('includes the missing billing agreement error state', async () => {
+      stripeHelper.getCustomerPaypalAgreement.restore();
+      sandbox.stub(stripeHelper, 'getCustomerPaypalAgreement').returns(null);
+
+      const actual = await stripeHelper.getBillingDetailsAndSubscriptions(
+        'uid'
+      );
+
+      assert.deepEqual(actual, {
+        customerId: customer.id,
+        subscriptions: [],
+        billing_agreement_id: null,
+        paypal_payment_error: PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,
+        ...billingDetails,
+      });
+    });
+
+    it('includes the funding source error state', async () => {
+      const actual = await stripeHelper.getBillingDetailsAndSubscriptions(
+        'uid'
+      );
+
+      assert.deepEqual(actual, {
+        customerId: customer.id,
+        subscriptions: [],
+        billing_agreement_id: null,
+        paypal_payment_error: PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE,
+        ...billingDetails,
+      });
+      sinon.assert.calledOnceWithExactly(stripeHelper.hasOpenInvoice, customer);
+    });
+
+    it('includes a list of subscriptions', async () => {
+      const subscriptions = [{ id: 'sub_testo' }];
+      stripeHelper.fetchCustomer.restore();
+      sandbox
+        .stub(stripeHelper, 'fetchCustomer')
+        .resolves({ ...customer, subscriptions });
+      sandbox
+        .stub(stripeHelper, 'subscriptionsToResponse')
+        .resolves(subscriptions);
+
+      const actual = await stripeHelper.getBillingDetailsAndSubscriptions(
+        'uid'
+      );
+      assert.deepEqual(actual, {
+        customerId: customer.id,
+        subscriptions,
+        billing_agreement_id: billingAgreementId,
+        ...billingDetails,
+      });
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.subscriptionsToResponse,
+        subscriptions
+      );
+    });
+  });
+
+  describe('extractBillingDetails', () => {
+    const paymentProvider = { payment_provider: 'stripe' };
+    const card = {
+      brand: 'visa',
+      exp_month: 8,
+      exp_year: 2022,
+      funding: 'credit',
+      last4: '4242',
+    };
+    const invoice_settings = {
+      default_payment_method: {
+        billing_details: {
+          name: 'Testo McTestson',
+        },
+        card,
+      },
+    };
+    const source = { name: 'Testo McTestson', object: 'card', ...card };
+
+    beforeEach(() => {
+      sandbox.stub(stripeHelper, 'getPaymentProvider').returns('stripe');
+    });
+
+    it('returns the correct payment provider', () => {
+      const customer = { id: 'cus_xyz', invoice_settings: {} };
+      const actual = stripeHelper.extractBillingDetails(customer);
+
+      assert.deepEqual(actual, paymentProvider);
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.getPaymentProvider,
+        customer
+      );
+    });
+
+    it('returns the card details from the default payment method', () => {
+      const customer = {
+        id: 'cus_xyz',
+        invoice_settings,
+      };
+
+      const actual = stripeHelper.extractBillingDetails(customer);
+
+      assert.deepEqual(actual, {
+        ...paymentProvider,
+        billing_name:
+          customer.invoice_settings.default_payment_method.billing_details.name,
+        payment_type:
+          customer.invoice_settings.default_payment_method.card.funding,
+        last4: customer.invoice_settings.default_payment_method.card.last4,
+        exp_month:
+          customer.invoice_settings.default_payment_method.card.exp_month,
+        exp_year:
+          customer.invoice_settings.default_payment_method.card.exp_year,
+        brand: customer.invoice_settings.default_payment_method.card.brand,
+      });
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.getPaymentProvider,
+        customer
+      );
+    });
+
+    it('returns the card details from the payment source', () => {
+      const customer = {
+        id: 'cus_xyz',
+        invoice_settings: {
+          default_payment_method: {},
+        },
+        sources: { data: [source] },
+      };
+
+      const actual = stripeHelper.extractBillingDetails(customer);
+
+      assert.deepEqual(actual, {
+        ...paymentProvider,
+        billing_name: customer.sources.data[0].name,
+        payment_type: customer.sources.data[0].funding,
+        last4: customer.sources.data[0].last4,
+        exp_month: customer.sources.data[0].exp_month,
+        exp_year: customer.sources.data[0].exp_year,
+        brand: customer.sources.data[0].brand,
+      });
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.getPaymentProvider,
+        customer
+      );
     });
   });
 });

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/mozilla.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/mozilla.js
@@ -1,0 +1,154 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const sinon = require('sinon');
+const chai = require('chai');
+const assert = { ...sinon.assert, ...chai.assert };
+const uuid = require('uuid');
+const sandbox = sinon.createSandbox();
+const { getRoute } = require('../../../routes_helpers');
+const { OAUTH_SCOPE_SUBSCRIPTIONS } = require('fxa-shared/oauth/constants');
+import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
+import { ERRNO } from '../../../../lib/error';
+
+const UID = uuid.v4({}, Buffer.alloc(16)).toString('hex');
+const TEST_EMAIL = 'testo@example.gg';
+const ACCOUNT_LOCALE = 'en-US';
+
+const MOCK_SCOPES = ['profile:email', OAUTH_SCOPE_SUBSCRIPTIONS];
+const VALID_REQUEST = {
+  auth: {
+    credentials: {
+      scope: MOCK_SCOPES,
+      user: `${UID}`,
+      email: `${TEST_EMAIL}`,
+    },
+  },
+};
+const mockSubsAndBillingDetials = {
+  subscriptions: [
+    {
+      _subscription_type: 'web',
+      subscription_id: 'sub_1JhyIYBVqmGyQTMa3XMF6ADj',
+    },
+  ],
+  payment_provider: 'dinersclub',
+};
+const iap_product_id = 'iap_prod_lol';
+const mocks = require('../../../mocks');
+const log = mocks.mockLog();
+const db = mocks.mockDB({
+  uid: UID,
+  email: TEST_EMAIL,
+  locale: ACCOUNT_LOCALE,
+});
+const customs = mocks.mockCustoms();
+const stripeHelper = {
+  getBillingDetailsAndSubscriptions: sandbox
+    .stub()
+    .resolves(mockSubsAndBillingDetials),
+};
+const capabilityService = {
+  fetchSubscribedProductsFromPlay: sandbox.stub().resolves([iap_product_id]),
+};
+const {
+  mozillaSubscriptionRoutes,
+} = require('../../../../lib/routes/subscriptions/mozilla');
+
+async function runTest(routePath, routeDependencies = {}) {
+  const routes = mozillaSubscriptionRoutes({
+    log,
+    db,
+    customs,
+    stripeHelper,
+    capabilityService,
+    ...routeDependencies,
+  });
+  const route = getRoute(routes, routePath, 'GET');
+  const request = mocks.mockRequest(VALID_REQUEST);
+  return route.handler(request);
+}
+
+describe('mozilla-subscriptions', () => {
+  beforeEach(() => {
+    sandbox.resetHistory();
+  });
+
+  describe('GET /customer/billing-and-subscriptions', () => {
+    it('gets customer billing details and Stripe and Google Play subscriptions', async () => {
+      const resp = await runTest(
+        '/oauth/mozilla-subscriptions/customer/billing-and-subscriptions'
+      );
+      assert.deepEqual(resp, {
+        ...mockSubsAndBillingDetials,
+        subscriptions: [
+          ...mockSubsAndBillingDetials.subscriptions,
+          {
+            _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+            product_id: iap_product_id,
+          },
+        ],
+      });
+    });
+
+    it('gets customer billing details and only Stripe subscriptions', async () => {
+      const capabilityService = {
+        fetchSubscribedProductsFromPlay: sandbox.stub().resolves([]),
+      };
+      const resp = await runTest(
+        '/oauth/mozilla-subscriptions/customer/billing-and-subscriptions',
+        {
+          capabilityService,
+        }
+      );
+      assert.deepEqual(resp, {
+        ...mockSubsAndBillingDetials,
+        subscriptions: [...mockSubsAndBillingDetials.subscriptions],
+      });
+    });
+
+    it('gets customer billing details and only Google Play subscriptions', async () => {
+      const stripeHelper = {
+        getBillingDetailsAndSubscriptions: sandbox.stub().resolves(null),
+      };
+      const resp = await runTest(
+        '/oauth/mozilla-subscriptions/customer/billing-and-subscriptions',
+        {
+          stripeHelper,
+        }
+      );
+      assert.deepEqual(resp, {
+        subscriptions: [
+          {
+            _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+            product_id: iap_product_id,
+          },
+        ],
+      });
+    });
+
+    it('throws an error when there are no subsriptions', async () => {
+      const capabilityService = {
+        fetchSubscribedProductsFromPlay: sandbox.stub().resolves([]),
+      };
+      const stripeHelper = {
+        getBillingDetailsAndSubscriptions: sandbox.stub().resolves(null),
+      };
+      try {
+        await runTest(
+          '/oauth/mozilla-subscriptions/customer/billing-and-subscriptions',
+          {
+            capabilityService,
+            stripeHelper,
+          }
+        );
+        assert.fail('an error should have been thrown');
+      } catch (e) {
+        assert.strictEqual(e.errno, ERRNO.UNKNOWN_SUBSCRIPTION_CUSTOMER);
+      }
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -13,10 +13,6 @@ const mocks = require('../../../mocks');
 const error = require('../../../../lib/error');
 const { StripeHelper } = require('../../../../lib/payments/stripe');
 const { CurrencyHelper } = require('../../../../lib/payments/currencies');
-const {
-  PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT,
-  PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE,
-} = require('fxa-shared/subscriptions/types');
 const WError = require('verror').WError;
 const uuidv4 = require('uuid').v4;
 
@@ -34,7 +30,6 @@ const cancelledSubscription = require('../../payments/fixtures/stripe/subscripti
 const trialSubscription = require('../../payments/fixtures/stripe/subscription_trialing.json');
 const pastDueSubscription = require('../../payments/fixtures/stripe/subscription_past_due.json');
 const customerFixture = require('../../payments/fixtures/stripe/customer1.json');
-const customerPMIExpanded = require('../../payments/fixtures/stripe/customer_new_pmi_default_invoice_expanded.json');
 const multiPlanSubscription = require('../../payments/fixtures/stripe/subscription_multiplan.json');
 const emptyCustomer = require('../../payments/fixtures/stripe/customer_new.json');
 const openInvoice = require('../../payments/fixtures/stripe/invoice_open.json');
@@ -1375,285 +1370,55 @@ describe('DirectStripeRoutes', () => {
 
   describe('getCustomer', () => {
     describe('customer is found', () => {
-      let customer;
+      const mockResp = {
+        subscriptions: [
+          {
+            _subscription_type: 'web',
+            subscription_id: 'sub_1JhyIYBVqmGyQTMa3XMF6ADj',
+          },
+        ],
+        payment_provider: 'dinersclub',
+      };
 
-      beforeEach(() => {
-        customer = deepCopy(emptyCustomer);
-        directStripeRoutesInstance.stripeHelper.subscriptionsToResponse.resolves(
-          []
+      it('calls getBillingDetailsAndSubscriptions on StripeHelper', async () => {
+        directStripeRoutesInstance.stripeHelper.getBillingDetailsAndSubscriptions.resolves(
+          mockResp
         );
-        directStripeRoutesInstance.stripeHelper.hasSubscriptionRequiringPaymentMethod.returns(
-          false
+        const resp = await directStripeRoutesInstance.getCustomer(
+          VALID_REQUEST
         );
+        sinon.assert.calledOnceWithExactly(
+          directStripeRoutesInstance.stripeHelper
+            .getBillingDetailsAndSubscriptions,
+          VALID_REQUEST.auth.credentials.user
+        );
+        assert.deepEqual(resp, mockResp);
       });
 
-      describe('customer has payment_provider property', () => {
-        it('calls getPaymentProvider once to determine payment_provider', async () => {
-          directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(
-            customer
-          );
+      it('throws when the customer has no subscriptions', async () => {
+        directStripeRoutesInstance.stripeHelper.getBillingDetailsAndSubscriptions.resolves(
+          { ...mockResp, subscriptions: [] }
+        );
+        try {
           await directStripeRoutesInstance.getCustomer(VALID_REQUEST);
-          sinon.assert.calledOnceWithExactly(
-            directStripeRoutesInstance.stripeHelper.getPaymentProvider,
-            customer
-          );
-        });
+          assert.fail('An error should have been thrown');
+        } catch (err) {
+          assert.strictEqual(err.errno, error.ERRNO.INTERNAL_VALIDATION_ERROR);
+        }
 
-        it('payment_provider === value returned by getPaymentProvider', async () => {
-          directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(
-            customer
-          );
-          directStripeRoutesInstance.stripeHelper.getPaymentProvider.returns(
-            'not_chosen'
-          );
-
-          const actual = await directStripeRoutesInstance.getCustomer(
-            VALID_REQUEST
-          );
-          assert.strictEqual(actual.payment_provider, 'not_chosen');
-        });
-      });
-
-      describe('customer has paypal_payment_error', () => {
-        it('shows missing agreement when none is present', async () => {
-          directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(
-            customer
-          );
-          directStripeRoutesInstance.stripeHelper.getPaymentProvider.returns(
-            'paypal'
-          );
-          directStripeRoutesInstance.stripeHelper.hasSubscriptionRequiringPaymentMethod.returns(
-            true
-          );
-          directStripeRoutesInstance.stripeHelper.getCustomerPaypalAgreement.returns(
-            false
-          );
-          directStripeRoutesInstance.stripeHelper.hasOpenInvoice.returns(false);
-
-          const actual = await directStripeRoutesInstance.getCustomer(
-            VALID_REQUEST
-          );
-          assert.strictEqual(actual.payment_provider, 'paypal');
-          assert.strictEqual(
-            actual.paypal_payment_error,
-            PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT
-          );
-          sinon.assert.calledOnceWithExactly(
-            directStripeRoutesInstance.stripeHelper
-              .hasSubscriptionRequiringPaymentMethod,
-            customer
-          );
-          sinon.assert.calledWithExactly(
-            directStripeRoutesInstance.stripeHelper.getCustomerPaypalAgreement,
-            customer
-          );
-          sinon.assert.notCalled(
-            directStripeRoutesInstance.stripeHelper.hasOpenInvoice
-          );
-        });
-
-        it('shows funding_source when agreement is present', async () => {
-          directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(
-            customer
-          );
-          directStripeRoutesInstance.stripeHelper.getPaymentProvider.returns(
-            'paypal'
-          );
-          directStripeRoutesInstance.stripeHelper.hasSubscriptionRequiringPaymentMethod.returns(
-            true
-          );
-          directStripeRoutesInstance.stripeHelper.getCustomerPaypalAgreement.returns(
-            true
-          );
-          directStripeRoutesInstance.stripeHelper.hasOpenInvoice.returns(true);
-
-          const actual = await directStripeRoutesInstance.getCustomer(
-            VALID_REQUEST
-          );
-          assert.strictEqual(actual.payment_provider, 'paypal');
-          assert.strictEqual(
-            actual.paypal_payment_error,
-            PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE
-          );
-          sinon.assert.calledOnceWithExactly(
-            directStripeRoutesInstance.stripeHelper
-              .hasSubscriptionRequiringPaymentMethod,
-            customer
-          );
-          sinon.assert.calledWithExactly(
-            directStripeRoutesInstance.stripeHelper.getCustomerPaypalAgreement,
-            customer
-          );
-          sinon.assert.calledOnceWithExactly(
-            directStripeRoutesInstance.stripeHelper.hasOpenInvoice,
-            customer
-          );
-        });
-
-        it('shows no error when no open invoice and agreement on file', async () => {
-          directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(
-            customer
-          );
-          directStripeRoutesInstance.stripeHelper.getPaymentProvider.returns(
-            'paypal'
-          );
-          directStripeRoutesInstance.stripeHelper.hasSubscriptionRequiringPaymentMethod.returns(
-            true
-          );
-          directStripeRoutesInstance.stripeHelper.getCustomerPaypalAgreement.returns(
-            true
-          );
-          directStripeRoutesInstance.stripeHelper.hasOpenInvoice.returns(false);
-
-          const actual = await directStripeRoutesInstance.getCustomer(
-            VALID_REQUEST
-          );
-          assert.strictEqual(actual.payment_provider, 'paypal');
-          assert.isUndefined(actual.paypal_payment_error);
-          sinon.assert.calledOnceWithExactly(
-            directStripeRoutesInstance.stripeHelper
-              .hasSubscriptionRequiringPaymentMethod,
-            customer
-          );
-          sinon.assert.calledWithExactly(
-            directStripeRoutesInstance.stripeHelper.getCustomerPaypalAgreement,
-            customer
-          );
-          sinon.assert.calledOnceWithExactly(
-            directStripeRoutesInstance.stripeHelper.hasOpenInvoice,
-            customer
-          );
-        });
-      });
-
-      describe('customer has payment sources', () => {
-        describe('default invoice payment method is a card object', () => {
-          it('adds payment method data to the response', async () => {
-            directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(
-              customerPMIExpanded
-            );
-            directStripeRoutesInstance.stripeHelper.getPaymentProvider.returns(
-              'not_chosen'
-            );
-
-            const defaultInvoice =
-              customerPMIExpanded.invoice_settings.default_payment_method;
-            const expected = {
-              subscriptions: [],
-              billing_name: defaultInvoice.billing_details.name,
-              brand: defaultInvoice.card.brand,
-              payment_provider: 'not_chosen',
-              payment_type: defaultInvoice.card.funding,
-              last4: defaultInvoice.card.last4,
-              exp_month: defaultInvoice.card.exp_month,
-              exp_year: defaultInvoice.card.exp_year,
-            };
-            const actual = await directStripeRoutesInstance.getCustomer(
-              VALID_REQUEST
-            );
-
-            assert.deepEqual(actual, expected);
-          });
-        });
-        describe('default invoice payment method is a string', () => {
-          it('throws error as it must be expanded', async () => {
-            const customerExpanded = deepCopy(customerPMIExpanded);
-            customerExpanded.invoice_settings.default_payment_method =
-              'pm_1H0FRp2eZvKYlo2CeIZoc0wj';
-            directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(
-              customerExpanded
-            );
-            try {
-              await directStripeRoutesInstance.getCustomer(VALID_REQUEST);
-              assert.fail('getCustomer should fail with string payment method');
-            } catch (err) {
-              assert.strictEqual(
-                err.errno,
-                error.ERRNO.BACKEND_SERVICE_FAILURE
-              );
-              assert.strictEqual(
-                err.message,
-                'A backend service request failed.'
-              );
-              assert.strictEqual(err.output.payload.service, 'stripe');
-            }
-          });
-        });
-        describe('payment source is a card object', () => {
-          it('adds source data to the response', async () => {
-            directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(
-              customer
-            );
-            directStripeRoutesInstance.stripeHelper.getPaymentProvider.returns(
-              'not_chosen'
-            );
-
-            const expected = {
-              subscriptions: [],
-              billing_name: customer.sources.data[0].name,
-              brand: customer.sources.data[0].brand,
-              payment_provider: 'not_chosen',
-              payment_type: customer.sources.data[0].funding,
-              last4: customer.sources.data[0].last4,
-              exp_month: customer.sources.data[0].exp_month,
-              exp_year: customer.sources.data[0].exp_year,
-            };
-            const actual = await directStripeRoutesInstance.getCustomer(
-              VALID_REQUEST
-            );
-
-            assert.deepEqual(actual, expected);
-          });
-        });
-        describe('payment source is a source object', () => {
-          it('does not add the source data to the response', async () => {
-            customer.sources.data[0].object = 'source';
-            customer.subscriptions.data = [];
-            directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(
-              customer
-            );
-            directStripeRoutesInstance.stripeHelper.getPaymentProvider.returns(
-              'not_chosen'
-            );
-
-            const expected = {
-              subscriptions: [],
-              payment_provider: 'not_chosen',
-            };
-            const actual = await directStripeRoutesInstance.getCustomer(
-              VALID_REQUEST
-            );
-
-            assert.deepEqual(actual, expected);
-          });
-        });
-      });
-      describe('customer has no payment sources', () => {
-        it('does not add source information to the response', async () => {
-          customer.sources.data = [];
-          customer.subscriptions.data = [];
-          directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves(
-            customer
-          );
-          directStripeRoutesInstance.stripeHelper.getPaymentProvider.returns(
-            'not_chosen'
-          );
-
-          const expected = {
-            subscriptions: [],
-            payment_provider: 'not_chosen',
-          };
-          const actual = await directStripeRoutesInstance.getCustomer(
-            VALID_REQUEST
-          );
-
-          assert.deepEqual(actual, expected);
-        });
+        sinon.assert.calledOnceWithExactly(
+          directStripeRoutesInstance.stripeHelper
+            .getBillingDetailsAndSubscriptions,
+          VALID_REQUEST.auth.credentials.user
+        );
       });
     });
+
     describe('customer is not found', () => {
       it('throws an error', async () => {
-        directStripeRoutesInstance.stripeHelper.fetchCustomer.resolves();
+        directStripeRoutesInstance.stripeHelper.getBillingDetailsAndSubscriptions.resolves(
+          null
+        );
 
         try {
           await directStripeRoutesInstance.getCustomer(VALID_REQUEST);
@@ -1668,6 +1433,11 @@ describe('DirectStripeRoutes', () => {
           assert.strictEqual(err.message, 'Unknown customer');
           assert.strictEqual(err.output.payload['uid'], UID);
         }
+        sinon.assert.calledOnceWithExactly(
+          directStripeRoutesInstance.stripeHelper
+            .getBillingDetailsAndSubscriptions,
+          VALID_REQUEST.auth.credentials.user
+        );
       });
     });
   });

--- a/packages/fxa-shared/subscriptions/metadata.ts
+++ b/packages/fxa-shared/subscriptions/metadata.ts
@@ -8,7 +8,7 @@ import {
   ProductDetailsStringProperty,
   ProductDetailsListProperties,
   ProductDetailsListProperty,
-  AccountSubscription,
+  WebSubscription,
   AbbrevPlan,
 } from './types';
 
@@ -146,7 +146,7 @@ export const productDetailsFromPlan = (
  * id.  This is used for the app/service select on the support form.
  */
 export const getProductSupportApps =
-  (subscriptions: AccountSubscription[]) => (plans: AbbrevPlan[]) => {
+  (subscriptions: WebSubscription[]) => (plans: AbbrevPlan[]) => {
     const metadataPrefix = 'support:app:';
     return plans.reduce((acc: { [keys: string]: string[] }, p) => {
       if (

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -87,9 +87,16 @@ export type AbbrevPlan = {
   product_name: string;
 };
 
-// The GET /account endpoint on the auth server includes a list of
-// subscriptions.  This type represents one of those subscriptions.
-export type AccountSubscription = Pick<
+// Do not re-order the list items without updating their references.
+export const SUBSCRIPTION_TYPES = ['web', 'iap_google', 'iap_apple'] as const;
+export type SubscriptionTypes = typeof SUBSCRIPTION_TYPES;
+export type SubscriptionType = SubscriptionTypes[number];
+export const MozillaSubscriptionTypes = {
+  WEB: SUBSCRIPTION_TYPES[0],
+  IAP_GOOGLE: SUBSCRIPTION_TYPES[1],
+  IAP_APPLE: SUBSCRIPTION_TYPES[2],
+} as const;
+export type WebSubscription = Pick<
   Stripe.Subscription,
   | 'created'
   | 'current_period_end'
@@ -97,6 +104,7 @@ export type AccountSubscription = Pick<
   | 'cancel_at_period_end'
 > &
   Partial<Pick<Stripe.Charge, 'failure_code' | 'failure_message'>> & {
+    _subscription_type: SubscriptionTypes[0];
     end_at: Stripe.Subscription['ended_at'];
     latest_invoice: Stripe.Invoice['number'];
     plan_id: Stripe.Plan['id'];
@@ -108,6 +116,11 @@ export type AccountSubscription = Pick<
     >;
     subscription_id: Stripe.Subscription['id'];
   };
+export type GooglePlaySubscription = {
+  _subscription_type: SubscriptionTypes[1];
+  product_id: Stripe.Product['id'];
+};
+export type MozillaSubscription = WebSubscription | GooglePlaySubscription;
 
 export const PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT = 'missing_agreement';
 export const PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE = 'funding_source';

--- a/packages/fxa-shared/test/subscriptions/metadata.ts
+++ b/packages/fxa-shared/test/subscriptions/metadata.ts
@@ -2,9 +2,10 @@ import { expect } from 'chai';
 
 import {
   AbbrevPlan,
-  AccountSubscription,
+  WebSubscription,
   Plan,
   ProductMetadata,
+  MozillaSubscriptionTypes,
 } from '../../subscriptions/types';
 import {
   DEFAULT_PRODUCT_DETAILS,
@@ -225,8 +226,9 @@ describe('subscriptions/metadata', () => {
   });
 
   describe('getProductSupportApps', () => {
-    const subscriptions: AccountSubscription[] = [
+    const subscriptions: WebSubscription[] = [
       {
+        _subscription_type: MozillaSubscriptionTypes.WEB,
         created: 1600208907,
         current_period_end: 1602800907,
         current_period_start: 1600208907,
@@ -240,6 +242,7 @@ describe('subscriptions/metadata', () => {
         subscription_id: 'sub_I1qKQD2YFCVdFI',
       },
       {
+        _subscription_type: MozillaSubscriptionTypes.WEB,
         created: 1600185585,
         current_period_end: 1600271985,
         current_period_start: 1600185585,


### PR DESCRIPTION
Because:
 - some clients might need to know that a customer has IAP subscriptions

This commit:
 - add a new endpoint to include Google Play subscriptions as well as
   Stripe subscriptions
   - the response is a superset of the response from
     /oauth/subscriptions/customer


## Issue that this pull request solves

Closes: #10095

