### PR TITLE
fix(ux): Remove newsletters when in pocket migration from signup

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -43,17 +43,19 @@
 
       {{^isCWTSOnSignupPasswordEnabled}}
       <section class="get-involved">
-        {{#isAnyNewsletterEnabled}}
-        <header>
-          <h2>{{#t}}Practical knowledge is coming to your inbox. Sign up for more:{{/t}}</h2>
-        </header>
-        {{/isAnyNewsletterEnabled}}
+      {{^isInPocketMigration}}
+          {{#isAnyNewsletterEnabled}}
+              <header>
+                  <h2>{{#t}}Practical knowledge is coming to your inbox. Sign up for more:{{/t}}</h2>
+              </header>
+          {{/isAnyNewsletterEnabled}}
 
-        {{#newsletters}}
-          <div class="input-row marketing-email-optin-row">
-            <input id="{{slug}}" type="checkbox" class="marketing-email-optin" value="{{slug}}"><label for="{{slug}}">{{label}}</label>
-          </div>
-        {{/newsletters}}
+          {{#newsletters}}
+              <div class="input-row marketing-email-optin-row">
+                  <input id="{{slug}}" type="checkbox" class="marketing-email-optin" value="{{slug}}"><label for="{{slug}}">{{label}}</label>
+              </div>
+          {{/newsletters}}
+      {{/isInPocketMigration}}
       </section>
       {{/isCWTSOnSignupPasswordEnabled}}
       {{#isCWTSOnSignupPasswordEnabled}}


### PR DESCRIPTION
## Because

- Pocket does not want to show the newsletter form when signing up

## This pull request

- Removes it when in pocket migration

## Issue that this pull request solves

Connects to https://github.com/mozilla/fxa/issues/10492

## Checklist

- [x] My commit is GPG signed.
- [] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

<img width="592" alt="Screen Shot 2021-10-13 at 2 20 33 PM" src="https://user-images.githubusercontent.com/1295288/137191267-96cf8eca-c69d-4f4c-93fc-ccb0e3231155.png">


