### PR TITLE
fix(auth): ignore handled webhook events

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2397,7 +2397,7 @@ export class StripeHelper {
 
   async processWebhookEventToFirestore(event: Stripe.Event) {
     if (!this.stripeFirestore) {
-      return;
+      return false;
     }
 
     const { type, data } = event;
@@ -2405,6 +2405,7 @@ export class StripeHelper {
     // Note that we must insert before any event handled by the general
     // webhook code to ensure the object is up to date in Firestore before
     // our code handles the event.
+    let handled = true;
     try {
       switch (type as Stripe.WebhookEndpointUpdateParams.EnabledEvent) {
         case 'invoice.created':
@@ -2444,6 +2445,8 @@ export class StripeHelper {
           await this.stripeFirestore.insertSubscriptionRecord(subscription);
           break;
         default: {
+          handled = false;
+          break;
         }
       }
     } catch (err) {
@@ -2451,10 +2454,11 @@ export class StripeHelper {
         // We cannot back-fill Firestore with records for deleted customers
         // as they're missing necessary metadata for us to know which user
         // the customer belongs to.
-        return;
+        return handled;
       }
       throw err;
     }
+    return handled;
   }
 
   /**

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -68,7 +68,8 @@ export class StripeWebhookHandler extends StripeHandler {
         request.headers['stripe-signature']
       );
 
-      await this.stripeHelper.processWebhookEventToFirestore(event);
+      const firestoreHandled =
+        await this.stripeHelper.processWebhookEventToFirestore(event);
 
       switch (event.type as Stripe.WebhookEndpointUpdateParams.EnabledEvent) {
         case 'credit_note.created':
@@ -123,15 +124,17 @@ export class StripeWebhookHandler extends StripeHandler {
           await this.handlePlanDeletedEvent(request, event);
           break;
         default:
-          Sentry.withScope((scope) => {
-            scope.setContext('stripeEvent', {
-              event: { id: event.id, type: event.type },
+          if (!firestoreHandled) {
+            Sentry.withScope((scope) => {
+              scope.setContext('stripeEvent', {
+                event: { id: event.id, type: event.type },
+              });
+              Sentry.captureMessage(
+                'Unhandled Stripe event received.',
+                Sentry.Severity.Info
+              );
             });
-            Sentry.captureMessage(
-              'Unhandled Stripe event received.',
-              Sentry.Severity.Info
-            );
-          });
+          }
           break;
       }
     } catch (error) {

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -4153,7 +4153,8 @@ describe('StripeHelper', () => {
         .stub()
         .resolves({});
       stripeFirestore.insertInvoiceRecord = sandbox.stub().resolves({});
-      await stripeHelper.processWebhookEventToFirestore(event);
+      const result = await stripeHelper.processWebhookEventToFirestore(event);
+      assert.isTrue(result);
       sinon.assert.calledOnceWithExactly(
         stripeHelper.stripeFirestore.retrieveAndFetchSubscription,
         event.data.object.subscription
@@ -4195,6 +4196,13 @@ describe('StripeHelper', () => {
         stripeHelper.stripeFirestore.insertSubscriptionRecord,
         event.data.object
       );
+    });
+
+    it('does not handle wibble events', async () => {
+      const event = deepCopy(eventSubscriptionUpdated);
+      event.type = 'wibble';
+      const result = await stripeHelper.processWebhookEventToFirestore(event);
+      assert.isFalse(result);
     });
   });
 });

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -351,6 +351,19 @@ describe('StripeWebhookHandler', () => {
           assertNamedHandlerCalled();
           assert.isTrue(scopeContextSpy.calledOnce, 'Expected to call Sentry');
         });
+
+        it('does not call sentry if handled by firestore', async () => {
+          const event = deepCopy(subscriptionCreated);
+          event.type = 'firestore.document.created';
+          StripeWebhookHandlerInstance.stripeHelper.constructWebhookEvent.returns(
+            event
+          );
+          StripeWebhookHandlerInstance.stripeHelper.processWebhookEventToFirestore =
+            sinon.stub().resolves(true);
+          await StripeWebhookHandlerInstance.handleWebhookEvent(request);
+          assertNamedHandlerCalled();
+          sinon.assert.notCalled(scopeContextSpy);
+        });
       });
     });
 


### PR DESCRIPTION
Because:

* We dont want to claim a webhook was not handled when the firestore
  handler did handle it.

This commit:

* Records whether the firestore handler can process the webhook and will
  not report it if so.

Closes #10681

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
