### PR TITLE
feat(auth): require auth firestore usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,11 +9,13 @@ executors:
       - image: memcached
       - image: pafortin/goaws
       - image: circleci/mysql:5.7.27
+      - image: jdlk7/firestore-emulator
         environment:
           NODE_ENV: dev
           FXA_EMAIL_ENV: dev
           FXA_EMAIL_LOG_LEVEL: debug
           RUST_BACKTRACE: 1
+          AUTH_FIRESTORE_EMULATOR_HOST: localhost:9090
     environment:
       FXA_MX_RECORD_EXCLUSIONS: restmail.dev.lcip.org
 
@@ -89,6 +91,11 @@ jobs:
       - image: memcached
       - image: pafortin/goaws
       - image: circleci/mysql:5.7.27
+      - image: jdlk7/firestore-emulator
+        environment:
+          NODE_ENV: dev
+          AUTH_FIRESTORE_EMULATOR_HOST: localhost:9090
+
     parameters:
       package:
         type: string

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -40,7 +40,7 @@ async function run(config) {
   const log = require('../lib/log')({ ...config.log, statsd });
   Container.set(AuthLogger, log);
 
-  if (config.authFirestore.enabled) {
+  if (!Container.has(AuthFirestore)) {
     const authFirestore = setupFirestore(config);
     Container.set(AuthFirestore, authFirestore);
   }

--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -78,12 +78,6 @@ const conf = convict({
         format: String,
       },
     },
-    enabled: {
-      default: false,
-      doc: 'Whether to use firestore',
-      env: 'AUTH_FIRESTORE_ENABLED',
-      format: Boolean,
-    },
     keyFilename: {
       default: path.resolve(__dirname, 'secret-key.json'),
       doc: 'Path to GCP key file',

--- a/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
@@ -87,7 +87,8 @@ const createRoutes = (
       )
     );
   }
-  if (config.authFirestore.enabled) {
+
+  if (config.subscriptions?.playApiServiceAccount?.enabled) {
     routes.push(...googleIapRoutes(db));
     routes.push(...playPubsubRoutes(db));
   }

--- a/packages/fxa-auth-server/pm2.config.js
+++ b/packages/fxa-auth-server/pm2.config.js
@@ -21,6 +21,7 @@ module.exports = {
         SIGNIN_UNBLOCK_FORCED_EMAILS: '^block.*@restmail\\.net$',
         SIGNIN_CONFIRMATION_ENABLED: 'true',
         SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX: '^sync.*@restmail\\.net$',
+        AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
         FORCE_PASSWORD_CHANGE_EMAIL_REGEX: 'forcepwdchange',
         CONFIG_FILES: 'config/secrets.json',
         EMAIL_CONFIG_USE_REDIS: 'false',

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -21,11 +21,13 @@ const subscription2 = require('../../payments/fixtures/stripe/subscription2.json
 const openInvoice = require('../../payments/fixtures/stripe/invoice_open.json');
 const { filterSubscription } = require('fxa-shared/subscriptions/stripe');
 const { CurrencyHelper } = require('../../../../lib/payments/currencies');
+const { AuthLogger } = require('../../../../lib/types');
 const buildRoutes = require('../../../../lib/routes/subscriptions');
 
 const ACCOUNT_LOCALE = 'en-US';
 const { OAUTH_SCOPE_SUBSCRIPTIONS } = require('fxa-shared/oauth/constants');
 const { CapabilityService } = require('../../../../lib/payments/capability');
+const { PlayBilling } = require('../../../../lib/payments/google-play');
 const TEST_EMAIL = 'test@email.com';
 const UID = uuid.v4({}, Buffer.alloc(16)).toString('hex');
 const MOCK_SCOPES = ['profile:email', OAUTH_SCOPE_SUBSCRIPTIONS];
@@ -112,6 +114,8 @@ describe('subscriptions payPalRoutes', () => {
     log = mocks.mockLog();
     customs = mocks.mockCustoms();
     token = uuid.v4();
+    Container.set(AuthLogger, log);
+    Container.set(PlayBilling, {});
     stripeHelper = sinon.createStubInstance(StripeHelper);
     Container.set(StripeHelper, stripeHelper);
     payPalHelper = sinon.createStubInstance(PayPalHelper);

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -25,6 +25,9 @@ const {
   handleAuth,
   DirectStripeRoutes,
 } = require('../../../../lib/routes/subscriptions');
+const { AuthLogger } = require('../../../../lib/types');
+const { CapabilityService } = require('../../../../lib/payments/capability');
+const { PlayBilling } = require('../../../../lib/payments/google-play');
 
 const { filterCustomer, filterSubscription, filterInvoice, filterIntent } =
   require('fxa-shared').subscriptions.stripe;
@@ -41,8 +44,6 @@ const openInvoice = require('../../payments/fixtures/stripe/invoice_open.json');
 const newSetupIntent = require('../../payments/fixtures/stripe/setup_intent_new.json');
 const stripePlan = require('../../payments/fixtures/stripe/plan1.json');
 const paymentMethodFixture = require('../../payments/fixtures/stripe/payment_method.json');
-
-const { CapabilityService } = require('../../../../lib/payments/capability');
 
 const currencyHelper = new CurrencyHelper({
   currenciesToCountries: { USD: ['US', 'GB', 'CA'] },
@@ -203,9 +204,6 @@ describe('subscriptions stripeRoutes', () => {
   beforeEach(() => {
     Container.reset();
     config = {
-      authFirestore: {
-        enabled: false,
-      },
       subscriptions: {
         enabled: true,
         managementClientId: MOCK_CLIENT_ID,
@@ -227,6 +225,9 @@ describe('subscriptions stripeRoutes', () => {
 
     log = mocks.mockLog();
     customs = mocks.mockCustoms();
+
+    Container.set(AuthLogger, log);
+    Container.set(PlayBilling, {});
 
     db = mocks.mockDB({
       uid: UID,

--- a/packages/fxa-auth-server/test/scripts/bulk-mailer.js
+++ b/packages/fxa-auth-server/test/scripts/bulk-mailer.js
@@ -72,6 +72,7 @@ const execOptions = {
   env: {
     NODE_ENV: 'dev',
     LOG_LEVEL: 'error',
+    AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
   },
 };
 

--- a/packages/fxa-auth-server/test/scripts/dump-users.js
+++ b/packages/fxa-auth-server/test/scripts/dump-users.js
@@ -63,6 +63,7 @@ const execOptions = {
   env: {
     NODE_ENV: 'dev',
     LOG_LEVEL: 'error',
+    AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
   },
 };
 

--- a/packages/fxa-auth-server/test/scripts/verification-reminders.js
+++ b/packages/fxa-auth-server/test/scripts/verification-reminders.js
@@ -18,6 +18,7 @@ const execOptions = {
   env: {
     NODE_ENV: 'dev',
     LOG_LEVEL: 'error',
+    AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
   },
 };
 

--- a/packages/fxa-auth-server/test/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/test/scripts/write-emails-to-disk.js
@@ -20,6 +20,7 @@ const execOptions = {
   env: {
     NODE_ENV: 'dev',
     LOG_LEVEL: 'error',
+    AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
   },
   stdio: 'ignore',
 };

--- a/packages/fxa-auth-server/test/test_server.js
+++ b/packages/fxa-auth-server/test/test_server.js
@@ -13,6 +13,7 @@ const proxyquire = require('proxyquire').noPreserveCache();
 const createMailHelper = require('./mail_helper');
 const createProfileHelper = require('./profile_helper');
 const { CapabilityService } = require('../lib/payments/capability');
+const { AuthFirestore } = require('../lib/types');
 
 let currentServer;
 
@@ -22,6 +23,11 @@ function TestServer(config, printLogs, options = {}) {
     Container.set(CapabilityService, {
       subscriptionCapabilities: sinon.fake.resolves([]),
       determineClientVisibleSubscriptionCapabilities: sinon.fake.resolves(''),
+    });
+  }
+  if (!Container.has(AuthFirestore)) {
+    Container.set(AuthFirestore, {
+      collection: sinon.fake.returns({}),
     });
   }
   this.options = options;


### PR DESCRIPTION
Because:

* Having a toggle to deactivate use of Firestore drastically increases
  code complexity.

This commit:

* Requires Firestore for running auth-server and uses the emulator for
  local running.

Closes #10710

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
