### PR TITLE
feat(auth-server): convert subscriptionReactivation email template to stack

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -461,7 +461,8 @@
       "passwordChangeRequired",
       "recovery",
       "subscriptionPaymentExpired",
-      "subscriptionsPaymentExpired"
+      "subscriptionsPaymentExpired",
+      "subscriptionReactivation"
     ]
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.scss
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.scss
@@ -77,3 +77,10 @@
 .footer-link {
   color: global.$white !important;
 }
+
+.product-icon {
+  display: block;
+  margin: 0 auto;
+  width: 58px;
+  height: 58px;
+}

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/en.ftl
@@ -1,0 +1,10 @@
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionReactivation-subject = { $productName } subscription reactivated
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionReactivation-title = Thank you for reactivating your { $productName } subscription!
+# Variables:
+#  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
+#  $nextInvoiceDateOnly (String) - The date of the next invoice, e.g. 2016/01/20
+subscriptionReactivation-content = Your billing cycle and payment will remain the same. Your next charge will be { $invoiceTotal } on { $nextInvoiceDateOnly }. Your subscription will automatically renew each billing period unless you choose to cancel.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.mjml
@@ -1,0 +1,25 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section css-class="mb-6">
+  <mj-column>
+    <mj-image src="<%- icon %>" alt="<%- productName %> icon" title="<%- productName %>" css-class="product-icon"></mj-image>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="subscriptionReactivation-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for reactivating your <%- productName %> subscription!</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionReactivation-content" data-l10n-args="<%= JSON.stringify({invoiceTotal, nextInvoiceDateOnly}) %>">
+        Your billing cycle and payment will remain the same. Your next charge will be <%- invoiceTotal %> on <%- nextInvoiceDateOnly %>. Your subscription will automatically renew each billing period unless you choose to cancel.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include ('/partials/subscriptionSupport/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.stories.ts
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionReactivation',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionReactivation',
+  'Sent when a user reactivates their subscription.',
+  {
+    productName: 'Firefox Fortress',
+    invoiceTotal: '$20',
+    nextInvoiceDateOnly: '11/13/2021',
+    icon: 'https://placekitten.com/512/512',
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+  }
+);
+
+export const SubscriptionReactivation = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionReactivation/index.txt
@@ -1,0 +1,5 @@
+subscriptionReactivation-title = "Thank you for reactivating your <%- productName %> subscription!"
+
+subscriptionReactivation-content = "Your billing cycle and payment will remain the same. Your next charge will be <%- invoiceTotal %> on <%- nextInvoiceDateOnly %>. Your subscription will automatically renew each billing period unless you choose to cancel."
+
+<%- include ('/partials/subscriptionSupport/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -1020,6 +1020,24 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ]), {updateTemplateValues: x => ({...x, productName: undefined})}],
+
+  ['subscriptionReactivationEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `${MESSAGE.productName} subscription reactivated` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionReactivation') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionReactivation' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionReactivation }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-reactivation', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: `reactivating your ${MESSAGE.productName} subscription` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `reactivating your ${MESSAGE.productName} subscription` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ])],
 ];
 
 describe('lib/senders/mjml-emails:', () => {


### PR DESCRIPTION
## Because

- We're actively converting old FxA emails to our new modernized stack.

## This pull request

- Converts the `subscriptionReactivation` subscription platform email to the new stack.

## Issue that this pull request solves

Closes: #9288

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots

<img width="713" alt="Screen Shot 2021-10-15 at 10 38 05 AM" src="https://user-images.githubusercontent.com/6392049/137496250-7f0badb9-cca1-4f25-9894-d610476942eb.png">