### PR TITLE
fix(auth): use local firestore emulator

### DIFF
--- a/packages/fxa-auth-server/lib/firestore-db.ts
+++ b/packages/fxa-auth-server/lib/firestore-db.ts
@@ -16,13 +16,13 @@ export function setupFirestore(config: ConfigType) {
   }
 
   // Utilize the local firestore emulator when the env indicates
-  if (process.env.AUTH_FIRESTORE_EMULATOR_HOST) {
+  if (process.env.FIRESTORE_EMULATOR_HOST) {
     return new Firestore({
       customHeaders: {
         Authorization: 'Bearer owner',
       },
       port: 9090,
-      projectId: 'fx-auth-server',
+      projectId: 'demo-fxa',
       servicePath: 'localhost',
       sslCreds: grpc.credentials.createInsecure(),
     });

--- a/packages/fxa-auth-server/pm2.config.js
+++ b/packages/fxa-auth-server/pm2.config.js
@@ -21,7 +21,7 @@ module.exports = {
         SIGNIN_UNBLOCK_FORCED_EMAILS: '^block.*@restmail\\.net$',
         SIGNIN_CONFIRMATION_ENABLED: 'true',
         SIGNIN_CONFIRMATION_FORCE_EMAIL_REGEX: '^sync.*@restmail\\.net$',
-        AUTH_FIRESTORE_EMULATOR_HOST: 'localhost:9090',
+        FIRESTORE_EMULATOR_HOST: 'localhost:9090',
         FORCE_PASSWORD_CHANGE_EMAIL_REGEX: 'forcepwdchange',
         CONFIG_FILES: 'config/secrets.json',
         EMAIL_CONFIG_USE_REDIS: 'false',


### PR DESCRIPTION
Because:

* Google firestore API requires the env var to be a specific value
  before using the local emulator.

This commit:

* Uses the appropriate env variable and project ID to use the local
  emulator.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
