### PR TITLE
fix(content-server): move pocket logo img rendering to css

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/index.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/index.mustache
@@ -6,7 +6,7 @@
         <!-- L10N: For languages structured like English, the phrase can read "to continue to %(serviceName)s" -->
         {{#isInPocketMigration}}
           {{#unsafeTranslate}}Continue to{{/unsafeTranslate}}
-          <img id="graphic-client-pocket" src="/images/pocket_logo_rounded.svg" alt="Pocket" />
+          <div class="graphic graphic-client-pocket">Pocket</div>
         {{/isInPocketMigration}}
         {{^isInPocketMigration}}
           {{#t}}Continue to %(serviceName)s{{/t}}

--- a/packages/fxa-content-server/app/scripts/templates/ready.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/ready.mustache
@@ -19,7 +19,7 @@
       {{#isFromRelyingParty}}
         {{#isInPocketMigration}}
           {{#unsafeTranslate}}You are now ready to use{{/unsafeTranslate}}
-          <img id="graphic-client-pocket" src="/images/pocket_logo_rounded.svg" alt="Pocket" />
+          <div class="graphic graphic-client-pocket">Pocket</div>
         {{/isInPocketMigration}}
         {{^isInPocketMigration}}
           <p class="account-ready-service">{{#t}}You are now ready to use %(serviceName)s{{/t}}</p>

--- a/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_in_password.mustache
@@ -6,7 +6,7 @@
         <!-- L10N: For languages structured like English, the phrase can read "to continue to %(serviceName)s" -->
         {{#isInPocketMigration}}
           {{#unsafeTranslate}}Continue to{{/unsafeTranslate}}
-          <img id="graphic-client-pocket" src="/images/pocket_logo_rounded.svg" alt="Pocket" />
+          <div class="graphic graphic-client-pocket">Pocket</div>
         {{/isInPocketMigration}}
         {{^isInPocketMigration}}
           {{#t}}Continue to %(serviceName)s{{/t}}

--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -6,7 +6,7 @@
           <!-- L10N: For languages structured like English, the phrase can read "to continue to %(serviceName)s" -->
           {{#isInPocketMigration}}
             {{#unsafeTranslate}}Continue to{{/unsafeTranslate}}
-            <img id="graphic-client-pocket" src="/images/pocket_logo_rounded.svg" alt="Pocket" />
+            <div class="graphic graphic-client-pocket">Pocket</div>
           {{/isInPocketMigration}}
           {{^isInPocketMigration}}
             {{#t}}Continue to %(serviceName)s{{/t}}

--- a/packages/fxa-content-server/app/styles/modules/_graphic.scss
+++ b/packages/fxa-content-server/app/styles/modules/_graphic.scss
@@ -143,7 +143,10 @@
   background-image: image-url('send_tab_complete.svg');
 }
 
-#graphic-client-pocket {
+.graphic-client-pocket {
+  background-image: image-url('pocket_logo_rounded.svg');
+  width: 90px;
+  margin-bottom: 0;
   display: inline-block;
   vertical-align: middle;
   height: 24px;

--- a/packages/fxa-content-server/tests/functional/lib/selectors.js
+++ b/packages/fxa-content-server/tests/functional/lib/selectors.js
@@ -462,7 +462,7 @@ module.exports = {
     HEADER: '.accepted-cards',
   },
   POCKET_OAUTH: {
-    LOGO_IMG: '#graphic-client-pocket',
+    LOGO_IMG: '.graphic-client-pocket',
     TOS: '#pocket-tos',
     PP: '#pocket-pp',
     SERVICE_TILE: '.service-pocket',


### PR DESCRIPTION
## Because

- We don't appear to swap img `src` values out with CDN URLs
 
## This pull request

- Changes the img for the Pocket logo to a div and moves the src image URL to the background-image in CSS.

## Issue that this pull request solves

Closes: #10756

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.