### PR TITLE
fix(content-server): remove en-CA locale from Fx products link

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/partial/firefox-family-services.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/partial/firefox-family-services.mustache
@@ -27,7 +27,7 @@
     </li>
   </ul>
   {{#isInPocketMigration}}
-    <a class="see-all-services" href="https://www.mozilla.org/en-CA/firefox/products/" rel="noopener noreferrer">
+    <a class="see-all-services" href="https://www.mozilla.org/firefox/products/" rel="noopener noreferrer">
       {{#t}}See all{{/t}}
     </a>
   {{/isInPocketMigration}}


### PR DESCRIPTION
## Because

- When I added this link, I first visited the URL and it auto-redirected to my locale (en-CA), so that's what I pasted into the code.

## This pull request

- Removes the locale from the URL so it can resolve to the locale of the person who clicks the link.

## Issue that this pull request solves

Closes: #10782