### PR TITLE
feat(settings): DataCollection copy updates & rtl styles

### DIFF
--- a/packages/fxa-settings/src/components/DataCollection/en-US.ftl
+++ b/packages/fxa-settings/src/components/DataCollection/en-US.ftl
@@ -1,8 +1,8 @@
 ## Data collection section
 
 dc-heading = Data Collection and Use
-dc-subheader = Analytics and Improvements
-dc-subheader-content = Allow Firefox Accounts to send technical and interaction data to Mozilla.
-dc-opt-out-success = You’ve successfully opted out from Firefox Accounts sending technical and interaction data to Mozilla.
-dc-opt-in-success = You’ve successfully opted in to Firefox Accounts sending technical and interaction data to Mozilla. Thank you!
+dc-subheader = Help improve { -product-firefox-accounts }
+dc-subheader-content = Allow { -product-firefox-accounts } to send technical and interaction data to { -brand-mozilla }.
+dc-opt-out-success = Opt out successful. { -product-firefox-accounts } won’t send technical or interaction data to { -brand-mozilla }.
+dc-opt-in-success = Thanks! Sharing this data helps us improve { -product-firefox-accounts }.
 dc-learn-more = Learn more

--- a/packages/fxa-settings/src/components/DataCollection/index.test.tsx
+++ b/packages/fxa-settings/src/components/DataCollection/index.test.tsx
@@ -18,7 +18,7 @@ describe('DataCollection', () => {
     const { container } = render(<DataCollection />);
 
     expect(container).toHaveTextContent('Data Collection and Use');
-    expect(container).toHaveTextContent('Analytics and Improvements');
+    expect(container).toHaveTextContent('Help improve Firefox Accounts');
     expect(container).toHaveTextContent(
       'Allow Firefox Accounts to send technical and interaction data to Mozilla.'
     );

--- a/packages/fxa-settings/src/components/DataCollection/index.tsx
+++ b/packages/fxa-settings/src/components/DataCollection/index.tsx
@@ -15,6 +15,10 @@ export const DataCollection = () => {
   const alertBar = useAlertBar();
   const { l10n } = useLocalization();
 
+  const localizedHeader = (
+    <Localized id="dc-heading">Data Collection and Use</Localized>
+  );
+
   const handleMetricsOptOutToggle = useCallback(async () => {
     try {
       setIsSubmitting(true);
@@ -24,12 +28,12 @@ export const DataCollection = () => {
         ? [
             'dc-opt-out-success',
             null,
-            'You’ve successfully opted out from Firefox Accounts sending technical and interaction data to Mozilla.',
+            'Opt out successful. Firefox Accounts won’t send technical or interaction data to Mozilla.',
           ]
         : [
             'dc-opt-in-success',
             null,
-            'You’ve successfully opted in to Firefox Accounts sending technical and interaction data to Mozilla. Thank you!',
+            'Thanks! Sharing this data helps us improve Firefox Accounts.',
           ];
       alertBar.success(l10n.getString.apply(l10n, alertArgs));
     } catch (err) {}
@@ -39,13 +43,15 @@ export const DataCollection = () => {
     <section className="mt-11" data-testid="settings-data-collection">
       <h2 className="font-header font-bold ltr:ml-4 rtl:mr-4 mb-4">
         <span id="data-collection" className="nav-anchor" />
-        <Localized id="dc-heading">Data Collection and Use</Localized>
+        {localizedHeader}
       </h2>
       <div className="bg-white tablet:rounded-xl shadow px-4 tablet:px-6 pt-7 pb-5">
         <div className="flex mb-4">
-          <div className="flex-5 tablet:flex-7 pr-6 tablet:pr-12">
+          <div className="flex-5 tablet:flex-7 ltr:pr-6 tablet:ltr:pr-12 rtl:pl-6 tablet:rtl:pl-12">
             <Localized id="dc-subheader">
-              <h3 className="font-header mb-4">Analytics and Improvements</h3>
+              <h3 className="font-header mb-4">
+                Help improve Firefox Accounts
+              </h3>
             </Localized>
 
             <p className="text-sm">
@@ -63,18 +69,14 @@ export const DataCollection = () => {
             </p>
           </div>
 
-          <div className="flex-1 text-center tablet:pt-1">
+          <div className="flex-1 flex justify-center tablet:justify-end tablet:pr-4 tablet:pt-1">
             <Switch
               {...{
                 isSubmitting,
                 isOn: !account.metricsOptOutAt,
                 id: 'metrics-opt-out',
                 handler: handleMetricsOptOutToggle,
-                localizedLabel: (
-                  <Localized id="dc-subheader">
-                    Analytics and Improvements
-                  </Localized>
-                ),
+                localizedLabel: localizedHeader,
               }}
             />
           </div>

--- a/packages/fxa-settings/src/styles/switch.scss
+++ b/packages/fxa-settings/src/styles/switch.scss
@@ -23,6 +23,10 @@
   &[aria-checked='true'] {
     @apply text-left border-transparent;
 
+    [dir='rtl'] & {
+      @apply text-right;
+    }
+
     .slider {
       @apply bg-blue-500;
 
@@ -39,17 +43,33 @@
         left: calc(
           100% - 1.25rem - 0.125rem
         ); /* 100% minus the width and padding of pseudo */
+
+        [dir='rtl'] & {
+          @apply left-auto;
+          right: calc(
+            100% - 1.25rem - 0.125rem
+          ); /* 100% minus the width and padding of pseudo */
+        }
       }
 
       &-status {
         /* pr matches pseudo width + .5 rem to account for long l10n */
         @apply text-grey-50 pr-6 pl-3;
+
+        [dir='rtl'] & {
+          /* pl matches pseudo width + .5 rem to account for long l10n */
+          @apply pl-6 pr-3;
+        }
       }
     }
   }
 
   &[aria-checked='false'] {
     @apply text-right border-grey-200;
+
+    [dir='rtl'] & {
+      @apply text-left;
+    }
 
     .slider {
       @apply bg-grey-50;
@@ -65,11 +85,20 @@
 
       &::before {
         @apply shadow left-0.5;
+
+        [dir='rtl'] & {
+          @apply left-auto right-0.5;
+        }
       }
 
       &-status {
         /* pl matches pseudo width + .5 rem to account for long l10n */
         @apply text-grey-500 pl-7 pr-2;
+
+        [dir='rtl'] & {
+          /* pr matches pseudo width + .5 rem to account for long l10n */
+          @apply pr-7 pl-2;
+        }
       }
     }
   }
@@ -80,7 +109,7 @@
 
     &::before {
       left: calc(
-        50% - ((1rem - 0.125rem) / 2)
+        50% - ((1.25rem - 0.125rem) / 2)
       ); /* 50% minus half the width and padding */
     }
   }
@@ -106,12 +135,24 @@
       &-status {
         /* pr matches pseudo width + .25rem to account for long l10n */
         @apply pr-4 pl-1;
+
+        [dir='rtl'] & {
+          /* pl matches pseudo width + .25rem to account for long l10n */
+          @apply pl-4 pr-1;
+        }
       }
 
       &::before {
         left: calc(
           100% - 0.75rem - 0.125rem
         ); /* 100% minus the width and padding */
+
+        [dir='rtl'] & {
+          @apply left-auto;
+          right: calc(
+            100% - 0.75rem - 0.125rem
+          ); /* 100% minus the width and padding */
+        }
       }
     }
 
@@ -121,6 +162,11 @@
       .slider-status {
         /* pl matches pseudo width + .25rem to account for long l10n */
         @apply pl-4 pr-1;
+
+        [dir='rtl'] & {
+          /* pr matches pseudo width + .25rem to account for long l10n */
+          @apply pr-4 pl-1;
+        }
       }
     }
 


### PR DESCRIPTION
follow ups to #10749

Because:
* Suggested copy was updated since the previous UI PR
* Styling tweaks were needed

This commit:
* Updates copy
* Adds RTL styles to DataCollection and Switch
* Better centers the Switch psuedo el when switch is submitting
* Tweaks Switch placement per UX suggestion

I also took the Switch button out of `<form>`. I previously added it out of habit but it makes the button "submit" by default onclick and we don't have other single-click interactive buttons in form tags. Doesn't affect anything from a screenreader POV either.

RTL support:
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/13018240/138135988-28c333a4-9771-476e-9639-6f030d25b6d6.png">


Opening this for review but ~I'm going to **wait until legal signs off on the new copy** before merging.~ They signed off on it.