### PR TITLE
feat(content-server): render pocket logo in confirm signup code screen for pocket clients

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/confirm_signup_code.mustache
@@ -1,8 +1,17 @@
 <div id="main-content" class="card confirm-signup">
     <header>
         <h1 id="fxa-confirm-signup-code-header">
-            <!-- L10N: For languages structured like English, the second phrase can read "to continue to %(serviceName)s" -->
-            {{#t}}Enter verification code{{/t}} <span class="service">{{#t}}Continue to %(serviceName)s{{/t}}</span>
+          {{#t}}Enter verification code{{/t}}
+          <span class="service">
+            <!-- L10N: For languages structured like English, the phrase can read "to continue to %(serviceName)s" -->
+            {{#isInPocketMigration}}
+              {{#unsafeTranslate}}Continue to{{/unsafeTranslate}}
+              <div class="graphic graphic-client-pocket">Pocket</div>
+            {{/isInPocketMigration}}
+            {{^isInPocketMigration}}
+              {{#t}}Continue to %(serviceName)s{{/t}}
+            {{/isInPocketMigration}}
+          </span>
         </h1>
     </header>
 

--- a/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
+++ b/packages/fxa-content-server/app/scripts/views/confirm_signup_code.js
@@ -12,6 +12,7 @@ import ServiceMixin from './mixins/service-mixin';
 import Template from 'templates/confirm_signup_code.mustache';
 import ResendMixin from './mixins/resend-mixin';
 import SessionVerificationPollMixin from './mixins/session-verification-poll-mixin';
+import PocketMigrationMixin from './mixins/pocket-migration-mixin';
 
 const CODE_INPUT_SELECTOR = 'input.otp-code';
 
@@ -118,7 +119,8 @@ Cocktail.mixin(
   NewsletterSyncExperiment,
   ResendMixin(),
   ServiceMixin,
-  SessionVerificationPollMixin
+  SessionVerificationPollMixin,
+  PocketMigrationMixin
 );
 
 export default ConfirmSignupCodeView;

--- a/packages/fxa-content-server/tests/functional/oauth_sign_up.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sign_up.js
@@ -30,6 +30,7 @@ const {
 const {
   openFxaFromRp: openFxaFromRpRm,
   testElementExists: testElementExistsRm,
+  fillOutEmailFirstSignUp: fillOutEmailFirstSignUpRm,
   fillOutEmailFirstEmail,
 } = FunctionalHelpers.helpersRemoteWrapped;
 
@@ -126,6 +127,15 @@ registerSuite('oauth signup', {
       await testElementExistsRm(selectors.POCKET_OAUTH.LOGO_IMG, remote);
       await testElementExistsRm(selectors.POCKET_OAUTH.TOS, remote);
       await testElementExistsRm(selectors.POCKET_OAUTH.PP, remote);
+
+      await fillOutEmailFirstSignUpRm(
+        email,
+        PASSWORD,
+        { enterEmail: false },
+        remote
+      );
+
+      await testElementExistsRm(selectors.POCKET_OAUTH.LOGO_IMG, remote);
     },
   },
 });


### PR DESCRIPTION
## Because

- We want to enhance the signup code confirmation UI for pocket clients

## This pull request

- Uses the same PocketMigrationMixin to conditionally render the Pocket logo in the UI when confirm signup code via a matching Pocket client ID

## Issue that this pull request solves

Closes: #10783

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.

## Screenshots (Optional)

<img width="544" alt="Screen Shot 2021-10-20 at 4 02 35 PM" src="https://user-images.githubusercontent.com/6392049/138155630-09119843-fd12-4f99-8797-62ca1df26658.png">

