### PR TITLE
feat(auth): restrict webhook event updates

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
@@ -117,14 +117,14 @@ export class StripeFirestore {
   /**
    * Insert a Stripe customer into Firestore keyed to the fxa id.
    */
-  insertCustomerRecord(uid: string, customer: Stripe.Customer) {
+  insertCustomerRecord(uid: string, customer: Partial<Stripe.Customer>) {
     return this.customerCollectionDbRef.doc(uid).set(customer, { merge: true });
   }
 
   /**
    * Insert a subscription record into Firestore under the customer's stripe id.
    */
-  async insertSubscriptionRecord(subscription: Stripe.Subscription) {
+  async insertSubscriptionRecord(subscription: Partial<Stripe.Subscription>) {
     const customerSnap = await this.customerCollectionDbRef
       .where('id', '==', subscription.customer as string)
       .get();
@@ -137,14 +137,14 @@ export class StripeFirestore {
 
     return customerSnap.docs[0].ref
       .collection(this.subscriptionCollection)
-      .doc(subscription.id)
+      .doc(subscription.id!)
       .set(subscription, { merge: true });
   }
 
   /**
    * Insert an invoice record into Firestore under the customer's stripe id.
    */
-  async insertInvoiceRecord(invoice: Stripe.Invoice) {
+  async insertInvoiceRecord(invoice: Partial<Stripe.Invoice>) {
     const customerSnap = await this.customerCollectionDbRef
       .where('id', '==', invoice.customer as string)
       .get();
@@ -163,7 +163,7 @@ export class StripeFirestore {
       .collection(this.subscriptionCollection)
       .doc(invoice.subscription)
       .collection(this.invoiceCollection)
-      .doc(invoice.id)
+      .doc(invoice.id!)
       .set(invoice, { merge: true });
   }
 


### PR DESCRIPTION
Because:

* We want to reduce risk of updating data in an object that
  wasn't actually changed.

This commit:

* Restricts the firestore object to just the keys that changed along
  with the minimal keys needed for the inserts.

Closes #10744

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
