### PR TITLE
feat(auth): create customer firestore record

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -323,7 +323,10 @@ export class StripeHelper {
         idempotency_key: idempotencyKey,
       }
     );
-    await createAccountCustomer(uid, stripeCustomer.id);
+    await Promise.all([
+      createAccountCustomer(uid, stripeCustomer.id),
+      this.stripeFirestore.insertCustomerRecord(uid, stripeCustomer),
+    ]);
     return stripeCustomer;
   }
 
@@ -2396,6 +2399,9 @@ export class StripeHelper {
           await this.stripeFirestore.insertInvoiceRecord(invoice);
           break;
         case 'customer.created':
+          if (event.request?.id) {
+            break;
+          }
         case 'customer.updated':
         case 'customer.deleted':
           let customer: Partial<Stripe.Customer>;

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -78,6 +78,11 @@ export class StripeWebhookHandler extends StripeHandler {
           }
           break;
         case 'customer.created':
+          // We don't need to setup the local customer if it happened via API
+          // because we already set this up during creation.
+          if (event.request?.id) {
+            break;
+          }
           await this.handleCustomerCreatedEvent(request, event);
           break;
         case 'customer.subscription.created':


### PR DESCRIPTION
Because:

* We want to eliminate latency from Stripe by inserting new customers
  into Firestore as soon as the Stripe create call completes.

This commit:

* Ignores the stripe customer create webhook and instead relies on
  inserting the stripe record with the new record returned from
  Stripe.

Closes #10739

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
