### PR TITLE
feat(auth): create sub firestore record

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
@@ -142,6 +142,25 @@ export class StripeFirestore {
   }
 
   /**
+   * Insert a subscription record into Firestore under the customer's stripe id.
+   * If the customer does not exist, this will backfill the customer with all their
+   * subscriptions.
+   */
+  async insertSubscriptionRecordWithBackfill(
+    subscription: Partial<Stripe.Subscription>
+  ) {
+    try {
+      await this.insertSubscriptionRecord(subscription);
+    } catch (err) {
+      if (err.name === FirestoreStripeError.FIRESTORE_CUSTOMER_NOT_FOUND) {
+        await this.fetchAndInsertCustomer(subscription.customer as string);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  /**
    * Insert an invoice record into Firestore under the customer's stripe id.
    */
   async insertInvoiceRecord(invoice: Partial<Stripe.Invoice>) {

--- a/packages/fxa-auth-server/test/local/payments/stripe-firestore.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe-firestore.js
@@ -255,6 +255,33 @@ describe('StripeFirestore', () => {
     });
   });
 
+  describe('insertSubscriptionRecordWithBackfill', () => {
+    it('inserts a record', async () => {
+      stripeFirestore.insertSubscriptionRecord = sinon.fake.resolves({});
+      const result = await stripeFirestore.insertSubscriptionRecordWithBackfill(
+        deepCopy(subscription1)
+      );
+      assert.isUndefined(result, {});
+      assert.calledOnce(stripeFirestore.insertSubscriptionRecord);
+    });
+
+    it('backfills on customer not found', async () => {
+      stripeFirestore.insertSubscriptionRecord = sinon.fake.rejects(
+        newFirestoreStripeError(
+          'no customer',
+          FirestoreStripeError.FIRESTORE_CUSTOMER_NOT_FOUND
+        )
+      );
+      stripeFirestore.fetchAndInsertCustomer = sinon.fake.resolves({});
+      const result = await stripeFirestore.insertSubscriptionRecordWithBackfill(
+        deepCopy(subscription1)
+      );
+      assert.isUndefined(result, {});
+      assert.calledOnce(stripeFirestore.insertSubscriptionRecord);
+      assert.calledOnce(stripeFirestore.fetchAndInsertCustomer);
+    });
+  });
+
   describe('insertInvoiceRecord', () => {
     let invoice;
 


### PR DESCRIPTION
Because:

* We want to eliminate latency from Stripe by inserting new
  subscriptions when we create them.

This commit:

* Ignores the stripe subscription.created event and instead inserts
  the subscription record when its created.

Closes #10740

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
