### PR TITLE
feat(subscriptions): block web subscription when IAP subscribed

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -9,6 +9,12 @@ project-brand = Firefox Accounts
 -brand-name-paypal = PayPal
 -brand-name-stripe = Stripe
 
+# the following are not terms because they are not used directly in messages,
+# but rather looked up in code and passed into the message as variables.
+brand-name-google-play = Google Play Store
+# App Store here refers to Apple's App Store not the genreic app store.
+brand-name-apple-app-store = App Store
+
 document =
   .title = Firefox Accounts
 
@@ -30,6 +36,9 @@ country-currency-mismatch = The currency of this subscription is not valid for t
 currency-currency-mismatch = Sorry. You can't switch between currencies.
 
 no-subscription-change = Sorry. You can't change your subscription plan.
+
+# $mobileAppStore (String) - "Google Play Store" or "App Store", localized when the translation is available.
+iap-already-subscribed = You’re already subscribed through the { $mobileAppStore }.
 
 expired-card-error = It looks like your credit card has expired. Try another card.
 insufficient-funds-error = It looks like your card has insufficient funds. Try another card.
@@ -60,6 +69,7 @@ subscription-success-title = Subscription confirmation
 subscription-processing-title = Confirming subscription…
 subscription-error-title = Error confirming subscription…
 subscription-noplanchange-title = This subscription plan change is not supported
+subscription-iapsubscribed-title = Already subscribed
 
 ##  $productName (String) - The name of the subscribed product.
 ##  $amount (Number) - The amount billed. It will be formatted as currency.

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+// React looks unused here, but we need it for Storybook.
+import React, { useCallback, useEffect, useState } from 'react';
 import { Localized } from '@fluent/react';
 
 import { isEmailValid } from '../../../../fxa-shared/email/helpers';

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.stories.tsx
@@ -4,6 +4,7 @@ import MockApp from '../../../.storybook/components/MockApp';
 import PaymentConfirmation from './index';
 import { Customer, Profile, Plan } from '../../store/types';
 import { PAYPAL_CUSTOMER } from '../../lib/mock-data';
+import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 
 const userProfile: Profile = {
   avatar: 'http://placekitten.com/256/256',
@@ -46,6 +47,7 @@ const customer: Customer = {
   brand: 'Visa',
   subscriptions: [
     {
+      _subscription_type: MozillaSubscriptionTypes.WEB,
       latest_invoice: '628031D-0002',
       subscription_id: 'sub0.28964929339372136',
       plan_id: '123doneProMonthly',
@@ -53,6 +55,7 @@ const customer: Customer = {
       product_name: '123 Done Pro',
       status: 'active',
       cancel_at_period_end: false,
+      created: Date.now(),
       current_period_end: Date.now() / 10 + 86400 * 31,
       current_period_start: Date.now() / 1000 - 86400 * 31,
       end_at: null,

--- a/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentConfirmation/index.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import { Localized, useLocalization } from '@fluent/react';
-import * as Provider from '../../lib/PaymentProvider';
 import { getLocalizedCurrency, formatPlanPricing } from '../../lib/formats';
 import { Plan, Profile, Customer } from '../../store/types';
 import { PaymentProviderDetails } from '../PaymentProviderDetails';
@@ -15,6 +14,7 @@ import checkmarkIcon from './images/checkmark.svg';
 import './index.scss';
 import { productDetailsFromPlan } from 'fxa-shared/subscriptions/metadata';
 import { AppContext } from '../../lib/AppContext';
+import { WebSubscription } from 'fxa-shared/subscriptions/types';
 
 type PaymentConfirmationProps = {
   customer: Customer;
@@ -45,7 +45,7 @@ export const PaymentConfirmation = ({
     navigatorLanguages
   ).successActionButtonLabel;
 
-  const invoiceNumber = subscriptions[0].latest_invoice;
+  const invoiceNumber = (subscriptions[0] as WebSubscription).latest_invoice;
   const date = new Date().toLocaleDateString(navigator.language, {
     year: 'numeric',
     month: 'long',

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.stories.tsx
@@ -6,7 +6,7 @@ import { SELECTED_PLAN } from '../../lib/mock-data';
 storiesOf('components/PaymentError', module).add('default', () => (
   <PaymentErrorView
     error={{ code: 'general-paypal-error' }}
-    onRetry={() => {}}
+    actionFn={() => {}}
     plan={SELECTED_PLAN}
   />
 ));

--- a/packages/fxa-payments-server/src/components/PaymentErrorView/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentErrorView/index.test.tsx
@@ -24,7 +24,7 @@ describe('PaymentErrorView test with l10n', () => {
   it('renders as expected', () => {
     const { queryByTestId, queryByAltText } = render(
       <PaymentErrorView
-        onRetry={() => {}}
+        actionFn={() => {}}
         error={{ code: 'general-paypal-error' }}
         plan={SELECTED_PLAN}
       />
@@ -53,7 +53,7 @@ describe('PaymentErrorView test with l10n', () => {
     const onRetry = jest.fn();
     const { getByTestId } = render(
       <PaymentErrorView
-        onRetry={onRetry}
+        actionFn={onRetry}
         error={{ code: 'general-paypal-error' }}
         plan={SELECTED_PLAN}
       />
@@ -69,7 +69,7 @@ describe('PaymentErrorView test with l10n', () => {
   it('navigates to the correct relative URL when the "Manage my subscription" button is clicked', async () => {
     const { getByTestId } = render(
       <PaymentErrorView
-        onRetry={() => {}}
+        actionFn={() => {}}
         error={{ code: 'no_subscription_change' }}
         plan={SELECTED_PLAN}
       />
@@ -86,7 +86,7 @@ describe('PaymentErrorView test with l10n', () => {
     const { getByTestId } = render(
       <PaymentErrorView
         subscriptionTitle={<SubscriptionTitle screenType={'noplanchange'} />}
-        onRetry={() => {}}
+        actionFn={() => {}}
         error={{ code: 'no_subscription_change' }}
         plan={SELECTED_PLAN}
       />
@@ -106,7 +106,7 @@ describe('PaymentErrorView test with l10n', () => {
   it('does not render the ActionButton for post-subscription creation errors', async () => {
     const { queryByTestId } = render(
       <PaymentErrorView
-        onRetry={() => {}}
+        actionFn={() => {}}
         error={{ code: 'fxa_fetch_profile_customer_error' }}
         plan={SELECTED_PLAN}
       />
@@ -128,10 +128,10 @@ describe('PaymentErrorView test with l10n', () => {
   it('shows FxA legal links in footer when isPasswordlessCheckout is true', async () => {
     const { queryByTestId } = render(
       <PaymentErrorView
-        onRetry={() => {}}
+        actionFn={() => {}}
         error={{ code: 'general-paypal-error' }}
         plan={SELECTED_PLAN}
-        isPasswordlessCheckout={true}
+        showFxaLegalFooterLinks={true}
       />
     );
 

--- a/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentForm/index.stories.tsx
@@ -10,6 +10,7 @@ import {
 import { Plan, Customer } from '../../store/types';
 import { useNonce } from '../../lib/hooks';
 import { SignInLayout } from '../AppLayout';
+import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 
 function init() {
   storiesOf('components/PaymentFormV2', module)
@@ -67,6 +68,7 @@ const CUSTOMER: Customer = {
   brand: 'Visa',
   subscriptions: [
     {
+      _subscription_type: MozillaSubscriptionTypes.WEB,
       subscription_id: 'sub0.28964929339372136',
       plan_id: '123doneProMonthly',
       product_id: 'prod_123',
@@ -74,6 +76,7 @@ const CUSTOMER: Customer = {
       latest_invoice: '628031D-0002',
       status: 'active',
       cancel_at_period_end: false,
+      created: Date.now(),
       current_period_end: Date.now() / 1000 + 86400 * 31,
       current_period_start: Date.now() / 1000 - 86400 * 31,
       end_at: null,

--- a/packages/fxa-payments-server/src/components/SubscriptionTitle/index.tsx
+++ b/packages/fxa-payments-server/src/components/SubscriptionTitle/index.tsx
@@ -9,6 +9,7 @@ export const titles = {
   processing: 'Confirming subscription…',
   error: 'Error confirming subscription…',
   noplanchange: 'This subscription plan change is not supported',
+  iapsubscribed: 'Already subscribed',
 } as const;
 
 export type SubscriptionTitleProps = {

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -212,9 +212,11 @@ describe('API requests', () => {
   });
 
   describe('apiFetchCustomer', () => {
-    it('GET {auth-server}/v1/oauth/subscriptions/customer', async () => {
+    it('GET {auth-server}/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions', async () => {
       const requestMock = nock(AUTH_BASE_URL)
-        .get('/v1/oauth/subscriptions/customer')
+        .get(
+          '/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions'
+        )
         .reply(200, MOCK_CUSTOMER);
       expect(await apiFetchCustomer()).toEqual(MOCK_CUSTOMER);
       requestMock.done();

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -139,7 +139,7 @@ export async function apiFetchToken(): Promise<Token> {
 export async function apiFetchCustomer(): Promise<Customer> {
   return apiFetch(
     'GET',
-    `${config.servers.auth.url}/v1/oauth/subscriptions/customer`
+    `${config.servers.auth.url}/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions`
   );
 }
 

--- a/packages/fxa-payments-server/src/lib/customer.ts
+++ b/packages/fxa-payments-server/src/lib/customer.ts
@@ -2,6 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { isIapSubscription } from 'fxa-shared/subscriptions/subscriptions';
+import {
+  IapSubscription,
+  MozillaSubscription,
+} from 'fxa-shared/subscriptions/types';
 import { Customer } from '../store/types';
 import {
   isNotChosen,
@@ -38,10 +43,20 @@ export const isExistingPaypalCustomer = (customer: Customer | null) =>
 export const isExistingCustomer = (customer?: Customer | null) =>
   !!(customer && hasSubscriptions(customer) && hasPaymentProvider(customer));
 
+export const findCustomerIapSubscriptionByProductId = (
+  subscriptions: MozillaSubscription[] | null,
+  productId: string
+) =>
+  subscriptions &&
+  (subscriptions.find(
+    (s) => isIapSubscription(s) && s.product_id === productId
+  ) as IapSubscription);
+
 export default {
   hasSubscriptions,
   hasPaymentProvider,
   isExistingCustomer,
   isExistingPaypalCustomer,
   isExistingStripeCustomer,
+  findCustomerIapSubscriptionByProductId,
 };

--- a/packages/fxa-payments-server/src/lib/errors.ts
+++ b/packages/fxa-payments-server/src/lib/errors.ts
@@ -52,6 +52,7 @@ const errorToErrorMessageMap: { [key: string]: string } = {
     'country-currency-mismatch',
   'Changing currencies is not permitted.': 'currency-currency-mismatch',
   no_subscription_change: 'no-subscription-change',
+  iap_already_subscribed: 'iap-already-subscribed',
 };
 
 const cardErrors = ['card_declined', 'incorrect_cvc'];

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -1,6 +1,7 @@
 import { Profile, Plan, Customer } from '../store/types';
 import { FilteredSetupIntent } from '../lib/apiClient';
 import { PaymentIntent, PaymentMethod } from '@stripe/stripe-js';
+import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 
 export const PROFILE: Profile = {
   amrValues: [],
@@ -28,12 +29,14 @@ export const CUSTOMER: Customer = {
   brand: 'Visa',
   subscriptions: [
     {
+      _subscription_type: MozillaSubscriptionTypes.WEB,
       subscription_id: 'sub0.28964929339372136',
       plan_id: '123doneProMonthly',
       product_id: 'prod_123',
       product_name: '123done Pro',
       latest_invoice: '628031D-0002',
       status: 'active',
+      created: Date.now(),
       cancel_at_period_end: false,
       current_period_end: Date.now() / 1000 + 86400 * 31,
       current_period_start: Date.now() / 1000 - 86400 * 31,
@@ -115,6 +118,7 @@ export const PAYPAL_CUSTOMER: Customer = {
   brand: '',
   subscriptions: [
     {
+      _subscription_type: MozillaSubscriptionTypes.WEB,
       subscription_id: 'sub0.28964929339372136',
       plan_id: 'plan_123',
       product_id: 'prod_123',
@@ -122,6 +126,7 @@ export const PAYPAL_CUSTOMER: Customer = {
       latest_invoice: '628031D-0002',
       status: 'active',
       cancel_at_period_end: false,
+      created: Date.now(),
       current_period_end: Date.now() / 1000 + 86400 * 31,
       current_period_start: Date.now() / 1000 - 86400 * 31,
       end_at: null,
@@ -212,4 +217,14 @@ export const MOCK_FXA_POST_PASSWORDLESS_SUB_ERROR = {
 };
 export const MOCK_GENERAL_PAYPAL_ERROR = {
   code: 'general-paypal-error',
+};
+
+export const IAP_GOOGLE_SUBSCRIPTION = {
+  _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+  product_id: 'prod_123',
+};
+
+export const IAP_APPLE_SUBSCRIPTION = {
+  _subscription_type: MozillaSubscriptionTypes.IAP_APPLE,
+  product_id: 'prod_123',
 };

--- a/packages/fxa-payments-server/src/lib/test-utils.tsx
+++ b/packages/fxa-payments-server/src/lib/test-utils.tsx
@@ -16,6 +16,10 @@ import { FluentBundle, FluentResource } from '@fluent/bundle';
 import { State } from '../store/state';
 import { Store, createAppStore } from '../../src/store';
 import { Plan, Token } from '../../src/store/types';
+import {
+  MozillaSubscription,
+  MozillaSubscriptionTypes,
+} from 'fxa-shared/subscriptions/types';
 
 declare global {
   namespace NodeJS {
@@ -586,6 +590,7 @@ export const MOCK_CUSTOMER = {
   exp_year: '2020',
   subscriptions: [
     {
+      _subscription_type: MozillaSubscriptionTypes.WEB,
       subscription_id: 'sub0.28964929339372136',
       plan_id: '123doneProMonthly',
       product_id: 'prod_123',
@@ -593,10 +598,11 @@ export const MOCK_CUSTOMER = {
       latest_invoice: '628031D-0002',
       status: 'active',
       cancel_at_period_end: false,
+      created: 1565815388.815,
       current_period_start: 1565816388.815,
       current_period_end: 1568408388.815,
       end_at: null,
-    },
+    } as MozillaSubscription,
   ],
 };
 
@@ -605,6 +611,7 @@ export const MOCK_CUSTOMER_AFTER_SUBSCRIPTION = {
   subscriptions: [
     ...MOCK_CUSTOMER.subscriptions,
     {
+      _subscription_type: MozillaSubscriptionTypes.WEB,
       subscription_id: 'sub0.21234123424',
       plan_id: PLAN_ID,
       product_id: PRODUCT_ID,

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -279,7 +279,7 @@ export const Checkout = ({
         {newsletterSignupError && <NewsletterErrorAlertBar />}
         <PaymentErrorView
           error={subscriptionError}
-          onRetry={() => {
+          actionFn={() => {
             setSubscriptionError(undefined);
             setTransactionInProgress(false);
           }}
@@ -287,7 +287,7 @@ export const Checkout = ({
             hidden: !subscriptionError,
           })}
           plan={selectedPlan}
-          isPasswordlessCheckout={true}
+          showFxaLegalFooterLinks={true}
         />
         <PaymentProcessing
           provider="paypal"

--- a/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.stories.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import MockApp from '../../../../.storybook/components/MockApp';
+import { defaultAppContext, AppContextType } from '../../../lib/AppContext';
+
+import { SignInLayout } from '../../../components/AppLayout';
+
+import {
+  CUSTOMER,
+  SELECTED_PLAN,
+  PROFILE,
+  IAP_GOOGLE_SUBSCRIPTION,
+  IAP_APPLE_SUBSCRIPTION,
+} from '../../../lib/mock-data';
+
+import IapRoadblock, { IapRoadblockProps } from './index';
+
+const MOCK_PROPS: IapRoadblockProps = {
+  customer: CUSTOMER,
+  isMobile: false,
+  profile: PROFILE,
+  selectedPlan: SELECTED_PLAN,
+  subscription: IAP_GOOGLE_SUBSCRIPTION,
+};
+
+const IapRoadblockView = ({
+  props = MOCK_PROPS,
+  appContextValue = defaultAppContext,
+}: {
+  props?: IapRoadblockProps;
+  appContextValue?: AppContextType;
+}) => (
+  <MockApp appContextValue={appContextValue}>
+    <SignInLayout>
+      <IapRoadblock {...props} />
+    </SignInLayout>
+  </MockApp>
+);
+
+function init() {
+  storiesOf('routes/Product/IapRoadblock', module)
+    .add('with a Google Play subscription', () => (
+      <IapRoadblockView
+        props={{
+          ...MOCK_PROPS,
+        }}
+      />
+    ))
+    .add('with an Apple App Store subscription', () => (
+      <IapRoadblockView
+        props={{
+          ...MOCK_PROPS,
+          subscription: IAP_APPLE_SUBSCRIPTION,
+        }}
+      />
+    ));
+}
+
+init();

--- a/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.test.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import { MockApp, MOCK_CUSTOMER } from '../../../lib/test-utils';
+import { SELECTED_PLAN, PROFILE } from '../../../lib/mock-data';
+import { SignInLayout } from '../../../components/AppLayout';
+import IapRoadblock, { IapRoadblockProps } from './index';
+import {
+  IapSubscription,
+  MozillaSubscriptionTypes,
+} from 'fxa-shared/subscriptions/types';
+import { Customer } from '../../../store/types';
+
+const subscription: IapSubscription = {
+  _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+  product_id: SELECTED_PLAN.product_id,
+};
+const MOCK_PROPS: IapRoadblockProps = {
+  profile: PROFILE,
+  selectedPlan: SELECTED_PLAN,
+  isMobile: false,
+  subscription,
+  customer: MOCK_CUSTOMER as Customer,
+};
+
+const Subject = () => {
+  return (
+    <MockApp>
+      <SignInLayout>
+        <IapRoadblock {...MOCK_PROPS} />
+      </SignInLayout>
+    </MockApp>
+  );
+};
+
+describe('routes/Product/IapRoadblock', () => {
+  it('renders as expected', async () => {
+    const { findByTestId } = render(<Subject />);
+    const titleEl = await findByTestId('subscription-iapsubscribed-title');
+    expect(titleEl).toBeInTheDocument();
+    const errorEl = await findByTestId('payment-error');
+    expect(errorEl).toBeInTheDocument();
+    const actionButton = await findByTestId('manage-subscription-link');
+    expect(actionButton).toBeInTheDocument();
+    const detailsEl = await findByTestId('plan-details-component');
+    expect(detailsEl).toBeInTheDocument();
+  });
+});

--- a/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/IapRoadblock/index.tsx
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import React from 'react';
+import { useHistory } from 'react-router-dom';
+import { useLocalization } from '@fluent/react';
+import {
+  AppleSubscription,
+  GooglePlaySubscription,
+  MozillaSubscriptionTypes,
+} from 'fxa-shared/subscriptions/types';
+import { Header } from '../../../components/Header';
+import { PaymentErrorView } from '../../../components/PaymentErrorView';
+import PlanDetails from '../../../components/PlanDetails';
+import SubscriptionTitle from '../../../components/SubscriptionTitle';
+import { Customer, Profile, Plan } from '../../../store/types';
+
+export type IapRoadblockProps = {
+  isMobile: boolean;
+  profile: Profile;
+  customer: Customer;
+  selectedPlan: Plan;
+  subscription: GooglePlaySubscription | AppleSubscription;
+};
+
+const getIapSubscriptionAppStoreL10Id = (
+  s: IapRoadblockProps['subscription']
+) => {
+  switch (s._subscription_type) {
+    case MozillaSubscriptionTypes.IAP_GOOGLE:
+      return 'brand-name-google-play';
+    case MozillaSubscriptionTypes.IAP_APPLE:
+      return 'brand-name-apple-app-store';
+  }
+};
+
+const getIapSubscriptionManagementUrl = (
+  s: IapRoadblockProps['subscription']
+) => {
+  switch (s._subscription_type) {
+    case MozillaSubscriptionTypes.IAP_GOOGLE:
+      return 'https://play.google.com/store/account/subscriptions';
+    case MozillaSubscriptionTypes.IAP_APPLE:
+      // TODO Need actual link
+      return 'https://apple.com';
+  }
+};
+
+export const IapRoadblock = ({
+  profile,
+  isMobile,
+  selectedPlan,
+  subscription,
+}: IapRoadblockProps) => {
+  const { l10n } = useLocalization();
+  const mobileAppStore = l10n.getString(
+    getIapSubscriptionAppStoreL10Id(subscription)
+  );
+  const appStoreLink = getIapSubscriptionManagementUrl(subscription);
+  const subtitle = <p />;
+  const title = (
+    <SubscriptionTitle screenType="iapsubscribed" subtitle={subtitle} />
+  );
+  const manageSubscription: VoidFunction = () =>
+    (window.location.href = appStoreLink);
+
+  return (
+    <>
+      <Header {...{ profile }} />
+      <div className="main-content">
+        <PaymentErrorView
+          {...{
+            subscriptionTitle: title,
+            error: { code: 'iap_already_subscribed' },
+            actionFn: manageSubscription,
+            plan: selectedPlan,
+            contentProps: { mobileAppStore },
+          }}
+        />
+
+        <PlanDetails
+          {...{
+            profile,
+            selectedPlan,
+            isMobile,
+            showExpandButton: isMobile,
+          }}
+        />
+      </div>
+    </>
+  );
+};
+
+export default IapRoadblock;

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionChangeRoadblock/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionChangeRoadblock/index.tsx
@@ -31,7 +31,7 @@ export const SubscriptionChangeRoadblock = ({
           {...{
             subscriptionTitle: title,
             error: { code: 'no_subscription_change' },
-            onRetry: () => {}, // PaymentErrorView actually ignores this
+            actionFn: () => {}, // PaymentErrorView actually ignores this
             plan: selectedPlan,
           }}
         />

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -200,7 +200,7 @@ export const SubscriptionCreate = ({
       <div className="main-content">
         <PaymentErrorView
           error={subscriptionError}
-          onRetry={() => {
+          actionFn={() => {
             setSubscriptionError(undefined);
             setTransactionInProgress(false);
           }}

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.stories.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../../lib/mock-data';
 
 import SubscriptionUpgrade, { SubscriptionUpgradeProps } from './index';
+import { WebSubscription } from 'fxa-shared/subscriptions/types';
 
 function init() {
   storiesOf('routes/Product/SubscriptionUpgrade', module)
@@ -100,7 +101,7 @@ const MOCK_PROPS: SubscriptionUpgradeProps = {
   customer: CUSTOMER,
   selectedPlan: SELECTED_PLAN,
   upgradeFromPlan: UPGRADE_FROM_PLAN,
-  upgradeFromSubscription: CUSTOMER.subscriptions[0],
+  upgradeFromSubscription: CUSTOMER.subscriptions[0] as WebSubscription,
   updateSubscriptionPlanStatus: {
     error: null,
     loading: false,

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.tsx
@@ -38,6 +38,7 @@ import './index.scss';
 import { ProductProps } from '../index';
 import { PaymentConsentCheckbox } from '../../../components/PaymentConsentCheckbox';
 import { PaymentProviderDetails } from '../../../components/PaymentProviderDetails';
+import { WebSubscription } from 'fxa-shared/subscriptions/types';
 
 export type SubscriptionUpgradeProps = {
   isMobile: boolean;
@@ -45,7 +46,7 @@ export type SubscriptionUpgradeProps = {
   customer: Customer;
   selectedPlan: Plan;
   upgradeFromPlan: Plan;
-  upgradeFromSubscription: CustomerSubscription;
+  upgradeFromSubscription: WebSubscription;
   updateSubscriptionPlanStatus: SelectorReturns['updateSubscriptionPlanStatus'];
   updateSubscriptionPlanAndRefresh: ProductProps['updateSubscriptionPlanAndRefresh'];
   resetUpdateSubscriptionPlan: ProductProps['resetUpdateSubscriptionPlan'];

--- a/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/index.stories.tsx
@@ -12,6 +12,7 @@ import { State as ValidatorState } from '../../lib/validator';
 import { Product, ProductProps } from './index';
 import { Customer, Plan, Profile } from '../../store/types';
 import { PAYPAL_CUSTOMER } from '../../lib/mock-data';
+import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 
 function init() {
   storiesOf('routes/Product', module)
@@ -51,6 +52,8 @@ function init() {
           },
           customerSubscriptions: [
             {
+              _subscription_type: MozillaSubscriptionTypes.WEB,
+              created: Date.now(),
               current_period_end: Date.now() / 1000 + 86400,
               current_period_start: Date.now() / 1000 - 86400,
               cancel_at_period_end: false,
@@ -222,6 +225,8 @@ const CUSTOMER: Customer = {
   brand: 'Visa',
   subscriptions: [
     {
+      _subscription_type: MozillaSubscriptionTypes.WEB,
+      created: Date.now(),
       subscription_id: 'sub0.28964929339372136',
       plan_id: '123doneProMonthly',
       product_id: 'prod_123',

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Cancel/CancelSubscriptionPanel.tsx
@@ -18,11 +18,12 @@ import { SubscriptionsProps } from '../index';
 import { metadataFromPlan } from 'fxa-shared/subscriptions/metadata';
 import * as Amplitude from '../../../lib/amplitude';
 import { PaymentProvider } from 'fxa-payments-server/src/lib/PaymentProvider';
+import { WebSubscription } from 'fxa-shared/subscriptions/types';
 
 export type CancelSubscriptionPanelProps = {
   plan: Plan;
   cancelSubscription: SubscriptionsProps['cancelSubscription'];
-  customerSubscription: CustomerSubscription;
+  customerSubscription: WebSubscription;
   cancelSubscriptionStatus: SelectorReturns['cancelSubscriptionStatus'];
   paymentProvider: PaymentProvider | undefined;
 };

--- a/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ManagementPanel.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/Reactivate/ManagementPanel.tsx
@@ -2,13 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// React looks unused here, but we need it for Storybook.
 import React, { useCallback } from 'react';
 import { Localized } from '@fluent/react';
-import { Plan, CustomerSubscription, Customer } from '../../../store/types';
+import { Plan, Customer } from '../../../store/types';
 import { useBooleanState } from 'fxa-react/lib/hooks';
 import { getLocalizedDateString, getLocalizedDate } from '../../../lib/formats';
 import { ActionFunctions } from '../../../store/actions';
 import ReactivationConfirmationDialog from './ConfirmationDialog';
+import { WebSubscription } from 'fxa-shared/subscriptions/types';
 
 export default ({
   plan,
@@ -17,7 +19,7 @@ export default ({
   reactivateSubscription,
 }: {
   plan: Plan;
-  customerSubscription: CustomerSubscription;
+  customerSubscription: WebSubscription;
   customer: Customer;
   reactivateSubscription: ActionFunctions['reactivateSubscription'];
 }) => {

--- a/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/SubscriptionItem.tsx
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+// React looks unused here, but we need it for Storybook.
 import React, { useContext } from 'react';
 import { Localized } from '@fluent/react';
-import { CustomerSubscription, Plan, Customer } from '../../store/types';
+import { Plan, Customer } from '../../store/types';
 import { SelectorReturns } from '../../store/selectors';
 import { SubscriptionsProps } from './index';
 
@@ -14,9 +15,10 @@ import AppContext from '../../lib/AppContext';
 import CancelSubscriptionPanel from './Cancel/CancelSubscriptionPanel';
 import ReactivateSubscriptionPanel from './Reactivate/ManagementPanel';
 import { PaymentProvider } from 'fxa-payments-server/src/lib/PaymentProvider';
+import { WebSubscription } from 'fxa-shared/subscriptions/types';
 
 export type SubscriptionItemProps = {
-  customerSubscription: CustomerSubscription;
+  customerSubscription: WebSubscription;
   plan: Plan | null;
   cancelSubscription: SubscriptionsProps['cancelSubscription'];
   reactivateSubscription: SubscriptionsProps['reactivateSubscription'];

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.stories.tsx
@@ -1,4 +1,3 @@
-import React, { ReactNode } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import MockApp, {
@@ -6,15 +5,16 @@ import MockApp, {
 } from '../../../.storybook/components/MockApp';
 import { SettingsLayout } from '../../components/AppLayout';
 import { Subscriptions, SubscriptionsProps } from './index';
-import {
-  PaymentUpdateStripeAPIs,
-  PaymentUpdateAuthServerAPIs,
-} from './PaymentUpdateForm';
+import { PaymentUpdateStripeAPIs } from './PaymentUpdateForm';
 import { QueryParams } from '../../lib/types';
 import { APIError } from '../../lib/apiClient';
 import { FetchState } from '../../store/types';
 import { linkTo } from '@storybook/addon-links';
 import { CUSTOMER, FILTERED_SETUP_INTENT } from '../../lib/mock-data';
+import {
+  MozillaSubscriptionTypes,
+  WebSubscription,
+} from 'fxa-shared/subscriptions/types';
 
 function init() {
   setupVariantStories('routes/Subscriptions', {
@@ -271,6 +271,8 @@ const baseProps: SubscriptionsProps = {
 
 const customerSubscriptions = [
   {
+    _subscription_type: MozillaSubscriptionTypes.WEB,
+    created: Date.now(),
     current_period_end: (Date.now() + 86400) / 1000,
     current_period_start: (Date.now() - 86400) / 1000,
     cancel_at_period_end: false,
@@ -282,7 +284,7 @@ const customerSubscriptions = [
     status: 'active',
     subscription_id: 'sub_5551212',
   },
-];
+] as WebSubscription[];
 
 const subscribedProps: SubscriptionsProps = {
   ...baseProps,
@@ -303,34 +305,15 @@ const subscribedProps: SubscriptionsProps = {
   customerSubscriptions: customerSubscriptions,
 };
 
-const subscribedWithPayPalProps: SubscriptionsProps = {
-  ...baseProps,
-  customer: {
-    loading: false,
-    error: null,
-    result: {
-      billing_name: 'Jane Doe',
-      payment_provider: 'paypal',
-      payment_type: 'card',
-      last4: '8675',
-      exp_month: '12',
-      exp_year: '2028',
-      brand: 'Visa',
-      subscriptions: customerSubscriptions,
-    },
-  },
-  customerSubscriptions: customerSubscriptions,
-};
-
 const cancelledProps: SubscriptionsProps = {
   ...subscribedProps,
   customerSubscriptions: subscribedProps.customerSubscriptions
-    ? [
+    ? ([
         {
           ...subscribedProps.customerSubscriptions[0],
           cancel_at_period_end: true,
         },
-      ]
+      ] as WebSubscription[])
     : null,
 };
 

--- a/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
+++ b/packages/fxa-payments-server/src/routes/Subscriptions/index.test.tsx
@@ -65,6 +65,7 @@ jest.mock('./PaymentUpdateForm', () => ({
 import { SettingsLayout } from '../../components/AppLayout';
 import Subscriptions from './index';
 import { AppContextType } from '../../lib/AppContext';
+import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 
 const { location } = window;
 
@@ -147,7 +148,7 @@ describe('routes/Subscriptions', () => {
       .get('/v1/oauth/subscriptions/active')
       .reply(200, mockActiveSubscriptions),
     nock(authServer)
-      .get('/v1/oauth/subscriptions/customer')
+      .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
       .reply(200, mockCustomer),
   ];
 
@@ -250,7 +251,9 @@ describe('routes/Subscriptions', () => {
         .reply(200, MOCK_PLANS),
       nock(authServer).get('/v1/oauth/subscriptions/active').reply(200, []),
       nock(authServer)
-        .get('/v1/oauth/subscriptions/customer')
+        .get(
+          '/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions'
+        )
         .reply(200, {
           ...MOCK_CUSTOMER,
           subscriptions: [],
@@ -273,7 +276,7 @@ describe('routes/Subscriptions', () => {
       .get('/v1/oauth/subscriptions/active')
       .reply(500, MOCK_ACTIVE_SUBSCRIPTIONS);
     nock(authServer)
-      .get('/v1/oauth/subscriptions/customer')
+      .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
       .reply(403, MOCK_CUSTOMER);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-loading-profile');
@@ -288,7 +291,7 @@ describe('routes/Subscriptions', () => {
       .get('/v1/oauth/subscriptions/active')
       .reply(500, MOCK_ACTIVE_SUBSCRIPTIONS);
     nock(authServer)
-      .get('/v1/oauth/subscriptions/customer')
+      .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
       .reply(403, MOCK_CUSTOMER);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-loading-plans');
@@ -302,7 +305,9 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/active')
       .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS);
-    nock(authServer).get('/v1/oauth/subscriptions/customer').reply(403, {});
+    nock(authServer)
+      .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
+      .reply(403, {});
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-loading-customer');
   });
@@ -315,9 +320,11 @@ describe('routes/Subscriptions', () => {
     nock(authServer)
       .get('/v1/oauth/subscriptions/active')
       .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS);
-    nock(authServer).get('/v1/oauth/subscriptions/customer').reply(404, {
-      errno: AuthServerErrno.UNKNOWN_SUBSCRIPTION_CUSTOMER,
-    });
+    nock(authServer)
+      .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
+      .reply(404, {
+        errno: AuthServerErrno.UNKNOWN_SUBSCRIPTION_CUSTOMER,
+      });
 
     const navigateToUrl = jest.fn();
     render(<Subject navigateToUrl={navigateToUrl} />);
@@ -374,11 +381,12 @@ describe('routes/Subscriptions', () => {
         },
       ]);
     nock(authServer)
-      .get('/v1/oauth/subscriptions/customer')
+      .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
       .reply(200, {
         ...MOCK_CUSTOMER,
         subscriptions: [
           {
+            _subscription_type: MozillaSubscriptionTypes.WEB,
             subscription_id: 'sub0.28964929339372136',
             plan_id: '123doneProMonthly',
             product_id: 'prod_123',
@@ -453,11 +461,12 @@ describe('routes/Subscriptions', () => {
         },
       ]);
     nock(authServer)
-      .get('/v1/oauth/subscriptions/customer')
+      .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
       .reply(200, {
         ...MOCK_CUSTOMER,
         subscriptions: [
           {
+            _subscription_type: MozillaSubscriptionTypes.WEB,
             subscription_id: 'sub0.28964929339372136',
             plan_id: '123doneProMonthly',
             product_id: 'prod_123',
@@ -546,25 +555,26 @@ describe('routes/Subscriptions', () => {
           ...MOCK_PLANS.slice(2),
         ];
 
-    nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE),
-      nock(authServer).get('/v1/oauth/subscriptions/plans').reply(200, plans),
-      nock(authServer)
-        .get('/v1/oauth/subscriptions/active')
-        .reply(200, [
-          {
-            uid: 'a90fef48240b49b2b6a33d333aee9b13',
-            subscriptionId: 'sub0.28964929339372136',
-            productId: '123doneProProduct',
-            createdAt: 1565816388815,
-            cancelledAt: cancelledAtIsUnavailable ? null : 1566252991684,
-          },
-        ]);
+    nock(profileServer).get('/v1/profile').reply(200, MOCK_PROFILE);
+    nock(authServer).get('/v1/oauth/subscriptions/plans').reply(200, plans);
     nock(authServer)
-      .get('/v1/oauth/subscriptions/customer')
+      .get('/v1/oauth/subscriptions/active')
+      .reply(200, [
+        {
+          uid: 'a90fef48240b49b2b6a33d333aee9b13',
+          subscriptionId: 'sub0.28964929339372136',
+          productId: '123doneProProduct',
+          createdAt: 1565816388815,
+          cancelledAt: cancelledAtIsUnavailable ? null : 1566252991684,
+        },
+      ]);
+    nock(authServer)
+      .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
       .reply(200, {
         ...MOCK_CUSTOMER,
         subscriptions: [
           {
+            _subscription_type: MozillaSubscriptionTypes.WEB,
             subscription_id: 'sub0.28964929339372136',
             plan_id: '123doneProMonthly',
             product_id: 'prod_123',
@@ -589,11 +599,12 @@ describe('routes/Subscriptions', () => {
         },
       ]);
     nock(authServer)
-      .get('/v1/oauth/subscriptions/customer')
+      .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
       .reply(200, {
         ...MOCK_CUSTOMER,
         subscriptions: [
           {
+            _subscription_type: MozillaSubscriptionTypes.WEB,
             subscription_id: 'sub0.28964929339372136',
             plan_id: '123doneProMonthly',
             product_id: 'prod_123',
@@ -677,9 +688,7 @@ describe('routes/Subscriptions', () => {
           .post('/v1/oauth/subscriptions/reactivate')
           .reply(500, {});
 
-        const { debug, findByTestId, getByTestId, getByAltText } = render(
-          <Subject />
-        );
+        const { findByTestId, getByTestId } = render(<Subject />);
 
         // Wait for the page to load with one subscription
         await findByTestId('subscription-management-loaded');
@@ -707,7 +716,7 @@ describe('routes/Subscriptions', () => {
       .get('/v1/oauth/subscriptions/active')
       .reply(200, MOCK_ACTIVE_SUBSCRIPTIONS);
     nock(authServer)
-      .get('/v1/oauth/subscriptions/customer')
+      .get('/v1/oauth/mozilla-subscriptions/customer/billing-and-subscriptions')
       .reply(200, MOCK_CUSTOMER);
     const { findByTestId } = render(<Subject />);
     await findByTestId('error-subhub-missing-plan');

--- a/packages/fxa-payments-server/src/store/types.tsx
+++ b/packages/fxa-payments-server/src/store/types.tsx
@@ -1,4 +1,7 @@
-import { PaypalPaymentError } from 'fxa-shared/subscriptions/types';
+import {
+  MozillaSubscription,
+  PaypalPaymentError,
+} from 'fxa-shared/subscriptions/types';
 import { Stripe } from 'stripe';
 import { PaymentProvider } from '../lib/PaymentProvider';
 
@@ -82,7 +85,7 @@ export type Customer = {
   payment_provider?: PaymentProvider;
   payment_type?: string;
   paypal_payment_error?: PaypalPaymentError;
-  subscriptions: Array<CustomerSubscription>;
+  subscriptions: Array<MozillaSubscription>;
 };
 
 export interface CreateSubscriptionResult {

--- a/packages/fxa-shared/index.ts
+++ b/packages/fxa-shared/index.ts
@@ -13,6 +13,7 @@ import {
   productDetailsFromPlan,
 } from './subscriptions/metadata';
 import * as stripe from './subscriptions/stripe';
+import * as subscriptions from './subscriptions/subscriptions';
 
 import amplitude from './metrics/amplitude';
 import flowPerformance from './metrics/flow-performance';
@@ -47,5 +48,6 @@ module.exports = {
       productDetailsFromPlan,
     },
     stripe,
+    subscriptions,
   },
 };

--- a/packages/fxa-shared/subscriptions/subscriptions.ts
+++ b/packages/fxa-shared/subscriptions/subscriptions.ts
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  AppleSubscription,
+  GooglePlaySubscription,
+  IapSubscription,
+  MozillaSubscription,
+  MozillaSubscriptionTypes,
+  WebSubscription,
+} from './types';
+
+export const isWebSubscription = (
+  s: MozillaSubscription
+): s is WebSubscription =>
+  s._subscription_type === MozillaSubscriptionTypes.WEB;
+
+export const isIapSubscription = (
+  s: MozillaSubscription
+): s is IapSubscription =>
+  isGooglePlaySubscription(s) || isAppleSubscription(s);
+
+export const isGooglePlaySubscription = (
+  s: MozillaSubscription
+): s is GooglePlaySubscription =>
+  s._subscription_type === MozillaSubscriptionTypes.IAP_GOOGLE;
+
+export const isAppleSubscription = (
+  s: MozillaSubscription
+): s is AppleSubscription =>
+  s._subscription_type === MozillaSubscriptionTypes.IAP_APPLE;

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -106,7 +106,7 @@ export type WebSubscription = Pick<
   Partial<Pick<Stripe.Charge, 'failure_code' | 'failure_message'>> & {
     _subscription_type: SubscriptionTypes[0];
     end_at: Stripe.Subscription['ended_at'];
-    latest_invoice: Stripe.Invoice['number'];
+    latest_invoice: string;
     plan_id: Stripe.Plan['id'];
     product_name: Stripe.Product['name'];
     product_id: Stripe.Product['id'];
@@ -120,7 +120,12 @@ export type GooglePlaySubscription = {
   _subscription_type: SubscriptionTypes[1];
   product_id: Stripe.Product['id'];
 };
-export type MozillaSubscription = WebSubscription | GooglePlaySubscription;
+export type AppleSubscription = {
+  _subscription_type: SubscriptionTypes[2];
+  product_id: Stripe.Product['id'];
+};
+export type IapSubscription = GooglePlaySubscription | AppleSubscription;
+export type MozillaSubscription = WebSubscription | IapSubscription;
 
 export const PAYPAL_PAYMENT_ERROR_MISSING_AGREEMENT = 'missing_agreement';
 export const PAYPAL_PAYMENT_ERROR_FUNDING_SOURCE = 'funding_source';


### PR DESCRIPTION
Because:
 - we do not want to allow a customer to subscribe to the same product
   through multiple methods (web, Google Play, Apple App Store)

This commit:
 - display an error message instead of a subscription form if the user
   is already subscribed through IAP

## Issue that this pull request solves

Closes: #10517 
