### PR TITLE
feat(settings): Disable metrics collection for opted out users

### DIFF
--- a/packages/fxa-settings/src/components/App/index.test.tsx
+++ b/packages/fxa-settings/src/components/App/index.test.tsx
@@ -54,7 +54,7 @@ it('Initializes metrics flow data when present', async () => {
     render(<App {...updatedAppProps} />);
   });
 
-  expect(flowInit).toHaveBeenCalledWith({
+  expect(flowInit).toHaveBeenCalledWith(true, {
     deviceId: DEVICE_ID,
     flowId: FLOW_ID,
     flowBeginTime: BEGIN_TIME,

--- a/packages/fxa-settings/src/components/App/index.tsx
+++ b/packages/fxa-settings/src/components/App/index.tsx
@@ -7,7 +7,7 @@ import AppLayout from '../AppLayout';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import AppErrorDialog from 'fxa-react/components/AppErrorDialog';
 import * as Metrics from '../../lib/metrics';
-import { useConfig, useInitialState } from '../../models';
+import { useAccount, useConfig, useInitialState } from '../../models';
 import { Router } from '@reach/router';
 import Head from 'fxa-react/components/Head';
 import PageSettings from '../PageSettings';
@@ -33,6 +33,7 @@ type AppProps = {
 
 export const App = ({ flowQueryParams, navigatorLanguages }: AppProps) => {
   const config = useConfig();
+  const { metricsEnabled } = useAccount();
 
   useEffect(() => {
     config.metrics.navTiming.enabled &&
@@ -41,8 +42,8 @@ export const App = ({ flowQueryParams, navigatorLanguages }: AppProps) => {
 
   const { loading, error } = useInitialState();
   useEffect(() => {
-    Metrics.init(flowQueryParams);
-  }, [flowQueryParams]);
+    Metrics.init(metricsEnabled, flowQueryParams);
+  }, [metricsEnabled, flowQueryParams]);
 
   // In case of an invalid token the page will redirect,
   // but to prevent a flash of the error message we show

--- a/packages/fxa-settings/src/components/DataCollection/index.test.tsx
+++ b/packages/fxa-settings/src/components/DataCollection/index.test.tsx
@@ -7,6 +7,7 @@ import { act, render, screen } from '@testing-library/react';
 import { DataCollection } from '.';
 import { mockAppContext, renderWithRouter } from '../../models/mocks';
 import { Account, AppContext } from '../../models';
+import * as Metrics from '../../lib/metrics';
 
 const account = {
   displayName: 'jrgm',
@@ -15,6 +16,12 @@ const account = {
 } as unknown as Account;
 
 describe('DataCollection', () => {
+  let setEnabledSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    setEnabledSpy = jest.spyOn(Metrics, 'setEnabled').mockImplementation();
+  });
+
   it('renders as expected', () => {
     const { container } = render(<DataCollection />);
 
@@ -42,9 +49,11 @@ describe('DataCollection', () => {
     // since metricsOpt is async and uses useState the `act` here is necessary
     await act(() => Promise.resolve(button.click()));
     expect(account.metricsOpt).toBeCalledWith('out');
+    expect(setEnabledSpy).toBeCalledWith(true);
     //@ts-ignore mock doesn't care that the prop is readonly
     account.metricsEnabled = false;
     await act(() => Promise.resolve(button.click()));
     expect(account.metricsOpt).toBeCalledWith('in');
+    expect(setEnabledSpy).toBeCalledWith(false);
   });
 });

--- a/packages/fxa-settings/src/components/DataCollection/index.tsx
+++ b/packages/fxa-settings/src/components/DataCollection/index.tsx
@@ -8,6 +8,7 @@ import Switch from '../Switch';
 import React, { useCallback, useState } from 'react';
 import { useAlertBar } from '../../models';
 import { useAccount } from '../../models';
+import { setEnabled } from '../../lib/metrics';
 
 export const DataCollection = () => {
   const account = useAccount();
@@ -24,6 +25,7 @@ export const DataCollection = () => {
       setIsSubmitting(true);
       await account.metricsOpt(account.metricsEnabled ? 'out' : 'in');
       setIsSubmitting(false);
+      setEnabled(account.metricsEnabled);
       const alertArgs: [string, null, string] = account.metricsEnabled
         ? [
             'dc-opt-in-success',

--- a/packages/fxa-settings/src/lib/metrics.test.ts
+++ b/packages/fxa-settings/src/lib/metrics.test.ts
@@ -84,8 +84,8 @@ function redefineProp<T>(o: any, p: string, value?: T): T {
   return value!;
 }
 
-function initFlow() {
-  init({
+function initFlow(enabled = true) {
+  init(enabled, {
     deviceId,
     flowBeginTime,
     flowId,
@@ -151,6 +151,14 @@ describe('init', () => {
 describe('postMetrics', () => {
   it('does not send metrics when uninitialized', () => {
     logEvents([eventSlug]);
+
+    expect(window.navigator.sendBeacon).not.toHaveBeenCalled();
+  });
+
+  it('does not send *any* metrics when disabled', () => {
+    initFlow(false);
+    logEvents([eventSlug]);
+    logViewEvent(eventGroup, eventType);
 
     expect(window.navigator.sendBeacon).not.toHaveBeenCalled();
   });

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -247,7 +247,13 @@ export class Account implements AccountData {
   }
 
   get metricsEnabled() {
-    return this.data.metricsEnabled;
+    // This might be requested before account data is ready,
+    // so default to disabled until we can get a proper read
+    try {
+      return this.data.metricsEnabled;
+    } catch {
+      return false;
+    }
   }
 
   get passwordCreated() {


### PR DESCRIPTION
## Because

- We don't want to send metrics data when a user has opted out

## This pull request

- Stops metrics events from sending when a user has opted out, by intercepting the delivery at the network request

## Issue that this pull request solves

Closes: #9086

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
