### PR TITLE
feat(auth): remove more direct stripe calls

### DIFF
--- a/packages/fxa-auth-server/lib/payments/paypal.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal.ts
@@ -208,9 +208,10 @@ export class PayPalHelper {
    *
    * @param idempotencyKey
    */
-  public parseIdempotencyKey(
-    idempotencyKey: string
-  ): { invoiceId: string; paymentAttempt: number } {
+  public parseIdempotencyKey(idempotencyKey: string): {
+    invoiceId: string;
+    paymentAttempt: number;
+  } {
     const parsedValue = idempotencyKey.split('-');
     return {
       invoiceId: parsedValue[0],
@@ -278,7 +279,8 @@ export class PayPalHelper {
       pendingReason: response.PENDINGREASON as ChargeResponse['pendingReason'],
       reasonCode: response.REASONCODE as ChargeResponse['reasonCode'],
       transactionId: response.TRANSACTIONID,
-      transactionType: response.TRANSACTIONTYPE as ChargeResponse['transactionType'],
+      transactionType:
+        response.TRANSACTIONTYPE as ChargeResponse['transactionType'],
     };
   }
 
@@ -291,7 +293,8 @@ export class PayPalHelper {
   ): Promise<AgreementDetails> {
     const response = await this.client.baUpdate(options);
     return {
-      status: response.BILLINGAGREEMENTSTATUS.toLowerCase() as AgreementDetails['status'],
+      status:
+        response.BILLINGAGREEMENTSTATUS.toLowerCase() as AgreementDetails['status'],
       city: response.CITY,
       countryCode: response.COUNTRYCODE,
       state: response.STATE,
@@ -371,9 +374,8 @@ export class PayPalHelper {
   async conditionallyRemoveBillingAgreement(
     customer: Stripe.Customer
   ): Promise<boolean> {
-    const billingAgreementId = this.stripeHelper.getCustomerPaypalAgreement(
-      customer
-    );
+    const billingAgreementId =
+      this.stripeHelper.getCustomerPaypalAgreement(customer);
     if (!billingAgreementId) {
       return false;
     }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -68,10 +68,8 @@ export class StripeHandler {
     protected profile: any,
     protected stripeHelper: StripeHelper
   ) {
-    this.subscriptionAccountReminders = require('../../subscription-account-reminders')(
-      log,
-      config
-    );
+    this.subscriptionAccountReminders =
+      require('../../subscription-account-reminders')(log, config);
   }
 
   /**
@@ -80,7 +78,7 @@ export class StripeHandler {
   async customerChanged(request: AuthRequest, uid: string, email: string) {
     const [devices] = await Promise.all([
       await request.app.devices,
-      await this.stripeHelper.refreshCachedCustomer(uid, email),
+      await this.stripeHelper.removeCustomerFromCache(uid, email),
       await this.profile.deleteCache(uid),
     ]);
     await this.push.notifyProfileUpdated(uid, devices);

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe.js
@@ -525,7 +525,7 @@ describe('DirectStripeRoutes', () => {
       );
 
       sinon.assert.calledOnceWithExactly(
-        directStripeRoutesInstance.stripeHelper.refreshCachedCustomer,
+        directStripeRoutesInstance.stripeHelper.removeCustomerFromCache,
         UID,
         TEST_EMAIL
       );


### PR DESCRIPTION
Because:

* We want to avoid Stripe calls if we can cache the data.

This commit:

* Removes additional uses of stripe retrieves for our expandResource
  which does Firestore caching.

Closes #10742

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
