### PR TITLE
fix(auth): insert invoices when not found

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2530,7 +2530,7 @@ export class StripeHelper {
       await this.stripeFirestore.retrieveInvoice(invoice.id!);
       return this.stripeFirestore.insertInvoiceRecord(invoice);
     } catch (err) {
-      if (err.name !== FirestoreStripeError.FIRESTORE_INVOICE_NOT_FOUND) {
+      if (err.name === FirestoreStripeError.FIRESTORE_INVOICE_NOT_FOUND) {
         await this.stripeFirestore.retrieveAndFetchSubscription(
           invoice.subscription as string
         );


### PR DESCRIPTION
Because:

* My prior commit had the wrong toggle and was missing a test that
  would've exposed the error that the invoice was not being inserted
  when it was missing.

This commit:

* Corrects the boolean condition and adds tests to verify that invoices
  are inserted when missing from Firestore.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
