### PR TITLE
fix(subscriptions): include empty subscriptions list for customer

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2404,12 +2404,10 @@ export class StripeHelper {
         );
         const subscriptions =
           await this.stripeFirestore.retrieveCustomerSubscriptions(resource);
-        if (subscriptions.length) {
-          (customer as any).subscriptions = {
-            data: subscriptions as any,
-            has_more: false,
-          };
-        }
+        (customer as any).subscriptions = {
+          data: subscriptions as any,
+          has_more: false,
+        };
         // @ts-ignore
         return customer;
       case SUBSCRIPTIONS_RESOURCE:

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -3859,6 +3859,28 @@ describe('StripeHelper', () => {
       );
     });
 
+    it('includes the empty subscriptions list on the expanded customer', async () => {
+      stripeFirestore.retrieveAndFetchCustomer = sandbox
+        .stub()
+        .resolves(deepCopy(customer));
+      stripeFirestore.retrieveCustomerSubscriptions = sandbox
+        .stub()
+        .resolves([]);
+      const result = await stripeHelper.expandResource(
+        customer.id,
+        CUSTOMER_RESOURCE
+      );
+      assert.deepEqual(result.subscriptions.data, []);
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripeFirestore.retrieveAndFetchCustomer,
+        customer.id
+      );
+      sinon.assert.calledOnceWithExactly(
+        stripeHelper.stripeFirestore.retrieveCustomerSubscriptions,
+        customer.id
+      );
+    });
+
     it('expands the subscription', async () => {
       stripeFirestore.retrieveAndFetchSubscription = sandbox
         .stub()


### PR DESCRIPTION
Because:
 - there's existing code that expect the "expanded" subscriptions list
   on a customer

This commit:
 - include the empty subscriptions list from Firestore on a customer, to
   match the previous behavior of expanding the subscriptions when
   retrieving a customer from Stripe


## Issue that this pull request solves

Closes: #10866 

