### PR TITLE
feat(auth): add more logging to PayPalClientError

### DIFF
--- a/packages/fxa-auth-server/bin/email_notifications.js
+++ b/packages/fxa-auth-server/bin/email_notifications.js
@@ -39,7 +39,8 @@ if (config.subscriptions && config.subscriptions.stripeApiKey) {
     const { PayPalClient } = require('../lib/payments/paypal-client');
     const { PayPalHelper } = require('../lib/payments/paypal');
     const paypalClient = new PayPalClient(
-      config.subscriptions.paypalNvpSigCredentials
+      config.subscriptions.paypalNvpSigCredentials,
+      log
     );
     Container.set(PayPalClient, paypalClient);
     const paypalHelper = new PayPalHelper({ log });

--- a/packages/fxa-auth-server/bin/key_server.js
+++ b/packages/fxa-auth-server/bin/key_server.js
@@ -87,7 +87,8 @@ async function run(config) {
       const { PayPalClient } = require('../lib/payments/paypal-client');
       const { PayPalHelper } = require('../lib/payments/paypal');
       const paypalClient = new PayPalClient(
-        config.subscriptions.paypalNvpSigCredentials
+        config.subscriptions.paypalNvpSigCredentials,
+        log
       );
       Container.set(PayPalClient, paypalClient);
       const paypalHelper = new PayPalHelper({ log });

--- a/packages/fxa-auth-server/scripts/delete-account.js
+++ b/packages/fxa-auth-server/scripts/delete-account.js
@@ -78,7 +78,8 @@ DB.connect(config).then(async (db) => {
     const currencyHelper = new CurrencyHelper(config);
     Container.set(CurrencyHelper, currencyHelper);
     const paypalClient = new PayPalClient(
-      config.subscriptions.paypalNvpSigCredentials
+      config.subscriptions.paypalNvpSigCredentials,
+      log
     );
     Container.set(PayPalClient, paypalClient);
     const { createStripeHelper } = require('../lib/payments/stripe');

--- a/packages/fxa-auth-server/scripts/paypal-processor.ts
+++ b/packages/fxa-auth-server/scripts/paypal-processor.ts
@@ -33,7 +33,8 @@ export async function init() {
   const { log, database, senders } = await setupProcesingTaskObjects();
 
   const paypalClient = new PayPalClient(
-    config.subscriptions.paypalNvpSigCredentials
+    config.subscriptions.paypalNvpSigCredentials,
+    log
   );
   Container.set(PayPalClient, paypalClient);
   const paypalHelper = new PayPalHelper({ log });

--- a/packages/fxa-auth-server/scripts/paypal-refund-fixer.ts
+++ b/packages/fxa-auth-server/scripts/paypal-refund-fixer.ts
@@ -75,9 +75,8 @@ class PayPalFixer {
   }
 
   async issueRefund(invoice: stripe.Invoice) {
-    const transactionId = this.stripeHelper.getInvoicePaypalTransactionId(
-      invoice
-    );
+    const transactionId =
+      this.stripeHelper.getInvoicePaypalTransactionId(invoice);
     if (!transactionId) {
       return;
     }
@@ -155,11 +154,11 @@ export async function init() {
           log.error('statsd.error', err);
         },
       })
-    : (({
+    : ({
         increment: () => {},
         timing: () => {},
         close: () => {},
-      } as unknown) as StatsD);
+      } as unknown as StatsD);
   Container.set(StatsD, statsd);
 
   const log = require('../lib/log')({ ...config.log, statsd });
@@ -168,7 +167,8 @@ export async function init() {
   const stripeHelper = new StripeHelper(log, config, statsd);
   Container.set(StripeHelper, stripeHelper);
   const paypalClient = new PayPalClient(
-    config.subscriptions.paypalNvpSigCredentials
+    config.subscriptions.paypalNvpSigCredentials,
+    log
   );
   Container.set(PayPalClient, paypalClient);
   const paypalHelper = new PayPalHelper({ log });

--- a/packages/fxa-auth-server/test/local/payments/paypal-client.js
+++ b/packages/fxa-auth-server/test/local/payments/paypal-client.js
@@ -7,6 +7,7 @@
 const { assert } = require('chai');
 const nock = require('nock');
 const sinon = require('sinon');
+const { mockLog } = require('../../mocks');
 
 const {
   PayPalClient,
@@ -28,8 +29,8 @@ const successfulDoReferenceTransactionResponse = require('./fixtures/paypal/do_r
 const unSuccessfulDoReferenceTransactionResponse = require('./fixtures/paypal/do_reference_transaction_failure.json');
 const successfulRefundTransactionResponse = require('./fixtures/paypal/refund_transaction_success.json');
 const searchTransactionResponse = require('./fixtures/paypal/transaction_search_success.json');
-const sampleIpnMessage = require('./fixtures/paypal/sample_ipn_message.json')
-  .message;
+const sampleIpnMessage =
+  require('./fixtures/paypal/sample_ipn_message.json').message;
 
 const sandbox = sinon.createSandbox();
 
@@ -38,12 +39,15 @@ describe('PayPalClient', () => {
   let client;
 
   beforeEach(() => {
-    client = new PayPalClient({
-      user: 'user',
-      sandbox: true,
-      pwd: 'pwd',
-      signature: 'sig',
-    });
+    client = new PayPalClient(
+      {
+        user: 'user',
+        sandbox: true,
+        pwd: 'pwd',
+        signature: 'sig',
+      },
+      mockLog()
+    );
   });
 
   afterEach(() => {
@@ -56,12 +60,15 @@ describe('PayPalClient', () => {
     });
 
     it('uses live', () => {
-      client = new PayPalClient({
-        user: 'user',
-        sandbox: false,
-        pwd: 'pwd',
-        signature: 'sig',
-      });
+      client = new PayPalClient(
+        {
+          user: 'user',
+          sandbox: false,
+          pwd: 'pwd',
+          signature: 'sig',
+        },
+        mockLog()
+      );
       assert.equal(client.url, PAYPAL_LIVE_API);
     });
   });


### PR DESCRIPTION
Because:

* We need more insight in the logs from the this.raw and this.data properties of the error

This commit:

* Logs the error object when it is thrown

Closes #8830

## Checklist

_Put an `x` in the boxes that apply_

- [X] My commit is GPG signed.
- [X] If applicable, I have modified or added tests which pass locally.
- [X] I have added necessary documentation (if appropriate).
- [X] I have verified that my changes render correctly in RTL (if appropriate).