### PR TITLE
are tests more stable on node 14?

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
   content-server-executor:
     resource_class: medium+
     docker:
-      - image: cimg/node:16.12-browsers
+      - image: cimg/node:14.18-browsers
       - image: redis
       - image: memcached
       - image: pafortin/goaws
@@ -97,7 +97,7 @@ jobs:
   test-package:
     resource_class: medium+
     docker:
-      - image: cimg/node:16.12
+      - image: cimg/node:14.18
       - image: redis
       - image: memcached
       - image: pafortin/goaws
@@ -125,7 +125,7 @@ jobs:
   test-many:
     resource_class: medium+
     docker:
-      - image: cimg/node:16.12
+      - image: cimg/node:14.18
       - image: circleci/mysql:5.7.27
       - image: jdlk7/firestore-emulator
       - image: memcached
@@ -224,7 +224,7 @@ jobs:
   deploy-packages:
     resource_class: small
     docker:
-      - image: cimg/node:16.12
+      - image: cimg/node:14.18
     environment:
       DOCKER_BUILDKIT: 1
     steps:
@@ -282,7 +282,7 @@ jobs:
   build-and-deploy-storybooks:
     resource_class: small
     docker:
-      - image: cimg/node:16.12
+      - image: cimg/node:14.18
     steps:
       - base-install:
           package: many

--- a/_dev/docker/builder/Dockerfile
+++ b/_dev/docker/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-slim
+FROM node:14-slim
 
 RUN set -x \
     && addgroup --gid 10001 app \

--- a/_dev/docker/mono/Dockerfile
+++ b/_dev/docker/mono/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-slim
+FROM node:14-slim
 
 RUN set -x \
     && addgroup --gid 10001 app \


### PR DESCRIPTION
Test stability has dropped with the change to node 16. Until we can resolve it we're reverting to 14. Local dev will continue on 16 in order to be able to fix the problems.