### PR TITLE
fix(subscriptions): update sub upgrade layout

### DIFF
--- a/packages/fxa-payments-server/src/components/PlanDetails/index.scss
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.scss
@@ -46,7 +46,7 @@
 
   .plan-details-component-inner {
     @include min-width('tablet') {
-      max-width: 343px;
+      max-width: 327px;
       position: fixed;
     }
   }

--- a/packages/fxa-payments-server/src/index.scss
+++ b/packages/fxa-payments-server/src/index.scss
@@ -59,14 +59,14 @@ h3.billing-title {
 
 .main-content {
   display: grid;
-  grid-template-columns: 100vw;
+  grid-template-columns: calc(100vw - 24px);
   grid-template-rows: min-content;
   grid-column-gap: 16px;
   margin-top: $header-height;
   min-height: calc(100vh - #{$header-height});
 
   @include min-width('tablet') {
-    grid-template-columns: minmax(375px, 500px) 343px;
+    grid-template-columns: minmax(359px, 500px) 327px;
     grid-column-gap: 32px;
     margin: $header-height-tablet 12px auto;
     min-height: calc(100vh - #{$header-height-tablet});

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/PlanUpgradeDetails.tsx
@@ -49,7 +49,7 @@ export const PlanUpgradeDetails = ({
         <PlanDetailsCard className="to-plan" plan={selectedPlan} />
 
         <div
-          className="plan-details-total"
+          className="plan-details-total plan-upgrade-details-total"
           aria-labelledby="plan-details-product"
         >
           <div className="plan-details-total-inner">

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.scss
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.scss
@@ -103,4 +103,8 @@
       padding-top: 30px;
     }
   }
+
+  .plan-upgrade-details-total {
+    border-top: 0;
+  }
 }


### PR DESCRIPTION
Because:

* Subscription upgrade page layout for tablets introduces a horizontal
  scroll bar, that cuts off the edges of the upgrade container.

This commit:

* Updates grid widths to accommodate for grid-column-gap
* Updates width of grid column, to accommodate for Always showing scroll
  bars.

Closes #
[Issue 9955](https://github.com/mozilla/fxa/issues/9955)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.