### PR TITLE
feat(auth): store payment methods in firestore

### DIFF
--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_payment_method_detached.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_payment_method_detached.json
@@ -1,0 +1,63 @@
+{
+  "id": "evt_1GQf15BVqmGyQTMamwMk1kdP",
+  "object": "event",
+  "api_version": "2019-12-03",
+  "created": 1585164955,
+  "data": {
+    "object": {
+      "id": "pm_1JS5bIBVqmGyQTMatF3BXGI2",
+      "object": "payment_method",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": null,
+          "line1": null,
+          "line2": null,
+          "postal_code": "42424",
+          "state": null
+        },
+        "email": null,
+        "name": null,
+        "phone": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": "pass",
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "exp_month": 4,
+        "exp_year": 2024,
+        "fingerprint": "IQ06Rmpq6ymItExn",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "0019",
+        "networks": {
+          "available": ["visa"],
+          "preferred": null
+        },
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1629834481,
+      "customer": null,
+      "livemode": false,
+      "metadata": {},
+      "type": "card"
+    },
+    "previous_attributes": {
+      "customer": "cus_K6IBhPPGEZeEHH"
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_k0H9kTbrxkqtfB",
+    "idempotency_key": "a9482497-dde5-4ac6-90c2-1d3f5cada747"
+  },
+  "type": "payment_method.detached"
+}


### PR DESCRIPTION
Because:

* We query payment methods on emails which can hit Stripe APIs
  extensively for data that rarely changes.

This commit:

* Stores the payment method object in Firestore.

Closes #10746

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
