### PR TITLE
fix(chore): Remove links to sms page from qr code page

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/post_verify/cad_qr/ready_to_scan.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/cad_qr/ready_to_scan.mustache
@@ -16,7 +16,6 @@
                 <button id="submit-btn" class="qr-code-button" type="submit">{{#t}}Ready to scan{{/t}}</button>
             </div>
             <div class="links centered">
-                <a id="use-sms-link" data-flow-event="link.use-sms">{{#t}}Use SMS instead{{/t}}</a>
                 <a id="maybe-later-link" data-flow-event="link.maybe-later">{{#t}}I'll do this later, send me a reminder{{/t}}</a>
             </div>
         </form>

--- a/packages/fxa-content-server/app/scripts/templates/post_verify/cad_qr/scan_code.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/post_verify/cad_qr/scan_code.mustache
@@ -16,9 +16,5 @@
         <p class="qr-code-step-message">{{#unsafeTranslate}}<span class="number">2</span>Point the camera at the QR code and tap the link that appears{{/unsafeTranslate}}</p>
         <p class="qr-code-step-message">{{#unsafeTranslate}}<span class="number">3</span>Install Firefox and open it on your device{{/unsafeTranslate}}</p>
         <p class="qr-code-step-message">{{#unsafeTranslate}}<span class="number">4</span>Sign into your account{{/unsafeTranslate}}</p>
-
-        <div class="links centered">
-            <a id="use-sms-link" data-flow-event="link.use-sms">{{#t}}Use SMS instead{{/t}}</a>
-        </div>
     </section>
 </div>

--- a/packages/fxa-content-server/app/scripts/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/scripts/views/connect_another_device.js
@@ -30,15 +30,9 @@ class ConnectAnotherDeviceView extends FormView {
   template = Template;
 
   beforeRender() {
-    const account = this.getAccount();
-
     // To avoid to redirection loops the forceView property might be set
     if (this.model.get('forceView')) {
       return;
-    }
-
-    if (this.isSignIn() && this._areSmsRequirementsMet(account)) {
-      return this.replaceCurrentPageWithQrCadScreen(account);
     }
 
     if (this.isEligibleForPairing()) {

--- a/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
+++ b/packages/fxa-content-server/app/tests/spec/views/connect_another_device.js
@@ -395,31 +395,6 @@ describe('views/connect_another_device', () => {
         assert.lengthOf(view.$('.success'), 1);
       });
     });
-
-    describe('with a Fx desktop user that completed sign-in', () => {
-      beforeEach(() => {
-        sinon.stub(view, 'isSignIn').callsFake(() => true);
-        sinon.stub(view, '_areSmsRequirementsMet').callsFake(() => true);
-        sinon.spy(view, 'replaceCurrentPage');
-
-        windowMock.navigator.userAgent =
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:55.0) Gecko/20100101 Firefox/55.0';
-
-        return view.render().then(() => {
-          view.afterVisible();
-        });
-      });
-
-      it('shows qr code cad', () => {
-        assert.isTrue(view.isSignIn.called);
-        assert.isTrue(
-          view.replaceCurrentPage.calledWith(
-            '/post_verify/cad_qr/get_started',
-            { account }
-          )
-        );
-      });
-    });
   });
 
   describe('_isSignedIn', () => {

--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/ready_to_scan.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/ready_to_scan.js
@@ -76,7 +76,6 @@ describe('views/post_verify/cad_qr/ready_to_scan', () => {
       assert.lengthOf(view.$('.graphic-laptop-mobile-qr'), 1);
       assert.lengthOf(view.$('#submit-btn'), 1);
       assert.lengthOf(view.$('#maybe-later-link'), 1);
-      assert.lengthOf(view.$('#use-sms-link'), 1);
     });
   });
 

--- a/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/scan_code.js
+++ b/packages/fxa-content-server/app/tests/spec/views/post_verify/cad_qr/scan_code.js
@@ -90,7 +90,6 @@ describe('views/post_verify/cad_qr/scan_code', () => {
       );
       assert.lengthOf(view.$('#graphic-cad-qr-code'), 1);
       assert.lengthOf(view.$('.qr-code-step-message'), 4);
-      assert.lengthOf(view.$('#use-sms-link'), 1);
     });
 
     it('polls for new devices', () => {

--- a/packages/fxa-content-server/tests/functional/oauth_sync_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/oauth_sync_sign_in.js
@@ -145,9 +145,7 @@ registerSuite('signin to Sync after OAuth', {
 
         .then(testElementExists(selectors.SIGNIN_TOKEN_CODE.HEADER))
         .then(fillOutSignInTokenCode(email, 0))
-        .then(
-          testElementExists(selectors.POST_VERIFY_CAD_QR_GET_STARTED.HEADER)
-        );
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER));
     },
   },
 });

--- a/packages/fxa-content-server/tests/functional/sync_v3_force_auth.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_force_auth.js
@@ -69,9 +69,7 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
 
         .then(fillOutSignInTokenCode(email, 0))
-        .then(
-          testElementExists(selectors.POST_VERIFY_CAD_QR_GET_STARTED.HEADER)
-        )
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
         .then(testIsBrowserNotified('fxaccounts:login'));
     },
 
@@ -105,9 +103,7 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
 
         .then(fillOutSignInTokenCode(email, 0))
-        .then(
-          testElementExists(selectors.POST_VERIFY_CAD_QR_GET_STARTED.HEADER)
-        )
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
         .then(testIsBrowserNotified('fxaccounts:login'));
     },
 
@@ -141,9 +137,7 @@ registerSuite('Firefox Desktop Sync v3 force_auth', {
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
 
         .then(fillOutSignInTokenCode(email, 0))
-        .then(
-          testElementExists(selectors.POST_VERIFY_CAD_QR_GET_STARTED.HEADER)
-        )
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
         .then(testIsBrowserNotified('fxaccounts:login'));
     },
 

--- a/packages/fxa-content-server/tests/functional/sync_v3_settings.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_settings.js
@@ -59,9 +59,7 @@ registerSuite('Firefox Desktop Sync v3 settings', {
         .then(testIsBrowserNotified('fxaccounts:can_link_account'))
         .then(fillOutSignInTokenCode(email, 0))
         .then(testIsBrowserNotified('fxaccounts:login'))
-        .then(
-          testElementExists(selectors.POST_VERIFY_CAD_QR_GET_STARTED.HEADER)
-        )
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
 
         // wait until account data is in localstorage before redirecting
         .then(
@@ -89,15 +87,16 @@ registerSuite('Firefox Desktop Sync v3 settings', {
         .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
     },
 
-    'sign in, change the password by browsing directly to settings': function () {
-      return this.remote
-        .then(openPage(SETTINGS_NOCONTEXT_URL, selectors.SETTINGS.HEADER))
-        .then(click(selectors.CHANGE_PASSWORD.MENU_BUTTON))
-        .then(visibleByQSA(selectors.CHANGE_PASSWORD.DETAILS))
-        .then(noSuchBrowserNotification('fxaccounts:change_password'))
+    'sign in, change the password by browsing directly to settings':
+      function () {
+        return this.remote
+          .then(openPage(SETTINGS_NOCONTEXT_URL, selectors.SETTINGS.HEADER))
+          .then(click(selectors.CHANGE_PASSWORD.MENU_BUTTON))
+          .then(visibleByQSA(selectors.CHANGE_PASSWORD.DETAILS))
+          .then(noSuchBrowserNotification('fxaccounts:change_password'))
 
-        .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
-    },
+          .then(fillOutChangePassword(FIRST_PASSWORD, SECOND_PASSWORD));
+      },
 
     'sign in, delete the account': function () {
       return this.remote

--- a/packages/fxa-content-server/tests/functional/sync_v3_sign_in.js
+++ b/packages/fxa-content-server/tests/functional/sync_v3_sign_in.js
@@ -91,9 +91,7 @@ registerSuite('Firefox Desktop Sync v3 signin', {
       return this.remote
         .then(setupTest({ preVerified: true }))
         .then(fillOutSignInTokenCode(email, 0))
-        .then(
-          testElementExists(selectors.POST_VERIFY_CAD_QR_GET_STARTED.HEADER)
-        )
+        .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
         .then(testIsBrowserNotified('fxaccounts:login'));
     },
 
@@ -108,9 +106,7 @@ registerSuite('Firefox Desktop Sync v3 signin', {
           // email 0 is the original signin email, open the resent email instead
           .then(fillOutSignInTokenCode(email, 1))
 
-          .then(
-            testElementExists(selectors.POST_VERIFY_CAD_QR_GET_STARTED.HEADER)
-          )
+          .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
           .then(testIsBrowserNotified('fxaccounts:login'))
       );
     },
@@ -126,9 +122,7 @@ registerSuite('Firefox Desktop Sync v3 signin', {
           .then(visibleByQSA(selectors.SIGNIN_TOKEN_CODE.TOOLTIP))
           .then(fillOutSignInTokenCode(email, 0))
 
-          .then(
-            testElementExists(selectors.POST_VERIFY_CAD_QR_GET_STARTED.HEADER)
-          )
+          .then(testElementExists(selectors.CONNECT_ANOTHER_DEVICE.HEADER))
           .then(testIsBrowserNotified('fxaccounts:login'))
       );
     },


### PR DESCRIPTION
## Because

- SMS is currently disabled in production, we shouldnt have any links to the page
- Disable the QR code page from connect another device because it has been a source of confusion for users

## This pull request

- Removes sms links
- Disables qr code cad

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/10891

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
