### PR TITLE
fix(subscriptions): filter canceled subscriptions

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1620,9 +1620,14 @@ export class StripeHelper {
     };
 
     if (customer.subscriptions) {
-      detailsAndSubs.subscriptions = await this.subscriptionsToResponse(
-        customer.subscriptions
+      const activeSubscriptions = customer.subscriptions.data.filter((sub) =>
+        ACTIVE_SUBSCRIPTION_STATUSES.includes(sub.status)
       );
+
+      detailsAndSubs.subscriptions = await this.subscriptionsToResponse({
+        ...customer.subscriptions,
+        data: activeSubscriptions,
+      });
     }
 
     return detailsAndSubs;

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -609,7 +609,6 @@ module.exports.subscriptionsMozillaSubscriptionsValidator = isA
         module.exports.subscriptionsSubscriptionValidator,
         module.exports.subscriptionsGooglePlaySubscriptionValidator
       )
-      .min(1)
       .required(),
   })
   .unknown(true);

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -741,12 +741,12 @@ describe('lib/routes/validators:', () => {
       assert.ok(!res.error);
     });
 
-    it('rejects an empty subscriptions list', () => {
+    it('allows an empty subscriptions list', () => {
       const res =
         validators.subscriptionsMozillaSubscriptionsValidator.validate({
           subscriptions: [],
         });
-      assert.ok(res.error);
+      assert.ok(!res.error);
     });
 
     it('rejects when the subscriptions property is missing', () => {


### PR DESCRIPTION
Because:
 - Stripe's default behavior of not returning canceled subscription no
   longer applies now that we get subscriptions from Firestore

This commit:
 - explicitly filtering for subscriptions with one of the active
   statuses for the endpoint that returns billing info and subscriptions

## Issue that this pull request solves

Closes: #10893 
