### PR TITLE
fix(auth): dont merge records

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
@@ -106,7 +106,7 @@ export class StripeFirestore {
             .doc(uid)
             .collection(this.subscriptionCollection)
             .doc(subscription.id)
-            .set(subscription, { merge: true })
+            .set(subscription)
         );
       }
     }
@@ -118,7 +118,7 @@ export class StripeFirestore {
    * Insert a Stripe customer into Firestore keyed to the fxa id.
    */
   insertCustomerRecord(uid: string, customer: Partial<Stripe.Customer>) {
-    return this.customerCollectionDbRef.doc(uid).set(customer, { merge: true });
+    return this.customerCollectionDbRef.doc(uid).set(customer);
   }
 
   /**
@@ -163,7 +163,7 @@ export class StripeFirestore {
     return customerSnap.docs[0].ref
       .collection(this.subscriptionCollection)
       .doc(subscription.id!)
-      .set(subscription, { merge: true });
+      .set(subscription);
   }
 
   /**
@@ -208,7 +208,7 @@ export class StripeFirestore {
       .doc(invoice.subscription)
       .collection(this.invoiceCollection)
       .doc(invoice.id!)
-      .set(invoice, { merge: true });
+      .set(invoice);
   }
 
   /**


### PR DESCRIPTION
Because:

* Firestore merge is not a depth merge, it will not properly remove
  nested values in a merge.

This commit:

* Uses a non-merge update, and removes partial inserts entirely.

Closes #10905

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
