### PR TITLE
fix(emails): pass language for new sub/stub acct email

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/account.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/account.ts
@@ -2,11 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { metadataFromPlan } from 'fxa-shared/subscriptions/metadata';
 import jwt from '../../oauth/jwt';
 
 export async function sendFinishSetupEmailForStubAccount({
-  email,
   uid,
   account,
   subscription,
@@ -15,7 +13,6 @@ export async function sendFinishSetupEmailForStubAccount({
   metricsContext,
   subscriptionAccountReminders,
 }: {
-  email: string;
   uid: string;
   account: any;
   subscription: any;
@@ -35,12 +32,11 @@ export async function sendFinishSetupEmailForStubAccount({
         },
       }
     );
-    const plan = await stripeHelper.findPlanById(subscription.plan!.id);
-    const meta = metadataFromPlan(plan);
     const invoiceDetails = await stripeHelper.extractInvoiceDetailsForEmail(
       subscription.latest_invoice
     );
     await mailer.sendSubscriptionAccountFinishSetupEmail([], account, {
+      acceptLanguage: account.locale,
       ...invoiceDetails,
       ...metricsContext,
       token,

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -44,10 +44,8 @@ export class PayPalHandler extends StripeWebhookHandler {
   ) {
     super(log, db, config, customs, push, mailer, profile, stripeHelper);
     this.paypalHelper = Container.get(PayPalHelper);
-    this.subscriptionAccountReminders = require('../../subscription-account-reminders')(
-      log,
-      config
-    );
+    this.subscriptionAccountReminders =
+      require('../../subscription-account-reminders')(log, config);
   }
 
   /**
@@ -129,7 +127,6 @@ export class PayPalHandler extends StripeWebhookHandler {
     });
 
     await sendFinishSetupEmailForStubAccount({
-      email,
       uid,
       account,
       subscription,

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -445,7 +445,6 @@ export class StripeHandler {
     });
 
     await sendFinishSetupEmailForStubAccount({
-      email,
       uid,
       account,
       subscription,

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/account.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/account.js
@@ -5,7 +5,6 @@
 'use strict';
 
 const sinon = require('sinon');
-const assert = require('chai').assert;
 const proxyquire = require('proxyquire');
 
 const token = 'a.test.jwt';
@@ -23,7 +22,7 @@ describe('routes/subscriptions/account', () => {
   describe('sendFinishSetupEmailForStubAccount', () => {
     const email = 'testo@moz.gg';
     const uid = 'quux';
-    const account = { email, verifierSetAt: 0 };
+    const account = { email, verifierSetAt: 0, locale: 'gd' };
     const plan = {
       id: 'testo',
       product: 'wedabest',
@@ -64,40 +63,14 @@ describe('routes/subscriptions/account', () => {
       sinon.assert.notCalled(mailer.sendSubscriptionAccountFinishSetupEmail);
     });
 
-    it('does not send an email when fails get the plan', async () => {
-      stripeHelper.findPlanById.rejects();
-      try {
-        await sendFinishSetupEmailForStubAccount({
-          email,
-          uid,
-          account,
-          subscription,
-          stripeHelper,
-          mailer,
-        });
-        assert.fail('should have thrown');
-      } catch (e) {
-        sinon.assert.calledOnceWithExactly(
-          stripeHelper.findPlanById,
-          subscription.plan.id
-        );
-        sinon.assert.notCalled(mailer.sendSubscriptionAccountFinishSetupEmail);
-      }
-    });
-
     it('sends an email to the stub account', async () => {
       await sendFinishSetupEmailForStubAccount({
-        email,
         uid,
         account,
         subscription,
         stripeHelper,
         mailer,
       });
-      sinon.assert.calledOnceWithExactly(
-        stripeHelper.findPlanById,
-        subscription.plan.id
-      );
       sinon.assert.calledOnceWithExactly(
         stripeHelper.extractInvoiceDetailsForEmail,
         invoice
@@ -107,6 +80,7 @@ describe('routes/subscriptions/account', () => {
         [],
         account,
         {
+          acceptLanguage: account.locale,
           ...invoiceDetails,
           token,
         }


### PR DESCRIPTION
Because:
 - we did not pass the account locale for the new account+subscription
   email

This commit:
 - pass in the account locale for the new account+subscription email


## Issue that this pull request solves

Closes: #10906
