### PR TITLE
fix(auth): only return active subs

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { CollectionReference, Firestore } from '@google-cloud/firestore';
+import { ACTIVE_SUBSCRIPTION_STATUSES } from 'fxa-shared/subscriptions/stripe';
 import { Stripe } from 'stripe';
 
 export enum FirestoreStripeError {
@@ -257,9 +258,9 @@ export class StripeFirestore {
     const subscriptionSnap = await customerSnap.docs[0].ref
       .collection(this.subscriptionCollection)
       .get();
-    return subscriptionSnap.docs.map(
-      (doc) => doc.data() as Stripe.Subscription
-    );
+    return subscriptionSnap.docs
+      .map((doc) => doc.data() as Stripe.Subscription)
+      .filter((sub) => ACTIVE_SUBSCRIPTION_STATUSES.includes(sub.status));
   }
 
   /**


### PR DESCRIPTION
Because:

* Stripe would only return non-cancelled subscriptions when they
  were expanded.

This commit:

* Updates Firestore to only return active subscriptions to match
  Stripe behavior.

Issue #10893

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
