### PR TITLE
feat(auth): remove redis customer caching

### DIFF
--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1098,10 +1098,7 @@ export class AccountHandler {
       scope.contains('profile:subscriptions')
     ) {
       const capabilities =
-        await this.capabilityService.subscriptionCapabilities(
-          uid as string,
-          account.primaryEmail.email
-        );
+        await this.capabilityService.subscriptionCapabilities(uid as string);
       if (Object.keys(capabilities).length > 0) {
         res.subscriptionsByClientId = capabilities;
       }
@@ -1477,10 +1474,10 @@ export class AccountHandler {
     if (this.config.subscriptions.enabled) {
       try {
         if (this.stripeHelper) {
-          const customer = await this.stripeHelper.customer({
-            uid: uid as string,
-            email: email as string,
-          });
+          const customer = await this.stripeHelper.fetchCustomer(
+            uid as string,
+            ['subscriptions']
+          );
           if (!customer) {
             throw error.unknownCustomer(uid);
           }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/google.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/google.ts
@@ -51,9 +51,6 @@ export class GoogleIapHandler {
       throw error.unknownAppName(appName);
     }
 
-    // Lookup the email for the user as we need it for capability checks
-    const { email } = (await this.db.account(uid)).primaryEmail;
-
     let purchase;
     try {
       purchase = await this.playBilling.purchaseManager.registerToUserAccount(
@@ -79,7 +76,7 @@ export class GoogleIapHandler {
           );
       }
     }
-    await this.capabilityService.playUpdate(uid, email, purchase);
+    await this.capabilityService.playUpdate(uid, purchase);
     return { tokenValid: true };
   }
 }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal-notifications.ts
@@ -110,10 +110,9 @@ export class PayPalNotificationHandler extends PayPalHandler {
       });
       return;
     }
-    const customer = await this.stripeHelper.customer({
-      uid: account.uid,
-      email: account.email,
-    });
+    const customer = await this.stripeHelper.fetchCustomer(account.uid, [
+      'subscriptions',
+    ]);
     if (!customer) {
       this.log.error('handleMpCancel', {
         message: 'Stripe customer not found',
@@ -137,9 +136,8 @@ export class PayPalNotificationHandler extends PayPalHandler {
       nextPeriodValidSubscription
     ) {
       const { uid, email } = account;
-      const subscriptions = await this.stripeHelper.formatSubscriptionsForEmails(
-        customer
-      );
+      const subscriptions =
+        await this.stripeHelper.formatSubscriptionsForEmails(customer);
       await this.mailer.sendSubscriptionPaymentProviderCancelledEmail(
         account.emails,
         account,

--- a/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/paypal.ts
@@ -53,7 +53,7 @@ export class PayPalHandler extends StripeWebhookHandler {
    */
   async getCheckoutToken(request: AuthRequest) {
     this.log.begin('subscriptions.getCheckoutToken', request);
-    const { uid, email } = await handleAuth(this.db, request.auth, true);
+    const { email } = await handleAuth(this.db, request.auth, true);
     await this.customs.check(request, email, 'getCheckoutToken');
 
     const { currencyCode } = request.payload as Record<string, string>;
@@ -81,10 +81,9 @@ export class PayPalHandler extends StripeWebhookHandler {
     );
     await this.customs.check(request, email, 'createSubscriptionWithPaypal');
 
-    let customer = await this.stripeHelper.customer({
-      uid,
-      email,
-    });
+    let customer = await this.stripeHelper.fetchCustomer(uid, [
+      'subscriptions',
+    ]);
 
     if (!customer) {
       throw error.unknownCustomer(uid);
@@ -271,10 +270,9 @@ export class PayPalHandler extends StripeWebhookHandler {
     const { uid, email } = await handleAuth(this.db, request.auth, true);
     await this.customs.check(request, email, 'updatePaypalBillingAgreement');
 
-    let customer = await this.stripeHelper.customer({
-      uid,
-      email,
-    });
+    let customer = await this.stripeHelper.fetchCustomer(uid, [
+      'subscriptions',
+    ]);
 
     if (!customer) {
       throw error.unknownCustomer(uid);

--- a/packages/fxa-auth-server/lib/routes/subscriptions/play-pubsub.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/play-pubsub.ts
@@ -63,16 +63,6 @@ export class PlayPubsubHandler {
       return {};
     }
     const uid = purchase.userId;
-
-    // Lookup the email for the user as we need it for capability checks
-    let email;
-    try {
-      email = (await this.db.account(uid)).primaryEmail.email;
-    } catch (err) {
-      reportSentryError(err, request);
-      return {};
-    }
-
     const updatedPurchase =
       await this.playBilling.purchaseManager.processDeveloperNotification(
         developerNotification.packageName,
@@ -83,7 +73,7 @@ export class PlayPubsubHandler {
       return {};
     }
 
-    await this.capabilityService.playUpdate(uid, email, updatedPurchase);
+    await this.capabilityService.playUpdate(uid, updatedPurchase);
 
     return {};
   }

--- a/packages/fxa-auth-server/test/local/payments/capability.js
+++ b/packages/fxa-auth-server/test/local/payments/capability.js
@@ -142,11 +142,7 @@ describe('CapabilityService', () => {
       await capabilityService.stripeUpdate({ sub, uid: UID, email: EMAIL });
       assert.notCalled(authDbModule.getUidAndEmailByStripeCustomerId);
       assert.calledWith(mockProfileClient.deleteCache, UID);
-      assert.calledWith(capabilityService.subscribedProductIds, {
-        uid: UID,
-        email: EMAIL,
-        forceRefresh: true,
-      });
+      assert.calledWith(capabilityService.subscribedProductIds, UID);
       assert.calledWith(capabilityService.processProductIdDiff, {
         uid: UID,
         priorProductIds: [],
@@ -160,11 +156,7 @@ describe('CapabilityService', () => {
       await capabilityService.stripeUpdate({ sub, uid: UID, email: EMAIL });
       assert.notCalled(authDbModule.getUidAndEmailByStripeCustomerId);
       assert.calledWith(mockProfileClient.deleteCache, UID);
-      assert.calledWith(capabilityService.subscribedProductIds, {
-        uid: UID,
-        email: EMAIL,
-        forceRefresh: true,
-      });
+      assert.calledWith(capabilityService.subscribedProductIds, UID);
       assert.calledWith(capabilityService.processProductIdDiff, {
         uid: UID,
         priorProductIds: ['prod_FUUNYnlDso7FeB'],
@@ -180,11 +172,7 @@ describe('CapabilityService', () => {
         sub.customer
       );
       assert.calledWith(mockProfileClient.deleteCache, UID);
-      assert.calledWith(capabilityService.subscribedProductIds, {
-        uid: UID,
-        email: EMAIL,
-        forceRefresh: true,
-      });
+      assert.calledWith(capabilityService.subscribedProductIds, UID);
       assert.calledWith(capabilityService.processProductIdDiff, {
         uid: UID,
         priorProductIds: [],
@@ -221,11 +209,7 @@ describe('CapabilityService', () => {
     it('handles a play purchase with new product', async () => {
       await capabilityService.playUpdate(UID, EMAIL, subscriptionPurchase);
       assert.calledWith(mockProfileClient.deleteCache, UID);
-      assert.calledWith(capabilityService.subscribedProductIds, {
-        uid: UID,
-        email: EMAIL,
-        forceRefresh: true,
-      });
+      assert.calledWith(capabilityService.subscribedProductIds, UID);
       assert.calledWith(capabilityService.processProductIdDiff, {
         uid: UID,
         priorProductIds: [],
@@ -237,11 +221,7 @@ describe('CapabilityService', () => {
       capabilityService.subscribedProductIds = sinon.fake.resolves([]);
       await capabilityService.playUpdate(UID, EMAIL, subscriptionPurchase);
       assert.calledWith(mockProfileClient.deleteCache, UID);
-      assert.calledWith(capabilityService.subscribedProductIds, {
-        uid: UID,
-        email: EMAIL,
-        forceRefresh: true,
-      });
+      assert.calledWith(capabilityService.subscribedProductIds, UID);
       assert.calledWith(capabilityService.processProductIdDiff, {
         uid: UID,
         priorProductIds: ['prod_FUUNYnlDso7FeB'],
@@ -309,7 +289,7 @@ describe('CapabilityService', () => {
 
   describe('determineClientVisibleSubscriptionCapabilities', () => {
     beforeEach(() => {
-      mockStripeHelper.customer = sinon.spy(async () => ({
+      mockStripeHelper.fetchCustomer = sinon.spy(async () => ({
         subscriptions: {
           data: [
             {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/google.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/google.js
@@ -91,7 +91,6 @@ describe('GoogleIapHandler', () => {
       const result = await googleIapHandler.registerToken(request);
       assert.calledOnce(playBilling.purchaseManager.registerToUserAccount);
       assert.calledOnce(playBilling.packageName);
-      assert.calledOnce(db.account);
       assert.calledOnce(mockCapabilityService.playUpdate);
       assert.deepEqual(result, { tokenValid: true });
     });
@@ -107,7 +106,6 @@ describe('GoogleIapHandler', () => {
       const result = await googleIapHandler.registerToken(request);
       assert.calledOnce(playBilling.purchaseManager.registerToUserAccount);
       assert.calledOnce(playBilling.packageName);
-      assert.calledOnce(db.account);
       assert.calledOnce(mockCapabilityService.playUpdate);
       assert.deepEqual(result, { tokenValid: true });
     });

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -191,7 +191,7 @@ describe('subscriptions payPalRoutes', () => {
       customer = deepCopy(customerFixture);
       subscription = deepCopy(subscription2);
       subscription.latest_invoice = deepCopy(openInvoice);
-      stripeHelper.customer = sinon.fake.resolves(customer);
+      stripeHelper.fetchCustomer = sinon.fake.resolves(customer);
       stripeHelper.findPlanById = sinon.fake.resolves(plan);
       payPalHelper.createBillingAgreement = sinon.fake.resolves('B-test');
       payPalHelper.agreementDetails = sinon.fake.resolves({
@@ -209,7 +209,7 @@ describe('subscriptions payPalRoutes', () => {
       it('throws a missing PayPal billing agreement error', async () => {
         const c = deepCopy(customer);
         c.subscriptions.data[0].collection_method = 'send_invoice';
-        stripeHelper.customer = sinon.fake.resolves(c);
+        stripeHelper.fetchCustomer = sinon.fake.resolves(c);
         stripeHelper.getCustomerPaypalAgreement = sinon.fake.returns(undefined);
 
         try {
@@ -246,7 +246,7 @@ describe('subscriptions payPalRoutes', () => {
       it('throws a billing agreement already exists error', async () => {
         const c = deepCopy(customer);
         c.subscriptions.data[0].collection_method = 'send_invoice';
-        stripeHelper.customer = sinon.fake.resolves(c);
+        stripeHelper.fetchCustomer = sinon.fake.resolves(c);
         authDbModule.getAccountCustomerByUid =
           sinon.fake.resolves(accountCustomer);
         stripeHelper.getCustomerPaypalAgreement =
@@ -282,7 +282,7 @@ describe('subscriptions payPalRoutes', () => {
           sourceCountry: 'CA',
           subscription: filterSubscription(subscription),
         });
-        sinon.assert.calledOnce(stripeHelper.customer);
+        sinon.assert.calledOnce(stripeHelper.fetchCustomer);
         sinon.assert.calledOnce(payPalHelper.createBillingAgreement);
         sinon.assert.calledOnce(payPalHelper.agreementDetails);
         sinon.assert.calledOnce(stripeHelper.createSubscriptionWithPaypal);
@@ -328,7 +328,7 @@ describe('subscriptions payPalRoutes', () => {
           sourceCountry: 'CA',
           subscription: filterSubscription(subscription),
         });
-        sinon.assert.calledOnce(stripeHelper.customer);
+        sinon.assert.calledOnce(stripeHelper.fetchCustomer);
         sinon.assert.calledOnce(payPalHelper.createBillingAgreement);
         sinon.assert.calledOnce(payPalHelper.agreementDetails);
         sinon.assert.calledOnce(stripeHelper.createSubscriptionWithPaypal);
@@ -448,7 +448,7 @@ describe('subscriptions payPalRoutes', () => {
           },
         };
         c.subscriptions.data[0].collection_method = 'send_invoice';
-        stripeHelper.customer = sinon.fake.resolves(c);
+        stripeHelper.fetchCustomer = sinon.fake.resolves(c);
         stripeHelper.getCustomerPaypalAgreement =
           sinon.fake.returns(paypalAgreementId);
         payPalHelper.processInvoice = sinon.fake.resolves({});
@@ -491,7 +491,7 @@ describe('subscriptions payPalRoutes', () => {
           sourceCountry: 'GD',
           subscription: filterSubscription(subscription),
         });
-        sinon.assert.calledOnce(stripeHelper.customer);
+        sinon.assert.calledOnce(stripeHelper.fetchCustomer);
         sinon.assert.calledOnce(stripeHelper.createSubscriptionWithPaypal);
         sinon.assert.calledOnce(payPalHelper.processInvoice);
       });
@@ -552,7 +552,7 @@ describe('subscriptions payPalRoutes', () => {
       subscription.collection_method = 'send_invoice';
       subscription.latest_invoice = deepCopy(openInvoice);
       customer.subscriptions.data = [subscription];
-      stripeHelper.customer = sinon.fake.resolves(customer);
+      stripeHelper.fetchCustomer = sinon.fake.resolves(customer);
       stripeHelper.findPlanById = sinon.fake.resolves(plan);
       payPalHelper.createBillingAgreement = sinon.fake.resolves('B-test');
       payPalHelper.agreementDetails = sinon.fake.resolves({
@@ -570,7 +570,7 @@ describe('subscriptions payPalRoutes', () => {
         defaultRequestOptions
       );
       assert.deepEqual(actual, filterCustomer(customer));
-      sinon.assert.calledOnce(stripeHelper.customer);
+      sinon.assert.calledOnce(stripeHelper.fetchCustomer);
       sinon.assert.calledOnce(payPalHelper.createBillingAgreement);
       sinon.assert.calledOnce(payPalHelper.agreementDetails);
       sinon.assert.calledOnce(stripeHelper.updateCustomerPaypalAgreement);
@@ -589,7 +589,7 @@ describe('subscriptions payPalRoutes', () => {
         defaultRequestOptions
       );
       assert.deepEqual(actual, filterCustomer(customer));
-      sinon.assert.calledOnce(stripeHelper.customer);
+      sinon.assert.calledOnce(stripeHelper.fetchCustomer);
       sinon.assert.calledOnce(payPalHelper.createBillingAgreement);
       sinon.assert.calledOnce(payPalHelper.agreementDetails);
       sinon.assert.calledOnce(stripeHelper.updateCustomerPaypalAgreement);
@@ -605,7 +605,7 @@ describe('subscriptions payPalRoutes', () => {
         defaultRequestOptions
       );
       assert.deepEqual(actual, filterCustomer(customer));
-      sinon.assert.calledOnce(stripeHelper.customer);
+      sinon.assert.calledOnce(stripeHelper.fetchCustomer);
       sinon.assert.calledOnce(payPalHelper.createBillingAgreement);
       sinon.assert.calledOnce(payPalHelper.agreementDetails);
       sinon.assert.calledOnce(stripeHelper.updateCustomerPaypalAgreement);

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/play-pubsub.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/play-pubsub.js
@@ -86,7 +86,6 @@ describe('PlayPubsubHandler', () => {
       assert.deepEqual(result, {});
       assert.calledOnce(playPubsubHandlerInstance.extractMessage);
       assert.calledOnce(mockPlayBilling.purchaseManager.getPurchase);
-      assert.calledOnce(db.account);
       assert.calledOnce(
         mockPlayBilling.purchaseManager.processDeveloperNotification
       );

--- a/packages/fxa-auth-server/test/remote/subscription_tests.js
+++ b/packages/fxa-auth-server/test/remote/subscription_tests.js
@@ -84,7 +84,7 @@ describe('remote subscriptions:', function () {
           },
         },
       ];
-      mockStripeHelper.customer = async (uid, email) => ({});
+      mockStripeHelper.fetchCustomer = async (uid, email) => ({});
       Container.set(StripeHelper, mockStripeHelper);
       Container.set(AuthLogger, {});
       Container.remove(CapabilityService);
@@ -163,7 +163,7 @@ describe('remote subscriptions:', function () {
 
     describe('with no subscriptions', () => {
       beforeEach(() => {
-        mockStripeHelper.customer = async (uid, email) => ({
+        mockStripeHelper.fetchCustomer = async (uid, email) => ({
           subscriptions: { data: [] },
         });
         mockStripeHelper.subscriptionsToResponse = async (subscriptions) => [];
@@ -197,7 +197,7 @@ describe('remote subscriptions:', function () {
       const subscriptionId = 'sub_12345';
       const date = Date.now();
       beforeEach(() => {
-        mockStripeHelper.customer = async (uid, email) => ({
+        mockStripeHelper.fetchCustomer = async (uid, email) => ({
           subscriptions: {
             data: [
               {


### PR DESCRIPTION
Because:

* We don't want to maintain multiple local caches now that
  we store copies in Firestore.
* It's more efficient to only manage one cache of Stripe data
  instead of maintaining multiple caches.
* Some methods were using customer functions that did not actually
  need the cached data, or all the data we fetched and cached.

This commit:

* Removes Redis caching of the customer object.
* Replaces customer calls with the appropriate underlying fetchCustomer
  call with the proper expansions in place as needed to reduce
  cache lookups.
* Replaces some customer calls with a db lookup to fetch the Stripe
  customer ID instead of a cache call.

Closes #10747

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
