### PR TITLE
feat(auth): 200 for webhook, deleted cust

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -159,6 +159,12 @@ export class StripeWebhookHandler extends StripeHandler {
       }
       // Caught an ignorable error, so let's log but continue to 200 OK response
       this.log.error('subscriptions.handleWebhookEvent.failure', { error });
+
+      // Caught an ignorable firestore stripe error, but log to Sentry
+      if (IGNORABLE_FIRESTORE_STRIPE_ERRORS.includes(error.name))
+        Sentry.withScope((scope) => {
+          Sentry.captureMessage(error.message, Sentry.Severity.Info);
+        });
     }
     return {};
   }


### PR DESCRIPTION
Because:

* If a customer has been deleted, the Stripe webhook will keep retrying.

This commit:

* Returns a 200 to Stripe for deleted customers.

Closes #
[Issue 10684](https://github.com/mozilla/fxa/issues/10684)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
