### PR TITLE
fix(auth): always fetch latest stripe object to store

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-firestore.ts
@@ -133,7 +133,7 @@ export class StripeFirestore {
    */
   async insertCustomerRecordWithBackfill(
     uid: string,
-    customer: Partial<Stripe.Customer>
+    customer: Partial<Stripe.Customer | Stripe.DeletedCustomer>
   ) {
     try {
       await this.retrieveCustomer({ uid });


### PR DESCRIPTION
Because:

* Webhooks may come out of order, or be triggered by requests we perform
  without storing the latest object.

This commit:

* Always stores the latest object from stripe in firestore.

Closes #10904

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
