### PR TITLE
feat(subscription): emit event on error sign in

### DIFF
--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.test.tsx
@@ -172,6 +172,7 @@ describe('NewUserEmailForm test', () => {
       (value: string) => {},
       checkAccountExists,
       'example.com/signin',
+      () => {},
       (id: string) => id
     );
 

--- a/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/NewUserEmailForm/index.tsx
@@ -110,6 +110,7 @@ export const NewUserEmailForm = ({
               setEmailInputState,
               checkAccountExists,
               signInURL,
+              onClickSignInButton,
               getString
             )
           }
@@ -171,6 +172,7 @@ export async function emailInputValidationAndAccountCheck(
   setEmailInputState: (value: string) => void,
   checkAccountExists: (email: string) => Promise<{ exists: boolean }>,
   signInURL: string,
+  onClickSignInButton: () => void,
   getString?: (id: string) => string
 ) {
   let error = null;
@@ -199,11 +201,15 @@ export async function emailInputValidationAndAccountCheck(
   const accountExistsMsg = (
     <Localized
       id="new-user-already-has-account-sign-in"
-      elems={{ a: <a href={signInURL}></a> }}
+      elems={{ a: <a onClick={onClickSignInButton} href={signInURL}></a> }}
     >
       <>
         You already have an account.{' '}
-        <a data-testid="already-have-account-link" href={signInURL}>
+        <a
+          data-testid="already-have-account-link"
+          onClick={onClickSignInButton}
+          href={signInURL}
+        >
           Sign in
         </a>
       </>


### PR DESCRIPTION
Because:

* The "Sign In" button in the "account exists" error message does not
  trigger the event fxa_pay_account_setup - other

This commit:

* Adds the onClick function to the Sign In button, which will trigger
  the event.

Closes #
[10838](https://github.com/mozilla/fxa/issues/10838)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
