### PR TITLE
feat(support-panel): add Play subscriptions to support-panel

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -14,7 +14,6 @@ import { PlayBilling } from './google-play/play-billing';
 import { SubscriptionPurchase } from './google-play/subscription-purchase';
 import { StripeHelper } from './stripe';
 import error from '../error';
-import { AbbrevPlayPurchase } from 'fxa-shared/subscriptions/types';
 
 function hex(blob: Buffer | string): string {
   if (Buffer.isBuffer(blob)) {
@@ -334,40 +333,6 @@ export class CapabilityService {
     return capabilitiesToReveal.size > 0
       ? Array.from(capabilitiesToReveal).sort()
       : undefined;
-  }
-
-  /**
-   * Extract an AbbrevPlayPurchase from a SubscriptionPurchase
-   */
-  private AbbrevPlayPurchaseFromSubscriptionPurchase(
-    purchase: SubscriptionPurchase
-  ): AbbrevPlayPurchase {
-    return {
-      auto_renewing: purchase.autoRenewing,
-      expiry_time_millis: purchase.expiryTimeMillis,
-      package_name: purchase.packageName,
-      sku: purchase.sku,
-      ...(purchase.cancelReason && { cancel_reason: purchase.cancelReason }),
-    };
-  }
-
-  /**
-   * Fetch the list of subscription purchases from Google Play and return
-   * a list of AbbrevPlayPurchases.
-   */
-  public async fetchSubscribedAbbrevPlayPurchasesFromPlay(
-    uid: string
-  ): Promise<AbbrevPlayPurchase[]> {
-    if (!this.playBilling) {
-      return [];
-    }
-    const allPurchases =
-      await this.playBilling.userManager.queryCurrentSubscriptions(uid);
-    const purchases = allPurchases.filter((purchase) =>
-      purchase.isEntitlementActive()
-    );
-
-    return purchases.map(this.AbbrevPlayPurchaseFromSubscriptionPurchase);
   }
 
   /**

--- a/packages/fxa-auth-server/lib/payments/google-play/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/payments/google-play/subscriptions.ts
@@ -4,10 +4,10 @@
 
 import Container from 'typedi';
 import { internalValidationError } from '../../../lib/error';
-import { AppConfig } from '../../types';
 import { PlayBilling } from './play-billing';
 import { AbbrevPlayPurchase } from 'fxa-shared/subscriptions/types';
 import { SubscriptionPurchase } from './subscription-purchase';
+import { ConfigType } from '../../../config';
 
 // TODO move this when we add support for Apple IAP subscriptions
 export interface SubscriptionsService<T> {
@@ -34,8 +34,7 @@ export class PlaySubscriptions
 {
   private playBilling?: PlayBilling;
 
-  constructor() {
-    const config = Container.get(AppConfig);
+  constructor(config: ConfigType) {
     if (!config.subscriptions.enabled) {
       throw internalValidationError(
         'PlaySubscriptions',

--- a/packages/fxa-auth-server/lib/payments/google-play/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/payments/google-play/subscriptions.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Container from 'typedi';
+import { internalValidationError } from '../../../lib/error';
+import { AppConfig } from '../../types';
+import { PlayBilling } from './play-billing';
+import { AbbrevPlayPurchase } from 'fxa-shared/subscriptions/types';
+import { SubscriptionPurchase } from './subscription-purchase';
+
+// TODO move this when we add support for Apple IAP subscriptions
+export interface SubscriptionsService<T> {
+  getSubscriptions: (uid: string) => Promise<T[]>;
+}
+
+/**
+ * Extract an AbbrevPlayPurchase from a SubscriptionPurchase
+ */
+export function abbrevPlayPurchaseFromSubscriptionPurchase(
+  purchase: SubscriptionPurchase
+): AbbrevPlayPurchase {
+  return {
+    auto_renewing: purchase.autoRenewing,
+    expiry_time_millis: purchase.expiryTimeMillis,
+    package_name: purchase.packageName,
+    sku: purchase.sku,
+    ...(purchase.cancelReason && { cancel_reason: purchase.cancelReason }),
+  };
+}
+
+export class PlaySubscriptions
+  implements SubscriptionsService<AbbrevPlayPurchase>
+{
+  private playBilling?: PlayBilling;
+
+  constructor() {
+    const config = Container.get(AppConfig);
+    if (!config.subscriptions.enabled) {
+      throw internalValidationError(
+        'PlaySubscriptions',
+        {},
+        new Error(
+          'Trying to new up PlaySubscriptions while subscriptions are disabled.  Check your dependency graph.'
+        )
+      );
+    }
+
+    if (Container.has(PlayBilling)) {
+      this.playBilling = Container.get(PlayBilling);
+    }
+  }
+
+  async getSubscriptions(uid: string) {
+    if (!this.playBilling) {
+      return [];
+    }
+
+    const allPurchases =
+      await this.playBilling.userManager.queryCurrentSubscriptions(uid);
+    const purchases = allPurchases.filter((purchase) =>
+      purchase.isEntitlementActive()
+    );
+
+    return purchases.map(abbrevPlayPurchaseFromSubscriptionPurchase);
+  }
+}

--- a/packages/fxa-auth-server/lib/payments/paypal-processor.ts
+++ b/packages/fxa-auth-server/lib/payments/paypal-processor.ts
@@ -238,9 +238,8 @@ export class PaypalProcessor {
       if (err instanceof PayPalClientError) {
         if (err.errorCode === PAYPAL_BILLING_AGREEMENT_INVALID) {
           const uid = customer.metadata.userid;
-          const billingAgreementId = this.stripeHelper.getCustomerPaypalAgreement(
-            customer
-          ) as string;
+          const billingAgreementId =
+            this.stripeHelper.getCustomerPaypalAgreement(customer) as string;
           await this.stripeHelper.removeCustomerPaypalAgreement(
             uid,
             customer.id,
@@ -335,9 +334,8 @@ export class PaypalProcessor {
     }
 
     // 5
-    const billingAgreementId = this.stripeHelper.getCustomerPaypalAgreement(
-      customer
-    );
+    const billingAgreementId =
+      this.stripeHelper.getCustomerPaypalAgreement(customer);
     if (!billingAgreementId) {
       await this.sendFailedPaymentEmail(invoice);
       return;

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1054,9 +1054,11 @@ export class StripeHelper {
   /**
    * Append any matching product ids to their corresponding AbbrevPlayPurchase.
    */
-  async appendAbbrevPlayPurchasesWithProductIds(
+  async addProductInfoToAbbrevPlayPurchases(
     purchases: AbbrevPlayPurchase[]
-  ): Promise<(AbbrevPlayPurchase & { product_id: string })[]> {
+  ): Promise<
+    (AbbrevPlayPurchase & { product_id: string; product_name: string })[]
+  > {
     const products = await this.allAbbrevProducts();
     const appendedAbbrevPlayPurchases = [];
     for (const product of products) {
@@ -1068,6 +1070,7 @@ export class StripeHelper {
         appendedAbbrevPlayPurchases.push({
           ...matchingAbbrevPlayPurchase,
           product_id: product.product_id,
+          product_name: product.product_name,
         });
       }
     }

--- a/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
@@ -62,7 +62,7 @@ const createRoutes = (
     );
     routes.push(...supportRoutes(log, db, config, customs, zendeskClient));
     routes.push(
-      ...mozillaSubscriptionRoutes({ log, db, customs, stripeHelper })
+      ...mozillaSubscriptionRoutes({ log, db, config, customs, stripeHelper })
     );
   }
   if (stripeHelper && config.subscriptions.paypalNvpSigCredentials.enabled) {

--- a/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
@@ -16,22 +16,25 @@ import {
 import { AuthLogger, AuthRequest } from '../../types';
 import { handleAuth } from './utils';
 import validators from '../validators';
+import { ConfigType } from '../../../config';
 
 export const mozillaSubscriptionRoutes = ({
   log,
   db,
+  config,
   customs,
   stripeHelper,
   playSubscriptions,
 }: {
   log: AuthLogger;
   db: any;
+  config: ConfigType;
   customs: any;
   stripeHelper: StripeHelper;
   playSubscriptions?: PlaySubscriptions;
 }): ServerRoute[] => {
   if (!playSubscriptions) {
-    playSubscriptions = Container.get(PlaySubscriptions);
+    playSubscriptions = new PlaySubscriptions(config);
   }
   const mozillaSubscriptionHandler = new MozillaSubscriptionHandler(
     log,

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe.ts
@@ -800,30 +800,6 @@ export const stripeRoutes = (
       handler: (request: AuthRequest) => stripeHandler.getProductName(request),
     },
     {
-      method: 'GET',
-      path: '/oauth/subscriptions/search',
-      options: {
-        auth: {
-          payload: false,
-          strategy: 'supportPanelSecret',
-        },
-        response: {
-          schema: isA
-            .array()
-            .items(validators.subscriptionsSubscriptionSupportValidator),
-        },
-        validate: {
-          query: {
-            uid: isA.string().required(),
-            email: validators.email().required(),
-            limit: isA.number().optional(),
-          },
-        },
-      },
-      handler: (request: AuthRequest) =>
-        stripeHandler.getSubscriptionsForSupport(request),
-    },
-    {
       method: 'PUT',
       path: '/oauth/subscriptions/active/{subscriptionId}',
       options: {

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -367,7 +367,7 @@ module.exports.subscriptionsSubscriptionValidator = isA.object({
 });
 
 // This is support-panel's perspective on a subscription
-module.exports.subscriptionsSubscriptionSupportValidator = isA.object({
+module.exports.subscriptionsWebSubscriptionSupportValidator = isA.object({
   created: isA.number().required(),
   current_period_end: isA.number().required(),
   current_period_start: isA.number().required(),
@@ -376,6 +376,23 @@ module.exports.subscriptionsSubscriptionSupportValidator = isA.object({
   product_name: isA.string().required(),
   status: isA.string().required(),
   subscription_id: module.exports.subscriptionsSubscriptionId.required(),
+});
+module.exports.subscriptionsPlaySubscriptionSupportValidator = isA.object({
+  auto_renewing: isA.bool().required(),
+  cancel_reason: isA.number().optional(),
+  expiry_time_millis: isA.number().required(),
+  package_name: isA.string().optional(),
+  sku: isA.string().optional(),
+  product_id: isA.string().optional(),
+  product_name: isA.string().required(),
+});
+module.exports.subscriptionsSubscriptionSupportValidator = isA.object({
+  [MozillaSubscriptionTypes.WEB]: isA
+    .array()
+    .items(module.exports.subscriptionsWebSubscriptionSupportValidator),
+  [MozillaSubscriptionTypes.IAP_GOOGLE]: isA
+    .array()
+    .items(module.exports.subscriptionsPlaySubscriptionSupportValidator),
 });
 
 module.exports.subscriptionsSubscriptionListValidator = isA.object({

--- a/packages/fxa-auth-server/scripts/paypal-refund-fixer.ts
+++ b/packages/fxa-auth-server/scripts/paypal-refund-fixer.ts
@@ -75,9 +75,8 @@ class PayPalFixer {
   }
 
   async issueRefund(invoice: stripe.Invoice) {
-    const transactionId = this.stripeHelper.getInvoicePaypalTransactionId(
-      invoice
-    );
+    const transactionId =
+      this.stripeHelper.getInvoicePaypalTransactionId(invoice);
     if (!transactionId) {
       return;
     }
@@ -155,11 +154,11 @@ export async function init() {
           log.error('statsd.error', err);
         },
       })
-    : (({
+    : ({
         increment: () => {},
         timing: () => {},
         close: () => {},
-      } as unknown) as StatsD);
+      } as unknown as StatsD);
   Container.set(StatsD, statsd);
 
   const log = require('../lib/log')({ ...config.log, statsd });

--- a/packages/fxa-auth-server/test/local/payments/capability.js
+++ b/packages/fxa-auth-server/test/local/payments/capability.js
@@ -230,32 +230,6 @@ describe('CapabilityService', () => {
     });
   });
 
-  describe('fetchSubscribedAbbrevPlayPurchasesFromPlay', () => {
-    mockSubscriptionPurchase = {
-      sku: 'play_1234',
-      isEntitlementActive: sinon.fake.returns(true),
-      autoRenewing: true,
-      expiryTimeMillis: Date.now(),
-      packageName: 'org.mozilla.cooking.with.foxkeh',
-      cancelReason: 1,
-    };
-    it('returns an active play subscription purchase with abbreviated properties', async () => {
-      const expected = {
-        sku: mockSubscriptionPurchase.sku,
-        auto_renewing: mockSubscriptionPurchase.autoRenewing,
-        expiry_time_millis: mockSubscriptionPurchase.expiryTimeMillis,
-        package_name: mockSubscriptionPurchase.packageName,
-        cancel_reason: mockSubscriptionPurchase.cancelReason,
-      };
-      mockPlayBilling.userManager.queryCurrentSubscriptions = sinon
-        .stub()
-        .resolves([mockSubscriptionPurchase]);
-      const result =
-        await capabilityService.fetchSubscribedAbbrevPlayPurchasesFromPlay(UID);
-      assert.deepEqual([expected], result);
-    });
-  });
-
   describe('broadcastCapabilitiesAdded', () => {
     it('should broadcast the capabilities added', async () => {
       const capabilities = ['cap2'];

--- a/packages/fxa-auth-server/test/local/payments/google-play/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/payments/google-play/subscriptions.js
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const sinon = require('sinon');
+const assert = { ...sinon.assert, ...require('chai').assert };
+const { Container } = require('typedi');
+const { AppConfig } = require('../../../../lib/types');
+const { PlayBilling } = require('../../../../lib/payments/google-play');
+const {
+  PlaySubscriptions,
+  abbrevPlayPurchaseFromSubscriptionPurchase,
+} = require('../../../../lib/payments/google-play/subscriptions');
+
+describe('PlaySubscriptions', () => {
+  const mockConfig = { subscriptions: { enabled: true } };
+  const UID = 'uid8675309';
+  const sandbox = sinon.createSandbox();
+
+  let playSubscriptions, mockPlayBilling;
+
+  beforeEach(() => {
+    Container.set(AppConfig, mockConfig);
+    mockPlayBilling = {
+      userManager: {},
+      purchaseManager: {},
+    };
+    Container.set(PlayBilling, mockPlayBilling);
+    playSubscriptions = new PlaySubscriptions();
+  });
+
+  afterEach(() => {
+    Container.reset();
+    sandbox.reset();
+  });
+
+  describe('getSubscriptions', () => {
+    const mockSubscriptionPurchase = {
+      sku: 'play_1234',
+      isEntitlementActive: sinon.fake.returns(true),
+      autoRenewing: true,
+      expiryTimeMillis: Date.now() + 99999,
+      packageName: 'org.mozilla.cooking.with.foxkeh',
+      cancelReason: 1,
+    };
+
+    it('returns an active play subscription purchase with abbreviated properties', async () => {
+      const expected = {
+        sku: mockSubscriptionPurchase.sku,
+        auto_renewing: mockSubscriptionPurchase.autoRenewing,
+        expiry_time_millis: mockSubscriptionPurchase.expiryTimeMillis,
+        package_name: mockSubscriptionPurchase.packageName,
+        cancel_reason: mockSubscriptionPurchase.cancelReason,
+      };
+      mockPlayBilling.userManager.queryCurrentSubscriptions = sinon
+        .stub()
+        .resolves([
+          {
+            ...mockSubscriptionPurchase,
+            isEntitlementActive: () => true,
+          },
+        ]);
+      const result = await playSubscriptions.getSubscriptions(UID);
+      assert.calledOnceWithExactly(
+        mockPlayBilling.userManager.queryCurrentSubscriptions,
+        UID
+      );
+      assert.deepEqual([expected], result);
+    });
+
+    it('returns an empty list when there are no subscriptions', async () => {
+      mockPlayBilling.userManager.queryCurrentSubscriptions = sinon
+        .stub()
+        .resolves([]);
+      const actual = await playSubscriptions.getSubscriptions(UID);
+      assert.calledOnceWithExactly(
+        mockPlayBilling.userManager.queryCurrentSubscriptions,
+        UID
+      );
+      assert.deepEqual(actual, []);
+    });
+
+    it('returns an empty list when there are no active subscriptions', async () => {
+      mockPlayBilling.userManager.queryCurrentSubscriptions = sinon
+        .stub()
+        .resolves([
+          {
+            ...mockSubscriptionPurchase,
+            isEntitlementActive: () => false,
+          },
+        ]);
+      const actual = await playSubscriptions.getSubscriptions(UID);
+      assert.calledOnceWithExactly(
+        mockPlayBilling.userManager.queryCurrentSubscriptions,
+        UID
+      );
+      assert.deepEqual(actual, []);
+    });
+
+    it('returns an empty list when the PlayBilling dependency is not present', async () => {
+      Container.remove(PlayBilling);
+      playSubscriptions = new PlaySubscriptions();
+      const actual = await playSubscriptions.getSubscriptions(UID);
+      assert.deepEqual(actual, []);
+    });
+  });
+});
+
+describe('abbrevPlayPurchaseFromSubscriptionPurchase', () => {
+  const subscriptionPurchase = {
+    kind: 'androidpublisher#subscriptionPurchase',
+    startTimeMillis: `${Date.now() - 10000}`,
+    expiryTimeMillis: `${Date.now() + 10000}`,
+    autoRenewing: true,
+    priceCurrencyCode: 'JPY',
+    priceAmountMicros: '99000000',
+    countryCode: 'JP',
+    developerPayload: '',
+    paymentState: 1,
+    orderId: 'GPA.3313-5503-3858-32549',
+    packageName: 'testPackage',
+    purchaseToken: 'testToken',
+    sku: 'sku',
+    verifiedAt: Date.now(),
+  };
+
+  it('returns an object with the AbbrevPlayPurchase properties', () => {
+    const actual =
+      abbrevPlayPurchaseFromSubscriptionPurchase(subscriptionPurchase);
+    assert.deepEqual(actual, {
+      auto_renewing: subscriptionPurchase.autoRenewing,
+      expiry_time_millis: subscriptionPurchase.expiryTimeMillis,
+      package_name: subscriptionPurchase.packageName,
+      sku: subscriptionPurchase.sku,
+    });
+  });
+
+  it('includes the cancelReason when present', () => {
+    const actual = abbrevPlayPurchaseFromSubscriptionPurchase({
+      ...subscriptionPurchase,
+      cancelReason: 5,
+    });
+    assert.deepEqual(actual, {
+      auto_renewing: subscriptionPurchase.autoRenewing,
+      expiry_time_millis: subscriptionPurchase.expiryTimeMillis,
+      package_name: subscriptionPurchase.packageName,
+      sku: subscriptionPurchase.sku,
+      cancel_reason: 5,
+    });
+  });
+});

--- a/packages/fxa-auth-server/test/local/payments/google-play/subscriptions.js
+++ b/packages/fxa-auth-server/test/local/payments/google-play/subscriptions.js
@@ -5,7 +5,6 @@
 const sinon = require('sinon');
 const assert = { ...sinon.assert, ...require('chai').assert };
 const { Container } = require('typedi');
-const { AppConfig } = require('../../../../lib/types');
 const { PlayBilling } = require('../../../../lib/payments/google-play');
 const {
   PlaySubscriptions,
@@ -20,13 +19,12 @@ describe('PlaySubscriptions', () => {
   let playSubscriptions, mockPlayBilling;
 
   beforeEach(() => {
-    Container.set(AppConfig, mockConfig);
     mockPlayBilling = {
       userManager: {},
       purchaseManager: {},
     };
     Container.set(PlayBilling, mockPlayBilling);
-    playSubscriptions = new PlaySubscriptions();
+    playSubscriptions = new PlaySubscriptions(mockConfig);
   });
 
   afterEach(() => {
@@ -99,7 +97,7 @@ describe('PlaySubscriptions', () => {
 
     it('returns an empty list when the PlayBilling dependency is not present', async () => {
       Container.remove(PlayBilling);
-      playSubscriptions = new PlaySubscriptions();
+      playSubscriptions = new PlaySubscriptions(mockConfig);
       const actual = await playSubscriptions.getSubscriptions(UID);
       assert.deepEqual(actual, []);
     });

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -4285,7 +4285,7 @@ describe('StripeHelper', () => {
       });
     });
 
-    describe('appendAbbrevPlayPurchasesWithProductIds', () => {
+    describe('addProductInfoToAbbrevPlayPurchases', () => {
       let mockAbbrevPlayPurchase;
 
       beforeEach(() => {
@@ -4297,15 +4297,15 @@ describe('StripeHelper', () => {
         };
       });
 
-      it('appends a matching product id to a subscription purchase', async () => {
+      it('adds matching product info to a subscription purchase', async () => {
         const expected = {
           ...mockAbbrevPlayPurchase,
           product_id: productId,
+          product_name: productName,
         };
-        const result =
-          await stripeHelper.appendAbbrevPlayPurchasesWithProductIds([
-            mockAbbrevPlayPurchase,
-          ]);
+        const result = await stripeHelper.addProductInfoToAbbrevPlayPurchases([
+          mockAbbrevPlayPurchase,
+        ]);
         assert.deepEqual([expected], result);
       });
       it('returns an empty list if no matching product ids are found', async () => {
@@ -4313,10 +4313,9 @@ describe('StripeHelper', () => {
           ...mockAbbrevPlayPurchase,
           sku: 'notMatchingSku',
         };
-        const result =
-          await stripeHelper.appendAbbrevPlayPurchasesWithProductIds([
-            mockAbbrevPlayPurchase1,
-          ]);
+        const result = await stripeHelper.addProductInfoToAbbrevPlayPurchases([
+          mockAbbrevPlayPurchase1,
+        ]);
         assert.isEmpty(result);
       });
     });

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -21,7 +21,7 @@ const subscription2 = require('../../payments/fixtures/stripe/subscription2.json
 const openInvoice = require('../../payments/fixtures/stripe/invoice_open.json');
 const { filterSubscription } = require('fxa-shared/subscriptions/stripe');
 const { CurrencyHelper } = require('../../../../lib/payments/currencies');
-const { AuthLogger } = require('../../../../lib/types');
+const { AuthLogger, AppConfig } = require('../../../../lib/types');
 const buildRoutes = require('../../../../lib/routes/subscriptions');
 
 const ACCOUNT_LOCALE = 'en-US';
@@ -114,6 +114,7 @@ describe('subscriptions payPalRoutes', () => {
     log = mocks.mockLog();
     customs = mocks.mockCustoms();
     token = uuid.v4();
+    Container.set(AppConfig, config);
     Container.set(AuthLogger, log);
     Container.set(PlayBilling, {});
     stripeHelper = sinon.createStubInstance(StripeHelper);

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -755,4 +755,96 @@ describe('lib/routes/validators:', () => {
       assert.ok(res.error);
     });
   });
+
+  describe('support-panel subscriptions', () => {
+    const webSub = {
+      created: 1636489882,
+      current_period_end: 1639081882,
+      current_period_start: 1636489882,
+      plan_changed: null,
+      previous_product: null,
+      product_name: 'Cooking with Foxkeh',
+      status: 'active',
+      subscription_id: 'sub_1Ju0yUBVqmGyQTMaG1mtTbdZ',
+    };
+    const playSub = {
+      auto_renewing: false,
+      expiry_time_millis: 1591650790000,
+      package_name: 'club.foxkeh',
+      sku: 'LOL.daily',
+      product_id: 'prod_testo',
+      product_name: 'LOL Daily',
+    };
+
+    describe('subscriptionsWebSubscriptionSupportValidator', () => {
+      const required = [
+        'created',
+        'current_period_end',
+        'current_period_start',
+        'product_name',
+        'status',
+        'subscription_id',
+      ];
+
+      it('accepts a valid web subscription for the support-panel', () => {
+        const res =
+          validators.subscriptionsWebSubscriptionSupportValidator.validate(
+            webSub
+          );
+        assert.ok(!res.error);
+      });
+
+      for (const x of required) {
+        it(`rejects when the required property ${x} is not present`, () => {
+          const s = { ...webSub, [x]: undefined };
+          const res =
+            validators.subscriptionsWebSubscriptionSupportValidator.validate(s);
+          assert.ok(res.error);
+        });
+      }
+    });
+
+    describe('subscriptionsPlaySubscriptionSupportValidator', () => {
+      const required = ['auto_renewing', 'expiry_time_millis', 'product_name'];
+
+      it('accepts a valid Play subscription for the support-panel', () => {
+        const res =
+          validators.subscriptionsPlaySubscriptionSupportValidator.validate(
+            playSub
+          );
+        assert.ok(!res.error);
+      });
+
+      for (const x of required) {
+        it(`rejects when the required property ${x} is not present`, () => {
+          const s = { ...playSub, [x]: undefined };
+          const res =
+            validators.subscriptionsWebSubscriptionSupportValidator.validate(s);
+          assert.ok(res.error);
+        });
+      }
+    });
+
+    describe('subscriptionsSubscriptionSupportValidator', () => {
+      it('accepts a valid response object', () => {
+        const subs = {
+          [MozillaSubscriptionTypes.WEB]: [webSub],
+          [MozillaSubscriptionTypes.IAP_GOOGLE]: [playSub],
+        };
+        const res =
+          validators.subscriptionsSubscriptionSupportValidator.validate(subs);
+        assert.ok(!res.error);
+      });
+
+      it('accepts empty arrays', () => {
+        const subs = {
+          [MozillaSubscriptionTypes.WEB]: [],
+          [MozillaSubscriptionTypes.IAP_GOOGLE]: [],
+        };
+        const res =
+          validators.subscriptionsSubscriptionSupportValidator.validate(subs);
+        assert.ok(!res.error);
+      });
+    });
+  });
 });

--- a/packages/fxa-auth-server/test/test_server.js
+++ b/packages/fxa-auth-server/test/test_server.js
@@ -13,12 +13,13 @@ const proxyquire = require('proxyquire').noPreserveCache();
 const createMailHelper = require('./mail_helper');
 const createProfileHelper = require('./profile_helper');
 const { CapabilityService } = require('../lib/payments/capability');
-const { AuthFirestore } = require('../lib/types');
+const { AuthFirestore, AppConfig } = require('../lib/types');
 
 let currentServer;
 
 /* eslint-disable no-console */
 function TestServer(config, printLogs, options = {}) {
+  Container.set(AppConfig, config);
   if (!Container.has(CapabilityService)) {
     Container.set(CapabilityService, {
       subscriptionCapabilities: sinon.fake.resolves([]),

--- a/packages/fxa-support-panel/src/app/app.controller.spec.ts
+++ b/packages/fxa-support-panel/src/app/app.controller.spec.ts
@@ -5,6 +5,7 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Account, Device, TotpToken } from 'fxa-shared/db/models/auth';
 import { MozLoggerService } from 'fxa-shared/nestjs/logger/logger.service';
+import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 
 import { RemoteLookupService } from '../remote-lookup/remote-lookup.service';
 import {
@@ -84,7 +85,9 @@ describe('AppController', () => {
         locale: MOCKDATA.account.locale,
         signinLocations: formattedSigninLocations,
         subscriptionStatus: true,
-        subscriptions: formattedSubscriptions,
+        webSubscriptions: formattedSubscriptions[MozillaSubscriptionTypes.WEB],
+        playSubscriptions:
+          formattedSubscriptions[MozillaSubscriptionTypes.IAP_GOOGLE],
         twoFactorAuth: true,
         uid: 'testuid',
       });

--- a/packages/fxa-support-panel/src/app/app.controller.ts
+++ b/packages/fxa-support-panel/src/app/app.controller.ts
@@ -17,6 +17,8 @@ import { CurrentUser } from '../auth/auth-header.decorator';
 import { AuthHeaderGuard } from '../auth/auth-header.guard';
 import { RemoteLookupService } from '../remote-lookup/remote-lookup.service';
 import { AccountQuery } from './account-query.dto';
+import { SubscriptionResponse } from '../remote-lookup/remote-responses.dto';
+import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 
 @Controller()
 @UseGuards(AuthHeaderGuard)
@@ -55,8 +57,11 @@ export class AppController {
       emailVerified: account!.emailVerified,
       locale: account!.locale,
       signinLocations,
-      subscriptionStatus: subscriptions.length > 0,
-      subscriptions,
+      subscriptionStatus: Object.keys(subscriptions).some(
+        (k) => subscriptions[k as keyof SubscriptionResponse].length > 0
+      ),
+      webSubscriptions: subscriptions[MozillaSubscriptionTypes.WEB],
+      playSubscriptions: subscriptions[MozillaSubscriptionTypes.IAP_GOOGLE],
       twoFactorAuth: !!totp,
       uid,
     };

--- a/packages/fxa-support-panel/src/config.ts
+++ b/packages/fxa-support-panel/src/config.ts
@@ -30,7 +30,7 @@ const conf = convict({
       format: String,
     },
     subscriptionsSearchPath: {
-      default: '/v1/oauth/subscriptions/search',
+      default: '/v1/oauth/mozilla-subscriptions/support-panel/subscriptions',
       doc: 'Auth server path for subscriptions search endpoint',
       env: 'AUTH_SERVER_SUBS_SEARCH_PATH',
       format: String,

--- a/packages/fxa-support-panel/src/remote-lookup/remote-lookup.service.ts
+++ b/packages/fxa-support-panel/src/remote-lookup/remote-lookup.service.ts
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
 import superagent from 'superagent';
 
 import { AppConfig } from '../config';
@@ -46,22 +47,37 @@ export class RemoteLookupService {
           this.authServer.subscriptionsSearchPath
         }?uid=${uid}&email=${encodeURIComponent(email)}`
       );
-      return subscriptions.map((s: any) => ({
-        ...s,
-        created: String(new Date(s.created * MS_IN_SEC)),
-        current_period_end: String(new Date(s.current_period_end * MS_IN_SEC)),
-        current_period_start: String(
-          new Date(s.current_period_start * MS_IN_SEC)
-        ),
-        plan_changed: s.plan_changed
-          ? String(new Date(s.plan_changed * MS_IN_SEC))
-          : 'N/A',
-        previous_product: s.previous_product || 'N/A',
-      }));
+      return {
+        [MozillaSubscriptionTypes.WEB]: subscriptions[
+          MozillaSubscriptionTypes.WEB
+        ].map((s: any) => ({
+          ...s,
+          created: String(new Date(s.created * MS_IN_SEC)),
+          current_period_end: String(
+            new Date(s.current_period_end * MS_IN_SEC)
+          ),
+          current_period_start: String(
+            new Date(s.current_period_start * MS_IN_SEC)
+          ),
+          plan_changed: s.plan_changed
+            ? String(new Date(s.plan_changed * MS_IN_SEC))
+            : 'N/A',
+          previous_product: s.previous_product || 'N/A',
+        })),
+        [MozillaSubscriptionTypes.IAP_GOOGLE]: subscriptions[
+          MozillaSubscriptionTypes.IAP_GOOGLE
+        ].map((s: any) => ({
+          ...s,
+          expiry: String(new Date(parseInt(s.expiry_time_millis))),
+        })),
+      };
     } catch (err) {
       // A lack of subscriptions results in a errno 998 for invalid user
       if (err.status === 500 && err.response?.body.errno === 998) {
-        return [];
+        return {
+          [MozillaSubscriptionTypes.WEB]: [],
+          [MozillaSubscriptionTypes.IAP_GOOGLE]: [],
+        };
       } else {
         throw err;
       }

--- a/packages/fxa-support-panel/src/remote-lookup/remote-responses.dto.ts
+++ b/packages/fxa-support-panel/src/remote-lookup/remote-responses.dto.ts
@@ -2,11 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import {
+  AbbrevPlayPurchase,
+  MozillaSubscriptionTypes,
+} from 'fxa-shared/subscriptions/types';
+
 // Note that these `*.Response` interfaces are purely for access to known
 // response keys and not an attempt to validate the return payloads from
 // fxa-auth-db-mysql.
 
-interface Subscription {
+interface WebSubscription {
   created: string;
   current_period_end: string;
   current_period_start: string;
@@ -17,7 +22,15 @@ interface Subscription {
   subscription_id: string;
 }
 
-export interface SubscriptionResponse extends Array<Subscription> {}
+type PlaySubscription = Omit<AbbrevPlayPurchase, 'expiry_time_millis'> & {
+  product_id: string;
+  expiry: string;
+};
+
+export type SubscriptionResponse = {
+  [MozillaSubscriptionTypes.WEB]: WebSubscription[];
+  [MozillaSubscriptionTypes.IAP_GOOGLE]: PlaySubscription[];
+};
 
 interface SigninLocation {
   city: string;

--- a/packages/fxa-support-panel/views/index.hbs
+++ b/packages/fxa-support-panel/views/index.hbs
@@ -54,8 +54,10 @@
     </table>
 
     {{#subscriptionStatus}}
-    <h3>Subscriptions</h3>
-    {{#subscriptions}}
+    <h3>Current Subscriptions</h3>
+
+    {{#webSubscriptions}}
+    <h4>Web Subscriptions</h4>
     <table>
 
       <tr>
@@ -65,10 +67,6 @@
       <tr>
         <th>Created:</th>
         <td>{{ created }}</td>
-      </tr>
-      <tr>
-        <th>Status:</th>
-        <td>{{ status }}</td>
       </tr>
       <tr>
         <th>Last Payment:</th>
@@ -88,7 +86,27 @@
       </tr>
     </table>
     <br/>
-    {{/subscriptions}}
+    {{/webSubscriptions}}
+
+    {{#playSubscriptions}}
+    <h4>Google Play Subscriptions</h4>
+    <table>
+
+      <tr>
+        <th>Subscription:</th>
+        <td>{{ product_name }}</td>
+      </tr>
+      <tr>
+        <th>Auto Renewing:</th>
+        <td>{{ auto_renewing }}</td>
+      </tr>
+      <tr>
+        <th>Next Payment:</th>
+        <td>{{ expiry }}</td>
+      </tr>
+    </table>
+    <br/>
+    {{/playSubscriptions}}
     {{/subscriptionStatus}}
 
   </body>


### PR DESCRIPTION
Because:
 - support agent might want to know whether a customer has IAP
   subscriptions

This commit:
 - replaced the endpoint that the Support Panel used to get a list of
   subscriptions with one that also includes Google Play subscriptions
 - update the Support Panel to use the new endpoint and display the
   Google Play subscriptions

Fixes: #10542 