### PR TITLE
fix(subscriptions): layout issue for 6m sub prices

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -209,8 +209,8 @@ plan-price-week = { $intervalCount ->
   *[other] { $amount } every { $intervalCount } weeks
 }
   .title = { $intervalCount ->
-    [one] { $amount } daily
-    *[other] { $amount } every { $intervalCount } days
+    [one] { $amount } weekly
+    *[other] { $amount } every { $intervalCount } weeks
   }
 #  $intervalCount (Number) - The interval between payments, in months.
 plan-price-month = { $intervalCount ->
@@ -227,8 +227,8 @@ plan-price-year = { $intervalCount ->
   *[other] { $amount } every { $intervalCount } years
 }
   .title = { $intervalCount ->
-    [one] { $amount } daily
-    *[other] { $amount } every { $intervalCount } days
+    [one] { $amount } yearly
+    *[other] { $amount } every { $intervalCount } years
   }
 
 

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -199,21 +199,37 @@ plan-price-day = { $intervalCount ->
   [one] { $amount } daily
   *[other] { $amount } every { $intervalCount } days
 }
+  .title = { $intervalCount ->
+    [one] { $amount } daily
+    *[other] { $amount } every { $intervalCount } days
+  }
 #  $intervalCount (Number) - The interval between payments, in weeks.
 plan-price-week = { $intervalCount ->
   [one] { $amount } weekly
   *[other] { $amount } every { $intervalCount } weeks
 }
+  .title = { $intervalCount ->
+    [one] { $amount } daily
+    *[other] { $amount } every { $intervalCount } days
+  }
 #  $intervalCount (Number) - The interval between payments, in months.
 plan-price-month = { $intervalCount ->
   [one] { $amount } monthly
   *[other] { $amount } every { $intervalCount } months
 }
+  .title = { $intervalCount ->
+    [one] { $amount } monthly
+    *[other] { $amount } every { $intervalCount } months
+  }
 #  $intervalCount (Number) - The interval between payments, in years.
 plan-price-year = { $intervalCount ->
   [one] { $amount } yearly
   *[other] { $amount } every { $intervalCount } years
 }
+  .title = { $intervalCount ->
+    [one] { $amount } daily
+    *[other] { $amount } every { $intervalCount } days
+  }
 
 
 ## subscription billing details

--- a/packages/fxa-payments-server/src/components/AppLayout/index.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.tsx
@@ -17,7 +17,6 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
         data-testid="stage"
         className="fade-in-forward"
         style={{ opacity: 1 }}
-        lang={navigator.language}
       >
         {children}
       </div>

--- a/packages/fxa-payments-server/src/components/AppLayout/index.tsx
+++ b/packages/fxa-payments-server/src/components/AppLayout/index.tsx
@@ -17,6 +17,7 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
         data-testid="stage"
         className="fade-in-forward"
         style={{ opacity: 1 }}
+        lang={navigator.language}
       >
         {children}
       </div>

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.scss
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.scss
@@ -200,6 +200,7 @@
     .plan-details-total-inner {
       display: flex;
       justify-content: space-between;
+      gap: 8px;
     }
 
     p {
@@ -210,13 +211,25 @@
     .label {
       color: #6d6d6e;
       font-weight: 600;
-      margin-top: 5px;
+      margin-top: auto;
     }
 
     .total-price {
       color: rgba(12, 12, 13, 0.8);
-      font-size: 22px;
+      font-size: 18px;
       font-weight: 600;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      margin-top: auto;
+    }
+
+    .label:lang(en) {
+      margin-top: 5px;
+    }
+
+    .total-price:lang(en) {
+      font-size: 22px;
     }
   }
 }

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.scss
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.scss
@@ -223,13 +223,5 @@
       white-space: nowrap;
       margin-top: auto;
     }
-
-    .label:lang(en) {
-      margin-top: 5px;
-    }
-
-    .total-price:lang(en) {
-      font-size: 22px;
-    }
   }
 }

--- a/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
+++ b/packages/fxa-payments-server/src/components/PlanDetails/index.tsx
@@ -115,12 +115,15 @@ export const PlanDetails = ({
                   </Localized>
                   <Localized
                     id={`plan-price-${interval}`}
+                    attrs={{ title: true }}
                     vars={{
                       amount: getLocalizedCurrency(amount, currency),
                       intervalCount: interval_count,
                     }}
                   >
-                    <p className="total-price">{planPrice}</p>
+                    <p className="total-price" title={planPrice}>
+                      {planPrice}
+                    </p>
                   </Localized>
                 </div>
               </div>


### PR DESCRIPTION
Because:

* Total price wraps around for certain languages and prices.

This commit:

* Adds lang to the AppLayout div.
* Ensures the price stays on a single line.
* Adds a title to the price.

Closes #
[10920](https://github.com/mozilla/fxa/issues/10920)

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Example in a non-English language, showing smaller total price text (Also showing default title text, if no translation is available)
<img width="941" alt="image" src="https://user-images.githubusercontent.com/10620585/141010575-df62edb9-1442-42da-a360-144d918bcf1c.png">

Example in a non-English language, showing smaller total price text (Also showing default title text, if no translation is available)
<img width="941" alt="image" src="https://user-images.githubusercontent.com/10620585/141010654-fb8d303e-56ec-4b87-9022-eba9e37fa9a4.png">

Example in English, showing normal total price text, without change.
<img width="941" alt="image" src="https://user-images.githubusercontent.com/10620585/141010372-543759ef-2d8d-4b89-9cb9-4d80f0898321.png">

## Other information (Optional)

This change requires a translation update to include attribute `title`.
