### PR TITLE
feat(auth): return IAP and web subscriptions in /account route

### DIFF
--- a/packages/fxa-auth-server/lib/payments/google-play/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/payments/google-play/subscriptions.ts
@@ -56,8 +56,9 @@ export class PlaySubscriptions
       this.playBilling = Container.get(PlayBilling);
     }
 
-    // Since config.subscriptions.enabled is true here, StripeHelper will already exist.
-    this.stripeHelper = Container.get(StripeHelper);
+    if (Container.has(StripeHelper)) {
+      this.stripeHelper = Container.get(StripeHelper);
+    }
   }
 
   async getAbbrevPlayPurchases(uid: string) {

--- a/packages/fxa-auth-server/lib/payments/google-play/subscriptions.ts
+++ b/packages/fxa-auth-server/lib/payments/google-play/subscriptions.ts
@@ -56,9 +56,8 @@ export class PlaySubscriptions
       this.playBilling = Container.get(PlayBilling);
     }
 
-    if (Container.has(StripeHelper)) {
-      this.stripeHelper = Container.get(StripeHelper);
-    }
+    // Since config.subscriptions.enabled is true here, StripeHelper will already exist.
+    this.stripeHelper = Container.get(StripeHelper);
   }
 
   async getAbbrevPlayPurchases(uid: string) {

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -1052,7 +1052,7 @@ export class StripeHelper {
   }
 
   /**
-   * Append any matching product ids to their corresponding AbbrevPlayPurchase.
+   * Append any matching product ids and names to their corresponding AbbrevPlayPurchase.
    */
   async addProductInfoToAbbrevPlayPurchases(
     purchases: AbbrevPlayPurchase[]

--- a/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
@@ -7,6 +7,7 @@ import {
   MozillaSubscription,
   MozillaSubscriptionTypes,
 } from 'fxa-shared/subscriptions/types';
+import { Container } from 'typedi';
 
 import { ConfigType } from '../../../config';
 import { PlaySubscriptions } from '../../../lib/payments/google-play/subscriptions';
@@ -32,7 +33,7 @@ export const mozillaSubscriptionRoutes = ({
   playSubscriptions?: PlaySubscriptions;
 }): ServerRoute[] => {
   if (!playSubscriptions) {
-    playSubscriptions = new PlaySubscriptions();
+    playSubscriptions = Container.get(PlaySubscriptions);
   }
   const mozillaSubscriptionHandler = new MozillaSubscriptionHandler(
     log,

--- a/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
@@ -1,22 +1,20 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 import { ServerRoute } from '@hapi/hapi';
 import isA from '@hapi/joi';
-import { Container } from 'typedi';
-import error from '../../error';
-import { PaymentBillingDetails, StripeHelper } from '../../payments/stripe';
-import { PlaySubscriptions } from '../../../lib/payments/google-play/subscriptions';
 import {
-  GooglePlaySubscription,
   MozillaSubscription,
   MozillaSubscriptionTypes,
 } from 'fxa-shared/subscriptions/types';
-import { AuthLogger, AuthRequest } from '../../types';
-import { handleAuth } from './utils';
-import validators from '../validators';
+
 import { ConfigType } from '../../../config';
+import { PlaySubscriptions } from '../../../lib/payments/google-play/subscriptions';
+import error from '../../error';
+import { PaymentBillingDetails, StripeHelper } from '../../payments/stripe';
+import { AuthLogger, AuthRequest } from '../../types';
+import validators from '../validators';
+import { handleAuth } from './utils';
 
 export const mozillaSubscriptionRoutes = ({
   log,
@@ -34,7 +32,7 @@ export const mozillaSubscriptionRoutes = ({
   playSubscriptions?: PlaySubscriptions;
 }): ServerRoute[] => {
   if (!playSubscriptions) {
-    playSubscriptions = new PlaySubscriptions(config);
+    playSubscriptions = new PlaySubscriptions();
   }
   const mozillaSubscriptionHandler = new MozillaSubscriptionHandler(
     log,
@@ -107,12 +105,12 @@ export class MozillaSubscriptionHandler {
 
     const stripeBillingDetailsAndSubscriptions =
       await this.stripeHelper.getBillingDetailsAndSubscriptions(uid);
-    const iapAbbrevPlayPurchasesWithProductIds =
-      await this.getPlaySubscriptions(uid);
+    const iapGooglePlaySubscriptions =
+      await this.playSubscriptions.getSubscriptions(uid);
 
     if (
       !stripeBillingDetailsAndSubscriptions &&
-      iapAbbrevPlayPurchasesWithProductIds.length === 0
+      iapGooglePlaySubscriptions.length === 0
     ) {
       throw error.unknownCustomer(uid);
     }
@@ -124,12 +122,6 @@ export class MozillaSubscriptionHandler {
       subscriptions: [],
     };
 
-    const iapGooglePlaySubscriptions: GooglePlaySubscription[] =
-      iapAbbrevPlayPurchasesWithProductIds.map((purchase) => ({
-        ...purchase,
-        _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
-      }));
-
     return {
       ...response,
       subscriptions: [...response.subscriptions, ...iapGooglePlaySubscriptions],
@@ -139,7 +131,9 @@ export class MozillaSubscriptionHandler {
   async getSubscriptionsForSupportPanel(request: AuthRequest) {
     this.log.begin('mozillaSubscriptions.supportPanelSubscriptions', request);
     const { uid } = request.query as Record<string, string>;
-    const iapPlaySubscriptions = await this.getPlaySubscriptions(uid);
+    const iapPlaySubscriptions = await this.playSubscriptions.getSubscriptions(
+      uid
+    );
     const customer = await this.stripeHelper.fetchCustomer(uid);
     const webSubscriptions = customer?.subscriptions;
     const formattedWebSubscriptions = webSubscriptions
@@ -150,13 +144,5 @@ export class MozillaSubscriptionHandler {
       [MozillaSubscriptionTypes.WEB]: formattedWebSubscriptions,
       [MozillaSubscriptionTypes.IAP_GOOGLE]: iapPlaySubscriptions,
     };
-  }
-
-  async getPlaySubscriptions(uid: string) {
-    const iapSubscribedGooglePlayAbbrevPlayPurchases =
-      await this.playSubscriptions.getSubscriptions(uid);
-    return this.stripeHelper.addProductInfoToAbbrevPlayPurchases(
-      iapSubscribedGooglePlayAbbrevPlayPurchases
-    );
   }
 }

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -581,6 +581,7 @@ module.exports.subscriptionsGooglePlaySubscriptionValidator = isA.object({
   expiry_time_millis: isA.number().required(),
   package_name: isA.string().required(),
   product_id: isA.string().required(),
+  product_name: isA.string().required(),
   sku: isA.string().required(),
 });
 

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -4210,7 +4210,7 @@ describe('StripeHelper', () => {
 
     beforeEach(() => {
       productId = 'prod_test';
-      productName = 'testProduct;';
+      productName = 'testProduct';
       mockProduct = {
         product_id: productId,
         product_name: productName,

--- a/packages/fxa-auth-server/test/local/routes/account.js
+++ b/packages/fxa-auth-server/test/local/routes/account.js
@@ -3451,7 +3451,7 @@ describe('/account', () => {
   });
 
   describe('web subscriptions', () => {
-    beforeEach(async () => {
+    beforeEach(() => {
       mockCustomer = {
         id: 1234,
         subscriptions: ['fake'],
@@ -3544,7 +3544,7 @@ describe('/account', () => {
 
     let subscriptionsEnabled, playSubscriptionsEnabled;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       subscriptionsEnabled = true;
       playSubscriptionsEnabled = true;
       mockCustomer = undefined;

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -28,9 +28,6 @@ const ACCOUNT_LOCALE = 'en-US';
 const { OAUTH_SCOPE_SUBSCRIPTIONS } = require('fxa-shared/oauth/constants');
 const { CapabilityService } = require('../../../../lib/payments/capability');
 const { PlayBilling } = require('../../../../lib/payments/google-play');
-const {
-  PlaySubscriptions,
-} = require('../../../../lib/payments/google-play/subscriptions');
 const TEST_EMAIL = 'test@email.com';
 const UID = uuid.v4({}, Buffer.alloc(16)).toString('hex');
 const MOCK_SCOPES = ['profile:email', OAUTH_SCOPE_SUBSCRIPTIONS];
@@ -128,7 +125,6 @@ describe('subscriptions payPalRoutes', () => {
     profile = {};
     Container.set(CapabilityService, {});
     push = {};
-    Container.set(PlaySubscriptions, {});
   });
 
   afterEach(() => {

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -28,6 +28,9 @@ const ACCOUNT_LOCALE = 'en-US';
 const { OAUTH_SCOPE_SUBSCRIPTIONS } = require('fxa-shared/oauth/constants');
 const { CapabilityService } = require('../../../../lib/payments/capability');
 const { PlayBilling } = require('../../../../lib/payments/google-play');
+const {
+  PlaySubscriptions,
+} = require('../../../../lib/payments/google-play/subscriptions');
 const TEST_EMAIL = 'test@email.com';
 const UID = uuid.v4({}, Buffer.alloc(16)).toString('hex');
 const MOCK_SCOPES = ['profile:email', OAUTH_SCOPE_SUBSCRIPTIONS];
@@ -125,6 +128,7 @@ describe('subscriptions payPalRoutes', () => {
     profile = {};
     Container.set(CapabilityService, {});
     push = {};
+    Container.set(PlaySubscriptions, {});
   });
 
   afterEach(() => {

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -611,6 +611,7 @@ describe('lib/routes/validators:', () => {
         validators.subscriptionsGooglePlaySubscriptionValidator.validate({
           _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
           product_id: 'xyz',
+          product_name: 'Awesome product',
           ...mockAbbrevPlayPurchase,
         });
       assert.ok(!res.error);
@@ -711,6 +712,7 @@ describe('lib/routes/validators:', () => {
     const playSub = {
       _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
       product_id: 'xyz',
+      product_name: 'Awesome product',
       auto_renewing: true,
       expiry_time_millis: Date.now(),
       package_name: 'org.mozilla.cooking.with.foxkeh',

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -215,6 +215,7 @@ module.exports = {
   mockCadReminders,
   mockStripeHelper,
   mockPayPalHelper,
+  mockPlaySubscriptions,
 };
 
 function mockCustoms(errors) {
@@ -834,4 +835,11 @@ function mockStripeHelper(methods) {
 
 function mockPayPalHelper(methods) {
   return mockObject(methods, require('../lib/payments/paypal').PayPalHelper);
+}
+
+function mockPlaySubscriptions(methods) {
+  return mockObject(
+    methods,
+    require('../lib/payments/google-play/subscriptions').PlaySubscriptions
+  );
 }

--- a/packages/fxa-graphql-api/src/gql/model/subscription.ts
+++ b/packages/fxa-graphql-api/src/gql/model/subscription.ts
@@ -5,7 +5,7 @@ import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType()
 export class Subscription {
-  @Field()
+  @Field({ nullable: true })
   public created!: number;
 
   @Field()

--- a/packages/fxa-payments-server/src/lib/mock-data.tsx
+++ b/packages/fxa-payments-server/src/lib/mock-data.tsx
@@ -1,7 +1,8 @@
-import { Profile, Plan, Customer } from '../store/types';
-import { FilteredSetupIntent } from '../lib/apiClient';
 import { PaymentIntent, PaymentMethod } from '@stripe/stripe-js';
 import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
+
+import { FilteredSetupIntent } from '../lib/apiClient';
+import { Customer, Plan, Profile } from '../store/types';
 
 export const PROFILE: Profile = {
   amrValues: [],
@@ -226,9 +227,11 @@ export const IAP_GOOGLE_SUBSCRIPTION = {
   expiry_time_millis: Date.now(),
   package_name: 'org.mozilla.cooking.with.foxkeh',
   sku: 'org.mozilla.foxkeh.yearly',
+  product_name: 'Cooking with Foxkeh',
 };
 
 export const IAP_APPLE_SUBSCRIPTION = {
   _subscription_type: MozillaSubscriptionTypes.IAP_APPLE,
   product_id: 'prod_123',
+  product_name: 'Cooking with Foxkeh',
 };

--- a/packages/fxa-shared/subscriptions/types.ts
+++ b/packages/fxa-shared/subscriptions/types.ts
@@ -127,10 +127,12 @@ export interface AbbrevPlayPurchase {
 export interface GooglePlaySubscription extends AbbrevPlayPurchase {
   _subscription_type: SubscriptionTypes[1];
   product_id: Stripe.Product['id'];
+  product_name: Stripe.Product['name'];
 }
 export type AppleSubscription = {
   _subscription_type: SubscriptionTypes[2];
   product_id: Stripe.Product['id'];
+  product_name: Stripe.Product['name'];
 };
 export type IapSubscription = GooglePlaySubscription | AppleSubscription;
 export type MozillaSubscription = WebSubscription | IapSubscription;


### PR DESCRIPTION
Because:
* We should show the 'Paid Subscriptions' link in FxA Settings for Google IAP subscribers.
* Currently, FxA Settings determines if a user has active subscriptions from the /account endpoint on the auth server.
* This endpoint previously only checked for subscriptions on the Stripe customer (what we call 'web subscriptions'), but a Google IAP subscriber with no web subscriptions won't have a Stripe customer.
    
This commit:
* Updates the /account route to return both IAP and web subscriptions.
    
Closes: #10725

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This PR should not be merged before #10948 . Only the last commit is new.
