### PR TITLE
fix: sentry depth filtering

### DIFF
--- a/packages/fxa-auth-server/lib/sentry.js
+++ b/packages/fxa-auth-server/lib/sentry.js
@@ -6,6 +6,7 @@
 
 const Hoek = require('@hapi/hoek');
 const Sentry = require('@sentry/node');
+const { ExtraErrorData } = require('@sentry/integrations');
 const verror = require('verror');
 
 const getVersion = require('./version').getVersion;
@@ -155,8 +156,10 @@ async function configureSentry(server, config) {
       beforeSend(event, hint) {
         return filterSentryEvent(event, hint);
       },
+      normalizeDepth: 6,
       integrations: [
         new Sentry.Integrations.LinkedErrors({ key: 'jse_cause' }),
+        new ExtraErrorData({ depth: 5 }),
       ],
     });
     Sentry.configureScope((scope) => {

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -53,6 +53,7 @@
     "@hapi/hawk": "^8.0.0",
     "@hapi/hoek": "^9.2.0",
     "@hapi/joi": "^15.1.1",
+    "@sentry/integrations": "^6.14.2",
     "@sentry/node": "^6.14.1",
     "@type-cacheable/core": "^10.0.2",
     "@type-cacheable/ioredis-adapter": "^10.0.2",

--- a/packages/fxa-shared/nestjs/sentry/sentry.service.ts
+++ b/packages/fxa-shared/nestjs/sentry/sentry.service.ts
@@ -15,7 +15,8 @@ export class SentryService {
     // Setup Sentry
     Sentry.init({
       ...sentryConfig,
-      integrations: [new ExtraErrorData()],
+      normalizeDepth: 6,
+      integrations: [new ExtraErrorData({ depth: 5 })],
       beforeSend(event, hint) {
         return filterSentryEvent(event, hint);
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4760,6 +4760,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/integrations@npm:^6.14.2":
+  version: 6.14.2
+  resolution: "@sentry/integrations@npm:6.14.2"
+  dependencies:
+    "@sentry/types": 6.14.2
+    "@sentry/utils": 6.14.2
+    localforage: ^1.8.1
+    tslib: ^1.9.3
+  checksum: 3e2777ff45fb6168a5ffe39e864e9e797032f309604b49f0df23a7f81100ecddb53b42044501a19beb07819074e1bce784c012c2a83c0b6c6e0b841b5716e1d4
+  languageName: node
+  linkType: hard
+
 "@sentry/minimal@npm:6.14.0":
   version: 6.14.0
   resolution: "@sentry/minimal@npm:6.14.0"
@@ -4826,6 +4838,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sentry/types@npm:6.14.2":
+  version: 6.14.2
+  resolution: "@sentry/types@npm:6.14.2"
+  checksum: 2e4bf8dc3d212c2d54b160056f7807668c7def8f9662c87b24d60908c21b1ecdaafc5368681f430db408f09a4b4e10a1b458cdb6921b843b1516c98af4cf063d
+  languageName: node
+  linkType: hard
+
 "@sentry/utils@npm:6.14.0":
   version: 6.14.0
   resolution: "@sentry/utils@npm:6.14.0"
@@ -4843,6 +4862,16 @@ __metadata:
     "@sentry/types": 6.14.1
     tslib: ^1.9.3
   checksum: 24add29f0e310c35278fca3a014da06998e4bceacfb26dc8fc4d0b1307662ac6d484194074ad000cbfd940220b3ca6134858ec134b8f653296baaad1426b5b37
+  languageName: node
+  linkType: hard
+
+"@sentry/utils@npm:6.14.2":
+  version: 6.14.2
+  resolution: "@sentry/utils@npm:6.14.2"
+  dependencies:
+    "@sentry/types": 6.14.2
+    tslib: ^1.9.3
+  checksum: 6fac18496eefa8dfa5f73efb178cbffead82472c1415cb6f0b2a2068aea6032ba221b091e1731853c83d2ab81d97573d683d3a201b4e5c4f2c4d07f6ebbb5c52
   languageName: node
   linkType: hard
 
@@ -19701,6 +19730,7 @@ fsevents@~2.1.1:
     "@hapi/hawk": ^8.0.0
     "@hapi/hoek": ^9.2.0
     "@hapi/joi": ^15.1.1
+    "@sentry/integrations": ^6.14.2
     "@sentry/node": ^6.14.1
     "@storybook/addon-controls": ^6.3.12
     "@storybook/addon-docs": ^6.3.12


### PR DESCRIPTION
Because:

* We'd like to know details of nested objects deeper than the default
  of 3.
* Auth server was not attaching extra non-native exception attributes.

This commit:

* Extends the depth of sentry object capture to 6 instead of 3.
* Adds the ExtraErrorData integration to auth-server to capture
  non-native properties.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
