### PR TITLE
fix(auth): remove remaining cache references

### DIFF
--- a/packages/fxa-auth-server/lib/routes/emails.js
+++ b/packages/fxa-auth-server/lib/routes/emails.js
@@ -886,10 +886,6 @@ module.exports = (
                 currentEmail,
                 newEmailRecord.email
               );
-              await stripeHelper.refreshCachedCustomer(
-                uid,
-                newEmailRecord.email
-              );
             } catch (err) {
               // Due to the work involved by this point, we cannot abort the
               // request. We instead report it for manual fixing with sufficient

--- a/packages/fxa-auth-server/test/local/routes/emails.js
+++ b/packages/fxa-auth-server/test/local/routes/emails.js
@@ -1602,7 +1602,6 @@ describe('/recovery_email', () => {
   describe('/recovery_email/set_primary', () => {
     it('should set primary email on account', () => {
       stripeHelper.fetchCustomer = sinon.fake.returns(CUSTOMER_1);
-      stripeHelper.refreshCachedCustomer = sinon.fake.resolves();
       stripeHelper.stripe = {
         customers: { update: sinon.fake.returns(CUSTOMER_1_UPDATED) },
       };
@@ -1667,7 +1666,6 @@ describe('/recovery_email', () => {
         );
         assert.equal(stripeHelper.fetchCustomer.callCount, 1);
         assert.equal(stripeHelper.stripe.customers.update.callCount, 1);
-        assert.equal(stripeHelper.refreshCachedCustomer.callCount, 1);
       });
     });
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -179,7 +179,6 @@ describe('subscriptions payPalRoutes', () => {
     let plan, customer, subscription;
 
     beforeEach(() => {
-      stripeHelper.refreshCachedCustomer = sinon.fake.resolves({});
       stripeHelper.cancelSubscription = sinon.fake.resolves({});
       stripeHelper.taxRateByCountryCode = sinon.fake.resolves({
         id: 'tr-1234',
@@ -531,7 +530,6 @@ describe('subscriptions payPalRoutes', () => {
     let plan, customer, subscription, invoices;
 
     beforeEach(() => {
-      stripeHelper.refreshCachedCustomer = sinon.fake.resolves({});
       invoices = [];
 
       async function* genInvoice() {


### PR DESCRIPTION
Because:

* Some cached customer references were remaining which are no longer
  used.

This commit:

* Removes the cached customer refresh calls.

Closes #10987

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
