### PR TITLE
fix(auth): add sentry process name and sub reminder stats

### DIFF
--- a/packages/fxa-auth-server/lib/payments/processing-tasks-setup.ts
+++ b/packages/fxa-auth-server/lib/payments/processing-tasks-setup.ts
@@ -13,8 +13,8 @@ import { StripeHelper } from './stripe';
 
 const config = require('../../config').getProperties();
 
-export async function setupProcesingTaskObjects() {
-  configureSentry(undefined, config);
+export async function setupProcesingTaskObjects(processName: string) {
+  configureSentry(undefined, config, processName);
   // Establish database connection and bind instance to Model using Knex
   setupAuthDatabase(config.database.mysql.auth);
 

--- a/packages/fxa-auth-server/lib/sentry.js
+++ b/packages/fxa-auth-server/lib/sentry.js
@@ -145,7 +145,7 @@ function reportSentryError(err, request) {
   });
 }
 
-async function configureSentry(server, config) {
+async function configureSentry(server, config, processName = 'key_server') {
   const sentryDsn = config.sentryDsn;
   const versionData = await getVersion();
   if (sentryDsn) {
@@ -160,7 +160,7 @@ async function configureSentry(server, config) {
       ],
     });
     Sentry.configureScope((scope) => {
-      scope.setTag('process', 'key_server');
+      scope.setTag('process', processName);
     });
 
     if (!server) {

--- a/packages/fxa-auth-server/scripts/paypal-processor.ts
+++ b/packages/fxa-auth-server/scripts/paypal-processor.ts
@@ -31,7 +31,9 @@ export async function init() {
     )
     .parse(process.argv);
 
-  const { log, database, senders } = await setupProcesingTaskObjects();
+  const { log, database, senders } = await setupProcesingTaskObjects(
+    'paypal-processor'
+  );
 
   const paypalClient = new PayPalClient(
     config.subscriptions.paypalNvpSigCredentials


### PR DESCRIPTION
Because:

* We want to emit metrics to know when our cron jobs start/stop.
* The processName for sentry errors in our scripts wasn't accurate
  making it hard to determine cron job errors from auth-server errors.

This commit:

* Adds metrics to subscription-reminders for start/stop.
* Makes the auth-server processName conifugrable when sentry is setup
  and carries the correct processName in for each subPlat script.

Closes #10991

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
