### PR TITLE
fix(subscription): enable paypal on consent

### DIFF
--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -397,3 +397,5 @@ new-user-submit = Subscribe Now
 
 manage-pocket-title = Looking for your { -brand-name-pocket } premium subscription?
 manage-pocket-body = To manage it, <a>click here</a>.
+
+payment-method-header = { $prefix }Choose your payment method

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -399,3 +399,4 @@ manage-pocket-title = Looking for your { -brand-name-pocket } premium subscripti
 manage-pocket-body = To manage it, <a>click here</a>.
 
 payment-method-header = { $prefix }Choose your payment method
+payment-method-required = Required

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -378,11 +378,9 @@ payment-confirmation-cc-card-ending-in = Card ending in { $last4 }
 ## new user email form
 new-user-sign-in-link = Already have a { -brand-name-firefox } account? <a>Sign in</a>
 new-user-step-1 = 1. Create a { -brand-name-firefox } account
-new-user-step-2 = 2. Choose your payment method
 # "Required" to indicate that the user must use the checkbox below this text to
 # agree to a payment method's terms of service and privacy notice in order to
 # continue.
-new-user-required-payment-consent = Required
 new-user-email =
   .label = Enter your email
 new-user-confirm-email =
@@ -398,5 +396,7 @@ new-user-submit = Subscribe Now
 manage-pocket-title = Looking for your { -brand-name-pocket } premium subscription?
 manage-pocket-body = To manage it, <a>click here</a>.
 
-payment-method-header = { $prefix }Choose your payment method
+payment-method-header = Choose your payment method
+## $prefix (string) - If header is part of a multi step process and needs a header. eg. '2.'
+payment-method-header-prefix = { $prefix } Choose your payment method
 payment-method-required = Required

--- a/packages/fxa-payments-server/public/locales/en-US/main.ftl
+++ b/packages/fxa-payments-server/public/locales/en-US/main.ftl
@@ -397,6 +397,6 @@ manage-pocket-title = Looking for your { -brand-name-pocket } premium subscripti
 manage-pocket-body = To manage it, <a>click here</a>.
 
 payment-method-header = Choose your payment method
-## $prefix (string) - If header is part of a multi step process and needs a header. eg. '2.'
+# $prefix (string) - If header is part of a multi step process and needs a header. eg. '2.'
 payment-method-header-prefix = { $prefix } Choose your payment method
 payment-method-required = Required

--- a/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
+++ b/packages/fxa-payments-server/src/components/PayPalButton/index.tsx
@@ -209,6 +209,7 @@ export const PaypalButton = ({
         className={classNames({
           'disabled-overlay': disabled,
         })}
+        data-testid="paypal-button-container"
       >
         {ButtonBase && (
           <ButtonBase

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.scss
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.scss
@@ -1,0 +1,3 @@
+.step-header {
+  margin-top: 40px;
+}

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.stories.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.stories.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import MockApp from '../../../.storybook/components/MockApp';
+import { PaymentMethodHeader } from './index';
+import { Plan } from '../../store/types';
+
+const selectedPlan: Plan = {
+  plan_id: 'planId',
+  product_id: 'fpnID',
+  product_name: 'Firefox Private Network Pro',
+  currency: 'usd',
+  amount: 935,
+  interval: 'month' as const,
+  interval_count: 1,
+  plan_metadata: null,
+  product_metadata: null,
+};
+
+storiesOf('components/PaymentMethodHeader', module)
+  .add('default', () => (
+    <MockApp>
+      <PaymentMethodHeader {...{ plan: selectedPlan, onClick: () => {} }} />
+    </MockApp>
+  ))
+  .add('With prefix', () => (
+    <MockApp>
+      <PaymentMethodHeader
+        {...{ plan: selectedPlan, onClick: () => {}, prefix: '2. ' }}
+      />
+    </MockApp>
+  ));

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import TestRenderer from 'react-test-renderer';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { PaymentMethodHeader } from '.';
+import {
+  getLocalizedMessage,
+  MOCK_PLANS,
+  setupFluentLocalizationTest,
+} from '../../lib/test-utils';
+import { act } from 'react-dom/test-utils';
+import { getLocalizedCurrency } from '../../lib/formats';
+
+jest.mock('../../lib/sentry');
+
+describe('components/PaymentMethodHeader', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    return cleanup();
+  });
+
+  it('renders as expected', async () => {
+    const plan = MOCK_PLANS[0];
+    const props = { plan, onClick: () => {} };
+    const { findByTestId } = render(<PaymentMethodHeader {...props} />);
+    const header = await findByTestId('header');
+
+    expect(header).toBeVisible();
+  });
+
+  describe('Fluent localized text', () => {
+    const bundle = setupFluentLocalizationTest('en-US');
+
+    it('returns correct heading without prefix', async () => {
+      const msgId = 'payment-method-header';
+      const prefix = '';
+      const expected = 'Choose your payment method';
+      const actual = getLocalizedMessage(bundle, msgId, { prefix });
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns correct heading with prefix', async () => {
+      const msgId = 'payment-method-header';
+      const prefix = '2. ';
+      const expected = '2. Choose your payment method';
+      const actual = getLocalizedMessage(bundle, msgId, { prefix });
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns correct text for required text', async () => {
+      const msgId = 'payment-method-required';
+      const expected = 'Required';
+      const actual = getLocalizedMessage(bundle, msgId, {});
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('PaymentConsentCheckbox component - Spot checks', () => {
+    it('Checkbox renders as expected', async () => {
+      const plan = MOCK_PLANS[0];
+      const props = { plan, onClick: () => {} };
+      const { findByTestId } = render(<PaymentMethodHeader {...props} />);
+      const checkbox = await findByTestId('confirm');
+
+      expect(checkbox).toBeVisible();
+    });
+
+    it('onClick works', async () => {
+      const plan = MOCK_PLANS[0];
+      const onClickSpy = jest.fn();
+      const props = { plan, onClick: onClickSpy };
+      const { findByTestId } = render(<PaymentMethodHeader {...props} />);
+      const checkbox = await findByTestId('confirm');
+
+      await act(async () => {
+        fireEvent.click(checkbox);
+      });
+
+      expect(onClickSpy).toHaveBeenCalled();
+    });
+
+    it('Legal text displayed correctly for given plan', async () => {
+      const plan =
+        MOCK_PLANS.find((p) => p.plan_id === 'plan_daily') || MOCK_PLANS[0];
+      const props = { plan, onClick: () => {} };
+      const expectedMsg =
+        'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
+
+      const testRenderer = TestRenderer.create(
+        <PaymentMethodHeader {...props} />
+      );
+      const testInstance = testRenderer.root;
+      const legalCheckbox = testInstance.findByProps({
+        id: 'payment-confirm-with-legal-links-day',
+      });
+      const expectedAmount = getLocalizedCurrency(plan.amount, plan.currency);
+
+      expect(legalCheckbox.props.vars.amount).toStrictEqual(expectedAmount);
+      expect(legalCheckbox.props.vars.intervalCount).toBe(plan.interval_count);
+      expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+    });
+  });
+});

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../lib/test-utils';
 import { act } from 'react-dom/test-utils';
 import { getLocalizedCurrency } from '../../lib/formats';
+import waitForExpect from 'wait-for-expect';
 
 jest.mock('../../lib/sentry');
 
@@ -19,13 +20,26 @@ describe('components/PaymentMethodHeader', () => {
     return cleanup();
   });
 
-  it('renders as expected', async () => {
+  it('render header without prefix', async () => {
     const plan = MOCK_PLANS[0];
     const props = { plan, onClick: () => {} };
-    const { findByTestId } = render(<PaymentMethodHeader {...props} />);
-    const header = await findByTestId('header');
+    const { queryByTestId } = render(<PaymentMethodHeader {...props} />);
 
-    expect(header).toBeVisible();
+    await waitForExpect(() => {
+      expect(queryByTestId('header')).toBeInTheDocument();
+      expect(queryByTestId('header-prefix')).not.toBeInTheDocument();
+    });
+  });
+
+  it('render header with prefix', async () => {
+    const plan = MOCK_PLANS[0];
+    const props = { plan, onClick: () => {}, prefix: '2.' };
+    const { queryByTestId } = render(<PaymentMethodHeader {...props} />);
+
+    await waitForExpect(() => {
+      expect(queryByTestId('header')).not.toBeInTheDocument();
+      expect(queryByTestId('header-prefix')).toBeInTheDocument();
+    });
   });
 
   describe('Fluent localized text', () => {
@@ -33,16 +47,15 @@ describe('components/PaymentMethodHeader', () => {
 
     it('returns correct heading without prefix', async () => {
       const msgId = 'payment-method-header';
-      const prefix = '';
       const expected = 'Choose your payment method';
-      const actual = getLocalizedMessage(bundle, msgId, { prefix });
+      const actual = getLocalizedMessage(bundle, msgId, {});
 
       expect(actual).toEqual(expected);
     });
 
     it('returns correct heading with prefix', async () => {
-      const msgId = 'payment-method-header';
-      const prefix = '2. ';
+      const msgId = 'payment-method-header-prefix';
+      const prefix = '2.';
       const expected = '2. Choose your payment method';
       const actual = getLocalizedMessage(bundle, msgId, { prefix });
 

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
@@ -25,10 +25,8 @@ describe('components/PaymentMethodHeader', () => {
     const props = { plan, onClick: () => {} };
     const { queryByTestId } = render(<PaymentMethodHeader {...props} />);
 
-    await waitForExpect(() => {
-      expect(queryByTestId('header')).toBeInTheDocument();
-      expect(queryByTestId('header-prefix')).not.toBeInTheDocument();
-    });
+    expect(queryByTestId('header')).toBeInTheDocument();
+    expect(queryByTestId('header-prefix')).not.toBeInTheDocument();
   });
 
   it('render header with prefix', async () => {
@@ -36,10 +34,8 @@ describe('components/PaymentMethodHeader', () => {
     const props = { plan, onClick: () => {}, prefix: '2.' };
     const { queryByTestId } = render(<PaymentMethodHeader {...props} />);
 
-    await waitForExpect(() => {
-      expect(queryByTestId('header')).not.toBeInTheDocument();
-      expect(queryByTestId('header-prefix')).toBeInTheDocument();
-    });
+    expect(queryByTestId('header')).not.toBeInTheDocument();
+    expect(queryByTestId('header-prefix')).toBeInTheDocument();
   });
 
   describe('Fluent localized text', () => {
@@ -101,18 +97,11 @@ describe('components/PaymentMethodHeader', () => {
       const expectedMsg =
         'I authorize Mozilla, maker of Firefox products, to charge my payment method <strong>$5.00 daily</strong>, according to <termsOfServiceLink>Terms of Service</termsOfServiceLink> and <privacyNoticeLink>Privacy Notice</privacyNoticeLink>, until I cancel my subscription.';
 
-      const testRenderer = TestRenderer.create(
-        <PaymentMethodHeader {...props} />
-      );
-      const testInstance = testRenderer.root;
-      const legalCheckbox = testInstance.findByProps({
-        id: 'payment-confirm-with-legal-links-day',
-      });
-      const expectedAmount = getLocalizedCurrency(plan.amount, plan.currency);
+      const { findByTestId } = render(<PaymentMethodHeader {...props} />);
 
-      expect(legalCheckbox.props.vars.amount).toStrictEqual(expectedAmount);
-      expect(legalCheckbox.props.vars.intervalCount).toBe(plan.interval_count);
-      expect(legalCheckbox.props.children.props.children).toBe(expectedMsg);
+      const checkbox = await findByTestId('confirm');
+
+      expect(checkbox.nextSibling?.textContent).toEqual(expectedMsg);
     });
   });
 });

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import TestRenderer from 'react-test-renderer';
 import { cleanup, fireEvent, render } from '@testing-library/react';
 import { PaymentMethodHeader } from '.';
 import {
@@ -9,8 +8,6 @@ import {
   setupFluentLocalizationTest,
 } from '../../lib/test-utils';
 import { act } from 'react-dom/test-utils';
-import { getLocalizedCurrency } from '../../lib/formats';
-import waitForExpect from 'wait-for-expect';
 
 jest.mock('../../lib/sentry');
 

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.test.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { cleanup, fireEvent, render, act } from '@testing-library/react';
 import { PaymentMethodHeader } from '.';
 import {
   getLocalizedMessage,
   MOCK_PLANS,
   setupFluentLocalizationTest,
 } from '../../lib/test-utils';
-import { act } from 'react-dom/test-utils';
 
 jest.mock('../../lib/sentry');
 

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
@@ -5,6 +5,8 @@ import useValidatorState from '../../lib/validator';
 import { Form } from '../fields';
 import { PaymentConsentCheckbox } from '../PaymentConsentCheckbox';
 
+import './index.scss';
+
 export type PaymentMethodHeaderProps = {
   plan: Plan;
   onClick: (event: React.MouseEvent<HTMLInputElement>) => void;
@@ -17,21 +19,17 @@ export const PaymentMethodHeader = ({
   prefix = '',
 }: PaymentMethodHeaderProps) => {
   const checkboxValidator = useValidatorState();
-  const headerMarginTop = '40px';
   return (
     <>
       {prefix ? (
         <Localized id="payment-method-header-prefix" vars={{ prefix }}>
-          <h2
-            style={{ marginTop: headerMarginTop }}
-            data-testid="header-prefix"
-          >
-            Choose your payment method
+          <h2 className="step-header" data-testid="header-prefix">
+            {`${prefix} Choose your payment method`}
           </h2>
         </Localized>
       ) : (
         <Localized id="payment-method-header">
-          <h2 style={{ marginTop: headerMarginTop }} data-testid="header">
+          <h2 className="step-header" data-testid="header">
             Choose your payment method
           </h2>
         </Localized>

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
@@ -17,13 +17,25 @@ export const PaymentMethodHeader = ({
   prefix = '',
 }: PaymentMethodHeaderProps) => {
   const checkboxValidator = useValidatorState();
+  const headerMarginTop = '40px';
   return (
     <>
-      <Localized id="payment-method-header" vars={{ prefix }}>
-        <h2 style={{ marginTop: '40px' }} data-testid="header">
-          Choose your payment method
-        </h2>
-      </Localized>
+      {prefix ? (
+        <Localized id="payment-method-header-prefix" vars={{ prefix }}>
+          <h2
+            style={{ marginTop: headerMarginTop }}
+            data-testid="header-prefix"
+          >
+            Choose your payment method
+          </h2>
+        </Localized>
+      ) : (
+        <Localized id="payment-method-header">
+          <h2 style={{ marginTop: headerMarginTop }} data-testid="header">
+            Choose your payment method
+          </h2>
+        </Localized>
+      )}
       <Localized id="payment-method-required">
         <strong>Required</strong>
       </Localized>

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
@@ -20,9 +20,11 @@ export const PaymentMethodHeader = ({
   return (
     <>
       <Localized id="payment-method-header" vars={{ prefix }}>
-        <h2 style={{ marginTop: '40px' }}>Choose your payment method</h2>
+        <h2 style={{ marginTop: '40px' }} data-testid="header">
+          Choose your payment method
+        </h2>
       </Localized>
-      <Localized id="new-user-required-payment-consent">
+      <Localized id="payment-method-required">
         <strong>Required</strong>
       </Localized>
       <Form validator={checkboxValidator}>

--- a/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
+++ b/packages/fxa-payments-server/src/components/PaymentMethodHeader/index.tsx
@@ -1,0 +1,33 @@
+import { Localized } from '@fluent/react';
+import { Plan } from 'fxa-shared/subscriptions/types';
+import React from 'react';
+import useValidatorState from '../../lib/validator';
+import { Form } from '../fields';
+import { PaymentConsentCheckbox } from '../PaymentConsentCheckbox';
+
+export type PaymentMethodHeaderProps = {
+  plan: Plan;
+  onClick: (event: React.MouseEvent<HTMLInputElement>) => void;
+  prefix?: string;
+};
+
+export const PaymentMethodHeader = ({
+  plan,
+  onClick,
+  prefix = '',
+}: PaymentMethodHeaderProps) => {
+  const checkboxValidator = useValidatorState();
+  return (
+    <>
+      <Localized id="payment-method-header" vars={{ prefix }}>
+        <h2 style={{ marginTop: '40px' }}>Choose your payment method</h2>
+      </Localized>
+      <Localized id="new-user-required-payment-consent">
+        <strong>Required</strong>
+      </Localized>
+      <Form validator={checkboxValidator}>
+        <PaymentConsentCheckbox plan={plan} onClick={onClick} />
+      </Form>
+    </>
+  );
+};

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -63,6 +63,7 @@ import * as apiClient from '../../lib/apiClient';
 import sentry from '../../lib/sentry';
 import { ButtonBaseProps } from '../../components/PayPalButton';
 import { AlertBar } from '../../components/AlertBar';
+import { PaymentMethodHeader } from '../../components/PaymentMethodHeader';
 
 const PaypalButton = React.lazy(() => import('../../components/PayPalButton'));
 
@@ -324,18 +325,11 @@ export const Checkout = ({
           />
 
           <hr />
-          <Localized id="new-user-step-2">
-            <h2 className="step-header">2. Choose your payment method</h2>
-          </Localized>
-          <Localized id="new-user-required-payment-consent">
-            <strong>Required</strong>
-          </Localized>
-          <Form validator={checkboxValidator}>
-            <PaymentConsentCheckbox
-              plan={selectedPlan}
-              onClick={() => setCheckboxSet(!checkboxSet)}
-            />
-          </Form>
+          <PaymentMethodHeader
+            plan={selectedPlan}
+            onClick={() => setCheckboxSet(!checkboxSet)}
+            prefix="2. "
+          />
           <>
             {paypalScriptLoaded && (
               <>

--- a/packages/fxa-payments-server/src/routes/Checkout/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Checkout/index.tsx
@@ -328,7 +328,7 @@ export const Checkout = ({
           <PaymentMethodHeader
             plan={selectedPlan}
             onClick={() => setCheckboxSet(!checkboxSet)}
-            prefix="2. "
+            prefix="2."
           />
           <>
             {paypalScriptLoaded && (

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.scss
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.scss
@@ -21,10 +21,6 @@
   }
 }
 
-.payment-method-header {
-  margin-bottom: 64px;
-}
-
 .product-payment {
   grid-row: 1/3;
   background: $color-white;

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.scss
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.scss
@@ -21,6 +21,10 @@
   }
 }
 
+.payment-method-header {
+  margin-bottom: 64px;
+}
+
 .product-payment {
   grid-row: 1/3;
   background: $color-white;

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -1,9 +1,7 @@
 import React, { useState, useCallback, Suspense, useContext } from 'react';
 import classNames from 'classnames';
 import { Plan, Profile, Customer } from '../../../store/types';
-import useValidatorState, {
-  State as ValidatorState,
-} from '../../../lib/validator';
+import { State as ValidatorState } from '../../../lib/validator';
 
 import { useNonce, usePaypalButtonSetup } from '../../../lib/hooks';
 
@@ -46,8 +44,6 @@ import AppContext from '../../../lib/AppContext';
 import { ButtonBaseProps } from '../../../components/PayPalButton';
 import { apiCapturePaypalPayment } from '../../../lib/apiClient';
 import { GeneralError } from '../../../lib/errors';
-import { Form } from '../../../components/fields';
-import { PaymentConsentCheckbox } from '../../../components/PaymentConsentCheckbox';
 import { PaymentMethodHeader } from '../../../components/PaymentMethodHeader';
 const PaypalButton = React.lazy(
   () => import('../../../components/PayPalButton')
@@ -233,12 +229,10 @@ export const SubscriptionCreate = ({
           })}
           data-testid="subscription-create"
         >
-          <div className="payment-method-header">
-            <PaymentMethodHeader
-              plan={selectedPlan}
-              onClick={() => setCheckboxSet(!checkboxSet)}
-            />
-          </div>
+          <PaymentMethodHeader
+            plan={selectedPlan}
+            onClick={() => setCheckboxSet(!checkboxSet)}
+          />
           {!hasPaymentProvider(customer) && (
             <>
               {paypalScriptLoaded && (
@@ -248,11 +242,6 @@ export const SubscriptionCreate = ({
                     data-testid="pay-with-other"
                   >
                     <Suspense fallback={<div>Loading...</div>}>
-                      {/* <Localized id="pay-with-heading-other">
-                        <p className="pay-with-heading">
-                          Select payment option
-                        </p>
-                      </Localized> */}
                       <div className="paypal-button">
                         <PaypalButton
                           disabled={!checkboxSet}

--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionCreate/index.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useCallback, Suspense, useContext } from 'react';
 import classNames from 'classnames';
 import { Plan, Profile, Customer } from '../../../store/types';
-import { State as ValidatorState } from '../../../lib/validator';
+import useValidatorState, {
+  State as ValidatorState,
+} from '../../../lib/validator';
 
 import { useNonce, usePaypalButtonSetup } from '../../../lib/hooks';
 
@@ -44,6 +46,9 @@ import AppContext from '../../../lib/AppContext';
 import { ButtonBaseProps } from '../../../components/PayPalButton';
 import { apiCapturePaypalPayment } from '../../../lib/apiClient';
 import { GeneralError } from '../../../lib/errors';
+import { Form } from '../../../components/fields';
+import { PaymentConsentCheckbox } from '../../../components/PaymentConsentCheckbox';
+import { PaymentMethodHeader } from '../../../components/PaymentMethodHeader';
 const PaypalButton = React.lazy(
   () => import('../../../components/PayPalButton')
 );
@@ -83,6 +88,7 @@ export const SubscriptionCreate = ({
 }: SubscriptionCreateProps) => {
   const [submitNonce, refreshSubmitNonce] = useNonce();
   const [transactionInProgress, setTransactionInProgress] = useState(false);
+  const [checkboxSet, setCheckboxSet] = useState(false);
 
   const onFormMounted = useCallback(
     () => Amplitude.createSubscriptionMounted(selectedPlan),
@@ -227,6 +233,12 @@ export const SubscriptionCreate = ({
           })}
           data-testid="subscription-create"
         >
+          <div className="payment-method-header">
+            <PaymentMethodHeader
+              plan={selectedPlan}
+              onClick={() => setCheckboxSet(!checkboxSet)}
+            />
+          </div>
           {!hasPaymentProvider(customer) && (
             <>
               {paypalScriptLoaded && (
@@ -236,14 +248,14 @@ export const SubscriptionCreate = ({
                     data-testid="pay-with-other"
                   >
                     <Suspense fallback={<div>Loading...</div>}>
-                      <Localized id="pay-with-heading-other">
+                      {/* <Localized id="pay-with-heading-other">
                         <p className="pay-with-heading">
                           Select payment option
                         </p>
-                      </Localized>
+                      </Localized> */}
                       <div className="paypal-button">
                         <PaypalButton
-                          disabled={false}
+                          disabled={!checkboxSet}
                           apiClientOverrides={apiClientOverrides}
                           currencyCode={selectedPlan.currency}
                           customer={customer}
@@ -299,9 +311,10 @@ export const SubscriptionCreate = ({
                 submitNonce,
                 onSubmit,
                 onChange,
+                shouldAllowSubmit: checkboxSet,
                 inProgress,
                 validatorInitialState,
-                confirm: true,
+                confirm: false,
                 plan: selectedPlan,
                 onMounted: onFormMounted,
                 onEngaged: onFormEngaged,


### PR DESCRIPTION
Because:

* The Paypal button should only be active once the consent checkbox is
  selected.

This commit:

* Moves the consent form in the existing user subscription flow to the
  top of the screen. Matches behaviour and look of new user flow.

Closes #
[10652](https://github.com/mozilla/fxa/issues/10652)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Without consent checked
<img width="545" alt="image" src="https://user-images.githubusercontent.com/10620585/141813863-97ed3547-d802-42ad-809a-b17d4c4ad6ea.png">


With consent checked
<img width="545" alt="image" src="https://user-images.githubusercontent.com/10620585/141813798-adbafcba-3f08-4bdd-a4e1-f8000c399a59.png">
