### PR TITLE
fix(l10n): Move l10n comments out of `unsafeTranslate` tag

### DIFF
--- a/packages/fxa-content-server/app/scripts/templates/ready.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/ready.mustache
@@ -18,10 +18,8 @@
     {{^isSync}}
       {{#isFromRelyingParty}}
         {{#isInPocketMigration}}
-          {{#unsafeTranslate}}
-              <!-- L10N: Pocket image follows `You are now ready to use` -->
-              You are now ready to use <div class="graphic graphic-client-pocket">Pocket</div>
-          {{/unsafeTranslate}}
+            <!-- L10N: Pocket image follows `You are now ready to use` -->
+            {{#unsafeTranslate}}You are now ready to use <div class="graphic graphic-client-pocket">Pocket</div>{{/unsafeTranslate}}
         {{/isInPocketMigration}}
         {{^isInPocketMigration}}
           <p class="account-ready-service">{{#t}}You are now ready to use %(serviceName)s{{/t}}</p>

--- a/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
+++ b/packages/fxa-content-server/app/scripts/templates/sign_up_password.mustache
@@ -4,10 +4,8 @@
         {{#t}}Create a Firefox Account{{/t}}
         <span class="service">
           {{#isInPocketMigration}}
-            {{#unsafeTranslate}}
-                <!-- L10N: For languages structured like English, the phrase can read "to continue to" with Pocket image following -->
-                Continue to <div class="graphic graphic-client-pocket">Pocket</div>
-            {{/unsafeTranslate}}
+              <!-- L10N: For languages structured like English, the phrase can read "to continue to" with Pocket image following -->
+              {{#unsafeTranslate}}Continue to <div class="graphic graphic-client-pocket">Pocket</div>{{/unsafeTranslate}}
           {{/isInPocketMigration}}
           {{^isInPocketMigration}}
               <!-- L10N: For languages structured like English, the phrase can read "to continue to %(serviceName)s" -->


### PR DESCRIPTION
TIL you can't have comments in the `unsafeTranslate` tag, it gets added as part of the string to localize 🥲