### PR TITLE
Automatic asset upload

### DIFF
--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -1,13 +1,10 @@
-# Upload files in assets/product-icons & assets/legal to S3 buckets for CDN distribution
+# Upload files in assets/product-icons & assets/legal to stage and prod S3 buckets for CDN distribution
 #
 # Requirements:
-# This action requires a set of AWS credentials with write access to the destination bucket directories (product-icons & legal)
-#
-#   Credentials must be passed in as the following secrets:
-#    - CDN_S3_AWS_ACCESS_KEY_ID
-#    - CDN_S3_AWS_SECRET_ACCESS_KEY
+# 1. Github OIDC Provider in destination AWS account - https://github.com/aws-actions/configure-aws-credentials
+# 2. IAM Role with write access to destination bucket paths, scoped to the repository running the action
 
-name: "Asset Upload"
+name: "CDN Asset Upload"
 on:
   push:
     branches:
@@ -20,12 +17,29 @@ jobs:
   Upload-assets-to-CDN:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name:  "Asset upload to CDN"
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Configure Stage AWS credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::142069644989:role/fxa-content-cdn-stage-asset-upload
+          role-session-name: CDNAssetUpload
+
+      - name: "Asset upload to stage CDN S3 bucket"
+        run: |
+          aws s3 cp --cache-control 'public,max-age=86400' --recursive assets/product-icons s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/product-icons
+          aws s3 cp --cache-control 'public,max-age=86400' --content-disposition attachment --recursive assets/legal s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/legal
+
+      - name: Configure Production AWS credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::361527076523:role/fxa-content-cdn-prod-asset-upload
+          role-session-name: CDNAssetUpload
+
+      - name: "Asset upload to production CDN S3 bucket"
         run: |
           aws s3 cp --cache-control 'public,max-age=86400' --recursive assets/product-icons s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/product-icons
           aws s3 cp --cache-control 'public,max-age=86400' --content-disposition attachment --recursive assets/legal s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/legal
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.CDN_S3_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CDN_S3_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: 'us-west-2'

--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -17,10 +17,10 @@ jobs:
   Upload-assets-to-CDN:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: "Checkout repository"
         uses: actions/checkout@v2
 
-      - name: Configure Stage AWS credentials
+      - name: "Configure Stage AWS credentials"
         uses: aws-actions/configure-aws-credentials@master
         with:
           aws-region: us-east-1
@@ -43,3 +43,11 @@ jobs:
         run: |
           aws s3 cp --cache-control 'public,max-age=86400' --recursive assets/product-icons --exclude "*" --include "*.svg" --include "*.png" s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/product-icons
           aws s3 cp --cache-control 'public,max-age=86400' --recursive --content-disposition attachment --exclude "*" --include "*.pdf"  assets/legal s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/legal
+
+      - name: "Post to fxa-team Slack channel"
+        uses: slackapi/slack-github-action@v1.16.0
+        with:
+          channel-id: 'CLV3KMZ8B'
+          slack-message: "New assets have been uploaded to CDN: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: "Asset upload to stage CDN S3 bucket"
         run: |
-          aws s3 cp --cache-control 'public,max-age=86400' --recursive assets/product-icons --exclude "*" --include "*.svg" --include "*.png" s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/product-icons
-          aws s3 cp --cache-control 'public,max-age=86400' --recursive --content-disposition attachment --exclude "*" --include "*.pdf" assets/legal s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/legal
+          aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.svg" --include "*.png" assets/product-icons  s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/product-icons
+          aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.pdf" --content-disposition attachment  assets/legal s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/legal
 
       - name: Configure Production AWS credentials
         uses: aws-actions/configure-aws-credentials@master
@@ -41,8 +41,8 @@ jobs:
 
       - name: "Asset upload to production CDN S3 bucket"
         run: |
-          aws s3 cp --cache-control 'public,max-age=86400' --recursive assets/product-icons --exclude "*" --include "*.svg" --include "*.png" s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/product-icons
-          aws s3 cp --cache-control 'public,max-age=86400' --recursive --content-disposition attachment --exclude "*" --include "*.pdf"  assets/legal s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/legal
+          aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.svg" --include "*.png" assets/product-icons  s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/product-icons
+          aws s3 sync --cache-control 'public,max-age=86400' --exclude "*" --include "*.pdf" --content-disposition attachment   assets/legal s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/legal
 
       - name: "Post to fxa-team Slack channel"
         uses: slackapi/slack-github-action@v1.16.0

--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: "Asset upload to stage CDN S3 bucket"
         run: |
-          aws s3 cp --cache-control 'public,max-age=86400' --recursive assets/product-icons s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/product-icons
-          aws s3 cp --cache-control 'public,max-age=86400' --content-disposition attachment --recursive assets/legal s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/legal
+          aws s3 cp --cache-control 'public,max-age=86400' --recursive assets/product-icons --exclude "*" --include "*.svg" --include "*.png" s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/product-icons
+          aws s3 cp --cache-control 'public,max-age=86400' --recursive --content-disposition attachment --exclude "*" --include "*.pdf" assets/legal s3://fxa-content-cdn-stage-distbucket-bpquvfnty86g/legal
 
       - name: Configure Production AWS credentials
         uses: aws-actions/configure-aws-credentials@master
@@ -41,5 +41,5 @@ jobs:
 
       - name: "Asset upload to production CDN S3 bucket"
         run: |
-          aws s3 cp --cache-control 'public,max-age=86400' --recursive assets/product-icons s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/product-icons
-          aws s3 cp --cache-control 'public,max-age=86400' --content-disposition attachment --recursive assets/legal s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/legal
+          aws s3 cp --cache-control 'public,max-age=86400' --recursive assets/product-icons --exclude "*" --include "*.svg" --include "*.png" s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/product-icons
+          aws s3 cp --cache-control 'public,max-age=86400' --recursive --content-disposition attachment --exclude "*" --include "*.pdf"  assets/legal s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/legal

--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -1,0 +1,31 @@
+# Upload files in assets/product-icons & assets/legal to S3 buckets for CDN distribution
+#
+# Requirements:
+# This action requires a set of AWS credentials with write access to the destination bucket directories (product-icons & legal)
+#
+#   Credentials must be passed in as the following secrets:
+#    - CDN_S3_AWS_ACCESS_KEY_ID
+#    - CDN_S3_AWS_SECRET_ACCESS_KEY
+
+name: "Asset Upload"
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'assets/**/'
+      - '!assets/other/**'
+
+jobs:
+  Upload-assets-to-CDN:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name:  "Asset upload to CDN"
+        run: |
+          aws s3 cp --cache-control 'public,max-age=86400' --recursive assets/product-icons s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/product-icons
+          aws s3 cp --cache-control 'public,max-age=86400' --content-disposition attachment --recursive assets/legal s3://fxa-content-cdn-prod-distbucket-gqg70i8xqycy/legal
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CDN_S3_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CDN_S3_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-west-2'

--- a/.github/workflows/upload-assets-to-cdn.yml
+++ b/.github/workflows/upload-assets-to-cdn.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Configure Stage AWS credentials
         uses: aws-actions/configure-aws-credentials@master
         with:
-          aws-region: us-west-2
+          aws-region: us-east-1
           role-to-assume: arn:aws:iam::142069644989:role/fxa-content-cdn-stage-asset-upload
           role-session-name: CDNAssetUpload
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+/assets/ @mozilla/fxa-devs


### PR DESCRIPTION
## Because

- Uploading assets to the CDN is currently a manual process.

## This pull request

- Github action that will upload assets to stage/prod CDNs when changes to assets/product-icons assets/legal are merged to main. 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

This has been tested in stage but the role has not been created in production yet. 
