### PR TITLE
fix(settings): load the user specified in url on settings

### DIFF
--- a/packages/fxa-settings/src/lib/cache.ts
+++ b/packages/fxa-settings/src/lib/cache.ts
@@ -1,6 +1,7 @@
 import { InMemoryCache, gql } from '@apollo/client';
 import Storage from './storage';
 import { Email } from '../models';
+import { searchParam } from '../lib/utilities';
 import config from './config';
 
 const storage = Storage.factory('localStorage');
@@ -25,6 +26,14 @@ function accounts(accounts?: LocalAccounts) {
 
 export function currentAccount(account?: OldSettingsData) {
   const all = accounts() || {};
+
+  // Current user can be specified in url params (ex. when clicking
+  // `Manage account` from sync prefs.
+  const forceUid = searchParam('uid', window.location.search);
+  if (forceUid && all[forceUid]) {
+    storage.set('currentAccountUid', forceUid);
+  }
+
   const uid = storage.get('currentAccountUid') as hexstring;
   if (account) {
     all[account.uid] = account;


### PR DESCRIPTION
## Because

- If you navigate to setting when you have multiple accounts logged in, the correct account might not load

## This pull request

- If `uid` is specified in url, load that user in settings if that have a valid local account

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
