### PR TITLE
fix(settings): l10n for email verif. error code

### DIFF
--- a/packages/fxa-settings/src/lib/auth-errors/en-US.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en-US.ftl
@@ -2,6 +2,7 @@
 
 auth-error-102 = Unknown account
 auth-error-103 = Incorrect password
+auth-error-105 = Invalid verification code
 auth-error-110 = Invalid token
 # This string is the amount of time required before a user can attempt another request.
 # Variables:


### PR DESCRIPTION
## Because

* On incorrect secondary email verification code, english message is
  shown instead of country translation.

## This pull request

* Adds error code translation for secondary email verification code.

## Issue that this pull request solves
Closes #
[9209](https://github.com/mozilla/fxa/issues/9209)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
