### PR TITLE
refactor(admin): use autogenerated ts types

### DIFF
--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -48,6 +48,7 @@
     "dateformat": "^4.3.1",
     "express": "^4.17.1",
     "express-http-proxy": "^1.6.3",
+    "fxa-admin-server": "workspace:*",
     "fxa-react": "workspace:*",
     "graphql": "^15.6.1",
     "helmet": "^4.6.0",

--- a/packages/fxa-admin-panel/src/App.test.tsx
+++ b/packages/fxa-admin-panel/src/App.test.tsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
 import App from './App';
 
 it('renders without imploding', () => {

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
@@ -6,10 +6,12 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
 import '@testing-library/jest-dom/extend-expect';
-import { Account } from './index';
+import { Account, AccountProps } from './index';
 
-let accountResponse = {
+let accountResponse: AccountProps = {
   uid: 'ca1c61239f2448b2af618f0b50226cde',
+  email: 'hey@happy.com',
+  emailVerified: true,
   emails: [
     {
       email: 'hey@happy.com',
@@ -74,7 +76,7 @@ it('displays the account', async () => {
   expect(getByTestId('account-section')).toBeInTheDocument();
   expect(getByTestId('verified-status')).toHaveTextContent('verified');
   expect(getByTestId('email-label')).toHaveTextContent(
-    accountResponse.emails[0].email
+    accountResponse.emails![0].email
   );
   expect(getByTestId('uid-label')).toHaveTextContent(accountResponse.uid);
   expect(getByTestId('createdat-label')).toHaveTextContent(
@@ -83,7 +85,7 @@ it('displays the account', async () => {
 });
 
 it('displays the unverified account', async () => {
-  accountResponse.emails[0].isVerified = false;
+  accountResponse.emails![0].isVerified = false;
   const { getByTestId } = render(
     <MockedProvider>
       <Account {...accountResponse} />
@@ -127,7 +129,7 @@ it('displays the session token status', async () => {
 });
 
 it('displays secondary emails', async () => {
-  accountResponse.emails.push({
+  accountResponse.emails!.push({
     email: 'ohdeceiver@gmail.com',
     isVerified: false,
     isPrimary: false,

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.test.tsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
-import '@testing-library/jest-dom/extend-expect';
 import { Account, AccountProps } from './index';
 
 let accountResponse: AccountProps = {

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
@@ -6,6 +6,15 @@ import React from 'react';
 import dateFormat from 'dateformat';
 import { gql, useMutation } from '@apollo/client';
 import './index.scss';
+import {
+  Account as AccountType,
+  EmailBounce as EmailBounceType,
+  Email as EmailType,
+  SecurityEvents as SecurityEventsType,
+  Totp as TotpType,
+  RecoveryKeys as RecoveryKeysType,
+  SessionTokens as SessionTokensType,
+} from 'fxa-admin-server/src/graphql';
 
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
@@ -15,68 +24,14 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
 
-type AccountProps = {
-  uid: string;
-  createdAt: number;
-  disabledAt: number | null;
-  emails: EmailProps[];
-  emailBounces: EmailBounceProps[];
-  totp: TotpProps[];
-  recoveryKeys: RecoveryKeysProps[];
-  sessionTokens: SessionTokensProps[];
+export type AccountProps = AccountType & {
   onCleared: Function;
   query: string;
-  securityEvents: SecurityEventsProps[];
-};
-
-type EmailBounceProps = {
-  email: string;
-  createdAt: number;
-  bounceType: string;
-  bounceSubType: string;
-};
-
-type EmailProps = {
-  email: string;
-  isVerified: boolean;
-  isPrimary: boolean;
-  createdAt: number;
-};
-
-type SecurityEventsProps = {
-  uid: string;
-  verified: boolean;
-  createdAt: number;
-  name: string;
-};
-
-type TotpProps = {
-  verified: boolean;
-  createdAt: number;
-  enabled: boolean;
-};
-
-type RecoveryKeysProps = {
-  createdAt: number;
-  verifiedAt: number;
-  enabled: boolean;
-};
-
-type SessionTokensProps = {
-  tokenId: string;
-  uid: string;
-  createdAt: number;
-  uaBrowser: string;
-  uaBrowserVersion: string;
-  uaOS: string;
-  uaOSVersion: string;
-  uaDeviceType: string;
-  lastAccessTime: number;
 };
 
 type DangerZoneProps = {
   uid: string;
-  email: EmailProps;
+  email: EmailType;
   disabledAt: number | null;
   onCleared: Function;
 };
@@ -236,8 +191,8 @@ export const Account = ({
   securityEvents,
 }: AccountProps) => {
   const date = dateFormat(new Date(createdAt), DATE_FORMAT);
-  const primaryEmail = emails.find((email) => email.isPrimary)!;
-  const secondaryEmails = emails.filter((email) => !email.isPrimary)!;
+  const primaryEmail = emails!.find((email) => email.isPrimary)!;
+  const secondaryEmails = emails!.filter((email) => !email.isPrimary);
 
   return (
     <section className="account" data-testid="account-section">
@@ -317,15 +272,15 @@ export const Account = ({
         <li>
           <h3>Email bounces</h3>
         </li>
-        {emailBounces.length > 0 ? (
+        {emailBounces && emailBounces.length > 0 ? (
           <>
             <ClearButton
               {...{
-                emails: emails.map((emails) => emails.email),
+                emails: emails!.map((emails) => emails.email),
                 onCleared,
               }}
             />
-            {emailBounces.map((emailBounce: EmailBounceProps) => (
+            {emailBounces.map((emailBounce: EmailBounceType) => (
               <EmailBounce key={emailBounce.createdAt} {...emailBounce} />
             ))}
           </>
@@ -340,9 +295,9 @@ export const Account = ({
         <li>
           <h3>TOTP (Time-Based One-Time Passwords)</h3>
         </li>
-        {totp.length > 0 ? (
+        {totp && totp.length > 0 ? (
           <>
-            {totp.map((totpIndex: TotpProps) => (
+            {totp.map((totpIndex: TotpType) => (
               <TotpEnabled key={totpIndex.createdAt} {...totpIndex} />
             ))}
           </>
@@ -357,9 +312,9 @@ export const Account = ({
         <li>
           <h3>Recovery Key</h3>
         </li>
-        {recoveryKeys.length > 0 ? (
+        {recoveryKeys && recoveryKeys.length > 0 ? (
           <>
-            {recoveryKeys.map((recoveryKeysIndex: RecoveryKeysProps) => (
+            {recoveryKeys.map((recoveryKeysIndex: RecoveryKeysType) => (
               <RecoveryKeys
                 key={recoveryKeysIndex.createdAt}
                 {...recoveryKeysIndex}
@@ -377,9 +332,9 @@ export const Account = ({
         <li>
           <h3>Current Session</h3>
         </li>
-        {sessionTokens.length > 0 ? (
+        {sessionTokens && sessionTokens.length > 0 ? (
           <>
-            {sessionTokens.map((sessionTokensIndex: SessionTokensProps) => (
+            {sessionTokens.map((sessionTokensIndex: SessionTokensType) => (
               <SessionTokens
                 key={sessionTokensIndex.createdAt}
                 {...sessionTokensIndex}
@@ -397,7 +352,7 @@ export const Account = ({
         <li>
           <h4>Account History</h4>
           <div className="account-history-info">
-            {securityEvents.length > 0 ? (
+            {securityEvents && securityEvents.length > 0 ? (
               <>
                 <TableContainer component={Paper}>
                   <Table
@@ -412,12 +367,12 @@ export const Account = ({
                     </TableHead>
                     <TableBody>
                       {securityEvents.map(
-                        (securityEvents: SecurityEventsProps) => (
+                        (securityEvents: SecurityEventsType) => (
                           <TableRow>
                             <TableCell>{securityEvents.name}</TableCell>
                             <TableCell>
                               {dateFormat(
-                                new Date(securityEvents.createdAt),
+                                new Date(securityEvents.createdAt!),
                                 DATE_FORMAT
                               )}
                             </TableCell>
@@ -442,7 +397,7 @@ export const Account = ({
         <DangerZone
           {...{
             uid,
-            disabledAt,
+            disabledAt: disabledAt!,
             email: primaryEmail, // only the primary for now
             onCleared: onCleared,
           }}
@@ -457,7 +412,7 @@ const EmailBounce = ({
   createdAt,
   bounceType,
   bounceSubType,
-}: EmailBounceProps) => {
+}: EmailBounceType) => {
   const date = dateFormat(new Date(createdAt), DATE_FORMAT);
   return (
     <li data-testid="bounce-group">
@@ -479,7 +434,7 @@ const EmailBounce = ({
   );
 };
 
-const TotpEnabled = ({ verified, createdAt, enabled }: TotpProps) => {
+const TotpEnabled = ({ verified, createdAt, enabled }: TotpType) => {
   const totpDate = dateFormat(new Date(createdAt), DATE_FORMAT);
   return (
     <li data-testid="">
@@ -513,13 +468,12 @@ const TotpEnabled = ({ verified, createdAt, enabled }: TotpProps) => {
   );
 };
 
-const RecoveryKeys = ({
-  verifiedAt,
-  createdAt,
-  enabled,
-}: RecoveryKeysProps) => {
-  const recoveryKeyCreatedDate = dateFormat(new Date(createdAt), DATE_FORMAT);
-  const recoveryKeyVerifiedDate = dateFormat(new Date(verifiedAt), DATE_FORMAT);
+const RecoveryKeys = ({ verifiedAt, createdAt, enabled }: RecoveryKeysType) => {
+  const recoveryKeyCreatedDate = dateFormat(new Date(createdAt!), DATE_FORMAT);
+  const recoveryKeyVerifiedDate = dateFormat(
+    new Date(verifiedAt!),
+    DATE_FORMAT
+  );
   return (
     <li data-testid="">
       <ul className="gradient-info-display">
@@ -562,20 +516,20 @@ const SessionTokens = ({
   uaOSVersion,
   uaDeviceType,
   lastAccessTime,
-}: SessionTokensProps) => {
+}: SessionTokensType) => {
   return (
     <li data-testid="">
       <ul className="gradient-info-display">
         <li>
           Created At:{' '}
           <span data-testid="session-token-created-at" className="result">
-            {dateFormat(new Date(createdAt), DATE_FORMAT)}
+            {dateFormat(new Date(createdAt!), DATE_FORMAT)}
           </span>
         </li>
         <li>
           Last Used:{' '}
           <span data-testid="session-token-accessed-at" className="result">
-            {dateFormat(new Date(lastAccessTime), DATE_FORMAT)}
+            {dateFormat(new Date(lastAccessTime!), DATE_FORMAT)}
           </span>
         </li>
         <li>

--- a/packages/fxa-admin-panel/src/components/AccountSearch/index.test.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/index.test.tsx
@@ -6,7 +6,6 @@ import React from 'react';
 import Chance from 'chance';
 import { render, fireEvent, act, screen } from '@testing-library/react';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
-import '@testing-library/jest-dom/extend-expect';
 import { CLEAR_BOUNCES_BY_EMAIL } from './Account/index';
 import { GET_ACCOUNT_BY_EMAIL, AccountSearch } from './index';
 

--- a/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/index.tsx
@@ -6,63 +6,7 @@ import React, { useState } from 'react';
 import { useLazyQuery, gql } from '@apollo/client';
 import Account from './Account';
 import './index.scss';
-
-interface AccountType {
-  uid: any;
-  createdAt: number;
-  disabledAt: number | null;
-  emails: [
-    {
-      email: string;
-      isVerified: boolean;
-      isPrimary: boolean;
-      createdAt: number;
-    }
-  ];
-  emailBounces: [
-    {
-      email: string;
-      createdAt: number;
-      bounceType: string;
-      bounceSubType: string;
-    }
-  ];
-  securityEvents: [
-    {
-      uid: string;
-      verified: boolean;
-      createdAt: number;
-      name: string;
-    }
-  ];
-  totp: [
-    {
-      verified: boolean;
-      createdAt: number;
-      enabled: boolean;
-    }
-  ];
-  recoveryKeys: [
-    {
-      createdAt: number;
-      verifiedAt: number;
-      enabled: boolean;
-    }
-  ];
-  sessionTokens: [
-    {
-      tokenId: string;
-      uid: string;
-      createdAt: number;
-      uaBrowser: string;
-      uaBrowserVersion: string;
-      uaOS: string;
-      uaOSVersion: string;
-      uaDeviceType: string;
-      lastAccessTime: number;
-    }
-  ];
-}
+import { Account as AccountType } from 'fxa-admin-server/src/graphql';
 
 export const GET_ACCOUNT_BY_EMAIL = gql`
   query getAccountByEmail($email: String!) {

--- a/packages/fxa-admin-panel/src/setupTests.js
+++ b/packages/fxa-admin-panel/src/setupTests.js
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import '@testing-library/jest-dom/extend-expect';

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -4,7 +4,7 @@
   "description": "FxA GraphQL Admin Server",
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "nest build",
+    "build": "yarn nest build",
     "lint": "eslint *",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "start": "pm2 start pm2.config.js",
@@ -60,6 +60,7 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@nestjs/cli": "^8.1.5",
     "@types/chance": "^1.1.2",
     "@types/convict": "^5.2.2",
     "@types/graphql": "^14.5.0",

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -79,6 +79,7 @@
     "proxyquire": "^2.1.3",
     "supertest": "^6.1.6",
     "ts-jest": "^27.0.7",
+    "ts-morph": "^12.2.0",
     "tsconfig-paths": "^3.11.0",
     "typescript": "^4.3.5",
     "yargs": "^17.0.1"

--- a/packages/fxa-admin-server/pm2.config.js
+++ b/packages/fxa-admin-server/pm2.config.js
@@ -10,7 +10,7 @@ module.exports = {
   apps: [
     {
       name: 'admin-server',
-      script: 'nest start --debug=9150 --watch',
+      script: 'yarn nest start --debug=9150 --watch',
       cwd: __dirname,
       max_restarts: '1',
       min_uptime: '2m',

--- a/packages/fxa-admin-server/src/app.module.ts
+++ b/packages/fxa-admin-server/src/app.module.ts
@@ -35,6 +35,9 @@ const version = getVersionInfo(__dirname);
         debug: configService.get<string>('env') !== 'production',
         playground: configService.get<string>('env') !== 'production',
         autoSchemaFile: join(__dirname, './schema.gql'),
+        definitions: {
+          path: join(process.cwd(), 'src/graphql.ts'),
+        },
         context: ({ req }) => ({ req }),
         plugins: [SentryPlugin],
       }),

--- a/packages/fxa-admin-server/src/graphql.ts
+++ b/packages/fxa-admin-server/src/graphql.ts
@@ -1,0 +1,110 @@
+
+/*
+ * -------------------------------------------------------
+ * THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+ * -------------------------------------------------------
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+export enum BounceType {
+    unmapped = "unmapped",
+    Permanent = "Permanent",
+    Transient = "Transient",
+    Complaint = "Complaint"
+}
+
+export enum BounceSubType {
+    unmapped = "unmapped",
+    Undetermined = "Undetermined",
+    General = "General",
+    NoEmail = "NoEmail",
+    Suppressed = "Suppressed",
+    MailboxFull = "MailboxFull",
+    MessageTooLarge = "MessageTooLarge",
+    ContentRejected = "ContentRejected",
+    AttachmentRejected = "AttachmentRejected",
+    Abuse = "Abuse",
+    AuthFailure = "AuthFailure",
+    Fraud = "Fraud",
+    NotSpam = "NotSpam",
+    Other = "Other",
+    Virus = "Virus"
+}
+
+export interface EmailBounce {
+    email: string;
+    bounceType: BounceType;
+    bounceSubType: BounceSubType;
+    createdAt: number;
+}
+
+export interface Email {
+    email: string;
+    isVerified: boolean;
+    isPrimary: boolean;
+    createdAt: number;
+}
+
+export interface SecurityEvents {
+    uid?: Nullable<string>;
+    nameId?: Nullable<number>;
+    verified?: Nullable<boolean>;
+    ipAddrHmac?: Nullable<string>;
+    createdAt?: Nullable<number>;
+    tokenVerificationId?: Nullable<string>;
+    name?: Nullable<string>;
+}
+
+export interface Totp {
+    verified: boolean;
+    createdAt: number;
+    enabled: boolean;
+}
+
+export interface RecoveryKeys {
+    createdAt?: Nullable<number>;
+    verifiedAt?: Nullable<number>;
+    enabled?: Nullable<boolean>;
+}
+
+export interface SessionTokens {
+    tokenId?: Nullable<string>;
+    tokenData?: Nullable<string>;
+    uid?: Nullable<string>;
+    createdAt?: Nullable<number>;
+    uaBrowser?: Nullable<string>;
+    uaBrowserVersion?: Nullable<string>;
+    uaOS?: Nullable<string>;
+    uaOSVersion?: Nullable<string>;
+    uaDeviceType?: Nullable<string>;
+    lastAccessTime?: Nullable<number>;
+}
+
+export interface Account {
+    uid: string;
+    email: string;
+    emailVerified: boolean;
+    createdAt: number;
+    disabledAt?: Nullable<number>;
+    emails?: Nullable<Email[]>;
+    emailBounces?: Nullable<EmailBounce[]>;
+    totp?: Nullable<Totp[]>;
+    recoveryKeys?: Nullable<RecoveryKeys[]>;
+    sessionTokens?: Nullable<SessionTokens[]>;
+    securityEvents?: Nullable<SecurityEvents[]>;
+}
+
+export interface IQuery {
+    accountByUid(uid: string): Nullable<Account> | Promise<Nullable<Account>>;
+    accountByEmail(email: string): Nullable<Account> | Promise<Nullable<Account>>;
+    getEmailsLike(search: string): Nullable<Email[]> | Promise<Nullable<Email[]>>;
+}
+
+export interface IMutation {
+    unverifyEmail(email: string): boolean | Promise<boolean>;
+    disableAccount(uid: string): boolean | Promise<boolean>;
+    clearEmailBounce(email: string): boolean | Promise<boolean>;
+}
+
+type Nullable<T> = T | null;

--- a/packages/fxa-admin-server/src/schema.gql
+++ b/packages/fxa-admin-server/src/schema.gql
@@ -81,7 +81,7 @@ type Account {
   email: String!
   emailVerified: Boolean!
   createdAt: Float!
-  disabledAt: Float!
+  disabledAt: Float
   emails: [Email!]
   emailBounces: [EmailBounce!]
   totp: [Totp!]

--- a/yarn.lock
+++ b/yarn.lock
@@ -69,6 +69,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@angular-devkit/core@npm:13.0.3":
+  version: 13.0.3
+  resolution: "@angular-devkit/core@npm:13.0.3"
+  dependencies:
+    ajv: 8.6.3
+    ajv-formats: 2.1.1
+    fast-json-stable-stringify: 2.1.0
+    magic-string: 0.25.7
+    rxjs: 6.6.7
+    source-map: 0.7.3
+  peerDependencies:
+    chokidar: ^3.5.2
+  peerDependenciesMeta:
+    chokidar:
+      optional: true
+  checksum: 80394699cac2de5984949c833266287b01984f9b035f2967e753607ed8c74bf80ae5e49a240379957729c603ff7e1720e0c572269df0a7727984d8bc62850c6d
+  languageName: node
+  linkType: hard
+
 "@angular-devkit/schematics-cli@npm:12.2.7":
   version: 12.2.7
   resolution: "@angular-devkit/schematics-cli@npm:12.2.7"
@@ -82,6 +101,22 @@ __metadata:
   bin:
     schematics: bin/schematics.js
   checksum: 02288415dc2512408f2b04dcc8892ee9bad537959c4f95348a2f6786ff599485515390c885fab5cdb0205e0e82ad9d3ea30f939d3f399b3b570006da618a3a1c
+  languageName: node
+  linkType: hard
+
+"@angular-devkit/schematics-cli@npm:13.0.3":
+  version: 13.0.3
+  resolution: "@angular-devkit/schematics-cli@npm:13.0.3"
+  dependencies:
+    "@angular-devkit/core": 13.0.3
+    "@angular-devkit/schematics": 13.0.3
+    ansi-colors: 4.1.1
+    inquirer: 8.2.0
+    minimist: 1.2.5
+    symbol-observable: 4.0.0
+  bin:
+    schematics: bin/schematics.js
+  checksum: a5dc5bc6619ded1eb8aa1a5df2d7e5bf3739224bd3b35037f633adc0da6a7b13b215bcd538fa14cc60dc7827d88e58b30115259902c3f3645e145446d406d635
   languageName: node
   linkType: hard
 
@@ -115,6 +150,19 @@ __metadata:
     ora: 5.4.1
     rxjs: 6.6.7
   checksum: 7ce859d19beb5ec953fcb488022ac46a453093ffeac0f8da8719023fe8b6f8c9cbc90fdbc05fa47ffe8fc5264ade3e5cd77660b92b7f4e84dd45cdab70ab1d08
+  languageName: node
+  linkType: hard
+
+"@angular-devkit/schematics@npm:13.0.3":
+  version: 13.0.3
+  resolution: "@angular-devkit/schematics@npm:13.0.3"
+  dependencies:
+    "@angular-devkit/core": 13.0.3
+    jsonc-parser: 3.0.0
+    magic-string: 0.25.7
+    ora: 5.4.1
+    rxjs: 6.6.7
+  checksum: d7ae8c87ff73cefe84e6ed9ab66dec6cdb5ff1ce37b80011f03b23508ca1dea488fbfd8fd1753b0ef62853134e0b66d8957bba6a7e406c7e1dc9e7e3f493e952
   languageName: node
   linkType: hard
 
@@ -4349,6 +4397,38 @@ __metadata:
   bin:
     nest: bin/nest.js
   checksum: 4199db7e3dd9c0589ba8493ec8041590110b89bd8029f0cd21812b19fa5a2f899bd2a1c6dc7459a14c4db0bb2997f29abdfc9aa6cf4a4fbc91a382211f429425
+  languageName: node
+  linkType: hard
+
+"@nestjs/cli@npm:^8.1.5":
+  version: 8.1.5
+  resolution: "@nestjs/cli@npm:8.1.5"
+  dependencies:
+    "@angular-devkit/core": 13.0.3
+    "@angular-devkit/schematics": 13.0.3
+    "@angular-devkit/schematics-cli": 13.0.3
+    "@nestjs/schematics": ^8.0.3
+    chalk: 3.0.0
+    chokidar: 3.5.2
+    cli-table3: 0.6.0
+    commander: 4.1.1
+    fork-ts-checker-webpack-plugin: 6.4.0
+    inquirer: 7.3.3
+    node-emoji: 1.11.0
+    ora: 5.4.1
+    os-name: 4.0.1
+    rimraf: 3.0.2
+    shelljs: 0.8.4
+    source-map-support: 0.5.20
+    tree-kill: 1.2.2
+    tsconfig-paths: 3.11.0
+    tsconfig-paths-webpack-plugin: 3.5.2
+    typescript: 4.3.5
+    webpack: 5.64.1
+    webpack-node-externals: 3.0.0
+  bin:
+    nest: bin/nest.js
+  checksum: 7818d8bfaf51513def32e90e0268fdafc0383c7a75ee0b270499cf5c5b8158f6e7e53fe296dad15858d74c063db5db49df50cf63967345fa1f2161844fa6dc02
   languageName: node
   linkType: hard
 
@@ -9857,6 +9937,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"acorn-import-assertions@npm:^1.7.6":
+  version: 1.8.0
+  resolution: "acorn-import-assertions@npm:1.8.0"
+  peerDependencies:
+    acorn: ^8
+  checksum: 5c4cf7c850102ba7ae0eeae0deb40fb3158c8ca5ff15c0bca43b5c47e307a1de3d8ef761788f881343680ea374631ae9e9615ba8876fee5268dbe068c98bcba6
+  languageName: node
+  linkType: hard
+
 "acorn-jsx@npm:^4.0.1":
   version: 4.1.1
   resolution: "acorn-jsx@npm:4.1.1"
@@ -10066,6 +10155,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-formats@npm:2.1.1":
+  version: 2.1.1
+  resolution: "ajv-formats@npm:2.1.1"
+  dependencies:
+    ajv: ^8.0.0
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 4a287d937f1ebaad4683249a4c40c0fa3beed30d9ddc0adba04859026a622da0d317851316ea64b3680dc60f5c3c708105ddd5d5db8fe595d9d0207fd19f90b7
+  languageName: node
+  linkType: hard
+
 "ajv-keywords@npm:^3.1.0, ajv-keywords@npm:^3.4.1, ajv-keywords@npm:^3.5.2":
   version: 3.5.2
   resolution: "ajv-keywords@npm:3.5.2"
@@ -10108,6 +10211,18 @@ __metadata:
     require-from-string: ^2.0.2
     uri-js: ^4.2.2
   checksum: b86d6cb86c69abbd8ce71ab7d4ff272660bf6d34fa9fbe770f73e54da59d531b2546692e36e2b35bbcfb11d20db774b4c09189671335185b8c799d65194e5169
+  languageName: node
+  linkType: hard
+
+"ajv@npm:8.6.3":
+  version: 8.6.3
+  resolution: "ajv@npm:8.6.3"
+  dependencies:
+    fast-deep-equal: ^3.1.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+    uri-js: ^4.2.2
+  checksum: 690ffb9408415fdab43686b3f92037ba0c8362f5d0709a123ba3fb546e6ad81414455f80a2b5cc432ce924afe9864671198f022bc331a19c072d4ede152ec3ca
   languageName: node
   linkType: hard
 
@@ -17191,6 +17306,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"enhanced-resolve@npm:^5.8.3":
+  version: 5.8.3
+  resolution: "enhanced-resolve@npm:5.8.3"
+  dependencies:
+    graceful-fs: ^4.2.4
+    tapable: ^2.2.0
+  checksum: d79fbe531106448b768bb0673fb623ec0202d7ee70373ab7d4f4745d5dfe0806f38c9db7e7da8c941288fe475ab3d538db3791fce522056eeea40ca398c9e287
+  languageName: node
+  linkType: hard
+
 "enquirer@npm:2.3.6, enquirer@npm:^2.3.5":
   version: 2.3.6
   resolution: "enquirer@npm:2.3.6"
@@ -17330,6 +17455,13 @@ __metadata:
   version: 0.7.1
   resolution: "es-module-lexer@npm:0.7.1"
   checksum: c66fb633cc521529862818caf603897d58d30442c885a1a1ed16823ddbbb8a437e3952454a4b2650242df1c1b4d0efa42fedbe49594e3ef2ceb3c891cf1211dd
+  languageName: node
+  linkType: hard
+
+"es-module-lexer@npm:^0.9.0":
+  version: 0.9.3
+  resolution: "es-module-lexer@npm:0.9.3"
+  checksum: 84bbab23c396281db2c906c766af58b1ae2a1a2599844a504df10b9e8dc77ec800b3211fdaa133ff700f5703d791198807bba25d9667392d27a5e9feda344da8
   languageName: node
   linkType: hard
 
@@ -19488,6 +19620,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fork-ts-checker-webpack-plugin@npm:6.4.0":
+  version: 6.4.0
+  resolution: "fork-ts-checker-webpack-plugin@npm:6.4.0"
+  dependencies:
+    "@babel/code-frame": ^7.8.3
+    "@types/json-schema": ^7.0.5
+    chalk: ^4.1.0
+    chokidar: ^3.4.2
+    cosmiconfig: ^6.0.0
+    deepmerge: ^4.2.2
+    fs-extra: ^9.0.0
+    glob: ^7.1.6
+    memfs: ^3.1.2
+    minimatch: ^3.0.4
+    schema-utils: 2.7.0
+    semver: ^7.3.2
+    tapable: ^1.0.0
+  peerDependencies:
+    eslint: ">= 6"
+    typescript: ">= 2.7"
+    vue-template-compiler: "*"
+    webpack: ">= 4"
+  peerDependenciesMeta:
+    eslint:
+      optional: true
+    vue-template-compiler:
+      optional: true
+  checksum: feba541453d4bdeaa743388541e125204789369920909f0152b11cfd1801a75fb2f6c708eae0174c9810ab4334fa21dea761037629440a647046581e7df62b8c
+  languageName: node
+  linkType: hard
+
 "fork-ts-checker-webpack-plugin@npm:^6.0.4":
   version: 6.3.1
   resolution: "fork-ts-checker-webpack-plugin@npm:6.3.1"
@@ -20014,6 +20177,7 @@ fsevents@~2.1.1:
   version: 0.0.0-use.local
   resolution: "fxa-admin-server@workspace:packages/fxa-admin-server"
   dependencies:
+    "@nestjs/cli": ^8.1.5
     "@nestjs/common": ^8.1.2
     "@nestjs/config": ^1.1.0
     "@nestjs/core": ^8.2.0
@@ -23994,6 +24158,28 @@ fsevents@~2.1.1:
     strip-ansi: ^6.0.0
     through: ^2.3.6
   checksum: fa6caec984d12a89f6bf926c3ee4924beed3dd1ceae66ad8ac287c3ef1b534e31cba86af66950f364305c42eb263c8f4a98c5a27227b3459308c8e3251c6d39a
+  languageName: node
+  linkType: hard
+
+"inquirer@npm:8.2.0":
+  version: 8.2.0
+  resolution: "inquirer@npm:8.2.0"
+  dependencies:
+    ansi-escapes: ^4.2.1
+    chalk: ^4.1.1
+    cli-cursor: ^3.1.0
+    cli-width: ^3.0.0
+    external-editor: ^3.0.3
+    figures: ^3.0.0
+    lodash: ^4.17.21
+    mute-stream: 0.0.8
+    ora: ^5.4.1
+    run-async: ^2.4.0
+    rxjs: ^7.2.0
+    string-width: ^4.1.0
+    strip-ansi: ^6.0.0
+    through: ^2.3.6
+  checksum: 861d1a9324ae933b49126b3541d94e4d6a2f2a25411b3f3cc00c34bf1bdab34146362d702cf289efe6d8034900dc5905bcf2ea716092a02b6fc390e5986dd236
   languageName: node
   linkType: hard
 
@@ -31087,7 +31273,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"ora@npm:5.4.1, ora@npm:^5.3.0":
+"ora@npm:5.4.1, ora@npm:^5.3.0, ora@npm:^5.4.1":
   version: 5.4.1
   resolution: "ora@npm:5.4.1"
   dependencies:
@@ -39605,6 +39791,17 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"tsconfig-paths-webpack-plugin@npm:3.5.2":
+  version: 3.5.2
+  resolution: "tsconfig-paths-webpack-plugin@npm:3.5.2"
+  dependencies:
+    chalk: ^4.1.0
+    enhanced-resolve: ^5.7.0
+    tsconfig-paths: ^3.9.0
+  checksum: e7872f45b10684204d4a6cbc7989073d885c99e0c9eb5222de6b2b83d2e1594bccb647f52d2f8e00c53da5b9a3084e47a2de44f41c6f7a607ec2b17330a8d9e9
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:3.11.0, tsconfig-paths@npm:^3.11.0, tsconfig-paths@npm:^3.9.0":
   version: 3.11.0
   resolution: "tsconfig-paths@npm:3.11.0"
@@ -41271,6 +41468,13 @@ typescript@^4.3.5:
   languageName: node
   linkType: hard
 
+"webpack-sources@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "webpack-sources@npm:3.2.2"
+  checksum: cc81f1f1bfd1c25c7a565598850294b515bcccf7974d0249b4a0c8c607307866ce3f9e8cdef1c74d5facfb0d993944c499cfd4b7c8f52d01359b6671cc5823d4
+  languageName: node
+  linkType: hard
+
 "webpack-virtual-modules@npm:^0.2.2":
   version: 0.2.2
   resolution: "webpack-virtual-modules@npm:0.2.2"
@@ -41401,6 +41605,43 @@ typescript@^4.3.5:
   bin:
     webpack: bin/webpack.js
   checksum: 7aca5a40bf95d83c89b30b7c58da70e6aba672fc97b8f8ddea18516ce026706982b3b6b5c9509a6295b87de889df64f9a08e125ba9a36a128cb84cbce742225c
+  languageName: node
+  linkType: hard
+
+"webpack@npm:5.64.1":
+  version: 5.64.1
+  resolution: "webpack@npm:5.64.1"
+  dependencies:
+    "@types/eslint-scope": ^3.7.0
+    "@types/estree": ^0.0.50
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/wasm-edit": 1.11.1
+    "@webassemblyjs/wasm-parser": 1.11.1
+    acorn: ^8.4.1
+    acorn-import-assertions: ^1.7.6
+    browserslist: ^4.14.5
+    chrome-trace-event: ^1.0.2
+    enhanced-resolve: ^5.8.3
+    es-module-lexer: ^0.9.0
+    eslint-scope: 5.1.1
+    events: ^3.2.0
+    glob-to-regexp: ^0.4.1
+    graceful-fs: ^4.2.4
+    json-parse-better-errors: ^1.0.2
+    loader-runner: ^4.2.0
+    mime-types: ^2.1.27
+    neo-async: ^2.6.2
+    schema-utils: ^3.1.0
+    tapable: ^2.1.1
+    terser-webpack-plugin: ^5.1.3
+    watchpack: ^2.2.0
+    webpack-sources: ^3.2.2
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: d2a1baddaed03f2ce70c13501b89935d4bb4af30b4accb0d2dfbd00ec6f491eaf46272346cedcf013b477e131c8cc202ee0b2d2c51ece1cfb713fd2d98b80a52
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7314,6 +7314,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ts-morph/common@npm:~0.11.1":
+  version: 0.11.1
+  resolution: "@ts-morph/common@npm:0.11.1"
+  dependencies:
+    fast-glob: ^3.2.7
+    minimatch: ^3.0.4
+    mkdirp: ^1.0.4
+    path-browserify: ^1.0.1
+  checksum: 2853215cfdfb9b65f96ceef91b15a73ab6591fd27d072801884ea5acc1a8f0becd5ac214d5f3d840f5d650b7654585a9b9df86fc4287872e7be1c6f566381bfd
+  languageName: node
+  linkType: hard
+
 "@tsconfig/node10@npm:^1.0.7":
   version: 1.0.7
   resolution: "@tsconfig/node10@npm:1.0.7"
@@ -14341,6 +14353,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"code-block-writer@npm:^10.1.1":
+  version: 10.1.1
+  resolution: "code-block-writer@npm:10.1.1"
+  checksum: e048037acbcbda19fca62a3a63e4a64226ea6b5dc0fad7632d34a88c1165b29a357e5e19f0497811e9911472e824ab85f68176f40e439da87e051908956eb47c
+  languageName: node
+  linkType: hard
+
 "code-excerpt@npm:^3.0.0":
   version: 3.0.0
   resolution: "code-excerpt@npm:3.0.0"
@@ -20041,6 +20060,7 @@ fsevents@~2.1.1:
     rxjs: ^7.2.0
     supertest: ^6.1.6
     ts-jest: ^27.0.7
+    ts-morph: ^12.2.0
     tsconfig-paths: ^3.11.0
     tslib: ^2.3.0
     typescript: ^4.3.5
@@ -31658,6 +31678,13 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
+"path-browserify@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "path-browserify@npm:1.0.1"
+  checksum: c6d7fa376423fe35b95b2d67990060c3ee304fc815ff0a2dc1c6c3cfaff2bd0d572ee67e18f19d0ea3bbe32e8add2a05021132ac40509416459fffee35200699
+  languageName: node
+  linkType: hard
+
 "path-dirname@npm:^1.0.0":
   version: 1.0.2
   resolution: "path-dirname@npm:1.0.2"
@@ -39510,6 +39537,16 @@ resolve@^2.0.0-next.3:
     typescript: "*"
     webpack: "*"
   checksum: 93dd15b553a2621f969c4c834e7eb085b9b079adb702cba68a7ee516bcd2c67620e62cc5a8c57345e90c644ff6b689ee5a09f0702e440284fdfe872e9aaeefd8
+  languageName: node
+  linkType: hard
+
+"ts-morph@npm:^12.2.0":
+  version: 12.2.0
+  resolution: "ts-morph@npm:12.2.0"
+  dependencies:
+    "@ts-morph/common": ~0.11.1
+    code-block-writer: ^10.1.1
+  checksum: c6c066d49da84555d56c1fd16d6de52cb123ea1b6eb71869b29a23ce351849aef3529396d7103a456e9f6e10c56493efe959b4331741e1db7c613d7f5a9de9c9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20148,6 +20148,7 @@ fsevents@~2.1.1:
     eslint-plugin-react: ^7.26.1
     express: ^4.17.1
     express-http-proxy: ^1.6.3
+    fxa-admin-server: "workspace:*"
     fxa-react: "workspace:*"
     fxa-shared: "workspace:*"
     graphql: ^15.6.1
@@ -20173,7 +20174,7 @@ fsevents@~2.1.1:
   languageName: unknown
   linkType: soft
 
-"fxa-admin-server@workspace:packages/fxa-admin-server":
+"fxa-admin-server@workspace:*, fxa-admin-server@workspace:packages/fxa-admin-server":
   version: 0.0.0-use.local
   resolution: "fxa-admin-server@workspace:packages/fxa-admin-server"
   dependencies:


### PR DESCRIPTION
## Because

- We currently manually define our GraphQL Typescript types, but we shouldn't need to 

## This pull request

- Generate them automatically, use them
- Bonus: adds the nest cli as a dev dependency so you don't need it installed on your system to call it
- Bonus: makes use of setupTests feature of Jest to import jest-dom globally