### PR TITLE
Support contextual  translation of  'None'

### DIFF
--- a/packages/fxa-settings/src/components/Profile/en-US.ftl
+++ b/packages/fxa-settings/src/components/Profile/en-US.ftl
@@ -13,5 +13,7 @@ profile-password =
 profile-password-created-date = Created { $date }
 profile-primary-email =
   .header = Primary email
+# Default value for the primary email when missing
+profile-primary-email-none = None
 
 ##

--- a/packages/fxa-settings/src/components/Profile/index.tsx
+++ b/packages/fxa-settings/src/components/Profile/index.tsx
@@ -3,10 +3,11 @@ import { useAccount } from '../../models';
 import { UnitRow } from '../UnitRow';
 import { UnitRowSecondaryEmail } from '../UnitRowSecondaryEmail';
 import { HomePath } from '../../constants';
-import { Localized } from '@fluent/react';
+import { Localized, useLocalization } from '@fluent/react';
 
 export const Profile = () => {
   const { avatar, primaryEmail, displayName, passwordCreated } = useAccount();
+  const { l10n } = useLocalization();
 
   const pwdDateText = Intl.DateTimeFormat('default', {
     year: 'numeric',
@@ -75,6 +76,11 @@ export const Profile = () => {
             header="Primary email"
             headerId="primary-email"
             headerValue={primaryEmail.email}
+            noHeaderValueText={l10n.getString(
+              'profile-primary-email-none',
+              null,
+              'None'
+            )}
             headerValueClassName="break-all"
             prefixDataTestId="primary-email"
           />

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/en-US.ftl
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/en-US.ftl
@@ -30,5 +30,7 @@ se-make-primary = Make primary
 se-default-content = Access your account if you can’t log in to your primary email.
 se-content-note = Note: a secondary email won’t restore your information — you’ll
   need a <a>recovery key</a> for that.
+# Default value for the secondary email when missing
+se-secondary-email-none = None
 
 ##

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -136,6 +136,11 @@ export const UnitRowSecondaryEmail = () => {
           headerId="secondary-email"
           prefixDataTestId="secondary-email"
           headerValue={null}
+          noHeaderValueText={l10n.getString(
+            'se-secondary-email-none',
+            null,
+            'None'
+          )}
           route={`${HomePath}/emails`}
           {...{
             alertBarRevealed: alertBar.visible,


### PR DESCRIPTION
## Because

- In some languages, the translation of 'none' can differ depending on the context. 
- In this case the translation of none as a default for primary email would not be the same as the translation of none as a default  for secondary email.

## This pull request

- Introduces distinct translations for 'none' when used in the context of either primary email or secondary email.

## Issue that this pull request solves

Closes: #9126

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
