### PR TITLE
chore(auth-server): Additional FTL tweaks based on feedback

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/auth.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/auth.ftl
@@ -7,14 +7,17 @@
 ### Emails have a rich HTML version and a plaintext version. The strings are usually identical
 ### but sometimes they differ slightly.
 
-## Firefox and Mozilla Brand
+# Firefox and Mozilla Brand
 -brand-mozilla = Mozilla
 -brand-firefox = Firefox
 
-## "Accounts" can be localized, "Firefox" must be treated as a brand.
+# "Accounts" can be localized and should be lowercase, "Firefox" must be treated as a brand.
 -product-firefox-accounts = Firefox accounts
 
-## "Account" can be localized, "Firefox" must be treated as a brand.
+# "Account" can be localized and should be lowercase, "Firefox" must be treated as a brand.
 -product-firefox-account = Firefox account
+
+# "Firefox Cloud" should be treated as a brand.
+-product-firefox-cloud = Firefox Cloud
 
 ## Email content

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/fxa/en.ftl
@@ -1,2 +1,2 @@
 fxa-privacy-url = { -brand-mozilla } Privacy Policy
-fxa-service-url = { -brand-firefox } Cloud Terms of Service
+fxa-service-url = { -product-firefox-cloud } Terms of Service

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/en.ftl
@@ -1,5 +1,9 @@
-# Variables:
-#  $clientName (String) - A client the user hasn't signed into before (e.g. Firefox, Sync)
+## Variables:
+##  $clientName (String) - A client the user hasn't signed into before (e.g. Firefox, Sync)
+
 newDeviceLogin-subject = New sign-in to { $clientName }
 newDeviceLogin-title = New sign-in to { $clientName }
+
+##
+
 newDeviceLogin-action = Manage account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddAccountRecovery/en.ftl
@@ -1,6 +1,6 @@
 postAddAccountRecovery-subject = Account recovery key generated
 postAddAccountRecovery-title = Account recovery key generated
-postAddAccountRecovery-description = You have successfully generated an account recovery key for your { -brand-firefox } Account using the following device:
+postAddAccountRecovery-description = You have successfully generated an account recovery key for your { -product-firefox-account } using the following device:
 postAddAccountRecovery-action = Manage account
 postAddAccountRecovery-recovery = If this was not you, <a data-l10n-name="revokeAccountRecoveryLink">click here</a>.
 postAddAccountRecovery-revoke = If this was not you, revoke key.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentExpired/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentExpired/en.ftl
@@ -1,6 +1,3 @@
 subscriptionsPaymentExpired-subject = Credit card for your subscriptions is expiring soon
 subscriptionsPaymentExpired-title = Your credit card is about to expire
 subscriptionsPaymentExpired-content = The credit card you’re using to make payments for the following subscriptions is about to expire.
-# Variables:
-#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
-subscriptionsPaymentExpired-name = { $productName }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentExpired/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentExpired/index.mjml
@@ -17,7 +17,7 @@
   <mj-text css-class="text-body">
     <ul>
       <% for (const { productName } of subscriptions) { %>
-        <li data-l10n-id="subscriptionsPaymentExpired-name" data-l10n-args="<%= JSON.stringify({productName}) %>">
+        <li>
           <%- productName %>
         </li>
       <% } %>


### PR DESCRIPTION
Because:
* Per our legal counsel, "Firefox Cloud" should be treated as a brand for now
* There is additional feedback in the l10n PR

This commit:
* Adds new product term, expands on comments for clarity, incorporates feedback

--

Hopefully the last round here. This is the branch I'm running [this script](https://github.com/LZoog/po-translations-to-ftl) (will tweak this later for reuse) on to generate [this PR](https://github.com/mozilla/fxa-content-server-l10n/pull/527). Once that PR is merged I'll merge this, and it'll close #10600 