### PR TITLE
fix(settings): support contextual  translation of  'None'

### DIFF
--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/en-US.ftl
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/en-US.ftl
@@ -30,5 +30,7 @@ se-make-primary = Make primary
 se-default-content = Access your account if you can’t log in to your primary email.
 se-content-note = Note: a secondary email won’t restore your information — you’ll
   need a <a>recovery key</a> for that.
+# Default value for the secondary email
+se-secondary-email-none = None
 
 ##

--- a/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
+++ b/packages/fxa-settings/src/components/UnitRowSecondaryEmail/index.tsx
@@ -136,6 +136,11 @@ export const UnitRowSecondaryEmail = () => {
           headerId="secondary-email"
           prefixDataTestId="secondary-email"
           headerValue={null}
+          noHeaderValueText={l10n.getString(
+            'se-secondary-email-none',
+            null,
+            'None'
+          )}
           route={`${HomePath}/emails`}
           {...{
             alertBarRevealed: alertBar.visible,


### PR DESCRIPTION
This applies to primary/secondary email fields.

## Because

- In some languages, the translation of 'none' can differ depending on the context.
- In this case the translation of none as a default for primary email would not be the same as the translation of none as a default  for secondary email.



## This pull request

- Introduces a distinct translation for 'none' when used in the context of secondary email.


## Issue that this pull request solves

closes #9126, closes mozilla/fxa-content-server-l10n/issues/472

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

