### PR TITLE
feature(subscriptions): allow IAP subscribers to use Support Form

### DIFF
--- a/packages/fxa-content-server/app/scripts/views/support.js
+++ b/packages/fxa-content-server/app/scripts/views/support.js
@@ -84,9 +84,8 @@ const SupportView = BaseView.extend({
         return account
           .fetchSubscriptionPlans()
           .then((plans) => {
-            const productSupportApps = getProductSupportApps(subscriptions)(
-              plans
-            );
+            const productSupportApps =
+              getProductSupportApps(subscriptions)(plans);
             this.productSupportApps = productSupportApps;
           })
           .then(() => account.fetchProfile());
@@ -158,7 +157,7 @@ const SupportView = BaseView.extend({
         'subscription.initialize',
         new SubscriptionModel(
           {
-            planId: subscription.plan_id,
+            planId: subscription.plan_id || subscription.sku,
             productId: subscription.product_id,
           },
           {

--- a/packages/fxa-content-server/app/tests/spec/views/support.js
+++ b/packages/fxa-content-server/app/tests/spec/views/support.js
@@ -212,6 +212,36 @@ describe('views/support', function () {
         });
     });
 
+    it('uses the SKU in place for plan ID in metrics when given a Google Play Subscription', () => {
+      account.getSubscriptions.restore();
+      sinon.stub(account, 'getSubscriptions').resolves([
+        {
+          product_id: '123done_xyz',
+          product_name: '123Done Pro',
+          sku: 'com.moz.stuff.cool',
+        },
+      ]);
+      return view
+        .render()
+        .then(function () {
+          view.afterVisible();
+          $('#container').append(view.el);
+        })
+        .then(function () {
+          view
+            .$('#product option:eq(1)')
+            .prop('selected', true)
+            .trigger('change');
+          assert.equal(notifier.trigger.callCount, 5);
+          const args = notifier.trigger.args[4];
+          assert.lengthOf(args, 3);
+          assert.equal(args[0], 'subscription.initialize');
+          assert.instanceOf(args[1], SubscriptionModel);
+          assert.equal(args[1].get('planId'), 'com.moz.stuff.cool');
+          assert.equal(args[1].get('productId'), '123done_xyz');
+        });
+    });
+
     it('should be prefixed "Other" when "Other" is selected', function () {
       return view
         .render()

--- a/packages/fxa-shared/subscriptions/metadata.ts
+++ b/packages/fxa-shared/subscriptions/metadata.ts
@@ -8,8 +8,8 @@ import {
   ProductDetailsStringProperty,
   ProductDetailsListProperties,
   ProductDetailsListProperty,
-  WebSubscription,
   AbbrevPlan,
+  MozillaSubscription,
 } from './types';
 
 const DEFAULT_LOCALE = 'en-US';
@@ -146,7 +146,7 @@ export const productDetailsFromPlan = (
  * id.  This is used for the app/service select on the support form.
  */
 export const getProductSupportApps =
-  (subscriptions: WebSubscription[]) => (plans: AbbrevPlan[]) => {
+  (subscriptions: MozillaSubscription[]) => (plans: AbbrevPlan[]) => {
     const metadataPrefix = 'support:app:';
     return plans.reduce((acc: { [keys: string]: string[] }, p) => {
       if (


### PR DESCRIPTION
Because:
 - IAP subscribers should be able to use the web support form

This commit:
 - handle Google Play IAP subscriptions for the support form by using
   the SKU as the plan id in metrics events
 - (the access to the form was granted as a side effect of adding the
   Google Play subscriptions to /account endpoint response)

## Issue that this pull request solves

Closes: #10865
