### PR TITLE
fix(pm2): resolve nest cli path in pm2 configs

### DIFF
--- a/packages/fxa-event-broker/pm2.config.js
+++ b/packages/fxa-event-broker/pm2.config.js
@@ -6,11 +6,13 @@ const PATH = process.env.PATH.split(':')
   .filter((p) => !p.includes(process.env.TMPDIR))
   .join(':');
 
+const nest = require.resolve('@nestjs/cli/bin/nest.js');
+
 module.exports = {
   apps: [
     {
       name: 'event-broker',
-      script: 'nest start --debug=9180 --watch',
+      script: `${nest} start --debug=9180 --watch`,
       cwd: __dirname,
       max_restarts: '1',
       env: {

--- a/packages/fxa-graphql-api/pm2.config.js
+++ b/packages/fxa-graphql-api/pm2.config.js
@@ -6,11 +6,13 @@ const PATH = process.env.PATH.split(':')
   .filter((p) => !p.includes(process.env.TMPDIR))
   .join(':');
 
+const nest = require.resolve('@nestjs/cli/bin/nest.js');
+
 module.exports = {
   apps: [
     {
       name: 'gql-api',
-      script: 'nest start --debug=9200 --watch',
+      script: `${nest} start --debug=9200 --watch`,
       cwd: __dirname,
       max_restarts: '1',
       min_uptime: '2m',

--- a/packages/fxa-support-panel/pm2.config.js
+++ b/packages/fxa-support-panel/pm2.config.js
@@ -6,12 +6,14 @@ const PATH = process.env.PATH.split(':')
   .filter((p) => !p.includes(process.env.TMPDIR))
   .join(':');
 
+const nest = require.resolve('@nestjs/cli/bin/nest.js');
+
 module.exports = {
   apps: [
     {
       name: 'support',
       cwd: __dirname,
-      script: 'nest start --debug=9190 --watch',
+      script: `${nest} start --debug=9190 --watch`,
       max_restarts: '1',
       min_uptime: '2m',
       env: {


### PR DESCRIPTION
There's a few cases where the 'nest' command might not be in the PATH when pm2 tries to run the script, and you end up with `/bin/bash: nest: command not found`. One example is starting a single service with `yarn workspace fxa-graphql-api start`. If we resolve the path we don't need to worry about what environment the command gets run in.