### PR TITLE
refactor(support-panel): move support panel subscriptions route

### DIFF
--- a/packages/fxa-auth-server/lib/routes/index.js
+++ b/packages/fxa-auth-server/lib/routes/index.js
@@ -165,6 +165,12 @@ module.exports = function (
     stripeHelper,
     zendeskClient
   );
+  const supportPanel = require('./support-panel')({
+    log,
+    db,
+    config,
+    stripeHelper,
+  });
   const newsletters = require('./newsletters')(log, db);
   const util = require('./util')(log, config, config.smtp.redirectDomain);
 
@@ -191,6 +197,7 @@ module.exports = function (
     util,
     recoveryKey,
     subscriptions,
+    supportPanel,
     newsletters
   );
   v1Routes.forEach((r) => {

--- a/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/index.ts
@@ -62,7 +62,7 @@ const createRoutes = (
     );
     routes.push(...supportRoutes(log, db, config, customs, zendeskClient));
     routes.push(
-      ...mozillaSubscriptionRoutes({ log, db, config, customs, stripeHelper })
+      ...mozillaSubscriptionRoutes({ log, db, customs, stripeHelper })
     );
   }
   if (stripeHelper && config.subscriptions.paypalNvpSigCredentials.enabled) {

--- a/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/mozilla.ts
@@ -2,14 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { ServerRoute } from '@hapi/hapi';
-import isA from '@hapi/joi';
-import {
-  MozillaSubscription,
-  MozillaSubscriptionTypes,
-} from 'fxa-shared/subscriptions/types';
+import { MozillaSubscription } from 'fxa-shared/subscriptions/types';
 import { Container } from 'typedi';
-
-import { ConfigType } from '../../../config';
 import { PlaySubscriptions } from '../../../lib/payments/google-play/subscriptions';
 import error from '../../error';
 import { PaymentBillingDetails, StripeHelper } from '../../payments/stripe';
@@ -20,14 +14,12 @@ import { handleAuth } from './utils';
 export const mozillaSubscriptionRoutes = ({
   log,
   db,
-  config,
   customs,
   stripeHelper,
   playSubscriptions,
 }: {
   log: AuthLogger;
   db: any;
-  config: ConfigType;
   customs: any;
   stripeHelper: StripeHelper;
   playSubscriptions?: PlaySubscriptions;
@@ -57,27 +49,6 @@ export const mozillaSubscriptionRoutes = ({
       },
       handler: (request: AuthRequest) =>
         mozillaSubscriptionHandler.getBillingDetailsAndSubscriptions(request),
-    },
-    {
-      // A Support Panel specific endpoint
-      method: 'GET',
-      path: '/oauth/mozilla-subscriptions/support-panel/subscriptions',
-      options: {
-        auth: {
-          payload: false,
-          strategy: 'supportPanelSecret',
-        },
-        response: {
-          schema: validators.subscriptionsSubscriptionSupportValidator,
-        },
-        validate: {
-          query: {
-            uid: isA.string().required(),
-          },
-        },
-      },
-      handler: (request: AuthRequest) =>
-        mozillaSubscriptionHandler.getSubscriptionsForSupportPanel(request),
     },
   ];
 };
@@ -126,24 +97,6 @@ export class MozillaSubscriptionHandler {
     return {
       ...response,
       subscriptions: [...response.subscriptions, ...iapGooglePlaySubscriptions],
-    };
-  }
-
-  async getSubscriptionsForSupportPanel(request: AuthRequest) {
-    this.log.begin('mozillaSubscriptions.supportPanelSubscriptions', request);
-    const { uid } = request.query as Record<string, string>;
-    const iapPlaySubscriptions = await this.playSubscriptions.getSubscriptions(
-      uid
-    );
-    const customer = await this.stripeHelper.fetchCustomer(uid);
-    const webSubscriptions = customer?.subscriptions;
-    const formattedWebSubscriptions = webSubscriptions
-      ? await this.stripeHelper.formatSubscriptionsForSupport(webSubscriptions)
-      : [];
-
-    return {
-      [MozillaSubscriptionTypes.WEB]: formattedWebSubscriptions,
-      [MozillaSubscriptionTypes.IAP_GOOGLE]: iapPlaySubscriptions,
     };
   }
 }

--- a/packages/fxa-auth-server/lib/routes/support-panel.ts
+++ b/packages/fxa-auth-server/lib/routes/support-panel.ts
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { ServerRoute } from '@hapi/hapi';
+import isA from '@hapi/joi';
+import { MozillaSubscriptionTypes } from 'fxa-shared/subscriptions/types';
+import { Container } from 'typedi';
+import { ConfigType } from '../../config';
+import { PlaySubscriptions } from '../../lib/payments/google-play/subscriptions';
+import { StripeHelper } from '../payments/stripe';
+import { AuthLogger, AuthRequest } from '../types';
+import validators from './validators';
+
+export const supportPanelRoutes = ({
+  log,
+  config,
+  stripeHelper,
+  playSubscriptions,
+}: {
+  log: AuthLogger;
+  config: ConfigType;
+  stripeHelper: StripeHelper;
+  playSubscriptions?: PlaySubscriptions;
+}): ServerRoute[] => {
+  if (!config.subscriptions.enabled) {
+    return [];
+  }
+
+  if (!playSubscriptions) {
+    playSubscriptions = Container.get(PlaySubscriptions);
+  }
+
+  const supportPanelHandler = new SupportPanelHandler(
+    log,
+    stripeHelper,
+    playSubscriptions
+  );
+  return [
+    {
+      method: 'GET',
+      path: '/oauth/support-panel/subscriptions',
+      options: {
+        auth: {
+          payload: false,
+          strategy: 'supportPanelSecret',
+        },
+        response: {
+          schema: validators.subscriptionsSubscriptionSupportValidator,
+        },
+        validate: {
+          query: {
+            uid: isA.string().required(),
+          },
+        },
+      },
+      handler: (request: AuthRequest) =>
+        supportPanelHandler.getSubscriptions(request),
+    },
+  ];
+};
+
+export class SupportPanelHandler {
+  constructor(
+    protected log: AuthLogger,
+    protected stripeHelper: StripeHelper,
+    protected playSubscriptions: PlaySubscriptions
+  ) {}
+
+  async getSubscriptions(request: AuthRequest) {
+    this.log.begin('supportPanelGetSubscriptions', request);
+    const { uid } = request.query as Record<string, string>;
+    const iapPlaySubscriptions = await this.playSubscriptions.getSubscriptions(
+      uid
+    );
+    const customer = await this.stripeHelper.fetchCustomer(uid);
+    const webSubscriptions = customer?.subscriptions;
+    const formattedWebSubscriptions = webSubscriptions
+      ? await this.stripeHelper.formatSubscriptionsForSupport(webSubscriptions)
+      : [];
+
+    return {
+      [MozillaSubscriptionTypes.WEB]: formattedWebSubscriptions,
+      [MozillaSubscriptionTypes.IAP_GOOGLE]: iapPlaySubscriptions,
+    };
+  }
+}
+
+module.exports = supportPanelRoutes;
+module.exports.supportPanelRoutes = supportPanelRoutes;

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/mozilla.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/mozilla.js
@@ -206,31 +206,4 @@ describe('mozilla-subscriptions', () => {
       }
     });
   });
-
-  describe('GET /oauth/mozilla-subscriptions/support-panel/subscriptions', () => {
-    it('gets the expected subscriptions', async () => {
-      const resp = await runTest(
-        '/oauth/mozilla-subscriptions/support-panel/subscriptions',
-        {
-          stripeHelper,
-        }
-      );
-      assert.deepEqual(resp, {
-        [MozillaSubscriptionTypes.WEB]: [mockFormattedWebSubscription],
-        [MozillaSubscriptionTypes.IAP_GOOGLE]: [
-          {
-            ...mockAbbrevPlayPurchase,
-            product_id: iap_product_id,
-            product_name: iap_product_name,
-            _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
-          },
-        ],
-      });
-      assert.calledOnceWithExactly(stripeHelper.fetchCustomer, UID);
-      assert.calledOnceWithExactly(
-        stripeHelper.formatSubscriptionsForSupport,
-        mockCustomer.subscriptions
-      );
-    });
-  });
 });

--- a/packages/fxa-auth-server/test/local/routes/support-panel.js
+++ b/packages/fxa-auth-server/test/local/routes/support-panel.js
@@ -1,0 +1,139 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const chai = require('chai');
+const mocks = require('../../mocks');
+const sinon = require('sinon');
+const uuid = require('uuid');
+const { getRoute } = require('../../routes_helpers');
+const { supportPanelRoutes } = require('../../../lib/routes/support-panel');
+const { MozillaSubscriptionTypes } = require('fxa-shared/subscriptions/types');
+const { OAUTH_SCOPE_SUBSCRIPTIONS } = require('fxa-shared/oauth/constants');
+
+const assert = { ...sinon.assert, ...chai.assert };
+const sandbox = sinon.createSandbox();
+const UID = uuid.v4({}, Buffer.alloc(16)).toString('hex');
+const TEST_EMAIL = 'testo@example.gg';
+const ACCOUNT_LOCALE = 'en-US';
+const MOCK_SCOPES = ['profile:email', OAUTH_SCOPE_SUBSCRIPTIONS];
+const VALID_REQUEST = {
+  auth: {
+    credentials: {
+      scope: MOCK_SCOPES,
+      user: `${UID}`,
+      email: `${TEST_EMAIL}`,
+    },
+  },
+  query: {
+    uid: `${UID}`,
+  },
+};
+const mockConfig = {
+  subscriptions: { enabled: true },
+};
+const mockCustomer = { id: 'cus_testo', subscriptions: { data: {} } };
+const mockFormattedWebSubscription = {
+  created: 1588972390,
+  current_period_end: 1591650790,
+  current_period_start: 1588972390,
+  plan_changed: null,
+  previous_product: null,
+  product_name: 'Amazing Product',
+  status: 'active',
+  subscription_id: 'sub_12345',
+};
+const mockAbbrevPlayPurchase = {
+  auto_renewing: true,
+  expiry_time_millis: Date.now(),
+  package_name: 'org.mozilla.cooking.with.foxkeh',
+  sku: 'org.mozilla.foxkeh.yearly',
+};
+const iap_product_id = 'iap_prod_lol';
+const iap_product_name = 'LOL Daily';
+const mockGooglePlaySubscription = {
+  _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+  product_id: iap_product_id,
+  product_name: iap_product_name,
+  ...mockAbbrevPlayPurchase,
+};
+const log = mocks.mockLog();
+const db = mocks.mockDB({
+  uid: UID,
+  email: TEST_EMAIL,
+  locale: ACCOUNT_LOCALE,
+});
+let stripeHelper;
+
+describe('support-panel', () => {
+  beforeEach(() => {
+    stripeHelper = {
+      addProductInfoToAbbrevPlayPurchases: sandbox.stub().resolves([
+        {
+          ...mockAbbrevPlayPurchase,
+          product_id: iap_product_id,
+          product_name: iap_product_name,
+        },
+      ]),
+      fetchCustomer: sandbox.stub().resolves(mockCustomer),
+      formatSubscriptionsForSupport: sandbox
+        .stub()
+        .resolves([mockFormattedWebSubscription]),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  describe('GET /oauth/support-panel/subscriptions', () => {
+    it('returns an empty list of routes when subscriptions is disabled', () => {
+      const routes = supportPanelRoutes({
+        log,
+        db,
+        config: { subscriptions: { enabled: false } },
+        stripeHelper,
+      });
+      assert.deepEqual(routes, []);
+    });
+
+    it('gets the expected subscriptions', async () => {
+      const playSubscriptions = {
+        getSubscriptions: sandbox.stub().resolves([mockGooglePlaySubscription]),
+      };
+      const routes = supportPanelRoutes({
+        log,
+        db,
+        config: mockConfig,
+        stripeHelper,
+        playSubscriptions,
+      });
+      const route = getRoute(
+        routes,
+        '/oauth/support-panel/subscriptions',
+        'GET'
+      );
+      const request = mocks.mockRequest(VALID_REQUEST);
+      const resp = await route.handler(request);
+
+      assert.deepEqual(resp, {
+        [MozillaSubscriptionTypes.WEB]: [mockFormattedWebSubscription],
+        [MozillaSubscriptionTypes.IAP_GOOGLE]: [
+          {
+            ...mockAbbrevPlayPurchase,
+            product_id: iap_product_id,
+            product_name: iap_product_name,
+            _subscription_type: MozillaSubscriptionTypes.IAP_GOOGLE,
+          },
+        ],
+      });
+      assert.calledOnceWithExactly(stripeHelper.fetchCustomer, UID);
+      assert.calledOnceWithExactly(
+        stripeHelper.formatSubscriptionsForSupport,
+        mockCustomer.subscriptions
+      );
+    });
+  });
+});

--- a/packages/fxa-support-panel/src/config.ts
+++ b/packages/fxa-support-panel/src/config.ts
@@ -30,8 +30,8 @@ const conf = convict({
       format: String,
     },
     subscriptionsSearchPath: {
-      default: '/v1/oauth/mozilla-subscriptions/support-panel/subscriptions',
-      doc: 'Auth server path for subscriptions search endpoint',
+      default: '/v1/oauth/support-panel/subscriptions',
+      doc: 'Auth server path for subscriptions',
       env: 'AUTH_SERVER_SUBS_SEARCH_PATH',
       format: String,
     },


### PR DESCRIPTION
Because:
 - the auth-server route for the Support Panel to fetch subscriptions
   was not in an intuitive location

This commit:
 - rename and move the route

This is a follow-up to PR #10948 based on https://github.com/mozilla/fxa/pull/10964#discussion_r751507150