### PR TITLE
slow down pm2 startup

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -1,21 +1,25 @@
 module.exports = {
   scripts: {
-    default: "nps help",
+    default: 'nps help',
     start: {
       default: `pm2 start _dev/pm2/infrastructure.config.js && _scripts/pm2-all.sh start && echo "Use 'yarn stop' to stop all the servers"`,
       infrastructure: `pm2 start _dev/pm2/infrastructure.config.js`,
       services: `_scripts/pm2-all.sh start`,
-      firefox: "./packages/fxa-dev-launcher/bin/fxa-dev-launcher &"
+      firefox: './packages/fxa-dev-launcher/bin/fxa-dev-launcher &',
     },
     stop: {
-      default: "pm2 kill",
+      default: 'pm2 kill',
       infrastructure: `pm2 stop _dev/pm2/infrastructure.config.js`,
-      services: `_scripts/pm2-all.sh stop`
+      services: `_scripts/pm2-all.sh stop`,
     },
     restart: {
-      default: "pm2 restart all",
+      default: 'pm2 restart all',
       infrastructure: `pm2 restart _dev/pm2/infrastructure.config.js`,
-      services: `_scripts/pm2-all.sh restart`
-    }
-  }
+      services: `_scripts/pm2-all.sh restart`,
+    },
+    delete: {
+      default: 'pm2 kill',
+      services: '_scripts/pm2-all.sh delete',
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "nps --prefix=start",
     "stop": "nps --prefix=stop",
     "restart": "nps --prefix=restart",
+    "delete": "nps --prefix=delete",
     "adb-reverse": "./_scripts/adb-reverse.sh",
     "test": "_scripts/test-package.sh",
     "config-fxios": "node _scripts/config-fxios.js",

--- a/packages/123done/package.json
+++ b/packages/123done/package.json
@@ -44,6 +44,7 @@
     "start": "pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
+    "delete": "pm2 delete pm2.config.js",
     "test": "npm run lint",
     "format": "prettier --write --config ../../_dev/.prettierrc '**'"
   }

--- a/packages/browserid-verifier/package.json
+++ b/packages/browserid-verifier/package.json
@@ -48,6 +48,7 @@
     "format": "prettier --write --config ../../_dev/.prettierrc '**'",
     "start": "pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
-    "restart": "pm2 restart pm2.config.js"
+    "restart": "pm2 restart pm2.config.js",
+    "delete": "pm2 delete pm2.config.js"
   }
 }

--- a/packages/fortress/package.json
+++ b/packages/fortress/package.json
@@ -44,6 +44,7 @@
     "start": "pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
+    "delete": "pm2 delete pm2.config.js",
     "test": "npm run lint",
     "format": "prettier --write --config ../../_dev/.prettierrc '**'"
   }

--- a/packages/functional-tests/scripts/test-ci.sh
+++ b/packages/functional-tests/scripts/test-ci.sh
@@ -21,15 +21,7 @@ yarn workspaces foreach \
     --include fxa-react \
     --include fxa-settings \
     --include fxa-shared \
-    --include fxa-support-panel \
     run start > ~/.pm2/logs/startup.log
-
-# ensure payments-server is ready
-_scripts/check-url.sh localhost:3031/__lbheartbeat__
-# ensure content-server is ready
-_scripts/check-url.sh localhost:3030/bundle/app.bundle.js
-# ensure settings is ready
-_scripts/check-url.sh localhost:3030/settings/static/js/bundle.js
 
 npx pm2 ls
 

--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -14,6 +14,7 @@
     "restart": "tsc --build ../fxa-react && npm run build-postcss && pm2 restart pm2.config.js",
     "start": "tsc --build ../fxa-react && npm run build-postcss && pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
+    "delete": "pm2 delete pm2.config.js",
     "storybook": "npm run build-postcss && start-storybook -p 6009",
     "test:frontend": "SKIP_PREFLIGHT_CHECK=true PUBLIC_URL=/ INLINE_RUNTIME_CHUNK=false rescripts test --coverage --verbose",
     "test:server": "jest --runInBand --coverage --verbose --config server/jest.config.js",

--- a/packages/fxa-admin-server/package.json
+++ b/packages/fxa-admin-server/package.json
@@ -11,6 +11,7 @@
     "stop": "pm2 stop pm2.config.js",
     "start:prod": "node dist/main",
     "restart": "pm2 restart pm2.config.js",
+    "delete": "pm2 delete pm2.config.js",
     "test": "jest --runInBand && yarn test:e2e",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/packages/fxa-auth-server/package.json
+++ b/packages/fxa-auth-server/package.json
@@ -17,6 +17,7 @@
     "start": "scripts/start-local.sh",
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
+    "delete": "pm2 delete pm2.config.js",
     "test": "VERIFIER_VERSION=0 scripts/test-local.sh",
     "test-ci": "scripts/test-local.sh && npm run test-e2e",
     "test-e2e": "NODE_ENV=dev mocha -r esbuild-register test/e2e",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -7,7 +7,7 @@
     "postinstall": "cp server/config/local.json-dist server/config/local.json && ../../_scripts/clone-l10n.sh fxa-content-server",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint": "eslint app server tests --cache",
-    "start": "node scripts/check-local-config && grunt l10n-create-json l10n-generate-tos-pp:app && pm2 start pm2.config.js",
+    "start": "node scripts/check-local-config && grunt l10n-create-json l10n-generate-tos-pp:app && pm2 start pm2.config.js && ../../_scripts/check-url.sh localhost:3030/bundle/app.bundle.js",
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
     "delete": "pm2 delete pm2.config.js",

--- a/packages/fxa-content-server/package.json
+++ b/packages/fxa-content-server/package.json
@@ -10,6 +10,7 @@
     "start": "node scripts/check-local-config && grunt l10n-create-json l10n-generate-tos-pp:app && pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
+    "delete": "pm2 delete pm2.config.js",
     "start-production": "NODE_ENV=production grunt build && CONFIG_FILES=server/config/local.json,server/config/production.json grunt serverproc:dist",
     "start-remote": "scripts/run_remote_dev.sh",
     "test": "node tests/intern.js --unit=true",

--- a/packages/fxa-content-server/scripts/test-ci.sh
+++ b/packages/fxa-content-server/scripts/test-ci.sh
@@ -31,7 +31,6 @@ yarn workspaces foreach \
     --topological-dev \
     --include 123done \
     --include browserid-verifier \
-    --include fxa-auth-db-mysql \
     --include fxa-auth-server \
     --include fxa-content-server \
     --include fxa-graphql-api \
@@ -40,16 +39,9 @@ yarn workspaces foreach \
     --include fxa-react \
     --include fxa-settings \
     --include fxa-shared \
-    --include fxa-support-panel \
     run start > ~/.pm2/logs/startup.log
 
 npx pm2 ls
-# ensure payments-server is ready
-_scripts/check-url.sh localhost:3031/__lbheartbeat__
-# ensure content-server is ready
-_scripts/check-url.sh localhost:3030/bundle/app.bundle.js
-# ensure settings is ready
-_scripts/check-url.sh localhost:3030/settings/static/js/bundle.js
 
 cd packages/fxa-content-server
 

--- a/packages/fxa-customs-server/package.json
+++ b/packages/fxa-customs-server/package.json
@@ -16,6 +16,7 @@
     "start": "pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
+    "delete": "pm2 delete pm2.config.js",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
     "lint": "eslint .",
     "test": "scripts/test-local.sh",

--- a/packages/fxa-event-broker/package.json
+++ b/packages/fxa-event-broker/package.json
@@ -16,7 +16,8 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r esbuild-register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "stop": "pm2 stop pm2.config.js",
-    "restart": "pm2 restart pm2.config.js"
+    "restart": "pm2 restart pm2.config.js",
+    "delete": "pm2 delete pm2.config.js"
   },
   "repository": {
     "type": "git",

--- a/packages/fxa-graphql-api/package.json
+++ b/packages/fxa-graphql-api/package.json
@@ -11,6 +11,7 @@
     "start": "pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
+    "delete": "pm2 delete pm2.config.js",
     "test": "jest --runInBand && yarn test:e2e",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -7,7 +7,7 @@
     "lint": "npm-run-all --parallel lint:eslint lint:sass",
     "lint:eslint": "eslint .",
     "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
-    "start": "pm2 start pm2.config.js",
+    "start": "pm2 start pm2.config.js && ../../_scripts/check-url.sh localhost:3031/__lbheartbeat__",
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
     "delete": "pm2 delete pm2.config.js",

--- a/packages/fxa-payments-server/package.json
+++ b/packages/fxa-payments-server/package.json
@@ -10,6 +10,7 @@
     "start": "pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
+    "delete": "pm2 delete pm2.config.js",
     "build": "tsc --build ../fxa-react && SKIP_PREFLIGHT_CHECK=true PUBLIC_URL=/ INLINE_RUNTIME_CHUNK=false CI=false rescripts build",
     "eject": "react-scripts eject",
     "test": "npm-run-all test:frontend test:server",

--- a/packages/fxa-profile-server/package.json
+++ b/packages/fxa-profile-server/package.json
@@ -10,6 +10,7 @@
     "start": "mkdirp var/public && pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
+    "delete": "pm2 delete pm2.config.js",
     "test": "scripts/test-local.sh",
     "format": "prettier --write --config ../../_dev/.prettierrc '**'"
   },

--- a/packages/fxa-react/package.json
+++ b/packages/fxa-react/package.json
@@ -18,6 +18,7 @@
     "restart": "pm2 restart pm2.config.js",
     "start": "pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
+    "delete": "pm2 delete pm2.config.js",
     "storybook": "npm run build-postcss && start-storybook -p 6007 --no-version-updates",
     "test": "jest --runInBand --env=jest-environment-jsdom"
   },

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -14,6 +14,7 @@
     "restart": "npm run build-postcss && pm2 restart pm2.config.js",
     "start": "npm run build-postcss && pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
+    "delete": "pm2 delete pm2.config.js",
     "storybook": "npm run build-postcss && start-storybook -p 6008 -s .storybook/design-guide --no-version-updates",
     "test": "SKIP_PREFLIGHT_CHECK=true rescripts test"
   },

--- a/packages/fxa-settings/package.json
+++ b/packages/fxa-settings/package.json
@@ -12,7 +12,7 @@
     "lint:eslint": "eslint .",
     "lint": "npm-run-all --parallel lint:eslint lint:sass",
     "restart": "npm run build-postcss && pm2 restart pm2.config.js",
-    "start": "npm run build-postcss && pm2 start pm2.config.js",
+    "start": "npm run build-postcss && pm2 start pm2.config.js && ../../_scripts/check-url.sh localhost:3000/settings/static/js/bundle.js",
     "stop": "pm2 stop pm2.config.js",
     "delete": "pm2 delete pm2.config.js",
     "storybook": "npm run build-postcss && start-storybook -p 6008 -s .storybook/design-guide --no-version-updates",

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -13,6 +13,7 @@
     "start": "pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
+    "delete": "pm2 delete pm2.config.js",
     "test": "yarn test:mocha && yarn test:jest",
     "test:mocha": "tsc --build && node ./scripts/mocha-coverage.js -r esbuild-register --recursive test/**/*.{js,ts}",
     "test:jest": "jest --runInBand --coverage",

--- a/packages/fxa-support-panel/package.json
+++ b/packages/fxa-support-panel/package.json
@@ -14,6 +14,7 @@
     "start": "pm2 start pm2.config.js",
     "stop": "pm2 stop pm2.config.js",
     "restart": "pm2 restart pm2.config.js",
+    "delete": "pm2 delete pm2.config.js",
     "test": "jest --runInBand && yarn test:e2e",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",


### PR DESCRIPTION
I've noticed ci failures where the services don't even get started up completely happening more frequently. During the brief time that circleci showed resource graphs the pm2 startup pegged both cpu and memory. If we wait for the services that have a lot of building at startup to finish before starting the next service maybe we'll have better stability.

<img width="509" alt="Screen Shot 2021-11-19 at 8 31 17 AM" src="https://user-images.githubusercontent.com/87619/142676529-da6ee97c-3c92-4d8a-9c5a-df68fa1d2342.png">


