### PR TITLE
feat(auth): include validation details for product/plan

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -44,6 +44,7 @@ import { ConfigType } from '../../config';
 import error from '../error';
 import Redis from '../redis';
 import { subscriptionProductMetadataValidator } from '../routes/validators';
+import { reportValidationError } from '../sentry';
 import { AuthFirestore } from '../types';
 import { CurrencyHelper } from './currencies';
 import { SubscriptionPurchase } from './google-play/subscription-purchase';
@@ -1181,22 +1182,16 @@ export class StripeHelper {
         continue;
       }
 
-      const result = subscriptionProductMetadataValidator.validate({
-        ...item.product.metadata,
-        ...item.metadata,
-      });
-
-      if (result?.error) {
-        const msg = `fetchAllPlans - Plan "${item.id}"'s metadata failed validation`;
-        this.log.error(msg, { error: result.error, plan: item });
-
-        Sentry.withScope((scope) => {
-          scope.setContext('validationError', {
-            error: result.error,
-          });
-          Sentry.captureMessage(msg, Sentry.Severity.Error);
+      const { error } =
+        await subscriptionProductMetadataValidator.validateAsync({
+          ...item.product.metadata,
+          ...item.metadata,
         });
 
+      if (error) {
+        const msg = `fetchAllPlans - Plan "${item.id}"'s metadata failed validation`;
+        this.log.error(msg, { error, plan: item });
+        reportValidationError(msg, error as any);
         continue;
       }
 

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -448,10 +448,36 @@ module.exports.subscriptionProductMetadataValidator = {
         error: 'Capability missing from metadata',
       };
     }
-
     return module.exports.subscriptionProductMetadataBaseValidator.validate(
-      metadata
+      metadata,
+      {
+        abortEarly: false,
+      }
     );
+  },
+  async validateAsync(metadata) {
+    const hasCapability = Object.keys(metadata).some((k) =>
+      capabilitiesClientIdPattern.test(k)
+    );
+
+    if (!hasCapability) {
+      return {
+        error: 'Capability missing from metadata',
+      };
+    }
+
+    try {
+      const value = await isA.validate(
+        metadata,
+        module.exports.subscriptionProductMetadataBaseValidator,
+        {
+          abortEarly: false,
+        }
+      );
+      return { value };
+    } catch (error) {
+      return { error };
+    }
   },
 };
 

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/stripe-webhooks.js
@@ -439,7 +439,9 @@ describe('StripeWebhookHandler', () => {
           product: updatedEvent.data.object,
         };
         const allPlans = [...validPlanList, invalidPlan];
-        StripeWebhookHandlerInstance.stripeHelper.allPlans.resolves(allPlans);
+        StripeWebhookHandlerInstance.stripeHelper.fetchAllPlans.resolves(
+          allPlans
+        );
         StripeWebhookHandlerInstance.stripeHelper.fetchPlansByProductId.resolves(
           [invalidPlan]
         );
@@ -451,7 +453,9 @@ describe('StripeWebhookHandler', () => {
         assert.calledOnce(scopeContextSpy);
         assert.calledOnce(captureMessageSpy);
 
-        assert.calledOnce(StripeWebhookHandlerInstance.stripeHelper.allPlans);
+        assert.calledOnce(
+          StripeWebhookHandlerInstance.stripeHelper.fetchAllPlans
+        );
         assert.calledOnceWithExactly(
           StripeWebhookHandlerInstance.stripeHelper.fetchPlansByProductId,
           updatedEvent.data.object.id
@@ -468,7 +472,7 @@ describe('StripeWebhookHandler', () => {
 
       it('does not throw a sentry error if the update event data is valid', async () => {
         const updatedEvent = deepCopy(eventProductUpdated);
-        StripeWebhookHandlerInstance.stripeHelper.allPlans.resolves(
+        StripeWebhookHandlerInstance.stripeHelper.fetchAllPlans.resolves(
           validPlanList
         );
         StripeWebhookHandlerInstance.stripeHelper.fetchPlansByProductId.resolves(
@@ -490,7 +494,7 @@ describe('StripeWebhookHandler', () => {
           ...deepCopy(eventProductUpdated),
           type: 'product.deleted',
         };
-        StripeWebhookHandlerInstance.stripeHelper.allPlans.resolves(
+        StripeWebhookHandlerInstance.stripeHelper.fetchAllPlans.resolves(
           validPlanList
         );
         StripeWebhookHandlerInstance.stripeHelper.fetchPlansByProductId.resolves(


### PR DESCRIPTION
Because:

* We want to update plans when the product information changes.
* We want more details about validation errors in product/plan
  information rather than just the first error.

This commit:

* Uses fetchAllPlans rather than the cached plans to ensure it can
  revalidate all of them when the product changes.
* Uses a new validation error Sentry reporter that extracts complete
  details of validation failures with abortEarly set to false so that
  all validation errors are included at once.

Closes #10826

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
