### PR TITLE
fix(content): l10n for texts in settings+content

### DIFF
--- a/packages/fxa-content-server/app/scripts/lib/email-domain-validator.js
+++ b/packages/fxa-content-server/app/scripts/lib/email-domain-validator.js
@@ -58,7 +58,11 @@ const checkEmailDomain = ($element, view) => {
 
   const showInvalidDomainError = (domain) => {
     const invalidDomainError = AuthErrors.toInvalidEmailDomainError(domain);
-    $(() => view.showValidationError($element, invalidDomainError));
+    $(() =>
+      view.showValidationError($element, invalidDomainError, undefined, {
+        domain,
+      })
+    );
     view.logEvent('emailDomainValidation.fail');
   };
 

--- a/packages/fxa-content-server/app/scripts/views/behaviors/navigate.js
+++ b/packages/fxa-content-server/app/scripts/views/behaviors/navigate.js
@@ -11,7 +11,8 @@ import _ from 'underscore';
 const NavigationBehavior = function (endpoint, options = {}) {
   const behavior = function (view, account) {
     if (account && options.success) {
-      account.set('alertText', options.success);
+      const translated = view.translate(options.success);
+      account.set('alertText', translated);
     }
     const navigateOptions = _.assign({}, options, { account });
     view.navigate(endpoint, navigateOptions);

--- a/packages/fxa-content-server/app/scripts/views/form.js
+++ b/packages/fxa-content-server/app/scripts/views/form.js
@@ -381,10 +381,10 @@ var FormView = BaseView.extend({
    * @returns {String}
    */
   showValidationError(el, err, shouldFocusEl = true) {
-    this.logError(err);
-
     const $invalidEl = this.$(el);
-    const message = AuthErrors.toMessage(err);
+    const message = AuthErrors.toInterpolatedMessage(err, this.translator);
+
+    this.logError(err);
 
     const maybeFocus = () => {
       return new Promise((resolve) => {

--- a/packages/fxa-content-server/app/scripts/views/form.js
+++ b/packages/fxa-content-server/app/scripts/views/form.js
@@ -380,9 +380,9 @@ var FormView = BaseView.extend({
    * @param {Boolean} shouldFocusEl
    * @returns {String}
    */
-  showValidationError(el, err, shouldFocusEl = true) {
+  showValidationError(el, err, shouldFocusEl = true, translationContext = {}) {
     const $invalidEl = this.$(el);
-    const message = AuthErrors.toInterpolatedMessage(err, this.translator);
+    const message = AuthErrors.toMessage(err);
 
     this.logError(err);
 
@@ -423,6 +423,7 @@ var FormView = BaseView.extend({
         invalidEl: $invalidEl,
         message,
         translator: this.translator,
+        translationContext,
       });
 
       maybeFocus().then(() => {

--- a/packages/fxa-content-server/app/scripts/views/tooltip.js
+++ b/packages/fxa-content-server/app/scripts/views/tooltip.js
@@ -40,6 +40,11 @@ const Tooltip = BaseView.extend({
     // element. If the element has the 'tooltip-below' class, the
     // tooltip is displayed just below it.
     this.invalidEl = $(options.invalidEl);
+    this.translationContext = options.translationContext;
+  },
+
+  setInitialContext(context) {
+    context.set(this.translationContext);
   },
 
   template() {

--- a/packages/fxa-content-server/app/tests/spec/views/behaviors/navigate.js
+++ b/packages/fxa-content-server/app/tests/spec/views/behaviors/navigate.js
@@ -14,9 +14,11 @@ describe('views/behaviors/navigate', function () {
     };
 
     const navigateBehavior = new NavigateBehavior('settings', options);
+    const translateMock = sinon.stub().returns(options.success);
     const viewMock = {
       navigate: sinon.spy(),
       config: {},
+      translate: translateMock,
     };
 
     const accountMock = { set: sinon.spy() };
@@ -32,6 +34,7 @@ describe('views/behaviors/navigate', function () {
     assert.isTrue(
       accountMock.set.calledOnceWithExactly('alertText', options.success)
     );
+    assert.isTrue(translateMock.calledOnce);
     assert.equal(endpoint, 'settings');
     assert.equal(navigateOptions.success, 'success');
     assert.equal(navigateOptions.error, 'error');

--- a/packages/fxa-settings/src/components/ModalVerifySession/en-US.ftl
+++ b/packages/fxa-settings/src/components/ModalVerifySession/en-US.ftl
@@ -8,3 +8,7 @@ mvs-enter-verification-code = Enter your verification code
 mvs-enter-verification-code-desc = Please enter the verification code that was sent to <email>{ $email }</email> within 5 minutes.
 msv-cancel-button = Cancel
 msv-submit-button = Verify
+
+## Auth-server based errors that originate from backend service
+
+auth-error-183 = Invalid or expired verification code

--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/en-US.ftl
@@ -9,4 +9,6 @@ add-secondary-email-enter-address =
 add-secondary-email-cancel-button = Cancel
 add-secondary-email-save-button = Save
 
-##
+## Auth-server based errors that originate from backend service
+
+auth-error-139 = Secondary email must be different than your account email


### PR DESCRIPTION
## Because

* Various error and notification texts are not rendered in the browsers
  lanugage.

## This pull request:

* Updated ftl's with missing error codes.
* Updated showValidationError to translate texts with string
  placeholders.
* Update navigate behavior to translate success texts.

Closes #
[9860](https://github.com/mozilla/fxa/issues/9860)
[10151](https://github.com/mozilla/fxa/issues/10151)
[9230](https://github.com/mozilla/fxa/issues/9230)
[9207](https://github.com/mozilla/fxa/issues/9207)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
