### PR TITLE
refactor(auth): cache tax rates in Redis (effectively) indefinitely

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import convict from 'convict';
 import fs from 'fs';
+import { makeMySQLConfig } from 'fxa-shared/db/config';
 import path from 'path';
 import url from 'url';
-import { makeMySQLConfig } from 'fxa-shared/db/config';
 
 const DEFAULT_SUPPORTED_LANGUAGES = require('./supportedLanguages');
 const ONE_DAY = 1000 * 60 * 60 * 24;
@@ -830,7 +830,7 @@ const conf = convict({
     stripeTaxRatesCacheTtlSeconds: {
       doc: 'The number of seconds to cache tax rates from Stripe',
       format: 'int',
-      default: 600,
+      default: 64000000, // about a couple years
       env: 'SUBHUB_TAX_RATES_CACHE_TTL_SECONDS',
     },
   },

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -62,6 +62,7 @@ export const MOZILLA_TAX_ID = 'Tax ID';
 
 export const STRIPE_PRODUCTS_CACHE_KEY = 'listStripeProducts';
 export const STRIPE_PLANS_CACHE_KEY = 'listStripePlans';
+export const STRIPE_TAX_RATES_CACHE_KEY = 'listStripeTaxRates';
 
 enum STRIPE_CUSTOMER_METADATA {
   PAYPAL_AGREEMENT = 'paypalAgreementId',
@@ -284,11 +285,21 @@ export class StripeHelper {
    * Uses Redis caching if configured.
    */
   @Cacheable({
-    cacheKey: 'listActiveTaxRates',
+    cacheKey: STRIPE_TAX_RATES_CACHE_KEY,
     ttlSeconds: (args, context) => context.stripeTaxRatesCacheTtlSeconds,
   })
   async allTaxRates() {
     return this.fetchAllTaxRates();
+  }
+
+  @CacheUpdate({
+    cacheKey: STRIPE_TAX_RATES_CACHE_KEY,
+    ttlSeconds: (args, context) => context.stripeTaxRatesCacheTtlSeconds,
+    cacheKeysToClear: 'noop',
+    clearStrategy: noopCacheClearStrategy,
+  })
+  async updateAllTaxRates(allTaxRates: Stripe.TaxRate[]) {
+    return allTaxRates;
   }
 
   /**

--- a/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/stripe-webhook.ts
@@ -117,6 +117,10 @@ export class StripeWebhookHandler extends StripeHandler {
         case 'plan.deleted':
           await this.handlePlanDeletedEvent(request, event);
           break;
+        case 'tax_rate.created':
+        case 'tax_rate.updated':
+          await this.handleTaxRateCreatedOrUpdatedEvent(request, event);
+          break;
         default:
           if (!firestoreHandled) {
             Sentry.withScope((scope) => {
@@ -425,6 +429,17 @@ export class StripeWebhookHandler extends StripeHandler {
     const plan = event.data.object as Stripe.Plan;
     const allPlans = await this.stripeHelper.allPlans();
     this.stripeHelper.updateAllPlans(allPlans.filter((p) => p.id !== plan.id));
+  }
+
+  async handleTaxRateCreatedOrUpdatedEvent(
+    request: AuthRequest,
+    event: Stripe.Event
+  ) {
+    const taxRate = event.data.object as Stripe.TaxRate;
+    const allTaxRates = await this.stripeHelper.allTaxRates();
+    const updatedList = allTaxRates.filter((tr) => tr.id !== taxRate.id);
+    updatedList.push(taxRate);
+    this.stripeHelper.updateAllTaxRates(updatedList);
   }
 
   /**

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_tax_rate_created.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_tax_rate_created.json
@@ -1,0 +1,32 @@
+{
+  "id": "evt_1Jxj70BVqmGyQTMa0yDZuWeU",
+  "object": "event",
+  "api_version": "2019-12-03",
+  "created": 1637374529,
+  "data": {
+    "object": {
+      "id": "txr_1Jxj6zBVqmGyQTMapD0Tt42M",
+      "object": "tax_rate",
+      "active": true,
+      "country": "IT",
+      "created": 1637374529,
+      "description": "IT VAT",
+      "display_name": "VAT",
+      "inclusive": false,
+      "jurisdiction": null,
+      "livemode": false,
+      "metadata": {
+      },
+      "percentage": 15,
+      "state": null,
+      "tax_type": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 2,
+  "request": {
+    "id": "req_ejiQzjIpytCA6q",
+    "idempotency_key": "8a38620e-2f04-4ca2-a88f-8b47f5220df4"
+  },
+  "type": "tax_rate.created"
+}

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_tax_rate_updated.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_tax_rate_updated.json
@@ -1,0 +1,35 @@
+{
+  "id": "evt_1Jxj70BVqmGyQTMa0yDZuWeU",
+  "object": "event",
+  "api_version": "2019-12-03",
+  "created": 1637374529,
+  "data": {
+    "object": {
+      "id": "txr_1Jxj6zBVqmGyQTMapD0Tt42M",
+      "object": "tax_rate",
+      "active": true,
+      "country": "IT",
+      "created": 1637374529,
+      "description": "IT VAT",
+      "display_name": "Sales tax",
+      "inclusive": false,
+      "jurisdiction": null,
+      "livemode": false,
+      "metadata": {
+      },
+      "percentage": 15,
+      "state": null,
+      "tax_type": null
+    },
+    "previous_attributes": {
+      "display_name": "VAT"
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 2,
+  "request": {
+    "id": "req_ejiQzjIpytCA6q",
+    "idempotency_key": "8a38620e-2f04-4ca2-a88f-8b47f5220df4"
+  },
+  "type": "tax_rate.updated"
+}

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -1495,7 +1495,22 @@ describe('StripeHelper', () => {
 
       assert.deepEqual(
         await stripeHelper.allTaxRates(),
-        JSON.parse(await mockRedis.get('listActiveTaxRates'))
+        JSON.parse(await mockRedis.get('listStripeTaxRates'))
+      );
+    });
+  });
+
+  describe('updateAllTaxRates', () => {
+    it('updates the tax rates in the cache', async () => {
+      const newList = ['xyz'];
+      await stripeHelper.updateAllTaxRates(newList);
+      assert.deepEqual(mockRedis.set.args[0][2], [
+        'EX',
+        mockConfig.subhub.stripeTaxRatesCacheTtlSeconds,
+      ]);
+      assert.deepEqual(
+        newList,
+        JSON.parse(await mockRedis.get('listStripeTaxRates'))
       );
     });
   });


### PR DESCRIPTION
Because:

* We want to reduce API calls to Stripe to avoid being rate limited.
* Similar to Stripe Plans and Products (#10518), Tax Rates don't change very often.
* Tax rates are unnecessarily fetched from Stripe every time a subscription is created with a TTL of 10 minutes.

This commit:

* Caches tax rates in Redis (effectively) indefinitely.
* Refreshes the cache on tax_rate.created or tax_rate.updated webhooks.

Closes #10745

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).