### PR TITLE
fix(settings): add confirm recovery code modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,31 @@ yarn test all
 
 - Note that this invokes the same test suite that CI uses, and is not necessarily the same as running `yarn test` in any given package.
 
+#### Functional Playwrite Tests
+
+You can run functional tests that emulate user behavior. This is a good final pass for any change that affects the UI. It can also save lots of time during development, because running the functional test is quite fast. Note that functional tests are not a replacement for unit tests, so use them judiciously.
+
+Make sure the stack has been started and is running (`yarn start`). From here, there are a few variants:
+
+```bash
+# Run tests in headless mode
+yarn workspace functional-tests test
+
+# Run tests in debug mode allowing step through of each test stage. Note, using the --grep argument
+# or adding .only statements to tests cases is a good idea when debugging, since stepping though every
+# single tests is not desirable.
+yarn workspace functional-tests test --debug --grep=$test_name
+
+# Run tests in debug console mode, allowing browser debugging.
+# https://playwright.dev/docs/debug#selectors-in-developer-tools-console
+PWDEBUG=console yarn workspace functional-tests test
+
+# Target a specific test
+yarn test workspace functional-tests test --grep=$test_name
+```
+
+For more info, see details at https://playwright.dev.
+
 #### Emulating CI environment
 
 It is possible to run various test suites (known as Jobs) acting as Circle CI. This is useful if you're encountering CI-specific failures. Please refer to [this documentation](https://github.com/mozilla/fxa/tree/main/.circleci#local-testing).

--- a/packages/functional-tests/pages/settings/layout.ts
+++ b/packages/functional-tests/pages/settings/layout.ts
@@ -29,6 +29,10 @@ export abstract class SettingsLayout extends BaseLayout {
     return this.page.click('[data-testid=modal-confirm]');
   }
 
+  clickRecoveryCodeAck() {
+    return this.page.click('[data-testid=ack-recovery-code]');
+  }
+
   async clickHelp() {
     const [helpPage] = await Promise.all([
       this.page.context().waitForEvent('page'),

--- a/packages/functional-tests/tests/prod.smoke.spec.ts
+++ b/packages/functional-tests/tests/prod.smoke.spec.ts
@@ -253,6 +253,10 @@ test.describe('severity-1', () => {
     for (const code of recoveryCodes) {
       expect(newCodes).not.toContain(code);
     }
+    await settings.clickRecoveryCodeAck();
+    await totp.setRecoveryCode(newCodes[0]);
+    await totp.submit();
+    await settings.waitForAlertBar();
     await settings.signOut();
     await login.login(credentials.email, credentials.password, newCodes[0]);
     expect(page.url()).toMatch(settings.url);

--- a/packages/fxa-auth-client/lib/client.ts
+++ b/packages/fxa-auth-client/lib/client.ts
@@ -1026,6 +1026,13 @@ export default class AuthClient {
     return this.sessionGet('/recoveryCodes', sessionToken);
   }
 
+  async updateRecoveryCodes(
+    sessionToken: hexstring,
+    recoveryCodes: string[]
+  ): Promise<{ success: boolean }> {
+    return this.sessionPut('/recoveryCodes', sessionToken, { recoveryCodes });
+  }
+
   async consumeRecoveryCode(sessionToken: hexstring, code: string) {
     return this.sessionPost('/session/verify/recoveryCode', sessionToken, {
       code,

--- a/packages/fxa-auth-server/lib/routes/validators.js
+++ b/packages/fxa-auth-server/lib/routes/validators.js
@@ -15,6 +15,7 @@ const HEX_STRING = /^(?:[a-fA-F0-9]{2})+$/;
 module.exports.HEX_STRING = HEX_STRING;
 
 module.exports.BASE_36 = /^[a-zA-Z0-9]*$/;
+module.exports.BASE_10 = /^[0-9]*$/;
 
 // RFC 4648, section 5
 module.exports.URL_SAFE_BASE_64 = /^[A-Za-z0-9_-]+$/;
@@ -282,6 +283,22 @@ module.exports.recoveryData = isA
   .regex(/[a-zA-Z0-9.]/)
   .max(1024)
   .required();
+
+module.exports.recoveryCode = function (len, base) {
+  const regex = base || module.exports.BASE_36;
+  return isA.string().regex(regex).min(8).max(len);
+};
+module.exports.recoveryCodes = function (codeCount, codeLen, base) {
+  return isA.object({
+    recoveryCodes: isA
+      .array()
+      .min(1)
+      .max(codeCount)
+      .unique()
+      .items(module.exports.recoveryCode(codeLen, base))
+      .required(),
+  });
+};
 
 module.exports.stripePaymentMethodId = isA.string().max(30);
 module.exports.paypalPaymentToken = isA.string().max(30);

--- a/packages/fxa-auth-server/test/local/routes/validators.js
+++ b/packages/fxa-auth-server/test/local/routes/validators.js
@@ -849,4 +849,77 @@ describe('lib/routes/validators:', () => {
       });
     });
   });
+
+  describe('recovery codes', () => {
+    it('allows base32 codes', () => {
+      assert.notExists(
+        validators
+          .recoveryCodes(2, 10)
+          .validate({ recoveryCodes: ['123456789A', '123456789B'] }).error
+      );
+    });
+
+    it('allows base36 codes', () => {
+      assert.notExists(
+        validators
+          .recoveryCodes(1, 10)
+          .validate({ recoveryCodes: ['012345678L'] }).error
+      );
+    });
+
+    it('detects missing recovery codes', () => {
+      assert.exists(
+        validators.recoveryCodes(2, 10).validate({ recoveryCodes: [] }).error
+      );
+      assert.exists(validators.recoveryCodes(2, 10).validate({}).error);
+    });
+
+    it('detects improper count', () => {
+      assert.exists(
+        validators.recoveryCodes(2, 10).validate({
+          recoveryCodes: ['123456789A', '123456789B', '123456789C'],
+        }).error
+      );
+    });
+
+    it('detects duplicates', () => {
+      assert.exists(
+        validators
+          .recoveryCodes(2, 10)
+          .validate({ recoveryCodes: ['1234567890', '1234567890'] }).error
+      );
+    });
+
+    it('detects allows less than maximum', () => {
+      assert.exists(
+        validators
+          .recoveryCodes(2, 10)
+          .validate({ recoveryCodes: ['123456789', '123456789'] }).error
+      );
+    });
+
+    it('detects minimum', () => {
+      assert.exists(
+        validators.recoveryCodes(2, 10).validate({ recoveryCodes: ['', ''] })
+          .error
+      );
+    });
+  });
+
+  describe('recovery code', () => {
+    it('validates recovery codes', () => {
+      assert.notExists(
+        validators.recoveryCode(10).validate('0123456789').error
+      );
+    });
+
+    it('invalidates recovery code', () => {
+      assert.exists(validators.recoveryCode(10).validate('012345678-').error);
+    });
+
+    it('requires proper length', () => {
+      assert.exists(validators.recoveryCode(5).validate('1234').error);
+      assert.exists(validators.recoveryCode(11).validate('123456').error);
+    });
+  });
 });

--- a/packages/fxa-auth-server/test/mocks.js
+++ b/packages/fxa-auth-server/test/mocks.js
@@ -47,6 +47,7 @@ const DB_METHOD_NAMES = [
   'createEmail',
   'createKeyFetchToken',
   'createPasswordForgotToken',
+  'createRecoveryCodes',
   'createRecoveryKey',
   'createSessionToken',
   'createSigninCode',
@@ -89,6 +90,7 @@ const DB_METHOD_NAMES = [
   'updateDevice',
   'updateEcosystemAnonId',
   'updateLocale',
+  'updateRecoveryCodes',
   'updateRecoveryKey',
   'updateSessionToken',
   'updateTotpToken',
@@ -549,6 +551,12 @@ function mockDB(data, errors) {
     }),
     replaceRecoveryCodes: sinon.spy(() => {
       return Promise.resolve(['12312312', '12312312']);
+    }),
+    createRecoveryCodes: sinon.spy(() => {
+      return Promise.resolve(['12312312', '12312312']);
+    }),
+    updateRecoveryCodes: sinon.spy(() => {
+      return Promise.resolve({ succes: true });
     }),
   });
 }

--- a/packages/fxa-content-server/server/config/local.json-dist
+++ b/packages/fxa-content-server/server/config/local.json-dist
@@ -45,5 +45,8 @@
   "csp": {
     "enabled": true,
     "reportUri": "/_/csp-violation"
+  },
+  "recovery_codes": {
+    "count": 3
   }
 }

--- a/packages/fxa-content-server/server/lib/beta-settings.js
+++ b/packages/fxa-content-server/server/lib/beta-settings.js
@@ -50,6 +50,10 @@ const settingsConfig = {
   oauth: {
     clientId: config.get('oauth_client_id'),
   },
+  recoveryCodes: {
+    count: config.get('recovery_codes.count'),
+    length: config.get('recovery_codes.length'),
+  },
 };
 
 // Inject Beta Settings meta content

--- a/packages/fxa-content-server/server/lib/configuration.js
+++ b/packages/fxa-content-server/server/lib/configuration.js
@@ -467,6 +467,20 @@ const conf = (module.exports = convict({
     doc: 'The publically visible URL of the deployment',
     env: 'PUBLIC_URL',
   },
+  recovery_codes: {
+    count: {
+      default: 8,
+      doc: 'The default number of recovery codes to create',
+      env: 'RECOVERY_CODE_COUNT',
+      format: 'nat',
+    },
+    length: {
+      default: 10,
+      doc: 'The default length of a recovery code',
+      env: 'RECOVERY_CODE_LENGTH',
+      format: 'nat',
+    },
+  },
   redirect_port: {
     default: 80,
     doc: 'Redirect port for HTTPS',

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/en-US.ftl
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/en-US.ftl
@@ -5,3 +5,5 @@ tfa-replace-code-success = New codes have been created. Save these one-time use
   codes in a safe place — you’ll need them to access your account if you don’t
   have your mobile device.
 tfa-replace-code-success-alert = Account recovery codes updated.
+tfa-replace-code-1-2 = Step 1 of 2
+tfa-replace-code-2-2 = Step 2 of 2

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
@@ -4,11 +4,13 @@
 
 import { RouteComponentProps, useNavigate } from '@reach/router';
 import React, { useCallback, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
 import FlowContainer from '../FlowContainer';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import DataBlock from '../DataBlock';
+import InputText from '../InputText';
 import { HomePath } from '../../constants';
-import { useAccount, useAlertBar, useSession } from '../../models';
+import { useAccount, useAlertBar, useConfig, useSession } from '../../models';
 import { useLocalization, Localized } from '@fluent/react';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
 import { copyRecoveryCodes } from '../../lib/totp';
@@ -18,8 +20,19 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
   const navigate = useNavigate();
   const session = useSession();
   const account = useAccount();
+  const config = useConfig();
+  const { l10n } = useLocalization();
+
   const goHome = () =>
     navigate(HomePath + '#two-step-authentication', { replace: true });
+
+  const [subtitle, setSubtitle] = useState<string>(
+    l10n.getString('tfa-replace-code-1-2', null, 'Step 1 of 2')
+  );
+  const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
+  const [recoveryCodesAcknowledged, setRecoveryCodesAcknowledged] =
+    useState<boolean>(false);
+
   const alertSuccessAndGoHome = () => {
     alertBar.success(
       l10n.getString(
@@ -30,14 +43,14 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
     );
     navigate(HomePath + '#two-step-authentication', { replace: true });
   };
-  const { l10n } = useLocalization();
 
-  const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
-
-  const replaceRecoveryCodes = useCallback(async () => {
+  const onRecoveryCodeSubmit = async (_: RecoveryCodeForm) => {
     try {
-      const { recoveryCodes } = await account.replaceRecoveryCodes();
-      setRecoveryCodes(recoveryCodes);
+      const { success } = await account.updateRecoveryCodes(recoveryCodes);
+
+      if (!success) throw new Error('Update recovery codes not successful.');
+
+      alertSuccessAndGoHome();
     } catch (e) {
       alertBar.error(
         l10n.getString(
@@ -47,47 +60,224 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
         )
       );
     }
-  }, [account, alertBar, l10n]);
+  };
+
+  const createRecoveryCodes = useCallback(async () => {
+    try {
+      if (
+        !config.recoveryCodes ||
+        !config.recoveryCodes.count ||
+        !config.recoveryCodes.length
+      ) {
+        throw new Error('Invalid config for recoveryCodes.');
+      }
+
+      const recoveryCodes = await account.generateRecoveryCodes(
+        config.recoveryCodes.count,
+        config.recoveryCodes.length
+      );
+      setRecoveryCodes(recoveryCodes);
+    } catch (e) {
+      alertBar.error(
+        l10n.getString(
+          'tfa-replace-code-error',
+          null,
+          'There was a problem creating your recovery codes.'
+        )
+      );
+    }
+  }, [config, account, alertBar, l10n]);
+
+  const activateStep = (step: number) => {
+    switch (step) {
+      case 1:
+        setSubtitle(
+          l10n.getString('tfa-replace-code-1-2', null, 'Step 1 of 2')
+        );
+        setRecoveryCodesAcknowledged(false);
+        break;
+
+      case 2:
+        setSubtitle(
+          l10n.getString('tfa-replace-code-2-2', null, 'Step 2 of 2')
+        );
+        setRecoveryCodesAcknowledged(true);
+        break;
+
+      default:
+        throw new Error(`Invalid step ${step}`);
+    }
+  };
+
+  const moveBack = () => {
+    if (!recoveryCodesAcknowledged) {
+      return goHome();
+    }
+    return activateStep(1);
+  };
 
   useEffect(() => {
-    session.verified && recoveryCodes.length < 1 && replaceRecoveryCodes();
-  }, [session, recoveryCodes, replaceRecoveryCodes]);
+    session.verified && recoveryCodes.length < 1 && createRecoveryCodes();
+  }, [session, recoveryCodes, createRecoveryCodes]);
 
   return (
     <FlowContainer
       title={l10n.getString('tfa-title', null, 'Two-step authentication')}
+      {...{ subtitle, onBackButtonClick: moveBack }}
     >
       <VerifiedSessionGuard onDismiss={goHome} onError={goHome} />
-      <div className="my-2" data-testid="2fa-recovery-codes">
-        <Localized id="tfa-replace-code-success">
-          New codes have been created. Save these one-time use codes in a safe
-          place — you’ll need them to access your account if you don’t have your
-          mobile device.
+
+      {!recoveryCodesAcknowledged && (
+        <>
+          <div className="my-2" data-testid="2fa-recovery-codes">
+            <Localized id="tfa-replace-code-success">
+              New codes have been created. Save these one-time use codes in a
+              safe place — you’ll need them to access your account if you don’t
+              have your mobile device.
+            </Localized>
+            <div className="mt-6 flex flex-col items-center h-auto justify-between">
+              {recoveryCodes.length > 0 ? (
+                <DataBlock
+                  value={recoveryCodes}
+                  separator=" "
+                  onCopy={copyRecoveryCodes}
+                />
+              ) : (
+                <LoadingSpinner />
+              )}
+            </div>
+          </div>
+          <div className="flex justify-center mt-6 mb-4 mx-auto max-w-64">
+            <Localized id="tfa-button-cancel">
+              <button
+                type="button"
+                className="cta-neutral mx-2 flex-1"
+                onClick={goHome}
+              >
+                Cancel
+              </button>
+            </Localized>
+            <Localized id="recovery-key-continue-button">
+              <button
+                type="submit"
+                className="cta-neutral mx-2 px-10"
+                data-testid="ack-recovery-code"
+                onClick={() => {
+                  activateStep(2);
+                }}
+              >
+                Continue
+              </button>
+            </Localized>
+          </div>
+        </>
+      )}
+
+      {recoveryCodesAcknowledged && (
+        <RecoveryCodeCheck
+          recoveryCodes={recoveryCodes}
+          goHome={goHome}
+          onRecoveryCodeSubmit={onRecoveryCodeSubmit}
+          cancellable={true}
+        />
+      )}
+    </FlowContainer>
+  );
+};
+
+// TODO: Reuse RecoveryCodeCheck in PageTwoStepAuthentication
+type RecoveryCodeForm = { recoveryCode: string };
+type RecoverCodeCheckType = {
+  cancellable: boolean;
+  recoveryCodes: string[];
+  onRecoveryCodeSubmit: ({ recoveryCode }: RecoveryCodeForm) => Promise<void>;
+  goHome: () => void;
+};
+const RecoveryCodeCheck = ({
+  cancellable,
+  recoveryCodes,
+  goHome,
+  onRecoveryCodeSubmit,
+}: RecoverCodeCheckType) => {
+  const { l10n } = useLocalization();
+
+  const [recoveryCodeError, setRecoveryCodeError] = useState<string>('');
+
+  const recoveryCodeForm = useForm<RecoveryCodeForm>({
+    mode: 'onTouched',
+  });
+
+  const onSubmit = async ({ recoveryCode }: RecoveryCodeForm) => {
+    if (!recoveryCodes.includes(recoveryCode)) {
+      setRecoveryCodeError(
+        l10n.getString(
+          'tfa-incorrect-recovery-code',
+          null,
+          'Incorrect recovery code'
+        )
+      );
+      return;
+    }
+
+    await onRecoveryCodeSubmit({ recoveryCode });
+  };
+
+  const isValidRecoveryCodeFormat = (recoveryCode: string) =>
+    /\w/.test(recoveryCode);
+
+  return (
+    <form onSubmit={recoveryCodeForm.handleSubmit(onSubmit)}>
+      <Localized id="tfa-enter-code-to-confirm">
+        <p className="mt-4 mb-4">
+          Please enter one of your recovery codes now to confirm you've saved
+          it. You'll need a code if you lose your device and want to access your
+          account.
+        </p>
+      </Localized>
+      <div className="mt-4 mb-6" data-testid="recovery-code-input">
+        <Localized id="tfa-enter-recovery-code" attrs={{ label: true }}>
+          <InputText
+            name="recoveryCode"
+            label="Enter a recovery code"
+            prefixDataTestId="recovery-code"
+            autoFocus
+            onChange={() => {
+              setRecoveryCodeError('');
+              recoveryCodeForm.trigger('recoveryCode');
+            }}
+            inputRef={recoveryCodeForm.register({
+              validate: isValidRecoveryCodeFormat,
+            })}
+            {...{ errorText: recoveryCodeError }}
+          />
         </Localized>
-        <div className="mt-6 flex flex-col items-center h-auto justify-between">
-          {recoveryCodes.length > 0 ? (
-            <DataBlock
-              value={recoveryCodes.map((x) => x)}
-              separator=" "
-              onCopy={copyRecoveryCodes}
-            />
-          ) : (
-            <LoadingSpinner />
-          )}
-        </div>
       </div>
-      <div className="flex justify-center mt-6 mb-4 mx-auto max-w-64">
-        <Localized id="recovery-key-close-button">
+      <div className="flex justify-center mb-4 mx-auto max-w-64">
+        {cancellable && (
+          <Localized id="tfa-button-cancel">
+            <button
+              type="button"
+              className="cta-neutral mx-2 flex-1"
+              onClick={goHome}
+            >
+              Cancel
+            </button>
+          </Localized>
+        )}
+        <Localized id="tfa-button-finish">
           <button
-            type="button"
-            className="cta-neutral mx-2 px-10"
-            data-testid="close-modal"
-            onClick={alertSuccessAndGoHome}
+            type="submit"
+            data-testid="submit-recovery-code"
+            className="cta-primary mx-2 flex-1"
+            disabled={
+              !recoveryCodeForm.formState.isDirty ||
+              !recoveryCodeForm.formState.isValid
+            }
           >
-            Close
+            Finish
           </button>
         </Localized>
       </div>
-    </FlowContainer>
+    </form>
   );
 };

--- a/packages/fxa-settings/src/lib/config.ts
+++ b/packages/fxa-settings/src/lib/config.ts
@@ -32,6 +32,10 @@ export interface Config {
   oauth: {
     clientId: string;
   };
+  recoveryCodes: {
+    count: number;
+    length: number;
+  };
   version: string;
 }
 
@@ -58,6 +62,10 @@ export function getDefault() {
     },
     oauth: {
       clientId: '',
+    },
+    recoveryCodes: {
+      count: 8,
+      length: 10,
     },
   } as Config;
 }

--- a/packages/fxa-settings/src/lib/random.test.ts
+++ b/packages/fxa-settings/src/lib/random.test.ts
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { assert } from 'chai';
+import random from './random';
+
+jest.mock('./random', () => {
+  const orig = jest.requireActual('./random');
+
+  return orig;
+});
+
+describe('lib/random', () => {
+  // mock the call to window.crypto since tests are running in node with jsdom
+  const spy = jest
+    .spyOn(random, 'getRandomBytes')
+    .mockImplementation((len: number) => {
+      const arr = new Uint32Array(len);
+      for (let i = 0; i < arr.length; i++) {
+        arr[i] = Math.random() * Number.MAX_SAFE_INTEGER;
+      }
+      return arr;
+    });
+
+  afterAll(function () {
+    spy.mockRestore();
+  });
+
+  type testcase = {
+    name: string;
+    generate: (len: number) => () => string;
+    regexBase: RegExp;
+    validCode: string;
+    invalidCode: string;
+  };
+
+  const baseChecks: testcase[] = [
+    {
+      name: 'base10',
+      generate: (len: number) => random.base10(len),
+      regexBase: random.regexs.base10,
+      validCode: '1234567890',
+      invalidCode: 'ABC4567890',
+    },
+    {
+      name: 'base16',
+      generate: (len: number) => random.base32(len),
+      regexBase: random.regexs.base16,
+      validCode: 'ABC4567890',
+      invalidCode: 'GHIJK67890',
+    },
+    {
+      name: 'base32',
+      generate: (len: number) => random.base32(len),
+      regexBase: random.regexs.base32,
+      validCode: 'ABC4567890',
+      invalidCode: 'ILOU567890',
+    },
+    {
+      name: 'base36',
+      generate: (len: number) => random.base36(len),
+      regexBase: random.regexs.base36,
+      validCode: 'ILOU567890',
+      invalidCode: 'ILOU5~7890',
+    },
+  ];
+
+  for (const base of baseChecks) {
+    const { name, generate, regexBase, validCode, invalidCode } = base;
+
+    describe(`${name} checks`, () => {
+      it('takes 1 integer argument, returns a function', () => {
+        const gen = generate(10);
+        assert.equal(typeof gen, 'function');
+        assert.equal(gen.length, 0);
+      });
+
+      it('should have correct output', () => {
+        const code = generate(10)();
+        assert.equal(code.length, 10, 'matches length');
+      });
+
+      it('should check code with regex', async () => {
+        assert.isTrue(regexBase.test(validCode), 'valid code for ' + name);
+      });
+
+      it('should detect invalid code with regex', () => {
+        assert.isFalse(regexBase.test(invalidCode), 'invalid code for ' + name);
+      });
+    });
+  }
+});

--- a/packages/fxa-settings/src/lib/random.ts
+++ b/packages/fxa-settings/src/lib/random.ts
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Adapted from from /fxa-authserver/lib/crypto
+
+// COMMON BASES
+// Note, uses Crockford Base32 for better UX
+const BASE36 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const BASE32 = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+const BASE16 = BASE32.substring(0, 16);
+const BASE10 = BASE32.substring(0, 10);
+
+export const bases: Record<string, string> = {
+  base10: BASE10,
+  base16: BASE16,
+  base32: BASE32,
+  base36: BASE36,
+};
+
+export const regexs: Record<string, RegExp> = {
+  base10: new RegExp(`^[${BASE10}]*$`),
+  base16: new RegExp(`^[${BASE32}]*$`, 'i'),
+  base32: new RegExp(`^[${BASE32}]*$`, 'i'),
+  base36: new RegExp(`^[${BASE36}]*$`, 'i'),
+};
+
+export class Random {
+  get regexs() {
+    return regexs;
+  }
+
+  get bases() {
+    return bases;
+  }
+
+  getRandomBytes(len: number) {
+    console.log('getRandomBytes original');
+    return window.crypto.getRandomValues(new Uint32Array(len));
+  }
+
+  randomValue(base: string, len: number) {
+    // To minimize bias in element selection, we generate a
+    // 32-bit unsigned int for each element and map it to a float in [0,1).
+    // This requires 4 bytes of randomness per element.
+    const bytes = this.getRandomBytes(len);
+    const out = [];
+
+    for (let i = 0; i < len; i++) {
+      const r = bytes[i] / 2 ** 32;
+      out.push(base[Math.floor(r * base.length)]);
+    }
+
+    return out.join('');
+  }
+
+  base10(len: number) {
+    return () => this.randomValue(BASE10, len);
+  }
+  base16(len: number) {
+    return () => this.randomValue(BASE16, len);
+  }
+  base32(len: number) {
+    return () => this.randomValue(BASE32, len);
+  }
+  base36(len: number) {
+    return () => this.randomValue(BASE36, len);
+  }
+}
+
+export default new Random();

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -4,6 +4,7 @@ import AuthClient, { generateRecoveryKey } from 'fxa-auth-client/browser';
 import { currentAccount, sessionToken } from '../lib/cache';
 import firefox from '../lib/firefox';
 import Storage from '../lib/storage';
+import random from '../lib/random';
 
 export interface DeviceLocation {
   city: string | null;
@@ -488,6 +489,25 @@ export class Account implements AccountData {
     return this.withLoadingStatus(
       this.authClient.replaceRecoveryCodes(sessionToken()!)
     );
+  }
+
+  async generateRecoveryCodes(count: number, length: number) {
+    const recoveryCodes: string[] = [];
+    const gen = random.base32(length);
+    while (recoveryCodes.length < count) {
+      const rc = (await gen()).toLowerCase();
+      if (recoveryCodes.indexOf(rc) === -1) {
+        recoveryCodes.push(rc);
+      }
+    }
+    return recoveryCodes;
+  }
+
+  async updateRecoveryCodes(recoveryCodes: string[]) {
+    const result = await this.withLoadingStatus(
+      this.authClient.updateRecoveryCodes(sessionToken()!, recoveryCodes)
+    );
+    return result;
   }
 
   async createSecondaryEmail(email: string) {


### PR DESCRIPTION
## Because

- When generating new recovery codes, there was no confirmation step, which might make it easy for a user to overlook the fact they should download / record their recovery codes.

## This pull request

- Introduces the same dialog, which existed in the initial 2FA flow, that prompted a user for at least one recovery code as a way to validate users had recorded them
- Introduces the same dialog, which existed in the initial 2FA flow, that prompted a user for at least one recovery code as a way to validate users had recorded them
- Introduces back end support for creating and updating recovery codes as a two step process
- Shifts recovery code generation to client, relocating crypto/random.ts to fxa-shared, so it's accessible
- Adds validation for recovery codes being updated
- Exposes recovery code length / count settings to client
- Adds section about running play write tests to read me

## Issue that this pull request solves

Closes: #9530

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
