### PR TITLE
fix(subscriptions): always show title on upgrade

### DIFF
--- a/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.scss
+++ b/packages/fxa-payments-server/src/routes/Product/SubscriptionUpgrade/index.scss
@@ -8,16 +8,12 @@
   }
 
   .subscription-update-heading {
-    display: none;
+    display: block;
+    text-align: center;
 
-    @include min-width('tablet') {
-      display: block;
-      text-align: center;
-
-      h2 {
-        font-weight: normal;
-        margin-top: 20px;
-      }
+    h2 {
+      font-weight: normal;
+      margin-top: 20px;
     }
   }
 


### PR DESCRIPTION
## Because:

* Title on subscription upgrade page isn't displayed when height is
  <= 480px and width >= 768px.

## This pull request:

* Always display title on subscription upgrade page.

Closes #
[9956](https://github.com/mozilla/fxa/issues/9956)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Before change for width 1058 x 480
![image](https://user-images.githubusercontent.com/10620585/142936356-6d3cb835-198e-4687-8528-e7d6267a8c7e.png)

After change for width 1058 x 480
![image](https://user-images.githubusercontent.com/10620585/142936417-bf635177-6e24-409e-b790-04285f68c6d3.png)

