### PR TITLE
chore(dev): wait for containers on 'yarn start'

### DIFF
--- a/_dev/pm2/infrastructure.config.js
+++ b/_dev/pm2/infrastructure.config.js
@@ -47,13 +47,15 @@ module.exports = {
       autorestart: false,
       kill_timeout: 20000,
     },
-    {
-      name: 'pushbox',
-      script: '_scripts/pushbox.sh',
-      max_restarts: '1',
-      min_uptime: '2m',
-      args: '3306 root@mydb:3306',
-      kill_timeout: 20000,
-    },
+
+    // TODO FIXME?? this has been broken for-ev-er, do we even want it?
+    // {
+    //   name: 'pushbox',
+    //   script: '_scripts/pushbox.sh',
+    //   max_restarts: '1',
+    //   min_uptime: '2m',
+    //   args: '3306 root@mydb:3306',
+    //   kill_timeout: 20000,
+    // },
   ],
 };

--- a/_dev/pm2/start.sh
+++ b/_dev/pm2/start.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+DIR=$(dirname "$0")
+cd "$DIR/../.."
+
+pm2 start _dev/pm2/infrastructure.config.js
+
+echo "waiting for containers to start"
+_scripts/check-url.sh localhost:4100/health
+_scripts/check-url.sh localhost:9299/api/config
+_scripts/check-mysql.sh

--- a/_scripts/check-url.sh
+++ b/_scripts/check-url.sh
@@ -3,7 +3,7 @@
 RETRY=60
 for i in $(eval echo "{1..$RETRY}"); do
   if [ "$(curl -s -o /dev/null --silent -w "%{http_code}"  http://$1)" == "${2:-200}" ]; then
-    echo "took $SECONDS seconds"
+    echo "$1 took $SECONDS seconds"
     exit 0
   else
     if [ "$i" -lt $RETRY ]; then

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -2,8 +2,8 @@ module.exports = {
   scripts: {
     default: 'nps help',
     start: {
-      default: `pm2 start _dev/pm2/infrastructure.config.js && _scripts/pm2-all.sh start && echo "Use 'yarn stop' to stop all the servers"`,
-      infrastructure: `pm2 start _dev/pm2/infrastructure.config.js`,
+      default: `_dev/pm2/start.sh && _scripts/pm2-all.sh start && pm2 restart sync && echo "Use 'yarn stop' to stop all the servers"`,
+      infrastructure: `_dev/pm2/start.sh`,
       services: `_scripts/pm2-all.sh start`,
       firefox: './packages/fxa-dev-launcher/bin/fxa-dev-launcher &',
     },


### PR DESCRIPTION
On M1 we currently sometimes need to 'yarn restart services' after a 'yarn start' before things start working. Maybe if we wait for the containers to be responsive before starting services we can avoid this. The important one seems to be mysql.
