### PR TITLE
fix(configs): fix CapabilityService's dep on StripeHelper again

### DIFF
--- a/packages/fxa-auth-server/lib/payments/capability.ts
+++ b/packages/fxa-auth-server/lib/payments/capability.ts
@@ -55,7 +55,7 @@ export class CapabilityService {
       ? Container.get(StripeHelper)
       : ({
           purchasesToProductIds: () => Promise.resolve([]),
-          customer: () => Promise.resolve(null),
+          fetchCustomer: () => Promise.resolve(null),
           allAbbrevPlans: () => Promise.resolve([]),
         } as unknown as StripeHelper);
     this.profileClient = Container.get(ProfileClient);

--- a/packages/fxa-auth-server/lib/routes/account.ts
+++ b/packages/fxa-auth-server/lib/routes/account.ts
@@ -1476,7 +1476,7 @@ export class AccountHandler {
     let webSubscriptions: Awaited<WebSubscription[]> = [];
     let iapGooglePlaySubscriptions: Awaited<GooglePlaySubscription[]> = [];
 
-    if (this.config.subscriptions.enabled) {
+    if (this.config.subscriptions?.enabled && this.stripeHelper) {
       try {
         const customer = await this.stripeHelper.fetchCustomer(uid as string, [
           'subscriptions',


### PR DESCRIPTION
Because:
 - CapabilityService uses StripeHelper without checking relevant feature
   flags, leading to https://github.com/mozilla/fxa/issues/10123, whose
   fix was broken by
   https://github.com/mozilla/fxa/commit/878a991ce489e4b28d289734933e0b945a506eb7

This commit:
 - update the temporary fix in
   https://github.com/mozilla/fxa/commit/3f5880ee168889c5d243c40846c533576144675c
   due to a change how CapabilityService uses StripeHelper

