### PR TITLE
chore(docs): Add parent selector example to rtl styles

### DIFF
--- a/packages/fxa-settings/README.md
+++ b/packages/fxa-settings/README.md
@@ -329,6 +329,24 @@ the RTL/LTR definitions. You can still use the tailwind classes, as shown below:
 }
 ```
 
+Alternatively, you can utilize the SCSS parent selector (`&`) to generate the same code as above while keeping nesting inside the parent class like so:
+
+```scss
+.drop-down-menu {
+  &::before {
+    content: '';
+    @apply caret-top absolute -top-3;
+  }
+
+  [dir='ltr'] &::before {
+    @apply left-55;
+  }
+  [dir='rtl'] &::before {
+    @apply right-55;
+  }
+}
+```
+
 #### PurgeCSS
 
 When it comes to time to create a production build we use PostCSS and PurgeCSS to strip out unused styles. PurgeCSS will look through all of the TSX files, including those of externally imported components, and identify which class names to keep styles for. In order for this to work properly it's important to avoid dynamic class names:


### PR DESCRIPTION
## Because

- We're going to be converting payments server styles over to Tailwind soon and could use another example

## This pull request

- Adds an alternative in our docs for keeping rtl styles nested within a parent class

---

smol PR, just wanted to quickly document this because it came in handy when working on the [switch UI rtl styles](https://github.com/mozilla/fxa/blob/main/packages/fxa-settings/src/styles/switch.scss).