### PR TITLE
fix(auth): remove payment method from Firestore on payment_method.det…

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -2491,6 +2491,14 @@ export class StripeHelper {
   }
 
   /**
+   * Process a payment_method.detached event. Remove the payment method from Firestore.
+   */
+  async processPaymentMethodDetachedEventToFirestore(event: Stripe.Event) {
+    const paymentMethodId = (event.data.object as Stripe.PaymentMethod).id;
+    await this.stripeFirestore.removePaymentMethodRecord(paymentMethodId);
+  }
+
+  /**
    * Process a webhook event from Stripe and if needed, save it to Firestore.
    */
   async processWebhookEventToFirestore(event: Stripe.Event) {
@@ -2523,9 +2531,11 @@ export class StripeHelper {
           break;
         case 'payment_method.attached':
         case 'payment_method.automatically_updated':
-        case 'payment_method.detached':
         case 'payment_method.updated':
           await this.processPaymentMethodEventToFirestore(event);
+          break;
+        case 'payment_method.detached':
+          await this.processPaymentMethodDetachedEventToFirestore(event);
           break;
         default: {
           handled = false;

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_payment_method_attached.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/event_payment_method_attached.json
@@ -1,0 +1,63 @@
+{
+  "id": "evt_1GQf15BVqmGyQTMamwMk1kdP",
+  "object": "event",
+  "api_version": "2019-12-03",
+  "created": 1585164955,
+  "data": {
+    "object": {
+      "id": "pm_1Jz6QHBVqmGyQTMac7e2nfNv",
+      "object": "payment_method",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": null,
+          "line1": null,
+          "line2": null,
+          "postal_code": "12345",
+          "state": null
+        },
+        "email": null,
+        "name": null,
+        "phone": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": "pass",
+          "cvc_check": "pass"
+        },
+        "country": "US",
+        "exp_month": 12,
+        "exp_year": 2022,
+        "fingerprint": "PXj5xzTtGdBo1fVl",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "networks": {
+          "available": [
+            "visa"
+          ],
+          "preferred": null
+        },
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1637702465,
+      "customer": "cus_KePEbKiLgAsB4n",
+      "livemode": false,
+      "metadata": {
+      },
+      "type": "card"
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_k0H9kTbrxkqtfB",
+    "idempotency_key": "a9482497-dde5-4ac6-90c2-1d3f5cada747"
+  },
+  "type": "payment_method.attached"
+}


### PR DESCRIPTION
…ached webhook

Because:

* Currently, we handle the payment_method.detached webhook event the same as other payment_method* events in terms of Firestore caching.
  * Practically, this means we try to insert a detached Payment Method into Firestore with a null customerId, which is causing these webhook events to permafail.
* The detached payment method should be removed from Firestore, as it will no longer be used by the associated Stripe customer.

This commit:

* Removes the detached payment method from Firestore on payment_method.detached webhooks.

Closes #11126

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

I didn't rename the existing `processPaymentMethodEventToFirestore`, since it still covers several `payment_method.*` webhook events, and the name would be too long to list them all explicitly. Open to alternatives.
