### PR TITLE
chore(db-migrations): support database configurations for db-migrations script.

### DIFF
--- a/packages/db-migrations/databases/development.json
+++ b/packages/db-migrations/databases/development.json
@@ -1,0 +1,24 @@
+{
+  "fxa": {
+    "database": "fxa",
+    "host": "localhost",
+    "port": 3306,
+    "user": "root",
+    "password": ""
+  },
+  "fxa_profile": {
+    "database": "fxa_profile",
+    "host": "localhost",
+    "port": 3306,
+    "user": "root",
+    "password": ""
+  },
+  "fxa_oauth": {
+    "database": "fxa_oauth",
+    "host": "localhost",
+    "port": 3306,
+    "user": "root",
+    "password": ""
+  }
+}
+

--- a/packages/db-migrations/package.json
+++ b/packages/db-migrations/package.json
@@ -6,6 +6,10 @@
   "license": "MPL-2.0",
   "bin": "./bin/patcher.mjs",
   "dependencies": {
+    "convict": "^6.2.1",
+    "convict-format-with-moment": "^6.2.0",
+    "convict-format-with-validator": "^6.2.0",
+    "fxa-shared": "workspace:*",
     "mysql": "^2.18.1",
     "mysql-patcher": "0.7.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14387,6 +14387,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "db-migrations@workspace:packages/db-migrations"
   dependencies:
+    convict: ^6.2.1
+    convict-format-with-moment: ^6.2.0
+    convict-format-with-validator: ^6.2.0
+    fxa-shared: "workspace:*"
     mysql: ^2.18.1
     mysql-patcher: 0.7.0
   bin:


### PR DESCRIPTION
## Because

- Currently, db-migrations script hard coded database configurations.


## This pull request

- Support reading configurations from environment or json configuration files.

## Issue that this pull request solves

Issue: #10526

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

It would be useful for self hosting.
