### PR TITLE
chore(dev): update dev docker-compose mysql server to 5.7

### DIFF
--- a/_dev/docker/docker-compose.yml
+++ b/_dev/docker/docker-compose.yml
@@ -135,7 +135,7 @@ services:
   redis:
     image: redis
   mysql:
-    image: mysql/mysql-server:5.6
+    image: mysql/mysql-server:5.7
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=true
       - MYSQL_ROOT_HOST=%


### PR DESCRIPTION
## Because

- db-migrations script failed to work on mysql 5.6

## This pull request

- update mysql server to 5.7

## Issue that this pull request solves

Issue #10526

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Here already using mysql server 5.7
https://github.com/mozilla/fxa/blob/9cda83496a410ad4df414a6730872e6aa0ef793f/_scripts/mysql.sh#L25
