### PR TITLE
feat(auth): include product/plan validation details in Sentry message

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -44,7 +44,10 @@ import { ConfigType } from '../../config';
 import error from '../error';
 import Redis from '../redis';
 import { subscriptionProductMetadataValidator } from '../routes/validators';
-import { reportValidationError } from '../sentry';
+import {
+  formatMetadataValidationErrorMessage,
+  reportValidationError,
+} from '../sentry';
 import { AuthFirestore } from '../types';
 import { CurrencyHelper } from './currencies';
 import { SubscriptionPurchase } from './google-play/subscription-purchase';
@@ -1200,8 +1203,8 @@ export class StripeHelper {
         });
 
       if (error) {
-        const msg = `fetchAllPlans - Plan "${item.id}"'s metadata failed validation`;
-        this.log.error(msg, { error, plan: item });
+        const msg = formatMetadataValidationErrorMessage(item.id, error as any);
+        this.log.error(`fetchAllPlans: ${msg}`, { error, plan: item });
         reportValidationError(msg, error as any);
         continue;
       }

--- a/packages/fxa-auth-server/lib/sentry.js
+++ b/packages/fxa-auth-server/lib/sentry.js
@@ -203,11 +203,11 @@ async function configureSentry(server, config, processName = 'key_server') {
 function formatMetadataValidationErrorMessage(planId, error) {
   let msg = `${planId} metadata invalid:`;
   if (typeof error === 'string') {
-    msg = msg + ' ' + error;
+    msg = `${msg} ${error}`;
   } else {
-    for (const errorItem of error.details) {
-      msg = msg + ' ' + errorItem.message + ';';
-    }
+    msg = `${msg}${error.details
+      .map(({ message }) => ` ${message};`)
+      .join('')}`;
   }
   return msg;
 }

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -1701,9 +1701,12 @@ describe('StripeHelper', () => {
       );
 
       /** Plan.product has invalid metadata */
-      assert.equal(
-        `fetchAllPlans - Plan "${planInvalidProductMetadata.id}"'s metadata failed validation`,
-        stripeHelper.log.error.getCall(3).args[0]
+      assert.isTrue(
+        stripeHelper.log.error
+          .getCall(3)
+          .args[0].includes(
+            `fetchAllPlans: ${planInvalidProductMetadata.id} metadata invalid:`
+          )
       );
     });
   });


### PR DESCRIPTION
Because:

* RPs may enter invalid product/plan metadata into Stripe, and the only feedback are Sentry errors in #fxa until a better solution is made following FXA-3655.
* The Sentry error message is currently not descriptive regarding what the issue is, and RPs may not have access to Sentry to view more error details.

This commit:

* Includes as much actionable information in the Sentry error message about the validation error as possible, up to the ~100 character limit.

Closes #10827 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).

## Other information (Optional)

The error message limited to around 100 characters in Slack, and given that a product or plan id can have around 30 characters, this doesn't leave much room for more descriptive messages.

E.g. a plan update with multiple validation errors would have a Sentry message like: 'price_1JfcqJBVqmGyQTMadYoEH25q metadata invalid: "webIconURL" must be a valid …'
I’m not sure how I can trim this further without causing confusion, but I’m open to suggestions. I did try doubling the `maxValueLength` option in `Sentry.init()`.

Also, FWICT Sentry already truncates error messages, so I didn't include a test for really long messages.

