### PR TITLE
fix(bulk-mailer): date normalization was wrong

### DIFF
--- a/packages/fxa-auth-server/scripts/bulk-mailer/normalize-user-records.js
+++ b/packages/fxa-auth-server/scripts/bulk-mailer/normalize-user-records.js
@@ -68,7 +68,7 @@ module.exports = class UserRecordNormalizer {
 
   formatDate(date) {
     return `${date.getUTCFullYear()}-${leftpad(
-      date.getUTCMonth(),
+      date.getUTCMonth() + 1,
       2
     )}-${leftpad(date.getUTCDate(), 2)} @ ${leftpad(
       date.getUTCHours(),

--- a/packages/fxa-auth-server/test/scripts/bulk-mailer/normalize-user-records.js
+++ b/packages/fxa-auth-server/test/scripts/bulk-mailer/normalize-user-records.js
@@ -55,14 +55,7 @@ describe('normalize-user-records', () => {
   });
 
   describe('normalizeLocationTimestamp', () => {
-    const date = new Date();
-    date.setUTCFullYear(2017);
-    date.setUTCMonth(1);
-    date.setUTCDate(2);
-    date.setUTCHours(3);
-    date.setUTCMinutes(4);
-    date.setUTCSeconds(5);
-    date.setUTCMilliseconds(678);
+    const date = new Date('2017-01-02T03:04Z');
 
     const expectedTimestamp = '2017-01-02 @ 03:04 UTC';
 


### PR DESCRIPTION
## Because

- `getUTCMonth` is 0 based
- `setUTCMonth` rolls over if the day of the month beforehand is larger than the target can handle

