### PR TITLE
feat(admin-panel): account history table styles not working

### DIFF
--- a/packages/fxa-admin-panel/package.json
+++ b/packages/fxa-admin-panel/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@apollo/client": "^3.4.5",
     "@emotion/react": "^11.6.0",
-    "@material-ui/core": "v5.0.0-alpha.24",
     "body-parser": "^1.19.0",
     "convict": "^6.2.1",
     "convict-format-with-moment": "^6.2.0",

--- a/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
+++ b/packages/fxa-admin-panel/src/components/AccountSearch/Account/index.tsx
@@ -15,14 +15,6 @@ import {
   SessionTokens as SessionTokensType,
 } from 'fxa-admin-server/src/graphql';
 
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableContainer from '@material-ui/core/TableContainer';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
-import Paper from '@material-ui/core/Paper';
-
 export type AccountProps = AccountType & {
   onCleared: Function;
   query: string;
@@ -376,29 +368,28 @@ export const Account = ({
       <div className={styleClasses.borderInfoDisplay}>
         {securityEvents && securityEvents.length > 0 ? (
           <>
-            <TableContainer component={Paper}>
-              <Table className="pt-1" aria-label="simple table">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Event</TableCell>
-                    <TableCell>Timestamp</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {securityEvents.map((securityEvents: SecurityEventsType) => (
-                    <TableRow key={securityEvents.createdAt}>
-                      <TableCell>{securityEvents.name}</TableCell>
-                      <TableCell>
-                        {dateFormat(
-                          new Date(securityEvents.createdAt!),
-                          DATE_FORMAT
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </TableContainer>
+            <table className="pt-1" aria-label="simple table">
+              <thead>
+                <tr>
+                  <th className="text-left">Event</th>
+                  <th className="text-left">Timestamp</th>
+                </tr>
+              </thead>
+
+              <tbody>
+                {securityEvents.map((securityEvents: SecurityEventsType) => (
+                  <tr key={securityEvents.createdAt}>
+                    <td className="pr-4">{securityEvents.name}</td>
+                    <td>
+                      {dateFormat(
+                        new Date(securityEvents.createdAt!),
+                        DATE_FORMAT
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </>
         ) : (
           <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -18370,7 +18370,6 @@ fsevents@~2.1.1:
     "@apollo/client": ^3.4.5
     "@babel/core": ^7.15.0
     "@emotion/react": ^11.6.0
-    "@material-ui/core": v5.0.0-alpha.24
     "@rescripts/cli": 0.0.16
     "@storybook/addon-actions": ^6.3.12
     "@storybook/addon-links": ^6.3.12


### PR DESCRIPTION
Because:

* The Account History table was styled locally but did not appear styled in production

This commit:

* Converts Material-UI styles to Tailwind classes

Closes #11100

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="823" alt="Screen Shot 2021-11-30 at 2 12 59 PM" src="https://user-images.githubusercontent.com/28129806/144113279-19e5ad4c-3759-4373-a805-924662c8f78e.png">

## Other information (Optional)
Material-UI is being used in one other component (fxa-settings - PageAvatar), and therefore the MUI dependency cannot yet be fully removed.
