### PR TITLE
Don't bounce emails that might stop user access

### DIFF
--- a/packages/fxa-auth-server/config/index.ts
+++ b/packages/fxa-auth-server/config/index.ts
@@ -418,6 +418,18 @@ const conf = convict({
         },
         env: 'BOUNCES_SOFT',
       },
+      ignoreTemplates: {
+        doc: 'Always ignore bounces from these email templates',
+        format: Array,
+        default: [
+          'verifyLoginCode',
+          'verifyLogin',
+          'recovery',
+          'unblockCode',
+          'subscriptionAccountFinishSetup',
+        ],
+        env: 'BOUNCES_IGNORE_TEMPLATES',
+      },
     },
   },
   maxEventLoopDelay: {

--- a/packages/fxa-auth-server/lib/bounces.js
+++ b/packages/fxa-auth-server/lib/bounces.js
@@ -8,6 +8,7 @@ const error = require('./error');
 
 module.exports = (config, db) => {
   const configBounces = (config.smtp && config.smtp.bounces) || {};
+  const ignoreTemplates = configBounces.ignoreTemplates || [];
   const BOUNCES_ENABLED = !!configBounces.enabled;
 
   const BOUNCE_TYPE_HARD = 1;
@@ -27,7 +28,11 @@ module.exports = (config, db) => {
     [BOUNCE_TYPE_COMPLAINT]: error.emailComplaint,
   };
 
-  function checkBounces(email) {
+  function checkBounces(email, template) {
+    if (ignoreTemplates.includes(template)) {
+      return;
+    }
+
     return db.emailBounces(email).then(applyRules);
   }
 

--- a/packages/fxa-auth-server/lib/senders/email.js
+++ b/packages/fxa-auth-server/lib/senders/email.js
@@ -31,7 +31,8 @@ module.exports = function (log, config, bounces) {
     config
   );
   const cadReminders = require('../cad-reminders')(config, log);
-  const subscriptionAccountReminders = require('../subscription-account-reminders')(log,config);
+  const subscriptionAccountReminders =
+    require('../subscription-account-reminders')(log, config);
 
   const paymentsServerURL = new URL(config.subscriptions.paymentsServer.url);
   const featureFlags = require('../features')(config);
@@ -510,7 +511,7 @@ module.exports = function (log, config, bounces) {
       const to = emailAddresses[0];
 
       try {
-        await bounces.check(to);
+        await bounces.check(to, template);
       } catch (err) {
         log.error('email.bounce.limit', {
           err: err.message,
@@ -765,7 +766,7 @@ module.exports = function (log, config, bounces) {
   });
 
   subscriptionAccountReminders.keys.forEach((key, index) => {
-        // Template names are generated in the form `verificationReminderFirstEmail`,
+    // Template names are generated in the form `verificationReminderFirstEmail`,
     // where `First` is the key derived from config, with an initial capital letter.
     const template = `subscriptionAccountReminder${key[0].toUpperCase()}${key.substr(
       1
@@ -777,20 +778,22 @@ module.exports = function (log, config, bounces) {
       subject = gettext('Final reminder: Setup your account');
     }
 
-    templateNameToCampaignMap[template] = `${key}-subscription-account-reminder`;
+    templateNameToCampaignMap[
+      template
+    ] = `${key}-subscription-account-reminder`;
     templateNameToContentMap[template] = 'subscrition-account-create-email';
 
     Mailer.prototype[`${template}Email`] = async function (message) {
-        const {
-          email,
-          uid,
-          productId,
-          productName,
-          token,
-          flowId,
-          flowBeginTime,
-          deviceId,
-        } = message;
+      const {
+        email,
+        uid,
+        productId,
+        productName,
+        token,
+        flowId,
+        flowBeginTime,
+        deviceId,
+      } = message;
 
       log.trace(`mailer.${template}`, { email, uid });
 
@@ -832,12 +835,11 @@ module.exports = function (log, config, bounces) {
           subject,
           supportUrl: links.supportUrl,
           supportLinkAttributes: links.supportLinkAttributes,
-          reminderShortForm: true
+          reminderShortForm: true,
         },
       });
     };
   });
-
 
   Mailer.prototype.unblockCodeEmail = function (message) {
     log.trace('mailer.unblockCodeEmail', {
@@ -1972,7 +1974,9 @@ module.exports = function (log, config, bounces) {
     });
   };
 
-  Mailer.prototype.subscriptionAccountFinishSetupEmail = async function (message) {
+  Mailer.prototype.subscriptionAccountFinishSetupEmail = async function (
+    message
+  ) {
     const {
       email,
       uid,

--- a/packages/fxa-auth-server/test/local/bounces.js
+++ b/packages/fxa-auth-server/test/local/bounces.js
@@ -181,4 +181,13 @@ describe('bounces', () => {
         });
     });
   });
+
+  it('ignores bounce for a specific email template', async () => {
+    const db = {
+      emailBounces: sinon.spy(() => Promise.resolve([])),
+    };
+    const bounces = createBounces(config, db);
+    await bounces.check(EMAIL, 'recovery');
+    assert.equal(db.emailBounces.callCount, 0);
+  });
 });


### PR DESCRIPTION
## Because

- We don't want to stop user from getting access to their account because of a bounced email

## This pull request

- Skips the bounce checks if it is a login verification emaill, password reset email, rate limiting unblock email or subscription service finish account setup email

## Issue that this pull request solves

Closes https://github.com/mozilla/fxa/issues/11047

## Checklist

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.