### PR TITLE
feat(auth-server): convert subscriptionUpgrade email template to stack

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -468,7 +468,8 @@
       "subscriptionsPaymentExpired",
       "subscriptionAccountReminderFirst",
       "subscriptionAccountReminderSecond",
-      "subscriptionReactivation"
+      "subscriptionReactivation",
+      "subscriptionUpgrade"
     ]
   }
 }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/en.ftl
@@ -1,0 +1,16 @@
+# Variables:
+# $productNameNew (String) - The name of the subscribed product, e.g. Mozilla VPN
+
+subscriptionUpgrade-subject = { $productNameNew } subscription upgraded
+
+subscriptionUpgrade-title = Thank you for upgrading!
+
+# Variables:
+# $productNameOld (String) - The name of the previously subscribed product, e.g. Mozilla VPN
+# $productNameNew (String) - The name of the new subscribed product, e.g. Mozilla VPN
+# $paymentAmountOld (String) - The amount of the previous subscription payment, including currency, e.g. $10.00
+# $paymentAmountNew (String) - The amount of the new subscription payment, including currency, e.g. $10.00
+# $productPaymentCycle (String) - The interval of time from the end of one payment statement date to the next payment statement date, e.g. month
+# $paymentProrated (String) - The one time fee to reflect the higher charge for the remainder of the payment cycle, including currency, e.g. $10.00
+
+subscriptionUpgrade-content = You have successfully upgraded from { $productNameOld } to { $productNameNew }. Starting with your next bill, your charge will change from { $paymentAmountOld } per { $productPaymentCycle } to { $paymentAmountNew }. At that time you will also be charged a one-time fee of { $paymentProrated } to reflect the higher charge for the remainder of this { $productPaymentCycle }. If there is new software for you to install in order to use { $productNameNew }, you will receive a separate email with download instructions. Your subscription will automatically renew each billing period unless you choose to cancel.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/en.ftl
@@ -1,7 +1,7 @@
 # Variables:
 # $productNameNew (String) - The name of the subscribed product, e.g. Mozilla VPN
 
-subscriptionUpgrade-subject = { $productNameNew } subscription upgraded
+subscriptionUpgrade-subject = You have upgraded to { $productNameNew }
 
 subscriptionUpgrade-title = Thank you for upgrading!
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/en.ftl
@@ -1,16 +1,18 @@
 # Variables:
 # $productNameNew (String) - The name of the subscribed product, e.g. Mozilla VPN
-
 subscriptionUpgrade-subject = You have upgraded to { $productNameNew }
-
 subscriptionUpgrade-title = Thank you for upgrading!
-
 # Variables:
 # $productNameOld (String) - The name of the previously subscribed product, e.g. Mozilla VPN
 # $productNameNew (String) - The name of the new subscribed product, e.g. Mozilla VPN
+subscriptionUpgrade-upgrade-info = You have successfully upgraded from { $productNameOld } to { $productNameNew }.
+# Variables:
 # $paymentAmountOld (String) - The amount of the previous subscription payment, including currency, e.g. $10.00
 # $paymentAmountNew (String) - The amount of the new subscription payment, including currency, e.g. $10.00
 # $productPaymentCycle (String) - The interval of time from the end of one payment statement date to the next payment statement date, e.g. month
 # $paymentProrated (String) - The one time fee to reflect the higher charge for the remainder of the payment cycle, including currency, e.g. $10.00
-
-subscriptionUpgrade-content = You have successfully upgraded from { $productNameOld } to { $productNameNew }. Starting with your next bill, your charge will change from { $paymentAmountOld } per { $productPaymentCycle } to { $paymentAmountNew }. At that time you will also be charged a one-time fee of { $paymentProrated } to reflect the higher charge for the remainder of this { $productPaymentCycle }. If there is new software for you to install in order to use { $productNameNew }, you will receive a separate email with download instructions. Your subscription will automatically renew each billing period unless you choose to cancel.
+subscriptionUpgrade-charge-info = Starting with your next bill, your charge will change from { $paymentAmountOld } per { $productPaymentCycle } to { $paymentAmountNew }. At that time you will also be charged a one-time fee of { $paymentProrated } to reflect the higher charge for the remainder of this { $productPaymentCycle }.
+# Variables:
+# $productNameNew (String) - The name of the new subscribed product, e.g. Mozilla VPN
+subscriptionUpgrade-install = If there is new software for you to install in order to use { $productNameNew }, you will receive a separate email with download instructions.
+subscriptionUpgrade-auto-renew = Your subscription will automatically renew each billing period unless you choose to cancel.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.mjml
@@ -1,6 +1,7 @@
 <%# This Source Code Form is subject to the terms of the Mozilla Public
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
 <mj-section css-class="mb-6">
   <mj-group>
     <mj-column>
@@ -17,19 +18,27 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="subscriptionUpgrade-title" data-l10n-args="<%= JSON.stringify({productNameNew}) %>">Thank you for upgrading to <%- productNameNew %>!</span>
+      <span data-l10n-id="subscriptionUpgrade-title" data-l10n-args="<%= JSON.stringify({productNameNew}) %>">Thank you for upgrading!</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionUpgrade-upgrade-info" data-l10n-args="<%= JSON.stringify({productNameNew, productNameOld}) %>">You have successfully upgraded from <%- productNameOld %> to <%- productNameNew %>.</span>
     </mj-text>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="subscriptionUpgrade-content" data-l10n-args="<%= JSON.stringify({paymentAmountNew, paymentAmountOld, paymentProrated, productNameNew, productNameOld, productPaymentCycle}) %>">
-        You have successfully upgraded from <%- productNameOld %> to <%- productNameNew %>.
-        <br><br>
-        Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycle %> to <%- paymentAmountNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycle %>.
-        <br><br>
-        If there is new software for you to install in order to use <%- productNameNew %>, you will receive a separate email with download instructions.
-        <br><br>
-        Your subscription will automatically renew each billing period unless you choose to cancel.
-      </span>
+      <span data-l10n-id="subscriptionUpgrade-charge-info" data-l10n-args="<%= JSON.stringify({paymentAmountNew, paymentAmountOld, paymentProrated, productPaymentCycle}) %>">Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycle %> to <%- paymentAmountNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycle %>.</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionUpgrade-install" data-l10n-args="<%= JSON.stringify({productNameNew}) %>">If there is new software for you to install in order to use <%- productNameNew %>, you will receive a separate email with download instructions.</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionUpgrade-auto-renew">Your subscription will automatically renew each billing period unless you choose to cancel.</span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.mjml
@@ -1,0 +1,37 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+<mj-section css-class="mb-6">
+  <mj-group>
+    <mj-column>
+      <mj-image src="<%- productIconURLOld %>" alt="<%- productNameOld %>" title="<%- productNameOld %>" css-class="product-icon">
+      </mj-image>
+    </mj-column>
+    <mj-column>
+      <mj-image src="<%- productIconURLNew %>" alt="<%- productNameNew %>" title="<%- productNameNew %>" css-class="product-icon">
+      </mj-image>
+    </mj-column>
+  </mj-group>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="subscriptionUpgrade-title" data-l10n-args="<%= JSON.stringify({productNameNew}) %>">Thank you for upgrading to <%- productNameNew %>!</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionUpgrade-content" data-l10n-args="<%= JSON.stringify({paymentAmountNew, paymentAmountOld, paymentProrated, productNameNew, productNameOld, productPaymentCycle}) %>">
+        You have successfully upgraded from <%- productNameOld %> to <%- productNameNew %>.
+        <br><br>
+        Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycle %> to <%- paymentAmountNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycle %>.
+        <br><br>
+        If there is new software for you to install in order to use <%- productNameNew %>, you will receive a separate email with download instructions.
+        <br><br>
+        Your subscription will automatically renew each billing period unless you choose to cancel.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include ('/partials/subscriptionSupport/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.stories.ts
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionUpgrade',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionUpgrade',
+  'Sent when a user upgrades their subscription.',
+  {
+    paymentAmountNew: '£123,121.00',
+    paymentAmountOld: '¥99,991',
+    productIconURLNew: 'http://example.com/icon-new',
+    productIconURLOld: 'http://example.com/icon-old',
+    productNameNew: 'Product Name B',
+    productNameOld: 'Product Name A',
+    productPaymentCycle: 'month',
+    paymentProrated: '$5,231.00',
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+  }
+);
+
+export const SubscriptionUpgrade = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.stories.ts
@@ -15,8 +15,10 @@ const createStory = subplatStoryWithProps(
   {
     paymentAmountNew: '£123,121.00',
     paymentAmountOld: '¥99,991',
-    productIconURLNew: 'http://example.com/icon-new',
-    productIconURLOld: 'http://example.com/icon-old',
+    productIconURLNew:
+      'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
+    productIconURLOld:
+      'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
     productNameNew: 'Product Name B',
     productNameOld: 'Product Name A',
     productPaymentCycle: 'month',

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.txt
@@ -1,4 +1,4 @@
-subscriptionUpgrade-subject = "<%- productNameNew %> subscription upgraded"
+subscriptionUpgrade-subject = "You have upgraded to <%- productNameNew %>"
 
 subscriptionUpgrade-title = "Thank you for upgrading!"
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.txt
@@ -1,0 +1,7 @@
+subscriptionUpgrade-subject = "<%- productNameNew %> subscription upgraded"
+
+subscriptionUpgrade-title = "Thank you for upgrading!"
+
+subscriptionUpgrade-content = "You have successfully upgraded from <%- productNameOld %> to <%- productNameNew %>. Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycle %> to <%- paymentAmountNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycle %>. If there is new software for you to install in order to use <%- productNameNew %>, you will receive a separate email with download instructions. Your subscription will automatically renew each billing period unless you choose to cancel."
+
+<%- include ('/partials/subscriptionSupport/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.txt
@@ -2,6 +2,12 @@ subscriptionUpgrade-subject = "You have upgraded to <%- productNameNew %>"
 
 subscriptionUpgrade-title = "Thank you for upgrading!"
 
-subscriptionUpgrade-content = "You have successfully upgraded from <%- productNameOld %> to <%- productNameNew %>. Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycle %> to <%- paymentAmountNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycle %>. If there is new software for you to install in order to use <%- productNameNew %>, you will receive a separate email with download instructions. Your subscription will automatically renew each billing period unless you choose to cancel."
+subscriptionUpgrade-upgrade-info = "You have successfully upgraded from <%- productNameOld %> to <%- productNameNew %>."
+
+subscriptionUpgrade-charge-info = "Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycle %> to <%- paymentAmountNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycle %>."
+
+subscriptionUpgrade-install = "If there is new software for you to install in order to use <%- productNameNew %>, you will receive a separate email with download instructions."
+
+subscriptionUpgrade-auto-renew = "Your subscription will automatically renew each billing period unless you choose to cancel."
 
 <%- include ('/partials/subscriptionSupport/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -53,9 +53,18 @@ const MESSAGE = {
   uaOSVersion: '10',
   uid: 'uid',
   unblockCode: 'AS6334PK',
+  paymentAmountOldInCents: 9999099.9,
+  paymentAmountOldCurrency: 'jpy',
+  paymentAmountNewInCents: 12312099.9,
+  paymentAmountNewCurrency: 'gbp',
+  paymentProratedInCents: 523099.9,
+  paymentProratedCurrency: 'usd',
   productId: 'wibble',
   planId: 'plan-example',
   productName: 'Firefox Fortress',
+  productNameOld: 'Product A',
+  productNameNew: 'Product B',
+  productPaymentCycle: 'month',
   subscription: {
     productName: 'Cooking with Foxkeh',
     planId: 'plan-example',
@@ -65,6 +74,14 @@ const MESSAGE = {
     { productName: 'Firefox Fortress' },
     { productName: 'Cooking with Foxkeh' },
   ],
+};
+
+const MESSAGE_FORMATTED = {
+  // Note: Intl.NumberFormat rounds 1/10 cent up
+  invoiceTotal: '€10,000.00',
+  paymentAmountOld: '¥99,991',
+  paymentAmountNew: '£123,121.00',
+  paymentProrated: '$5,231.00',
 };
 
 // key = query param name, value = MESSAGE property name
@@ -990,7 +1007,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ])],
     ['html', [
       { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-payment-expired', 'update-billing', 'plan_id', 'product_id', 'uid', 'email')) },
-      // commented out during template conversion - this doesn't appear to actually existin rendered old templates but passes the test?
+      // commented out during template conversion - this doesn't appear to actually exist in rendered old templates but passes the test?
       // { test: 'include', expected: decodeUrl(configHref('subscriptionTermsUrl', 'subscription-payment-expired', 'subscription-terms')) },
       { test: 'include', expected: `for ${MESSAGE.productName} is about to expire.` },
       { test: 'notInclude', expected: 'utm_source=email' },
@@ -1035,6 +1052,32 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ]],
     ['text', [
       { test: 'include', expected: `reactivating your ${MESSAGE.productName} subscription` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ])],
+
+  ['subscriptionUpgradeEmail', new Map([
+    ['subject', { test: 'equal', expected: `You have upgraded to ${MESSAGE.productNameNew}` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionUpgrade') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionUpgrade' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionUpgrade }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-upgrade', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      // commented out during template conversion - this doesn't appear to actually exist in rendered old templates but passes the test?
+      // { test: 'include', expected: decodeUrl(configHref('subscriptionTermsUrl', 'subscription-upgrade', 'subscription-terms')) },
+      { test: 'include', expected: `from ${MESSAGE.productNameOld} to ${MESSAGE.productNameNew}.` },
+      { test: 'include', expected: `from ${MESSAGE_FORMATTED.paymentAmountOld} per ${MESSAGE.productPaymentCycle} to ${MESSAGE_FORMATTED.paymentAmountNew}.` },
+      { test: 'include', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect the higher charge for the remainder of this ${MESSAGE.productPaymentCycle}.` },
+      { test: 'include', expected: `to use ${MESSAGE.productNameNew},` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `from ${MESSAGE.productNameOld} to ${MESSAGE.productNameNew}.` },
+      { test: 'include', expected: `from ${MESSAGE_FORMATTED.paymentAmountOld} per ${MESSAGE.productPaymentCycle} to ${MESSAGE_FORMATTED.paymentAmountNew}.` },
+      { test: 'include', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect the higher charge for the remainder of this ${MESSAGE.productPaymentCycle}.` },
+      { test: 'include', expected: `to use ${MESSAGE.productNameNew},` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],


### PR DESCRIPTION
Because:

* We are actively converting old FxA emails to our new modernized stack.

This commit:

* Converts the `subscriptionUpgrade` subscription platform email to the new stack.

Closes #9293

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
<img width="639" alt="Screen Shot 2021-12-02 at 5 43 46 PM" src="https://user-images.githubusercontent.com/28129806/144514967-7832970f-9802-4128-aff5-6093f2a6e90c.png">

