### PR TITLE
fix(metrics): Don't override hapi request artifacts

### DIFF
--- a/packages/fxa-auth-server/lib/metrics/amplitude.js
+++ b/packages/fxa-auth-server/lib/metrics/amplitude.js
@@ -202,8 +202,8 @@ module.exports = (log, config) => {
     }
 
     const uid = data.uid || getFromToken(request, 'uid');
-    if (uid) {
-      request.auth.artifacts = { metricsUid: uid };
+    if (uid && request.auth.artifacts) {
+      request.auth.artifacts.metricsUid = uid;
     }
 
     let devices;

--- a/packages/fxa-auth-server/lib/metrics/events.js
+++ b/packages/fxa-auth-server/lib/metrics/events.js
@@ -103,8 +103,8 @@ module.exports = (log, config) => {
 
       const request = this;
 
-      if (data && data.uid) {
-        request.auth.artifacts = { metricsUid: data.uid };
+      if (data && data.uid && request.auth && request.auth.artifacts) {
+        request.auth.artifacts.metricsUid = data.uid;
       }
 
       const isMetricsEnabled = await request.app.isMetricsEnabled;

--- a/packages/fxa-auth-server/test/local/metrics/amplitude.js
+++ b/packages/fxa-auth-server/test/local/metrics/amplitude.js
@@ -189,6 +189,9 @@ describe('metrics/amplitude', () => {
           credentials: {
             uid: 'blee',
           },
+          auth: {
+            artifacts: {},
+          },
         });
         await amplitude('account.confirmed', request);
         assert.equal(request.auth.artifacts.metricsUid, 'blee');


### PR DESCRIPTION
## Because

- We were overriding hapi request artifacts when setting metrics uid to be used later

## This pull request

- Adds the uid to object

## Issue that this pull request solves

Closes: https://github.com/mozilla/fxa/issues/11209

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Notes

Targeted as a point release on train-220.

