### PR TITLE
fix(settings): fix copy and paste of recovery codes

### DIFF
--- a/packages/fxa-settings/src/components/DataBlock/index.test.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.test.tsx
@@ -21,11 +21,11 @@ const multiValue = [
   'D4J6KY8FL4',
 ];
 
-const account = ({
+const account = {
   primaryEmail: {
     email: 'pbooth@mozilla.com',
   },
-} as unknown) as Account;
+} as unknown as Account;
 
 Object.defineProperty(window.navigator, 'clipboard', {
   value: { writeText: jest.fn() },
@@ -50,6 +50,18 @@ it('can render multiple values', () => {
   multiValue.forEach((value) => {
     expect(screen.getByText(value)).toBeInTheDocument();
   });
+});
+
+it('can apply spacing to multiple values', () => {
+  render(
+    <AppContext.Provider value={{ account }}>
+      <DataBlock value={multiValue} separator=" " />
+    </AppContext.Provider>
+  );
+
+  expect(screen.getByTestId('datablock').textContent?.trim()).toEqual(
+    multiValue.join(' ')
+  );
 });
 
 it('displays a tooltip on action', async () => {

--- a/packages/fxa-settings/src/components/DataBlock/index.tsx
+++ b/packages/fxa-settings/src/components/DataBlock/index.tsx
@@ -19,12 +19,16 @@ type actionFn = (action: actions) => void;
 export type DataBlockProps = {
   value: string | string[];
   prefixDataTestId?: string;
+  separator?: string;
+  onCopy?: (event: React.ClipboardEvent<HTMLDivElement>) => void;
   onAction?: actionFn;
 };
 
 export const DataBlock = ({
   value,
   prefixDataTestId,
+  separator,
+  onCopy,
   onAction = () => {},
 }: DataBlockProps) => {
   const valueIsArray = Array.isArray(value);
@@ -47,11 +51,13 @@ export const DataBlock = ({
           valueIsArray ? 'py-4' : 'py-5'
         }`}
         data-testid={dataTestId}
+        {...{onCopy}}
       >
         {valueIsArray ? (
           (value as string[]).map((item) => (
             <span key={item} className="flex-50% py-1">
               {item}
+              {separator || ''}
             </span>
           ))
         ) : (

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.test.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.test.tsx
@@ -36,6 +36,10 @@ it('renders', async () => {
   expect(screen.getByTestId('2fa-recovery-codes')).toHaveTextContent(
     recoveryCodes[0]
   );
+
+  expect(screen.getByTestId('datablock').textContent?.trim()).toEqual(
+    recoveryCodes.join(' ')
+  );
 });
 
 it('displays an error when fails to fetch new recovery codes', async () => {

--- a/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
+++ b/packages/fxa-settings/src/components/Page2faReplaceRecoveryCodes/index.tsx
@@ -11,6 +11,7 @@ import { HomePath } from '../../constants';
 import { useAccount, useAlertBar, useSession } from '../../models';
 import { useLocalization, Localized } from '@fluent/react';
 import LoadingSpinner from 'fxa-react/components/LoadingSpinner';
+import { copyRecoveryCodes } from '../../lib/totp';
 
 export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
   const alertBar = useAlertBar();
@@ -65,7 +66,11 @@ export const Page2faReplaceRecoveryCodes = (_: RouteComponentProps) => {
         </Localized>
         <div className="mt-6 flex flex-col items-center h-auto justify-between">
           {recoveryCodes.length > 0 ? (
-            <DataBlock value={recoveryCodes} />
+            <DataBlock
+              value={recoveryCodes.map((x) => x)}
+              separator=" "
+              onCopy={copyRecoveryCodes}
+            />
           ) : (
             <LoadingSpinner />
           )}

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.test.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.test.tsx
@@ -145,6 +145,9 @@ describe('step 2', () => {
     expect(screen.getByTestId('2fa-recovery-codes')).toHaveTextContent(
       totp.recoveryCodes[0]
     );
+    expect(screen.getByTestId('datablock').textContent?.trim()).toEqual(
+      totp.recoveryCodes.join(' ')
+    );
   });
 
   it('shows an error when an invalid auth code is entered', async () => {

--- a/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
+++ b/packages/fxa-settings/src/components/PageTwoStepAuthentication/index.tsx
@@ -11,7 +11,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import VerifiedSessionGuard from '../VerifiedSessionGuard';
 import DataBlock from '../DataBlock';
 import { useAccount, useAlertBar, useSession } from '../../models';
-import { checkCode, getCode } from '../../lib/totp';
+import { checkCode, copyRecoveryCodes, getCode } from '../../lib/totp';
 import { HomePath } from '../../constants';
 import { logViewEvent, useMetrics } from '../../lib/metrics';
 import { Localized, useLocalization } from '@fluent/react';
@@ -63,9 +63,8 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
   const [showQrCode, setShowQrCode] = useState(true);
   const [totpVerified, setTotpVerified] = useState<boolean>(false);
   const [invalidCodeError, setInvalidCodeError] = useState<string>('');
-  const [recoveryCodesAcknowledged, setRecoveryCodesAcknowledged] = useState<
-    boolean
-  >(false);
+  const [recoveryCodesAcknowledged, setRecoveryCodesAcknowledged] =
+    useState<boolean>(false);
   const [recoveryCodeError, setRecoveryCodeError] = useState<string>('');
 
   // Handles the "Continue" on step two, which doesn't submits any values.
@@ -307,8 +306,10 @@ export const PageTwoStepAuthentication = (_: RouteComponentProps) => {
             </Localized>
             <div className="mt-6 flex flex-col items-center justify-between">
               <DataBlock
-                value={totpInfo.result.recoveryCodes}
+                value={totpInfo.result.recoveryCodes.map((x) => x)}
+                separator=" "
                 onAction={logDataTrioActionEvent}
+                onCopy={copyRecoveryCodes}
               ></DataBlock>
             </div>
           </div>

--- a/packages/fxa-settings/src/lib/totp.ts
+++ b/packages/fxa-settings/src/lib/totp.ts
@@ -53,3 +53,14 @@ export async function checkCode(
 
   return false;
 }
+
+export function copyRecoveryCodes(event: React.ClipboardEvent<HTMLDivElement>) {
+  const selection = document.getSelection();
+  if (selection) {
+    event.clipboardData.setData(
+      'text/plain',
+      selection.toString().replace(/\s/g, '\n')
+    );
+    event.preventDefault();
+  }
+}


### PR DESCRIPTION
## Because:

* When a user would manually copy recovery codes, codes would be mashed together without any newline or white space to separate them.

## This pull request

- Introduces a trailing whitespace on recovery codes, which allows copy and paste to be more user friendly.
- Hijacks onCopy event, which allows white space to be converted to newlines.

Closes #11042

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
