### PR TITLE
feat(auth): add invoice preview route

### DIFF
--- a/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe-formatter.ts
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import * as invoiceDTO from 'fxa-shared/dto/auth/payments/invoice';
+import { Stripe } from 'stripe';
+
+/**
+ * Formats a Stripe Invoice to the InvoicePreview DTO format.
+ */
+export function stripeInvoiceToInvoicePreviewDTO(
+  invoice: Stripe.Invoice
+): invoiceDTO.InvoicePreview {
+  const invoicePreview: invoiceDTO.invoicePreviewSchema = {
+    subtotal: invoice.subtotal,
+    total: invoice.total,
+    line_items: invoice.lines.data.map((line) => ({
+      amount: line.amount,
+      currency: line.currency,
+      id: line.price!.id,
+      name: line.description || '',
+    })),
+  };
+
+  // Add tax if it exists
+  if (
+    invoice.total_tax_amounts.length > 0 &&
+    invoice.default_tax_rates.length > 0
+  ) {
+    const taxObject = invoice.default_tax_rates[0];
+    const tax = invoice.total_tax_amounts[0];
+    invoicePreview.tax = {
+      amount: tax.amount,
+      inclusive: tax.inclusive,
+      name: taxObject.display_name,
+      percentage: taxObject.percentage,
+    };
+  }
+
+  // Add discount if it exists
+  if (invoice.discount && invoice.total_discount_amounts) {
+    invoicePreview.discount = {
+      amount: invoice.total_discount_amounts[0].amount,
+      amount_off: invoice.discount.coupon.amount_off,
+      percent_off: invoice.discount.coupon.percent_off,
+    };
+  }
+  return invoicePreview;
+}

--- a/packages/fxa-auth-server/lib/types.ts
+++ b/packages/fxa-auth-server/lib/types.ts
@@ -44,7 +44,7 @@ export interface AuthApp extends RequestApplicationState {
   };
   isSuspiciousRequest: boolean;
   geo: {
-    location: {
+    location?: {
       city: string;
       state: string;
       country: string;

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_preview_tax.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_preview_tax.json
@@ -1,0 +1,189 @@
+{
+  "object": "invoice",
+  "account_country": "US",
+  "account_name": "Mozilla Corporation",
+  "account_tax_ids": null,
+  "amount_due": 2323,
+  "amount_paid": 0,
+  "amount_remaining": 2323,
+  "application_fee_amount": null,
+  "attempt_count": 0,
+  "attempted": false,
+  "automatic_tax": {
+    "enabled": false,
+    "status": null
+  },
+  "billing_reason": "upcoming",
+  "charge": null,
+  "collection_method": "charge_automatically",
+  "created": 1638387404,
+  "currency": "usd",
+  "custom_fields": null,
+  "customer": null,
+  "customer_address": {
+    "city": null,
+    "country": "DE",
+    "line1": null,
+    "line2": null,
+    "postal_code": null,
+    "state": null
+  },
+  "customer_email": null,
+  "customer_name": null,
+  "customer_phone": null,
+  "customer_shipping": null,
+  "customer_tax_exempt": "none",
+  "customer_tax_ids": [],
+  "default_payment_method": null,
+  "default_source": null,
+  "default_tax_rates": [
+    {
+      "id": "txr_1JALB2BVqmGyQTMa3ltU6p6y",
+      "object": "tax_rate",
+      "active": true,
+      "country": "DE",
+      "created": 1625604452,
+      "description": "DE VAT",
+      "display_name": "VAT",
+      "inclusive": true,
+      "jurisdiction": null,
+      "livemode": false,
+      "metadata": {},
+      "percentage": 19,
+      "state": null,
+      "tax_type": null
+    }
+  ],
+  "description": null,
+  "discount": null,
+  "discounts": [],
+  "due_date": null,
+  "ending_balance": 0,
+  "footer": null,
+  "last_finalization_error": null,
+  "lines": {
+    "object": "list",
+    "data": [
+      {
+        "id": "il_tmp_1b032fBVqmGyQTMa6c981a47",
+        "object": "line_item",
+        "amount": 2323,
+        "currency": "usd",
+        "description": "1 × Robin K Wilson (at $23.23 / month)",
+        "discount_amounts": [],
+        "discountable": true,
+        "discounts": [],
+        "livemode": false,
+        "metadata": {},
+        "period": {
+          "end": 1641065804,
+          "start": 1638387404
+        },
+        "plan": {
+          "id": "price_1JkZUtBVqmGyQTMabzHiPgmR",
+          "object": "plan",
+          "active": true,
+          "aggregate_usage": null,
+          "amount": 2323,
+          "amount_decimal": "2323",
+          "billing_scheme": "per_unit",
+          "created": 1634239307,
+          "currency": "usd",
+          "interval": "month",
+          "interval_count": 1,
+          "livemode": false,
+          "metadata": {},
+          "nickname": null,
+          "product": "prod_KPOHRv5MheicuD",
+          "tiers_mode": null,
+          "transform_usage": null,
+          "trial_period_days": null,
+          "usage_type": "licensed"
+        },
+        "price": {
+          "id": "price_1JkZUtBVqmGyQTMabzHiPgmR",
+          "object": "price",
+          "active": true,
+          "billing_scheme": "per_unit",
+          "created": 1634239307,
+          "currency": "usd",
+          "livemode": false,
+          "lookup_key": null,
+          "metadata": {},
+          "nickname": null,
+          "product": "prod_KPOHRv5MheicuD",
+          "recurring": {
+            "aggregate_usage": null,
+            "interval": "month",
+            "interval_count": 1,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "tax_behavior": "unspecified",
+          "tiers_mode": null,
+          "transform_quantity": null,
+          "type": "recurring",
+          "unit_amount": 2323,
+          "unit_amount_decimal": "2323"
+        },
+        "proration": false,
+        "quantity": 1,
+        "subscription": "sub_1K1ybgBVqmGyQTMapiusG1Xd",
+        "subscription_item": "si_KhNMIdH4bqqOyQ",
+        "tax_amounts": [
+          {
+            "amount": 371,
+            "inclusive": true,
+            "tax_rate": "txr_1JALB2BVqmGyQTMa3ltU6p6y"
+          }
+        ],
+        "tax_rates": [],
+        "type": "subscription"
+      }
+    ],
+    "has_more": false,
+    "total_count": 1,
+    "url": "/v1/invoices/upcoming/lines?"
+  },
+  "livemode": false,
+  "metadata": {},
+  "next_payment_attempt": 1638391004,
+  "number": "72ABE14-0001",
+  "on_behalf_of": null,
+  "paid": false,
+  "payment_intent": null,
+  "payment_settings": {
+    "payment_method_options": null,
+    "payment_method_types": null
+  },
+  "period_end": 1638387404,
+  "period_start": 1638387404,
+  "post_payment_credit_notes_amount": 0,
+  "pre_payment_credit_notes_amount": 0,
+  "quote": null,
+  "receipt_number": null,
+  "starting_balance": 0,
+  "statement_descriptor": null,
+  "status": "draft",
+  "status_transitions": {
+    "finalized_at": null,
+    "marked_uncollectible_at": null,
+    "paid_at": null,
+    "voided_at": null
+  },
+  "subscription": "sub_1K1ybgBVqmGyQTMapiusG1Xd",
+  "subscription_proration_date": 1638387404,
+  "subtotal": 2323,
+  "tax": 371,
+  "total": 2323,
+  "total_discount_amounts": [],
+  "total_tax_amounts": [
+    {
+      "amount": 371,
+      "inclusive": true,
+      "tax_rate": "txr_1JALB2BVqmGyQTMa3ltU6p6y"
+    }
+  ],
+  "transfer_data": null,
+  "webhooks_delivered_at": null
+}

--- a/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_preview_tax_discount.json
+++ b/packages/fxa-auth-server/test/local/payments/fixtures/stripe/invoice_preview_tax_discount.json
@@ -1,0 +1,227 @@
+{
+  "object": "invoice",
+  "account_country": "US",
+  "account_name": "Mozilla Corporation",
+  "account_tax_ids": null,
+  "amount_due": 1824,
+  "amount_paid": 0,
+  "amount_remaining": 1824,
+  "application_fee_amount": null,
+  "attempt_count": 0,
+  "attempted": false,
+  "automatic_tax": {
+    "enabled": false,
+    "status": null
+  },
+  "billing_reason": "upcoming",
+  "charge": null,
+  "collection_method": "charge_automatically",
+  "created": 1638235373,
+  "currency": "usd",
+  "custom_fields": null,
+  "customer": null,
+  "customer_address": {
+    "city": null,
+    "country": null,
+    "line1": null,
+    "line2": null,
+    "postal_code": null,
+    "state": "DE"
+  },
+  "customer_email": null,
+  "customer_name": null,
+  "customer_phone": null,
+  "customer_shipping": null,
+  "customer_tax_exempt": "none",
+  "customer_tax_ids": [],
+  "default_payment_method": null,
+  "default_source": null,
+  "default_tax_rates": [
+    {
+      "id": "txr_1JALB2BVqmGyQTMa3ltU6p6y",
+      "object": "tax_rate",
+      "active": true,
+      "country": "DE",
+      "created": 1625604452,
+      "description": "DE VAT",
+      "display_name": "VAT",
+      "inclusive": true,
+      "jurisdiction": null,
+      "livemode": false,
+      "metadata": {},
+      "percentage": 19,
+      "state": null,
+      "tax_type": null
+    }
+  ],
+  "description": null,
+  "discount": {
+    "id": "di_1K1L3ZBVqmGyQTMaIu772FxN",
+    "object": "discount",
+    "checkout_session": null,
+    "coupon": {
+      "id": "BPGwCW2H",
+      "object": "coupon",
+      "amount_off": 499,
+      "created": 1591322557,
+      "currency": "usd",
+      "duration": "once",
+      "duration_in_months": null,
+      "livemode": false,
+      "max_redemptions": 50,
+      "metadata": {},
+      "name": "Discount $4.99 50 times",
+      "percent_off": null,
+      "redeem_by": null,
+      "times_redeemed": 13,
+      "valid": true
+    },
+    "customer": "cus_KgiUdgpzGqzCea",
+    "end": null,
+    "invoice": null,
+    "invoice_item": null,
+    "promotion_code": null,
+    "start": 1638235373,
+    "subscription": "sub_1K1L3ZBVqmGyQTMascpG5XMk"
+  },
+  "discounts": ["di_1K1L3ZBVqmGyQTMaIu772FxN"],
+  "due_date": null,
+  "ending_balance": 0,
+  "footer": null,
+  "last_finalization_error": null,
+  "lines": {
+    "object": "list",
+    "data": [
+      {
+        "id": "il_tmp_172d3eBVqmGyQTMa2cb1d666",
+        "object": "line_item",
+        "amount": 2323,
+        "currency": "usd",
+        "description": "1 × Robin K Wilson (at $23.23 / month)",
+        "discount_amounts": [
+          {
+            "amount": 499,
+            "discount": "di_1K1L3ZBVqmGyQTMaIu772FxN"
+          }
+        ],
+        "discountable": true,
+        "discounts": [],
+        "livemode": false,
+        "metadata": {},
+        "period": {
+          "end": 1640827373,
+          "start": 1638235373
+        },
+        "plan": {
+          "id": "price_1JkZUtBVqmGyQTMabzHiPgmR",
+          "object": "plan",
+          "active": true,
+          "aggregate_usage": null,
+          "amount": 2323,
+          "amount_decimal": "2323",
+          "billing_scheme": "per_unit",
+          "created": 1634239307,
+          "currency": "usd",
+          "interval": "month",
+          "interval_count": 1,
+          "livemode": false,
+          "metadata": {},
+          "nickname": null,
+          "product": "prod_KPOHRv5MheicuD",
+          "tiers_mode": null,
+          "transform_usage": null,
+          "trial_period_days": null,
+          "usage_type": "licensed"
+        },
+        "price": {
+          "id": "price_1JkZUtBVqmGyQTMabzHiPgmR",
+          "object": "price",
+          "active": true,
+          "billing_scheme": "per_unit",
+          "created": 1634239307,
+          "currency": "usd",
+          "livemode": false,
+          "lookup_key": null,
+          "metadata": {},
+          "nickname": null,
+          "product": "prod_KPOHRv5MheicuD",
+          "recurring": {
+            "aggregate_usage": null,
+            "interval": "month",
+            "interval_count": 1,
+            "trial_period_days": null,
+            "usage_type": "licensed"
+          },
+          "tax_behavior": "unspecified",
+          "tiers_mode": null,
+          "transform_quantity": null,
+          "type": "recurring",
+          "unit_amount": 2323,
+          "unit_amount_decimal": "2323"
+        },
+        "proration": false,
+        "quantity": 1,
+        "subscription": "sub_1K1L3ZBVqmGyQTMascpG5XMk",
+        "subscription_item": "si_KgiUz0pUJIOrfh",
+        "tax_amounts": [
+          {
+            "amount": 291,
+            "inclusive": true,
+            "tax_rate": "txr_1JALB2BVqmGyQTMa3ltU6p6y"
+          }
+        ],
+        "tax_rates": [],
+        "type": "subscription"
+      }
+    ],
+    "has_more": false,
+    "total_count": 1,
+    "url": "/v1/invoices/upcoming/lines?coupon=BPGwCW2H"
+  },
+  "livemode": false,
+  "metadata": {},
+  "next_payment_attempt": 1638238973,
+  "number": "A17F35F-0001",
+  "on_behalf_of": null,
+  "paid": false,
+  "payment_intent": null,
+  "payment_settings": {
+    "payment_method_options": null,
+    "payment_method_types": null
+  },
+  "period_end": 1638235373,
+  "period_start": 1638235373,
+  "post_payment_credit_notes_amount": 0,
+  "pre_payment_credit_notes_amount": 0,
+  "quote": null,
+  "receipt_number": null,
+  "starting_balance": 0,
+  "statement_descriptor": null,
+  "status": "draft",
+  "status_transitions": {
+    "finalized_at": null,
+    "marked_uncollectible_at": null,
+    "paid_at": null,
+    "voided_at": null
+  },
+  "subscription": "sub_1K1L3ZBVqmGyQTMascpG5XMk",
+  "subscription_proration_date": 1638235373,
+  "subtotal": 2323,
+  "tax": 291,
+  "total": 1824,
+  "total_discount_amounts": [
+    {
+      "amount": 499,
+      "discount": "di_1K1L3ZBVqmGyQTMaIu772FxN"
+    }
+  ],
+  "total_tax_amounts": [
+    {
+      "amount": 291,
+      "inclusive": true,
+      "tax_rate": "txr_1JALB2BVqmGyQTMa3ltU6p6y"
+    }
+  ],
+  "transfer_data": null,
+  "webhooks_delivered_at": null
+}

--- a/packages/fxa-auth-server/test/local/payments/stripe-formatter.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe-formatter.js
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+const { assert } = require('chai');
+
+const {
+  stripeInvoiceToInvoicePreviewDTO,
+} = require('../../../lib/payments/stripe-formatter');
+const previewInvoiceWithTax = require('./fixtures/stripe/invoice_preview_tax.json');
+const previewInvoiceWithDiscountAndTax = require('./fixtures/stripe/invoice_preview_tax_discount.json');
+const { deepCopy } = require('./util');
+
+describe('stripeInvoiceToInvoicePreviewDTO', () => {
+  it('formats an invoice with tax', () => {
+    const invoice = stripeInvoiceToInvoicePreviewDTO(
+      deepCopy(previewInvoiceWithTax)
+    );
+    assert.equal(invoice.total, previewInvoiceWithTax.total);
+    assert.equal(invoice.subtotal, previewInvoiceWithTax.subtotal);
+    assert.equal(
+      invoice.tax.amount,
+      previewInvoiceWithTax.total_tax_amounts[0].amount
+    );
+    assert.equal(
+      invoice.tax.percentage,
+      previewInvoiceWithTax.default_tax_rates[0].percentage
+    );
+    assert.equal(invoice.tax.inclusive, true);
+    assert.isUndefined(invoice.discount);
+  });
+
+  it('formats an invoice with tax and discount', () => {
+    const invoice = stripeInvoiceToInvoicePreviewDTO(
+      deepCopy(previewInvoiceWithDiscountAndTax)
+    );
+    assert.equal(invoice.total, previewInvoiceWithDiscountAndTax.total);
+    assert.equal(invoice.subtotal, previewInvoiceWithDiscountAndTax.subtotal);
+    assert.equal(
+      invoice.tax.amount,
+      previewInvoiceWithDiscountAndTax.total_tax_amounts[0].amount
+    );
+    assert.equal(
+      invoice.tax.percentage,
+      previewInvoiceWithDiscountAndTax.default_tax_rates[0].percentage
+    );
+    assert.equal(invoice.tax.inclusive, true);
+    assert.equal(
+      invoice.discount.amount,
+      previewInvoiceWithDiscountAndTax.total_discount_amounts[0].amount
+    );
+    assert.equal(
+      invoice.discount.amount_off,
+      previewInvoiceWithDiscountAndTax.discount.coupon.amount_off
+    );
+    assert.equal(
+      invoice.discount.percent_off,
+      previewInvoiceWithDiscountAndTax.discount.coupon.percent_off
+    );
+  });
+});

--- a/packages/fxa-auth-server/test/local/payments/util.js
+++ b/packages/fxa-auth-server/test/local/payments/util.js
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * To prevent the modification of the test objects loaded, which can impact other tests referencing the object,
+ * a deep copy of the object can be created which uses the test object as a template
+ *
+ * @param {Object} object
+ */
+function deepCopy(object) {
+  return JSON.parse(JSON.stringify(object));
+}
+
+module.exports.deepCopy = deepCopy;

--- a/packages/fxa-shared/dto/auth/payments/invoice.ts
+++ b/packages/fxa-shared/dto/auth/payments/invoice.ts
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import joi from 'typesafe-joi';
+
+export interface InvoiceLineItem {
+  amount: number;
+  currency: string;
+  id: string;
+  name: string;
+}
+
+export interface InvoiceTax {
+  amount: number;
+  inclusive: boolean;
+  name: string;
+  percentage: number;
+}
+
+export interface InvoiceDiscount {
+  amount: number;
+  amount_off: number | null;
+  percent_off: number | null;
+}
+
+/**
+ * Defines an interface for the invoice preview response from the
+ * auth-server.
+ */
+export interface InvoicePreview {
+  line_items: InvoiceLineItem[];
+  subtotal: number;
+  total: number;
+  tax?: InvoiceTax;
+  discount?: InvoiceDiscount;
+}
+
+export const invoicePreviewSchema = joi.object({
+  line_items: joi
+    .array()
+    .items(
+      joi
+        .object({
+          amount: joi.number().required(),
+          currency: joi.string().required(),
+          id: joi.string().required(),
+          name: joi.string().required(),
+        })
+        .required()
+    )
+    .required(),
+  subtotal: joi.number().required(),
+  total: joi.number().required(),
+  tax: joi.object({
+    amount: joi.number().required(),
+    inclusive: joi.boolean().required(),
+    name: joi.string().required(),
+    percentage: joi.number().required(),
+  }),
+  discount: joi.object({
+    amount: joi.number().required(),
+    amount_off: joi.number().required().allow(null),
+    percent_off: joi.number().required().allow(null),
+  }),
+});
+
+export type invoicePreviewSchema = joi.Literal<typeof invoicePreviewSchema>;

--- a/packages/fxa-shared/index.ts
+++ b/packages/fxa-shared/index.ts
@@ -12,6 +12,7 @@ import {
   metadataFromPlan,
   productDetailsFromPlan,
 } from './subscriptions/metadata';
+import * as invoice from './dto/auth/payments/invoice';
 import * as stripe from './subscriptions/stripe';
 import * as subscriptions from './subscriptions/subscriptions';
 
@@ -49,5 +50,12 @@ module.exports = {
     },
     stripe,
     subscriptions,
+  },
+  dto: {
+    auth: {
+      payments: {
+        invoice,
+      },
+    },
   },
 };

--- a/packages/fxa-shared/package.json
+++ b/packages/fxa-shared/package.json
@@ -112,7 +112,8 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0",
     "stripe": "^8.191.0",
-    "superagent": "^6.1.0"
+    "superagent": "^6.1.0",
+    "typesafe-joi": "^2.1.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -19711,6 +19711,7 @@ fsevents@~2.1.1:
     ts-jest: ^27.0.7
     ts-loader: ^8.3.0
     tsconfig-paths: ^3.12.0
+    typesafe-joi: ^2.1.0
     typescript: ^4.5.2
     underscore: ^1.13.1
     uuid: ^8.3.2


### PR DESCRIPTION
Because:

* We want to preview coupon code application to an invoice in the
  checkout flow.

This commit:

* Adds an invoice preview route that takes promotion codes and returns
  an invoice preview suitable for the checkout display.

Closes #10856

## Checklist

_Put an `x` in the boxes that apply_

- [ ] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Please attach the screenshots of the changes made in case of change in user interface.

## Other information (Optional)

Any other information that is important to this pull request.
