### PR TITLE
fix(settings): move auth errors to common file

### DIFF
--- a/packages/fxa-settings/src/components/ModalVerifySession/en-US.ftl
+++ b/packages/fxa-settings/src/components/ModalVerifySession/en-US.ftl
@@ -8,7 +8,3 @@ mvs-enter-verification-code = Enter your verification code
 mvs-enter-verification-code-desc = Please enter the verification code that was sent to <email>{ $email }</email> within 5 minutes.
 msv-cancel-button = Cancel
 msv-submit-button = Verify
-
-## Auth-server based errors that originate from backend service
-
-auth-error-183 = Invalid or expired verification code

--- a/packages/fxa-settings/src/components/PageSecondaryEmailAdd/en-US.ftl
+++ b/packages/fxa-settings/src/components/PageSecondaryEmailAdd/en-US.ftl
@@ -8,7 +8,3 @@ add-secondary-email-enter-address =
   .label = Enter email address
 add-secondary-email-cancel-button = Cancel
 add-secondary-email-save-button = Save
-
-## Auth-server based errors that originate from backend service
-
-auth-error-139 = Secondary email must be different than your account email

--- a/packages/fxa-settings/src/lib/auth-errors/en-US.ftl
+++ b/packages/fxa-settings/src/lib/auth-errors/en-US.ftl
@@ -13,5 +13,7 @@ auth-error-110 = Invalid token
 #                           (for example: "in 15 minutes")
 auth-error-114 = You've tried too many times. Please try again { $retryAfter }.
 auth-error-138 = Unverified session
+auth-error-139 = Secondary email must be different than your account email
 auth-error-155 = TOTP token not found
+auth-error-183 = Invalid or expired verification code
 auth-error-1008 = Your new password must be different


### PR DESCRIPTION
## Because

- Current location of auth errors creates new sections in settings.ftl.

## This pull request

- Moves all auth-error-xxx messages to common location.

## Issue that this pull request solves

Closes: # (issue number)

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
