### PR TITLE
chore(deps): Update fxa-dev-launcher to use esm

### DIFF
--- a/package-scripts.js
+++ b/package-scripts.js
@@ -5,7 +5,7 @@ module.exports = {
       default: `_dev/pm2/start.sh && _scripts/pm2-all.sh start && pm2 restart sync && echo "Use 'yarn stop' to stop all the servers"`,
       infrastructure: `_dev/pm2/start.sh`,
       services: `_scripts/pm2-all.sh start`,
-      firefox: './packages/fxa-dev-launcher/bin/fxa-dev-launcher &',
+      firefox: './packages/fxa-dev-launcher/bin/fxa-dev-launcher.mjs &',
     },
     stop: {
       default: 'pm2 kill',

--- a/packages/fxa-dev-launcher/bin/fxa-dev-launcher
+++ b/packages/fxa-dev-launcher/bin/fxa-dev-launcher
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-require('../index');

--- a/packages/fxa-dev-launcher/bin/fxa-dev-launcher.mjs
+++ b/packages/fxa-dev-launcher/bin/fxa-dev-launcher.mjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import foxfire from "foxfire";
+import profile from "../profile.mjs";
+
+foxfire({
+  args: [!!process.env.FIREFOX_DEBUGGER ? "-jsdebugger" : ""],
+  profileOptions: profile
+})

--- a/packages/fxa-dev-launcher/index.js
+++ b/packages/fxa-dev-launcher/index.js
@@ -1,6 +1,0 @@
-#!/usr/bin/env node
-
-require("foxfire")({
-  args: [!!process.env.FIREFOX_DEBUGGER ? "-jsdebugger" : ""],
-  profileOptions: require("./profile")
-});

--- a/packages/fxa-dev-launcher/package.json
+++ b/packages/fxa-dev-launcher/package.json
@@ -2,12 +2,10 @@
   "name": "fxa-dev-launcher",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
   "scripts": {
-    "audit": "npm audit --json | audit-filter --nsp-config=.nsprc --audit=-",
-    "start": "bin/fxa-dev-launcher"
+    "start": "./bin/fxa-dev-launcher.mjs"
   },
-  "bin": "./bin/fxa-dev-launcher",
+  "bin": "./bin/fxa-dev-launcher.mjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/vladikoff/fxa-dev-launcher"
@@ -17,8 +15,5 @@
   "dependencies": {
     "chalk": "^5.0.0",
     "foxfire": "^2.0.0"
-  },
-  "devDependencies": {
-    "audit-filter": "^0.5.0"
   }
 }

--- a/packages/fxa-dev-launcher/profile.mjs
+++ b/packages/fxa-dev-launcher/profile.mjs
@@ -1,6 +1,6 @@
-var chalk = require("chalk");
+import chalk from "chalk";
 
-var CONFIGS = {
+const CONFIGS = {
   local: {
     auth: "http://localhost:9000/v1",
     content: "http://localhost:3030/",
@@ -46,14 +46,14 @@ var CONFIGS = {
   }
 };
 
-var env = process.env.FXA_ENV || "local";
-var FXA_DESKTOP_CONTEXT = process.env.FXA_DESKTOP_CONTEXT || "fx_desktop_v3";
-var e10sDisabled = process.env.DISABLE_E10S === "true";
-var fxaEnv = CONFIGS[env];
+const env = process.env.FXA_ENV || "local";
+const FXA_DESKTOP_CONTEXT = process.env.FXA_DESKTOP_CONTEXT || "fx_desktop_v3";
+const e10sDisabled = process.env.DISABLE_E10S === "true";
+let fxaEnv = CONFIGS[env];
 
 if (!fxaEnv) {
   // If env is not found in the above list, assume it's an fxa-dev box.
-  var host = "https://" + env + ".dev.lcip.org/";
+  const host = "https://" + env + ".dev.lcip.org/";
 
   fxaEnv = {
     auth: host + "auth/v1",
@@ -64,7 +64,7 @@ if (!fxaEnv) {
   };
 }
 
-var fxaProfile = {
+const fxaProfile = {
   // enable debugger and toolbox
   "devtools.chrome.enabled": true,
   "devtools.debugger.remote-enabled": true,
@@ -118,11 +118,6 @@ var fxaProfile = {
 
 // Configuration for local sync development
 
-// The loop server is either production or local, nothing on stable or latest
-if (fxaEnv.loop) {
-  fxaProfile["loop.server"] = fxaEnv.loop;
-}
-
 if (e10sDisabled) {
   // disable e10s
   fxaProfile["browser.tabs.remote.autostart"] = false;
@@ -143,4 +138,4 @@ console.log(chalk.yellow("FXA_DESKTOP_CONTEXT:", FXA_DESKTOP_CONTEXT));
 console.log(chalk.yellow("FIREFOX_DEBUGGER:", !!process.env.FIREFOX_DEBUGGER));
 console.log(chalk.yellow("FXA_DESKTOP_CONTEXT:", FXA_DESKTOP_CONTEXT));
 
-module.exports = fxaProfile;
+export default fxaProfile;

--- a/yarn.lock
+++ b/yarn.lock
@@ -19015,11 +19015,10 @@ fsevents@~2.1.1:
   version: 0.0.0-use.local
   resolution: "fxa-dev-launcher@workspace:packages/fxa-dev-launcher"
   dependencies:
-    audit-filter: ^0.5.0
     chalk: ^5.0.0
     foxfire: ^2.0.0
   bin:
-    fxa-dev-launcher: ./bin/fxa-dev-launcher
+    fxa-dev-launcher: ./bin/fxa-dev-launcher.mjs
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Because

- fxa-dev-launcher module uses `chalk` dep, which was updated to be an esm module, this caused fxa-dev-launcher to break because it couldn't use commonJS and esm syntax

## This pull request

- Updates fxa-dev-launcher to use new esm syntanx
- Removes audit filter checks sicne we don't that use that anymore

## Issue that this pull request solves

Closes: #

## Checklist

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
