### PR TITLE
fix(auth-server): fix email footer text in subscriptionUpgrade

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
@@ -2,6 +2,8 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
+<% if (!locals.productName && locals.productNameNew) { locals.productName = locals.productNameNew %><% } %>
+
 <mjml>
   <mj-head>
     <mj-raw>


### PR DESCRIPTION
Because:

* `subscriptionUpgrade` email was generating incorrect footer text

This commit:

* Fixes footer text in `subscriptionUpgrade`, and it should generate the correct footer text when `subscriptionDowngrade` is created

Closes #11252

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Old email template with correct footer text
<img width="644" alt="Screen Shot 2021-12-06 at 2 40 27 PM" src="https://user-images.githubusercontent.com/28129806/144912916-0ba72676-c1f8-4d7a-a658-5ac8759da187.png">

Converted template - before
<img width="639" alt="144514967-7832970f-9802-4128-aff5-6093f2a6e90c" src="https://user-images.githubusercontent.com/28129806/144913171-671cc173-1e46-4ed2-b4aa-3b1dfd866c5b.png">

Converted template - after
<img width="522" alt="Screen Shot 2021-12-06 at 12 57 53 PM" src="https://user-images.githubusercontent.com/28129806/144913221-449d443c-e2ea-4dd4-a400-179a8aecbe2a.png">
