### PR TITLE
fix(tokens): Don't check expiration dates for pocket access token on profile server

### DIFF
--- a/packages/fxa-auth-server/lib/oauth/db/index.js
+++ b/packages/fxa-auth-server/lib/oauth/db/index.js
@@ -196,6 +196,10 @@ class OauthDB {
     const db = await this.mysql;
     await db._removeUser(uid);
   }
+
+  getPocketIds() {
+    return POCKET_IDS;
+  }
 }
 
 function clientEquals(configClient, dbClient) {

--- a/packages/fxa-auth-server/test/lib/oauth-test.json
+++ b/packages/fxa-auth-server/test/lib/oauth-test.json
@@ -9,6 +9,17 @@
     },
     "clients": [
       {
+        "id": "749818d3f2e7857f",
+        "hashedSecret": "289a885946ee316844d9ffd0d725ee714901548a1e6507f1a40fb3c2ae0c99f1",
+        "hashedSecretPrevious": "0726282857047586fb4edc335b5492ef1e4a0d95d3f1114627bb89b4e57cf6e1",
+        "name": "Pocket",
+        "imageUri": "https://example.domain/logo",
+        "redirectUri": "https://example.domain/return?foo=bar",
+        "trusted": true,
+        "canGrant": false,
+        "allowedScopes": "https://identity.mozilla.com/apps/notes https://identity.mozilla.com/apps/lockbox"
+      },
+      {
         "id": "dcdb5ae7add825d2",
         "hashedSecret": "289a885946ee316844d9ffd0d725ee714901548a1e6507f1a40fb3c2ae0c99f1",
         "hashedSecretPrevious": "0726282857047586fb4edc335b5492ef1e4a0d95d3f1114627bb89b4e57cf6e1",

--- a/packages/fxa-auth-server/test/oauth/db/index.js
+++ b/packages/fxa-auth-server/test/oauth/db/index.js
@@ -654,20 +654,6 @@ describe('db', function () {
         scope: ScopeSet.fromArray(['no_scope']),
       };
 
-      before(function () {
-        return db.registerClient({
-          id: pocketId,
-          name: 'pocket',
-          hashedSecret: randomString(32),
-          imageUri: 'https://example.domain/logo',
-          redirectUri: 'https://example.domain/return?foo=bar',
-          trusted: true,
-        });
-      });
-      after(function () {
-        return db.removeClient(pocketId);
-      });
-
       it('stores them in mysql', async () => {
         const t = await db.generateAccessToken(tokenData);
         const mysql = await db.mysql;


### PR DESCRIPTION
## Because

- For legacy reasons, we still need to allow expired pocket tokens to fetch a users profile, regardless of expiration

## This pull request

- Skips expriation check for pocket client ids

## Issue that this pull request solves

Closes: #11250

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).