### PR TITLE
fix(auth): do not log hard email bounces to sentry

### DIFF
--- a/packages/fxa-auth-server/lib/sentry.js
+++ b/packages/fxa-auth-server/lib/sentry.js
@@ -8,6 +8,7 @@ const Hoek = require('@hapi/hoek');
 const Sentry = require('@sentry/node');
 const { ExtraErrorData } = require('@sentry/integrations');
 const verror = require('verror');
+const { ERRNO } = require('./error');
 
 const getVersion = require('./version').getVersion;
 
@@ -16,6 +17,9 @@ const getVersion = require('./version').getVersion;
 const TOKENREGEX = /[a-fA-F0-9]{32,}/gi;
 const FILTERED = '[Filtered]';
 const URIENCODEDFILTERED = encodeURIComponent(FILTERED);
+
+// Maintain list of errors that should not be sent to Sentry
+const IGNORED_ERROR_NUMBERS = [ERRNO.BOUNCE_HARD];
 
 /**
  * Filters all of an objects string properties to remove tokens.
@@ -87,6 +91,10 @@ function reportSentryError(err, request) {
     } catch (e) {
       // ignore bad stack frames
     }
+  }
+
+  if (ignoreErrors(err)) {
+    return;
   }
 
   Sentry.withScope((scope) => {
@@ -189,6 +197,25 @@ async function configureSentry(server, config, processName = 'key_server') {
         reportSentryError(err, request);
       }
     );
+  }
+}
+
+/**
+ * Prevents errors from being captured in sentry.
+ *
+ * @param {Error} error An error with an error number. Note that errors of type vError will
+ *                use the underlying jse_cause error if possible.
+ */
+function ignoreErrors(error) {
+  if (!error) return;
+
+  // If the jse error exists target that.
+  error = error.jse_cause || error;
+
+  // Ingore specific error numbers
+  if (error.errno && IGNORED_ERROR_NUMBERS.indexOf(error.errno) >= 0) {
+    console.log('Ignoring error: ' + error.errno);
+    return true;
   }
 }
 


### PR DESCRIPTION
## Because

- Logging hard email bounces to sentry is unnecessary.

## This pull request

- Adds a constant, IGNORED_ERROR_NUMBERS, that contains a set of error numbers to ignore that will not be reported to sentry.

## Issue that this pull request solves

Closes: #10679

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

