### PR TITLE
fix(auth): do not log hard email bounces to sentry

### DIFF
--- a/packages/fxa-auth-server/test/local/sentry.js
+++ b/packages/fxa-auth-server/test/local/sentry.js
@@ -134,6 +134,70 @@ describe('Sentry', () => {
     assert.equal(ctx.errorName, 'EndpointError');
     assert.equal(ctx.reason, endError.reason);
   });
+
+  describe('ignores errors', () => {
+    let sentryCaptureSpy;
+
+    beforeEach(async () => {
+      config.sentryDsn = 'https://deadbeef:deadbeef@localhost/123';
+      sentryCaptureSpy = sandbox.stub(Sentry, 'captureException');
+      const scopeSpy = {
+        addEventProcessor: sinon.fake(),
+        setContext: sinon.fake(),
+        setExtra: sinon.fake(),
+      };
+      sandbox.replace(Sentry, 'withScope', (fn) => fn(scopeSpy));
+
+      await configureSentry(server, config);
+    });
+
+    afterEach(() => {
+      sandbox.reset();
+    });
+
+    it('ignores WError by error number', async () => {
+      await server.events.emit({ name: 'request', channel: 'error' }, [
+        {},
+        {
+          error: new verror.WError(
+            error.emailBouncedHard(),
+            'Something bad happened'
+          ),
+        },
+      ]);
+      sinon.assert.notCalled(sentryCaptureSpy);
+    });
+
+    it('ignores error by error number', async () => {
+      await server.events.emit({ name: 'request', channel: 'error' }, [
+        {},
+        { error: error.emailBouncedHard() },
+      ]);
+      sinon.assert.notCalled(sentryCaptureSpy);
+    });
+
+    it('does not ignore valid error', async () => {
+      await server.events.emit({ name: 'request', channel: 'error' }, [
+        {},
+        {
+          error: new verror.WError(
+            error.unknownRefreshToken(),
+            'Something bad happened'
+          ),
+        },
+      ]);
+      sinon.assert.calledOnce(sentryCaptureSpy);
+    });
+
+    it('does not ingore valid error', async () => {
+      await server.events.emit({ name: 'request', channel: 'error' }, [
+        {},
+        { error: error.unknownRefreshToken() },
+      ]);
+      sinon.assert.calledOnce(sentryCaptureSpy);
+    });
+  });
+
   describe('Sentry helpers', () => {
     describe('formatMetadataValidationErrorMessage', () => {
       let error, actualMsg, expectedMsg;


### PR DESCRIPTION
## Because

- Logging hard email bounces to sentry is unnecessary.

## This pull request

- Adds a constant, IGNORED_ERROR_NUMBERS, that contains a set of error numbers to ignore that will not be reported to sentry.

## Issue that this pull request solves

Closes: #10679

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).


