### PR TITLE
feat(auth-server): convert subscriptionAccountDeletion email template to stack

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -466,6 +466,7 @@
       "recovery",
       "subscriptionPaymentExpired",
       "subscriptionsPaymentExpired",
+      "subscriptionAccountDeletion",
       "subscriptionAccountReminderFirst",
       "subscriptionAccountReminderSecond",
       "subscriptionReactivation",

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/en.ftl
@@ -14,6 +14,7 @@ subplat-terms-policy-plaintext = { subplat-terms-policy }:
 subplat-cancel = Cancel subscription
 subplat-cancel-plaintext = { subplat-cancel }:
 subplat-reactivate = Reactivate subscription
+subplat-reactivate-plaintext = { subplat-reactivate }:
 subplat-update-billing = Update billing information
 subplat-legal = Legal
 subplat-privacy = Privacy

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
@@ -10,8 +10,13 @@ subplat-privacy-plaintext = "Privacy notice:"
 <%- subscriptionPrivacyUrl %>
 <% } %>
 
+<% if (locals.isCancellationEmail) { %>
+subplat-reactivate-plaintext = "Reactivate subscription:"
+<%- reactivateSubscriptionUrl %>
+<% } else { %>
 subplat-cancel-plaintext = "Cancel subscription:"
 <%- cancelSubscriptionUrl %>
+<% } %>
 
 subplat-update-billing-plaintext = "Update billing information:"
 <%- updateBillingUrl %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/cancellationSurvey/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/cancellationSurvey/en.ftl
@@ -1,0 +1,3 @@
+cancellationSurvey = Please help us improve our services by taking this <a data-l10n-name="cancellationSurveyUrl")s>short survey</a>.
+# After the colon, there's a link to https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21
+cancellationSurvey-plaintext = Please help us improve our services by taking this short survey:

--- a/packages/fxa-auth-server/lib/senders/emails/partials/cancellationSurvey/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/cancellationSurvey/index.mjml
@@ -1,0 +1,13 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="cancellationSurvey">
+        Please help us improve our services by taking this <a data-l10n-name="cancellationSurveyUrl" href="<%- cancellationSurveyUrl %>">short survey</a>.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/cancellationSurvey/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/cancellationSurvey/index.txt
@@ -1,0 +1,2 @@
+cancellationSurvey-plaintext = "Please help us improve our services by taking this short survey:"
+<%- cancellationSurveyUrl %>

--- a/packages/fxa-auth-server/lib/senders/emails/storybook-email.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/storybook-email.ts
@@ -32,6 +32,8 @@ const subplatCommonArgs = {
   updateBillingUrl: 'http://localhost:3030/subscriptions',
   reactivateSubscriptionUrl: 'http://localhost:3030/subscriptions',
   accountSettingsUrl: 'http://localhost:3030/settings',
+  cancellationSurveyUrl:
+    'https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21',
 };
 
 const storybookEmail = ({

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/en.ftl
@@ -1,0 +1,9 @@
+#  Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionAccountDeletion-subject = Your { $productName } subscription has been cancelled
+subscriptionAccountDeletion-title = Sorry to see you go
+#  Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+#  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
+#  $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
+subscriptionAccountDeletion-content-cancelled = You recently deleted your Firefox Account. As a result, we've cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.mjml
@@ -1,0 +1,23 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+	# License, v. 2.0. If a copy of the MPL was not distributed with this
+	# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="subscriptionAccountDeletion-title">Sorry to see you go</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionAccountDeletion-content-cancelled" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly}) %>">
+        You recently deleted your Firefox Account. As a result, we've cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include ('/partials/cancellationSurvey/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.stories.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionAccountDeletion',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionAccountDeletion',
+  'Sent when a user deletes their account subscription.',
+  {
+    productName: 'Firefox Fortress',
+    isCancellationEmail: true,
+    invoiceTotal: '$20',
+    invoiceDateOnly: '11/13/2021',
+    cancellationSurveryUrl:
+      'https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21',
+  }
+);
+
+export const SubscriptionAccountDeletion = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.txt
@@ -1,0 +1,7 @@
+subscriptionAccountDeletion-subject = "Your <%- productName %> subscription has been cancelled"
+
+subscriptionAccountDeletion-title = "Sorry to see you go"
+
+subscriptionAccountDeletion-content-cancelled = "You recently deleted your Firefox Account. As a result, we've cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>."
+
+<%- include ('/partials/cancellationSurvey/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -1028,7 +1028,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionAccountDeletion }],
     ])],
     ['html', [
-      { test: 'include', expected: configHref('subscriptionSettingsUrl', 'subscription-account-deletion', 'reactivate-subscription', 'plan_id', 'product_id', 'uid', 'email') },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-account-deletion', 'reactivate-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
       { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-account-deletion', 'subscription-terms') },
       { test: 'include', expected: `cancelled your ${MESSAGE.productName} subscription` },
       { test: 'include', expected: `final payment of ${MESSAGE_FORMATTED.invoiceTotal} was paid on 03/20/2020.` },

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -71,6 +71,9 @@ const MESSAGE = {
   uaOSVersion: '10',
   uid: 'uid',
   unblockCode: 'AS6334PK',
+  invoiceDate: new Date(1584747098816),
+  invoiceTotalInCents: 999999.9,
+  invoiceTotalCurrency: 'eur',
   paymentAmountOldInCents: 9999099.9,
   paymentAmountOldCurrency: 'jpy',
   paymentAmountNewInCents: 12312099.9,
@@ -1015,6 +1018,28 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'password-change-required', 'privacy')}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
+  ])],
+
+  ['subscriptionAccountDeletionEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `Your ${MESSAGE.productName} subscription has been cancelled` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionAccountDeletion') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionAccountDeletion' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionAccountDeletion }],
+    ])],
+    ['html', [
+      { test: 'include', expected: configHref('subscriptionSettingsUrl', 'subscription-account-deletion', 'reactivate-subscription', 'plan_id', 'product_id', 'uid', 'email') },
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-account-deletion', 'subscription-terms') },
+      { test: 'include', expected: `cancelled your ${MESSAGE.productName} subscription` },
+      { test: 'include', expected: `final payment of ${MESSAGE_FORMATTED.invoiceTotal} was paid on 03/20/2020.` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Your ${MESSAGE.productName} subscription has been cancelled` },
+      { test: 'include', expected: `cancelled your ${MESSAGE.productName} subscription` },
+      { test: 'include', expected: `final payment of ${MESSAGE_FORMATTED.invoiceTotal} was paid on 03/20/2020.` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
   ])],
 
   ['subscriptionPaymentExpiredEmail', new Map<string, Test | any>([


### PR DESCRIPTION
feat(auth-server): convert subscriptionAccountDeletion email template to stack

Because:

* We are actively converting old FxA emails to our new modernized stack

This commit:

* Converts the `subscriptionAccountDeletion` subscription platform email to the new stack.

Closes #9270

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Old template
<img width="646" alt="Screen Shot 2021-12-07 at 2 41 32 PM" src="https://user-images.githubusercontent.com/28129806/145095379-6a4d06e2-4abd-414d-9c65-55edc7d0763c.png">

New template
<img width="644" alt="Screen Shot 2021-12-07 at 2 41 59 PM" src="https://user-images.githubusercontent.com/28129806/145095326-b10cb317-73ff-4ae7-ae5a-0d3a2fa9d6f3.png">

## Other information (Optional)
Just wanted to call out that there are a few new additions other than the converted `subscriptionAccountDeletion` email templates. Please see below:

(1) The plaintext in the old email template has `Cancel subscription` in its footer, while the HTML has `Reactivate subscription`. As this is a cancellation email, both HTML and plaintext should reflect `Reactivate subscription`. Therefore, the following files needed to be updated:
* `emails/layouts/subscription/en.ftl`
* `emails/layouts/subsctiption/index.txt`

(2) The partials for `cancellationSurvey` had to be created:
* `emails/partials/cancellationSurvey/en.ftl`
* `emails/partials/cancellationSurvey/index.mjml`
* `emails/partials/cancellationSurvey/index.txt`

(3) As the `cancellationSurvey` partial was added, the variable/link had to be added to Storybook:
* `emails/storybook-email.ts`
* `emails/templates/subscriptionAccountDeletion/index.stories.ts`
