### PR TITLE
fix(auth-server): variables are not replaced in new email templates

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailChangePassword/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailChangePassword/index.txt
@@ -1,1 +1,1 @@
-automated-email-change-plaintext = "This is an automated email; if you didn’t add a new device to your Firefox account, you should change your password immediately at { $passwordChangeLink }"
+automated-email-change-plaintext = "This is an automated email; if you didn’t add a new device to your Firefox account, you should change your password immediately at <%- passwordChangeLink %>"

--- a/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailResetPassword/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/automatedEmailResetPassword/index.txt
@@ -1,1 +1,1 @@
-automated-email-reset-plaintext = "If you did not change it, please reset your password now at { $resetLink }"
+automated-email-reset-plaintext = "If you did not change it, please reset your password now at <%- resetLink %>"

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/en.ftl
@@ -1,9 +1,7 @@
-## Variables:
-##  $clientName (String) - A client the user hasn't signed into before (e.g. Firefox, Sync)
-
+# Variables:
+# $clientName (String) - A client the user hasn't signed into before (e.g. Firefox, Sync)
 newDeviceLogin-subject = New sign-in to { $clientName }
+# Variables:
+# $clientName (String) - A client the user hasn't signed into before (e.g. Firefox, Sync)
 newDeviceLogin-title = New sign-in to { $clientName }
-
-##
-
 newDeviceLogin-action = Manage account

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.mjml
@@ -5,7 +5,7 @@
 <mj-section>
   <mj-column>
     <mj-text css-class="text-header">
-      <span data-l10n-id="newDeviceLogin-title" data-l10n-args='<%= JSON.stringify({clientName}) %>'>New sign-in to <%- clientName %></span>
+      <span data-l10n-id="newDeviceLogin-title" data-l10n-args="<%= JSON.stringify({clientName}) %>">New sign-in to <%- clientName %></span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/newDeviceLogin/index.txt
@@ -1,4 +1,4 @@
-newDeviceLogin-title = "New sign-in to { $clientName }"
+newDeviceLogin-title = "New sign-in to <%- clientName %>"
 
 <%- include('/partials/location/index.txt') %>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.mjml
@@ -9,7 +9,7 @@
     </mj-text>
 
     <mj-text css-class="text-body">
-      <span data-l10n-id="postChangePrimary-description" data-l10n-args='<%= JSON.stringify({ email }) %>'>You have successfully changed your primary email to <%- email %>. This address is now your username for signing in to your Firefox account, as well as receiving security notifications and sign-in confirmations.</span>
+      <span data-l10n-id="postChangePrimary-description" data-l10n-args="<%= JSON.stringify({ email }) %>">You have successfully changed your primary email to <%- email %>. This address is now your username for signing in to your Firefox account, as well as receiving security notifications and sign-in confirmations.</span>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postChangePrimary/index.txt
@@ -1,6 +1,6 @@
 postChangePrimary-title = "New primary email"
 
-postChangePrimary-description = "You have successfully changed your primary email to { $email }. This address is now your username for signing in to your Firefox account, as well as receiving security notifications and sign-in confirmations."
+postChangePrimary-description = "You have successfully changed your primary email to <%- email %>. This address is now your username for signing in to your Firefox account, as well as receiving security notifications and sign-in confirmations."
 
 <%- include('/partials/manageAccount/index.txt') %>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postRemoveSecondary/index.txt
@@ -1,6 +1,6 @@
 postRemoveSecondary-title = "Secondary email removed"
 
-postRemoveSecondary-description = "You have successfully removed { $secondaryEmail } as a secondary email from your Firefox account. Security notifications and sign-in confirmations will no longer be delivered to this address."
+postRemoveSecondary-description = "You have successfully removed <%- secondaryEmail %> as a secondary email from your Firefox account. Security notifications and sign-in confirmations will no longer be delivered to this address."
 
 <%- include('/partials/manageAccount/index.txt') %>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postVerifySecondary/index.txt
@@ -1,6 +1,6 @@
 postVerifySecondary-title = "Secondary email added"
 
-postVerifySecondary-description = "You have successfully added { $secondaryEmail } as a secondary email from your Firefox account. Security notifications and sign-in confirmations will now be delivered to both email addresses."
+postVerifySecondary-description = "You have successfully added <%- secondaryEmail %> as a secondary email from your Firefox account. Security notifications and sign-in confirmations will now be delivered to both email addresses."
 
 <%- include('/partials/manageAccount/index.txt') %>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondaryCode/index.txt
@@ -1,6 +1,6 @@
 verifySecondaryCode-title = "Verify secondary email"
 
-verifySecondaryCode-explainer = "A request to use { $email } as a secondary email address has been made from the following Firefox account:"
+verifySecondaryCode-explainer = "A request to use <%- email %> as a secondary email address has been made from the following Firefox account:"
 
 <%- include('/partials/location/index.txt') %>
 


### PR DESCRIPTION
Because:

* variables were not replaced with the corresponding data in plaintext version of templates

This commit:

* fixes the plaintext templates

Closes #11236

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
