### PR TITLE
feat(auth): add coupon to new sub api

### DIFF
--- a/packages/fxa-auth-server/lib/error.js
+++ b/packages/fxa-auth-server/lib/error.js
@@ -113,6 +113,8 @@ const ERRNO = {
   IAP_INTERNAL_OTHER: 197,
   IAP_UNKNOWN_APPNAME: 198,
 
+  INVALID_PROMOTION_CODE: 199,
+
   SERVER_BUSY: 201,
   FEATURE_NOT_ENABLED: 202,
   BACKEND_SERVICE_FAILURE: 203,
@@ -1248,6 +1250,20 @@ AppError.invalidPkceChallenge = (pkceHashValue) => {
     },
     {
       pkceHashValue,
+    }
+  );
+};
+
+AppError.invalidPromoCode = (promtionCode) => {
+  return new AppError(
+    {
+      code: 400,
+      error: 'Bad Request',
+      errno: ERRNO.INVALID_PROMOTION_CODE,
+      message: 'Invalid promotion code',
+    },
+    {
+      promtionCode,
     }
   );
 };

--- a/packages/fxa-auth-server/lib/payments/stripe.ts
+++ b/packages/fxa-auth-server/lib/payments/stripe.ts
@@ -402,6 +402,7 @@ export class StripeHelper {
     customerId: string;
     priceId: string;
     paymentMethodId?: string;
+    couponId?: string;
     subIdempotencyKey: string;
     taxRateId?: string;
   }) {
@@ -409,6 +410,7 @@ export class StripeHelper {
       customerId,
       priceId,
       paymentMethodId,
+      couponId,
       subIdempotencyKey,
       taxRateId,
     } = opts;
@@ -450,6 +452,7 @@ export class StripeHelper {
         items: [{ price: priceId }],
         expand: ['latest_invoice.payment_intent'],
         default_tax_rates: taxRates,
+        coupon: couponId,
       },
       { idempotencyKey: `ssc-${subIdempotencyKey}` }
     );
@@ -475,10 +478,11 @@ export class StripeHelper {
   async createSubscriptionWithPaypal(opts: {
     customer: Stripe.Customer;
     priceId: string;
+    couponId?: string;
     subIdempotencyKey: string;
     taxRateId?: string;
   }) {
-    const { customer, priceId, subIdempotencyKey, taxRateId } = opts;
+    const { customer, priceId, couponId, subIdempotencyKey, taxRateId } = opts;
     const taxRates = taxRateId ? [taxRateId] : [];
 
     const sub = this.findCustomerSubscriptionByPlanId(customer, priceId);
@@ -508,6 +512,7 @@ export class StripeHelper {
         collection_method: 'send_invoice',
         days_until_due: 1,
         default_tax_rates: taxRates,
+        coupon: couponId,
       },
       { idempotencyKey: `ssc-${subIdempotencyKey}` }
     );

--- a/packages/fxa-auth-server/test/local/payments/stripe.js
+++ b/packages/fxa-auth-server/test/local/payments/stripe.js
@@ -724,6 +724,7 @@ describe('StripeHelper', () => {
           items: [{ price: 'priceId' }],
           expand: ['latest_invoice.payment_intent'],
           default_tax_rates: ['tr_asdf'],
+          coupon: undefined,
         },
         { idempotencyKey: `ssc-${subIdempotencyKey}` }
       );
@@ -822,6 +823,7 @@ describe('StripeHelper', () => {
           expand: ['latest_invoice'],
           collection_method: 'send_invoice',
           days_until_due: 1,
+          coupon: undefined,
           default_tax_rates: ['tr_asdf'],
         },
         { idempotencyKey: `ssc-${subIdempotencyKey}` }


### PR DESCRIPTION
Because:
    
* We want to accept promotion codes when creating a new subscription.

This commit:

* Updates the new subscription routes for stripe and paypal to validate
  the coupon for the plan and apply it when creating the subscription.

Closes #10854

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
