### PR TITLE
fix(auth-server): [new email templates] postAddTwoStepAuthentication

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/postAddTwoStepAuthentication/index.txt
@@ -1,6 +1,6 @@
 postAddTwoStepAuthentication-title = "Two-step authentication enabled"
 
-postAddTwoStepAuthentication-description-plaintext = "You have successfully reset your password using a recovery key from the following device:"
+postAddTwoStepAuthentication-description-plaintext = "You have successfully enabled two-step authentication on your Firefox account. Security codes from your authentication app will now be required at each sign-in."
 
 <%- include('/partials/location/index.txt') %>
 


### PR DESCRIPTION
Because:

* plaintext version of template contained incorrect text

This commit:

* reflects the revised text

Closes: #11221 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [ ] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

