### PR TITLE
Merge subscriptionUpgrade and subscriptionAccountDeletion into main

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -468,7 +468,8 @@
       "subscriptionsPaymentExpired",
       "subscriptionAccountReminderFirst",
       "subscriptionAccountReminderSecond",
-      "subscriptionReactivation"
+      "subscriptionReactivation",
+      "subscriptionUpgrade"
     ]
   }
 }

--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -466,6 +466,7 @@
       "recovery",
       "subscriptionPaymentExpired",
       "subscriptionsPaymentExpired",
+      "subscriptionAccountDeletion",
       "subscriptionAccountReminderFirst",
       "subscriptionAccountReminderSecond",
       "subscriptionReactivation",

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/en.ftl
@@ -14,6 +14,7 @@ subplat-terms-policy-plaintext = { subplat-terms-policy }:
 subplat-cancel = Cancel subscription
 subplat-cancel-plaintext = { subplat-cancel }:
 subplat-reactivate = Reactivate subscription
+subplat-reactivate-plaintext = { subplat-reactivate }:
 subplat-update-billing = Update billing information
 subplat-legal = Legal
 subplat-privacy = Privacy

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
@@ -2,6 +2,8 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
+<% if (!locals.productName && locals.productNameNew) { locals.productName = locals.productNameNew %><% } %>
+
 <mjml>
   <mj-head>
     <mj-raw>

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
@@ -10,8 +10,13 @@ subplat-privacy-plaintext = "Privacy notice:"
 <%- subscriptionPrivacyUrl %>
 <% } %>
 
+<% if (locals.isCancellationEmail) { %>
+subplat-reactivate-plaintext = "Reactivate subscription:"
+<%- reactivateSubscriptionUrl %>
+<% } else { %>
 subplat-cancel-plaintext = "Cancel subscription:"
 <%- cancelSubscriptionUrl %>
+<% } %>
 
 subplat-update-billing-plaintext = "Update billing information:"
 <%- updateBillingUrl %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/cancellationSurvey/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/cancellationSurvey/en.ftl
@@ -1,0 +1,3 @@
+cancellationSurvey = Please help us improve our services by taking this <a data-l10n-name="cancellationSurveyUrl")s>short survey</a>.
+# After the colon, there's a link to https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21
+cancellationSurvey-plaintext = Please help us improve our services by taking this short survey:

--- a/packages/fxa-auth-server/lib/senders/emails/partials/cancellationSurvey/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/cancellationSurvey/index.mjml
@@ -1,0 +1,13 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="cancellationSurvey">
+        Please help us improve our services by taking this <a data-l10n-name="cancellationSurveyUrl" href="<%- cancellationSurveyUrl %>">short survey</a>.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/cancellationSurvey/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/cancellationSurvey/index.txt
@@ -1,0 +1,2 @@
+cancellationSurvey-plaintext = "Please help us improve our services by taking this short survey:"
+<%- cancellationSurveyUrl %>

--- a/packages/fxa-auth-server/lib/senders/emails/storybook-email.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/storybook-email.ts
@@ -32,6 +32,8 @@ const subplatCommonArgs = {
   updateBillingUrl: 'http://localhost:3030/subscriptions',
   reactivateSubscriptionUrl: 'http://localhost:3030/subscriptions',
   accountSettingsUrl: 'http://localhost:3030/settings',
+  cancellationSurveyUrl:
+    'https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21',
 };
 
 const storybookEmail = ({

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/en.ftl
@@ -1,0 +1,9 @@
+#  Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionAccountDeletion-subject = Your { $productName } subscription has been cancelled
+subscriptionAccountDeletion-title = Sorry to see you go
+#  Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+#  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
+#  $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
+subscriptionAccountDeletion-content-cancelled = You recently deleted your Firefox Account. As a result, we've cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.mjml
@@ -1,0 +1,23 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+	# License, v. 2.0. If a copy of the MPL was not distributed with this
+	# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="subscriptionAccountDeletion-title">Sorry to see you go</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionAccountDeletion-content-cancelled" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly}) %>">
+        You recently deleted your Firefox Account. As a result, we've cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include ('/partials/cancellationSurvey/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.stories.ts
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionAccountDeletion',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionAccountDeletion',
+  'Sent when a user deletes their account subscription.',
+  {
+    productName: 'Firefox Fortress',
+    isCancellationEmail: true,
+    invoiceTotal: '$20',
+    invoiceDateOnly: '11/13/2021',
+    cancellationSurveryUrl:
+      'https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21',
+  }
+);
+
+export const SubscriptionAccountDeletion = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.txt
@@ -1,0 +1,7 @@
+subscriptionAccountDeletion-subject = "Your <%- productName %> subscription has been cancelled"
+
+subscriptionAccountDeletion-title = "Sorry to see you go"
+
+subscriptionAccountDeletion-content-cancelled = "You recently deleted your Firefox Account. As a result, we've cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>."
+
+<%- include ('/partials/cancellationSurvey/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/en.ftl
@@ -1,0 +1,18 @@
+# Variables:
+# $productNameNew (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionUpgrade-subject = You have upgraded to { $productNameNew }
+subscriptionUpgrade-title = Thank you for upgrading!
+# Variables:
+# $productNameOld (String) - The name of the previously subscribed product, e.g. Mozilla VPN
+# $productNameNew (String) - The name of the new subscribed product, e.g. Mozilla VPN
+subscriptionUpgrade-upgrade-info = You have successfully upgraded from { $productNameOld } to { $productNameNew }.
+# Variables:
+# $paymentAmountOld (String) - The amount of the previous subscription payment, including currency, e.g. $10.00
+# $paymentAmountNew (String) - The amount of the new subscription payment, including currency, e.g. $10.00
+# $productPaymentCycle (String) - The interval of time from the end of one payment statement date to the next payment statement date, e.g. month
+# $paymentProrated (String) - The one time fee to reflect the higher charge for the remainder of the payment cycle, including currency, e.g. $10.00
+subscriptionUpgrade-charge-info = Starting with your next bill, your charge will change from { $paymentAmountOld } per { $productPaymentCycle } to { $paymentAmountNew }. At that time you will also be charged a one-time fee of { $paymentProrated } to reflect the higher charge for the remainder of this { $productPaymentCycle }.
+# Variables:
+# $productNameNew (String) - The name of the new subscribed product, e.g. Mozilla VPN
+subscriptionUpgrade-install = If there is new software for you to install in order to use { $productNameNew }, you will receive a separate email with download instructions.
+subscriptionUpgrade-auto-renew = Your subscription will automatically renew each billing period unless you choose to cancel.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.mjml
@@ -1,0 +1,46 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section css-class="mb-6">
+  <mj-group>
+    <mj-column>
+      <mj-image src="<%- productIconURLOld %>" alt="<%- productNameOld %>" title="<%- productNameOld %>" css-class="product-icon">
+      </mj-image>
+    </mj-column>
+    <mj-column>
+      <mj-image src="<%- productIconURLNew %>" alt="<%- productNameNew %>" title="<%- productNameNew %>" css-class="product-icon">
+      </mj-image>
+    </mj-column>
+  </mj-group>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="subscriptionUpgrade-title" data-l10n-args="<%= JSON.stringify({productNameNew}) %>">Thank you for upgrading!</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionUpgrade-upgrade-info" data-l10n-args="<%= JSON.stringify({productNameNew, productNameOld}) %>">You have successfully upgraded from <%- productNameOld %> to <%- productNameNew %>.</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionUpgrade-charge-info" data-l10n-args="<%= JSON.stringify({paymentAmountNew, paymentAmountOld, paymentProrated, productPaymentCycle}) %>">Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycle %> to <%- paymentAmountNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycle %>.</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionUpgrade-install" data-l10n-args="<%= JSON.stringify({productNameNew}) %>">If there is new software for you to install in order to use <%- productNameNew %>, you will receive a separate email with download instructions.</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionUpgrade-auto-renew">Your subscription will automatically renew each billing period unless you choose to cancel.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include ('/partials/subscriptionSupport/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.stories.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionUpgrade',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionUpgrade',
+  'Sent when a user upgrades their subscription.',
+  {
+    paymentAmountNew: '£123,121.00',
+    paymentAmountOld: '¥99,991',
+    productIconURLNew:
+      'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
+    productIconURLOld:
+      'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
+    productNameNew: 'Product Name B',
+    productNameOld: 'Product Name A',
+    productPaymentCycle: 'month',
+    paymentProrated: '$5,231.00',
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+  }
+);
+
+export const SubscriptionUpgrade = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionUpgrade/index.txt
@@ -1,0 +1,13 @@
+subscriptionUpgrade-subject = "You have upgraded to <%- productNameNew %>"
+
+subscriptionUpgrade-title = "Thank you for upgrading!"
+
+subscriptionUpgrade-upgrade-info = "You have successfully upgraded from <%- productNameOld %> to <%- productNameNew %>."
+
+subscriptionUpgrade-charge-info = "Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycle %> to <%- paymentAmountNew %>. At that time you will also be charged a one-time fee of <%- paymentProrated %> to reflect the higher charge for the remainder of this <%- productPaymentCycle %>."
+
+subscriptionUpgrade-install = "If there is new software for you to install in order to use <%- productNameNew %>, you will receive a separate email with download instructions."
+
+subscriptionUpgrade-auto-renew = "Your subscription will automatically renew each billing period unless you choose to cancel."
+
+<%- include ('/partials/subscriptionSupport/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -71,6 +71,9 @@ const MESSAGE = {
   uaOSVersion: '10',
   uid: 'uid',
   unblockCode: 'AS6334PK',
+  invoiceDate: new Date(1584747098816),
+  invoiceTotalInCents: 999999.9,
+  invoiceTotalCurrency: 'eur',
   paymentAmountOldInCents: 9999099.9,
   paymentAmountOldCurrency: 'jpy',
   paymentAmountNewInCents: 12312099.9,
@@ -1015,6 +1018,28 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `Mozilla Privacy Policy\n${configUrl('privacyUrl', 'password-change-required', 'privacy')}` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
+  ])],
+
+  ['subscriptionAccountDeletionEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `Your ${MESSAGE.productName} subscription has been cancelled` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionAccountDeletion') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionAccountDeletion' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionAccountDeletion }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-account-deletion', 'reactivate-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-account-deletion', 'subscription-terms') },
+      { test: 'include', expected: `cancelled your ${MESSAGE.productName} subscription` },
+      { test: 'include', expected: `final payment of ${MESSAGE_FORMATTED.invoiceTotal} was paid on 03/20/2020.` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Your ${MESSAGE.productName} subscription has been cancelled` },
+      { test: 'include', expected: `cancelled your ${MESSAGE.productName} subscription` },
+      { test: 'include', expected: `final payment of ${MESSAGE_FORMATTED.invoiceTotal} was paid on 03/20/2020.` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
   ])],
 
   ['subscriptionPaymentExpiredEmail', new Map<string, Test | any>([

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -53,9 +53,18 @@ const MESSAGE = {
   uaOSVersion: '10',
   uid: 'uid',
   unblockCode: 'AS6334PK',
+  paymentAmountOldInCents: 9999099.9,
+  paymentAmountOldCurrency: 'jpy',
+  paymentAmountNewInCents: 12312099.9,
+  paymentAmountNewCurrency: 'gbp',
+  paymentProratedInCents: 523099.9,
+  paymentProratedCurrency: 'usd',
   productId: 'wibble',
   planId: 'plan-example',
   productName: 'Firefox Fortress',
+  productNameOld: 'Product A',
+  productNameNew: 'Product B',
+  productPaymentCycle: 'month',
   subscription: {
     productName: 'Cooking with Foxkeh',
     planId: 'plan-example',
@@ -65,6 +74,14 @@ const MESSAGE = {
     { productName: 'Firefox Fortress' },
     { productName: 'Cooking with Foxkeh' },
   ],
+};
+
+const MESSAGE_FORMATTED = {
+  // Note: Intl.NumberFormat rounds 1/10 cent up
+  invoiceTotal: '€10,000.00',
+  paymentAmountOld: '¥99,991',
+  paymentAmountNew: '£123,121.00',
+  paymentProrated: '$5,231.00',
 };
 
 // key = query param name, value = MESSAGE property name
@@ -990,7 +1007,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ])],
     ['html', [
       { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-payment-expired', 'update-billing', 'plan_id', 'product_id', 'uid', 'email')) },
-      // commented out during template conversion - this doesn't appear to actually existin rendered old templates but passes the test?
+      // commented out during template conversion - this doesn't appear to actually exist in rendered old templates but passes the test?
       // { test: 'include', expected: decodeUrl(configHref('subscriptionTermsUrl', 'subscription-payment-expired', 'subscription-terms')) },
       { test: 'include', expected: `for ${MESSAGE.productName} is about to expire.` },
       { test: 'notInclude', expected: 'utm_source=email' },
@@ -1035,6 +1052,32 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ]],
     ['text', [
       { test: 'include', expected: `reactivating your ${MESSAGE.productName} subscription` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ])],
+
+  ['subscriptionUpgradeEmail', new Map([
+    ['subject', { test: 'equal', expected: `You have upgraded to ${MESSAGE.productNameNew}` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionUpgrade') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionUpgrade' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionUpgrade }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-upgrade', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      // commented out during template conversion - this doesn't appear to actually exist in rendered old templates but passes the test?
+      // { test: 'include', expected: decodeUrl(configHref('subscriptionTermsUrl', 'subscription-upgrade', 'subscription-terms')) },
+      { test: 'include', expected: `from ${MESSAGE.productNameOld} to ${MESSAGE.productNameNew}.` },
+      { test: 'include', expected: `from ${MESSAGE_FORMATTED.paymentAmountOld} per ${MESSAGE.productPaymentCycle} to ${MESSAGE_FORMATTED.paymentAmountNew}.` },
+      { test: 'include', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect the higher charge for the remainder of this ${MESSAGE.productPaymentCycle}.` },
+      { test: 'include', expected: `to use ${MESSAGE.productNameNew},` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `from ${MESSAGE.productNameOld} to ${MESSAGE.productNameNew}.` },
+      { test: 'include', expected: `from ${MESSAGE_FORMATTED.paymentAmountOld} per ${MESSAGE.productPaymentCycle} to ${MESSAGE_FORMATTED.paymentAmountNew}.` },
+      { test: 'include', expected: `one-time fee of ${MESSAGE_FORMATTED.paymentProrated} to reflect the higher charge for the remainder of this ${MESSAGE.productPaymentCycle}.` },
+      { test: 'include', expected: `to use ${MESSAGE.productNameNew},` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],


### PR DESCRIPTION
We merged these into a separate branch at first while we worked on #11249 to help the l10n team out, but I've got it working locally now and will get the l10n PR (unopened at present, but [here's the branch](https://github.com/mozilla/fxa-content-server-l10n/compare/subplat-email-templates))  merged by Friday (when our cron job occurs), so it's fine to get these merged into `main` for the train.