### PR TITLE
feat(auth-server): convert `subscriptionCancellation`

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -469,6 +469,7 @@
       "subscriptionAccountDeletion",
       "subscriptionAccountReminderFirst",
       "subscriptionAccountReminderSecond",
+      "subscriptionCancellation",
       "subscriptionDowngrade",
       "subscriptionReactivation",
       "subscriptionUpgrade"

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/en.ftl
@@ -6,4 +6,4 @@ subscriptionAccountDeletion-title = Sorry to see you go
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
 #  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
 #  $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
-subscriptionAccountDeletion-content-cancelled = You recently deleted your Firefox Account. As a result, we've cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }.
+subscriptionAccountDeletion-content-cancelled = You recently deleted your Firefox Account. As a result, we‘ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.mjml
@@ -14,7 +14,7 @@
   <mj-column>
     <mj-text css-class="text-body">
       <span data-l10n-id="subscriptionAccountDeletion-content-cancelled" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly}) %>">
-        You recently deleted your Firefox Account. As a result, we've cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>.
+        You recently deleted your Firefox Account. As a result, we‘ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>.
       </span>
     </mj-text>
   </mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.txt
@@ -2,6 +2,6 @@ subscriptionAccountDeletion-subject = "Your <%- productName %> subscription has 
 
 subscriptionAccountDeletion-title = "Sorry to see you go"
 
-subscriptionAccountDeletion-content-cancelled = "You recently deleted your Firefox Account. As a result, we've cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>."
+subscriptionAccountDeletion-content-cancelled = "You recently deleted your Firefox Account. As a result, we‘ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>."
 
 <%- include ('/partials/cancellationSurvey/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/en.ftl
@@ -1,0 +1,10 @@
+# Variables
+#   $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionCancellation-subject = Your { $productName } subscription has been cancelled
+subscriptionCancellation-title = Sorry to see you go
+# Variables
+#   $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+#   $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
+#   $invoiceDateOnly (String) - The date of the invoice, e.g. 01/20/2016
+#   $serviceLastActiveDateOnly (String) - The date of last active service, e.g. 01/20/2016
+subscriptionCancellation-content = We've cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }. Your service will continue until the end of your current billing period, which is { $serviceLastActiveDateOnly }.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/en.ftl
@@ -7,4 +7,4 @@ subscriptionCancellation-title = Sorry to see you go
 #   $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
 #   $invoiceDateOnly (String) - The date of the invoice, e.g. 01/20/2016
 #   $serviceLastActiveDateOnly (String) - The date of last active service, e.g. 01/20/2016
-subscriptionCancellation-content = We've cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }. Your service will continue until the end of your current billing period, which is { $serviceLastActiveDateOnly }.
+subscriptionCancellation-content = We‘ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }. Your service will continue until the end of your current billing period, which is { $serviceLastActiveDateOnly }.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.mjml
@@ -14,7 +14,7 @@
   <mj-column>
     <mj-text css-class="text-body">
       <span data-l10n-id="subscriptionCancellation-content" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly, serviceLastActiveDateOnly}) %>">
-          We've cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>.
+          We‘ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>.
       </span>
     </mj-text>
   </mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.mjml
@@ -1,0 +1,23 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="subscriptionCancellation-title">Sorry to see you go</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionCancellation-content" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly, serviceLastActiveDateOnly}) %>">
+          We've cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include ('/partials/cancellationSurvey/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.stories.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionCancellation',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionCancellation',
+  'Sent when a user cancels their subscription.',
+  {
+    productName: 'Firefox Fortress',
+    isCancellationEmail: true,
+    invoiceTotal: '$2,000.00',
+    invoiceDateOnly: '11/13/2021',
+    serviceLastActiveDateOnly: '12/13/2021',
+    cancellationSurveryUrl:
+      'https://survey.alchemer.com/s3/6534408/Privacy-Security-Product-Cancellation-of-Service-Q4-21',
+  }
+);
+
+export const SubscriptionCancellation = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.txt
@@ -2,6 +2,6 @@ subscriptionCancellation-subject = "Your <%- productName %> subscription has bee
 
 subscriptionCancellation-title = "Sorry to see you go"
 
-subscriptionCancellation-content = "We've cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>."
+subscriptionCancellation-content = "We‘ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>."
 
 <%- include ('/partials/cancellationSurvey/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.txt
@@ -1,0 +1,7 @@
+subscriptionCancellation-subject = "Your <%- productName %> subscription has been cancelled"
+
+subscriptionCancellation-title = "Sorry to see you go"
+
+subscriptionCancellation-content = "We've cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>."
+
+<%- include ('/partials/cancellationSurvey/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -87,6 +87,7 @@ const MESSAGE = {
   productNameOld: 'Product A',
   productNameNew: 'Product B',
   productPaymentCycle: 'month',
+  serviceLastActiveDate: new Date(1587339098816),
   subscription: {
     productName: 'Cooking with Foxkeh',
     planId: 'plan-example',
@@ -1063,6 +1064,29 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `from ${MESSAGE_FORMATTED.paymentAmountOld} per ${MESSAGE.productPaymentCycle} to ${MESSAGE_FORMATTED.paymentAmountNew}.` },
       { test: 'include', expected: `one-time credit of ${MESSAGE_FORMATTED.paymentProrated} to reflect the lower charge for the remainder of this ${MESSAGE.productPaymentCycle}.` },
       { test: 'include', expected: `to use ${MESSAGE.productNameNew},` },
+    ]]
+  ])],
+
+  ['subscriptionCancellationEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `Your ${MESSAGE.productName} subscription has been cancelled` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionCancellation') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionCancellation' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionCancellation }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-cancellation', 'reactivate-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionTermsUrl', 'subscription-cancellation', 'subscription-terms')) },
+      { test: 'include', expected: `cancelled your ${MESSAGE.productName} subscription` },
+      { test: 'include', expected: `final payment of ${MESSAGE_FORMATTED.invoiceTotal} was paid on 03/20/2020.` },
+      { test: 'include', expected: `billing period, which is 04/19/2020.` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `Your ${MESSAGE.productName} subscription has been cancelled` },
+      { test: 'include', expected: `cancelled your ${MESSAGE.productName} subscription` },
+      { test: 'include', expected: `final payment of ${MESSAGE_FORMATTED.invoiceTotal} was paid on 03/20/2020.` },
+      { test: 'include', expected: `billing period, which is 04/19/2020.` },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -1064,6 +1064,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `from ${MESSAGE_FORMATTED.paymentAmountOld} per ${MESSAGE.productPaymentCycle} to ${MESSAGE_FORMATTED.paymentAmountNew}.` },
       { test: 'include', expected: `one-time credit of ${MESSAGE_FORMATTED.paymentProrated} to reflect the lower charge for the remainder of this ${MESSAGE.productPaymentCycle}.` },
       { test: 'include', expected: `to use ${MESSAGE.productNameNew},` },
+      { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],
 


### PR DESCRIPTION
Because:

* We are actively converting old FxA emails to our new modernized stack

This commit:

* Converts the `subscriptionCancellation` subscription platform email to the new stack.

Closes #9272

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Old template
<img width="649" alt="Screen Shot 2021-12-08 at 9 57 03 AM" src="https://user-images.githubusercontent.com/28129806/145275499-a84483ca-b3ca-4d56-8874-99b5c8fff459.png">

New template
<img width="651" alt="Screen Shot 2021-12-08 at 9 57 26 AM" src="https://user-images.githubusercontent.com/28129806/145275531-394f4764-85ad-44b6-9617-4427cc76bfa7.png">

## Other information (Optional)
In addition to the `subscriptionCancellation` email templates, the apostrophes in the following 3 files have also been updated:
* `emails/templates/subscriptionAccountDeletion/en.ftl `
* `emails/templates/subscriptionAccountDeletion/index.mjml `
* `emails/templates/subscriptionAccountDeletion/index.txt `
