### PR TITLE
chore(ci): increase content-server tests to large size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 executors:
   content-server-executor:
-    resource_class: medium+
+    resource_class: large
     docker:
       - image: cimg/node:14.18-browsers
       - image: redis


### PR DESCRIPTION
Ever since circleci released their resources panel (or thereabout) we've been getting a lot of these from settings-react:

```
The build failed because the process exited too early. This probably means the system ran out of memory or someone called `kill -9` on the process.
```

In order to unblock PRs this increases the size to large so we won't run out of memory until we can investigate further.