### PR TITLE
feat(auth-server): convert `subscriptionDowngrade`

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -469,6 +469,7 @@
       "subscriptionAccountDeletion",
       "subscriptionAccountReminderFirst",
       "subscriptionAccountReminderSecond",
+      "subscriptionDowngrade",
       "subscriptionReactivation",
       "subscriptionUpgrade"
     ]

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
@@ -1,3 +1,5 @@
+<% if (!locals.productName && locals.productNameNew) { locals.productName = locals.productNameNew %><% } %>
+
 <%- body %>
 
 subplat-automated-email = "This is an automated email; if you received it in error, no action is required."

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionDowngrade/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionDowngrade/en.ftl
@@ -1,0 +1,17 @@
+# Variables:
+# $productNameNew (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionDowngrade-subject = You have switched to { $productNameNew }
+# Variables:
+# $productNameOld (String) - The name of the previously subscribed product, e.g. Mozilla VPN
+# $productNameNew (String) - The name of the new subscribed product, e.g. Mozilla VPN
+subscriptionDowngrade-content-switch = You have successfully switched from { $productNameOld } to { $productNameNew }.
+# Variables:
+# $paymentAmountOld (String) - The amount of the previous subscription payment, including currency, e.g. $10.00
+# $paymentAmountNew (String) - The amount of the new subscription payment, including currency, e.g. $10.00
+# $productPaymentCycle (String) - The interval of time from the end of one payment statement date to the next payment statement date, e.g. month
+# $paymentProrated (String) - The one time fee to reflect the higher charge for the remainder of the payment cycle, including currency, e.g. $10.00
+subscriptionDowngrade-content-charge = Starting with your next bill, your charge will change from { $paymentAmountOld } per { $productPaymentCycle } to { $paymentAmountNew }. At that time you will also be given a one-time credit of { $paymentProrated } to reflect the lower charge for the remainder of this { $productPaymentCycle }.
+# Variables:
+# $productNameNew (String) - The name of the new subscribed product, e.g. Mozilla VPN
+subscriptionDowngrade-content-install = If there is new software for you to install in order to use { $productNameNew }, you will receive a separate email with download instructions.
+subscriptionDowngrade-content-auto-renew = Your subscription will automatically renew each billing period unless you choose to cancel.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionDowngrade/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionDowngrade/index.mjml
@@ -1,0 +1,38 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section css-class="mb-6">
+  <mj-group>
+    <mj-column>
+      <mj-image src="<%- productIconURLOld %>" alt="<%- productNameOld %>" title="<%- productNameOld %>" css-class="product-icon">
+      </mj-image>
+    </mj-column>
+    <mj-column>
+      <mj-image src="<%- productIconURLNew %>" alt="<%- productNameNew %>" title="<%- productNameNew %>" css-class="product-icon">
+      </mj-image>
+    </mj-column>
+  </mj-group>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionDowngrade-content-switch" data-l10n-args="<%= JSON.stringify({productNameNew, productNameOld}) %>">You have successfully switched from <%- productNameOld %> to <%- productNameNew %>.</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionDowngrade-content-charge" data-l10n-args="<%= JSON.stringify({paymentAmountNew, paymentAmountOld, paymentProrated, productPaymentCycle}) %>">Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycle %> to <%- paymentAmountNew %>. At that time you will also be given a one-time credit of <%- paymentProrated %> to reflect the lower charge for the remainder of this <%- productPaymentCycle %>.</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionDowngrade-content-install" data-l10n-args="<%= JSON.stringify({productNameNew}) %>">If there is new software for you to install in order to use <%- productNameNew %>, you will receive a separate email with download instructions.</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionDowngrade-content-auto-renew">Your subscription will automatically renew each billing period unless you choose to cancel.</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include ('/partials/subscriptionSupport/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionDowngrade/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionDowngrade/index.stories.ts
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionDowngrade',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionDowngrade',
+  'Sent when a user downgrades their subscription.',
+  {
+    paymentAmountNew: '£123,121.00',
+    paymentAmountOld: '¥99,991',
+    paymentProrated: '$5,231.00',
+    productIconURLNew:
+      'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
+    productIconURLOld:
+      'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
+    productNameNew: 'Product Name B',
+    productNameOld: 'Product Name A',
+    productPaymentCycle: 'month',
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+  }
+);
+
+export const SubscriptionDowngrade = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionDowngrade/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionDowngrade/index.txt
@@ -1,0 +1,11 @@
+subscriptionDowngrade-subject = "You have switched to <%- productNameNew %>"
+
+subscriptionDowngrade-content-switch = "You have successfully switched from <%- productNameOld %> to <%- productNameNew %>."
+
+subscriptionDowngrade-content-charge = "Starting with your next bill, your charge will change from <%- paymentAmountOld %> per <%- productPaymentCycle %> to <%- paymentAmountNew %>. At that time you will also be given a one-time credit of <%- paymentProrated %> to reflect the lower charge for the remainder of this <%- productPaymentCycle %>."
+
+subscriptionDowngrade-content-install = "If there is new software for you to install in order to use <%- productNameNew %>, you will receive a separate email with download instructions."
+
+subscriptionDowngrade-content-auto-renew = "Your subscription will automatically renew each billing period unless you choose to cancel."
+
+<%- include ('/partials/subscriptionSupport/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -1042,6 +1042,31 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ]]
   ])],
 
+  ['subscriptionDowngradeEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `You have switched to ${MESSAGE.productNameNew}` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionDowngrade') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionDowngrade' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionDowngrade }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-downgrade', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-downgrade', 'subscription-terms') },
+      { test: 'include', expected: `from ${MESSAGE.productNameOld} to ${MESSAGE.productNameNew}.` },
+      { test: 'include', expected: `from ${MESSAGE_FORMATTED.paymentAmountOld} per ${MESSAGE.productPaymentCycle} to ${MESSAGE_FORMATTED.paymentAmountNew}.` },
+      { test: 'include', expected: `one-time credit of ${MESSAGE_FORMATTED.paymentProrated} to reflect the lower charge for the remainder of this ${MESSAGE.productPaymentCycle}.` },
+      { test: 'include', expected: `to use ${MESSAGE.productNameNew},` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `from ${MESSAGE.productNameOld} to ${MESSAGE.productNameNew}.` },
+      { test: 'include', expected: `from ${MESSAGE_FORMATTED.paymentAmountOld} per ${MESSAGE.productPaymentCycle} to ${MESSAGE_FORMATTED.paymentAmountNew}.` },
+      { test: 'include', expected: `one-time credit of ${MESSAGE_FORMATTED.paymentProrated} to reflect the lower charge for the remainder of this ${MESSAGE.productPaymentCycle}.` },
+      { test: 'include', expected: `to use ${MESSAGE.productNameNew},` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ])],
+
   ['subscriptionPaymentExpiredEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: `Credit card for ${MESSAGE.productName} expiring soon` }],
     ['headers', new Map([


### PR DESCRIPTION
Because:

* We are actively converting old FxA emails to our new modernized stack

This commit:

* Converts the `subscriptionDowngrade` subscription platform email to the new stack.

Closes: #9274

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Old template
<img width="651" alt="Screen Shot 2021-12-09 at 9 06 01 AM" src="https://user-images.githubusercontent.com/28129806/145414355-87ec3cab-ddef-4e62-8489-5559b467bdf2.png">

New template
<img width="653" alt="Screen Shot 2021-12-09 at 9 06 19 AM" src="https://user-images.githubusercontent.com/28129806/145414389-59d0ed4b-b7da-4417-9a47-ce933bc98952.png">

## Other information (Optional)
A revision  of the following file is needed to include the `Terms and cancellation policy` link when emails have the `productNameNew` variable instead of `productName`.
* `emails/layouts/subscription/index.txt`

Please note, `emails/layouts/subscription/index.mjml` was  revised in #11253.