### PR TITLE
chore(auth-server): Update email storybook docs, update Fx 'Account' to Fx 'account'

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/en.ftl
@@ -6,4 +6,4 @@ subscriptionAccountDeletion-title = Sorry to see you go
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
 #  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
 #  $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
-subscriptionAccountDeletion-content-cancelled = You recently deleted your Firefox Account. As a result, we‘ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }.
+subscriptionAccountDeletion-content-cancelled = You recently deleted your { -product-firefox-account }. As a result, we‘ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.mjml
@@ -14,7 +14,7 @@
   <mj-column>
     <mj-text css-class="text-body">
       <span data-l10n-id="subscriptionAccountDeletion-content-cancelled" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly}) %>">
-        You recently deleted your Firefox Account. As a result, we‘ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>.
+        You recently deleted your Firefox account. As a result, we‘ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>.
       </span>
     </mj-text>
   </mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.stories.ts
@@ -11,7 +11,7 @@ export default {
 
 const createStory = subplatStoryWithProps(
   'subscriptionAccountDeletion',
-  'Sent when a user deletes their account subscription.',
+  'Sent when a user with an active subscription deletes their Firefox account.',
   {
     productName: 'Firefox Fortress',
     isCancellationEmail: true,

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.txt
@@ -2,6 +2,6 @@ subscriptionAccountDeletion-subject = "Your <%- productName %> subscription has 
 
 subscriptionAccountDeletion-title = "Sorry to see you go"
 
-subscriptionAccountDeletion-content-cancelled = "You recently deleted your Firefox Account. As a result, we‘ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>."
+subscriptionAccountDeletion-content-cancelled = "You recently deleted your Firefox account. As a result, we‘ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>."
 
 <%- include ('/partials/cancellationSurvey/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/unblockCode/index.stories.ts
@@ -12,7 +12,7 @@ export default {
 
 const createStory = storyWithProps(
   'unblockCode',
-  'Sent to verify or unblock a blocked account sign-in via code.',
+  'Sent to verify or unblock an account via code that has reached the login attempt rate limit.',
   {
     ...MOCK_LOCATION,
     unblockCode: '1ILO0Z5P',

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verify/index.stories.ts
@@ -12,7 +12,7 @@ export default {
 
 const createStory = storyWithProps(
   'verify',
-  'Received by all who complete FxA registration form.',
+  "Sent to users that create an account through Firefox, don't verify their email, and go into Sync preferences to resend the verification email as a link.",
   {
     ...MOCK_LOCATION,
     link: 'http://localhost:3030/verify_email',

--- a/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/verifySecondary/index.stories.ts
@@ -12,7 +12,7 @@ export default {
 
 const createStory = storyWithProps(
   'verifySecondary',
-  'Sent to verify the addition of a secondary email via link.',
+  '*NO LONGER USED* This used to be sent to verify the addition of a secondary email via link, but we only send a code now. This should be removed in the future.',
   {
     ...MOCK_LOCATION,
     email: 'foo@bar.com',


### PR DESCRIPTION
This commit:
* Modifies a few email Storybook docs
* Changes 'Firefox Account' to 'Firefox account', uses the ftl placeholder

Because:
* Some descriptions could be more accurate
* We recently decided to use "account" rather than "Account", this follows our new pattern set in emails