### PR TITLE
fix(auth-server): revise emails to update apostrophes

### DIFF
--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/en.ftl
@@ -6,4 +6,4 @@ subscriptionAccountDeletion-title = Sorry to see you go
 #  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
 #  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
 #  $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
-subscriptionAccountDeletion-content-cancelled = You recently deleted your { -product-firefox-account }. As a result, we‘ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }.
+subscriptionAccountDeletion-content-cancelled = You recently deleted your { -product-firefox-account }. As a result, we’ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.mjml
@@ -14,7 +14,7 @@
   <mj-column>
     <mj-text css-class="text-body">
       <span data-l10n-id="subscriptionAccountDeletion-content-cancelled" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly}) %>">
-        You recently deleted your Firefox account. As a result, we‘ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>.
+        You recently deleted your Firefox account. As a result, we’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>.
       </span>
     </mj-text>
   </mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionAccountDeletion/index.txt
@@ -2,6 +2,6 @@ subscriptionAccountDeletion-subject = "Your <%- productName %> subscription has 
 
 subscriptionAccountDeletion-title = "Sorry to see you go"
 
-subscriptionAccountDeletion-content-cancelled = "You recently deleted your Firefox account. As a result, we‘ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>."
+subscriptionAccountDeletion-content-cancelled = "You recently deleted your Firefox account. As a result, we’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>."
 
 <%- include ('/partials/cancellationSurvey/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/en.ftl
@@ -7,4 +7,4 @@ subscriptionCancellation-title = Sorry to see you go
 #   $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
 #   $invoiceDateOnly (String) - The date of the invoice, e.g. 01/20/2016
 #   $serviceLastActiveDateOnly (String) - The date of last active service, e.g. 01/20/2016
-subscriptionCancellation-content = We‘ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }. Your service will continue until the end of your current billing period, which is { $serviceLastActiveDateOnly }.
+subscriptionCancellation-content = We’ve cancelled your { $productName } subscription. Your final payment of { $invoiceTotal } was paid on { $invoiceDateOnly }. Your service will continue until the end of your current billing period, which is { $serviceLastActiveDateOnly }.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.mjml
@@ -14,7 +14,7 @@
   <mj-column>
     <mj-text css-class="text-body">
       <span data-l10n-id="subscriptionCancellation-content" data-l10n-args="<%= JSON.stringify({productName, invoiceTotal, invoiceDateOnly, serviceLastActiveDateOnly}) %>">
-          We‘ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>.
+          We’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>.
       </span>
     </mj-text>
   </mj-column>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionCancellation/index.txt
@@ -2,6 +2,6 @@ subscriptionCancellation-subject = "Your <%- productName %> subscription has bee
 
 subscriptionCancellation-title = "Sorry to see you go"
 
-subscriptionCancellation-content = "We‘ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>."
+subscriptionCancellation-content = "We’ve cancelled your <%- productName %> subscription. Your final payment of <%- invoiceTotal %> was paid on <%- invoiceDateOnly %>. Your service will continue until the end of your current billing period, which is <%- serviceLastActiveDateOnly %>."
 
 <%- include ('/partials/cancellationSurvey/index.txt') %>


### PR DESCRIPTION
Because:

* opening single quotes were used instead of closing quotes.

This commit:

* replaces opening quotes with closing ones.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
