### PR TITLE
fix(auth): fix location optional

### DIFF
--- a/packages/fxa-auth-server/lib/routes/subscriptions/support.ts
+++ b/packages/fxa-auth-server/lib/routes/subscriptions/support.ts
@@ -134,9 +134,9 @@ export const supportRoutes = (
               { id: productVersionFieldId, value: productVersion },
               { id: topicFieldId, value: topic },
               { id: appFieldId, value: app },
-              { id: locationCityFieldId, value: location.city },
-              { id: locationStateFieldId, value: location.state },
-              { id: locationCountryFieldId, value: location.country },
+              { id: locationCityFieldId, value: location?.city },
+              { id: locationStateFieldId, value: location?.state },
+              { id: locationCountryFieldId, value: location?.country },
             ],
           },
         };


### PR DESCRIPTION
Because:

* The location may not be defined in some scenarios, such as local
  testing, which a prior commit made optional as a result.

This commit:

* Uses optional chaining for properties that may not be present.

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
