### PR TITLE
feat(auth-server): convert `subscriptionPaymentFailed`

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -471,6 +471,7 @@
       "subscriptionAccountReminderSecond",
       "subscriptionCancellation",
       "subscriptionDowngrade",
+      "subscriptionPaymentFailed",
       "subscriptionReactivation",
       "subscriptionUpgrade"
     ]

--- a/packages/fxa-auth-server/lib/senders/emails/partials/updateBilling/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/updateBilling/en.ftl
@@ -1,0 +1,3 @@
+updateBilling = We’ll try your payment again over the next few days, but you may need to help us fix it by <a data-l10n-name="updateBillingUrl">updating your payment information</a>.
+# After the colon, there's a link to https://accounts.firefox.com/subscriptions
+updateBilling-plaintext = We’ll try your payment again over the next few days, but you may need to help us fix it by updating your payment information:

--- a/packages/fxa-auth-server/lib/senders/emails/partials/updateBilling/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/updateBilling/index.mjml
@@ -1,0 +1,13 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="updateBilling">
+        We’ll try your payment again over the next few days, but you may need to help us fix it by <a data-l10n-name="updateBillingUrl" href="<%- updateBillingUrl %>">updating your payment information</a>.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/updateBilling/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/updateBilling/index.txt
@@ -1,0 +1,2 @@
+updateBilling-plaintext = "We’ll try your payment again over the next few days, but you may need to help us fix it by updating your payment information:"
+<%- updateBillingUrl %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/en.ftl
@@ -1,0 +1,8 @@
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionPaymentFailed-subject = { $productName } payment failed
+subscriptionPaymentFailed-title = Sorry, we’re having trouble with your payment
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionPaymentFailed-content-problem = We had a problem with your latest payment for { $productName }.
+subscriptionPaymentFailed-content-outdated = It may be that your credit card has expired, or your current payment method is out of date.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/index.mjml
@@ -1,0 +1,36 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section css-class="mb-6">
+  <mj-column>
+    <mj-image src="<%- icon %>" alt="<%- productName %> icon" title="<%- productName %>" css-class="product-icon"></mj-image>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="subscriptionPaymentFailed-title">Sorry, we’re having trouble with your payment</span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionPaymentFailed-content-problem" data-l10n-args="<%= JSON.stringify({productName}) %>">
+          We had a problem with your latest payment for <%- productName %>.
+      </span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionPaymentFailed-content-outdated">
+        It may be that your credit card has expired, or your current payment method is out of date.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include ('/partials/updateBilling/index.mjml') %>
+<%- include ('/partials/subscriptionSupport/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/index.stories.ts
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionPaymentFailed',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionPaymentFailed',
+  'Sent when there is a problem with the latest payment.',
+  {
+    icon: 'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
+    productName: 'Firefox Fortress',
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+    updateBillingUrl: 'http://localhost:3030/subscriptions',
+  }
+);
+
+export const SubscriptionPaymentFailed = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentFailed/index.txt
@@ -1,0 +1,10 @@
+subscriptionPaymentFailed-subject = "<%- productName %> payment failed"
+
+subscriptionPaymentFailed-title = "Sorry, we’re having trouble with your payment"
+
+subscriptionPaymentFailed-content-problem = "We had a problem with your latest payment for <%- productName %>."
+
+subscriptionPaymentFailed-content-outdated = "It may be that your credit card has expired, or your current payment method is out of date."
+
+<%- include ('/partials/updateBilling/index.txt') %>
+<%- include ('/partials/subscriptionSupport/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentExpired/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentExpired/index.mjml
@@ -14,16 +14,15 @@
       </span>
     </mj-text>
 
-  <mj-text css-class="text-body">
-    <ul>
-      <% for (const { productName } of subscriptions) { %>
-        <li>
-          <%- productName %>
-        </li>
-      <% } %>
-    </ul>
-  </mj-text>
-
+    <mj-text css-class="text-body">
+      <ul>
+        <% for (const { productName } of subscriptions) { %>
+          <li>
+            <%- productName %>
+          </li>
+        <% } %>
+      </ul>
+    </mj-text>
   </mj-column>
 </mj-section>
 

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -1131,6 +1131,27 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ]]
   ]), {updateTemplateValues: x => ({...x, productName: undefined})}],
 
+  ['subscriptionPaymentFailedEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `${MESSAGE.productName} payment failed` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionPaymentFailed') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionPaymentFailed' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionPaymentFailed }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-payment-failed', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-payment-failed', 'subscription-terms') },
+      { test: 'include', expected: `latest payment for ${MESSAGE.productName}.` },
+      { test: 'include', expected: 'We’ll try your payment again over the next few days, but you may need to help us fix it' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `latest payment for ${MESSAGE.productName}.` },
+      { test: 'include', expected: 'We’ll try your payment again over the next few days, but you may need to help us fix it' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ])],
+
   ['subscriptionReactivationEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: `${MESSAGE.productName} subscription reactivated` }],
     ['headers', new Map([


### PR DESCRIPTION
Because:

* We are actively converting old FxA emails to our new modernized stack

This commit:

* Converts the `subscriptionPaymentFailed` subscription platform email to the new stack

Closes: #9282 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Old template
<img width="649" alt="Screen Shot 2021-12-10 at 3 00 56 PM" src="https://user-images.githubusercontent.com/28129806/145635170-86fb4a62-095a-45a4-81ad-58741445c124.png">

New template
<img width="652" alt="Screen Shot 2021-12-10 at 3 01 04 PM" src="https://user-images.githubusercontent.com/28129806/145635187-e8fed1f7-f68c-4d1f-9b73-37f861c0aee7.png">

## Other information (Optional)
The following files were added to create the `updateBilling` partial:
* `emails/partials/updateBilling/en.ftl`
* `emails/partials/updateBilling/index.mjml`
* `emails/partials/updateBilling/index.txt`

In addition, the whitespace was revised in the following file:
* `emails/templates/subscriptionsPaymentExpired/index.mjml`