### PR TITLE
bug(auth): destroying attached client would fail

### DIFF
--- a/packages/functional-tests/tests/prod.smoke.spec.ts
+++ b/packages/functional-tests/tests/prod.smoke.spec.ts
@@ -20,8 +20,8 @@ test.describe('severity-1', () => {
     await sync.signout();
     await page.click('text=Rather not say >> input[name="reason"]');
     await settings.clickModalConfirm();
-    await page.waitForURL('**/signin', { waitUntil: 'networkidle' });
-    expect(page.locator('#password')).toBeVisible();
+    await page.waitForNavigation({ waitUntil: 'networkidle' });
+    expect(page.locator('input[type=email]')).toBeVisible();
   });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293385

--- a/packages/functional-tests/tests/prod.smoke.spec.ts
+++ b/packages/functional-tests/tests/prod.smoke.spec.ts
@@ -19,7 +19,6 @@ test.describe('severity-1', () => {
     const sync = services.find((s) => s.name !== 'playwright');
     await sync.signout();
     await page.click('text=Rather not say >> input[name="reason"]');
-    await settings.clickModalConfirm();
     // FIXME
     // Playwright isn't behaving like a vanilla browser when
     // sync is disconnected. It's logging out of the web context
@@ -40,6 +39,10 @@ test.describe('severity-1', () => {
         })
       );
     }, credentials.uid);
+
+    // The clickModalConfirm needs to follow the above event. If
+    // it does not, a race condition can occur.
+    await settings.clickModalConfirm();
     await login.setEmail(credentials.email);
     expect(page.url()).toMatch(login.url);
   });

--- a/packages/functional-tests/tests/prod.smoke.spec.ts
+++ b/packages/functional-tests/tests/prod.smoke.spec.ts
@@ -9,22 +9,19 @@ test.describe('severity-1', () => {
     credentials,
     pages: { login, settings },
   }) => {
-    test.fixme(
-      true,
-      '(Invalid parameter in request body) response to attachedClientDisconnect mutation'
-    );
     await page.goto(
       target.contentServerUrl +
         '?context=fx_desktop_v3&entrypoint=fxa%3Aenter_email&service=sync&action=email'
     );
     await login.login(credentials.email, credentials.password);
     await settings.goto();
-    const services = await settings.connectedServices.services();
+    let services = await settings.connectedServices.services();
     const sync = services.find((s) => s.name !== 'playwright');
     await sync.signout();
     await page.click('text=Rather not say >> input[name="reason"]');
     await settings.clickModalConfirm();
-    // The sync row should be removed but isn't
+    await page.waitForURL('**/signin', { waitUntil: 'networkidle' });
+    expect(page.locator('#password')).toBeVisible();
   });
 
   // https://testrail.stage.mozaws.net/index.php?/cases/view/1293385

--- a/packages/fxa-settings/src/components/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/index.tsx
@@ -102,7 +102,6 @@ export const ConnectedServices = () => {
         // old-settings? #6903
         if (client.isCurrentSession) {
           clearSignedInAccountUid();
-          await account.signout();
           window.location.assign(`${window.location.origin}/signin`);
         } else if (reason === 'suspicious' || reason === 'lost') {
           // Wait to clear disconnecting state till the advice modal has been shown

--- a/packages/fxa-settings/src/components/ConnectedServices/index.tsx
+++ b/packages/fxa-settings/src/components/ConnectedServices/index.tsx
@@ -73,11 +73,8 @@ export const ConnectedServices = () => {
   // After the user confirms they want to disconnect from sync in Confirm Disconnect modal,
   // if their reason was a lost/stolen device, or a suspicious device, then we show them
   // an informative modal with some advice on next steps to take.
-  const [
-    adviceModalRevealed,
-    revealAdviceModal,
-    hideAdviceModal,
-  ] = useBooleanState();
+  const [adviceModalRevealed, revealAdviceModal, hideAdviceModal] =
+    useBooleanState();
 
   const [selectedClient, setSelectedClient] = useState<AttachedClient | null>(
     null
@@ -105,6 +102,7 @@ export const ConnectedServices = () => {
         // old-settings? #6903
         if (client.isCurrentSession) {
           clearSignedInAccountUid();
+          await account.signout();
           window.location.assign(`${window.location.origin}/signin`);
         } else if (reason === 'suspicious' || reason === 'lost') {
           // Wait to clear disconnecting state till the advice modal has been shown

--- a/packages/fxa-settings/src/lib/firefox.ts
+++ b/packages/fxa-settings/src/lib/firefox.ts
@@ -1,5 +1,4 @@
 export enum FirefoxCommand {
-  Signout = 'fxaccounts:logout',
   AccountDeleted = 'fxaccounts:delete',
   ProfileChanged = 'profile:change',
   PasswordChanged = 'fxaccounts:change_password',
@@ -120,10 +119,6 @@ export class Firefox extends EventTarget {
   accountDeleted(uid: hexstring) {
     this.send(FirefoxCommand.AccountDeleted, { uid });
     this.broadcast(FirefoxCommand.AccountDeleted, { uid });
-  }
-
-  signout(uid: hexstring) {
-    this.send(FirefoxCommand.Signout, { uid });
   }
 
   passwordChanged(

--- a/packages/fxa-settings/src/lib/firefox.ts
+++ b/packages/fxa-settings/src/lib/firefox.ts
@@ -1,4 +1,5 @@
 export enum FirefoxCommand {
+  Signout = 'fxaccounts:logout',
   AccountDeleted = 'fxaccounts:delete',
   ProfileChanged = 'profile:change',
   PasswordChanged = 'fxaccounts:change_password',
@@ -121,6 +122,10 @@ export class Firefox extends EventTarget {
     this.broadcast(FirefoxCommand.AccountDeleted, { uid });
   }
 
+  signout(uid: hexstring) {
+    this.send(FirefoxCommand.Signout, { uid });
+  }
+
   passwordChanged(
     email: string,
     uid: hexstring,
@@ -162,7 +167,7 @@ function noop() {}
 const firefox = canUseEventTarget
   ? new Firefox()
   : // otherwise a mock
-    ((Object.fromEntries(
+    (Object.fromEntries(
       Object.getOwnPropertyNames(Firefox.prototype)
         .map((name) => [name, noop])
         .concat([
@@ -170,6 +175,6 @@ const firefox = canUseEventTarget
           ['removeEventListener', noop],
           ['dispatchEvent', noop],
         ])
-    ) as unknown) as Firefox);
+    ) as unknown as Firefox);
 
 export default firefox;

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -778,4 +778,11 @@ export class Account implements AccountData {
     firefox.accountDeleted(this.uid);
     Storage.factory('localStorage').clear();
   }
+
+  async signout() {
+    // Not 100% sure this okay but it works. When this is called,
+    // if the firefox account is connected, then this will log
+    // you out.
+    firefox.signout(this.uid);
+  }
 }

--- a/packages/fxa-settings/src/models/Account.ts
+++ b/packages/fxa-settings/src/models/Account.ts
@@ -778,11 +778,4 @@ export class Account implements AccountData {
     firefox.accountDeleted(this.uid);
     Storage.factory('localStorage').clear();
   }
-
-  async signout() {
-    // Not 100% sure this okay but it works. When this is called,
-    // if the firefox account is connected, then this will log
-    // you out.
-    firefox.signout(this.uid);
-  }
 }

--- a/packages/fxa-shared/db/models/auth/device.ts
+++ b/packages/fxa-shared/db/models/auth/device.ts
@@ -194,7 +194,10 @@ export class Device extends BaseAuthModel {
     if (!result) {
       throw notFound();
     }
-    return result;
+    return {
+      sessionTokenId: uuidTransformer.from(result.sessionTokenId),
+      refreshTokenId: uuidTransformer.from(result.refreshTokenId),
+    };
   }
 
   static fromRows(rows: object[]): Device[] {


### PR DESCRIPTION
## Because

- A test started failing that was destroying attached devices

## This pull request

- Coerces device.sessionTokenId from a buffer into a hex string for comparison
- Coerces device.refreshTokenId from a buffer into a hex string for comparison

## Issue that this pull request solves

closes #11011

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).
