### PR TITLE
feat(auth-server): convert `subscriptionFirstInvoice`

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -471,6 +471,7 @@
       "subscriptionAccountReminderSecond",
       "subscriptionCancellation",
       "subscriptionDowngrade",
+      "subscriptionFirstInvoice",
       "subscriptionPaymentFailed",
       "subscriptionPaymentProviderCancelled",
       "subscriptionReactivation",

--- a/packages/fxa-auth-server/lib/senders/emails/auth.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/auth.ftl
@@ -20,4 +20,7 @@
 # "Firefox Cloud" should be treated as a brand.
 -product-firefox-cloud = Firefox Cloud
 
+# Other brands
+-paypal = PayPal
+
 ## Email content

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/en.ftl
@@ -1,6 +1,6 @@
-payment-method = Payment method: PayPal
-credit-card = Credit card:
+payment-provider-paypal = Payment Method: { -paypal }
+payment-method = Payment Method:
 # Variables:
-#  $cardType (String) - The name of the credit card, e.g. Visa
+#  $cardType (String) - The type of the credit card, e.g. Visa
 #  $lastFour (String) - The last four digits of the credit card, e.g. 5309
 card-ending-in = { $cardType } card ending in { $lastFour }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/en.ftl
@@ -1,7 +1,6 @@
+# After the colon is how the user paid, e.g. PayPal or credit card
 payment-method = Payment Method:
--paypal = PayPal
-paypal = { -paypal }
-payment-provider-paypal-plaintext = Payment Method: { -paypal }
+payment-provider-paypal-plaintext = { payment-method } { -paypal }
 # Variables:
 #  $cardType (String) - The type of the credit card, e.g. Visa
 #  $lastFour (String) - The last four digits of the credit card, e.g. 5309

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/en.ftl
@@ -1,3 +1,5 @@
+payment-method = Payment method: Paypal
+credit-card = Credit card:
 # Variables:
 #  $cardType (String) - The name of the credit card, e.g. Visa
 #  $lastFour (String) - The last four digits of the credit card, e.g. 5309

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/en.ftl
@@ -1,0 +1,4 @@
+# Variables:
+#  $cardType (String) - The name of the credit card, e.g. Visa
+#  $lastFour (String) - The last four digits of the credit card, e.g. 5309
+card-ending-in = { $cardType } card ending in { $lastFour }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/en.ftl
@@ -1,4 +1,4 @@
-payment-method = Payment method: Paypal
+payment-method = Payment method: PayPal
 credit-card = Credit card:
 # Variables:
 #  $cardType (String) - The name of the credit card, e.g. Visa

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/en.ftl
@@ -1,5 +1,7 @@
-payment-provider-paypal = Payment Method: { -paypal }
 payment-method = Payment Method:
+-paypal = PayPal
+paypal = { -paypal }
+payment-provider-paypal-plaintext = Payment Method: { -paypal }
 # Variables:
 #  $cardType (String) - The type of the credit card, e.g. Visa
 #  $lastFour (String) - The last four digits of the credit card, e.g. 5309

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
@@ -3,12 +3,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
 <% if (payment_provider === 'paypal') { %>
-  <span data-l10n-id="payment-method">Payment Method: PayPal</span>
+  <mj-text css-class="text-body">
+    <span data-l10n-id="payment-provider-paypal" css-class="margin-top">Payment Method: PayPal</span>
+  </mj-text>
 <% } %>
 
 <% if (payment_provider === "stripe" && lastFour) { %>
-  <span data-l10n-id="credit-card">Credit Card:</span>
-  <span data-l10n-id="card-ending-in" data-l10n-args="<%= JSON.stringify({cardType, lastFour}) %>">
-    <%- cardType %> card ending in <%- lastFour %>
-  </span>
+  <mj-text css-class="text-body">
+    <span data-l10n-id="payment-method" css-class="margin-top">Payment Method:</span>
+    <span data-l10n-id="card-ending-in" data-l10n-args="<%= JSON.stringify({cardType, lastFour}) %>">
+      <%- cardType %> card ending in <%- lastFour %>
+    </span>
+  </mj-text>
 <% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
@@ -3,10 +3,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
 <% if (payment_provider === 'paypal') { %>
-  <span>PayPal</span>
+  <span data-l10n-id="payment-method">Payment Method: PayPal</span>
 <% } %>
 
 <% if (payment_provider === "stripe" && lastFour) { %>
+  <span data-l10n-id="credit-card">Credit Card:</span>
   <span data-l10n-id="card-ending-in" data-l10n-args="<%= JSON.stringify({cardType, lastFour}) %>">
     <%- cardType %> card ending in <%- lastFour %>
   </span>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
@@ -3,10 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
 <mj-text css-class="text-body margin-top">
-  <span data-l10n-id="payment-method" >Payment Method:</span>
+  <span data-l10n-id="payment-method">Payment Method: </span>
 
   <% if (payment_provider === 'paypal') { %>
-    <span data-l10n-id="paypal">PayPal</span>
+    <span>PayPal</span>
   <% } %>
 
   <% if (payment_provider === "stripe" && lastFour) { %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
@@ -1,0 +1,13 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<% if (payment_provider === 'paypal') { %>
+  <span>PayPal</span>
+<% } %>
+
+<% if (payment_provider === "stripe" && lastFour) { %>
+  <span data-l10n-id="card-ending-in" data-l10n-args="<%= JSON.stringify({cardType, lastFour}) %>">
+    <%- cardType %> card ending in <%- lastFour %>
+  </span>
+<% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.mjml
@@ -2,17 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<% if (payment_provider === 'paypal') { %>
-  <mj-text css-class="text-body">
-    <span data-l10n-id="payment-provider-paypal" css-class="margin-top">Payment Method: PayPal</span>
-  </mj-text>
-<% } %>
+<mj-text css-class="text-body margin-top">
+  <span data-l10n-id="payment-method" >Payment Method:</span>
 
-<% if (payment_provider === "stripe" && lastFour) { %>
-  <mj-text css-class="text-body">
-    <span data-l10n-id="payment-method" css-class="margin-top">Payment Method:</span>
+  <% if (payment_provider === 'paypal') { %>
+    <span data-l10n-id="paypal">PayPal</span>
+  <% } %>
+
+  <% if (payment_provider === "stripe" && lastFour) { %>
     <span data-l10n-id="card-ending-in" data-l10n-args="<%= JSON.stringify({cardType, lastFour}) %>">
       <%- cardType %> card ending in <%- lastFour %>
     </span>
-  </mj-text>
-<% } %>
+  <% } %>
+</mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
@@ -1,7 +1,7 @@
 <% if (payment_provider === "paypal") { %>
-    payment-provider = "Payment method: PayPal"
+    payment-provider-paypal = "Payment Method: PayPal"
 <% } %>
 <% if (payment_provider === "stripe" && lastFour) { %>
-    credit-card = "Credit Card:"
+    payment-method = "Payment Method:"
     card-ending-in = "<%- cardType %> card ending in <%- lastFour %>"
 <% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
@@ -1,5 +1,5 @@
 <% if (payment_provider === "paypal") { %>
-    payment-provider-paypal = "Payment Method: PayPal"
+    payment-provider-paypal-plaintext = "Payment Method: PayPal"
 <% } %>
 <% if (payment_provider === "stripe" && lastFour) { %>
     payment-method = "Payment Method:"

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
@@ -1,6 +1,7 @@
 <% if (payment_provider === "paypal") { %>
-    payment-provider = "PayPal"
+    payment-provider = "Payment method: PayPal"
 <% } %>
 <% if (payment_provider === "stripe" && lastFour) { %>
+    credit-card = "Credit Card:"
     card-ending-in = "<%- cardType %> card ending in <%- lastFour %>"
 <% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
@@ -2,6 +2,6 @@
     payment-provider-paypal-plaintext = "Payment Method: PayPal"
 <% } %>
 <% if (payment_provider === "stripe" && lastFour) { %>
-    payment-method = "Payment Method:"
+    payment-method = "Payment Method: "
     card-ending-in = "<%- cardType %> card ending in <%- lastFour %>"
 <% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/paymentProvider/index.txt
@@ -1,0 +1,6 @@
+<% if (payment_provider === "paypal") { %>
+    payment-provider = "PayPal"
+<% } %>
+<% if (payment_provider === "stripe" && lastFour) { %>
+    card-ending-in = "<%- cardType %> card ending in <%- lastFour %>"
+<% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/viewInvoice/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/viewInvoice/en.ftl
@@ -1,0 +1,3 @@
+view-invoice = <a data-l10n-name="invoiceLink">View your invoice</a>.
+# After the colon, there's a link to https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp
+view-invoice-plaintext = View invoice:

--- a/packages/fxa-auth-server/lib/senders/emails/partials/viewInvoice/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/viewInvoice/en.ftl
@@ -1,3 +1,5 @@
 view-invoice = <a data-l10n-name="invoiceLink">View your invoice</a>.
-# After the colon, there's a link to https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp
-view-invoice-plaintext = View invoice:
+# Variables:
+#  $invoiceLink (String) - The link to the invoice
+# After the colon, there's a link to https://pay.stripe.com/
+view-invoice-plaintext = View Invoice: { $invoiceLink }

--- a/packages/fxa-auth-server/lib/senders/emails/partials/viewInvoice/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/viewInvoice/index.mjml
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
 
-<span data-l10n-id="view-invoice">
-  <a data-l10n-name="invoiceLink" href="<%- invoiceLink %>">View your invoice</a>.
-</span>
+<mj-text css-class="text-body-no-bottom-margin margin-top">
+  <span data-l10n-id="view-invoice">
+    <a data-l10n-name="invoiceLink" href="<%- invoiceLink %>">View your invoice</a>.
+  </span>
+</mj-text>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/viewInvoice/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/viewInvoice/index.mjml
@@ -1,0 +1,7 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<span data-l10n-id="view-invoice">
+  <a data-l10n-name="invoiceLink" href="<%- invoiceLink %>">View your invoice</a>.
+</span>

--- a/packages/fxa-auth-server/lib/senders/emails/partials/viewInvoice/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/viewInvoice/index.txt
@@ -1,2 +1,1 @@
-view-invoice-plaintext = "View invoice:"
-<%- invoiceLink %>
+view-invoice-plaintext = "View Invoice: <%- invoiceLink %>"

--- a/packages/fxa-auth-server/lib/senders/emails/partials/viewInvoice/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/partials/viewInvoice/index.txt
@@ -1,0 +1,2 @@
+view-invoice-plaintext = "View invoice:"
+<%- invoiceLink %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/en.ftl
@@ -1,0 +1,25 @@
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionFirstInvoice-subject = { $productName } payment confirmed
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionFirstInvoice-title = Thank you for subscribing to { $productName }
+subscriptionFirstInvoice-content-processing = Your payment is currently processing and may take up to four business days to complete.
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionFirstInvoice-content-install = You will receive a separate email with download instructions on how to start using { $productName }.
+subscriptionFirstInvoice-content-auto-renew = Your subscription will automatically renew each billing period unless you choose to cancel.
+subscriptionFirstInvoice-content-invoice-number-label = Invoice Number:
+# Variables:
+#  $invoiceNumber (String) - The invoice number of the subscription invoice, e.g. 8675309
+subscriptionFirstInvoice-content-invoice-number-value = { $invoiceNumber }
+# Variables:
+#  $invoiceNumber (String) - The invoice number of the subscription invoice, e.g. 8675309
+subscriptionFirstInvoice-content-invoice-number-plaintext = Invoice Number: { $invoiceNumber }
+# Variables:
+#  $invoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
+#  $invoiceTotal (String) - The amount of the subscription invoice, including currency, e.g. $10.00
+subscriptionFirstInvoice-content-charge = Charged { $invoiceTotal } on { $invoiceDateOnly }
+# Variables:
+#  $nextInvoiceDateOnly (String) - The date of the next invoice, e.g. 01/20/2016
+subscriptionFirstInvoice-content-next-invoice = Next Invoice: { $nextInvoiceDateOnly }

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.mjml
@@ -1,0 +1,60 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section css-class="mb-6">
+  <mj-column>
+    <mj-image src="<%- icon %>" alt="<%- productName %> icon" title="<%- productName %>" css-class="product-icon"></mj-image>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="subscriptionFirstInvoice-title" data-l10n-args="<%= JSON.stringify({productName}) %>">Thank you for subscribing to <%- productName %></span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionFirstInvoice-content-processing">
+        Your payment is currently processing and may take up to four business days to complete.
+      </span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionFirstInvoice-content-install" data-l10n-args="<%= JSON.stringify({productName}) %>">
+        You will receive a separate email with download instructions on how to start using <%- productName %>.
+      </span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionFirstInvoice-content-auto-renew">
+        Your subscription will automatically renew each billing period unless you choose to cancel.
+      </span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionFirstInvoice-content-invoice-number-label">Invoice Number:</span>
+      <span>
+        <b data-l10n-id="subscriptionFirstInvoice-content-invoice-number-value" data-l10n-args="<%= JSON.stringify({invoiceNumber}) %>"><%- invoiceNumber %></b>
+      </span>
+      <br />
+      <span data-l10n-id="subscriptionFirstInvoice-content-charge" data-l10n-args="<%= JSON.stringify({invoiceDateOnly, invoiceTotal}) %>">
+        Charged <%- invoiceTotal %> on <%- invoiceDateOnly %>
+      </span>
+      <br />
+      <%- include ('/partials/viewInvoice/index.mjml') %>
+      <% if (locals.payment_provider) { %>
+        <br />
+        <%- include ('/partials/paymentProvider/index.mjml') %>
+      <% } %>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionFirstInvoice-content-next-invoice" data-l10n-args="<%= JSON.stringify({nextInvoiceDateOnly}) %>">
+        Next Invoice: <%- nextInvoiceDateOnly %>
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include ('/partials/subscriptionSupport/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.mjml
@@ -32,7 +32,7 @@
       </span>
     </mj-text>
 
-    <mj-text css-class="text-body">
+    <mj-text css-class="text-body-no-bottom-margin">
       <span data-l10n-id="subscriptionFirstInvoice-content-invoice-number-label">Invoice Number:</span>
       <span>
         <b data-l10n-id="subscriptionFirstInvoice-content-invoice-number-value" data-l10n-args="<%= JSON.stringify({invoiceNumber}) %>"><%- invoiceNumber %></b>
@@ -43,11 +43,11 @@
       </span>
       <br />
       <%- include ('/partials/viewInvoice/index.mjml') %>
-      <% if (locals.payment_provider) { %>
-        <br />
-        <%- include ('/partials/paymentProvider/index.mjml') %>
-      <% } %>
     </mj-text>
+
+    <% if (locals.payment_provider) { %>
+      <%- include ('/partials/paymentProvider/index.mjml') %>
+    <% } %>
 
     <mj-text css-class="text-body">
       <span data-l10n-id="subscriptionFirstInvoice-content-next-invoice" data-l10n-args="<%= JSON.stringify({nextInvoiceDateOnly}) %>">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.mjml
@@ -41,13 +41,10 @@
       <span data-l10n-id="subscriptionFirstInvoice-content-charge" data-l10n-args="<%= JSON.stringify({invoiceDateOnly, invoiceTotal}) %>">
         Charged <%- invoiceTotal %> on <%- invoiceDateOnly %>
       </span>
-      <br />
-      <%- include ('/partials/viewInvoice/index.mjml') %>
     </mj-text>
 
-    <% if (locals.payment_provider) { %>
-      <%- include ('/partials/paymentProvider/index.mjml') %>
-    <% } %>
+    <%- include ('/partials/viewInvoice/index.mjml') %>
+    <%- include ('/partials/paymentProvider/index.mjml') %>
 
     <mj-text css-class="text-body">
       <span data-l10n-id="subscriptionFirstInvoice-content-next-invoice" data-l10n-args="<%= JSON.stringify({nextInvoiceDateOnly}) %>">

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.stories.ts
@@ -25,8 +25,6 @@ const createStory = subplatStoryWithProps(
   }
 );
 
-export const SubscriptionFirstInvoice = createStory();
-
 export const SubscriptionFirstInvoiceWithPayPal = createStory(
   {
     payment_provider: 'paypal',

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.stories.ts
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionFirstInvoice',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionFirstInvoice',
+  'Sent to inform a user that their payment is currently being processed.',
+  {
+    productName: 'Firefox Fortress',
+    cardType: 'MasterCard',
+    icon: 'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
+    invoiceDateOnly: '10/13/2021',
+    invoiceLink:
+      'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
+    invoiceNumber: '8675309',
+    invoiceTotal: '$20.00',
+    lastFour: '5309',
+    nextInvoiceDateOnly: '11/13/2021',
+    payment_provider: 'stripe',
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+  }
+);
+
+export const SubscriptionFirstInvoice = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.stories.ts
@@ -11,7 +11,7 @@ export default {
 
 const createStory = subplatStoryWithProps(
   'subscriptionFirstInvoice',
-  'Sent to inform a user that their payment is currently being processed.',
+  'Sent to inform a user that their first payment is currently being processed.',
   {
     productName: 'Firefox Fortress',
     icon: 'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
@@ -29,34 +29,16 @@ export const SubscriptionFirstInvoice = createStory();
 
 export const SubscriptionFirstInvoiceWithPayPal = createStory(
   {
-    productName: 'Firefox Fortress',
-    icon: 'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
-    invoiceDateOnly: '10/13/2021',
-    invoiceLink:
-      'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
-    invoiceNumber: '8675309',
-    invoiceTotal: '$20.00',
-    nextInvoiceDateOnly: '11/13/2021',
     payment_provider: 'paypal',
-    subscriptionSupportUrl: 'http://localhost:3030/support',
   },
-  'PayPal'
+  'Payment method - PayPal'
 );
 
 export const SubscriptionFirstInvoiceWithStripe = createStory(
   {
-    productName: 'Firefox Fortress',
     cardType: 'MasterCard',
-    icon: 'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
-    invoiceDateOnly: '10/13/2021',
-    invoiceLink:
-      'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
-    invoiceNumber: '8675309',
-    invoiceTotal: '$20.00',
     lastFour: '5309',
-    nextInvoiceDateOnly: '11/13/2021',
     payment_provider: 'stripe',
-    subscriptionSupportUrl: 'http://localhost:3030/support',
   },
-  'Stripe'
+  'Payment method - Stripe'
 );

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.stories.ts
@@ -14,6 +14,38 @@ const createStory = subplatStoryWithProps(
   'Sent to inform a user that their payment is currently being processed.',
   {
     productName: 'Firefox Fortress',
+    icon: 'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
+    invoiceDateOnly: '10/13/2021',
+    invoiceLink:
+      'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
+    invoiceNumber: '8675309',
+    invoiceTotal: '$20.00',
+    nextInvoiceDateOnly: '11/13/2021',
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+  }
+);
+
+export const SubscriptionFirstInvoice = createStory();
+
+export const SubscriptionFirstInvoiceWithPayPal = createStory(
+  {
+    productName: 'Firefox Fortress',
+    icon: 'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
+    invoiceDateOnly: '10/13/2021',
+    invoiceLink:
+      'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
+    invoiceNumber: '8675309',
+    invoiceTotal: '$20.00',
+    nextInvoiceDateOnly: '11/13/2021',
+    payment_provider: 'paypal',
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+  },
+  'PayPal'
+);
+
+export const SubscriptionFirstInvoiceWithStripe = createStory(
+  {
+    productName: 'Firefox Fortress',
     cardType: 'MasterCard',
     icon: 'https://accounts-static.cdn.mozilla.net/product-icons/mozilla-vpn-email.png',
     invoiceDateOnly: '10/13/2021',
@@ -25,7 +57,6 @@ const createStory = subplatStoryWithProps(
     nextInvoiceDateOnly: '11/13/2021',
     payment_provider: 'stripe',
     subscriptionSupportUrl: 'http://localhost:3030/support',
-  }
+  },
+  'Stripe'
 );
-
-export const SubscriptionFirstInvoice = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.txt
@@ -4,7 +4,7 @@ subscriptionFirstInvoice-title = "Thank you for subscribing to <%- productName%>
 
 subscriptionFirstInvoice-content-processing = "Your payment is currently processing and may take up to four business days to complete."
 
-subscriptionFirstInvoice-content-install = "You will receive a separate email with download instructions on how to start using <%- productName %>"
+subscriptionFirstInvoice-content-install = "You will receive a separate email with download instructions on how to start using <%- productName %>."
 
 subscriptionFirstInvoice-content-auto-renew = "Your subscription will automatically renew each billing period unless you choose to cancel."
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.txt
@@ -1,0 +1,19 @@
+subscriptionFirstInvoice-subject = "<%- productName %> payment confirmed"
+
+subscriptionFirstInvoice-title = "Thank you for subscribing to <%- productName%>"
+
+subscriptionFirstInvoice-content-processing = "Your payment is currently processing and may take up to four business days to complete."
+
+subscriptionFirstInvoice-content-install = "You will receive a separate email with download instructions on how to start using <%- productName %>"
+
+subscriptionFirstInvoice-content-auto-renew = "Your subscription will automatically renew each billing period unless you choose to cancel."
+
+subscriptionFirstInvoice-content-invoice-number-plaintext = "Invoice Number: <%- invoiceNumber %>"
+subscriptionFirstInvoice-content-charge = "Charged <%- invoiceTotal %> on <%- invoiceDateOnly %>"
+<%- include ('/partials/viewInvoice/index.txt') %>
+<% if (locals.payment_provider) { %>
+<%- include ('/partials/paymentProvider/index.txt') %>
+<% } %>
+subscriptionFirstInvoice-content-next-invoice = "Next Invoice: <%- nextInvoiceDateOnly %>"
+
+<%- include ('/partials/subscriptionSupport/index.txt') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionFirstInvoice/index.txt
@@ -11,9 +11,8 @@ subscriptionFirstInvoice-content-auto-renew = "Your subscription will automatica
 subscriptionFirstInvoice-content-invoice-number-plaintext = "Invoice Number: <%- invoiceNumber %>"
 subscriptionFirstInvoice-content-charge = "Charged <%- invoiceTotal %> on <%- invoiceDateOnly %>"
 <%- include ('/partials/viewInvoice/index.txt') %>
-<% if (locals.payment_provider) { %>
 <%- include ('/partials/paymentProvider/index.txt') %>
-<% } %>
+
 subscriptionFirstInvoice-content-next-invoice = "Next Invoice: <%- nextInvoiceDateOnly %>"
 
 <%- include ('/partials/subscriptionSupport/index.txt') %>

--- a/packages/fxa-auth-server/scripts/write-emails-to-disk.js
+++ b/packages/fxa-auth-server/scripts/write-emails-to-disk.js
@@ -130,6 +130,8 @@ function sendMail(mailer, messageToSend) {
     productIconURLOld: 'http://placekitten.com/512/512?image=1',
     productNameOld: 'Product A',
     productNameNew: 'Product B',
+    invoiceLink:
+      'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
     invoiceTotalInCents: 999999.9,
     invoiceTotalCurrency: 'eur',
     paymentAmountOldInCents: 9999099.9,

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -71,15 +71,22 @@ const MESSAGE = {
   uaOSVersion: '10',
   uid: 'uid',
   unblockCode: 'AS6334PK',
+  cardType: 'mastercard',
   invoiceDate: new Date(1584747098816),
+  invoiceLink:
+    'https://pay.stripe.com/invoice/acct_1GCAr3BVqmGyQTMa/invst_GyHjTyIXBg8jj5yjt7Z0T4CCG3hfGtp',
+  invoiceNumber: '8675309',
   invoiceTotalInCents: 999999.9,
   invoiceTotalCurrency: 'eur',
+  lastFour: '5309',
+  nextInvoiceDate: new Date(1587339098816),
   paymentAmountOldInCents: 9999099.9,
   paymentAmountOldCurrency: 'jpy',
   paymentAmountNewInCents: 12312099.9,
   paymentAmountNewCurrency: 'gbp',
   paymentProratedInCents: 523099.9,
   paymentProratedCurrency: 'usd',
+  payment_provider: 'stripe',
   planId: 'plan-example',
   productId: 'wibble',
   productMetadata,
@@ -1089,6 +1096,42 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `final payment of ${MESSAGE_FORMATTED.invoiceTotal} was paid on 03/20/2020.` },
       { test: 'include', expected: `billing period, which is 04/19/2020.` },
       { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ])],
+
+  ['subscriptionFirstInvoiceEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `${MESSAGE.productName} payment confirmed` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionFirstInvoice') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionFirstInvoice' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionFirstInvoice }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-first-invoice', 'cancel-subscription', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-first-invoice', 'subscription-terms') },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSupportUrl', 'subscription-first-invoice', 'subscription-support')) },
+      { test: 'include', expected: `Thank you for subscribing to ${MESSAGE.productName}` },
+      { test: 'include', expected: `start using ${MESSAGE.productName}` },
+      // Need to rewrite - attributes cause this to fail
+      // { test: 'include', expected: `Invoice Number: <b>${MESSAGE.invoiceNumber}</b>` },
+      { test: 'include', expected: `MasterCard card ending in 5309` },
+      { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      { test: 'include', expected: `View your invoice` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+      { test: 'notInclude', expected: 'PayPal' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `${MESSAGE.productName} payment confirmed` },
+      { test: 'include', expected: `start using ${MESSAGE.productName}` },
+      { test: 'include', expected: `Invoice Number: ${MESSAGE.invoiceNumber}` },
+      { test: 'include', expected: `MasterCard card ending in 5309` },
+      { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
+      { test: 'include', expected: `Next Invoice: 04/19/2020` },
+      // Link appears in Storybook, undefined in HTML, does not exist in txt
+      // { test: 'include', expected: `View Invoice: ${MESSAGE.invoiceLink}` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+      { test: 'notInclude', expected: 'PayPal' },
     ]]
   ])],
 

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -1112,8 +1112,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: decodeUrl(configHref('subscriptionSupportUrl', 'subscription-first-invoice', 'subscription-support')) },
       { test: 'include', expected: `Thank you for subscribing to ${MESSAGE.productName}` },
       { test: 'include', expected: `start using ${MESSAGE.productName}` },
-      // Need to rewrite - attributes cause this to fail
-      // { test: 'include', expected: `Invoice Number: <b>${MESSAGE.invoiceNumber}</b>` },
+      { test: 'include', expected: `${MESSAGE.invoiceNumber}</b>` },
       { test: 'include', expected: `MasterCard card ending in 5309` },
       { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
       { test: 'include', expected: `Next Invoice: 04/19/2020` },
@@ -1128,8 +1127,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'include', expected: `MasterCard card ending in 5309` },
       { test: 'include', expected: `Charged ${MESSAGE_FORMATTED.invoiceTotal} on 03/20/2020` },
       { test: 'include', expected: `Next Invoice: 04/19/2020` },
-      // Link appears in Storybook, undefined in HTML, does not exist in txt
-      // { test: 'include', expected: `View Invoice: ${MESSAGE.invoiceLink}` },
+      { test: 'include', expected: `View Invoice: ${MESSAGE.invoiceLink}` },
       { test: 'notInclude', expected: 'utm_source=email' },
       { test: 'notInclude', expected: 'PayPal' },
     ]]


### PR DESCRIPTION
Because:

* We are actively converting old FxA emails to our new modernized stack

This commit:

* Converts the `subscriptionFirstInvoice` subscription platform email to the new stack

Closes: #8276

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)

Old template
<img width="649" alt="Screen Shot 2021-12-13 at 4 40 20 PM" src="https://user-images.githubusercontent.com/28129806/145893723-9a25b80b-69dc-4aa0-8afc-3d99b40e9a27.png">

New template - PayPal
<img width="651" alt="Screen Shot 2021-12-15 at 10 36 45 AM" src="https://user-images.githubusercontent.com/28129806/146216849-27224869-e9c7-4d89-9a75-6e6ba08817cc.png">

New template - Stripe
<img width="658" alt="Screen Shot 2021-12-15 at 10 36 36 AM" src="https://user-images.githubusercontent.com/28129806/146216876-ef4c1346-9637-4ae7-a068-baa8ad4b0d8c.png">

## Other information (Optional)
Two new partials were created - `paymentProvider` and `viewInvoice`
* `emails/partials/paymentProvider/en.ftl`
* `emails/partials/paymentProvider/index.mjml`
* `emails/partials/paymentProvider/index.txt`

* `emails/partials/viewInvoice/en.ftl`
* `emails/partials/viewInvoice/index.mjml `
* `emails/partials/viewInvoice/index.txt`

Draft pull request due to the following:
~~* PayPal placeholder (WIP)~~
~~* Link to use for `invoiceLink` in `emails/partials/viewInvoice/en.ftl`?~~
~~* Failing test - link to view invoice appears in HTML and plain text in Storybook, but does not appear when running `yarn write-emails`; need fresh eyes~~
~~* Failing test - test to ensure `invoiceNumber` is bolded - attributes cause this to fail; will rewrite later~~