### PR TITLE
feat(auth-server): convert `subscriptionPaymentProviderCancelled`

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -472,6 +472,7 @@
       "subscriptionCancellation",
       "subscriptionDowngrade",
       "subscriptionPaymentFailed",
+      "subscriptionPaymentProviderCancelled",
       "subscriptionReactivation",
       "subscriptionUpgrade"
     ]

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentProviderCancelled/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentProviderCancelled/en.ftl
@@ -1,0 +1,8 @@
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionPaymentProviderCancelled-subject = Payment information update required for { $productName }
+subscriptionPaymentProviderCancelled-title = Sorry, we’re having trouble with your payment method
+# Variables:
+#  $productName (String) - The name of the subscribed product, e.g. Mozilla VPN
+subscriptionPaymentProviderCancelled-content-detect = We have detected a problem with your payment method for { $productName }.
+subscriptionPaymentProviderCancelled-content-reason = It may be that your credit card has expired, or your current payment method is out of date.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentProviderCancelled/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentProviderCancelled/index.mjml
@@ -1,0 +1,26 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="subscriptionPaymentProviderCancelled-title">Sorry, we’re having trouble with your payment method</span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionPaymentProviderCancelled-content-detect" data-l10n-args="<%= JSON.stringify({productName}) %>">
+        We have detected a problem with your payment method for <%- productName %>.
+      </span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionPaymentProviderCancelled-content-reason">
+        It may be that your credit card has expired, or your current payment method is out of date.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/subscriptionUpdatePayment/index.mjml', { updateBillingUrl }) %>
+<%- include ('/partials/subscriptionSupport/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentProviderCancelled/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentProviderCancelled/index.stories.ts
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionPaymentProviderCancelled',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionPaymentProviderCancelled',
+  'Sent when a problem is detected with the payment method.',
+  {
+    productName: 'Firefox Fortress',
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+    updateBillingUrl: 'http://localhost:3030/subscriptions',
+  }
+);
+
+export const SubscriptionPaymentProviderCancelled = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentProviderCancelled/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionPaymentProviderCancelled/index.txt
@@ -1,0 +1,10 @@
+subscriptionPaymentProviderCancelled-subject = "Payment information update required for <%- productName %>"
+
+subscriptionPaymentProviderCancelled-title = "Sorry, we’re having trouble with your payment method"
+
+subscriptionPaymentProviderCancelled-content-detect = "We have detected a problem with your payment method for <%- productName %>."
+
+subscriptionPaymentProviderCancelled-content-reason = "It may be that your credit card has expired, or your current payment method is out of date."
+
+<%- include('/partials/subscriptionUpdatePayment/index.txt', { updateBillingUrl }) %>
+<%- include ('/partials/subscriptionSupport/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -1151,6 +1151,28 @@ const TESTS: [string, any, Record<string, any>?][] = [
       { test: 'notInclude', expected: 'utm_source=email' },
     ]]
   ])],
+  ['subscriptionPaymentProviderCancelledEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: `Payment information update required for ${MESSAGE.productName}` }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionPaymentProviderCancelled') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionPaymentProviderCancelled' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionPaymentProviderCancelled }],
+    ])],
+    ['html', [
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscription-payment-provider-cancelled', 'subscription-terms') },
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscription-payment-provider-cancelled', 'update-billing', 'plan_id', 'product_id', 'uid', 'email')) },
+      { test: 'include', expected: `We have detected a problem with your payment method for ${MESSAGE.productName}.` },
+      { test: 'include', expected: 'It may be that your credit card has expired, or your current payment method is out of date.' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: `We have detected a problem with your payment method for ${MESSAGE.productName}.` },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ]),
+    {updateTemplateValues: x => (
+      {...x, subscriptions: [{planId: MESSAGE.planId, productId: MESSAGE.productId, ...x.subscriptions[0]}]})}
+  ],
 
   ['subscriptionReactivationEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: `${MESSAGE.productName} subscription reactivated` }],


### PR DESCRIPTION
Because:

* We are actively converting old FxA emails to our new modernized stack

This commit:

* Converts the `subscriptionPaymentProviderCancelled` subscription platform email to the new stack.

Closes: #9284 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Old template
<img width="649" alt="Screen Shot 2021-12-13 at 6 02 40 PM" src="https://user-images.githubusercontent.com/28129806/145903440-4fd1035c-5eea-4124-ae5d-e55bc1e61cf5.png">

New template
<img width="652" alt="Screen Shot 2021-12-13 at 6 00 33 PM" src="https://user-images.githubusercontent.com/28129806/145903417-86d4d914-8a42-41b7-9924-d752edb3a85c.png">
