### PR TITLE
feat(auth-server): convert `subscriptionsPaymentProviderCancelled`

### DIFF
--- a/packages/fxa-auth-server/config/dev.json
+++ b/packages/fxa-auth-server/config/dev.json
@@ -475,6 +475,7 @@
       "subscriptionPaymentFailed",
       "subscriptionPaymentProviderCancelled",
       "subscriptionReactivation",
+      "subscriptionsPaymentProviderCancelled",
       "subscriptionUpgrade"
     ]
   }

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
@@ -67,7 +67,7 @@
         </mj-text>
 
         <mj-text css-class="footer-text">
-          <% if (locals.productName) { %>
+          <% if (locals.productName || locals.subscriptions.length > 0) { %>
             <a href="<%- subscriptionTermsUrl %>" class="footer-link" data-l10n-id="subplat-terms-policy">Terms and cancellation policy</a>
             &nbsp;&nbsp;&bull;&nbsp;&nbsp;
           <% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.mjml
@@ -67,7 +67,7 @@
         </mj-text>
 
         <mj-text css-class="footer-text">
-          <% if (locals.productName || locals.subscriptions.length > 0) { %>
+          <% if (locals.productName || locals.subscriptions?.length > 0) { %>
             <a href="<%- subscriptionTermsUrl %>" class="footer-link" data-l10n-id="subplat-terms-policy">Terms and cancellation policy</a>
             &nbsp;&nbsp;&bull;&nbsp;&nbsp;
           <% } %>

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.stories.ts
@@ -17,7 +17,19 @@ const createStory = subplatStoryWithProps(
   }
 );
 
-export const LayoutNoProduct = createStory({}, 'Multiple products');
+export const LayoutMultipleProducts = createStory(
+  {
+    subscriptions: [
+      {
+        productName: 'Firefox Fortress',
+      },
+      {
+        productName: 'Mozilla VPN',
+      },
+    ],
+  },
+  'Multiple products'
+);
 
 export const LayoutWithProduct = createStory(
   {

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
@@ -4,7 +4,7 @@
 
 subplat-automated-email = "This is an automated email; if you received it in error, no action is required."
 
-<% if (locals.productName || locals.subscriptions.length > 0) { %>
+<% if (locals.productName || locals.subscriptions?.length > 0) { %>
 subplat-terms-policy-plaintext = "Terms and cancellation policy:"
 <%- subscriptionTermsUrl %>
 

--- a/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/layouts/subscription/index.txt
@@ -4,7 +4,7 @@
 
 subplat-automated-email = "This is an automated email; if you received it in error, no action is required."
 
-<% if (locals.productName) { %>
+<% if (locals.productName || locals.subscriptions.length > 0) { %>
 subplat-terms-policy-plaintext = "Terms and cancellation policy:"
 <%- subscriptionTermsUrl %>
 

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentProviderCancelled/en.ftl
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentProviderCancelled/en.ftl
@@ -1,0 +1,4 @@
+subscriptionsPaymentProviderCancelled-subject = Payment information update required for Mozilla subscriptions
+subscriptionsPaymentProviderCancelled-title = Sorry, we’re having trouble with your payment method
+subscriptionsPaymentProviderCancelled-content-detected = We have detected a problem with your payment method for the following subscriptions.
+subscriptionsPaymentProviderCancelled-content-payment = It may be that your credit card has expired, or your current payment method is out of date.

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentProviderCancelled/index.mjml
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentProviderCancelled/index.mjml
@@ -1,0 +1,36 @@
+<%# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. %>
+
+<mj-section>
+  <mj-column>
+    <mj-text css-class="text-header">
+      <span data-l10n-id="subscriptionsPaymentProviderCancelled-title">Sorry, we’re having trouble with your payment method</span>
+    </mj-text>
+
+    <mj-text css-class="text-body-no-bottom-margin">
+      <span data-l10n-id="subscriptionsPaymentProviderCancelled-content-detected">
+        We have detected a problem with your payment method for the following subscriptions.
+      </span>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <ul>
+        <% for (const { productName } of subscriptions) { %>
+          <li>
+            <%- productName %>
+          </li>
+        <% } %>
+      </ul>
+    </mj-text>
+
+    <mj-text css-class="text-body">
+      <span data-l10n-id="subscriptionsPaymentProviderCancelled-content-payment">
+        It may be that your credit card has expired, or your current payment method is out of date.
+      </span>
+    </mj-text>
+  </mj-column>
+</mj-section>
+
+<%- include('/partials/subscriptionUpdatePayment/index.mjml', { updateBillingUrl }) %>
+<%- include ('/partials/subscriptionSupport/index.mjml') %>

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentProviderCancelled/index.stories.ts
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentProviderCancelled/index.stories.ts
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { Meta } from '@storybook/html';
+import { subplatStoryWithProps } from '../../storybook-email';
+
+export default {
+  title: 'SubPlat Emails/Templates/subscriptionsPaymentProviderCancelled',
+} as Meta;
+
+const createStory = subplatStoryWithProps(
+  'subscriptionsPaymentProviderCancelled',
+  'Sent when a user has multiple subscriptions and a problem has been detected with payment method.',
+  {
+    subscriptions: [
+      {
+        productName: 'Firefox Fortress',
+      },
+      {
+        productName: 'Mozilla VPN',
+      },
+    ],
+    subscriptionSupportUrl: 'http://localhost:3030/support',
+    updateBillingUrl: 'http://localhost:3030/subscriptions',
+  }
+);
+
+export const SubscriptionsPaymentProviderCancelled = createStory();

--- a/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentProviderCancelled/index.txt
+++ b/packages/fxa-auth-server/lib/senders/emails/templates/subscriptionsPaymentProviderCancelled/index.txt
@@ -1,0 +1,13 @@
+subscriptionsPaymentProviderCancelled-subject = "Payment information update required for Mozilla subscriptions"
+
+subscriptionsPaymentProviderCancelled-title = "Sorry, we’re having trouble with your payment method"
+
+subscriptionsPaymentProviderCancelled-content-detected = "We have detected a problem with your payment method for the following subscriptions."
+
+<%- subscriptions.map(({ productName }) => `  - ${productName}`).join("\r") %>
+
+subscriptionsPaymentProviderCancelled-content-payment = "It may be that your credit card has expired, or your current payment method is out of date."
+
+<%- include ('/partials/subscriptionUpdatePayment/index.txt', { updateBillingUrl }) %>
+
+<%- include ('/partials/subscriptionSupport/index.txt') %>

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -1215,6 +1215,25 @@ const TESTS: [string, any, Record<string, any>?][] = [
       {...x, subscriptions: [{planId: MESSAGE.planId, productId: MESSAGE.productId, ...x.subscriptions[0]}]})}
   ],
 
+  ['subscriptionPaymentProviderCancelledEmail', new Map<string, Test | any>([
+    ['subject', { test: 'equal', expected: 'Payment information update required for Mozilla subscriptions' }],
+    ['headers', new Map([
+      ['X-SES-MESSAGE-TAGS', { test: 'equal', expected: sesMessageTagsHeaderValue('subscriptionsPaymentProviderCancelled') }],
+      ['X-Template-Name', { test: 'equal', expected: 'subscriptionsPaymentProviderCancelled' }],
+      ['X-Template-Version', { test: 'equal', expected: TEMPLATE_VERSIONS.subscriptionsPaymentProviderCancelled }],
+    ])],
+    ['html', [
+      { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscriptions-payment-provider-cancelled', 'update-billing', 'email', 'uid')) },
+      { test: 'include', expected: 'We have detected a problem with your payment method for the following subscriptions.' },
+      { test: 'include', expected: 'It may be that your credit card has expired, or your current payment method is out of date.' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]],
+    ['text', [
+      { test: 'include', expected: 'We have detected a problem with your payment method for the following subscriptions.' },
+      { test: 'notInclude', expected: 'utm_source=email' },
+    ]]
+  ]), {updateTemplateValues: x => ({...x, productName: undefined})}],
+
   ['subscriptionReactivationEmail', new Map<string, Test | any>([
     ['subject', { test: 'equal', expected: `${MESSAGE.productName} subscription reactivated` }],
     ['headers', new Map([

--- a/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
+++ b/packages/fxa-auth-server/test/local/senders/mjml-emails.ts
@@ -1163,6 +1163,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ])],
     ['html', [
       { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscriptions-payment-expired', 'update-billing', 'email', 'uid')) },
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscriptions-payment-expired', 'subscription-terms') },
       { test: 'include', expected: 'using to make payments for the following subscriptions is about to expire.' },
       { test: 'notInclude', expected: 'utm_source=email' },
     ]],
@@ -1224,6 +1225,7 @@ const TESTS: [string, any, Record<string, any>?][] = [
     ])],
     ['html', [
       { test: 'include', expected: decodeUrl(configHref('subscriptionSettingsUrl', 'subscriptions-payment-provider-cancelled', 'update-billing', 'email', 'uid')) },
+      { test: 'include', expected: configHref('subscriptionTermsUrl', 'subscriptions-payment-provider-cancelled', 'subscription-terms') },
       { test: 'include', expected: 'We have detected a problem with your payment method for the following subscriptions.' },
       { test: 'include', expected: 'It may be that your credit card has expired, or your current payment method is out of date.' },
       { test: 'notInclude', expected: 'utm_source=email' },


### PR DESCRIPTION
Because:

* We are actively converting old FxA emails to our new modernized stack

This commit:

* Converts the `subscriptionsPaymentProviderCancelled` subscription platform email to the new stack.

Closes: #9299 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [ ] I have added necessary documentation (if appropriate).
- [ ] I have verified that my changes render correctly in RTL (if appropriate).

## Screenshots (Optional)
Old template
<img width="654" alt="Screen Shot 2021-12-15 at 9 32 34 AM" src="https://user-images.githubusercontent.com/28129806/146208448-d480ae3d-a482-4d34-8869-59fd8222edaa.png">

New template
<img width="658" alt="Screen Shot 2021-12-15 at 9 48 24 AM" src="https://user-images.githubusercontent.com/28129806/146208112-128b9324-67d3-4726-ab82-a8b96a12f275.png">

## Other information (Optional)
* The `Terms and cancellation policy` link has been added to the footer of emails with multiple subscriptions.
* The Storybook layout for multiple products has been updated.