### PR TITLE
feat(coupons): add coupon metrics

### DIFF
--- a/packages/fxa-auth-server/lib/routes/util.js
+++ b/packages/fxa-auth-server/lib/routes/util.js
@@ -60,12 +60,5 @@ module.exports = (log, config, redirectDomain) => {
         return h.redirect(config.contentServer.url + request.raw.req.url);
       },
     },
-    {
-      method: 'GET',
-      path: '/reinotest',
-      handler: function (request, h) {
-        return 'Hello workd!';
-      },
-    },
   ];
 };

--- a/packages/fxa-auth-server/lib/routes/util.js
+++ b/packages/fxa-auth-server/lib/routes/util.js
@@ -60,5 +60,12 @@ module.exports = (log, config, redirectDomain) => {
         return h.redirect(config.contentServer.url + request.raw.req.url);
       },
     },
+    {
+      method: 'GET',
+      path: '/reinotest',
+      handler: function (request, h) {
+        return 'Hello workd!';
+      },
+    },
   ];
 };

--- a/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
+++ b/packages/fxa-auth-server/test/local/routes/subscriptions/paypal.js
@@ -358,7 +358,7 @@ describe('subscriptions payPalRoutes', () => {
           {
             customer,
             priceId: undefined,
-            promotionCode: promoCode,
+            promotionCode,
             subIdempotencyKey: undefined,
             taxRateId: 'tr-1234',
           }
@@ -615,7 +615,7 @@ describe('subscriptions payPalRoutes', () => {
               },
             },
             priceId: undefined,
-            promotionCode: promoCode,
+            promotionCode,
             subIdempotencyKey: undefined,
             taxRateId: 'tr-1234',
           }

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/event-properties.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/event-properties.ts
@@ -34,6 +34,7 @@ const EVENT_PROPERTIES: {
   [GROUPS.subPaySetup]: NOP,
   [GROUPS.subPayUpgrade]: NOP,
   [GROUPS.subSupport]: NOP,
+  [GROUPS.subCoupon]: NOP,
 } as const;
 
 const CONNECT_DEVICE_FLOWS = {

--- a/packages/fxa-metrics-processor/src/lib/amplitude/transforms/types.ts
+++ b/packages/fxa-metrics-processor/src/lib/amplitude/transforms/types.ts
@@ -25,6 +25,7 @@ export enum GROUPS {
   subPaySetup = 'fxa_pay_setup',
   subPayUpgrade = 'fxa_pay_upgrade',
   subSupport = 'fxa_subscribe_support',
+  subCoupon = 'fxa_subscribe_coupon',
 }
 
 export type OptionalString = string | null;

--- a/packages/fxa-payments-server/src/components/CouponForm/index.tsx
+++ b/packages/fxa-payments-server/src/components/CouponForm/index.tsx
@@ -1,11 +1,20 @@
 import './index.scss';
 
 import { Localized } from '@fluent/react';
-import React, { FormEventHandler, MouseEventHandler, useState } from 'react';
+import React, {
+  FormEventHandler,
+  MouseEventHandler,
+  useState,
+  useCallback,
+  useEffect,
+} from 'react';
 
 import { APIError, apiInvoicePreview } from '../../lib/apiClient';
 import { Coupon } from '../../lib/Coupon';
 import sentry from '../../lib/sentry';
+
+import * as Amplitude from '../../lib/amplitude';
+import { useCallbackOnce } from '../../lib/hooks';
 
 /*
  * Check if the coupon promotion code provided by the user is valid.
@@ -18,7 +27,7 @@ const checkPromotionCode = async (planId: string, promotionCode: string) => {
       promotionCode,
     });
 
-    if (!discount) {
+    if (!discount?.amount) {
       throw new Error('No discount for coupon');
     }
     return discount.amount;
@@ -43,6 +52,22 @@ export const CouponForm = ({ planId, coupon, setCoupon }: CouponFormProps) => {
   );
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+
+  const onFormMounted = useCallback(
+    () => Amplitude.couponMounted({ planId }),
+    [planId]
+  );
+  useEffect(() => {
+    onFormMounted();
+  }, [onFormMounted, planId]);
+
+  const onFormEngaged = useCallbackOnce(
+    () => Amplitude.couponEngaged({ planId }),
+    [planId]
+  );
+  const onChange = useCallback(() => {
+    onFormEngaged();
+  }, [onFormEngaged]);
 
   const onSubmit: FormEventHandler = async (event) => {
     event.preventDefault();
@@ -107,7 +132,11 @@ export const CouponForm = ({ planId, coupon, setCoupon }: CouponFormProps) => {
             </button>
           </div>
         ) : (
-          <form onSubmit={onSubmit} data-testid="coupon-form">
+          <form
+            onSubmit={onSubmit}
+            onChange={onChange}
+            data-testid="coupon-form"
+          >
             <div className="input-row">
               <Localized attrs={{ placeholder: true }} id="coupon-enter-code">
                 <input

--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -41,7 +41,7 @@ export type EventProperties = GlobalEventProperties & {
   productId?: string;
   product_id?: string;
   paymentProvider?: PaymentProvider;
-  couponPromoCode?: string;
+  promotionCode?: string;
   error?: Error;
   checkoutType?: string;
   utm_campaign?: string;

--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -13,6 +13,7 @@ const eventGroupNames = {
   manageSubscriptions: 'subManage',
   createSubscriptionWithPaymentMethod: 'subPaySetup',
   updateDefaultPaymentMethod: 'subPayManage',
+  coupon: 'subCoupon',
 } as const;
 
 const eventTypeNames = {
@@ -40,6 +41,7 @@ export type EventProperties = GlobalEventProperties & {
   productId?: string;
   product_id?: string;
   paymentProvider?: PaymentProvider;
+  couponPromoCode?: string;
   error?: Error;
   checkoutType?: string;
   utm_campaign?: string;
@@ -384,6 +386,46 @@ export function createAccountSignIn(eventProperties: EventProperties) {
   safeLogAmplitudeEvent(
     eventGroupNames.createAccount,
     eventTypeNames.other,
+    eventProperties
+  );
+}
+
+export function couponMounted(eventProperties: EventProperties) {
+  safeLogAmplitudeEvent(
+    eventGroupNames.coupon,
+    eventTypeNames.view,
+    eventProperties
+  );
+}
+
+export function couponEngaged(eventProperties: EventProperties) {
+  safeLogAmplitudeEvent(
+    eventGroupNames.coupon,
+    eventTypeNames.engage,
+    eventProperties
+  );
+}
+
+export function couponMounted_PENDING(eventProperties: EventProperties) {
+  safeLogAmplitudeEvent(
+    eventGroupNames.coupon,
+    eventTypeNames.submit,
+    eventProperties
+  );
+}
+
+export function couponEngaged_FULFILLED(eventProperties: EventProperties) {
+  safeLogAmplitudeEvent(
+    eventGroupNames.coupon,
+    eventTypeNames.success,
+    eventProperties
+  );
+}
+
+export function couponEngaged_REJECTED(eventProperties: EventProperties) {
+  safeLogAmplitudeEvent(
+    eventGroupNames.coupon,
+    eventTypeNames.fail,
     eventProperties
   );
 }

--- a/packages/fxa-payments-server/src/lib/amplitude.ts
+++ b/packages/fxa-payments-server/src/lib/amplitude.ts
@@ -406,7 +406,7 @@ export function couponEngaged(eventProperties: EventProperties) {
   );
 }
 
-export function couponMounted_PENDING(eventProperties: EventProperties) {
+export function coupon_PENDING(eventProperties: EventProperties) {
   safeLogAmplitudeEvent(
     eventGroupNames.coupon,
     eventTypeNames.submit,
@@ -414,7 +414,7 @@ export function couponMounted_PENDING(eventProperties: EventProperties) {
   );
 }
 
-export function couponEngaged_FULFILLED(eventProperties: EventProperties) {
+export function coupon_FULFILLED(eventProperties: EventProperties) {
   safeLogAmplitudeEvent(
     eventGroupNames.coupon,
     eventTypeNames.success,
@@ -422,7 +422,7 @@ export function couponEngaged_FULFILLED(eventProperties: EventProperties) {
   );
 }
 
-export function couponEngaged_REJECTED(eventProperties: EventProperties) {
+export function coupon_REJECTED(eventProperties: EventProperties) {
   safeLogAmplitudeEvent(
     eventGroupNames.coupon,
     eventTypeNames.fail,

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -376,11 +376,13 @@ describe('API requests', () => {
       productId: 'prod_abdce',
       paymentMethodId: 'pm_test',
       idempotencyKey: 'idk-8675309',
+      promotionCode: 'VALID',
     };
-    const metricsOptions = {
+    const metricsOptions: EventProperties = {
       planId: params.priceId,
       productId: params.productId,
       paymentProvider: 'stripe',
+      promotionCode: params.promotionCode,
     };
 
     it(`POST {auth-server}${path}`, async () => {
@@ -404,7 +406,8 @@ describe('API requests', () => {
     });
 
     it('sends amplitude ping on error', async () => {
-      const { priceId, paymentMethodId, idempotencyKey } = params;
+      const { priceId, paymentMethodId, idempotencyKey, promotionCode } =
+        params;
       const requestMock = nock(AUTH_BASE_URL)
         .post(path, { priceId, paymentMethodId, idempotencyKey })
         .reply(400, { message: 'oops' });
@@ -480,7 +483,7 @@ describe('API requests', () => {
       const promotionCode = 'VALID';
       const metricsOptions: EventProperties = {
         ...metricsOptionsBase,
-        couponPromoCode: promotionCode,
+        promotionCode,
       };
       const expected: InvoicePreview = {
         subtotal: 200,
@@ -518,7 +521,7 @@ describe('API requests', () => {
       const promotionCode = 'INVALID';
       const metricsOptions: EventProperties = {
         ...metricsOptionsBase,
-        couponPromoCode: promotionCode,
+        promotionCode,
       };
       const expected: InvoicePreview = {
         subtotal: 200,
@@ -660,14 +663,17 @@ describe('API requests', () => {
 
   describe('apiCapturePaypalPayment', () => {
     const path = '/v1/oauth/subscriptions/active/new-paypal';
+    const promotionCode = 'VALID';
     const params = {
       idempotencyKey: 'idk-8675309',
       priceId: 'price_12345',
+      promotionCode,
       ...MOCK_CHECKOUT_TOKEN,
     };
     const metricsOptions = {
       planId: params.priceId,
       paymentProvider: 'paypal',
+      promotionCode,
     };
 
     it('POST {auth-server}/v1/oauth/subscriptions/active/new-paypal', async () => {

--- a/packages/fxa-payments-server/src/lib/apiClient.test.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.test.ts
@@ -471,7 +471,7 @@ describe('API requests', () => {
     });
   });
 
-  describe.only('apiInvoicePreview', () => {
+  describe('apiInvoicePreview', () => {
     const path = '/v1/oauth/subscriptions/invoice/preview';
     const priceId = 'price_kkljasdk32lkjasd';
 

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -261,7 +261,7 @@ export async function apiCapturePaypalPayment(params: {
   idempotencyKey: string;
   priceId: string;
   token?: string;
-  promotionCode: string;
+  promotionCode?: string;
 }): Promise<{
   sourceCountry: string;
   subscription: Subscription;
@@ -302,7 +302,7 @@ export async function apiCreateSubscriptionWithPaymentMethod(params: {
   productId: string;
   paymentMethodId?: string;
   idempotencyKey: string;
-  promotionCode: string;
+  promotionCode?: string;
 }): Promise<{
   id: string;
   latest_invoice: {

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -261,7 +261,7 @@ export async function apiCapturePaypalPayment(params: {
   idempotencyKey: string;
   priceId: string;
   token?: string;
-  promotionCode?: string;
+  promotionCode: string;
 }): Promise<{
   sourceCountry: string;
   subscription: Subscription;
@@ -269,7 +269,7 @@ export async function apiCapturePaypalPayment(params: {
   const metricsOptions: Amplitude.EventProperties = {
     planId: params.priceId,
     paymentProvider: 'paypal',
-    couponPromoCode: params.couponPromoCode,
+    promotionCode: params.promotionCode,
   };
   Amplitude.createSubscriptionWithPaymentMethod_PENDING(metricsOptions);
   try {
@@ -302,7 +302,7 @@ export async function apiCreateSubscriptionWithPaymentMethod(params: {
   productId: string;
   paymentMethodId?: string;
   idempotencyKey: string;
-  promotionCode?: string;
+  promotionCode: string;
 }): Promise<{
   id: string;
   latest_invoice: {
@@ -321,7 +321,7 @@ export async function apiCreateSubscriptionWithPaymentMethod(params: {
     planId: params.priceId,
     productId: params.productId,
     paymentProvider: 'stripe',
-    couponPromoCode: params.couponPromoCode,
+    promotionCode: params.promotionCode,
   };
   try {
     Amplitude.createSubscriptionWithPaymentMethod_PENDING(metricsOptions);
@@ -384,11 +384,31 @@ export async function apiInvoicePreview(params: {
   priceId: string;
   promotionCode: string;
 }): Promise<InvoicePreview> {
-  return apiFetch(
-    'POST',
-    `${config.servers.auth.url}/v1/oauth/subscriptions/invoice/preview`,
-    { body: JSON.stringify(params) }
-  );
+  const metricsOptions: Amplitude.EventProperties = {
+    planId: params.priceId,
+    promotionCode: params.promotionCode,
+  };
+  try {
+    Amplitude.coupon_PENDING(metricsOptions);
+    const result: InvoicePreview = await apiFetch(
+      'POST',
+      `${config.servers.auth.url}/v1/oauth/subscriptions/invoice/preview`,
+      { body: JSON.stringify(params) }
+    );
+
+    if (!result?.discount?.amount) {
+      throw new Error('No discount for coupon');
+    }
+
+    Amplitude.coupon_FULFILLED(metricsOptions);
+    return result;
+  } catch (error) {
+    Amplitude.coupon_REJECTED({
+      ...metricsOptions,
+      error,
+    });
+    throw error;
+  }
 }
 
 export type FilteredSetupIntent = {

--- a/packages/fxa-payments-server/src/lib/apiClient.ts
+++ b/packages/fxa-payments-server/src/lib/apiClient.ts
@@ -269,6 +269,7 @@ export async function apiCapturePaypalPayment(params: {
   const metricsOptions: Amplitude.EventProperties = {
     planId: params.priceId,
     paymentProvider: 'paypal',
+    couponPromoCode: params.couponPromoCode,
   };
   Amplitude.createSubscriptionWithPaymentMethod_PENDING(metricsOptions);
   try {
@@ -320,6 +321,7 @@ export async function apiCreateSubscriptionWithPaymentMethod(params: {
     planId: params.priceId,
     productId: params.productId,
     paymentProvider: 'stripe',
+    couponPromoCode: params.couponPromoCode,
   };
   try {
     Amplitude.createSubscriptionWithPaymentMethod_PENDING(metricsOptions);

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -33,6 +33,7 @@ const GROUPS = {
   subPayAccountSetup: 'fxa_pay_account_setup',
   subPayUpgrade: 'fxa_pay_upgrade',
   subSupport: 'fxa_subscribe_support',
+  subCoupon: 'fxa_subscribe_coupon',
   qrConnectDevice: 'fxa_qr_connect_device',
 };
 
@@ -65,6 +66,7 @@ const EVENT_PROPERTIES = {
   [GROUPS.subPayAccountSetup]: mapSubscriptionPaymentEventProperties,
   [GROUPS.subPayUpgrade]: NOP,
   [GROUPS.subSupport]: NOP,
+  [GROUPS.subCoupon]: NOP,
   [GROUPS.qrConnectDevice]: NOP,
 };
 

--- a/packages/fxa-shared/metrics/amplitude.js
+++ b/packages/fxa-shared/metrics/amplitude.js
@@ -326,6 +326,7 @@ module.exports = {
           plan_id: data.planId || data.plan_id,
           product_id: data.productId || data.product_id,
           payment_provider: data.paymentProvider,
+          promotionCode: data.promotionCode,
         }),
         EVENT_PROPERTIES[eventGroup](
           eventType,


### PR DESCRIPTION
## Because

- We want to add new coupon metrics for view, engage, submit, fail and
  success.
- Update existing payment metrics to include coupon code if used.

## This pull request

- Adds the new event type as well as event functions.
- Trigger event functions in Coupons components (TODO)
- Update existing payments events with coupon codes.

## Issue that this pull request solves

Closes: #11361

## Checklist

_Put an `x` in the boxes that apply_

- [x] My commit is GPG signed.
- [x] If applicable, I have modified or added tests which pass locally.
- [x] I have added necessary documentation (if appropriate).
- [x] I have verified that my changes render correctly in RTL (if appropriate).
